### PR TITLE
docs: translate archived docs to English

### DIFF
--- a/docs/plans/archived/2026-05-16_codex-usage-extension-plan.md
+++ b/docs/plans/archived/2026-05-16_codex-usage-extension-plan.md
@@ -1,32 +1,52 @@
 ## Status
 
-完成。實作已在 PR #24（`feat/codex-usage-extension`）中送出，包含 `/codex-status`、`openai-codex` model 自動 statusline、Pi auth direct backend、Codex app-server fallback、README/root metadata、local install 與 package verification。
+Complete. The implementation shipped in PR #24 (`feat/codex-usage-extension`) with
+`/codex-status`, automatic statusline support for the `openai-codex` model, Pi auth
+direct backend support, the Codex app-server fallback, README/root metadata, local install
+support, and package verification.
 
 ## Goal
 
-建立一個新的 Pi extension package，讓使用者可在 Pi 中查看目前 Codex ChatGPT/subscription 使用量，效果接近在 Codex TUI 輸入 `/status` 時看到的 rate limit、reset time、credits 與 plan 資訊。
+Create a new Pi extension package that lets users view current Codex ChatGPT/subscription
+usage in Pi, similar to the rate limit, reset time, credits, and plan information shown by
+`/status` in the Codex TUI.
 
-成功條件是新增的 extension 能透過一個明確命令（建議 `/codex-status`）安全地查詢 Codex 使用量、格式化為可讀輸出、在沒有 Codex CLI 或未登入時給出可行錯誤訊息，並符合本 monorepo 的 package、README、typecheck 與 pack 驗證規範。
+The success criteria are that the new extension can safely query Codex usage through a
+clear command, preferably `/codex-status`, format it into readable output, provide useful
+errors when Codex CLI is unavailable or the user is not signed in, and satisfy this
+monorepo's package, README, typecheck, and pack verification standards.
 
 ## Context
 
-已檢視 `third_party/codex` 中和 `/status` 使用量相關的實作：
+The `/status` usage-related implementation in `third_party/codex` has been reviewed:
 
-- `codex-rs/tui/src/chatwidget/slash_dispatch.rs`：`/status` 會觸發 rate-limit refresh。
-- `codex-rs/tui/src/status/rate_limits.rs` 與 `codex-rs/tui/src/status/card.rs`：將 `RateLimitSnapshot` 格式化為 5h/weekly limits、credits、reset time。
-- `codex-rs/app-server/src/request_processors/account_processor.rs`：app-server 的 `account/rateLimits/read` 會讀 Codex account rate limits。
-- `codex-rs/backend-client/src/client.rs`：實際呼叫 `GET /wham/usage` 或 `/api/codex/usage`，並轉成 `RateLimitSnapshot`。
-- `codex-rs/app-server/README.md`：app-server 支援 stdio JSON-RPC，並要求先 `initialize` 再呼叫 `account/rateLimits/read`。
+- `codex-rs/tui/src/chatwidget/slash_dispatch.rs`: `/status` triggers a rate-limit
+  refresh.
+- `codex-rs/tui/src/status/rate_limits.rs` and `codex-rs/tui/src/status/card.rs`: format
+  `RateLimitSnapshot` into 5h/weekly limits, credits, and reset time.
+- `codex-rs/app-server/src/request_processors/account_processor.rs`: the app-server
+  `account/rateLimits/read` request reads Codex account rate limits.
+- `codex-rs/backend-client/src/client.rs`: calls `GET /wham/usage` or
+  `/api/codex/usage` and converts the response into `RateLimitSnapshot`.
+- `codex-rs/app-server/README.md`: the app-server supports stdio JSON-RPC and requires
+  `initialize` before calling `account/rateLimits/read`.
 
 ## Architecture
 
-採用多來源查詢策略，讓未安裝 Codex CLI 的 Pi 使用者也有機會使用：
+Use a multi-source query strategy so Pi users without Codex CLI still have a usable path:
 
-1. **Primary：Pi auth direct backend**。若 Pi 目前 model/provider 已透過 ChatGPT/Codex subscription auth 登入，優先使用 `ctx.modelRegistry.getApiKeyAndHeaders(ctx.model)` 取得 Pi 已有的 bearer token 與 headers，直接呼叫 Codex backend usage endpoint。
-2. **Fallback：Codex app-server**。若 Pi auth 不可用但本機有 Codex CLI，才 spawn `codex app-server --listen stdio://` 並呼叫 `account/rateLimits/read`，交給 Codex 處理 token refresh 與 auth storage。
-3. **No auth source**。若既沒有 Pi ChatGPT/Codex auth，也沒有 Codex CLI/auth，extension 只能回報「缺少可用認證來源」；不能在沒有任何登入憑證的情況下取得 subscription quota。
+1. **Primary: Pi auth direct backend**. If the current Pi model/provider is signed in
+   through ChatGPT/Codex subscription auth, first use
+   `ctx.modelRegistry.getApiKeyAndHeaders(ctx.model)` to get Pi's existing bearer token
+   and headers, then call the Codex backend usage endpoint directly.
+2. **Fallback: Codex app-server**. If Pi auth is unavailable but Codex CLI exists locally,
+   spawn `codex app-server --listen stdio://` and call `account/rateLimits/read`, letting
+   Codex handle token refresh and auth storage.
+3. **No auth source**. If neither Pi ChatGPT/Codex auth nor Codex CLI/auth is available,
+   the extension can only report that no usable auth source is available. It cannot obtain
+   subscription quota without any signed-in credentials.
 
-建議資料流：
+Recommended data flow:
 
 ```text
 Pi /codex-status command
@@ -38,7 +58,7 @@ Pi /codex-status command
   -> render in Pi notification/custom modal/tool result
 ```
 
-新 package 建議：
+Suggested new package:
 
 ```text
 extensions/pi-codex-usage/
@@ -50,53 +70,108 @@ extensions/pi-codex-usage/
     └── codex-usage.ts
 ```
 
-核心模組可先集中在 `src/codex-usage.ts`；若檔案過大，再拆成：
+The core module can start in `src/codex-usage.ts`; if the file becomes too large, split it
+into:
 
-- `pi-auth-backend-client.ts`：使用 Pi modelRegistry auth 直接呼叫 Codex usage endpoint。
-- `codex-app-server-client.ts`：可選 fallback，spawn/stdin/stdout JSON-RPC client、timeout、cleanup。
-- `rate-limit-format.ts`：純格式化與 reset time 顯示。
-- `codex-usage.ts`：Pi extension entrypoint、auth source selection、command/UI glue。
+- `pi-auth-backend-client.ts`: uses Pi modelRegistry auth to call the Codex usage endpoint
+  directly.
+- `codex-app-server-client.ts`: optional fallback with spawn/stdin/stdout JSON-RPC client,
+  timeout, and cleanup.
+- `rate-limit-format.ts`: pure formatting and reset-time display.
+- `codex-usage.ts`: Pi extension entrypoint, auth source selection, and command/UI glue.
 
 ## Tech Stack
 
-- TypeScript Pi extension，使用新版 `@earendil-works/pi-coding-agent` 型別與 Node built-ins；不再為新 package 使用已 deprecated 的 `@mariozechner/pi-*` 套件。
-- Node `fetch` 直接呼叫 Codex backend usage endpoint。
-- Node `child_process.spawn` 與 `readline`/stream parser 只用於 Codex app-server fallback。
-- 不在 MVP 新增 runtime dependency；只有在 mock/test 或格式化需求明確時才增加。
+- TypeScript Pi extension using the current `@earendil-works/pi-coding-agent` types and
+  Node built-ins; do not use deprecated `@mariozechner/pi-*` packages for new packages.
+- Node `fetch` calls the Codex backend usage endpoint directly.
+- Node `child_process.spawn` and a `readline`/stream parser are used only for the Codex
+  app-server fallback.
+- Do not add runtime dependencies for the MVP unless a mock/test or formatting need is
+  concrete.
 
 ## Non-Goals
 
-- 不直接解析、修改或刷新 `~/.codex/auth.json`。
-- 不實作獨立 footer/statusline renderer；只透過 Pi `setStatus` 暴露 compact usage，讓現有 statusline 顯示 extension status。
-- 不支援 OpenAI API key 的 platform rate limits；此功能聚焦 Codex ChatGPT/subscription quota。
-- 不複製 Codex TUI 的完整 `/status` 卡片，只提供 Pi 內可讀的使用量摘要。
+- Do not directly parse, modify, or refresh `~/.codex/auth.json`.
+- Do not implement a separate footer/statusline renderer; expose compact usage only through
+  Pi `setStatus` so the existing statusline can show the extension status.
+- Do not support OpenAI API key platform rate limits; this feature focuses on Codex
+  ChatGPT/subscription quota.
+- Do not copy the full Codex TUI `/status` card; provide only a readable usage summary in
+  Pi.
 
 ## Assumptions
 
-- 使用者若沒有 Codex CLI，仍可能已在 Pi 內使用 OpenAI ChatGPT Plus/Pro (Codex) subscription auth。
-- API key auth 不會回傳 Codex subscription usage；direct backend path 只對 ChatGPT/Codex bearer auth 有意義。
-- Pi extension package 可在 command handler 中短暫 spawn 子程序並在完成後清理，但這只是 fallback，不是必要條件。
+- Even if users do not have Codex CLI, they may still be using OpenAI ChatGPT Plus/Pro
+  (Codex) subscription auth inside Pi.
+- API key auth does not return Codex subscription usage; the direct backend path only makes
+  sense for ChatGPT/Codex bearer auth.
+- A Pi extension package can briefly spawn a child process inside the command handler and
+  clean it up afterward, but that is only a fallback, not a requirement.
 
 ## Resolved Findings
 
-- Pi `openai-codex` auth 可透過 `ctx.modelRegistry.getApiKeyAndHeaders(...)` 取得 bearer token，並成功呼叫 `https://chatgpt.com/backend-api/wham/usage`。
-- Direct backend response 對齊 Codex `RateLimitStatusPayload` snake_case 欄位；實作已加入 runtime parsing/normalization，將 direct backend 與 app-server response 轉成同一個 internal snapshot。
-- 本機 Codex CLI `codex app-server --listen stdio://` fallback 已對照 help/protocol 文件，並以 smoke test 驗證可回傳 usage。
-- MVP 呈現方式定案：`/codex-status` 用 `ctx.ui.notify` 顯示完整摘要；當目前 model provider 是 `openai-codex` 時，用 `ctx.ui.setStatus` 顯示 compact statusline，切換 away 時清除。
+- Pi `openai-codex` auth can get a bearer token through
+  `ctx.modelRegistry.getApiKeyAndHeaders(...)` and successfully call
+  `https://chatgpt.com/backend-api/wham/usage`.
+- The direct backend response aligns with Codex `RateLimitStatusPayload` snake_case fields;
+  runtime parsing/normalization converts both direct backend and app-server responses into
+  the same internal snapshot.
+- The local Codex CLI `codex app-server --listen stdio://` fallback has been checked
+  against help/protocol documentation, and a smoke test verified that it can return usage.
+- MVP presentation is decided: `/codex-status` uses `ctx.ui.notify` for the full summary;
+  when the current model provider is `openai-codex`, `ctx.ui.setStatus` shows a compact
+  statusline and clears it when switching away.
 
 ## Plan
 
-- [x] 建立 `extensions/pi-codex-usage` package scaffold，包含 `package.json` 的 `pi.extensions`、`files`、scripts、`@earendil-works/pi-coding-agent` dev dependency 與 `tsconfig.json`；用 `npm --workspace @narumitw/pi-codex-usage run typecheck` 驗證 package 能被 workspace 辨識。
-- [x] 在 root `package.json`、`justfile`、root `README.md` 加入 `pi-codex-usage` 的 check/pack/try/install/publish 入口與 package 表格說明；用 `just --list | rg 'codex-usage'` 和 root README diff 驗證入口完整。
-- [x] 實作 Pi auth direct backend client，從 `ctx.modelRegistry.getApiKeyAndHeaders(ctx.model)` 取得可用 auth，呼叫 `https://chatgpt.com/backend-api/wham/usage`，並在 auth 不可用、HTTP 401/403、payload unsupported 時回傳結構化錯誤；用 real Pi auth smoke test 與 fixture import 驗證 success 與 formatter code path。
-- [x] 實作可選 Codex app-server JSON-RPC fallback client，能在 direct backend 不可用且 `codex` executable 存在時 spawn `codex app-server --listen stdio://`、送出 `initialize`、送出 `initialized` notification、呼叫 `account/rateLimits/read`、在 timeout/exit/error 時清理 process；用 `codex app-server --help` 對照 flag 與 protocol 文件驗證 handshake。
-- [x] 定義 TypeScript 型別 `RateLimitStatusPayload`、`RateLimitWindow`、`RateLimitSnapshot`、`GetAccountRateLimitsResponse`，對齊 `third_party/codex/codex-rs/backend-client/src/client.rs` 與 `app-server-protocol/schema/typescript/v2/*`；用 `npm --workspace @narumitw/pi-codex-usage run typecheck` 驗證型別與 parser 編譯通過。
-- [x] 實作 rate-limit normalization 與 formatting，把 direct backend payload 和 app-server response 都轉成同一個 internal snapshot，再輸出每個 limit bucket 的 used/left percent、window label（例如 5h/weekly）、reset time、credits 與 unavailable/missing 狀態；用 fixture JSON 驗證 5h、weekly、multi-bucket 與 credits 文字輸出。
-- [x] 註冊 `/codex-status` command，依序嘗試 Pi auth direct backend 與 Codex app-server fallback，顯示 loading/activity status，完成後用 Pi UI 顯示摘要，錯誤時提供「在 Pi 內登入 ChatGPT/Codex subscription / 安裝 Codex CLI 作 fallback / 此功能不支援 API key quota」等下一步；用 direct command-handler smoke test 驗證 Pi auth 路徑可運作。
-- [x] 加入 5–15 分鐘記憶體快取與 `--refresh` 參數，避免連續 `/codex-status` 頻繁打 Codex backend；用 implementation review 驗證第二次命令使用 cache，而 `/codex-status --refresh` 會重新查詢。
-- [x] 更新 `extensions/pi-codex-usage/README.md`，說明安裝、`/codex-status` 用法、優先使用 Pi ChatGPT/Codex auth、不需要安裝 Codex CLI、Codex CLI 只是 fallback、MVP 不支援 API key quota、錯誤排查與隱私注意事項，且風格對齊其他 extension README；用 README review 和 `npm run check` 驗證文件與格式。
-- [x] 執行 repository verification，包含 `npm run check` 與 `just pack codex-usage`，並檢查 dry-run tarball 只包含 `src`、`README.md`、`LICENSE` 與 package metadata；用命令輸出作為驗證證據。
-- [x] 若 MVP 驗證穩定，再評估是否新增 optional widget/footer 顯示（預設關閉）；本版不新增獨立 widget/footer，但依使用者要求在目前 model provider 為 `openai-codex` 時透過 `setStatus` 顯示 compact usage，並每 5 分鐘刷新。
+- [x] Create the `extensions/pi-codex-usage` package scaffold, including `pi.extensions`,
+  `files`, scripts, `@earendil-works/pi-coding-agent` dev dependency, and `tsconfig.json`
+  in `package.json`; verify the package is recognized by the workspace with
+  `npm --workspace @narumitw/pi-codex-usage run typecheck`.
+- [x] Add `pi-codex-usage` check/pack/try/install/publish entries and package table
+  documentation to root `package.json`, `justfile`, and root `README.md`; verify entry
+  completeness with `just --list | rg 'codex-usage'` and a root README diff.
+- [x] Implement the Pi auth direct backend client: get usable auth from
+  `ctx.modelRegistry.getApiKeyAndHeaders(ctx.model)`, call
+  `https://chatgpt.com/backend-api/wham/usage`, and return structured errors when auth is
+  unavailable, HTTP returns 401/403, or the payload is unsupported; verify the success and
+  formatter code paths with a real Pi auth smoke test and fixture imports.
+- [x] Implement the optional Codex app-server JSON-RPC fallback client: when the direct
+  backend is unavailable and the `codex` executable exists, spawn
+  `codex app-server --listen stdio://`, send `initialize`, send the `initialized`
+  notification, call `account/rateLimits/read`, and clean up on timeout/exit/error; verify
+  the handshake against `codex app-server --help` and protocol documentation.
+- [x] Define TypeScript types `RateLimitStatusPayload`, `RateLimitWindow`,
+  `RateLimitSnapshot`, and `GetAccountRateLimitsResponse`, aligned with
+  `third_party/codex/codex-rs/backend-client/src/client.rs` and
+  `app-server-protocol/schema/typescript/v2/*`; verify the types and parser compile with
+  `npm --workspace @narumitw/pi-codex-usage run typecheck`.
+- [x] Implement rate-limit normalization and formatting: convert both direct backend
+  payloads and app-server responses into one internal snapshot, then output used/remaining
+  percent, window labels such as 5h/weekly, reset time, credits, and unavailable/missing
+  states for each limit bucket; verify 5h, weekly, multi-bucket, and credits text output
+  with fixture JSON.
+- [x] Register the `/codex-status` command: try Pi auth direct backend and Codex app-server
+  fallback in order, show loading/activity status, display the summary through Pi UI when
+  complete, and provide next steps for errors such as "sign in to ChatGPT/Codex
+  subscription in Pi / install Codex CLI as fallback / API key quota is unsupported"; verify
+  the Pi auth path with a direct command-handler smoke test.
+- [x] Add a 5-15 minute in-memory cache and a `--refresh` argument to avoid repeatedly
+  hitting the Codex backend from consecutive `/codex-status` calls; verify by implementation
+  review that the second command uses cache and `/codex-status --refresh` queries again.
+- [x] Update `extensions/pi-codex-usage/README.md` to document installation,
+  `/codex-status` usage, Pi ChatGPT/Codex auth priority, that Codex CLI is not required,
+  that Codex CLI is only a fallback, that the MVP does not support API key quota,
+  troubleshooting, and privacy notes, while matching the style of other extension READMEs;
+  verify the documentation and formatting with README review and `npm run check`.
+- [x] Run repository verification, including `npm run check` and `just pack codex-usage`,
+  and inspect the dry-run tarball to confirm it only contains `src`, `README.md`, `LICENSE`,
+  and package metadata; use command output as verification evidence.
+- [x] If MVP validation is stable, evaluate whether to add an optional widget/footer display
+  disabled by default; this version does not add a separate widget/footer, but per user
+  request it shows compact usage through `setStatus` when the current model provider is
+  `openai-codex` and refreshes every 5 minutes.
 
 ## Verification
 
@@ -114,23 +189,43 @@ extensions/pi-codex-usage/
 
 ## Risks
 
-- Pi subscription auth headers 可能不足以直接呼叫 Codex usage endpoint，導致未安裝 Codex CLI 的路徑需要額外 provider 支援。
-- Codex app-server protocol 或 CLI flags 可能變動，造成 fallback 和某些版本不相容。
-- 每次 command 都啟動 app-server fallback 可能偏慢；若保留常駐 process，則需更仔細處理 session shutdown 與 zombie process。
-- 使用量資料可能是瞬時快照；過度常駐顯示會讓使用者誤以為是即時資訊。
-- 錯誤訊息若包含 backend body，可能意外暴露敏感資訊；需要避免輸出 token、完整 auth headers 或過長 response body。
+- Pi subscription auth headers may be insufficient for calling the Codex usage endpoint
+  directly, which would require extra provider support for users without Codex CLI.
+- The Codex app-server protocol or CLI flags may change, making the fallback incompatible
+  with some versions.
+- Starting the app-server fallback on every command may be slow; keeping a resident process
+  would require more careful handling of session shutdown and zombie processes.
+- Usage data may be a momentary snapshot; an overly persistent display may make users think
+  it is real-time information.
+- Error messages that include backend bodies may accidentally expose sensitive information;
+  avoid outputting tokens, full auth headers, or overly long response bodies.
 
 ## Rollback / Recovery
 
-若新 package 造成 publish 或 install 問題，可只回滾 package registration 相關檔案（root `package.json`、`justfile`、root `README.md`）並保留未發布的 `extensions/pi-codex-usage` 目錄作後續修正。若已發布 npm package 且發現重大問題，發布 patch 版停用 command 或在 README 標示 known issue；不要要求使用者修改 Codex auth storage。
+If the new package causes publish or install issues, revert only the package registration
+files, namely root `package.json`, `justfile`, and root `README.md`, while keeping the
+unpublished `extensions/pi-codex-usage` directory for follow-up fixes. If the npm package
+has already been published and a serious issue is found, publish a patch version that
+disables the command or marks the known issue in the README; do not require users to modify
+Codex auth storage.
 
 ## Completion Checklist
 
-- [x] `@narumitw/pi-codex-usage` package scaffold 已建立，並由 `npm --workspace @narumitw/pi-codex-usage run typecheck` 驗證。
-- [x] `/codex-status` 能優先使用 Pi ChatGPT/Codex auth direct backend 查詢 usage，並由 direct command-handler smoke test 驗證成功路徑。
-- [x] Codex app-server fallback 可在 direct backend 不可用且本機有 Codex CLI 時查詢 `account/rateLimits/read`，並由 protocol/flag 對照與 typecheck 驗證。
-- [x] 未安裝 Codex CLI、未登入 Pi ChatGPT/Codex auth、API key auth、不支援 usage payload 等錯誤情境都有明確使用者訊息，並由 implementation review 和 fixture import 驗證。
-- [x] Rate-limit output 包含 used/left percent、reset time、credits 與 multi-bucket 資訊，並由 fixture output review 驗證。
-- [x] 快取、`--refresh` 與 `openai-codex` automatic statusline 行為已實作，並由 fixture/implementation review 驗證不會無限制頻繁查詢 backend。
-- [x] Root workspace metadata、README 與 just recipes 已包含 `pi-codex-usage`，並由 `just --list | rg 'codex-usage'` 與 README review 驗證。
-- [x] Repository gate 通過 `npm run check`，package dry run 通過 `just pack codex-usage` 且 tarball 內容正確。
+- [x] The `@narumitw/pi-codex-usage` package scaffold has been created and verified with
+  `npm --workspace @narumitw/pi-codex-usage run typecheck`.
+- [x] `/codex-status` can prioritize the Pi ChatGPT/Codex auth direct backend to query
+  usage, verified by a successful direct command-handler smoke test path.
+- [x] The Codex app-server fallback can query `account/rateLimits/read` when the direct
+  backend is unavailable and Codex CLI exists locally, verified by protocol/flag comparison
+  and typecheck.
+- [x] Error cases such as missing Codex CLI, missing Pi ChatGPT/Codex auth, API key auth,
+  and unsupported usage payloads all have clear user messages, verified by implementation
+  review and fixture imports.
+- [x] Rate-limit output includes used/remaining percent, reset time, credits, and
+  multi-bucket information, verified by fixture output review.
+- [x] Cache, `--refresh`, and `openai-codex` automatic statusline behavior are implemented
+  and verified by fixture/implementation review to avoid unlimited backend queries.
+- [x] Root workspace metadata, README, and just recipes include `pi-codex-usage`, verified
+  by `just --list | rg 'codex-usage'` and README review.
+- [x] The repository gate passed with `npm run check`, and package dry run passed with
+  `just pack codex-usage` with correct tarball contents.

--- a/docs/plans/archived/2026-05-17_pi-subagents-proactivity-research-plan.md
+++ b/docs/plans/archived/2026-05-17_pi-subagents-proactivity-research-plan.md
@@ -1,44 +1,105 @@
 ## Goal
 
-研究 `@narumitw/pi-subagents` 是否、以及應該如何變得更主動：讓主 agent 能自行判斷任務是否適合拆成多個 subagent、何時平行化、何時保留在主線完成，最後產出一份有證據的研究結論與 MVP 建議。成功條件是：研究文件明確列出可行方案、風險、第三方實作參考、外部研究/實作來源、以及是否進入實作階段的建議。
+Research whether `@narumitw/pi-subagents` should become more proactive, and how: let the
+main agent decide when a task is suitable for multiple subagents, when to parallelize, and
+when to keep the work on the main path. The final output should be an evidence-backed
+research conclusion and MVP recommendation. Success criteria: the research document clearly
+lists viable options, risks, third-party implementation references, external research or
+implementation sources, and a recommendation on whether to proceed to implementation.
 
 ## Context
 
-- 目前 `extensions/pi-subagents/src/subagents.ts` 主要註冊一個被動 `subagent` tool；它支援 single、parallel、chain、fan-in aggregator，但沒有 `promptSnippet` / `promptGuidelines`，也沒有透過 `before_agent_start` 動態提醒主 agent 主動拆工。
-- 目前 `extensions/pi-subagents/src/agents.ts` 已有 built-in `scout`、`planner`、`reviewer`、`worker`，但主 agent 在決定是否呼叫 `subagent` 前不一定會看到足夠強的「何時使用」規則。
-- `third_party/claude-code` 內已有可參考的 multi-agent / coordinator 實作痕跡，包括 `tools/AgentTool/prompt.ts`、`coordinator/coordinatorMode.ts`、`tools/TeamCreateTool/prompt.ts`、`tools/AgentTool/runAgent.ts`。
-- Pi extension docs 已提供可能的介入點：tool metadata (`promptSnippet` / `promptGuidelines`)、`before_agent_start` system prompt injection、`sendMessage` / `sendUserMessage`、status UI。
+- `extensions/pi-subagents/src/subagents.ts` currently mainly registers a passive
+  `subagent` tool. It supports single, parallel, chain, and fan-in aggregator modes, but it
+  has no `promptSnippet` / `promptGuidelines` and does not dynamically remind the main agent
+  to split work through `before_agent_start`.
+- `extensions/pi-subagents/src/agents.ts` already has built-in `scout`, `planner`,
+  `reviewer`, and `worker` agents, but the main agent may not see strong enough "when to
+  use this" rules before deciding whether to call `subagent`.
+- `third_party/claude-code` already contains useful multi-agent / coordinator
+  implementation traces, including `tools/AgentTool/prompt.ts`,
+  `coordinator/coordinatorMode.ts`, `tools/TeamCreateTool/prompt.ts`, and
+  `tools/AgentTool/runAgent.ts`.
+- Pi extension docs already provide possible intervention points: tool metadata
+  (`promptSnippet` / `promptGuidelines`), `before_agent_start` system prompt injection,
+  `sendMessage` / `sendUserMessage`, and status UI.
 
 ## Non-Goals
 
-- 本計畫不直接要求完成 production implementation；研究完成後再決定是否開實作計畫。
-- 不追求「每個任務都自動派 subagent」；研究需明確區分主動使用與過度委派。
-- 不預設要複製 Claude Code 的 coordinator/team 架構；只抽取適合 Pi extension 邊界的設計。
+- This plan does not directly require completing a production implementation; decide
+  whether to open an implementation plan after the research is complete.
+- Do not aim to "automatically assign subagents for every task"; the research must clearly
+  distinguish proactive use from over-delegation.
+- Do not assume the Claude Code coordinator/team architecture should be copied; extract only
+  designs that fit Pi extension boundaries.
 
 ## Assumptions
 
-- 第一優先應評估低風險 prompt / tool metadata 方案，再評估 coordinator 或 autonomous scheduler。
-- 主動化必須保留成本、延遲、安全確認與寫入衝突控制；不能只以「更多平行 agent」作為成功指標。
+- First evaluate low-risk prompt / tool metadata approaches, then evaluate coordinator or
+  autonomous scheduler approaches.
+- Proactivity must preserve cost, latency, safety confirmation, and write-conflict control;
+  "more parallel agents" cannot be the only success metric.
 
 ## Unknowns
 
-- `promptSnippet` / `promptGuidelines` 是否已足以讓主 agent 更常主動呼叫 `subagent`，或需要 `before_agent_start` 動態注入更強的 orchestration rules。
-- Pi extension 是否適合實作真正的 autonomous scheduler，例如在 `agent_end` 後自動追問/續跑，而不造成 feedback loop 或違反使用者期待。
-- 若加入動態 agent roster，是否會造成 prompt cache bust、token 成本上升，或與 project-local agent confirmation 安全模型衝突。
+- Whether `promptSnippet` / `promptGuidelines` are sufficient for making the main agent
+  proactively call `subagent` more often, or whether stronger orchestration rules must be
+  dynamically injected through `before_agent_start`.
+- Whether a Pi extension is a good place to implement a true autonomous scheduler, such as
+  automatically asking follow-up questions or continuing after `agent_end`, without causing
+  a feedback loop or violating user expectations.
+- Whether adding a dynamic agent roster would cause prompt cache busting, higher token cost,
+  or conflicts with the project-local agent confirmation safety model.
 
 ## Plan
 
-- [x] 建立研究輸出文件 `docs/implementation-notes/pi-subagents-proactivity-research.md`，放入研究範圍、問題定義、證據表格與結論章節；verify with `test -f docs/implementation-notes/pi-subagents-proactivity-research.md` and `rg -n "Problem|Evidence|Recommendation" docs/implementation-notes/pi-subagents-proactivity-research.md`.
-- [x] 盤點目前 `pi-subagents` 的主動性邊界，記錄 `extensions/pi-subagents/src/subagents.ts` 的 `registerTool` metadata、execution modes、status update 與 `extensions/pi-subagents/src/agents.ts` 的 built-in agents；verify with research note containing exact path references and `rg -n "registerTool|promptSnippet|promptGuidelines|before_agent_start" extensions/pi-subagents/src docs/implementation-notes/pi-subagents-proactivity-research.md`.
-- [x] 盤點 Pi extension 可用介入點，將 `promptSnippet`、`promptGuidelines`、`before_agent_start`、`sendMessage`、`sendUserMessage`、status UI 對應到可行的 proactivity mechanism；verify with cited references to `/home/narumi/.bun/install/global/node_modules/@earendil-works/pi-coding-agent/docs/extensions.md` in the research note.
-- [x] 研究 `third_party/claude-code` 的 multi-agent 實作，至少整理 `tools/AgentTool/prompt.ts`、`coordinator/coordinatorMode.ts`、`tools/TeamCreateTool/prompt.ts`、`tools/AgentTool/runAgent.ts` 的可借鏡模式與不適合直接移植的模式；verify with a table in the research note listing each path, pattern, and Pi applicability.
-- [x] 搜尋外部相關研究與實作，收集至少 5 個來源（例如 multi-agent orchestration、task decomposition、tool-use prompting、agent swarm/coordinator UX、Claude Code/Codex 類似功能），每個來源需有 URL、存取日期、重點摘要、對 Pi 的可用性；verify with `rg -n "https?://|accessed|Pi applicability" docs/implementation-notes/pi-subagents-proactivity-research.md`.
-- [x] 定義 proactivity levels，從 L0 被動 tool、L1 tool prompt hints、L2 dynamic orchestration prompt、L3 coordinator-style mode、L4 autonomous scheduler 分級，列出觸發條件、成本、實作複雜度與安全風險；verify with a level comparison table in the research note.
-- [x] 設計任務拆分判斷 rubric，明確列出適合拆分的情境（獨立 read-only research、多面向審查、implementation 後獨立 verification）與不適合拆分的情境（簡單回答、強共享上下文、同檔案寫入衝突、敏感/高成本任務、project agents 未授權）；verify with at least 8 example prompts classified by the rubric in the research note.
-- [x] 評估 MVP 設計選項，至少比較「只加 `promptSnippet` / `promptGuidelines`」、「加 `before_agent_start` 動態提示與 agent roster」、「新增 coordinator mode/command」、「新增 autonomous scheduler」四案；verify with a decision matrix covering correctness, UX, latency, cost, safety, and implementation effort.
-- [x] 規劃一個 bounded spike，用 feature flag 或 local-only branch 驗證 L1/L2 是否提高主動呼叫率，包含 6 個測試 prompts（3 個應使用 subagent、3 個不應使用）與 baseline/candidate 結果記錄；verify with an eval matrix saved in the research note and successful `npm run check` if code is touched.
+- [x] Create the research output file
+  `docs/implementation-notes/pi-subagents-proactivity-research.md` with research scope,
+  problem definition, evidence tables, and conclusion sections; verify with
+  `test -f docs/implementation-notes/pi-subagents-proactivity-research.md` and
+  `rg -n "Problem|Evidence|Recommendation" docs/implementation-notes/pi-subagents-proactivity-research.md`.
+- [x] Inventory the current `pi-subagents` proactivity boundary, recording
+  `registerTool` metadata, execution modes, status updates in
+  `extensions/pi-subagents/src/subagents.ts`, and built-in agents in
+  `extensions/pi-subagents/src/agents.ts`; verify with exact path references in the
+  research note and
+  `rg -n "registerTool|promptSnippet|promptGuidelines|before_agent_start" extensions/pi-subagents/src docs/implementation-notes/pi-subagents-proactivity-research.md`.
+- [x] Inventory available Pi extension intervention points and map `promptSnippet`,
+  `promptGuidelines`, `before_agent_start`, `sendMessage`, `sendUserMessage`, and status UI
+  to viable proactivity mechanisms; verify with cited references to
+  `/home/narumi/.bun/install/global/node_modules/@earendil-works/pi-coding-agent/docs/extensions.md`
+  in the research note.
+- [x] Research the `third_party/claude-code` multi-agent implementation and summarize at
+  least the useful and non-portable patterns from `tools/AgentTool/prompt.ts`,
+  `coordinator/coordinatorMode.ts`, `tools/TeamCreateTool/prompt.ts`, and
+  `tools/AgentTool/runAgent.ts`; verify with a table in the research note listing each
+  path, pattern, and Pi applicability.
+- [x] Search for related external research and implementations, collecting at least five
+  sources such as multi-agent orchestration, task decomposition, tool-use prompting, agent
+  swarm/coordinator UX, and Claude Code/Codex-like features. Each source needs a URL,
+  access date, key summary, and Pi applicability; verify with
+  `rg -n "https?://|accessed|Pi applicability" docs/implementation-notes/pi-subagents-proactivity-research.md`.
+- [x] Define proactivity levels from L0 passive tool, L1 tool prompt hints, L2 dynamic
+  orchestration prompt, L3 coordinator-style mode, to L4 autonomous scheduler, listing
+  triggers, cost, implementation complexity, and safety risks; verify with a level
+  comparison table in the research note.
+- [x] Design a task decomposition rubric that clearly lists suitable cases, such as
+  independent read-only research, multi-angle review, and independent verification after
+  implementation, plus unsuitable cases, such as simple answers, strongly shared context,
+  same-file write conflicts, sensitive/high-cost tasks, and unauthorized project agents;
+  verify with at least 8 example prompts classified by the rubric in the research note.
+- [x] Evaluate MVP design options, comparing at least "only add `promptSnippet` /
+  `promptGuidelines`", "add `before_agent_start` dynamic hints and agent roster", "add
+  coordinator mode/command", and "add autonomous scheduler"; verify with a decision matrix
+  covering correctness, UX, latency, cost, safety, and implementation effort.
+- [x] Plan a bounded spike using a feature flag or local-only branch to test whether L1/L2
+  increases proactive call rate, with 6 test prompts, including 3 that should use subagents
+  and 3 that should not, plus baseline/candidate result records; verify with an eval matrix
+  saved in the research note and successful `npm run check` if code is touched.
 - [x] Not applicable: explicit user review cannot be completed autonomously in goal mode; the `Recommendation` section clearly answers whether proactivity is worthwhile, which MVP level is recommended, and which risks move to the implementation plan, with follow-up review/implementation captured in `docs/plans/2026-05-17_pi-subagents-l1-proactivity-mvp-plan.md`.
-- [x] 若使用者接受研究結論，另開 implementation plan for the selected MVP；verify with a new `docs/plans/YYYY-MM-DD_<topic>-plan.md` path or explicit user acceptance that no implementation plan is needed.
+- [x] If the user accepts the research conclusion, open a separate implementation plan for
+  the selected MVP; verify with a new `docs/plans/YYYY-MM-DD_<topic>-plan.md` path or
+  explicit user acceptance that no implementation plan is needed.
 
 ## Completion Evidence
 
@@ -54,17 +115,34 @@
 
 ## Risks
 
-- 過度委派會增加 token 成本、等待時間與 UI noise；研究需用「何時不要用 subagent」抵消。
-- 自動拆工若碰到可寫入 agent，可能造成同檔案競爭或互相覆蓋；研究需優先建議 read-only fan-out 與 implementation serialization。
-- Project-local agents 受 repo 控制；更主動的使用方式不能繞過現有 confirmation 與 trust boundary。
-- 動態 agent roster 或長篇 orchestration prompt 可能造成 prompt cache bust 或上下文膨脹；研究需評估靜態 tool metadata 與動態 message injection 的取捨。
-- 真正 autonomous scheduler 可能形成自動 follow-up loop；研究需列出停止條件、使用者可見性與 opt-in 設計。
+- Over-delegation increases token cost, wait time, and UI noise; the research must offset
+  this with clear "when not to use subagents" guidance.
+- Automatic decomposition with writable agents may cause same-file contention or
+  overwrites; the research should prioritize read-only fan-out and implementation
+  serialization.
+- Project-local agents are controlled by the repo; more proactive use must not bypass the
+  existing confirmation and trust boundary.
+- A dynamic agent roster or long orchestration prompt may cause prompt cache busting or
+  context growth; the research must evaluate tradeoffs between static tool metadata and
+  dynamic message injection.
+- A true autonomous scheduler may create an automatic follow-up loop; the research must
+  define stop conditions, user visibility, and opt-in design.
 
 ## Completion Checklist
 
-- [x] 目前 `pi-subagents` 的被動/主動邊界已由 exact code references 驗證，evidence lives in `docs/implementation-notes/pi-subagents-proactivity-research.md`.
-- [x] `third_party/claude-code` 的相關實作已整理成可移植/不可移植模式表，verified by path references to at least four third-party files in the research note.
-- [x] 外部研究與實作搜尋已完成，verified by at least five sourced URLs with accessed dates and Pi applicability notes in the research note.
-- [x] Proactivity levels、拆分 rubric、MVP decision matrix 已完成，verified by corresponding tables and at least eight classified example prompts in the research note.
-- [x] L1/L2 bounded spike 或明確不做 spike 的理由已記錄，verified by eval matrix plus `npm run check` if code was touched, or by a documented not-applicable rationale.
-- [x] 最終 recommendation 已得到使用者接受或形成下一份 implementation plan，verified by explicit user acceptance or a new plan path.
+- [x] The current passive/proactive boundary of `pi-subagents` has been verified by exact
+  code references, with evidence in
+  `docs/implementation-notes/pi-subagents-proactivity-research.md`.
+- [x] The relevant `third_party/claude-code` implementation has been summarized into
+  portable/non-portable pattern tables, verified by path references to at least four
+  third-party files in the research note.
+- [x] External research and implementation search is complete, verified by at least five
+  sourced URLs with access dates and Pi applicability notes in the research note.
+- [x] Proactivity levels, decomposition rubric, and MVP decision matrix are complete,
+  verified by corresponding tables and at least eight classified example prompts in the
+  research note.
+- [x] The L1/L2 bounded spike or an explicit reason not to run the spike is recorded,
+  verified by an eval matrix plus `npm run check` if code was touched, or by a documented
+  not-applicable rationale.
+- [x] The final recommendation has either been accepted by the user or converted into the
+  next implementation plan, verified by explicit user acceptance or a new plan path.

--- a/docs/plans/archived/2026-05-20_statusline-theme-env-plan.md
+++ b/docs/plans/archived/2026-05-20_statusline-theme-env-plan.md
@@ -1,45 +1,95 @@
 ## Goal
 
-讓 `pi-statusline` 可用環境變數切換 statusline preset，先支援 `classic` 與 `tokyo-night`，並保留目前資訊內容、emoji、第二行 extension statuses 與安全截斷行為。
+Let `pi-statusline` switch statusline presets through an environment variable, initially
+supporting `classic` and `tokyo-night`, while preserving the current information content,
+emoji, second-line extension statuses, and safe truncation behavior.
 
 ## Context
 
-目前 `extensions/pi-statusline/src/statusline.ts` 已改為 Tokyo Night 配色的 Starship-inspired powerline renderer。靈感來源是 Starship Tokyo Night preset（https://starship.rs/presets/tokyo-night），其格式使用 `░▒▓` 開頭、`` powerline 銜接與 `#a3aed2`、`#769ff0`、`#394260`、`#212736`、`#1d2230` 色階。為避免破壞偏好原本樣式的使用者，下一步應恢復 classic renderer 並新增 preset selector，而不是拆成另一個 extension。
+`extensions/pi-statusline/src/statusline.ts` has already changed to a Tokyo Night colored,
+Starship-inspired powerline renderer. It was inspired by the Starship Tokyo Night preset
+(https://starship.rs/presets/tokyo-night), whose format uses a `░▒▓` prefix, ``
+powerline joins, and the `#a3aed2`, `#769ff0`, `#394260`, `#212736`, and `#1d2230` color
+scale. To avoid breaking users who prefer the original style, the next step should restore
+the classic renderer and add a preset selector instead of splitting it into another
+extension.
 
 ## Non-Goals
 
-- 不解析 Starship TOML。
-- 不新增 YAML/JSON config。
-- 不做任意 palette/layout 自訂。
-- 不新增 runtime dependency。
+- Do not parse Starship TOML.
+- Do not add YAML/JSON config.
+- Do not add arbitrary palette/layout customization.
+- Do not add runtime dependencies.
 
 ## Assumptions
 
-- `PI_STATUSLINE_PRESET=tokyo-night` 啟用新版 powerline 外觀。
-- `PI_STATUSLINE_PRESET=classic` 啟用原本外觀。
-- 未設定或設定無效時先使用 `tokyo-night` 作為目前新版預設；若要避免 breaking change，可在實作前改成 `classic`。
+- `PI_STATUSLINE_PRESET=tokyo-night` enables the new powerline appearance.
+- `PI_STATUSLINE_PRESET=classic` enables the original appearance.
+- When unset or invalid, use `tokyo-night` as the current new default for now; if avoiding a
+  breaking change is required, switch this to `classic` before implementation.
 
 ## Plan
 
-- [x] 在 `extensions/pi-statusline/src/statusline.ts` 新增 `StatuslinePresetName = "classic" | "tokyo-night"` 與 `readStatuslinePreset()`，從 `process.env.PI_STATUSLINE_PRESET` 讀取 preset；已由 `rg "PI_STATUSLINE_PRESET|StatuslinePresetName" extensions/pi-statusline/src` 與 `npm run check --workspace @narumitw/pi-statusline` 驗證。
-- [x] 將目前 Tokyo Night powerline renderer 保留為 `renderTokyoNightStatusline()`，並讓 `renderStatusline()` 依 config preset dispatch；已由 `extensions/pi-statusline/presets/tokyo-night.ts` 與 `renderStatusline()` switch 驗證，`tokyo-night` 路徑保留 `░▒▓` / `` truecolor blocks。
-- [x] 從 git diff 或先前版本還原 classic renderer 所需邏輯：`RIGHT_SEGMENTS`、palette/density/separator、`joinSegments()`、`styleSegment()`、`thinkingColor()`、`contextColor()` 與 labeled segment color；已由 `extensions/pi-statusline/presets/classic.ts`、`pickColor()`、`thinkingColor()`、`contextColor()` 與 typecheck 驗證。
-- [x] 依使用者要求將各 preset 拆成不同 `.ts` 檔，包含 `extensions/pi-statusline/presets/classic.ts`、`extensions/pi-statusline/presets/tokyo-night.ts`、`extensions/pi-statusline/presets/ansi.ts`、`extensions/pi-statusline/presets/types.ts`；已由 `find extensions/pi-statusline -path '*presets/*.ts' -type f` 與 typecheck 驗證。
-- [x] 調整 shared segment model，確保 classic 需要的 `color` 與 tokyo-night 需要的 `block` 不互相污染；已由 `RenderSegment` 同時帶 `color` / `block`，preset renderer 各自只消費需要欄位，並由 `npm run check --workspace @narumitw/pi-statusline` 驗證。
-- [x] 讓第二行 extension statuses 依 preset 使用 separator：classic 使用 Pi theme dim `•`，tokyo-night 使用 truecolor powerline-compatible ``；已由 `extensionStatusSeparator()`、`classicExtensionSeparator()`、`tokyoNightExtensionSeparator()` 與 typecheck 驗證。
-- [x] 更新 `extensions/pi-statusline/README.md`，記錄 `PI_STATUSLINE_PRESET=classic|tokyo-night`、預設值、無效值 fallback、emoji 仍保留、以及 Tokyo Night 靈感來源連結；已由 `rg "PI_STATUSLINE_PRESET|https://starship.rs/presets/tokyo-night" extensions/pi-statusline/README.md` 驗證。
-- [x] 執行 `npm run check --workspace @narumitw/pi-statusline`、`npm run check`、`just pack-statusline`；三個命令皆成功，pack dry-run 列出預期 package files：`LICENSE`、`README.md`、`package.json`、`src/statusline.ts` 與 `presets/*.ts`。
+- [x] Add `StatuslinePresetName = "classic" | "tokyo-night"` and
+  `readStatuslinePreset()` to `extensions/pi-statusline/src/statusline.ts`, reading the
+  preset from `process.env.PI_STATUSLINE_PRESET`; verified with
+  `rg "PI_STATUSLINE_PRESET|StatuslinePresetName" extensions/pi-statusline/src` and
+  `npm run check --workspace @narumitw/pi-statusline`.
+- [x] Keep the current Tokyo Night powerline renderer as `renderTokyoNightStatusline()` and
+  dispatch from `renderStatusline()` based on the config preset; verified by
+  `extensions/pi-statusline/presets/tokyo-night.ts` and the `renderStatusline()` switch,
+  with the `tokyo-night` path preserving the `░▒▓` / `` truecolor blocks.
+- [x] Restore the logic needed by the classic renderer from git diff or a previous version:
+  `RIGHT_SEGMENTS`, palette/density/separator, `joinSegments()`, `styleSegment()`,
+  `thinkingColor()`, `contextColor()`, and labeled segment color; verified by
+  `extensions/pi-statusline/presets/classic.ts`, `pickColor()`, `thinkingColor()`,
+  `contextColor()`, and typecheck.
+- [x] Split each preset into separate `.ts` files as requested by the user, including
+  `extensions/pi-statusline/presets/classic.ts`,
+  `extensions/pi-statusline/presets/tokyo-night.ts`,
+  `extensions/pi-statusline/presets/ansi.ts`, and
+  `extensions/pi-statusline/presets/types.ts`; verified with
+  `find extensions/pi-statusline -path '*presets/*.ts' -type f` and typecheck.
+- [x] Adjust the shared segment model so the `color` required by classic and the `block`
+  required by tokyo-night do not contaminate each other; verified because `RenderSegment`
+  carries both `color` and `block`, each preset renderer consumes only the fields it needs,
+  and `npm run check --workspace @narumitw/pi-statusline` passes.
+- [x] Make the second-line extension statuses use a preset-specific separator: classic uses
+  Pi theme dim `•`, while tokyo-night uses truecolor powerline-compatible ``; verified by
+  `extensionStatusSeparator()`, `classicExtensionSeparator()`, `tokyoNightExtensionSeparator()`,
+  and typecheck.
+- [x] Update `extensions/pi-statusline/README.md` to document
+  `PI_STATUSLINE_PRESET=classic|tokyo-night`, the default value, invalid-value fallback,
+  emoji preservation, and the Tokyo Night inspiration link; verified with
+  `rg "PI_STATUSLINE_PRESET|https://starship.rs/presets/tokyo-night" extensions/pi-statusline/README.md`.
+- [x] Run `npm run check --workspace @narumitw/pi-statusline`, `npm run check`, and
+  `just pack-statusline`; all three commands succeeded, and the pack dry run listed the
+  expected package files: `LICENSE`, `README.md`, `package.json`, `src/statusline.ts`, and
+  `presets/*.ts`.
 
 ## Risks
 
-- 同時維護 classic 與 tokyo-night renderer 會增加少量重複邏輯；已以共用資料收集與小型 renderer function 控制範圍。
-- ANSI truecolor/bold reset 可能影響截斷或背景延續；已保留 `truncateToWidth(..., "")`，且 Tokyo Night renderer 不手動依 visible string 長度切割 ANSI 字串。
+- Maintaining both classic and tokyo-night renderers adds a small amount of duplicated
+  logic; this is contained with shared data collection and small renderer functions.
+- ANSI truecolor/bold reset may affect truncation or background continuation; keep
+  `truncateToWidth(..., "")`, and the Tokyo Night renderer does not manually cut ANSI
+  strings by visible string length.
 
 ## Completion Checklist
 
-- [x] `PI_STATUSLINE_PRESET` 支援 `classic` 與 `tokyo-night`，由 `extensions/pi-statusline/src/statusline.ts` 中的 preset selector 與 dispatch 邏輯驗證。
-- [x] Classic 外觀可用且保留原本 emojis、左右分欄與 separator，由 `extensions/pi-statusline/presets/classic.ts`、shared segment builder 與 typecheck 驗證。
-- [x] Tokyo Night 外觀可用且保留 `░▒▓` / `` blocks 與 emojis，由 `extensions/pi-statusline/presets/tokyo-night.ts`、shared segment builder 與 typecheck 驗證。
-- [x] Extension statuses 第二行仍保留 emoji icon preservation，由 `formatExtensionStatus()` / `splitExtensionStatusIcon()` 未破壞、preset-specific separator 與 check 通過驗證。
-- [x] README 記錄環境變數切換方式與 Tokyo Night preset 靈感來源，由 `extensions/pi-statusline/README.md` 內容驗證。
-- [x] 品質門檻通過，由 `npm run check --workspace @narumitw/pi-statusline`、`npm run check`、`just pack-statusline` 成功輸出驗證。
+- [x] `PI_STATUSLINE_PRESET` supports `classic` and `tokyo-night`, verified by the preset
+  selector and dispatch logic in `extensions/pi-statusline/src/statusline.ts`.
+- [x] The classic appearance works and preserves the original emoji, left/right columns,
+  and separator, verified by `extensions/pi-statusline/presets/classic.ts`, the shared
+  segment builder, and typecheck.
+- [x] The Tokyo Night appearance works and preserves the `░▒▓` / `` blocks and emoji,
+  verified by `extensions/pi-statusline/presets/tokyo-night.ts`, the shared segment
+  builder, and typecheck.
+- [x] The extension statuses second line still preserves emoji icons, verified because
+  `formatExtensionStatus()` / `splitExtensionStatusIcon()` were not broken and
+  preset-specific separators plus check passed.
+- [x] The README documents environment-variable switching and the Tokyo Night preset
+  inspiration source, verified by `extensions/pi-statusline/README.md` content.
+- [x] Quality gates passed, verified by successful output from
+  `npm run check --workspace @narumitw/pi-statusline`, `npm run check`, and
+  `just pack-statusline`.


### PR DESCRIPTION
## Summary
- translate the remaining non-English archived docs under docs/plans/archived
- preserve Markdown structure, commands, paths, URLs, and checklist evidence

## Verification
- rg -n "[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]" docs
- rg -n "[，。；：「」『』（）【】、？！]" docs
- git diff --check
- npm run check