### PR TITLE
feat(caffeinate): add PI_CAFFEINATE_ICON env var for configurable status icon

### DIFF
--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -14,6 +14,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 - Supports macOS, Windows, WSL, and Linux.
 - Provides `/caffeinate-status` and `/caffeinate-stop` commands.
 - Allows a custom inhibitor command through environment configuration.
+- Allows a custom status icon through environment configuration.
 - Fails safely when no supported inhibitor is available.
 
 ## 📦 Install
@@ -73,6 +74,12 @@ PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mo
 ```
 
 The custom command is parsed with shell-like quoting and is run directly without a shell.
+
+Customise the status bar icon (default: `💊`):
+
+```bash
+PI_CAFFEINATE_ICON='☕️' pi
+```
 
 ## 🧠 Why use pi-caffeinate?
 

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -320,12 +320,12 @@ function updateStatus(ctx: ExtensionContext) {
 	}
 
 	if (state.process) {
-		ctx.ui.setStatus(STATUS_KEY, "💊 awake");
+		ctx.ui.setStatus(STATUS_KEY, `${getIcon()} awake`);
 		return;
 	}
 
 	if (!state.available) {
-		ctx.ui.setStatus(STATUS_KEY, "💊 unavailable");
+		ctx.ui.setStatus(STATUS_KEY, `${getIcon()} unavailable`);
 		return;
 	}
 
@@ -351,4 +351,8 @@ function formatExit(code: number | null, signal: NodeJS.Signals | null) {
 function isDisabled() {
 	const value = process.env.PI_CAFFEINATE_DISABLED?.trim().toLowerCase();
 	return value ? DISABLED_VALUES.has(value) : false;
+}
+
+function getIcon() {
+	return process.env.PI_CAFFEINATE_ICON?.trim() ?? "💊";
 }


### PR DESCRIPTION
## What

Adds a `PI_CAFFEINATE_ICON` environment variable to allow users to customise the footer status icon, falling back to the existing `💊` default if unset.

```bash
PI_CAFFEINATE_ICON='☕️' pi
```

## Why

The icon is currently hardcoded. This mirrors the existing `PI_CAFFEINATE_DISABLED` and `PI_CAFFEINATE_COMMAND` configuration pattern already in the extension — one small `getIcon()` helper and two substitutions in `updateStatus()`.

Related: the same request was raised for `codex-usage` in #78.