### PR TITLE
fix(plan-mode): simplify ready flow

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -10,7 +10,7 @@
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
-- Symptom: extension accept/execute actions from `agent_end` may not trigger a new turn. Cause: `pi.sendMessage({ triggerTurn: true })` only triggers when idle. Fix: use `pi.sendUserMessage(..., { deliverAs: "followUp" })` when `ctx.isIdle()` is false.
+- Symptom: extension accept/execute actions from `agent_end` may not trigger a new turn. Cause: `pi.sendMessage({ triggerTurn: true })` only triggers when idle, and `sendUserMessage(..., { deliverAs: "followUp" })` can miss the current drain point late in `agent_end`. Fix: avoid starting new user turns from `agent_end`; let the user submit normally or schedule work after the agent is truly idle.
 - Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.

--- a/docs/plans/archived/2026-05-26_pi-plan-mode-codex-ready-flow-plan.md
+++ b/docs/plans/archived/2026-05-26_pi-plan-mode-codex-ready-flow-plan.md
@@ -1,0 +1,44 @@
+## Goal
+
+Align `@narumitw/pi-plan-mode`'s plan-ready flow with Codex-style interaction: remove the separate `Revise plan` action from the automatic ready popup, keep `Stay in Plan mode` as the path for revision through the normal composer, and prevent stale ready-state plans from remaining one-click implementable after a new Plan-mode turn starts. Success means the ready popup is focused, revision no longer depends on an `agent_end` modal/editor send path, and existing `/plan tools` management remains available.
+
+## Context
+
+- Current code in `extensions/pi-plan-mode/src/plan-mode.ts` opened `ctx.ui.editor("Revise the plan", "")` from `showPlanReadyMenu()` during `agent_end`, then sent the revision through `sendPlanModeUserMessage()`. This could queue a follow-up after Pi had already drained follow-ups, so the first revision message might not trigger until the next user input.
+- Codex CLI's comparable ready popup in `third_party/codex/codex-rs/tui/src/chatwidget/plan_implementation.rs` offers implement, clear-context implement, and `No, stay in Plan mode`; revision is done by submitting another normal Plan-mode user message.
+- Codex tests in `third_party/codex/codex-rs/tui/src/chatwidget/tests/plan_mode.rs` cover the pattern where a user types `Please revise.` after a plan, and the implementation popup is skipped until a newer proposed plan is produced.
+- Claude Code's `No, keep planning` path can collect feedback, but we chose the simpler Codex parity path for Pi.
+
+## Non-Goals
+
+- Do not add Codex's clear-context implement option in this change.
+- Do not remove `/plan tools` or redesign the Plan-mode tool selector.
+- Do not remove `Exit Plan mode`; it remains Pi's explicit discard escape hatch.
+
+## Plan
+
+- [x] Update `showPlanReadyMenu()` in `extensions/pi-plan-mode/src/plan-mode.ts` so the automatic ready popup has exactly `Implement this plan`, `Stay in Plan mode`, and `Exit Plan mode`; verified by code inspection of `showPlanReadyMenu()` lines 300-314.
+- [x] Remove the `Revise plan` branch and its `ctx.ui.editor()` send path from `showPlanReadyMenu()` to eliminate the `agent_end` follow-up timing bug; verified with `rg -n "Revise plan|Revise the plan" extensions/pi-plan-mode/src/plan-mode.ts` returning no matches.
+- [x] Keep manual `/plan` management behavior in `showPlanMenu()` unchanged, including `Configure Plan-mode tools`, so tool configuration remains discoverable outside the automatic ready popup; verified by code inspection of `showPlanMenu()` lines 264-298 and the `/plan tools` handler.
+- [x] Change the Plan-mode `before_agent_start` handler to clear `state.latestPlan` and `state.awaitingAction` before injecting the Plan-mode context for a new Plan-mode agent turn, while preserving conversation history; verified by code inspection of lines 162-176, where clearing happens only when `state.enabled` is true and no active Plan-mode context filtering was added.
+- [x] Schedule the ready popup and proposed-plan custom message after the current agent run so any implementation action from the popup sends while Pi is idle rather than late in `agent_end`; verified by code inspection of `scheduleAfterCurrentAgentRun()` lines 240-247 and the scheduled `agent_end` callback lines 194-207.
+- [x] Ensure selecting `Stay in Plan mode` only dismisses the ready popup and keeps the current plan ready state until the next Plan-mode turn starts; verified by code inspection that `showPlanReadyMenu()` has no Stay branch calling `exitPlanMode()`, `sendPlanModeUserMessage()`, or clearing `state.latestPlan`.
+- [x] Update `extensions/pi-plan-mode/README.md` to document that revising a plan is done by choosing `Stay in Plan mode` and typing revision feedback in the normal prompt; verified with `rg -n "Revise plan|Stay in Plan mode|revision|revise" extensions/pi-plan-mode/README.md` showing the updated workflow text.
+- [x] Run `npm --workspace @narumitw/pi-plan-mode run typecheck` to verify the package compiles after the behavior change; command passed.
+- [x] Run `npm run check` from the repository root to verify formatting, boundary checks, and all workspace typechecks pass; command passed.
+
+## Risks
+
+- Clearing `latestPlan` too early could remove the implement shortcut before the user intentionally starts a new Plan-mode turn. Mitigated by clearing only in `before_agent_start`, not when selecting Stay or opening `/plan` menus.
+- Leaving previous proposed-plan text in context could influence the revised plan. This is intentional so the model can revise from the prior version; only extension state is cleared to avoid stale one-click implementation.
+
+## Completion Checklist
+
+- [x] Automatic plan-ready popup options are verified in `extensions/pi-plan-mode/src/plan-mode.ts` as exactly `Implement this plan`, `Stay in Plan mode`, and `Exit Plan mode` by code inspection of lines 300-314.
+- [x] `Revise plan` modal/editor code is removed, verified by `rg -n "Revise plan|Revise the plan" extensions/pi-plan-mode/src/plan-mode.ts` returning no matches.
+- [x] Manual Plan-mode tool configuration remains available, verified by `/plan tools` handler and `showPlanMenu()` retaining `Configure Plan-mode tools`.
+- [x] Starting a new Plan-mode turn clears stale ready state without stripping prior plan context, verified by `before_agent_start` code inspection.
+- [x] Ready-popup implementation starts from an idle-safe path, verified by `scheduleAfterCurrentAgentRun()` and the scheduled `agent_end` callback.
+- [x] User-facing docs describe the new revise-through-Stay workflow, verified in `extensions/pi-plan-mode/README.md`.
+- [x] Package verification passes with `npm --workspace @narumitw/pi-plan-mode run typecheck`.
+- [x] Repository verification passes with `npm run check`.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -14,7 +14,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Disables extension and custom tools by default, with a `/plan tools` selector for explicit user-risk opt-in.
 - Blocks mutating built-in tools and bash commands such as `rm`, `git commit`, dependency installs, redirects, and editor launches.
 - Injects Codex-like Plan mode instructions: explore first, ask only non-discoverable questions, do not mutate files, and finish with `<proposed_plan>`.
-- Detects proposed plan blocks and prompts you to implement, revise, stay in Plan mode, or exit and discard the plan.
+- Detects proposed plan blocks and prompts you to implement, stay in Plan mode, or exit and discard the plan.
 - Shows Plan mode state in Pi's statusline as `📝 plan active` or `📝 plan ready`.
 - Persists Plan mode state in the Pi session so resume restores the mode.
 
@@ -72,12 +72,12 @@ A complete Plan mode answer should include exactly one block like this:
 </proposed_plan>
 ```
 
-After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, revise it, stay in Plan mode, or exit Plan mode. Choosing implementation disables Plan mode, restores full tool access, and immediately starts an implementation turn with the proposed plan. Choosing exit/off disables Plan mode and discards the proposed plan so it is not carried into later non-plan turns.
+After a proposed plan is detected, `/plan` lets you choose whether to implement the plan, stay in Plan mode, or exit Plan mode. Choosing implementation disables Plan mode, restores full tool access, and immediately starts an implementation turn with the proposed plan. Choosing Stay keeps the plan ready while you decide what to do next; to revise the plan, choose Stay and type your revision feedback in the normal prompt. When that next Plan-mode turn starts, the previous plan is no longer treated as the latest implementable plan unless the agent produces an updated `<proposed_plan>`. Choosing exit/off disables Plan mode and discards the proposed plan so it is not carried into later non-plan turns.
 
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 
 - `📝 plan active`: Plan mode is enabled and still gathering context or drafting a plan.
-- `📝 plan ready`: A `<proposed_plan>` was detected and is waiting for your next `/plan` action.
+- `📝 plan ready`: A `<proposed_plan>` was detected and remains ready until you implement it, continue planning, or exit Plan mode.
 
 You can also exit directly. Direct exit discards the latest proposed plan instead of treating it as an implementation request:
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -159,8 +159,13 @@ export default function planMode(pi: ExtensionAPI) {
 		};
 	});
 
-	pi.on("before_agent_start", () => {
+	pi.on("before_agent_start", (_event, ctx) => {
 		if (!state.enabled) return;
+		if (state.latestPlan || state.awaitingAction) {
+			state = { ...state, latestPlan: undefined, awaitingAction: false };
+			persistState();
+			updateUi(ctx);
+		}
 		applyPlanModeTools();
 		return {
 			message: {
@@ -186,17 +191,20 @@ export default function planMode(pi: ExtensionAPI) {
 		persistState();
 		updateUi(ctx);
 
-		if (ctx.hasUI) await showPlanReadyMenu(ctx);
-		if (!state.enabled || !state.latestPlan) return;
+		scheduleAfterCurrentAgentRun(async () => {
+			if (!state.enabled || state.latestPlan !== proposedPlan) return;
+			if (ctx.hasUI) await showPlanReadyMenu(ctx);
+			if (!state.enabled || state.latestPlan !== proposedPlan) return;
 
-		pi.sendMessage(
-			{
-				customType: PROPOSED_PLAN_MESSAGE_TYPE,
-				content: `**Proposed Plan**\n\n${proposedPlan}`,
-				display: true,
-			},
-			{ triggerTurn: false },
-		);
+			pi.sendMessage(
+				{
+					customType: PROPOSED_PLAN_MESSAGE_TYPE,
+					content: `**Proposed Plan**\n\n${proposedPlan}`,
+					display: true,
+				},
+				{ triggerTurn: false },
+			);
+		});
 	});
 
 	function enterPlanMode(ctx: ExtensionContext) {
@@ -227,6 +235,15 @@ export default function planMode(pi: ExtensionAPI) {
 	function sendPlanModeUserMessage(message: string, ctx: ExtensionContext) {
 		if (ctx.isIdle()) pi.sendUserMessage(message);
 		else pi.sendUserMessage(message, { deliverAs: "followUp" });
+	}
+
+	function scheduleAfterCurrentAgentRun(task: () => Promise<void> | void) {
+		setTimeout(() => {
+			void Promise.resolve(task()).catch((error: unknown) => {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(`Plan mode follow-up failed: ${message}`);
+			});
+		}, 0);
 	}
 
 	function startImplementation(ctx: ExtensionContext) {
@@ -283,22 +300,11 @@ export default function planMode(pi: ExtensionAPI) {
 	async function showPlanReadyMenu(ctx: ExtensionContext) {
 		const choice = await ctx.ui.select("Proposed plan ready. What next?", [
 			"Implement this plan",
-			"Revise plan",
-			"Configure Plan-mode tools",
 			"Stay in Plan mode",
 			"Exit Plan mode",
 		]);
 		if (choice === "Implement this plan") {
 			startImplementation(ctx);
-			return;
-		}
-		if (choice === "Configure Plan-mode tools") {
-			await showToolSelector(ctx);
-			return;
-		}
-		if (choice === "Revise plan") {
-			const refinement = await ctx.ui.editor("Revise the plan", "");
-			if (refinement?.trim()) sendPlanModeUserMessage(refinement.trim(), ctx);
 			return;
 		}
 		if (choice === "Exit Plan mode") {


### PR DESCRIPTION
## Summary
- remove the automatic ready-popup Revise action in favor of Stay in Plan mode
- clear stale latest-plan state when a new Plan-mode turn starts
- schedule the ready popup after agent_end so implementation starts from an idle-safe path
- document the revise-through-Stay workflow and archive the completed plan

## Verification
- npm --workspace @narumitw/pi-plan-mode run typecheck
- npm run check