### PR TITLE
feat: add pi-python-lsp extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Run commands from the repository root unless noted otherwise.
 - Full verification: `npm run check` or `just check`
 - Format with Biome: `npm run format` or `just format`
 - Typecheck all workspaces: `npm run typecheck`
-- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, or `just pack-retry`
-- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, or `just try-retry`
+- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, `just pack-python-lsp`, or `just pack-retry`
+- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, `just try-python-lsp`, or `just try-retry`
 - Inspect available recipes before adding new workflow commands: `just --list`
 
 ## Code style

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,6 +5,8 @@
 - `MEMORY.md` is not auto-loaded; check it before non-trivial debugging or design work when prior project context may matter.
 - npm can show a scoped package dist-tag (for example `latest`) while `npm view <package>` still returns 404; fix visibility with `npm access set status=public <package> --otp=<otp>` or publish a bumped version.
 - For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
+- When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
+- ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 
 ## TASTE
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Monorepo for independently installable Pi extension packages.
 | `@narumitw/pi-chrome-devtools` | [`extensions/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | `pi install npm:@narumitw/pi-chrome-devtools` |
 | `@narumitw/pi-firecrawl` | [`extensions/pi-firecrawl`](./extensions/pi-firecrawl) | `pi install npm:@narumitw/pi-firecrawl` |
 | `@narumitw/pi-goal` | [`extensions/pi-goal`](./extensions/pi-goal) | `pi install npm:@narumitw/pi-goal` |
+| `@narumitw/pi-python-lsp` | [`extensions/pi-python-lsp`](./extensions/pi-python-lsp) | `pi install npm:@narumitw/pi-python-lsp` |
 | `@narumitw/pi-retry` | [`extensions/pi-retry`](./extensions/pi-retry) | `pi install npm:@narumitw/pi-retry` |
 
 ## Local development
@@ -27,6 +28,7 @@ pi -e ./extensions/pi-caffeinate
 pi -e ./extensions/pi-chrome-devtools
 pi -e ./extensions/pi-firecrawl
 pi -e ./extensions/pi-goal
+pi -e ./extensions/pi-python-lsp
 pi -e ./extensions/pi-retry
 ```
 
@@ -37,6 +39,7 @@ npm run pack:caffeinate
 npm run pack:chrome-devtools
 npm run pack:firecrawl
 npm run pack:goal
+npm run pack:python-lsp
 npm run pack:retry
 ```
 
@@ -47,5 +50,6 @@ cd extensions/pi-caffeinate && npm publish --access public
 cd extensions/pi-chrome-devtools && npm publish --access public
 cd extensions/pi-firecrawl && npm publish --access public
 cd extensions/pi-goal && npm publish --access public
+cd extensions/pi-python-lsp && npm publish --access public
 cd extensions/pi-retry && npm publish --access public
 ```

--- a/extensions/pi-python-lsp/LICENSE
+++ b/extensions/pi-python-lsp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-python-lsp/README.md
+++ b/extensions/pi-python-lsp/README.md
@@ -1,0 +1,97 @@
+# pi-python-lsp
+
+A public [pi](https://pi.dev) extension package that exposes Python language-server tools from [ty](https://github.com/astral-sh/ty) and [Ruff](https://docs.astral.sh/ruff/).
+
+The extension starts `ty server` or `ruff server` on demand for each tool call, opens the requested Python files over Language Server Protocol (LSP), pulls diagnostics or edits, and then shuts the server down.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-python-lsp
+```
+
+Try without installing:
+
+```bash
+pi -e npm:@narumitw/pi-python-lsp
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-python-lsp
+```
+
+## Requirements
+
+Install `ty` and/or `ruff` somewhere on `PATH`, for example:
+
+```bash
+uv tool install ty
+uv tool install ruff
+```
+
+Or provide custom server commands:
+
+```bash
+PI_TY_LSP_COMMAND="uvx ty server" PI_RUFF_LSP_COMMAND="uvx ruff server" pi -e ./extensions/pi-python-lsp
+```
+
+Optional timeout overrides:
+
+```bash
+PI_TY_LSP_TIMEOUT_MS=30000 PI_RUFF_LSP_TIMEOUT_MS=30000 pi -e ./extensions/pi-python-lsp
+```
+
+## Tools
+
+- `ty_lsp_diagnostics` — start `ty server`, open Python files, and return type diagnostics.
+- `ruff_lsp_diagnostics` — start `ruff server`, open Python files, and return lint diagnostics.
+- `ruff_lsp_format` — compute or write Ruff formatting edits for one Python file.
+- `ruff_lsp_fix` — compute or write Ruff source actions such as `source.fixAll.ruff` or `source.organizeImports.ruff`.
+
+Examples:
+
+```json
+{
+  "paths": ["src", "tests"],
+  "limit": 100
+}
+```
+
+```json
+{
+  "path": "src/app.py",
+  "write": true
+}
+```
+
+```json
+{
+  "path": "src/app.py",
+  "kind": "source.organizeImports.ruff",
+  "write": true
+}
+```
+
+If `paths` is omitted for diagnostics, the tool recursively discovers Python files under the workspace root, skipping common cache and virtualenv directories.
+
+## Command
+
+```text
+/python-lsp
+```
+
+Shows the configured ty and Ruff LSP commands and whether each command is available on `PATH`.
+
+## Package layout
+
+```txt
+extensions/pi-python-lsp/
+├── src/
+│   └── python-lsp.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```

--- a/extensions/pi-python-lsp/package.json
+++ b/extensions/pi-python-lsp/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "@narumitw/pi-python-lsp",
+	"version": "0.1.3",
+	"description": "Pi extension that exposes ty and Ruff language-server tools for Python.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"python",
+		"lsp",
+		"ty",
+		"ruff",
+		"lint",
+		"format"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/python-lsp.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"typebox": "^1.1.37"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
+	}
+}

--- a/extensions/pi-python-lsp/src/python-lsp.ts
+++ b/extensions/pi-python-lsp/src/python-lsp.ts
@@ -1,0 +1,818 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+const STATUS_KEY = "python-lsp";
+const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_FILE_LIMIT = 50;
+const SKIP_DIRECTORIES = new Set([
+	".git",
+	".hg",
+	".mypy_cache",
+	".ruff_cache",
+	".tox",
+	".venv",
+	"__pycache__",
+	"node_modules",
+	"venv",
+]);
+
+type ServerKind = "ty" | "ruff";
+
+interface ServerCommand {
+	command: string;
+	args: string[];
+}
+
+interface LspPosition {
+	line: number;
+	character: number;
+}
+
+interface LspRange {
+	start: LspPosition;
+	end: LspPosition;
+}
+
+interface LspDiagnostic {
+	range: LspRange;
+	severity?: number;
+	code?: string | number;
+	codeDescription?: { href?: string };
+	source?: string;
+	message: string;
+}
+
+interface LspTextEdit {
+	range: LspRange;
+	newText: string;
+}
+
+interface WorkspaceEdit {
+	changes?: Record<string, LspTextEdit[]>;
+	documentChanges?: Array<{
+		textDocument?: { uri?: string; version?: number | null };
+		edits?: LspTextEdit[];
+	}>;
+}
+
+interface CodeAction {
+	title: string;
+	kind?: string;
+	edit?: WorkspaceEdit;
+	data?: unknown;
+}
+
+interface DiagnosticEntry {
+	path: string;
+	uri: string;
+	diagnostics: LspDiagnostic[];
+}
+
+interface JsonRpcMessage {
+	jsonrpc?: "2.0";
+	id?: number | string | null;
+	method?: string;
+	params?: unknown;
+	result?: unknown;
+	error?: { code: number; message: string; data?: unknown };
+}
+
+const PathsParameters = {
+	paths: Type.Optional(
+		Type.Array(Type.String(), {
+			description: "Python files or directories to check. Defaults to the project root.",
+		}),
+	),
+	root: Type.Optional(
+		Type.String({ description: "Workspace root for the language server. Defaults to cwd." }),
+	),
+	limit: Type.Optional(
+		Type.Number({ description: "Maximum Python files to open when directories are provided." }),
+	),
+};
+
+const tyDiagnosticsTool = defineTool({
+	name: "ty_lsp_diagnostics",
+	label: "Python LSP: ty Diagnostics",
+	description: "Run ty's language server and return Python type diagnostics for files.",
+	promptSnippet: "Get Python type diagnostics from ty's language server",
+	promptGuidelines: [
+		"Use ty_lsp_diagnostics when Python changes need type-checking through ty's language server.",
+		"If ty is missing, report the configuration error and suggest installing ty or setting PI_TY_LSP_COMMAND.",
+	],
+	parameters: Type.Object(PathsParameters),
+	async execute(_toolCallId, params, signal) {
+		return runDiagnostics("ty", params, signal);
+	},
+});
+
+const ruffDiagnosticsTool = defineTool({
+	name: "ruff_lsp_diagnostics",
+	label: "Python LSP: Ruff Diagnostics",
+	description: "Run Ruff's language server and return Python lint diagnostics for files.",
+	promptSnippet: "Get Python lint diagnostics from Ruff's language server",
+	promptGuidelines: [
+		"Use ruff_lsp_diagnostics when Python changes need Ruff lint checks through the language server.",
+		"If ruff is missing, report the configuration error and suggest installing ruff or setting PI_RUFF_LSP_COMMAND.",
+	],
+	parameters: Type.Object(PathsParameters),
+	async execute(_toolCallId, params, signal) {
+		return runDiagnostics("ruff", params, signal);
+	},
+});
+
+const ruffFormatTool = defineTool({
+	name: "ruff_lsp_format",
+	label: "Python LSP: Ruff Format",
+	description: "Format a Python file through Ruff's language server.",
+	promptSnippet: "Format a Python file through Ruff LSP",
+	parameters: Type.Object({
+		path: Type.String({ description: "Python file to format." }),
+		root: Type.Optional(
+			Type.String({ description: "Workspace root for the language server. Defaults to cwd." }),
+		),
+		write: Type.Optional(
+			Type.Boolean({ description: "Write formatted text back to the file. Defaults to false." }),
+		),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const root = resolveRoot(params.root);
+		const file = resolvePythonFile(root, params.path);
+		const client = new LspClient("ruff", getServerCommand("ruff"), root, getTimeoutMs("ruff"));
+		const abort = () => client.close();
+		signal?.addEventListener("abort", abort, { once: true });
+
+		try {
+			await client.start();
+			await client.initialize(root, { codeAction: true });
+			const uri = pathToFileURL(file).href;
+			const text = readFileSync(file, "utf8");
+			client.didOpen(uri, text);
+			const edits = await client.format(uri);
+			const newText = applyTextEdits(text, edits);
+			const changed = newText !== text;
+
+			if (params.write && changed) writeFileSync(file, newText);
+
+			return textResult(formatEditSummary("format", root, file, changed, params.write, newText), {
+				path: path.relative(root, file) || file,
+				uri,
+				changed,
+				write: params.write ?? false,
+				edits,
+				text: params.write ? undefined : newText,
+			});
+		} finally {
+			signal?.removeEventListener("abort", abort);
+			await client.shutdown();
+		}
+	},
+});
+
+const ruffFixTool = defineTool({
+	name: "ruff_lsp_fix",
+	label: "Python LSP: Ruff Fix",
+	description: "Apply Ruff LSP source fixes or import organization to a Python file.",
+	promptSnippet: "Apply Ruff LSP fixes to a Python file",
+	parameters: Type.Object({
+		path: Type.String({ description: "Python file to fix." }),
+		root: Type.Optional(
+			Type.String({ description: "Workspace root for the language server. Defaults to cwd." }),
+		),
+		kind: Type.Optional(
+			Type.String({
+				description:
+					"Ruff source action kind. Defaults to source.fixAll.ruff. Common value: source.organizeImports.ruff.",
+			}),
+		),
+		write: Type.Optional(
+			Type.Boolean({ description: "Write fixed text back to the file. Defaults to false." }),
+		),
+	}),
+	async execute(_toolCallId, params, signal) {
+		const root = resolveRoot(params.root);
+		const file = resolvePythonFile(root, params.path);
+		const actionKind = params.kind?.trim() || "source.fixAll.ruff";
+		const client = new LspClient("ruff", getServerCommand("ruff"), root, getTimeoutMs("ruff"));
+		const abort = () => client.close();
+		signal?.addEventListener("abort", abort, { once: true });
+
+		try {
+			await client.start();
+			await client.initialize(root, { codeAction: true });
+			const uri = pathToFileURL(file).href;
+			const text = readFileSync(file, "utf8");
+			client.didOpen(uri, text);
+			const diagnostics = await client.diagnostics(uri);
+			const actions = await client.codeActions(uri, text, diagnostics, actionKind);
+			const resolvedActions = await client.resolveActions(actions);
+			const edits = resolvedActions.flatMap((action) => collectWorkspaceEdits(action.edit, uri));
+			const newText = applyTextEdits(text, edits);
+			const changed = newText !== text;
+
+			if (params.write && changed) writeFileSync(file, newText);
+
+			return textResult(formatEditSummary("fix", root, file, changed, params.write, newText), {
+				path: path.relative(root, file) || file,
+				uri,
+				changed,
+				write: params.write ?? false,
+				kind: actionKind,
+				actions: resolvedActions.map(({ title, kind }) => ({ title, kind })),
+				edits,
+				text: params.write ? undefined : newText,
+			});
+		} finally {
+			signal?.removeEventListener("abort", abort);
+			await client.shutdown();
+		}
+	},
+});
+
+export default function pythonLsp(pi: ExtensionAPI) {
+	pi.registerTool(tyDiagnosticsTool);
+	pi.registerTool(ruffDiagnosticsTool);
+	pi.registerTool(ruffFormatTool);
+	pi.registerTool(ruffFixTool);
+
+	pi.registerCommand("python-lsp", {
+		description: "Show Python LSP extension configuration",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(buildStatusMessage(), statusLevel());
+			updateStatus(ctx);
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		updateStatus(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}
+
+async function runDiagnostics(
+	kind: ServerKind,
+	params: { root?: string; paths?: string[]; limit?: number },
+	signal: AbortSignal | undefined,
+) {
+	const root = resolveRoot(params.root);
+	const files = collectPythonFiles(root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
+	if (files.length === 0) {
+		return textResult(`${labelFor(kind)} LSP found no Python files to check.`, { root, files: [] });
+	}
+
+	const client = new LspClient(kind, getServerCommand(kind), root, getTimeoutMs(kind));
+	const abort = () => client.close();
+	signal?.addEventListener("abort", abort, { once: true });
+
+	try {
+		await client.start();
+		await client.initialize(root, { codeAction: kind === "ruff" });
+
+		const entries: DiagnosticEntry[] = [];
+		for (const file of files) {
+			const uri = pathToFileURL(file).href;
+			const text = readFileSync(file, "utf8");
+			client.didOpen(uri, text);
+			const diagnostics = await client.diagnostics(uri);
+			entries.push({ path: path.relative(root, file) || file, uri, diagnostics });
+		}
+
+		return textResult(formatDiagnostics(entries, kind), {
+			root,
+			command: getServerCommand(kind),
+			files: entries,
+			summary: summarize(entries),
+		});
+	} finally {
+		signal?.removeEventListener("abort", abort);
+		await client.shutdown();
+	}
+}
+
+function getServerCommand(kind: ServerKind): ServerCommand {
+	const customCommand = (
+		kind === "ty" ? process.env.PI_TY_LSP_COMMAND : process.env.PI_RUFF_LSP_COMMAND
+	)?.trim();
+	if (customCommand) {
+		const [command, ...args] = splitCommand(customCommand);
+		if (command) return { command, args };
+	}
+
+	return kind === "ty"
+		? { command: "ty", args: ["server"] }
+		: { command: "ruff", args: ["server"] };
+}
+
+function getTimeoutMs(kind: ServerKind) {
+	const envValue =
+		kind === "ty" ? process.env.PI_TY_LSP_TIMEOUT_MS : process.env.PI_RUFF_LSP_TIMEOUT_MS;
+	const rawValue = Number(envValue ?? DEFAULT_TIMEOUT_MS);
+	return Number.isFinite(rawValue) && rawValue > 0 ? rawValue : DEFAULT_TIMEOUT_MS;
+}
+
+function updateStatus(ctx: {
+	ui: { setStatus: (key: string, value: string | undefined) => void };
+}) {
+	const tyReady = commandExists(getServerCommand("ty").command);
+	const ruffReady = commandExists(getServerCommand("ruff").command);
+	ctx.ui.setStatus(
+		STATUS_KEY,
+		`python-lsp: ty ${tyReady ? "ready" : "missing"}, ruff ${ruffReady ? "ready" : "missing"}`,
+	);
+}
+
+function buildStatusMessage() {
+	const ty = getServerCommand("ty");
+	const ruff = getServerCommand("ruff");
+	return [
+		`ty LSP command: ${ty.command} ${ty.args.join(" ")}`.trim(),
+		`ty status: ${commandExists(ty.command) ? "ready" : "command missing"}`,
+		`Ruff LSP command: ${ruff.command} ${ruff.args.join(" ")}`.trim(),
+		`Ruff status: ${commandExists(ruff.command) ? "ready" : "command missing"}`,
+	].join("\n");
+}
+
+function statusLevel() {
+	return commandExists(getServerCommand("ty").command) &&
+		commandExists(getServerCommand("ruff").command)
+		? "info"
+		: "warning";
+}
+
+function resolveRoot(root?: string) {
+	return path.resolve(root?.trim() || process.cwd());
+}
+
+function directoryUri(directory: string) {
+	return pathToFileURL(directory.endsWith(path.sep) ? directory : `${directory}${path.sep}`).href;
+}
+
+function resolvePythonFile(root: string, filePath: string) {
+	const resolvedPath = path.resolve(root, filePath);
+	if (!existsSync(resolvedPath)) throw new Error(`Python file does not exist: ${resolvedPath}`);
+	if (!statSync(resolvedPath).isFile()) throw new Error(`Expected a Python file: ${resolvedPath}`);
+	if (!isPythonFile(resolvedPath)) throw new Error(`Expected a .py or .pyi file: ${resolvedPath}`);
+	return resolvedPath;
+}
+
+function collectPythonFiles(root: string, requestedPaths: string[] | undefined, limit: number) {
+	const cappedLimit = Math.max(1, Math.floor(limit));
+	const files: string[] = [];
+	const inputs = requestedPaths?.length ? requestedPaths : [root];
+
+	for (const input of inputs) {
+		collectPath(path.resolve(root, input), files, cappedLimit);
+		if (files.length >= cappedLimit) break;
+	}
+
+	return files;
+}
+
+function collectPath(targetPath: string, files: string[], limit: number) {
+	if (files.length >= limit || !existsSync(targetPath)) return;
+
+	const stats = statSync(targetPath);
+	if (stats.isFile()) {
+		if (isPythonFile(targetPath)) files.push(targetPath);
+		return;
+	}
+
+	if (!stats.isDirectory()) return;
+	for (const entry of readdirSync(targetPath, { withFileTypes: true })) {
+		if (files.length >= limit) break;
+		if (entry.isDirectory() && SKIP_DIRECTORIES.has(entry.name)) continue;
+		collectPath(path.join(targetPath, entry.name), files, limit);
+	}
+}
+
+function isPythonFile(filePath: string) {
+	return filePath.endsWith(".py") || filePath.endsWith(".pyi");
+}
+
+function formatDiagnostics(entries: DiagnosticEntry[], kind: ServerKind) {
+	const lines = entries.flatMap((entry) => {
+		if (entry.diagnostics.length === 0) return [`${entry.path}: no diagnostics`];
+
+		return entry.diagnostics.map((diagnostic) => {
+			const line = diagnostic.range.start.line + 1;
+			const column = diagnostic.range.start.character + 1;
+			const severity = severityName(diagnostic.severity);
+			const source = diagnostic.source ?? labelFor(kind);
+			const code = diagnostic.code === undefined ? "" : ` ${diagnostic.code}`;
+			return `${entry.path}:${line}:${column}: ${severity} ${source}${code}: ${diagnostic.message}`;
+		});
+	});
+
+	const summary = summarize(entries);
+	return [
+		`${labelFor(kind)} LSP diagnostics: ${summary.diagnostics} diagnostic(s) across ${summary.files} file(s).`,
+		"",
+		...lines,
+	].join("\n");
+}
+
+function formatEditSummary(
+	action: "fix" | "format",
+	root: string,
+	file: string,
+	changed: boolean,
+	write: boolean | undefined,
+	text: string,
+) {
+	const relativePath = path.relative(root, file) || file;
+	const status = changed ? (write ? "updated" : "computed changes for") : "left unchanged";
+	const summary = `Ruff LSP ${action} ${status} ${relativePath}.`;
+	if (write || !changed) return summary;
+	return `${summary}\n\n${text}`;
+}
+
+function summarize(entries: DiagnosticEntry[]) {
+	return {
+		files: entries.length,
+		diagnostics: entries.reduce((total, entry) => total + entry.diagnostics.length, 0),
+	};
+}
+
+function severityName(severity: number | undefined) {
+	if (severity === 1) return "error";
+	if (severity === 2) return "warning";
+	if (severity === 3) return "info";
+	if (severity === 4) return "hint";
+	return "diagnostic";
+}
+
+function labelFor(kind: ServerKind) {
+	return kind === "ty" ? "ty" : "Ruff";
+}
+
+function textResult(text: string, details: unknown) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details,
+	};
+}
+
+function commandExists(command: string) {
+	if (command.includes("/") || command.includes("\\")) return existsSync(command);
+
+	const pathValue = process.env.PATH ?? "";
+	const extensions = process.platform === "win32" ? ["", ".exe", ".cmd", ".bat"] : [""];
+	for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+		if (!directory) continue;
+		for (const extension of extensions) {
+			if (existsSync(path.join(directory, `${command}${extension}`))) return true;
+		}
+	}
+
+	return false;
+}
+
+function splitCommand(input: string) {
+	const parts: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let escaping = false;
+
+	for (const char of input) {
+		if (escaping) {
+			current += char;
+			escaping = false;
+			continue;
+		}
+
+		if (char === "\\") {
+			escaping = true;
+			continue;
+		}
+
+		if ((char === '"' || char === "'") && !quote) {
+			quote = char;
+			continue;
+		}
+
+		if (char === quote) {
+			quote = undefined;
+			continue;
+		}
+
+		if (/\s/.test(char) && !quote) {
+			if (current) {
+				parts.push(current);
+				current = "";
+			}
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current) parts.push(current);
+	return parts;
+}
+
+function positionAt(text: string, offset: number): LspPosition {
+	const boundedOffset = Math.max(0, Math.min(offset, text.length));
+	let line = 0;
+	let lineStart = 0;
+
+	for (let index = 0; index < boundedOffset; index += 1) {
+		if (text[index] === "\n") {
+			line += 1;
+			lineStart = index + 1;
+		}
+	}
+
+	return { line, character: boundedOffset - lineStart };
+}
+
+function offsetAt(text: string, position: LspPosition) {
+	let line = 0;
+	let lineStart = 0;
+
+	for (let index = 0; index < text.length && line < position.line; index += 1) {
+		if (text[index] === "\n") {
+			line += 1;
+			lineStart = index + 1;
+		}
+	}
+
+	if (line < position.line) return text.length;
+
+	let lineEnd = text.indexOf("\n", lineStart);
+	if (lineEnd < 0) lineEnd = text.length;
+	return Math.min(lineStart + position.character, lineEnd);
+}
+
+function applyTextEdits(text: string, edits: LspTextEdit[]) {
+	let output = text;
+	const sortedEdits = [...edits].sort((left, right) => {
+		const leftOffset = offsetAt(text, left.range.start);
+		const rightOffset = offsetAt(text, right.range.start);
+		return rightOffset - leftOffset;
+	});
+
+	for (const edit of sortedEdits) {
+		const start = offsetAt(output, edit.range.start);
+		const end = offsetAt(output, edit.range.end);
+		output = `${output.slice(0, start)}${edit.newText}${output.slice(end)}`;
+	}
+
+	return output;
+}
+
+function collectWorkspaceEdits(edit: WorkspaceEdit | undefined, uri: string) {
+	if (!edit) return [];
+	if (edit.documentChanges) {
+		return edit.documentChanges.flatMap((change) =>
+			change.textDocument?.uri === uri ? (change.edits ?? []) : [],
+		);
+	}
+
+	return edit.changes?.[uri] ?? [];
+}
+
+class LspClient {
+	#child?: ChildProcessWithoutNullStreams;
+	#buffer = Buffer.alloc(0);
+	#nextId = 1;
+	#pending = new Map<
+		number,
+		{
+			resolve: (message: JsonRpcMessage) => void;
+			reject: (reason: unknown) => void;
+			timeout: NodeJS.Timeout;
+		}
+	>();
+	#stderr = "";
+	#kind: ServerKind;
+	#command: ServerCommand;
+	#cwd: string;
+	#timeoutMs: number;
+
+	constructor(kind: ServerKind, command: ServerCommand, cwd: string, timeoutMs: number) {
+		this.#kind = kind;
+		this.#command = command;
+		this.#cwd = cwd;
+		this.#timeoutMs = timeoutMs;
+	}
+
+	async start() {
+		if (!commandExists(this.#command.command)) {
+			throw new Error(
+				`${labelFor(this.#kind)} LSP command not found: ${this.#command.command}. Install ${this.#kind} or set ${this.#kind === "ty" ? "PI_TY_LSP_COMMAND" : "PI_RUFF_LSP_COMMAND"}.`,
+			);
+		}
+
+		this.#child = spawn(this.#command.command, this.#command.args, {
+			cwd: this.#cwd,
+			stdio: "pipe",
+		});
+		this.#child.stdout.on("data", (chunk) => this.#onData(chunk));
+		this.#child.stderr.on("data", (chunk) => {
+			this.#stderr += chunk.toString();
+		});
+		this.#child.once("exit", (code, signal) => {
+			const reason = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+			for (const [id, pending] of this.#pending.entries()) {
+				clearTimeout(pending.timeout);
+				pending.reject(
+					new Error(
+						`${labelFor(this.#kind)} LSP server exited before response ${id} (${reason}).${this.#formatStderr()}`,
+					),
+				);
+			}
+			this.#pending.clear();
+		});
+	}
+
+	async initialize(root: string, options: { codeAction: boolean }) {
+		const rootUri = directoryUri(root);
+		await this.request("initialize", {
+			processId: process.pid,
+			rootUri,
+			workspaceFolders: [{ uri: rootUri, name: path.basename(root) || "workspace" }],
+			capabilities: {
+				textDocument: {
+					...(options.codeAction
+						? { codeAction: { resolveSupport: { properties: ["edit"] } } }
+						: {}),
+					diagnostic: { dynamicRegistration: false },
+					publishDiagnostics: {},
+					synchronization: { didSave: true },
+				},
+				workspace: {
+					configuration: true,
+					workspaceEdit: { documentChanges: true },
+					workspaceFolders: true,
+				},
+			},
+		});
+		this.notify("initialized", {});
+	}
+
+	didOpen(uri: string, text: string) {
+		this.notify("textDocument/didOpen", {
+			textDocument: { uri, languageId: "python", version: 1, text },
+		});
+	}
+
+	async diagnostics(uri: string) {
+		const response = await this.request("textDocument/diagnostic", {
+			textDocument: { uri },
+			identifier: null,
+			previousResultId: null,
+		});
+		const result = response.result as { items?: LspDiagnostic[] } | undefined;
+		return result?.items ?? [];
+	}
+
+	async format(uri: string) {
+		const response = await this.request("textDocument/formatting", {
+			textDocument: { uri },
+			options: { tabSize: 4, insertSpaces: true },
+		});
+		return (response.result as LspTextEdit[] | null | undefined) ?? [];
+	}
+
+	async codeActions(uri: string, text: string, diagnostics: LspDiagnostic[], kind: string) {
+		const response = await this.request("textDocument/codeAction", {
+			textDocument: { uri },
+			range: { start: { line: 0, character: 0 }, end: positionAt(text, text.length) },
+			context: { diagnostics, only: [kind] },
+		});
+		return (response.result as CodeAction[] | null | undefined) ?? [];
+	}
+
+	async resolveActions(actions: CodeAction[]) {
+		const resolvedActions: CodeAction[] = [];
+		for (const action of actions) {
+			if (action.edit) {
+				resolvedActions.push(action);
+				continue;
+			}
+
+			const response = await this.request("codeAction/resolve", action);
+			resolvedActions.push((response.result as CodeAction | undefined) ?? action);
+		}
+
+		return resolvedActions;
+	}
+
+	async shutdown() {
+		if (!this.#child) return;
+
+		try {
+			await this.request("shutdown", null);
+			this.notify("exit", undefined);
+		} catch {
+			// The process may already be gone; close below still guarantees cleanup.
+		} finally {
+			this.close();
+		}
+	}
+
+	close() {
+		for (const pending of this.#pending.values()) {
+			clearTimeout(pending.timeout);
+			pending.reject(new Error(`${labelFor(this.#kind)} LSP request cancelled.`));
+		}
+		this.#pending.clear();
+
+		if (this.#child && !this.#child.killed) this.#child.kill("SIGTERM");
+		this.#child = undefined;
+	}
+
+	private request(method: string, params: unknown) {
+		const id = this.#nextId++;
+		this.#send({ jsonrpc: "2.0", id, method, params });
+
+		return new Promise<JsonRpcMessage>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.#pending.delete(id);
+				reject(
+					new Error(
+						`${labelFor(this.#kind)} LSP request timed out: ${method}.${this.#formatStderr()}`,
+					),
+				);
+			}, this.#timeoutMs);
+			this.#pending.set(id, { resolve, reject, timeout });
+		});
+	}
+
+	private notify(method: string, params: unknown) {
+		this.#send(
+			params === undefined ? { jsonrpc: "2.0", method } : { jsonrpc: "2.0", method, params },
+		);
+	}
+
+	#send(message: JsonRpcMessage) {
+		if (!this.#child) throw new Error(`${labelFor(this.#kind)} LSP server is not running.`);
+
+		const body = JSON.stringify(message);
+		this.#child.stdin.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+	}
+
+	#onData(chunk: Buffer) {
+		this.#buffer = Buffer.concat([this.#buffer, chunk]);
+
+		while (true) {
+			const separator = this.#buffer.indexOf("\r\n\r\n");
+			if (separator < 0) return;
+
+			const header = this.#buffer.subarray(0, separator).toString("utf8");
+			const contentLength = /Content-Length:\s*(\d+)/i.exec(header)?.[1];
+			if (!contentLength) throw new Error(`Invalid LSP response header: ${header}`);
+
+			const bodyStart = separator + 4;
+			const bodyLength = Number(contentLength);
+			if (this.#buffer.length < bodyStart + bodyLength) return;
+
+			const rawBody = this.#buffer.subarray(bodyStart, bodyStart + bodyLength).toString("utf8");
+			this.#buffer = this.#buffer.subarray(bodyStart + bodyLength);
+			this.#handleMessage(JSON.parse(rawBody) as JsonRpcMessage);
+		}
+	}
+
+	#handleMessage(message: JsonRpcMessage) {
+		if (Object.hasOwn(message, "id") && !message.method) {
+			const pending = typeof message.id === "number" ? this.#pending.get(message.id) : undefined;
+			if (!pending) return;
+
+			clearTimeout(pending.timeout);
+			this.#pending.delete(message.id as number);
+			if (message.error) {
+				pending.reject(new Error(`${labelFor(this.#kind)} LSP error: ${message.error.message}`));
+			} else {
+				pending.resolve(message);
+			}
+			return;
+		}
+
+		if (Object.hasOwn(message, "id") && message.method) {
+			this.#respondToServerRequest(message);
+		}
+	}
+
+	#respondToServerRequest(message: JsonRpcMessage) {
+		let result: unknown = null;
+		if (message.method === "workspace/configuration") {
+			const params = message.params as { items?: unknown[] } | undefined;
+			result = (params?.items ?? []).map(() => ({}));
+		}
+
+		this.#send({ jsonrpc: "2.0", id: message.id, result });
+	}
+
+	#formatStderr() {
+		const stderr = this.#stderr.trim();
+		return stderr ? `\nServer stderr:\n${stderr}` : "";
+	}
+}

--- a/extensions/pi-python-lsp/tsconfig.json
+++ b/extensions/pi-python-lsp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ caffeinate := "@narumitw/pi-caffeinate"
 chrome_devtools := "@narumitw/pi-chrome-devtools"
 firecrawl := "@narumitw/pi-firecrawl"
 goal := "@narumitw/pi-goal"
+python_lsp := "@narumitw/pi-python-lsp"
 retry := "@narumitw/pi-retry"
 
 # Show available commands
@@ -42,6 +43,7 @@ doctor-all:
     just doctor {{chrome_devtools}}
     just doctor {{firecrawl}}
     just doctor {{goal}}
+    just doctor {{python_lsp}}
     just doctor {{retry}}
 
 # Make a scoped npm package public after publish if npm registry returns 404
@@ -66,6 +68,10 @@ pack-firecrawl:
 pack-goal:
     npm run pack:goal
 
+# Preview the python-lsp package that npm would publish
+pack-python-lsp:
+    npm run pack:python-lsp
+
 # Preview the retry package that npm would publish
 pack-retry:
     npm run pack:retry
@@ -86,6 +92,10 @@ try-firecrawl:
 try-goal:
     pi -e ./extensions/pi-goal
 
+# Try python-lsp from this working tree as a temporary pi package
+try-python-lsp:
+    pi -e ./extensions/pi-python-lsp
+
 # Try retry from this working tree as a temporary pi package
 try-retry:
     pi -e ./extensions/pi-retry
@@ -105,6 +115,10 @@ install-firecrawl:
 # Install the published goal package through pi
 install-goal:
     pi install npm:{{goal}}
+
+# Install python-lsp through pi, falling back to the local workspace if unpublished
+install-python-lsp:
+    if npm view {{python_lsp}} version >/dev/null 2>&1; then pi install npm:{{python_lsp}}; else echo "{{python_lsp}} is not published; installing local workspace package instead."; pi install ./extensions/pi-python-lsp; fi
 
 # Install the published retry package through pi
 install-retry:
@@ -130,6 +144,11 @@ publish-firecrawl otp="":
 publish-goal otp="":
     version="$(node -p "require('./extensions/pi-goal/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{goal}}@"$version" version >/dev/null 2>&1; then echo "{{goal}}@$version already exists; skipping publish."; else npm --workspace {{goal}} pack --dry-run; npm --workspace {{goal}} publish --access public $otp_arg; fi
 
+# Publish python-lsp to npm, skipping if the current version already exists
+# Usage with 2FA: just publish-python-lsp 123456
+publish-python-lsp otp="":
+    version="$(node -p "require('./extensions/pi-python-lsp/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{python_lsp}}@"$version" version >/dev/null 2>&1; then echo "{{python_lsp}}@$version already exists; skipping publish."; else npm --workspace {{python_lsp}} pack --dry-run; npm --workspace {{python_lsp}} publish --access public $otp_arg; fi
+
 # Publish retry to npm, skipping if the current version already exists
 # Usage with 2FA: just publish-retry 123456
 publish-retry otp="":
@@ -142,6 +161,7 @@ publish-all otp="":
     just publish-chrome-devtools {{otp}}
     just publish-firecrawl {{otp}}
     just publish-goal {{otp}}
+    just publish-python-lsp {{otp}}
     just publish-retry {{otp}}
 
 # Install all published extension packages through pi
@@ -150,6 +170,7 @@ install-all:
     just install-chrome-devtools
     just install-firecrawl
     just install-goal
+    just install-python-lsp
     just install-retry
 
 # Bump one workspace package without creating a git tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -480,6 +480,123 @@
 				"koffi": "^2.9.0"
 			}
 		},
+		"extensions/pi-python-lsp": {
+			"name": "@narumitw/pi-python-lsp",
+			"version": "0.1.3",
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "^1.1.37"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"@types/node": "25.6.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-python-lsp/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-python-lsp/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-python-lsp/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-python-lsp/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"extensions/pi-retry": {
 			"name": "@narumitw/pi-retry",
 			"version": "0.1.3",
@@ -1961,6 +2078,10 @@
 		},
 		"node_modules/@narumitw/pi-goal": {
 			"resolved": "extensions/pi-goal",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-python-lsp": {
+			"resolved": "extensions/pi-python-lsp",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-retry": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
+		"pack:python-lsp": "npm --workspace @narumitw/pi-python-lsp pack --dry-run",
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- Add `@narumitw/pi-python-lsp` as a combined Python LSP extension
- Expose `ty_lsp_diagnostics`, `ruff_lsp_diagnostics`, `ruff_lsp_fix`, and `ruff_lsp_format` tools
- Share one on-demand LSP JSON-RPC client for `ty server` and `ruff server`
- Wire README, AGENTS.md, package scripts, just recipes, and package-lock entries

## Verification
- `npm run check`
- `just pack-python-lsp`
- `just install-python-lsp`
- Runtime simulation verified ty diagnostics plus Ruff diagnostics, fix, and format against temporary Python files
