### PR TITLE
feat: add pi-firecrawl extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Run commands from the repository root unless noted otherwise.
 - Full verification: `npm run check` or `just check`
 - Format with Biome: `npm run format` or `just format`
 - Typecheck all workspaces: `npm run typecheck`
-- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-goal`, or `just pack-retry`
-- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-goal`, or `just try-retry`
+- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, or `just pack-retry`
+- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, or `just try-retry`
 - Inspect available recipes before adding new workflow commands: `just --list`
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monorepo for independently installable Pi extension packages.
 | --- | --- | --- |
 | `@narumitw/pi-caffeinate` | [`extensions/pi-caffeinate`](./extensions/pi-caffeinate) | `pi install npm:@narumitw/pi-caffeinate` |
 | `@narumitw/pi-chrome-devtools` | [`extensions/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | `pi install npm:@narumitw/pi-chrome-devtools` |
+| `@narumitw/pi-firecrawl` | [`extensions/pi-firecrawl`](./extensions/pi-firecrawl) | `pi install npm:@narumitw/pi-firecrawl` |
 | `@narumitw/pi-goal` | [`extensions/pi-goal`](./extensions/pi-goal) | `pi install npm:@narumitw/pi-goal` |
 | `@narumitw/pi-retry` | [`extensions/pi-retry`](./extensions/pi-retry) | `pi install npm:@narumitw/pi-retry` |
 
@@ -24,6 +25,7 @@ Try a package locally:
 ```bash
 pi -e ./extensions/pi-caffeinate
 pi -e ./extensions/pi-chrome-devtools
+pi -e ./extensions/pi-firecrawl
 pi -e ./extensions/pi-goal
 pi -e ./extensions/pi-retry
 ```
@@ -33,6 +35,7 @@ Preview package contents:
 ```bash
 npm run pack:caffeinate
 npm run pack:chrome-devtools
+npm run pack:firecrawl
 npm run pack:goal
 npm run pack:retry
 ```
@@ -42,6 +45,7 @@ Publish packages from their package directories:
 ```bash
 cd extensions/pi-caffeinate && npm publish --access public
 cd extensions/pi-chrome-devtools && npm publish --access public
+cd extensions/pi-firecrawl && npm publish --access public
 cd extensions/pi-goal && npm publish --access public
 cd extensions/pi-retry && npm publish --access public
 ```

--- a/extensions/pi-firecrawl/LICENSE
+++ b/extensions/pi-firecrawl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-firecrawl/README.md
+++ b/extensions/pi-firecrawl/README.md
@@ -1,0 +1,99 @@
+# pi-firecrawl
+
+A public [pi](https://pi.dev) extension package that exposes [Firecrawl](https://www.firecrawl.dev/) web scraping, crawling, URL discovery, and search APIs as native pi tools.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-firecrawl
+```
+
+Try without installing:
+
+```bash
+FIRECRAWL_API_KEY=fc-... pi -e npm:@narumitw/pi-firecrawl
+```
+
+Try this package locally from the repository root:
+
+```bash
+FIRECRAWL_API_KEY=fc-... pi -e ./extensions/pi-firecrawl
+```
+
+## Configuration
+
+Set a Firecrawl API key before running pi:
+
+```bash
+export FIRECRAWL_API_KEY=fc-your-key
+```
+
+Optional API endpoint override:
+
+```bash
+export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
+```
+
+`FIRECRAWL_BASE_URL` is also accepted for compatibility. The extension never logs or displays the API key.
+
+## Tools
+
+- `firecrawl_scrape` — scrape a single URL and return requested formats such as markdown, HTML, links, or JSON.
+- `firecrawl_crawl` — start a site crawl job and return the Firecrawl job id.
+- `firecrawl_crawl_status` — check a crawl job status and retrieve completed crawl data.
+- `firecrawl_map` — discover URLs for a site.
+- `firecrawl_search` — search the web through Firecrawl and optionally scrape result pages.
+
+All tools fail with a clear configuration error when `FIRECRAWL_API_KEY` is missing.
+
+## Command
+
+```text
+/firecrawl
+```
+
+Shows whether the extension sees an API key and which Firecrawl API URL it will call.
+
+## Examples
+
+Scrape a page as markdown:
+
+```json
+{
+  "url": "https://example.com",
+  "formats": ["markdown"]
+}
+```
+
+Map a small site:
+
+```json
+{
+  "url": "https://example.com",
+  "limit": 20
+}
+```
+
+Start a crawl with markdown extraction:
+
+```json
+{
+  "url": "https://example.com",
+  "limit": 10,
+  "scrapeOptions": {
+    "formats": ["markdown"]
+  }
+}
+```
+
+## Package layout
+
+```txt
+extensions/pi-firecrawl/
+├── src/
+│   └── firecrawl.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@narumitw/pi-firecrawl",
+	"version": "0.1.3",
+	"description": "Pi extension that exposes Firecrawl web scraping and crawling tools.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"firecrawl",
+		"scrape",
+		"crawl"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/firecrawl.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"typebox": "^1.1.37"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"typescript": "6.0.3"
+	}
+}

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -1,0 +1,297 @@
+import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+const DEFAULT_API_URL = "https://api.firecrawl.dev/v1";
+const STATUS_KEY = "firecrawl";
+
+const StringArray = Type.Array(Type.String());
+
+interface FirecrawlState {
+	apiUrl: string;
+}
+
+const state: FirecrawlState = {
+	apiUrl: normalizeApiUrl(process.env.FIRECRAWL_API_URL ?? process.env.FIRECRAWL_BASE_URL),
+};
+
+const scrapeTool = defineTool({
+	name: "firecrawl_scrape",
+	label: "Firecrawl: Scrape",
+	description: "Scrape a single URL through Firecrawl and return requested formats.",
+	promptSnippet: "Scrape a URL through Firecrawl",
+	promptGuidelines: [
+		"Use firecrawl_scrape when you need clean markdown, HTML, links, screenshots, or structured extraction for one URL.",
+		"If FIRECRAWL_API_KEY is missing, report the configuration error instead of retrying repeatedly.",
+	],
+	parameters: Type.Object({
+		url: Type.String({ description: "URL to scrape." }),
+		formats: Type.Optional(
+			Type.Array(
+				Type.String({
+					description:
+						"Requested Firecrawl output format, such as markdown, html, rawHtml, links, screenshot, or json.",
+				}),
+				{ description: "Firecrawl output formats. Defaults to Firecrawl's API default." },
+			),
+		),
+		onlyMainContent: Type.Optional(
+			Type.Boolean({ description: "Return only the main page content when supported." }),
+		),
+		includeTags: Type.Optional(StringArray),
+		excludeTags: Type.Optional(StringArray),
+		waitFor: Type.Optional(Type.Number({ description: "Milliseconds to wait before scraping." })),
+		timeout: Type.Optional(
+			Type.Number({ description: "Firecrawl request timeout in milliseconds." }),
+		),
+		mobile: Type.Optional(Type.Boolean({ description: "Use a mobile user agent when supported." })),
+		skipTlsVerification: Type.Optional(
+			Type.Boolean({ description: "Skip TLS certificate verification when supported." }),
+		),
+		removeBase64Images: Type.Optional(
+			Type.Boolean({ description: "Remove base64 image data from the response when supported." }),
+		),
+		blockAds: Type.Optional(
+			Type.Boolean({ description: "Block ads while scraping when supported." }),
+		),
+		headers: Type.Optional(
+			Type.Record(Type.String(), Type.String(), {
+				description: "Additional HTTP headers Firecrawl should use while fetching the target URL.",
+			}),
+		),
+		jsonOptions: Type.Optional(
+			Type.Any({ description: "Firecrawl jsonOptions for structured extraction." }),
+		),
+		actions: Type.Optional(
+			Type.Array(Type.Any(), {
+				description: "Firecrawl browser actions to perform before scraping.",
+			}),
+		),
+		location: Type.Optional(Type.Any({ description: "Firecrawl location options." })),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const payload = await firecrawlRequest("POST", "/scrape", cleanObject(params), signal);
+		return jsonResult(payload);
+	},
+});
+
+const crawlTool = defineTool({
+	name: "firecrawl_crawl",
+	label: "Firecrawl: Crawl",
+	description: "Start a Firecrawl crawl job for a website.",
+	promptSnippet: "Start a Firecrawl site crawl job",
+	parameters: Type.Object({
+		url: Type.String({ description: "Starting URL for the crawl." }),
+		limit: Type.Optional(Type.Number({ description: "Maximum number of pages to crawl." })),
+		maxDepth: Type.Optional(Type.Number({ description: "Maximum crawl depth when supported." })),
+		includePaths: Type.Optional(
+			Type.Array(Type.String(), { description: "URL path patterns to include." }),
+		),
+		excludePaths: Type.Optional(
+			Type.Array(Type.String(), { description: "URL path patterns to exclude." }),
+		),
+		allowBackwardLinks: Type.Optional(
+			Type.Boolean({ description: "Allow crawling backward links when supported." }),
+		),
+		allowExternalLinks: Type.Optional(
+			Type.Boolean({ description: "Allow crawling external links when supported." }),
+		),
+		ignoreSitemap: Type.Optional(Type.Boolean({ description: "Ignore sitemap discovery." })),
+		deduplicateSimilarURLs: Type.Optional(
+			Type.Boolean({ description: "Deduplicate similar URLs when supported." }),
+		),
+		scrapeOptions: Type.Optional(
+			Type.Any({ description: "Firecrawl scrapeOptions applied to crawled pages." }),
+		),
+		webhook: Type.Optional(Type.Any({ description: "Firecrawl webhook configuration." })),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const payload = await firecrawlRequest("POST", "/crawl", cleanObject(params), signal);
+		return jsonResult(payload);
+	},
+});
+
+const crawlStatusTool = defineTool({
+	name: "firecrawl_crawl_status",
+	label: "Firecrawl: Crawl Status",
+	description: "Check a Firecrawl crawl job status and retrieve completed crawl data.",
+	promptSnippet: "Check a Firecrawl crawl job status",
+	parameters: Type.Object({
+		id: Type.String({ description: "Crawl job id returned by firecrawl_crawl." }),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const payload = await firecrawlRequest(
+			"GET",
+			`/crawl/${encodeURIComponent(params.id)}`,
+			undefined,
+			signal,
+		);
+		return jsonResult(payload);
+	},
+});
+
+const mapTool = defineTool({
+	name: "firecrawl_map",
+	label: "Firecrawl: Map",
+	description: "Discover URLs for a site through Firecrawl's map endpoint.",
+	promptSnippet: "Map/discover URLs for a site through Firecrawl",
+	parameters: Type.Object({
+		url: Type.String({ description: "Website URL to map." }),
+		search: Type.Optional(
+			Type.String({ description: "Optional search term to filter discovered URLs." }),
+		),
+		ignoreSitemap: Type.Optional(Type.Boolean({ description: "Ignore sitemap discovery." })),
+		sitemapOnly: Type.Optional(
+			Type.Boolean({ description: "Only use sitemap URLs when supported." }),
+		),
+		includeSubdomains: Type.Optional(
+			Type.Boolean({ description: "Include subdomains when supported." }),
+		),
+		limit: Type.Optional(Type.Number({ description: "Maximum number of URLs to return." })),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const payload = await firecrawlRequest("POST", "/map", cleanObject(params), signal);
+		return jsonResult(payload);
+	},
+});
+
+const searchTool = defineTool({
+	name: "firecrawl_search",
+	label: "Firecrawl: Search",
+	description: "Search the web through Firecrawl and optionally scrape search results.",
+	promptSnippet: "Search the web through Firecrawl",
+	parameters: Type.Object({
+		query: Type.String({ description: "Search query." }),
+		limit: Type.Optional(Type.Number({ description: "Maximum number of search results." })),
+		tbs: Type.Optional(
+			Type.String({ description: "Google-style time based search filter when supported." }),
+		),
+		location: Type.Optional(Type.String({ description: "Search location when supported." })),
+		scrapeOptions: Type.Optional(
+			Type.Any({ description: "Firecrawl scrapeOptions for search result pages." }),
+		),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const payload = await firecrawlRequest("POST", "/search", cleanObject(params), signal);
+		return jsonResult(payload);
+	},
+});
+
+export default function firecrawl(pi: ExtensionAPI) {
+	pi.registerTool(scrapeTool);
+	pi.registerTool(crawlTool);
+	pi.registerTool(crawlStatusTool);
+	pi.registerTool(mapTool);
+	pi.registerTool(searchTool);
+
+	pi.registerCommand("firecrawl", {
+		description: "Show Firecrawl extension configuration status",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(buildStatusMessage(), hasApiKey() ? "info" : "warning");
+			updateStatus(ctx);
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		updateStatus(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}
+
+async function firecrawlRequest(
+	method: "GET" | "POST",
+	path: string,
+	body: unknown,
+	signal: AbortSignal | undefined,
+) {
+	const apiKey = getApiKey();
+	const response = await fetch(`${state.apiUrl}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			...(body === undefined ? {} : { "Content-Type": "application/json" }),
+		},
+		body: body === undefined ? undefined : JSON.stringify(body),
+		signal,
+	});
+
+	const responseText = await response.text();
+	const payload = parseResponseBody(responseText);
+
+	if (!response.ok) {
+		throw new Error(
+			`Firecrawl ${method} ${path} returned ${response.status} ${response.statusText}: ${formatPayload(payload)}`,
+		);
+	}
+
+	return payload;
+}
+
+function getApiKey() {
+	const apiKey = process.env.FIRECRAWL_API_KEY?.trim();
+	if (!apiKey) {
+		throw new Error(
+			"FIRECRAWL_API_KEY is required for pi-firecrawl. Set it in the environment before running pi.",
+		);
+	}
+
+	return apiKey;
+}
+
+function hasApiKey() {
+	return Boolean(process.env.FIRECRAWL_API_KEY?.trim());
+}
+
+function normalizeApiUrl(apiUrl: string | undefined) {
+	return (apiUrl?.trim() || DEFAULT_API_URL).replace(/\/+$/, "");
+}
+
+function parseResponseBody(responseText: string) {
+	if (!responseText) return null;
+
+	try {
+		return JSON.parse(responseText) as unknown;
+	} catch {
+		return responseText;
+	}
+}
+
+function formatPayload(payload: unknown) {
+	if (typeof payload === "string") return payload;
+	return JSON.stringify(payload);
+}
+
+function jsonResult(payload: unknown) {
+	return {
+		content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+		details: payload,
+	};
+}
+
+function updateStatus(ctx: {
+	ui: { setStatus: (key: string, value: string | undefined) => void };
+}) {
+	ctx.ui.setStatus(STATUS_KEY, hasApiKey() ? "firecrawl: configured" : "firecrawl: missing key");
+}
+
+function buildStatusMessage() {
+	return hasApiKey()
+		? `Firecrawl configured: ${state.apiUrl} (API key present).`
+		: `Firecrawl missing FIRECRAWL_API_KEY. API URL: ${state.apiUrl}.`;
+}
+
+function cleanObject<T>(value: T): T {
+	if (Array.isArray(value)) {
+		return value.map((item) => cleanObject(item)) as T;
+	}
+
+	if (!value || typeof value !== "object") return value;
+
+	const entries = Object.entries(value)
+		.filter(([, entryValue]) => entryValue !== undefined)
+		.map(([entryKey, entryValue]) => [entryKey, cleanObject(entryValue)]);
+
+	return Object.fromEntries(entries) as T;
+}

--- a/extensions/pi-firecrawl/tsconfig.json
+++ b/extensions/pi-firecrawl/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 
 caffeinate := "@narumitw/pi-caffeinate"
 chrome_devtools := "@narumitw/pi-chrome-devtools"
+firecrawl := "@narumitw/pi-firecrawl"
 goal := "@narumitw/pi-goal"
 retry := "@narumitw/pi-retry"
 
@@ -39,6 +40,7 @@ doctor package="@narumitw/pi-chrome-devtools":
 doctor-all:
     just doctor {{caffeinate}}
     just doctor {{chrome_devtools}}
+    just doctor {{firecrawl}}
     just doctor {{goal}}
     just doctor {{retry}}
 
@@ -56,6 +58,10 @@ pack-caffeinate:
 pack-chrome-devtools:
     npm run pack:chrome-devtools
 
+# Preview the firecrawl package that npm would publish
+pack-firecrawl:
+    npm run pack:firecrawl
+
 # Preview the goal package that npm would publish
 pack-goal:
     npm run pack:goal
@@ -72,6 +78,10 @@ try-caffeinate:
 try-chrome-devtools:
     pi -e ./extensions/pi-chrome-devtools
 
+# Try firecrawl from this working tree as a temporary pi package
+try-firecrawl:
+    pi -e ./extensions/pi-firecrawl
+
 # Try goal from this working tree as a temporary pi package
 try-goal:
     pi -e ./extensions/pi-goal
@@ -87,6 +97,10 @@ install-caffeinate:
 # Install chrome-devtools through pi, falling back to the local workspace if unpublished
 install-chrome-devtools:
     if npm view {{chrome_devtools}} version >/dev/null 2>&1; then pi install npm:{{chrome_devtools}}; else echo "{{chrome_devtools}} is not published; installing local workspace package instead."; pi install ./extensions/pi-chrome-devtools; fi
+
+# Install firecrawl through pi, falling back to the local workspace if unpublished
+install-firecrawl:
+    if npm view {{firecrawl}} version >/dev/null 2>&1; then pi install npm:{{firecrawl}}; else echo "{{firecrawl}} is not published; installing local workspace package instead."; pi install ./extensions/pi-firecrawl; fi
 
 # Install the published goal package through pi
 install-goal:
@@ -106,6 +120,11 @@ publish-caffeinate otp="":
 publish-chrome-devtools otp="":
     version="$(node -p "require('./extensions/pi-chrome-devtools/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{chrome_devtools}}@"$version" version >/dev/null 2>&1; then echo "{{chrome_devtools}}@$version already exists; skipping publish."; else npm --workspace {{chrome_devtools}} pack --dry-run; npm --workspace {{chrome_devtools}} publish --access public $otp_arg; fi
 
+# Publish firecrawl to npm, skipping if the current version already exists
+# Usage with 2FA: just publish-firecrawl 123456
+publish-firecrawl otp="":
+    version="$(node -p "require('./extensions/pi-firecrawl/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{firecrawl}}@"$version" version >/dev/null 2>&1; then echo "{{firecrawl}}@$version already exists; skipping publish."; else npm --workspace {{firecrawl}} pack --dry-run; npm --workspace {{firecrawl}} publish --access public $otp_arg; fi
+
 # Publish goal to npm, skipping if the current version already exists
 # Usage with 2FA: just publish-goal 123456
 publish-goal otp="":
@@ -121,6 +140,7 @@ publish-retry otp="":
 publish-all otp="":
     just publish-caffeinate {{otp}}
     just publish-chrome-devtools {{otp}}
+    just publish-firecrawl {{otp}}
     just publish-goal {{otp}}
     just publish-retry {{otp}}
 
@@ -128,6 +148,7 @@ publish-all otp="":
 install-all:
     just install-caffeinate
     just install-chrome-devtools
+    just install-firecrawl
     just install-goal
     just install-retry
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,122 @@
 				"koffi": "^2.9.0"
 			}
 		},
+		"extensions/pi-firecrawl": {
+			"name": "@narumitw/pi-firecrawl",
+			"version": "0.1.3",
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "^1.1.37"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-firecrawl/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-firecrawl/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-firecrawl/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-firecrawl/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"extensions/pi-goal": {
 			"name": "@narumitw/pi-goal",
 			"version": "0.1.3",
@@ -1837,6 +1953,10 @@
 		},
 		"node_modules/@narumitw/pi-chrome-devtools": {
 			"resolved": "extensions/pi-chrome-devtools",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-firecrawl": {
+			"resolved": "extensions/pi-firecrawl",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-goal": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"check": "npm run biome:check && npm run typecheck",
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
+		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run"
 	},


### PR DESCRIPTION
## Summary
- Add `@narumitw/pi-firecrawl` as a new Pi extension workspace
- Register native Firecrawl tools for scrape, crawl, crawl status, map, and search
- Use `FIRECRAWL_API_KEY` with Bearer auth plus optional `FIRECRAWL_API_URL` / `FIRECRAWL_BASE_URL` overrides
- Wire README, AGENTS.md, package scripts, just recipes, and package-lock entries

## Auth approach
- Recommended auth is environment-only: set `FIRECRAWL_API_KEY` before launching Pi
- The API key is never accepted as a tool argument, so it is less likely to leak into prompts, transcripts, or tool call logs
- Requests send `Authorization: Bearer <FIRECRAWL_API_KEY>`

## Verification
- `npm run check`
- `just pack-firecrawl`
- `just install-firecrawl`
- Runtime simulation verified tool registration, missing-key error, Bearer auth header, endpoint paths, and request bodies against a local fake Firecrawl server

Closes #3