### PR TITLE
feat: add pi-btw extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Monorepo for independently installable Pi extension packages.
 
 | Package | Source | Install |
 | --- | --- | --- |
+| `@narumitw/pi-btw` | [`extensions/pi-btw`](./extensions/pi-btw) | `pi install npm:@narumitw/pi-btw` |
 | `@narumitw/pi-caffeinate` | [`extensions/pi-caffeinate`](./extensions/pi-caffeinate) | `pi install npm:@narumitw/pi-caffeinate` |
 | `@narumitw/pi-chrome-devtools` | [`extensions/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | `pi install npm:@narumitw/pi-chrome-devtools` |
 | `@narumitw/pi-firecrawl` | [`extensions/pi-firecrawl`](./extensions/pi-firecrawl) | `pi install npm:@narumitw/pi-firecrawl` |
@@ -25,6 +26,7 @@ npm run check
 Try a package locally:
 
 ```bash
+pi -e ./extensions/pi-btw
 pi -e ./extensions/pi-caffeinate
 pi -e ./extensions/pi-chrome-devtools
 pi -e ./extensions/pi-firecrawl
@@ -37,6 +39,7 @@ pi -e ./extensions/pi-statusline
 Preview package contents:
 
 ```bash
+npm run pack:btw
 npm run pack:caffeinate
 npm run pack:chrome-devtools
 npm run pack:firecrawl
@@ -49,6 +52,7 @@ npm run pack:statusline
 Publish packages from their package directories:
 
 ```bash
+cd extensions/pi-btw && npm publish --access public
 cd extensions/pi-caffeinate && npm publish --access public
 cd extensions/pi-chrome-devtools && npm publish --access public
 cd extensions/pi-firecrawl && npm publish --access public

--- a/extensions/pi-btw/LICENSE
+++ b/extensions/pi-btw/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-btw/README.md
+++ b/extensions/pi-btw/README.md
@@ -1,0 +1,51 @@
+# pi-btw
+
+A public [pi](https://pi.dev) extension package that adds `/btw`, a side-question command for asking quick questions without interrupting the main conversation.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-btw
+```
+
+Try without installing:
+
+```bash
+pi -e npm:@narumitw/pi-btw
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-btw
+```
+
+## Usage
+
+```text
+/btw <your side question>
+```
+
+The command answers the question in a temporary UI using the current session branch as context, but it does not append the side question or answer to the main conversation.
+
+## Package layout
+
+```txt
+extensions/pi-btw/
+├── src/
+│   └── btw.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/btw.ts"]
+  }
+}
+```

--- a/extensions/pi-btw/package.json
+++ b/extensions/pi-btw/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@narumitw/pi-btw",
+	"version": "0.1.4",
+	"description": "Pi extension that adds a /btw side-question command.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"btw",
+		"side-question"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/btw.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-ai": "0.73.0",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"@mariozechner/pi-tui": "0.73.0",
+		"typescript": "6.0.3"
+	}
+}

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -1,0 +1,220 @@
+import { complete, type UserMessage } from "@mariozechner/pi-ai";
+import {
+	BorderedLoader,
+	DynamicBorder,
+	getMarkdownTheme,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+import { Container, Markdown, matchesKey, Text } from "@mariozechner/pi-tui";
+
+const MAX_CONTEXT_CHARS = 40_000;
+const SYSTEM_PROMPT = `You answer quick side questions for a coding-agent user.
+
+Use the provided conversation context only as background. Answer the user's side question directly and concisely. Do not claim to have changed files, run tools, or affected the main task. If the context is insufficient, say what is unknown and give the best next step.`;
+
+type MessageContentBlock = {
+	type?: string;
+	text?: string;
+	name?: string;
+	arguments?: unknown;
+	result?: unknown;
+};
+
+type SessionMessage = {
+	role?: string;
+	content?: unknown;
+	stopReason?: string;
+};
+
+type SessionEntry = {
+	type: string;
+	message?: SessionMessage;
+};
+
+export default function btw(pi: ExtensionAPI) {
+	pi.registerCommand("btw", {
+		description: "Ask a quick side question without adding it to the main conversation",
+		handler: async (args, ctx) => {
+			const question = args.trim();
+			if (!question) {
+				ctx.ui.notify("Usage: /btw <your side question>", "warning");
+				return;
+			}
+
+			if (!ctx.hasUI) {
+				ctx.ui.notify("/btw requires interactive mode", "error");
+				return;
+			}
+
+			if (!ctx.model) {
+				ctx.ui.notify("No model selected", "error");
+				return;
+			}
+
+			const answer = await askSideQuestion(question, ctx);
+			if (answer === undefined) {
+				ctx.ui.notify("Cancelled", "info");
+				return;
+			}
+
+			await showAnswer(question, answer, ctx);
+		},
+	});
+}
+
+async function askSideQuestion(
+	question: string,
+	ctx: ExtensionCommandContext,
+): Promise<string | undefined> {
+	return ctx.ui.custom<string | undefined>((tui, theme, _keybindings, done) => {
+		const loader = new BorderedLoader(tui, theme, `Answering /btw with ${ctx.model!.id}...`);
+		loader.onAbort = () => done(undefined);
+
+		const ask = async () => {
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model!);
+			if (!auth.ok || !auth.apiKey) {
+				throw new Error(auth.ok ? `No API key for ${ctx.model!.provider}` : auth.error);
+			}
+
+			const conversationContext = buildConversationContext(ctx.sessionManager.getBranch());
+			const userMessage: UserMessage = {
+				role: "user",
+				content: [
+					{
+						type: "text",
+						text: buildUserPrompt(question, conversationContext),
+					},
+				],
+				timestamp: Date.now(),
+			};
+
+			const response = await complete(
+				ctx.model!,
+				{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
+				{ apiKey: auth.apiKey, headers: auth.headers, signal: loader.signal },
+			);
+
+			if (response.stopReason === "aborted") {
+				return undefined;
+			}
+
+			const text = response.content
+				.filter((content): content is { type: "text"; text: string } => content.type === "text")
+				.map((content) => content.text)
+				.join("\n")
+				.trim();
+
+			return text || "No response received.";
+		};
+
+		ask()
+			.then(done)
+			.catch((error: unknown) => {
+				const message = error instanceof Error ? error.message : String(error);
+				done(`Error: ${message}`);
+			});
+
+		return loader;
+	});
+}
+
+async function showAnswer(question: string, answer: string, ctx: ExtensionCommandContext) {
+	await ctx.ui.custom((_tui, theme, _keybindings, done) => {
+		const container = new Container();
+		const border = new DynamicBorder((text: string) => theme.fg("warning", text));
+		const markdownTheme = getMarkdownTheme();
+
+		container.addChild(border);
+		container.addChild(new Text(theme.fg("warning", theme.bold(`/btw ${question}`)), 1, 0));
+		container.addChild(new Markdown(answer, 1, 1, markdownTheme));
+		container.addChild(new Text(theme.fg("dim", "Press Enter, Space, or Esc to close"), 1, 1));
+		container.addChild(border);
+
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput: (data: string) => {
+				if (matchesKey(data, "enter") || matchesKey(data, "space") || matchesKey(data, "escape")) {
+					done(undefined);
+				}
+			},
+		};
+	});
+}
+
+function buildUserPrompt(question: string, conversationContext: string) {
+	return [
+		"Answer this side question without modifying the main conversation.",
+		"",
+		"<side_question>",
+		question,
+		"</side_question>",
+		"",
+		"<conversation_context>",
+		conversationContext || "No prior conversation context was available.",
+		"</conversation_context>",
+	].join("\n");
+}
+
+function buildConversationContext(entries: readonly SessionEntry[]) {
+	const sections: string[] = [];
+
+	for (const entry of entries) {
+		if (entry.type !== "message" || !entry.message?.role) continue;
+
+		const role = entry.message.role;
+		if (role !== "user" && role !== "assistant") continue;
+
+		const contentLines = extractContentLines(entry.message.content);
+		if (contentLines.length === 0) continue;
+
+		const label = role === "user" ? "User" : "Assistant";
+		const status = entry.message.stopReason && entry.message.stopReason !== "stop"
+			? ` (${entry.message.stopReason})`
+			: "";
+		sections.push(`${label}${status}: ${contentLines.join("\n")}`);
+	}
+
+	return truncateFromStart(sections.join("\n\n"), MAX_CONTEXT_CHARS);
+}
+
+function extractContentLines(content: unknown): string[] {
+	if (typeof content === "string") {
+		return [content.trim()].filter(Boolean);
+	}
+
+	if (!Array.isArray(content)) {
+		return [];
+	}
+
+	const lines: string[] = [];
+	for (const part of content) {
+		if (!part || typeof part !== "object") continue;
+
+		const block = part as MessageContentBlock;
+		if (block.type === "text" && typeof block.text === "string") {
+			lines.push(block.text.trim());
+		} else if (block.type === "toolCall" && typeof block.name === "string") {
+			lines.push(`Tool call: ${block.name}(${formatJson(block.arguments)})`);
+		} else if (block.type === "toolResult" && typeof block.name === "string") {
+			lines.push(`Tool result from ${block.name}: ${formatJson(block.result)}`);
+		}
+	}
+
+	return lines.filter(Boolean);
+}
+
+function formatJson(value: unknown) {
+	if (value === undefined) return "";
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function truncateFromStart(text: string, maxChars: number) {
+	if (text.length <= maxChars) return text;
+	return `[Earlier context omitted; showing the last ${maxChars} characters.]\n${text.slice(-maxChars)}`;
+}

--- a/extensions/pi-btw/tsconfig.json
+++ b/extensions/pi-btw/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+btw := "@narumitw/pi-btw"
 caffeinate := "@narumitw/pi-caffeinate"
 chrome_devtools := "@narumitw/pi-chrome-devtools"
 firecrawl := "@narumitw/pi-firecrawl"
@@ -40,6 +41,7 @@ doctor package="@narumitw/pi-chrome-devtools":
 
 # Show npm visibility/version information for all packages
 doctor-all:
+    just doctor {{btw}}
     just doctor {{caffeinate}}
     just doctor {{chrome_devtools}}
     just doctor {{firecrawl}}
@@ -53,6 +55,10 @@ doctor-all:
 npm-public package="@narumitw/pi-goal" otp="":
     otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; npm access set status=public {{package}} $otp_arg
     npm view {{package}} version
+
+# Preview the btw package that npm would publish
+pack-btw:
+    npm run pack:btw
 
 # Preview the caffeinate package that npm would publish
 pack-caffeinate:
@@ -82,6 +88,10 @@ pack-retry:
 pack-statusline:
     npm run pack:statusline
 
+# Try btw from this working tree as a temporary pi package
+try-btw:
+    pi -e ./extensions/pi-btw
+
 # Try caffeinate from this working tree as a temporary pi package
 try-caffeinate:
     pi -e ./extensions/pi-caffeinate
@@ -110,6 +120,10 @@ try-retry:
 try-statusline:
     pi -e ./extensions/pi-statusline
 
+# Install btw through pi, falling back to the local workspace if unpublished
+install-btw:
+    if npm view {{btw}} version >/dev/null 2>&1; then pi install npm:{{btw}}; else echo "{{btw}} is not published; installing local workspace package instead."; pi install ./extensions/pi-btw; fi
+
 # Install caffeinate through pi, falling back to the local workspace if unpublished
 install-caffeinate:
     if npm view {{caffeinate}} version >/dev/null 2>&1; then pi install npm:{{caffeinate}}; else echo "{{caffeinate}} is not published; installing local workspace package instead."; pi install ./extensions/pi-caffeinate; fi
@@ -137,6 +151,11 @@ install-retry:
 # Install statusline through pi, falling back to the local workspace if unpublished
 install-statusline:
     if npm view {{statusline}} version >/dev/null 2>&1; then pi install npm:{{statusline}}; else echo "{{statusline}} is not published; installing local workspace package instead."; pi install ./extensions/pi-statusline; fi
+
+# Publish btw to npm, skipping if the current version already exists
+# Usage with 2FA: just publish-btw 123456
+publish-btw otp="":
+    version="$(node -p "require('./extensions/pi-btw/package.json').version")"; otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; if npm view {{btw}}@"$version" version >/dev/null 2>&1; then echo "{{btw}}@$version already exists; skipping publish."; else npm --workspace {{btw}} pack --dry-run; npm --workspace {{btw}} publish --access public $otp_arg; fi
 
 # Publish caffeinate to npm, skipping if the current version already exists
 # Usage with 2FA: just publish-caffeinate 123456
@@ -176,6 +195,7 @@ publish-statusline otp="":
 # Publish all extension packages to npm
 # Usage with 2FA: just publish-all 123456
 publish-all otp="":
+    just publish-btw {{otp}}
     just publish-caffeinate {{otp}}
     just publish-chrome-devtools {{otp}}
     just publish-firecrawl {{otp}}
@@ -186,6 +206,7 @@ publish-all otp="":
 
 # Install all published extension packages through pi
 install-all:
+    just install-btw
     just install-caffeinate
     just install-chrome-devtools
     just install-firecrawl

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,148 @@
 				"typescript": "^6.0.3"
 			}
 		},
+		"extensions/pi-btw": {
+			"name": "@narumitw/pi-btw",
+			"version": "0.1.4",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-ai": "0.73.0",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"@mariozechner/pi-tui": "0.73.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-btw/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-btw/node_modules/@mariozechner/pi-agent-core/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-btw/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.0.tgz",
+			"integrity": "sha512-phKOpcde/ssz6UYszkmaGJ9LF9mgt/AP8LrtSwsfap+kMSeFfSQ2/mCSBT1mLJ2BqVuff9uXs1/+op1aQeaafQ==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-btw/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-btw/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.0.tgz",
+			"integrity": "sha512-St1W+tMPKHatfK+lblsKfL+SsFyFVMK2tW6xHpBfCiMuevbOCRo/CMatso7mu1642UO04ncmfCrrpUK5L9aoog==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"extensions/pi-caffeinate": {
 			"name": "@narumitw/pi-caffeinate",
 			"version": "0.1.4",
@@ -2178,6 +2320,10 @@
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
 			}
+		},
+		"node_modules/@narumitw/pi-btw": {
+			"resolved": "extensions/pi-btw",
+			"link": true
 		},
 		"node_modules/@narumitw/pi-caffeinate": {
 			"resolved": "extensions/pi-caffeinate",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"biome:check": "biome check .",
 		"typecheck": "npm --workspaces run typecheck",
 		"check": "npm run biome:check && npm run typecheck",
+		"pack:btw": "npm --workspace @narumitw/pi-btw pack --dry-run",
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",


### PR DESCRIPTION
## Summary
- add @narumitw/pi-btw extension with a /btw side-question command
- document local usage, package metadata, and publish/install recipes
- include the new workspace in pack scripts and lockfile

## Verification
- npm run check
- npm run pack:btw
- just --list