### PR TITLE
feat(lsp): use simple server config

### DIFF
--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -1,19 +1,18 @@
-# 🧠 pi-lsp — Shared Language Server Tools for Pi
+# 🧠 pi-lsp — Configurable Language Server Tools for Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-lsp)](https://www.npmjs.com/package/@narumitw/pi-lsp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-lsp` is a native [Pi coding agent](https://pi.dev) extension that exposes Biome, ty, and Ruff language-server behavior through language/file-extension routed Pi tools.
+`@narumitw/pi-lsp` is a native [Pi coding agent](https://pi.dev) extension that exposes diagnostics and source-fix tools through configurable Language Server Protocol routes.
 
-It supersedes the older split packages `@narumitw/pi-biome-lsp` and `@narumitw/pi-python-lsp`, which now live under `extensions/deprecated/` and are excluded from active workspace scripts.
+The extension is language-agnostic: servers are selected by config and file extension instead of hard-coded language families.
 
 ## ✨ Features
 
-- Routes Biome-supported web/config files to `biome lsp-proxy` for diagnostics, formatting, import organization, and source fixes.
-- Routes Python `.py` and `.pyi` type diagnostics to `ty server`.
-- Routes Python `.py` and `.pyi` lint diagnostics, formatting, import organization, and source fixes to `ruff server`.
-- Uses one internal LSP runner for JSON-RPC framing, subprocess lifecycle, diagnostics, formatting, code actions, and workspace edit application.
-- Keeps Biome, ty, and Ruff behavior in small server adapters.
-- Supports workspace roots, file limits, recursive file discovery, language overrides, and write-or-preview edits.
+- Configure LSP servers with simple JSON keyed by server name.
+- Routes diagnostics and source fixes by configured file extensions.
+- Supports multiple servers for the same extension, for example `ty` and `ruff` for `.py`/`.pyi` diagnostics.
+- Uses one internal LSP runner for JSON-RPC framing, subprocess lifecycle, diagnostics, code actions, and workspace edit application.
+- Supports workspace roots, file limits, recursive file discovery, server overrides, and write-or-preview edits.
 - Starts language servers only for tool calls, then shuts them down.
 - Shows statusline activity only while LSP tools are running.
 
@@ -23,65 +22,92 @@ It supersedes the older split packages `@narumitw/pi-biome-lsp` and `@narumitw/p
 pi install npm:@narumitw/pi-lsp
 ```
 
-Try without installing permanently:
-
-```bash
-pi -e npm:@narumitw/pi-lsp
-```
-
 Try this package locally from the repository root:
 
 ```bash
 pi -e ./extensions/pi-lsp
 ```
 
-## ⚠️ Tool-name compatibility
+## ⚙️ Configuration
 
-This package now exposes three language/file-extension routed tools instead of the old backend-specific tool names:
+If no config is provided, pi-lsp ships compatible defaults for Biome, ty, and Ruff.
 
-| Old tool | New call |
-| --- | --- |
-| `biome_lsp_diagnostics` | `lsp_diagnostics` with `language: "web"` when an override is needed |
-| `biome_lsp_format` | `lsp_format` for a Biome-supported file |
-| `biome_lsp_fix` | `lsp_fix` for a Biome-supported file |
-| `ty_lsp_diagnostics` | `lsp_diagnostics` with `language: "python"`, `checker: "type"` |
-| `ruff_lsp_diagnostics` | `lsp_diagnostics` with `language: "python"`, `checker: "lint"` |
-| `ruff_lsp_format` | `lsp_format` for a Python file |
-| `ruff_lsp_fix` | `lsp_fix` for a Python file |
+Custom config can be supplied in one of these locations:
 
-Avoid installing `@narumitw/pi-lsp` side by side with the older deprecated LSP packages unless you have verified how your Pi version handles overlapping capabilities.
+1. `PI_LSP_CONFIG` as inline JSON or a path to a JSON file
+2. `<workspace>/.pi/lsp.json`
+3. `~/.pi/agent/lsp.json`
 
-## ✅ Requirements
+`lsp.json` can be a plain object keyed by server name:
 
-Install the language servers you want to use somewhere on `PATH`:
-
-```bash
-uv tool install ty
-uv tool install ruff
+```json
+{
+  "ty": {
+    "command": ["ty", "server"],
+    "extensions": [".py", ".pyi"]
+  },
+  "ruff": {
+    "command": ["ruff", "server"],
+    "extensions": [".py", ".pyi"]
+  },
+  "biome": {
+    "command": ["biome", "lsp-proxy"],
+    "extensions": [
+      ".astro",
+      ".css",
+      ".graphql",
+      ".gql",
+      ".html",
+      ".js",
+      ".jsx",
+      ".json",
+      ".jsonc",
+      ".ts",
+      ".tsx",
+      ".vue"
+    ]
+  }
+}
 ```
 
-For Biome, either install it globally/on `PATH`, add your project's `node_modules/.bin` to `PATH`, or point the extension at a project-local command. For example:
+Use `servers` when you need global pi-lsp options such as timeout:
 
-```bash
-npm install -D @biomejs/biome
-PI_BIOME_LSP_COMMAND="./node_modules/.bin/biome lsp-proxy" pi -e ./extensions/pi-lsp
+```json
+{
+  "timeout": 30000,
+  "servers": {
+    "ty": {
+      "command": ["ty", "server"],
+      "extensions": [".py", ".pyi"],
+      "env": {
+        "LSP_LOG": "debug"
+      },
+      "initialization": {
+        "settings": {}
+      }
+    }
+  }
+}
 ```
 
-Or provide custom server commands:
+Each server entry supports:
+
+- `command`: argv array used to start the LSP server.
+- `extensions`: file extensions that should route to this server.
+- `env`: extra environment variables for the LSP server process.
+- `initialization`: LSP initialization options and workspace configuration values.
+
+Global options:
+
+- `timeout`: request timeout in milliseconds. Defaults to `20000`.
+
+pi-lsp infers `languageId` from common extensions and falls back to the extension without the leading dot.
+
+Per-server command overrides still use the normalized server name:
 
 ```bash
-PI_BIOME_LSP_COMMAND="npx biome lsp-proxy" \
 PI_TY_LSP_COMMAND="uvx ty server" \
 PI_RUFF_LSP_COMMAND="uvx ruff server" \
-pi -e ./extensions/pi-lsp
-```
-
-Optional timeout overrides:
-
-```bash
-PI_BIOME_LSP_TIMEOUT_MS=30000 \
-PI_TY_LSP_TIMEOUT_MS=30000 \
-PI_RUFF_LSP_TIMEOUT_MS=30000 \
 pi -e ./extensions/pi-lsp
 ```
 
@@ -89,108 +115,26 @@ pi -e ./extensions/pi-lsp
 
 ### `lsp_diagnostics`
 
-Run diagnostics through language/file-extension routes.
+Run diagnostics through configured servers.
 
 Parameters:
 
 - `paths?`: files or directories to check. Defaults to the workspace root.
 - `root?`: workspace root. Defaults to cwd.
-- `limit?`: maximum files to open per selected route.
-- `language?`: optional override, either `"web"` for Biome-supported web/config files or `"python"` for `.py`/`.pyi` files.
-- `checker?`: Python diagnostics checker, one of `"type"`, `"lint"`, or `"all"`. Defaults to `"all"`.
-
-Routes:
-
-- Biome-supported web/config files → Biome diagnostics.
-- Python `.py`/`.pyi` + `checker: "type"` → ty diagnostics.
-- Python `.py`/`.pyi` + `checker: "lint"` → Ruff diagnostics.
-- Python `.py`/`.pyi` + `checker: "all"` → both ty and Ruff diagnostics.
-
-### `lsp_format`
-
-Format one file through the route selected from its file extension.
-
-Parameters:
-
-- `path`: file to format.
-- `root?`: workspace root. Defaults to cwd.
-- `write?`: write formatted text back to the file. Defaults to false.
-- `language?`: optional route override, either `"web"` or `"python"`.
-
-Routes:
-
-- Biome-supported web/config files → Biome formatting.
-- Python `.py`/`.pyi` files → Ruff formatting.
+- `limit?`: maximum files to open per selected server.
+- `server?`: configured server name, or an array of names. Defaults to all matching servers.
 
 ### `lsp_fix`
 
-Apply source fixes or import organization through the route selected from the file extension.
+Apply source fixes or import organization through a configured server that matches its extension. If multiple servers match, pass `server` explicitly.
 
 Parameters:
 
 - `path`: file to fix.
 - `root?`: workspace root. Defaults to cwd.
-- `kind?`: source action kind. Defaults to the routed backend's fix-all action.
+- `kind?`: source action kind. Defaults to `source.fixAll`.
 - `write?`: write fixed text back to the file. Defaults to false.
-- `language?`: optional route override, either `"web"` or `"python"`.
-
-Routes:
-
-- Biome-supported web/config files → Biome source fixes such as `source.fixAll.biome` or `source.organizeImports.biome`.
-- Python `.py`/`.pyi` files → Ruff source fixes such as `source.fixAll.ruff` or `source.organizeImports.ruff`.
-
-## 🚀 Examples
-
-Check a mixed project subset and run all applicable diagnostics:
-
-```json
-{
-  "paths": ["src", "extensions/pi-lsp/src"],
-  "limit": 100
-}
-```
-
-Check only Biome-supported web/config files:
-
-```json
-{
-  "language": "web",
-  "paths": ["extensions/pi-lsp/src"],
-  "limit": 100
-}
-```
-
-Check Python type diagnostics only:
-
-```json
-{
-  "language": "python",
-  "checker": "type",
-  "paths": ["src", "tests"],
-  "limit": 100
-}
-```
-
-Format a TypeScript file with the inferred Biome route:
-
-```json
-{
-  "path": "src/index.ts",
-  "write": true
-}
-```
-
-Organize Python imports with the inferred Ruff route:
-
-```json
-{
-  "path": "src/app.py",
-  "kind": "source.organizeImports.ruff",
-  "write": true
-}
-```
-
-If `paths` is omitted for diagnostics, the tool recursively discovers supported files under the workspace root while skipping common generated, dependency, cache, and virtualenv directories.
+- `server?`: optional configured server name.
 
 ## 💬 Command
 
@@ -198,7 +142,7 @@ If `paths` is omitted for diagnostics, the tool recursively discovers supported 
 /lsp
 ```
 
-Shows the configured Biome, ty, and Ruff LSP commands and whether each command is available on `PATH`.
+Shows configured LSP commands and whether each command is available on `PATH`.
 
 ## 🗂️ Package layout
 
@@ -219,10 +163,6 @@ extensions/pi-lsp/
 ├── tsconfig.json
 └── package.json
 ```
-
-## 🔎 Keywords
-
-Pi extension, Pi coding agent, Language Server Protocol, Biome LSP, ty, Ruff, Python LSP, formatter, linter, import organization, AI coding tools.
 
 ## 📄 License
 

--- a/extensions/pi-lsp/package.json
+++ b/extensions/pi-lsp/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-lsp",
 	"version": "0.1.26",
-	"description": "Pi extension that exposes language-server tools for Biome, ty, and Ruff through a shared LSP runner.",
+	"description": "Pi extension that exposes configurable, language-agnostic LSP tools through a shared runner.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -10,12 +10,11 @@
 		"pi-extension",
 		"pi",
 		"lsp",
-		"biome",
-		"python",
-		"ty",
-		"ruff",
+		"language-server-protocol",
+		"configurable",
 		"lint",
-		"format"
+		"diagnostics",
+		"code-action"
 	],
 	"files": [
 		"src",

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -1,19 +1,30 @@
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import type { LspServerAdapter } from "./types.js";
+import process from "node:process";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { InternalLspServer, LspConfig, LspServerAdapter } from "./types.js";
 
-const BIOME_SKIP_DIRECTORIES = new Set([
+const COMMON_SKIP_DIRECTORIES = new Set([
 	".git",
 	".hg",
+	".mypy_cache",
 	".next",
 	".nuxt",
 	".output",
+	".ruff_cache",
 	".svelte-kit",
+	".tox",
+	".venv",
+	"__pycache__",
 	"coverage",
 	"dist",
 	"node_modules",
 	"out",
+	"venv",
 ]);
-const BIOME_SUPPORTED_EXTENSIONS = new Set([
+
+const BIOME_EXTENSIONS = [
 	".astro",
 	".css",
 	".cts",
@@ -31,111 +42,210 @@ const BIOME_SUPPORTED_EXTENSIONS = new Set([
 	".ts",
 	".tsx",
 	".vue",
-]);
+];
 
-const PYTHON_SKIP_DIRECTORIES = new Set([
-	".git",
-	".hg",
-	".mypy_cache",
-	".ruff_cache",
-	".tox",
-	".venv",
-	"__pycache__",
-	"node_modules",
-	"venv",
-]);
-
-export const biomeAdapter: LspServerAdapter = {
-	label: "Biome",
-	statusPrefix: "🧬",
-	defaultCommand: { command: "biome", args: ["lsp-proxy"] },
-	commandEnvVar: "PI_BIOME_LSP_COMMAND",
-	timeoutEnvVar: "PI_BIOME_LSP_TIMEOUT_MS",
-	missingCommandHint: "Install @biomejs/biome or set PI_BIOME_LSP_COMMAND.",
-	skipDirectories: BIOME_SKIP_DIRECTORIES,
-	isSupportedFile: (filePath) => BIOME_SUPPORTED_EXTENSIONS.has(path.extname(filePath)),
-	languageIdFor: biomeLanguageIdFor,
-	formattingOptions: { tabSize: 2, insertSpaces: false },
-	initialize: {
-		codeAction: true,
-		diagnosticDynamicRegistration: true,
-		formattingDynamicRegistration: true,
-		codeActionDynamicRegistration: true,
-		didChangeConfigurationDynamicRegistration: true,
-		didSaveDynamicRegistration: true,
+export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
+	{
+		name: "biome",
+		command: ["biome", "lsp-proxy"],
+		extensions: BIOME_EXTENSIONS,
 	},
-	fallbackToPublishDiagnostics: true,
-	resolveUnsupportedCodeActions: true,
-	serverRequestWorkspaceFolders: true,
-	emptyDiagnosticsMessage: "Biome LSP found no supported files to check.",
-	formatDiagnosticsHeader: (summary) =>
-		`Biome LSP diagnostics: ${summary.diagnostics} diagnostic(s) across ${summary.files} file(s).`,
-	editSummaryLabel: "Biome",
-	defaultFixKind: "source.fixAll.biome",
-};
-
-export const tyAdapter: LspServerAdapter = {
-	label: "ty",
-	statusPrefix: "🐍 ty",
-	defaultCommand: { command: "ty", args: ["server"] },
-	commandEnvVar: "PI_TY_LSP_COMMAND",
-	timeoutEnvVar: "PI_TY_LSP_TIMEOUT_MS",
-	missingCommandHint: "Install ty or set PI_TY_LSP_COMMAND.",
-	skipDirectories: PYTHON_SKIP_DIRECTORIES,
-	isSupportedFile: isPythonFile,
-	languageIdFor: () => "python",
-	formattingOptions: { tabSize: 4, insertSpaces: true },
-	initialize: {
-		codeAction: false,
-		diagnosticDynamicRegistration: false,
+	{
+		name: "ty",
+		command: ["ty", "server"],
+		extensions: [".py", ".pyi"],
 	},
-	fallbackToPublishDiagnostics: false,
-	resolveUnsupportedCodeActions: false,
-	serverRequestWorkspaceFolders: false,
-	emptyDiagnosticsMessage: "ty LSP found no Python files to check.",
-	formatDiagnosticsHeader: (summary) =>
-		`ty LSP diagnostics: ${summary.diagnostics} diagnostic(s) across ${summary.files} file(s).`,
-	editSummaryLabel: "ty",
-};
-
-export const ruffAdapter: LspServerAdapter = {
-	label: "Ruff",
-	statusPrefix: "🐍 ruff",
-	defaultCommand: { command: "ruff", args: ["server"] },
-	commandEnvVar: "PI_RUFF_LSP_COMMAND",
-	timeoutEnvVar: "PI_RUFF_LSP_TIMEOUT_MS",
-	missingCommandHint: "Install ruff or set PI_RUFF_LSP_COMMAND.",
-	skipDirectories: PYTHON_SKIP_DIRECTORIES,
-	isSupportedFile: isPythonFile,
-	languageIdFor: () => "python",
-	formattingOptions: { tabSize: 4, insertSpaces: true },
-	initialize: {
-		codeAction: true,
-		diagnosticDynamicRegistration: false,
+	{
+		name: "ruff",
+		command: ["ruff", "server"],
+		extensions: [".py", ".pyi"],
 	},
-	fallbackToPublishDiagnostics: false,
-	resolveUnsupportedCodeActions: false,
-	serverRequestWorkspaceFolders: false,
-	emptyDiagnosticsMessage: "Ruff LSP found no Python files to check.",
-	formatDiagnosticsHeader: (summary) =>
-		`Ruff LSP diagnostics: ${summary.diagnostics} diagnostic(s) across ${summary.files} file(s).`,
-	editSummaryLabel: "Ruff",
-	defaultFixKind: "source.fixAll.ruff",
-};
+];
 
-export const adapters = [biomeAdapter, tyAdapter, ruffAdapter] as const;
-
-function biomeLanguageIdFor(filePath: string) {
-	const extension = path.extname(filePath);
-	if (extension === ".js" || extension === ".cjs" || extension === ".mjs") return "javascript";
-	if (extension === ".jsx") return "javascriptreact";
-	if (extension === ".ts" || extension === ".cts" || extension === ".mts") return "typescript";
-	if (extension === ".tsx") return "typescriptreact";
-	if (extension === ".gql") return "graphql";
-	if (extension === ".jsonc") return "jsonc";
-	return extension.slice(1);
+export function loadRuntime(cwd = process.cwd()) {
+	const config = loadConfig(cwd);
+	return {
+		adapters: config.servers.map(configToAdapter),
+		timeoutMs: config.timeout ?? 20_000,
+	};
 }
 
-function isPythonFile(filePath: string) {
-	return filePath.endsWith(".py") || filePath.endsWith(".pyi");
+export function loadConfig(cwd = process.cwd()): LspConfig {
+	const configured = loadConfiguredConfig(cwd);
+	return configured ?? { servers: DEFAULT_SERVER_CONFIGS };
+}
+
+function loadConfiguredConfig(cwd: string): LspConfig | undefined {
+	const rawConfig = process.env.PI_LSP_CONFIG?.trim();
+	if (rawConfig) return parseConfigSource(rawConfig, cwd, "PI_LSP_CONFIG");
+
+	const projectConfig = path.join(cwd, ".pi", "lsp.json");
+	if (existsSync(projectConfig)) return parseConfigFile(projectConfig);
+
+	const userConfig = path.join(getAgentDir(), "lsp.json");
+	if (existsSync(userConfig)) return parseConfigFile(userConfig);
+
+	return undefined;
+}
+
+function parseConfigSource(source: string, cwd: string, label: string): LspConfig {
+	if (source.startsWith("{")) return normalizeConfig(JSON.parse(source), label);
+	const expandedSource = expandHome(source);
+	const filePath = path.isAbsolute(expandedSource) ? expandedSource : path.resolve(cwd, expandedSource);
+	return parseConfigFile(filePath);
+}
+
+function parseConfigFile(filePath: string): LspConfig {
+	return normalizeConfig(JSON.parse(readFileSync(filePath, "utf8")), filePath);
+}
+
+function normalizeConfig(value: unknown, label: string): LspConfig {
+	if (!isRecord(value) || Array.isArray(value)) {
+		throw new Error(`${label} must be a JSON object mapping server names to LSP server config.`);
+	}
+
+	if ("servers" in value) {
+		if (isServerEntry(value.servers)) {
+			throw new Error(
+				`${label} uses reserved top-level key 'servers'. Use the wrapper shape ` +
+					`{ "servers": { "<name>": { "command": [...], "extensions": [...] } } }` +
+					" or choose a different server name.",
+			);
+		}
+		const timeout = normalizeTimeout(value.timeout, label);
+		const servers = value.servers;
+		if (!isRecord(servers) || Array.isArray(servers)) {
+			throw new Error(`${label}.servers must be a JSON object mapping server names to LSP server config.`);
+		}
+		return { timeout, servers: normalizeServerMap(servers, `${label}.servers`) };
+	}
+
+	if ("timeout" in value) {
+		throw new Error(`${label}.timeout requires the wrapper shape with a servers object.`);
+	}
+
+	return { servers: normalizeServerMap(value, label) };
+}
+
+function normalizeServerMap(value: Record<string, unknown>, label: string) {
+	return Object.entries(value).map(([name, server]) => normalizeServer(name, server, `${label}.${name}`));
+}
+
+function isServerEntry(value: unknown) {
+	return (
+		isRecord(value) &&
+		(Array.isArray(value.command) || Array.isArray(value.extensions))
+	);
+}
+
+function normalizeServer(name: string, value: unknown, label: string): InternalLspServer {
+	if (!isRecord(value)) throw new Error(`${label} must be an object.`);
+	const command = stringArrayField(value, "command", label);
+	const extensions = stringArrayField(value, "extensions", label).map(normalizeExtension);
+	return {
+		name,
+		command,
+		extensions,
+		env: optionalStringRecordField(value, "env", label),
+		initialization: optionalRecordField(value, "initialization", label),
+	};
+}
+
+function normalizeTimeout(value: unknown, label: string) {
+	if (value === undefined) return undefined;
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		throw new Error(`${label}.timeout must be a positive number.`);
+	}
+	return value;
+}
+
+function configToAdapter(config: InternalLspServer): LspServerAdapter {
+	const extensionSet = new Set(config.extensions.map(normalizeExtension));
+	const [command, ...args] = config.command;
+	if (!command) throw new Error(`${config.name}.command must contain at least one string.`);
+	return {
+		name: config.name,
+		defaultCommand: { command, args },
+		commandEnvVar: envName(config.name, "COMMAND"),
+		missingCommandHint: `Install ${config.name} or set ${envName(config.name, "COMMAND")}.`,
+		extensions: config.extensions,
+		env: config.env,
+		initialization: config.initialization,
+		skipDirectories: COMMON_SKIP_DIRECTORIES,
+		isSupportedFile: (filePath) => extensionSet.has(path.extname(filePath)),
+		languageIdFor: (filePath) => languageIdFor(config, filePath),
+	};
+}
+
+function languageIdFor(_config: InternalLspServer, filePath: string) {
+	const extension = path.extname(filePath);
+	return LANGUAGE_IDS[extension] ?? extension.slice(1);
+}
+
+const LANGUAGE_IDS: Record<string, string> = {
+	".cjs": "javascript",
+	".cts": "typescript",
+	".gql": "graphql",
+	".js": "javascript",
+	".jsx": "javascriptreact",
+	".jsonc": "jsonc",
+	".mjs": "javascript",
+	".mts": "typescript",
+	".py": "python",
+	".pyi": "python",
+	".ts": "typescript",
+	".tsx": "typescriptreact",
+};
+
+function commandFromEnvName(name: string): string {
+	return name.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase();
+}
+
+function envName(name: string, suffix: "COMMAND") {
+	return `PI_${commandFromEnvName(name)}_LSP_${suffix}`;
+}
+
+function normalizeExtension(extension: string) {
+	return extension.startsWith(".") ? extension : `.${extension}`;
+}
+
+function stringArrayField(value: Record<string, unknown>, field: string, label: string) {
+	const fieldValue = value[field];
+	if (!Array.isArray(fieldValue) || !fieldValue.every((item) => typeof item === "string")) {
+		throw new Error(`${label}.${field} must be an array of strings.`);
+	}
+	return fieldValue;
+}
+
+function optionalStringRecordField(value: Record<string, unknown>, field: string, label: string) {
+	const fieldValue = value[field];
+	if (fieldValue === undefined) return undefined;
+	if (!isRecord(fieldValue) || Array.isArray(fieldValue)) {
+		throw new Error(`${label}.${field} must be an object with string values.`);
+	}
+	if (!Object.values(fieldValue).every((item) => typeof item === "string")) {
+		throw new Error(`${label}.${field} must be an object with string values.`);
+	}
+	return fieldValue as Record<string, string>;
+}
+
+function optionalRecordField(value: Record<string, unknown>, field: string, label: string) {
+	const fieldValue = value[field];
+	if (fieldValue === undefined) return undefined;
+	if (!isRecord(fieldValue) || Array.isArray(fieldValue)) {
+		throw new Error(`${label}.${field} must be an object.`);
+	}
+	return fieldValue;
+}
+
+function expandHome(filePath: string) {
+	if (filePath === "~") return os.homedir();
+	if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+		return path.join(os.homedir(), filePath.slice(2));
+	}
+	return filePath;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
 }

--- a/extensions/pi-lsp/src/command.ts
+++ b/extensions/pi-lsp/src/command.ts
@@ -13,11 +13,6 @@ export function commandFromEnv(envVar: string, fallback: ServerCommand): ServerC
 	return fallback;
 }
 
-export function timeoutFromEnv(envVar: string, defaultTimeoutMs: number) {
-	const rawValue = Number(process.env[envVar] ?? defaultTimeoutMs);
-	return Number.isFinite(rawValue) && rawValue > 0 ? rawValue : defaultTimeoutMs;
-}
-
 export function commandExists(command: string, cwd = process.cwd()) {
 	if (command.includes("/") || command.includes("\\")) {
 		return isRunnableFile(path.isAbsolute(command) ? command : path.resolve(cwd, command));

--- a/extensions/pi-lsp/src/files.ts
+++ b/extensions/pi-lsp/src/files.ts
@@ -19,13 +19,13 @@ export function directoryUri(directory: string) {
 
 export function resolveSupportedFile(adapter: LspServerAdapter, root: string, filePath: string) {
 	const resolvedPath = resolveWorkspacePath(root, filePath, "File path");
-	if (!existsSync(resolvedPath)) throw new Error(`${adapter.label} file does not exist: ${resolvedPath}`);
+	if (!existsSync(resolvedPath)) throw new Error(`${adapter.name} file does not exist: ${resolvedPath}`);
 	if (!isInsidePath(realpathSync(root), realpathSync(resolvedPath))) {
 		throw new Error(`File resolves outside workspace root: ${resolvedPath}`);
 	}
 	if (!statSync(resolvedPath).isFile()) throw new Error(`Expected a file: ${resolvedPath}`);
 	if (!adapter.isSupportedFile(resolvedPath)) {
-		throw new Error(`Expected a ${adapter.label} supported file: ${resolvedPath}`);
+		throw new Error(`Expected a ${adapter.name} supported file: ${resolvedPath}`);
 	}
 	return resolvedPath;
 }

--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -9,7 +9,6 @@ import type {
 	JsonRpcMessage,
 	LspDiagnostic,
 	LspServerAdapter,
-	LspTextEdit,
 	ServerCommand,
 } from "./types.js";
 
@@ -50,12 +49,13 @@ export class LspClient {
 	async start() {
 		if (!commandExists(this.#command.command, this.#cwd)) {
 			throw new Error(
-				`${this.#adapter.label} LSP command not found: ${this.#command.command}. ${this.#adapter.missingCommandHint}`,
+				`${this.#adapter.name} LSP command not found: ${this.#command.command}. ${this.#adapter.missingCommandHint}`,
 			);
 		}
 
 		const child = spawn(this.#command.command, this.#command.args, {
 			cwd: this.#cwd,
+			env: { ...process.env, ...this.#adapter.env },
 			stdio: "pipe",
 		});
 		this.#child = child;
@@ -64,7 +64,7 @@ export class LspClient {
 				this.#onData(chunk);
 			} catch (error) {
 				this.#fail(
-					`${this.#adapter.label} LSP server sent invalid JSON-RPC data: ${formatErrorMessage(error)}.${this.#formatStderr()}`,
+					`${this.#adapter.name} LSP server sent invalid JSON-RPC data: ${formatErrorMessage(error)}.${this.#formatStderr()}`,
 				);
 			}
 		});
@@ -73,7 +73,7 @@ export class LspClient {
 		});
 		child.stdin.on("error", (error) => {
 			this.#fail(
-				`${this.#adapter.label} LSP stdin write failed: ${formatErrorMessage(error)}.${this.#formatStderr()}`,
+				`${this.#adapter.name} LSP stdin write failed: ${formatErrorMessage(error)}.${this.#formatStderr()}`,
 			);
 		});
 		child.once("exit", (code, signal) => {
@@ -81,14 +81,14 @@ export class LspClient {
 			const reason = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
 			this.#rejectPending(
 				(id) =>
-					`${this.#adapter.label} LSP server exited before response ${id} (${reason}).${this.#formatStderr()}`,
+					`${this.#adapter.name} LSP server exited before response ${id} (${reason}).${this.#formatStderr()}`,
 			);
 		});
 
 		await new Promise<void>((resolve, reject) => {
 			child.once("spawn", resolve);
 			child.once("error", (error) => {
-				const message = `${this.#adapter.label} LSP process failed to start: ${error.message}.${this.#formatStderr()}`;
+				const message = `${this.#adapter.name} LSP process failed to start: ${error.message}.${this.#formatStderr()}`;
 				this.#rejectPending(message);
 				if (this.#child === child) this.#child = undefined;
 				reject(new Error(message));
@@ -99,49 +99,32 @@ export class LspClient {
 	async initialize(root: string) {
 		const rootUri = directoryUri(root);
 		const workspaceFolders = [{ uri: rootUri, name: path.basename(root) || "workspace" }];
-		const init = this.#adapter.initialize;
 		await this.request("initialize", {
 			processId: process.pid,
 			rootUri,
-			workspaceFolders: this.#adapter.serverRequestWorkspaceFolders ? workspaceFolders : null,
+			workspaceFolders,
+			initializationOptions: this.#adapter.initialization ?? {},
 			capabilities: {
 				textDocument: {
-					...(init.codeAction
-						? {
-								codeAction: {
-									dynamicRegistration: init.codeActionDynamicRegistration,
-									resolveSupport: { properties: ["edit"] },
-								},
-							}
-						: {}),
-					diagnostic: { dynamicRegistration: init.diagnosticDynamicRegistration },
-					...(init.formattingDynamicRegistration === undefined
-						? {}
-						: { formatting: { dynamicRegistration: init.formattingDynamicRegistration } }),
-					publishDiagnostics: {},
-					synchronization: {
-						didSave: true,
-						...(init.didSaveDynamicRegistration === undefined
-							? {}
-							: { dynamicRegistration: init.didSaveDynamicRegistration }),
+					codeAction: {
+						dynamicRegistration: true,
+						resolveSupport: { properties: ["edit"] },
 					},
+					diagnostic: { dynamicRegistration: true, relatedDocumentSupport: true },
+					publishDiagnostics: {},
+					synchronization: { didSave: true },
 				},
 				workspace: {
 					configuration: true,
-					...(init.didChangeConfigurationDynamicRegistration === undefined
-						? {}
-						: {
-								didChangeConfiguration: {
-									dynamicRegistration: init.didChangeConfigurationDynamicRegistration,
-								},
-							}),
 					workspaceEdit: { documentChanges: true },
-					workspaceFolders: this.#adapter.serverRequestWorkspaceFolders,
+					workspaceFolders: true,
 				},
 			},
 		});
 		this.notify("initialized", {});
-		if (this.#adapter.fallbackToPublishDiagnostics) await wait(300);
+		if (this.#adapter.initialization) {
+			this.notify("workspace/didChangeConfiguration", { settings: this.#adapter.initialization });
+		}
 	}
 
 	didOpen(uri: string, text: string, languageId: string) {
@@ -168,17 +151,9 @@ export class LspClient {
 			const result = response.result as { items?: LspDiagnostic[] } | undefined;
 			return result?.items ?? [];
 		} catch (error) {
-			if (!this.#adapter.fallbackToPublishDiagnostics || !isUnsupportedMethodError(error)) throw error;
+			if (!isUnsupportedMethodError(error)) throw error;
 			return this.#waitForPublishedDiagnostics(uri);
 		}
-	}
-
-	async format(uri: string) {
-		const response = await this.request("textDocument/formatting", {
-			textDocument: { uri },
-			options: this.#adapter.formattingOptions,
-		});
-		return (response.result as LspTextEdit[] | null | undefined) ?? [];
 	}
 
 	async codeActions(uri: string, text: string, diagnostics: LspDiagnostic[], kind: string) {
@@ -202,7 +177,7 @@ export class LspClient {
 				const response = await this.request("codeAction/resolve", action);
 				resolvedActions.push((response.result as CodeAction | undefined) ?? action);
 			} catch (error) {
-				if (!this.#adapter.resolveUnsupportedCodeActions || !isUnsupportedMethodError(error)) throw error;
+				if (!isUnsupportedMethodError(error)) throw error;
 				resolvedActions.push(action);
 			}
 		}
@@ -224,7 +199,7 @@ export class LspClient {
 	}
 
 	close() {
-		this.#rejectPending(`${this.#adapter.label} LSP request cancelled.`);
+		this.#rejectPending(`${this.#adapter.name} LSP request cancelled.`);
 
 		if (this.#child && !this.#child.killed) this.#child.kill("SIGTERM");
 		this.#child = undefined;
@@ -258,7 +233,7 @@ export class LspClient {
 			const timeout = setTimeout(() => {
 				this.#pending.delete(id);
 				reject(
-					new Error(`${this.#adapter.label} LSP request timed out: ${method}.${this.#formatStderr()}`),
+					new Error(`${this.#adapter.name} LSP request timed out: ${method}.${this.#formatStderr()}`),
 				);
 			}, this.#timeoutMs);
 			this.#pending.set(id, { resolve, reject, timeout });
@@ -280,14 +255,14 @@ export class LspClient {
 	}
 
 	#send(message: JsonRpcMessage) {
-		if (!this.#child) throw new Error(`${this.#adapter.label} LSP server is not running.`);
+		if (!this.#child) throw new Error(`${this.#adapter.name} LSP server is not running.`);
 
 		const body = JSON.stringify(message);
 		try {
 			this.#child.stdin.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
 		} catch (error) {
 			const errorMessage =
-				`${this.#adapter.label} LSP stdin write failed: ${formatErrorMessage(error)}.` +
+				`${this.#adapter.name} LSP stdin write failed: ${formatErrorMessage(error)}.` +
 				this.#formatStderr();
 			this.#fail(errorMessage);
 			throw new Error(errorMessage);
@@ -323,7 +298,7 @@ export class LspClient {
 			clearTimeout(pending.timeout);
 			this.#pending.delete(message.id as number);
 			if (message.error) {
-				pending.reject(new Error(`${this.#adapter.label} LSP error: ${message.error.message}`));
+				pending.reject(new Error(`${this.#adapter.name} LSP error: ${message.error.message}`));
 			} else {
 				pending.resolve(message);
 			}
@@ -362,7 +337,11 @@ export class LspClient {
 					const waiters = this.#diagnosticWaiters.get(uri)?.filter((entry) => entry !== waiter) ?? [];
 					if (waiters.length) this.#diagnosticWaiters.set(uri, waiters);
 					else this.#diagnosticWaiters.delete(uri);
-					resolve(this.#publishedDiagnostics.get(uri) ?? []);
+					reject(
+						new Error(
+							`${this.#adapter.name} LSP did not return diagnostics for ${uri} before timeout.`,
+						),
+					);
 				}, this.#timeoutMs),
 			};
 			this.#diagnosticWaiters.set(uri, [...(this.#diagnosticWaiters.get(uri) ?? []), waiter]);
@@ -371,11 +350,11 @@ export class LspClient {
 
 	#respondToServerRequest(message: JsonRpcMessage) {
 		if (message.method === "workspace/configuration") {
-			const params = message.params as { items?: unknown[] } | undefined;
+			const params = message.params as { items?: Array<{ section?: string }> } | undefined;
 			this.#send({
 				jsonrpc: "2.0",
 				id: message.id,
-				result: (params?.items ?? []).map(() => ({})),
+				result: (params?.items ?? []).map((item) => this.#configurationValue(item.section)),
 			});
 			return;
 		}
@@ -385,9 +364,7 @@ export class LspClient {
 			this.#send({
 				jsonrpc: "2.0",
 				id: message.id,
-				result: this.#adapter.serverRequestWorkspaceFolders
-					? [{ uri: rootUri, name: path.basename(this.#cwd) || "workspace" }]
-					: null,
+				result: [{ uri: rootUri, name: path.basename(this.#cwd) || "workspace" }],
 			});
 			return;
 		}
@@ -407,6 +384,11 @@ export class LspClient {
 		});
 	}
 
+	#configurationValue(section: string | undefined) {
+		if (!section) return this.#adapter.initialization ?? {};
+		return this.#adapter.initialization?.[section] ?? {};
+	}
+
 	#formatStderr() {
 		const stderr = this.#stderr.trim();
 		return stderr ? `\nServer stderr:\n${stderr}` : "";
@@ -419,8 +401,4 @@ function isUnsupportedMethodError(error: unknown) {
 
 function formatErrorMessage(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
-}
-
-function wait(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/extensions/pi-lsp/src/pi-lsp.ts
+++ b/extensions/pi-lsp/src/pi-lsp.ts
@@ -1,16 +1,17 @@
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { adapters } from "./adapters.js";
+import { loadRuntime } from "./adapters.js";
 import { commandExists, commandFromEnv } from "./command.js";
-import { selectDiagnosticRoutes, selectFixRoute, selectFormatRoute } from "./routes.js";
-import { DEFAULT_FILE_LIMIT, runDiagnostics, runFix, runFormat, textResult } from "./runner.js";
+import { resolveRoot } from "./files.js";
+import { selectDiagnosticRoutes, selectFixRoute } from "./routes.js";
+import { DEFAULT_FILE_LIMIT, runDiagnostics, runFix, textResult } from "./runner.js";
 
 const STATUS_KEY = "lsp";
 
-const LanguageParameter = Type.Optional(
-	Type.Union([Type.Literal("web"), Type.Literal("python")], {
+const ServerParameter = Type.Optional(
+	Type.Union([Type.String(), Type.Array(Type.String())], {
 		description:
-			"Optional language/file class override. Defaults to file-extension inference. Use 'web' for Biome-supported web/config files or 'python' for .py/.pyi files.",
+			"Optional configured LSP server name, or names for diagnostics. Defaults to all servers matching the file extension.",
 	}),
 );
 
@@ -18,25 +19,19 @@ const DiagnosticsParameters = Type.Object({
 	paths: Type.Optional(
 		Type.Array(Type.String(), {
 			description:
-				"Files or directories to check. Defaults to the workspace root and routes by supported file extensions.",
+				"Files or directories to check. Defaults to the workspace root and routes by configured server extensions.",
 		}),
 	),
 	root: Type.Optional(
 		Type.String({ description: "Workspace root for language servers. Defaults to cwd." }),
 	),
-	limit: Type.Optional(Type.Number({ description: "Maximum files to open per selected route." })),
-	language: LanguageParameter,
-	checker: Type.Optional(
-		Type.Union([Type.Literal("type"), Type.Literal("lint"), Type.Literal("all")], {
-			description:
-				"Python diagnostics checker: 'type' uses ty, 'lint' uses Ruff, and 'all' runs both. Defaults to 'all'. Ignored for web/config diagnostics.",
-		}),
-	),
+	limit: Type.Optional(Type.Number({ description: "Maximum files to open per selected server." })),
+	server: ServerParameter,
 });
 
 const SingleFileParameters = {
 	path: Type.String({
-		description: "File to process. The route is selected from the file extension.",
+		description: "File to process. The server is selected from configured file extensions.",
 	}),
 	root: Type.Optional(
 		Type.String({ description: "Workspace root for language servers. Defaults to cwd." }),
@@ -44,28 +39,38 @@ const SingleFileParameters = {
 	write: Type.Optional(
 		Type.Boolean({ description: "Write changed text back to the file. Defaults to false." }),
 	),
-	language: LanguageParameter,
+	server: Type.Optional(
+		Type.String({
+			description: "Optional configured LSP server name. Defaults to extension-based inference.",
+		}),
+	),
 };
 
 const lspDiagnosticsTool = defineTool({
 	name: "lsp_diagnostics",
 	label: "LSP: Diagnostics",
-	description:
-		"Run diagnostics using language/file-extension routing: Biome for supported web/config files, ty for Python type diagnostics, and Ruff for Python lint diagnostics.",
-	promptSnippet: "Get language-routed LSP diagnostics for web/config or Python files",
+	description: "Run diagnostics using configured, language-agnostic LSP server routes.",
+	promptSnippet: "Get diagnostics from configured LSP servers selected by file extension",
 	promptGuidelines: [
-		"Use lsp_diagnostics when JavaScript, TypeScript, JSON, CSS, GraphQL, HTML, Vue, Astro, Svelte, or Python files need LSP diagnostics.",
-		"For Python diagnostics, use checker='type' for ty, checker='lint' for Ruff, or checker='all' when both type and lint diagnostics are useful.",
-		"If a routed backend is missing, report the configuration error and suggest installing the backend or setting its PI_*_LSP_COMMAND environment variable.",
+		"Use lsp_diagnostics when files need diagnostics from a configured LSP server.",
+		"Use the server parameter only when the user asks for a specific configured LSP server or multiple servers match the same extension.",
+		"If a configured server command is missing, report the configuration error and suggest installing the command or setting its PI_<SERVER>_LSP_COMMAND environment variable.",
 	],
 	parameters: DiagnosticsParameters,
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		const { root, routes } = selectDiagnosticRoutes(params, DEFAULT_FILE_LIMIT);
+		const requestedRoot = resolveRoot(params.root);
+		const { adapters, timeoutMs } = loadRuntime(requestedRoot);
+		const { root, routes } = selectDiagnosticRoutes(
+			adapters,
+			{ ...params, root: requestedRoot },
+			DEFAULT_FILE_LIMIT,
+		);
 		const results = [];
 		for (const route of routes) {
 			const result = await runDiagnostics(
 				route.adapter,
 				{ root, paths: params.paths, limit: params.limit, files: route.files },
+				timeoutMs,
 				signal,
 				ctx,
 				STATUS_KEY,
@@ -79,9 +84,8 @@ const lspDiagnosticsTool = defineTool({
 		return textResult(text, {
 			root,
 			routes: results.map(({ route, result }) => ({
-				language: route.language,
-				checker: route.checker,
-				backend: route.adapter.label,
+				server: route.adapter.name,
+				backend: route.adapter.name,
 				reason: route.reason,
 				files: route.files,
 				details: result.details,
@@ -90,54 +94,31 @@ const lspDiagnosticsTool = defineTool({
 	},
 });
 
-const lspFormatTool = defineTool({
-	name: "lsp_format",
-	label: "LSP: Format",
-	description:
-		"Format one file using language/file-extension routing: Biome for supported web/config files and Ruff for Python files.",
-	promptSnippet: "Format a file through the routed LSP formatter",
-	promptGuidelines: [
-		"Use lsp_format for Biome-supported web/config files or Python .py/.pyi files.",
-		"Do not request ty for formatting; Python formatting routes to Ruff.",
-	],
-	parameters: Type.Object(SingleFileParameters),
-	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		const { root, route } = selectFormatRoute(params);
-		return runFormat(
-			route.adapter,
-			{ root, path: params.path, write: params.write },
-			signal,
-			ctx,
-			STATUS_KEY,
-		);
-	},
-});
-
 const lspFixTool = defineTool({
 	name: "lsp_fix",
 	label: "LSP: Fix",
-	description:
-		"Apply source fixes or import organization using language/file-extension routing: Biome for supported web/config files and Ruff for Python files.",
-	promptSnippet: "Apply routed LSP source fixes to a file",
+	description: "Apply source fixes or import organization using configured LSP server routes.",
+	promptSnippet: "Apply configured LSP source fixes to a file",
 	promptGuidelines: [
-		"Use lsp_fix for Biome-supported web/config files or Python .py/.pyi files.",
-		"Use kind='source.organizeImports.biome' for Biome import organization or kind='source.organizeImports.ruff' for Python import organization when needed.",
-		"Do not request ty for fixes; Python fixes route to Ruff.",
+		"Use lsp_fix for files handled by a configured LSP code-action server.",
+		"Use kind when the server needs a specific source action kind such as source.organizeImports.",
 	],
 	parameters: Type.Object({
 		...SingleFileParameters,
 		kind: Type.Optional(
 			Type.String({
-				description:
-					"Source action kind. Defaults to the routed backend's fix-all action. Common values: source.organizeImports.biome or source.organizeImports.ruff.",
+				description: "Source action kind. Defaults to source.fixAll.",
 			}),
 		),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		const { root, route } = selectFixRoute(params);
+		const requestedRoot = resolveRoot(params.root);
+		const { adapters, timeoutMs } = loadRuntime(requestedRoot);
+		const { root, route } = selectFixRoute(adapters, { ...params, root: requestedRoot });
 		return runFix(
 			route.adapter,
 			{ root, path: params.path, kind: params.kind, write: params.write },
+			timeoutMs,
 			signal,
 			ctx,
 			STATUS_KEY,
@@ -147,13 +128,13 @@ const lspFixTool = defineTool({
 
 export default function lsp(pi: ExtensionAPI) {
 	pi.registerTool(lspDiagnosticsTool);
-	pi.registerTool(lspFormatTool);
 	pi.registerTool(lspFixTool);
 
 	pi.registerCommand("lsp", {
 		description: "Show shared LSP extension configuration",
 		handler: async (_args, ctx) => {
-			ctx.ui.notify(buildStatusMessage(), statusLevel());
+			const { adapters } = loadRuntime(ctx.cwd);
+			ctx.ui.notify(buildStatusMessage(adapters, ctx.cwd), statusLevel(adapters, ctx.cwd));
 		},
 	});
 
@@ -170,22 +151,22 @@ function textFromResult(result: { content?: Array<{ type?: string; text?: string
 	return result.content?.find((item) => item.type === "text")?.text ?? "";
 }
 
-function buildStatusMessage() {
+function buildStatusMessage(adapters: ReturnType<typeof loadRuntime>["adapters"], cwd: string) {
 	return adapters
 		.flatMap((adapter) => {
 			const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
 			return [
-				`${adapter.label} LSP command: ${command.command} ${command.args.join(" ")}`.trim(),
-				`${adapter.label} status: ${commandExists(command.command) ? "ready" : "command missing"}`,
+				`${adapter.name} LSP command: ${command.command} ${command.args.join(" ")}`.trim(),
+				`${adapter.name} status: ${commandExists(command.command, cwd) ? "ready" : "command missing"}`,
 			];
 		})
 		.join("\n");
 }
 
-function statusLevel() {
+function statusLevel(adapters: ReturnType<typeof loadRuntime>["adapters"], cwd: string) {
 	return adapters.every((adapter) => {
 		const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
-		return commandExists(command.command);
+		return commandExists(command.command, cwd);
 	})
 		? "info"
 		: "warning";

--- a/extensions/pi-lsp/src/routes.ts
+++ b/extensions/pi-lsp/src/routes.ts
@@ -1,23 +1,17 @@
 import path from "node:path";
-import { biomeAdapter, ruffAdapter, tyAdapter } from "./adapters.js";
 import { collectSupportedFiles, resolveRoot } from "./files.js";
 import type { LspServerAdapter } from "./types.js";
 
-export type LanguageFamily = "web" | "python";
-export type DiagnosticChecker = "type" | "lint" | "all";
-export type LspAction = "diagnostics" | "format" | "fix";
+export type LspAction = "diagnostics" | "fix";
 
 export interface DiagnosticRoute {
 	adapter: LspServerAdapter;
-	language: LanguageFamily;
-	checker?: DiagnosticChecker;
 	reason: string;
 	files: string[];
 }
 
 export interface SingleFileRoute {
 	adapter: LspServerAdapter;
-	language: LanguageFamily;
 	reason: string;
 }
 
@@ -25,167 +19,80 @@ export interface DiagnosticRouteParams {
 	root?: string;
 	paths?: string[];
 	limit?: number;
-	language?: LanguageFamily;
-	checker?: DiagnosticChecker;
+	server?: string | string[];
 }
 
 export interface SingleFileRouteParams {
 	root?: string;
 	path: string;
-	language?: LanguageFamily;
+	server?: string;
 }
 
-export const SUPPORTED_LANGUAGE_DESCRIPTION =
-	"Supported language/file classes: web/config files supported by Biome, and Python .py/.pyi files.";
+export const SUPPORTED_SERVER_DESCRIPTION =
+	"Supported LSP servers are defined by pi-lsp config and selected by file extension.";
 
-export function selectDiagnosticRoutes(params: DiagnosticRouteParams, defaultLimit: number) {
+export function selectDiagnosticRoutes(
+	adapters: LspServerAdapter[],
+	params: DiagnosticRouteParams,
+	defaultLimit: number,
+) {
 	const root = resolveRoot(params.root);
-	const checker = params.checker ?? "all";
-	const candidates = diagnosticCandidates(params.language, checker);
-	const filesByLanguage = new Map<LanguageFamily, string[]>();
+	const candidates = filterAdapters(adapters, params.server);
+	const filesByExtensions = new Map<string, string[]>();
 	const routes = candidates
-		.map((candidate) => {
-			let files = filesByLanguage.get(candidate.language);
+		.map((adapter) => {
+			const key = adapter.extensions.join("\0");
+			let files = filesByExtensions.get(key);
 			if (!files) {
-				files = collectSupportedFiles(
-					discoveryAdapterFor(candidate.language),
-					root,
-					params.paths,
-					params.limit ?? defaultLimit,
-				);
-				filesByLanguage.set(candidate.language, files);
+				files = collectSupportedFiles(adapter, root, params.paths, params.limit ?? defaultLimit);
+				filesByExtensions.set(key, files);
 			}
-			return { ...candidate, files };
+			return { adapter, reason: `${adapter.name} diagnostics`, files };
 		})
 		.filter((route) => route.files.length > 0);
 
 	if (routes.length === 0) {
 		const scope = params.paths?.length ? ` in requested paths: ${params.paths.join(", ")}` : "";
-		throw new Error(`No supported files found${scope}. ${SUPPORTED_LANGUAGE_DESCRIPTION}`);
+		throw new Error(`No supported files found${scope}. ${SUPPORTED_SERVER_DESCRIPTION}`);
 	}
 
 	return { root, routes };
 }
 
-export function selectFormatRoute(params: SingleFileRouteParams) {
-	return selectSingleFileRoute("format", params);
-}
-
-export function selectFixRoute(params: SingleFileRouteParams) {
-	return selectSingleFileRoute("fix", params);
-}
-
-function diagnosticCandidates(language: LanguageFamily | undefined, checker: DiagnosticChecker) {
-	if (language === "web") {
-		return [
-			{
-				adapter: biomeAdapter,
-				language,
-				reason: "Biome-supported web/config diagnostics",
-			},
-		];
-	}
-
-	if (language === "python") return pythonDiagnosticCandidates(checker);
-
-	return [
-		{
-			adapter: biomeAdapter,
-			language: "web" as const,
-			reason: "Biome-supported web/config diagnostics",
-		},
-		...pythonDiagnosticCandidates(checker),
-	];
-}
-
-function discoveryAdapterFor(language: LanguageFamily) {
-	if (language === "web") return biomeAdapter;
-	return ruffAdapter;
-}
-
-function pythonDiagnosticCandidates(checker: DiagnosticChecker) {
-	const routes: Array<Omit<DiagnosticRoute, "files">> = [];
-	if (checker === "type" || checker === "all") {
-		routes.push({
-			adapter: tyAdapter,
-			language: "python",
-			checker: "type",
-			reason: "Python type diagnostics through ty",
-		});
-	}
-	if (checker === "lint" || checker === "all") {
-		routes.push({
-			adapter: ruffAdapter,
-			language: "python",
-			checker: "lint",
-			reason: "Python lint diagnostics through Ruff",
-		});
-	}
-	return routes;
-}
-
-function selectSingleFileRoute(action: "format" | "fix", params: SingleFileRouteParams) {
+export function selectFixRoute(adapters: LspServerAdapter[], params: SingleFileRouteParams) {
 	const root = resolveRoot(params.root);
 	const file = path.resolve(root, params.path);
-	const webSupported = biomeAdapter.isSupportedFile(file);
-	const pythonSupported = ruffAdapter.isSupportedFile(file);
-
-	if (params.language === "web") {
-		if (!webSupported) throw unsupportedFileError(action, params.path, params.language);
-		return {
-			root,
-			route: {
-				adapter: biomeAdapter,
-				language: "web" as const,
-				reason: `Biome-supported web/config ${action}`,
-			},
-		};
+	const candidates = filterAdapters(adapters, params.server).filter((adapter) => adapter.isSupportedFile(file));
+	if (candidates.length === 0) throw unsupportedFileError("fix", params.path, params.server);
+	if (!params.server && candidates.length > 1) {
+		throw new Error(
+			`Multiple LSP servers support ${params.path}: ${candidates.map((adapter) => adapter.name).join(", ")}. ` +
+				"Specify the server parameter for lsp_fix.",
+		);
 	}
-
-	if (params.language === "python") {
-		if (!pythonSupported) throw unsupportedFileError(action, params.path, params.language);
-		return {
-			root,
-			route: {
-				adapter: ruffAdapter,
-				language: "python" as const,
-				reason: `Python ${action} through Ruff`,
-			},
-		};
-	}
-
-	if (webSupported) {
-		return {
-			root,
-			route: {
-				adapter: biomeAdapter,
-				language: "web" as const,
-				reason: `Biome-supported web/config ${action}`,
-			},
-		};
-	}
-
-	if (pythonSupported) {
-		return {
-			root,
-			route: {
-				adapter: ruffAdapter,
-				language: "python" as const,
-				reason: `Python ${action} through Ruff`,
-			},
-		};
-	}
-
-	throw unsupportedFileError(action, params.path, params.language);
+	const adapter = candidates[0];
+	return {
+		root,
+		route: {
+			adapter,
+			reason: `${adapter.name} fix`,
+		},
+	};
 }
 
-function unsupportedFileError(
-	action: LspAction,
-	filePath: string,
-	language: LanguageFamily | undefined,
-) {
-	const override = language ? ` for language override '${language}'` : "";
-	return new Error(
-		`No ${action} route supports ${filePath}${override}. ${SUPPORTED_LANGUAGE_DESCRIPTION}`,
+function filterAdapters(adapters: LspServerAdapter[], selected: string | string[] | undefined) {
+	if (!selected) return adapters;
+	const names = [...new Set((Array.isArray(selected) ? selected : [selected]).map((name) => name.trim()))].filter(
+		(name) => name.length > 0,
 	);
+	if (names.length === 0) throw new Error("LSP server parameter must not be blank.");
+	const matched = adapters.filter((adapter) => names.includes(adapter.name));
+	const missing = names.filter((name) => !adapters.some((adapter) => adapter.name === name));
+	if (missing.length) throw new Error(`Unknown LSP server(s): ${missing.join(", ")}.`);
+	return matched;
+}
+
+function unsupportedFileError(action: LspAction, filePath: string, server: string | undefined) {
+	const override = server ? ` for server '${server}'` : "";
+	return new Error(`No ${action} route supports ${filePath}${override}. ${SUPPORTED_SERVER_DESCRIPTION}`);
 }

--- a/extensions/pi-lsp/src/runner.ts
+++ b/extensions/pi-lsp/src/runner.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { commandFromEnv, timeoutFromEnv } from "./command.js";
+import { commandFromEnv } from "./command.js";
 import { collectSupportedFiles, resolveRoot, resolveSupportedFile } from "./files.js";
 import { LspClient } from "./lsp-client.js";
 import { applyTextEdits, collectWorkspaceEdits, hasOverlappingTextEdits } from "./text-edits.js";
@@ -13,12 +13,12 @@ import type {
 	StatusContext,
 } from "./types.js";
 
-export const DEFAULT_TIMEOUT_MS = 20_000;
 export const DEFAULT_FILE_LIMIT = 50;
 
 export async function runDiagnostics(
 	adapter: LspServerAdapter,
 	params: { root?: string; paths?: string[]; limit?: number; files?: string[] },
+	timeoutMs: number,
 	signal: AbortSignal | undefined,
 	ctx: StatusContext,
 	statusKey: string,
@@ -29,7 +29,7 @@ export async function runDiagnostics(
 		params.files ??
 		collectSupportedFiles(adapter, root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
 	if (files.length === 0) {
-		return textResult(adapter.emptyDiagnosticsMessage, {
+		return textResult(`${adapter.name} LSP found no supported files to check.`, {
 			root,
 			command,
 			files: [],
@@ -37,16 +37,11 @@ export async function runDiagnostics(
 		});
 	}
 
-	const client = new LspClient(
-		adapter,
-		command,
-		root,
-		timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS),
-	);
+	const client = new LspClient(adapter, command, root, timeoutMs);
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
 	throwIfAborted(signal, adapter);
-	ctx.ui.setStatus(statusKey, `${adapter.statusPrefix} diagnostics`);
+	ctx.ui.setStatus(statusKey, `${adapter.name} diagnostics`);
 
 	try {
 		await client.start();
@@ -79,87 +74,24 @@ export async function runDiagnostics(
 	}
 }
 
-export async function runFormat(
-	adapter: LspServerAdapter,
-	params: { root?: string; path: string; write?: boolean },
-	signal: AbortSignal | undefined,
-	ctx: StatusContext,
-	statusKey: string,
-) {
-	const root = resolveRoot(params.root);
-	const file = resolveSupportedFile(adapter, root, params.path);
-	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
-	const client = new LspClient(
-		adapter,
-		command,
-		root,
-		timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS),
-	);
-	const abort = () => client.close();
-	signal?.addEventListener("abort", abort, { once: true });
-	throwIfAborted(signal, adapter);
-	ctx.ui.setStatus(statusKey, `${adapter.statusPrefix} format`);
-
-	try {
-		await client.start();
-		await client.initialize(root);
-		throwIfAborted(signal, adapter);
-		const uri = pathToFileURL(file).href;
-		const text = readFileSync(file, "utf8");
-		client.didOpen(uri, text, adapter.languageIdFor(file));
-		let newText: string;
-		let edits: LspTextEdit[];
-		try {
-			edits = await client.format(uri);
-			newText = applyTextEdits(text, edits);
-		} finally {
-			client.didClose(uri);
-		}
-		const changed = newText !== text;
-
-		if (params.write && changed) writeFileSync(file, newText);
-
-		return textResult(
-			formatEditSummary(adapter, "format", root, file, changed, params.write, newText),
-			{
-				path: path.relative(root, file) || file,
-				uri,
-				changed,
-				write: params.write ?? false,
-				edits,
-				text: params.write ? undefined : newText,
-			},
-		);
-	} finally {
-		ctx.ui.setStatus(statusKey, undefined);
-		signal?.removeEventListener("abort", abort);
-		await client.shutdown();
-	}
-}
-
 export async function runFix(
 	adapter: LspServerAdapter,
 	params: { root?: string; path: string; kind?: string; write?: boolean },
+	timeoutMs: number,
 	signal: AbortSignal | undefined,
 	ctx: StatusContext,
 	statusKey: string,
 ) {
 	const root = resolveRoot(params.root);
 	const file = resolveSupportedFile(adapter, root, params.path);
-	const actionKind = params.kind?.trim() || adapter.defaultFixKind;
-	if (!actionKind) throw new Error(`${adapter.label} LSP adapter does not support source fixes.`);
+	const actionKind = params.kind?.trim() || "source.fixAll";
 
 	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
-	const client = new LspClient(
-		adapter,
-		command,
-		root,
-		timeoutFromEnv(adapter.timeoutEnvVar, DEFAULT_TIMEOUT_MS),
-	);
+	const client = new LspClient(adapter, command, root, timeoutMs);
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });
 	throwIfAborted(signal, adapter);
-	ctx.ui.setStatus(statusKey, `${adapter.statusPrefix} fix`);
+	ctx.ui.setStatus(statusKey, `${adapter.name} fix`);
 
 	try {
 		await client.start();
@@ -181,7 +113,7 @@ export async function runFix(
 			if (hasOverlappingTextEdits(text, edits)) {
 				const relativePath = path.relative(root, file) || file;
 				throw new Error(
-					`${adapter.label} LSP returned overlapping code-action edits for ${relativePath}; ` +
+					`${adapter.name} LSP returned overlapping code-action edits for ${relativePath}; ` +
 						"use a narrower action kind.",
 				);
 			}
@@ -228,18 +160,23 @@ function formatDiagnostics(adapter: LspServerAdapter, entries: DiagnosticEntry[]
 			const line = diagnostic.range.start.line + 1;
 			const column = diagnostic.range.start.character + 1;
 			const severity = severityName(diagnostic.severity);
-			const source = diagnostic.source ?? adapter.label;
+			const source = diagnostic.source ?? adapter.name;
 			const code = diagnostic.code === undefined ? "" : ` ${diagnostic.code}`;
 			return `${entry.path}:${line}:${column}: ${severity} ${source}${code}: ${diagnostic.message}`;
 		});
 	});
 
-	return [adapter.formatDiagnosticsHeader(summarize(entries)), "", ...lines].join("\n");
+	const summary = summarize(entries);
+	return [
+		`${adapter.name} LSP diagnostics: ${summary.diagnostics} diagnostic(s) across ${summary.files} file(s).`,
+		"",
+		...lines,
+	].join("\n");
 }
 
 function formatEditSummary(
 	adapter: LspServerAdapter,
-	action: "fix" | "format",
+	action: "fix",
 	root: string,
 	file: string,
 	changed: boolean,
@@ -248,7 +185,7 @@ function formatEditSummary(
 ) {
 	const relativePath = path.relative(root, file) || file;
 	const status = changed ? (write ? "updated" : "computed changes for") : "left unchanged";
-	const summary = `${adapter.editSummaryLabel} LSP ${action} ${status} ${relativePath}.`;
+	const summary = `${adapter.name} LSP ${action} ${status} ${relativePath}.`;
 	if (write || !changed) return summary;
 	return `${summary}\n\n${text}`;
 }
@@ -269,7 +206,7 @@ function severityName(severity: number | undefined) {
 }
 
 function throwIfAborted(signal: AbortSignal | undefined, adapter: LspServerAdapter) {
-	if (signal?.aborted) throw new Error(`${adapter.label} LSP request aborted.`);
+	if (signal?.aborted) throw new Error(`${adapter.name} LSP request aborted.`);
 }
 
 export function textResult(text: string, details: unknown) {

--- a/extensions/pi-lsp/src/types.ts
+++ b/extensions/pi-lsp/src/types.ts
@@ -61,32 +61,33 @@ export interface JsonRpcMessage {
 	error?: { code: number; message: string; data?: unknown };
 }
 
+export interface ConfiguredLspServer {
+	command: string[];
+	extensions: string[];
+	env?: Record<string, string>;
+	initialization?: Record<string, unknown>;
+}
+
+export interface LspConfig {
+	timeout?: number;
+	servers: InternalLspServer[];
+}
+
+export interface InternalLspServer extends ConfiguredLspServer {
+	name: string;
+}
+
 export interface LspServerAdapter {
-	label: string;
-	statusPrefix: string;
+	name: string;
 	defaultCommand: ServerCommand;
 	commandEnvVar: string;
-	timeoutEnvVar: string;
 	missingCommandHint: string;
+	extensions: string[];
+	env?: Record<string, string>;
+	initialization?: Record<string, unknown>;
 	skipDirectories: Set<string>;
 	isSupportedFile: (filePath: string) => boolean;
 	languageIdFor: (filePath: string) => string;
-	formattingOptions: { tabSize: number; insertSpaces: boolean };
-	initialize: {
-		codeAction: boolean;
-		diagnosticDynamicRegistration: boolean;
-		formattingDynamicRegistration?: boolean;
-		codeActionDynamicRegistration?: boolean;
-		didChangeConfigurationDynamicRegistration?: boolean;
-		didSaveDynamicRegistration?: boolean;
-	};
-	fallbackToPublishDiagnostics: boolean;
-	resolveUnsupportedCodeActions: boolean;
-	serverRequestWorkspaceFolders: boolean;
-	emptyDiagnosticsMessage: string;
-	formatDiagnosticsHeader: (summary: DiagnosticSummary) => string;
-	editSummaryLabel: string;
-	defaultFixKind?: string;
 }
 
 export interface DiagnosticSummary {


### PR DESCRIPTION
## Summary
- replace language-specific LSP routing with a simple server-name keyed config
- support .pi/lsp.json, user lsp.json, and PI_LSP_CONFIG using JSON { command, extensions }
- support optional global config with { timeout, servers } for shared pi-lsp settings
- support generic per-server LSP options: env and initialization
- remove lsp_format and keep pi-lsp focused on LSP diagnostics and code actions
- remove server-specific adapter tuning fields so LSP behavior is handled uniformly by the client/runner
- load LSP config per requested root and require explicit server selection for ambiguous lsp_fix routes

## Verification
- npm run check
- just pack-lsp
- PI_LSP_CONFIG smoke tests for direct server map and { timeout, servers } JSON config with per-server env/initialization