### PR TITLE
feat(plan-mode): submit inline plan prompts

### DIFF
--- a/docs/plans/archived/2026-05-17_plan-command-inline-prompt-plan.md
+++ b/docs/plans/archived/2026-05-17_plan-command-inline-prompt-plan.md
@@ -1,0 +1,39 @@
+## Goal
+
+Allow `@narumitw/pi-plan-mode` to accept an inline prompt through `/plan <prompt>` while keeping bare `/plan` behavior unchanged. Success means `/plan` still enters or manages Plan mode, and `/plan build the feature` enters Plan mode and immediately submits `build the feature` as the user prompt in Plan mode.
+
+## Context
+
+Codex implements this behavior in `third_party/codex/codex-rs/tui/src/chatwidget/slash_dispatch.rs`:
+
+- Bare `SlashCommand::Plan` calls `apply_plan_slash_command()` and only switches to Plan mode.
+- `SlashCommand::Plan if !trimmed.is_empty()` first calls `apply_plan_slash_command()`, then submits the remaining text as a user message in Plan mode.
+- `third_party/codex/codex-rs/tui/src/chatwidget/tests/plan_mode.rs` has `plan_slash_command_with_args_submits_prompt_in_plan_mode`, which verifies `/plan build the plan` submits `build the plan` and leaves the active collaboration mode as `ModeKind::Plan`.
+
+Current `extensions/pi-plan-mode/src/plan-mode.ts` treats the full slash argument as a subcommand only. If Plan mode is disabled, non-empty text such as `/plan build the plan` only enters Plan mode and drops the text.
+
+## Non-Goals
+
+- Do not change proposed-plan detection, implementation prompting, or read-only tool blocking.
+- Do not add new slash commands.
+- Do not implement Codex's fresh-context implementation option in this slice.
+
+## Plan
+
+- [x] Update `extensions/pi-plan-mode/src/plan-mode.ts` `/plan` command parsing so reserved subcommands `exit` and `off` keep disabling Plan mode, while any other non-empty argument is treated as an inline planning prompt; verified by code review of the handler branches.
+- [x] Add `enterPlanModeWithPrompt(prompt, ctx)` that calls `enterPlanMode(ctx)`, notifies Plan mode is enabled, and sends the trimmed prompt via `pi.sendUserMessage()` when idle or `{ deliverAs: "followUp" }` when busy; verified by code review: it calls `enterPlanMode(ctx)` before `pi.sendUserMessage()`.
+- [x] Keep bare `/plan` behavior unchanged: when Plan mode is off it only enters Plan mode; when Plan mode is on it opens the Plan mode menu; verified by reviewing the handler branches.
+- [x] Update `extensions/pi-plan-mode/README.md` with examples for `/plan` and `/plan <prompt>`, including that the inline text becomes the first Plan-mode prompt; verified by README review.
+- [x] Run `npm --workspace @narumitw/pi-plan-mode run typecheck`, `npm run check`, and `just pack plan-mode`; verified all commands passed and the dry-run tarball contains LICENSE, README.md, package.json, and src/plan-mode.ts.
+
+## Risks
+
+- If inline text is sent before `enterPlanMode()` finishes updating active tools/state, the first prompt could run with full tools. Mitigate by entering Plan mode and persisting/updating tools before `sendUserMessage()`.
+- Some users might expect `/plan status` to be a status subcommand. Current package does not document `status`; this plan treats unknown non-empty args as prompts, matching Codex.
+
+## Completion Checklist
+
+- [x] `/plan <prompt>` starts Plan mode and submits `<prompt>` as a Plan-mode user prompt, verified by implementation review and `npm --workspace @narumitw/pi-plan-mode run typecheck`.
+- [x] Bare `/plan`, `/plan exit`, and `/plan off` behavior remains unchanged, verified by implementation review.
+- [x] Documentation shows both bare and inline `/plan` usage, verified by `extensions/pi-plan-mode/README.md`.
+- [x] Repository checks pass, verified by `npm --workspace @narumitw/pi-plan-mode run typecheck`, `npm run check`, and `just pack plan-mode`.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -38,7 +38,10 @@ pi -e ./extensions/pi-plan-mode
 
 ```text
 /plan
+/plan <prompt>
 ```
+
+Use `/plan` to enter Plan mode before writing your planning prompt. Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user message.
 
 When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation.
 
@@ -75,6 +78,7 @@ You can also exit directly:
 This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 
 - Plan mode is a conversational collaboration mode, not TODO/progress tracking.
+- `/plan <prompt>` follows Codex behavior by switching to Plan mode before submitting the inline prompt.
 - `update_plan`-style checklist use is discouraged while Plan mode is active.
 - The implementation boundary is explicit: Plan mode restores tools before starting implementation, and choosing implementation immediately triggers a normal agent turn with full tool access.
 - Pi extension safety is approximated with active-tool restriction plus bash filtering, so it may be stricter or looser than Codex core in edge cases.

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -192,8 +192,11 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function enterPlanModeWithPrompt(prompt: string, ctx: ExtensionContext) {
+		const wasEnabled = state.enabled;
 		enterPlanMode(ctx);
-		ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+		if (!wasEnabled) {
+			ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+		}
 		if (ctx.isIdle()) pi.sendUserMessage(prompt);
 		else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
 	}

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -88,10 +88,15 @@ export default function planMode(pi: ExtensionAPI) {
 	pi.registerCommand("plan", {
 		description: "Enter or manage Codex-like Plan mode",
 		handler: async (args, ctx) => {
-			const command = args.trim().toLowerCase();
+			const prompt = args.trim();
+			const command = prompt.toLowerCase();
 			if (command === "exit" || command === "off") {
 				exitPlanMode(ctx);
 				ctx.ui.notify("Plan mode disabled. Full tool access restored.", "info");
+				return;
+			}
+			if (prompt) {
+				enterPlanModeWithPrompt(prompt, ctx);
 				return;
 			}
 			if (!state.enabled) {
@@ -184,6 +189,13 @@ export default function planMode(pi: ExtensionAPI) {
 		activateReadOnlyTools();
 		persistState();
 		updateUi(ctx);
+	}
+
+	function enterPlanModeWithPrompt(prompt: string, ctx: ExtensionContext) {
+		enterPlanMode(ctx);
+		ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+		if (ctx.isIdle()) pi.sendUserMessage(prompt);
+		else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary
- support `/plan <prompt>` by entering Plan mode and immediately sending the inline prompt
- keep bare `/plan`, `/plan exit`, and `/plan off` behavior unchanged
- document the new usage and archive the completed implementation plan

## Codex reference
- `third_party/codex/codex-rs/tui/src/chatwidget/slash_dispatch.rs` handles `SlashCommand::Plan if !trimmed.is_empty()` by applying Plan mode before submitting the args as a user message
- `third_party/codex/codex-rs/tui/src/chatwidget/tests/plan_mode.rs` verifies `/plan build the plan` submits `build the plan` in Plan mode

## Verification
- `npm --workspace @narumitw/pi-plan-mode run typecheck`
- `npm run check`
- `just pack plan-mode`