### PR TITLE
fix(plan-mode): avoid marker-based cleanup

### DIFF
--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -635,8 +635,7 @@ function messageContainsInactivePlanModeArtifact(message: unknown) {
 	const candidate = unwrapSessionMessage(message);
 	return (
 		candidate.customType === PLAN_CONTEXT_MESSAGE_TYPE ||
-		candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE ||
-		contentText(candidate.content).includes(PLAN_CONTEXT_MARKER)
+		candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE
 	);
 }
 


### PR DESCRIPTION
## Summary
- stop treating arbitrary message content containing the plan-mode banner as inactive plan-mode artifacts
- keep cleanup scoped to extension-owned custom message types when plan mode is off

## Verification
- npm --workspace @narumitw/pi-plan-mode run check
- npm run check

Fixes #73