### PR TITLE
feat(plan-mode): paginate tool selector

### DIFF
--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -44,7 +44,7 @@ pi -e ./extensions/pi-plan-mode
 /plan tools
 ```
 
-Use `/plan` to enter Plan mode before writing your planning prompt. Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user message. Use `/plan tools` to choose which tools are active while Plan mode is enabled.
+Use `/plan` to enter Plan mode before writing your planning prompt. Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user message. Use `/plan tools` to choose which tools are active while Plan mode is enabled; the selector is paginated at 10 tools per page.
 
 When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation.
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -7,6 +7,7 @@ const PLAN_CONTEXT_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const SAFE_BUILTIN_PLAN_TOOLS = new Set(["read", "bash", "grep", "find", "ls"]);
 const BLOCKED_BUILTIN_TOOLS = new Set(["edit", "write"]);
 const DEFAULT_TOOLS = ["read", "bash", "edit", "write"];
+const TOOL_SELECTOR_PAGE_SIZE = 10;
 const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/i;
 
 interface PlanModeState {
@@ -298,21 +299,41 @@ export default function planMode(pi: ExtensionAPI) {
 			return;
 		}
 
+		let pageIndex = 0;
 		while (true) {
 			const tools = selectableTools();
+			const pageCount = toolSelectorPageCount(tools);
+			pageIndex = Math.min(pageIndex, pageCount - 1);
+			const pageStart = pageIndex * TOOL_SELECTOR_PAGE_SIZE;
+			const pageTools = tools.slice(pageStart, pageStart + TOOL_SELECTOR_PAGE_SIZE);
 			const selectedNames = planModeSelectedNames(tools);
-			const choices = tools.map((tool, index) =>
-				formatToolChoice(tool, selectedNames.has(tool.name), index),
+			const choices = pageTools.map((tool, index) =>
+				formatToolChoice(tool, selectedNames.has(tool.name), pageStart + index),
 			);
+			const previousChoice = "Previous page";
+			const nextChoice = "Next page";
 			const doneChoice = "Done";
+			const navigationChoices = [
+				...(pageIndex > 0 ? [previousChoice] : []),
+				...(pageIndex < pageCount - 1 ? [nextChoice] : []),
+				doneChoice,
+			];
 			const choice = await ctx.ui.select(
-				"Plan-mode tools. Non-built-in tools run at user risk.",
-				[...choices, doneChoice],
+				`Plan-mode tools (${pageIndex + 1}/${pageCount}). Non-built-in tools run at user risk.`,
+				[...choices, ...navigationChoices],
 			);
 			if (!choice || choice === doneChoice) break;
+			if (choice === previousChoice) {
+				pageIndex = Math.max(0, pageIndex - 1);
+				continue;
+			}
+			if (choice === nextChoice) {
+				pageIndex = Math.min(pageCount - 1, pageIndex + 1);
+				continue;
+			}
 
 			const selectedIndex = choices.indexOf(choice);
-			const tool = tools[selectedIndex];
+			const tool = pageTools[selectedIndex];
 			if (!tool) continue;
 			if (!canSelectToolInPlanMode(tool)) {
 				ctx.ui.notify(`${tool.name} is blocked in Plan mode.`, "warning");
@@ -388,6 +409,10 @@ export default function planMode(pi: ExtensionAPI) {
 
 	function selectableTools() {
 		return safeGetAllTools().sort(compareTools);
+	}
+
+	function toolSelectorPageCount(tools: ToolInfo[]) {
+		return Math.max(1, Math.ceil(tools.length / TOOL_SELECTOR_PAGE_SIZE));
 	}
 
 	function safeGetAllTools() {


### PR DESCRIPTION
## Summary
- Paginate `/plan tools` at 10 tools per page.
- Add Previous/Next page navigation and page count in the selector title.
- Document the 10-tool page size in the README.

## Verification
- npm --workspace @narumitw/pi-plan-mode run typecheck
- npm run check
- npm run pack:plan-mode
- Node smoke script verified 25 tools paginate as 10,10,5.