### PR TITLE
fix(pi-retry): increase default stall timeout

### DIFF
--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -41,7 +41,7 @@ pi -e ./extensions/pi-retry
 
 When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
 
-After Pi sends a provider request, the extension also starts a stall watchdog. Provider responses and assistant stream events briefly refresh a `📥 receiving` statusline item, so you can tell that data is still arriving while Pi shows its normal working indicator. If no provider response or assistant stream event is observed for 30000ms, it briefly shows `🔁 retrying`, calls `ctx.abort()`, and rewrites the resulting assistant abort/error as a retryable provider error.
+After Pi sends a provider request, the extension also starts a stall watchdog. Provider responses and assistant stream events briefly refresh a `📥 receiving` statusline item, so you can tell that data is still arriving while Pi shows its normal working indicator. If no provider response or assistant stream event is observed for 90s, it briefly shows `🔁 retrying`, calls `ctx.abort()`, and rewrites the resulting assistant abort/error as a retryable provider error.
 
 Configure the watchdog with:
 

--- a/extensions/pi-retry/src/retry.ts
+++ b/extensions/pi-retry/src/retry.ts
@@ -7,7 +7,7 @@ const STALL_WATCHDOG_TAG = "[stall-watchdog-retry]";
 const STATUS_KEY = "unknown-error-retry";
 const STATUS_VISIBLE_MS = 8_000;
 const INCOMING_STATUS_VISIBLE_MS = 1_500;
-const DEFAULT_STALL_TIMEOUT_MS = 30_000;
+const DEFAULT_STALL_TIMEOUT_MS = 90_000;
 const STALL_TIMEOUT_FLAG = "retry-stall-timeout-ms";
 const STALL_TIMEOUT_ENV = "PI_RETRY_STALL_TIMEOUT_MS";
 


### PR DESCRIPTION
## Summary
- increase the pi-retry stall watchdog default from 30s to 90s
- update README wording to describe the 90s default

## Verification
- `npm --workspace @narumitw/pi-retry run check`