### PR TITLE
ci: update npm before trusted publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: npm
 
+      - name: Update npm for OIDC publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install dependencies
         run: npm ci
 
@@ -36,6 +41,8 @@ jobs:
         run: npm run check
 
       - name: Publish unpublished workspace packages
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
         run: |
           set -euo pipefail
 
@@ -68,5 +75,5 @@ jobs:
             fi
 
             echo "Publishing ${package}@${version}..."
-            npm --workspace "$package" publish --access public --provenance
+            npm --workspace "$package" publish --access public --loglevel verbose
           done < /tmp/pi-workspaces.tsv


### PR DESCRIPTION
## Summary
- update npm to latest before running trusted publishing
- use NPM_CONFIG_PROVENANCE=true for OIDC publish
- publish with verbose logs to expose OIDC token exchange diagnostics

## Verification
- npm run check
- Node YAML parse of .github/workflows/publish.yml

## Notes
Each npm package still needs Trusted Publisher configured as repo `narumiruna/pi-extensions` and workflow `publish.yml`.