### PR TITLE
feat: add pi-wait-what extension

### DIFF
--- a/docs/plans/archived/2026-06-11_pi-wait-what-plan.md
+++ b/docs/plans/archived/2026-06-11_pi-wait-what-plan.md
@@ -1,6 +1,6 @@
 ## Goal
 
-Add a small `@narumitw/pi-wait-what` Pi extension package that lets the user type `/ww` or `/wait-what` when the agent's behavior is surprising, then steers the main conversation so the agent pauses, explains what it was doing, and waits for user confirmation before continuing.
+Add a small `@narumitw/pi-wait-what` Pi extension package that lets the user type `/wait-what` when the agent's behavior is surprising, then steers the main conversation so the agent pauses, explains what it was doing, and waits for user confirmation before continuing.
 
 Success means the package is npm-ready, follows this monorepo's extension conventions, and passes the repository verification gates.
 
@@ -8,8 +8,8 @@ Success means the package is npm-ready, follows this monorepo's extension conven
 
 The agreed v0 design is intentionally simple:
 
-- Register both `/ww` and `/wait-what`.
-- Allow an optional concern/question argument; naked `/ww` and `/wait-what` are valid.
+- Register `/wait-what`.
+- Allow an optional concern/question argument; naked `/wait-what` is valid.
 - Write the intervention into the main conversation, not a side UI.
 - Use `pi.sendUserMessage()` with `deliverAs: "steer"` while the agent is active; send normally while idle.
 - Do not force-abort running tools and do not hard-block future tool calls.
@@ -17,13 +17,13 @@ The agreed v0 design is intentionally simple:
 
 ## Architecture
 
-`pi-wait-what` should be a standalone workspace package under `extensions/pi-wait-what/`. Its extension source should be a single TypeScript file that registers slash commands and builds the steering prompt. No persistent state, custom tools, custom UI, background events, or package-to-package dependencies are needed for v0.
+`pi-wait-what` should be a standalone workspace package under `extensions/pi-wait-what/`. Its extension source should be a single TypeScript file that registers the slash command and builds the steering prompt. No persistent state, custom tools, custom UI, background events, or package-to-package dependencies are needed for v0.
 
 ## Non-Goals
 
 - Do not implement automatic suspicious-action detection.
 - Do not add keyboard shortcuts.
-- Do not add `/ww resume` or paused-state management.
+- Do not add `/wait-what resume` or paused-state management.
 - Do not create side-channel answer UI like `pi-btw`.
 - Do not abort currently running tools or block tool calls at the extension layer.
 
@@ -36,13 +36,13 @@ The agreed v0 design is intentionally simple:
 ## Plan
 
 - [x] Create `extensions/pi-wait-what/` package metadata (`package.json`, `tsconfig.json`, `LICENSE`) matching active workspace package conventions and using `@earendil-works/pi-coding-agent` as the Pi API dev dependency; verified with `node -p "require('./extensions/pi-wait-what/package.json').name"` returning `@narumitw/pi-wait-what`.
-- [x] Implement `extensions/pi-wait-what/src/wait-what.ts` to register `/ww` and `/wait-what`, accept optional arguments, build the agreed fixed-checklist prompt, send it with `pi.sendUserMessage(prompt)` when idle, and send it with `pi.sendUserMessage(prompt, { deliverAs: "steer" })` when busy; verified by source review, direct Node command smoke test, and `npm --workspace @narumitw/pi-wait-what run typecheck`.
+- [x] Implement `extensions/pi-wait-what/src/wait-what.ts` to register `/wait-what`, accept optional arguments, build the agreed fixed-checklist prompt, send it with `pi.sendUserMessage(prompt)` when idle, and send it with `pi.sendUserMessage(prompt, { deliverAs: "steer" })` when busy; verified by source review, direct Node command smoke test, and `npm --workspace @narumitw/pi-wait-what run typecheck`.
 - [x] Add `extensions/pi-wait-what/README.md` following the repository README style with badges, features, install/try commands, usage examples for naked and argument forms, limitations, package layout, keywords, and license; verified by reading `extensions/pi-wait-what/README.md`.
 - [x] Update root workspace affordances for the new package by adding `pack:wait-what` to `package.json` scripts and `pack-wait-what`, `try-wait-what`, `install-wait-what`, and `publish-wait-what` recipes to `justfile`; verified with `npm run pack:wait-what` and `just pack-wait-what` dry runs.
 - [x] Refresh dependency metadata if required by npm workspaces so `package-lock.json` includes the new workspace package; verified with `npm install --package-lock-only` and `git diff -- package-lock.json` showing `extensions/pi-wait-what` plus the workspace link.
 - [x] Run formatting and repository checks; verified with `npm run check` from the repository root.
 - [x] Preview the npm package contents; verified with `just pack-wait-what`, which reported only `LICENSE`, `README.md`, `package.json`, and `src/wait-what.ts` in the tarball.
-- [x] Not applicable: skipped interactive `just try-wait-what` because it opens Pi TUI; command behavior was verified non-interactively with a direct Node smoke test that registered both commands and asserted idle vs busy `sendUserMessage` delivery.
+- [x] Not applicable: skipped interactive `just try-wait-what` because it opens Pi TUI; command behavior was verified non-interactively with a direct Node smoke test that registered `/wait-what` and asserted idle vs busy `sendUserMessage` delivery.
 
 ## Risks
 
@@ -53,7 +53,7 @@ The agreed v0 design is intentionally simple:
 ## Completion Checklist
 
 - [x] `@narumitw/pi-wait-what` package exists under `extensions/pi-wait-what/` with npm-ready metadata verified by `npm --workspace @narumitw/pi-wait-what run typecheck`.
-- [x] `/ww` and `/wait-what` both send the agreed main-conversation prompt, with optional concern handling, verified by source review and the direct Node command smoke test output `wait-what command smoke test passed`.
+- [x] `/wait-what` sends the agreed main-conversation prompt, with optional concern handling, verified by source review and the direct Node command smoke test output `wait-what command smoke test passed`.
 - [x] Root scripts and `justfile` include wait-what pack/try/install/publish commands verified by `npm run pack:wait-what` and `just pack-wait-what`.
 - [x] README documents usage, examples, and steer-only limitations verified by reading `extensions/pi-wait-what/README.md`.
 - [x] Repository checks pass, verified by `npm run check`.

--- a/docs/plans/archived/2026-06-11_pi-wait-what-plan.md
+++ b/docs/plans/archived/2026-06-11_pi-wait-what-plan.md
@@ -1,0 +1,60 @@
+## Goal
+
+Add a small `@narumitw/pi-wait-what` Pi extension package that lets the user type `/ww` or `/wait-what` when the agent's behavior is surprising, then steers the main conversation so the agent pauses, explains what it was doing, and waits for user confirmation before continuing.
+
+Success means the package is npm-ready, follows this monorepo's extension conventions, and passes the repository verification gates.
+
+## Context
+
+The agreed v0 design is intentionally simple:
+
+- Register both `/ww` and `/wait-what`.
+- Allow an optional concern/question argument; naked `/ww` and `/wait-what` are valid.
+- Write the intervention into the main conversation, not a side UI.
+- Use `pi.sendUserMessage()` with `deliverAs: "steer"` while the agent is active; send normally while idle.
+- Do not force-abort running tools and do not hard-block future tool calls.
+- Ask the agent to answer in the current conversation language, not call tools in the explanation response, use a fixed checklist, and wait for confirmation.
+
+## Architecture
+
+`pi-wait-what` should be a standalone workspace package under `extensions/pi-wait-what/`. Its extension source should be a single TypeScript file that registers slash commands and builds the steering prompt. No persistent state, custom tools, custom UI, background events, or package-to-package dependencies are needed for v0.
+
+## Non-Goals
+
+- Do not implement automatic suspicious-action detection.
+- Do not add keyboard shortcuts.
+- Do not add `/ww resume` or paused-state management.
+- Do not create side-channel answer UI like `pi-btw`.
+- Do not abort currently running tools or block tool calls at the extension layer.
+
+## Assumptions
+
+- `deliverAs: "steer"` is sufficient for v0 even though it waits until any already-running tool batch finishes before the next model turn.
+- New extension work should prefer `@earendil-works/*` Pi packages instead of deprecated `@mariozechner/*` packages.
+- The repository's package version stays aligned with the current monorepo version unless a separate release task changes it.
+
+## Plan
+
+- [x] Create `extensions/pi-wait-what/` package metadata (`package.json`, `tsconfig.json`, `LICENSE`) matching active workspace package conventions and using `@earendil-works/pi-coding-agent` as the Pi API dev dependency; verified with `node -p "require('./extensions/pi-wait-what/package.json').name"` returning `@narumitw/pi-wait-what`.
+- [x] Implement `extensions/pi-wait-what/src/wait-what.ts` to register `/ww` and `/wait-what`, accept optional arguments, build the agreed fixed-checklist prompt, send it with `pi.sendUserMessage(prompt)` when idle, and send it with `pi.sendUserMessage(prompt, { deliverAs: "steer" })` when busy; verified by source review, direct Node command smoke test, and `npm --workspace @narumitw/pi-wait-what run typecheck`.
+- [x] Add `extensions/pi-wait-what/README.md` following the repository README style with badges, features, install/try commands, usage examples for naked and argument forms, limitations, package layout, keywords, and license; verified by reading `extensions/pi-wait-what/README.md`.
+- [x] Update root workspace affordances for the new package by adding `pack:wait-what` to `package.json` scripts and `pack-wait-what`, `try-wait-what`, `install-wait-what`, and `publish-wait-what` recipes to `justfile`; verified with `npm run pack:wait-what` and `just pack-wait-what` dry runs.
+- [x] Refresh dependency metadata if required by npm workspaces so `package-lock.json` includes the new workspace package; verified with `npm install --package-lock-only` and `git diff -- package-lock.json` showing `extensions/pi-wait-what` plus the workspace link.
+- [x] Run formatting and repository checks; verified with `npm run check` from the repository root.
+- [x] Preview the npm package contents; verified with `just pack-wait-what`, which reported only `LICENSE`, `README.md`, `package.json`, and `src/wait-what.ts` in the tarball.
+- [x] Not applicable: skipped interactive `just try-wait-what` because it opens Pi TUI; command behavior was verified non-interactively with a direct Node smoke test that registered both commands and asserted idle vs busy `sendUserMessage` delivery.
+
+## Risks
+
+- A model may ignore the prompt-only instruction and call tools anyway; v0 accepts this tradeoff to stay simple.
+- `deliverAs: "steer"` cannot interrupt an already-running tool call; README should document this limitation.
+- If package metadata uses deprecated Pi package names, future installs may inherit deprecation warnings; prefer `@earendil-works/*` for new work.
+
+## Completion Checklist
+
+- [x] `@narumitw/pi-wait-what` package exists under `extensions/pi-wait-what/` with npm-ready metadata verified by `npm --workspace @narumitw/pi-wait-what run typecheck`.
+- [x] `/ww` and `/wait-what` both send the agreed main-conversation prompt, with optional concern handling, verified by source review and the direct Node command smoke test output `wait-what command smoke test passed`.
+- [x] Root scripts and `justfile` include wait-what pack/try/install/publish commands verified by `npm run pack:wait-what` and `just pack-wait-what`.
+- [x] README documents usage, examples, and steer-only limitations verified by reading `extensions/pi-wait-what/README.md`.
+- [x] Repository checks pass, verified by `npm run check`.
+- [x] Package dry-run contents are correct, verified by `just pack-wait-what` output showing four files: `LICENSE`, `README.md`, `package.json`, and `src/wait-what.ts`.

--- a/extensions/pi-wait-what/LICENSE
+++ b/extensions/pi-wait-what/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-wait-what/README.md
+++ b/extensions/pi-wait-what/README.md
@@ -2,13 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-wait-what)](https://www.npmjs.com/package/@narumitw/pi-wait-what) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-wait-what` is a native [Pi coding agent](https://pi.dev) extension that adds `/ww` and `/wait-what`, quick commands for pausing the main conversation and asking the agent to explain surprising behavior.
+`@narumitw/pi-wait-what` is a native [Pi coding agent](https://pi.dev) extension that adds `/wait-what`, a quick command for pausing the main conversation and asking the agent to explain surprising behavior.
 
 Use it when the agent starts doing something unexpected, unclear, or more aggressive than you intended and you want it to explain before continuing.
 
 ## ✨ Features
 
-- Adds `/ww` and `/wait-what` commands to Pi.
+- Adds a `/wait-what` command to Pi.
 - Works with or without an extra concern/question.
 - Sends a main-conversation steering message, so the agent remembers the interruption.
 - Asks the agent to avoid tools in the explanation response.
@@ -37,17 +37,15 @@ pi -e ./extensions/pi-wait-what
 ## 🚀 Usage
 
 ```text
-/ww
 /wait-what
-/ww <your concern or question>
 /wait-what <your concern or question>
 ```
 
 Examples:
 
 ```text
-/ww
-/ww why are you editing package-lock?
+/wait-what
+/wait-what why are you editing package-lock?
 /wait-what I thought we agreed not to implement yet
 ```
 

--- a/extensions/pi-wait-what/README.md
+++ b/extensions/pi-wait-what/README.md
@@ -1,0 +1,106 @@
+# 🤔 pi-wait-what — Pause and Ask What the Agent Is Doing
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-wait-what)](https://www.npmjs.com/package/@narumitw/pi-wait-what) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-wait-what` is a native [Pi coding agent](https://pi.dev) extension that adds `/ww` and `/wait-what`, quick commands for pausing the main conversation and asking the agent to explain surprising behavior.
+
+Use it when the agent starts doing something unexpected, unclear, or more aggressive than you intended and you want it to explain before continuing.
+
+## ✨ Features
+
+- Adds `/ww` and `/wait-what` commands to Pi.
+- Works with or without an extra concern/question.
+- Sends a main-conversation steering message, so the agent remembers the interruption.
+- Asks the agent to avoid tools in the explanation response.
+- Uses a fixed checklist: what it was doing, why, assumptions, next step, and what it needs from you.
+- Keeps v0 simple: no automatic detection, no custom UI, no shortcuts, no aborts, and no tool blocking.
+- Works as an independently installable npm Pi extension package.
+
+## 📦 Install
+
+```bash
+pi install npm:@narumitw/pi-wait-what
+```
+
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-wait-what
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-wait-what
+```
+
+## 🚀 Usage
+
+```text
+/ww
+/wait-what
+/ww <your concern or question>
+/wait-what <your concern or question>
+```
+
+Examples:
+
+```text
+/ww
+/ww why are you editing package-lock?
+/wait-what I thought we agreed not to implement yet
+```
+
+When triggered, the extension sends a user message like:
+
+```text
+Wait, what? Pause here and explain what you were doing before taking any more actions.
+
+Respond in the current conversation language. Do not call tools in this response. Be concise and use this checklist:
+
+1. What you were doing
+2. Why you chose that action
+3. What you assumed
+4. What you were about to do next
+5. What you need from me before continuing
+
+After explaining, wait for my confirmation before continuing.
+```
+
+If you include a concern, the command adds it to the message and asks the agent to address it directly.
+
+## ⚠️ Limitations
+
+`pi-wait-what` is intentionally prompt-only in v0. It does not abort already-running tools and does not hard-block future tool calls. When the agent is busy, the extension uses Pi's steering delivery mode, so the wait-what message is inserted before the next model turn after the current tool batch finishes.
+
+If you need to continue after the explanation, just type a normal reply such as `ok continue`, `no, do not edit that file`, or another follow-up question.
+
+## 🗂️ Package layout
+
+```txt
+extensions/pi-wait-what/
+├── src/
+│   └── wait-what.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+The package exposes its Pi extension through `package.json`:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/wait-what.ts"]
+  }
+}
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, wait what, pause agent, agent clarification, steering command, TypeScript Pi package, npm Pi extension.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-wait-what/package.json
+++ b/extensions/pi-wait-what/package.json
@@ -1,0 +1,44 @@
+{
+	"name": "@narumitw/pi-wait-what",
+	"version": "0.1.37",
+	"description": "Pi extension that lets you pause and ask the agent to explain surprising actions.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"wait-what",
+		"pause",
+		"clarification"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/wait-what.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.14",
+		"@earendil-works/pi-coding-agent": "0.74.0",
+		"typescript": "6.0.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "extensions/pi-wait-what"
+	}
+}

--- a/extensions/pi-wait-what/src/wait-what.ts
+++ b/extensions/pi-wait-what/src/wait-what.ts
@@ -1,21 +1,13 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 const WAIT_WHAT_COMMAND = "wait-what";
-const WAIT_WHAT_ALIAS = "ww";
 
 export default function waitWhat(pi: ExtensionAPI) {
-	const handler = async (args: string, ctx: ExtensionCommandContext) => {
-		sendWaitWhatPrompt(pi, ctx, args);
-	};
-
-	pi.registerCommand(WAIT_WHAT_ALIAS, {
-		description: "Pause and ask the agent to explain what it is doing",
-		handler,
-	});
-
 	pi.registerCommand(WAIT_WHAT_COMMAND, {
 		description: "Pause and ask the agent to explain what it is doing",
-		handler,
+		handler: async (args, ctx) => {
+			sendWaitWhatPrompt(pi, ctx, args);
+		},
 	});
 }
 

--- a/extensions/pi-wait-what/src/wait-what.ts
+++ b/extensions/pi-wait-what/src/wait-what.ts
@@ -1,0 +1,59 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+const WAIT_WHAT_COMMAND = "wait-what";
+const WAIT_WHAT_ALIAS = "ww";
+
+export default function waitWhat(pi: ExtensionAPI) {
+	const handler = async (args: string, ctx: ExtensionCommandContext) => {
+		sendWaitWhatPrompt(pi, ctx, args);
+	};
+
+	pi.registerCommand(WAIT_WHAT_ALIAS, {
+		description: "Pause and ask the agent to explain what it is doing",
+		handler,
+	});
+
+	pi.registerCommand(WAIT_WHAT_COMMAND, {
+		description: "Pause and ask the agent to explain what it is doing",
+		handler,
+	});
+}
+
+function sendWaitWhatPrompt(pi: ExtensionAPI, ctx: ExtensionCommandContext, rawConcern: string) {
+	const prompt = buildWaitWhatPrompt(rawConcern);
+	if (ctx.isIdle()) {
+		pi.sendUserMessage(prompt);
+		return;
+	}
+
+	pi.sendUserMessage(prompt, { deliverAs: "steer" });
+}
+
+export function buildWaitWhatPrompt(rawConcern = "") {
+	const concern = rawConcern.trim();
+	const concernBlock = concern
+		? [
+				"My concern/question:",
+				"<concern>",
+				concern,
+				"</concern>",
+				"Address this directly in your explanation.",
+				"",
+			]
+		: [];
+
+	return [
+		"Wait, what? Pause here and explain what you were doing before taking any more actions.",
+		"",
+		...concernBlock,
+		"Respond in the current conversation language. Do not call tools in this response. Be concise and use this checklist:",
+		"",
+		"1. What you were doing",
+		"2. Why you chose that action",
+		"3. What you assumed",
+		"4. What you were about to do next",
+		"5. What you need from me before continuing",
+		"",
+		"After explaining, wait for my confirmation before continuing.",
+	].join("\n");
+}

--- a/extensions/pi-wait-what/tsconfig.json
+++ b/extensions/pi-wait-what/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -103,6 +103,9 @@ pack-sync:
 pack-subagents:
     just pack subagents
 
+pack-wait-what:
+    just pack wait-what
+
 # Try individual packages from this working tree as temporary pi packages
 try-btw:
     just try btw
@@ -139,6 +142,9 @@ try-sync:
 
 try-subagents:
     just try subagents
+
+try-wait-what:
+    just try wait-what
 
 # Install individual packages through pi
 install-btw:
@@ -177,6 +183,9 @@ install-sync:
 install-subagents:
     just install subagents
 
+install-wait-what:
+    just install wait-what
+
 # Publish individual packages to npm
 publish-btw:
     just publish btw
@@ -213,6 +222,9 @@ publish-sync:
 
 publish-subagents:
     just publish subagents
+
+publish-wait-what:
+    just publish wait-what
 
 # Bump one workspace package without creating a git tag
 # Usage: just bump @narumitw/pi-goal patch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,6 +1119,19 @@
 				"koffi": "^2.9.0"
 			}
 		},
+		"extensions/pi-wait-what": {
+			"name": "@narumitw/pi-wait-what",
+			"version": "0.1.37",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.4.14",
+				"@earendil-works/pi-coding-agent": "0.74.0",
+				"typescript": "6.0.3"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
@@ -2622,6 +2635,10 @@
 		},
 		"node_modules/@narumitw/pi-sync": {
 			"resolved": "extensions/pi-sync",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-wait-what": {
+			"resolved": "extensions/pi-wait-what",
 			"link": true
 		},
 		"node_modules/@nodable/entities": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"pack:retry": "npm --workspace @narumitw/pi-retry pack --dry-run",
 		"pack:statusline": "npm --workspace @narumitw/pi-statusline pack --dry-run",
 		"pack:sync": "npm --workspace @narumitw/pi-sync pack --dry-run",
-		"pack:subagents": "npm --workspace @narumitw/pi-subagents pack --dry-run"
+		"pack:subagents": "npm --workspace @narumitw/pi-subagents pack --dry-run",
+		"pack:wait-what": "npm --workspace @narumitw/pi-wait-what pack --dry-run"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.14",


### PR DESCRIPTION
## Summary
- add the @narumitw/pi-wait-what workspace package with the /wait-what command
- steer the main conversation with a fixed explanation checklist and optional user concern
- add README, package metadata, root pack script, just recipes, lockfile entry, and archived implementation plan

## Verification
- npm --workspace @narumitw/pi-wait-what run typecheck
- node --input-type=module smoke test for command registration, no /ww alias, and idle/steer delivery
- npm run check
- npm run pack:wait-what
- just pack-wait-what