### PR TITLE
fix(pi-goal): pause continuations after interruptions

### DIFF
--- a/docs/implementation-notes/pi-goal-interruption-research.md
+++ b/docs/implementation-notes/pi-goal-interruption-research.md
@@ -1,0 +1,216 @@
+# pi-goal interruption research
+
+This note investigates why `@narumitw/pi-goal` can lose momentum or continue at the
+wrong time, and compares it with the native goal runtime in `third_party/codex`.
+
+## Scope
+
+Reviewed active code and docs only. Deprecated extensions are out of scope.
+
+Primary sources:
+
+- `extensions/pi-goal/src/goal.ts`
+- Pi extension docs for `before_agent_start`, `agent_end`, `sendUserMessage`,
+  `appendEntry`, `ctx.isIdle()`, and `ctx.hasPendingMessages()`
+- `third_party/codex/codex-rs/core/src/goals.rs`
+- `third_party/codex/codex-rs/core/src/context/goal_context.rs`
+- `third_party/codex/codex-rs/core/src/context/turn_aborted.rs`
+- `third_party/codex/codex-rs/core/templates/goals/*.md`
+- `third_party/codex/codex-rs/tui/src/bottom_pane/pending_input_preview.rs`
+- `third_party/codex/codex-rs/tui/src/chatwidget/input_queue.rs`
+
+## Current `pi-goal` behavior
+
+`pi-goal` is implemented entirely as a Pi extension:
+
+1. `/goal <objective>` creates an in-memory `activeGoal`, persists it as a
+   custom session entry, updates the statusline, and calls `pi.sendUserMessage()`
+   with a kickoff prompt.
+2. `before_agent_start` appends active-goal rules to the system prompt.
+3. `goal_complete` marks the goal complete, clears persisted state, and returns
+   `terminate: true`.
+4. `agent_end` increments the goal iteration, updates usage, checks token
+   budget, and sends a continuation prompt if the same goal id is still active.
+5. Continuation delivery is delegated to Pi messaging:
+   - if `ctx.isIdle()` is true, call `pi.sendUserMessage(prompt)`;
+   - otherwise call `pi.sendUserMessage(prompt, { deliverAs: "followUp" })`.
+
+This is small and idiomatic for an extension, but the continuation policy is not
+owned by the agent runtime. That is the main source of fragility.
+
+## Where interruptions can break `pi-goal`
+
+### 1. User interrupt is not goal-aware
+
+`pi-goal` has no explicit `turn_aborted` or `interrupt` event. If Pi surfaces an
+aborted assistant message through normal turn/agent events, `agent_end` still has
+enough information to send another continuation unless `pi-goal` separately
+checks for aborted/error stop reasons.
+
+Codex treats `TurnAbortReason::Interrupted` as a first-class runtime event. The
+goal runtime accounts progress, clears the continuation turn id, and pauses the
+active goal. That makes Esc/user interrupt mean "stop this goal loop for now",
+not "immediately schedule another continuation".
+
+### 2. Continuation is scheduled from `agent_end`, not from a runtime idle gate
+
+`pi-goal` schedules the next turn from an extension `agent_end` handler. That
+handler is downstream of the agent loop and does not own the runtime's active
+turn reservation. Depending on exact event ordering, queued follow-ups,
+compaction, retry, or other extension work can race with the continuation.
+
+Codex separates "turn finished" from "maybe continue if idle". After a turn is
+fully cleared, it calls a runtime-owned `MaybeContinueIfIdle` path. That path
+first starts any pending non-goal work, then tries goal continuation only if the
+session is still idle.
+
+### 3. Pending user input is not prioritized
+
+`pi-goal` does not check `ctx.hasPendingMessages()` before scheduling an
+automatic continuation. A user follow-up, steering message, or another extension
+message can be queued at the same boundary as the goal continuation.
+
+Codex explicitly skips active-goal continuation when queued response items or
+trigger-turn mailbox items are pending. User or inter-agent work wins over the
+automatic goal loop.
+
+### 4. No continuation lock or reserved continuation turn id
+
+`pi-goal` guards against stale goals by comparing the goal id before sending, but
+it does not keep a continuation lock or a reserved continuation turn id. Multiple
+`agent_end`-like boundaries, reload/resume timing, or queued messages can still
+produce duplicate or stale continuation pressure.
+
+Codex has both a `continuation_lock` and a `continuation_turn_id`. It reserves an
+active turn before injecting continuation input, re-reads the goal from state,
+and clears the reservation if the goal changed or another turn appeared.
+
+### 5. The continuation prompt is a visible user message
+
+`pi-goal` continuation uses normal `sendUserMessage()`. This makes continuation
+look like user input and subjects it to the same queue semantics as real user
+messages.
+
+Codex injects hidden user-context fragments wrapped in `<goal_context>`. The
+model sees runtime-owned steering, but the UI and input queue can still treat
+real user input separately.
+
+### 6. Goal objective text is not escaped inside prompt delimiters
+
+Codex escapes objective text before placing it inside XML-like tags in goal
+prompts. `pi-goal` currently interpolates the objective directly into plain text
+prompts. That is simpler, but a goal containing delimiter-like or instruction-like
+text can make the continuation prompt less robust.
+
+### 7. Budget handling happens only at turn end
+
+`pi-goal` checks token budget in `agent_end`. Long turns with many tools can
+exceed the budget substantially before the extension can react.
+
+Codex accounts goal usage after tool completion and at turn finish. When the
+budget is reached, it can inject a budget-limit steering item during the current
+turn and mark the goal `budget_limited` once.
+
+## Codex design points worth copying
+
+### Runtime event dispatcher
+
+Codex centralizes lifecycle policy behind `GoalRuntimeEvent`:
+
+- `TurnStarted`
+- `ToolCompleted`
+- `ToolCompletedGoal`
+- `TurnFinished`
+- `MaybeContinueIfIdle`
+- `TaskAborted`
+- `ExternalMutationStarting`
+- `ExternalSet`
+- `ExternalClear`
+- `ThreadResumed`
+
+This keeps accounting, continuation, abort, resume, and external goal mutation
+rules in one place.
+
+### Interrupt means pause
+
+On user interrupt, Codex accounts current progress and pauses the active goal.
+It also records model-visible interrupted-turn context so future turns do not
+assume commands or tools cleanly completed.
+
+### Continuation is idle-only and lock-protected
+
+Codex continuation is not just "send a follow-up". It:
+
+1. checks that goals are enabled and the current mode allows goals;
+2. checks no active turn exists;
+3. checks no queued user or trigger-turn mailbox input exists;
+4. reads the current persisted goal and requires `status == active`;
+5. acquires a continuation lock;
+6. reserves an active turn;
+7. re-reads the goal before launch;
+8. injects hidden goal context;
+9. marks the generated turn id as the continuation turn.
+
+### Hidden goal context
+
+Codex continuation, budget-limit, and objective-update prompts are runtime-owned
+hidden context fragments, not ordinary user messages. This preserves the user
+queue as user intent while still giving the model persistent goal guidance.
+
+### Completion audit prompt
+
+The Codex continuation template strongly warns the model not to redefine the
+goal into a smaller task, and requires evidence-based completion before calling
+`update_goal` with status `complete`. `pi-goal` has similar rules, but Codex's
+template is more explicit about requirement-by-requirement verification and
+using the current worktree/external state as authoritative.
+
+## Recommendations
+
+### Extension-only improvements
+
+These can be implemented inside `pi-goal` without Pi core changes:
+
+1. **Detect aborted/error agent endings.** If the final assistant message has
+   `stopReason: "aborted"`, pause the goal and do not auto-continue. If it has
+   `stopReason: "error"`, consider pausing or requiring explicit `/goal resume`.
+2. **Respect pending user work.** Before sending a continuation, check
+   `ctx.hasPendingMessages()` and skip or delay goal continuation when user or
+   extension messages are already queued.
+3. **Add a continuation-pending guard.** Track goal id + iteration for a queued
+   continuation so repeated end events cannot enqueue duplicates.
+4. **Escape objective text in XML-like prompts.** If prompts use delimiters,
+   escape `&`, `<`, and `>` like Codex does.
+5. **Strengthen continuation prompts.** Borrow Codex's "current state is
+   authoritative" and "completion audit" language.
+6. **Document interruption semantics.** Make `/goal pause` and user interrupt
+   behavior explicit in the README once implemented.
+
+### Pi core improvements needed for Codex parity
+
+Some Codex behavior cannot be faithfully reproduced by an extension alone:
+
+1. **Abort lifecycle event.** Extensions need a first-class event carrying abort
+   reason so goal-like extensions can distinguish user interrupt from normal
+   completion.
+2. **Runtime-owned continuation scheduling.** Pi needs an idle-only scheduling
+   API with pending-input checks, a lock, and a turn reservation, rather than
+   requiring extensions to call `sendUserMessage()` from `agent_end`.
+3. **Hidden contextual input.** A hidden context-message API would let runtime
+   steering reach the model without appearing as user-submitted text or fighting
+   the normal user queue.
+4. **Pending-input categories.** Codex's UI distinguishes pending steers,
+   rejected steers, and queued follow-ups. Pi goal continuation would be safer if
+   automatic continuation could be lower priority than all user-visible queues.
+5. **Tool-boundary accounting hooks.** Budget-aware goals need accounting after
+   tool completion, not only at agent end.
+
+## Suggested next step
+
+Implement the extension-only safety fixes first, especially abort/error detection
+and pending-message checks. That should reduce the most visible "goal keeps going
+after I interrupted it" and "goal races my next message" failures.
+
+If goal mode is expected to match Codex long-term, move the continuation policy
+into Pi core or add core APIs that let `pi-goal` request a locked, idle-only,
+hidden-context continuation.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds session-scoped `/goal` commands and a `goal_complete` tool for autonomous, verifiable task completion.
 
-Goal mode uses Codex-like persistence instructions and keeps sending guarded continuation messages until the agent calls `goal_complete`, the user pauses or clears the goal, or an optional token budget is reached.
+Goal mode uses Codex-like persistence instructions and keeps sending guarded continuation messages until the agent calls `goal_complete`, the user pauses or clears the goal, an interrupt/error pauses the goal, or an optional token budget is reached.
 
 ## ✨ Features
 
@@ -16,9 +16,10 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Tracks `active`, `paused`, `budget_limited`, and `complete` states.
 - Stores goal state in the current Pi session, following Codex's thread-owned goal model instead of using a global per-directory goal.
 - Registers a `goal_complete` tool for explicit completion.
-- Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle.
-- Guards auto-follow-ups so replaced, paused, cleared, completed, or budget-limited goals are not continued.
-- Encourages verification before the goal is marked complete.
+- Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle and no pending messages are queued.
+- Pauses instead of auto-continuing when Pi reports an aborted or errored assistant turn.
+- Guards auto-follow-ups so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
+- Encourages requirement-by-requirement verification before the goal is marked complete.
 
 ## 📦 Install
 
@@ -55,7 +56,7 @@ pi -e ./extensions/pi-goal
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
 - `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. Active goals stay active, paused goals stay paused, and budget-limited goals remain budget-limited if their budget is still exhausted.
 - `/goal pause` stops prompt injection and auto-continuation without forgetting the goal.
-- `/goal resume` resumes a paused or budget-limited goal when the token budget allows it.
+- `/goal resume` resumes a paused or budget-limited goal when the token budget allows it, then queues a resume prompt so work continues.
 - `/goal clear` cancels the current goal and also removes any legacy persisted state for the current working directory.
 
 Goal objectives are limited to 4,000 characters. Put longer instructions in a file and reference the file path from `/goal`.
@@ -78,9 +79,17 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 ## ✅ How completion works
 
-The extension registers a `goal_complete` tool. While a goal is active, the system prompt uses Codex-like persistence rules: keep going until the goal is resolved end-to-end, do not stop at analysis, a plan, partial fixes, or suggested next steps, use available tools for implementation and verification, and call `goal_complete` only when the goal is fully done.
+The extension registers a `goal_complete` tool. While a goal is active, the system prompt uses Codex-like persistence rules: keep going until the goal is resolved end-to-end, treat current files, command output, tests, and external state as authoritative, avoid redefining the goal into a smaller task, and call `goal_complete` only after requirement-by-requirement verification.
 
-If an agent turn ends before `goal_complete` is called, the extension records elapsed time and token usage, checks the budget, verifies that the same goal id is still active, then sends a continuation prompt for the same goal. When Pi is already idle, this directly triggers the next turn; otherwise it is queued as a follow-up until the agent finishes current work.
+If an agent turn ends before `goal_complete` is called, the extension records elapsed time and token usage, checks the budget, verifies that the same goal id is still active, and sends a continuation prompt only when no user or extension messages are already pending. When Pi is already idle, this directly triggers the next turn; otherwise it is queued as a follow-up until the agent finishes current work. A continuation-pending guard prevents repeated end events from enqueueing duplicate continuations.
+
+## 🛑 Interruption and queued-input behavior
+
+When Pi reports the final assistant message with `stopReason: "aborted"` or `stopReason: "error"`, `pi-goal` records usage, changes the goal to `paused`, and does not auto-continue. Run `/goal resume` to continue after reviewing the interruption or error.
+
+If user or extension messages are already queued at the end of a goal turn, those messages take priority and `pi-goal` skips that automatic continuation. Active goal instructions are still injected into the next agent turn, and normal continuation can resume after pending work finishes.
+
+Queued automatic continuation prompts are tracked by goal id and iteration. If a queued continuation is invalidated by `/goal pause`, `/goal clear`, `/goal edit`, replacement, or completion before delivery, the extension handles that stale prompt instead of letting it restart old goal work.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -184,17 +184,11 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("agent_end", async (event, ctx) => {
 		if (!activeGoal || activeGoal.status !== "active") return;
 
-		if (continuationPending?.goalId === activeGoal.id) {
-			updateGoalUsage(activeGoal, ctx);
-			persistGoal(activeGoal);
-			updateStatus(ctx, activeGoal);
-			if (hasPendingMessages(ctx)) return;
-			continuationPending = undefined;
-		}
-
 		const goalId = activeGoal.id;
+		const hadPendingContinuation = continuationPending?.goalId === goalId;
 		const finalAssistant = findFinalAssistantMessage(event.messages);
-		activeGoal = incrementGoal(activeGoal);
+
+		if (!hadPendingContinuation) activeGoal = incrementGoal(activeGoal);
 		updateGoalUsage(activeGoal, ctx);
 
 		if (finalAssistant?.stopReason === "aborted" || finalAssistant?.stopReason === "error") {
@@ -203,6 +197,7 @@ export default function goal(pi: ExtensionAPI) {
 		}
 
 		if (activeGoal.tokenBudget !== undefined && activeGoal.tokensUsed >= activeGoal.tokenBudget) {
+			cancelContinuationPending();
 			activeGoal = transitionGoal(activeGoal, "budget_limited");
 			persistGoal(activeGoal);
 			updateStatus(ctx, activeGoal);
@@ -212,6 +207,11 @@ export default function goal(pi: ExtensionAPI) {
 
 		persistGoal(activeGoal);
 		updateStatus(ctx, activeGoal);
+
+		if (hadPendingContinuation) {
+			if (hasPendingMessages(ctx)) return;
+			if (continuationPending?.goalId === goalId) continuationPending = undefined;
+		}
 
 		const currentGoal = activeGoal;
 		if (!currentGoal || currentGoal.id !== goalId || currentGoal.status !== "active") return;
@@ -638,8 +638,16 @@ function continuationMarkerComment(marker: string) {
 	return `<!-- ${CONTINUATION_MARKER_PREFIX}${marker} -->`;
 }
 
+function escapeRegExpText(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const CONTINUATION_MARKER_PATTERN = new RegExp(
+	`<!--\\s*${escapeRegExpText(CONTINUATION_MARKER_PREFIX)}([^\\s>]+)\\s*-->`,
+);
+
 function extractContinuationMarker(prompt: string) {
-	return new RegExp(`<!--\\s*${CONTINUATION_MARKER_PREFIX}([^\\s>]+)\\s*-->`).exec(prompt)?.[1];
+	return CONTINUATION_MARKER_PATTERN.exec(prompt)?.[1];
 }
 
 function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -29,6 +29,7 @@ interface GoalCompleteDetails {
 interface ContinuationPending {
 	goalId: string;
 	iteration: number;
+	marker: string;
 	prompt: string;
 }
 
@@ -64,6 +65,7 @@ const STATUS_KEY = "goal";
 const GOAL_STATE_ENTRY_TYPE = "goal-state";
 const MAX_OBJECTIVE_LENGTH = 4_000;
 const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
+const CONTINUATION_MARKER_PREFIX = "pi-goal-continuation:";
 const STATE_FILE = join(
 	process.env.PI_CODING_AGENT_DIR ?? join(process.env.HOME ?? ".", ".pi", "agent"),
 	"pi-goal-state.json",
@@ -73,7 +75,7 @@ let activeGoal: ActiveGoal | undefined;
 let completionStatusTimer: NodeJS.Timeout | undefined;
 let extensionApi: ExtensionAPI | undefined;
 let continuationPending: ContinuationPending | undefined;
-const cancelledContinuationPrompts = new Set<string>();
+const cancelledContinuationMarkers = new Set<string>();
 
 const goalCompleteTool = defineTool({
 	name: "goal_complete",
@@ -136,13 +138,13 @@ export default function goal(pi: ExtensionAPI) {
 					pauseGoal(ctx);
 					return;
 				case "resume":
-					resumeGoal(pi, ctx);
+					await resumeGoal(pi, ctx);
 					return;
 				case "clear":
 					clearGoal(ctx);
 					return;
 				case "edit":
-					editGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
+					await editGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
 					return;
 				case "start":
 					await startGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
@@ -179,14 +181,15 @@ export default function goal(pi: ExtensionAPI) {
 		};
 	});
 
-	pi.on("agent_end", (event, ctx) => {
+	pi.on("agent_end", async (event, ctx) => {
 		if (!activeGoal || activeGoal.status !== "active") return;
 
 		if (continuationPending?.goalId === activeGoal.id) {
 			updateGoalUsage(activeGoal, ctx);
 			persistGoal(activeGoal);
 			updateStatus(ctx, activeGoal);
-			return;
+			if (hasPendingMessages(ctx)) return;
+			continuationPending = undefined;
 		}
 
 		const goalId = activeGoal.id;
@@ -213,7 +216,7 @@ export default function goal(pi: ExtensionAPI) {
 		const currentGoal = activeGoal;
 		if (!currentGoal || currentGoal.id !== goalId || currentGoal.status !== "active") return;
 		if (hasPendingMessages(ctx)) return;
-		sendContinuationPrompt(pi, ctx, currentGoal);
+		await sendContinuationPrompt(pi, ctx, currentGoal);
 	});
 }
 
@@ -246,7 +249,7 @@ async function startGoal(
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
 	ctx.ui.notify(existingGoal ? `Goal replaced: ${objective}` : `Goal started: ${objective}`, "info");
-	sendGoalPrompt(pi, ctx, activeGoal);
+	await sendGoalPrompt(pi, ctx, activeGoal);
 }
 
 function pauseGoal(ctx: StatusContext) {
@@ -265,7 +268,7 @@ function pauseGoal(ctx: StatusContext) {
 	ctx.ui.notify(`Goal paused: ${activeGoal.text}`, "info");
 }
 
-function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
+async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 	if (!activeGoal) {
 		ctx.ui.notify("No active goal.", "info");
 		return;
@@ -282,7 +285,7 @@ function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 		return;
 	}
 	ctx.ui.notify(`Goal resumed: ${activeGoal.text}`, "info");
-	sendResumePrompt(pi, ctx, activeGoal);
+	await sendResumePrompt(pi, ctx, activeGoal);
 }
 
 function clearGoal(ctx: StatusContext) {
@@ -299,7 +302,7 @@ function clearGoal(ctx: StatusContext) {
 	ctx.ui.notify(`Goal cleared: ${stoppedGoal}`, "warning");
 }
 
-function editGoal(
+async function editGoal(
 	objective: string,
 	tokenBudget: number | undefined,
 	pi: ExtensionAPI,
@@ -327,7 +330,7 @@ function editGoal(
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
 	ctx.ui.notify(`Goal updated: ${objective}`, "info");
-	if (activeGoal.status === "active") sendObjectiveUpdatedPrompt(pi, ctx, activeGoal);
+	if (activeGoal.status === "active") await sendObjectiveUpdatedPrompt(pi, ctx, activeGoal);
 }
 
 function showGoal(ctx: StatusContext) {
@@ -479,33 +482,36 @@ function validateObjective(objective: string): string | undefined {
 	return undefined;
 }
 
-function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	sendPrompt(pi, ctx, buildGoalPrompt(goal));
+async function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	return sendPrompt(pi, ctx, buildGoalPrompt(goal));
 }
 
-function sendObjectiveUpdatedPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
+async function sendObjectiveUpdatedPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	return sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
 }
 
-function sendResumePrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	sendPrompt(pi, ctx, buildResumePrompt(goal));
+async function sendResumePrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	return sendPrompt(pi, ctx, buildResumePrompt(goal));
 }
 
-function sendContinuationPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+async function sendContinuationPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
 	if (continuationPending?.goalId === goal.id) return false;
 	if (hasPendingMessages(ctx)) return false;
 
-	const prompt = buildContinuePrompt(goal);
-	continuationPending = { goalId: goal.id, iteration: goal.iteration, prompt };
-	const sent = sendPrompt(pi, ctx, prompt);
-	if (!sent && continuationPending?.prompt === prompt) continuationPending = undefined;
+	const marker = continuationMarker(goal);
+	const prompt = buildContinuePrompt(goal, marker);
+	continuationPending = { goalId: goal.id, iteration: goal.iteration, marker, prompt };
+	const sent = await sendPrompt(pi, ctx, prompt);
+	if (!sent && continuationPending?.marker === marker) continuationPending = undefined;
 	return sent;
 }
 
-function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
+async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
 	try {
-		if (ctx.isIdle?.()) pi.sendUserMessage(prompt);
-		else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+		const sent = ctx.isIdle?.()
+			? (pi.sendUserMessage(prompt) as void | Promise<void>)
+			: (pi.sendUserMessage(prompt, { deliverAs: "followUp" }) as void | Promise<void>);
+		await sent;
 		return true;
 	} catch (error) {
 		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
@@ -581,8 +587,8 @@ function buildGoalSystemPrompt(goal: ActiveGoal) {
 	return `Active /goal:\n${goalObjectiveBlock(goal)}\n\nGoal-mode rules:\n- Keep going until the active goal is completely resolved end-to-end.\n- Treat the current worktree, command output, tests, and external state as authoritative.\n- Do not redefine the goal into a smaller task; audit every requirement before completion.\n- Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps.\n- Autonomously perform implementation and verification with the available tools when they are needed to complete the goal.\n- Persevere through recoverable tool failures by trying reasonable alternatives instead of yielding early.\n- If the goal is not complete at the end of a turn, expect an automatic continuation and keep working from where you left off.\n- Only call the goal_complete tool after the goal is fully complete and verified.${budgetLine}`;
 }
 
-function buildContinuePrompt(goal: ActiveGoal) {
-	return `Continue the active /goal until it is complete:\n\n${goalObjectiveBlock(goal)}\n\nThis is automatic continuation #${goal.iteration}. Current files, command output, tests, and external state are authoritative; re-check them as needed. ${goalPersistenceRules("this goal")}`;
+function buildContinuePrompt(goal: ActiveGoal, marker: string) {
+	return `Continue the active /goal until it is complete:\n\n${goalObjectiveBlock(goal)}\n\nThis is automatic continuation #${goal.iteration}. Current files, command output, tests, and external state are authoritative; re-check them as needed. ${goalPersistenceRules("this goal")}\n\n${continuationMarkerComment(marker)}`;
 }
 
 function goalObjectiveBlock(goal: ActiveGoal) {
@@ -599,27 +605,41 @@ function hasPendingMessages(ctx: StatusContext) {
 
 function clearContinuationTracking() {
 	continuationPending = undefined;
-	cancelledContinuationPrompts.clear();
+	cancelledContinuationMarkers.clear();
 }
 
 function cancelContinuationPending() {
-	if (continuationPending) rememberCancelledContinuationPrompt(continuationPending.prompt);
+	if (continuationPending) rememberCancelledContinuationMarker(continuationPending.marker);
 	continuationPending = undefined;
 }
 
-function rememberCancelledContinuationPrompt(prompt: string) {
-	cancelledContinuationPrompts.add(prompt);
-	if (cancelledContinuationPrompts.size <= MAX_CANCELLED_CONTINUATION_PROMPTS) return;
-	const oldest = cancelledContinuationPrompts.values().next().value;
-	if (oldest) cancelledContinuationPrompts.delete(oldest);
+function rememberCancelledContinuationMarker(marker: string) {
+	cancelledContinuationMarkers.add(marker);
+	if (cancelledContinuationMarkers.size <= MAX_CANCELLED_CONTINUATION_PROMPTS) return;
+	const oldest = cancelledContinuationMarkers.values().next().value;
+	if (oldest) cancelledContinuationMarkers.delete(oldest);
 }
 
 function consumeCancelledContinuationPrompt(prompt: string) {
-	return cancelledContinuationPrompts.delete(prompt);
+	const marker = extractContinuationMarker(prompt);
+	return marker ? cancelledContinuationMarkers.delete(marker) : false;
 }
 
 function markContinuationDelivered(prompt: string) {
-	if (continuationPending?.prompt === prompt) continuationPending = undefined;
+	const marker = extractContinuationMarker(prompt);
+	if (marker && continuationPending?.marker === marker) continuationPending = undefined;
+}
+
+function continuationMarker(goal: ActiveGoal) {
+	return `${goal.id}:${goal.iteration}`;
+}
+
+function continuationMarkerComment(marker: string) {
+	return `<!-- ${CONTINUATION_MARKER_PREFIX}${marker} -->`;
+}
+
+function extractContinuationMarker(prompt: string) {
+	return new RegExp(`<!--\\s*${CONTINUATION_MARKER_PREFIX}([^\\s>]+)\\s*-->`).exec(prompt)?.[1];
 }
 
 function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -6,6 +6,7 @@ import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 
 type GoalStatus = "active" | "paused" | "budget_limited" | "complete";
+type AgentStopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 
 interface ActiveGoal {
 	id: string;
@@ -23,6 +24,18 @@ interface ActiveGoal {
 interface GoalCompleteDetails {
 	goal: string;
 	summary: string;
+}
+
+interface ContinuationPending {
+	goalId: string;
+	iteration: number;
+	prompt: string;
+}
+
+interface AssistantMessageLike {
+	role: "assistant";
+	stopReason?: AgentStopReason;
+	errorMessage?: string;
 }
 
 interface GoalStateEntryData {
@@ -43,12 +56,14 @@ interface StatusContext {
 		setStatus: (key: string, value: string | undefined) => void;
 	};
 	isIdle?: () => boolean;
+	hasPendingMessages?: () => boolean;
 	sessionManager?: unknown;
 }
 
 const STATUS_KEY = "goal";
 const GOAL_STATE_ENTRY_TYPE = "goal-state";
 const MAX_OBJECTIVE_LENGTH = 4_000;
+const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
 const STATE_FILE = join(
 	process.env.PI_CODING_AGENT_DIR ?? join(process.env.HOME ?? ".", ".pi", "agent"),
 	"pi-goal-state.json",
@@ -57,6 +72,8 @@ const STATE_FILE = join(
 let activeGoal: ActiveGoal | undefined;
 let completionStatusTimer: NodeJS.Timeout | undefined;
 let extensionApi: ExtensionAPI | undefined;
+let continuationPending: ContinuationPending | undefined;
+const cancelledContinuationPrompts = new Set<string>();
 
 const goalCompleteTool = defineTool({
 	name: "goal_complete",
@@ -66,6 +83,7 @@ const goalCompleteTool = defineTool({
 	promptSnippet: "Mark the active /goal as complete after fully finishing and verifying it",
 	promptGuidelines: [
 		"When a /goal is active, keep working until the goal is complete; do not stop with only a plan or partial progress.",
+		"Before calling goal_complete, audit the active goal requirement by requirement against the current files, command output, tests, or external state.",
 		"Call goal_complete only after the requested goal is fully implemented, verified, and no known required work remains.",
 	],
 	parameters: Type.Object({
@@ -118,7 +136,7 @@ export default function goal(pi: ExtensionAPI) {
 					pauseGoal(ctx);
 					return;
 				case "resume":
-					resumeGoal(ctx);
+					resumeGoal(pi, ctx);
 					return;
 				case "clear":
 					clearGoal(ctx);
@@ -134,6 +152,7 @@ export default function goal(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		clearContinuationTracking();
 		activeGoal = loadGoalFromSession(ctx);
 		if (activeGoal) updateStatus(ctx, activeGoal);
 		else ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -141,11 +160,18 @@ export default function goal(pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (activeGoal) persistGoal(activeGoal);
+		clearContinuationTracking();
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		if (completionStatusTimer) clearTimeout(completionStatusTimer);
 	});
 
+	pi.on("input", (event) => {
+		if (event.source !== "extension") return;
+		if (consumeCancelledContinuationPrompt(event.text)) return { action: "handled" as const };
+	});
+
 	pi.on("before_agent_start", (event) => {
+		markContinuationDelivered(event.prompt);
 		if (!activeGoal || activeGoal.status !== "active") return;
 
 		return {
@@ -153,12 +179,25 @@ export default function goal(pi: ExtensionAPI) {
 		};
 	});
 
-	pi.on("agent_end", (_event, ctx) => {
+	pi.on("agent_end", (event, ctx) => {
 		if (!activeGoal || activeGoal.status !== "active") return;
 
+		if (continuationPending?.goalId === activeGoal.id) {
+			updateGoalUsage(activeGoal, ctx);
+			persistGoal(activeGoal);
+			updateStatus(ctx, activeGoal);
+			return;
+		}
+
 		const goalId = activeGoal.id;
+		const finalAssistant = findFinalAssistantMessage(event.messages);
 		activeGoal = incrementGoal(activeGoal);
 		updateGoalUsage(activeGoal, ctx);
+
+		if (finalAssistant?.stopReason === "aborted" || finalAssistant?.stopReason === "error") {
+			pauseGoalAfterAgentEnd(ctx, activeGoal, finalAssistant);
+			return;
+		}
 
 		if (activeGoal.tokenBudget !== undefined && activeGoal.tokensUsed >= activeGoal.tokenBudget) {
 			activeGoal = transitionGoal(activeGoal, "budget_limited");
@@ -173,6 +212,7 @@ export default function goal(pi: ExtensionAPI) {
 
 		const currentGoal = activeGoal;
 		if (!currentGoal || currentGoal.id !== goalId || currentGoal.status !== "active") return;
+		if (hasPendingMessages(ctx)) return;
 		sendContinuationPrompt(pi, ctx, currentGoal);
 	});
 }
@@ -201,6 +241,7 @@ async function startGoal(
 		}
 	}
 
+	cancelContinuationPending();
 	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
@@ -217,13 +258,14 @@ function pauseGoal(ctx: StatusContext) {
 		ctx.ui.notify(`Goal is ${activeGoal.status}; only active goals can be paused.`, "warning");
 		return;
 	}
+	cancelContinuationPending();
 	activeGoal = transitionGoal(activeGoal, "paused");
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
 	ctx.ui.notify(`Goal paused: ${activeGoal.text}`, "info");
 }
 
-function resumeGoal(ctx: StatusContext) {
+function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 	if (!activeGoal) {
 		ctx.ui.notify("No active goal.", "info");
 		return;
@@ -235,12 +277,18 @@ function resumeGoal(ctx: StatusContext) {
 	activeGoal = transitionGoal(activeGoal, "active");
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
+	if (activeGoal.status !== "active") {
+		ctx.ui.notify(`Goal token budget is still reached: ${formatBudget(activeGoal)}`, "warning");
+		return;
+	}
 	ctx.ui.notify(`Goal resumed: ${activeGoal.text}`, "info");
+	sendResumePrompt(pi, ctx, activeGoal);
 }
 
 function clearGoal(ctx: StatusContext) {
 	if (!activeGoal) {
 		ctx.ui.notify("No active goal.", "info");
+		cancelContinuationPending();
 		clearPersistedGoal(ctx.cwd);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		return;
@@ -268,6 +316,7 @@ function editGoal(
 	}
 
 	updateGoalUsage(activeGoal, ctx);
+	cancelContinuationPending();
 	activeGoal = normalizeGoalForBudget({
 		...activeGoal,
 		text: objective,
@@ -330,6 +379,21 @@ function normalizeGoalForBudget(goal: ActiveGoal): ActiveGoal {
 
 function incrementGoal(goal: ActiveGoal): ActiveGoal {
 	return { ...goal, iteration: goal.iteration + 1, updatedAt: Date.now() };
+}
+
+function pauseGoalAfterAgentEnd(
+	ctx: StatusContext,
+	goal: ActiveGoal,
+	assistant: AssistantMessageLike,
+) {
+	cancelContinuationPending();
+	activeGoal = transitionGoal(goal, "paused");
+	persistGoal(activeGoal);
+	updateStatus(ctx, activeGoal);
+
+	const reason = assistant.stopReason === "aborted" ? "interruption" : "agent error";
+	const details = assistant.errorMessage ? ` (${truncateNotification(assistant.errorMessage)})` : "";
+	ctx.ui.notify(`Goal paused after ${reason}${details}. Run /goal resume to continue.`, "warning");
 }
 
 function updateGoalUsage(goal: ActiveGoal, ctx: StatusContext) {
@@ -423,13 +487,30 @@ function sendObjectiveUpdatedPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: 
 	sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
 }
 
+function sendResumePrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	sendPrompt(pi, ctx, buildResumePrompt(goal));
+}
+
 function sendContinuationPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	sendPrompt(pi, ctx, buildContinuePrompt(goal));
+	if (continuationPending?.goalId === goal.id) return false;
+	if (hasPendingMessages(ctx)) return false;
+
+	const prompt = buildContinuePrompt(goal);
+	continuationPending = { goalId: goal.id, iteration: goal.iteration, prompt };
+	const sent = sendPrompt(pi, ctx, prompt);
+	if (!sent && continuationPending?.prompt === prompt) continuationPending = undefined;
+	return sent;
 }
 
 function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
-	if (ctx.isIdle?.()) pi.sendUserMessage(prompt);
-	else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+	try {
+		if (ctx.isIdle?.()) pi.sendUserMessage(prompt);
+		else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+		return true;
+	} catch (error) {
+		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
+		return false;
+	}
 }
 
 function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
@@ -482,25 +563,94 @@ function formatTokenCount(value: number) {
 
 function buildGoalPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatTokenCount(goal.tokenBudget)}.`;
-	return `Goal mode is active. Complete this goal fully:\n\n${goal.text}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
+	return `Goal mode is active. Complete this goal fully:\n\n${goalObjectiveBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
 }
 
 function buildObjectiveUpdatedPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatBudget(goal)} used.`;
-	return `The active /goal objective was updated. Continue working toward this goal:\n\n${goal.text}${budgetLine}\n\n${goalPersistenceRules("the updated goal")}`;
+	return `The active /goal objective was updated. Continue working toward this goal:\n\n${goalObjectiveBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("the updated goal")}`;
+}
+
+function buildResumePrompt(goal: ActiveGoal) {
+	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatBudget(goal)} used.`;
+	return `The user explicitly resumed the paused /goal. Continue working toward this goal:\n\n${goalObjectiveBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
 }
 
 function buildGoalSystemPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\n- Respect the goal token budget (${formatBudget(goal)} used).`;
-	return `Active /goal: ${goal.text}\n\nGoal-mode rules:\n- Keep going until the active goal is completely resolved end-to-end.\n- Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps.\n- Autonomously perform implementation and verification with the available tools when they are needed to complete the goal.\n- Persevere through recoverable tool failures by trying reasonable alternatives instead of yielding early.\n- If the goal is not complete at the end of a turn, expect an automatic continuation and keep working from where you left off.\n- Only call the goal_complete tool after the goal is fully complete and verified.${budgetLine}`;
+	return `Active /goal:\n${goalObjectiveBlock(goal)}\n\nGoal-mode rules:\n- Keep going until the active goal is completely resolved end-to-end.\n- Treat the current worktree, command output, tests, and external state as authoritative.\n- Do not redefine the goal into a smaller task; audit every requirement before completion.\n- Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps.\n- Autonomously perform implementation and verification with the available tools when they are needed to complete the goal.\n- Persevere through recoverable tool failures by trying reasonable alternatives instead of yielding early.\n- If the goal is not complete at the end of a turn, expect an automatic continuation and keep working from where you left off.\n- Only call the goal_complete tool after the goal is fully complete and verified.${budgetLine}`;
 }
 
 function buildContinuePrompt(goal: ActiveGoal) {
-	return `Continue the active /goal until it is complete:\n\n${goal.text}\n\nThis is automatic continuation #${goal.iteration}. ${goalPersistenceRules("this goal")}`;
+	return `Continue the active /goal until it is complete:\n\n${goalObjectiveBlock(goal)}\n\nThis is automatic continuation #${goal.iteration}. Current files, command output, tests, and external state are authoritative; re-check them as needed. ${goalPersistenceRules("this goal")}`;
+}
+
+function goalObjectiveBlock(goal: ActiveGoal) {
+	return `<goal_objective>\n${escapeXmlText(goal.text)}\n</goal_objective>`;
 }
 
 function goalPersistenceRules(goalLabel: string) {
-	return `Keep going until ${goalLabel} is completely resolved end-to-end. Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps. Autonomously perform implementation and verification with the available tools when they are needed. If a tool call fails, try reasonable alternatives instead of yielding early. Only call the goal_complete tool after ${goalLabel} is fully complete and verified.`;
+	return `Keep going until ${goalLabel} is completely resolved end-to-end. Do not redefine ${goalLabel} into a smaller task. Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps. Autonomously perform implementation and verification with the available tools when they are needed. Treat the current worktree, command output, tests, and external state as authoritative. If a tool call fails, try reasonable alternatives instead of yielding early. Before calling goal_complete, audit ${goalLabel} requirement by requirement against the verified current state. Only call the goal_complete tool after ${goalLabel} is fully complete and verified.`;
+}
+
+function hasPendingMessages(ctx: StatusContext) {
+	return ctx.hasPendingMessages?.() ?? false;
+}
+
+function clearContinuationTracking() {
+	continuationPending = undefined;
+	cancelledContinuationPrompts.clear();
+}
+
+function cancelContinuationPending() {
+	if (continuationPending) rememberCancelledContinuationPrompt(continuationPending.prompt);
+	continuationPending = undefined;
+}
+
+function rememberCancelledContinuationPrompt(prompt: string) {
+	cancelledContinuationPrompts.add(prompt);
+	if (cancelledContinuationPrompts.size <= MAX_CANCELLED_CONTINUATION_PROMPTS) return;
+	const oldest = cancelledContinuationPrompts.values().next().value;
+	if (oldest) cancelledContinuationPrompts.delete(oldest);
+}
+
+function consumeCancelledContinuationPrompt(prompt: string) {
+	return cancelledContinuationPrompts.delete(prompt);
+}
+
+function markContinuationDelivered(prompt: string) {
+	if (continuationPending?.prompt === prompt) continuationPending = undefined;
+}
+
+function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (!message || typeof message !== "object") continue;
+		const candidate = message as Record<string, unknown>;
+		if (candidate.role !== "assistant") continue;
+		return {
+			role: "assistant",
+			stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
+			errorMessage: typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
+		};
+	}
+	return undefined;
+}
+
+function isAgentStopReason(value: unknown): value is AgentStopReason {
+	return ["stop", "length", "toolUse", "error", "aborted"].includes(String(value));
+}
+
+function escapeXmlText(value: string) {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function formatError(error: unknown) {
+	return truncateNotification(error instanceof Error ? error.message : String(error));
+}
+
+function truncateNotification(value: string) {
+	return value.length > 160 ? `${value.slice(0, 157)}...` : value;
 }
 
 function currentTokenTotal(ctx: StatusContext): number {
@@ -543,6 +693,7 @@ function loadGoalFromSession(ctx: StatusContext): ActiveGoal | undefined {
 }
 
 function clearActiveGoal(ctx: StatusContext) {
+	cancelContinuationPending();
 	activeGoal = undefined;
 	clearPersistedGoal(ctx.cwd);
 	ctx.ui.setStatus(STATUS_KEY, undefined);


### PR DESCRIPTION
## Summary
- pause active goals after aborted or errored assistant endings instead of auto-continuing
- skip/guard automatic continuations when pending input or stale continuation prompts exist
- strengthen goal prompts and README interruption semantics

## Verification
- npm --workspace @narumitw/pi-goal run typecheck
- npm --workspace @narumitw/pi-goal run check
- npm run check
- npm run pack:goal
- git diff --check