### PR TITLE
docs: improve extension README SEO

### DIFF
--- a/extensions/pi-btw/README.md
+++ b/extensions/pi-btw/README.md
@@ -1,14 +1,26 @@
-# pi-btw
+# 💬 pi-btw — Side Questions for the Pi Coding Agent
 
-A public [pi](https://pi.dev) extension package that adds `/btw`, a side-question command for asking quick questions without interrupting the main conversation.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-btw)](https://www.npmjs.com/package/@narumitw/pi-btw) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-## Install
+`@narumitw/pi-btw` is a native [Pi coding agent](https://pi.dev) extension that adds `/btw`, a side-question command for quick clarifications that should not interrupt or pollute the main agent conversation.
+
+Use it when you want to ask a temporary question, inspect context, or get a short explanation while keeping the primary coding task focused.
+
+## ✨ Features
+
+- Adds a `/btw <question>` command to Pi.
+- Answers side questions in a temporary UI.
+- Uses the current session branch as context.
+- Does not append the side question or answer to the main conversation.
+- Works as an independently installable npm Pi extension package.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-btw
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-btw
@@ -20,15 +32,25 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-btw
 ```
 
-## Usage
+## 🚀 Usage
 
 ```text
 /btw <your side question>
 ```
 
-The command answers the question in a temporary UI using the current session branch as context, but it does not append the side question or answer to the main conversation.
+Examples:
 
-## Package layout
+```text
+/btw what does this TypeScript error mean?
+/btw summarize the current implementation before we continue
+/btw is this API name idiomatic?
+```
+
+## 🧠 Why use pi-btw?
+
+Normal assistant messages become part of the main Pi conversation and can distract the coding agent from the task. `pi-btw` creates a lightweight side channel for context-aware questions, making it useful for pair programming, debugging, code review, and repository exploration.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-btw/
@@ -40,7 +62,7 @@ extensions/pi-btw/
 └── package.json
 ```
 
-The package exposes its extension through `package.json`:
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -49,3 +71,11 @@ The package exposes its extension through `package.json`:
   }
 }
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, AI coding agent, side question command, agent chat workflow, TypeScript Pi package, npm Pi extension.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -1,16 +1,27 @@
-# pi-caffeinate
+# ☕ pi-caffeinate — Keep Your Computer Awake While Pi Works
 
-A public [pi](https://pi.dev) extension package that keeps your computer awake while the pi agent is processing a prompt.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-caffeinate)](https://www.npmjs.com/package/@narumitw/pi-caffeinate) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-The extension starts an OS sleep inhibitor on `agent_start` and releases it on `agent_end` or `session_shutdown`.
+`@narumitw/pi-caffeinate` is a cross-platform [Pi coding agent](https://pi.dev) extension that prevents your computer from sleeping while the Pi agent is processing a prompt.
 
-## Install
+It is designed for long-running coding, refactoring, debugging, web research, and autonomous agent workflows where a suspended laptop or desktop would interrupt progress.
+
+## ✨ Features
+
+- Starts an OS sleep inhibitor when Pi begins processing (`agent_start`).
+- Releases the inhibitor when processing ends (`agent_end`) or the session shuts down.
+- Supports macOS, Windows, WSL, and Linux.
+- Provides `/caffeinate-status` and `/caffeinate-stop` commands.
+- Allows a custom inhibitor command through environment configuration.
+- Fails safely when no supported inhibitor is available.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-caffeinate
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-caffeinate
@@ -22,17 +33,17 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-caffeinate
 ```
 
-## Supported platforms
+## 🖥️ Supported platforms
 
-- macOS: uses `caffeinate -dimsu`
-- Windows: uses PowerShell `SetThreadExecutionState`
-- WSL: uses Windows `powershell.exe` with `SetThreadExecutionState`
-- Linux: uses `systemd-inhibit` with `sleep infinity`
-- Linux fallback: uses `caffeinate -dimsu` if available
+- macOS: uses `caffeinate -dimsu`.
+- Windows: uses PowerShell `SetThreadExecutionState`.
+- WSL: uses Windows `powershell.exe` with `SetThreadExecutionState`.
+- Linux: uses `systemd-inhibit` with `sleep infinity`.
+- Linux fallback: uses `caffeinate -dimsu` when available.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
-## Commands
+## 🚀 Commands
 
 ```text
 /caffeinate-status
@@ -46,7 +57,7 @@ Shows whether an inhibitor is active, unavailable, or disabled.
 
 Manually releases any active inhibitor for the current session.
 
-## Configuration
+## ⚙️ Configuration
 
 Disable the extension:
 
@@ -62,7 +73,11 @@ PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mo
 
 The custom command is parsed with shell-like quoting and is run directly without a shell.
 
-## Package layout
+## 🧠 Why use pi-caffeinate?
+
+AI coding agents often run tool-heavy tasks that take several minutes. `pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-caffeinate/
@@ -73,3 +88,11 @@ extensions/pi-caffeinate/
 ├── tsconfig.json
 └── package.json
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, caffeinate, prevent sleep, keep awake, sleep inhibitor, AI agent automation, long-running coding task, TypeScript Pi package.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -1,16 +1,29 @@
-# pi-chrome-devtools
+# 🌐 pi-chrome-devtools — Chrome DevTools Tools for Pi Agents
 
-A public [pi](https://pi.dev) extension package that exposes Chrome DevTools Protocol (CDP) tools to the agent.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-chrome-devtools)](https://www.npmjs.com/package/@narumitw/pi-chrome-devtools) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-It is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), but implemented as native pi tools instead of an MCP server.
+`@narumitw/pi-chrome-devtools` is a native [Pi coding agent](https://pi.dev) extension that exposes Chrome DevTools Protocol (CDP) automation as Pi tools.
 
-## Install
+Use it to let the Pi agent inspect browser tabs, navigate pages, evaluate JavaScript, and capture screenshots while debugging web apps or validating UI behavior.
+
+This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), but it is implemented as native Pi tools instead of an MCP server.
+
+## ✨ Features
+
+- Lists inspectable Chrome tabs and pages.
+- Selects an active Chrome page for later tool calls.
+- Navigates Chrome to a target URL.
+- Evaluates JavaScript in the selected page.
+- Captures PNG screenshots, including optional full-page screenshots.
+- Uses a local Chrome DevTools Protocol endpoint.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-chrome-devtools
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-chrome-devtools
@@ -22,7 +35,7 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-chrome-devtools
 ```
 
-## Start Chrome with CDP enabled
+## 🚀 Start Chrome with CDP enabled
 
 The extension connects to `127.0.0.1:9222` by default.
 
@@ -44,7 +57,7 @@ Override the endpoint if needed:
 PI_CHROME_DEVTOOLS_HOST=127.0.0.1 PI_CHROME_DEVTOOLS_PORT=9223 pi -e ./extensions/pi-chrome-devtools
 ```
 
-## Tools
+## 🛠️ Pi tools
 
 - `chrome_devtools_list_pages` — list inspectable Chrome tabs/pages.
 - `chrome_devtools_select_page` — select the active page for later tool calls.
@@ -52,15 +65,23 @@ PI_CHROME_DEVTOOLS_HOST=127.0.0.1 PI_CHROME_DEVTOOLS_PORT=9223 pi -e ./extension
 - `chrome_devtools_evaluate` — evaluate JavaScript in the selected page.
 - `chrome_devtools_screenshot` — capture a PNG screenshot.
 
-## Command
+## 💬 Command
 
 ```text
 /chrome-devtools
 ```
 
-Shows the configured CDP endpoint and quick start hint.
+Shows the configured CDP endpoint and a quick-start hint.
 
-## Package layout
+## 🧠 Use cases
+
+- Debug front-end applications with an AI coding agent.
+- Verify DOM state after code changes.
+- Capture screenshots for visual inspection.
+- Drive local browser workflows without a separate MCP server.
+- Combine with Pi coding tools for end-to-end web app fixes.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-chrome-devtools/
@@ -72,7 +93,7 @@ extensions/pi-chrome-devtools/
 └── package.json
 ```
 
-The package exposes its extension through `package.json`:
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -81,3 +102,11 @@ The package exposes its extension through `package.json`:
   }
 }
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, Chrome DevTools Protocol, CDP, browser automation, web debugging, JavaScript evaluation, screenshot automation, AI coding agent tools.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-firecrawl/README.md
+++ b/extensions/pi-firecrawl/README.md
@@ -1,14 +1,28 @@
-# pi-firecrawl
+# 🔥 pi-firecrawl — Firecrawl Web Scraping Tools for Pi Agents
 
-A public [pi](https://pi.dev) extension package that exposes [Firecrawl](https://www.firecrawl.dev/) web scraping, crawling, URL discovery, and search APIs as native pi tools.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-firecrawl)](https://www.npmjs.com/package/@narumitw/pi-firecrawl) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-## Install
+`@narumitw/pi-firecrawl` is a native [Pi coding agent](https://pi.dev) extension that exposes [Firecrawl](https://www.firecrawl.dev/) scraping, crawling, URL discovery, and search APIs as Pi tools.
+
+Use it to give your AI coding agent reliable web research capabilities for documentation lookup, website audits, competitive research, content extraction, and retrieval-friendly markdown scraping.
+
+## ✨ Features
+
+- Scrape a single URL into markdown, HTML, raw HTML, links, screenshots, or JSON.
+- Start Firecrawl crawl jobs from Pi.
+- Check crawl job status and retrieve completed crawl data.
+- Discover URLs with Firecrawl map.
+- Search the web and optionally scrape search result pages.
+- Supports Firecrawl API endpoint overrides.
+- Never logs or displays your Firecrawl API key.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-firecrawl
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 FIRECRAWL_API_KEY=fc-... pi -e npm:@narumitw/pi-firecrawl
@@ -20,9 +34,9 @@ Try this package locally from the repository root:
 FIRECRAWL_API_KEY=fc-... pi -e ./extensions/pi-firecrawl
 ```
 
-## Configuration
+## ⚙️ Configuration
 
-Set a Firecrawl API key before running pi:
+Set a Firecrawl API key before running Pi:
 
 ```bash
 export FIRECRAWL_API_KEY=fc-your-key
@@ -36,9 +50,9 @@ export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
 
 `FIRECRAWL_BASE_URL` is also accepted for compatibility. The extension never logs or displays the API key.
 
-## Tools
+## 🛠️ Pi tools
 
-- `firecrawl_scrape` — scrape a single URL and return requested formats such as markdown, HTML, links, or JSON.
+- `firecrawl_scrape` — scrape a single URL and return requested formats such as markdown, HTML, links, screenshots, or JSON.
 - `firecrawl_crawl` — start a site crawl job and return the Firecrawl job id.
 - `firecrawl_crawl_status` — check a crawl job status and retrieve completed crawl data.
 - `firecrawl_map` — discover URLs for a site.
@@ -46,7 +60,7 @@ export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
 
 All tools fail with a clear configuration error when `FIRECRAWL_API_KEY` is missing.
 
-## Command
+## 💬 Command
 
 ```text
 /firecrawl
@@ -54,7 +68,7 @@ All tools fail with a clear configuration error when `FIRECRAWL_API_KEY` is miss
 
 Shows whether the extension sees an API key and which Firecrawl API URL it will call.
 
-## Examples
+## 🚀 Examples
 
 Scrape a page as markdown:
 
@@ -86,7 +100,15 @@ Start a crawl with markdown extraction:
 }
 ```
 
-## Package layout
+## 🧠 Use cases
+
+- Research documentation from inside Pi.
+- Crawl websites for migration or audit tasks.
+- Extract clean markdown for AI context.
+- Discover URLs before scraping a site.
+- Combine web search with coding-agent implementation work.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-firecrawl/
@@ -97,3 +119,11 @@ extensions/pi-firecrawl/
 ├── tsconfig.json
 └── package.json
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, Firecrawl, web scraping, web crawling, URL discovery, web search, markdown extraction, AI research agent, TypeScript Pi tools.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -1,16 +1,27 @@
-# pi-goal
+# 🎯 pi-goal — Goal Mode for the Pi Coding Agent
 
-A public [pi](https://pi.dev) extension package that adds `/goal <goal_to_complete>`.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-goal)](https://www.npmjs.com/package/@narumitw/pi-goal) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Goal mode keeps sending automatic follow-up messages until the agent calls the `goal_complete` tool, so tasks such as `/goal implement snake game` continue past planning and partial progress.
+`@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds `/goal <goal_to_complete>` and a `goal_complete` tool for autonomous, verifiable task completion.
 
-## Install
+Goal mode keeps sending automatic follow-up messages until the agent calls `goal_complete`, so tasks such as `/goal implement snake game` continue past planning, partial progress, and intermediate tool calls.
+
+## ✨ Features
+
+- Adds `/goal <goal_to_complete>` to start goal mode.
+- Adds `/goal-status` to show the active goal.
+- Adds `/goal-stop` to cancel the active goal loop.
+- Registers a `goal_complete` tool for explicit completion.
+- Automatically prompts the agent to continue if a turn ends early.
+- Encourages verification before the goal is marked complete.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-goal
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-goal
@@ -22,9 +33,9 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-goal
 ```
 
-## Commands
+## 🚀 Commands
 
-```bash
+```text
 /goal implement snake game
 /goal-status
 /goal-stop
@@ -34,13 +45,21 @@ pi -e ./extensions/pi-goal
 - `/goal-status` shows the active goal.
 - `/goal-stop` cancels the active goal loop.
 
-## How completion works
+## ✅ How completion works
 
 The extension registers a `goal_complete` tool. While a goal is active, the system prompt tells the agent to keep working, verify the result, and call `goal_complete` only when the goal is fully done.
 
 If an agent turn ends before `goal_complete` is called, the extension automatically sends a follow-up prompt to continue the same goal.
 
-## Package layout
+## 🧠 Use cases
+
+- Finish implementation tasks without stopping at a plan.
+- Keep debugging until the bug is verified fixed.
+- Run refactors that require multiple tool cycles.
+- Encourage agents to test, lint, or typecheck before completion.
+- Make long-running Pi coding sessions more autonomous.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-goal/
@@ -52,7 +71,7 @@ extensions/pi-goal/
 └── package.json
 ```
 
-The package exposes its extension through `package.json`:
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -61,3 +80,11 @@ The package exposes its extension through `package.json`:
   }
 }
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, goal mode, autonomous coding agent, AI agent workflow, task completion, agent loop, verification, TypeScript Pi package.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-python-lsp/README.md
+++ b/extensions/pi-python-lsp/README.md
@@ -1,16 +1,28 @@
-# pi-python-lsp
+# 🐍 pi-python-lsp — ty and Ruff Language Server Tools for Pi
 
-A public [pi](https://pi.dev) extension package that exposes Python language-server tools from [ty](https://github.com/astral-sh/ty) and [Ruff](https://docs.astral.sh/ruff/).
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-python-lsp)](https://www.npmjs.com/package/@narumitw/pi-python-lsp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-The extension starts `ty server` or `ruff server` on demand for each tool call, opens the requested Python files over Language Server Protocol (LSP), pulls diagnostics or edits, and then shuts the server down.
+`@narumitw/pi-python-lsp` is a native [Pi coding agent](https://pi.dev) extension that exposes Python language-server tools from [ty](https://github.com/astral-sh/ty) and [Ruff](https://docs.astral.sh/ruff/).
 
-## Install
+Use it to give Pi reliable Python type diagnostics, Ruff lint diagnostics, formatting, import organization, and source fixes through Language Server Protocol (LSP) workflows.
+
+## ✨ Features
+
+- Runs `ty server` on demand for Python type diagnostics.
+- Runs `ruff server` on demand for lint diagnostics.
+- Computes or writes Ruff formatting edits.
+- Computes or writes Ruff source actions such as `source.fixAll.ruff` and `source.organizeImports.ruff`.
+- Supports workspace roots, file limits, and recursive Python file discovery.
+- Starts language servers only for tool calls, then shuts them down.
+- Provides clear setup errors when ty or Ruff is missing.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-python-lsp
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-python-lsp
@@ -22,7 +34,7 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-python-lsp
 ```
 
-## Requirements
+## ✅ Requirements
 
 Install `ty` and/or `ruff` somewhere on `PATH`, for example:
 
@@ -43,14 +55,16 @@ Optional timeout overrides:
 PI_TY_LSP_TIMEOUT_MS=30000 PI_RUFF_LSP_TIMEOUT_MS=30000 pi -e ./extensions/pi-python-lsp
 ```
 
-## Tools
+## 🛠️ Pi tools
 
 - `ty_lsp_diagnostics` — start `ty server`, open Python files, and return type diagnostics.
 - `ruff_lsp_diagnostics` — start `ruff server`, open Python files, and return lint diagnostics.
 - `ruff_lsp_format` — compute or write Ruff formatting edits for one Python file.
 - `ruff_lsp_fix` — compute or write Ruff source actions such as `source.fixAll.ruff` or `source.organizeImports.ruff`.
 
-Examples:
+## 🚀 Examples
+
+Check a Python project with ty or Ruff diagnostics:
 
 ```json
 {
@@ -59,12 +73,16 @@ Examples:
 }
 ```
 
+Format a Python file with Ruff:
+
 ```json
 {
   "path": "src/app.py",
   "write": true
 }
 ```
+
+Organize imports with Ruff:
 
 ```json
 {
@@ -76,7 +94,7 @@ Examples:
 
 If `paths` is omitted for diagnostics, the tool recursively discovers Python files under the workspace root, skipping common cache and virtualenv directories.
 
-## Command
+## 💬 Command
 
 ```text
 /python-lsp
@@ -84,7 +102,15 @@ If `paths` is omitted for diagnostics, the tool recursively discovers Python fil
 
 Shows the configured ty and Ruff LSP commands and whether each command is available on `PATH`.
 
-## Package layout
+## 🧠 Use cases
+
+- Let Pi typecheck Python code with ty before completing a task.
+- Ask Pi to run Ruff lint diagnostics while editing.
+- Format Python files through a native Pi tool.
+- Organize imports and apply safe Ruff fixes.
+- Add Python quality gates to AI coding agent workflows.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-python-lsp/
@@ -95,3 +121,11 @@ extensions/pi-python-lsp/
 ├── tsconfig.json
 └── package.json
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, Python LSP, ty, Ruff, Python type checking, Python linting, Python formatter, import organization, Language Server Protocol, AI coding tools.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -1,14 +1,27 @@
-# pi-retry
+# 🔁 pi-retry — Retry Hints for Pi Provider Errors
 
-A public [pi](https://pi.dev) extension package that treats provider responses containing `Unknown error (no error details in response)` as retryable.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-retry)](https://www.npmjs.com/package/@narumitw/pi-retry) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-## Install
+`@narumitw/pi-retry` is a native [Pi coding agent](https://pi.dev) extension that treats provider responses containing `Unknown error (no error details in response)` as retryable.
+
+Use it to make Pi sessions more resilient when an upstream AI provider returns a transient unknown error without useful details.
+
+## ✨ Features
+
+- Detects assistant messages that end with `stopReason: "error"`.
+- Matches the known provider error text `Unknown error (no error details in response)`.
+- Appends Pi's retryable-provider-error hint.
+- Lets Pi's built-in retry path continue the turn.
+- Requires no commands or configuration.
+- Works as a small, focused npm Pi extension package.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-retry
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-retry
@@ -20,11 +33,18 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-retry
 ```
 
-## What it does
+## 🚀 What it does
 
-When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends pi's retryable-provider-error hint so pi's built-in retry path can continue the turn.
+When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
 
-## Package layout
+## 🧠 Use cases
+
+- Reduce manual restarts after transient provider failures.
+- Improve reliability during long Pi coding agent sessions.
+- Keep tool-heavy implementation tasks moving when a provider returns an unknown error.
+- Pair with `@narumitw/pi-goal` for more robust autonomous task loops.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-retry/
@@ -36,7 +56,7 @@ extensions/pi-retry/
 └── package.json
 ```
 
-The package exposes its extension through `package.json`:
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -46,8 +66,10 @@ The package exposes its extension through `package.json`:
 }
 ```
 
-Install this package with Pi:
+## 🔎 Keywords
 
-```bash
-pi install npm:@narumitw/pi-retry
-```
+Pi extension, Pi coding agent, retry, provider error, unknown error, AI provider reliability, agent resilience, TypeScript Pi package, npm Pi extension.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -1,14 +1,27 @@
-# pi-statusline
+# ✨ pi-statusline — Rich Statusline for the Pi Coding Agent
 
-A public [pi](https://pi.dev) extension package that replaces Pi's footer with a beautiful, information-rich statusline.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-statusline)](https://www.npmjs.com/package/@narumitw/pi-statusline) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-## Install
+`@narumitw/pi-statusline` is a native [Pi coding agent](https://pi.dev) extension that replaces Pi's footer with a beautiful, information-rich terminal statusline.
+
+Use it to monitor model selection, thinking level, git branch, working directory, active tools, context usage, token totals, estimated cost, time, and statuses from other Pi extensions.
+
+## ✨ Features
+
+- Replaces the default Pi footer with a compact rich statusline.
+- Shows model, thinking level, git branch, project directory, active tool, context usage, tokens, cost, and clock.
+- Displays statuses from other extensions, such as goal mode.
+- Uses emoji-labeled segments for readability.
+- Adapts to terminal width and truncates safely.
+- Requires no configuration.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-statusline
 ```
 
-Try without installing:
+Try without installing permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-statusline
@@ -20,25 +33,32 @@ Try this package locally from the repository root:
 pi -e ./extensions/pi-statusline
 ```
 
-## What it shows
+## 👀 What it shows
 
 The default statusline includes:
 
-- `π` brand marker
-- emoji-labeled current model
-- emoji-labeled thinking level
-- emoji-labeled git branch
-- emoji-labeled current project directory
-- emoji-labeled active or last tool
-- emoji-labeled context usage percentage
-- emoji-labeled token totals
-- emoji-labeled estimated cost
-- emoji-labeled clock
+- `π` brand marker.
+- 🤖 current model.
+- 🧠 thinking level.
+- 🌿 git branch.
+- 📁 current project directory.
+- 🔧 active or last tool.
+- 📊 context usage percentage.
+- 🔢 token totals.
+- 💰 estimated cost.
+- 🕒 clock.
 
 Statuses from other extensions, such as goal mode, appear on their own emoji-labeled line below the main statusline and are separated with ``.
-The layout adapts to terminal width and truncates safely.
 
-## Package layout
+## 🧠 Use cases
+
+- Track agent context usage during long coding sessions.
+- See which model and thinking level are active.
+- Monitor token totals and estimated cost.
+- Keep git branch and project directory visible.
+- Make Pi terminal sessions easier to scan at a glance.
+
+## 🗂️ Package layout
 
 ```txt
 extensions/pi-statusline/
@@ -50,7 +70,7 @@ extensions/pi-statusline/
 └── package.json
 ```
 
-The package exposes its extension through `package.json`:
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -59,3 +79,11 @@ The package exposes its extension through `package.json`:
   }
 }
 ```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, statusline, terminal UI, AI coding agent status, token usage, context window, model status, TypeScript Pi package.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).


### PR DESCRIPTION
## Summary
- polish all extension README files with keyword-rich titles and SEO-friendly descriptions
- add npm/Pi/license badges, feature lists, use cases, keyword sections, and license sections
- preserve install, local try, command, tool, and package layout information

## Verification
- npm run check