### PR TITLE
docs: document new npm package publishing

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,6 +4,7 @@
 
 - `MEMORY.md` is not auto-loaded; check it before non-trivial debugging or design work when prior project context may matter.
 - npm can show a scoped package dist-tag (for example `latest`) while `npm view <package>` still returns 404; fix visibility with `npm access set status=public <package> --otp=<otp>` or publish a bumped version.
+- `npm access set status=public <package>` cannot create brand-new scoped packages; if it returns access 404, first run `npm publish --workspace <package> --access public`.
 - For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
 - When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ npm run pack:statusline
 npm run pack:subagents
 ```
 
+Publishing note for new scoped packages: `just npm-public <package>` only changes visibility for an already-published package. If npm returns 404 for a brand-new package such as `@narumitw/pi-subagents`, create it first with:
+
+```bash
+npm publish --workspace @narumitw/pi-subagents --access public
+```
+
 ## 🗂️ Repository structure
 
 ```txt

--- a/justfile
+++ b/justfile
@@ -54,8 +54,10 @@ doctor-all:
     just doctor {{statusline}}
     just doctor {{subagents}}
 
-# Make a scoped npm package public after publish if npm registry returns 404
-# Usage: just npm-public @narumitw/pi-goal 123456
+# Make an already-published scoped npm package public if npm view returns 404
+# This does not create a package. For a brand-new package, first run:
+#   npm publish --workspace @narumitw/pi-subagents --access public
+# Usage for existing packages: just npm-public @narumitw/pi-goal 123456
 npm-public package="@narumitw/pi-goal" otp="":
     otp_arg=""; if [ -n "{{otp}}" ]; then otp_arg="--otp={{otp}}"; fi; npm access set status=public {{package}} $otp_arg
     npm view {{package}} version


### PR DESCRIPTION
## Summary
- clarify that `just npm-public` only changes visibility for already-published scoped packages
- document first-time scoped package publishing with `npm publish --workspace ... --access public`
- record the npm access 404 gotcha in MEMORY.md

## Verification
- npm run biome:check
- pre-commit hook: npm typecheck