### PR TITLE
fix(caffeinate): release sleep inhibitors on shutdown

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,7 +5,7 @@
 - `MEMORY.md` is not auto-loaded; check it before non-trivial debugging or design work when prior project context may matter.
 - npm can show a scoped package dist-tag (for example `latest`) while `npm view <package>` still returns 404; fix visibility with `npm access set status=public <package> --otp=<otp>` or publish a bumped version.
 - `npm access set status=public <package>` cannot create brand-new scoped packages; if it returns access 404, first run `npm publish --workspace <package> --access public`.
-- For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session. Ensure Windows inhibitors exit on stdin EOF and clear `ES_CONTINUOUS`; ensure Unix inhibitors are parent-bound and trap cleanup, or Pi shutdown can leave a power request/process active.
+- For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session. Ensure Windows inhibitors exit on stdin EOF, clear `ES_CONTINUOUS`, and pass execution-state flags as `[uint32]'0x...'`; ensure Unix inhibitors are parent-bound and trap cleanup, or Pi shutdown can leave a power request/process active.
 - When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,7 +5,7 @@
 - `MEMORY.md` is not auto-loaded; check it before non-trivial debugging or design work when prior project context may matter.
 - npm can show a scoped package dist-tag (for example `latest`) while `npm view <package>` still returns 404; fix visibility with `npm access set status=public <package> --otp=<otp>` or publish a bumped version.
 - `npm access set status=public <package>` cannot create brand-new scoped packages; if it returns access 404, first run `npm publish --workspace <package> --access public`.
-- For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session.
+- For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session. Ensure Windows inhibitors exit on stdin EOF and clear `ES_CONTINUOUS`; ensure Unix inhibitors are parent-bound and trap cleanup, or Pi shutdown can leave a power request/process active.
 - When testing TypeScript extensions via direct Node import, avoid parameter properties; Node's strip-only TypeScript loader rejects them even though `tsc` accepts them.
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -302,7 +302,7 @@ function windowsPowerInhibitorCommand(command: string): InhibitorCommand {
 }
 
 function windowsInhibitorScript() {
-	return `$ErrorActionPreference = 'Stop'; Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; $flags = 0x80000000 -bor 0x00000001 -bor 0x00000002; $release = 0x80000000; $stdin = [Console]::OpenStandardInput(); $buffer = New-Object byte[] 1; $readTask = $stdin.ReadAsync($buffer, 0, 1); try { while ($true) { [Native.Power]::SetThreadExecutionState($flags) | Out-Null; if ($readTask.Wait(30000)) { break } } } finally { [Native.Power]::SetThreadExecutionState($release) | Out-Null }`;
+	return `$ErrorActionPreference = 'Stop'; Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; $flags = [uint32]'0x80000003'; $release = [uint32]'0x80000000'; $stdin = [Console]::OpenStandardInput(); $buffer = New-Object byte[] 1; $readTask = $stdin.ReadAsync($buffer, 0, 1); try { while ($true) { [Native.Power]::SetThreadExecutionState($flags) | Out-Null; if ($readTask.Wait(30000)) { break } } } finally { [Native.Power]::SetThreadExecutionState($release) | Out-Null }`;
 }
 
 function isWsl() {

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -11,6 +11,7 @@ interface InhibitorCommand {
 	command: string;
 	args: string[];
 	description: string;
+	releaseOnStdinClose?: boolean;
 }
 
 interface CaffeinateState {
@@ -92,7 +93,7 @@ function startInhibitor(ctx: ExtensionContext) {
 	try {
 		const child = spawn(command.command, command.args, {
 			detached: false,
-			stdio: ["ignore", "pipe", "pipe"],
+			stdio: [command.releaseOnStdinClose ? "pipe" : "ignore", "pipe", "pipe"],
 		});
 
 		state.process = child;
@@ -144,12 +145,20 @@ function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?
 	child.removeAllListeners("error");
 
 	if (!child.killed) {
-		if (process.platform === "win32") {
+		if (state.command?.releaseOnStdinClose && child.stdin && !child.stdin.destroyed) {
+			child.stdin.end();
+			const killTimer = setTimeout(() => {
+				if (!child.killed) child.kill();
+			}, 2000);
+			killTimer.unref();
+		} else if (process.platform === "win32") {
 			child.kill();
 		} else {
 			child.kill("SIGTERM");
 		}
 	}
+
+	state.command = undefined;
 
 	if (options.notify !== false) {
 		ctx.ui.notify(`Released pi-caffeinate (${reason}).`, "info");
@@ -164,7 +173,7 @@ function getInhibitorCommand(): InhibitorCommand | undefined {
 	}
 
 	if (process.platform === "darwin") {
-		return { command: "caffeinate", args: ["-dimsu"], description: "caffeinate" };
+		return parentBoundUnixCommand("caffeinate", ["-dimsu"], "caffeinate");
 	}
 
 	if (process.platform === "linux") {
@@ -173,9 +182,9 @@ function getInhibitorCommand(): InhibitorCommand | undefined {
 		}
 
 		if (commandExists("systemd-inhibit")) {
-			return {
-				command: "systemd-inhibit",
-				args: [
+			return parentBoundUnixCommand(
+				"systemd-inhibit",
+				[
 					"--what=idle:sleep",
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
@@ -183,12 +192,12 @@ function getInhibitorCommand(): InhibitorCommand | undefined {
 					"sleep",
 					"infinity",
 				],
-				description: "systemd-inhibit",
-			};
+				"systemd-inhibit",
+			);
 		}
 
 		if (commandExists("caffeinate")) {
-			return { command: "caffeinate", args: ["-dimsu"], description: "caffeinate" };
+			return parentBoundUnixCommand("caffeinate", ["-dimsu"], "caffeinate");
 		}
 	}
 
@@ -197,6 +206,29 @@ function getInhibitorCommand(): InhibitorCommand | undefined {
 	}
 
 	return undefined;
+}
+
+function parentBoundUnixCommand(
+	command: string,
+	args: string[],
+	description: string,
+): InhibitorCommand {
+	return {
+		command: "sh",
+		args: [
+			"-c",
+			unixParentBoundScript(),
+			"pi-caffeinate-watch",
+			String(process.pid),
+			command,
+			...args,
+		],
+		description,
+	};
+}
+
+function unixParentBoundScript() {
+	return `parent=$1; shift; "$@" & child=$!; ( while kill -0 "$parent" 2>/dev/null; do sleep 5; done; kill "$child" 2>/dev/null ) & watcher=$!; cleanup() { kill "$watcher" 2>/dev/null; kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; }; trap 'cleanup; exit 0' INT TERM HUP EXIT; wait "$child"; status=$?; kill "$watcher" 2>/dev/null; trap - EXIT; exit "$status"`;
 }
 
 function commandExists(command: string) {
@@ -262,11 +294,12 @@ function windowsPowerInhibitorCommand(command: string): InhibitorCommand {
 		command,
 		args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", windowsInhibitorScript()],
 		description: "PowerShell SetThreadExecutionState",
+		releaseOnStdinClose: true,
 	};
 }
 
 function windowsInhibitorScript() {
-	return `Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; while ($true) { [Native.Power]::SetThreadExecutionState(0x80000000 -bor 0x00000001 -bor 0x00000002) | Out-Null; Start-Sleep -Seconds 30 }`;
+	return `$ErrorActionPreference = 'Stop'; Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; $flags = 0x80000000 -bor 0x00000001 -bor 0x00000002; $release = 0x80000000; $stdin = [Console]::OpenStandardInput(); $buffer = New-Object byte[] 1; $readTask = $stdin.ReadAsync($buffer, 0, 1); try { while ($true) { [Native.Power]::SetThreadExecutionState($flags) | Out-Null; if ($readTask.Wait(30000)) { break } } } finally { [Native.Power]::SetThreadExecutionState($release) | Out-Null }`;
 }
 
 function isWsl() {

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -147,10 +147,13 @@ function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?
 	if (!child.killed) {
 		if (state.command?.releaseOnStdinClose && child.stdin && !child.stdin.destroyed) {
 			child.stdin.end();
-			const killTimer = setTimeout(() => {
-				if (!child.killed) child.kill();
-			}, 2000);
-			killTimer.unref();
+			if (child.exitCode === null && child.signalCode === null) {
+				const killTimer = setTimeout(() => {
+					if (child.exitCode === null && child.signalCode === null && !child.killed) child.kill();
+				}, 2000);
+				killTimer.unref();
+				child.once("exit", () => clearTimeout(killTimer));
+			}
 		} else if (process.platform === "win32") {
 			child.kill();
 		} else {


### PR DESCRIPTION
## Summary
- release Windows SetThreadExecutionState inhibitors by closing stdin and clearing ES_CONTINUOUS
- wrap macOS/Linux inhibitors so they clean up on stop or parent process exit
- document the shutdown gotcha in MEMORY.md

## Verification
- npm run check
- commit hook: biome check, npm typecheck
- manual shell wrapper SIGTERM cleanup check
- manual shell wrapper parent-exit cleanup check