### PR TITLE
fix(pi-subagents): use Earendil Pi packages

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -1,90 +1,83 @@
-# @narumitw/pi-subagents
+# 🧑‍🤝‍🧑 pi-subagents — Isolated Subagents for the Pi Coding Agent
 
-Delegate work from Pi to specialized subagents running in isolated `pi --mode json -p --no-session` subprocesses.
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-subagents)](https://www.npmjs.com/package/@narumitw/pi-subagents) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-## Install
+`@narumitw/pi-subagents` is a native [Pi coding agent](https://pi.dev) extension that adds a `subagent` tool for delegating work to specialized agents running in isolated Pi subprocesses.
+
+Use it to split research, planning, implementation, and review work across focused workers while keeping each subprocess context, tools, and prompt boundary separate from the main conversation.
+
+## ✨ Features
+
+- Registers a `subagent` tool for single-agent, parallel, fan-in, and chained delegation.
+- Runs workers as isolated `pi --mode json -p --no-session` subprocesses.
+- Supports built-in `scout`, `planner`, `reviewer`, and `worker` agents.
+- Loads custom user agents from `~/.pi/agent/agents/*.md`.
+- Optionally loads project agents from `.pi/agents/*.md` with confirmation.
+- Supports per-task `cwd`, hard subprocess `timeoutMs`, abort propagation, and streaming progress.
+- Returns complete worker output in tool details and a concise result for the main agent.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-subagents
 ```
 
-Try locally from this repository:
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-subagents
+```
+
+Try this package locally from the repository root:
 
 ```bash
 pi -e ./extensions/pi-subagents
 ```
 
-## What it adds
+## 🛠️ Pi tool
 
-A `subagent` tool with three execution modes:
+`pi-subagents` registers one tool:
 
-- **single**: run one `{ agent, task }`
-- **parallel**: run multiple `{ agent, task }` jobs with bounded concurrency
-- **parallel + aggregator**: run parallel jobs, then fan their complete outputs into one follow-up agent
-- **chain**: run sequential steps, passing prior output with `{previous}`
+- `subagent` — delegate work to one or more specialized agents.
 
-The design borrows from Pi/Claude-style subagents: each worker has its own system prompt, tool boundary, optional model, subprocess context window, streaming progress, abort propagation, hard subprocess timeout, complete final output in tool details, and summarized sidechain result.
+Execution modes:
 
-## Built-in agents
+- **single** — run one `{ agent, task }` job.
+- **parallel** — run multiple `{ agent, task }` jobs independently.
+- **parallel + aggregator** — run parallel jobs, then pass all outputs into one fan-in agent.
+- **chain** — run sequential steps, passing prior output with `{previous}`.
 
-These are available without setup and can be overridden by user/project agents of the same name:
+## 🚀 Examples
 
-| Agent | Purpose | Tools |
-| --- | --- | --- |
-| `scout` | Read-only codebase reconnaissance | `read`, `grep`, `find`, `ls`, `bash` |
-| `planner` | Grounded implementation plans | `read`, `grep`, `find`, `ls` |
-| `reviewer` | Independent review and verification | `read`, `grep`, `find`, `ls`, `bash` |
-| `worker` | General-purpose implementation | Pi default tools |
-| `general`, `general-purpose` | Aliases for `worker` | Pi default tools |
-
-Built-in agents intentionally inherit the active/default Pi model instead of forcing a model alias; this keeps subprocesses usable across provider setups.
-
-## Custom agents
-
-Create markdown files in:
-
-- `~/.pi/agent/agents/*.md` for user agents
-- `.pi/agents/*.md` for project agents
-
-```markdown
----
-name: api-reviewer
-description: Review API changes for compatibility and tests
-tools: read, grep, find, ls, bash
-model: sonnet
----
-
-You are an API review subagent. Do not edit files. Check compatibility,
-test coverage, and migration risks. Report PASS/FAIL/PARTIAL with evidence.
-```
-
-Project agents are repo-controlled and disabled by default. To allow them, set `agentScope` to `"project"` or `"both"`; interactive sessions ask for confirmation.
-
-## Runtime limits
-
-Each subagent subprocess has a hard timeout to avoid runaway workers. Set `timeoutMs` on the top-level call or per task/chain step. The default is `PI_SUBAGENT_TIMEOUT_MS`, or 600000ms (10 minutes) when unset. On timeout, the extension sends SIGTERM, escalates to SIGKILL after a short grace period, and returns any partial messages/stderr collected so far.
-
-## Example tool calls
-
-Single:
+Run one read-only reconnaissance agent:
 
 ```json
-{ "agent": "scout", "task": "Find the statusline extension entry points" }
+{
+  "agent": "scout",
+  "task": "Find the statusline extension entry points"
+}
 ```
 
-Parallel:
+Run multiple agents in parallel:
 
 ```json
 {
   "tasks": [
-    { "agent": "scout", "task": "Map package metadata files", "timeoutMs": 30000 },
-    { "agent": "reviewer", "task": "Review TypeScript config consistency" }
+    {
+      "agent": "scout",
+      "task": "Map package metadata files",
+      "timeoutMs": 30000
+    },
+    {
+      "agent": "reviewer",
+      "task": "Review TypeScript config consistency"
+    }
   ],
   "timeoutMs": 120000
 }
 ```
 
-Parallel with fan-in aggregation:
+Run parallel workers, then aggregate their results:
 
 ```json
 {
@@ -99,17 +92,97 @@ Parallel with fan-in aggregation:
 }
 ```
 
-Chain:
+Run a chain where each step receives the previous output:
 
 ```json
 {
   "chain": [
     { "agent": "scout", "task": "Find subagent-related code" },
-    { "agent": "planner", "task": "Using this context, plan the extension: {previous}" }
+    {
+      "agent": "planner",
+      "task": "Using this context, plan the extension: {previous}"
+    }
   ]
 }
 ```
 
-## Safety notes
+## 🤖 Built-in agents
 
-Subagents are separate Pi processes and may use the tools allowed by their agent definition. Treat project-local agent prompts as code: only enable them in trusted repositories.
+Built-in agents are available without setup and can be overridden by user or project agents with the same name.
+
+| Agent | Purpose | Tools |
+| --- | --- | --- |
+| `scout` | Read-only codebase reconnaissance. | `read`, `grep`, `find`, `ls`, `bash` |
+| `planner` | Grounded implementation plans. | `read`, `grep`, `find`, `ls` |
+| `reviewer` | Independent review and verification. | `read`, `grep`, `find`, `ls`, `bash` |
+| `worker` | General-purpose implementation. | Pi default tools |
+| `general`, `general-purpose` | Aliases for `worker`. | Pi default tools |
+
+Built-in agents inherit the active/default Pi model instead of forcing a provider-specific model alias, which keeps subprocesses usable across different Pi setups.
+
+## 🧩 Custom agents
+
+Create markdown agent definitions in either location:
+
+- `~/.pi/agent/agents/*.md` for user agents.
+- `.pi/agents/*.md` for project-local agents.
+
+Example:
+
+```markdown
+---
+name: api-reviewer
+description: Review API changes for compatibility and tests
+tools: read, grep, find, ls, bash
+model: sonnet
+---
+
+You are an API review subagent. Do not edit files. Check compatibility,
+test coverage, and migration risks. Report PASS/FAIL/PARTIAL with evidence.
+```
+
+By default, `subagent` loads user agents only. Set `agentScope` to `"project"` or `"both"` to load project-local agents. Interactive sessions ask for confirmation before using project agents unless `confirmProjectAgents` is disabled.
+
+## ⏱️ Runtime limits
+
+Each subprocess has a hard timeout to avoid runaway workers.
+
+- Set `timeoutMs` on the top-level call to apply a default for all jobs.
+- Set `timeoutMs` on a task, chain step, or aggregator to override it locally.
+- If omitted, the default is `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset.
+
+On timeout, the extension sends `SIGTERM`, escalates to `SIGKILL` after a short grace period, and returns any partial messages or stderr collected so far.
+
+## 🔒 Safety notes
+
+Subagents are separate Pi processes and may use the tools allowed by their agent definition. Treat project-local agent prompts like executable project configuration: only enable them in trusted repositories.
+
+## 🗂️ Package layout
+
+```txt
+extensions/pi-subagents/
+├── src/
+│   └── subagents.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its Pi extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/subagents.ts"]
+  }
+}
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, subagents, agent delegation, parallel agents, fan-in aggregation, chained agents, isolated subprocesses, AI coding workflow, TypeScript Pi package.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -29,14 +29,20 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@mariozechner/pi-agent-core": "0.73.0",
-		"@mariozechner/pi-ai": "0.73.0",
-		"@mariozechner/pi-coding-agent": "0.73.0",
-		"@mariozechner/pi-tui": "0.73.0",
 		"typebox": "^1.1.37"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-agent-core": "*",
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.14",
+		"@earendil-works/pi-agent-core": "0.74.0",
+		"@earendil-works/pi-ai": "0.74.0",
+		"@earendil-works/pi-coding-agent": "0.74.0",
+		"@earendil-works/pi-tui": "0.74.0",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -4,7 +4,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getAgentDir, parseFrontmatter } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 
 export type AgentScope = "user" | "project" | "both";
 

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -16,11 +16,15 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import type { Message } from "@mariozechner/pi-ai";
-import { StringEnum } from "@mariozechner/pi-ai";
-import { type ExtensionAPI, getMarkdownTheme, withFileMutationQueue } from "@mariozechner/pi-coding-agent";
-import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { Message } from "@earendil-works/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
+import {
+	type ExtensionAPI,
+	getMarkdownTheme,
+	withFileMutationQueue,
+} from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { type AgentConfig, type AgentScope, type AgentSource, discoverAgents } from "./agents.js";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,120 +1085,28 @@
 			"version": "0.1.10",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-agent-core": "0.73.0",
-				"@mariozechner/pi-ai": "0.73.0",
-				"@mariozechner/pi-coding-agent": "0.73.0",
-				"@mariozechner/pi-tui": "0.73.0",
 				"typebox": "^1.1.37"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.14",
+				"@earendil-works/pi-agent-core": "0.74.0",
+				"@earendil-works/pi-ai": "0.74.0",
+				"@earendil-works/pi-coding-agent": "0.74.0",
+				"@earendil-works/pi-tui": "0.74.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-subagents/node_modules/@mariozechner/pi-agent-core": {
-			"version": "0.73.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.0.tgz",
-			"integrity": "sha512-ugcpvq0X9fr9fTSK29/3S4+KU/eeVMrBb7ZU3HqiF3xD7I1GlgumLj4FYmDrYSEA6+rzgNWlJUKwjKh9o0Z6AA==",
-			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@mariozechner/pi-ai": "^0.73.0",
-				"typebox": "^1.1.24"
 			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-subagents/node_modules/@mariozechner/pi-ai": {
-			"version": "0.73.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.0.tgz",
-			"integrity": "sha512-phKOpcde/ssz6UYszkmaGJ9LF9mgt/AP8LrtSwsfap+kMSeFfSQ2/mCSBT1mLJ2BqVuff9uXs1/+op1aQeaafQ==",
-			"deprecated": "please use @earendil-works/pi-ai instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.91.1",
-				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"typebox": "^1.1.24",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"pi-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-subagents/node_modules/@mariozechner/pi-coding-agent": {
-			"version": "0.73.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
-			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
-			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@mariozechner/jiti": "^2.6.2",
-				"@mariozechner/pi-agent-core": "^0.73.0",
-				"@mariozechner/pi-ai": "^0.73.0",
-				"@mariozechner/pi-tui": "^0.73.0",
-				"@silvia-odwyer/photon-node": "^0.3.4",
-				"chalk": "^5.5.0",
-				"cli-highlight": "^2.1.11",
-				"diff": "^8.0.2",
-				"extract-zip": "^2.0.1",
-				"file-type": "^21.1.1",
-				"glob": "^13.0.1",
-				"hosted-git-info": "^9.0.2",
-				"ignore": "^7.0.5",
-				"marked": "^15.0.12",
-				"minimatch": "^10.2.3",
-				"proper-lockfile": "^4.1.2",
-				"strip-ansi": "^7.1.0",
-				"typebox": "^1.1.24",
-				"undici": "^7.19.1",
-				"uuid": "^14.0.0",
-				"yaml": "^2.8.2"
-			},
-			"bin": {
-				"pi": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.6.0"
-			},
-			"optionalDependencies": {
-				"@mariozechner/clipboard": "^0.3.5"
-			}
-		},
-		"extensions/pi-subagents/node_modules/@mariozechner/pi-tui": {
-			"version": "0.73.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.0.tgz",
-			"integrity": "sha512-St1W+tMPKHatfK+lblsKfL+SsFyFVMK2tW6xHpBfCiMuevbOCRo/CMatso7mu1642UO04ncmfCrrpUK5L9aoog==",
-			"deprecated": "please use @earendil-works/pi-tui instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mime-types": "^2.1.4",
-				"chalk": "^5.5.0",
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12",
-				"mime-types": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"koffi": "^2.9.0"
+			"peerDependencies": {
+				"@earendil-works/pi-agent-core": "*",
+				"@earendil-works/pi-ai": "*",
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
 			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"json-schema-to-ts": "^3.1.1"
@@ -1219,6 +1127,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
 			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
@@ -1233,6 +1142,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-js": "^5.2.0",
@@ -1248,6 +1158,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1260,6 +1171,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
@@ -1273,6 +1185,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
@@ -1286,6 +1199,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
@@ -1300,6 +1214,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1309,6 +1224,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.222.0",
@@ -1320,6 +1236,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1332,6 +1249,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
@@ -1345,6 +1263,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
@@ -1358,6 +1277,7 @@
 			"version": "3.1042.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1042.0.tgz",
 			"integrity": "sha512-uYJ/HDSQvorlgYqZSwRFGolEx5wygqyuBRfemXJ3Bla2yiRj9maSVOvWP88i/hDC2BKoH6NQw8GPB9Z4RYAnwQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -1416,6 +1336,7 @@
 			"version": "3.974.8",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
 			"integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1441,6 +1362,7 @@
 			"version": "3.972.34",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
 			"integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1457,6 +1379,7 @@
 			"version": "3.972.36",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
 			"integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1478,6 +1401,7 @@
 			"version": "3.972.38",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
 			"integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1503,6 +1427,7 @@
 			"version": "3.972.38",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
 			"integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1522,6 +1447,7 @@
 			"version": "3.972.39",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
 			"integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "^3.972.34",
@@ -1545,6 +1471,7 @@
 			"version": "3.972.34",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
 			"integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1562,6 +1489,7 @@
 			"version": "3.972.38",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
 			"integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1581,6 +1509,7 @@
 			"version": "3.1041.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
 			"integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1599,6 +1528,7 @@
 			"version": "3.972.38",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
 			"integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1617,6 +1547,7 @@
 			"version": "3.972.14",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
 			"integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1632,6 +1563,7 @@
 			"version": "3.972.10",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
 			"integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1647,6 +1579,7 @@
 			"version": "3.972.10",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
 			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1662,6 +1595,7 @@
 			"version": "3.972.10",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
 			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1676,6 +1610,7 @@
 			"version": "3.972.11",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
 			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1692,6 +1627,7 @@
 			"version": "3.972.37",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
 			"integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1717,6 +1653,7 @@
 			"version": "3.972.38",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
 			"integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1736,6 +1673,7 @@
 			"version": "3.972.16",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
 			"integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1759,6 +1697,7 @@
 			"version": "3.997.6",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
 			"integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -1809,6 +1748,7 @@
 			"version": "3.972.13",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
 			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1825,6 +1765,7 @@
 			"version": "3.996.25",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
 			"integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/middleware-sdk-s3": "^3.972.37",
@@ -1842,6 +1783,7 @@
 			"version": "3.1042.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1042.0.tgz",
 			"integrity": "sha512-rOEGTVOrceb/1CfIWK0zl1v2WS70f/i5bDirLl5xdFAbVQ5znub6Ezf2ugmJEg+rionO0IkwbKX3Dh3T/oZjbA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -1860,6 +1802,7 @@
 			"version": "3.973.8",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
 			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -1873,6 +1816,7 @@
 			"version": "3.972.3",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
 			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1885,6 +1829,7 @@
 			"version": "3.996.8",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
 			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1901,6 +1846,7 @@
 			"version": "3.972.10",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
 			"integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1916,6 +1862,7 @@
 			"version": "3.965.5",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
 			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1928,6 +1875,7 @@
 			"version": "3.972.10",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
 			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
@@ -1940,6 +1888,7 @@
 			"version": "3.973.24",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
 			"integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/middleware-user-agent": "^3.972.38",
@@ -1965,6 +1914,7 @@
 			"version": "3.972.22",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
 			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@nodable/entities": "2.1.0",
@@ -1980,6 +1930,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
 			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.0.0"
@@ -1989,6 +1940,7 @@
 			"version": "7.29.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
 			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -2161,16 +2113,117 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
 			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+			"integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.74.0",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+			"integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+			"integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.74.0",
+				"@earendil-works/pi-ai": "^0.74.0",
+				"@earendil-works/pi-tui": "^0.74.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"jiti": "^2.7.0",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+			"integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"node_modules/@google/genai": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
 			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2195,6 +2248,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
 			"integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -2220,6 +2274,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2233,6 +2288,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
 			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2249,6 +2305,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2265,6 +2322,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2281,6 +2339,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2297,6 +2356,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2313,6 +2373,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2329,6 +2390,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2345,6 +2407,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2361,6 +2424,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2374,6 +2438,7 @@
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
 			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"std-env": "^3.10.0",
@@ -2486,6 +2551,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
 			"integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"ws": "^8.18.0",
@@ -2537,6 +2603,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
 			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2549,30 +2616,35 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
 			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
 			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
 			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
 			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
 			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.1",
@@ -2583,42 +2655,49 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
 			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
 			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
 			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
 			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
 			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@smithy/config-resolver": {
 			"version": "4.4.17",
 			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
 			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.3.14",
@@ -2636,6 +2715,7 @@
 			"version": "3.23.17",
 			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
 			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.3.14",
@@ -2657,6 +2737,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
 			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.3.14",
@@ -2673,6 +2754,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
 			"integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
@@ -2688,6 +2770,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
 			"integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/eventstream-serde-universal": "^4.2.14",
@@ -2702,6 +2785,7 @@
 			"version": "4.3.14",
 			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
 			"integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2715,6 +2799,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
 			"integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/eventstream-serde-universal": "^4.2.14",
@@ -2729,6 +2814,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
 			"integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/eventstream-codec": "^4.2.14",
@@ -2743,6 +2829,7 @@
 			"version": "5.3.17",
 			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
 			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.3.14",
@@ -2759,6 +2846,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
 			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2774,6 +2862,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
 			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2787,6 +2876,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
 			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2799,6 +2889,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
 			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.3.14",
@@ -2813,6 +2904,7 @@
 			"version": "4.4.32",
 			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
 			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.23.17",
@@ -2832,6 +2924,7 @@
 			"version": "4.5.7",
 			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
 			"integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.23.17",
@@ -2853,6 +2946,7 @@
 			"version": "4.2.20",
 			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
 			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.23.17",
@@ -2868,6 +2962,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
 			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2881,6 +2976,7 @@
 			"version": "4.3.14",
 			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
 			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.2.14",
@@ -2896,6 +2992,7 @@
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
 			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.3.14",
@@ -2911,6 +3008,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
 			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2924,6 +3022,7 @@
 			"version": "5.3.14",
 			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
 			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2937,6 +3036,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
 			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2951,6 +3051,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
 			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2964,6 +3065,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
 			"integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1"
@@ -2976,6 +3078,7 @@
 			"version": "4.4.9",
 			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
 			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -2989,6 +3092,7 @@
 			"version": "5.3.14",
 			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
 			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^4.2.2",
@@ -3008,6 +3112,7 @@
 			"version": "4.12.13",
 			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
 			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.23.17",
@@ -3026,6 +3131,7 @@
 			"version": "4.14.1",
 			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
 			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3038,6 +3144,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
 			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/querystring-parser": "^4.2.14",
@@ -3052,6 +3159,7 @@
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
 			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^4.2.2",
@@ -3066,6 +3174,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
 			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3078,6 +3187,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
 			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3090,6 +3200,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
 			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^4.2.2",
@@ -3103,6 +3214,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
 			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3115,6 +3227,7 @@
 			"version": "4.3.49",
 			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
 			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.2.14",
@@ -3130,6 +3243,7 @@
 			"version": "4.2.54",
 			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
 			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/config-resolver": "^4.4.17",
@@ -3148,6 +3262,7 @@
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
 			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.3.14",
@@ -3162,6 +3277,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
 			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3174,6 +3290,7 @@
 			"version": "4.2.14",
 			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
 			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
@@ -3187,6 +3304,7 @@
 			"version": "4.3.8",
 			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
 			"integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/service-error-classification": "^4.3.1",
@@ -3201,6 +3319,7 @@
 			"version": "4.5.25",
 			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
 			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/fetch-http-handler": "^5.3.17",
@@ -3220,6 +3339,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
 			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3232,6 +3352,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
 			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^4.2.2",
@@ -3245,6 +3366,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
 			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3257,6 +3379,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
 			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3",
@@ -3274,24 +3397,28 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
 			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/mime-types": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
 			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "25.6.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
 			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.19.0"
@@ -3301,12 +3428,14 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/yauzl": {
 			"version": "2.10.3",
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
 			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -3317,6 +3446,7 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
 			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -3326,6 +3456,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -3338,6 +3469,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -3353,12 +3485,14 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
 			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.1"
@@ -3371,6 +3505,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -3380,6 +3515,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3400,6 +3536,7 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
 			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -3409,6 +3546,7 @@
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
 			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -3418,12 +3556,14 @@
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
 			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
 			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -3436,6 +3576,7 @@
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -3445,12 +3586,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/chalk": {
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
 			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -3463,6 +3606,7 @@
 			"version": "2.1.11",
 			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
 			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"chalk": "^4.0.0",
@@ -3484,6 +3628,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -3500,6 +3645,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
 			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -3511,6 +3657,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3520,6 +3667,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -3532,6 +3680,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -3544,12 +3693,14 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
 			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -3559,6 +3710,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -3576,6 +3728,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
 			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ast-types": "^0.13.4",
@@ -3590,6 +3743,7 @@
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
 			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -3599,6 +3753,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
 			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
@@ -3608,12 +3763,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
 			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
@@ -3623,6 +3780,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3632,6 +3790,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
 			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esprima": "^4.0.1",
@@ -3653,6 +3812,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
@@ -3666,6 +3826,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
@@ -3675,6 +3836,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3684,12 +3846,14 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
 			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"debug": "^4.1.1",
@@ -3710,6 +3874,7 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
 			"integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3725,6 +3890,7 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
 			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3746,6 +3912,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pend": "~1.2.0"
@@ -3755,6 +3922,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
 			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3778,6 +3946,7 @@
 			"version": "21.3.4",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
 			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/inflate": "^0.4.1",
@@ -3796,6 +3965,7 @@
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
 			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fetch-blob": "^3.1.2"
@@ -3808,6 +3978,7 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
 			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"extend": "^3.0.2",
@@ -3822,6 +3993,7 @@
 			"version": "8.1.2",
 			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
 			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"gaxios": "^7.0.0",
@@ -3836,6 +4008,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
@@ -3845,6 +4018,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
 			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3857,6 +4031,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
@@ -3872,6 +4047,7 @@
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
 			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"basic-ftp": "^5.0.2",
@@ -3886,6 +4062,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
 			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -3895,6 +4072,7 @@
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
 			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"minimatch": "^10.2.2",
@@ -3912,6 +4090,7 @@
 			"version": "10.6.2",
 			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
 			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"base64-js": "^1.3.0",
@@ -3929,6 +4108,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
 			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3938,12 +4118,14 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3953,6 +4135,7 @@
 			"version": "10.7.3",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
 			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": "*"
@@ -3962,6 +4145,7 @@
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
 			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^11.1.0"
@@ -3974,6 +4158,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
 			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.0",
@@ -3987,6 +4172,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
 			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.2",
@@ -4000,6 +4186,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4020,6 +4207,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -4029,6 +4217,7 @@
 			"version": "10.2.0",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
 			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -4038,15 +4227,27 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
@@ -4056,6 +4257,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
 			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
@@ -4069,6 +4271,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
 			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-equal-constant-time": "^1.0.1",
@@ -4080,6 +4283,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
 			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"jwa": "^2.0.1",
@@ -4090,6 +4294,7 @@
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
 			"integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -4101,12 +4306,14 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
 			"version": "11.3.6",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
 			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -4116,6 +4323,7 @@
 			"version": "15.0.12",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
 			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
@@ -4128,6 +4336,7 @@
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
 			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -4137,6 +4346,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.54.0"
@@ -4153,6 +4363,7 @@
 			"version": "10.2.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
 			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"brace-expansion": "^5.0.5"
@@ -4168,6 +4379,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -4177,12 +4389,14 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
 			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0",
@@ -4194,6 +4408,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
 			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4.0"
@@ -4204,6 +4419,7 @@
 			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
 			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
 			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4223,6 +4439,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
 			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
@@ -4241,6 +4458,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4250,6 +4468,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -4259,6 +4478,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
 			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"openai": "bin/cli"
@@ -4280,6 +4500,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
 			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/retry": "0.12.0",
@@ -4293,6 +4514,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
 			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -4312,6 +4534,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
 			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"degenerator": "^5.0.0",
@@ -4325,12 +4548,14 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
 			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
 			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"parse5": "^6.0.1"
@@ -4340,18 +4565,21 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/partial-json": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
 			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-expression-matcher": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
 			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4367,6 +4595,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
 			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^11.0.0",
@@ -4383,12 +4612,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/proper-lockfile": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
 			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -4400,6 +4631,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -4409,6 +4641,7 @@
 			"version": "7.5.6",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
 			"integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4433,6 +4666,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
 			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.2",
@@ -4452,6 +4686,7 @@
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
 			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -4461,12 +4696,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pump": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
 			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -4477,6 +4714,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4486,6 +4724,7 @@
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
 			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -4495,6 +4734,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4515,12 +4755,14 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/smart-buffer": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6.0.0",
@@ -4531,6 +4773,7 @@
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
 			"integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ip-address": "^10.1.1",
@@ -4545,6 +4788,7 @@
 			"version": "8.0.5",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
 			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.2",
@@ -4559,6 +4803,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"optional": true,
 			"engines": {
@@ -4569,12 +4814,14 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -4589,6 +4836,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4598,6 +4846,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -4610,6 +4859,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
 			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.2.2"
@@ -4625,6 +4875,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
 			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4637,6 +4888,7 @@
 			"version": "10.3.5",
 			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
 			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
@@ -4653,6 +4905,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -4665,6 +4918,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
 			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0"
@@ -4674,6 +4928,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
 			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"thenify": ">= 3.1.0 < 4"
@@ -4686,6 +4941,7 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
 			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@borewit/text-codec": "^0.2.1",
@@ -4704,12 +4960,14 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
 			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/typebox": {
@@ -4736,6 +4994,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
 			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -4748,6 +5007,7 @@
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
 			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -4757,12 +5017,14 @@
 			"version": "7.19.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
 			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
 			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -4776,6 +5038,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
 			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -4785,6 +5048,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -4802,6 +5066,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4811,6 +5076,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -4823,12 +5089,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ws": {
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
 			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -4850,6 +5118,7 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -4859,6 +5128,7 @@
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
 			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -4874,6 +5144,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
 			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
@@ -4892,6 +5163,7 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -4901,6 +5173,7 @@
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
@@ -4911,6 +5184,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
 			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -4923,6 +5197,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -4932,6 +5207,7 @@
 			"version": "3.25.2",
 			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
 			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
 			"license": "ISC",
 			"peerDependencies": {
 				"zod": "^3.25.28 || ^4"


### PR DESCRIPTION
## Summary
- migrate pi-subagents imports from deprecated @mariozechner packages to @earendil-works packages
- move Pi runtime packages to peerDependencies and keep @earendil-works packages for development typechecking
- rewrite pi-subagents README to match the other extension README format

## Verification
- npm run check
- just pack-subagents
- pre-commit hook: biome check
- pre-commit hook: npm typecheck