### PR TITLE
fix(plan-mode): start implementation after plan selection

### DIFF
--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -62,7 +62,7 @@ A complete Plan mode answer should include exactly one block like this:
 </proposed_plan>
 ```
 
-After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode.
+After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode. Choosing implementation disables Plan mode, restores full tool access, and immediately starts an implementation turn with the proposed plan.
 
 You can also exit directly:
 
@@ -76,7 +76,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 
 - Plan mode is a conversational collaboration mode, not TODO/progress tracking.
 - `update_plan`-style checklist use is discouraged while Plan mode is active.
-- The implementation boundary is explicit: Plan mode restores tools only after you choose to leave it.
+- The implementation boundary is explicit: Plan mode restores tools before starting implementation, and choosing implementation immediately triggers a normal agent turn with full tool access.
 - Pi extension safety is approximated with active-tool restriction plus bash filtering, so it may be stricter or looser than Codex core in edge cases.
 
 ## 🗂️ Package layout

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -193,6 +193,25 @@ export default function planMode(pi: ExtensionAPI) {
 		updateUi(ctx);
 	}
 
+	function startImplementation(ctx: ExtensionContext) {
+		const plan = state.latestPlan?.trim();
+		exitPlanMode(ctx);
+
+		if (!plan) {
+			ctx.ui.notify("Plan mode disabled. No proposed plan is available to implement.", "warning");
+			return;
+		}
+
+		pi.sendMessage(
+			{
+				customType: "plan-mode-implementation",
+				content: `Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`,
+				display: true,
+			},
+			{ triggerTurn: true },
+		);
+	}
+
 	async function showPlanMenu(ctx: ExtensionContext) {
 		if (!ctx.hasUI) {
 			ctx.ui.notify(planStatusText(), "info");
@@ -207,7 +226,11 @@ export default function planMode(pi: ExtensionAPI) {
 			ctx.ui.notify(state.latestPlan ?? "No proposed plan yet.", "info");
 			return;
 		}
-		if (choice === "Implement this plan" || choice === "Exit Plan mode") {
+		if (choice === "Implement this plan") {
+			startImplementation(ctx);
+			return;
+		}
+		if (choice === "Exit Plan mode") {
 			exitPlanMode(ctx);
 			ctx.ui.notify("Plan mode disabled. Full tool access restored.", "info");
 			return;
@@ -222,8 +245,7 @@ export default function planMode(pi: ExtensionAPI) {
 			"Stay in Plan mode",
 		]);
 		if (choice === "Implement this plan") {
-			exitPlanMode(ctx);
-			ctx.ui.notify("Plan mode disabled. Ask me to implement the proposed plan when ready.", "info");
+			startImplementation(ctx);
 			return;
 		}
 		if (choice === "Revise plan") {


### PR DESCRIPTION
## Summary
- start an implementation turn immediately after choosing "Implement this plan"
- include the saved proposed plan in the triggered turn
- update README behavior docs

## Verification
- npm --workspace @narumitw/pi-plan-mode run typecheck
- npm run check
- just pack plan-mode