### PR TITLE
feat: add R2-backed pi sync extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Run commands from the repository root unless noted otherwise.
 - Full verification: `npm run check` or `just check`
 - Format with Biome: `npm run format` or `just format`
 - Typecheck all workspaces: `npm run typecheck`
-- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, `just pack-lsp`, `just pack-retry`, or `just pack-statusline`
-- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, `just try-lsp`, `just try-retry`, or `just try-statusline`
+- Preview npm package contents: `just pack-caffeinate`, `just pack-chrome-devtools`, `just pack-firecrawl`, `just pack-goal`, `just pack-lsp`, `just pack-retry`, `just pack-statusline`, or `just pack-sync`
+- Try a local extension without installing: `just try-caffeinate`, `just try-chrome-devtools`, `just try-firecrawl`, `just try-goal`, `just try-lsp`, `just try-retry`, `just try-statusline`, or `just try-sync`
 - Inspect available recipes before adding new workflow commands: `just --list`
 
 ## Code style

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -15,6 +15,7 @@
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.
 - `node-domexception` deprecation comes via `@google/genai -> google-auth-library -> gaxios -> node-fetch -> fetch-blob`; use the root npm override to `npm:@profoundlogic/node-domexception`.
 - New filesystem-writing Pi tools need a pre-review edge-case pass: workspace containment, absolute/`..` paths, symlink loops/escapes, duplicate paths, cancellation, process errors, protocol errors, and edit ordering.
+- New extension package source may match the root `.gitignore` `src/` rule; stage intended `extensions/<pkg>/src/*.ts` with `git add -f`.
 - When PR comments expose one class of bug, stop patching comment-by-comment and do a holistic pass over adjacent Modules before pushing again.
 - Symptom: Chrome DevTools `/json/new` may reject unsafe `GET`. Cause: modern Chrome expects `PUT` for target creation. Fix: use `PUT /json/new?${encodeURIComponent(url)}`.
 - Symptom: Telegram bot polling can replay stale queued messages or conflict across Pi processes. Cause: `getUpdates` is a single bot-token queue controlled by offsets. Fix: discard pending updates on startup with an offset and run one active polling Pi per bot token.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm scope](https://img.shields.io/badge/npm-@narumitw-blue)](https://www.npmjs.com/org/narumitw) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Production-ready, independently installable [Pi](https://pi.dev) extension packages for the Pi coding agent. This monorepo provides native Pi tools and commands for configurable LSP diagnostics and source fixes, Chrome DevTools automation, Codex usage status, Firecrawl web scraping, goal-driven task completion, retry handling, terminal statuslines, and keep-awake automation.
+Production-ready, independently installable [Pi](https://pi.dev) extension packages for the Pi coding agent. This monorepo provides native Pi tools and commands for configurable LSP diagnostics and source fixes, Chrome DevTools automation, Codex usage status, Firecrawl web scraping, goal-driven task completion, retry handling, R2/S3 settings sync, terminal statuslines, and keep-awake automation.
 
 ## 📦 Pi extension packages
 
@@ -19,6 +19,7 @@ Install only the Pi extensions you need. Each package is published under the `@n
 | [`@narumitw/pi-lsp`](./extensions/pi-lsp) | 🧠 Configurable language-server diagnostics and source-fix tools routed by file extension. | `pi install npm:@narumitw/pi-lsp` |
 | [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for provider responses that fail with `Unknown error (no error details in response)`. | `pi install npm:@narumitw/pi-retry` |
 | [`@narumitw/pi-statusline`](./extensions/pi-statusline) | ✨ A rich Pi terminal statusline with model, tools, git branch, context usage, token totals, cost, and time. | `pi install npm:@narumitw/pi-statusline` |
+| [`@narumitw/pi-sync`](./extensions/pi-sync) | ☁️ Sync allowlisted Pi settings, skills, prompts, themes, and extensions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
 | [`@narumitw/pi-subagents`](./extensions/pi-subagents) | 🤖 Delegate work to specialized isolated subagents with single, parallel, and chained execution modes. | `pi install npm:@narumitw/pi-subagents` |
 
 ## 🚀 Quick start
@@ -33,6 +34,7 @@ Try an extension once without adding it permanently:
 
 ```bash
 pi -e npm:@narumitw/pi-statusline
+pi -e npm:@narumitw/pi-sync
 ```
 
 Use multiple Pi extensions together:
@@ -109,6 +111,7 @@ pi -e ./extensions/pi-goal
 pi -e ./extensions/pi-lsp
 pi -e ./extensions/pi-retry
 pi -e ./extensions/pi-statusline
+pi -e ./extensions/pi-sync
 pi -e ./extensions/pi-subagents
 ```
 
@@ -124,6 +127,7 @@ npm run pack:goal
 npm run pack:lsp
 npm run pack:retry
 npm run pack:statusline
+npm run pack:sync
 npm run pack:subagents
 ```
 
@@ -152,6 +156,7 @@ extensions/
 ├── pi-lsp/
 ├── pi-retry/
 ├── pi-statusline/
+├── pi-sync/
 └── pi-subagents/
 ```
 

--- a/docs/plans/archived/2026-05-21_pi-sync-pr-review-fixes-plan.md
+++ b/docs/plans/archived/2026-05-21_pi-sync-pr-review-fixes-plan.md
@@ -1,0 +1,35 @@
+## Goal
+
+Fix the pi-sync PR review blockers so startup auto-sync is safe by default, remote latest updates do not silently overwrite concurrent pushes, and snapshot apply cannot leave Pi settings partially written after invalid snapshot content.
+
+## Context
+
+PR #59 adds `@narumitw/pi-sync` with R2/S3 snapshot sync. Review found three blockers: first-run auto-sync can silently pull over local settings, latest pointer updates can race without a real compare-and-swap, and `applySnapshot()` writes files before prevalidating the full snapshot.
+
+## Plan
+
+- [x] Change startup auto-sync first-run behavior in `extensions/pi-sync/src/sync.ts` so a machine with no `lastAppliedSnapshot` never silently pulls over existing local files; verified by `syncBoth()` rejecting auto first-run local+remote content with a warning requiring manual `/pisync pull` or `/pisync push`.
+- [x] Restore safe remote latest concurrency in `S3Client` and `uploadSnapshot()` using R2-compatible conditional update semantics or an explicit documented fallback that cannot claim fail-safe CAS; verified by R2 `/pisync push --yes` succeeding without `412 PreconditionFailed` and README documenting the best-effort re-read fallback rather than atomic CAS.
+- [x] Add full snapshot preflight before `applySnapshot()` writes files: duplicate path detection, safe path validation, base64/checksum validation, and deletion list calculation; verified by `preflightSnapshotApply()` building all writes/deletes before `applySnapshot()` writes or removes files.
+- [x] Update `extensions/pi-sync/README.md` to describe the safer auto-sync first-run behavior and the actual concurrency guarantees; verified by README text describing first-run skip and best-effort remote re-read guard.
+- [x] Run `npm run check` and `npm --workspace @narumitw/pi-sync pack --dry-run`; verified both commands pass.
+- [x] Commit and push the review fixes to `feat/pi-sync-r2`; verified after commit/push step.
+
+## Risks
+
+- R2 conditional write behavior may differ between missing and existing objects; if missing-object CAS remains unsupported, remote-empty first push may need to accept a narrow race or use a separate lock object.
+- Auto-sync UX can become too conservative if first-run detection treats legitimate new-machine pulls as conflicts; README should explain the manual first pull requirement when local settings already exist.
+
+## Rollback / Recovery
+
+- If the concurrency fix breaks R2 writes, revert the latest commit and keep manual `/pisync push` working with the previous re-read guard while documenting the limitation.
+- If apply preflight rejects valid snapshots, users can still recover local state from `~/.pi/agent/.pisync/backups/` created before pull/rollback.
+
+## Completion Checklist
+
+- [x] First-run auto-sync cannot silently overwrite existing local Pi settings, verified by code path review in `syncBoth()`/auto-sync logic.
+- [x] Remote latest updates reject already-visible concurrent changes without the previous R2 `412` failure for normal pushes, verified by an R2 push test and explicit documented best-effort fallback evidence.
+- [x] Snapshot apply validates the whole snapshot before changing files, verified by `applySnapshot()` preflight code structure.
+- [x] Documentation matches behavior, verified by `extensions/pi-sync/README.md` review.
+- [x] Quality gates pass, verified by `npm run check` and `npm --workspace @narumitw/pi-sync pack --dry-run`.
+- [x] PR #59 contains the review-fix commit, verified by git push output.

--- a/docs/plans/archived/2026-05-21_pi-sync-r2-plan.md
+++ b/docs/plans/archived/2026-05-21_pi-sync-r2-plan.md
@@ -1,0 +1,42 @@
+## Goal
+
+Implement a new `@narumitw/pi-sync` Pi extension that syncs selected Pi configuration files through Cloudflare R2 / S3-compatible storage using conservative snapshot bundles, local locking, secret scanning, backups, and explicit user commands.
+
+## Architecture
+
+The extension will expose `/pisync` subcommands. Local state and lock files live under `~/.pi/agent/.pisync/`. Remote storage uses immutable gzip-compressed JSON snapshot bundles under a profile prefix plus a `latest.json` pointer. Apply operations create local backups before writing files.
+
+## Non-Goals
+
+- Do not implement Git sync in this phase.
+- Do not auto-apply remote changes on startup.
+- Do not sync sessions, auth tokens, npm caches, or `node_modules`.
+
+## Plan
+
+- [x] Add a new `extensions/pi-sync` workspace package with package metadata, TypeScript config, license, README, and Pi extension entry; verified by files under `extensions/pi-sync/` and `package.json` `pi.extensions`.
+- [x] Implement R2/S3 configuration loading from environment variables and `~/.pi/agent/pi-sync.local.json`; verified by `src/sync.ts` `/pisync config` implementation redacting credentials.
+- [x] Implement allowlisted file collection from `~/.pi/agent`, denylisted path filtering, SHA-256 hashing, and secret scanning; verified by `npm run check`.
+- [x] Implement gzip JSON snapshot bundle creation and extraction plus remote `latest.json` pointer operations using AWS Signature V4 over `fetch`; verified by `npm run check`.
+- [x] Implement local exclusive lock, local state, backup, diff, push, pull, sync, history, rollback, and doctor commands; verified by command handler code in `extensions/pi-sync/src/sync.ts` and `npm run check`.
+- [x] Wire the new package into root README, package scripts, and just recipes; verified by `README.md`, `package.json`, `justfile`, and `package-lock.json` changes.
+- [x] Run formatting, typechecking, repository checks, and package dry-run; verified by `npm run check` and `npm --workspace @narumitw/pi-sync pack --dry-run`.
+
+## Risks
+
+- S3 conditional writes vary across compatible providers; the first version should still re-read remote state before writing and fail safely on unexpected responses.
+- JSON gzip bundles are less manually inspectable than a file tree; README must document export/recovery behavior clearly.
+- Secret scanning can only catch common patterns; allowlist and denylist remain the primary protection.
+
+## Rollback / Recovery
+
+- Pull and rollback must create timestamped backups under `~/.pi/agent/.pisync/backups/` before applying remote files.
+- Remote snapshots are immutable; rollback updates `latest.json` to an older snapshot rather than deleting data.
+- If a command fails while the lock is held, stale lock recovery is available through `/pisync unlock --stale`.
+
+## Completion Checklist
+
+- [x] `@narumitw/pi-sync` is implemented and exposed by package metadata, verified by `npm --workspace @narumitw/pi-sync run typecheck` passing during `npm run check`.
+- [x] Repository metadata includes pi-sync, verified by root README, root `package.json`, `package-lock.json`, `AGENTS.md`, and `justfile` entries.
+- [x] Repository quality gates pass, verified by `npm run check`.
+- [x] Package contents are correct, verified by `npm --workspace @narumitw/pi-sync pack --dry-run` showing `LICENSE`, `README.md`, `package.json`, and `src/sync.ts`.

--- a/extensions/pi-sync/LICENSE
+++ b/extensions/pi-sync/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -1,0 +1,157 @@
+# ☁️ pi-sync — R2/S3 Pi Settings Sync
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-sync` is a native [Pi coding agent](https://pi.dev) extension that syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage.
+
+It uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups so multiple Pi processes and multiple machines fail safely instead of silently overwriting settings.
+
+## ✨ Features
+
+- Adds a `/pisync` command with `status`, `diff`, `push`, `pull`, `sync`, `history`, `rollback`, `doctor`, and `unlock` subcommands.
+- Syncs allowlisted Pi configuration from `~/.pi/agent`:
+  - `settings.json`
+  - `keybindings.json`
+  - `models.json`
+  - `AGENTS.md`
+  - `skills/`, `prompts/`, `themes/`, and `extensions/`
+- Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
+- Updates remote state through `latest.json`, guarded by S3 conditional writes when possible.
+- Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
+- Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations.
+- Refuses to push common secret patterns and denylisted paths such as `.env`, token/secret files, `.pisync`, `.git`, and `node_modules`.
+
+## 📦 Install
+
+```bash
+pi install npm:@narumitw/pi-sync
+```
+
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-sync
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-sync
+```
+
+## ⚙️ Configuration
+
+Run:
+
+```text
+/pisync init
+```
+
+Then edit:
+
+```text
+~/.pi/agent/pi-sync.local.json
+```
+
+Example:
+
+```json
+{
+  "endpoint": "https://<account-id>.r2.cloudflarestorage.com",
+  "bucket": "pi-sync",
+  "region": "auto",
+  "accessKeyId": "<access-key-id>",
+  "secretAccessKey": "<secret-access-key>",
+  "profile": "default",
+  "prefix": "pi-sync"
+}
+```
+
+Environment variables override the local config file:
+
+```bash
+export PI_SYNC_ENDPOINT="https://<account-id>.r2.cloudflarestorage.com"
+export PI_SYNC_BUCKET="pi-sync"
+export PI_SYNC_REGION="auto"
+export PI_SYNC_ACCESS_KEY_ID="..."
+export PI_SYNC_SECRET_ACCESS_KEY="..."
+export PI_SYNC_PROFILE="default"
+export PI_SYNC_PREFIX="pi-sync"
+```
+
+`PI_SYNC_ACCESS_KEY_ID` and `PI_SYNC_SECRET_ACCESS_KEY` are local-only credentials. Do not put them in files that pi-sync syncs.
+
+## 🚀 Usage
+
+```text
+/pisync config
+/pisync doctor
+/pisync status
+/pisync diff
+/pisync push
+/pisync pull
+/pisync sync
+/pisync history
+/pisync rollback <snapshot-id>
+/pisync unlock --stale
+```
+
+Useful flags:
+
+- `--yes` / `-y`: skip confirmation prompts.
+- `--force`: allow push or pull when both local and remote state changed.
+- `--stale`: remove a stale local lock with `/pisync unlock --stale`.
+
+## 🧠 Sync model
+
+Remote layout:
+
+```txt
+pi-sync/
+└── profiles/
+    └── default/
+        ├── latest.json
+        ├── history.json
+        └── snapshots/
+            └── 2026-05-21T12-00-00-000Z-abcd1234.json.gz
+```
+
+Each snapshot contains the selected file tree and SHA-256 hashes. `latest.json` points to the active snapshot. Rollback applies an older snapshot locally and moves `latest.json` back to that snapshot.
+
+## 🛡️ Safety notes
+
+- pi-sync does not auto-apply remote changes on startup.
+- pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `node_modules`, or `.pisync` state.
+- If another Pi process is already syncing on the same machine, destructive commands stop at the local lock.
+- If another machine updates remote state first, push is rejected unless you explicitly use `--force`.
+- Pull and rollback create backups before writing local files.
+
+## 🗂️ Package layout
+
+```txt
+extensions/pi-sync/
+├── src/
+│   └── sync.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its Pi extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/sync.ts"]
+  }
+}
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, settings sync, Cloudflare R2, S3-compatible storage, snapshot sync, dotfiles sync.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-sync` is a native [Pi coding agent](https://pi.dev) extension that syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage.
 
-It syncs automatically by default when Pi starts, then uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups so multiple Pi processes and multiple machines fail safely instead of silently overwriting settings.
+It syncs automatically by default when Pi starts, then uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups. Cross-machine pushes use a best-effort remote re-read guard because R2 rejected conditional `latest.json` writes during testing.
 
 ## ✨ Features
 
@@ -16,7 +16,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
   - `AGENTS.md`
   - `skills/`, `prompts/`, `themes/`, and `extensions/`
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
-- Updates remote state through `latest.json`, guarded by S3 conditional writes when possible.
+- Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
 - Runs `/pisync sync` automatically on Pi startup when R2/S3 config is present.
 - Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations.
@@ -110,7 +110,8 @@ Useful flags:
 `autoSync` defaults to `true`. When Pi starts, pi-sync runs the same conservative decision logic as `/pisync sync`:
 
 - only local changed or remote is empty → push
-- only remote changed → pull with a backup
+- first sync with both existing local settings and an existing remote snapshot → skip and show a warning so you manually choose `/pisync pull` or `/pisync push`
+- only remote changed after an established sync → pull with a backup
 - both local and remote changed after a previous sync → skip and show a warning
 - no config present → do nothing
 
@@ -144,12 +145,14 @@ pi-sync/
 
 Each snapshot contains the selected file tree and SHA-256 hashes. `latest.json` points to the active snapshot. Rollback applies an older snapshot locally and moves `latest.json` back to that snapshot.
 
+Before updating `latest.json`, pi-sync re-reads the current pointer and rejects the push if it already differs from the version seen at the start of the command. This prevents overwriting changes that are visible before the final write. It is not a true atomic cross-machine compare-and-swap on R2, so two machines that push at the same instant can still race; run `/pisync status` before important manual pushes if you use multiple machines heavily.
+
 ## 🛡️ Safety notes
 
-- pi-sync auto-syncs on startup by default, but skips instead of overwriting when both local and remote changed after a previous sync.
+- pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
 - pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `node_modules`, or `.pisync` state.
 - If another Pi process is already syncing on the same machine, destructive commands stop at the local lock.
-- If another machine updates remote state first, push is rejected unless you explicitly use `--force`.
+- If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
 - Pull and rollback create backups before writing local files.
 
 ## 🗂️ Package layout

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-sync` is a native [Pi coding agent](https://pi.dev) extension that syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage.
 
-It uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups so multiple Pi processes and multiple machines fail safely instead of silently overwriting settings.
+It syncs automatically by default when Pi starts, then uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups so multiple Pi processes and multiple machines fail safely instead of silently overwriting settings.
 
 ## ✨ Features
 
@@ -18,6 +18,7 @@ It uses immutable snapshot bundles, a `latest.json` pointer, local locking, secr
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
 - Updates remote state through `latest.json`, guarded by S3 conditional writes when possible.
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
+- Runs `/pisync sync` automatically on Pi startup when R2/S3 config is present.
 - Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations.
 - Refuses to push common secret patterns and denylisted paths such as `.env`, token/secret files, `.pisync`, `.git`, and `node_modules`.
 
@@ -63,7 +64,8 @@ Example:
   "accessKeyId": "<access-key-id>",
   "secretAccessKey": "<secret-access-key>",
   "profile": "default",
-  "prefix": "pi-sync"
+  "prefix": "pi-sync",
+  "autoSync": true
 }
 ```
 
@@ -77,6 +79,7 @@ export PI_SYNC_ACCESS_KEY_ID="..."
 export PI_SYNC_SECRET_ACCESS_KEY="..."
 export PI_SYNC_PROFILE="default"
 export PI_SYNC_PREFIX="pi-sync"
+export PI_SYNC_AUTO_SYNC="true"
 ```
 
 `PI_SYNC_ACCESS_KEY_ID` and `PI_SYNC_SECRET_ACCESS_KEY` are local-only credentials. Do not put them in files that pi-sync syncs.
@@ -102,6 +105,29 @@ Useful flags:
 - `--force`: allow push or pull when both local and remote state changed.
 - `--stale`: remove a stale local lock with `/pisync unlock --stale`.
 
+## 🔄 Automatic sync
+
+`autoSync` defaults to `true`. When Pi starts, pi-sync runs the same conservative decision logic as `/pisync sync`:
+
+- only local changed or remote is empty → push
+- only remote changed → pull with a backup
+- both local and remote changed after a previous sync → skip and show a warning
+- no config present → do nothing
+
+Disable startup sync with either:
+
+```json
+{
+  "autoSync": false
+}
+```
+
+or:
+
+```bash
+export PI_SYNC_AUTO_SYNC=false
+```
+
 ## 🧠 Sync model
 
 Remote layout:
@@ -120,7 +146,7 @@ Each snapshot contains the selected file tree and SHA-256 hashes. `latest.json` 
 
 ## 🛡️ Safety notes
 
-- pi-sync does not auto-apply remote changes on startup.
+- pi-sync auto-syncs on startup by default, but skips instead of overwriting when both local and remote changed after a previous sync.
 - pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `node_modules`, or `.pisync` state.
 - If another Pi process is already syncing on the same machine, destructive commands stop at the local lock.
 - If another machine updates remote state first, push is rejected unless you explicitly use `--force`.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -19,8 +19,9 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
 - Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
 - Runs `/pisync sync` automatically on Pi startup when R2/S3 config is present.
-- Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations.
+- Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations and only treats locks as stale after checking process liveness.
 - Refuses to push common secret patterns and denylisted paths such as `.env`, `.env.local`, token/secret files, `.pisync`, `.git`, and `node_modules`.
+- Preflights snapshot apply operations before mutating local files, refuses symlink path escapes, and rejects writes over symlinks or directories.
 
 ## 📦 Install
 
@@ -63,6 +64,7 @@ Example:
   "region": "auto",
   "accessKeyId": "<access-key-id>",
   "secretAccessKey": "<secret-access-key>",
+  "sessionToken": "<optional-session-token>",
   "profile": "default",
   "prefix": "pi-sync",
   "autoSync": true
@@ -77,12 +79,13 @@ export PI_SYNC_BUCKET="pi-sync"
 export PI_SYNC_REGION="auto"
 export PI_SYNC_ACCESS_KEY_ID="..."
 export PI_SYNC_SECRET_ACCESS_KEY="..."
+export PI_SYNC_SESSION_TOKEN="..." # optional, for temporary STS/SSO credentials
 export PI_SYNC_PROFILE="default"
 export PI_SYNC_PREFIX="pi-sync"
 export PI_SYNC_AUTO_SYNC="true"
 ```
 
-`PI_SYNC_ACCESS_KEY_ID` and `PI_SYNC_SECRET_ACCESS_KEY` are local-only credentials. Do not put them in files that pi-sync syncs.
+`PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, or assumed roles. pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set.
 
 ## 🚀 Usage
 
@@ -110,7 +113,8 @@ Useful flags:
 `autoSync` defaults to `true`. When Pi starts, pi-sync runs the same conservative decision logic as `/pisync sync`:
 
 - only local changed or remote is empty → push
-- first sync with both existing local settings and an existing remote snapshot → skip and show a warning so you manually choose `/pisync pull` or `/pisync push`
+- first sync with existing local settings and an identical remote snapshot → initialize local sync state without rewriting files
+- first sync with existing local settings and a different remote snapshot → skip and show a warning so you manually choose `/pisync pull` or `/pisync push`
 - only remote changed after an established sync → pull with a backup
 - both local and remote changed after a previous sync → skip and show a warning
 - no config present → do nothing
@@ -151,9 +155,10 @@ Before updating `latest.json`, pi-sync re-reads the current pointer and rejects 
 
 - pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
 - pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
-- If another Pi process is already syncing on the same machine, destructive commands stop at the local lock.
+- If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/pisync unlock --stale` is intended for locks whose process is gone or invalid.
 - If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
-- Pull and rollback create backups before writing local files.
+- Pull and rollback create backups before writing local files, then preflight deletes and writes before mutating the local settings tree.
+- Pull and rollback refuse to follow symlinked parent paths during snapshot apply and refuse to overwrite a symlink or directory with file content.
 
 ## 🗂️ Package layout
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -20,7 +20,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
 - Runs `/pisync sync` automatically on Pi startup when R2/S3 config is present.
 - Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations.
-- Refuses to push common secret patterns and denylisted paths such as `.env`, token/secret files, `.pisync`, `.git`, and `node_modules`.
+- Refuses to push common secret patterns and denylisted paths such as `.env`, `.env.local`, token/secret files, `.pisync`, `.git`, and `node_modules`.
 
 ## 📦 Install
 
@@ -150,7 +150,7 @@ Before updating `latest.json`, pi-sync re-reads the current pointer and rejects 
 ## 🛡️ Safety notes
 
 - pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
-- pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `node_modules`, or `.pisync` state.
+- pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
 - If another Pi process is already syncing on the same machine, destructive commands stop at the local lock.
 - If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
 - Pull and rollback create backups before writing local files.

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@narumitw/pi-sync",
+	"version": "0.1.29",
+	"description": "Pi extension that syncs Pi configuration through Cloudflare R2 or S3-compatible storage.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"sync",
+		"r2",
+		"s3"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/sync.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"typescript": "6.0.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "extensions/pi-sync"
+	}
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1,0 +1,998 @@
+import { createHash, createHmac, randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { gunzip, gzip } from "node:zlib";
+import { promisify } from "node:util";
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+
+const STATUS_KEY = "pisync";
+const VERSION = 1;
+const DEFAULT_PROFILE = "default";
+const DEFAULT_PREFIX = "pi-sync";
+const DEFAULT_REGION = "auto";
+const LOCK_STALE_MS = 30 * 60 * 1000;
+
+const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md"]);
+const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
+const SECRET_PATTERNS = [
+	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,
+	/(ANTHROPIC|OPENAI|GEMINI|GOOGLE|FIRECRAWL|GITHUB|CLOUDFLARE|R2|S3)_[A-Z0-9_]*(KEY|TOKEN|SECRET)\s*[=:]\s*['\"]?[^\s'\"]{12,}/i,
+	/sk-ant-[A-Za-z0-9_-]{20,}/,
+	/sk-[A-Za-z0-9]{20,}/,
+	/gh[pousr]_[A-Za-z0-9_]{20,}/,
+];
+
+interface SyncConfig {
+	endpoint: string;
+	bucket: string;
+	region: string;
+	accessKeyId: string;
+	secretAccessKey: string;
+	profile: string;
+	prefix: string;
+}
+
+interface PartialConfig {
+	endpoint?: string;
+	bucket?: string;
+	region?: string;
+	accessKeyId?: string;
+	secretAccessKey?: string;
+	profile?: string;
+	prefix?: string;
+}
+
+interface SnapshotFile {
+	path: string;
+	contentBase64: string;
+	sha256: string;
+}
+
+interface Snapshot {
+	version: number;
+	id: string;
+	createdAt: string;
+	machine: string;
+	profile: string;
+	files: SnapshotFile[];
+}
+
+interface LatestPointer {
+	version: number;
+	profile: string;
+	snapshot: string;
+	sha256: string;
+	createdAt: string;
+	machine: string;
+}
+
+interface RemoteObject<T> {
+	value?: T;
+	etag?: string;
+	missing: boolean;
+}
+
+interface SyncState {
+	version: number;
+	profile: string;
+	lastAppliedSnapshot?: string;
+	lastRemoteEtag?: string;
+	lastFileHashes: Record<string, string>;
+}
+
+interface LockFile {
+	pid: number;
+	command: string;
+	startedAt: string;
+}
+
+interface CommandOptions {
+	yes: boolean;
+	force: boolean;
+	stale: boolean;
+	args: string[];
+}
+
+export default function sync(pi: ExtensionAPI) {
+	pi.registerCommand("pisync", {
+		description: "Sync Pi settings through Cloudflare R2 or S3-compatible storage",
+		handler: async (args, ctx) => {
+			await handleCommand(args, ctx);
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}
+
+async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
+	const [subcommand = "status", ...rest] = splitArgs(rawArgs);
+	const options = parseOptions(rest);
+
+	try {
+		await ensureStateDir();
+
+		switch (subcommand) {
+			case "help":
+				ctx.ui.notify(usage(), "info");
+				return;
+			case "init":
+				await initConfig(ctx);
+				return;
+			case "config":
+				await showConfig(ctx);
+				return;
+			case "status":
+				await status(ctx);
+				return;
+			case "diff":
+				await diff(ctx);
+				return;
+			case "doctor":
+				await doctor(ctx);
+				return;
+			case "push":
+				await withLock("push", () => push(ctx, options));
+				return;
+			case "pull":
+				await withLock("pull", () => pull(ctx, options));
+				return;
+			case "sync":
+				await withLock("sync", () => syncBoth(ctx, options));
+				return;
+			case "history":
+				await history(ctx);
+				return;
+			case "rollback":
+				await withLock("rollback", () => rollback(ctx, options));
+				return;
+			case "unlock":
+				await unlock(ctx, options);
+				return;
+			default:
+				ctx.ui.notify(`Unknown /pisync command: ${subcommand}\n\n${usage()}`, "warning");
+		}
+	} catch (error) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.notify(errorMessage(error), "error");
+	}
+}
+
+async function initConfig(ctx: ExtensionCommandContext) {
+	const configPath = localConfigPath();
+	try {
+		await fs.access(configPath, fsConstants.F_OK);
+		ctx.ui.notify(`Config already exists: ${configPath}`, "info");
+		return;
+	} catch {
+		// Create below.
+	}
+
+	const sample = {
+		endpoint: "https://<account-id>.r2.cloudflarestorage.com",
+		bucket: "pi-sync",
+		region: DEFAULT_REGION,
+		accessKeyId: "<access-key-id>",
+		secretAccessKey: "<secret-access-key>",
+		profile: DEFAULT_PROFILE,
+		prefix: DEFAULT_PREFIX,
+	};
+	await writeJson(configPath, sample);
+	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /pisync doctor.`, "info");
+}
+
+async function showConfig(ctx: ExtensionCommandContext) {
+	const partial = await loadPartialConfig();
+	ctx.ui.notify(
+		[
+			"pi-sync config:",
+			`endpoint: ${partial.endpoint ?? "missing"}`,
+			`bucket: ${partial.bucket ?? "missing"}`,
+			`region: ${partial.region ?? DEFAULT_REGION}`,
+			`accessKeyId: ${partial.accessKeyId ? redact(partial.accessKeyId) : "missing"}`,
+			`secretAccessKey: ${partial.secretAccessKey ? "configured" : "missing"}`,
+			`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
+			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
+			`local config: ${localConfigPath()}`,
+		].join("\n"),
+		"info",
+	);
+}
+
+async function status(ctx: ExtensionCommandContext) {
+	ctx.ui.setStatus(STATUS_KEY, "sync status");
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const local = await createSnapshot(config.profile);
+	const state = await readState(config.profile);
+	const latest = await client.getJson<LatestPointer>(latestKey(config));
+	const localChanged = hasLocalChanges(local, state);
+
+	let remoteText = "remote: empty";
+	let remoteChanged = false;
+	if (!latest.missing && latest.value) {
+		remoteChanged = latest.value.snapshot !== state.lastAppliedSnapshot;
+		remoteText = `remote: ${latest.value.snapshot} from ${latest.value.machine} at ${latest.value.createdAt}`;
+	}
+
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+	ctx.ui.notify(
+		[
+			`profile: ${config.profile}`,
+			remoteText,
+			`local files: ${local.files.length}`,
+			`local changed since last sync: ${localChanged ? "yes" : "no"}`,
+			`remote changed since last sync: ${remoteChanged ? "yes" : "no"}`,
+		].join("\n"),
+		localChanged || remoteChanged ? "warning" : "info",
+	);
+}
+
+async function diff(ctx: ExtensionCommandContext) {
+	ctx.ui.setStatus(STATUS_KEY, "sync diff");
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const local = await createSnapshot(config.profile);
+	const remote = await readRemoteSnapshot(client, config);
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+
+	if (!remote) {
+		ctx.ui.notify(formatSnapshotOnlyDiff("Remote is empty. Local push would upload", local), "info");
+		return;
+	}
+
+	ctx.ui.notify(formatDiff(local, remote), "info");
+}
+
+async function doctor(ctx: ExtensionCommandContext) {
+	const messages: string[] = [];
+	let level: "info" | "warning" = "info";
+
+	try {
+		const config = await loadConfig();
+		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
+	} catch (error) {
+		level = "warning";
+		messages.push(`config: ${errorMessage(error)}`);
+	}
+
+	const local = await createSnapshot(DEFAULT_PROFILE);
+	const secrets = scanSnapshot(local);
+	if (secrets.length > 0) {
+		level = "warning";
+		messages.push("secret scan: possible secrets found:");
+		messages.push(...secrets.map((secret) => `- ${secret}`));
+	} else {
+		messages.push(`secret scan: ok (${local.files.length} files checked)`);
+	}
+
+	const lock = await readLock();
+	messages.push(lock ? `lock: held by pid ${lock.pid} since ${lock.startedAt}` : "lock: free");
+	ctx.ui.notify(messages.join("\n"), level);
+}
+
+async function push(ctx: ExtensionCommandContext, options: CommandOptions) {
+	ctx.ui.setStatus(STATUS_KEY, "sync push");
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const state = await readState(config.profile);
+	const local = await createSnapshot(config.profile);
+	const secrets = scanSnapshot(local);
+	if (secrets.length > 0) {
+		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
+	}
+
+	const latest = await client.getJson<LatestPointer>(latestKey(config));
+	if (remoteChangedSinceState(latest, state) && !options.force) {
+		throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
+	}
+
+	if (!options.yes && !(await ctx.ui.confirm("Push pi settings?", formatPushSummary(local, latest)))) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.notify("Push cancelled.", "info");
+		return;
+	}
+
+	const pointer = await uploadSnapshot(client, config, local, latest, options.force);
+	await updateHistory(client, config, pointer);
+	await writeState(config.profile, {
+		version: VERSION,
+		profile: config.profile,
+		lastAppliedSnapshot: pointer.snapshot,
+		lastRemoteEtag: undefined,
+		lastFileHashes: fileHashMap(local),
+	});
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+	ctx.ui.notify(`Pushed ${local.files.length} files as ${pointer.snapshot}.`, "info");
+}
+
+async function pull(ctx: ExtensionCommandContext, options: CommandOptions) {
+	ctx.ui.setStatus(STATUS_KEY, "sync pull");
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const state = await readState(config.profile);
+	const local = await createSnapshot(config.profile);
+	const remote = await readRemoteSnapshot(client, config);
+	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
+
+	const localChanged = hasLocalChanges(local, state);
+	const remoteChanged = remote.id !== state.lastAppliedSnapshot;
+	if (localChanged && remoteChanged && !options.force) {
+		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
+	}
+
+	if (!options.yes && !(await ctx.ui.confirm("Pull pi settings?", formatDiff(local, remote)))) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.notify("Pull cancelled.", "info");
+		return;
+	}
+
+	const backup = await backupLocal(config.profile);
+	await applySnapshot(remote);
+	await writeState(config.profile, {
+		version: VERSION,
+		profile: config.profile,
+		lastAppliedSnapshot: remote.id,
+		lastRemoteEtag: undefined,
+		lastFileHashes: fileHashMap(remote),
+	});
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+	ctx.ui.notify(`Pulled ${remote.files.length} files from ${remote.id}. Backup: ${backup}`, "info");
+	await maybeReload(ctx);
+}
+
+async function syncBoth(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const state = await readState(config.profile);
+	const local = await createSnapshot(config.profile);
+	const remote = await readRemoteSnapshot(client, config);
+	const localChanged = hasLocalChanges(local, state);
+	const remoteChanged = remote ? remote.id !== state.lastAppliedSnapshot : false;
+
+	if (localChanged && remoteChanged) {
+		throw new Error("Both local and remote changed. Run /pisync diff and resolve with push --force or pull --force.");
+	}
+	if (remoteChanged) {
+		await pull(ctx, options);
+		return;
+	}
+	if (localChanged || !remote) {
+		await push(ctx, options);
+		return;
+	}
+	ctx.ui.notify("pi-sync is already up to date.", "info");
+}
+
+async function history(ctx: ExtensionCommandContext) {
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const remote = await client.getJson<{ snapshots?: LatestPointer[] }>(historyKey(config));
+	if (remote.missing || !remote.value?.snapshots?.length) {
+		ctx.ui.notify("No remote pi-sync history found.", "info");
+		return;
+	}
+
+	ctx.ui.notify(
+		remote.value.snapshots
+			.slice(-20)
+			.reverse()
+			.map((item) => `${item.snapshot} ${item.createdAt} ${item.machine}`)
+			.join("\n"),
+		"info",
+	);
+}
+
+async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const target = options.args[0];
+	if (!target) throw new Error("Usage: /pisync rollback <snapshot-id> [--yes]");
+
+	const config = await loadConfig();
+	const client = new S3Client(config);
+	const snapshot = await client.getBuffer(snapshotKey(config, target));
+	if (!snapshot.value) throw new Error(`Snapshot not found: ${target}`);
+	const remote = await decodeSnapshot(snapshot.value);
+
+	if (!options.yes && !(await ctx.ui.confirm("Rollback pi settings?", formatSnapshotOnlyDiff("Rollback would apply", remote)))) {
+		ctx.ui.notify("Rollback cancelled.", "info");
+		return;
+	}
+
+	const backup = await backupLocal(config.profile);
+	await applySnapshot(remote);
+	const pointer = pointerFor(config, remote, sha256(snapshot.value));
+	await client.putJson(latestKey(config), pointer);
+	await updateHistory(client, config, pointer);
+	await writeState(config.profile, {
+		version: VERSION,
+		profile: config.profile,
+		lastAppliedSnapshot: remote.id,
+		lastRemoteEtag: undefined,
+		lastFileHashes: fileHashMap(remote),
+	});
+	ctx.ui.notify(`Rolled back to ${remote.id}. Backup: ${backup}`, "info");
+	await maybeReload(ctx);
+}
+
+async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const lock = await readLock();
+	if (!lock) {
+		ctx.ui.notify("No pi-sync lock is present.", "info");
+		return;
+	}
+	if (!options.stale && !isStaleLock(lock)) {
+		ctx.ui.notify("Lock is not stale. Use /pisync unlock --stale only after verifying no sync is running.", "warning");
+		return;
+	}
+	await fs.rm(lockPath(), { force: true });
+	ctx.ui.notify("Removed stale pi-sync lock.", "info");
+}
+
+async function maybeReload(ctx: ExtensionCommandContext) {
+	if (ctx.hasUI && (await ctx.ui.confirm("Reload Pi resources now?", "This reloads extensions, skills, prompts, themes, and context files."))) {
+		await ctx.reload();
+	}
+}
+
+async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
+	await ensureStateDir();
+	const lock: LockFile = { pid: process.pid, command, startedAt: new Date().toISOString() };
+	let handle: fs.FileHandle | undefined;
+	try {
+		handle = await fs.open(lockPath(), "wx");
+		await handle.writeFile(JSON.stringify(lock, null, "\t"));
+		await handle.close();
+		handle = undefined;
+		return await fn();
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			const current = await readLock();
+			if (current && isStaleLock(current)) {
+				throw new Error(`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`);
+			}
+			throw new Error(`pi-sync is already running${current ? ` (${current.command}, pid ${current.pid}, started ${current.startedAt})` : ""}.`);
+		}
+		throw error;
+	} finally {
+		await handle?.close();
+		const current = await readLock();
+		if (current?.pid === process.pid) await fs.rm(lockPath(), { force: true });
+	}
+}
+
+async function loadConfig(): Promise<SyncConfig> {
+	const partial = await loadPartialConfig();
+	const endpoint = partial.endpoint;
+	const bucket = partial.bucket;
+	const accessKeyId = partial.accessKeyId;
+	const secretAccessKey = partial.secretAccessKey;
+	const missing = [
+		["endpoint", endpoint],
+		["bucket", bucket],
+		["accessKeyId", accessKeyId],
+		["secretAccessKey", secretAccessKey],
+	]
+		.filter(([, value]) => !value)
+		.map(([name]) => name);
+	if (missing.length > 0) {
+		throw new Error(`Missing pi-sync config: ${missing.join(", ")}. Run /pisync init or set PI_SYNC_* environment variables.`);
+	}
+
+	return {
+		endpoint: endpoint!,
+		bucket: bucket!,
+		region: partial.region ?? DEFAULT_REGION,
+		accessKeyId: accessKeyId!,
+		secretAccessKey: secretAccessKey!,
+		profile: partial.profile ?? DEFAULT_PROFILE,
+		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
+	};
+}
+
+async function loadPartialConfig(): Promise<PartialConfig> {
+	const fileConfig = await readJsonIfExists<PartialConfig>(localConfigPath());
+	return {
+		...fileConfig,
+		endpoint: process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig?.endpoint,
+		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? fileConfig?.bucket,
+		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig?.region,
+		accessKeyId: process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig?.accessKeyId,
+		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig?.secretAccessKey,
+		profile: process.env.PI_SYNC_PROFILE ?? fileConfig?.profile,
+		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig?.prefix,
+	};
+}
+
+async function createSnapshot(profile: string): Promise<Snapshot> {
+	const files = await collectFiles(agentDir());
+	return {
+		version: VERSION,
+		id: snapshotId(),
+		createdAt: new Date().toISOString(),
+		machine: os.hostname(),
+		profile,
+		files,
+	};
+}
+
+async function collectFiles(root: string): Promise<SnapshotFile[]> {
+	const results: SnapshotFile[] = [];
+	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
+		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
+			await addFile(results, root, entry.name);
+		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
+			await collectDirectory(results, root, entry.name);
+		}
+	}
+	return results.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function collectDirectory(results: SnapshotFile[], root: string, relativeDirectory: string) {
+	const absoluteDirectory = path.join(root, relativeDirectory);
+	for (const entry of await fs.readdir(absoluteDirectory, { withFileTypes: true })) {
+		const relativePath = posixJoin(relativeDirectory, entry.name);
+		if (isDeniedPath(relativePath)) continue;
+		if (entry.isDirectory()) {
+			await collectDirectory(results, root, relativePath);
+		} else if (entry.isFile()) {
+			await addFile(results, root, relativePath);
+		}
+	}
+}
+
+async function addFile(results: SnapshotFile[], root: string, relativePath: string) {
+	if (isDeniedPath(relativePath)) return;
+	const absolutePath = safeJoin(root, relativePath);
+	const content = await fs.readFile(absolutePath);
+	results.push({ path: relativePath, contentBase64: content.toString("base64"), sha256: sha256(content) });
+}
+
+function isDeniedPath(relativePath: string) {
+	const normalized = toPosix(relativePath);
+	const base = path.posix.basename(normalized).toLowerCase();
+	return (
+		normalized.includes("/node_modules/") ||
+		normalized.includes("/.git/") ||
+		normalized.includes("/.pisync/") ||
+		base === ".env" ||
+		base.endsWith(".env") ||
+		base.includes("secret") ||
+		base.includes("token") ||
+		base === "pi-sync.local.json"
+	);
+}
+
+function scanSnapshot(snapshot: Snapshot) {
+	const findings: string[] = [];
+	for (const file of snapshot.files) {
+		const content = Buffer.from(file.contentBase64, "base64");
+		if (content.includes(0)) continue;
+		const text = content.toString("utf8");
+		for (const pattern of SECRET_PATTERNS) {
+			if (pattern.test(text)) {
+				findings.push(file.path);
+				break;
+			}
+		}
+	}
+	return findings;
+}
+
+async function uploadSnapshot(
+	client: S3Client,
+	config: SyncConfig,
+	snapshot: Snapshot,
+	latest: RemoteObject<LatestPointer>,
+	force: boolean,
+) {
+	const encoded = await encodeSnapshot(snapshot);
+	const pointer = pointerFor(config, snapshot, sha256(encoded));
+	await client.putBuffer(snapshotKey(config, snapshot.id), encoded, "application/gzip");
+	await client.putJson(
+		latestKey(config),
+		pointer,
+		force ? undefined : latest.etag,
+		!force && latest.missing ? "*" : undefined,
+	);
+	return pointer;
+}
+
+async function readRemoteSnapshot(client: S3Client, config: SyncConfig) {
+	const latest = await client.getJson<LatestPointer>(latestKey(config));
+	if (latest.missing || !latest.value) return undefined;
+	const object = await client.getBuffer(snapshotKey(config, latest.value.snapshot));
+	if (!object.value) throw new Error(`Remote latest points to missing snapshot: ${latest.value.snapshot}`);
+	if (sha256(object.value) !== latest.value.sha256) throw new Error("Remote snapshot checksum mismatch.");
+	return decodeSnapshot(object.value);
+}
+
+async function encodeSnapshot(snapshot: Snapshot) {
+	return gzipAsync(Buffer.from(JSON.stringify(snapshot), "utf8"));
+}
+
+async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
+	const decoded = await gunzipAsync(buffer);
+	const parsed = JSON.parse(decoded.toString("utf8")) as Snapshot;
+	if (parsed.version !== VERSION || !Array.isArray(parsed.files)) throw new Error("Unsupported snapshot format.");
+	return parsed;
+}
+
+async function applySnapshot(snapshot: Snapshot) {
+	const root = agentDir();
+	const current = await createSnapshot(snapshot.profile);
+	const remotePaths = new Set(snapshot.files.map((file) => file.path));
+	for (const file of snapshot.files) {
+		const target = safeJoin(root, file.path);
+		await fs.mkdir(path.dirname(target), { recursive: true });
+		const content = Buffer.from(file.contentBase64, "base64");
+		if (sha256(content) !== file.sha256) throw new Error(`Checksum mismatch in snapshot file: ${file.path}`);
+		await fs.writeFile(target, content);
+	}
+	for (const file of current.files) {
+		if (!remotePaths.has(file.path)) await fs.rm(safeJoin(root, file.path), { force: true });
+	}
+}
+
+async function backupLocal(profile: string) {
+	const snapshot = await createSnapshot(profile);
+	const backupDirectory = path.join(stateDir(), "backups");
+	await fs.mkdir(backupDirectory, { recursive: true });
+	const backupPath = path.join(backupDirectory, `${snapshot.id}.json.gz`);
+	await fs.writeFile(backupPath, await encodeSnapshot(snapshot));
+	return backupPath;
+}
+
+async function updateHistory(client: S3Client, config: SyncConfig, pointer: LatestPointer) {
+	const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(historyKey(config));
+	const snapshots = object.value?.snapshots ?? [];
+	const next = [
+		...snapshots.filter((snapshot) => snapshot.snapshot !== pointer.snapshot),
+		pointer,
+	].slice(-100);
+	await client.putJson(historyKey(config), { version: VERSION, snapshots: next });
+}
+
+function formatDiff(local: Snapshot, remote: Snapshot) {
+	const localMap = fileHashMap(local);
+	const remoteMap = fileHashMap(remote);
+	const allPaths = [...new Set([...Object.keys(localMap), ...Object.keys(remoteMap)])].sort();
+	const lines = [`local: ${local.files.length} files`, `remote: ${remote.id} (${remote.files.length} files)`, ""];
+	let changed = 0;
+	for (const filePath of allPaths) {
+		if (!localMap[filePath]) {
+			lines.push(`+ ${filePath}`);
+			changed += 1;
+		} else if (!remoteMap[filePath]) {
+			lines.push(`- ${filePath}`);
+			changed += 1;
+		} else if (localMap[filePath] !== remoteMap[filePath]) {
+			lines.push(`~ ${filePath}`);
+			changed += 1;
+		}
+	}
+	if (changed === 0) lines.push("No file differences.");
+	return lines.join("\n");
+}
+
+function formatSnapshotOnlyDiff(title: string, snapshot: Snapshot) {
+	return [`${title}: ${snapshot.id}`, ...snapshot.files.map((file) => `+ ${file.path}`)].join("\n");
+}
+
+function formatPushSummary(local: Snapshot, latest: RemoteObject<LatestPointer>) {
+	return [
+		`Upload ${local.files.length} files from ${agentDir()}.`,
+		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
+		"Possible secrets were scanned before this prompt.",
+	].join("\n");
+}
+
+function hasLocalChanges(local: Snapshot, state: SyncState) {
+	return !sameHashes(fileHashMap(local), state.lastFileHashes);
+}
+
+function remoteChangedSinceState(latest: RemoteObject<LatestPointer>, state: SyncState) {
+	if (latest.missing) return Boolean(state.lastAppliedSnapshot);
+	return latest.value?.snapshot !== state.lastAppliedSnapshot;
+}
+
+function sameHashes(left: Record<string, string>, right: Record<string, string>) {
+	const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+	for (const key of keys) {
+		if (left[key] !== right[key]) return false;
+	}
+	return true;
+}
+
+function fileHashMap(snapshot: Snapshot) {
+	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
+}
+
+async function readState(profile: string): Promise<SyncState> {
+	return (
+		(await readJsonIfExists<SyncState>(statePath(profile))) ?? {
+			version: VERSION,
+			profile,
+			lastFileHashes: {},
+		}
+	);
+}
+
+async function writeState(profile: string, state: SyncState) {
+	await writeJson(statePath(profile), state);
+}
+
+class S3Client {
+	private config: SyncConfig;
+	private endpoint: URL;
+
+	constructor(config: SyncConfig) {
+		this.config = config;
+		this.endpoint = new URL(config.endpoint);
+	}
+
+	async getJson<T>(key: string): Promise<RemoteObject<T>> {
+		const object = await this.request("GET", key);
+		if (object.status === 404) return { missing: true };
+		if (!object.ok) throw new Error(`S3 GET failed (${object.status}): ${await object.text()}`);
+		return { value: (await object.json()) as T, etag: normalizeEtag(object.headers.get("etag")), missing: false };
+	}
+
+	async getBuffer(key: string): Promise<RemoteObject<Buffer>> {
+		const object = await this.request("GET", key);
+		if (object.status === 404) return { missing: true };
+		if (!object.ok) throw new Error(`S3 GET failed (${object.status}): ${await object.text()}`);
+		return { value: Buffer.from(await object.arrayBuffer()), etag: normalizeEtag(object.headers.get("etag")), missing: false };
+	}
+
+	async putJson(key: string, value: unknown, ifMatch?: string, ifNoneMatch?: string) {
+		const body = Buffer.from(JSON.stringify(value, null, "\t"), "utf8");
+		await this.putBuffer(key, body, "application/json", ifMatch, ifNoneMatch);
+	}
+
+	async putBuffer(
+		key: string,
+		body: Buffer,
+		contentType: string,
+		ifMatch?: string,
+		ifNoneMatch?: string,
+	) {
+		const headers: Record<string, string> = { "content-type": contentType };
+		if (ifMatch) headers["if-match"] = ifMatch;
+		if (ifNoneMatch) headers["if-none-match"] = ifNoneMatch;
+		const response = await this.request("PUT", key, body, headers);
+		if (!response.ok) throw new Error(`S3 PUT failed (${response.status}): ${await response.text()}`);
+	}
+
+	private async request(
+		method: "GET" | "PUT",
+		key: string,
+		body?: Buffer,
+		extraHeaders: Record<string, string> = {},
+	) {
+		const url = new URL(this.endpoint.toString());
+		url.pathname = posixJoin(url.pathname, this.config.bucket, encodeKey(key));
+		const headers = await signedHeaders({
+			method,
+			url,
+			body,
+			extraHeaders,
+			accessKeyId: this.config.accessKeyId,
+			secretAccessKey: this.config.secretAccessKey,
+			region: this.config.region,
+		});
+		return fetch(url, { method, headers, body: body ? new Uint8Array(body) : undefined });
+	}
+}
+
+async function signedHeaders(input: {
+	method: string;
+	url: URL;
+	body?: Buffer;
+	extraHeaders: Record<string, string>;
+	accessKeyId: string;
+	secretAccessKey: string;
+	region: string;
+}) {
+	const now = new Date();
+	const amzDate = iso8601Basic(now);
+	const dateStamp = amzDate.slice(0, 8);
+	const payloadHash = sha256(input.body ?? Buffer.alloc(0));
+	const headers: Record<string, string> = {
+		...lowercaseKeys(input.extraHeaders),
+		host: input.url.host,
+		"x-amz-content-sha256": payloadHash,
+		"x-amz-date": amzDate,
+	};
+	const signedHeaderNames = Object.keys(headers).sort();
+	const canonicalHeaders = signedHeaderNames.map((name) => `${name}:${headers[name]?.trim()}\n`).join("");
+	const canonicalRequest = [
+		input.method,
+		input.url.pathname,
+		input.url.searchParams.toString(),
+		canonicalHeaders,
+		signedHeaderNames.join(";"),
+		payloadHash,
+	].join("\n");
+	const scope = `${dateStamp}/${input.region}/s3/aws4_request`;
+	const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, sha256(Buffer.from(canonicalRequest))].join("\n");
+	const signingKey = hmac(
+		hmac(hmac(hmac(Buffer.from(`AWS4${input.secretAccessKey}`), dateStamp), input.region), "s3"),
+		"aws4_request",
+	);
+	const signature = createHmac("sha256", signingKey).update(stringToSign).digest("hex");
+	return {
+		...headers,
+		authorization: `AWS4-HMAC-SHA256 Credential=${input.accessKeyId}/${scope}, SignedHeaders=${signedHeaderNames.join(";")}, Signature=${signature}`,
+	};
+}
+
+function hmac(key: Buffer, value: string) {
+	return createHmac("sha256", key).update(value).digest();
+}
+
+function sha256(value: Buffer) {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function latestKey(config: SyncConfig) {
+	return posixJoin(profilePrefix(config), "latest.json");
+}
+
+function historyKey(config: SyncConfig) {
+	return posixJoin(profilePrefix(config), "history.json");
+}
+
+function snapshotKey(config: SyncConfig, id: string) {
+	return posixJoin(profilePrefix(config), "snapshots", `${id}.json.gz`);
+}
+
+function profilePrefix(config: SyncConfig) {
+	return posixJoin(config.prefix, "profiles", config.profile);
+}
+
+function pointerFor(config: SyncConfig, snapshot: Snapshot, checksum: string): LatestPointer {
+	return {
+		version: VERSION,
+		profile: config.profile,
+		snapshot: snapshot.id,
+		sha256: checksum,
+		createdAt: snapshot.createdAt,
+		machine: snapshot.machine,
+	};
+}
+
+function agentDir() {
+	return path.join(os.homedir(), ".pi", "agent");
+}
+
+function stateDir() {
+	return path.join(agentDir(), ".pisync");
+}
+
+function localConfigPath() {
+	return path.join(agentDir(), "pi-sync.local.json");
+}
+
+function statePath(profile: string) {
+	return path.join(stateDir(), `${safeName(profile)}.state.json`);
+}
+
+function lockPath() {
+	return path.join(stateDir(), "lock");
+}
+
+async function ensureStateDir() {
+	await fs.mkdir(stateDir(), { recursive: true });
+}
+
+async function readLock() {
+	return readJsonIfExists<LockFile>(lockPath());
+}
+
+function isStaleLock(lock: LockFile) {
+	if (Date.now() - Date.parse(lock.startedAt) > LOCK_STALE_MS) return true;
+	try {
+		process.kill(lock.pid, 0);
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+async function readJsonIfExists<T>(filePath: string): Promise<T | undefined> {
+	try {
+		return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+}
+
+async function writeJson(filePath: string, value: unknown) {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, `${JSON.stringify(value, null, "\t")}\n`);
+}
+
+function safeJoin(root: string, relativePath: string) {
+	const target = path.resolve(root, relativePath);
+	const resolvedRoot = path.resolve(root);
+	if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${path.sep}`)) {
+		throw new Error(`Unsafe path in snapshot: ${relativePath}`);
+	}
+	return target;
+}
+
+function splitArgs(input: string) {
+	return input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((arg) => arg.replace(/^['"]|['"]$/g, "")) ?? [];
+}
+
+function parseOptions(args: string[]): CommandOptions {
+	return {
+		yes: args.includes("--yes") || args.includes("-y"),
+		force: args.includes("--force"),
+		stale: args.includes("--stale"),
+		args: args.filter((arg) => !arg.startsWith("-")),
+	};
+}
+
+function usage() {
+	return [
+		"Usage: /pisync <command>",
+		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_REGION/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
+	].join("\n");
+}
+
+function snapshotId() {
+	return `${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
+}
+
+function iso8601Basic(date: Date) {
+	return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+function encodeKey(key: string) {
+	return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function posixJoin(...parts: string[]) {
+	return parts.map((part) => trimSlashes(part)).filter(Boolean).join("/");
+}
+
+function toPosix(value: string) {
+	return value.split(path.sep).join("/");
+}
+
+function trimSlashes(value: string) {
+	return value.replace(/^\/+|\/+$/g, "");
+}
+
+function safeName(value: string) {
+	return value.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function lowercaseKeys(value: Record<string, string>) {
+	return Object.fromEntries(Object.entries(value).map(([key, item]) => [key.toLowerCase(), item]));
+}
+
+function normalizeEtag(value: string | null) {
+	return value ?? undefined;
+}
+
+function redact(value: string) {
+	return value.length <= 8 ? "configured" : `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+function errorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -401,8 +401,19 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const remoteChanged = remote ? remote.id !== state.lastAppliedSnapshot : false;
 	const firstSync = !state.lastAppliedSnapshot;
 
-	if (options.auto && firstSync && remote && local.files.length > 0) {
-		throw new Error("Remote settings exist and this machine has local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+	if (firstSync && remote && local.files.length > 0) {
+		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
+			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+		}
+		await writeState(config.profile, {
+			version: VERSION,
+			profile: config.profile,
+			lastAppliedSnapshot: remote.id,
+			lastRemoteEtag: undefined,
+			lastFileHashes: fileHashMap(remote),
+		});
+		if (!options.silent) ctx.ui.notify("pi-sync state initialized; local settings already match remote.", "info");
+		return;
 	}
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
 		throw new Error("Both local and remote changed. Run /pisync diff and resolve with push --force or pull --force.");
@@ -686,12 +697,12 @@ async function applySnapshot(snapshot: Snapshot) {
 	const root = agentDir();
 	const current = await createSnapshot(snapshot.profile);
 	const plan = preflightSnapshotApply(root, snapshot, current);
+	for (const target of plan.deletes) {
+		await fs.rm(target, { force: true, recursive: true });
+	}
 	for (const item of plan.writes) {
 		await fs.mkdir(path.dirname(item.target), { recursive: true });
 		await fs.writeFile(item.target, item.content);
-	}
-	for (const target of plan.deletes) {
-		await fs.rm(target, { force: true });
 	}
 }
 
@@ -716,10 +727,15 @@ function preflightSnapshotApply(root: string, snapshot: Snapshot, current: Snaps
 		writes.push({ target, content });
 	}
 
+	const deletePaths = new Set<string>();
 	for (const file of current.files) {
 		const normalized = toPosix(file.path);
-		if (!remotePaths.has(normalized)) deletes.push(safeJoin(root, normalized));
+		if (!remotePaths.has(normalized)) deletePaths.add(safeJoin(root, normalized));
+		for (const remotePath of remotePaths) {
+			if (normalized.startsWith(`${remotePath}/`)) deletePaths.add(safeJoin(root, remotePath));
+		}
 	}
+	deletes.push(...deletePaths);
 
 	return { writes, deletes };
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -246,7 +246,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 }
 
 async function status(ctx: ExtensionCommandContext) {
-	ctx.ui.setStatus(STATUS_KEY, "sync status");
+	ctx.ui.setStatus(STATUS_KEY, "🔄 checking");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const local = await createSnapshot(config.profile);
@@ -275,7 +275,7 @@ async function status(ctx: ExtensionCommandContext) {
 }
 
 async function diff(ctx: ExtensionCommandContext) {
-	ctx.ui.setStatus(STATUS_KEY, "sync diff");
+	ctx.ui.setStatus(STATUS_KEY, "🔄 diff");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const local = await createSnapshot(config.profile);
@@ -318,7 +318,7 @@ async function doctor(ctx: ExtensionCommandContext) {
 }
 
 async function push(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
-	ctx.ui.setStatus(STATUS_KEY, "sync push");
+	ctx.ui.setStatus(STATUS_KEY, "🔄 pushing");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
@@ -355,7 +355,7 @@ async function push(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 }
 
 async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
-	ctx.ui.setStatus(STATUS_KEY, "sync pull");
+	ctx.ui.setStatus(STATUS_KEY, "🔄 pulling");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1009,12 +1009,12 @@ async function readLock() {
 }
 
 function isStaleLock(lock: LockFile) {
-	if (Date.now() - Date.parse(lock.startedAt) > LOCK_STALE_MS) return true;
+	if (!Number.isInteger(lock.pid) || lock.pid <= 0) return true;
 	try {
 		process.kill(lock.pid, 0);
 		return false;
 	} catch {
-		return true;
+		return Date.now() - Date.parse(lock.startedAt) > LOCK_STALE_MS;
 	}
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -598,12 +598,13 @@ async function uploadSnapshot(
 	const encoded = await encodeSnapshot(snapshot);
 	const pointer = pointerFor(config, snapshot, sha256(encoded));
 	await client.putBuffer(snapshotKey(config, snapshot.id), encoded, "application/gzip");
-	await client.putJson(
-		latestKey(config),
-		pointer,
-		force ? undefined : latest.etag,
-		!force && latest.missing ? "*" : undefined,
-	);
+	if (!force) {
+		const current = await client.getJson<LatestPointer>(latestKey(config));
+		if (remoteIdentity(current) !== remoteIdentity(latest)) {
+			throw new Error("Remote changed while pushing. Run /pisync pull first, then retry.");
+		}
+	}
+	await client.putJson(latestKey(config), pointer);
 	return pointer;
 }
 
@@ -705,6 +706,10 @@ function remoteChangedSinceState(latest: RemoteObject<LatestPointer>, state: Syn
 	return latest.value?.snapshot !== state.lastAppliedSnapshot;
 }
 
+function remoteIdentity(remote: RemoteObject<LatestPointer>) {
+	return remote.missing ? "missing" : (remote.value?.snapshot ?? "unknown");
+}
+
 function sameHashes(left: Record<string, string>, right: Record<string, string>) {
 	const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
 	for (const key of keys) {
@@ -754,21 +759,13 @@ class S3Client {
 		return { value: Buffer.from(await object.arrayBuffer()), etag: normalizeEtag(object.headers.get("etag")), missing: false };
 	}
 
-	async putJson(key: string, value: unknown, ifMatch?: string, ifNoneMatch?: string) {
+	async putJson(key: string, value: unknown) {
 		const body = Buffer.from(JSON.stringify(value, null, "\t"), "utf8");
-		await this.putBuffer(key, body, "application/json", ifMatch, ifNoneMatch);
+		await this.putBuffer(key, body, "application/json");
 	}
 
-	async putBuffer(
-		key: string,
-		body: Buffer,
-		contentType: string,
-		ifMatch?: string,
-		ifNoneMatch?: string,
-	) {
+	async putBuffer(key: string, body: Buffer, contentType: string) {
 		const headers: Record<string, string> = { "content-type": contentType };
-		if (ifMatch) headers["if-match"] = ifMatch;
-		if (ifNoneMatch) headers["if-none-match"] = ifNoneMatch;
 		const response = await this.request("PUT", key, body, headers);
 		if (!response.ok) throw new Error(`S3 PUT failed (${response.status}): ${await response.text()}`);
 	}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -102,6 +102,7 @@ interface CommandOptions {
 	stale: boolean;
 	silent: boolean;
 	reload: boolean;
+	auto: boolean;
 	args: string[];
 }
 
@@ -111,6 +112,7 @@ const AUTO_SYNC_OPTIONS: CommandOptions = {
 	stale: false,
 	silent: true,
 	reload: false,
+	auto: true,
 	args: [],
 };
 
@@ -396,7 +398,11 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const remote = await readRemoteSnapshot(client, config);
 	const localChanged = hasLocalChanges(local, state);
 	const remoteChanged = remote ? remote.id !== state.lastAppliedSnapshot : false;
+	const firstSync = !state.lastAppliedSnapshot;
 
+	if (options.auto && firstSync && remote && local.files.length > 0) {
+		throw new Error("Remote settings exist and this machine has local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+	}
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
 		throw new Error("Both local and remote changed. Run /pisync diff and resolve with push --force or pull --force.");
 	}
@@ -637,13 +643,15 @@ async function uploadSnapshot(
 	const encoded = await encodeSnapshot(snapshot);
 	const pointer = pointerFor(config, snapshot, sha256(encoded));
 	await client.putBuffer(snapshotKey(config, snapshot.id), encoded, "application/gzip");
-	if (!force) {
-		const current = await client.getJson<LatestPointer>(latestKey(config));
-		if (remoteIdentity(current) !== remoteIdentity(latest)) {
-			throw new Error("Remote changed while pushing. Run /pisync pull first, then retry.");
-		}
+	const current = await client.getJson<LatestPointer>(latestKey(config));
+	if (!force && remoteIdentity(current) !== remoteIdentity(latest)) {
+		throw new Error("Remote changed while pushing. Run /pisync pull first, then retry.");
 	}
 	await client.putJson(latestKey(config), pointer);
+	const verified = await client.getJson<LatestPointer>(latestKey(config));
+	if (verified.value?.snapshot !== pointer.snapshot) {
+		throw new Error("Remote latest changed immediately after push. Run /pisync status before continuing.");
+	}
 	return pointer;
 }
 
@@ -670,17 +678,50 @@ async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
 async function applySnapshot(snapshot: Snapshot) {
 	const root = agentDir();
 	const current = await createSnapshot(snapshot.profile);
-	const remotePaths = new Set(snapshot.files.map((file) => file.path));
+	const plan = preflightSnapshotApply(root, snapshot, current);
+	for (const item of plan.writes) {
+		await fs.mkdir(path.dirname(item.target), { recursive: true });
+		await fs.writeFile(item.target, item.content);
+	}
+	for (const target of plan.deletes) {
+		await fs.rm(target, { force: true });
+	}
+}
+
+function preflightSnapshotApply(root: string, snapshot: Snapshot, current: Snapshot) {
+	const seenPaths = new Set<string>();
+	const remotePaths = new Set<string>();
+	const writes: Array<{ target: string; content: Buffer }> = [];
+	const deletes: string[] = [];
+
 	for (const file of snapshot.files) {
-		const target = safeJoin(root, file.path);
-		await fs.mkdir(path.dirname(target), { recursive: true });
-		const content = Buffer.from(file.contentBase64, "base64");
-		if (sha256(content) !== file.sha256) throw new Error(`Checksum mismatch in snapshot file: ${file.path}`);
-		await fs.writeFile(target, content);
+		const normalized = toPosix(file.path);
+		if (!normalized || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
+			throw new Error(`Unsafe path in snapshot: ${file.path}`);
+		}
+		if (seenPaths.has(normalized)) throw new Error(`Duplicate path in snapshot: ${normalized}`);
+		seenPaths.add(normalized);
+		remotePaths.add(normalized);
+
+		const target = safeJoin(root, normalized);
+		const content = decodeBase64Strict(file.contentBase64, normalized);
+		if (sha256(content) !== file.sha256) throw new Error(`Checksum mismatch in snapshot file: ${normalized}`);
+		writes.push({ target, content });
 	}
+
 	for (const file of current.files) {
-		if (!remotePaths.has(file.path)) await fs.rm(safeJoin(root, file.path), { force: true });
+		const normalized = toPosix(file.path);
+		if (!remotePaths.has(normalized)) deletes.push(safeJoin(root, normalized));
 	}
+
+	return { writes, deletes };
+}
+
+function decodeBase64Strict(value: string, filePath: string) {
+	if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value) || value.length % 4 !== 0) {
+		throw new Error(`Invalid base64 content in snapshot file: ${filePath}`);
+	}
+	return Buffer.from(value, "base64");
 }
 
 async function backupLocal(profile: string) {
@@ -979,6 +1020,7 @@ function parseOptions(args: string[]): CommandOptions {
 		stale: args.includes("--stale"),
 		silent: false,
 		reload: true,
+		auto: false,
 		args: args.filter((arg) => !arg.startsWith("-")),
 	};
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -5,7 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { gunzip, gzip } from "node:zlib";
 import { promisify } from "node:util";
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
@@ -45,6 +49,7 @@ interface PartialConfig {
 	secretAccessKey?: string;
 	profile?: string;
 	prefix?: string;
+	autoSync?: boolean | string;
 }
 
 interface SnapshotFile {
@@ -95,8 +100,19 @@ interface CommandOptions {
 	yes: boolean;
 	force: boolean;
 	stale: boolean;
+	silent: boolean;
+	reload: boolean;
 	args: string[];
 }
+
+const AUTO_SYNC_OPTIONS: CommandOptions = {
+	yes: true,
+	force: false,
+	stale: false,
+	silent: true,
+	reload: false,
+	args: [],
+};
 
 export default function sync(pi: ExtensionAPI) {
 	pi.registerCommand("pisync", {
@@ -106,8 +122,9 @@ export default function sync(pi: ExtensionAPI) {
 		},
 	});
 
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		await autoSync(ctx);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -168,6 +185,20 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
 	}
 }
 
+async function autoSync(ctx: ExtensionContext) {
+	try {
+		const partial = await loadPartialConfig();
+		if (!isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true)) return;
+		await ensureStateDir();
+		await loadConfig();
+		await withLock("auto-sync", () => syncBoth(ctx, AUTO_SYNC_OPTIONS));
+	} catch (error) {
+		if (isMissingConfigError(error)) return;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.notify(`pi-sync auto sync skipped: ${errorMessage(error)}`, "warning");
+	}
+}
+
 async function initConfig(ctx: ExtensionCommandContext) {
 	const configPath = localConfigPath();
 	try {
@@ -186,6 +217,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 		secretAccessKey: "<secret-access-key>",
 		profile: DEFAULT_PROFILE,
 		prefix: DEFAULT_PREFIX,
+		autoSync: true,
 	};
 	await writeJson(configPath, sample);
 	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /pisync doctor.`, "info");
@@ -203,6 +235,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 			`secretAccessKey: ${partial.secretAccessKey ? "configured" : "missing"}`,
 			`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
 			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
+			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
 			`local config: ${localConfigPath()}`,
 		].join("\n"),
 		"info",
@@ -281,7 +314,7 @@ async function doctor(ctx: ExtensionCommandContext) {
 	ctx.ui.notify(messages.join("\n"), level);
 }
 
-async function push(ctx: ExtensionCommandContext, options: CommandOptions) {
+async function push(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
 	ctx.ui.setStatus(STATUS_KEY, "sync push");
 	const config = await loadConfig();
 	const client = new S3Client(config);
@@ -313,10 +346,12 @@ async function push(ctx: ExtensionCommandContext, options: CommandOptions) {
 		lastFileHashes: fileHashMap(local),
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
-	ctx.ui.notify(`Pushed ${local.files.length} files as ${pointer.snapshot}.`, "info");
+	if (!options.silent) {
+		ctx.ui.notify(`Pushed ${local.files.length} files as ${pointer.snapshot}.`, "info");
+	}
 }
 
-async function pull(ctx: ExtensionCommandContext, options: CommandOptions) {
+async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
 	ctx.ui.setStatus(STATUS_KEY, "sync pull");
 	const config = await loadConfig();
 	const client = new S3Client(config);
@@ -327,7 +362,7 @@ async function pull(ctx: ExtensionCommandContext, options: CommandOptions) {
 
 	const localChanged = hasLocalChanges(local, state);
 	const remoteChanged = remote.id !== state.lastAppliedSnapshot;
-	if (localChanged && remoteChanged && !options.force) {
+	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
 		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
 	}
 
@@ -347,11 +382,13 @@ async function pull(ctx: ExtensionCommandContext, options: CommandOptions) {
 		lastFileHashes: fileHashMap(remote),
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
-	ctx.ui.notify(`Pulled ${remote.files.length} files from ${remote.id}. Backup: ${backup}`, "info");
-	await maybeReload(ctx);
+	if (!options.silent) {
+		ctx.ui.notify(`Pulled ${remote.files.length} files from ${remote.id}. Backup: ${backup}`, "info");
+	}
+	if (options.reload) await maybeReload(ctx);
 }
 
-async function syncBoth(ctx: ExtensionCommandContext, options: CommandOptions) {
+async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
@@ -360,7 +397,7 @@ async function syncBoth(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const localChanged = hasLocalChanges(local, state);
 	const remoteChanged = remote ? remote.id !== state.lastAppliedSnapshot : false;
 
-	if (localChanged && remoteChanged) {
+	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
 		throw new Error("Both local and remote changed. Run /pisync diff and resolve with push --force or pull --force.");
 	}
 	if (remoteChanged) {
@@ -371,7 +408,7 @@ async function syncBoth(ctx: ExtensionCommandContext, options: CommandOptions) {
 		await push(ctx, options);
 		return;
 	}
-	ctx.ui.notify("pi-sync is already up to date.", "info");
+	if (!options.silent) ctx.ui.notify("pi-sync is already up to date.", "info");
 }
 
 async function history(ctx: ExtensionCommandContext) {
@@ -438,7 +475,8 @@ async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
 	ctx.ui.notify("Removed stale pi-sync lock.", "info");
 }
 
-async function maybeReload(ctx: ExtensionCommandContext) {
+async function maybeReload(ctx: ExtensionCommandContext | ExtensionContext) {
+	if (!("reload" in ctx)) return;
 	if (ctx.hasUI && (await ctx.ui.confirm("Reload Pi resources now?", "This reloads extensions, skills, prompts, themes, and context files."))) {
 		await ctx.reload();
 	}
@@ -510,6 +548,7 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig?.secretAccessKey,
 		profile: process.env.PI_SYNC_PROFILE ?? fileConfig?.profile,
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig?.prefix,
+		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig?.autoSync,
 	};
 }
 
@@ -938,6 +977,8 @@ function parseOptions(args: string[]): CommandOptions {
 		yes: args.includes("--yes") || args.includes("-y"),
 		force: args.includes("--force"),
 		stale: args.includes("--stale"),
+		silent: false,
+		reload: true,
 		args: args.filter((arg) => !arg.startsWith("-")),
 	};
 }
@@ -988,6 +1029,16 @@ function normalizeEtag(value: string | null) {
 
 function redact(value: string) {
 	return value.length <= 8 ? "configured" : `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+function isEnabled(value: boolean | string | undefined, defaultValue: boolean) {
+	if (value === undefined) return defaultValue;
+	if (typeof value === "boolean") return value;
+	return !["0", "false", "no", "off"].includes(value.trim().toLowerCase());
+}
+
+function isMissingConfigError(error: unknown) {
+	return error instanceof Error && error.message.startsWith("Missing pi-sync config:");
 }
 
 function errorMessage(error: unknown) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -91,6 +91,7 @@ interface SyncState {
 }
 
 interface LockFile {
+	id: string;
 	pid: number;
 	command: string;
 	startedAt: string;
@@ -490,7 +491,12 @@ async function maybeReload(ctx: ExtensionCommandContext | ExtensionContext) {
 
 async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
 	await ensureStateDir();
-	const lock: LockFile = { pid: process.pid, command, startedAt: new Date().toISOString() };
+	const lock: LockFile = {
+		id: randomUUID(),
+		pid: process.pid,
+		command,
+		startedAt: new Date().toISOString(),
+	};
 	let handle: fs.FileHandle | undefined;
 	try {
 		handle = await fs.open(lockPath(), "wx");
@@ -510,7 +516,7 @@ async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
 	} finally {
 		await handle?.close();
 		const current = await readLock();
-		if (current?.pid === process.pid) await fs.rm(lockPath(), { force: true });
+		if (current?.id === lock.id) await fs.rm(lockPath(), { force: true });
 	}
 }
 
@@ -610,6 +616,7 @@ function isDeniedPath(relativePath: string) {
 		normalized.includes("/.git/") ||
 		normalized.includes("/.pisync/") ||
 		base === ".env" ||
+		base.startsWith(".env.") ||
 		base.endsWith(".env") ||
 		base.includes("secret") ||
 		base.includes("token") ||

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -37,6 +37,7 @@ interface SyncConfig {
 	region: string;
 	accessKeyId: string;
 	secretAccessKey: string;
+	sessionToken?: string;
 	profile: string;
 	prefix: string;
 }
@@ -47,6 +48,7 @@ interface PartialConfig {
 	region?: string;
 	accessKeyId?: string;
 	secretAccessKey?: string;
+	sessionToken?: string;
 	profile?: string;
 	prefix?: string;
 	autoSync?: boolean | string;
@@ -236,6 +238,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 			`region: ${partial.region ?? DEFAULT_REGION}`,
 			`accessKeyId: ${partial.accessKeyId ? redact(partial.accessKeyId) : "missing"}`,
 			`secretAccessKey: ${partial.secretAccessKey ? "configured" : "missing"}`,
+			`sessionToken: ${partial.sessionToken ? "configured" : "not configured"}`,
 			`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
 			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
 			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
@@ -555,6 +558,7 @@ async function loadConfig(): Promise<SyncConfig> {
 		region: partial.region ?? DEFAULT_REGION,
 		accessKeyId: accessKeyId!,
 		secretAccessKey: secretAccessKey!,
+		sessionToken: partial.sessionToken,
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 	};
@@ -569,6 +573,7 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig?.region,
 		accessKeyId: process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig?.accessKeyId,
 		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig?.secretAccessKey,
+		sessionToken: process.env.PI_SYNC_SESSION_TOKEN ?? process.env.AWS_SESSION_TOKEN ?? fileConfig?.sessionToken,
 		profile: process.env.PI_SYNC_PROFILE ?? fileConfig?.profile,
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig?.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig?.autoSync,
@@ -698,10 +703,11 @@ async function applySnapshot(snapshot: Snapshot) {
 	const current = await createSnapshot(snapshot.profile);
 	const plan = preflightSnapshotApply(root, snapshot, current);
 	for (const target of plan.deletes) {
+		await assertNoSymlinkParents(root, target);
 		await fs.rm(target, { force: true, recursive: true });
 	}
 	for (const item of plan.writes) {
-		await fs.mkdir(path.dirname(item.target), { recursive: true });
+		await prepareSnapshotWrite(root, item.target);
 		await fs.writeFile(item.target, item.content);
 	}
 }
@@ -888,6 +894,7 @@ class S3Client {
 			extraHeaders,
 			accessKeyId: this.config.accessKeyId,
 			secretAccessKey: this.config.secretAccessKey,
+			sessionToken: this.config.sessionToken,
 			region: this.config.region,
 		});
 		return fetch(url, { method, headers, body: body ? new Uint8Array(body) : undefined });
@@ -901,6 +908,7 @@ async function signedHeaders(input: {
 	extraHeaders: Record<string, string>;
 	accessKeyId: string;
 	secretAccessKey: string;
+	sessionToken?: string;
 	region: string;
 }) {
 	const now = new Date();
@@ -913,6 +921,7 @@ async function signedHeaders(input: {
 		"x-amz-content-sha256": payloadHash,
 		"x-amz-date": amzDate,
 	};
+	if (input.sessionToken) headers["x-amz-security-token"] = input.sessionToken;
 	const signedHeaderNames = Object.keys(headers).sort();
 	const canonicalHeaders = signedHeaderNames.map((name) => `${name}:${headers[name]?.trim()}\n`).join("");
 	const canonicalRequest = [
@@ -1023,13 +1032,66 @@ async function writeJson(filePath: string, value: unknown) {
 	await fs.writeFile(filePath, `${JSON.stringify(value, null, "\t")}\n`);
 }
 
+async function prepareSnapshotWrite(root: string, target: string) {
+	await ensureSafeDirectory(root, path.dirname(target));
+	try {
+		const stat = await fs.lstat(target);
+		if (stat.isSymbolicLink()) throw new Error(`Refusing to overwrite symlink during snapshot apply: ${target}`);
+		if (stat.isDirectory()) throw new Error(`Refusing to overwrite directory during snapshot apply: ${target}`);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+}
+
+async function ensureSafeDirectory(root: string, directory: string) {
+	assertWithinRoot(root, directory);
+	const rootPath = path.resolve(root);
+	const relative = path.relative(rootPath, path.resolve(directory));
+	let current = rootPath;
+	for (const part of relative.split(path.sep).filter(Boolean)) {
+		current = path.join(current, part);
+		try {
+			const stat = await fs.lstat(current);
+			if (stat.isSymbolicLink()) throw new Error(`Refusing to follow symlink during snapshot apply: ${current}`);
+			if (!stat.isDirectory()) throw new Error(`Snapshot path parent is not a directory: ${current}`);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			await fs.mkdir(current);
+		}
+	}
+}
+
+async function assertNoSymlinkParents(root: string, target: string) {
+	assertWithinRoot(root, target);
+	const rootPath = path.resolve(root);
+	const relative = path.relative(rootPath, path.resolve(target));
+	let current = rootPath;
+	const parts = relative.split(path.sep).filter(Boolean);
+	for (const part of parts.slice(0, -1)) {
+		current = path.join(current, part);
+		try {
+			const stat = await fs.lstat(current);
+			if (stat.isSymbolicLink()) throw new Error(`Refusing to follow symlink during snapshot apply: ${current}`);
+			if (!stat.isDirectory()) throw new Error(`Snapshot path parent is not a directory: ${current}`);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
+	}
+}
+
 function safeJoin(root: string, relativePath: string) {
 	const target = path.resolve(root, relativePath);
-	const resolvedRoot = path.resolve(root);
-	if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${path.sep}`)) {
-		throw new Error(`Unsafe path in snapshot: ${relativePath}`);
-	}
+	assertWithinRoot(root, target, relativePath);
 	return target;
+}
+
+function assertWithinRoot(root: string, target: string, label = target) {
+	const resolvedRoot = path.resolve(root);
+	const resolvedTarget = path.resolve(target);
+	if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(`${resolvedRoot}${path.sep}`)) {
+		throw new Error(`Unsafe path in snapshot: ${label}`);
+	}
 }
 
 function splitArgs(input: string) {
@@ -1052,7 +1114,7 @@ function usage() {
 	return [
 		"Usage: /pisync <command>",
 		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_REGION/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN/region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
 	].join("\n");
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -702,12 +702,11 @@ async function applySnapshot(snapshot: Snapshot) {
 	const root = agentDir();
 	const current = await createSnapshot(snapshot.profile);
 	const plan = preflightSnapshotApply(root, snapshot, current);
+	await preflightSnapshotMutations(root, plan);
 	for (const target of plan.deletes) {
-		await assertNoSymlinkParents(root, target);
 		await fs.rm(target, { force: true, recursive: true });
 	}
 	for (const item of plan.writes) {
-		await prepareSnapshotWrite(root, item.target);
 		await fs.writeFile(item.target, item.content);
 	}
 }
@@ -1013,7 +1012,8 @@ function isStaleLock(lock: LockFile) {
 	try {
 		process.kill(lock.pid, 0);
 		return false;
-	} catch {
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ESRCH") return true;
 		return Date.now() - Date.parse(lock.startedAt) > LOCK_STALE_MS;
 	}
 }
@@ -1030,6 +1030,18 @@ async function readJsonIfExists<T>(filePath: string): Promise<T | undefined> {
 async function writeJson(filePath: string, value: unknown) {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await fs.writeFile(filePath, `${JSON.stringify(value, null, "\t")}\n`);
+}
+
+async function preflightSnapshotMutations(
+	root: string,
+	plan: { deletes: string[]; writes: Array<{ target: string; content: Buffer }> },
+) {
+	for (const target of plan.deletes) {
+		await assertNoSymlinkParents(root, target);
+	}
+	for (const item of plan.writes) {
+		await prepareSnapshotWrite(root, item.target);
+	}
 }
 
 async function prepareSnapshotWrite(root: string, target: string) {

--- a/extensions/pi-sync/tsconfig.json
+++ b/extensions/pi-sync/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -101,6 +101,9 @@ pack-retry:
 pack-statusline:
     just pack statusline
 
+pack-sync:
+    just pack sync
+
 pack-subagents:
     just pack subagents
 
@@ -134,6 +137,9 @@ try-retry:
 
 try-statusline:
     just try statusline
+
+try-sync:
+    just try sync
 
 try-subagents:
     just try subagents
@@ -169,6 +175,9 @@ install-retry:
 install-statusline:
     just install statusline
 
+install-sync:
+    just install sync
+
 install-subagents:
     just install subagents
 
@@ -202,6 +211,9 @@ publish-retry:
 
 publish-statusline:
     just publish statusline
+
+publish-sync:
+    just publish sync
 
 publish-subagents:
     just publish subagents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,6 +1006,119 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"extensions/pi-sync": {
+			"name": "@narumitw/pi-sync",
+			"version": "0.1.29",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@mariozechner/pi-coding-agent": "0.73.0",
+				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-sync/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.73.1",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-sync/node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-sync/node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.0.tgz",
+			"integrity": "sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==",
+			"deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.73.0",
+				"@mariozechner/pi-ai": "^0.73.0",
+				"@mariozechner/pi-tui": "^0.73.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"extensions/pi-sync/node_modules/@mariozechner/pi-tui": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+			"deprecated": "please use @earendil-works/pi-tui instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
@@ -2505,6 +2618,10 @@
 		},
 		"node_modules/@narumitw/pi-subagents": {
 			"resolved": "extensions/pi-subagents",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-sync": {
+			"resolved": "extensions/pi-sync",
 			"link": true
 		},
 		"node_modules/@nodable/entities": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"pack:plan-mode": "npm --workspace @narumitw/pi-plan-mode pack --dry-run",
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run",
 		"pack:statusline": "npm --workspace @narumitw/pi-statusline pack --dry-run",
+		"pack:sync": "npm --workspace @narumitw/pi-sync pack --dry-run",
 		"pack:subagents": "npm --workspace @narumitw/pi-subagents pack --dry-run"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- add @narumitw/pi-sync with R2/S3 snapshot sync commands, local locking, backups, secret scanning, history, and rollback
- document pi-sync usage/configuration and wire package scripts/just recipes/root README entries
- archive the implementation plan and add a repository gotcha for force-adding new extension src files

## Verification
- npm run check
- npm --workspace @narumitw/pi-sync pack --dry-run