### PR TITLE
feat(goal): align command flow with Codex

### DIFF
--- a/docs/plans/archived/2026-05-17_goal-overwrite-plan.md
+++ b/docs/plans/archived/2026-05-17_goal-overwrite-plan.md
@@ -1,0 +1,29 @@
+## Goal
+
+Make `/goal <your_goal>` replace an existing unfinished goal directly, so users can update the active objective without first running `/goal clear`, `/goal stop`, or `/goal edit`.
+
+## Context
+
+`extensions/pi-goal/src/goal.ts` previously rejected `/goal <objective>` when a non-complete goal existed and told users to run `/goal edit <objective>` or `/goal clear` first. The README documented the same behavior.
+
+## Non-Goals
+
+- Remove `/goal edit`; it remains as a compatibility/explicit-edit command.
+- Change `/goal pause`, `/goal resume`, `/goal clear`, `/goal status`, `/goal-stop`, or `goal_complete` semantics.
+
+## Plan
+
+- [x] Update `startGoal` in `extensions/pi-goal/src/goal.ts` so a valid `/goal <objective>` always creates and persists a new active goal, replacing any unfinished goal; verified with `npm run check`.
+- [x] Adjust the user notification for replaced goals to distinguish first start from replacement; verified by diff review of `extensions/pi-goal/src/goal.ts` showing `Goal replaced (...)` versus `Goal started`.
+- [x] Update `extensions/pi-goal/README.md` command docs so `/goal <goal_to_complete>` is documented as start-or-replace while `/goal edit` remains an alias/explicit replacement path; verified with `rg -n "starts goal mode when no other|edit <goal|replace|replaces" extensions/pi-goal/README.md`.
+- [x] Run formatting and repository checks for the touched TypeScript/docs; verified with `npm run check`.
+
+## Risks
+
+- A user might accidentally overwrite an active goal by typing a new `/goal`; this is intentional for this change and mitigated by keeping `/goal` bare as status-only and notifying that the previous goal was replaced.
+
+## Completion Checklist
+
+- [x] `/goal <your_goal>` replacement behavior is implemented in `extensions/pi-goal/src/goal.ts` and verified by successful `npm run check` output.
+- [x] README usage and command reference match the new replacement behavior, verified by repository diff review and `rg -n "starts goal mode when no other|edit <goal|replace|replaces" extensions/pi-goal/README.md`.
+- [x] All relevant validation commands completed successfully, verified by successful `npm run check` output.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -8,7 +8,7 @@ Goal mode keeps sending guarded automatic follow-up messages until the agent cal
 
 ## ✨ Features
 
-- Adds `/goal <goal_to_complete>` to start goal mode.
+- Adds `/goal <goal_to_complete>` to start goal mode or replace the current goal.
 - Bare `/goal` shows the current goal summary.
 - Adds `/goal pause`, `/goal resume`, `/goal clear`, and `/goal edit <goal_to_complete>`.
 - Keeps `/goal-status` and `/goal-stop` as compatibility aliases.
@@ -53,12 +53,12 @@ pi -e ./extensions/pi-goal
 ```
 
 - `/goal` shows the current goal, status, iteration count, elapsed time, and token usage.
-- `/goal <goal_to_complete>` starts goal mode when no other goal is active.
-- `/goal --tokens 100k <goal_to_complete>` starts goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
+- `/goal <goal_to_complete>` starts goal mode, or replaces the current unfinished goal with a new active goal.
+- `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
 - `/goal pause` stops prompt injection and auto-continuation without forgetting the goal.
 - `/goal resume` resumes a paused or budget-limited goal.
 - `/goal clear` cancels the current goal and clears persisted state.
-- `/goal edit <goal_to_complete>` replaces the current goal with a new active goal.
+- `/goal edit <goal_to_complete>` also replaces the current goal with a new active goal, for explicit edit-style workflows.
 - `/goal-status` is a compatibility alias for `/goal`.
 - `/goal-stop` is a compatibility alias for `/goal clear`.
 

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -8,10 +8,10 @@ Goal mode keeps sending guarded automatic follow-up messages until the agent cal
 
 ## ✨ Features
 
-- Adds `/goal <goal_to_complete>` to start goal mode or replace the current goal.
+- Adds `/goal <goal_to_complete>` to start goal mode, with confirmation before replacing an existing goal.
 - Bare `/goal` shows the current goal summary.
-- Adds `/goal pause`, `/goal resume`, `/goal clear`, and `/goal edit <goal_to_complete>`.
-- Keeps `/goal-status` and `/goal-stop` as compatibility aliases.
+- Keeps advanced goal management inside `/goal` subcommands: `pause`, `resume`, `clear`, and `edit`.
+- Exposes only one top-level command: `/goal`.
 - Supports optional token budgets such as `/goal --tokens 100k <goal>`.
 - Tracks `active`, `paused`, `budget_limited`, and `complete` states.
 - Persists in-progress goal state per working directory under the Pi agent config directory.
@@ -44,23 +44,19 @@ pi -e ./extensions/pi-goal
 /goal
 /goal implement snake game
 /goal --tokens 100k fix the failing test and verify it
+/goal edit ship the smaller fix first
 /goal pause
 /goal resume
 /goal clear
-/goal edit ship the smaller fix first
-/goal-status
-/goal-stop
 ```
 
-- `/goal` shows the current goal, status, iteration count, elapsed time, and token usage.
-- `/goal <goal_to_complete>` starts goal mode, or replaces the current unfinished goal with a new active goal.
+- `/goal` shows the current goal, status, iteration count, elapsed time, token usage, and available `/goal` subcommands.
+- `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters.
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
+- `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. Active goals stay active, paused goals stay paused, and budget-limited goals remain budget-limited if their budget is still exhausted.
 - `/goal pause` stops prompt injection and auto-continuation without forgetting the goal.
-- `/goal resume` resumes a paused or budget-limited goal.
+- `/goal resume` resumes a paused or budget-limited goal when the token budget allows it.
 - `/goal clear` cancels the current goal and clears persisted state.
-- `/goal edit <goal_to_complete>` also replaces the current goal with a new active goal, for explicit edit-style workflows.
-- `/goal-status` is a compatibility alias for `/goal`.
-- `/goal-stop` is a compatibility alias for `/goal clear`.
 
 Goal objectives are limited to 4,000 characters. Put longer instructions in a file and reference the file path from `/goal`.
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -186,18 +186,17 @@ function startGoal(objective: string, tokenBudget: number | undefined, pi: Exten
 		return;
 	}
 
-	if (activeGoal && activeGoal.status !== "complete") {
-		ctx.ui.notify(
-			`A goal is already ${activeGoal.status}. Use /goal edit <objective> to replace it, /goal clear to stop it, or /goal to inspect it.`,
-			"warning",
-		);
-		return;
-	}
+	const replacedGoal = activeGoal?.status !== "complete" ? activeGoal : undefined;
 
 	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
 	persistGoal(ctx.cwd, activeGoal);
 	updateStatus(ctx, activeGoal);
-	ctx.ui.notify(`Goal started: ${objective}`, "info");
+	ctx.ui.notify(
+		replacedGoal
+			? `Goal replaced (${replacedGoal.status}): ${replacedGoal.text} → ${objective}`
+			: `Goal started: ${objective}`,
+		"info",
+	);
 	sendGoalPrompt(pi, ctx, activeGoal);
 }
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -34,6 +34,7 @@ interface CommandResult {
 interface StatusContext {
 	cwd: string;
 	ui: {
+		confirm: (title: string, message: string) => Promise<boolean>;
 		notify: (message: string, level?: "info" | "warning" | "error") => void;
 		setStatus: (key: string, value: string | undefined) => void;
 	};
@@ -116,23 +117,13 @@ export default function goal(pi: ExtensionAPI) {
 					clearGoal(ctx);
 					return;
 				case "edit":
-					editGoal(result.objective ?? "", result.tokenBudget, ctx);
+					editGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
 					return;
 				case "start":
-					startGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
+					await startGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
 					return;
 			}
 		},
-	});
-
-	pi.registerCommand("goal-stop", {
-		description: "Compatibility alias for /goal clear",
-		handler: async (_args, ctx) => clearGoal(ctx),
-	});
-
-	pi.registerCommand("goal-status", {
-		description: "Compatibility alias for bare /goal",
-		handler: async (_args, ctx) => showGoal(ctx),
 	});
 
 	pi.on("session_start", (_event, ctx) => {
@@ -179,24 +170,34 @@ export default function goal(pi: ExtensionAPI) {
 	});
 }
 
-function startGoal(objective: string, tokenBudget: number | undefined, pi: ExtensionAPI, ctx: StatusContext) {
+async function startGoal(
+	objective: string,
+	tokenBudget: number | undefined,
+	pi: ExtensionAPI,
+	ctx: StatusContext,
+) {
 	const validationError = validateObjective(objective);
 	if (validationError) {
 		ctx.ui.notify(validationError, "warning");
 		return;
 	}
 
-	const replacedGoal = activeGoal?.status !== "complete" ? activeGoal : undefined;
+	const existingGoal = activeGoal?.status !== "complete" ? activeGoal : undefined;
+	if (existingGoal) {
+		const shouldReplace = await ctx.ui.confirm(
+			"Replace goal?",
+			`Current goal: ${existingGoal.text}\n\nNew goal: ${objective}`,
+		);
+		if (!shouldReplace) {
+			ctx.ui.notify(`Goal kept: ${existingGoal.text}`, "info");
+			return;
+		}
+	}
 
 	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
 	persistGoal(ctx.cwd, activeGoal);
 	updateStatus(ctx, activeGoal);
-	ctx.ui.notify(
-		replacedGoal
-			? `Goal replaced (${replacedGoal.status}): ${replacedGoal.text} → ${objective}`
-			: `Goal started: ${objective}`,
-		"info",
-	);
+	ctx.ui.notify(existingGoal ? `Goal replaced: ${objective}` : `Goal started: ${objective}`, "info");
 	sendGoalPrompt(pi, ctx, activeGoal);
 }
 
@@ -243,22 +244,39 @@ function clearGoal(ctx: StatusContext) {
 	ctx.ui.notify(`Goal cleared: ${stoppedGoal}`, "warning");
 }
 
-function editGoal(objective: string, tokenBudget: number | undefined, ctx: StatusContext) {
+function editGoal(
+	objective: string,
+	tokenBudget: number | undefined,
+	pi: ExtensionAPI,
+	ctx: StatusContext,
+) {
 	const validationError = validateObjective(objective);
 	if (validationError) {
 		ctx.ui.notify(validationError, "warning");
 		return;
 	}
+	if (!activeGoal) {
+		ctx.ui.notify("No active goal. Use /goal <objective> to start one.", "warning");
+		return;
+	}
 
-	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
+	updateGoalUsage(activeGoal, ctx);
+	activeGoal = normalizeGoalForBudget({
+		...activeGoal,
+		text: objective,
+		status: editedGoalStatus(activeGoal.status),
+		tokenBudget: tokenBudget ?? activeGoal.tokenBudget,
+		updatedAt: Date.now(),
+	});
 	persistGoal(ctx.cwd, activeGoal);
 	updateStatus(ctx, activeGoal);
 	ctx.ui.notify(`Goal updated: ${objective}`, "info");
+	if (activeGoal.status === "active") sendObjectiveUpdatedPrompt(pi, ctx, activeGoal);
 }
 
 function showGoal(ctx: StatusContext) {
 	if (!activeGoal) {
-		ctx.ui.notify("No active goal.", "info");
+		ctx.ui.notify("Usage: /goal <objective>\nNo goal is currently set.", "info");
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		return;
 	}
@@ -285,7 +303,22 @@ function createGoal(text: string, tokenBudget: number | undefined, baselineToken
 }
 
 function transitionGoal(goal: ActiveGoal, status: GoalStatus): ActiveGoal {
-	return { ...goal, status, updatedAt: Date.now() };
+	return normalizeGoalForBudget({ ...goal, status, updatedAt: Date.now() });
+}
+
+function editedGoalStatus(status: GoalStatus): GoalStatus {
+	return status === "paused" ? "paused" : "active";
+}
+
+function normalizeGoalForBudget(goal: ActiveGoal): ActiveGoal {
+	if (
+		goal.status === "active" &&
+		goal.tokenBudget !== undefined &&
+		goal.tokensUsed >= goal.tokenBudget
+	) {
+		return { ...goal, status: "budget_limited" };
+	}
+	return goal;
 }
 
 function incrementGoal(goal: ActiveGoal): ActiveGoal {
@@ -381,6 +414,12 @@ function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) 
 	else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
 }
 
+function sendObjectiveUpdatedPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	const prompt = buildObjectiveUpdatedPrompt(goal);
+	if (ctx.isIdle?.()) pi.sendUserMessage(prompt);
+	else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+}
+
 function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
 	ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
 }
@@ -405,7 +444,14 @@ function goalSummary(goal: ActiveGoal) {
 		`Iteration: ${goal.iteration}`,
 		`Elapsed: ${formatDuration(goal.timeUsedSeconds)}`,
 		`Tokens: ${goal.tokenBudget === undefined ? formatTokenCount(goal.tokensUsed) : formatBudget(goal)}`,
+		`Commands: ${goalCommandHint(goal.status)}`,
 	].join("\n");
+}
+
+function goalCommandHint(status: GoalStatus) {
+	if (status === "active") return "/goal edit <objective>, /goal pause, /goal clear";
+	if (status === "paused") return "/goal edit <objective>, /goal resume, /goal clear";
+	return "/goal edit <objective>, /goal clear";
 }
 
 function formatDuration(seconds: number) {
@@ -425,6 +471,11 @@ function formatTokenCount(value: number) {
 function buildGoalPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatTokenCount(goal.tokenBudget)}.`;
 	return `Goal mode is active. Complete this goal fully:\n\n${goal.text}${budgetLine}\n\nKeep working until the goal is done. Do not stop after planning or partial progress. When the goal is fully complete and verified, call the goal_complete tool with a concise completion summary.`;
+}
+
+function buildObjectiveUpdatedPrompt(goal: ActiveGoal) {
+	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatBudget(goal)} used.`;
+	return `The active /goal objective was updated. Continue working toward this goal:\n\n${goal.text}${budgetLine}\n\nKeep working until the updated goal is fully complete and verified, then call the goal_complete tool.`;
 }
 
 function buildGoalSystemPrompt(goal: ActiveGoal) {


### PR DESCRIPTION
## Summary
- keep `/goal` as the only top-level pi-goal slash command
- make `/goal <objective>` confirm before replacing an unfinished goal
- make `/goal edit <objective>` update the existing goal without resetting usage
- update README command docs for the Codex-like flow

## Verification
- npm run check