### PR TITLE
ci: add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish packages to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify packages
+        run: npm run check
+
+      - name: Publish unpublished workspace packages
+        run: |
+          set -euo pipefail
+
+          node - <<'NODE' > /tmp/pi-workspaces.tsv
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const extensionsDir = "extensions";
+          for (const dirent of fs.readdirSync(extensionsDir, { withFileTypes: true })) {
+            if (!dirent.isDirectory()) continue;
+
+            const packageJsonPath = path.join(extensionsDir, dirent.name, "package.json");
+            if (!fs.existsSync(packageJsonPath)) continue;
+
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+            if (packageJson.private) continue;
+
+            console.log(`${packageJson.name}\t${packageJson.version}`);
+          }
+          NODE
+
+          while IFS=$'\t' read -r package version; do
+            if [ -z "$package" ] || [ -z "$version" ]; then
+              continue
+            fi
+
+            if npm view "${package}@${version}" version >/dev/null 2>&1; then
+              echo "${package}@${version} already exists; skipping publish."
+              continue
+            fi
+
+            echo "Publishing ${package}@${version}..."
+            npm --workspace "$package" publish --access public --provenance
+          done < /tmp/pi-workspaces.tsv


### PR DESCRIPTION
## Summary
- add tag-triggered publish workflow for npm packages
- use GitHub OIDC Trusted Publishing with id-token permission
- skip workspace packages when the same version already exists on npm

## Verification
- npm run check
- Node YAML parse of .github/workflows/publish.yml
- pre-commit npm typecheck hook during commit