### PR TITLE
docs: improve README SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,75 @@
-# pi extensions
+# 🧩 Pi Extensions for the Pi Coding Agent
 
-Monorepo for independently installable Pi extension packages.
+[![npm scope](https://img.shields.io/badge/npm-@narumitw-blue)](https://www.npmjs.com/org/narumitw) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-## Packages
+Production-ready, independently installable [Pi](https://pi.dev) extension packages for the Pi coding agent. This monorepo provides native Pi tools and commands for Chrome DevTools automation, Firecrawl web scraping, Python LSP diagnostics with ty and Ruff, goal-driven task completion, retry handling, terminal statuslines, and keep-awake automation.
 
-| Package | Source | Install |
+## 📦 Pi extension packages
+
+Install only the Pi extensions you need. Each package is published under the `@narumitw` npm scope and can be installed directly with `pi install npm:<package>`.
+
+| Pi extension | What it adds | Install |
 | --- | --- | --- |
-| `@narumitw/pi-btw` | [`extensions/pi-btw`](./extensions/pi-btw) | `pi install npm:@narumitw/pi-btw` |
-| `@narumitw/pi-caffeinate` | [`extensions/pi-caffeinate`](./extensions/pi-caffeinate) | `pi install npm:@narumitw/pi-caffeinate` |
-| `@narumitw/pi-chrome-devtools` | [`extensions/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | `pi install npm:@narumitw/pi-chrome-devtools` |
-| `@narumitw/pi-firecrawl` | [`extensions/pi-firecrawl`](./extensions/pi-firecrawl) | `pi install npm:@narumitw/pi-firecrawl` |
-| `@narumitw/pi-goal` | [`extensions/pi-goal`](./extensions/pi-goal) | `pi install npm:@narumitw/pi-goal` |
-| `@narumitw/pi-python-lsp` | [`extensions/pi-python-lsp`](./extensions/pi-python-lsp) | `pi install npm:@narumitw/pi-python-lsp` |
-| `@narumitw/pi-retry` | [`extensions/pi-retry`](./extensions/pi-retry) | `pi install npm:@narumitw/pi-retry` |
-| `@narumitw/pi-statusline` | [`extensions/pi-statusline`](./extensions/pi-statusline) | `pi install npm:@narumitw/pi-statusline` |
+| [`@narumitw/pi-btw`](./extensions/pi-btw) | 💬 `/btw` side-question command for asking quick questions without polluting the main conversation. | `pi install npm:@narumitw/pi-btw` |
+| [`@narumitw/pi-caffeinate`](./extensions/pi-caffeinate) | ☕ Cross-platform sleep prevention while the Pi agent is processing long-running prompts. | `pi install npm:@narumitw/pi-caffeinate` |
+| [`@narumitw/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | 🌐 Native Chrome DevTools Protocol tools for listing tabs, navigating pages, evaluating JavaScript, and taking screenshots. | `pi install npm:@narumitw/pi-chrome-devtools` |
+| [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) | 🔥 Firecrawl-powered web scraping, crawling, URL discovery, and web search tools for research workflows. | `pi install npm:@narumitw/pi-firecrawl` |
+| [`@narumitw/pi-goal`](./extensions/pi-goal) | 🎯 `/goal` mode that keeps the agent working until a verifiable task is complete. | `pi install npm:@narumitw/pi-goal` |
+| [`@narumitw/pi-python-lsp`](./extensions/pi-python-lsp) | 🐍 Python language-server tools for ty type diagnostics and Ruff linting, formatting, and fixes. | `pi install npm:@narumitw/pi-python-lsp` |
+| [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for provider responses that fail with `Unknown error (no error details in response)`. | `pi install npm:@narumitw/pi-retry` |
+| [`@narumitw/pi-statusline`](./extensions/pi-statusline) | ✨ A rich Pi terminal statusline with model, tools, git branch, context usage, token totals, cost, and time. | `pi install npm:@narumitw/pi-statusline` |
 
-## Local development
+## 🚀 Quick start
 
-Run checks for all packages:
+Install a package from npm:
+
+```bash
+pi install npm:@narumitw/pi-goal
+```
+
+Try an extension once without adding it permanently:
+
+```bash
+pi -e npm:@narumitw/pi-statusline
+```
+
+Use multiple Pi extensions together:
+
+```bash
+pi -e npm:@narumitw/pi-goal -e npm:@narumitw/pi-statusline -e npm:@narumitw/pi-python-lsp
+```
+
+## 🛠️ Extension use cases
+
+### 🌐 Browser automation and debugging
+
+Use [`@narumitw/pi-chrome-devtools`](./extensions/pi-chrome-devtools) when you want the Pi agent to inspect browser tabs, navigate web apps, run JavaScript in Chrome, or capture screenshots through the Chrome DevTools Protocol.
+
+### 🔎 Web scraping, crawling, and research
+
+Use [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) to give Pi native Firecrawl tools for scraping markdown or HTML, mapping URLs, crawling websites, and searching the web from inside an agent workflow.
+
+### 🐍 Python coding with ty and Ruff
+
+Use [`@narumitw/pi-python-lsp`](./extensions/pi-python-lsp) to let Pi run Python type checks through `ty server`, lint diagnostics through `ruff server`, Ruff formatting, and Ruff source fixes such as import organization.
+
+### 🎯 Autonomous task completion
+
+Use [`@narumitw/pi-goal`](./extensions/pi-goal) for long-running implementation, debugging, refactoring, and verification tasks where the agent should continue past planning and call `goal_complete` only after the goal is done.
+
+### ✨ Better agent ergonomics
+
+Use [`@narumitw/pi-btw`](./extensions/pi-btw), [`@narumitw/pi-caffeinate`](./extensions/pi-caffeinate), [`@narumitw/pi-retry`](./extensions/pi-retry), and [`@narumitw/pi-statusline`](./extensions/pi-statusline) to improve day-to-day Pi coding agent sessions with side questions, sleep prevention, automatic retry hints, and a more informative terminal UI.
+
+## 🧑‍💻 Local development
+
+Install dependencies from the repository root:
+
+```bash
+npm install
+```
+
+Run the full repository check:
 
 ```bash
 npm run check
@@ -36,7 +88,7 @@ pi -e ./extensions/pi-retry
 pi -e ./extensions/pi-statusline
 ```
 
-Preview package contents:
+Preview npm package contents before publishing:
 
 ```bash
 npm run pack:btw
@@ -49,15 +101,22 @@ npm run pack:retry
 npm run pack:statusline
 ```
 
-Publish packages from their package directories:
+## 🗂️ Repository structure
 
-```bash
-cd extensions/pi-btw && npm publish --access public
-cd extensions/pi-caffeinate && npm publish --access public
-cd extensions/pi-chrome-devtools && npm publish --access public
-cd extensions/pi-firecrawl && npm publish --access public
-cd extensions/pi-goal && npm publish --access public
-cd extensions/pi-python-lsp && npm publish --access public
-cd extensions/pi-retry && npm publish --access public
-cd extensions/pi-statusline && npm publish --access public
+```txt
+extensions/
+├── pi-btw/
+├── pi-caffeinate/
+├── pi-chrome-devtools/
+├── pi-firecrawl/
+├── pi-goal/
+├── pi-python-lsp/
+├── pi-retry/
+└── pi-statusline/
 ```
+
+Each extension package contains its own `package.json`, `README.md`, `LICENSE`, `tsconfig.json`, and TypeScript source under `src/`.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).


### PR DESCRIPTION
## Summary
- rewrite the root README with a more searchable Pi coding agent extension overview
- add install-focused package table, quick-start examples, and use-case sections
- add emojis and badges while keeping package links and local development commands

## Verification
- npm run check