### PR TITLE
fix(plan-mode): discard proposed plans on exit

### DIFF
--- a/docs/plans/archived/2026-05-20_pi-plan-mode-discard-proposed-plan-plan.md
+++ b/docs/plans/archived/2026-05-20_pi-plan-mode-discard-proposed-plan-plan.md
@@ -1,0 +1,41 @@
+## Goal
+
+Fix `pi-plan-mode` so exiting Plan mode means discarding the currently proposed plan, preventing an unwanted `<proposed_plan>` from being reintroduced into later non-plan conversation turns. Success means explicit implementation still carries the plan forward, but plain exit/off does not.
+
+## Context
+
+Current behavior in `extensions/pi-plan-mode/src/plan-mode.ts` stores detected plans in `state.latestPlan` and emits a visible `customType: "proposed-plan"` message. `exitPlanMode()` disables Plan mode but leaves `latestPlan` in state, and the non-plan `context` filter only removes `plan-mode-context`, so stale proposed-plan artifacts can remain available to the model after the user exits without choosing implementation.
+
+## Non-Goals
+
+- Do not change the `<proposed_plan>` XML contract or Plan-mode prompt shape.
+- Do not remove the explicit `Implement this plan` flow; that path should still pass the selected plan into the implementation turn.
+- Do not add a broader session-pruning feature beyond Plan-mode artifacts needed for this bug.
+
+## Assumptions
+
+- `/plan exit`, `/plan off`, and the menu option `Exit Plan mode` should all mean “discard this proposed plan.”
+- The visible `proposed-plan` message is useful while Plan mode is active, but should not participate in non-plan context after discard.
+
+## Plan
+
+- [x] Add a small state transition helper in `extensions/pi-plan-mode/src/plan-mode.ts` that exits Plan mode and clears `latestPlan`/`awaitingAction` by default; verified by code inspection of `exitPlanMode()` and all `/plan exit`, `/plan off`, and menu exit call paths.
+- [x] Preserve the implementation behavior by capturing `state.latestPlan` before discard and sending only the `plan-mode-implementation` message in `startImplementation()`; verified by code inspection and `npm --workspace @narumitw/pi-plan-mode run typecheck`.
+- [x] Extend the non-plan `context` filter to remove Plan-mode artifacts that should not leak after exit, including `plan-mode-context` and visible `proposed-plan` custom messages; verified by code inspection of `messageContainsInactivePlanModeArtifact()` and successful root `npm run check`.
+- [x] Decide whether assistant messages containing raw `<proposed_plan>...</proposed_plan>` need scrubbing in addition to removing extension custom messages; implemented bounded scrubbing of exact proposed-plan XML blocks in assistant text content and verified by code inspection of `stripProposedPlanBlocksFromMessage()` plus successful root `npm run check`.
+- [x] Update `extensions/pi-plan-mode/README.md` to document that exiting discards the proposed plan while choosing implementation carries it forward; verified by README review.
+- [x] Run `npm --workspace @narumitw/pi-plan-mode run typecheck` to verify the package compiles; command passed.
+- [x] Run `npm run check` from the repository root to verify formatting, linting, and workspace typechecks; command passed.
+
+## Risks
+
+- Over-filtering could remove useful historical planning context from ordinary resumed sessions; mitigated by filtering only Plan-mode custom artifacts and scrubbing only exact `<proposed_plan>` blocks from assistant text.
+- Clearing `latestPlan` too early could break the implementation path; mitigated by capturing the plan before calling `exitPlanMode()` in `startImplementation()`.
+
+## Completion Checklist
+
+- [x] Plain Plan-mode exit discards `state.latestPlan` and `awaitingAction`, verified by code inspection of all exit/off call paths in `extensions/pi-plan-mode/src/plan-mode.ts`.
+- [x] `Implement this plan` still starts a normal implementation turn with the selected plan text, verified by code inspection of `startImplementation()` and successful `npm --workspace @narumitw/pi-plan-mode run typecheck`.
+- [x] Non-plan context no longer includes stale Plan-mode proposed-plan artifacts after discard, verified by predicate/scrubber code review and successful `npm run check`.
+- [x] User-facing docs describe discard-vs-implement behavior, verified in `extensions/pi-plan-mode/README.md`.
+- [x] Repository verification passes with `npm --workspace @narumitw/pi-plan-mode run typecheck` and `npm run check`.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -14,7 +14,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Disables extension and custom tools by default, with a `/plan tools` selector for explicit user-risk opt-in.
 - Blocks mutating built-in tools and bash commands such as `rm`, `git commit`, dependency installs, redirects, and editor launches.
 - Injects Codex-like Plan mode instructions: explore first, ask only non-discoverable questions, do not mutate files, and finish with `<proposed_plan>`.
-- Detects proposed plan blocks and prompts you to implement, revise, or stay in Plan mode.
+- Detects proposed plan blocks and prompts you to implement, revise, stay in Plan mode, or exit and discard the plan.
 - Shows Plan mode state in Pi's statusline as `📝 plan active` or `📝 plan ready`.
 - Persists Plan mode state in the Pi session so resume restores the mode.
 
@@ -72,14 +72,14 @@ A complete Plan mode answer should include exactly one block like this:
 </proposed_plan>
 ```
 
-After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode. Choosing implementation disables Plan mode, restores full tool access, and immediately starts an implementation turn with the proposed plan.
+After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode. Choosing implementation disables Plan mode, restores full tool access, and immediately starts an implementation turn with the proposed plan. Choosing exit/off disables Plan mode and discards the proposed plan so it is not carried into later non-plan turns.
 
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 
 - `📝 plan active`: Plan mode is enabled and still gathering context or drafting a plan.
 - `📝 plan ready`: A `<proposed_plan>` was detected and is waiting for your next `/plan` action.
 
-You can also exit directly:
+You can also exit directly. Direct exit discards the latest proposed plan instead of treating it as an implementation request:
 
 ```text
 /plan exit
@@ -92,7 +92,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - Plan mode is a conversational collaboration mode, not TODO/progress tracking.
 - `/plan <prompt>` follows Codex behavior by switching to Plan mode before submitting the inline prompt.
 - `update_plan`-style checklist use is discouraged while Plan mode is active.
-- The implementation boundary is explicit: Plan mode restores tools before starting implementation, and choosing implementation immediately triggers a normal agent turn with full tool access.
+- The implementation boundary is explicit: Plan mode restores tools before starting implementation, choosing implementation immediately triggers a normal agent turn with full tool access, and plain exit/off discards the proposed plan.
 - Pi extension safety is approximated with built-in tool restriction plus bash filtering; non-built-in tools are user-selected at user risk because Plan mode does not classify extension/custom tool behavior.
 
 ## 🗂️ Package layout

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -3,12 +3,16 @@ import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@mariozechner/pi-
 const STATE_ENTRY_TYPE = "plan-mode-state";
 const STATUS_KEY = "plan-mode";
 const PLAN_WIDGET_KEY = "plan-mode-plan";
+const PLAN_CONTEXT_MESSAGE_TYPE = "plan-mode-context";
+const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
+const PLAN_IMPLEMENTATION_MESSAGE_TYPE = "plan-mode-implementation";
 const PLAN_CONTEXT_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const SAFE_BUILTIN_PLAN_TOOLS = new Set(["read", "bash", "grep", "find", "ls"]);
 const BLOCKED_BUILTIN_TOOLS = new Set(["edit", "write"]);
 const DEFAULT_TOOLS = ["read", "bash", "edit", "write"];
 const TOOL_SELECTOR_PAGE_SIZE = 10;
 const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/i;
+const PROPOSED_PLAN_BLOCK_PATTERN = /<proposed_plan>\s*[\s\S]*?\s*<\/proposed_plan>/gi;
 
 interface PlanModeState {
 	enabled: boolean;
@@ -95,7 +99,7 @@ export default function planMode(pi: ExtensionAPI) {
 			const command = prompt.toLowerCase();
 			if (command === "exit" || command === "off") {
 				exitPlanMode(ctx);
-				ctx.ui.notify("Plan mode disabled. Full tool access restored.", "info");
+				ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
 				return;
 			}
 			if (command === "tools") {
@@ -150,7 +154,9 @@ export default function planMode(pi: ExtensionAPI) {
 	pi.on("context", async (event) => {
 		if (state.enabled) return;
 		return {
-			messages: event.messages.filter((message: unknown) => !messageContainsPlanModeContext(message)),
+			messages: event.messages
+				.filter((message: unknown) => !messageContainsInactivePlanModeArtifact(message))
+				.map(stripProposedPlanBlocksFromMessage),
 		};
 	});
 
@@ -159,7 +165,7 @@ export default function planMode(pi: ExtensionAPI) {
 		applyPlanModeTools();
 		return {
 			message: {
-				customType: "plan-mode-context",
+				customType: PLAN_CONTEXT_MESSAGE_TYPE,
 				content: buildPlanModePrompt(),
 				display: false,
 			},
@@ -182,7 +188,7 @@ export default function planMode(pi: ExtensionAPI) {
 		updateUi(ctx);
 		pi.sendMessage(
 			{
-				customType: "proposed-plan",
+				customType: PROPOSED_PLAN_MESSAGE_TYPE,
 				content: `**Proposed Plan**\n\n${proposedPlan}`,
 				display: true,
 			},
@@ -211,7 +217,7 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {
-		state = { ...state, enabled: false, awaitingAction: false };
+		state = { ...state, enabled: false, latestPlan: undefined, awaitingAction: false };
 		restoreTools();
 		persistState();
 		updateUi(ctx);
@@ -228,7 +234,7 @@ export default function planMode(pi: ExtensionAPI) {
 
 		pi.sendMessage(
 			{
-				customType: "plan-mode-implementation",
+				customType: PLAN_IMPLEMENTATION_MESSAGE_TYPE,
 				content: `Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`,
 				display: true,
 			},
@@ -266,7 +272,7 @@ export default function planMode(pi: ExtensionAPI) {
 		}
 		if (choice === "Exit Plan mode") {
 			exitPlanMode(ctx);
-			ctx.ui.notify("Plan mode disabled. Full tool access restored.", "info");
+			ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
 			return;
 		}
 		updateUi(ctx);
@@ -278,6 +284,7 @@ export default function planMode(pi: ExtensionAPI) {
 			"Revise plan",
 			"Configure Plan-mode tools",
 			"Stay in Plan mode",
+			"Exit Plan mode",
 		]);
 		if (choice === "Implement this plan") {
 			startImplementation(ctx);
@@ -290,6 +297,11 @@ export default function planMode(pi: ExtensionAPI) {
 		if (choice === "Revise plan") {
 			const refinement = await ctx.ui.editor("Revise the plan", "");
 			if (refinement?.trim()) pi.sendUserMessage(refinement.trim());
+			return;
+		}
+		if (choice === "Exit Plan mode") {
+			exitPlanMode(ctx);
+			ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
 		}
 	}
 
@@ -446,10 +458,11 @@ export default function planMode(pi: ExtensionAPI) {
 			.filter((candidate) => candidate.type === "custom" && candidate.customType === STATE_ENTRY_TYPE)
 			.pop();
 		if (!entry?.data) return;
+		const enabled = entry.data.enabled ?? false;
 		state = {
-			enabled: entry.data.enabled ?? false,
-			latestPlan: entry.data.latestPlan,
-			awaitingAction: entry.data.awaitingAction ?? false,
+			enabled,
+			latestPlan: enabled ? entry.data.latestPlan : undefined,
+			awaitingAction: enabled ? (entry.data.awaitingAction ?? false) : false,
 			selectedToolNames: entry.data.selectedToolNames,
 			selectedToolKeys: entry.data.selectedToolKeys,
 		};
@@ -616,10 +629,44 @@ function latestAssistantText(messages: unknown) {
 	return "";
 }
 
-function messageContainsPlanModeContext(message: unknown) {
+function messageContainsInactivePlanModeArtifact(message: unknown) {
 	const candidate = message as { customType?: string; content?: unknown };
-	if (candidate.customType === "plan-mode-context") return true;
-	return contentText(candidate.content).includes(PLAN_CONTEXT_MARKER);
+	return (
+		candidate.customType === PLAN_CONTEXT_MESSAGE_TYPE ||
+		candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE ||
+		contentText(candidate.content).includes(PLAN_CONTEXT_MARKER)
+	);
+}
+
+function stripProposedPlanBlocksFromMessage<T>(message: T): T {
+	const candidate = message as { role?: string; content?: unknown };
+	if (candidate.role !== "assistant") return message;
+
+	const content = stripProposedPlanBlocksFromContent(candidate.content);
+	if (content === candidate.content) return message;
+	return { ...candidate, content } as T;
+}
+
+function stripProposedPlanBlocksFromContent(content: unknown) {
+	if (typeof content === "string") return stripProposedPlanBlocks(content);
+	if (!Array.isArray(content)) return content;
+
+	let changed = false;
+	const nextContent = content.map((block) => {
+		const textBlock = block as TextBlock;
+		if (textBlock.type !== "text" || typeof textBlock.text !== "string") return block;
+
+		const text = stripProposedPlanBlocks(textBlock.text);
+		if (text === textBlock.text) return block;
+
+		changed = true;
+		return { ...textBlock, text };
+	});
+	return changed ? nextContent : content;
+}
+
+function stripProposedPlanBlocks(text: string) {
+	return text.replace(PROPOSED_PLAN_BLOCK_PATTERN, "");
 }
 
 function messageText(message: SessionMessage) {

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -217,8 +217,9 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {
+		const wasEnabled = state.enabled;
 		state = { ...state, enabled: false, latestPlan: undefined, awaitingAction: false };
-		restoreTools();
+		if (wasEnabled) restoreTools();
 		persistState();
 		updateUi(ctx);
 	}
@@ -630,7 +631,7 @@ function latestAssistantText(messages: unknown) {
 }
 
 function messageContainsInactivePlanModeArtifact(message: unknown) {
-	const candidate = message as { customType?: string; content?: unknown };
+	const candidate = unwrapSessionMessage(message);
 	return (
 		candidate.customType === PLAN_CONTEXT_MESSAGE_TYPE ||
 		candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE ||
@@ -639,12 +640,25 @@ function messageContainsInactivePlanModeArtifact(message: unknown) {
 }
 
 function stripProposedPlanBlocksFromMessage<T>(message: T): T {
-	const candidate = message as { role?: string; content?: unknown };
+	const candidate = unwrapSessionMessage(message);
 	if (candidate.role !== "assistant") return message;
 
 	const content = stripProposedPlanBlocksFromContent(candidate.content);
 	if (content === candidate.content) return message;
+
+	if (isSessionMessageEntry(message)) {
+		return { ...message, message: { ...candidate, content } };
+	}
 	return { ...candidate, content } as T;
+}
+
+function unwrapSessionMessage(message: unknown) {
+	const entry = message as { message?: unknown };
+	return (entry.message ?? message) as { role?: string; customType?: string; content?: unknown };
+}
+
+function isSessionMessageEntry<T>(message: T): message is T & { message: SessionMessage } {
+	return typeof message === "object" && message !== null && "message" in message;
 }
 
 function stripProposedPlanBlocksFromContent(content: unknown) {


### PR DESCRIPTION
## Summary
- clear stored proposed plans when Plan mode exits without implementation
- filter stale Plan-mode artifacts and scrub raw proposed-plan blocks from non-plan context
- document exit/off discard behavior and archive the completed implementation plan

## Verification
- npm --workspace @narumitw/pi-plan-mode run typecheck
- npm run check