### PR TITLE
feat: add pi-caffeinate extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Run commands from the repository root unless noted otherwise.
 - Full verification: `npm run check` or `just check`
 - Format with Biome: `npm run format` or `just format`
 - Typecheck all workspaces: `npm run typecheck`
-- Preview npm package contents: `just pack-chrome-devtools`, `just pack-goal`, or `just pack-retry`
-- Try a local extension without installing: `just try-chrome-devtools`, `just try-goal`, or `just try-retry`
+- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-goal`, or `just pack-retry`
+- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-goal`, or `just try-retry`
 - Inspect available recipes before adding new workflow commands: `just --list`
 
 ## Code style

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,6 +4,7 @@
 
 - `MEMORY.md` is not auto-loaded; check it before non-trivial debugging or design work when prior project context may matter.
 - npm can show a scoped package dist-tag (for example `latest`) while `npm view <package>` still returns 404; fix visibility with `npm access set status=public <package> --otp=<otp>` or publish a bumped version.
+- For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
 
 ## TASTE
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Monorepo for independently installable Pi extension packages.
 
 | Package | Source | Install |
 | --- | --- | --- |
+| `@narumitw/pi-caffeinate` | [`extensions/pi-caffeinate`](./extensions/pi-caffeinate) | `pi install npm:@narumitw/pi-caffeinate` |
 | `@narumitw/pi-chrome-devtools` | [`extensions/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | `pi install npm:@narumitw/pi-chrome-devtools` |
 | `@narumitw/pi-goal` | [`extensions/pi-goal`](./extensions/pi-goal) | `pi install npm:@narumitw/pi-goal` |
 | `@narumitw/pi-retry` | [`extensions/pi-retry`](./extensions/pi-retry) | `pi install npm:@narumitw/pi-retry` |
@@ -21,6 +22,7 @@ npm run check
 Try a package locally:
 
 ```bash
+pi -e ./extensions/pi-caffeinate
 pi -e ./extensions/pi-chrome-devtools
 pi -e ./extensions/pi-goal
 pi -e ./extensions/pi-retry
@@ -29,6 +31,7 @@ pi -e ./extensions/pi-retry
 Preview package contents:
 
 ```bash
+npm run pack:caffeinate
 npm run pack:chrome-devtools
 npm run pack:goal
 npm run pack:retry
@@ -37,6 +40,7 @@ npm run pack:retry
 Publish packages from their package directories:
 
 ```bash
+cd extensions/pi-caffeinate && npm publish --access public
 cd extensions/pi-chrome-devtools && npm publish --access public
 cd extensions/pi-goal && npm publish --access public
 cd extensions/pi-retry && npm publish --access public

--- a/extensions/pi-caffeinate/LICENSE
+++ b/extensions/pi-caffeinate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -1,0 +1,75 @@
+# pi-caffeinate
+
+A public [pi](https://pi.dev) extension package that keeps your computer awake while the pi agent is processing a prompt.
+
+The extension starts an OS sleep inhibitor on `agent_start` and releases it on `agent_end` or `session_shutdown`.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-caffeinate
+```
+
+Try without installing:
+
+```bash
+pi -e npm:@narumitw/pi-caffeinate
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-caffeinate
+```
+
+## Supported platforms
+
+- macOS: uses `caffeinate -dimsu`
+- Windows: uses PowerShell `SetThreadExecutionState`
+- WSL: uses Windows `powershell.exe` with `SetThreadExecutionState`
+- Linux: uses `systemd-inhibit` with `sleep infinity`
+- Linux fallback: uses `caffeinate -dimsu` if available
+
+If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
+
+## Commands
+
+```text
+/caffeinate-status
+```
+
+Shows whether an inhibitor is active, unavailable, or disabled.
+
+```text
+/caffeinate-stop
+```
+
+Manually releases any active inhibitor for the current session.
+
+## Configuration
+
+Disable the extension:
+
+```bash
+PI_CAFFEINATE_DISABLED=1 pi
+```
+
+Use a custom inhibitor command:
+
+```bash
+PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mode=block sleep infinity' pi
+```
+
+The custom command is parsed with shell-like quoting and is run directly without a shell.
+
+## Package layout
+
+```txt
+extensions/pi-caffeinate/
+├── src/
+│   └── caffeinate.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```

--- a/extensions/pi-caffeinate/package.json
+++ b/extensions/pi-caffeinate/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@narumitw/pi-caffeinate",
+	"version": "0.1.3",
+	"description": "Pi extension that keeps the computer awake while the agent is running.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"caffeinate",
+		"awake",
+		"sleep"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/caffeinate.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
+	}
+}

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -1,0 +1,318 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import pathModule from "node:path";
+import process from "node:process";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+const STATUS_KEY = "caffeinate";
+const DISABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+
+interface InhibitorCommand {
+	command: string;
+	args: string[];
+	description: string;
+}
+
+interface CaffeinateState {
+	process?: ChildProcess;
+	startedAt?: number;
+	command?: InhibitorCommand;
+	lastError?: string;
+	activeTurns: number;
+	available: boolean;
+	disabled: boolean;
+}
+
+const state: CaffeinateState = {
+	activeTurns: 0,
+	available: true,
+	disabled: isDisabled(),
+};
+
+export default function caffeinate(pi: ExtensionAPI) {
+	pi.on("session_start", (_event, ctx) => {
+		updateStatus(ctx);
+	});
+
+	pi.on("agent_start", (_event, ctx) => {
+		state.activeTurns += 1;
+		startInhibitor(ctx);
+	});
+
+	pi.on("agent_end", (_event, ctx) => {
+		state.activeTurns = Math.max(0, state.activeTurns - 1);
+		if (state.activeTurns === 0) stopInhibitor(ctx, "agent finished");
+		updateStatus(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		state.activeTurns = 0;
+		stopInhibitor(ctx, "session shutdown", { notify: false });
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+
+	pi.registerCommand("caffeinate-status", {
+		description: "Show whether pi-caffeinate is currently keeping the computer awake",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(describeState(), state.process ? "info" : state.available ? "info" : "warning");
+			updateStatus(ctx);
+		},
+	});
+
+	pi.registerCommand("caffeinate-stop", {
+		description: "Release the active pi-caffeinate sleep inhibitor",
+		handler: async (_args, ctx) => {
+			state.activeTurns = 0;
+			stopInhibitor(ctx, "manual stop");
+			updateStatus(ctx);
+		},
+	});
+}
+
+function startInhibitor(ctx: ExtensionContext) {
+	if (state.disabled) {
+		updateStatus(ctx);
+		return;
+	}
+
+	if (state.process) {
+		updateStatus(ctx);
+		return;
+	}
+
+	const command = getInhibitorCommand();
+	if (!command) {
+		state.available = false;
+		state.lastError = `No supported sleep inhibitor found for ${process.platform}.`;
+		ctx.ui.notify(state.lastError, "warning");
+		updateStatus(ctx);
+		return;
+	}
+
+	try {
+		const child = spawn(command.command, command.args, {
+			detached: false,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		state.process = child;
+		state.startedAt = Date.now();
+		state.command = command;
+		state.available = true;
+		state.lastError = undefined;
+
+		child.once("error", (error) => {
+			if (state.process === child) {
+				state.process = undefined;
+				state.startedAt = undefined;
+			}
+			state.available = false;
+			state.lastError = `${command.description} failed: ${error.message}`;
+			ctx.ui.notify(state.lastError, "warning");
+			updateStatus(ctx);
+		});
+
+		child.once("exit", (code, signal) => {
+			if (state.process !== child) return;
+			state.process = undefined;
+			state.startedAt = undefined;
+			state.lastError = `${command.description} exited unexpectedly (${formatExit(code, signal)}).`;
+			ctx.ui.notify(state.lastError, "warning");
+			updateStatus(ctx);
+		});
+
+		ctx.ui.notify(`Keeping computer awake with ${command.description}.`, "info");
+		updateStatus(ctx);
+	} catch (error) {
+		state.process = undefined;
+		state.startedAt = undefined;
+		state.available = false;
+		state.lastError = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(`Unable to start pi-caffeinate: ${state.lastError}`, "warning");
+		updateStatus(ctx);
+	}
+}
+
+function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?: boolean } = {}) {
+	const child = state.process;
+	if (!child) return;
+
+	state.process = undefined;
+	state.startedAt = undefined;
+
+	child.removeAllListeners("exit");
+	child.removeAllListeners("error");
+
+	if (!child.killed) {
+		if (process.platform === "win32") {
+			child.kill();
+		} else {
+			child.kill("SIGTERM");
+		}
+	}
+
+	if (options.notify !== false) {
+		ctx.ui.notify(`Released pi-caffeinate (${reason}).`, "info");
+	}
+}
+
+function getInhibitorCommand(): InhibitorCommand | undefined {
+	const customCommand = process.env.PI_CAFFEINATE_COMMAND?.trim();
+	if (customCommand) {
+		const [command, ...args] = splitCommand(customCommand);
+		if (command) return { command, args, description: command };
+	}
+
+	if (process.platform === "darwin") {
+		return { command: "caffeinate", args: ["-dimsu"], description: "caffeinate" };
+	}
+
+	if (process.platform === "linux") {
+		if (isWsl() && commandExists("powershell.exe")) {
+			return windowsPowerInhibitorCommand("powershell.exe");
+		}
+
+		if (commandExists("systemd-inhibit")) {
+			return {
+				command: "systemd-inhibit",
+				args: [
+					"--what=idle:sleep",
+					"--who=pi-caffeinate",
+					"--why=Pi agent is running",
+					"--mode=block",
+					"sleep",
+					"infinity",
+				],
+				description: "systemd-inhibit",
+			};
+		}
+
+		if (commandExists("caffeinate")) {
+			return { command: "caffeinate", args: ["-dimsu"], description: "caffeinate" };
+		}
+	}
+
+	if (process.platform === "win32") {
+		return windowsPowerInhibitorCommand("powershell.exe");
+	}
+
+	return undefined;
+}
+
+function commandExists(command: string) {
+	const path = process.env.PATH ?? "";
+	const extensions = process.platform === "win32" ? ["", ".exe", ".cmd", ".bat"] : [""];
+
+	for (const directory of path.split(process.platform === "win32" ? ";" : ":")) {
+		if (!directory) continue;
+		for (const extension of extensions) {
+			const candidate = pathModule.join(directory, `${command}${extension}`);
+			if (existsSync(candidate)) return true;
+		}
+	}
+
+	return false;
+}
+
+function splitCommand(input: string) {
+	const parts: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let escaping = false;
+
+	for (const char of input) {
+		if (escaping) {
+			current += char;
+			escaping = false;
+			continue;
+		}
+
+		if (char === "\\") {
+			escaping = true;
+			continue;
+		}
+
+		if ((char === '"' || char === "'") && !quote) {
+			quote = char;
+			continue;
+		}
+
+		if (char === quote) {
+			quote = undefined;
+			continue;
+		}
+
+		if (/\s/.test(char) && !quote) {
+			if (current) {
+				parts.push(current);
+				current = "";
+			}
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current) parts.push(current);
+	return parts;
+}
+
+function windowsPowerInhibitorCommand(command: string): InhibitorCommand {
+	return {
+		command,
+		args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", windowsInhibitorScript()],
+		description: "PowerShell SetThreadExecutionState",
+	};
+}
+
+function windowsInhibitorScript() {
+	return `Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; while ($true) { [Native.Power]::SetThreadExecutionState(0x80000000 -bor 0x00000001 -bor 0x00000002) | Out-Null; Start-Sleep -Seconds 30 }`;
+}
+
+function isWsl() {
+	try {
+		return existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");
+	} catch {
+		return false;
+	}
+}
+
+function updateStatus(ctx: ExtensionContext) {
+	if (state.disabled) {
+		ctx.ui.setStatus(STATUS_KEY, "caffeinate: disabled");
+		return;
+	}
+
+	if (state.process) {
+		ctx.ui.setStatus(STATUS_KEY, `caffeinate: on (${state.command?.description ?? "active"})`);
+		return;
+	}
+
+	if (!state.available) {
+		ctx.ui.setStatus(STATUS_KEY, "caffeinate: unavailable");
+		return;
+	}
+
+	ctx.ui.setStatus(STATUS_KEY, "caffeinate: idle");
+}
+
+function describeState() {
+	if (state.disabled) return "pi-caffeinate is disabled by PI_CAFFEINATE_DISABLED.";
+	if (state.process) {
+		const seconds = state.startedAt ? Math.round((Date.now() - state.startedAt) / 1000) : 0;
+		return `pi-caffeinate is active using ${state.command?.description ?? "an inhibitor"} for ${seconds}s.`;
+	}
+	if (!state.available)
+		return `pi-caffeinate is unavailable: ${state.lastError ?? "unknown reason"}`;
+	return "pi-caffeinate is idle and will keep the computer awake during the next agent run.";
+}
+
+function formatExit(code: number | null, signal: NodeJS.Signals | null) {
+	if (signal) return `signal ${signal}`;
+	return `code ${code ?? "unknown"}`;
+}
+
+function isDisabled() {
+	const value = process.env.PI_CAFFEINATE_DISABLED?.trim().toLowerCase();
+	return value ? DISABLED_VALUES.has(value) : false;
+}

--- a/extensions/pi-caffeinate/tsconfig.json
+++ b/extensions/pi-caffeinate/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+caffeinate := "@narumitw/pi-caffeinate"
 chrome_devtools := "@narumitw/pi-chrome-devtools"
 goal := "@narumitw/pi-goal"
 retry := "@narumitw/pi-retry"
@@ -36,6 +37,7 @@ doctor package="@narumitw/pi-chrome-devtools":
 
 # Show npm visibility/version information for all packages
 doctor-all:
+    just doctor {{caffeinate}}
     just doctor {{chrome_devtools}}
     just doctor {{goal}}
     just doctor {{retry}}
@@ -45,6 +47,10 @@ doctor-all:
 npm-public package="@narumitw/pi-goal" otp="":
     otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; npm access set status=public {{package}} $otp_arg
     npm view {{package}} version
+
+# Preview the caffeinate package that npm would publish
+pack-caffeinate:
+    npm run pack:caffeinate
 
 # Preview the chrome-devtools package that npm would publish
 pack-chrome-devtools:
@@ -58,6 +64,10 @@ pack-goal:
 pack-retry:
     npm run pack:retry
 
+# Try caffeinate from this working tree as a temporary pi package
+try-caffeinate:
+    pi -e ./extensions/pi-caffeinate
+
 # Try chrome-devtools from this working tree as a temporary pi package
 try-chrome-devtools:
     pi -e ./extensions/pi-chrome-devtools
@@ -70,6 +80,10 @@ try-goal:
 try-retry:
     pi -e ./extensions/pi-retry
 
+# Install caffeinate through pi, falling back to the local workspace if unpublished
+install-caffeinate:
+    if npm view {{caffeinate}} version >/dev/null 2>&1; then pi install npm:{{caffeinate}}; else echo "{{caffeinate}} is not published; installing local workspace package instead."; pi install ./extensions/pi-caffeinate; fi
+
 # Install chrome-devtools through pi, falling back to the local workspace if unpublished
 install-chrome-devtools:
     if npm view {{chrome_devtools}} version >/dev/null 2>&1; then pi install npm:{{chrome_devtools}}; else echo "{{chrome_devtools}} is not published; installing local workspace package instead."; pi install ./extensions/pi-chrome-devtools; fi
@@ -81,6 +95,11 @@ install-goal:
 # Install the published retry package through pi
 install-retry:
     pi install npm:{{retry}}
+
+# Publish caffeinate to npm, skipping if the current version already exists
+# Usage with 2FA: just publish-caffeinate 123456
+publish-caffeinate otp="":
+    version="$(node -p "require('./extensions/pi-caffeinate/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{caffeinate}}@"$version" version >/dev/null 2>&1; then echo "{{caffeinate}}@$version already exists; skipping publish."; else npm --workspace {{caffeinate}} pack --dry-run; npm --workspace {{caffeinate}} publish --access public $otp_arg; fi
 
 # Publish chrome-devtools to npm, skipping if the current version already exists
 # Usage with 2FA: just publish-chrome-devtools 123456
@@ -100,12 +119,14 @@ publish-retry otp="":
 # Publish all extension packages to npm
 # Usage with 2FA: just publish-all 123456
 publish-all otp="":
+    just publish-caffeinate {{otp}}
     just publish-chrome-devtools {{otp}}
     just publish-goal {{otp}}
     just publish-retry {{otp}}
 
 # Install all published extension packages through pi
 install-all:
+    just install-caffeinate
     just install-chrome-devtools
     just install-goal
     just install-retry

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,120 @@
 				"typescript": "^6.0.3"
 			}
 		},
+		"extensions/pi-caffeinate": {
+			"name": "@narumitw/pi-caffeinate",
+			"version": "0.1.3",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"@types/node": "25.6.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-caffeinate/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-caffeinate/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-caffeinate/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-caffeinate/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"extensions/pi-chrome-devtools": {
 			"name": "@narumitw/pi-chrome-devtools",
 			"version": "0.1.3",
@@ -1716,6 +1830,10 @@
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
 			}
+		},
+		"node_modules/@narumitw/pi-caffeinate": {
+			"resolved": "extensions/pi-caffeinate",
+			"link": true
 		},
 		"node_modules/@narumitw/pi-chrome-devtools": {
 			"resolved": "extensions/pi-chrome-devtools",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"biome:check": "biome check .",
 		"typecheck": "npm --workspaces run typecheck",
 		"check": "npm run biome:check && npm run typecheck",
+		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run"


### PR DESCRIPTION
## Summary
- Add @narumitw/pi-caffeinate to keep the computer awake while pi is processing an agent run
- Add status/stop commands plus macOS, Linux, WSL, Windows inhibitor support
- Wire README, just recipes, package scripts, package-lock, and agent guidance for the new workspace

## Verification
- npm run check
- just pack-caffeinate
- just install-caffeinate
- Runtime handler simulation started and released the WSL PowerShell SetThreadExecutionState inhibitor