### PR TITLE
fix(plan-mode): trigger accepted plans as follow-ups

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -10,6 +10,7 @@
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
+- Symptom: extension accept/execute actions from `agent_end` may not trigger a new turn. Cause: `pi.sendMessage({ triggerTurn: true })` only triggers when idle. Fix: use `pi.sendUserMessage(..., { deliverAs: "followUp" })` when `ctx.isIdle()` is false.
 - Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -5,7 +5,6 @@ const STATUS_KEY = "plan-mode";
 const PLAN_WIDGET_KEY = "plan-mode-plan";
 const PLAN_CONTEXT_MESSAGE_TYPE = "plan-mode-context";
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
-const PLAN_IMPLEMENTATION_MESSAGE_TYPE = "plan-mode-implementation";
 const PLAN_CONTEXT_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const SAFE_BUILTIN_PLAN_TOOLS = new Set(["read", "bash", "grep", "find", "ls"]);
 const BLOCKED_BUILTIN_TOOLS = new Set(["edit", "write"]);
@@ -214,8 +213,7 @@ export default function planMode(pi: ExtensionAPI) {
 		if (!wasEnabled) {
 			ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
 		}
-		if (ctx.isIdle()) pi.sendUserMessage(prompt);
-		else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+		sendPlanModeUserMessage(prompt, ctx);
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {
@@ -224,6 +222,11 @@ export default function planMode(pi: ExtensionAPI) {
 		if (wasEnabled) restoreTools();
 		persistState();
 		updateUi(ctx);
+	}
+
+	function sendPlanModeUserMessage(message: string, ctx: ExtensionContext) {
+		if (ctx.isIdle()) pi.sendUserMessage(message);
+		else pi.sendUserMessage(message, { deliverAs: "followUp" });
 	}
 
 	function startImplementation(ctx: ExtensionContext) {
@@ -235,13 +238,9 @@ export default function planMode(pi: ExtensionAPI) {
 			return;
 		}
 
-		pi.sendMessage(
-			{
-				customType: PLAN_IMPLEMENTATION_MESSAGE_TYPE,
-				content: `Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`,
-				display: true,
-			},
-			{ triggerTurn: true },
+		sendPlanModeUserMessage(
+			`Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`,
+			ctx,
 		);
 	}
 
@@ -299,7 +298,7 @@ export default function planMode(pi: ExtensionAPI) {
 		}
 		if (choice === "Revise plan") {
 			const refinement = await ctx.ui.editor("Revise the plan", "");
-			if (refinement?.trim()) pi.sendUserMessage(refinement.trim());
+			if (refinement?.trim()) sendPlanModeUserMessage(refinement.trim(), ctx);
 			return;
 		}
 		if (choice === "Exit Plan mode") {


### PR DESCRIPTION
## Summary
- send accepted plan implementation requests as user messages instead of custom messages
- queue implementation/refinement prompts as follow-ups when the agent is not idle
- record the Pi extension trigger-turn gotcha in MEMORY.md

## Verification
- npm --workspace @narumitw/pi-plan-mode run typecheck
- npm run check