### PR TITLE
fix(sync): ignore session tokens for R2

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -19,7 +19,7 @@
 - When PR comments expose one class of bug, stop patching comment-by-comment and do a holistic pass over adjacent Modules before pushing again.
 - Symptom: Chrome DevTools `/json/new` may reject unsafe `GET`. Cause: modern Chrome expects `PUT` for target creation. Fix: use `PUT /json/new?${encodeURIComponent(url)}`.
 - Symptom: Telegram bot polling can replay stale queued messages or conflict across Pi processes. Cause: `getUpdates` is a single bot-token queue controlled by offsets. Fix: discard pending updates on startup with an offset and run one active polling Pi per bot token.
-- For pi-sync on Cloudflare R2, ignore every session token source (`PI_SYNC_SESSION_TOKEN`, `AWS_SESSION_TOKEN`, local `sessionToken`); R2 static keys reject `X-Amz-Security-Token`.
+- For pi-sync on Cloudflare R2, keep session-token support for temporary credentials but retry once without the token when R2 static keys reject `X-Amz-Security-Token`.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -19,6 +19,7 @@
 - When PR comments expose one class of bug, stop patching comment-by-comment and do a holistic pass over adjacent Modules before pushing again.
 - Symptom: Chrome DevTools `/json/new` may reject unsafe `GET`. Cause: modern Chrome expects `PUT` for target creation. Fix: use `PUT /json/new?${encodeURIComponent(url)}`.
 - Symptom: Telegram bot polling can replay stale queued messages or conflict across Pi processes. Cause: `getUpdates` is a single bot-token queue controlled by offsets. Fix: discard pending updates on startup with an offset and run one active polling Pi per bot token.
+- For pi-sync on Cloudflare R2, ignore every session token source (`PI_SYNC_SESSION_TOKEN`, `AWS_SESSION_TOKEN`, local `sessionToken`); R2 static keys reject `X-Amz-Security-Token`.
 
 ## TASTE
 

--- a/docs/plans/archived/2026-05-22_r2-session-token-plan.md
+++ b/docs/plans/archived/2026-05-22_r2-session-token-plan.md
@@ -1,47 +1,54 @@
 ## Goal
 
-Fix `@narumitw/pi-sync` in code so Cloudflare R2 auto sync no longer fails from accidentally sending `X-Amz-Security-Token`. Do not require users to unset or override environment variables as a quick workaround. The success condition is that when R2 static access keys are used, pi-sync will not include a session token in R2 requests even if one exists in the shell or local config, and the repository checks still pass.
+Fix `@narumitw/pi-sync` in code so Cloudflare R2 auto sync no longer fails from stale or unrelated session tokens. Do not require users to unset or override environment variables as a quick workaround. The success condition is that R2 static access keys recover automatically when R2 rejects `X-Amz-Security-Token`, while valid R2 temporary credentials can still use a session token.
 
 ## Context
 
-Previously, `loadPartialConfig()` in `extensions/pi-sync/src/sync.ts` could apply a session token to R2 requests. This is useful for AWS STS/SSO S3, but Cloudflare R2 static keys reject signed requests that include `x-amz-security-token` and return:
+Previously, `loadPartialConfig()` in `extensions/pi-sync/src/sync.ts` could apply a session token to R2 requests. This is useful for AWS STS/SSO S3 and any R2 temporary credentials, but Cloudflare R2 static keys reject signed requests that include `x-amz-security-token` and return:
 
 ```text
 InvalidArgument: X-Amz-Security-Token
 ```
 
+A first implementation avoided the error by ignoring all session tokens for R2 endpoints. PR review correctly flagged that as a regression for valid R2 temporary credentials, so the final fix keeps session-token support and adds an R2-specific retry fallback when the token is rejected.
+
 ## Assumptions
 
-- This fix targets R2 static access keys and does not require R2 session tokens.
+- R2 static access keys usually do not need a session token.
+- R2 temporary credentials may require a session token and must remain supported.
 - Regular AWS S3 must still support `AWS_SESSION_TOKEN`.
 
 ## Non-Goals
 
 - Do not require users to unset `AWS_SESSION_TOKEN`, edit shell profiles, or launch Pi with `PI_SYNC_SESSION_TOKEN=`.
+- Do not introduce a new opt-in flag for R2 temporary credentials.
 
 ## Plan
 
-- [x] Update session-token resolution in `extensions/pi-sync/src/sync.ts`: detect Cloudflare R2 endpoints by hostname ending in `.r2.cloudflarestorage.com`, and ignore `PI_SYNC_SESSION_TOKEN`, `AWS_SESSION_TOKEN`, and local config `sessionToken` for R2 endpoints; verified by reviewing `selectSessionToken()` and by an equivalent live `/pisync status` handler check.
-- [x] Normalize empty token strings as unset so `PI_SYNC_SESSION_TOKEN=`, whitespace-only strings, or `"sessionToken": ""` in config do not confuse display or later logic; verified by the `normalizeOptionalString()` implementation.
-- [x] Strengthen `/pisync doctor` and `/pisync config` diagnostics: when session-token sources exist under an R2 endpoint, show which sources are ignored without leaking token values; verified with live config and doctor handler output.
-- [x] Update `extensions/pi-sync/README.md` R2 configuration docs: document that R2 static keys do not need session tokens and that R2 endpoints ignore all session-token sources; verified by the README diff.
+- [x] Restore normal session-token resolution in `extensions/pi-sync/src/sync.ts`: `PI_SYNC_SESSION_TOKEN` takes precedence, then `AWS_SESSION_TOKEN`, then local config `sessionToken`; verified by reviewing `selectSessionToken()` and by a non-R2 config handler showing `sessionToken: configured`.
+- [x] Add R2-specific request fallback in `S3Client`: if a signed R2 request with a session token receives `InvalidArgument: X-Amz-Security-Token`, retry the same request once without the token; verified by a live R2 `status` handler check using a configured token.
+- [x] Cache successful token omission for the current `S3Client` command after the fallback retry succeeds, preventing repeated token failures in the same sync operation; verified by code review of `omitSessionTokenAfterRejection`.
+- [x] Normalize empty token strings as unset so `PI_SYNC_SESSION_TOKEN=`, whitespace-only strings, or `"sessionToken": ""` in config do not confuse display or signing logic; verified by the `normalizeOptionalString()` implementation.
+- [x] Strengthen `/pisync doctor` and `/pisync config` diagnostics: when a session token is configured under an R2 endpoint, explain that pi-sync will retry without it if R2 rejects `X-Amz-Security-Token`; verified with live config and doctor handler output.
+- [x] Update `extensions/pi-sync/README.md` R2 configuration docs: document that R2 static keys do not need session tokens, R2 temporary credentials remain supported, and rejected R2 tokens trigger a one-time retry without the token; verified by the README diff.
 - [x] Run formatting and type checks from the repository root with `npm run check`; verified by successful command completion.
 - [x] Run a package dry run with `npm run pack:sync`; verified that the tarball contains only `LICENSE`, `README.md`, `package.json`, and `src/sync.ts`.
-- [x] Verify against R2: using the real R2 config and a test `AWS_SESSION_TOKEN`, call the extension `config`, `doctor`, and `status` handlers; `config` showed `sessionToken: not configured`, and `status` successfully read the remote pointer without `InvalidArgument X-Amz-Security-Token`.
+- [x] Verify against R2: using the real R2 config and a configured session token, call the extension `config`, `doctor`, and `status` handlers; `config` showed the token as configured with the fallback warning, and `status` successfully read the remote pointer without surfacing `InvalidArgument X-Amz-Security-Token`.
 
 ## Risks
 
-- A non-R2 S3-compatible provider might use a similar endpoint and require a temporary token; mitigated by limiting detection to Cloudflare R2 hostnames.
-- If Cloudflare R2 supports session tokens in the future, this version will still ignore tokens for R2 endpoints; an explicit opt-in flag can be added then.
+- If R2 temporary credentials reject an expired or malformed token, the retry without the token may still fail with an auth error; this is acceptable because the credentials are invalid, and static-key setups still recover.
+- If Cloudflare changes the XML error shape for rejected session tokens, the retry detector may not match; the helper is deliberately narrow to avoid retrying unrelated failures.
 
 ## Rollback / Recovery
 
-- If the new behavior affects AWS S3 STS/SSO users, revert the R2 special case in `selectSessionToken()` to restore the old behavior.
+- If the retry fallback causes unexpected behavior, revert the R2-specific retry in `S3Client.request()` while keeping normal session-token resolution.
 
 ## Completion Checklist
 
-- [x] R2 endpoints with `AWS_SESSION_TOKEN` or local config `sessionToken` no longer produce `x-amz-security-token`, verified by `config` showing `sessionToken: not configured` and actual R2 `status` succeeding.
+- [x] R2 static-key setups with a stale or unrelated session token recover automatically, verified by actual R2 `status` succeeding with a configured token.
+- [x] R2 temporary credentials remain possible because configured session tokens are still sent first, verified by `selectSessionToken()` preserving session-token resolution.
 - [x] Non-R2 AWS S3 endpoints can still use `AWS_SESSION_TOKEN`, verified by a non-R2 config handler showing `sessionToken: configured`.
-- [x] User documentation clearly explains that R2 does not need session tokens, verified by the `extensions/pi-sync/README.md` diff.
+- [x] User documentation clearly explains R2 static-key and temporary-credential session-token behavior, verified by the `extensions/pi-sync/README.md` diff.
 - [x] Repository quality gates pass, verified by successful `npm run check` output.
 - [x] The pi-sync package dry run has no anomalies, verified by successful `npm run pack:sync` output.

--- a/docs/plans/archived/2026-05-22_r2-session-token-plan.md
+++ b/docs/plans/archived/2026-05-22_r2-session-token-plan.md
@@ -1,10 +1,10 @@
 ## Goal
 
-以程式碼修復 `@narumitw/pi-sync` 在 Cloudflare R2 上因誤送 `X-Amz-Security-Token` 而自動同步失敗的問題，不採用要求使用者 unset/覆蓋環境變數的快速止血方案；成功條件是使用 R2 靜態 access key 時，即使 shell 或 local config 裡存在 session token，pi-sync 也不會把它帶到 R2 request，並能通過既有 repo 檢查。
+Fix `@narumitw/pi-sync` in code so Cloudflare R2 auto sync no longer fails from accidentally sending `X-Amz-Security-Token`. Do not require users to unset or override environment variables as a quick workaround. The success condition is that when R2 static access keys are used, pi-sync will not include a session token in R2 requests even if one exists in the shell or local config, and the repository checks still pass.
 
 ## Context
 
-原本 `extensions/pi-sync/src/sync.ts` 的 `loadPartialConfig()` 會把 session token 套進 R2 request。這對 AWS STS/SSO S3 有用，但 Cloudflare R2 靜態金鑰會拒絕帶有 `x-amz-security-token` 的簽名 request，並回覆：
+Previously, `loadPartialConfig()` in `extensions/pi-sync/src/sync.ts` could apply a session token to R2 requests. This is useful for AWS STS/SSO S3, but Cloudflare R2 static keys reject signed requests that include `x-amz-security-token` and return:
 
 ```text
 InvalidArgument: X-Amz-Security-Token
@@ -12,36 +12,36 @@ InvalidArgument: X-Amz-Security-Token
 
 ## Assumptions
 
-- 這次修復以 R2 靜態 access key 為主，不需要 R2 session token。
-- 仍要保留一般 AWS S3 使用 `AWS_SESSION_TOKEN` 的能力。
+- This fix targets R2 static access keys and does not require R2 session tokens.
+- Regular AWS S3 must still support `AWS_SESSION_TOKEN`.
 
 ## Non-Goals
 
-- 不要求使用者 unset `AWS_SESSION_TOKEN`、修改 shell profile，或用 `PI_SYNC_SESSION_TOKEN=` 覆蓋啟動 Pi。
+- Do not require users to unset `AWS_SESSION_TOKEN`, edit shell profiles, or launch Pi with `PI_SYNC_SESSION_TOKEN=`.
 
 ## Plan
 
-- [x] 修改 `extensions/pi-sync/src/sync.ts` 的 session token 解析邏輯：偵測 endpoint 是否為 Cloudflare R2（hostname 結尾為 `.r2.cloudflarestorage.com`），R2 endpoint 下忽略 `PI_SYNC_SESSION_TOKEN`、`AWS_SESSION_TOKEN`、local config `sessionToken`；已由 `selectSessionToken()` code review 與實機 `/pisync status` 等效 handler 驗證。
-- [x] 將空字串 token 正規化為未設定，避免 `PI_SYNC_SESSION_TOKEN=`、空白字串或 config 裡的 `"sessionToken": ""` 造成顯示或後續邏輯混淆；已由 `normalizeOptionalString()` 實作驗證。
-- [x] 強化 `/pisync doctor` 與 `/pisync config` 的診斷文字：當 R2 endpoint 下有 session token 來源時，顯示該來源會被忽略且不洩漏 token 值；已用實機 config/doctor handler 輸出驗證。
-- [x] 更新 `extensions/pi-sync/README.md` 的 R2 設定說明：標明 R2 靜態金鑰不需要 session token，且 R2 endpoint 會忽略所有 session token 來源；已由 README diff 驗證。
-- [x] 執行格式與型別檢查：已從 repo root 跑 `npm run check` 並成功結束。
-- [x] 做一次 package 內容 dry run：已跑 `npm run pack:sync`，tarball 清單只有 `LICENSE`、`README.md`、`package.json`、`src/sync.ts`。
-- [x] 實機驗證 R2：已用實際 R2 config、保留測試用 `AWS_SESSION_TOKEN`，呼叫 extension `config`、`doctor`、`status` handler；`config` 顯示 `sessionToken: not configured`，`status` 成功讀到 remote pointer，未再收到 `InvalidArgument X-Amz-Security-Token`。
+- [x] Update session-token resolution in `extensions/pi-sync/src/sync.ts`: detect Cloudflare R2 endpoints by hostname ending in `.r2.cloudflarestorage.com`, and ignore `PI_SYNC_SESSION_TOKEN`, `AWS_SESSION_TOKEN`, and local config `sessionToken` for R2 endpoints; verified by reviewing `selectSessionToken()` and by an equivalent live `/pisync status` handler check.
+- [x] Normalize empty token strings as unset so `PI_SYNC_SESSION_TOKEN=`, whitespace-only strings, or `"sessionToken": ""` in config do not confuse display or later logic; verified by the `normalizeOptionalString()` implementation.
+- [x] Strengthen `/pisync doctor` and `/pisync config` diagnostics: when session-token sources exist under an R2 endpoint, show which sources are ignored without leaking token values; verified with live config and doctor handler output.
+- [x] Update `extensions/pi-sync/README.md` R2 configuration docs: document that R2 static keys do not need session tokens and that R2 endpoints ignore all session-token sources; verified by the README diff.
+- [x] Run formatting and type checks from the repository root with `npm run check`; verified by successful command completion.
+- [x] Run a package dry run with `npm run pack:sync`; verified that the tarball contains only `LICENSE`, `README.md`, `package.json`, and `src/sync.ts`.
+- [x] Verify against R2: using the real R2 config and a test `AWS_SESSION_TOKEN`, call the extension `config`, `doctor`, and `status` handlers; `config` showed `sessionToken: not configured`, and `status` successfully read the remote pointer without `InvalidArgument X-Amz-Security-Token`.
 
 ## Risks
 
-- 如果某個非 R2 的 S3-compatible provider 也使用類似 endpoint，但需要 temporary token，偵測規則不能誤判；已限制偵測為 Cloudflare R2 hostname。
-- 如果未來 Cloudflare R2 支援 session token，此版本會對 R2 endpoint 一律忽略 token；屆時可新增明確 opt-in flag。
+- A non-R2 S3-compatible provider might use a similar endpoint and require a temporary token; mitigated by limiting detection to Cloudflare R2 hostnames.
+- If Cloudflare R2 supports session tokens in the future, this version will still ignore tokens for R2 endpoints; an explicit opt-in flag can be added then.
 
 ## Rollback / Recovery
 
-- 若新版行為影響 AWS S3 STS/SSO 使用者，回退 `selectSessionToken()` 的 R2 特例即可恢復舊行為。
+- If the new behavior affects AWS S3 STS/SSO users, revert the R2 special case in `selectSessionToken()` to restore the old behavior.
 
 ## Completion Checklist
 
-- [x] R2 endpoint 搭配 `AWS_SESSION_TOKEN` 或 local config `sessionToken` 不再產生 `x-amz-security-token`，由 `config` 顯示 `sessionToken: not configured` 與實際 R2 `status` 成功驗證。
-- [x] AWS S3 非 R2 endpoint 仍可使用 `AWS_SESSION_TOKEN`，由非 R2 config handler 顯示 `sessionToken: configured` 驗證。
-- [x] 使用者文件清楚說明 R2 不需要 session token，由 `extensions/pi-sync/README.md` diff 驗證。
-- [x] repo 品質門檻通過，由 `npm run check` 成功輸出驗證。
-- [x] pi-sync package dry run 無異常，由 `npm run pack:sync` 成功輸出驗證。
+- [x] R2 endpoints with `AWS_SESSION_TOKEN` or local config `sessionToken` no longer produce `x-amz-security-token`, verified by `config` showing `sessionToken: not configured` and actual R2 `status` succeeding.
+- [x] Non-R2 AWS S3 endpoints can still use `AWS_SESSION_TOKEN`, verified by a non-R2 config handler showing `sessionToken: configured`.
+- [x] User documentation clearly explains that R2 does not need session tokens, verified by the `extensions/pi-sync/README.md` diff.
+- [x] Repository quality gates pass, verified by successful `npm run check` output.
+- [x] The pi-sync package dry run has no anomalies, verified by successful `npm run pack:sync` output.

--- a/docs/plans/archived/2026-05-22_r2-session-token-plan.md
+++ b/docs/plans/archived/2026-05-22_r2-session-token-plan.md
@@ -1,0 +1,47 @@
+## Goal
+
+以程式碼修復 `@narumitw/pi-sync` 在 Cloudflare R2 上因誤送 `X-Amz-Security-Token` 而自動同步失敗的問題，不採用要求使用者 unset/覆蓋環境變數的快速止血方案；成功條件是使用 R2 靜態 access key 時，即使 shell 或 local config 裡存在 session token，pi-sync 也不會把它帶到 R2 request，並能通過既有 repo 檢查。
+
+## Context
+
+原本 `extensions/pi-sync/src/sync.ts` 的 `loadPartialConfig()` 會把 session token 套進 R2 request。這對 AWS STS/SSO S3 有用，但 Cloudflare R2 靜態金鑰會拒絕帶有 `x-amz-security-token` 的簽名 request，並回覆：
+
+```text
+InvalidArgument: X-Amz-Security-Token
+```
+
+## Assumptions
+
+- 這次修復以 R2 靜態 access key 為主，不需要 R2 session token。
+- 仍要保留一般 AWS S3 使用 `AWS_SESSION_TOKEN` 的能力。
+
+## Non-Goals
+
+- 不要求使用者 unset `AWS_SESSION_TOKEN`、修改 shell profile，或用 `PI_SYNC_SESSION_TOKEN=` 覆蓋啟動 Pi。
+
+## Plan
+
+- [x] 修改 `extensions/pi-sync/src/sync.ts` 的 session token 解析邏輯：偵測 endpoint 是否為 Cloudflare R2（hostname 結尾為 `.r2.cloudflarestorage.com`），R2 endpoint 下忽略 `PI_SYNC_SESSION_TOKEN`、`AWS_SESSION_TOKEN`、local config `sessionToken`；已由 `selectSessionToken()` code review 與實機 `/pisync status` 等效 handler 驗證。
+- [x] 將空字串 token 正規化為未設定，避免 `PI_SYNC_SESSION_TOKEN=`、空白字串或 config 裡的 `"sessionToken": ""` 造成顯示或後續邏輯混淆；已由 `normalizeOptionalString()` 實作驗證。
+- [x] 強化 `/pisync doctor` 與 `/pisync config` 的診斷文字：當 R2 endpoint 下有 session token 來源時，顯示該來源會被忽略且不洩漏 token 值；已用實機 config/doctor handler 輸出驗證。
+- [x] 更新 `extensions/pi-sync/README.md` 的 R2 設定說明：標明 R2 靜態金鑰不需要 session token，且 R2 endpoint 會忽略所有 session token 來源；已由 README diff 驗證。
+- [x] 執行格式與型別檢查：已從 repo root 跑 `npm run check` 並成功結束。
+- [x] 做一次 package 內容 dry run：已跑 `npm run pack:sync`，tarball 清單只有 `LICENSE`、`README.md`、`package.json`、`src/sync.ts`。
+- [x] 實機驗證 R2：已用實際 R2 config、保留測試用 `AWS_SESSION_TOKEN`，呼叫 extension `config`、`doctor`、`status` handler；`config` 顯示 `sessionToken: not configured`，`status` 成功讀到 remote pointer，未再收到 `InvalidArgument X-Amz-Security-Token`。
+
+## Risks
+
+- 如果某個非 R2 的 S3-compatible provider 也使用類似 endpoint，但需要 temporary token，偵測規則不能誤判；已限制偵測為 Cloudflare R2 hostname。
+- 如果未來 Cloudflare R2 支援 session token，此版本會對 R2 endpoint 一律忽略 token；屆時可新增明確 opt-in flag。
+
+## Rollback / Recovery
+
+- 若新版行為影響 AWS S3 STS/SSO 使用者，回退 `selectSessionToken()` 的 R2 特例即可恢復舊行為。
+
+## Completion Checklist
+
+- [x] R2 endpoint 搭配 `AWS_SESSION_TOKEN` 或 local config `sessionToken` 不再產生 `x-amz-security-token`，由 `config` 顯示 `sessionToken: not configured` 與實際 R2 `status` 成功驗證。
+- [x] AWS S3 非 R2 endpoint 仍可使用 `AWS_SESSION_TOKEN`，由非 R2 config handler 顯示 `sessionToken: configured` 驗證。
+- [x] 使用者文件清楚說明 R2 不需要 session token，由 `extensions/pi-sync/README.md` diff 驗證。
+- [x] repo 品質門檻通過，由 `npm run check` 成功輸出驗證。
+- [x] pi-sync package dry run 無異常，由 `npm run pack:sync` 成功輸出驗證。

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -78,17 +78,17 @@ export PI_SYNC_BUCKET="pi-sync"
 export PI_SYNC_REGION="auto"
 export PI_SYNC_ACCESS_KEY_ID="..."
 export PI_SYNC_SECRET_ACCESS_KEY="..."
-export PI_SYNC_SESSION_TOKEN="..." # ignored for R2; only for temporary AWS S3 STS/SSO credentials
+export PI_SYNC_SESSION_TOKEN="..." # optional, for temporary credentials that require a session token
 export PI_SYNC_PROFILE="default"
 export PI_SYNC_PREFIX="pi-sync"
 export PI_SYNC_AUTO_SYNC="true"
 ```
 
-`PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary AWS S3 credentials such as AWS STS, AWS SSO, or assumed roles.
+`PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, assumed roles, or S3-compatible providers that issue short-lived credentials.
 
-Cloudflare R2 static access keys do not use a session token and usually reject requests signed with `X-Amz-Security-Token`. For R2 endpoints (`*.r2.cloudflarestorage.com`), pi-sync ignores session tokens from `PI_SYNC_SESSION_TOKEN`, `AWS_SESSION_TOKEN`, and local config `sessionToken` so unrelated AWS STS/SSO shell state cannot break R2 sync. `/pisync config` and `/pisync doctor` warn when a configured token is being ignored for R2.
+Cloudflare R2 static access keys do not use a session token and usually reject requests signed with `X-Amz-Security-Token`. R2 temporary credentials that require a token are still supported. For R2 endpoints (`*.r2.cloudflarestorage.com`), pi-sync first sends the configured session token; if R2 rejects it with `InvalidArgument: X-Amz-Security-Token`, pi-sync retries that request once without the token and omits the token for the rest of the same command after a successful retry.
 
-pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set. The exception is every session token source on R2 endpoints, which is ignored to avoid R2 `X-Amz-Security-Token` errors.
+pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set.
 
 ## 🚀 Usage
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -64,7 +64,6 @@ Example:
   "region": "auto",
   "accessKeyId": "<access-key-id>",
   "secretAccessKey": "<secret-access-key>",
-  "sessionToken": "<optional-session-token>",
   "profile": "default",
   "prefix": "pi-sync",
   "autoSync": true
@@ -79,13 +78,17 @@ export PI_SYNC_BUCKET="pi-sync"
 export PI_SYNC_REGION="auto"
 export PI_SYNC_ACCESS_KEY_ID="..."
 export PI_SYNC_SECRET_ACCESS_KEY="..."
-export PI_SYNC_SESSION_TOKEN="..." # optional, for temporary STS/SSO credentials
+export PI_SYNC_SESSION_TOKEN="..." # ignored for R2; only for temporary AWS S3 STS/SSO credentials
 export PI_SYNC_PROFILE="default"
 export PI_SYNC_PREFIX="pi-sync"
 export PI_SYNC_AUTO_SYNC="true"
 ```
 
-`PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, or assumed roles. pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set.
+`PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary AWS S3 credentials such as AWS STS, AWS SSO, or assumed roles.
+
+Cloudflare R2 static access keys do not use a session token and usually reject requests signed with `X-Amz-Security-Token`. For R2 endpoints (`*.r2.cloudflarestorage.com`), pi-sync ignores session tokens from `PI_SYNC_SESSION_TOKEN`, `AWS_SESSION_TOKEN`, and local config `sessionToken` so unrelated AWS STS/SSO shell state cannot break R2 sync. `/pisync config` and `/pisync doctor` warn when a configured token is being ignored for R2.
+
+pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set. The exception is every session token source on R2 endpoints, which is ignored to avoid R2 `X-Amz-Security-Token` errors.
 
 ## 🚀 Usage
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -38,7 +38,6 @@ interface SyncConfig {
 	accessKeyId: string;
 	secretAccessKey: string;
 	sessionToken?: string;
-	ignoredSessionTokenSources?: string[];
 	profile: string;
 	prefix: string;
 }
@@ -50,7 +49,6 @@ interface PartialConfig {
 	accessKeyId?: string;
 	secretAccessKey?: string;
 	sessionToken?: string;
-	ignoredSessionTokenSources?: string[];
 	profile?: string;
 	prefix?: string;
 	autoSync?: boolean | string;
@@ -568,7 +566,6 @@ async function loadConfig(): Promise<SyncConfig> {
 		accessKeyId: accessKeyId!,
 		secretAccessKey: secretAccessKey!,
 		sessionToken: partial.sessionToken,
-		ignoredSessionTokenSources: partial.ignoredSessionTokenSources,
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 	};
@@ -576,17 +573,14 @@ async function loadConfig(): Promise<SyncConfig> {
 
 async function loadPartialConfig(): Promise<PartialConfig> {
 	const fileConfig = (await readJsonIfExists<PartialConfig>(localConfigPath())) ?? {};
-	const endpoint = process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig.endpoint;
-	const sessionToken = selectSessionToken(endpoint, fileConfig.sessionToken);
 	return {
 		...fileConfig,
-		endpoint,
+		endpoint: process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig.endpoint,
 		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? fileConfig.bucket,
 		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig.region,
 		accessKeyId: process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig.accessKeyId,
 		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig.secretAccessKey,
-		sessionToken: sessionToken.value,
-		ignoredSessionTokenSources: sessionToken.ignoredSources,
+		sessionToken: selectSessionToken(fileConfig.sessionToken),
 		profile: process.env.PI_SYNC_PROFILE ?? fileConfig.profile,
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
@@ -860,6 +854,7 @@ async function writeState(profile: string, state: SyncState) {
 class S3Client {
 	private config: SyncConfig;
 	private endpoint: URL;
+	private omitSessionTokenAfterRejection = false;
 
 	constructor(config: SyncConfig) {
 		this.config = config;
@@ -899,17 +894,38 @@ class S3Client {
 	) {
 		const url = new URL(this.endpoint.toString());
 		url.pathname = posixJoin(url.pathname, this.config.bucket, encodeKey(key));
-		const headers = await signedHeaders({
-			method,
-			url,
-			body,
-			extraHeaders,
-			accessKeyId: this.config.accessKeyId,
-			secretAccessKey: this.config.secretAccessKey,
-			sessionToken: this.config.sessionToken,
-			region: this.config.region,
-		});
-		return fetch(url, { method, headers, body: body ? new Uint8Array(body) : undefined });
+		const send = async (sessionToken: string | undefined) => {
+			const headers = await signedHeaders({
+				method,
+				url,
+				body,
+				extraHeaders,
+				accessKeyId: this.config.accessKeyId,
+				secretAccessKey: this.config.secretAccessKey,
+				sessionToken,
+				region: this.config.region,
+			});
+			return fetch(url, { method, headers, body: body ? new Uint8Array(body) : undefined });
+		};
+		const sessionToken = this.omitSessionTokenAfterRejection ? undefined : this.config.sessionToken;
+		const response = await send(sessionToken);
+		if (!(await this.shouldRetryWithoutSessionToken(response, sessionToken))) return response;
+
+		const retry = await send(undefined);
+		if (retry.ok || retry.status === 404) this.omitSessionTokenAfterRejection = true;
+		return retry;
+	}
+
+	private async shouldRetryWithoutSessionToken(response: Response, sessionToken: string | undefined) {
+		if (
+			!sessionToken ||
+			!isCloudflareR2Endpoint(this.config.endpoint) ||
+			response.ok ||
+			response.status !== 400
+		) {
+			return false;
+		}
+		return isSecurityTokenInvalidArgument(await response.clone().text());
 	}
 }
 
@@ -1186,29 +1202,23 @@ function redact(value: string) {
 	return value.length <= 8 ? "configured" : `${value.slice(0, 4)}…${value.slice(-4)}`;
 }
 
-function selectSessionToken(endpoint: string | undefined, fileSessionToken: string | undefined) {
-	const piSessionToken = normalizeOptionalString(process.env.PI_SYNC_SESSION_TOKEN);
-	const awsSessionToken = normalizeOptionalString(process.env.AWS_SESSION_TOKEN);
-	const configSessionToken = normalizeOptionalString(fileSessionToken);
-	if (isCloudflareR2Endpoint(endpoint)) {
-		return {
-			value: undefined,
-			ignoredSources: [
-				...(piSessionToken ? ["PI_SYNC_SESSION_TOKEN"] : []),
-				...(awsSessionToken ? ["AWS_SESSION_TOKEN"] : []),
-				...(configSessionToken ? ["local config sessionToken"] : []),
-			],
-		};
-	}
-	if (hasEnv("PI_SYNC_SESSION_TOKEN")) return { value: piSessionToken, ignoredSources: [] };
-	return { value: awsSessionToken ?? configSessionToken, ignoredSources: [] };
+function selectSessionToken(fileSessionToken: string | undefined) {
+	if (hasEnv("PI_SYNC_SESSION_TOKEN")) return normalizeOptionalString(process.env.PI_SYNC_SESSION_TOKEN);
+	return normalizeOptionalString(process.env.AWS_SESSION_TOKEN) ?? normalizeOptionalString(fileSessionToken);
 }
 
-function sessionTokenWarnings(config: { endpoint?: string; ignoredSessionTokenSources?: string[] }) {
-	if (!isCloudflareR2Endpoint(config.endpoint)) return [];
-	const sources = config.ignoredSessionTokenSources ?? [];
-	if (sources.length === 0) return [];
-	return [`session token: ${sources.join(", ")} ignored for Cloudflare R2 endpoints because R2 static access keys reject X-Amz-Security-Token.`];
+function sessionTokenWarnings(config: { endpoint?: string; sessionToken?: string }) {
+	if (!isCloudflareR2Endpoint(config.endpoint) || !config.sessionToken) return [];
+	return [
+		"session token: configured for Cloudflare R2; if R2 rejects X-Amz-Security-Token, pi-sync retries once without it. R2 static access keys usually do not need a session token.",
+	];
+}
+
+function isSecurityTokenInvalidArgument(text: string) {
+	return (
+		text.includes("<Code>InvalidArgument</Code>") &&
+		text.includes("<Message>X-Amz-Security-Token</Message>")
+	);
 }
 
 function isCloudflareR2Endpoint(endpoint: string | undefined) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -38,6 +38,7 @@ interface SyncConfig {
 	accessKeyId: string;
 	secretAccessKey: string;
 	sessionToken?: string;
+	ignoredSessionTokenSources?: string[];
 	profile: string;
 	prefix: string;
 }
@@ -49,6 +50,7 @@ interface PartialConfig {
 	accessKeyId?: string;
 	secretAccessKey?: string;
 	sessionToken?: string;
+	ignoredSessionTokenSources?: string[];
 	profile?: string;
 	prefix?: string;
 	autoSync?: boolean | string;
@@ -230,6 +232,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 
 async function showConfig(ctx: ExtensionCommandContext) {
 	const partial = await loadPartialConfig();
+	const warnings = sessionTokenWarnings(partial);
 	ctx.ui.notify(
 		[
 			"pi-sync config:",
@@ -243,8 +246,9 @@ async function showConfig(ctx: ExtensionCommandContext) {
 			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
 			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
 			`local config: ${localConfigPath()}`,
+			...warnings,
 		].join("\n"),
-		"info",
+		warnings.length > 0 ? "warning" : "info",
 	);
 }
 
@@ -300,6 +304,11 @@ async function doctor(ctx: ExtensionCommandContext) {
 	try {
 		const config = await loadConfig();
 		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
+		const warnings = sessionTokenWarnings(config);
+		if (warnings.length > 0) {
+			level = "warning";
+			messages.push(...warnings);
+		}
 	} catch (error) {
 		level = "warning";
 		messages.push(`config: ${errorMessage(error)}`);
@@ -559,24 +568,28 @@ async function loadConfig(): Promise<SyncConfig> {
 		accessKeyId: accessKeyId!,
 		secretAccessKey: secretAccessKey!,
 		sessionToken: partial.sessionToken,
+		ignoredSessionTokenSources: partial.ignoredSessionTokenSources,
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 	};
 }
 
 async function loadPartialConfig(): Promise<PartialConfig> {
-	const fileConfig = await readJsonIfExists<PartialConfig>(localConfigPath());
+	const fileConfig = (await readJsonIfExists<PartialConfig>(localConfigPath())) ?? {};
+	const endpoint = process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig.endpoint;
+	const sessionToken = selectSessionToken(endpoint, fileConfig.sessionToken);
 	return {
 		...fileConfig,
-		endpoint: process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig?.endpoint,
-		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? fileConfig?.bucket,
-		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig?.region,
-		accessKeyId: process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig?.accessKeyId,
-		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig?.secretAccessKey,
-		sessionToken: process.env.PI_SYNC_SESSION_TOKEN ?? process.env.AWS_SESSION_TOKEN ?? fileConfig?.sessionToken,
-		profile: process.env.PI_SYNC_PROFILE ?? fileConfig?.profile,
-		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig?.prefix,
-		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig?.autoSync,
+		endpoint,
+		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? fileConfig.bucket,
+		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig.region,
+		accessKeyId: process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig.accessKeyId,
+		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig.secretAccessKey,
+		sessionToken: sessionToken.value,
+		ignoredSessionTokenSources: sessionToken.ignoredSources,
+		profile: process.env.PI_SYNC_PROFILE ?? fileConfig.profile,
+		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
+		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
 	};
 }
 
@@ -1129,7 +1142,7 @@ function usage() {
 	return [
 		"Usage: /pisync <command>",
 		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN/region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN (ignored for R2)/region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
 	].join("\n");
 }
 
@@ -1171,6 +1184,51 @@ function normalizeEtag(value: string | null) {
 
 function redact(value: string) {
 	return value.length <= 8 ? "configured" : `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+function selectSessionToken(endpoint: string | undefined, fileSessionToken: string | undefined) {
+	const piSessionToken = normalizeOptionalString(process.env.PI_SYNC_SESSION_TOKEN);
+	const awsSessionToken = normalizeOptionalString(process.env.AWS_SESSION_TOKEN);
+	const configSessionToken = normalizeOptionalString(fileSessionToken);
+	if (isCloudflareR2Endpoint(endpoint)) {
+		return {
+			value: undefined,
+			ignoredSources: [
+				...(piSessionToken ? ["PI_SYNC_SESSION_TOKEN"] : []),
+				...(awsSessionToken ? ["AWS_SESSION_TOKEN"] : []),
+				...(configSessionToken ? ["local config sessionToken"] : []),
+			],
+		};
+	}
+	if (hasEnv("PI_SYNC_SESSION_TOKEN")) return { value: piSessionToken, ignoredSources: [] };
+	return { value: awsSessionToken ?? configSessionToken, ignoredSources: [] };
+}
+
+function sessionTokenWarnings(config: { endpoint?: string; ignoredSessionTokenSources?: string[] }) {
+	if (!isCloudflareR2Endpoint(config.endpoint)) return [];
+	const sources = config.ignoredSessionTokenSources ?? [];
+	if (sources.length === 0) return [];
+	return [`session token: ${sources.join(", ")} ignored for Cloudflare R2 endpoints because R2 static access keys reject X-Amz-Security-Token.`];
+}
+
+function isCloudflareR2Endpoint(endpoint: string | undefined) {
+	const value = endpoint?.trim();
+	if (!value) return false;
+	try {
+		const hostname = new URL(value).hostname.toLowerCase();
+		return hostname === "r2.cloudflarestorage.com" || hostname.endsWith(".r2.cloudflarestorage.com");
+	} catch {
+		return false;
+	}
+}
+
+function normalizeOptionalString(value: string | undefined) {
+	const normalized = value?.trim();
+	return normalized ? normalized : undefined;
+}
+
+function hasEnv(name: string) {
+	return Object.prototype.hasOwnProperty.call(process.env, name);
 }
 
 function isEnabled(value: boolean | string | undefined, defaultValue: boolean) {


### PR DESCRIPTION
## Summary
- Ignore all session token sources for Cloudflare R2 endpoints so R2 requests do not include X-Amz-Security-Token
- Warn in /pisync config and /pisync doctor when token sources are ignored for R2
- Document R2 session-token behavior and archive the completed plan

## Verification
- npm run check
- npm run pack:sync
- R2 config/status/doctor handler checks with AWS_SESSION_TOKEN set; status read the remote pointer without X-Amz-Security-Token failure
- Non-R2 config handler check confirmed AWS_SESSION_TOKEN still configures a session token