### PR TITLE
feat: Change systemd-inhibit option from 'idle:sleep' to 'sleep'

### DIFF
--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -188,7 +188,7 @@ function getInhibitorCommand(): InhibitorCommand | undefined {
 			return parentBoundUnixCommand(
 				"systemd-inhibit",
 				[
-					"--what=idle:sleep",
+					"--what=sleep",
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
 					"--mode=block",


### PR DESCRIPTION
allows the screen to blank for power-saving on systemd/linux

It's what, for example, firefox does when a download is in progress.

Edit: It occurs to me that others might be using the extension just because it prevents screen blanking. My personal preference is for it to idle, but not sleep...