### PR TITLE
feat(auto-thinking): add automatic thinking level extension

### DIFF
--- a/docs/plans/2026-05-16_auto-thinking-extension-plan.md
+++ b/docs/plans/2026-05-16_auto-thinking-extension-plan.md
@@ -1,0 +1,83 @@
+## Goal
+
+Build a publish-ready `@narumitw/pi-auto-thinking` extension that automatically selects Pi's thinking level for each user task based on the active model's reasoning capability and a deterministic task-difficulty heuristic. Success means the extension is packaged consistently with the monorepo, exposes understandable controls, avoids noisy UI behavior, and passes repository checks plus a package dry run.
+
+## Context
+
+- This repository is a Node/TypeScript monorepo for Pi extensions under `extensions/pi-*`.
+- Existing extension packages import Pi APIs from `@mariozechner/pi-coding-agent` and expose source files through each package's `pi.extensions` field.
+- Pi supports `before_agent_start`, `model_select`, and `thinking_level_select` extension events, and exposes `pi.getThinkingLevel()` / `pi.setThinkingLevel(level)`.
+- `ctx.model` exposes model metadata including `provider`, `id`, `reasoning`, and `thinkingLevelMap`.
+- Pi clamps `setThinkingLevel()` to model capabilities, but the extension should still compute and explain its intended decision.
+
+## Architecture
+
+- Add a new single-purpose package at `extensions/pi-auto-thinking`.
+- Implement the extension in `src/auto-thinking.ts` with these internal modules/functions kept in the same file unless the file becomes hard to navigate:
+  - config loading and validation
+  - prompt scoring
+  - model-aware level selection and clamping
+  - runtime state and command handlers
+- Keep runtime state in memory:
+  - `enabled`
+  - `lastDecision`
+  - `manualSuppressionTurnsRemaining`
+  - an `internalThinkingChange` guard to distinguish extension-triggered thinking changes from likely user changes
+- Use `ctx.ui.setStatus("auto-thinking", ...)` for passive status and reserve `ctx.ui.notify()` for explicit commands or warnings.
+
+## Tech Stack
+
+- TypeScript, NodeNext, no new runtime dependencies by default.
+- Use Node built-ins (`node:fs`, `node:path`, `node:process`) for optional JSON config loading.
+- Use existing repository gates: Biome, TypeScript, `npm run check`, and npm pack dry run.
+
+## Non-Goals
+
+- Do not call an LLM to classify task difficulty in the MVP.
+- Do not rewrite provider payloads or system prompts.
+- Do not maintain a large hard-coded model profile database.
+- Do not publish to npm as part of implementation unless explicitly requested.
+
+## Assumptions
+
+- The extension should default to enabled with conservative caps: `minLevel: "minimal"`, `maxLevel: "high"`.
+- `xhigh` should only be selected when config or model override permits `maxLevel: "xhigh"`.
+- The default config path should be `PI_CODING_AGENT_DIR/pi-auto-thinking.json`, falling back to `~/.pi/agent/pi-auto-thinking.json`.
+
+## Plan
+
+- [x] Confirm current package conventions and Pi API surface before editing; verified with `extensions/pi-statusline/package.json`, `extensions/pi-statusline/src/statusline.ts`, `node_modules/@earendil-works/pi-coding-agent/docs/extensions.md`, and `node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts`.
+- [x] Create `extensions/pi-auto-thinking` package skeleton (`package.json`, `README.md`, `LICENSE`, `tsconfig.json`, `src/auto-thinking.ts`) following existing package naming and `pi.extensions` conventions; verified with `npm --workspace @narumitw/pi-auto-thinking run typecheck`.
+- [x] Implement typed thinking-level utilities in `src/auto-thinking.ts` (`LEVELS`, level comparison, min/max clamp, supported-level filtering from `model.reasoning` and `model.thinkingLevelMap`) to produce deterministic candidate levels; verified with `npm --workspace @narumitw/pi-auto-thinking run typecheck`.
+- [x] Implement JSON config loading with safe defaults for `enabled`, `minLevel`, `maxLevel`, `respectManualTurns`, and `modelOverrides`; verified with validation-branch code review and `npm run check`.
+- [x] Implement prompt scoring as a pure deterministic heuristic with explicit keyword/structure weights for quick requests, simple Q&A, code paths, code blocks, debugging, tests, design, architecture, migration, refactor, security, and explicit “think hard” intent; verified by the score table in `extensions/pi-auto-thinking/README.md` and `npm run check`.
+- [x] Implement `before_agent_start` behavior to skip when disabled or manually suppressed, compute a decision from prompt/images/model/config, compare against `pi.getThinkingLevel()`, call `pi.setThinkingLevel()` only when needed, then record `lastDecision`; verified with `npm --workspace @narumitw/pi-auto-thinking run typecheck` and the non-interactive Node extension event smoke test.
+- [x] Implement `thinking_level_select` handling with an internal-change guard so extension-triggered changes do not count as manual overrides, while likely user changes suppress automation for `respectManualTurns`; verified by code review, `npm run check`, and the smoke test's extension-triggered level changes.
+- [x] Implement `model_select` handling to refresh the passive status and let the next prompt recompute based on the new model; verified by code review and `npm run check`.
+- [x] Register `/auto-thinking` command with `on`, `off`, `status`, and `explain` subcommands; verified by `pi -e ./extensions/pi-auto-thinking --no-session --no-context-files --no-skills -p "/auto-thinking status"` and README command documentation.
+- [x] Update root integration points for consistency: root `package.json` pack script and `justfile` recipes for `pack-auto-thinking`, `try-auto-thinking`, `install-auto-thinking`, and `publish-auto-thinking`; verified with `just --list | grep auto-thinking`.
+- [x] Write `extensions/pi-auto-thinking/README.md` with install/try instructions, config example, heuristic explanation, command reference, model capability behavior, and cost/latency caveats; verified package dry-run includes `README.md`, `LICENSE`, and `src/auto-thinking.ts`.
+- [x] Run repository verification after implementation; verified with `npm run check`, `npm --workspace @narumitw/pi-auto-thinking pack --dry-run`, and `just pack-auto-thinking`.
+- [x] Perform one bounded runtime smoke test with the local extension using one simple prompt, one design/debug prompt, a non-reasoning model case, and `/auto-thinking explain`; verified with the non-interactive Node extension event harness output `auto-thinking smoke test passed`.
+
+## Risks
+
+- Heuristic misclassification could increase cost or latency; mitigate with conservative defaults, `maxLevel: "high"`, `/auto-thinking off`, and clear `/auto-thinking explain` output.
+- Manual override detection is approximate because `thinking_level_select` does not expose a source; mitigate with an internal-change guard and conservative suppression semantics.
+- Model-specific thinking support can vary; mitigate by respecting `model.reasoning`, `thinkingLevelMap`, and Pi's built-in clamping.
+- UI noise could annoy users; mitigate by using status text by default and notifications only for explicit commands or config warnings.
+
+## Rollback / Recovery
+
+- Users can disable behavior at runtime with `/auto-thinking off`.
+- Users can remove the package from Pi configuration or uninstall the package if the extension causes bad defaults.
+- If a release is published with bad behavior, ship a patch release that defaults `enabled` to `false` or tightens `maxLevel`, and document the config workaround in the README.
+
+## Completion Checklist
+
+- [x] The new extension package exists under `extensions/pi-auto-thinking` with package metadata, source, README, license, and tsconfig verified by file paths in the repository.
+- [x] Automatic thinking selection is implemented through `before_agent_start` and model-aware clamping verified by code review and `npm run check`.
+- [x] Runtime controls `/auto-thinking on|off|status|explain` are documented and verified by README review plus `pi -e ./extensions/pi-auto-thinking --no-session --no-context-files --no-skills -p "/auto-thinking status"`.
+- [x] Root scripts/recipes include auto-thinking pack/try/install/publish entries verified by `just --list | grep auto-thinking`.
+- [x] Repository quality gates pass, verified by `npm run check`.
+- [x] Package contents are publish-ready, verified by `npm --workspace @narumitw/pi-auto-thinking pack --dry-run` and `just pack-auto-thinking`.

--- a/extensions/pi-auto-thinking/LICENSE
+++ b/extensions/pi-auto-thinking/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-auto-thinking/README.md
+++ b/extensions/pi-auto-thinking/README.md
@@ -1,0 +1,168 @@
+# 🧠 pi-auto-thinking — Automatic Thinking Level for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-auto-thinking)](https://www.npmjs.com/package/@narumitw/pi-auto-thinking) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-auto-thinking` is a native [Pi coding agent](https://pi.dev) extension that selects Pi's thinking level for each user task from the active model capability and a deterministic task-difficulty score.
+
+Use it when you want simple prompts to stay cheap and fast, while design, debugging, migration, security, or refactor tasks automatically get more reasoning budget.
+
+## ✨ Features
+
+- Automatically selects `minimal`, `low`, `medium`, `high`, or `xhigh` before each agent turn.
+- Turns thinking `off` for models that do not advertise reasoning support.
+- Respects model `thinkingLevelMap` entries that mark levels unsupported.
+- Uses conservative defaults: enabled, `minLevel: "minimal"`, `maxLevel: "high"`.
+- Avoids extra LLM calls; task difficulty is scored with local deterministic heuristics.
+- Detects likely manual thinking-level changes and pauses automation for a few turns.
+- Adds `/auto-thinking` commands for status, enable/disable, and explaining the last decision.
+- Shows a compact statusline item after decisions without notifying every turn.
+
+## 📦 Install
+
+```bash
+pi install npm:@narumitw/pi-auto-thinking
+```
+
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-auto-thinking
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-auto-thinking
+```
+
+## 🚀 Usage
+
+```text
+/auto-thinking status
+/auto-thinking on
+/auto-thinking off
+/auto-thinking explain
+```
+
+- `status` shows whether automation is enabled, the loaded config path, bounds, and warnings.
+- `on` enables automatic thinking selection for subsequent user prompts.
+- `off` disables automation and clears the extension statusline item.
+- `explain` shows the score, selected level, and matched signals from the last decision.
+
+## 🧮 How scoring works
+
+The extension scores each prompt locally before Pi starts the agent loop. The base level mapping is:
+
+| Score | Base thinking level |
+| ---: | --- |
+| `<= 0` | `minimal` |
+| `1..2` | `low` |
+| `3..5` | `medium` |
+| `6..8` | `high` |
+| `>= 9` | `xhigh` |
+
+Default weights:
+
+| Signal | Weight |
+| --- | ---: |
+| Quick, brief, concise, simple, or equivalent Chinese wording | `-2` |
+| Simple explanation, translation, or summary | `-1` |
+| Implementation, editing, or code-change request | `+2` |
+| Debugging, exception, stack trace, failure, or broken behavior | `+2` |
+| Tests, lint, typecheck, TypeScript, CI, or similar | `+1` |
+| Design, architecture, plan, proposal, or tradeoff work | `+3` |
+| Migration, refactor, compatibility, or breaking-change work | `+3` |
+| Security, auth, secrets, concurrency, transaction, rollback, or data-loss topic | `+3` |
+| Explicit deep reasoning request such as “think hard”, “carefully”, “深入”, or “仔細” | `+3` |
+| Code block included | `+1` |
+| One file path mentioned | `+1` |
+| Three or more file paths mentioned | `+2` |
+| Long prompt | `+1` |
+| Image input attached | `+1` |
+
+After scoring, config bounds and model support are applied. For example, with the default `maxLevel: "high"`, a score that maps to `xhigh` is capped at `high`.
+
+## ⚙️ Configuration
+
+Optional config file:
+
+```text
+$PI_CODING_AGENT_DIR/pi-auto-thinking.json
+```
+
+When `PI_CODING_AGENT_DIR` is unset, the extension reads:
+
+```text
+~/.pi/agent/pi-auto-thinking.json
+```
+
+Example:
+
+```json
+{
+  "enabled": true,
+  "minLevel": "minimal",
+  "maxLevel": "high",
+  "respectManualTurns": 3,
+  "modelOverrides": {
+    "anthropic/claude-haiku-4-5": {
+      "maxLevel": "medium"
+    },
+    "anthropic/claude-opus-4-5": {
+      "maxLevel": "xhigh"
+    },
+    "local/small-fast-model": {
+      "enabled": false
+    }
+  }
+}
+```
+
+Supported levels are:
+
+```text
+off, minimal, low, medium, high, xhigh
+```
+
+`respectManualTurns` must be an integer from `0` to `20`. When a thinking level changes outside this extension, automation pauses for that many future user prompts. Pi's event does not expose the change source, so this detection is intentionally conservative.
+
+## 🤖 Model capability behavior
+
+- If `ctx.model` is unavailable, the extension selects `off`.
+- If `ctx.model.reasoning` is false, the extension selects `off`.
+- If `ctx.model.thinkingLevelMap` marks a level as `null`, the extension skips that level.
+- Pi still performs its own final clamp when `pi.setThinkingLevel()` is called.
+
+## 💸 Cost and latency caveats
+
+Higher thinking levels can increase latency and token usage depending on the provider. The default maximum is `high`, not `xhigh`, to avoid unexpectedly expensive turns. Use `/auto-thinking explain` to inspect why a level was selected, or `/auto-thinking off` to disable automation for the session.
+
+## 🗂️ Package layout
+
+```txt
+extensions/pi-auto-thinking/
+├── src/
+│   └── auto-thinking.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its Pi extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/auto-thinking.ts"]
+  }
+}
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, automatic thinking, reasoning level, task difficulty, TypeScript Pi package, npm Pi extension.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-auto-thinking/package.json
+++ b/extensions/pi-auto-thinking/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "@narumitw/pi-auto-thinking",
+	"version": "0.1.12",
+	"description": "Pi extension that automatically adjusts thinking level from model capability and task difficulty.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"thinking",
+		"reasoning",
+		"automation"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/auto-thinking.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@earendil-works/pi-coding-agent": "0.74.0",
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "extensions/pi-auto-thinking"
+	}
+}

--- a/extensions/pi-auto-thinking/src/auto-thinking.ts
+++ b/extensions/pi-auto-thinking/src/auto-thinking.ts
@@ -1,0 +1,666 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+
+type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
+type Model = NonNullable<ExtensionContext["model"]>;
+
+type Config = {
+	enabled: boolean;
+	minLevel: ThinkingLevel;
+	maxLevel: ThinkingLevel;
+	respectManualTurns: number;
+	modelOverrides: Record<string, ModelOverride>;
+};
+
+type ModelOverride = {
+	enabled?: boolean;
+	minLevel?: ThinkingLevel;
+	maxLevel?: ThinkingLevel;
+};
+
+type LoadedConfig = {
+	config: Config;
+	path: string;
+	warnings: string[];
+};
+
+type ScoreSignal = {
+	label: string;
+	weight: number;
+};
+
+type PromptScore = {
+	score: number;
+	baseLevel: ThinkingLevel;
+	signals: ScoreSignal[];
+};
+
+type ThinkingDecision = {
+	kind: "selected";
+	level: ThinkingLevel;
+	baseLevel: ThinkingLevel;
+	score: number;
+	reasons: string[];
+	modelKey?: string;
+};
+
+type SkippedDecision = {
+	kind: "skipped";
+	reason: string;
+	reasons: string[];
+};
+
+type LastDecision = ThinkingDecision | SkippedDecision;
+
+type RuntimeState = {
+	config: Config;
+	configPath: string;
+	configWarnings: string[];
+	enabled: boolean;
+	lastDecision?: LastDecision;
+	manualSuppressionTurnsRemaining: number;
+	pendingManualSuppression: boolean;
+	expectedThinkingLevel?: ThinkingLevel;
+};
+
+const STATUS_KEY = "auto-thinking";
+const COMMAND_NAME = "auto-thinking";
+const CONFIG_FILE_NAME = "pi-auto-thinking.json";
+const LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly ThinkingLevel[];
+const MAX_RESPECT_MANUAL_TURNS = 20;
+
+const DEFAULT_CONFIG: Config = {
+	enabled: true,
+	minLevel: "minimal",
+	maxLevel: "high",
+	respectManualTurns: 3,
+	modelOverrides: {},
+};
+
+const RULES: Array<{
+	label: string;
+	weight: number;
+	patterns: RegExp[];
+}> = [
+	{
+		label: "quick or brief response requested",
+		weight: -2,
+		patterns: [
+			/\b(quick|brief|short|concise|fast|simple|tl;dr)\b/i,
+			/(快速|簡短|簡潔|簡單|摘要|不用詳細)/,
+		],
+	},
+	{
+		label: "simple explanation or translation",
+		weight: -1,
+		patterns: [
+			/\b(explain|translate|summari[sz]e|what is|how do i)\b/i,
+			/(解釋|翻譯|說明|什麼是|怎麼)/,
+		],
+	},
+	{
+		label: "implementation or editing task",
+		weight: 2,
+		patterns: [
+			/\b(implement|add|update|change|modify|fix|create|write|build)\b/i,
+			/(實作|新增|更新|修改|修正|建立|撰寫|完成)/,
+		],
+	},
+	{
+		label: "debugging or failure investigation",
+		weight: 2,
+		patterns: [
+			/\b(bug|debug|error|exception|stack trace|traceback|failing|fails|failure|broken)\b/i,
+			/(錯誤|除錯|失敗|例外|堆疊|壞掉|修 bug)/i,
+		],
+	},
+	{
+		label: "tests, lint, or typechecking mentioned",
+		weight: 1,
+		patterns: [
+			/\b(test|tests|testing|lint|typecheck|typescript|tsc|biome|ruff|pytest|ci)\b/i,
+			/(測試|型別|檢查|CI|lint)/i,
+		],
+	},
+	{
+		label: "design, architecture, or planning task",
+		weight: 3,
+		patterns: [
+			/\b(design|architecture|architect|plan|roadmap|proposal|trade-?off|review the plan)\b/i,
+			/(設計|架構|計畫|規劃|取捨|方案|審查計畫)/,
+		],
+	},
+	{
+		label: "migration, refactor, or compatibility work",
+		weight: 3,
+		patterns: [
+			/\b(migrat(e|ion)|refactor|restructure|compatibility|backwards compatible|breaking change)\b/i,
+			/(遷移|重構|相容|破壞性變更)/,
+		],
+	},
+	{
+		label: "security, concurrency, or data-risk topic",
+		weight: 3,
+		patterns: [
+			/\b(security|permission|auth|token|secret|credential|race|concurrency|transaction|data loss|rollback|recovery)\b/i,
+			/(安全|權限|認證|密鑰|憑證|併發|交易|資料遺失|回復|復原)/,
+		],
+	},
+	{
+		label: "deep reasoning explicitly requested",
+		weight: 3,
+		patterns: [
+			/\b(think hard|think deeply|deep dive|carefully|thorough|comprehensive|ultrathink)\b/i,
+			/(仔細|深入|完整|全面|深度思考|認真想)/,
+		],
+	},
+];
+
+export default function autoThinking(pi: ExtensionAPI) {
+	const loaded = loadConfig();
+	const runtime: RuntimeState = {
+		config: loaded.config,
+		configPath: loaded.path,
+		configWarnings: loaded.warnings,
+		enabled: loaded.config.enabled,
+		manualSuppressionTurnsRemaining: 0,
+		pendingManualSuppression: false,
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		const next = loadConfig();
+		runtime.config = next.config;
+		runtime.configPath = next.path;
+		runtime.configWarnings = next.warnings;
+		runtime.enabled = next.config.enabled;
+		runtime.manualSuppressionTurnsRemaining = 0;
+		runtime.pendingManualSuppression = false;
+		runtime.expectedThinkingLevel = undefined;
+		runtime.lastDecision = undefined;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		for (const warning of next.warnings) ctx.ui.notify(warning, "warning");
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+
+	pi.on("before_agent_start", (event, ctx) => {
+		if (!runtime.enabled) {
+			const decision = skippedDecision("Auto thinking is disabled.");
+			runtime.lastDecision = decision;
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+
+		if (runtime.manualSuppressionTurnsRemaining > 0) {
+			runtime.pendingManualSuppression = false;
+			const skippedTurns = runtime.manualSuppressionTurnsRemaining;
+			runtime.manualSuppressionTurnsRemaining -= 1;
+			const decision = skippedDecision(
+				`Manual thinking change detected; automation paused for ${skippedTurns} more turn${skippedTurns === 1 ? "" : "s"}.`,
+			);
+			runtime.lastDecision = decision;
+			ctx.ui.setStatus(
+				STATUS_KEY,
+				`auto-thinking paused ${runtime.manualSuppressionTurnsRemaining}`,
+			);
+			return;
+		}
+
+		const decision = decideThinkingLevel({
+			config: runtime.config,
+			hasImages: (event.images?.length ?? 0) > 0,
+			model: ctx.model,
+			prompt: event.prompt,
+		});
+		runtime.lastDecision = decision;
+
+		const currentLevel = pi.getThinkingLevel();
+		if (currentLevel !== decision.level) {
+			runtime.expectedThinkingLevel = decision.level;
+			pi.setThinkingLevel(decision.level);
+			setTimeout(() => {
+				if (runtime.expectedThinkingLevel === decision.level) {
+					runtime.expectedThinkingLevel = undefined;
+				}
+			}, 0).unref?.();
+		}
+
+		ctx.ui.setStatus(STATUS_KEY, formatStatus(decision));
+	});
+
+	pi.on("thinking_level_select", (event, ctx) => {
+		if (runtime.expectedThinkingLevel === event.level) {
+			runtime.expectedThinkingLevel = undefined;
+			return;
+		}
+
+		if (!runtime.enabled || runtime.config.respectManualTurns <= 0) return;
+
+		runtime.manualSuppressionTurnsRemaining = runtime.config.respectManualTurns;
+		runtime.pendingManualSuppression = true;
+		runtime.lastDecision = skippedDecision(
+			`Thinking level changed outside auto-thinking (${event.previousLevel} -> ${event.level}); automation will pause for ${runtime.manualSuppressionTurnsRemaining} turn${runtime.manualSuppressionTurnsRemaining === 1 ? "" : "s"}.`,
+		);
+		ctx.ui.setStatus(STATUS_KEY, `auto-thinking paused ${runtime.manualSuppressionTurnsRemaining}`);
+	});
+
+	pi.on("model_select", (_event, ctx) => {
+		if (runtime.pendingManualSuppression) {
+			runtime.manualSuppressionTurnsRemaining = 0;
+			runtime.pendingManualSuppression = false;
+			runtime.lastDecision = undefined;
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+		}
+		if (!runtime.enabled) {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+		if (runtime.lastDecision) ctx.ui.setStatus(STATUS_KEY, formatLastDecision(runtime.lastDecision));
+	});
+
+	pi.registerCommand(COMMAND_NAME, {
+		description: "Configure automatic thinking level selection",
+		handler: async (args, ctx) => {
+			handleCommand(args, runtime, ctx);
+		},
+	});
+}
+
+function loadConfig(): LoadedConfig {
+	const configPath = getConfigPath();
+	if (!existsSync(configPath)) return { config: { ...DEFAULT_CONFIG }, path: configPath, warnings: [] };
+
+	try {
+		const raw = readFileSync(configPath, "utf8");
+		const parsed = JSON.parse(raw) as unknown;
+		const warnings: string[] = [];
+		const config = parseConfig(parsed, warnings);
+		return { config, path: configPath, warnings };
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			config: { ...DEFAULT_CONFIG },
+			path: configPath,
+			warnings: [
+				`Failed to load ${CONFIG_FILE_NAME}; using defaults. ${message}`,
+			],
+		};
+	}
+}
+
+function getConfigPath(): string {
+	const agentDir = process.env.PI_CODING_AGENT_DIR ?? join(process.env.HOME ?? ".", ".pi", "agent");
+	return join(agentDir, CONFIG_FILE_NAME);
+}
+
+function parseConfig(value: unknown, warnings: string[]): Config {
+	if (!isRecord(value)) {
+		warnings.push(`${CONFIG_FILE_NAME} must contain a JSON object; using defaults.`);
+		return { ...DEFAULT_CONFIG };
+	}
+
+	return {
+		enabled: readBoolean(value.enabled, DEFAULT_CONFIG.enabled, "enabled", warnings),
+		minLevel: readThinkingLevel(value.minLevel, DEFAULT_CONFIG.minLevel, "minLevel", warnings),
+		maxLevel: readThinkingLevel(value.maxLevel, DEFAULT_CONFIG.maxLevel, "maxLevel", warnings),
+		respectManualTurns: readInteger(
+			value.respectManualTurns,
+			DEFAULT_CONFIG.respectManualTurns,
+			"respectManualTurns",
+			warnings,
+		),
+		modelOverrides: readModelOverrides(value.modelOverrides, warnings),
+	};
+}
+
+function readModelOverrides(value: unknown, warnings: string[]): Record<string, ModelOverride> {
+	if (value === undefined) return {};
+	if (!isRecord(value)) {
+		warnings.push("modelOverrides must be an object; ignoring it.");
+		return {};
+	}
+
+	const overrides: Record<string, ModelOverride> = {};
+	for (const [modelKey, overrideValue] of Object.entries(value)) {
+		if (!isRecord(overrideValue)) {
+			warnings.push(`modelOverrides.${modelKey} must be an object; ignoring it.`);
+			continue;
+		}
+		const override: ModelOverride = {};
+		if (overrideValue.enabled !== undefined) {
+			override.enabled = readBoolean(
+				overrideValue.enabled,
+				DEFAULT_CONFIG.enabled,
+				`modelOverrides.${modelKey}.enabled`,
+				warnings,
+			);
+		}
+		if (overrideValue.minLevel !== undefined) {
+			override.minLevel = readThinkingLevel(
+				overrideValue.minLevel,
+				DEFAULT_CONFIG.minLevel,
+				`modelOverrides.${modelKey}.minLevel`,
+				warnings,
+			);
+		}
+		if (overrideValue.maxLevel !== undefined) {
+			override.maxLevel = readThinkingLevel(
+				overrideValue.maxLevel,
+				DEFAULT_CONFIG.maxLevel,
+				`modelOverrides.${modelKey}.maxLevel`,
+				warnings,
+			);
+		}
+		overrides[modelKey] = override;
+	}
+	return overrides;
+}
+
+function readBoolean(value: unknown, fallback: boolean, field: string, warnings: string[]): boolean {
+	if (value === undefined) return fallback;
+	if (typeof value === "boolean") return value;
+	warnings.push(`${field} must be a boolean; using ${fallback}.`);
+	return fallback;
+}
+
+function readInteger(value: unknown, fallback: number, field: string, warnings: string[]): number {
+	if (value === undefined) return fallback;
+	if (typeof value !== "number" || !Number.isInteger(value)) {
+		warnings.push(`${field} must be an integer; using ${fallback}.`);
+		return fallback;
+	}
+	if (value < 0 || value > MAX_RESPECT_MANUAL_TURNS) {
+		warnings.push(`${field} must be between 0 and ${MAX_RESPECT_MANUAL_TURNS}; using ${fallback}.`);
+		return fallback;
+	}
+	return value;
+}
+
+function readThinkingLevel(
+	value: unknown,
+	fallback: ThinkingLevel,
+	field: string,
+	warnings: string[],
+): ThinkingLevel {
+	if (value === undefined) return fallback;
+	if (typeof value === "string" && isThinkingLevel(value)) return value;
+	warnings.push(`${field} must be one of ${LEVELS.join(", ")}; using ${fallback}.`);
+	return fallback;
+}
+
+function decideThinkingLevel(input: {
+	config: Config;
+	hasImages: boolean;
+	model: ExtensionContext["model"];
+	prompt: string;
+}): ThinkingDecision {
+	const modelKey = input.model ? getModelKey(input.model) : undefined;
+	const override = modelKey ? input.config.modelOverrides[modelKey] : undefined;
+	const enabled = override?.enabled ?? input.config.enabled;
+	if (!enabled) {
+		return {
+			kind: "selected",
+			level: "off",
+			baseLevel: "off",
+			score: 0,
+			reasons: [`Automation disabled for ${modelKey ?? "current model"}.`],
+			modelKey,
+		};
+	}
+
+	const minLevel = override?.minLevel ?? input.config.minLevel;
+	const maxLevel = override?.maxLevel ?? input.config.maxLevel;
+	const promptScore = scorePrompt(input.prompt, input.hasImages);
+	const boundedLevel = clampLevel(promptScore.baseLevel, minLevel, maxLevel);
+	const level = selectSupportedLevel(input.model, boundedLevel, minLevel, maxLevel);
+	const reasons = buildDecisionReasons({
+		boundedLevel,
+		level,
+		maxLevel,
+		minLevel,
+		model: input.model,
+		modelKey,
+		promptScore,
+	});
+
+	return {
+		kind: "selected",
+		level,
+		baseLevel: promptScore.baseLevel,
+		score: promptScore.score,
+		reasons,
+		modelKey,
+	};
+}
+
+function scorePrompt(prompt: string, hasImages: boolean): PromptScore {
+	const signals: ScoreSignal[] = [];
+	const normalizedPrompt = prompt.trim();
+
+	for (const rule of RULES) {
+		if (rule.patterns.some((pattern) => pattern.test(normalizedPrompt))) {
+			signals.push({ label: rule.label, weight: rule.weight });
+		}
+	}
+
+	const codeBlockCount = countMatches(normalizedPrompt, /```/g) / 2;
+	if (codeBlockCount >= 1) signals.push({ label: "code block included", weight: 1 });
+
+	const filePathCount = countFilePaths(normalizedPrompt);
+	if (filePathCount >= 3) signals.push({ label: "multiple file paths mentioned", weight: 2 });
+	else if (filePathCount >= 1) signals.push({ label: "file path mentioned", weight: 1 });
+
+	const longPromptWords = normalizedPrompt.split(/\s+/).filter(Boolean).length;
+	if (longPromptWords >= 180) signals.push({ label: "long prompt", weight: 1 });
+
+	if (hasImages) signals.push({ label: "image input attached", weight: 1 });
+
+	const score = signals.reduce((total, signal) => total + signal.weight, 0);
+	return { score, baseLevel: levelForScore(score), signals };
+}
+
+function levelForScore(score: number): ThinkingLevel {
+	if (score <= 0) return "minimal";
+	if (score <= 2) return "low";
+	if (score <= 5) return "medium";
+	if (score <= 8) return "high";
+	return "xhigh";
+}
+
+function selectSupportedLevel(
+	model: ExtensionContext["model"],
+	candidate: ThinkingLevel,
+	minLevel: ThinkingLevel,
+	maxLevel: ThinkingLevel,
+): ThinkingLevel {
+	if (!model) return "off";
+	if (!model.reasoning) return "off";
+
+	const supported = LEVELS.filter((level) => isModelLevelSupported(model, level));
+	const boundedSupported = supported.filter(
+		(level) => compareLevels(level, minLevel) >= 0 && compareLevels(level, maxLevel) <= 0,
+	);
+	const candidates = boundedSupported.length > 0 ? boundedSupported : supported;
+	if (candidates.length === 0) return "off";
+	if (candidates.includes(candidate)) return candidate;
+
+	const lowerOrEqual = candidates
+		.filter((level) => compareLevels(level, candidate) <= 0)
+		.sort((a, b) => compareLevels(b, a));
+	if (lowerOrEqual[0]) return lowerOrEqual[0];
+
+	return [...candidates].sort(compareLevels)[0] ?? "off";
+}
+
+function isModelLevelSupported(model: Model, level: ThinkingLevel): boolean {
+	if (!model.reasoning) return level === "off";
+	return model.thinkingLevelMap?.[level] !== null;
+}
+
+function clampLevel(level: ThinkingLevel, minLevel: ThinkingLevel, maxLevel: ThinkingLevel): ThinkingLevel {
+	const low = Math.min(levelIndex(minLevel), levelIndex(maxLevel));
+	const high = Math.max(levelIndex(minLevel), levelIndex(maxLevel));
+	return LEVELS[Math.min(Math.max(levelIndex(level), low), high)];
+}
+
+function compareLevels(a: ThinkingLevel, b: ThinkingLevel): number {
+	return levelIndex(a) - levelIndex(b);
+}
+
+function levelIndex(level: ThinkingLevel): number {
+	return LEVELS.indexOf(level);
+}
+
+function isThinkingLevel(value: string): value is ThinkingLevel {
+	return LEVELS.includes(value as ThinkingLevel);
+}
+
+function getModelKey(model: Model): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function buildDecisionReasons(input: {
+	boundedLevel: ThinkingLevel;
+	level: ThinkingLevel;
+	maxLevel: ThinkingLevel;
+	minLevel: ThinkingLevel;
+	model: ExtensionContext["model"];
+	modelKey?: string;
+	promptScore: PromptScore;
+}): string[] {
+	const reasons: string[] = [];
+	if (!input.model) {
+		reasons.push("No active model is available, so auto-thinking selected off.");
+		return reasons;
+	}
+
+	reasons.push(`Model: ${input.modelKey}.`);
+	if (!input.model.reasoning) {
+		reasons.push("The active model does not advertise reasoning support, so thinking is off.");
+		return reasons;
+	}
+
+	reasons.push(`Task score ${input.promptScore.score} mapped to ${input.promptScore.baseLevel}.`);
+	for (const signal of input.promptScore.signals) {
+		const sign = signal.weight > 0 ? "+" : "";
+		reasons.push(`${sign}${signal.weight}: ${signal.label}.`);
+	}
+	if (input.promptScore.signals.length === 0) reasons.push("No complexity signals matched.");
+
+	if (input.boundedLevel !== input.promptScore.baseLevel) {
+		reasons.push(
+			`Config bounds ${input.minLevel}..${input.maxLevel} changed ${input.promptScore.baseLevel} to ${input.boundedLevel}.`,
+		);
+	} else {
+		reasons.push(`Config bounds ${input.minLevel}..${input.maxLevel} kept ${input.boundedLevel}.`);
+	}
+
+	if (input.level !== input.boundedLevel) {
+		reasons.push(`Model thinkingLevelMap changed ${input.boundedLevel} to ${input.level}.`);
+	}
+
+	return reasons;
+}
+
+function skippedDecision(reason: string): SkippedDecision {
+	return { kind: "skipped", reason, reasons: [reason] };
+}
+
+function handleCommand(args: string, runtime: RuntimeState, ctx: ExtensionCommandContext): void {
+	const command = args.trim().toLowerCase();
+	switch (command || "status") {
+		case "on":
+			runtime.enabled = true;
+			runtime.manualSuppressionTurnsRemaining = 0;
+			runtime.pendingManualSuppression = false;
+			ctx.ui.notify("Auto thinking enabled.", "info");
+			return;
+		case "off":
+			runtime.enabled = false;
+			runtime.manualSuppressionTurnsRemaining = 0;
+			runtime.pendingManualSuppression = false;
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			ctx.ui.notify("Auto thinking disabled.", "info");
+			return;
+		case "status":
+			ctx.ui.notify(formatRuntimeStatus(runtime), "info");
+			return;
+		case "explain":
+			ctx.ui.notify(formatExplanation(runtime.lastDecision), "info");
+			return;
+		case "help":
+			ctx.ui.notify(formatHelp(), "info");
+			return;
+		default:
+			ctx.ui.notify(`Unknown /${COMMAND_NAME} command: ${args.trim()}\n\n${formatHelp()}`, "warning");
+	}
+}
+
+function formatRuntimeStatus(runtime: RuntimeState): string {
+	return [
+		`Auto thinking: ${runtime.enabled ? "on" : "off"}`,
+		`Config: ${runtime.configPath}`,
+		`Bounds: ${runtime.config.minLevel}..${runtime.config.maxLevel}`,
+		`Respect manual turns: ${runtime.config.respectManualTurns}`,
+		`Manual suppression remaining: ${runtime.manualSuppressionTurnsRemaining}`,
+		runtime.configWarnings.length > 0
+			? `Config warnings:\n${runtime.configWarnings.map((warning) => `- ${warning}`).join("\n")}`
+			: "Config warnings: none",
+	].join("\n");
+}
+
+function formatExplanation(decision: LastDecision | undefined): string {
+	if (!decision) return "No auto-thinking decision has been made yet.";
+	if (decision.kind === "skipped") return decision.reasons.join("\n");
+	return [
+		`Selected: ${decision.level}`,
+		`Base level: ${decision.baseLevel}`,
+		`Score: ${decision.score}`,
+		...decision.reasons,
+	].join("\n");
+}
+
+function formatHelp(): string {
+	return [
+		`/${COMMAND_NAME} status - show current auto-thinking state`,
+		`/${COMMAND_NAME} on - enable automatic thinking selection`,
+		`/${COMMAND_NAME} off - disable automatic thinking selection`,
+		`/${COMMAND_NAME} explain - explain the last decision`,
+	].join("\n");
+}
+
+function formatStatus(decision: ThinkingDecision): string {
+	if (decision.level === "off") return "auto-thinking off";
+	return `auto-thinking ${decision.level}`;
+}
+
+function formatLastDecision(decision: LastDecision): string | undefined {
+	if (decision.kind === "selected") return formatStatus(decision);
+	return decision.reason.includes("disabled") ? undefined : "auto-thinking paused";
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+	return [...value.matchAll(pattern)].length;
+}
+
+function countFilePaths(value: string): number {
+	const pathMatches = value.match(
+		/(?:^|[\s"'`(])(?:\.?\.?\/|~\/)?(?:[\w.-]+\/)+[\w.-]+(?:\.[\w-]+)?/g,
+	);
+	const filenameMatches = value.match(
+		/\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|css|html|py|rs|go|java|kt|swift|sh|yml|yaml|toml)\b/g,
+	);
+	return new Set([...(pathMatches ?? []), ...(filenameMatches ?? [])]).size;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/extensions/pi-auto-thinking/tsconfig.json
+++ b/extensions/pi-auto-thinking/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "src"
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -71,6 +71,9 @@ install-all:
     for package_json in extensions/*/package.json; do dir="$(basename "$(dirname "$package_json")")"; just install "${dir#pi-}"; done
 
 # Preview individual packages that npm would publish
+pack-auto-thinking:
+    just pack auto-thinking
+
 pack-biome-lsp:
     just pack biome-lsp
 
@@ -105,6 +108,9 @@ pack-subagents:
     just pack subagents
 
 # Try individual packages from this working tree as temporary pi packages
+try-auto-thinking:
+    just try auto-thinking
+
 try-biome-lsp:
     just try biome-lsp
 
@@ -139,6 +145,9 @@ try-subagents:
     just try subagents
 
 # Install individual packages through pi
+install-auto-thinking:
+    just install auto-thinking
+
 install-biome-lsp:
     just install biome-lsp
 
@@ -173,6 +182,9 @@ install-subagents:
     just install subagents
 
 # Publish individual packages to npm
+publish-auto-thinking:
+    just publish auto-thinking
+
 publish-biome-lsp:
     just publish biome-lsp
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,17 @@
 				"typescript": "^6.0.3"
 			}
 		},
+		"extensions/pi-auto-thinking": {
+			"name": "@narumitw/pi-auto-thinking",
+			"version": "0.1.12",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@earendil-works/pi-coding-agent": "0.74.0",
+				"@types/node": "25.6.0",
+				"typescript": "6.0.3"
+			}
+		},
 		"extensions/pi-biome-lsp": {
 			"name": "@narumitw/pi-biome-lsp",
 			"version": "0.1.12",
@@ -2569,6 +2580,10 @@
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
 			}
+		},
+		"node_modules/@narumitw/pi-auto-thinking": {
+			"resolved": "extensions/pi-auto-thinking",
+			"link": true
 		},
 		"node_modules/@narumitw/pi-biome-lsp": {
 			"resolved": "extensions/pi-biome-lsp",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"biome:check": "biome check .",
 		"typecheck": "npm --workspaces run typecheck",
 		"check": "npm run biome:check && npm run typecheck",
+		"pack:auto-thinking": "npm --workspace @narumitw/pi-auto-thinking pack --dry-run",
 		"pack:biome-lsp": "npm --workspace @narumitw/pi-biome-lsp pack --dry-run",
 		"pack:btw": "npm --workspace @narumitw/pi-btw pack --dry-run",
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",


### PR DESCRIPTION
## Summary
- add the new `@narumitw/pi-auto-thinking` Pi extension package
- implement model-aware deterministic thinking-level selection with config, manual override suppression, statusline updates, and `/auto-thinking` commands
- document usage/configuration and mark the implementation plan complete
- add root npm and just recipes for auto-thinking package workflows

## Verification
- `npm run check`
- `npm --workspace @narumitw/pi-auto-thinking pack --dry-run`
- `just pack-auto-thinking`
- `just --list | grep auto-thinking`
- `pi -e ./extensions/pi-auto-thinking --no-session --no-context-files --no-skills -p "/auto-thinking status"`
- non-interactive Node extension event smoke test (`auto-thinking smoke test passed`)