### PR TITLE
feat(plan-mode): add interactive planning questions

### DIFF
--- a/docs/plans/archived/2026-05-26_pi-plan-mode-interactive-planning-plan.md
+++ b/docs/plans/archived/2026-05-26_pi-plan-mode-interactive-planning-plan.md
@@ -1,0 +1,62 @@
+## Goal
+
+Make `@narumitw/pi-plan-mode` behave more like Codex Plan Mode by encouraging real interactive planning before a `<proposed_plan>` is emitted. Success means Plan mode explores first, asks user-facing decision questions when high-impact ambiguity remains, only finalizes a plan when decision-complete, and keeps Plan-mode instructions scoped to active Plan-mode turns.
+
+## Context
+
+Current `extensions/pi-plan-mode/src/plan-mode.ts` injects a short hidden custom message from `buildPlanModePrompt()`, detects any assistant `<proposed_plan>` block in `agent_end`, and immediately opens the ready menu. Codex's third-party implementation uses a stronger prompt in `third_party/codex/codex-rs/collaboration-mode-templates/templates/plan.md` plus a dedicated `request_user_input` tool contract in `third_party/codex/codex-rs/core/src/tools/handlers/request_user_input_spec.rs` for decision questions. Codex keeps the implementation popup as the finalization path, not the clarification path.
+
+## Architecture
+
+- Prompt scoping should move from a persistent custom message to a per-turn `systemPrompt` append in `before_agent_start`, guarded by `state.enabled`, so Plan-mode rules disappear automatically when Plan mode is off.
+- Legacy `plan-mode-context` custom messages should be filtered from LLM context even when Plan mode remains active, because the new system-prompt path replaces them; visible `proposed-plan` artifacts should still be filtered when leaving Plan mode or otherwise inactive.
+- Following Codex's `request_user_input` design, `pi-plan-mode` should register a dedicated `plan_mode_question` tool with a dependency-free schema: `questions` contains 1-3 questions, each with `id`, `header`, `question`, and 2-4 meaningful `{ label, description }` options. The tool should add a free-form Other path in the UI, return structured answers to the model, and reject calls when Plan mode is not active.
+- `plan_mode_question` should be a required Plan-mode tool: available by default while Plan mode is active, hidden or inactive after Plan mode exit, and not user-disableable through `/plan tools`.
+- Proposed-plan detection and the ready menu should remain the finalization path, not the clarification path.
+
+## Non-Goals
+
+- Do not redesign Plan mode's user-selectable non-built-in tool risk model beyond pinning the required question tool.
+- Do not change the `<proposed_plan>` XML contract used by plan detection.
+- Do not implement a general Pi collaboration-mode framework outside this extension.
+
+## Assumptions
+
+- Pi's `before_agent_start` `systemPrompt` override is per-turn and safe to gate on `state.enabled`.
+- A Codex-like question tool can be implemented with the current extension API and `ctx.ui` without adding package dependencies, using the local Pi `question` example as the UI pattern but not importing its `typebox` dependency.
+
+## Unknowns
+
+- Resolved: `plan_mode_question` uses `ctx.ui.select()` for option choice plus `ctx.ui.editor()` for the free-form Other path, based on the local `question.ts` pattern and verified by the smoke harness.
+
+## Plan
+
+- [x] Inspect Pi's `question.ts` and `questionnaire.ts` examples to choose the smallest UI primitive for `plan_mode_question`; verified by implementing `ctx.ui.select()` plus `ctx.ui.editor()` and by the smoke harness output `pi-plan-mode smoke passed: select+editor primitive, question result contract, prompt scoping, context filtering, ready menu implement/stay`.
+- [x] Replace the hidden Plan-mode context message in `before_agent_start` with a `systemPrompt: event.systemPrompt + ...` append guarded by `state.enabled`, keeping `applyPlanModeTools()` and ready-state clearing intact; verify by code inspection that active Plan-mode turns no longer emit new `PLAN_CONTEXT_MESSAGE_TYPE` messages, legacy `plan-mode-context` custom messages are always filtered from model context even while Plan mode is active, visible `proposed-plan` artifacts are still filtered after Plan mode exit, and `npm --workspace @narumitw/pi-plan-mode run typecheck` passes.
+- [x] Rewrite `buildPlanModePrompt()` using Codex's phases: explore first, intent chat, implementation chat, asking-question rules, finalization-only `<proposed_plan>`, and no "should I proceed?" in final output; verify with a side-by-side review against `third_party/codex/codex-rs/collaboration-mode-templates/templates/plan.md` and ensure the final prompt still references Pi's tool-safety boundaries, `plan_mode_question` as the preferred question path, and the required behavior for cancellation/no-UI results.
+- [x] Register `plan_mode_question` in `extensions/pi-plan-mode/src/plan-mode.ts` with a dependency-free parameter schema for 1-3 questions, 2-4 meaningful options per question, a UI-added free-form Other path, structured answer details, cancellation output, and `ctx.hasUI` fallback; verify with typecheck and a local harness or smoke run that a selected answer is returned to the model without adding `typebox` or other runtime dependencies.
+- [x] Define the `plan_mode_question` result contract so option/custom answers return `{ cancelled: false, answers: [...] }`, user cancellation returns `{ cancelled: true, reason: "cancelled" }`, no-UI returns `{ cancelled: true, reason: "ui_unavailable" }`, and outside-Plan calls return a clear unavailable error; verify with unit-style harness cases or manual smoke output for each path.
+- [x] Enforce Plan-mode-only availability for `plan_mode_question` by rejecting handler calls when `state.enabled` is false, excluding it from restored non-plan active tools after exit/session start, and pinning it into the active tool list while Plan mode is enabled; verify by inspecting `activatePlanModeTools()`, `restoreTools()`, and session-start behavior.
+- [x] Keep `plan_mode_question` required and non-disableable in `/plan tools` by excluding it from user-risk toggles or rendering it as fixed/on; verify by code inspection of the selector and a smoke check that user-selected non-built-in tools still persist independently.
+- [x] Adjust proposed-plan readiness handling only as needed so clarification turns without `<proposed_plan>` do not open the ready menu, while completed plan turns still show `Implement this plan`, `Stay in Plan mode`, and `Exit Plan mode`; verify with code inspection of `agent_end` and a local scripted or manual smoke run for question-only response → `📝 plan active`.
+- [x] Smoke test the finalization path `<proposed_plan>` → ready menu → `Implement this plan` starts a normal implementation turn, and `Stay in Plan mode` allows a revision turn before a replacement plan; verify with a local scripted or manual run and record the observed behavior in the handoff.
+- [x] Update `extensions/pi-plan-mode/README.md` to describe the interactive workflow: explore, ask decision questions, finalize with `<proposed_plan>`, revise by staying in Plan mode, and implement only after approval; verify by README review plus `rg -n "ask|question|proposed_plan|Stay in Plan mode" extensions/pi-plan-mode/README.md`.
+- [x] Run repository verification for the changed package with `npm --workspace @narumitw/pi-plan-mode run typecheck`, root `npm run check`, and `npm run pack:plan-mode`; verify all commands pass and the dry-run package does not rely on undeclared runtime dependencies.
+
+## Risks
+
+- A too-strong prompt could over-ask for simple tasks; mitigate by keeping Codex's rule that questions must materially affect the plan or confirm important assumptions.
+- A question tool that waits incorrectly could deadlock or fail in non-interactive/RPC sessions; mitigate with an explicit `ctx.hasUI` result contract, cancellation output, and a smoke test.
+- Registering `plan_mode_question` as a normal Pi tool could expose it outside Plan mode; mitigate by filtering active tools outside Plan mode and refusing handler execution when `state.enabled` is false.
+- Importing schema helpers from an example-only dependency could break the published extension; mitigate with a dependency-free schema or, if that proves impossible, adding a real runtime dependency and verifying with `npm run pack:plan-mode`.
+- Moving from custom message to `systemPrompt` could remove useful persisted reminders after resume; mitigate by re-appending on every active Plan-mode `before_agent_start`.
+
+## Completion Checklist
+
+- [x] Plan-mode instructions are scoped to active Plan-mode turns only, verified by code inspection of `before_agent_start`, absence of new active `plan-mode-context` custom message injection, and continued filtering of legacy Plan-mode context artifacts both inside and outside active Plan mode.
+- [x] Plan-mode prompt matches the Codex interaction model, verified by review against `third_party/codex/codex-rs/collaboration-mode-templates/templates/plan.md` for exploration, question, and finalization rules.
+- [x] The model has a structured Codex-like path to ask user decision questions before finalizing, verified by a smoke run or harness covering `plan_mode_question` option answer, custom answer, cancellation, no-UI fallback, and outside-Plan rejection.
+- [x] `plan_mode_question` is Plan-mode-only and required while planning, verified by active-tool code inspection and a smoke/harness check that it is rejected or inactive outside Plan mode and cannot be disabled from `/plan tools`.
+- [x] Existing finalization and implementation actions still work, verified by a smoke/harness run for `<proposed_plan>` → ready menu → implement and Stay/revision behavior plus a successful package typecheck.
+- [x] User-facing documentation explains the new interactive behavior without exposing unnecessary implementation details, verified by README review.
+- [x] Package and repository checks pass, verified by `npm --workspace @narumitw/pi-plan-mode run typecheck`, `npm run check`, and `npm run pack:plan-mode`.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -13,7 +13,8 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Enables built-in read-only tools by default while Plan mode is active.
 - Disables extension and custom tools by default, with a `/plan tools` selector for explicit user-risk opt-in.
 - Blocks mutating built-in tools and bash commands such as `rm`, `git commit`, dependency installs, redirects, and editor launches.
-- Injects Codex-like Plan mode instructions: explore first, ask only non-discoverable questions, do not mutate files, and finish with `<proposed_plan>`.
+- Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finish with `<proposed_plan>` only when decision-complete.
+- Adds a required `plan_mode_question` tool so the agent can ask structured Plan-mode questions before finalizing a plan.
 - Detects proposed plan blocks and prompts you to implement, stay in Plan mode, or exit and discard the plan.
 - Shows Plan mode state in Pi's statusline as `📝 plan active` or `📝 plan ready`.
 - Persists Plan mode state in the Pi session so resume restores the mode.
@@ -46,13 +47,15 @@ pi -e ./extensions/pi-plan-mode
 
 Use `/plan` to enter Plan mode before writing your planning prompt. Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user message. Use `/plan tools` to choose which tools are active while Plan mode is enabled; the selector is paginated at 10 tools per page.
 
-When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation.
+When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation. It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
 
-By default, Plan mode manages only Pi's built-in tools: `read`, limited `bash`, and available read-only built-ins such as `grep`, `find`, and `ls`. Built-in `edit` and `write` are blocked. Extension and custom tools are disabled by default because Pi tools do not expose standardized mutability metadata; enable them from `/plan tools` only when you accept the risk for that session. For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `biome_lsp_diagnostics` if those extensions are loaded and you want to use them during planning.
+By default, Plan mode manages only Pi's built-in tools: `read`, limited `bash`, available read-only built-ins such as `grep`, `find`, and `ls`, plus the required `plan_mode_question` tool. Built-in `edit` and `write` are blocked. Extension and custom tools are disabled by default because Pi tools do not expose standardized mutability metadata; enable them from `/plan tools` only when you accept the risk for that session. For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `biome_lsp_diagnostics` if those extensions are loaded and you want to use them during planning.
+
+`plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path. If you cancel or no interactive UI is available, the agent should ask a concise plain-text question or proceed only with a clearly stated low-risk assumption instead of prematurely producing a final plan.
 
 Pi activates tools by tool name. The `/plan tools` selector stores selections by name and shows each currently effective tool's source from Pi metadata, such as `built-in`, a user extension path, or a project extension path. If an extension overrides a built-in tool with the same name, Pi exposes the effective tool for that name and the selector shows that source.
 
-A complete Plan mode answer should include exactly one block like this:
+A complete Plan mode answer should appear only after the agent has resolved discoverable facts and any high-impact user decisions. It should include exactly one block like this:
 
 ```xml
 <proposed_plan>
@@ -91,6 +94,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 
 - Plan mode is a conversational collaboration mode, not TODO/progress tracking.
 - `/plan <prompt>` follows Codex behavior by switching to Plan mode before submitting the inline prompt.
+- The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
 - `update_plan`-style checklist use is discouraged while Plan mode is active.
 - The implementation boundary is explicit: Plan mode restores tools before starting implementation, choosing implementation immediately triggers a normal agent turn with full tool access, and plain exit/off discards the proposed plan.
 - Pi extension safety is approximated with built-in tool restriction plus bash filtering; non-built-in tools are user-selected at user risk because Plan mode does not classify extension/custom tool behavior.

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -5,6 +5,7 @@ const STATUS_KEY = "plan-mode";
 const PLAN_WIDGET_KEY = "plan-mode-plan";
 const PLAN_CONTEXT_MESSAGE_TYPE = "plan-mode-context";
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
+const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
 const PLAN_CONTEXT_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const SAFE_BUILTIN_PLAN_TOOLS = new Set(["read", "bash", "grep", "find", "ls"]);
 const BLOCKED_BUILTIN_TOOLS = new Set(["edit", "write"]);
@@ -37,6 +38,95 @@ type TextBlock = {
 	type?: string;
 	text?: string;
 };
+
+type PlanModeQuestionOption = {
+	label: string;
+	description?: string;
+};
+
+type PlanModeQuestion = {
+	id: string;
+	header: string;
+	question: string;
+	options: PlanModeQuestionOption[];
+};
+
+type PlanModeQuestionParams = {
+	questions: PlanModeQuestion[];
+};
+
+type PlanModeQuestionAnswer = {
+	id: string;
+	header: string;
+	question: string;
+	answer: string;
+	wasCustom: boolean;
+	optionIndex?: number;
+};
+
+type PlanModeQuestionReason = "cancelled" | "ui_unavailable" | "plan_mode_inactive" | "invalid_input";
+
+type PlanModeQuestionDetails = {
+	cancelled: boolean;
+	reason?: PlanModeQuestionReason;
+	questions: PlanModeQuestion[];
+	answers?: PlanModeQuestionAnswer[];
+};
+
+const PLAN_MODE_QUESTION_PARAMS = {
+	type: "object",
+	additionalProperties: false,
+	required: ["questions"],
+	properties: {
+		questions: {
+			type: "array",
+			minItems: 1,
+			maxItems: 3,
+			description: "Questions to show the user. Prefer 1 and do not exceed 3.",
+			items: {
+				type: "object",
+				additionalProperties: false,
+				required: ["id", "header", "question", "options"],
+				properties: {
+					id: {
+						type: "string",
+						description: "Stable identifier for mapping answers (snake_case).",
+					},
+					header: {
+						type: "string",
+						description: "Short header label shown in the UI (12 or fewer chars).",
+					},
+					question: {
+						type: "string",
+						description: "Single-sentence prompt shown to the user.",
+					},
+					options: {
+						type: "array",
+						minItems: 2,
+						maxItems: 4,
+						description:
+							"Provide 2-4 mutually exclusive choices. Put the recommended option first when there is a clear default.",
+						items: {
+							type: "object",
+							additionalProperties: false,
+							required: ["label", "description"],
+							properties: {
+								label: {
+									type: "string",
+									description: "User-facing label (1-5 words).",
+								},
+								description: {
+									type: "string",
+									description: "One short sentence explaining impact/tradeoff if selected.",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+} as const;
 
 const MUTATING_BASH_PATTERNS = [
 	/\brm\b/i,
@@ -91,6 +181,51 @@ export default function planMode(pi: ExtensionAPI) {
 		default: false,
 	});
 
+	pi.registerTool({
+		name: PLAN_MODE_QUESTION_TOOL_NAME,
+		label: "Plan question",
+		description:
+			"Ask the user one to three Plan-mode clarification questions with meaningful options, then wait for the answer. Only available while Plan mode is active.",
+		promptSnippet: "Ask user decision questions while Plan mode is active",
+		promptGuidelines: [
+			"In Plan mode, use plan_mode_question for important preferences, tradeoffs, or assumptions that cannot be discovered from read-only exploration.",
+		],
+		parameters: PLAN_MODE_QUESTION_PARAMS,
+		async execute(_toolCallId, params: unknown, _signal, _onUpdate, ctx) {
+			if (!state.enabled) {
+				return planModeQuestionCancelled(
+					[],
+					"plan_mode_inactive",
+					"Error: plan_mode_question is only available while Plan mode is active.",
+				);
+			}
+
+			const parsed = normalizePlanModeQuestionParams(params);
+			if (!parsed.ok) {
+				return planModeQuestionCancelled([], "invalid_input", `Error: ${parsed.error}`);
+			}
+
+			if (!ctx.hasUI) {
+				return planModeQuestionCancelled(
+					parsed.questions,
+					"ui_unavailable",
+					"Unable to ask Plan-mode questions because interactive UI is not available.",
+				);
+			}
+
+			const answers = await askPlanModeQuestions(parsed.questions, ctx);
+			if (!answers) {
+				return planModeQuestionCancelled(
+					parsed.questions,
+					"cancelled",
+					"User cancelled the Plan-mode question prompt.",
+				);
+			}
+
+			return planModeQuestionAnswered(parsed.questions, answers);
+		},
+	});
+
 	pi.registerCommand("plan", {
 		description: "Enter or manage Codex-like Plan mode",
 		handler: async (args, ctx) => {
@@ -123,6 +258,7 @@ export default function planMode(pi: ExtensionAPI) {
 		restoreState(ctx);
 		if (pi.getFlag("plan") === true) state.enabled = true;
 		if (state.enabled) activatePlanModeTools();
+		else deactivatePlanModeQuestionTool();
 		updateUi(ctx);
 	});
 
@@ -151,15 +287,18 @@ export default function planMode(pi: ExtensionAPI) {
 	});
 
 	pi.on("context", async (event) => {
-		if (state.enabled) return;
+		const messagesWithoutLegacyPlanContext = event.messages.filter(
+			(message: unknown) => !messageContainsLegacyPlanModeContextArtifact(message),
+		);
+		if (state.enabled) return { messages: messagesWithoutLegacyPlanContext };
 		return {
-			messages: event.messages
+			messages: messagesWithoutLegacyPlanContext
 				.filter((message: unknown) => !messageContainsInactivePlanModeArtifact(message))
 				.map(stripProposedPlanBlocksFromMessage),
 		};
 	});
 
-	pi.on("before_agent_start", (_event, ctx) => {
+	pi.on("before_agent_start", (event, ctx) => {
 		if (!state.enabled) return;
 		if (state.latestPlan || state.awaitingAction) {
 			state = { ...state, latestPlan: undefined, awaitingAction: false };
@@ -168,11 +307,7 @@ export default function planMode(pi: ExtensionAPI) {
 		}
 		applyPlanModeTools();
 		return {
-			message: {
-				customType: PLAN_CONTEXT_MESSAGE_TYPE,
-				content: buildPlanModePrompt(),
-				display: false,
-			},
+			systemPrompt: `${event.systemPrompt}\n\n${buildPlanModePrompt()}`,
 		};
 	});
 
@@ -208,7 +343,7 @@ export default function planMode(pi: ExtensionAPI) {
 	});
 
 	function enterPlanMode(ctx: ExtensionContext) {
-		if (!state.enabled) previousTools = safeGetActiveTools();
+		if (!state.enabled) previousTools = withoutPlanModeQuestionTool(safeGetActiveTools());
 		state = { ...state, enabled: true, awaitingAction: false };
 		activatePlanModeTools();
 		persistState();
@@ -379,7 +514,7 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function activatePlanModeTools() {
-		previousTools ??= safeGetActiveTools();
+		previousTools ??= withoutPlanModeQuestionTool(safeGetActiveTools());
 		applyPlanModeTools();
 	}
 
@@ -389,12 +524,14 @@ export default function planMode(pi: ExtensionAPI) {
 
 	function planModeToolNames() {
 		const tools = selectableTools();
-		if (tools.length === 0) return ["read", "bash"];
+		if (tools.length === 0) return ["read", "bash", PLAN_MODE_QUESTION_TOOL_NAME];
 
 		const selectedNames = planModeSelectedNames(tools);
-		return tools
-			.filter((tool) => selectedNames.has(tool.name) && canSelectToolInPlanMode(tool))
-			.map((tool) => tool.name);
+		return withRequiredPlanModeTools(
+			tools
+				.filter((tool) => selectedNames.has(tool.name) && canSelectToolInPlanMode(tool))
+				.map((tool) => tool.name),
+		);
 	}
 
 	function planModeSelectedNames(tools: ToolInfo[]) {
@@ -428,7 +565,9 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function selectableTools() {
-		return safeGetAllTools().sort(compareTools);
+		return safeGetAllTools()
+			.filter((tool) => tool.name !== PLAN_MODE_QUESTION_TOOL_NAME)
+			.sort(compareTools);
 	}
 
 	function toolSelectorPageCount(tools: ToolInfo[]) {
@@ -444,8 +583,17 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function restoreTools() {
-		pi.setActiveTools(previousTools && previousTools.length > 0 ? previousTools : DEFAULT_TOOLS);
+		const restoredTools = previousTools && previousTools.length > 0 ? previousTools : DEFAULT_TOOLS;
+		pi.setActiveTools(withoutPlanModeQuestionTool(restoredTools));
 		previousTools = undefined;
+	}
+
+	function deactivatePlanModeQuestionTool() {
+		const activeTools = safeGetActiveTools();
+		const filteredTools = withoutPlanModeQuestionTool(activeTools);
+		if (filteredTools.length !== activeTools.length) {
+			pi.setActiveTools(filteredTools);
+		}
 	}
 
 	function safeGetActiveTools() {
@@ -578,19 +726,194 @@ function unique(values: string[]) {
 	return Array.from(new Set(values));
 }
 
+function withRequiredPlanModeTools(toolNames: string[]) {
+	return unique([...withoutPlanModeQuestionTool(toolNames), PLAN_MODE_QUESTION_TOOL_NAME]);
+}
+
+function withoutPlanModeQuestionTool(toolNames: string[]) {
+	return toolNames.filter((toolName) => toolName !== PLAN_MODE_QUESTION_TOOL_NAME);
+}
+
+type NormalizePlanModeQuestionParamsResult =
+	| { ok: true; questions: PlanModeQuestion[] }
+	| { ok: false; error: string };
+
+function normalizePlanModeQuestionParams(input: unknown): NormalizePlanModeQuestionParamsResult {
+	if (!isRecord(input) || !Array.isArray(input.questions)) {
+		return { ok: false, error: "questions must be an array" };
+	}
+	if (input.questions.length < 1 || input.questions.length > 3) {
+		return { ok: false, error: "questions must contain 1-3 items" };
+	}
+
+	const questions: PlanModeQuestion[] = [];
+	for (const [questionIndex, rawQuestion] of input.questions.entries()) {
+		if (!isRecord(rawQuestion)) {
+			return { ok: false, error: `question ${questionIndex + 1} must be an object` };
+		}
+
+		const id = stringField(rawQuestion.id);
+		const header = stringField(rawQuestion.header);
+		const question = stringField(rawQuestion.question);
+		if (!id || !header || !question) {
+			return {
+				ok: false,
+				error: `question ${questionIndex + 1} requires non-empty id, header, and question`,
+			};
+		}
+
+		if (!Array.isArray(rawQuestion.options)) {
+			return { ok: false, error: `question ${questionIndex + 1} options must be an array` };
+		}
+		if (rawQuestion.options.length < 2 || rawQuestion.options.length > 4) {
+			return { ok: false, error: `question ${questionIndex + 1} options must contain 2-4 items` };
+		}
+
+		const options: PlanModeQuestionOption[] = [];
+		for (const [optionIndex, rawOption] of rawQuestion.options.entries()) {
+			if (!isRecord(rawOption)) {
+				return {
+					ok: false,
+					error: `question ${questionIndex + 1} option ${optionIndex + 1} must be an object`,
+				};
+			}
+
+			const label = stringField(rawOption.label);
+			if (!label) {
+				return {
+					ok: false,
+					error: `question ${questionIndex + 1} option ${optionIndex + 1} requires a label`,
+				};
+			}
+			const description = stringField(rawOption.description);
+			if (!description) {
+				return {
+					ok: false,
+					error: `question ${questionIndex + 1} option ${optionIndex + 1} requires a description`,
+				};
+			}
+			options.push({ label, description });
+		}
+
+		questions.push({ id, header, question, options });
+	}
+
+	return { ok: true, questions };
+}
+
+async function askPlanModeQuestions(
+	questions: PlanModeQuestion[],
+	ctx: ExtensionContext,
+): Promise<PlanModeQuestionAnswer[] | undefined> {
+	const answers: PlanModeQuestionAnswer[] = [];
+	for (const question of questions) {
+		const choices = question.options.map(formatPlanModeQuestionChoice);
+		const otherChoice = `${question.options.length + 1}. Other (free-form)`;
+		const choice = await ctx.ui.select(`${question.header}: ${question.question}`, [...choices, otherChoice]);
+		if (!choice) return undefined;
+
+		if (choice === otherChoice) {
+			const customAnswer = (await ctx.ui.editor(question.question, ""))?.trim();
+			if (!customAnswer) return undefined;
+			answers.push({
+				id: question.id,
+				header: question.header,
+				question: question.question,
+				answer: customAnswer,
+				wasCustom: true,
+			});
+			continue;
+		}
+
+		const optionIndex = choices.indexOf(choice);
+		const option = question.options[optionIndex];
+		if (!option) return undefined;
+		answers.push({
+			id: question.id,
+			header: question.header,
+			question: question.question,
+			answer: option.label,
+			wasCustom: false,
+			optionIndex: optionIndex + 1,
+		});
+	}
+	return answers;
+}
+
+function formatPlanModeQuestionChoice(option: PlanModeQuestionOption, index: number) {
+	return `${index + 1}. ${option.label}${option.description ? ` — ${option.description}` : ""}`;
+}
+
+function planModeQuestionAnswered(questions: PlanModeQuestion[], answers: PlanModeQuestionAnswer[]) {
+	return {
+		content: [{ type: "text" as const, text: formatPlanModeQuestionPayload({ cancelled: false, answers }) }],
+		details: { cancelled: false, questions, answers } satisfies PlanModeQuestionDetails,
+	};
+}
+
+function planModeQuestionCancelled(
+	questions: PlanModeQuestion[],
+	reason: PlanModeQuestionReason,
+	message: string,
+) {
+	return {
+		content: [{ type: "text" as const, text: formatPlanModeQuestionPayload({ cancelled: true, reason, message }) }],
+		details: { cancelled: true, reason, questions } satisfies PlanModeQuestionDetails,
+	};
+}
+
+function formatPlanModeQuestionPayload(payload: {
+	cancelled: boolean;
+	reason?: PlanModeQuestionReason;
+	message?: string;
+	answers?: PlanModeQuestionAnswer[];
+}) {
+	return JSON.stringify(payload, null, 2);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function stringField(value: unknown) {
+	return typeof value === "string" ? value.trim() : undefined;
+}
+
 function buildPlanModePrompt() {
 	return `${PLAN_CONTEXT_MARKER}
-You are in Plan Mode, a Codex-like collaboration mode for producing a decision-complete implementation plan.
+# Plan Mode (Conversational)
 
-Mode rules:
+You are in Plan Mode, a Codex-like collaboration mode for producing a decision-complete implementation plan. Chat your way to the plan before finalizing it. A final plan must leave no implementation decisions unresolved.
+
+## Mode rules
+
 - Stay in Plan Mode until a developer or extension explicitly exits it.
 - Treat requests to implement as requests to plan the implementation; do not edit files or carry out the plan.
-- Use non-mutating exploration first: read files, search, inspect configuration, run read-only checks, and resolve discoverable facts before asking the user.
-- Ask the user only for preferences or tradeoffs that cannot be discovered from the repository.
 - Do not use update_plan/TODO tooling in Plan Mode; Plan Mode is conversational planning, not execution progress tracking.
 - Plan Mode manages built-in tool safety only. Non-built-in tools are disabled by default and may be enabled by the user at their own risk.
 - Do not perform mutating actions: no edit/write tools, no patching, no formatting that rewrites files, no dependency installation, no commits, no migrations.
-- When the plan is decision-complete, output exactly one proposed plan block using:
+
+## Phase 1 — Ground in the environment
+
+- Explore first and ask second. Use non-mutating exploration to read files, search, inspect configuration, run read-only checks, and resolve discoverable facts.
+- Before asking the user any question, perform at least one targeted non-mutating exploration pass unless no local environment or repository is available.
+- Do not ask questions that can be answered from repository or system truth. Ask only when multiple plausible choices remain, a needed identifier/context is missing, or the ambiguity is product intent.
+
+## Phase 2 — Intent chat
+
+- Keep asking until you can clearly state the goal, success criteria, in/out of scope, constraints, current state, and key preferences/tradeoffs.
+- Bias toward questions over guessing: if a high-impact ambiguity remains, do not produce a proposed plan yet.
+
+## Phase 3 — Implementation chat
+
+- Once intent is stable, keep asking until the spec is decision-complete: approach, interfaces, data flow, edge cases/failure modes, testing and acceptance criteria, and any migration or compatibility constraints.
+- Use plan_mode_question for important preferences, tradeoffs, or assumption locks that cannot be discovered by non-mutating exploration. Ask 1-3 concise questions with 2-4 meaningful options. Do not include filler options.
+- If plan_mode_question returns cancelled or ui_unavailable, do not jump straight to a final plan when the missing answer is high impact. Ask one concise plain-text question or proceed only with a clearly stated low-risk assumption.
+
+## Finalization rule
+
+Only output the final plan when it is decision-complete and leaves no decisions to the implementer. When presenting the official plan, output exactly one proposed plan block and keep the tags exactly as shown:
+
 <proposed_plan>
 # Title
 
@@ -606,7 +929,8 @@ Mode rules:
 ## Assumptions
 ...
 </proposed_plan>
-- Keep the proposed plan concise, implementation-ready, and free of open decisions.`;
+
+Keep the proposed plan concise, human and agent digestible, and free of open decisions. Do not ask "should I proceed?" in the final output; the Plan-mode ready menu handles implementation, staying in Plan mode, or exit.`;
 }
 
 function readCommand(input: unknown) {
@@ -637,12 +961,14 @@ function latestAssistantText(messages: unknown) {
 	return "";
 }
 
+function messageContainsLegacyPlanModeContextArtifact(message: unknown) {
+	const candidate = unwrapSessionMessage(message);
+	return candidate.customType === PLAN_CONTEXT_MESSAGE_TYPE;
+}
+
 function messageContainsInactivePlanModeArtifact(message: unknown) {
 	const candidate = unwrapSessionMessage(message);
-	return (
-		candidate.customType === PLAN_CONTEXT_MESSAGE_TYPE ||
-		candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE
-	);
+	return candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE;
 }
 
 function stripProposedPlanBlocksFromMessage<T>(message: T): T {


### PR DESCRIPTION
## Summary
- add a required Plan-mode-only `plan_mode_question` tool with structured option/custom/cancel/no-UI results
- scope Plan-mode instructions through per-turn system prompt injection and filter legacy Plan-mode context artifacts
- refresh README docs for the interactive Codex-like planning workflow

## Verification
- `npm --workspace @narumitw/pi-plan-mode run typecheck`
- `npm run check`
- `npm run pack:plan-mode`
- targeted Node smoke harnesses for question flows, prompt scoping, context filtering, and ready-menu implement/stay behavior