### PR TITLE
fix: show extension statuses only when active

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -10,6 +10,7 @@
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
+- Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 
 ## TASTE
 

--- a/extensions/pi-biome-lsp/README.md
+++ b/extensions/pi-biome-lsp/README.md
@@ -13,6 +13,7 @@ Use it to give Pi Biome diagnostics, formatting, import organization, and safe s
 - Computes or writes Biome source actions such as `source.fixAll.biome` and `source.organizeImports.biome`.
 - Supports workspace roots, file limits, and recursive file discovery.
 - Starts the language server only for tool calls, then shuts it down.
+- Shows statusline activity only while Biome LSP tools are running.
 - Provides clear setup errors when Biome is missing.
 
 ## 📦 Install

--- a/extensions/pi-biome-lsp/src/biome-lsp.ts
+++ b/extensions/pi-biome-lsp/src/biome-lsp.ts
@@ -46,6 +46,10 @@ interface ServerCommand {
 	args: string[];
 }
 
+interface StatusContext {
+	ui: { setStatus: (key: string, value: string | undefined) => void };
+}
+
 interface LspPosition {
 	line: number;
 	character: number;
@@ -124,8 +128,8 @@ const biomeDiagnosticsTool = defineTool({
 		"If Biome is missing, report the configuration error and suggest installing @biomejs/biome or setting PI_BIOME_LSP_COMMAND.",
 	],
 	parameters: Type.Object(PathsParameters),
-	async execute(_toolCallId, params, signal) {
-		return runDiagnostics(params, signal);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return runDiagnostics(params, signal, ctx);
 	},
 });
 
@@ -143,12 +147,13 @@ const biomeFormatTool = defineTool({
 			Type.Boolean({ description: "Write formatted text back to the file. Defaults to false." }),
 		),
 	}),
-	async execute(_toolCallId, params, signal) {
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const root = resolveRoot(params.root);
 		const file = resolveBiomeFile(root, params.path);
 		const client = new LspClient(getServerCommand(), root, getTimeoutMs());
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
+		ctx.ui.setStatus(STATUS_KEY, "biome-lsp: format");
 
 		try {
 			await client.start();
@@ -171,6 +176,7 @@ const biomeFormatTool = defineTool({
 				text: params.write ? undefined : newText,
 			});
 		} finally {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
 			signal?.removeEventListener("abort", abort);
 			await client.shutdown();
 		}
@@ -197,13 +203,14 @@ const biomeFixTool = defineTool({
 			Type.Boolean({ description: "Write fixed text back to the file. Defaults to false." }),
 		),
 	}),
-	async execute(_toolCallId, params, signal) {
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const root = resolveRoot(params.root);
 		const file = resolveBiomeFile(root, params.path);
 		const actionKind = params.kind?.trim() || "source.fixAll.biome";
 		const client = new LspClient(getServerCommand(), root, getTimeoutMs());
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
+		ctx.ui.setStatus(STATUS_KEY, "biome-lsp: fix");
 
 		try {
 			await client.start();
@@ -231,6 +238,7 @@ const biomeFixTool = defineTool({
 				text: params.write ? undefined : newText,
 			});
 		} finally {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
 			signal?.removeEventListener("abort", abort);
 			await client.shutdown();
 		}
@@ -246,12 +254,11 @@ export default function biomeLsp(pi: ExtensionAPI) {
 		description: "Show Biome LSP extension configuration",
 		handler: async (_args, ctx) => {
 			ctx.ui.notify(buildStatusMessage(), statusLevel());
-			updateStatus(ctx);
 		},
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		updateStatus(ctx);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -262,6 +269,7 @@ export default function biomeLsp(pi: ExtensionAPI) {
 async function runDiagnostics(
 	params: { root?: string; paths?: string[]; limit?: number },
 	signal: AbortSignal | undefined,
+	ctx: StatusContext,
 ) {
 	const root = resolveRoot(params.root);
 	const files = collectBiomeFiles(root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
@@ -272,6 +280,7 @@ async function runDiagnostics(
 	const client = new LspClient(getServerCommand(), root, getTimeoutMs());
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
+	ctx.ui.setStatus(STATUS_KEY, "biome-lsp: diagnostics");
 
 	try {
 		await client.start();
@@ -293,6 +302,7 @@ async function runDiagnostics(
 			summary: summarize(entries),
 		});
 	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 		signal?.removeEventListener("abort", abort);
 		await client.shutdown();
 	}
@@ -311,13 +321,6 @@ function getServerCommand(): ServerCommand {
 function getTimeoutMs() {
 	const rawValue = Number(process.env.PI_BIOME_LSP_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS);
 	return Number.isFinite(rawValue) && rawValue > 0 ? rawValue : DEFAULT_TIMEOUT_MS;
-}
-
-function updateStatus(ctx: {
-	ui: { setStatus: (key: string, value: string | undefined) => void };
-}) {
-	const command = getServerCommand();
-	ctx.ui.setStatus(STATUS_KEY, `biome-lsp: ${commandExists(command.command) ? "ready" : "missing"}`);
 }
 
 function buildStatusMessage() {

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -16,6 +16,7 @@ This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDev
 - Evaluates JavaScript in the selected page.
 - Captures PNG screenshots, including optional full-page screenshots.
 - Uses a local Chrome DevTools Protocol endpoint.
+- Shows statusline activity only while Chrome DevTools tools are running.
 
 ## 📦 Install
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -4,6 +4,11 @@ import { Type } from "typebox";
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 9222;
 const DEFAULT_TIMEOUT_MS = 10_000;
+const STATUS_KEY = "chrome-devtools";
+
+interface StatusContext {
+	ui: { setStatus: (key: string, value: string | undefined) => void };
+}
 
 interface DevToolsPage {
 	id: string;
@@ -40,9 +45,11 @@ const listPagesTool = defineTool({
 	description: "List Chrome tabs/pages from a running Chrome DevTools Protocol endpoint.",
 	promptSnippet: "List Chrome tabs/pages available over Chrome DevTools Protocol",
 	parameters: Type.Object({}),
-	async execute() {
-		const pages = await listPages();
-		return textResult(JSON.stringify(pages.map(formatPage), null, 2), { pages });
+	async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+		return withStatus(ctx, "cdp: list pages", async () => {
+			const pages = await listPages();
+			return textResult(JSON.stringify(pages.map(formatPage), null, 2), { pages });
+		});
 	},
 });
 
@@ -54,11 +61,13 @@ const selectPageTool = defineTool({
 	parameters: Type.Object({
 		pageId: Type.String({ description: "Page id from chrome_devtools_list_pages." }),
 	}),
-	async execute(_toolCallId, params) {
-		const page = await getPage(params.pageId);
-		state.activePageId = page.id;
-		return textResult(`Selected page ${page.id}: ${page.title}\n${page.url}`, {
-			page: formatPage(page),
+	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		return withStatus(ctx, "cdp: select page", async () => {
+			const page = await getPage(params.pageId);
+			state.activePageId = page.id;
+			return textResult(`Selected page ${page.id}: ${page.title}\n${page.url}`, {
+				page: formatPage(page),
+			});
 		});
 	},
 });
@@ -74,15 +83,17 @@ const navigateTool = defineTool({
 			Type.String({ description: "Optional page id. Defaults to selected or first page." }),
 		),
 	}),
-	async execute(_toolCallId, params) {
-		const page = await resolvePage(params.pageId);
-		const result = await withCdp(page, async (client) => {
-			await client.send("Page.enable");
-			return client.send("Page.navigate", { url: params.url });
-		});
+	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		return withStatus(ctx, "cdp: navigate", async () => {
+			const page = await resolvePage(params.pageId);
+			const result = await withCdp(page, async (client) => {
+				await client.send("Page.enable");
+				return client.send("Page.navigate", { url: params.url });
+			});
 
-		state.activePageId = page.id;
-		return textResult(`Navigated ${page.id} to ${params.url}`, { page: formatPage(page), result });
+			state.activePageId = page.id;
+			return textResult(`Navigated ${page.id} to ${params.url}`, { page: formatPage(page), result });
+		});
 	},
 });
 
@@ -100,18 +111,20 @@ const evaluateTool = defineTool({
 			Type.Boolean({ description: "Whether to await a returned Promise. Defaults to true." }),
 		),
 	}),
-	async execute(_toolCallId, params) {
-		const page = await resolvePage(params.pageId);
-		const result = await withCdp(page, (client) =>
-			client.send("Runtime.evaluate", {
-				expression: params.expression,
-				awaitPromise: params.awaitPromise ?? true,
-				returnByValue: true,
-			}),
-		);
+	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		return withStatus(ctx, "cdp: evaluate", async () => {
+			const page = await resolvePage(params.pageId);
+			const result = await withCdp(page, (client) =>
+				client.send("Runtime.evaluate", {
+					expression: params.expression,
+					awaitPromise: params.awaitPromise ?? true,
+					returnByValue: true,
+				}),
+			);
 
-		state.activePageId = page.id;
-		return textResult(JSON.stringify(result, null, 2), { page: formatPage(page), result });
+			state.activePageId = page.id;
+			return textResult(JSON.stringify(result, null, 2), { page: formatPage(page), result });
+		});
 	},
 });
 
@@ -128,40 +141,42 @@ const screenshotTool = defineTool({
 			Type.Boolean({ description: "Capture the full document, not just the viewport." }),
 		),
 	}),
-	async execute(_toolCallId, params) {
-		const page = await resolvePage(params.pageId);
-		const result = await withCdp(page, async (client) => {
-			await client.send("Page.enable");
+	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		return withStatus(ctx, "cdp: screenshot", async () => {
+			const page = await resolvePage(params.pageId);
+			const result = await withCdp(page, async (client) => {
+				await client.send("Page.enable");
 
-			if (!params.fullPage) {
-				return client.send<{ data: string }>("Page.captureScreenshot", { format: "png" });
-			}
+				if (!params.fullPage) {
+					return client.send<{ data: string }>("Page.captureScreenshot", { format: "png" });
+				}
 
-			const metrics = await client.send<{
-				contentSize: { x: number; y: number; width: number; height: number };
-			}>("Page.getLayoutMetrics");
+				const metrics = await client.send<{
+					contentSize: { x: number; y: number; width: number; height: number };
+				}>("Page.getLayoutMetrics");
 
-			return client.send<{ data: string }>("Page.captureScreenshot", {
-				captureBeyondViewport: true,
-				format: "png",
-				clip: {
-					x: metrics.contentSize.x,
-					y: metrics.contentSize.y,
-					width: metrics.contentSize.width,
-					height: metrics.contentSize.height,
-					scale: 1,
-				},
+				return client.send<{ data: string }>("Page.captureScreenshot", {
+					captureBeyondViewport: true,
+					format: "png",
+					clip: {
+						x: metrics.contentSize.x,
+						y: metrics.contentSize.y,
+						width: metrics.contentSize.width,
+						height: metrics.contentSize.height,
+						scale: 1,
+					},
+				});
 			});
-		});
 
-		state.activePageId = page.id;
-		return {
-			content: [
-				{ type: "text", text: `Captured PNG screenshot from ${page.title || page.url}` },
-				{ type: "image", data: result.data, mimeType: "image/png" },
-			],
-			details: { page: formatPage(page), bytes: Buffer.byteLength(result.data, "base64") },
-		};
+			state.activePageId = page.id;
+			return {
+				content: [
+					{ type: "text", text: `Captured PNG screenshot from ${page.title || page.url}` },
+					{ type: "image", data: result.data, mimeType: "image/png" },
+				],
+				details: { page: formatPage(page), bytes: Buffer.byteLength(result.data, "base64") },
+			};
+		});
 	},
 });
 
@@ -183,11 +198,11 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		ctx.ui.setStatus("chrome-devtools", `cdp: ${state.host}:${state.port}`);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
-		ctx.ui.setStatus("chrome-devtools", undefined);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 }
 
@@ -237,6 +252,15 @@ function textResult(text: string, details: unknown) {
 		content: [{ type: "text" as const, text }],
 		details,
 	};
+}
+
+async function withStatus<T>(ctx: StatusContext, status: string, callback: () => Promise<T>) {
+	ctx.ui.setStatus(STATUS_KEY, status);
+	try {
+		return await callback();
+	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
 }
 
 async function withCdp<T>(page: DevToolsPage, callback: (client: CdpClient) => Promise<T>) {

--- a/extensions/pi-firecrawl/README.md
+++ b/extensions/pi-firecrawl/README.md
@@ -14,6 +14,7 @@ Use it to give your AI coding agent reliable web research capabilities for docum
 - Discover URLs with Firecrawl map.
 - Search the web and optionally scrape search result pages.
 - Supports Firecrawl API endpoint overrides.
+- Shows statusline activity only while Firecrawl tools are running.
 - Never logs or displays your Firecrawl API key.
 
 ## 📦 Install

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -10,6 +10,10 @@ interface FirecrawlState {
 	apiUrl: string;
 }
 
+interface StatusContext {
+	ui: { setStatus: (key: string, value: string | undefined) => void };
+}
+
 const state: FirecrawlState = {
 	apiUrl: normalizeApiUrl(process.env.FIRECRAWL_API_URL ?? process.env.FIRECRAWL_BASE_URL),
 };
@@ -68,9 +72,11 @@ const scrapeTool = defineTool({
 		),
 		location: Type.Optional(Type.Any({ description: "Firecrawl location options." })),
 	}),
-	async execute(_toolCallId, params, signal) {
-		const payload = await firecrawlRequest("POST", "/scrape", cleanObject(params), signal);
-		return jsonResult(payload);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return withStatus(ctx, "firecrawl: scrape", async () => {
+			const payload = await firecrawlRequest("POST", "/scrape", cleanObject(params), signal);
+			return jsonResult(payload);
+		});
 	},
 });
 
@@ -104,9 +110,11 @@ const crawlTool = defineTool({
 		),
 		webhook: Type.Optional(Type.Any({ description: "Firecrawl webhook configuration." })),
 	}),
-	async execute(_toolCallId, params, signal) {
-		const payload = await firecrawlRequest("POST", "/crawl", cleanObject(params), signal);
-		return jsonResult(payload);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return withStatus(ctx, "firecrawl: crawl", async () => {
+			const payload = await firecrawlRequest("POST", "/crawl", cleanObject(params), signal);
+			return jsonResult(payload);
+		});
 	},
 });
 
@@ -118,14 +126,16 @@ const crawlStatusTool = defineTool({
 	parameters: Type.Object({
 		id: Type.String({ description: "Crawl job id returned by firecrawl_crawl." }),
 	}),
-	async execute(_toolCallId, params, signal) {
-		const payload = await firecrawlRequest(
-			"GET",
-			`/crawl/${encodeURIComponent(params.id)}`,
-			undefined,
-			signal,
-		);
-		return jsonResult(payload);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return withStatus(ctx, "firecrawl: crawl status", async () => {
+			const payload = await firecrawlRequest(
+				"GET",
+				`/crawl/${encodeURIComponent(params.id)}`,
+				undefined,
+				signal,
+			);
+			return jsonResult(payload);
+		});
 	},
 });
 
@@ -148,9 +158,11 @@ const mapTool = defineTool({
 		),
 		limit: Type.Optional(Type.Number({ description: "Maximum number of URLs to return." })),
 	}),
-	async execute(_toolCallId, params, signal) {
-		const payload = await firecrawlRequest("POST", "/map", cleanObject(params), signal);
-		return jsonResult(payload);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return withStatus(ctx, "firecrawl: map", async () => {
+			const payload = await firecrawlRequest("POST", "/map", cleanObject(params), signal);
+			return jsonResult(payload);
+		});
 	},
 });
 
@@ -170,9 +182,11 @@ const searchTool = defineTool({
 			Type.Any({ description: "Firecrawl scrapeOptions for search result pages." }),
 		),
 	}),
-	async execute(_toolCallId, params, signal) {
-		const payload = await firecrawlRequest("POST", "/search", cleanObject(params), signal);
-		return jsonResult(payload);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return withStatus(ctx, "firecrawl: search", async () => {
+			const payload = await firecrawlRequest("POST", "/search", cleanObject(params), signal);
+			return jsonResult(payload);
+		});
 	},
 });
 
@@ -187,12 +201,11 @@ export default function firecrawl(pi: ExtensionAPI) {
 		description: "Show Firecrawl extension configuration status",
 		handler: async (_args, ctx) => {
 			ctx.ui.notify(buildStatusMessage(), hasApiKey() ? "info" : "warning");
-			updateStatus(ctx);
 		},
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		updateStatus(ctx);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -270,10 +283,13 @@ function jsonResult(payload: unknown) {
 	};
 }
 
-function updateStatus(ctx: {
-	ui: { setStatus: (key: string, value: string | undefined) => void };
-}) {
-	ctx.ui.setStatus(STATUS_KEY, hasApiKey() ? "firecrawl: configured" : "firecrawl: missing key");
+async function withStatus<T>(ctx: StatusContext, status: string, callback: () => Promise<T>) {
+	ctx.ui.setStatus(STATUS_KEY, status);
+	try {
+		return await callback();
+	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
 }
 
 function buildStatusMessage() {

--- a/extensions/pi-python-lsp/README.md
+++ b/extensions/pi-python-lsp/README.md
@@ -14,6 +14,7 @@ Use it to give Pi reliable Python type diagnostics, Ruff lint diagnostics, forma
 - Computes or writes Ruff source actions such as `source.fixAll.ruff` and `source.organizeImports.ruff`.
 - Supports workspace roots, file limits, and recursive Python file discovery.
 - Starts language servers only for tool calls, then shuts them down.
+- Shows statusline activity only while Python LSP tools are running.
 - Provides clear setup errors when ty or Ruff is missing.
 
 ## 📦 Install

--- a/extensions/pi-python-lsp/src/python-lsp.ts
+++ b/extensions/pi-python-lsp/src/python-lsp.ts
@@ -28,6 +28,10 @@ interface ServerCommand {
 	args: string[];
 }
 
+interface StatusContext {
+	ui: { setStatus: (key: string, value: string | undefined) => void };
+}
+
 interface LspPosition {
 	line: number;
 	character: number;
@@ -106,8 +110,8 @@ const tyDiagnosticsTool = defineTool({
 		"If ty is missing, report the configuration error and suggest installing ty or setting PI_TY_LSP_COMMAND.",
 	],
 	parameters: Type.Object(PathsParameters),
-	async execute(_toolCallId, params, signal) {
-		return runDiagnostics("ty", params, signal);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return runDiagnostics("ty", params, signal, ctx);
 	},
 });
 
@@ -121,8 +125,8 @@ const ruffDiagnosticsTool = defineTool({
 		"If ruff is missing, report the configuration error and suggest installing ruff or setting PI_RUFF_LSP_COMMAND.",
 	],
 	parameters: Type.Object(PathsParameters),
-	async execute(_toolCallId, params, signal) {
-		return runDiagnostics("ruff", params, signal);
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return runDiagnostics("ruff", params, signal, ctx);
 	},
 });
 
@@ -140,12 +144,13 @@ const ruffFormatTool = defineTool({
 			Type.Boolean({ description: "Write formatted text back to the file. Defaults to false." }),
 		),
 	}),
-	async execute(_toolCallId, params, signal) {
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const root = resolveRoot(params.root);
 		const file = resolvePythonFile(root, params.path);
 		const client = new LspClient("ruff", getServerCommand("ruff"), root, getTimeoutMs("ruff"));
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
+		ctx.ui.setStatus(STATUS_KEY, "python-lsp: ruff format");
 
 		try {
 			await client.start();
@@ -168,6 +173,7 @@ const ruffFormatTool = defineTool({
 				text: params.write ? undefined : newText,
 			});
 		} finally {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
 			signal?.removeEventListener("abort", abort);
 			await client.shutdown();
 		}
@@ -194,13 +200,14 @@ const ruffFixTool = defineTool({
 			Type.Boolean({ description: "Write fixed text back to the file. Defaults to false." }),
 		),
 	}),
-	async execute(_toolCallId, params, signal) {
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const root = resolveRoot(params.root);
 		const file = resolvePythonFile(root, params.path);
 		const actionKind = params.kind?.trim() || "source.fixAll.ruff";
 		const client = new LspClient("ruff", getServerCommand("ruff"), root, getTimeoutMs("ruff"));
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
+		ctx.ui.setStatus(STATUS_KEY, "python-lsp: ruff fix");
 
 		try {
 			await client.start();
@@ -228,6 +235,7 @@ const ruffFixTool = defineTool({
 				text: params.write ? undefined : newText,
 			});
 		} finally {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
 			signal?.removeEventListener("abort", abort);
 			await client.shutdown();
 		}
@@ -244,12 +252,11 @@ export default function pythonLsp(pi: ExtensionAPI) {
 		description: "Show Python LSP extension configuration",
 		handler: async (_args, ctx) => {
 			ctx.ui.notify(buildStatusMessage(), statusLevel());
-			updateStatus(ctx);
 		},
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		updateStatus(ctx);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -261,6 +268,7 @@ async function runDiagnostics(
 	kind: ServerKind,
 	params: { root?: string; paths?: string[]; limit?: number },
 	signal: AbortSignal | undefined,
+	ctx: StatusContext,
 ) {
 	const root = resolveRoot(params.root);
 	const files = collectPythonFiles(root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
@@ -271,6 +279,7 @@ async function runDiagnostics(
 	const client = new LspClient(kind, getServerCommand(kind), root, getTimeoutMs(kind));
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
+	ctx.ui.setStatus(STATUS_KEY, `python-lsp: ${kind} diagnostics`);
 
 	try {
 		await client.start();
@@ -292,6 +301,7 @@ async function runDiagnostics(
 			summary: summarize(entries),
 		});
 	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 		signal?.removeEventListener("abort", abort);
 		await client.shutdown();
 	}
@@ -316,17 +326,6 @@ function getTimeoutMs(kind: ServerKind) {
 		kind === "ty" ? process.env.PI_TY_LSP_TIMEOUT_MS : process.env.PI_RUFF_LSP_TIMEOUT_MS;
 	const rawValue = Number(envValue ?? DEFAULT_TIMEOUT_MS);
 	return Number.isFinite(rawValue) && rawValue > 0 ? rawValue : DEFAULT_TIMEOUT_MS;
-}
-
-function updateStatus(ctx: {
-	ui: { setStatus: (key: string, value: string | undefined) => void };
-}) {
-	const tyReady = commandExists(getServerCommand("ty").command);
-	const ruffReady = commandExists(getServerCommand("ruff").command);
-	ctx.ui.setStatus(
-		STATUS_KEY,
-		`python-lsp: ty ${tyReady ? "ready" : "missing"}, ruff ${ruffReady ? "ready" : "missing"}`,
-	);
 }
 
 function buildStatusMessage() {

--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -12,6 +12,7 @@ Use it to make Pi sessions more resilient when an upstream AI provider returns a
 - Matches the known provider error text `Unknown error (no error details in response)`.
 - Appends Pi's retryable-provider-error hint.
 - Lets Pi's built-in retry path continue the turn.
+- Shows a short-lived statusline item only when a matching error triggers retry.
 - Requires no commands or configuration.
 - Works as a small, focused npm Pi extension package.
 
@@ -36,6 +37,8 @@ pi -e ./extensions/pi-retry
 ## 🚀 What it does
 
 When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
+
+The extension does not keep a permanent statusline entry. It briefly shows `unknown-error retry: retrying` only when it has matched the error and asked Pi to retry.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-retry/src/unknown-error-retry.ts
+++ b/extensions/pi-retry/src/unknown-error-retry.ts
@@ -3,14 +3,35 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 const UNKNOWN_NO_DETAILS_RE = /Unknown error \(no error details in response\)/i;
 const RETRYABLE_HINT = "provider returned error";
 const EXTENSION_TAG = "[unknown-error-retry]";
+const STATUS_KEY = "unknown-error-retry";
+const STATUS_VISIBLE_MS = 8_000;
 
 export default function unknownErrorRetry(pi: ExtensionAPI) {
+	let clearStatusTimer: NodeJS.Timeout | undefined;
+
+	const clearStatus = (ctx: { ui: { setStatus: (key: string, value: string | undefined) => void } }) => {
+		if (clearStatusTimer) clearTimeout(clearStatusTimer);
+		clearStatusTimer = undefined;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	};
+
+	const showTransientStatus = (ctx: {
+		ui: { setStatus: (key: string, value: string | undefined) => void };
+	}) => {
+		if (clearStatusTimer) clearTimeout(clearStatusTimer);
+		ctx.ui.setStatus(STATUS_KEY, "unknown-error retry: retrying");
+		clearStatusTimer = setTimeout(() => {
+			clearStatusTimer = undefined;
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+		}, STATUS_VISIBLE_MS);
+	};
+
 	pi.on("session_start", (_event, ctx) => {
-		ctx.ui.setStatus("unknown-error-retry", "unknown-error retry: on");
+		clearStatus(ctx);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
-		ctx.ui.setStatus("unknown-error-retry", undefined);
+		clearStatus(ctx);
 	});
 
 	pi.on("message_end", (event, ctx) => {
@@ -37,6 +58,7 @@ export default function unknownErrorRetry(pi: ExtensionAPI) {
 		const errorMessage = `${message.errorMessage}\n\n${EXTENSION_TAG} ${RETRYABLE_HINT}; treating empty-detail provider failure as retryable.`;
 
 		if (ctx.hasUI) {
+			showTransientStatus(ctx);
 			ctx.ui.notify(
 				"Matched provider 'Unknown error (no error details in response)'; letting pi auto-retry this turn.",
 				"warning",


### PR DESCRIPTION
## Summary
- remove permanent statusline entries from chrome-devtools, firecrawl, python-lsp, biome-lsp, and retry
- show extension status only while tools are actively running or retry is triggered
- update extension READMEs and memory guidance for activity-based statuses

## Verification
- npm run check
- just pack-chrome-devtools
- just pack-firecrawl
- just pack-python-lsp
- just pack-biome-lsp
- just pack-retry
- pre-commit hook: biome check
- pre-commit hook: npm typecheck