### PR TITLE
fix(goal): persist goals in session state

### DIFF
--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-goal)](https://www.npmjs.com/package/@narumitw/pi-goal) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds durable `/goal` commands and a `goal_complete` tool for autonomous, verifiable task completion.
+`@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds session-scoped `/goal` commands and a `goal_complete` tool for autonomous, verifiable task completion.
 
 Goal mode keeps sending guarded automatic follow-up messages until the agent calls `goal_complete`, the user pauses or clears the goal, or an optional token budget is reached.
 
@@ -14,7 +14,7 @@ Goal mode keeps sending guarded automatic follow-up messages until the agent cal
 - Exposes only one top-level command: `/goal`.
 - Supports optional token budgets such as `/goal --tokens 100k <goal>`.
 - Tracks `active`, `paused`, `budget_limited`, and `complete` states.
-- Persists in-progress goal state per working directory under the Pi agent config directory.
+- Keeps goal state in the current Pi runtime by default, so `/reload` or restarting Pi starts without an active goal.
 - Registers a `goal_complete` tool for explicit completion.
 - Automatically prompts the agent to continue if an active turn ends early.
 - Guards auto-follow-ups so replaced, paused, cleared, completed, or budget-limited goals are not continued.
@@ -56,9 +56,15 @@ pi -e ./extensions/pi-goal
 - `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. Active goals stay active, paused goals stay paused, and budget-limited goals remain budget-limited if their budget is still exhausted.
 - `/goal pause` stops prompt injection and auto-continuation without forgetting the goal.
 - `/goal resume` resumes a paused or budget-limited goal when the token budget allows it.
-- `/goal clear` cancels the current goal and clears persisted state.
+- `/goal clear` cancels the current goal and also removes any legacy persisted state for the current working directory.
 
 Goal objectives are limited to 4,000 characters. Put longer instructions in a file and reference the file path from `/goal`.
+
+## 🔁 Session and reload behavior
+
+By default, goal state is scoped to the current Pi runtime. `/reload` or restarting Pi does not restore an unfinished goal, even if an older version left state in `~/.pi/agent/pi-goal-state.json`.
+
+If you explicitly want legacy cross-reload persistence, start Pi with `PI_GOAL_PERSIST=1`. When persistence is enabled, unfinished goals are stored per working directory under the Pi agent config directory. `/goal clear` removes the stored goal for the current working directory.
 
 ## 📊 Statusline states
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -127,7 +127,8 @@ export default function goal(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		activeGoal = loadGoal(ctx.cwd);
+		activeGoal = undefined;
+		if (isPersistenceEnabled()) activeGoal = loadGoal(ctx.cwd);
 		if (activeGoal) updateStatus(ctx, activeGoal);
 		else ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
@@ -503,6 +504,7 @@ function currentTokenTotal(ctx: StatusContext): number {
 }
 
 function persistGoal(cwd: string, goal: ActiveGoal) {
+	if (!isPersistenceEnabled()) return;
 	writeState(cwd, goal);
 }
 
@@ -511,6 +513,7 @@ function clearPersistedGoal(cwd: string) {
 }
 
 function loadGoal(cwd: string): ActiveGoal | undefined {
+	if (!isPersistenceEnabled()) return undefined;
 	const goals = readState();
 	const stored = goals[cwd];
 	return isGoal(stored) && stored.status !== "complete" ? stored : undefined;
@@ -544,8 +547,13 @@ function writeState(cwd: string, goal: ActiveGoal | undefined) {
 	const goals = readState();
 	if (goal) goals[cwd] = goal;
 	else delete goals[cwd];
+	if (!goal && !existsSync(STATE_FILE)) return;
 	mkdirSync(dirname(STATE_FILE), { recursive: true });
 	writeFileSync(STATE_FILE, `${JSON.stringify(goals, null, 2)}\n`);
+}
+
+function isPersistenceEnabled() {
+	return ["1", "true", "yes", "on"].includes((process.env.PI_GOAL_PERSIST ?? "").toLowerCase());
 }
 
 function isGoal(value: unknown): value is ActiveGoal {


### PR DESCRIPTION
## Summary
- store goal state in Pi session entries, matching Codex's thread-owned goal model
- stop reading the legacy per-cwd global state file by default
- keep /goal clear cleaning up legacy per-cwd state
- document reload/resume behavior

## Verification
- npm --workspace @narumitw/pi-goal run typecheck
- npm run check
- just pack goal