### PR TITLE
feat(pi-lsp): route tools by language

### DIFF
--- a/docs/implementation-notes/pi-lsp-parity-checklist.md
+++ b/docs/implementation-notes/pi-lsp-parity-checklist.md
@@ -1,16 +1,30 @@
 # pi-lsp parity checklist
 
-`@narumitw/pi-lsp` keeps the public tool Interface from the now-deprecated `@narumitw/pi-biome-lsp` and `@narumitw/pi-python-lsp` packages while moving common LSP behavior into a shared runner Module.
+`@narumitw/pi-lsp` keeps Biome, ty, and Ruff behavior from the now-deprecated `@narumitw/pi-biome-lsp` and `@narumitw/pi-python-lsp` packages while exposing a smaller language/file-extension routed public tool interface.
 
 ## Tool names and parameters
 
-- [x] `biome_lsp_diagnostics`: `paths?`, `root?`, `limit?`.
-- [x] `biome_lsp_format`: `path`, `root?`, `write?`.
-- [x] `biome_lsp_fix`: `path`, `root?`, `kind?`, `write?`; default kind `source.fixAll.biome`.
-- [x] `ty_lsp_diagnostics`: `paths?`, `root?`, `limit?`.
-- [x] `ruff_lsp_diagnostics`: `paths?`, `root?`, `limit?`.
-- [x] `ruff_lsp_format`: `path`, `root?`, `write?`.
-- [x] `ruff_lsp_fix`: `path`, `root?`, `kind?`, `write?`; default kind `source.fixAll.ruff`.
+- [x] `lsp_diagnostics`: `paths?`, `root?`, `limit?`, `language?`, `checker?`.
+  - [x] Biome-supported web/config diagnostics route to Biome.
+  - [x] Python `checker: "type"` diagnostics route to ty.
+  - [x] Python `checker: "lint"` diagnostics route to Ruff.
+  - [x] Python `checker: "all"` diagnostics route to both ty and Ruff.
+- [x] `lsp_format`: `path`, `root?`, `write?`, `language?`.
+  - [x] Biome-supported web/config files route to Biome.
+  - [x] Python `.py`/`.pyi` files route to Ruff.
+- [x] `lsp_fix`: `path`, `root?`, `kind?`, `write?`, `language?`.
+  - [x] Biome-supported web/config files route to Biome; default kind `source.fixAll.biome`.
+  - [x] Python `.py`/`.pyi` files route to Ruff; default kind `source.fixAll.ruff`.
+
+## Migration from deprecated public tool names
+
+- [x] `biome_lsp_diagnostics` maps to `lsp_diagnostics` with `language: "web"` when an override is needed.
+- [x] `biome_lsp_format` maps to `lsp_format` for a Biome-supported file.
+- [x] `biome_lsp_fix` maps to `lsp_fix` for a Biome-supported file.
+- [x] `ty_lsp_diagnostics` maps to `lsp_diagnostics` with `language: "python"`, `checker: "type"`.
+- [x] `ruff_lsp_diagnostics` maps to `lsp_diagnostics` with `language: "python"`, `checker: "lint"`.
+- [x] `ruff_lsp_format` maps to `lsp_format` for a Python file.
+- [x] `ruff_lsp_fix` maps to `lsp_fix` for a Python file.
 
 ## Server commands and environment variables
 
@@ -30,20 +44,22 @@
 ## LSP behavior
 
 - [x] Shared runner owns JSON-RPC framing, subprocess lifecycle, initialize/shutdown, file open/close, diagnostics, formatting, code actions, action resolution, and workspace edit application.
-- [x] Biome Adapter keeps dynamic registration capabilities, publish-diagnostics fallback, workspace-folder request handling, tab size 2, and tabs.
-- [x] ty Adapter keeps diagnostic requests without code actions, tab size 4, and spaces.
-- [x] Ruff Adapter keeps diagnostic requests, code actions, tab size 4, and spaces.
+- [x] Biome adapter keeps dynamic registration capabilities, publish-diagnostics fallback, workspace-folder request handling, tab size 2, and tabs.
+- [x] ty adapter keeps diagnostic requests without code actions, tab size 4, and spaces.
+- [x] Ruff adapter keeps diagnostic requests, code actions, tab size 4, and spaces.
+- [x] Route selection is centralized above the adapters and prevents ty from being selected for format/fix.
 
 ## Result shapes and messages
 
 - [x] Tool results still return `{ content: [{ type: "text", text }], details }`.
-- [x] Diagnostics details include `root`, `command`, `files`, and `summary`.
+- [x] Diagnostics details include root, selected routes, backend details, files, and summaries.
 - [x] Format/fix details include `path`, `uri`, `changed`, `write`, `edits`, and preview `text` when `write` is false.
 - [x] Fix details include `kind` and resolved `actions`.
 - [x] Missing-command errors preserve server-specific install guidance.
+- [x] Unsupported extensions and contradictory language overrides produce route errors that name supported language/file-extension classes.
 
 ## Documentation and compatibility
 
-- [x] `extensions/pi-lsp/README.md` documents tool-name compatibility, environment variables, and the deprecated status for the old packages.
+- [x] `extensions/pi-lsp/README.md` documents the three routed tools, environment variables, and migration from old tool names.
 - [x] Root `README.md`, `package.json`, and `justfile` include `pi-lsp` integration.
 - [x] `pi-biome-lsp` and `pi-python-lsp` now live under `extensions/deprecated/` and are excluded from active workspace scripts.

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -2,18 +2,18 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-lsp)](https://www.npmjs.com/package/@narumitw/pi-lsp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-lsp` is a native [Pi coding agent](https://pi.dev) extension that exposes Biome, ty, and Ruff language-server tools through one shared LSP runner Module.
+`@narumitw/pi-lsp` is a native [Pi coding agent](https://pi.dev) extension that exposes Biome, ty, and Ruff language-server behavior through language/file-extension routed Pi tools.
 
 It supersedes the older split packages `@narumitw/pi-biome-lsp` and `@narumitw/pi-python-lsp`, which now live under `extensions/deprecated/` and are excluded from active workspace scripts.
 
 ## ✨ Features
 
-- Runs `biome lsp-proxy` on demand for diagnostics, formatting, import organization, and source fixes.
-- Runs `ty server` on demand for Python type diagnostics.
-- Runs `ruff server` on demand for Python lint diagnostics, formatting, import organization, and source fixes.
+- Routes Biome-supported web/config files to `biome lsp-proxy` for diagnostics, formatting, import organization, and source fixes.
+- Routes Python `.py` and `.pyi` type diagnostics to `ty server`.
+- Routes Python `.py` and `.pyi` lint diagnostics, formatting, import organization, and source fixes to `ruff server`.
 - Uses one internal LSP runner for JSON-RPC framing, subprocess lifecycle, diagnostics, formatting, code actions, and workspace edit application.
-- Keeps Biome, ty, and Ruff behavior in small server Adapters.
-- Supports workspace roots, file limits, recursive file discovery, and write-or-preview edits.
+- Keeps Biome, ty, and Ruff behavior in small server adapters.
+- Supports workspace roots, file limits, recursive file discovery, language overrides, and write-or-preview edits.
 - Starts language servers only for tool calls, then shuts them down.
 - Shows statusline activity only while LSP tools are running.
 
@@ -37,17 +37,19 @@ pi -e ./extensions/pi-lsp
 
 ## ⚠️ Tool-name compatibility
 
-This package intentionally registers the same tool names as `@narumitw/pi-biome-lsp` and `@narumitw/pi-python-lsp`:
+This package now exposes three language/file-extension routed tools instead of the old backend-specific tool names:
 
-- `biome_lsp_diagnostics`
-- `biome_lsp_format`
-- `biome_lsp_fix`
-- `ty_lsp_diagnostics`
-- `ruff_lsp_diagnostics`
-- `ruff_lsp_format`
-- `ruff_lsp_fix`
+| Old tool | New call |
+| --- | --- |
+| `biome_lsp_diagnostics` | `lsp_diagnostics` with `language: "web"` when an override is needed |
+| `biome_lsp_format` | `lsp_format` for a Biome-supported file |
+| `biome_lsp_fix` | `lsp_fix` for a Biome-supported file |
+| `ty_lsp_diagnostics` | `lsp_diagnostics` with `language: "python"`, `checker: "type"` |
+| `ruff_lsp_diagnostics` | `lsp_diagnostics` with `language: "python"`, `checker: "lint"` |
+| `ruff_lsp_format` | `lsp_format` for a Python file |
+| `ruff_lsp_fix` | `lsp_fix` for a Python file |
 
-Avoid installing `@narumitw/pi-lsp` side by side with the older deprecated LSP packages unless you have verified how your Pi version handles duplicate tool names.
+Avoid installing `@narumitw/pi-lsp` side by side with the older deprecated LSP packages unless you have verified how your Pi version handles overlapping capabilities.
 
 ## ✅ Requirements
 
@@ -85,22 +87,61 @@ pi -e ./extensions/pi-lsp
 
 ## 🛠️ Pi tools
 
-### Biome
+### `lsp_diagnostics`
 
-- `biome_lsp_diagnostics` — start `biome lsp-proxy`, open supported files, and return diagnostics.
-- `biome_lsp_format` — compute or write formatting edits for one Biome-supported file.
-- `biome_lsp_fix` — compute or write source actions such as `source.fixAll.biome` or `source.organizeImports.biome`.
+Run diagnostics through language/file-extension routes.
 
-### Python
+Parameters:
 
-- `ty_lsp_diagnostics` — start `ty server`, open Python files, and return type diagnostics.
-- `ruff_lsp_diagnostics` — start `ruff server`, open Python files, and return lint diagnostics.
-- `ruff_lsp_format` — compute or write Ruff formatting edits for one Python file.
-- `ruff_lsp_fix` — compute or write Ruff source actions such as `source.fixAll.ruff` or `source.organizeImports.ruff`.
+- `paths?`: files or directories to check. Defaults to the workspace root.
+- `root?`: workspace root. Defaults to cwd.
+- `limit?`: maximum files to open per selected route.
+- `language?`: optional override, either `"web"` for Biome-supported web/config files or `"python"` for `.py`/`.pyi` files.
+- `checker?`: Python diagnostics checker, one of `"type"`, `"lint"`, or `"all"`. Defaults to `"all"`.
+
+Routes:
+
+- Biome-supported web/config files → Biome diagnostics.
+- Python `.py`/`.pyi` + `checker: "type"` → ty diagnostics.
+- Python `.py`/`.pyi` + `checker: "lint"` → Ruff diagnostics.
+- Python `.py`/`.pyi` + `checker: "all"` → both ty and Ruff diagnostics.
+
+### `lsp_format`
+
+Format one file through the route selected from its file extension.
+
+Parameters:
+
+- `path`: file to format.
+- `root?`: workspace root. Defaults to cwd.
+- `write?`: write formatted text back to the file. Defaults to false.
+- `language?`: optional route override, either `"web"` or `"python"`.
+
+Routes:
+
+- Biome-supported web/config files → Biome formatting.
+- Python `.py`/`.pyi` files → Ruff formatting.
+
+### `lsp_fix`
+
+Apply source fixes or import organization through the route selected from the file extension.
+
+Parameters:
+
+- `path`: file to fix.
+- `root?`: workspace root. Defaults to cwd.
+- `kind?`: source action kind. Defaults to the routed backend's fix-all action.
+- `write?`: write fixed text back to the file. Defaults to false.
+- `language?`: optional route override, either `"web"` or `"python"`.
+
+Routes:
+
+- Biome-supported web/config files → Biome source fixes such as `source.fixAll.biome` or `source.organizeImports.biome`.
+- Python `.py`/`.pyi` files → Ruff source fixes such as `source.fixAll.ruff` or `source.organizeImports.ruff`.
 
 ## 🚀 Examples
 
-Check a project subset with Biome diagnostics:
+Check a mixed project subset and run all applicable diagnostics:
 
 ```json
 {
@@ -109,7 +150,28 @@ Check a project subset with Biome diagnostics:
 }
 ```
 
-Format a TypeScript file with Biome:
+Check only Biome-supported web/config files:
+
+```json
+{
+  "language": "web",
+  "paths": ["extensions/pi-lsp/src"],
+  "limit": 100
+}
+```
+
+Check Python type diagnostics only:
+
+```json
+{
+  "language": "python",
+  "checker": "type",
+  "paths": ["src", "tests"],
+  "limit": 100
+}
+```
+
+Format a TypeScript file with the inferred Biome route:
 
 ```json
 {
@@ -118,16 +180,7 @@ Format a TypeScript file with Biome:
 }
 ```
 
-Check a Python project with ty or Ruff diagnostics:
-
-```json
-{
-  "paths": ["src", "tests"],
-  "limit": 100
-}
-```
-
-Organize Python imports with Ruff:
+Organize Python imports with the inferred Ruff route:
 
 ```json
 {
@@ -157,6 +210,7 @@ extensions/pi-lsp/
 │   ├── files.ts
 │   ├── lsp-client.ts
 │   ├── pi-lsp.ts
+│   ├── routes.ts
 │   ├── runner.ts
 │   ├── text-edits.ts
 │   └── types.ts

--- a/extensions/pi-lsp/src/pi-lsp.ts
+++ b/extensions/pi-lsp/src/pi-lsp.ts
@@ -1,180 +1,154 @@
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { adapters, biomeAdapter, ruffAdapter, tyAdapter } from "./adapters.js";
+import { adapters } from "./adapters.js";
 import { commandExists, commandFromEnv } from "./command.js";
-import { runDiagnostics, runFix, runFormat } from "./runner.js";
+import { selectDiagnosticRoutes, selectFixRoute, selectFormatRoute } from "./routes.js";
+import { DEFAULT_FILE_LIMIT, runDiagnostics, runFix, runFormat, textResult } from "./runner.js";
 
 const STATUS_KEY = "lsp";
 
-const BiomePathsParameters = {
+const LanguageParameter = Type.Optional(
+	Type.Union([Type.Literal("web"), Type.Literal("python")], {
+		description:
+			"Optional language/file class override. Defaults to file-extension inference. Use 'web' for Biome-supported web/config files or 'python' for .py/.pyi files.",
+	}),
+);
+
+const DiagnosticsParameters = Type.Object({
 	paths: Type.Optional(
 		Type.Array(Type.String(), {
-			description: "Biome-supported files or directories to check. Defaults to the project root.",
+			description:
+				"Files or directories to check. Defaults to the workspace root and routes by supported file extensions.",
 		}),
 	),
 	root: Type.Optional(
-		Type.String({ description: "Workspace root for the Biome language server. Defaults to cwd." }),
+		Type.String({ description: "Workspace root for language servers. Defaults to cwd." }),
 	),
-	limit: Type.Optional(
-		Type.Number({ description: "Maximum files to open when directories are provided." }),
-	),
-};
-
-const PythonPathsParameters = {
-	paths: Type.Optional(
-		Type.Array(Type.String(), {
-			description: "Python files or directories to check. Defaults to the project root.",
+	limit: Type.Optional(Type.Number({ description: "Maximum files to open per selected route." })),
+	language: LanguageParameter,
+	checker: Type.Optional(
+		Type.Union([Type.Literal("type"), Type.Literal("lint"), Type.Literal("all")], {
+			description:
+				"Python diagnostics checker: 'type' uses ty, 'lint' uses Ruff, and 'all' runs both. Defaults to 'all'. Ignored for web/config diagnostics.",
 		}),
 	),
+});
+
+const SingleFileParameters = {
+	path: Type.String({
+		description: "File to process. The route is selected from the file extension.",
+	}),
 	root: Type.Optional(
-		Type.String({ description: "Workspace root for the language server. Defaults to cwd." }),
+		Type.String({ description: "Workspace root for language servers. Defaults to cwd." }),
 	),
-	limit: Type.Optional(
-		Type.Number({ description: "Maximum Python files to open when directories are provided." }),
+	write: Type.Optional(
+		Type.Boolean({ description: "Write changed text back to the file. Defaults to false." }),
 	),
+	language: LanguageParameter,
 };
 
-const biomeDiagnosticsTool = defineTool({
-	name: "biome_lsp_diagnostics",
-	label: "Biome LSP: Diagnostics",
-	description: "Run Biome's language server and return diagnostics for supported files.",
-	promptSnippet: "Get Biome diagnostics through the Biome language server",
+const lspDiagnosticsTool = defineTool({
+	name: "lsp_diagnostics",
+	label: "LSP: Diagnostics",
+	description:
+		"Run diagnostics using language/file-extension routing: Biome for supported web/config files, ty for Python type diagnostics, and Ruff for Python lint diagnostics.",
+	promptSnippet: "Get language-routed LSP diagnostics for web/config or Python files",
 	promptGuidelines: [
-		"Use biome_lsp_diagnostics when JavaScript, TypeScript, JSON, CSS, GraphQL, or framework files need Biome lint/format diagnostics.",
-		"If Biome is missing, report the configuration error and suggest installing @biomejs/biome or setting PI_BIOME_LSP_COMMAND.",
+		"Use lsp_diagnostics when JavaScript, TypeScript, JSON, CSS, GraphQL, HTML, Vue, Astro, Svelte, or Python files need LSP diagnostics.",
+		"For Python diagnostics, use checker='type' for ty, checker='lint' for Ruff, or checker='all' when both type and lint diagnostics are useful.",
+		"If a routed backend is missing, report the configuration error and suggest installing the backend or setting its PI_*_LSP_COMMAND environment variable.",
 	],
-	parameters: Type.Object(BiomePathsParameters),
+	parameters: DiagnosticsParameters,
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runDiagnostics(biomeAdapter, params, signal, ctx, STATUS_KEY);
+		const { root, routes } = selectDiagnosticRoutes(params, DEFAULT_FILE_LIMIT);
+		const results = [];
+		for (const route of routes) {
+			const result = await runDiagnostics(
+				route.adapter,
+				{ root, paths: params.paths, limit: params.limit, files: route.files },
+				signal,
+				ctx,
+				STATUS_KEY,
+			);
+			results.push({ route, result });
+		}
+
+		const text = results
+			.map(({ route, result }) => `${route.reason}\n\n${textFromResult(result)}`)
+			.join("\n\n---\n\n");
+		return textResult(text, {
+			root,
+			routes: results.map(({ route, result }) => ({
+				language: route.language,
+				checker: route.checker,
+				backend: route.adapter.label,
+				reason: route.reason,
+				files: route.files,
+				details: result.details,
+			})),
+		});
 	},
 });
 
-const biomeFormatTool = defineTool({
-	name: "biome_lsp_format",
-	label: "Biome LSP: Format",
-	description: "Format a Biome-supported file through Biome's language server.",
-	promptSnippet: "Format a file through Biome LSP",
-	parameters: Type.Object({
-		path: Type.String({ description: "File to format." }),
-		root: Type.Optional(
-			Type.String({ description: "Workspace root for the Biome language server. Defaults to cwd." }),
-		),
-		write: Type.Optional(
-			Type.Boolean({ description: "Write formatted text back to the file. Defaults to false." }),
-		),
-	}),
+const lspFormatTool = defineTool({
+	name: "lsp_format",
+	label: "LSP: Format",
+	description:
+		"Format one file using language/file-extension routing: Biome for supported web/config files and Ruff for Python files.",
+	promptSnippet: "Format a file through the routed LSP formatter",
+	promptGuidelines: [
+		"Use lsp_format for Biome-supported web/config files or Python .py/.pyi files.",
+		"Do not request ty for formatting; Python formatting routes to Ruff.",
+	],
+	parameters: Type.Object(SingleFileParameters),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runFormat(biomeAdapter, params, signal, ctx, STATUS_KEY);
+		const { root, route } = selectFormatRoute(params);
+		return runFormat(
+			route.adapter,
+			{ root, path: params.path, write: params.write },
+			signal,
+			ctx,
+			STATUS_KEY,
+		);
 	},
 });
 
-const biomeFixTool = defineTool({
-	name: "biome_lsp_fix",
-	label: "Biome LSP: Fix",
-	description: "Apply Biome LSP source fixes or import organization to a file.",
-	promptSnippet: "Apply Biome LSP fixes to a file",
+const lspFixTool = defineTool({
+	name: "lsp_fix",
+	label: "LSP: Fix",
+	description:
+		"Apply source fixes or import organization using language/file-extension routing: Biome for supported web/config files and Ruff for Python files.",
+	promptSnippet: "Apply routed LSP source fixes to a file",
+	promptGuidelines: [
+		"Use lsp_fix for Biome-supported web/config files or Python .py/.pyi files.",
+		"Use kind='source.organizeImports.biome' for Biome import organization or kind='source.organizeImports.ruff' for Python import organization when needed.",
+		"Do not request ty for fixes; Python fixes route to Ruff.",
+	],
 	parameters: Type.Object({
-		path: Type.String({ description: "File to fix." }),
-		root: Type.Optional(
-			Type.String({ description: "Workspace root for the Biome language server. Defaults to cwd." }),
-		),
+		...SingleFileParameters,
 		kind: Type.Optional(
 			Type.String({
 				description:
-					"Biome source action kind. Defaults to source.fixAll.biome. Common value: source.organizeImports.biome.",
+					"Source action kind. Defaults to the routed backend's fix-all action. Common values: source.organizeImports.biome or source.organizeImports.ruff.",
 			}),
 		),
-		write: Type.Optional(
-			Type.Boolean({ description: "Write fixed text back to the file. Defaults to false." }),
-		),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runFix(biomeAdapter, params, signal, ctx, STATUS_KEY);
-	},
-});
-
-const tyDiagnosticsTool = defineTool({
-	name: "ty_lsp_diagnostics",
-	label: "Python LSP: ty Diagnostics",
-	description: "Run ty's language server and return Python type diagnostics for files.",
-	promptSnippet: "Get Python type diagnostics from ty's language server",
-	promptGuidelines: [
-		"Use ty_lsp_diagnostics when Python changes need type-checking through ty's language server.",
-		"If ty is missing, report the configuration error and suggest installing ty or setting PI_TY_LSP_COMMAND.",
-	],
-	parameters: Type.Object(PythonPathsParameters),
-	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runDiagnostics(tyAdapter, params, signal, ctx, STATUS_KEY);
-	},
-});
-
-const ruffDiagnosticsTool = defineTool({
-	name: "ruff_lsp_diagnostics",
-	label: "Python LSP: Ruff Diagnostics",
-	description: "Run Ruff's language server and return Python lint diagnostics for files.",
-	promptSnippet: "Get Python lint diagnostics from Ruff's language server",
-	promptGuidelines: [
-		"Use ruff_lsp_diagnostics when Python changes need Ruff lint checks through the language server.",
-		"If ruff is missing, report the configuration error and suggest installing ruff or setting PI_RUFF_LSP_COMMAND.",
-	],
-	parameters: Type.Object(PythonPathsParameters),
-	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runDiagnostics(ruffAdapter, params, signal, ctx, STATUS_KEY);
-	},
-});
-
-const ruffFormatTool = defineTool({
-	name: "ruff_lsp_format",
-	label: "Python LSP: Ruff Format",
-	description: "Format a Python file through Ruff's language server.",
-	promptSnippet: "Format a Python file through Ruff LSP",
-	parameters: Type.Object({
-		path: Type.String({ description: "Python file to format." }),
-		root: Type.Optional(
-			Type.String({ description: "Workspace root for the language server. Defaults to cwd." }),
-		),
-		write: Type.Optional(
-			Type.Boolean({ description: "Write formatted text back to the file. Defaults to false." }),
-		),
-	}),
-	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runFormat(ruffAdapter, params, signal, ctx, STATUS_KEY);
-	},
-});
-
-const ruffFixTool = defineTool({
-	name: "ruff_lsp_fix",
-	label: "Python LSP: Ruff Fix",
-	description: "Apply Ruff LSP source fixes or import organization to a Python file.",
-	promptSnippet: "Apply Ruff LSP fixes to a Python file",
-	parameters: Type.Object({
-		path: Type.String({ description: "Python file to fix." }),
-		root: Type.Optional(
-			Type.String({ description: "Workspace root for the language server. Defaults to cwd." }),
-		),
-		kind: Type.Optional(
-			Type.String({
-				description:
-					"Ruff source action kind. Defaults to source.fixAll.ruff. Common value: source.organizeImports.ruff.",
-			}),
-		),
-		write: Type.Optional(
-			Type.Boolean({ description: "Write fixed text back to the file. Defaults to false." }),
-		),
-	}),
-	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return runFix(ruffAdapter, params, signal, ctx, STATUS_KEY);
+		const { root, route } = selectFixRoute(params);
+		return runFix(
+			route.adapter,
+			{ root, path: params.path, kind: params.kind, write: params.write },
+			signal,
+			ctx,
+			STATUS_KEY,
+		);
 	},
 });
 
 export default function lsp(pi: ExtensionAPI) {
-	pi.registerTool(biomeDiagnosticsTool);
-	pi.registerTool(biomeFormatTool);
-	pi.registerTool(biomeFixTool);
-	pi.registerTool(tyDiagnosticsTool);
-	pi.registerTool(ruffDiagnosticsTool);
-	pi.registerTool(ruffFormatTool);
-	pi.registerTool(ruffFixTool);
+	pi.registerTool(lspDiagnosticsTool);
+	pi.registerTool(lspFormatTool);
+	pi.registerTool(lspFixTool);
 
 	pi.registerCommand("lsp", {
 		description: "Show shared LSP extension configuration",
@@ -190,6 +164,10 @@ export default function lsp(pi: ExtensionAPI) {
 	pi.on("session_shutdown", (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
+}
+
+function textFromResult(result: { content?: Array<{ type?: string; text?: string }> }) {
+	return result.content?.find((item) => item.type === "text")?.text ?? "";
 }
 
 function buildStatusMessage() {

--- a/extensions/pi-lsp/src/routes.ts
+++ b/extensions/pi-lsp/src/routes.ts
@@ -1,0 +1,191 @@
+import path from "node:path";
+import { biomeAdapter, ruffAdapter, tyAdapter } from "./adapters.js";
+import { collectSupportedFiles, resolveRoot } from "./files.js";
+import type { LspServerAdapter } from "./types.js";
+
+export type LanguageFamily = "web" | "python";
+export type DiagnosticChecker = "type" | "lint" | "all";
+export type LspAction = "diagnostics" | "format" | "fix";
+
+export interface DiagnosticRoute {
+	adapter: LspServerAdapter;
+	language: LanguageFamily;
+	checker?: DiagnosticChecker;
+	reason: string;
+	files: string[];
+}
+
+export interface SingleFileRoute {
+	adapter: LspServerAdapter;
+	language: LanguageFamily;
+	reason: string;
+}
+
+export interface DiagnosticRouteParams {
+	root?: string;
+	paths?: string[];
+	limit?: number;
+	language?: LanguageFamily;
+	checker?: DiagnosticChecker;
+}
+
+export interface SingleFileRouteParams {
+	root?: string;
+	path: string;
+	language?: LanguageFamily;
+}
+
+export const SUPPORTED_LANGUAGE_DESCRIPTION =
+	"Supported language/file classes: web/config files supported by Biome, and Python .py/.pyi files.";
+
+export function selectDiagnosticRoutes(params: DiagnosticRouteParams, defaultLimit: number) {
+	const root = resolveRoot(params.root);
+	const checker = params.checker ?? "all";
+	const candidates = diagnosticCandidates(params.language, checker);
+	const filesByLanguage = new Map<LanguageFamily, string[]>();
+	const routes = candidates
+		.map((candidate) => {
+			let files = filesByLanguage.get(candidate.language);
+			if (!files) {
+				files = collectSupportedFiles(
+					discoveryAdapterFor(candidate.language),
+					root,
+					params.paths,
+					params.limit ?? defaultLimit,
+				);
+				filesByLanguage.set(candidate.language, files);
+			}
+			return { ...candidate, files };
+		})
+		.filter((route) => route.files.length > 0);
+
+	if (routes.length === 0) {
+		const scope = params.paths?.length ? ` in requested paths: ${params.paths.join(", ")}` : "";
+		throw new Error(`No supported files found${scope}. ${SUPPORTED_LANGUAGE_DESCRIPTION}`);
+	}
+
+	return { root, routes };
+}
+
+export function selectFormatRoute(params: SingleFileRouteParams) {
+	return selectSingleFileRoute("format", params);
+}
+
+export function selectFixRoute(params: SingleFileRouteParams) {
+	return selectSingleFileRoute("fix", params);
+}
+
+function diagnosticCandidates(language: LanguageFamily | undefined, checker: DiagnosticChecker) {
+	if (language === "web") {
+		return [
+			{
+				adapter: biomeAdapter,
+				language,
+				reason: "Biome-supported web/config diagnostics",
+			},
+		];
+	}
+
+	if (language === "python") return pythonDiagnosticCandidates(checker);
+
+	return [
+		{
+			adapter: biomeAdapter,
+			language: "web" as const,
+			reason: "Biome-supported web/config diagnostics",
+		},
+		...pythonDiagnosticCandidates(checker),
+	];
+}
+
+function discoveryAdapterFor(language: LanguageFamily) {
+	if (language === "web") return biomeAdapter;
+	return ruffAdapter;
+}
+
+function pythonDiagnosticCandidates(checker: DiagnosticChecker) {
+	const routes: Array<Omit<DiagnosticRoute, "files">> = [];
+	if (checker === "type" || checker === "all") {
+		routes.push({
+			adapter: tyAdapter,
+			language: "python",
+			checker: "type",
+			reason: "Python type diagnostics through ty",
+		});
+	}
+	if (checker === "lint" || checker === "all") {
+		routes.push({
+			adapter: ruffAdapter,
+			language: "python",
+			checker: "lint",
+			reason: "Python lint diagnostics through Ruff",
+		});
+	}
+	return routes;
+}
+
+function selectSingleFileRoute(action: "format" | "fix", params: SingleFileRouteParams) {
+	const root = resolveRoot(params.root);
+	const file = path.resolve(root, params.path);
+	const webSupported = biomeAdapter.isSupportedFile(file);
+	const pythonSupported = ruffAdapter.isSupportedFile(file);
+
+	if (params.language === "web") {
+		if (!webSupported) throw unsupportedFileError(action, params.path, params.language);
+		return {
+			root,
+			route: {
+				adapter: biomeAdapter,
+				language: "web" as const,
+				reason: `Biome-supported web/config ${action}`,
+			},
+		};
+	}
+
+	if (params.language === "python") {
+		if (!pythonSupported) throw unsupportedFileError(action, params.path, params.language);
+		return {
+			root,
+			route: {
+				adapter: ruffAdapter,
+				language: "python" as const,
+				reason: `Python ${action} through Ruff`,
+			},
+		};
+	}
+
+	if (webSupported) {
+		return {
+			root,
+			route: {
+				adapter: biomeAdapter,
+				language: "web" as const,
+				reason: `Biome-supported web/config ${action}`,
+			},
+		};
+	}
+
+	if (pythonSupported) {
+		return {
+			root,
+			route: {
+				adapter: ruffAdapter,
+				language: "python" as const,
+				reason: `Python ${action} through Ruff`,
+			},
+		};
+	}
+
+	throw unsupportedFileError(action, params.path, params.language);
+}
+
+function unsupportedFileError(
+	action: LspAction,
+	filePath: string,
+	language: LanguageFamily | undefined,
+) {
+	const override = language ? ` for language override '${language}'` : "";
+	return new Error(
+		`No ${action} route supports ${filePath}${override}. ${SUPPORTED_LANGUAGE_DESCRIPTION}`,
+	);
+}

--- a/extensions/pi-lsp/src/runner.ts
+++ b/extensions/pi-lsp/src/runner.ts
@@ -5,21 +5,29 @@ import { commandFromEnv, timeoutFromEnv } from "./command.js";
 import { collectSupportedFiles, resolveRoot, resolveSupportedFile } from "./files.js";
 import { LspClient } from "./lsp-client.js";
 import { applyTextEdits, collectWorkspaceEdits, hasOverlappingTextEdits } from "./text-edits.js";
-import type { CodeAction, DiagnosticEntry, LspServerAdapter, StatusContext } from "./types.js";
+import type {
+	CodeAction,
+	DiagnosticEntry,
+	LspServerAdapter,
+	LspTextEdit,
+	StatusContext,
+} from "./types.js";
 
 export const DEFAULT_TIMEOUT_MS = 20_000;
 export const DEFAULT_FILE_LIMIT = 50;
 
 export async function runDiagnostics(
 	adapter: LspServerAdapter,
-	params: { root?: string; paths?: string[]; limit?: number },
+	params: { root?: string; paths?: string[]; limit?: number; files?: string[] },
 	signal: AbortSignal | undefined,
 	ctx: StatusContext,
 	statusKey: string,
 ) {
 	const root = resolveRoot(params.root);
 	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
-	const files = collectSupportedFiles(adapter, root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
+	const files =
+		params.files ??
+		collectSupportedFiles(adapter, root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
 	if (files.length === 0) {
 		return textResult(adapter.emptyDiagnosticsMessage, {
 			root,
@@ -29,7 +37,12 @@ export async function runDiagnostics(
 		});
 	}
 
-	const client = new LspClient(adapter, command, root, timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS));
+	const client = new LspClient(
+		adapter,
+		command,
+		root,
+		timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS),
+	);
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
 	throwIfAborted(signal, adapter);
@@ -76,7 +89,12 @@ export async function runFormat(
 	const root = resolveRoot(params.root);
 	const file = resolveSupportedFile(adapter, root, params.path);
 	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
-	const client = new LspClient(adapter, command, root, timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS));
+	const client = new LspClient(
+		adapter,
+		command,
+		root,
+		timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS),
+	);
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
 	throwIfAborted(signal, adapter);
@@ -90,7 +108,7 @@ export async function runFormat(
 		const text = readFileSync(file, "utf8");
 		client.didOpen(uri, text, adapter.languageIdFor(file));
 		let newText: string;
-		let edits;
+		let edits: LspTextEdit[];
 		try {
 			edits = await client.format(uri);
 			newText = applyTextEdits(text, edits);
@@ -101,14 +119,17 @@ export async function runFormat(
 
 		if (params.write && changed) writeFileSync(file, newText);
 
-		return textResult(formatEditSummary(adapter, "format", root, file, changed, params.write, newText), {
-			path: path.relative(root, file) || file,
-			uri,
-			changed,
-			write: params.write ?? false,
-			edits,
-			text: params.write ? undefined : newText,
-		});
+		return textResult(
+			formatEditSummary(adapter, "format", root, file, changed, params.write, newText),
+			{
+				path: path.relative(root, file) || file,
+				uri,
+				changed,
+				write: params.write ?? false,
+				edits,
+				text: params.write ? undefined : newText,
+			},
+		);
 	} finally {
 		ctx.ui.setStatus(statusKey, undefined);
 		signal?.removeEventListener("abort", abort);
@@ -129,7 +150,12 @@ export async function runFix(
 	if (!actionKind) throw new Error(`${adapter.label} LSP adapter does not support source fixes.`);
 
 	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
-	const client = new LspClient(adapter, command, root, timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS));
+	const client = new LspClient(
+		adapter,
+		command,
+		root,
+		timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS),
+	);
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
 	throwIfAborted(signal, adapter);
@@ -144,7 +170,7 @@ export async function runFix(
 		client.didOpen(uri, text, adapter.languageIdFor(file));
 		let resolvedActions: CodeAction[];
 		let selectedActions: CodeAction[];
-		let edits;
+		let edits: LspTextEdit[];
 		let newText: string;
 		try {
 			const diagnostics = await client.diagnostics(uri);
@@ -167,17 +193,20 @@ export async function runFix(
 
 		if (params.write && changed) writeFileSync(file, newText);
 
-		return textResult(formatEditSummary(adapter, "fix", root, file, changed, params.write, newText), {
-			path: path.relative(root, file) || file,
-			uri,
-			changed,
-			write: params.write ?? false,
-			kind: actionKind,
-			actions: resolvedActions.map(({ title, kind }) => ({ title, kind })),
-			appliedActions: selectedActions.map(({ title, kind }) => ({ title, kind })),
-			edits,
-			text: params.write ? undefined : newText,
-		});
+		return textResult(
+			formatEditSummary(adapter, "fix", root, file, changed, params.write, newText),
+			{
+				path: path.relative(root, file) || file,
+				uri,
+				changed,
+				write: params.write ?? false,
+				kind: actionKind,
+				actions: resolvedActions.map(({ title, kind }) => ({ title, kind })),
+				appliedActions: selectedActions.map(({ title, kind }) => ({ title, kind })),
+				edits,
+				text: params.write ? undefined : newText,
+			},
+		);
 	} finally {
 		ctx.ui.setStatus(statusKey, undefined);
 		signal?.removeEventListener("abort", abort);


### PR DESCRIPTION
## Summary
- Replace backend-specific pi-lsp tools with `lsp_diagnostics`, `lsp_format`, and `lsp_fix`
- Add centralized language/file-extension routing for Biome-supported web/config files and Python files
- Update pi-lsp documentation and parity notes with migration guidance

## Verification
- `npm run check`
- `just pack-lsp`

Stacked on #50 (plan PR).