### PR TITLE
feat(plan-mode): show statusline state

### DIFF
--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -14,6 +14,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Blocks mutating bash commands such as `rm`, `git commit`, dependency installs, redirects, and editor launches.
 - Injects Codex-like Plan mode instructions: explore first, ask only non-discoverable questions, do not mutate files, and finish with `<proposed_plan>`.
 - Detects proposed plan blocks and prompts you to implement, revise, or stay in Plan mode.
+- Shows Plan mode state in Pi's statusline as `📝 plan active` or `📝 plan ready`.
 - Persists Plan mode state in the Pi session so resume restores the mode.
 
 ## 📦 Install
@@ -66,6 +67,11 @@ A complete Plan mode answer should include exactly one block like this:
 ```
 
 After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode. Choosing implementation disables Plan mode, restores full tool access, and immediately starts an implementation turn with the proposed plan.
+
+While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
+
+- `📝 plan active`: Plan mode is enabled and still gathering context or drafting a plan.
+- `📝 plan ready`: A `<proposed_plan>` was detected and is waiting for your next `/plan` action.
 
 You can also exit directly:
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -305,7 +305,7 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function updateUi(ctx: ExtensionContext) {
-		ctx.ui.setStatus(STATUS_KEY, state.enabled ? "plan: active" : undefined);
+		ctx.ui.setStatus(STATUS_KEY, formatStatus());
 		if (state.enabled && state.latestPlan) {
 			ctx.ui.setWidget(PLAN_WIDGET_KEY, [
 				"Proposed plan ready",
@@ -316,6 +316,12 @@ export default function planMode(pi: ExtensionAPI) {
 		} else {
 			ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
 		}
+	}
+
+	function formatStatus() {
+		if (!state.enabled) return undefined;
+		if (state.awaitingAction || state.latestPlan) return "📝 plan ready";
+		return "📝 plan active";
 	}
 
 	function clearUi(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary
- show pi-plan-mode status as `📝 plan active` while planning
- show `📝 plan ready` after a proposed plan is detected
- document the statusline states in the plan-mode README

## Verification
- npm run check
- commit hook: biome check
- commit hook: npm typecheck