### PR TITLE
feat(plan-mode): add Codex-like planning extension

### DIFF
--- a/docs/plans/archived/2026-05-17_codex-like-plan-mode-plan.md
+++ b/docs/plans/archived/2026-05-17_codex-like-plan-mode-plan.md
@@ -1,0 +1,68 @@
+## Goal
+
+Implement a Codex-like Plan mode as a Pi extension package that lets users enter a read-only conversational planning mode, collaborate until a decision-complete implementation plan is produced, and then explicitly leave plan mode before code mutation happens.
+
+## Context
+
+Codex separates two concepts that should not be conflated:
+
+- Plan mode is a collaboration mode: non-mutating exploration, user clarification, and a final `<proposed_plan>` block.
+- `update_plan`-style TODO tracking is execution progress tracking and should not be used as the Plan mode UI itself.
+
+Pi already has a sample `examples/extensions/plan-mode/` extension with useful primitives (`registerCommand`, `registerFlag`, `setActiveTools`, `tool_call` blocking, injected context, `setStatus`, `setWidget`, `appendEntry`). That sample is read-only and TODO-oriented, but the Codex-like target should emphasize conversational planning and explicit exit to execute.
+
+## Architecture
+
+Created a new workspace extension, `extensions/pi-plan-mode`, rather than mixing this into `pi-goal`:
+
+- Command layer: one `/plan` top-level command toggles or manages Plan mode.
+- Runtime state: per-session mode state persisted with `appendEntry` and restored on `session_start`.
+- Safety layer: restrict active tools and block mutating bash/tool calls while Plan mode is active.
+- Prompt layer: inject Codex-like Plan mode instructions before agent turns.
+- Finalization layer: detect or guide `<proposed_plan>` output, then let the user explicitly leave Plan mode before implementation.
+
+## Non-Goals
+
+- Do not implement code changes while Plan mode is active.
+- Do not build a separate `update_plan` TODO tool in v1.
+- Do not make Plan mode depend on `pi-goal` goal-loop behavior.
+- Do not replace Pi's normal planning guidance outside Plan mode.
+
+## Assumptions
+
+- V1 uses `/plan` as the only top-level command for this extension.
+- A final plan is considered complete when the assistant emits a single `<proposed_plan>...</proposed_plan>` block.
+- Read-only bash allowlisting starts from the Pi sample extension and can be tightened as issues are found.
+
+## Unknowns
+
+- [x] Whether Pi core exposes enough collaboration-mode metadata to make Plan mode visible outside extension status widgets; resolved by implementing extension status/widget UI because Pi core does not expose a native collaboration mode API.
+- [x] Whether `ctx.ui.select()` is available in all target modes, including RPC; resolved by using `ctx.hasUI` guards and documenting Plan mode as an interactive extension workflow.
+
+## Plan
+
+- [x] Create `extensions/pi-plan-mode` with `package.json`, `tsconfig.json`, `README.md`, `LICENSE`, and `src/plan-mode.ts` following existing package structure; verified with `npm --workspace @narumitw/pi-plan-mode run typecheck`.
+- [x] Add the package to root workspaces/scripts/just recipes only where this repository expects per-package support (`pack`, `try`, `install`, `publish`); verified with `just --list | rg "plan-mode"` and `npm run check`.
+- [x] Implement persisted Plan mode state with fields for `enabled`, optional latest proposed plan text, and optional awaiting-user-action flag; verified by typecheck and code review of `STATE_ENTRY_TYPE` persistence/restore paths in `extensions/pi-plan-mode/src/plan-mode.ts`.
+- [x] Register `/plan` and optional `--plan` flag so `/plan` enters Plan mode when off and shows a small action menu/status when on; verified by `pi -e ./extensions/pi-plan-mode --help` showing `--plan` and by typecheck.
+- [x] Inject Codex-like Plan mode instructions in `before_agent_start`: three phases, explore first, ask only non-discoverable questions, no mutations, final `<proposed_plan>` block; verified by code review of `buildPlanModePrompt()`.
+- [x] Restrict tools while Plan mode is active by calling `setActiveTools` with read/search/question tools and restoring the prior/full tool set when leaving Plan mode; verified by typecheck and code review of `activateReadOnlyTools()`/`restoreTools()`.
+- [x] Add a `tool_call` guard for `bash` that blocks mutating commands using an allowlist/denylist derived from the sample extension; verified by code review of `MUTATING_BASH_PATTERNS`, `SAFE_BASH_PATTERNS`, and successful `npm run check`.
+- [x] Detect `<proposed_plan>` in assistant output after `agent_end`, store the latest plan, display a concise status/widget, and prompt the user to stay in Plan mode, refine, or exit Plan mode; verified by code review of `PROPOSED_PLAN_PATTERN` and `showPlanReadyMenu()`.
+- [x] Ensure execution is explicit: exiting Plan mode restores full tools but does not automatically run implementation unless the user sends a normal follow-up request; verified by code review of the `Implement this plan` branch, which exits Plan mode and notifies without sending an implementation turn.
+- [x] Document Codex-like behavior, safety rules, slash command usage, examples, and known limitations in `extensions/pi-plan-mode/README.md`; verified with README review and `npm run check`.
+- [x] Run repository verification with `npm run check`; for packaging changes, run `just pack plan-mode` and inspect the dry-run file list; verified by successful command outputs.
+
+## Risks
+
+- Tool restriction may be incomplete if Pi tools are added by other extensions after Plan mode activates; accepted for v1 and documented as a safety approximation.
+- Bash filtering can block harmless commands or allow obscure mutations; mitigated with conservative defaults and clear block messages.
+- Automatic `<proposed_plan>` detection may miss malformed plans; mitigated by keeping user-visible `/plan` status and allowing refinement rather than treating detection as authoritative.
+
+## Completion Checklist
+
+- [x] A new `@narumitw/pi-plan-mode` package exists and is included in workspace tooling, verified by `npm run check` and `just pack plan-mode` output.
+- [x] Plan mode prevents repo-tracked mutations while active, verified by implemented edit/write blocking and bash allowlist/denylist guards in `extensions/pi-plan-mode/src/plan-mode.ts` plus successful typecheck.
+- [x] Plan mode injects Codex-like conversational planning instructions and final `<proposed_plan>` requirements, verified by `buildPlanModePrompt()` in `extensions/pi-plan-mode/src/plan-mode.ts`.
+- [x] Users can enter, inspect, refine, and explicitly exit Plan mode through `/plan`, verified by `/plan` command implementation, `--plan` help output from `pi -e ./extensions/pi-plan-mode --help`, and successful `npm run check`.
+- [x] Documentation explains usage and safety boundaries, verified by `extensions/pi-plan-mode/README.md` review and `npm run check`.

--- a/extensions/pi-plan-mode/LICENSE
+++ b/extensions/pi-plan-mode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -1,0 +1,110 @@
+# 🧭 pi-plan-mode — Codex-like Plan Mode for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-plan-mode)](https://www.npmjs.com/package/@narumitw/pi-plan-mode) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-plan-mode` adds a Codex-like `/plan` collaboration mode to Pi. Plan mode is for read-only exploration, clarifying questions, and a final implementation-ready `<proposed_plan>` block before any code mutation happens.
+
+Pi core intentionally does not ship a built-in plan mode; this package provides one as an independently installable extension.
+
+## ✨ Features
+
+- Adds `/plan` to enter or manage Plan mode.
+- Adds `--plan` to start a session in Plan mode.
+- Restricts active tools to read-only tools while Plan mode is active.
+- Blocks mutating bash commands such as `rm`, `git commit`, dependency installs, redirects, and editor launches.
+- Injects Codex-like Plan mode instructions: explore first, ask only non-discoverable questions, do not mutate files, and finish with `<proposed_plan>`.
+- Detects proposed plan blocks and prompts you to implement, revise, or stay in Plan mode.
+- Persists Plan mode state in the Pi session so resume restores the mode.
+
+## 📦 Install
+
+```bash
+pi install npm:@narumitw/pi-plan-mode
+```
+
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-plan-mode
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-plan-mode
+```
+
+## 🚀 Usage
+
+```text
+/plan
+```
+
+When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation.
+
+A complete Plan mode answer should include exactly one block like this:
+
+```xml
+<proposed_plan>
+# Title
+
+## Summary
+...
+
+## Key Changes
+...
+
+## Test Plan
+...
+
+## Assumptions
+...
+</proposed_plan>
+```
+
+After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode.
+
+You can also exit directly:
+
+```text
+/plan exit
+```
+
+## 🧠 Codex-like behavior
+
+This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
+
+- Plan mode is a conversational collaboration mode, not TODO/progress tracking.
+- `update_plan`-style checklist use is discouraged while Plan mode is active.
+- The implementation boundary is explicit: Plan mode restores tools only after you choose to leave it.
+- Pi extension safety is approximated with active-tool restriction plus bash filtering, so it may be stricter or looser than Codex core in edge cases.
+
+## 🗂️ Package layout
+
+```txt
+extensions/pi-plan-mode/
+├── src/
+│   └── plan-mode.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its Pi extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/plan-mode.ts"]
+  }
+}
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, plan mode, Codex-like plan mode, AI coding workflow, read-only planning, implementation plan.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "@narumitw/pi-plan-mode",
+	"version": "0.1.17",
+	"description": "Pi extension that adds a Codex-like read-only /plan collaboration mode.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"plan-mode",
+		"planning"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/plan-mode.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"typescript": "6.0.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "extensions/pi-plan-mode"
+	}
+}

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -1,0 +1,374 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+const STATE_ENTRY_TYPE = "plan-mode-state";
+const STATUS_KEY = "plan-mode";
+const PLAN_WIDGET_KEY = "plan-mode-plan";
+const PLAN_CONTEXT_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
+const READ_ONLY_TOOLS = ["read", "bash"];
+const DEFAULT_TOOLS = ["read", "bash", "edit", "write"];
+const MUTATING_TOOLS = new Set(["edit", "write"]);
+const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/i;
+
+interface PlanModeState {
+	enabled: boolean;
+	latestPlan?: string;
+	awaitingAction: boolean;
+}
+
+type SessionEntry = {
+	type?: string;
+	customType?: string;
+	data?: Partial<PlanModeState>;
+	message?: SessionMessage;
+};
+
+type SessionMessage = {
+	role?: string;
+	content?: unknown;
+};
+
+type TextBlock = {
+	type?: string;
+	text?: string;
+};
+
+const MUTATING_BASH_PATTERNS = [
+	/\brm\b/i,
+	/\brmdir\b/i,
+	/\bmv\b/i,
+	/\bcp\b/i,
+	/\bmkdir\b/i,
+	/\btouch\b/i,
+	/\bchmod\b/i,
+	/\bchown\b/i,
+	/\bchgrp\b/i,
+	/\bln\b/i,
+	/\btee\b/i,
+	/\btruncate\b/i,
+	/\bdd\b/i,
+	/(^|[^<])>(?!>)/,
+	/>>/,
+	/\bnpm\s+(install|uninstall|update|ci|link|publish|version)\b/i,
+	/\byarn\s+(add|remove|install|publish|upgrade)\b/i,
+	/\bpnpm\s+(add|remove|install|publish|update)\b/i,
+	/\bbun\s+(add|remove|install|update|publish)\b/i,
+	/\bpip\s+(install|uninstall)\b/i,
+	/\buv\s+(add|remove|sync|lock|pip\s+install)\b/i,
+	/\bgit\s+(add|commit|push|pull|merge|rebase|reset|checkout|switch|stash|cherry-pick|revert|tag|init|clone)\b/i,
+	/\bsudo\b/i,
+	/\bsu\b/i,
+	/\bkill\b/i,
+	/\bpkill\b/i,
+	/\bkillall\b/i,
+	/\breboot\b/i,
+	/\bshutdown\b/i,
+	/\bsystemctl\s+(start|stop|restart|enable|disable)\b/i,
+	/\bservice\s+\S+\s+(start|stop|restart)\b/i,
+	/\b(vim?|nano|emacs|code|subl)\b/i,
+];
+
+const SAFE_BASH_PATTERNS = [
+	/^\s*(cat|head|tail|less|more|grep|find|ls|pwd|echo|printf|wc|sort|uniq|diff|file|stat|du|df|tree|which|whereis|type|env|printenv|uname|whoami|id|date|uptime|ps|jq|awk|rg|fd|bat|eza)\b/i,
+	/^\s*sed\s+-n\b/i,
+	/^\s*git\s+(status|log|diff|show|branch|remote|config\s+--get|ls-files|grep)\b/i,
+	/^\s*npm\s+(list|ls|view|info|search|outdated|audit)\b/i,
+	/^\s*(node|python|python3|npm|tsc|biome|ruff|ty)\s+--version\b/i,
+];
+
+export default function planMode(pi: ExtensionAPI) {
+	let state: PlanModeState = { enabled: false, awaitingAction: false };
+	let previousTools: string[] | undefined;
+
+	pi.registerFlag("plan", {
+		description: "Start in Codex-like Plan mode",
+		type: "boolean",
+		default: false,
+	});
+
+	pi.registerCommand("plan", {
+		description: "Enter or manage Codex-like Plan mode",
+		handler: async (args, ctx) => {
+			const command = args.trim().toLowerCase();
+			if (command === "exit" || command === "off") {
+				exitPlanMode(ctx);
+				ctx.ui.notify("Plan mode disabled. Full tool access restored.", "info");
+				return;
+			}
+			if (!state.enabled) {
+				enterPlanMode(ctx);
+				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+				return;
+			}
+			await showPlanMenu(ctx);
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		restoreState(ctx);
+		if (pi.getFlag("plan") === true) state.enabled = true;
+		if (state.enabled) activateReadOnlyTools();
+		updateUi(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		persistState();
+		clearUi(ctx);
+	});
+
+	pi.on("tool_call", async (event) => {
+		if (!state.enabled) return;
+		if (MUTATING_TOOLS.has(event.toolName)) {
+			return {
+				block: true,
+				reason: `Plan mode blocks mutating tool '${event.toolName}'. Use /plan and choose implementation when the plan is ready.`,
+			};
+		}
+		if (event.toolName !== "bash") return;
+
+		const command = readCommand(event.input);
+		if (!isSafeCommand(command)) {
+			return {
+				block: true,
+				reason: `Plan mode blocks mutating or non-allowlisted bash commands.\nCommand: ${command}`,
+			};
+		}
+	});
+
+	pi.on("context", async (event) => {
+		if (state.enabled) return;
+		return {
+			messages: event.messages.filter((message: unknown) => !messageContainsPlanModeContext(message)),
+		};
+	});
+
+	pi.on("before_agent_start", () => {
+		if (!state.enabled) return;
+		return {
+			message: {
+				customType: "plan-mode-context",
+				content: buildPlanModePrompt(),
+				display: false,
+			},
+		};
+	});
+
+	pi.on("agent_end", async (event, ctx) => {
+		if (!state.enabled) return;
+
+		const text = latestAssistantText(event.messages);
+		const proposedPlan = extractProposedPlan(text);
+		if (!proposedPlan) {
+			persistState();
+			updateUi(ctx);
+			return;
+		}
+
+		state = { ...state, latestPlan: proposedPlan, awaitingAction: true };
+		persistState();
+		updateUi(ctx);
+		pi.sendMessage(
+			{
+				customType: "proposed-plan",
+				content: `**Proposed Plan**\n\n${proposedPlan}`,
+				display: true,
+			},
+			{ triggerTurn: false },
+		);
+
+		if (ctx.hasUI) await showPlanReadyMenu(ctx);
+	});
+
+	function enterPlanMode(ctx: ExtensionContext) {
+		if (!state.enabled) previousTools = safeGetActiveTools();
+		state = { ...state, enabled: true, awaitingAction: false };
+		activateReadOnlyTools();
+		persistState();
+		updateUi(ctx);
+	}
+
+	function exitPlanMode(ctx: ExtensionContext) {
+		state = { ...state, enabled: false, awaitingAction: false };
+		restoreTools();
+		persistState();
+		updateUi(ctx);
+	}
+
+	async function showPlanMenu(ctx: ExtensionContext) {
+		if (!ctx.hasUI) {
+			ctx.ui.notify(planStatusText(), "info");
+			return;
+		}
+
+		const choices = state.latestPlan
+			? ["Show latest proposed plan", "Implement this plan", "Stay in Plan mode", "Exit Plan mode"]
+			: ["Stay in Plan mode", "Exit Plan mode"];
+		const choice = await ctx.ui.select(planStatusText(), choices);
+		if (choice === "Show latest proposed plan") {
+			ctx.ui.notify(state.latestPlan ?? "No proposed plan yet.", "info");
+			return;
+		}
+		if (choice === "Implement this plan" || choice === "Exit Plan mode") {
+			exitPlanMode(ctx);
+			ctx.ui.notify("Plan mode disabled. Full tool access restored.", "info");
+			return;
+		}
+		updateUi(ctx);
+	}
+
+	async function showPlanReadyMenu(ctx: ExtensionContext) {
+		const choice = await ctx.ui.select("Proposed plan ready. What next?", [
+			"Implement this plan",
+			"Revise plan",
+			"Stay in Plan mode",
+		]);
+		if (choice === "Implement this plan") {
+			exitPlanMode(ctx);
+			ctx.ui.notify("Plan mode disabled. Ask me to implement the proposed plan when ready.", "info");
+			return;
+		}
+		if (choice === "Revise plan") {
+			const refinement = await ctx.ui.editor("Revise the plan", "");
+			if (refinement?.trim()) pi.sendUserMessage(refinement.trim());
+		}
+	}
+
+	function activateReadOnlyTools() {
+		previousTools ??= safeGetActiveTools();
+		pi.setActiveTools(READ_ONLY_TOOLS);
+	}
+
+	function restoreTools() {
+		pi.setActiveTools(previousTools && previousTools.length > 0 ? previousTools : DEFAULT_TOOLS);
+		previousTools = undefined;
+	}
+
+	function safeGetActiveTools() {
+		try {
+			return pi.getActiveTools();
+		} catch {
+			return DEFAULT_TOOLS;
+		}
+	}
+
+	function persistState() {
+		pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
+	}
+
+	function restoreState(ctx: ExtensionContext) {
+		const entries = ctx.sessionManager.getEntries() as SessionEntry[];
+		const entry = entries
+			.filter((candidate) => candidate.type === "custom" && candidate.customType === STATE_ENTRY_TYPE)
+			.pop();
+		if (!entry?.data) return;
+		state = {
+			enabled: entry.data.enabled ?? false,
+			latestPlan: entry.data.latestPlan,
+			awaitingAction: entry.data.awaitingAction ?? false,
+		};
+	}
+
+	function updateUi(ctx: ExtensionContext) {
+		ctx.ui.setStatus(STATUS_KEY, state.enabled ? "plan: active" : undefined);
+		if (state.enabled && state.latestPlan) {
+			ctx.ui.setWidget(PLAN_WIDGET_KEY, [
+				"Proposed plan ready",
+				"Use /plan to implement, revise, or exit Plan mode.",
+			]);
+		} else if (state.enabled) {
+			ctx.ui.setWidget(PLAN_WIDGET_KEY, ["Plan mode: read-only", "Produce a <proposed_plan> block."]);
+		} else {
+			ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
+		}
+	}
+
+	function clearUi(ctx: ExtensionContext) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
+	}
+
+	function planStatusText() {
+		if (!state.enabled) return "Plan mode is off.";
+		if (state.latestPlan) return "Plan mode is active and a proposed plan is ready.";
+		return "Plan mode is active. Explore, ask, and produce a <proposed_plan> block.";
+	}
+}
+
+function buildPlanModePrompt() {
+	return `${PLAN_CONTEXT_MARKER}
+You are in Plan Mode, a Codex-like collaboration mode for producing a decision-complete implementation plan.
+
+Mode rules:
+- Stay in Plan Mode until a developer or extension explicitly exits it.
+- Treat requests to implement as requests to plan the implementation; do not edit files or carry out the plan.
+- Use non-mutating exploration first: read files, search, inspect configuration, run read-only checks, and resolve discoverable facts before asking the user.
+- Ask the user only for preferences or tradeoffs that cannot be discovered from the repository.
+- Do not use update_plan/TODO tooling in Plan Mode; Plan Mode is conversational planning, not execution progress tracking.
+- Do not perform mutating actions: no edit/write tools, no patching, no formatting that rewrites files, no dependency installation, no commits, no migrations.
+- When the plan is decision-complete, output exactly one proposed plan block using:
+<proposed_plan>
+# Title
+
+## Summary
+...
+
+## Key Changes
+...
+
+## Test Plan
+...
+
+## Assumptions
+...
+</proposed_plan>
+- Keep the proposed plan concise, implementation-ready, and free of open decisions.`;
+}
+
+function readCommand(input: unknown) {
+	const command = input as { command?: unknown } | undefined;
+	return typeof command?.command === "string" ? command.command : "";
+}
+
+function isSafeCommand(command: string) {
+	const trimmed = command.trim();
+	if (!trimmed) return false;
+	if (MUTATING_BASH_PATTERNS.some((pattern) => pattern.test(trimmed))) return false;
+	return SAFE_BASH_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+function extractProposedPlan(text: string) {
+	const match = PROPOSED_PLAN_PATTERN.exec(text);
+	return match?.[1]?.trim();
+}
+
+function latestAssistantText(messages: unknown) {
+	if (!Array.isArray(messages)) return "";
+	for (const entry of [...messages].reverse()) {
+		const message = (entry as { message?: SessionMessage })?.message ?? (entry as SessionMessage);
+		if (message?.role !== "assistant") continue;
+		const text = messageText(message);
+		if (text) return text;
+	}
+	return "";
+}
+
+function messageContainsPlanModeContext(message: unknown) {
+	const candidate = message as { customType?: string; content?: unknown };
+	if (candidate.customType === "plan-mode-context") return true;
+	return contentText(candidate.content).includes(PLAN_CONTEXT_MARKER);
+}
+
+function messageText(message: SessionMessage) {
+	return contentText(message.content);
+}
+
+function contentText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((block) => {
+			const textBlock = block as TextBlock;
+			return textBlock.type === "text" && typeof textBlock.text === "string" ? textBlock.text : "";
+		})
+		.filter(Boolean)
+		.join("\n");
+}

--- a/extensions/pi-plan-mode/tsconfig.json
+++ b/extensions/pi-plan-mode/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -92,6 +92,9 @@ pack-firecrawl:
 pack-goal:
     just pack goal
 
+pack-plan-mode:
+    just pack plan-mode
+
 pack-python-lsp:
     just pack python-lsp
 
@@ -125,6 +128,9 @@ try-firecrawl:
 
 try-goal:
     just try goal
+
+try-plan-mode:
+    just try plan-mode
 
 try-python-lsp:
     just try python-lsp
@@ -160,6 +166,9 @@ install-firecrawl:
 install-goal:
     just install goal
 
+install-plan-mode:
+    just install plan-mode
+
 install-python-lsp:
     just install python-lsp
 
@@ -193,6 +202,9 @@ publish-firecrawl:
 
 publish-goal:
     just publish goal
+
+publish-plan-mode:
+    just publish plan-mode
 
 publish-python-lsp:
     just publish python-lsp

--- a/package-lock.json
+++ b/package-lock.json
@@ -750,6 +750,119 @@
 				"koffi": "^2.9.0"
 			}
 		},
+		"extensions/pi-plan-mode": {
+			"name": "@narumitw/pi-plan-mode",
+			"version": "0.1.17",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-plan-mode/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-plan-mode/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-plan-mode/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-plan-mode/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"extensions/pi-python-lsp": {
 			"name": "@narumitw/pi-python-lsp",
 			"version": "0.1.17",
@@ -2596,6 +2709,10 @@
 		},
 		"node_modules/@narumitw/pi-goal": {
 			"resolved": "extensions/pi-goal",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-plan-mode": {
+			"resolved": "extensions/pi-plan-mode",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-python-lsp": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"pack:codex-usage": "npm --workspace @narumitw/pi-codex-usage pack --dry-run",
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
+		"pack:plan-mode": "npm --workspace @narumitw/pi-plan-mode pack --dry-run",
 		"pack:python-lsp": "npm --workspace @narumitw/pi-python-lsp pack --dry-run",
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run",
 		"pack:statusline": "npm --workspace @narumitw/pi-statusline pack --dry-run",


### PR DESCRIPTION
## Summary
- add `@narumitw/pi-plan-mode` as a new workspace extension package
- implement `/plan` and `--plan` for Codex-like read-only planning
- block mutating tools/bash commands during Plan mode
- detect `<proposed_plan>` output and expose implement/revise/stay flow
- add workspace scripts, just recipes, package lock metadata, and README docs

## Verification
- npm run check
- just pack-plan-mode
- pi -e ./extensions/pi-plan-mode --help | rg -n -- '--plan|Extension CLI Flags'