### PR TITLE
feat(caffeinate): add configurable keep-awake mode

### DIFF
--- a/docs/plans/archived/2026-06-12_pi-caffeinate-command-plan.md
+++ b/docs/plans/archived/2026-06-12_pi-caffeinate-command-plan.md
@@ -1,0 +1,74 @@
+## Goal
+
+Add a `/caffeinate` slash command to `@narumitw/pi-caffeinate` so users can choose and persist the keep-awake mode:
+
+- `sleep`: prevent system sleep/suspend/hibernate while allowing normal display idle behavior.
+- `display`: prevent system sleep and keep the screen/display awake.
+
+Success means every supported OS defaults to `display` mode, `/caffeinate` is the only slash command for this extension, `/caffeinate` provides a menu to choose the mode, the chosen mode is saved in a user-level JSON config, restored on Pi startup/reload, reflected in status/help output, documented in the README, and mapped consistently across Linux/systemd, macOS, Windows, WSL, and Linux `caffeinate` fallback where platform support allows.
+
+## Context
+
+Current `extensions/pi-caffeinate/src/caffeinate.ts` starts an inhibitor on `agent_start` and stops it on `agent_end` or shutdown. The new command surface should be a single `/caffeinate` command with menu choices and direct subcommands. Current platform mappings are:
+
+- macOS: `caffeinate -dimsu` keeps system and display awake.
+- Windows/WSL: `SetThreadExecutionState(0x80000003)` keeps system and display awake.
+- Linux/systemd: current branch uses `systemd-inhibit --what=sleep`, while PR #88 changes from the older `idle:sleep` behavior to allow screen blanking.
+- Linux fallback: `caffeinate -dimsu` keeps system and display awake.
+
+Existing extensions such as `pi-firecrawl` and `pi-chrome-devtools` already use user-level JSON settings under `${PI_CODING_AGENT_DIR:-~/.pi/agent}` and interactive slash-command menus.
+
+## Architecture
+
+- Add a small persisted settings object, for example `{ "mode": "sleep" | "display", "updatedAt": number }`, stored at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-caffeinate-settings.json`.
+- Treat missing, invalid, or reset settings as `display` mode on every supported OS: prevent system sleep/suspend/hibernate and keep the display awake.
+- Keep environment overrides (`PI_CAFFEINATE_DISABLED`, `PI_CAFFEINATE_COMMAND`, `PI_CAFFEINATE_ICON`) working. `PI_CAFFEINATE_COMMAND` should remain the highest-priority inhibitor command and should be reported as a custom command mode rather than rewritten by the new setting.
+- Use the selected mode when building the inhibitor command. If mode changes while an inhibitor is active, restart the inhibitor so the new behavior applies immediately.
+- Prefer non-secret, atomic JSON writes using the same `write temp file + rename + cleanup` pattern used by other extensions.
+
+## Assumptions
+
+- Default mode must be `display` on all supported OSes to prioritize uninterrupted long-running Pi work, including Linux desktops that require idle inhibition to prevent automatic suspend. Users can explicitly select `sleep` to allow the screen/display to blank or turn off.
+- Backward compatibility for users who relied on display wakefulness is preserved by making `display` the default. Users who prefer screen power saving can choose `/caffeinate sleep`.
+- Remove the legacy `/caffeinate-status` and `/caffeinate-stop` commands; `/caffeinate` is the single command surface, with menu choices and direct subcommands for status, mode selection, and stop.
+- The Pi command API supports command completions and `ctx.ui.select()` similarly to `pi-firecrawl` and `pi-chrome-devtools`.
+
+## Unknowns
+
+- Resolved: macOS/Linux `caffeinate` `sleep` mode uses `-ims`, omitting display/user-active flags from `-dimsu`; documented in `extensions/pi-caffeinate/README.md`.
+- Resolved: Windows `sleep` mode uses `ES_CONTINUOUS | ES_SYSTEM_REQUIRED` (`0x80000001`), while `display` mode keeps the prior `0x80000003`; documented in `extensions/pi-caffeinate/README.md`.
+
+## Plan
+
+- [x] Confirm command API details for `/caffeinate` arguments, completions, and interactive `ctx.ui.select()` by comparing `extensions/pi-firecrawl/src/firecrawl.ts`, `extensions/pi-chrome-devtools/src/chrome-devtools.ts`, and Pi extension docs if needed; verified by copying the existing command handler, completion, non-UI fallback, and selector patterns into `extensions/pi-caffeinate/src/caffeinate.ts`.
+- [x] Define `CaffeinateMode = "sleep" | "display"`, a single cross-platform default mode of `display`, command completions, menu labels, and settings path constants in `extensions/pi-caffeinate/src/caffeinate.ts`; verified with `npm --workspace @narumitw/pi-caffeinate run typecheck`.
+- [x] Add JSON settings helpers that read, validate, normalize, and atomically write `{ mode, updatedAt }` at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-caffeinate-settings.json`, ignoring missing files and warning without crashing on invalid JSON; verified by code review of `loadSettingsIntoState()`, `normalizeCaffeinateSettings()`, and `saveSettings()` plus `npm --workspace @narumitw/pi-caffeinate run typecheck`.
+- [x] Register `/caffeinate` as the only slash command, with a no-arg interactive menu and direct subcommands such as `help`, `status`, `mode`, `sleep`, `display`, and `stop`; verified by code review of `pi.registerCommand("caffeinate")`, `parseCommand()`, `showMenu()`, `showModeSelector()`, and `buildCommandGuide()` plus `npm --workspace @narumitw/pi-caffeinate run check`.
+- [x] Remove `/caffeinate-status` and `/caffeinate-stop` command registrations so users access status and stop through `/caffeinate status`, `/caffeinate stop`, or the `/caffeinate` menu; verified with `rg "caffeinate-status|caffeinate-stop" extensions/pi-caffeinate/src extensions/pi-caffeinate/README.md` returning no matches.
+- [x] Update inhibitor command construction to accept the selected mode: Linux/systemd uses `--what=sleep` for `sleep` and `--what=idle:sleep` for `display`; Windows/WSL uses `0x80000001` for `sleep` and `0x80000003` for `display`; macOS/Linux `caffeinate` fallback uses display-preventing flags only in `display` mode; verified by code review of `getInhibitorCommand()`, `macCaffeinateArgs()`, and `windowsInhibitorScript()` plus README platform table.
+- [x] When `/caffeinate sleep` or `/caffeinate display` changes the mode, save the JSON settings and restart any active inhibitor so the new mode applies immediately; verified by code review of `setMode()` saving settings, stopping the active inhibitor, and calling `startInhibitor()` when the mode changes.
+- [x] Update notifications, status text, and `describeState()` to include the selected mode and settings file path where useful; verified by code review of `describeState()`, `statusModeLabel()`, and `setMode()`.
+- [x] Update `extensions/pi-caffeinate/README.md` to document `/caffeinate`, its menu, direct subcommands, persisted JSON path, mode semantics, platform mappings, and env var precedence, without documenting removed legacy commands; verified by README review and `rg "caffeinate-status|caffeinate-stop" extensions/pi-caffeinate/src extensions/pi-caffeinate/README.md` returning no matches.
+- [x] Run repository verification with `npm run check`; verified passing.
+- [x] Preview package contents with `just pack-caffeinate`; verified dry-run tarball contains `LICENSE`, `README.md`, `package.json`, and `src/caffeinate.ts`.
+
+## Risks
+
+- Platform flag semantics are not perfectly symmetric: macOS/Linux `caffeinate` and Windows expose different primitives, so `sleep` mode may not mean exactly the same thing on every OS.
+- Keeping the default as display-awake uses more power and may surprise users who expect background tasks to allow screen blanking.
+- Restarting an active inhibitor on mode change must avoid leaving orphaned `sleep infinity`, `caffeinate`, or PowerShell child processes.
+
+## Rollback / Recovery
+
+- Users can recover old display-awake behavior by running `/caffeinate display`, or by setting `PI_CAFFEINATE_COMMAND` to a custom inhibitor command.
+- If the settings file is invalid or unwanted, deleting `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-caffeinate-settings.json` should restore the default `display` mode on next startup/reload.
+- If implementation causes runtime problems, revert `extensions/pi-caffeinate/src/caffeinate.ts` and `extensions/pi-caffeinate/README.md`; no data migration is required because the settings file is optional and non-secret.
+
+## Completion Checklist
+
+- [x] `/caffeinate` is the only slash command and provides a no-arg menu plus direct subcommands, verified by code review of `extensions/pi-caffeinate/src/caffeinate.ts`, `rg "caffeinate-status|caffeinate-stop" extensions/pi-caffeinate/src extensions/pi-caffeinate/README.md` returning no matches, and `npm run check` passing.
+- [x] Mode selection persists to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-caffeinate-settings.json` and restores on startup/reload, verified by `loadSettingsIntoState()`, `setMode()`, `saveSettings()`, and `npm run check` passing.
+- [x] Missing/reset settings default to `display` mode on Linux/systemd, Windows/WSL, macOS, and Linux fallback, and both `sleep` and `display` modes map to documented inhibitor commands, verified by `DEFAULT_MODE = "display"`, `getInhibitorCommand()`, `macCaffeinateArgs()`, `windowsInhibitorScript()`, and the README platform table.
+- [x] README documents the single `/caffeinate` command, menu, modes, config file, environment precedence, and recovery path, verified in `extensions/pi-caffeinate/README.md`.
+- [x] `npm run check` passes from the repository root.
+- [x] `just pack-caffeinate` dry run shows the expected package contents: `LICENSE`, `README.md`, `package.json`, and `src/caffeinate.ts`.

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -10,9 +10,11 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 
 - Starts an OS sleep inhibitor when Pi begins processing (`agent_start`).
 - Releases the inhibitor when processing ends (`agent_end`) or the session shuts down.
-- Publishes an `awake` status only while an inhibitor is active.
+- Publishes the active keep-awake mode as status while an inhibitor is active.
 - Supports macOS, Windows, WSL, and Linux.
-- Provides `/caffeinate-status` and `/caffeinate-stop` commands.
+- Defaults to display-awake mode on every supported OS: prevent system sleep and keep the screen/display awake.
+- Provides a single `/caffeinate` command with menu-based controls and direct subcommands.
+- Persists the selected keep-awake mode in a small JSON settings file.
 - Allows a custom inhibitor command through environment configuration.
 - Allows a custom status icon through environment configuration.
 - Fails safely when no supported inhibitor is available.
@@ -37,29 +39,80 @@ pi -e ./extensions/pi-caffeinate
 
 ## 🖥️ Supported platforms
 
-- macOS: uses `caffeinate -dimsu`.
-- Windows: uses PowerShell `SetThreadExecutionState`.
-- WSL: uses Windows `powershell.exe` with `SetThreadExecutionState`.
-- Linux: uses `systemd-inhibit` with `sleep infinity`.
-- Linux fallback: uses `caffeinate -dimsu` when available.
+The default mode is `display` on every supported OS. That means pi-caffeinate prevents system sleep, suspend, or hibernate and keeps the screen/display awake.
+
+Use `/caffeinate sleep` if you want to prevent system sleep while allowing normal display idle behavior such as screen blanking or monitor power-off.
+
+| Platform | `sleep` mode | `display` mode, default |
+| --- | --- | --- |
+| macOS | `caffeinate -ims` | `caffeinate -dimsu` |
+| Windows | PowerShell `SetThreadExecutionState(0x80000001)` | PowerShell `SetThreadExecutionState(0x80000003)` |
+| WSL | Windows `powershell.exe` with `SetThreadExecutionState(0x80000001)` | Windows `powershell.exe` with `SetThreadExecutionState(0x80000003)` |
+| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | `systemd-inhibit --what=idle:sleep ... sleep infinity` |
+| Linux fallback | `caffeinate -ims` when available | `caffeinate -dimsu` when available |
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
 ## 🚀 Commands
 
 ```text
-/caffeinate-status
+/caffeinate
 ```
 
-Shows whether an inhibitor is active, unavailable, or disabled.
+Opens mode and status controls. In non-interactive sessions, it prints command usage and status.
 
 ```text
-/caffeinate-stop
+/caffeinate status
 ```
 
-Manually releases any active inhibitor for the current session.
+Shows whether an inhibitor is active, unavailable, disabled, or idle. The status includes the current mode and settings file path.
+
+```text
+/caffeinate mode
+```
+
+Opens an interactive selector for the keep-awake mode.
+
+```text
+/caffeinate sleep
+```
+
+Prevents system sleep only and allows the display to turn off. If an inhibitor is currently active, it is restarted so the new mode applies immediately.
+
+```text
+/caffeinate display
+```
+
+Prevents system sleep and keeps the screen/display awake. If an inhibitor is currently active, it is restarted so the new mode applies immediately.
+
+```text
+/caffeinate stop
+```
+
+Manually releases any active inhibitor until Pi starts another agent run.
 
 ## ⚙️ Configuration
+
+### Persisted mode
+
+`/caffeinate sleep` and `/caffeinate display` save the selected mode to:
+
+```text
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-caffeinate-settings.json
+```
+
+Example:
+
+```json
+{
+  "mode": "display",
+  "updatedAt": 1791763200000
+}
+```
+
+Missing, invalid, or deleted settings default back to `display` mode on every supported OS.
+
+### Environment variables
 
 Disable the extension:
 
@@ -73,7 +126,7 @@ Use a custom inhibitor command:
 PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mode=block sleep infinity' pi
 ```
 
-The custom command is parsed with shell-like quoting and is run directly without a shell.
+The custom command is parsed with shell-like quoting and is run directly without a shell. `PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
 
 Customise the status bar icon (default: `💊`):
 
@@ -84,6 +137,8 @@ PI_CAFFEINATE_ICON='☕️' pi
 ## 🧠 Why use pi-caffeinate?
 
 AI coding agents often run tool-heavy tasks that take several minutes. `pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
+
+The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend. Use sleep-only mode when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
 
 ## 🗂️ Package layout
 

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -1,17 +1,53 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import pathModule from "node:path";
 import process from "node:process";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
 
 const STATUS_KEY = "caffeinate";
 const DISABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+const DEFAULT_MODE = "display" satisfies CaffeinateMode;
+const SETTINGS_FILE = join(
+	process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent"),
+	"pi-caffeinate-settings.json",
+);
+const COMMAND_COMPLETIONS = [
+	{ value: "help", label: "Show command usage" },
+	{ value: "status", label: "Show current caffeinate status" },
+	{ value: "mode", label: "Select keep-awake mode" },
+	{ value: "sleep", label: "Sleep only — let screen turn off" },
+	{ value: "display", label: "Keep screen awake" },
+	{ value: "stop", label: "Stop keeping awake" },
+];
+const MENU_OPTIONS = {
+	status: "Status",
+	sleep: "Sleep only — let screen turn off",
+	display: "Keep screen awake",
+	stop: "Stop keeping awake",
+	help: "Help",
+} as const;
+const MODE_OPTIONS = {
+	sleep: "Sleep only — let screen turn off",
+	display: "Keep screen awake",
+} as const;
+
+type CaffeinateMode = "sleep" | "display";
+type CommandAction = "menu" | "help" | "status" | "mode" | "sleep" | "display" | "stop";
+type CommandContext = ExtensionCommandContext;
 
 interface InhibitorCommand {
 	command: string;
 	args: string[];
 	description: string;
 	releaseOnStdinClose?: boolean;
+	custom?: boolean;
 }
 
 interface CaffeinateState {
@@ -22,20 +58,32 @@ interface CaffeinateState {
 	activeTurns: number;
 	available: boolean;
 	disabled: boolean;
+	mode: CaffeinateMode;
+	settingsLoaded: boolean;
+	settingsError?: string;
+}
+
+interface CaffeinateSettings {
+	mode: CaffeinateMode;
+	updatedAt: number;
 }
 
 const state: CaffeinateState = {
 	activeTurns: 0,
 	available: true,
 	disabled: isDisabled(),
+	mode: DEFAULT_MODE,
+	settingsLoaded: false,
 };
 
 export default function caffeinate(pi: ExtensionAPI) {
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
+		await loadSettingsIntoState(ctx);
 		updateStatus(ctx);
 	});
 
-	pi.on("agent_start", (_event, ctx) => {
+	pi.on("agent_start", async (_event, ctx) => {
+		await ensureSettingsLoaded(ctx);
 		state.activeTurns += 1;
 		startInhibitor(ctx);
 	});
@@ -52,22 +100,167 @@ export default function caffeinate(pi: ExtensionAPI) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
-	pi.registerCommand("caffeinate-status", {
-		description: "Show whether pi-caffeinate is currently keeping the computer awake",
-		handler: async (_args, ctx) => {
-			ctx.ui.notify(describeState(), state.process ? "info" : state.available ? "info" : "warning");
-			updateStatus(ctx);
+	pi.registerCommand("caffeinate", {
+		description: "Open pi-caffeinate mode and status controls",
+		getArgumentCompletions: (prefix) => commandCompletions(prefix),
+		handler: async (args, ctx) => {
+			await ensureSettingsLoaded(ctx);
+			await handleCaffeinateCommand(args, ctx);
 		},
 	});
 
-	pi.registerCommand("caffeinate-stop", {
-		description: "Release the active pi-caffeinate sleep inhibitor",
-		handler: async (_args, ctx) => {
-			state.activeTurns = 0;
-			stopInhibitor(ctx, "manual stop");
-			updateStatus(ctx);
-		},
-	});
+}
+
+async function handleCaffeinateCommand(args: string, ctx: CommandContext) {
+	const command = parseCommand(args);
+	switch (command) {
+		case "menu":
+			await showMenu(ctx);
+			return;
+		case "help":
+			ctx.ui.notify(buildCommandGuide(), "info");
+			return;
+		case "status":
+			showStatus(ctx);
+			return;
+		case "mode":
+			await showModeSelector(ctx);
+			return;
+		case "sleep":
+			await setMode(ctx, "sleep");
+			return;
+		case "display":
+			await setMode(ctx, "display");
+			return;
+		case "stop":
+			stopCaffeinate(ctx, "manual stop");
+			return;
+	}
+
+	ctx.ui.notify(`Unknown /caffeinate command: ${args.trim()}\n\n${buildCommandGuide()}`, "warning");
+}
+
+async function showMenu(ctx: CommandContext) {
+	if (!ctx.hasUI) {
+		ctx.ui.notify(`${buildCommandGuide()}\n\n${describeState()}`, statusLevel());
+		updateStatus(ctx);
+		return;
+	}
+
+	const choice = await ctx.ui.select("pi-caffeinate", Object.values(MENU_OPTIONS));
+	switch (choice) {
+		case MENU_OPTIONS.status:
+			showStatus(ctx);
+			return;
+		case MENU_OPTIONS.sleep:
+			await setMode(ctx, "sleep");
+			return;
+		case MENU_OPTIONS.display:
+			await setMode(ctx, "display");
+			return;
+		case MENU_OPTIONS.stop:
+			stopCaffeinate(ctx, "manual stop");
+			return;
+		case MENU_OPTIONS.help:
+			ctx.ui.notify(buildCommandGuide(), "info");
+			return;
+	}
+}
+
+async function showModeSelector(ctx: CommandContext) {
+	if (!ctx.hasUI) {
+		ctx.ui.notify(
+			`Mode selection needs an interactive UI. Run /caffeinate sleep or /caffeinate display.\n\n${describeState()}`,
+			statusLevel(),
+		);
+		updateStatus(ctx);
+		return;
+	}
+
+	const choice = await ctx.ui.select(
+		`pi-caffeinate mode (current: ${formatMode(state.mode)})`,
+		Object.values(MODE_OPTIONS),
+	);
+	if (choice === MODE_OPTIONS.sleep) {
+		await setMode(ctx, "sleep");
+		return;
+	}
+	if (choice === MODE_OPTIONS.display) {
+		await setMode(ctx, "display");
+	}
+}
+
+async function setMode(ctx: ExtensionContext, mode: CaffeinateMode) {
+	const previousMode = state.mode;
+	state.mode = mode;
+	state.settingsError = undefined;
+
+	let saved = true;
+	try {
+		await saveSettings({ mode, updatedAt: Date.now() });
+	} catch (error) {
+		saved = false;
+		state.settingsError = `settings save failed: ${formatError(error)}`;
+		ctx.ui.notify(`pi-caffeinate settings save failed: ${formatError(error)}`, "warning");
+	}
+
+	if (state.process && previousMode !== mode && !state.command?.custom) {
+		stopInhibitor(ctx, "mode changed", { notify: false });
+		startInhibitor(ctx);
+	}
+
+	ctx.ui.notify(
+		saved
+			? `pi-caffeinate mode set to ${formatMode(mode)} and saved.`
+			: `pi-caffeinate mode set to ${formatMode(mode)} for this session, but settings were not saved.`,
+		saved ? "info" : "warning",
+	);
+	updateStatus(ctx);
+}
+
+function showStatus(ctx: ExtensionContext) {
+	ctx.ui.notify(describeState(), statusLevel());
+	updateStatus(ctx);
+}
+
+function stopCaffeinate(ctx: ExtensionContext, reason: string) {
+	state.activeTurns = 0;
+	stopInhibitor(ctx, reason);
+	updateStatus(ctx);
+}
+
+function parseCommand(args: string): CommandAction | "unknown" {
+	const command = args.trim().toLowerCase();
+	if (!command) return "menu";
+	if (command === "help") return "help";
+	if (command === "status") return "status";
+	if (command === "mode" || command === "config" || command === "settings") return "mode";
+	if (command === "sleep" || command === "system") return "sleep";
+	if (command === "display" || command === "screen") return "display";
+	if (command === "stop" || command === "off") return "stop";
+	return "unknown";
+}
+
+function commandCompletions(prefix: string) {
+	const normalized = prefix.trim().toLowerCase();
+	if (normalized.includes(" ")) return null;
+
+	const matches = COMMAND_COMPLETIONS.filter((completion) =>
+		completion.value.startsWith(normalized),
+	);
+	return matches.length > 0 ? matches : null;
+}
+
+function buildCommandGuide() {
+	return [
+		"pi-caffeinate commands:",
+		"/caffeinate — open mode and status controls",
+		"/caffeinate status — show current mode, settings, and inhibitor state",
+		"/caffeinate mode — choose sleep-only or display-awake mode",
+		"/caffeinate sleep — prevent system sleep only and allow the display to turn off",
+		"/caffeinate display — prevent system sleep and keep the screen awake",
+		"/caffeinate stop — release the active inhibitor until the next agent run",
+	].join("\n");
 }
 
 function startInhibitor(ctx: ExtensionContext) {
@@ -81,7 +274,7 @@ function startInhibitor(ctx: ExtensionContext) {
 		return;
 	}
 
-	const command = getInhibitorCommand();
+	const command = getInhibitorCommand(state.mode);
 	if (!command) {
 		state.available = false;
 		state.lastError = `No supported sleep inhibitor found for ${process.platform}.`;
@@ -168,47 +361,60 @@ function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?
 	}
 }
 
-function getInhibitorCommand(): InhibitorCommand | undefined {
+function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | undefined {
 	const customCommand = process.env.PI_CAFFEINATE_COMMAND?.trim();
 	if (customCommand) {
 		const [command, ...args] = splitCommand(customCommand);
-		if (command) return { command, args, description: command };
+		if (command) return { command, args, description: `custom command (${command})`, custom: true };
 	}
 
 	if (process.platform === "darwin") {
-		return parentBoundUnixCommand("caffeinate", ["-dimsu"], "caffeinate");
+		return parentBoundUnixCommand("caffeinate", macCaffeinateArgs(mode), caffeinateDescription(mode));
 	}
 
 	if (process.platform === "linux") {
 		if (isWsl() && commandExists("powershell.exe")) {
-			return windowsPowerInhibitorCommand("powershell.exe");
+			return windowsPowerInhibitorCommand("powershell.exe", mode);
 		}
 
 		if (commandExists("systemd-inhibit")) {
+			const what = mode === "sleep" ? "sleep" : "idle:sleep";
 			return parentBoundUnixCommand(
 				"systemd-inhibit",
 				[
-					"--what=sleep",
+					`--what=${what}`,
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
 					"--mode=block",
 					"sleep",
 					"infinity",
 				],
-				"systemd-inhibit",
+				`systemd-inhibit (${formatMode(mode)})`,
 			);
 		}
 
 		if (commandExists("caffeinate")) {
-			return parentBoundUnixCommand("caffeinate", ["-dimsu"], "caffeinate");
+			return parentBoundUnixCommand(
+				"caffeinate",
+				macCaffeinateArgs(mode),
+				caffeinateDescription(mode),
+			);
 		}
 	}
 
 	if (process.platform === "win32") {
-		return windowsPowerInhibitorCommand("powershell.exe");
+		return windowsPowerInhibitorCommand("powershell.exe", mode);
 	}
 
 	return undefined;
+}
+
+function macCaffeinateArgs(mode: CaffeinateMode) {
+	return mode === "sleep" ? ["-ims"] : ["-dimsu"];
+}
+
+function caffeinateDescription(mode: CaffeinateMode) {
+	return `caffeinate (${formatMode(mode)})`;
 }
 
 function parentBoundUnixCommand(
@@ -292,17 +498,18 @@ function splitCommand(input: string) {
 	return parts;
 }
 
-function windowsPowerInhibitorCommand(command: string): InhibitorCommand {
+function windowsPowerInhibitorCommand(command: string, mode: CaffeinateMode): InhibitorCommand {
 	return {
 		command,
-		args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", windowsInhibitorScript()],
-		description: "PowerShell SetThreadExecutionState",
+		args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", windowsInhibitorScript(mode)],
+		description: `PowerShell SetThreadExecutionState (${formatMode(mode)})`,
 		releaseOnStdinClose: true,
 	};
 }
 
-function windowsInhibitorScript() {
-	return `$ErrorActionPreference = 'Stop'; Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; $flags = [uint32]'0x80000003'; $release = [uint32]'0x80000000'; $stdin = [Console]::OpenStandardInput(); $buffer = New-Object byte[] 1; $readTask = $stdin.ReadAsync($buffer, 0, 1); try { while ($true) { [Native.Power]::SetThreadExecutionState($flags) | Out-Null; if ($readTask.Wait(30000)) { break } } } finally { [Native.Power]::SetThreadExecutionState($release) | Out-Null }`;
+function windowsInhibitorScript(mode: CaffeinateMode) {
+	const flags = mode === "sleep" ? "0x80000001" : "0x80000003";
+	return `$ErrorActionPreference = 'Stop'; Add-Type -Namespace Native -Name Power -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint esFlags);'; $flags = [uint32]'${flags}'; $release = [uint32]'0x80000000'; $stdin = [Console]::OpenStandardInput(); $buffer = New-Object byte[] 1; $readTask = $stdin.ReadAsync($buffer, 0, 1); try { while ($true) { [Native.Power]::SetThreadExecutionState($flags) | Out-Null; if ($readTask.Wait(30000)) { break } } } finally { [Native.Power]::SetThreadExecutionState($release) | Out-Null }`;
 }
 
 function isWsl() {
@@ -320,7 +527,7 @@ function updateStatus(ctx: ExtensionContext) {
 	}
 
 	if (state.process) {
-		ctx.ui.setStatus(STATUS_KEY, `${getIcon()} awake`);
+		ctx.ui.setStatus(STATUS_KEY, `${getIcon()} ${statusModeLabel()}`);
 		return;
 	}
 
@@ -333,14 +540,133 @@ function updateStatus(ctx: ExtensionContext) {
 }
 
 function describeState() {
-	if (state.disabled) return "pi-caffeinate is disabled by PI_CAFFEINATE_DISABLED.";
+	const customCommand = hasCustomCommand();
+	const lines = [
+		`Mode: ${formatMode(state.mode)}${customCommand ? " (overridden by custom command)" : ""}`,
+		`Settings: ${SETTINGS_FILE}`,
+	];
+
+	if (customCommand) lines.push("Custom command: PI_CAFFEINATE_COMMAND overrides the saved mode.");
+	if (state.settingsError) lines.push(`Settings warning: ${state.settingsError}`);
+	if (state.disabled) {
+		lines.unshift("pi-caffeinate is disabled by PI_CAFFEINATE_DISABLED.");
+		return lines.join("\n");
+	}
+
 	if (state.process) {
 		const seconds = state.startedAt ? Math.round((Date.now() - state.startedAt) / 1000) : 0;
-		return `pi-caffeinate is active using ${state.command?.description ?? "an inhibitor"} for ${seconds}s.`;
+		lines.unshift(
+			`pi-caffeinate is active using ${state.command?.description ?? "an inhibitor"} for ${seconds}s.`,
+		);
+		return lines.join("\n");
 	}
-	if (!state.available)
-		return `pi-caffeinate is unavailable: ${state.lastError ?? "unknown reason"}`;
-	return "pi-caffeinate is idle and will keep the computer awake during the next agent run.";
+
+	if (!state.available) {
+		lines.unshift(`pi-caffeinate is unavailable: ${state.lastError ?? "unknown reason"}`);
+		return lines.join("\n");
+	}
+
+	lines.unshift("pi-caffeinate is idle and will keep the computer awake during the next agent run.");
+	return lines.join("\n");
+}
+
+function statusLevel() {
+	return state.available && !state.settingsError ? "info" : "warning";
+}
+
+function statusModeLabel() {
+	if (state.command?.custom) return "custom";
+	return state.mode === "sleep" ? "sleep" : "display";
+}
+
+function formatMode(mode: CaffeinateMode) {
+	return mode === "sleep" ? "sleep-only" : "display-awake";
+}
+
+async function ensureSettingsLoaded(ctx: ExtensionContext) {
+	if (state.disabled || state.settingsLoaded) return;
+	await loadSettingsIntoState(ctx);
+}
+
+async function loadSettingsIntoState(ctx: ExtensionContext) {
+	if (state.disabled) {
+		state.settingsLoaded = true;
+		state.settingsError = undefined;
+		return;
+	}
+
+	const settings = await loadSettings();
+	state.settingsLoaded = true;
+	state.settingsError = undefined;
+
+	if (settings.kind === "loaded") {
+		state.mode = settings.settings.mode;
+		return;
+	}
+
+	state.mode = DEFAULT_MODE;
+	if (settings.kind === "invalid") {
+		state.settingsError = settings.reason;
+		ctx.ui.notify(
+			`pi-caffeinate settings ignored: ${settings.reason}; using ${formatMode(DEFAULT_MODE)} mode.`,
+			"warning",
+		);
+	}
+}
+
+async function loadSettings(): Promise<
+	| { kind: "missing" }
+	| { kind: "invalid"; reason: string }
+	| { kind: "loaded"; settings: CaffeinateSettings }
+> {
+	let text: string;
+	try {
+		text = await readFile(SETTINGS_FILE, "utf8");
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
+		return { kind: "invalid", reason: formatError(error) };
+	}
+
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		const settings = normalizeCaffeinateSettings(parsed);
+		if (settings) return { kind: "loaded", settings };
+		return { kind: "invalid", reason: 'expected { "mode": "sleep" | "display" }' };
+	} catch (error) {
+		return { kind: "invalid", reason: formatError(error) };
+	}
+}
+
+function normalizeCaffeinateSettings(value: unknown): CaffeinateSettings | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const settings = value as { mode?: unknown; updatedAt?: unknown };
+	if (!isCaffeinateMode(settings.mode)) return undefined;
+	if (settings.updatedAt !== undefined && typeof settings.updatedAt !== "number") return undefined;
+	return { mode: settings.mode, updatedAt: settings.updatedAt ?? 0 };
+}
+
+function isCaffeinateMode(value: unknown): value is CaffeinateMode {
+	return value === "sleep" || value === "display";
+}
+
+async function saveSettings(settings: CaffeinateSettings) {
+	await mkdir(dirname(SETTINGS_FILE), { recursive: true });
+	const tempFile = `${SETTINGS_FILE}.${process.pid}.${Date.now()}.tmp`;
+	try {
+		await writeFile(tempFile, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+		await rename(tempFile, SETTINGS_FILE);
+	} catch (error) {
+		await rm(tempFile, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
 }
 
 function formatExit(code: number | null, signal: NodeJS.Signals | null) {
@@ -351,6 +677,10 @@ function formatExit(code: number | null, signal: NodeJS.Signals | null) {
 function isDisabled() {
 	const value = process.env.PI_CAFFEINATE_DISABLED?.trim().toLowerCase();
 	return value ? DISABLED_VALUES.has(value) : false;
+}
+
+function hasCustomCommand() {
+	return Boolean(process.env.PI_CAFFEINATE_COMMAND?.trim());
 }
 
 function getIcon() {

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -188,7 +188,7 @@ function getInhibitorCommand(): InhibitorCommand | undefined {
 			return parentBoundUnixCommand(
 				"systemd-inhibit",
 				[
-					"--what=idle:sleep",
+					"--what=sleep",
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
 					"--mode=block",


### PR DESCRIPTION
## Summary
- add a single `/caffeinate` command with menu and direct subcommands for status, sleep-only mode, display-awake mode, and stop
- persist the selected mode in `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-caffeinate-settings.json` with display-awake as the cross-platform default
- map sleep/display modes across Linux systemd, macOS/Linux caffeinate, Windows, and WSL, and document the behavior

## Verification
- `npm run check`
- `just pack-caffeinate`
- `rg "caffeinate-status|caffeinate-stop" extensions/pi-caffeinate/src extensions/pi-caffeinate/README.md` (no matches)