### PR TITLE
fix(caffeinate): hide inactive statusline entry

### DIFF
--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -10,6 +10,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 
 - Starts an OS sleep inhibitor when Pi begins processing (`agent_start`).
 - Releases the inhibitor when processing ends (`agent_end`) or the session shuts down.
+- Publishes an `awake` status only while an inhibitor is active.
 - Supports macOS, Windows, WSL, and Linux.
 - Provides `/caffeinate-status` and `/caffeinate-stop` commands.
 - Allows a custom inhibitor command through environment configuration.

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -279,12 +279,12 @@ function isWsl() {
 
 function updateStatus(ctx: ExtensionContext) {
 	if (state.disabled) {
-		ctx.ui.setStatus(STATUS_KEY, "caffeinate: disabled");
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 		return;
 	}
 
 	if (state.process) {
-		ctx.ui.setStatus(STATUS_KEY, `caffeinate: on (${state.command?.description ?? "active"})`);
+		ctx.ui.setStatus(STATUS_KEY, "caffeinate: awake");
 		return;
 	}
 
@@ -293,7 +293,7 @@ function updateStatus(ctx: ExtensionContext) {
 		return;
 	}
 
-	ctx.ui.setStatus(STATUS_KEY, "caffeinate: idle");
+	ctx.ui.setStatus(STATUS_KEY, undefined);
 }
 
 function describeState() {

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -55,6 +55,7 @@ Statuses from other extensions, such as goal mode, appear on their own compact i
 Examples:
 
 - `🎯 active` for goal mode.
+- `💊 awake` while pi-caffeinate is preventing sleep.
 - `🧬 ✓` for Biome LSP readiness.
 - `🐍 ty ✓ ruff ✓` for Python LSP readiness.
 - `🧑‍🤝‍🧑 2 parallel` while subagents are active.

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -452,7 +452,7 @@ function extensionIcon(key: string): string {
 	if (normalizedKey.includes("python") || normalizedKey.includes("ruff") || normalizedKey.includes("ty"))
 		return "🐍";
 	if (normalizedKey.includes("subagent")) return "🧑‍🤝‍🧑";
-	if (normalizedKey.includes("caffeinate")) return "☕";
+	if (normalizedKey.includes("caffeinate")) return "💊";
 	if (normalizedKey.includes("chrome") || normalizedKey.includes("devtools") || normalizedKey === "cdp")
 		return "🌐";
 	if (normalizedKey.includes("codex")) return "📊";
@@ -464,9 +464,9 @@ function extensionIcon(key: string): string {
 
 function extensionColor(key: string, value: string): ThemeColor {
 	const normalized = `${key} ${value}`.toLowerCase();
-	if (/missing|error|fail|conflict|duplicate/.test(normalized)) return "warning";
+	if (/missing|error|fail|conflict|duplicate|unavailable/.test(normalized)) return "warning";
 	if (normalized.includes("codex")) return "accent";
-	if (/ready|active|running|enabled|ok/.test(normalized)) return "success";
+	if (/ready|active|running|enabled|awake|ok/.test(normalized)) return "success";
 	return "muted";
 }
 


### PR DESCRIPTION
## Summary
- hide pi-caffeinate status while inactive or disabled
- show active caffeinate status as `💊 awake` in pi-statusline
- keep unavailable caffeinate status visible as a warning

## Verification
- npm run check
- commit hook: biome check
- commit hook: npm typecheck