### PR TITLE
fix: replace deprecated node-domexception

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -13,6 +13,7 @@
 - Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.
+- `node-domexception` deprecation comes via `@google/genai -> google-auth-library -> gaxios -> node-fetch -> fetch-blob`; use the root npm override to `npm:@profoundlogic/node-domexception`.
 
 ## TASTE
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3957,6 +3957,14 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
+		"node_modules/fetch-blob/node_modules/node-domexception": {
+			"name": "@profoundlogic/node-domexception",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@profoundlogic/node-domexception/-/node-domexception-1.0.2.tgz",
+			"integrity": "sha512-qeEIO+aJIGHxEwCtAHoPH8VrWFvWh3zFmr2/cb9gFGc6qyYW9r48Q2vg8YwME/PyIt98GaR42kPVUkN4n0a19A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/file-type": {
 			"version": "21.3.4",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
@@ -4427,27 +4435,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"deprecated": "Use your platform's native DOMException instead",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.5.0"
 			}
 		},
 		"node_modules/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
 		"@types/node": "^25.6.0",
 		"typebox": "^1.1.37",
 		"typescript": "^6.0.3"
+	},
+	"overrides": {
+		"node-domexception": "npm:@profoundlogic/node-domexception@1.0.2"
 	}
 }


### PR DESCRIPTION
## Summary
- add an npm override that aliases deprecated `node-domexception` to `@profoundlogic/node-domexception`
- update the lockfile to remove the deprecated `node-domexception@1.0.0` package
- document the transitive dependency path in `MEMORY.md`

## Verification
- `npm install --ignore-scripts`
- `npm ls node-domexception --all`
- `npm run check`
- `npm run biome:check`