### PR TITLE
feat: add chrome devtools extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Monorepo for independently installable Pi extension packages.
 
 | Package | Source | Install |
 | --- | --- | --- |
+| `@narumitw/pi-chrome-devtools` | [`extensions/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | `pi install npm:@narumitw/pi-chrome-devtools` |
 | `@narumitw/pi-goal` | [`extensions/pi-goal`](./extensions/pi-goal) | `pi install npm:@narumitw/pi-goal` |
 | `@narumitw/pi-retry` | [`extensions/pi-retry`](./extensions/pi-retry) | `pi install npm:@narumitw/pi-retry` |
 
@@ -20,6 +21,7 @@ npm run check
 Try a package locally:
 
 ```bash
+pi -e ./extensions/pi-chrome-devtools
 pi -e ./extensions/pi-goal
 pi -e ./extensions/pi-retry
 ```
@@ -27,6 +29,7 @@ pi -e ./extensions/pi-retry
 Preview package contents:
 
 ```bash
+npm run pack:chrome-devtools
 npm run pack:goal
 npm run pack:retry
 ```
@@ -34,6 +37,7 @@ npm run pack:retry
 Publish packages from their package directories:
 
 ```bash
+cd extensions/pi-chrome-devtools && npm publish --access public
 cd extensions/pi-goal && npm publish --access public
 cd extensions/pi-retry && npm publish --access public
 ```

--- a/extensions/pi-chrome-devtools/LICENSE
+++ b/extensions/pi-chrome-devtools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -1,0 +1,83 @@
+# pi-chrome-devtools
+
+A public [pi](https://pi.dev) extension package that exposes Chrome DevTools Protocol (CDP) tools to the agent.
+
+It is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), but implemented as native pi tools instead of an MCP server.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-chrome-devtools
+```
+
+Try without installing:
+
+```bash
+pi -e npm:@narumitw/pi-chrome-devtools
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-chrome-devtools
+```
+
+## Start Chrome with CDP enabled
+
+The extension connects to `127.0.0.1:9222` by default.
+
+```bash
+google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/pi-chrome-devtools
+```
+
+On macOS:
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/pi-chrome-devtools
+```
+
+Override the endpoint if needed:
+
+```bash
+PI_CHROME_DEVTOOLS_HOST=127.0.0.1 PI_CHROME_DEVTOOLS_PORT=9223 pi -e ./extensions/pi-chrome-devtools
+```
+
+## Tools
+
+- `chrome_devtools_list_pages` — list inspectable Chrome tabs/pages.
+- `chrome_devtools_select_page` — select the active page for later tool calls.
+- `chrome_devtools_navigate` — navigate a page to a URL.
+- `chrome_devtools_evaluate` — evaluate JavaScript in the selected page.
+- `chrome_devtools_screenshot` — capture a PNG screenshot.
+
+## Command
+
+```text
+/chrome-devtools
+```
+
+Shows the configured CDP endpoint and quick start hint.
+
+## Package layout
+
+```txt
+extensions/pi-chrome-devtools/
+├── src/
+│   └── chrome-devtools.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/chrome-devtools.ts"]
+  }
+}
+```

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@narumitw/pi-chrome-devtools",
+	"version": "0.1.3",
+	"description": "Pi extension that exposes Chrome DevTools Protocol tools.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"chrome",
+		"devtools",
+		"cdp"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/chrome-devtools.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"typebox": "^1.1.37"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"typescript": "6.0.3"
+	}
+}

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1,0 +1,337 @@
+import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 9222;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface DevToolsPage {
+	id: string;
+	type: string;
+	title: string;
+	url: string;
+	webSocketDebuggerUrl?: string;
+}
+
+interface ChromeDevToolsState {
+	host: string;
+	port: number;
+	activePageId?: string;
+}
+
+interface CdpResponse<T = unknown> {
+	id: number;
+	result?: T;
+	error?: {
+		code: number;
+		message: string;
+		data?: unknown;
+	};
+}
+
+const state: ChromeDevToolsState = {
+	host: process.env.PI_CHROME_DEVTOOLS_HOST ?? DEFAULT_HOST,
+	port: Number(process.env.PI_CHROME_DEVTOOLS_PORT ?? DEFAULT_PORT),
+};
+
+const listPagesTool = defineTool({
+	name: "chrome_devtools_list_pages",
+	label: "Chrome DevTools: List Pages",
+	description: "List Chrome tabs/pages from a running Chrome DevTools Protocol endpoint.",
+	promptSnippet: "List Chrome tabs/pages available over Chrome DevTools Protocol",
+	parameters: Type.Object({}),
+	async execute() {
+		const pages = await listPages();
+		return textResult(JSON.stringify(pages.map(formatPage), null, 2), { pages });
+	},
+});
+
+const selectPageTool = defineTool({
+	name: "chrome_devtools_select_page",
+	label: "Chrome DevTools: Select Page",
+	description: "Select the active Chrome page for later chrome_devtools_* tool calls.",
+	promptSnippet: "Select the Chrome tab/page to inspect or control",
+	parameters: Type.Object({
+		pageId: Type.String({ description: "Page id from chrome_devtools_list_pages." }),
+	}),
+	async execute(_toolCallId, params) {
+		const page = await getPage(params.pageId);
+		state.activePageId = page.id;
+		return textResult(`Selected page ${page.id}: ${page.title}\n${page.url}`, {
+			page: formatPage(page),
+		});
+	},
+});
+
+const navigateTool = defineTool({
+	name: "chrome_devtools_navigate",
+	label: "Chrome DevTools: Navigate",
+	description: "Navigate a Chrome page to a URL through Chrome DevTools Protocol.",
+	promptSnippet: "Navigate the selected Chrome tab to a URL",
+	parameters: Type.Object({
+		url: Type.String({ description: "URL to navigate to." }),
+		pageId: Type.Optional(
+			Type.String({ description: "Optional page id. Defaults to selected or first page." }),
+		),
+	}),
+	async execute(_toolCallId, params) {
+		const page = await resolvePage(params.pageId);
+		const result = await withCdp(page, async (client) => {
+			await client.send("Page.enable");
+			return client.send("Page.navigate", { url: params.url });
+		});
+
+		state.activePageId = page.id;
+		return textResult(`Navigated ${page.id} to ${params.url}`, { page: formatPage(page), result });
+	},
+});
+
+const evaluateTool = defineTool({
+	name: "chrome_devtools_evaluate",
+	label: "Chrome DevTools: Evaluate",
+	description: "Evaluate JavaScript in a Chrome page through Chrome DevTools Protocol.",
+	promptSnippet: "Evaluate JavaScript in the selected Chrome tab",
+	parameters: Type.Object({
+		expression: Type.String({ description: "JavaScript expression to evaluate." }),
+		pageId: Type.Optional(
+			Type.String({ description: "Optional page id. Defaults to selected or first page." }),
+		),
+		awaitPromise: Type.Optional(
+			Type.Boolean({ description: "Whether to await a returned Promise. Defaults to true." }),
+		),
+	}),
+	async execute(_toolCallId, params) {
+		const page = await resolvePage(params.pageId);
+		const result = await withCdp(page, (client) =>
+			client.send("Runtime.evaluate", {
+				expression: params.expression,
+				awaitPromise: params.awaitPromise ?? true,
+				returnByValue: true,
+			}),
+		);
+
+		state.activePageId = page.id;
+		return textResult(JSON.stringify(result, null, 2), { page: formatPage(page), result });
+	},
+});
+
+const screenshotTool = defineTool({
+	name: "chrome_devtools_screenshot",
+	label: "Chrome DevTools: Screenshot",
+	description: "Capture a PNG screenshot from a Chrome page through Chrome DevTools Protocol.",
+	promptSnippet: "Capture a screenshot from the selected Chrome tab",
+	parameters: Type.Object({
+		pageId: Type.Optional(
+			Type.String({ description: "Optional page id. Defaults to selected or first page." }),
+		),
+		fullPage: Type.Optional(
+			Type.Boolean({ description: "Capture the full document, not just the viewport." }),
+		),
+	}),
+	async execute(_toolCallId, params) {
+		const page = await resolvePage(params.pageId);
+		const result = await withCdp(page, async (client) => {
+			await client.send("Page.enable");
+
+			if (!params.fullPage) {
+				return client.send<{ data: string }>("Page.captureScreenshot", { format: "png" });
+			}
+
+			const metrics = await client.send<{
+				contentSize: { x: number; y: number; width: number; height: number };
+			}>("Page.getLayoutMetrics");
+
+			return client.send<{ data: string }>("Page.captureScreenshot", {
+				captureBeyondViewport: true,
+				format: "png",
+				clip: {
+					x: metrics.contentSize.x,
+					y: metrics.contentSize.y,
+					width: metrics.contentSize.width,
+					height: metrics.contentSize.height,
+					scale: 1,
+				},
+			});
+		});
+
+		state.activePageId = page.id;
+		return {
+			content: [
+				{ type: "text", text: `Captured PNG screenshot from ${page.title || page.url}` },
+				{ type: "image", data: result.data, mimeType: "image/png" },
+			],
+			details: { page: formatPage(page), bytes: Buffer.byteLength(result.data, "base64") },
+		};
+	},
+});
+
+export default function chromeDevtools(pi: ExtensionAPI) {
+	pi.registerTool(listPagesTool);
+	pi.registerTool(selectPageTool);
+	pi.registerTool(navigateTool);
+	pi.registerTool(evaluateTool);
+	pi.registerTool(screenshotTool);
+
+	pi.registerCommand("chrome-devtools", {
+		description: "Show Chrome DevTools endpoint and quick start help",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(
+				`Chrome DevTools endpoint: http://${state.host}:${state.port}. Start Chrome with --remote-debugging-port=${state.port}.`,
+				"info",
+			);
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		ctx.ui.setStatus("chrome-devtools", `cdp: ${state.host}:${state.port}`);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus("chrome-devtools", undefined);
+	});
+}
+
+async function listPages() {
+	const response = await fetch(`http://${state.host}:${state.port}/json/list`);
+	if (!response.ok) {
+		throw new Error(`Chrome DevTools endpoint returned ${response.status} ${response.statusText}`);
+	}
+
+	const pages = (await response.json()) as DevToolsPage[];
+	return pages.filter((page) => page.type === "page" && page.webSocketDebuggerUrl);
+}
+
+async function getPage(pageId: string) {
+	const pages = await listPages();
+	const page = pages.find((candidate) => candidate.id === pageId);
+	if (!page) throw new Error(`Chrome DevTools page not found: ${pageId}`);
+	return page;
+}
+
+async function resolvePage(pageId?: string) {
+	if (pageId) return getPage(pageId);
+	if (state.activePageId) return getPage(state.activePageId);
+
+	const pages = await listPages();
+	const page = pages[0];
+	if (!page) {
+		throw new Error(
+			`No Chrome pages found at http://${state.host}:${state.port}. Start Chrome with --remote-debugging-port=${state.port}.`,
+		);
+	}
+
+	return page;
+}
+
+function formatPage(page: DevToolsPage) {
+	return {
+		id: page.id,
+		type: page.type,
+		title: page.title,
+		url: page.url,
+	};
+}
+
+function textResult(text: string, details: unknown) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details,
+	};
+}
+
+async function withCdp<T>(page: DevToolsPage, callback: (client: CdpClient) => Promise<T>) {
+	if (!page.webSocketDebuggerUrl) throw new Error(`Page has no webSocketDebuggerUrl: ${page.id}`);
+
+	const client = await CdpClient.connect(page.webSocketDebuggerUrl);
+	try {
+		return await callback(client);
+	} finally {
+		client.close();
+	}
+}
+
+class CdpClient {
+	#nextId = 1;
+	#pending = new Map<
+		number,
+		{
+			resolve: (value: unknown) => void;
+			reject: (reason: unknown) => void;
+			timeout: NodeJS.Timeout;
+		}
+	>();
+
+	private constructor(private readonly socket: WebSocket) {
+		socket.addEventListener("message", (event) => {
+			const response = JSON.parse(String(event.data)) as CdpResponse;
+			if (typeof response.id !== "number") return;
+
+			const pending = this.#pending.get(response.id);
+			if (!pending) return;
+
+			clearTimeout(pending.timeout);
+			this.#pending.delete(response.id);
+
+			if (response.error) {
+				pending.reject(new Error(`CDP error ${response.error.code}: ${response.error.message}`));
+			} else {
+				pending.resolve(response.result);
+			}
+		});
+
+		socket.addEventListener("close", () => {
+			this.rejectAll(new Error("Chrome DevTools WebSocket closed"));
+		});
+
+		socket.addEventListener("error", () => {
+			this.rejectAll(new Error("Chrome DevTools WebSocket error"));
+		});
+	}
+
+	static connect(url: string) {
+		return new Promise<CdpClient>((resolve, reject) => {
+			const socket = new WebSocket(url);
+			const timeout = setTimeout(() => {
+				socket.close();
+				reject(new Error(`Timed out connecting to Chrome DevTools WebSocket: ${url}`));
+			}, DEFAULT_TIMEOUT_MS);
+
+			socket.addEventListener("open", () => {
+				clearTimeout(timeout);
+				resolve(new CdpClient(socket));
+			});
+
+			socket.addEventListener("error", () => {
+				clearTimeout(timeout);
+				reject(new Error(`Failed to connect to Chrome DevTools WebSocket: ${url}`));
+			});
+		});
+	}
+
+	send<T = unknown>(method: string, params?: Record<string, unknown>) {
+		const id = this.#nextId;
+		this.#nextId += 1;
+
+		return new Promise<T>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.#pending.delete(id);
+				reject(new Error(`Timed out waiting for CDP response: ${method}`));
+			}, DEFAULT_TIMEOUT_MS);
+
+			this.#pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timeout });
+			this.socket.send(JSON.stringify({ id, method, params: params ?? {} }));
+		});
+	}
+
+	close() {
+		this.socket.close();
+	}
+
+	private rejectAll(error: Error) {
+		for (const [id, pending] of this.#pending) {
+			clearTimeout(pending.timeout);
+			pending.reject(error);
+			this.#pending.delete(id);
+		}
+	}
+}

--- a/extensions/pi-chrome-devtools/tsconfig.json
+++ b/extensions/pi-chrome-devtools/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+chrome_devtools := "@narumitw/pi-chrome-devtools"
 goal := "@narumitw/pi-goal"
 retry := "@narumitw/pi-retry"
 
@@ -24,8 +25,8 @@ pre-commit:
     pre-commit run --all-files
 
 # Show npm account/registry/package visibility information for one package
-# Usage: just doctor @narumitw/pi-goal
-doctor package="@narumitw/pi-goal":
+# Usage: just doctor @narumitw/pi-chrome-devtools
+doctor package="@narumitw/pi-chrome-devtools":
     @echo "package: {{package}}"
     npm whoami
     npm config get registry
@@ -35,6 +36,7 @@ doctor package="@narumitw/pi-goal":
 
 # Show npm visibility/version information for all packages
 doctor-all:
+    just doctor {{chrome_devtools}}
     just doctor {{goal}}
     just doctor {{retry}}
 
@@ -44,6 +46,10 @@ npm-public package="@narumitw/pi-goal":
     npm access public {{package}}
     npm view {{package}} version
 
+# Preview the chrome-devtools package that npm would publish
+pack-chrome-devtools:
+    npm run pack:chrome-devtools
+
 # Preview the goal package that npm would publish
 pack-goal:
     npm run pack:goal
@@ -51,6 +57,10 @@ pack-goal:
 # Preview the retry package that npm would publish
 pack-retry:
     npm run pack:retry
+
+# Try chrome-devtools from this working tree as a temporary pi package
+try-chrome-devtools:
+    pi -e ./extensions/pi-chrome-devtools
 
 # Try goal from this working tree as a temporary pi package
 try-goal:
@@ -60,6 +70,10 @@ try-goal:
 try-retry:
     pi -e ./extensions/pi-retry
 
+# Install the published chrome-devtools package through pi
+install-chrome-devtools:
+    pi install npm:{{chrome_devtools}}
+
 # Install the published goal package through pi
 install-goal:
     pi install npm:{{goal}}
@@ -67,6 +81,11 @@ install-goal:
 # Install the published retry package through pi
 install-retry:
     pi install npm:{{retry}}
+
+# Publish chrome-devtools to npm, skipping if the current version already exists
+# Usage with 2FA: just publish-chrome-devtools 123456
+publish-chrome-devtools otp="":
+    version="$(node -p "require('./extensions/pi-chrome-devtools/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{chrome_devtools}}@"$version" version >/dev/null 2>&1; then echo "{{chrome_devtools}}@$version already exists; skipping publish."; else npm --workspace {{chrome_devtools}} pack --dry-run; npm --workspace {{chrome_devtools}} publish --access public $otp_arg; fi
 
 # Publish goal to npm, skipping if the current version already exists
 # Usage with 2FA: just publish-goal 123456
@@ -81,11 +100,13 @@ publish-retry otp="":
 # Publish all extension packages to npm
 # Usage with 2FA: just publish-all 123456
 publish-all otp="":
+    just publish-chrome-devtools {{otp}}
     just publish-goal {{otp}}
     just publish-retry {{otp}}
 
 # Install all published extension packages through pi
 install-all:
+    just install-chrome-devtools
     just install-goal
     just install-retry
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,122 @@
 				"typescript": "^6.0.3"
 			}
 		},
+		"extensions/pi-chrome-devtools": {
+			"name": "@narumitw/pi-chrome-devtools",
+			"version": "0.1.3",
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "^1.1.37"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-chrome-devtools/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-chrome-devtools/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-chrome-devtools/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-chrome-devtools/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"extensions/pi-goal": {
 			"name": "@narumitw/pi-goal",
 			"version": "0.1.3",
@@ -1600,6 +1716,10 @@
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
 			}
+		},
+		"node_modules/@narumitw/pi-chrome-devtools": {
+			"resolved": "extensions/pi-chrome-devtools",
+			"link": true
 		},
 		"node_modules/@narumitw/pi-goal": {
 			"resolved": "extensions/pi-goal",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"biome:check": "biome check .",
 		"typecheck": "npm --workspaces run typecheck",
 		"check": "npm run biome:check && npm run typecheck",
+		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run"
 	},


### PR DESCRIPTION
## Summary
- add @narumitw/pi-chrome-devtools package with CDP tools for listing/selecting pages, navigating, evaluating JavaScript, and screenshots
- document Chrome remote debugging setup and package usage
- wire package scripts and just recipes for pack/install/publish flows

## Verification
- npm run check
- npm run pack:chrome-devtools