### PR TITLE
feat(statusline): add customizable footer extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Run commands from the repository root unless noted otherwise.
 - Full verification: `npm run check` or `just check`
 - Format with Biome: `npm run format` or `just format`
 - Typecheck all workspaces: `npm run typecheck`
-- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, `just pack-python-lsp`, or `just pack-retry`
-- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, `just try-python-lsp`, or `just try-retry`
+- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, `just pack-python-lsp`, `just pack-retry`, or `just pack-statusline`
+- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, `just try-python-lsp`, `just try-retry`, or `just try-statusline`
 - Inspect available recipes before adding new workflow commands: `just --list`
 
 ## Code style

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,6 +9,7 @@
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - For natural-language statusline parsing, avoid segment keywords that overlap control phrases (`statusline` vs `status`, `turn off` vs `turn`) or direct input gets misclassified.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
+- Direct statusline input interception should stay short/single-line; long prompts that mention statusline must pass through to the agent to avoid feeling swallowed.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -7,9 +7,8 @@
 - For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
 - When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
-- For natural-language statusline parsing, avoid segment keywords that overlap control phrases (`statusline` vs `status`, `turn off` vs `turn`) or direct input gets misclassified.
+- For statusline slash-command parsing, avoid segment keywords that overlap control phrases (`statusline` vs `status`, `turn off` vs `turn`).
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
-- Direct statusline input interception should stay short/single-line; long prompts that mention statusline must pass through to the agent to avoid feeling swallowed.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -7,7 +7,7 @@
 - For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
 - When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
-- For statusline slash-command parsing, avoid segment keywords that overlap control phrases (`statusline` vs `status`, `turn off` vs `turn`).
+- pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
 
 ## TASTE

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -7,6 +7,8 @@
 - For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
 - When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
+- For natural-language statusline parsing, avoid segment keywords that overlap control phrases (`statusline` vs `status`, `turn off` vs `turn`) or direct input gets misclassified.
+- In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
 
 ## TASTE
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Monorepo for independently installable Pi extension packages.
 | `@narumitw/pi-goal` | [`extensions/pi-goal`](./extensions/pi-goal) | `pi install npm:@narumitw/pi-goal` |
 | `@narumitw/pi-python-lsp` | [`extensions/pi-python-lsp`](./extensions/pi-python-lsp) | `pi install npm:@narumitw/pi-python-lsp` |
 | `@narumitw/pi-retry` | [`extensions/pi-retry`](./extensions/pi-retry) | `pi install npm:@narumitw/pi-retry` |
+| `@narumitw/pi-statusline` | [`extensions/pi-statusline`](./extensions/pi-statusline) | `pi install npm:@narumitw/pi-statusline` |
 
 ## Local development
 
@@ -30,6 +31,7 @@ pi -e ./extensions/pi-firecrawl
 pi -e ./extensions/pi-goal
 pi -e ./extensions/pi-python-lsp
 pi -e ./extensions/pi-retry
+pi -e ./extensions/pi-statusline
 ```
 
 Preview package contents:
@@ -41,6 +43,7 @@ npm run pack:firecrawl
 npm run pack:goal
 npm run pack:python-lsp
 npm run pack:retry
+npm run pack:statusline
 ```
 
 Publish packages from their package directories:
@@ -52,4 +55,5 @@ cd extensions/pi-firecrawl && npm publish --access public
 cd extensions/pi-goal && npm publish --access public
 cd extensions/pi-python-lsp && npm publish --access public
 cd extensions/pi-retry && npm publish --access public
+cd extensions/pi-statusline && npm publish --access public
 ```

--- a/extensions/pi-statusline/LICENSE
+++ b/extensions/pi-statusline/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -2,8 +2,6 @@
 
 A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline.
 
-The extension is display-only: it does not intercept prompts or register customization commands.
-
 ## Install
 
 ```bash

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -1,8 +1,8 @@
 # pi-statusline
 
-A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline and lets you customize it in natural language.
+A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline and lets you customize it with `/statusline <prompt>`.
 
-No slash command is required: type a normal request such as “make the statusline minimal and blue, hide cost” and the extension applies it directly.
+Use the slash command for changes, such as `/statusline make it minimal and blue, hide cost`. Normal prompts are not intercepted.
 
 ## Install
 
@@ -22,23 +22,23 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-statusline
 ```
 
-## Natural-language examples
+## Slash command examples
 
-Type these as normal prompts:
+Use `/statusline <prompt>`:
 
 ```text
-make the statusline beautiful and compact
-make the footer minimal, blue, and show git branch plus time
-hide cost and tokens from the statusline
-use a rainbow statusline with context, tools, and cwd
-make the status bar monochrome with no separators
-show current statusline configuration
-reset the statusline to default
-turn off the custom statusline
-turn on the custom statusline
+/statusline make it beautiful and compact
+/statusline minimal, blue, and show git branch plus time
+/statusline hide cost and tokens
+/statusline use rainbow colors with context, tools, and cwd
+/statusline monochrome with no separators
+/statusline show current configuration
+/statusline reset to default
+/statusline turn off
+/statusline turn on
 ```
 
-The extension only intercepts prompts that clearly mention the statusline/footer/status bar and ask for a change. Other prompts continue to the agent normally.
+Only the `/statusline` command applies changes directly. Other prompts continue to the agent normally.
 
 ## What it shows
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -35,7 +35,7 @@ The default statusline includes:
 - estimated cost
 - clock
 
-Statuses from other extensions, such as goal mode, appear on their own line below the main statusline.
+Statuses from other extensions, such as goal mode, appear on their own line below the main statusline and are separated with ``.
 The layout adapts to terminal width and truncates safely.
 
 ## Package layout

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -1,8 +1,8 @@
 # pi-statusline
 
-A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline and lets you customize it with `/statusline <prompt>`.
+A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline.
 
-Use the slash command for changes, such as `/statusline make it minimal and blue, hide cost`. Normal prompts are not intercepted.
+The extension is display-only: it does not intercept prompts or register customization commands.
 
 ## Install
 
@@ -22,24 +22,6 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-statusline
 ```
 
-## Slash command examples
-
-Use `/statusline <prompt>`:
-
-```text
-/statusline make it beautiful and compact
-/statusline minimal, blue, and show git branch plus time
-/statusline hide cost and tokens
-/statusline use rainbow colors with context, tools, and cwd
-/statusline monochrome with no separators
-/statusline show current configuration
-/statusline reset to default
-/statusline turn off
-/statusline turn on
-```
-
-Only the `/statusline` command applies changes directly. Other prompts continue to the agent normally.
-
 ## What it shows
 
 The default statusline includes:
@@ -57,10 +39,6 @@ The default statusline includes:
 - clock
 
 The layout adapts to terminal width and truncates safely.
-
-## Agent tool
-
-The package also registers `statusline_customize`, so the agent can apply statusline changes when a statusline request is part of a broader natural-language conversation.
 
 ## Package layout
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -32,12 +32,12 @@ The default statusline includes:
 - git branch
 - current project directory
 - active or last tool
-- statuses from other extensions, such as goal mode
 - context usage percentage
 - token totals
 - estimated cost
 - clock
 
+Statuses from other extensions, such as goal mode, appear on their own line below the main statusline.
 The layout adapts to terminal width and truncates safely.
 
 ## Package layout

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -1,0 +1,85 @@
+# pi-statusline
+
+A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline and lets you customize it in natural language.
+
+No slash command is required: type a normal request such as “make the statusline minimal and blue, hide cost” and the extension applies it directly.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-statusline
+```
+
+Try without installing:
+
+```bash
+pi -e npm:@narumitw/pi-statusline
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-statusline
+```
+
+## Natural-language examples
+
+Type these as normal prompts:
+
+```text
+make the statusline beautiful and compact
+make the footer minimal, blue, and show git branch plus time
+hide cost and tokens from the statusline
+use a rainbow statusline with context, tools, and cwd
+make the status bar monochrome with no separators
+show current statusline configuration
+reset the statusline to default
+turn off the custom statusline
+turn on the custom statusline
+```
+
+The extension only intercepts prompts that clearly mention the statusline/footer/status bar and ask for a change. Other prompts continue to the agent normally.
+
+## What it shows
+
+The default statusline includes:
+
+- `π` brand marker
+- current model
+- thinking level
+- git branch
+- current project directory
+- active or last tool
+- statuses from other extensions, such as goal mode
+- context usage percentage
+- token totals
+- estimated cost
+- clock
+
+The layout adapts to terminal width and truncates safely.
+
+## Agent tool
+
+The package also registers `statusline_customize`, so the agent can apply statusline changes when a statusline request is part of a broader natural-language conversation.
+
+## Package layout
+
+```txt
+extensions/pi-statusline/
+├── src/
+│   └── statusline.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/statusline.ts"]
+  }
+}
+```

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-statusline",
 	"version": "0.1.3",
-	"description": "Pi extension that customizes the footer/statusline from natural-language requests.",
+	"description": "Pi extension that customizes the footer/statusline with /statusline prompts.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@narumitw/pi-statusline",
+	"version": "0.1.3",
+	"description": "Pi extension that customizes the footer/statusline from natural-language requests.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"statusline",
+		"footer",
+		"natural-language"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/statusline.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"typebox": "^1.1.37"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"@mariozechner/pi-tui": "0.73.0",
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
+	}
+}

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-statusline",
 	"version": "0.1.3",
-	"description": "Pi extension that customizes the footer/statusline with /statusline prompts.",
+	"description": "Pi extension that replaces the footer with an information-rich statusline.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -10,8 +10,7 @@
 		"pi-extension",
 		"pi",
 		"statusline",
-		"footer",
-		"natural-language"
+		"footer"
 	],
 	"files": [
 		"src",
@@ -27,9 +26,6 @@
 		"check": "biome check . && npm run typecheck",
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"typebox": "^1.1.37"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.14",

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -481,19 +481,35 @@ const STATUSLINE_QUESTION_WORDS = [
 	"how do",
 	"how to",
 	"what is",
+	"what are",
+	"where",
 	"why",
 	"explain",
 	"document",
 	"docs",
 	"如何",
-	"什麼是",
+	"什麼",
+	"哪裡",
+	"哪個",
+	"為什麼",
+	"作用",
+	"用途",
 	"解釋",
+	"說明",
+	"介紹",
 	"文件",
 ];
+const MAX_DIRECT_STATUSLINE_REQUEST_LENGTH = 240;
 
 function getDirectStatuslineRequest(text: string): string | undefined {
 	const request = text.trim();
 	if (!request || request.startsWith("/")) return undefined;
+
+	// Direct input interception is only for short, obvious customization commands.
+	// Longer or multi-line prompts should continue to the agent so they do not feel swallowed.
+	if (request.includes("\n") || request.length > MAX_DIRECT_STATUSLINE_REQUEST_LENGTH) {
+		return undefined;
+	}
 
 	const lower = request.toLowerCase();
 	if (!hasAny(lower, STATUSLINE_NOUNS)) return undefined;

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -214,20 +214,23 @@ export default function statusline(pi: ExtensionAPI) {
 		},
 	});
 
-	pi.on("input", (event, ctx) => {
-		if (event.source === "extension") return;
+	pi.registerCommand("statusline", {
+		description: "Customize the footer/statusline. Usage: /statusline <request>",
+		handler: async (args, ctx) => {
+			const request = args.trim();
+			if (!request) {
+				ctx.ui.notify(`Usage: /statusline <request>\n${summarizeConfig(config, [])}`, "info");
+				return;
+			}
 
-		const request = getDirectStatuslineRequest(event.text);
-		if (!request) return;
+			if (isStatuslineShowRequest(request)) {
+				ctx.ui.notify(summarizeConfig(config, []), "info");
+				return;
+			}
 
-		if (isStatuslineShowRequest(request)) {
-			ctx.ui.notify(summarizeConfig(config, []), "info");
-			return { action: "handled" as const };
-		}
-
-		const result = applyRequest(request, ctx);
-		ctx.ui.notify(summarizeConfig(result.config, result.changes), "info");
-		return { action: "handled" as const };
+			const result = applyRequest(request, ctx);
+			ctx.ui.notify(summarizeConfig(result.config, result.changes), "info");
+		},
 	});
 
 	pi.on("session_start", (_event, ctx) => {
@@ -429,111 +432,14 @@ function applyNaturalLanguageRequest(
 
 const SHOW_WORDS = ["show", "add", "include", "with", "display", "顯示", "加入", "包含"];
 const HIDE_WORDS = ["hide", "remove", "without", "no ", "omit", "隱藏", "移除", "不要", "沒有"];
-const STATUSLINE_NOUNS = [
-	"statusline",
-	"status line",
-	"status bar",
-	"footer",
-	"bottom bar",
-	"狀態列",
-	"狀態欄",
-	"底部列",
-	"頁尾",
-];
-const STATUSLINE_ACTIONS = [
-	"make",
-	"set",
-	"change",
-	"customize",
-	"customise",
-	"style",
-	"show",
-	"hide",
-	"add",
-	"remove",
-	"enable",
-	"disable",
-	"turn on",
-	"turn off",
-	"reset",
-	"beautiful",
-	"pretty",
-	"minimal",
-	"compact",
-	"rainbow",
-	"powerline",
-	"改",
-	"設定",
-	"美化",
-	"顯示",
-	"隱藏",
-	"加入",
-	"移除",
-	"啟用",
-	"停用",
-	"開啟",
-	"關閉",
-	"重設",
-	"漂亮",
-	"極簡",
-];
-const STATUSLINE_QUESTION_WORDS = [
-	"how do",
-	"how to",
-	"what is",
-	"what are",
-	"where",
-	"why",
-	"explain",
-	"document",
-	"docs",
-	"如何",
-	"什麼",
-	"哪裡",
-	"哪個",
-	"為什麼",
-	"作用",
-	"用途",
-	"解釋",
-	"說明",
-	"介紹",
-	"文件",
-];
-const MAX_DIRECT_STATUSLINE_REQUEST_LENGTH = 240;
-
-function getDirectStatuslineRequest(text: string): string | undefined {
-	const request = text.trim();
-	if (!request || request.startsWith("/")) return undefined;
-
-	// Direct input interception is only for short, obvious customization commands.
-	// Longer or multi-line prompts should continue to the agent so they do not feel swallowed.
-	if (request.includes("\n") || request.length > MAX_DIRECT_STATUSLINE_REQUEST_LENGTH) {
-		return undefined;
-	}
-
-	const lower = request.toLowerCase();
-	if (!hasAny(lower, STATUSLINE_NOUNS)) return undefined;
-	if (hasAny(lower, STATUSLINE_QUESTION_WORDS)) return undefined;
-	if (!hasStatuslineAction(lower) && getMentionedSegments(lower).length === 0) return undefined;
-
-	return request;
-}
-
-function hasStatuslineAction(text: string): boolean {
-	return (
-		hasAny(text, STATUSLINE_ACTIONS) ||
-		hasStandaloneWord(text, "on") ||
-		hasStandaloneWord(text, "off")
-	);
-}
 
 function isStatuslineShowRequest(request: string): boolean {
 	const lower = request.toLowerCase().trim();
-	if (!hasAny(lower, STATUSLINE_NOUNS)) return false;
+	if (!lower) return false;
 	if (hasAny(lower, ["config", "configuration", "current", "目前", "現在", "設定值"])) {
 		return true;
 	}
-	return /^(show|display)\s+(the\s+)?(statusline|status line|footer)(\s+status)?$/i.test(lower);
+	return /^(show|display)(\s+(the\s+)?(statusline|status line|footer)(\s+status)?)?$/i.test(lower);
 }
 
 function detectPreset(text: string): PresetName | undefined {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -236,8 +236,7 @@ function renderExtensionStatusline(
 	const status = formatExtensionStatuses(footerData.getExtensionStatuses(), theme);
 	if (!status) return undefined;
 
-	const prefix = theme.fg("dim", "ext ");
-	return truncateToWidth(`${prefix}${status}`, width, "");
+	return truncateToWidth(status, width, "");
 }
 
 function buildSegment(

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -384,15 +384,29 @@ function formatToolActivity(runtime: RuntimeState): string {
 }
 
 function formatExtensionStatuses(statuses: ReadonlyMap<string, string>, theme: Theme): string {
+	const separator = theme.fg("dim", "  ");
 	const visibleStatuses = [...statuses.entries()]
 		.filter(([key, value]) => key !== STATUSLINE_KEY && value.trim().length > 0)
-		.slice(0, 2)
+		.slice(0, 3)
 		.map(([key, value]) => {
-			if (visibleWidth(value) <= 28) return value;
-			return `${theme.fg("dim", `${key}:`)} ${truncateToWidth(value, 24)}`;
+			const label = theme.fg("dim", `${key}: `);
+			const text = truncateToWidth(simplifyExtensionStatus(key, value), 24, "…");
+			return `${label}${text}`;
 		});
 
-	return visibleStatuses.join(" ");
+	return visibleStatuses.join(separator);
+}
+
+function simplifyExtensionStatus(key: string, value: string): string {
+	return value
+		.trim()
+		.replace(new RegExp(`^${escapeRegExp(key)}\\s*:\\s*`, "iu"), "")
+		.replace(/\s+\([^)]*\)\s*$/, "")
+		.replace(/\s+/g, " ");
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function getTokenTotals(ctx: ExtensionContext): TokenTotals {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -15,7 +15,6 @@ type SegmentName =
 	| "branch"
 	| "cwd"
 	| "tools"
-	| "status"
 	| "context"
 	| "tokens"
 	| "cost"
@@ -68,7 +67,6 @@ const DEFAULT_SEGMENTS: SegmentName[] = [
 	"branch",
 	"cwd",
 	"tools",
-	"status",
 	"context",
 	"tokens",
 	"cost",
@@ -112,7 +110,10 @@ export default function statusline(pi: ExtensionAPI) {
 				},
 				invalidate() {},
 				render(width: number): string[] {
-					return [renderStatusline(width, ctx, footerData, theme, config, runtime)];
+					const lines = [renderStatusline(width, ctx, footerData, theme, config, runtime)];
+					const extensionStatusLine = renderExtensionStatusline(width, footerData, theme);
+					if (extensionStatusLine) lines.push(extensionStatusLine);
+					return lines;
 				},
 			};
 		});
@@ -197,7 +198,7 @@ function renderStatusline(
 	if (width <= 0) return "";
 
 	const segments = config.segments
-		.map((segment, index) => buildSegment(segment, index, ctx, footerData, theme, config, runtime))
+		.map((segment, index) => buildSegment(segment, index, ctx, footerData, config, runtime))
 		.filter(
 			(segment): segment is RenderSegment => segment !== undefined && segment.text.length > 0,
 		);
@@ -227,12 +228,23 @@ function renderStatusline(
 	return truncateToWidth(`${trimmedLeft}${padding}${right}`, width, "");
 }
 
+function renderExtensionStatusline(
+	width: number,
+	footerData: ReadonlyFooterDataProvider,
+	theme: Theme,
+): string | undefined {
+	const status = formatExtensionStatuses(footerData.getExtensionStatuses(), theme);
+	if (!status) return undefined;
+
+	const prefix = theme.fg("dim", "ext ");
+	return truncateToWidth(`${prefix}${status}`, width, "");
+}
+
 function buildSegment(
 	name: SegmentName,
 	index: number,
 	ctx: ExtensionContext,
 	footerData: ReadonlyFooterDataProvider,
-	theme: Theme,
 	config: StatuslineConfig,
 	runtime: RuntimeState,
 ): RenderSegment | undefined {
@@ -251,10 +263,6 @@ function buildSegment(
 			return labeled(name, basename(ctx.cwd) || ctx.cwd, color, config);
 		case "tools":
 			return labeled(name, formatToolActivity(runtime), color, config);
-		case "status": {
-			const status = formatExtensionStatuses(footerData.getExtensionStatuses(), theme);
-			return status ? labeled(name, status, color, config) : undefined;
-		}
 		case "context": {
 			const usage = ctx.getContextUsage();
 			const value =

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -7,7 +7,6 @@ import type {
 	ThemeColor,
 } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { Type } from "typebox";
 
 type SegmentName =
 	| "brand"
@@ -23,7 +22,6 @@ type SegmentName =
 	| "time"
 	| "turn";
 
-type PresetName = "minimal" | "balanced" | "powerline" | "rainbow" | "focus";
 type PaletteName = "ocean" | "sunset" | "forest" | "candy" | "neon" | "mono";
 type Density = "compact" | "cozy";
 type SeparatorName = "dot" | "bar" | "powerline" | "round" | "none";
@@ -31,19 +29,11 @@ type SeparatorName = "dot" | "bar" | "powerline" | "round" | "none";
 type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
 
 interface StatuslineConfig {
-	enabled: boolean;
-	preset: PresetName;
 	palette: PaletteName;
 	density: Density;
 	separator: SeparatorName;
 	showLabels: boolean;
 	segments: SegmentName[];
-}
-
-interface StatuslineEntry {
-	config: StatuslineConfig;
-	request: string;
-	updatedAt: number;
 }
 
 interface RuntimeState {
@@ -54,11 +44,6 @@ interface RuntimeState {
 	isStreaming: boolean;
 	thinkingLevel: ThinkingLevel;
 	requestRender?: () => void;
-}
-
-interface CustomizeResult {
-	config: StatuslineConfig;
-	changes: string[];
 }
 
 interface TokenTotals {
@@ -90,30 +75,7 @@ const DEFAULT_SEGMENTS: SegmentName[] = [
 	"time",
 ];
 
-const PRESET_SEGMENTS: Record<PresetName, SegmentName[]> = {
-	minimal: ["brand", "model", "branch", "context"],
-	balanced: DEFAULT_SEGMENTS,
-	powerline: DEFAULT_SEGMENTS,
-	rainbow: DEFAULT_SEGMENTS,
-	focus: ["brand", "cwd", "tools", "status", "context", "time"],
-};
-
 const RIGHT_SEGMENTS = new Set<SegmentName>(["context", "tokens", "cost", "time", "turn"]);
-
-const SEGMENT_KEYWORDS: Record<SegmentName, string[]> = {
-	brand: ["brand", "logo", "pi", "π", "標誌", "品牌"],
-	model: ["model", "ai", "llm", "模型"],
-	thinking: ["thinking", "reasoning", "think", "推理", "思考"],
-	branch: ["branch", "git", "repo", "repository", "分支", "版本"],
-	cwd: ["cwd", "directory", "dir", "folder", "path", "project", "專案", "目錄", "路徑"],
-	tools: ["tool", "tools", "activity", "busy", "工具", "活動"],
-	status: ["extension", "extensions", "goal", "狀態", "擴充"],
-	context: ["context", "usage", "percent", "window", "上下文", "使用率", "百分比"],
-	tokens: ["token", "tokens", "input", "output", "tok", "權杖", "token數"],
-	cost: ["cost", "price", "money", "spend", "usd", "成本", "花費", "費用"],
-	time: ["time", "clock", "date", "時間", "時鐘"],
-	turn: ["turns", "iteration", "輪次", "回合"],
-};
 
 const PALETTES: Record<PaletteName, ThemeColor[]> = {
 	ocean: ["accent", "muted", "success", "warning"],
@@ -124,15 +86,8 @@ const PALETTES: Record<PaletteName, ThemeColor[]> = {
 	mono: ["muted", "dim"],
 };
 
-const STATUSLINE_TOOL_PARAMETERS = Type.Object({
-	request: Type.String({
-		description:
-			"Natural-language statusline request, such as 'make it minimal, hide cost, show git branch and time'.",
-	}),
-});
-
 export default function statusline(pi: ExtensionAPI) {
-	let config = createDefaultConfig();
+	const config = createDefaultConfig();
 	const runtime: RuntimeState = {
 		turnCount: 0,
 		activeTools: new Map(),
@@ -140,24 +95,9 @@ export default function statusline(pi: ExtensionAPI) {
 		thinkingLevel: "off",
 	};
 
-	const persistConfig = (request: string) => {
-		pi.appendEntry(STATUSLINE_KEY, {
-			config,
-			request,
-			updatedAt: Date.now(),
-		} satisfies StatuslineEntry);
-	};
-
 	const refresh = () => runtime.requestRender?.();
 
 	const installFooter = (ctx: ExtensionContext) => {
-		if (!config.enabled) {
-			ctx.ui.setFooter(undefined);
-			ctx.ui.setStatus(STATUSLINE_KEY, undefined);
-			runtime.requestRender = undefined;
-			return;
-		}
-
 		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			runtime.requestRender = () => tui.requestRender();
@@ -178,69 +118,12 @@ export default function statusline(pi: ExtensionAPI) {
 		});
 	};
 
-	const applyRequest = (request: string, ctx: ExtensionContext): CustomizeResult => {
-		const result = applyNaturalLanguageRequest(request, config);
-		config = result.config;
-		persistConfig(request);
-		installFooter(ctx);
-		refresh();
-		return result;
-	};
-
-	pi.registerTool({
-		name: "statusline_customize",
-		label: "Statusline Customize",
-		description:
-			"Customize Pi's footer/statusline from a natural-language request. Use when the user asks to change the statusline, footer, shown segments, colors, density, or style.",
-		promptSnippet: "Customize the Pi footer/statusline from natural-language requests",
-		promptGuidelines: [
-			"Use statusline_customize when the user asks to customize the statusline/footer appearance or visible footer segments.",
-			"Pass the user's natural-language request verbatim when possible so pi-statusline can parse style, palette, and segment preferences.",
-		],
-		parameters: STATUSLINE_TOOL_PARAMETERS,
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const result = applyRequest(params.request, ctx);
-			const summary = summarizeConfig(result.config, result.changes);
-			if (ctx.hasUI) ctx.ui.notify(summary, "info");
-
-			return {
-				content: [{ type: "text", text: summary }],
-				details: {
-					request: params.request,
-					config: result.config,
-					changes: result.changes,
-				},
-			};
-		},
-	});
-
-	pi.registerCommand("statusline", {
-		description: "Customize the footer/statusline. Usage: /statusline <request>",
-		handler: async (args, ctx) => {
-			const request = args.trim();
-			if (!request) {
-				ctx.ui.notify(`Usage: /statusline <request>\n${summarizeConfig(config, [])}`, "info");
-				return;
-			}
-
-			if (isStatuslineShowRequest(request)) {
-				ctx.ui.notify(summarizeConfig(config, []), "info");
-				return;
-			}
-
-			const result = applyRequest(request, ctx);
-			ctx.ui.notify(summarizeConfig(result.config, result.changes), "info");
-		},
-	});
-
 	pi.on("session_start", (_event, ctx) => {
-		config = readPersistedConfig(ctx) ?? config;
 		runtime.thinkingLevel = pi.getThinkingLevel();
 		installFooter(ctx);
 	});
 
 	pi.on("session_tree", (_event, ctx) => {
-		config = readPersistedConfig(ctx) ?? createDefaultConfig();
 		installFooter(ctx);
 		refresh();
 	});
@@ -295,222 +178,12 @@ export default function statusline(pi: ExtensionAPI) {
 
 function createDefaultConfig(): StatuslineConfig {
 	return {
-		enabled: true,
-		preset: "powerline",
 		palette: "candy",
 		density: "compact",
 		separator: "powerline",
 		showLabels: false,
 		segments: [...DEFAULT_SEGMENTS],
 	};
-}
-
-function readPersistedConfig(ctx: ExtensionContext): StatuslineConfig | undefined {
-	let latest: StatuslineConfig | undefined;
-
-	for (const entry of ctx.sessionManager.getBranch()) {
-		if (entry.type !== "custom" || entry.customType !== STATUSLINE_KEY) continue;
-
-		const data = entry.data as Partial<StatuslineEntry> | undefined;
-		const config = normalizeConfig(data?.config);
-		if (config) latest = config;
-	}
-
-	return latest;
-}
-
-function normalizeConfig(value: unknown): StatuslineConfig | undefined {
-	if (!value || typeof value !== "object") return undefined;
-
-	const input = value as Partial<StatuslineConfig>;
-	const fallback = createDefaultConfig();
-
-	return {
-		enabled: typeof input.enabled === "boolean" ? input.enabled : fallback.enabled,
-		preset: isPreset(input.preset) ? input.preset : fallback.preset,
-		palette: isPalette(input.palette) ? input.palette : fallback.palette,
-		density:
-			input.density === "cozy" || input.density === "compact" ? input.density : fallback.density,
-		separator: isSeparator(input.separator) ? input.separator : fallback.separator,
-		showLabels: typeof input.showLabels === "boolean" ? input.showLabels : fallback.showLabels,
-		segments: normalizeSegments(input.segments, fallback.segments),
-	};
-}
-
-function applyNaturalLanguageRequest(
-	request: string,
-	currentConfig: StatuslineConfig,
-): CustomizeResult {
-	const text = request.trim();
-	const lower = text.toLowerCase();
-	let next: StatuslineConfig = {
-		...currentConfig,
-		segments: [...currentConfig.segments],
-	};
-	const changes: string[] = [];
-
-	if (hasAny(lower, ["reset", "default", "factory", "重設", "預設", "恢復預設"])) {
-		next = createDefaultConfig();
-		changes.push("reset to the balanced default");
-	}
-
-	if (
-		hasAny(lower, ["disable", "turn off", "restore pi footer", "關閉", "停用"]) ||
-		hasStandaloneWord(lower, "off")
-	) {
-		next.enabled = false;
-		changes.push("disabled custom statusline");
-	}
-
-	if (hasAny(lower, ["enable", "turn on", "啟用", "開啟"]) || hasStandaloneWord(lower, "on")) {
-		next.enabled = true;
-		changes.push("enabled custom statusline");
-	}
-
-	const preset = detectPreset(lower);
-	if (preset) {
-		next.preset = preset;
-		next.segments = [...PRESET_SEGMENTS[preset]];
-		changes.push(`preset: ${preset}`);
-	}
-
-	const palette = detectPalette(lower);
-	if (palette) {
-		next.palette = palette;
-		changes.push(`palette: ${palette}`);
-	}
-
-	const separator = detectSeparator(lower, next.separator);
-	if (separator !== next.separator) {
-		next.separator = separator;
-		changes.push(`separator: ${separator}`);
-	}
-
-	if (hasAny(lower, ["compact", "dense", "short", "精簡", "緊湊"])) {
-		next.density = "compact";
-		changes.push("density: compact");
-	}
-
-	if (hasAny(lower, ["cozy", "spacious", "roomy", "with labels", "labeled", "詳細", "寬鬆"])) {
-		next.density = "cozy";
-		next.showLabels = true;
-		changes.push("density: cozy");
-	}
-
-	if (hasAny(lower, ["no labels", "hide labels", "without labels", "無標籤", "隱藏標籤"])) {
-		next.showLabels = false;
-		changes.push("labels hidden");
-	} else if (hasAny(lower, ["labels", "show labels", "with labels", "顯示標籤", "標籤"])) {
-		next.showLabels = true;
-		changes.push("labels shown");
-	}
-
-	const mentionedSegments = getMentionedSegments(lower);
-	if (hasAny(lower, ["only", "just", "僅", "只顯示", "只有"]) && mentionedSegments.length > 0) {
-		next.segments = mentionedSegments.includes("brand")
-			? mentionedSegments
-			: ["brand", ...mentionedSegments];
-		changes.push(`showing only: ${next.segments.join(", ")}`);
-	} else {
-		for (const segment of mentionedSegments) {
-			if (hasHideIntentForSegment(lower, segment)) {
-				next.segments = next.segments.filter((item) => item !== segment);
-				changes.push(`hidden: ${segment}`);
-				continue;
-			}
-
-			if (hasShowIntentForSegment(lower, segment) || !hasAny(lower, HIDE_WORDS)) {
-				next.segments = appendUnique(next.segments, segment);
-				changes.push(`shown: ${segment}`);
-			}
-		}
-	}
-
-	next.segments = normalizeSegments(next.segments, createDefaultConfig().segments);
-	return { config: next, changes: dedupe(changes) };
-}
-
-const SHOW_WORDS = ["show", "add", "include", "with", "display", "顯示", "加入", "包含"];
-const HIDE_WORDS = ["hide", "remove", "without", "no ", "omit", "隱藏", "移除", "不要", "沒有"];
-
-function isStatuslineShowRequest(request: string): boolean {
-	const lower = request.toLowerCase().trim();
-	if (!lower) return false;
-	if (hasAny(lower, ["config", "configuration", "current", "目前", "現在", "設定值"])) {
-		return true;
-	}
-	return /^(show|display)(\s+(the\s+)?(statusline|status line|footer)(\s+status)?)?$/i.test(lower);
-}
-
-function detectPreset(text: string): PresetName | undefined {
-	if (hasAny(text, ["minimal", "simple", "clean", "zen", "極簡", "簡潔"])) return "minimal";
-	if (hasAny(text, ["focus", "focused", "work mode", "專注"])) return "focus";
-	if (hasAny(text, ["rainbow", "colorful", "colourful", "彩虹", "多彩"])) return "rainbow";
-	if (
-		hasAny(text, ["powerline", "fancy", "beautiful", "pretty", "gorgeous", "漂亮", "美化", "華麗"])
-	) {
-		return "powerline";
-	}
-	if (hasAny(text, ["balanced", "classic", "normal", "完整", "平衡"])) return "balanced";
-	return undefined;
-}
-
-function detectPalette(text: string): PaletteName | undefined {
-	if (hasAny(text, ["mono", "monochrome", "gray", "grey", "no color", "plain", "黑白", "單色"])) {
-		return "mono";
-	}
-	if (hasAny(text, ["ocean", "blue", "cyan", "sea", "藍", "海洋"])) return "ocean";
-	if (hasAny(text, ["sunset", "orange", "amber", "warm", "夕陽", "橘", "暖色"])) return "sunset";
-	if (hasAny(text, ["forest", "green", "nature", "綠", "森林"])) return "forest";
-	if (hasAny(text, ["neon", "cyber", "terminal", "matrix", "霓虹", "賽博"])) return "neon";
-	if (hasAny(text, ["candy", "pink", "purple", "magenta", "粉", "紫", "糖果"])) return "candy";
-	return undefined;
-}
-
-function detectSeparator(text: string, fallback: SeparatorName): SeparatorName {
-	if (hasAny(text, ["powerline", "nerd font", "nerdfont"])) return "powerline";
-	if (hasAny(text, ["dot", "dots", "bullet", "圓點"])) return "dot";
-	if (hasAny(text, ["bar", "pipe", "vertical", "直線", "分隔線"])) return "bar";
-	if (hasAny(text, ["round", "rounded", "soft", "圓角"])) return "round";
-	if (hasAny(text, ["none", "no separator", "plain", "不要分隔"])) return "none";
-	return fallback;
-}
-
-function getMentionedSegments(text: string): SegmentName[] {
-	const segments: SegmentName[] = [];
-	for (const [segment, keywords] of Object.entries(SEGMENT_KEYWORDS) as [SegmentName, string[]][]) {
-		if (hasAny(text, keywords)) segments.push(segment);
-	}
-	return segments;
-}
-
-function hasShowIntentForSegment(text: string, segment: SegmentName): boolean {
-	return hasIntentForSegment(text, SHOW_WORDS, SEGMENT_KEYWORDS[segment]);
-}
-
-function hasHideIntentForSegment(text: string, segment: SegmentName): boolean {
-	return hasIntentForSegment(text, HIDE_WORDS, SEGMENT_KEYWORDS[segment]);
-}
-
-function hasIntentForSegment(text: string, intents: string[], keywords: string[]): boolean {
-	for (const intent of intents) {
-		for (const keyword of keywords) {
-			if (!text.includes(intent) || !text.includes(keyword)) continue;
-			if (intent.length === 1 || keyword.length === 1) return true;
-
-			const intentBefore = new RegExp(
-				`${escapeRegExp(intent)}(?:\\W+\\w+){0,5}\\W+${escapeRegExp(keyword)}`,
-				"iu",
-			);
-			const keywordBefore = new RegExp(
-				`${escapeRegExp(keyword)}(?:\\W+\\w+){0,5}\\W+${escapeRegExp(intent)}`,
-				"iu",
-			);
-			if (intentBefore.test(text) || keywordBefore.test(text)) return true;
-		}
-	}
-
-	return false;
 }
 
 function renderStatusline(
@@ -755,72 +428,4 @@ function shortenModel(model: string): string {
 		.replace(/^gpt-/, "gpt ")
 		.replace(/-20\d{6}$/, "")
 		.replace(/-latest$/, "");
-}
-
-function summarizeConfig(config: StatuslineConfig, changes: string[]): string {
-	const state = config.enabled ? "enabled" : "disabled";
-	const prefix = changes.length > 0 ? `${changes.join("; ")}. ` : "";
-	return `${prefix}pi-statusline ${state}: ${config.preset}/${config.palette}, ${config.density}, segments: ${config.segments.join(", ")}`;
-}
-
-function normalizeSegments(input: unknown, fallback: SegmentName[]): SegmentName[] {
-	if (!Array.isArray(input)) return [...fallback];
-
-	const segments = input.filter(isSegmentName);
-	return segments.length > 0 ? dedupe(segments) : [...fallback];
-}
-
-function appendUnique<T>(items: T[], item: T): T[] {
-	return items.includes(item) ? items : [...items, item];
-}
-
-function dedupe<T>(items: T[]): T[] {
-	return [...new Set(items)];
-}
-
-function hasAny(text: string, needles: string[]): boolean {
-	return needles.some((needle) => text.includes(needle));
-}
-
-function hasStandaloneWord(text: string, word: string): boolean {
-	return new RegExp(`(^|\\W)${escapeRegExp(word)}(\\W|$)`, "iu").test(text);
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function isSegmentName(value: unknown): value is SegmentName {
-	return typeof value === "string" && Object.hasOwn(SEGMENT_KEYWORDS, value);
-}
-
-function isPreset(value: unknown): value is PresetName {
-	return (
-		value === "minimal" ||
-		value === "balanced" ||
-		value === "powerline" ||
-		value === "rainbow" ||
-		value === "focus"
-	);
-}
-
-function isPalette(value: unknown): value is PaletteName {
-	return (
-		value === "ocean" ||
-		value === "sunset" ||
-		value === "forest" ||
-		value === "candy" ||
-		value === "neon" ||
-		value === "mono"
-	);
-}
-
-function isSeparator(value: unknown): value is SeparatorName {
-	return (
-		value === "dot" ||
-		value === "bar" ||
-		value === "powerline" ||
-		value === "round" ||
-		value === "none"
-	);
 }

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -1,0 +1,904 @@
+import { basename } from "node:path";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ReadonlyFooterDataProvider,
+	Theme,
+	ThemeColor,
+} from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+
+type SegmentName =
+	| "brand"
+	| "model"
+	| "thinking"
+	| "branch"
+	| "cwd"
+	| "tools"
+	| "status"
+	| "context"
+	| "tokens"
+	| "cost"
+	| "time"
+	| "turn";
+
+type PresetName = "minimal" | "balanced" | "powerline" | "rainbow" | "focus";
+type PaletteName = "ocean" | "sunset" | "forest" | "candy" | "neon" | "mono";
+type Density = "compact" | "cozy";
+type SeparatorName = "dot" | "bar" | "powerline" | "round" | "none";
+
+type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
+
+interface StatuslineConfig {
+	enabled: boolean;
+	preset: PresetName;
+	palette: PaletteName;
+	density: Density;
+	separator: SeparatorName;
+	showLabels: boolean;
+	segments: SegmentName[];
+}
+
+interface StatuslineEntry {
+	config: StatuslineConfig;
+	request: string;
+	updatedAt: number;
+}
+
+interface RuntimeState {
+	turnCount: number;
+	activeTools: Map<string, number>;
+	lastTool?: string;
+	lastCompletedTool?: string;
+	isStreaming: boolean;
+	thinkingLevel: ThinkingLevel;
+	requestRender?: () => void;
+}
+
+interface CustomizeResult {
+	config: StatuslineConfig;
+	changes: string[];
+}
+
+interface TokenTotals {
+	input: number;
+	output: number;
+	cost: number;
+}
+
+interface RenderSegment {
+	name: SegmentName;
+	text: string;
+	color: ThemeColor;
+	emphasis?: boolean;
+}
+
+const STATUSLINE_KEY = "statusline";
+
+const DEFAULT_SEGMENTS: SegmentName[] = [
+	"brand",
+	"model",
+	"thinking",
+	"branch",
+	"cwd",
+	"tools",
+	"status",
+	"context",
+	"tokens",
+	"cost",
+	"time",
+];
+
+const PRESET_SEGMENTS: Record<PresetName, SegmentName[]> = {
+	minimal: ["brand", "model", "branch", "context"],
+	balanced: DEFAULT_SEGMENTS,
+	powerline: DEFAULT_SEGMENTS,
+	rainbow: DEFAULT_SEGMENTS,
+	focus: ["brand", "cwd", "tools", "status", "context", "time"],
+};
+
+const RIGHT_SEGMENTS = new Set<SegmentName>(["context", "tokens", "cost", "time", "turn"]);
+
+const SEGMENT_KEYWORDS: Record<SegmentName, string[]> = {
+	brand: ["brand", "logo", "pi", "π", "標誌", "品牌"],
+	model: ["model", "ai", "llm", "模型"],
+	thinking: ["thinking", "reasoning", "think", "推理", "思考"],
+	branch: ["branch", "git", "repo", "repository", "分支", "版本"],
+	cwd: ["cwd", "directory", "dir", "folder", "path", "project", "專案", "目錄", "路徑"],
+	tools: ["tool", "tools", "activity", "busy", "工具", "活動"],
+	status: ["extension", "extensions", "goal", "狀態", "擴充"],
+	context: ["context", "usage", "percent", "window", "上下文", "使用率", "百分比"],
+	tokens: ["token", "tokens", "input", "output", "tok", "權杖", "token數"],
+	cost: ["cost", "price", "money", "spend", "usd", "成本", "花費", "費用"],
+	time: ["time", "clock", "date", "時間", "時鐘"],
+	turn: ["turns", "iteration", "輪次", "回合"],
+};
+
+const PALETTES: Record<PaletteName, ThemeColor[]> = {
+	ocean: ["accent", "muted", "success", "warning"],
+	sunset: ["warning", "accent", "success", "muted"],
+	forest: ["success", "accent", "muted", "warning"],
+	candy: ["accent", "warning", "success", "muted"],
+	neon: ["accent", "success", "warning", "error"],
+	mono: ["muted", "dim"],
+};
+
+const STATUSLINE_TOOL_PARAMETERS = Type.Object({
+	request: Type.String({
+		description:
+			"Natural-language statusline request, such as 'make it minimal, hide cost, show git branch and time'.",
+	}),
+});
+
+export default function statusline(pi: ExtensionAPI) {
+	let config = createDefaultConfig();
+	const runtime: RuntimeState = {
+		turnCount: 0,
+		activeTools: new Map(),
+		isStreaming: false,
+		thinkingLevel: "off",
+	};
+
+	const persistConfig = (request: string) => {
+		pi.appendEntry(STATUSLINE_KEY, {
+			config,
+			request,
+			updatedAt: Date.now(),
+		} satisfies StatuslineEntry);
+	};
+
+	const refresh = () => runtime.requestRender?.();
+
+	const installFooter = (ctx: ExtensionContext) => {
+		if (!config.enabled) {
+			ctx.ui.setFooter(undefined);
+			ctx.ui.setStatus(STATUSLINE_KEY, undefined);
+			runtime.requestRender = undefined;
+			return;
+		}
+
+		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
+		ctx.ui.setFooter((tui, theme, footerData) => {
+			runtime.requestRender = () => tui.requestRender();
+
+			const branchUnsubscribe = footerData.onBranchChange(() => tui.requestRender());
+			const clock = setInterval(() => tui.requestRender(), 30_000);
+
+			return {
+				dispose() {
+					branchUnsubscribe();
+					clearInterval(clock);
+				},
+				invalidate() {},
+				render(width: number): string[] {
+					return [renderStatusline(width, ctx, footerData, theme, config, runtime)];
+				},
+			};
+		});
+	};
+
+	const applyRequest = (request: string, ctx: ExtensionContext): CustomizeResult => {
+		const result = applyNaturalLanguageRequest(request, config);
+		config = result.config;
+		persistConfig(request);
+		installFooter(ctx);
+		refresh();
+		return result;
+	};
+
+	pi.registerTool({
+		name: "statusline_customize",
+		label: "Statusline Customize",
+		description:
+			"Customize Pi's footer/statusline from a natural-language request. Use when the user asks to change the statusline, footer, shown segments, colors, density, or style.",
+		promptSnippet: "Customize the Pi footer/statusline from natural-language requests",
+		promptGuidelines: [
+			"Use statusline_customize when the user asks to customize the statusline/footer appearance or visible footer segments.",
+			"Pass the user's natural-language request verbatim when possible so pi-statusline can parse style, palette, and segment preferences.",
+		],
+		parameters: STATUSLINE_TOOL_PARAMETERS,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const result = applyRequest(params.request, ctx);
+			const summary = summarizeConfig(result.config, result.changes);
+			if (ctx.hasUI) ctx.ui.notify(summary, "info");
+
+			return {
+				content: [{ type: "text", text: summary }],
+				details: {
+					request: params.request,
+					config: result.config,
+					changes: result.changes,
+				},
+			};
+		},
+	});
+
+	pi.on("input", (event, ctx) => {
+		if (event.source === "extension") return;
+
+		const request = getDirectStatuslineRequest(event.text);
+		if (!request) return;
+
+		if (isStatuslineShowRequest(request)) {
+			ctx.ui.notify(summarizeConfig(config, []), "info");
+			return { action: "handled" as const };
+		}
+
+		const result = applyRequest(request, ctx);
+		ctx.ui.notify(summarizeConfig(result.config, result.changes), "info");
+		return { action: "handled" as const };
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		config = readPersistedConfig(ctx) ?? config;
+		runtime.thinkingLevel = pi.getThinkingLevel();
+		installFooter(ctx);
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		config = readPersistedConfig(ctx) ?? createDefaultConfig();
+		installFooter(ctx);
+		refresh();
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setFooter(undefined);
+		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
+		runtime.requestRender = undefined;
+	});
+
+	pi.on("model_select", () => refresh());
+
+	pi.on("thinking_level_select", (event) => {
+		runtime.thinkingLevel = event.level;
+		refresh();
+	});
+
+	pi.on("agent_start", () => {
+		runtime.isStreaming = true;
+		refresh();
+	});
+
+	pi.on("agent_end", () => {
+		runtime.isStreaming = false;
+		refresh();
+	});
+
+	pi.on("turn_start", () => {
+		runtime.turnCount += 1;
+		runtime.isStreaming = true;
+		refresh();
+	});
+
+	pi.on("turn_end", () => refresh());
+
+	pi.on("tool_execution_start", (event) => {
+		const currentCount = runtime.activeTools.get(event.toolName) ?? 0;
+		runtime.activeTools.set(event.toolName, currentCount + 1);
+		runtime.lastTool = event.toolName;
+		refresh();
+	});
+
+	pi.on("tool_execution_end", (event) => {
+		const currentCount = runtime.activeTools.get(event.toolName) ?? 0;
+		if (currentCount <= 1) runtime.activeTools.delete(event.toolName);
+		else runtime.activeTools.set(event.toolName, currentCount - 1);
+
+		runtime.lastCompletedTool = event.toolName;
+		refresh();
+	});
+}
+
+function createDefaultConfig(): StatuslineConfig {
+	return {
+		enabled: true,
+		preset: "powerline",
+		palette: "candy",
+		density: "compact",
+		separator: "powerline",
+		showLabels: false,
+		segments: [...DEFAULT_SEGMENTS],
+	};
+}
+
+function readPersistedConfig(ctx: ExtensionContext): StatuslineConfig | undefined {
+	let latest: StatuslineConfig | undefined;
+
+	for (const entry of ctx.sessionManager.getBranch()) {
+		if (entry.type !== "custom" || entry.customType !== STATUSLINE_KEY) continue;
+
+		const data = entry.data as Partial<StatuslineEntry> | undefined;
+		const config = normalizeConfig(data?.config);
+		if (config) latest = config;
+	}
+
+	return latest;
+}
+
+function normalizeConfig(value: unknown): StatuslineConfig | undefined {
+	if (!value || typeof value !== "object") return undefined;
+
+	const input = value as Partial<StatuslineConfig>;
+	const fallback = createDefaultConfig();
+
+	return {
+		enabled: typeof input.enabled === "boolean" ? input.enabled : fallback.enabled,
+		preset: isPreset(input.preset) ? input.preset : fallback.preset,
+		palette: isPalette(input.palette) ? input.palette : fallback.palette,
+		density:
+			input.density === "cozy" || input.density === "compact" ? input.density : fallback.density,
+		separator: isSeparator(input.separator) ? input.separator : fallback.separator,
+		showLabels: typeof input.showLabels === "boolean" ? input.showLabels : fallback.showLabels,
+		segments: normalizeSegments(input.segments, fallback.segments),
+	};
+}
+
+function applyNaturalLanguageRequest(
+	request: string,
+	currentConfig: StatuslineConfig,
+): CustomizeResult {
+	const text = request.trim();
+	const lower = text.toLowerCase();
+	let next: StatuslineConfig = {
+		...currentConfig,
+		segments: [...currentConfig.segments],
+	};
+	const changes: string[] = [];
+
+	if (hasAny(lower, ["reset", "default", "factory", "重設", "預設", "恢復預設"])) {
+		next = createDefaultConfig();
+		changes.push("reset to the balanced default");
+	}
+
+	if (
+		hasAny(lower, ["disable", "turn off", "restore pi footer", "關閉", "停用"]) ||
+		hasStandaloneWord(lower, "off")
+	) {
+		next.enabled = false;
+		changes.push("disabled custom statusline");
+	}
+
+	if (hasAny(lower, ["enable", "turn on", "啟用", "開啟"]) || hasStandaloneWord(lower, "on")) {
+		next.enabled = true;
+		changes.push("enabled custom statusline");
+	}
+
+	const preset = detectPreset(lower);
+	if (preset) {
+		next.preset = preset;
+		next.segments = [...PRESET_SEGMENTS[preset]];
+		changes.push(`preset: ${preset}`);
+	}
+
+	const palette = detectPalette(lower);
+	if (palette) {
+		next.palette = palette;
+		changes.push(`palette: ${palette}`);
+	}
+
+	const separator = detectSeparator(lower, next.separator);
+	if (separator !== next.separator) {
+		next.separator = separator;
+		changes.push(`separator: ${separator}`);
+	}
+
+	if (hasAny(lower, ["compact", "dense", "short", "精簡", "緊湊"])) {
+		next.density = "compact";
+		changes.push("density: compact");
+	}
+
+	if (hasAny(lower, ["cozy", "spacious", "roomy", "with labels", "labeled", "詳細", "寬鬆"])) {
+		next.density = "cozy";
+		next.showLabels = true;
+		changes.push("density: cozy");
+	}
+
+	if (hasAny(lower, ["no labels", "hide labels", "without labels", "無標籤", "隱藏標籤"])) {
+		next.showLabels = false;
+		changes.push("labels hidden");
+	} else if (hasAny(lower, ["labels", "show labels", "with labels", "顯示標籤", "標籤"])) {
+		next.showLabels = true;
+		changes.push("labels shown");
+	}
+
+	const mentionedSegments = getMentionedSegments(lower);
+	if (hasAny(lower, ["only", "just", "僅", "只顯示", "只有"]) && mentionedSegments.length > 0) {
+		next.segments = mentionedSegments.includes("brand")
+			? mentionedSegments
+			: ["brand", ...mentionedSegments];
+		changes.push(`showing only: ${next.segments.join(", ")}`);
+	} else {
+		for (const segment of mentionedSegments) {
+			if (hasHideIntentForSegment(lower, segment)) {
+				next.segments = next.segments.filter((item) => item !== segment);
+				changes.push(`hidden: ${segment}`);
+				continue;
+			}
+
+			if (hasShowIntentForSegment(lower, segment) || !hasAny(lower, HIDE_WORDS)) {
+				next.segments = appendUnique(next.segments, segment);
+				changes.push(`shown: ${segment}`);
+			}
+		}
+	}
+
+	next.segments = normalizeSegments(next.segments, createDefaultConfig().segments);
+	return { config: next, changes: dedupe(changes) };
+}
+
+const SHOW_WORDS = ["show", "add", "include", "with", "display", "顯示", "加入", "包含"];
+const HIDE_WORDS = ["hide", "remove", "without", "no ", "omit", "隱藏", "移除", "不要", "沒有"];
+const STATUSLINE_NOUNS = [
+	"statusline",
+	"status line",
+	"status bar",
+	"footer",
+	"bottom bar",
+	"狀態列",
+	"狀態欄",
+	"底部列",
+	"頁尾",
+];
+const STATUSLINE_ACTIONS = [
+	"make",
+	"set",
+	"change",
+	"customize",
+	"customise",
+	"style",
+	"show",
+	"hide",
+	"add",
+	"remove",
+	"enable",
+	"disable",
+	"turn on",
+	"turn off",
+	"reset",
+	"beautiful",
+	"pretty",
+	"minimal",
+	"compact",
+	"rainbow",
+	"powerline",
+	"改",
+	"設定",
+	"美化",
+	"顯示",
+	"隱藏",
+	"加入",
+	"移除",
+	"啟用",
+	"停用",
+	"開啟",
+	"關閉",
+	"重設",
+	"漂亮",
+	"極簡",
+];
+const STATUSLINE_QUESTION_WORDS = [
+	"how do",
+	"how to",
+	"what is",
+	"why",
+	"explain",
+	"document",
+	"docs",
+	"如何",
+	"什麼是",
+	"解釋",
+	"文件",
+];
+
+function getDirectStatuslineRequest(text: string): string | undefined {
+	const request = text.trim();
+	if (!request || request.startsWith("/")) return undefined;
+
+	const lower = request.toLowerCase();
+	if (!hasAny(lower, STATUSLINE_NOUNS)) return undefined;
+	if (hasAny(lower, STATUSLINE_QUESTION_WORDS)) return undefined;
+	if (!hasStatuslineAction(lower) && getMentionedSegments(lower).length === 0) return undefined;
+
+	return request;
+}
+
+function hasStatuslineAction(text: string): boolean {
+	return (
+		hasAny(text, STATUSLINE_ACTIONS) ||
+		hasStandaloneWord(text, "on") ||
+		hasStandaloneWord(text, "off")
+	);
+}
+
+function isStatuslineShowRequest(request: string): boolean {
+	const lower = request.toLowerCase().trim();
+	if (!hasAny(lower, STATUSLINE_NOUNS)) return false;
+	if (hasAny(lower, ["config", "configuration", "current", "目前", "現在", "設定值"])) {
+		return true;
+	}
+	return /^(show|display)\s+(the\s+)?(statusline|status line|footer)(\s+status)?$/i.test(lower);
+}
+
+function detectPreset(text: string): PresetName | undefined {
+	if (hasAny(text, ["minimal", "simple", "clean", "zen", "極簡", "簡潔"])) return "minimal";
+	if (hasAny(text, ["focus", "focused", "work mode", "專注"])) return "focus";
+	if (hasAny(text, ["rainbow", "colorful", "colourful", "彩虹", "多彩"])) return "rainbow";
+	if (
+		hasAny(text, ["powerline", "fancy", "beautiful", "pretty", "gorgeous", "漂亮", "美化", "華麗"])
+	) {
+		return "powerline";
+	}
+	if (hasAny(text, ["balanced", "classic", "normal", "完整", "平衡"])) return "balanced";
+	return undefined;
+}
+
+function detectPalette(text: string): PaletteName | undefined {
+	if (hasAny(text, ["mono", "monochrome", "gray", "grey", "no color", "plain", "黑白", "單色"])) {
+		return "mono";
+	}
+	if (hasAny(text, ["ocean", "blue", "cyan", "sea", "藍", "海洋"])) return "ocean";
+	if (hasAny(text, ["sunset", "orange", "amber", "warm", "夕陽", "橘", "暖色"])) return "sunset";
+	if (hasAny(text, ["forest", "green", "nature", "綠", "森林"])) return "forest";
+	if (hasAny(text, ["neon", "cyber", "terminal", "matrix", "霓虹", "賽博"])) return "neon";
+	if (hasAny(text, ["candy", "pink", "purple", "magenta", "粉", "紫", "糖果"])) return "candy";
+	return undefined;
+}
+
+function detectSeparator(text: string, fallback: SeparatorName): SeparatorName {
+	if (hasAny(text, ["powerline", "nerd font", "nerdfont"])) return "powerline";
+	if (hasAny(text, ["dot", "dots", "bullet", "圓點"])) return "dot";
+	if (hasAny(text, ["bar", "pipe", "vertical", "直線", "分隔線"])) return "bar";
+	if (hasAny(text, ["round", "rounded", "soft", "圓角"])) return "round";
+	if (hasAny(text, ["none", "no separator", "plain", "不要分隔"])) return "none";
+	return fallback;
+}
+
+function getMentionedSegments(text: string): SegmentName[] {
+	const segments: SegmentName[] = [];
+	for (const [segment, keywords] of Object.entries(SEGMENT_KEYWORDS) as [SegmentName, string[]][]) {
+		if (hasAny(text, keywords)) segments.push(segment);
+	}
+	return segments;
+}
+
+function hasShowIntentForSegment(text: string, segment: SegmentName): boolean {
+	return hasIntentForSegment(text, SHOW_WORDS, SEGMENT_KEYWORDS[segment]);
+}
+
+function hasHideIntentForSegment(text: string, segment: SegmentName): boolean {
+	return hasIntentForSegment(text, HIDE_WORDS, SEGMENT_KEYWORDS[segment]);
+}
+
+function hasIntentForSegment(text: string, intents: string[], keywords: string[]): boolean {
+	for (const intent of intents) {
+		for (const keyword of keywords) {
+			if (!text.includes(intent) || !text.includes(keyword)) continue;
+			if (intent.length === 1 || keyword.length === 1) return true;
+
+			const intentBefore = new RegExp(
+				`${escapeRegExp(intent)}(?:\\W+\\w+){0,5}\\W+${escapeRegExp(keyword)}`,
+				"iu",
+			);
+			const keywordBefore = new RegExp(
+				`${escapeRegExp(keyword)}(?:\\W+\\w+){0,5}\\W+${escapeRegExp(intent)}`,
+				"iu",
+			);
+			if (intentBefore.test(text) || keywordBefore.test(text)) return true;
+		}
+	}
+
+	return false;
+}
+
+function renderStatusline(
+	width: number,
+	ctx: ExtensionContext,
+	footerData: ReadonlyFooterDataProvider,
+	theme: Theme,
+	config: StatuslineConfig,
+	runtime: RuntimeState,
+): string {
+	if (width <= 0) return "";
+
+	const segments = config.segments
+		.map((segment, index) => buildSegment(segment, index, ctx, footerData, theme, config, runtime))
+		.filter(
+			(segment): segment is RenderSegment => segment !== undefined && segment.text.length > 0,
+		);
+
+	const left = joinSegments(
+		segments.filter((segment) => !RIGHT_SEGMENTS.has(segment.name)),
+		theme,
+		config,
+	);
+	const right = joinSegments(
+		segments.filter((segment) => RIGHT_SEGMENTS.has(segment.name)),
+		theme,
+		config,
+	);
+
+	if (!left && !right) return truncateToWidth(theme.fg("dim", "pi-statusline"), width);
+	if (!right) return truncateToWidth(left, width);
+	if (!left) return truncateToWidth(right, width);
+
+	const rightWidth = visibleWidth(right);
+	if (rightWidth + 1 >= width) return truncateToWidth(right, width);
+
+	const leftWidth = Math.max(0, width - rightWidth - 1);
+	const trimmedLeft = truncateToWidth(left, leftWidth, "…");
+	const padding = " ".repeat(Math.max(1, width - visibleWidth(trimmedLeft) - rightWidth));
+
+	return truncateToWidth(`${trimmedLeft}${padding}${right}`, width, "");
+}
+
+function buildSegment(
+	name: SegmentName,
+	index: number,
+	ctx: ExtensionContext,
+	footerData: ReadonlyFooterDataProvider,
+	theme: Theme,
+	config: StatuslineConfig,
+	runtime: RuntimeState,
+): RenderSegment | undefined {
+	const color = pickColor(config, index);
+
+	switch (name) {
+		case "brand":
+			return { name, text: "π", color: "accent", emphasis: true };
+		case "model":
+			return labeled(name, shortenModel(ctx.model?.id ?? "no-model"), color, config);
+		case "thinking":
+			return labeled(name, runtime.thinkingLevel, thinkingColor(runtime.thinkingLevel), config);
+		case "branch":
+			return labeled(name, footerData.getGitBranch() ?? "no-git", color, config);
+		case "cwd":
+			return labeled(name, basename(ctx.cwd) || ctx.cwd, color, config);
+		case "tools":
+			return labeled(name, formatToolActivity(runtime), color, config);
+		case "status": {
+			const status = formatExtensionStatuses(footerData.getExtensionStatuses(), theme);
+			return status ? labeled(name, status, color, config) : undefined;
+		}
+		case "context": {
+			const usage = ctx.getContextUsage();
+			const value =
+				usage?.percent === null || usage?.percent === undefined
+					? "ctx ?"
+					: `ctx ${usage.percent.toFixed(0)}%`;
+			return labeled(name, value, contextColor(usage?.percent), config);
+		}
+		case "tokens": {
+			const totals = getTokenTotals(ctx);
+			if (totals.input === 0 && totals.output === 0) return labeled(name, "tok 0", color, config);
+			return labeled(
+				name,
+				`↑${formatCount(totals.input)} ↓${formatCount(totals.output)}`,
+				color,
+				config,
+			);
+		}
+		case "cost": {
+			const totals = getTokenTotals(ctx);
+			return labeled(name, `$${totals.cost.toFixed(totals.cost >= 1 ? 2 : 3)}`, color, config);
+		}
+		case "time":
+			return labeled(name, formatTime(), color, config);
+		case "turn":
+			return labeled(name, `#${runtime.turnCount}`, color, config);
+	}
+}
+
+function labeled(
+	name: SegmentName,
+	value: string,
+	color: ThemeColor,
+	config: StatuslineConfig,
+): RenderSegment {
+	if (!config.showLabels || name === "brand") return { name, text: value, color };
+	return { name, text: `${name} ${value}`, color };
+}
+
+function joinSegments(segments: RenderSegment[], theme: Theme, config: StatuslineConfig): string {
+	const separator = separatorText(config.separator);
+	return segments
+		.map((segment, index) => styleSegment(segment, index, theme, config))
+		.join(theme.fg("dim", separator));
+}
+
+function styleSegment(
+	segment: RenderSegment,
+	index: number,
+	theme: Theme,
+	config: StatuslineConfig,
+): string {
+	const padding = config.density === "cozy" ? " " : "";
+	const text = `${padding}${segment.text}${padding}`;
+	const styledText = segment.emphasis ? theme.bold(text) : text;
+
+	if (config.palette === "mono") {
+		return index === 0 ? theme.fg("muted", styledText) : theme.fg("dim", styledText);
+	}
+
+	return theme.fg(segment.color, styledText);
+}
+
+function separatorText(separator: SeparatorName): string {
+	switch (separator) {
+		case "powerline":
+			return "  ";
+		case "bar":
+			return " │ ";
+		case "round":
+			return " ❯ ";
+		case "none":
+			return " ";
+		case "dot":
+			return " • ";
+	}
+}
+
+function pickColor(config: StatuslineConfig, index: number): ThemeColor {
+	const palette = PALETTES[config.palette];
+	return palette[index % palette.length] ?? "muted";
+}
+
+function thinkingColor(level: ThinkingLevel): ThemeColor {
+	switch (level) {
+		case "off":
+			return "dim";
+		case "minimal":
+			return "thinkingMinimal";
+		case "low":
+			return "thinkingLow";
+		case "medium":
+			return "thinkingMedium";
+		case "high":
+			return "thinkingHigh";
+		case "xhigh":
+			return "thinkingXhigh";
+	}
+}
+
+function contextColor(percent: number | null | undefined): ThemeColor {
+	if (percent === null || percent === undefined) return "dim";
+	if (percent >= 90) return "error";
+	if (percent >= 70) return "warning";
+	return "success";
+}
+
+function formatToolActivity(runtime: RuntimeState): string {
+	const active = [...runtime.activeTools.entries()];
+	if (active.length > 0) {
+		const [name, count] = active[0] ?? ["tool", 1];
+		const suffix = count > 1 ? `×${count}` : active.length > 1 ? `+${active.length - 1}` : "";
+		return `⚙ ${name}${suffix}`;
+	}
+
+	if (runtime.isStreaming) return "thinking";
+	if (runtime.lastCompletedTool) return `✓ ${runtime.lastCompletedTool}`;
+	return "idle";
+}
+
+function formatExtensionStatuses(statuses: ReadonlyMap<string, string>, theme: Theme): string {
+	const visibleStatuses = [...statuses.entries()]
+		.filter(([key, value]) => key !== STATUSLINE_KEY && value.trim().length > 0)
+		.slice(0, 2)
+		.map(([key, value]) => {
+			if (visibleWidth(value) <= 28) return value;
+			return `${theme.fg("dim", `${key}:`)} ${truncateToWidth(value, 24)}`;
+		});
+
+	return visibleStatuses.join(" ");
+}
+
+function getTokenTotals(ctx: ExtensionContext): TokenTotals {
+	const totals: TokenTotals = { input: 0, output: 0, cost: 0 };
+
+	for (const entry of ctx.sessionManager.getBranch()) {
+		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+
+		const usage = entry.message.usage as
+			| {
+					input?: number;
+					output?: number;
+					cost?: { total?: number };
+			  }
+			| undefined;
+
+		totals.input += usage?.input ?? 0;
+		totals.output += usage?.output ?? 0;
+		totals.cost += usage?.cost?.total ?? 0;
+	}
+
+	return totals;
+}
+
+function formatCount(value: number): string {
+	if (value < 1000) return `${value}`;
+	if (value < 1_000_000) return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}k`;
+	return `${(value / 1_000_000).toFixed(1)}m`;
+}
+
+function formatTime(): string {
+	const now = new Date();
+	const hours = now.getHours().toString().padStart(2, "0");
+	const minutes = now.getMinutes().toString().padStart(2, "0");
+	return `${hours}:${minutes}`;
+}
+
+function shortenModel(model: string): string {
+	return model
+		.replace(/^claude-/, "")
+		.replace(/^gpt-/, "gpt ")
+		.replace(/-20\d{6}$/, "")
+		.replace(/-latest$/, "");
+}
+
+function summarizeConfig(config: StatuslineConfig, changes: string[]): string {
+	const state = config.enabled ? "enabled" : "disabled";
+	const prefix = changes.length > 0 ? `${changes.join("; ")}. ` : "";
+	return `${prefix}pi-statusline ${state}: ${config.preset}/${config.palette}, ${config.density}, segments: ${config.segments.join(", ")}`;
+}
+
+function normalizeSegments(input: unknown, fallback: SegmentName[]): SegmentName[] {
+	if (!Array.isArray(input)) return [...fallback];
+
+	const segments = input.filter(isSegmentName);
+	return segments.length > 0 ? dedupe(segments) : [...fallback];
+}
+
+function appendUnique<T>(items: T[], item: T): T[] {
+	return items.includes(item) ? items : [...items, item];
+}
+
+function dedupe<T>(items: T[]): T[] {
+	return [...new Set(items)];
+}
+
+function hasAny(text: string, needles: string[]): boolean {
+	return needles.some((needle) => text.includes(needle));
+}
+
+function hasStandaloneWord(text: string, word: string): boolean {
+	return new RegExp(`(^|\\W)${escapeRegExp(word)}(\\W|$)`, "iu").test(text);
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isSegmentName(value: unknown): value is SegmentName {
+	return typeof value === "string" && Object.hasOwn(SEGMENT_KEYWORDS, value);
+}
+
+function isPreset(value: unknown): value is PresetName {
+	return (
+		value === "minimal" ||
+		value === "balanced" ||
+		value === "powerline" ||
+		value === "rainbow" ||
+		value === "focus"
+	);
+}
+
+function isPalette(value: unknown): value is PaletteName {
+	return (
+		value === "ocean" ||
+		value === "sunset" ||
+		value === "forest" ||
+		value === "candy" ||
+		value === "neon" ||
+		value === "mono"
+	);
+}
+
+function isSeparator(value: unknown): value is SeparatorName {
+	return (
+		value === "dot" ||
+		value === "bar" ||
+		value === "powerline" ||
+		value === "round" ||
+		value === "none"
+	);
+}

--- a/extensions/pi-statusline/tsconfig.json
+++ b/extensions/pi-statusline/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ firecrawl := "@narumitw/pi-firecrawl"
 goal := "@narumitw/pi-goal"
 python_lsp := "@narumitw/pi-python-lsp"
 retry := "@narumitw/pi-retry"
+statusline := "@narumitw/pi-statusline"
 
 # Show available commands
 default:
@@ -45,6 +46,7 @@ doctor-all:
     just doctor {{goal}}
     just doctor {{python_lsp}}
     just doctor {{retry}}
+    just doctor {{statusline}}
 
 # Make a scoped npm package public after publish if npm registry returns 404
 # Usage: just npm-public @narumitw/pi-goal 123456
@@ -76,6 +78,10 @@ pack-python-lsp:
 pack-retry:
     npm run pack:retry
 
+# Preview the statusline package that npm would publish
+pack-statusline:
+    npm run pack:statusline
+
 # Try caffeinate from this working tree as a temporary pi package
 try-caffeinate:
     pi -e ./extensions/pi-caffeinate
@@ -100,6 +106,10 @@ try-python-lsp:
 try-retry:
     pi -e ./extensions/pi-retry
 
+# Try statusline from this working tree as a temporary pi package
+try-statusline:
+    pi -e ./extensions/pi-statusline
+
 # Install caffeinate through pi, falling back to the local workspace if unpublished
 install-caffeinate:
     if npm view {{caffeinate}} version >/dev/null 2>&1; then pi install npm:{{caffeinate}}; else echo "{{caffeinate}} is not published; installing local workspace package instead."; pi install ./extensions/pi-caffeinate; fi
@@ -123,6 +133,10 @@ install-python-lsp:
 # Install the published retry package through pi
 install-retry:
     pi install npm:{{retry}}
+
+# Install statusline through pi, falling back to the local workspace if unpublished
+install-statusline:
+    if npm view {{statusline}} version >/dev/null 2>&1; then pi install npm:{{statusline}}; else echo "{{statusline}} is not published; installing local workspace package instead."; pi install ./extensions/pi-statusline; fi
 
 # Publish caffeinate to npm, skipping if the current version already exists
 # Usage with 2FA: just publish-caffeinate 123456
@@ -154,6 +168,11 @@ publish-python-lsp otp="":
 publish-retry otp="":
     version="$(node -p "require('./extensions/pi-retry/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{retry}}@"$version" version >/dev/null 2>&1; then echo "{{retry}}@$version already exists; skipping publish."; else npm --workspace {{retry}} pack --dry-run; npm --workspace {{retry}} publish --access public $otp_arg; fi
 
+# Publish statusline to npm, skipping if the current version already exists
+# Usage with 2FA: just publish-statusline 123456
+publish-statusline otp="":
+    version="$(node -p "require('./extensions/pi-statusline/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{statusline}}@"$version" version >/dev/null 2>&1; then echo "{{statusline}}@$version already exists; skipping publish."; else npm --workspace {{statusline}} pack --dry-run; npm --workspace {{statusline}} publish --access public $otp_arg; fi
+
 # Publish all extension packages to npm
 # Usage with 2FA: just publish-all 123456
 publish-all otp="":
@@ -163,6 +182,7 @@ publish-all otp="":
     just publish-goal {{otp}}
     just publish-python-lsp {{otp}}
     just publish-retry {{otp}}
+    just publish-statusline {{otp}}
 
 # Install all published extension packages through pi
 install-all:
@@ -172,6 +192,7 @@ install-all:
     just install-goal
     just install-python-lsp
     just install-retry
+    just install-statusline
 
 # Bump one workspace package without creating a git tag
 # Usage: just bump @narumitw/pi-goal patch

--- a/package-lock.json
+++ b/package-lock.json
@@ -706,6 +706,124 @@
 				"koffi": "^2.9.0"
 			}
 		},
+		"extensions/pi-statusline": {
+			"name": "@narumitw/pi-statusline",
+			"version": "0.1.3",
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "^1.1.37"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"@mariozechner/pi-tui": "0.73.0",
+				"@types/node": "25.6.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-statusline/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-statusline/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-statusline/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-statusline/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.0.tgz",
+			"integrity": "sha512-St1W+tMPKHatfK+lblsKfL+SsFyFVMK2tW6xHpBfCiMuevbOCRo/CMatso7mu1642UO04ncmfCrrpUK5L9aoog==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
@@ -2086,6 +2204,10 @@
 		},
 		"node_modules/@narumitw/pi-retry": {
 			"resolved": "extensions/pi-retry",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-statusline": {
+			"resolved": "extensions/pi-statusline",
 			"link": true
 		},
 		"node_modules/@nodable/entities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,9 +710,6 @@
 			"name": "@narumitw/pi-statusline",
 			"version": "0.1.3",
 			"license": "MIT",
-			"dependencies": {
-				"typebox": "^1.1.37"
-			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.14",
 				"@mariozechner/pi-coding-agent": "0.73.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
 		"pack:python-lsp": "npm --workspace @narumitw/pi-python-lsp pack --dry-run",
-		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run"
+		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run",
+		"pack:statusline": "npm --workspace @narumitw/pi-statusline pack --dry-run"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.14",


### PR DESCRIPTION
## Summary
- add the @narumitw/pi-statusline package with a custom display-only footer renderer
- show other extension statuses on their own line below the main statusline, simplified and separated with 
- remove prompt interception, natural-language customization tools, and customization slash commands from pi-statusline
- wire statusline workspace scripts, just recipes, README, and agent guidance
- defer runtime-only statusline state reads until session startup so the extension loads under Pi 0.74

## Testing
- npm run check
- just pack-statusline
- pi --no-extensions -e ./extensions/pi-statusline --list-models sonnet
- node --input-type=module smoke test confirming no registered tools, commands, or input interception