### PR TITLE
feat: make status icons producer-owned

### DIFF
--- a/extensions/pi-biome-lsp/src/biome-lsp.ts
+++ b/extensions/pi-biome-lsp/src/biome-lsp.ts
@@ -153,7 +153,7 @@ const biomeFormatTool = defineTool({
 		const client = new LspClient(getServerCommand(), root, getTimeoutMs());
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
-		ctx.ui.setStatus(STATUS_KEY, "biome-lsp: format");
+		ctx.ui.setStatus(STATUS_KEY, "🧬 format");
 
 		try {
 			await client.start();
@@ -210,7 +210,7 @@ const biomeFixTool = defineTool({
 		const client = new LspClient(getServerCommand(), root, getTimeoutMs());
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
-		ctx.ui.setStatus(STATUS_KEY, "biome-lsp: fix");
+		ctx.ui.setStatus(STATUS_KEY, "🧬 fix");
 
 		try {
 			await client.start();
@@ -280,7 +280,7 @@ async function runDiagnostics(
 	const client = new LspClient(getServerCommand(), root, getTimeoutMs());
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
-	ctx.ui.setStatus(STATUS_KEY, "biome-lsp: diagnostics");
+	ctx.ui.setStatus(STATUS_KEY, "🧬 diagnostics");
 
 	try {
 		await client.start();

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -284,12 +284,12 @@ function updateStatus(ctx: ExtensionContext) {
 	}
 
 	if (state.process) {
-		ctx.ui.setStatus(STATUS_KEY, "caffeinate: awake");
+		ctx.ui.setStatus(STATUS_KEY, "💊 awake");
 		return;
 	}
 
 	if (!state.available) {
-		ctx.ui.setStatus(STATUS_KEY, "caffeinate: unavailable");
+		ctx.ui.setStatus(STATUS_KEY, "💊 unavailable");
 		return;
 	}
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -46,7 +46,7 @@ const listPagesTool = defineTool({
 	promptSnippet: "List Chrome tabs/pages available over Chrome DevTools Protocol",
 	parameters: Type.Object({}),
 	async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "cdp: list pages", async () => {
+		return withStatus(ctx, "🌐 list pages", async () => {
 			const pages = await listPages();
 			return textResult(JSON.stringify(pages.map(formatPage), null, 2), { pages });
 		});
@@ -62,7 +62,7 @@ const selectPageTool = defineTool({
 		pageId: Type.String({ description: "Page id from chrome_devtools_list_pages." }),
 	}),
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "cdp: select page", async () => {
+		return withStatus(ctx, "🌐 select page", async () => {
 			const page = await getPage(params.pageId);
 			state.activePageId = page.id;
 			return textResult(`Selected page ${page.id}: ${page.title}\n${page.url}`, {
@@ -84,7 +84,7 @@ const navigateTool = defineTool({
 		),
 	}),
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "cdp: navigate", async () => {
+		return withStatus(ctx, "🌐 navigate", async () => {
 			const page = await resolvePage(params.pageId);
 			const result = await withCdp(page, async (client) => {
 				await client.send("Page.enable");
@@ -112,7 +112,7 @@ const evaluateTool = defineTool({
 		),
 	}),
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "cdp: evaluate", async () => {
+		return withStatus(ctx, "🌐 evaluate", async () => {
 			const page = await resolvePage(params.pageId);
 			const result = await withCdp(page, (client) =>
 				client.send("Runtime.evaluate", {
@@ -142,7 +142,7 @@ const screenshotTool = defineTool({
 		),
 	}),
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "cdp: screenshot", async () => {
+		return withStatus(ctx, "🌐 screenshot", async () => {
 			const page = await resolvePage(params.pageId);
 			const result = await withCdp(page, async (client) => {
 				await client.send("Page.enable");

--- a/extensions/pi-codex-usage/README.md
+++ b/extensions/pi-codex-usage/README.md
@@ -66,8 +66,8 @@ information on rate limits and credits
 When the selected Pi model provider is `openai-codex`, `pi-codex-usage` refreshes a compact statusline item automatically:
 
 ```text
-codex 59% 5h 61% wk
-codex spark 100% 5h 100% wk
+📊 codex 59% 5h 61% wk
+📊 codex spark 100% 5h 100% wk
 ```
 
 The statusline value uses the cached usage snapshot and refreshes every five minutes while the current model remains `openai-codex`.

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -204,7 +204,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 			return;
 		}
 
-		ctx.ui.setStatus(STATUS_KEY, "codex usage: checking");
+		ctx.ui.setStatus(STATUS_KEY, "📊 checking");
 		const result = await queryUsage(ctx, { timeoutMs: DEFAULT_TIMEOUT_MS });
 		if (requestId !== statuslineRequestId) return;
 		if (!isOpenAICodexModel(ctx.model)) {
@@ -213,7 +213,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 		}
 
 		if (!result.ok) {
-			ctx.ui.setStatus(STATUS_KEY, "codex usage error");
+			ctx.ui.setStatus(STATUS_KEY, "📊 usage error");
 			scheduleStatuslineRefresh(ctx);
 			return;
 		}
@@ -250,7 +250,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 			}
 
 			let keepStatusline = false;
-			if (options.value.statusline) ctx.ui.setStatus(STATUS_KEY, "codex usage: checking");
+			if (options.value.statusline) ctx.ui.setStatus(STATUS_KEY, "📊 checking");
 			try {
 				const result = await queryUsage(ctx, options.value);
 				if (!result.ok) {
@@ -825,9 +825,9 @@ export function formatCodexUsageStatusline(
 	model?: CodexUsageModel,
 ): string {
 	const snapshot = selectSnapshotForModel(report, model);
-	if (!snapshot) return "codex usage unavailable";
+	if (!snapshot) return "📊 usage unavailable";
 
-	const parts = [formatStatuslinePrefix(snapshot)];
+	const parts = [`📊 ${formatStatuslinePrefix(snapshot)}`];
 	if (snapshot.primary) parts.push(`${formatRemainingPercent(snapshot.primary)} 5h`);
 	if (snapshot.secondary) parts.push(`${formatRemainingPercent(snapshot.secondary)} wk`);
 	if (parts.length === 1 && snapshot.credits) parts.push(formatCredits(snapshot.credits));

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -73,7 +73,7 @@ const scrapeTool = defineTool({
 		location: Type.Optional(Type.Any({ description: "Firecrawl location options." })),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "firecrawl: scrape", async () => {
+		return withStatus(ctx, "🔥 scrape", async () => {
 			const payload = await firecrawlRequest("POST", "/scrape", cleanObject(params), signal);
 			return jsonResult(payload);
 		});
@@ -111,7 +111,7 @@ const crawlTool = defineTool({
 		webhook: Type.Optional(Type.Any({ description: "Firecrawl webhook configuration." })),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "firecrawl: crawl", async () => {
+		return withStatus(ctx, "🔥 crawl", async () => {
 			const payload = await firecrawlRequest("POST", "/crawl", cleanObject(params), signal);
 			return jsonResult(payload);
 		});
@@ -127,7 +127,7 @@ const crawlStatusTool = defineTool({
 		id: Type.String({ description: "Crawl job id returned by firecrawl_crawl." }),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "firecrawl: crawl status", async () => {
+		return withStatus(ctx, "🔥 crawl status", async () => {
 			const payload = await firecrawlRequest(
 				"GET",
 				`/crawl/${encodeURIComponent(params.id)}`,
@@ -159,7 +159,7 @@ const mapTool = defineTool({
 		limit: Type.Optional(Type.Number({ description: "Maximum number of URLs to return." })),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "firecrawl: map", async () => {
+		return withStatus(ctx, "🔥 map", async () => {
 			const payload = await firecrawlRequest("POST", "/map", cleanObject(params), signal);
 			return jsonResult(payload);
 		});
@@ -183,7 +183,7 @@ const searchTool = defineTool({
 		),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "firecrawl: search", async () => {
+		return withStatus(ctx, "🔥 search", async () => {
 			const payload = await firecrawlRequest("POST", "/search", cleanObject(params), signal);
 			return jsonResult(payload);
 		});

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -64,11 +64,11 @@ Goal objectives are limited to 4,000 characters. Put longer instructions in a fi
 
 `pi-goal` writes compact status strings for statusline extensions:
 
-- `goal: active 3m` — an active goal without a token budget.
-- `goal: active 18k/100k` — an active goal with token usage and budget.
-- `goal: paused` — auto-continuation is paused.
-- `goal: budget 100k/100k` — the token budget was reached; auto-continuation stops.
-- `goal: complete` — shown briefly after `goal_complete` succeeds.
+- `🎯 active 3m` — an active goal without a token budget.
+- `🎯 active 18k/100k` — an active goal with token usage and budget.
+- `🎯 paused` — auto-continuation is paused.
+- `🎯 budget 100k/100k` — the token budget was reached; auto-continuation stops.
+- `🎯 complete` — shown briefly after `goal_complete` succeeds.
 
 ## ✅ How completion works
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -426,11 +426,11 @@ function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
 
 function formatStatus(goal: ActiveGoal | undefined) {
 	if (!goal) return undefined;
-	if (goal.status === "complete") return "goal: complete";
-	if (goal.status === "paused") return "goal: paused";
-	if (goal.status === "budget_limited") return `goal: budget ${formatBudget(goal)}`;
-	if (goal.tokenBudget !== undefined) return `goal: active ${formatBudget(goal)}`;
-	return `goal: active ${formatDuration(goal.timeUsedSeconds)}`;
+	if (goal.status === "complete") return "🎯 complete";
+	if (goal.status === "paused") return "🎯 paused";
+	if (goal.status === "budget_limited") return `🎯 budget ${formatBudget(goal)}`;
+	if (goal.tokenBudget !== undefined) return `🎯 active ${formatBudget(goal)}`;
+	return `🎯 active ${formatDuration(goal.timeUsedSeconds)}`;
 }
 
 function formatBudget(goal: ActiveGoal) {
@@ -524,7 +524,7 @@ function clearActiveGoal(ctx: StatusContext) {
 
 function showCompletionStatus(ctx: StatusContext) {
 	if (completionStatusTimer) clearTimeout(completionStatusTimer);
-	ctx.ui.setStatus(STATUS_KEY, "goal: complete");
+	ctx.ui.setStatus(STATUS_KEY, "🎯 complete");
 	completionStatusTimer = setTimeout(() => ctx.ui.setStatus(STATUS_KEY, undefined), 8_000);
 }
 

--- a/extensions/pi-python-lsp/src/python-lsp.ts
+++ b/extensions/pi-python-lsp/src/python-lsp.ts
@@ -150,7 +150,7 @@ const ruffFormatTool = defineTool({
 		const client = new LspClient("ruff", getServerCommand("ruff"), root, getTimeoutMs("ruff"));
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
-		ctx.ui.setStatus(STATUS_KEY, "python-lsp: ruff format");
+		ctx.ui.setStatus(STATUS_KEY, "🐍 ruff format");
 
 		try {
 			await client.start();
@@ -207,7 +207,7 @@ const ruffFixTool = defineTool({
 		const client = new LspClient("ruff", getServerCommand("ruff"), root, getTimeoutMs("ruff"));
 		const abort = () => client.close();
 		signal?.addEventListener("abort", abort, { once: true });
-		ctx.ui.setStatus(STATUS_KEY, "python-lsp: ruff fix");
+		ctx.ui.setStatus(STATUS_KEY, "🐍 ruff fix");
 
 		try {
 			await client.start();
@@ -279,7 +279,7 @@ async function runDiagnostics(
 	const client = new LspClient(kind, getServerCommand(kind), root, getTimeoutMs(kind));
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
-	ctx.ui.setStatus(STATUS_KEY, `python-lsp: ${kind} diagnostics`);
+	ctx.ui.setStatus(STATUS_KEY, `🐍 ${kind} diagnostics`);
 
 	try {
 		await client.start();

--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -38,7 +38,7 @@ pi -e ./extensions/pi-retry
 
 When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
 
-The extension does not keep a permanent statusline entry. It briefly shows `unknown-error retry: retrying` only when it has matched the error and asked Pi to retry.
+The extension does not keep a permanent statusline entry. It briefly shows `🔁 retrying` only when it has matched the error and asked Pi to retry.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-retry/src/unknown-error-retry.ts
+++ b/extensions/pi-retry/src/unknown-error-retry.ts
@@ -19,7 +19,7 @@ export default function unknownErrorRetry(pi: ExtensionAPI) {
 		ui: { setStatus: (key: string, value: string | undefined) => void };
 	}) => {
 		if (clearStatusTimer) clearTimeout(clearStatusTimer);
-		ctx.ui.setStatus(STATUS_KEY, "unknown-error retry: retrying");
+		ctx.ui.setStatus(STATUS_KEY, "🔁 retrying");
 		clearStatusTimer = setTimeout(() => {
 			clearStatusTimer = undefined;
 			ctx.ui.setStatus(STATUS_KEY, undefined);

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -10,8 +10,9 @@ Use it to monitor model selection, thinking level, git branch, working directory
 
 - Replaces the default Pi footer with a compact rich statusline.
 - Shows model, thinking level, git branch, project directory, active tool, context usage, tokens, cost, and clock.
-- Displays compact icon statuses from other extensions, such as goal mode and LSP readiness.
-- Shows active subagent count and execution mode while `pi-subagents` is running.
+- Displays compact statuses from other extensions without knowing about specific packages.
+- Preserves extension-provided status icons when the status text starts with one.
+- Shows active subagent count and execution mode while subagent tools are running.
 - Warns when the same extension package is installed from multiple sources.
 - Uses emoji-labeled segments for readability.
 - Adapts to terminal width and truncates safely.
@@ -50,15 +51,16 @@ The default statusline includes:
 - 💰 estimated cost.
 - 🕒 clock.
 
-Statuses from other extensions, such as goal mode, appear on their own compact icon line below the main statusline and are separated with ``.
+Statuses from other extensions appear on their own compact line below the main statusline and are separated with ``.
+
+`pi-statusline` is extension-agnostic: it does not map package names to icons. If an extension wants a custom icon, it should include that icon at the start of its status text, for example `ctx.ui.setStatus("goal", "🎯 active")`. Statuses without a leading icon use the generic `🔌` icon.
 
 Examples:
 
-- `🎯 active` for goal mode.
-- `💊 awake` while pi-caffeinate is preventing sleep.
-- `🧬 ✓` for Biome LSP readiness.
-- `🐍 ty ✓ ruff ✓` for Python LSP readiness.
-- `🧑‍🤝‍🧑 2 parallel` while subagents are active.
+- `🔌 active` for a plain status such as `goal: active`.
+- `🎯 active` when the producing extension sets `🎯 active`.
+- `🔌 ty ✓ ruff ✓` for a plain LSP readiness status.
+- `🧑‍🤝‍🧑 2 parallel` while subagent tool calls are active.
 - `⚠️ dup biome-lsp` when local and npm installs register the same extension.
 
 ## 🧠 Use cases

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -59,7 +59,7 @@ Examples:
 
 - `🔌 active` for a plain status such as `goal: active`.
 - `🎯 active` when the producing extension sets `🎯 active`.
-- `🔌 ty ✓ ruff ✓` for a plain LSP readiness status.
+- `🐍 ty ✓ ruff ✓` when the producing extension sets a Python status with a leading icon.
 - `🧑‍🤝‍🧑 2 parallel` while subagent tool calls are active.
 - `⚠️ dup biome-lsp` when local and npm installs register the same extension.
 

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -457,7 +457,9 @@ function splitExtensionStatusIcon(value: string): { icon: string; text: string }
 }
 
 function isEmojiOnlyToken(value: string): boolean {
-	return /^(?:\p{Extended_Pictographic}|\p{Emoji_Modifier}|\u200d|\ufe0f)+$/u.test(value);
+	return /^[\p{Extended_Pictographic}\p{Emoji_Modifier}\p{Regional_Indicator}0-9#*\u200d\ufe0f\u20e3]+$/u.test(
+		value,
+	);
 }
 
 function extensionColor(key: string, value: string): ThemeColor {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -423,10 +423,11 @@ function formatExtensionStatuses(
 }
 
 function formatExtensionStatus(key: string, value: string, theme: Theme): string {
-	const text = truncateToWidth(simplifyExtensionStatus(key, value), 22, "…");
+	const status = splitExtensionStatusIcon(simplifyExtensionStatus(key, value));
+	const text = truncateToWidth(status.text, 22, "…");
 	const color = extensionColor(key, value);
-	const textColor = key.toLowerCase().includes("codex") ? color : "muted";
-	return `${theme.fg(color, extensionIcon(key))} ${theme.fg(textColor, text)}`;
+	const textColor = color === "warning" ? "warning" : "muted";
+	return `${theme.fg(color, status.icon)} ${theme.fg(textColor, text)}`;
 }
 
 function formatSubagentStatus(runtime: RuntimeState, theme: Theme): string[] {
@@ -446,20 +447,13 @@ function formatDuplicateExtensionStatus(runtime: RuntimeState, theme: Theme): st
 	return [`${theme.fg("warning", "⚠️")} ${theme.fg("warning", `dup ${names}${suffix}`)}`];
 }
 
-function extensionIcon(key: string): string {
-	const normalizedKey = key.toLowerCase();
-	if (normalizedKey.includes("biome")) return "🧬";
-	if (normalizedKey.includes("python") || normalizedKey.includes("ruff") || normalizedKey.includes("ty"))
-		return "🐍";
-	if (normalizedKey.includes("subagent")) return "🧑‍🤝‍🧑";
-	if (normalizedKey.includes("caffeinate")) return "💊";
-	if (normalizedKey.includes("chrome") || normalizedKey.includes("devtools") || normalizedKey === "cdp")
-		return "🌐";
-	if (normalizedKey.includes("codex")) return "📊";
-	if (normalizedKey.includes("firecrawl")) return "🔥";
-	if (normalizedKey.includes("goal")) return "🎯";
-	if (normalizedKey.includes("retry")) return "🔁";
-	return "🔌";
+function splitExtensionStatusIcon(value: string): { icon: string; text: string } {
+	const trimmed = value.trim();
+	const [firstToken, ...restTokens] = trimmed.split(/\s+/);
+	if (firstToken && /\p{Extended_Pictographic}/u.test(firstToken)) {
+		return { icon: firstToken, text: restTokens.join(" ") };
+	}
+	return { icon: "🔌", text: trimmed };
 }
 
 function extensionColor(key: string, value: string): ThemeColor {
@@ -474,8 +468,6 @@ function simplifyExtensionStatus(key: string, value: string): string {
 	return value
 		.trim()
 		.replace(new RegExp(`^${escapeRegExp(key)}\\s*:\\s*`, "iu"), "")
-		.replace(/^python-lsp\s*:\s*/iu, "")
-		.replace(/^biome-lsp\s*:\s*/iu, "")
 		.replace(/\bready\b/giu, "✓")
 		.replace(/\bmissing\b/giu, "✗")
 		.replace(/,\s*/g, " ")

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -450,10 +450,14 @@ function formatDuplicateExtensionStatus(runtime: RuntimeState, theme: Theme): st
 function splitExtensionStatusIcon(value: string): { icon: string; text: string } {
 	const trimmed = value.trim();
 	const [firstToken, ...restTokens] = trimmed.split(/\s+/);
-	if (firstToken && /\p{Extended_Pictographic}/u.test(firstToken)) {
+	if (firstToken && isEmojiOnlyToken(firstToken)) {
 		return { icon: firstToken, text: restTokens.join(" ") };
 	}
 	return { icon: "🔌", text: trimmed };
+}
+
+function isEmojiOnlyToken(value: string): boolean {
+	return /^(?:\p{Extended_Pictographic}|\p{Emoji_Modifier}|\u200d|\ufe0f)+$/u.test(value);
 }
 
 function extensionColor(key: string, value: string): ThemeColor {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -423,8 +423,8 @@ function formatExtensionStatuses(
 }
 
 function formatExtensionStatus(key: string, value: string, theme: Theme): string {
-	const status = splitExtensionStatusIcon(simplifyExtensionStatus(key, value));
-	const text = truncateToWidth(status.text, 22, "…");
+	const status = splitExtensionStatusIcon(stripExtensionStatusPrefix(key, value));
+	const text = truncateToWidth(simplifyExtensionStatusText(status.text), 22, "…");
 	const color = extensionColor(key, value);
 	const textColor = color === "warning" ? "warning" : "muted";
 	return `${theme.fg(color, status.icon)} ${theme.fg(textColor, text)}`;
@@ -470,10 +470,13 @@ function extensionColor(key: string, value: string): ThemeColor {
 	return "muted";
 }
 
-function simplifyExtensionStatus(key: string, value: string): string {
+function stripExtensionStatusPrefix(key: string, value: string): string {
+	return value.trim().replace(new RegExp(`^${escapeRegExp(key)}\\s*:\\s*`, "iu"), "");
+}
+
+function simplifyExtensionStatusText(value: string): string {
 	return value
 		.trim()
-		.replace(new RegExp(`^${escapeRegExp(key)}\\s*:\\s*`, "iu"), "")
 		.replace(/\bready\b/giu, "✓")
 		.replace(/\bmissing\b/giu, "✗")
 		.replace(/,\s*/g, " ")

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -457,7 +457,7 @@ function splitExtensionStatusIcon(value: string): { icon: string; text: string }
 }
 
 function isEmojiOnlyToken(value: string): boolean {
-	return /^[\p{Extended_Pictographic}\p{Emoji_Modifier}\p{Regional_Indicator}0-9#*\u200d\ufe0f\u20e3]+$/u.test(
+	return /^(?=.*(?:\p{Extended_Pictographic}|\p{Regional_Indicator}|[0-9#*]\ufe0f?\u20e3))(?:\p{Extended_Pictographic}|\p{Emoji_Modifier}|\p{Regional_Indicator}|\u200d|\ufe0f|[0-9#*]\ufe0f?\u20e3)+$/u.test(
 		value,
 	);
 }


### PR DESCRIPTION
## Summary
- make pi-statusline extension status rendering generic instead of mapping package keys to icons
- preserve leading producer-provided emoji icons and use 🔌 fallback otherwise
- move existing pi-extension status icons into their producer status strings

## Verification
- npm run typecheck
- npm run check