### PR TITLE
fix(statusline): use bullet for Tokyo Night separator

### DIFF
--- a/extensions/pi-statusline/presets/tokyo-night.ts
+++ b/extensions/pi-statusline/presets/tokyo-night.ts
@@ -36,7 +36,7 @@ export function renderTokyoNightStatusline(width: number, segments: RenderSegmen
 }
 
 export function tokyoNightExtensionSeparator(_theme: Theme): string {
-	return ansiFg(TOKYO_NIGHT_COLORS.extensionSeparator, "  ");
+	return ansiFg(TOKYO_NIGHT_COLORS.extensionSeparator, " • ");
 }
 
 function joinTokyoNightSegments(segments: RenderSegment[]): string {


### PR DESCRIPTION
## Summary
- replace the Tokyo Night extension separator glyph with a bullet

## Tests
- npm run check