### PR TITLE
fix(plan-mode): avoid appending discarded plans

### DIFF
--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -186,6 +186,10 @@ export default function planMode(pi: ExtensionAPI) {
 		state = { ...state, latestPlan: proposedPlan, awaitingAction: true };
 		persistState();
 		updateUi(ctx);
+
+		if (ctx.hasUI) await showPlanReadyMenu(ctx);
+		if (!state.enabled || !state.latestPlan) return;
+
 		pi.sendMessage(
 			{
 				customType: PROPOSED_PLAN_MESSAGE_TYPE,
@@ -194,8 +198,6 @@ export default function planMode(pi: ExtensionAPI) {
 			},
 			{ triggerTurn: false },
 		);
-
-		if (ctx.hasUI) await showPlanReadyMenu(ctx);
 	});
 
 	function enterPlanMode(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary
- Delay appending the proposed-plan session message until after the ready menu resolves
- Skip appending when the user exits Plan mode and the proposed plan is discarded

## Tests
- npm --workspace @narumitw/pi-plan-mode run check
- node mock runtime check for Exit Plan mode vs Stay in Plan mode proposed-plan append behavior