### PR TITLE
feat(chrome-devtools): save screenshots to disk

### DIFF
--- a/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
+++ b/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
@@ -24,12 +24,12 @@ Current evidence:
 
 - When `savePath` is omitted, auto-save to a unique PNG under the OS temp directory, for example `/tmp/pi-chrome-devtools-screenshot-<uuid>.png`.
 - When `savePath` is relative, resolve it from the tool execution `ctx.cwd`; a single leading `@` is stripped to match Pi file-mention paths.
-- Explicit save paths are constrained to relative paths under `ctx.cwd`, or absolute paths under `ctx.cwd` / the OS temp directory. Paths with `..`, NUL bytes, symlinked parent directories, and final symlink targets are rejected.
+- Explicit save paths are constrained to relative paths under `ctx.cwd`, or absolute paths under `ctx.cwd` / the OS temp directory. Paths with `..`, NUL bytes, symlinked parent directories, directories as targets, final symlink targets, and other non-regular file targets are rejected.
 
 ## Plan
 
 - [x] Extend the `chrome_devtools_screenshot` parameter schema in `extensions/pi-chrome-devtools/src/chrome-devtools.ts` with optional `savePath: string`; verified by Node harness assertion that `screenshot.parameters.properties.savePath` exists.
-- [x] Add a `resolveScreenshotPath(savePath, ctx.cwd)` helper that defaults to `join(tmpdir(), "pi-chrome-devtools-screenshot-<uuid>.png")`, resolves relative paths from `ctx.cwd`, rejects invalid/NUL paths, and documents any absolute-path restrictions; verified by Node harness covering omitted/default path, relative path, leading `@`, absolute temp path, `..`, NUL, forbidden absolute path, symlinked parent directory, and final symlink rejection.
+- [x] Add a `resolveScreenshotPath(savePath, ctx.cwd)` helper that defaults to `join(tmpdir(), "pi-chrome-devtools-screenshot-<uuid>.png")`, resolves relative paths from `ctx.cwd`, rejects invalid/NUL paths, and documents any absolute-path restrictions; verified by Node harness covering omitted/default path, relative path, leading `@`, absolute temp path, `..`, NUL, forbidden absolute path, symlinked parent directory, final symlink rejection, and non-regular target rejection.
 - [x] Write the decoded PNG bytes to the resolved path with safe parent-directory creation, an exclusive temp file, rename-based replacement with a Windows existing-file fallback, cleanup on error, and `withFileMutationQueue(path, ...)`; verified by Node harness checking PNG signature bytes, overwrites to an existing explicit path, concurrent writes to the same explicit path, no mutation through symlinked parents, and no leftover temp files after successful writes.
 - [x] Update the screenshot tool result text and details to include `savedPath`, byte count, page metadata, and a hint such as `Use read({ path: "..." }) to inspect the screenshot`; verified by Node harness result inspection and source review of returned `details.page`.
 - [x] Keep the `{ type: "image", mimeType: "image/png" }` content block for models/providers that can consume images directly; verified by Node harness returned `content` inspection.
@@ -40,7 +40,7 @@ Current evidence:
 
 ## Risks
 
-- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlinked parent directories, symlink final targets, and physical parent-directory escapes, plus temp-file replacement for writes.
+- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlinked parent directories, directories as targets, symlink final targets, non-regular file targets, and physical parent-directory escapes, plus temp-file replacement for writes.
 - Default auto-saving creates temporary files. Mitigated by making the result text and README show the saved temp path.
 - Very large full-page screenshots can produce large files. Mitigated by reporting byte size and relying on CDP/browser limits rather than embedding extra base64 text.
 
@@ -53,7 +53,7 @@ Current evidence:
 
 - [x] `chrome_devtools_screenshot({ fullPage: true })` saves a PNG to a unique temp path and reports that path, verified by Node mocked-CDP harness output containing a `pi-chrome-devtools-screenshot-<uuid>.png` default path and file existence check.
 - [x] `chrome_devtools_screenshot({ savePath: "foo.png" })` writes or overwrites the PNG relative to `ctx.cwd` and reports the resolved path, verified by Node mocked-CDP harness reading the PNG signature from a temp workspace path.
-- [x] Unsafe or unsupported paths are rejected with actionable errors, verified by Node mocked-CDP harness cases for `../escape.png`, NUL byte paths, forbidden absolute paths, symlinked parent directories, and final symlink targets.
+- [x] Unsafe or unsupported paths are rejected with actionable errors, verified by Node mocked-CDP harness cases for `../escape.png`, NUL byte paths, forbidden absolute paths, symlinked parent directories, final symlink targets, and non-regular file targets.
 - [x] The result still includes an image content block for image-capable models, verified by Node mocked-CDP harness returned `content` inspection.
 - [x] README documents default save behavior and `savePath`, verified in `extensions/pi-chrome-devtools/README.md`.
 - [x] Typecheck, repo check, and package dry-run pass, verified by `npm --workspace @narumitw/pi-chrome-devtools run check`, `npm run check`, and `just pack-chrome-devtools`.

--- a/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
+++ b/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
@@ -30,7 +30,7 @@ Current evidence:
 
 - [x] Extend the `chrome_devtools_screenshot` parameter schema in `extensions/pi-chrome-devtools/src/chrome-devtools.ts` with optional `savePath: string`; verified by Node harness assertion that `screenshot.parameters.properties.savePath` exists.
 - [x] Add a `resolveScreenshotPath(savePath, ctx.cwd)` helper that defaults to `join(tmpdir(), "pi-chrome-devtools-screenshot-<uuid>.png")`, resolves relative paths from `ctx.cwd`, rejects invalid/NUL paths, and documents any absolute-path restrictions; verified by Node harness covering omitted/default path, relative path, leading `@`, absolute temp path, `..`, NUL, forbidden absolute path, symlinked parent directory, and final symlink rejection.
-- [x] Write the decoded PNG bytes to the resolved path with safe parent-directory creation, an exclusive temp file, atomic rename, cleanup on error, and `withFileMutationQueue(path, ...)`; verified by Node harness checking PNG signature bytes, concurrent writes to the same explicit path, no mutation through symlinked parents, and no leftover temp files after successful writes.
+- [x] Write the decoded PNG bytes to the resolved path with safe parent-directory creation, an exclusive temp file, rename-based replacement with a Windows existing-file fallback, cleanup on error, and `withFileMutationQueue(path, ...)`; verified by Node harness checking PNG signature bytes, overwrites to an existing explicit path, concurrent writes to the same explicit path, no mutation through symlinked parents, and no leftover temp files after successful writes.
 - [x] Update the screenshot tool result text and details to include `savedPath`, byte count, page metadata, and a hint such as `Use read({ path: "..." }) to inspect the screenshot`; verified by Node harness result inspection and source review of returned `details.page`.
 - [x] Keep the `{ type: "image", mimeType: "image/png" }` content block for models/providers that can consume images directly; verified by Node harness returned `content` inspection.
 - [x] Improve `renderScreenshotResult()` so expanded output shows the saved path and byte count from text/details instead of hiding the useful result; verified by source review of `renderScreenshotResult()` and `screenshotTextContent()`.
@@ -40,7 +40,7 @@ Current evidence:
 
 ## Risks
 
-- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlinked parent directories, symlink final targets, and physical parent-directory escapes, plus atomic temp-file rename for writes.
+- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlinked parent directories, symlink final targets, and physical parent-directory escapes, plus temp-file replacement for writes.
 - Default auto-saving creates temporary files. Mitigated by making the result text and README show the saved temp path.
 - Very large full-page screenshots can produce large files. Mitigated by reporting byte size and relying on CDP/browser limits rather than embedding extra base64 text.
 
@@ -52,7 +52,7 @@ Current evidence:
 ## Completion Checklist
 
 - [x] `chrome_devtools_screenshot({ fullPage: true })` saves a PNG to a unique temp path and reports that path, verified by Node mocked-CDP harness output containing a `pi-chrome-devtools-screenshot-<uuid>.png` default path and file existence check.
-- [x] `chrome_devtools_screenshot({ savePath: "foo.png" })` writes the PNG relative to `ctx.cwd` and reports the resolved path, verified by Node mocked-CDP harness reading the PNG signature from a temp workspace path.
+- [x] `chrome_devtools_screenshot({ savePath: "foo.png" })` writes or overwrites the PNG relative to `ctx.cwd` and reports the resolved path, verified by Node mocked-CDP harness reading the PNG signature from a temp workspace path.
 - [x] Unsafe or unsupported paths are rejected with actionable errors, verified by Node mocked-CDP harness cases for `../escape.png`, NUL byte paths, forbidden absolute paths, symlinked parent directories, and final symlink targets.
 - [x] The result still includes an image content block for image-capable models, verified by Node mocked-CDP harness returned `content` inspection.
 - [x] README documents default save behavior and `savePath`, verified in `extensions/pi-chrome-devtools/README.md`.

--- a/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
+++ b/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
@@ -23,14 +23,14 @@ Current evidence:
 ## Assumptions
 
 - When `savePath` is omitted, auto-save to a unique PNG under the OS temp directory, for example `/tmp/pi-chrome-devtools-screenshot-<uuid>.png`.
-- When `savePath` is relative, resolve it from the tool execution `ctx.cwd`.
-- Explicit save paths are constrained to relative paths under `ctx.cwd`, or absolute paths under `ctx.cwd` / the OS temp directory. Paths with `..`, NUL bytes, and final symlink targets are rejected.
+- When `savePath` is relative, resolve it from the tool execution `ctx.cwd`; a single leading `@` is stripped to match Pi file-mention paths.
+- Explicit save paths are constrained to relative paths under `ctx.cwd`, or absolute paths under `ctx.cwd` / the OS temp directory. Paths with `..`, NUL bytes, symlinked parent directories, and final symlink targets are rejected.
 
 ## Plan
 
 - [x] Extend the `chrome_devtools_screenshot` parameter schema in `extensions/pi-chrome-devtools/src/chrome-devtools.ts` with optional `savePath: string`; verified by Node harness assertion that `screenshot.parameters.properties.savePath` exists.
-- [x] Add a `resolveScreenshotPath(savePath, ctx.cwd)` helper that defaults to `join(tmpdir(), "pi-chrome-devtools-screenshot-<uuid>.png")`, resolves relative paths from `ctx.cwd`, rejects invalid/NUL paths, and documents any absolute-path restrictions; verified by Node harness covering omitted/default path, relative path, absolute temp path, `..`, NUL, forbidden absolute path, and symlink rejection.
-- [x] Write the decoded PNG bytes to the resolved path with `mkdir(dirname(path), { recursive: true })`, `writeFile(path, Buffer.from(data, "base64"))`, and `withFileMutationQueue(path, ...)`; verified by Node harness checking PNG signature bytes and concurrent writes to the same explicit path.
+- [x] Add a `resolveScreenshotPath(savePath, ctx.cwd)` helper that defaults to `join(tmpdir(), "pi-chrome-devtools-screenshot-<uuid>.png")`, resolves relative paths from `ctx.cwd`, rejects invalid/NUL paths, and documents any absolute-path restrictions; verified by Node harness covering omitted/default path, relative path, leading `@`, absolute temp path, `..`, NUL, forbidden absolute path, symlinked parent directory, and final symlink rejection.
+- [x] Write the decoded PNG bytes to the resolved path with safe parent-directory creation, an exclusive temp file, atomic rename, cleanup on error, and `withFileMutationQueue(path, ...)`; verified by Node harness checking PNG signature bytes, concurrent writes to the same explicit path, no mutation through symlinked parents, and no leftover temp files after successful writes.
 - [x] Update the screenshot tool result text and details to include `savedPath`, byte count, page metadata, and a hint such as `Use read({ path: "..." }) to inspect the screenshot`; verified by Node harness result inspection and source review of returned `details.page`.
 - [x] Keep the `{ type: "image", mimeType: "image/png" }` content block for models/providers that can consume images directly; verified by Node harness returned `content` inspection.
 - [x] Improve `renderScreenshotResult()` so expanded output shows the saved path and byte count from text/details instead of hiding the useful result; verified by source review of `renderScreenshotResult()` and `screenshotTextContent()`.
@@ -40,7 +40,7 @@ Current evidence:
 
 ## Risks
 
-- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlink final targets, and physical parent-directory escapes.
+- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlinked parent directories, symlink final targets, and physical parent-directory escapes, plus atomic temp-file rename for writes.
 - Default auto-saving creates temporary files. Mitigated by making the result text and README show the saved temp path.
 - Very large full-page screenshots can produce large files. Mitigated by reporting byte size and relying on CDP/browser limits rather than embedding extra base64 text.
 
@@ -53,7 +53,7 @@ Current evidence:
 
 - [x] `chrome_devtools_screenshot({ fullPage: true })` saves a PNG to a unique temp path and reports that path, verified by Node mocked-CDP harness output containing a `pi-chrome-devtools-screenshot-<uuid>.png` default path and file existence check.
 - [x] `chrome_devtools_screenshot({ savePath: "foo.png" })` writes the PNG relative to `ctx.cwd` and reports the resolved path, verified by Node mocked-CDP harness reading the PNG signature from a temp workspace path.
-- [x] Unsafe or unsupported paths are rejected with actionable errors, verified by Node mocked-CDP harness cases for `../escape.png`, NUL byte paths, forbidden absolute paths, and final symlink targets.
+- [x] Unsafe or unsupported paths are rejected with actionable errors, verified by Node mocked-CDP harness cases for `../escape.png`, NUL byte paths, forbidden absolute paths, symlinked parent directories, and final symlink targets.
 - [x] The result still includes an image content block for image-capable models, verified by Node mocked-CDP harness returned `content` inspection.
 - [x] README documents default save behavior and `savePath`, verified in `extensions/pi-chrome-devtools/README.md`.
 - [x] Typecheck, repo check, and package dry-run pass, verified by `npm --workspace @narumitw/pi-chrome-devtools run check`, `npm run check`, and `just pack-chrome-devtools`.

--- a/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
+++ b/docs/plans/archived/2026-06-12_chrome-devtools-screenshot-save-path-plan.md
@@ -1,0 +1,59 @@
+## Goal
+
+Improve `chrome_devtools_screenshot` so agents can reliably inspect or reuse captured images even when inline image tool results are not usable. Success means every screenshot can be saved as a PNG file, the tool result tells the agent the saved path and byte count, optional `savePath` is documented, and the existing image content result remains available for image-capable models.
+
+## Context
+
+Issue: <https://github.com/narumiruna/pi-extensions/issues/89>
+
+Current evidence:
+
+- `extensions/pi-chrome-devtools/src/chrome-devtools.ts` now returns screenshot data as both `{ type: "image", data, mimeType: "image/png" }` and text/details containing the saved PNG path and byte count.
+- The screenshot tool schema accepts `pageId`, `fullPage`, and optional `savePath`.
+- `renderScreenshotResult()` uses screenshot text and falls back to `details.savedPath` / `details.bytes` when needed.
+- Pi session/tool result types support image content, but the saved file path lets the agent call the built-in `read` tool or attach the file in later steps.
+
+## Architecture
+
+- Keep one screenshot tool and extend its parameters instead of adding a second tool.
+- Save PNG bytes from the CDP base64 payload with Node filesystem APIs.
+- Use Pi's file mutation queue for explicit `savePath` writes so screenshot writes do not race with other file-writing tools.
+- Return both the saved path in text/details and the existing image content block.
+
+## Assumptions
+
+- When `savePath` is omitted, auto-save to a unique PNG under the OS temp directory, for example `/tmp/pi-chrome-devtools-screenshot-<uuid>.png`.
+- When `savePath` is relative, resolve it from the tool execution `ctx.cwd`.
+- Explicit save paths are constrained to relative paths under `ctx.cwd`, or absolute paths under `ctx.cwd` / the OS temp directory. Paths with `..`, NUL bytes, and final symlink targets are rejected.
+
+## Plan
+
+- [x] Extend the `chrome_devtools_screenshot` parameter schema in `extensions/pi-chrome-devtools/src/chrome-devtools.ts` with optional `savePath: string`; verified by Node harness assertion that `screenshot.parameters.properties.savePath` exists.
+- [x] Add a `resolveScreenshotPath(savePath, ctx.cwd)` helper that defaults to `join(tmpdir(), "pi-chrome-devtools-screenshot-<uuid>.png")`, resolves relative paths from `ctx.cwd`, rejects invalid/NUL paths, and documents any absolute-path restrictions; verified by Node harness covering omitted/default path, relative path, absolute temp path, `..`, NUL, forbidden absolute path, and symlink rejection.
+- [x] Write the decoded PNG bytes to the resolved path with `mkdir(dirname(path), { recursive: true })`, `writeFile(path, Buffer.from(data, "base64"))`, and `withFileMutationQueue(path, ...)`; verified by Node harness checking PNG signature bytes and concurrent writes to the same explicit path.
+- [x] Update the screenshot tool result text and details to include `savedPath`, byte count, page metadata, and a hint such as `Use read({ path: "..." }) to inspect the screenshot`; verified by Node harness result inspection and source review of returned `details.page`.
+- [x] Keep the `{ type: "image", mimeType: "image/png" }` content block for models/providers that can consume images directly; verified by Node harness returned `content` inspection.
+- [x] Improve `renderScreenshotResult()` so expanded output shows the saved path and byte count from text/details instead of hiding the useful result; verified by source review of `renderScreenshotResult()` and `screenshotTextContent()`.
+- [x] Update `extensions/pi-chrome-devtools/README.md` to document default auto-save, `savePath`, relative path behavior, full-page screenshots, and how to read the saved image afterward; verified by README review.
+- [x] Run `npm --workspace @narumitw/pi-chrome-devtools run check` and `npm run check`; verified both commands exit successfully.
+- [x] Run `just pack-chrome-devtools`; verified the package dry-run includes `src/chrome-devtools.ts`, `README.md`, `LICENSE`, and `package.json`.
+
+## Risks
+
+- Writing files from an LLM-controlled argument can overwrite or escape intended locations if path rules are too permissive. Mitigated by rejecting `..`, NUL bytes, absolute paths outside `ctx.cwd`/temp, symlink final targets, and physical parent-directory escapes.
+- Default auto-saving creates temporary files. Mitigated by making the result text and README show the saved temp path.
+- Very large full-page screenshots can produce large files. Mitigated by reporting byte size and relying on CDP/browser limits rather than embedding extra base64 text.
+
+## Rollback / Recovery
+
+- If file-saving causes regressions, disable the new write path by reverting the screenshot parameter/result changes while leaving the existing image content return shape intact.
+- If the default temp-file behavior is too noisy, keep `savePath` support but change the default in a follow-up release after documenting the behavior change.
+
+## Completion Checklist
+
+- [x] `chrome_devtools_screenshot({ fullPage: true })` saves a PNG to a unique temp path and reports that path, verified by Node mocked-CDP harness output containing a `pi-chrome-devtools-screenshot-<uuid>.png` default path and file existence check.
+- [x] `chrome_devtools_screenshot({ savePath: "foo.png" })` writes the PNG relative to `ctx.cwd` and reports the resolved path, verified by Node mocked-CDP harness reading the PNG signature from a temp workspace path.
+- [x] Unsafe or unsupported paths are rejected with actionable errors, verified by Node mocked-CDP harness cases for `../escape.png`, NUL byte paths, forbidden absolute paths, and final symlink targets.
+- [x] The result still includes an image content block for image-capable models, verified by Node mocked-CDP harness returned `content` inspection.
+- [x] README documents default save behavior and `savePath`, verified in `extensions/pi-chrome-devtools/README.md`.
+- [x] Typecheck, repo check, and package dry-run pass, verified by `npm --workspace @narumitw/pi-chrome-devtools run check`, `npm run check`, and `just pack-chrome-devtools`.

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -93,10 +93,11 @@ chrome_devtools_screenshot({
 Relative `savePath` values resolve from Pi's current working directory. A single leading `@`
 is stripped to match Pi file-mention paths. Absolute paths are accepted only when they stay
 inside the current working directory or the OS temp directory. Paths containing `..` segments,
-NUL bytes, symlinked parent directories, or a final symbolic-link target are rejected. The tool
-result includes the resolved path, byte count, and an inline image block when the active
-model/provider can consume images. If the model cannot inspect the inline image, ask it to read
-the saved path, for example `read({ path: "artifacts/homepage.png" })`.
+NUL bytes, symlinked parent directories, or a final symbolic-link target are rejected. Existing
+regular files at the target path are replaced. The tool result includes the resolved path, byte
+count, and an inline image block when the active model/provider can consume images. If the model
+cannot inspect the inline image, ask it to read the saved path, for example
+`read({ path: "artifacts/homepage.png" })`.
 
 ## 💬 Command
 

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -93,11 +93,11 @@ chrome_devtools_screenshot({
 Relative `savePath` values resolve from Pi's current working directory. A single leading `@`
 is stripped to match Pi file-mention paths. Absolute paths are accepted only when they stay
 inside the current working directory or the OS temp directory. Paths containing `..` segments,
-NUL bytes, symlinked parent directories, or a final symbolic-link target are rejected. Existing
-regular files at the target path are replaced. The tool result includes the resolved path, byte
-count, and an inline image block when the active model/provider can consume images. If the model
-cannot inspect the inline image, ask it to read the saved path, for example
-`read({ path: "artifacts/homepage.png" })`.
+NUL bytes, symlinked parent directories, directories as targets, final symbolic-link targets, or
+other non-regular file targets are rejected. Existing regular files at the target path are
+replaced. The tool result includes the resolved path, byte count, and an inline image block when
+the active model/provider can consume images. If the model cannot inspect the inline image, ask it
+to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 
 ## 💬 Command
 

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -15,7 +15,7 @@ This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDev
 - Navigates Chrome to a target URL, creating an inspectable page when none exists.
 - Recovers from stale active page selections by falling back to an available page.
 - Evaluates JavaScript in the selected page.
-- Captures PNG screenshots, including optional full-page screenshots.
+- Captures PNG screenshots, including optional full-page screenshots, and saves them to disk.
 - Renders compact tool results that expand/collapse with Pi's default output toggle (`Ctrl+O`).
 - Uses a local Chrome DevTools Protocol endpoint.
 - Retries briefly while Chrome is starting and reports actionable endpoint errors.
@@ -70,7 +70,32 @@ PI_CHROME_DEVTOOLS_HOST=127.0.0.1 PI_CHROME_DEVTOOLS_PORT=9223 pi -e ./extension
 - `chrome_devtools_select_page` — select the active page for later tool calls.
 - `chrome_devtools_navigate` — navigate a page to a URL; if no page exists, create one first.
 - `chrome_devtools_evaluate` — evaluate JavaScript in the selected page.
-- `chrome_devtools_screenshot` — capture a PNG screenshot.
+- `chrome_devtools_screenshot` — capture a PNG screenshot and save it as a PNG file.
+
+### Screenshot files
+
+`chrome_devtools_screenshot` always saves the captured PNG to disk. If `savePath` is omitted,
+the extension writes a unique temp file such as:
+
+```text
+/tmp/pi-chrome-devtools-screenshot-<uuid>.png
+```
+
+Pass `savePath` to choose the output path:
+
+```js
+chrome_devtools_screenshot({
+  fullPage: true,
+  savePath: "artifacts/homepage.png",
+});
+```
+
+Relative `savePath` values resolve from Pi's current working directory. Absolute paths are
+accepted only when they stay inside the current working directory or the OS temp directory.
+Paths containing `..` segments, NUL bytes, or a final symbolic-link target are rejected. The
+tool result includes the resolved path, byte count, and an inline image block when the active
+model/provider can consume images. If the model cannot inspect the inline image, ask it to read
+the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 
 ## 💬 Command
 

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -90,10 +90,11 @@ chrome_devtools_screenshot({
 });
 ```
 
-Relative `savePath` values resolve from Pi's current working directory. Absolute paths are
-accepted only when they stay inside the current working directory or the OS temp directory.
-Paths containing `..` segments, NUL bytes, or a final symbolic-link target are rejected. The
-tool result includes the resolved path, byte count, and an inline image block when the active
+Relative `savePath` values resolve from Pi's current working directory. A single leading `@`
+is stripped to match Pi file-mention paths. Absolute paths are accepted only when they stay
+inside the current working directory or the OS temp directory. Paths containing `..` segments,
+NUL bytes, symlinked parent directories, or a final symbolic-link target are rejected. The tool
+result includes the resolved path, byte count, and an inline image block when the active
 model/provider can consume images. If the model cannot inspect the inline image, ask it to read
 the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1,12 +1,14 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import {
 	defineTool,
 	type AgentToolResult,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ToolRenderResultOptions,
+	withFileMutationQueue,
 } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 
@@ -112,6 +114,18 @@ interface CdpResponse<T = unknown> {
 		message: string;
 		data?: unknown;
 	};
+}
+
+interface ResolvedScreenshotPath {
+	path: string;
+	allowedRoots: string[];
+	isDefault: boolean;
+}
+
+interface ScreenshotSaveResult {
+	savedPath: string;
+	bytes: number;
+	isDefaultPath: boolean;
 }
 
 const state: ChromeDevToolsState = {
@@ -234,13 +248,20 @@ const screenshotTool = defineTool({
 		fullPage: Type.Optional(
 			Type.Boolean({ description: "Capture the full document, not just the viewport." }),
 		),
+		savePath: Type.Optional(
+			Type.String({
+				description:
+					"Optional PNG file path to save the screenshot. Defaults to a unique temp file; relative paths resolve from the current working directory.",
+			}),
+		),
 	}),
 	renderCall: renderToolCall("screenshot"),
 	renderResult: renderScreenshotResult,
-	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		return withStatus(ctx, "🌐 screenshot", async () => {
 			const page = await resolvePage(params.pageId);
 			const result = await withCdp(page, async (client) => {
+				throwIfAborted(signal);
 				await client.send("Page.enable");
 
 				if (!params.fullPage) {
@@ -251,6 +272,7 @@ const screenshotTool = defineTool({
 					contentSize: { x: number; y: number; width: number; height: number };
 				}>("Page.getLayoutMetrics");
 
+				throwIfAborted(signal);
 				return client.send<{ data: string }>("Page.captureScreenshot", {
 					captureBeyondViewport: true,
 					format: "png",
@@ -265,12 +287,21 @@ const screenshotTool = defineTool({
 			});
 
 			state.activePageId = page.id;
+			const savedScreenshot = await saveScreenshot(result.data, params.savePath, ctx.cwd, signal);
 			return {
 				content: [
-					{ type: "text", text: `Captured PNG screenshot from ${page.title || page.url}` },
+					{
+						type: "text",
+						text: formatScreenshotText(page, savedScreenshot),
+					},
 					{ type: "image", data: result.data, mimeType: "image/png" },
 				],
-				details: { page: formatPage(page), bytes: Buffer.byteLength(result.data, "base64") },
+				details: {
+					page: formatPage(page),
+					bytes: savedScreenshot.bytes,
+					savedPath: savedScreenshot.savedPath,
+					isDefaultPath: savedScreenshot.isDefaultPath,
+				},
 			};
 		});
 	},
@@ -945,6 +976,124 @@ function textResult(text: string, details: unknown) {
 	};
 }
 
+async function saveScreenshot(
+	base64Png: string,
+	savePath: string | undefined,
+	cwd: string,
+	signal: AbortSignal | undefined,
+): Promise<ScreenshotSaveResult> {
+	const resolvedPath = resolveScreenshotPath(savePath, cwd);
+	const pngBytes = Buffer.from(base64Png, "base64");
+
+	await withFileMutationQueue(resolvedPath.path, async () => {
+		throwIfAborted(signal);
+		await mkdir(dirname(resolvedPath.path), { recursive: true });
+		await assertSafeScreenshotWritePath(resolvedPath);
+		await writeFile(resolvedPath.path, pngBytes, { signal });
+	});
+
+	return {
+		savedPath: resolvedPath.path,
+		bytes: pngBytes.byteLength,
+		isDefaultPath: resolvedPath.isDefault,
+	};
+}
+
+function resolveScreenshotPath(savePath: string | undefined, cwd: string): ResolvedScreenshotPath {
+	const cwdRoot = resolve(cwd);
+	const tempRoot = resolve(tmpdir());
+
+	if (savePath === undefined) {
+		return {
+			path: join(tempRoot, `pi-chrome-devtools-screenshot-${randomUUID()}.png`),
+			allowedRoots: [tempRoot],
+			isDefault: true,
+		};
+	}
+
+	const normalizedPath = stripLeadingAtPath(savePath);
+	if (!normalizedPath.trim()) {
+		throw new Error("Screenshot savePath must not be empty.");
+	}
+	if (normalizedPath.includes("\0")) {
+		throw new Error("Screenshot savePath must not contain NUL bytes.");
+	}
+	if (hasParentPathSegment(normalizedPath)) {
+		throw new Error("Screenshot savePath must not contain '..' path segments.");
+	}
+
+	const isAbsolutePath = isAbsolute(normalizedPath);
+	const path = isAbsolutePath ? resolve(normalizedPath) : resolve(cwdRoot, normalizedPath);
+	const allowedRoots = isAbsolutePath ? unique([cwdRoot, tempRoot]) : [cwdRoot];
+	if (!allowedRoots.some((root) => isPathInsideRoot(path, root))) {
+		throw new Error(
+			"Screenshot savePath must be relative to the current working directory, or an absolute path inside the current working directory or OS temp directory.",
+		);
+	}
+
+	return { path, allowedRoots, isDefault: false };
+}
+
+function stripLeadingAtPath(path: string) {
+	return path.startsWith("@") ? path.slice(1) : path;
+}
+
+function hasParentPathSegment(path: string) {
+	return path.split(/[\\/]+/).some((part) => part === "..");
+}
+
+async function assertSafeScreenshotWritePath(resolvedPath: ResolvedScreenshotPath) {
+	const existingTarget = await lstat(resolvedPath.path).catch((error: unknown) => {
+		if (isNodeError(error) && error.code === "ENOENT") return undefined;
+		throw error;
+	});
+	if (existingTarget?.isSymbolicLink()) {
+		throw new Error("Screenshot savePath must not point to a symbolic link.");
+	}
+
+	const [realParent, realAllowedRoots] = await Promise.all([
+		realpath(dirname(resolvedPath.path)),
+		Promise.all(resolvedPath.allowedRoots.map(realpathOrResolvedPath)),
+	]);
+	const realTargetPath = join(realParent, basename(resolvedPath.path));
+	if (!realAllowedRoots.some((root) => isPathInsideRoot(realTargetPath, root))) {
+		throw new Error(
+			"Screenshot savePath resolves outside the current working directory or OS temp directory.",
+		);
+	}
+}
+
+async function realpathOrResolvedPath(path: string) {
+	return realpath(path).catch(() => resolve(path));
+}
+
+function isPathInsideRoot(path: string, root: string) {
+	const normalizedPath = normalizePathForComparison(resolve(path));
+	const normalizedRoot = normalizePathForComparison(resolve(root));
+	if (normalizedPath === normalizedRoot) return true;
+	const rootWithSeparator = normalizedRoot.endsWith(sep) ? normalizedRoot : `${normalizedRoot}${sep}`;
+	return normalizedPath.startsWith(rootWithSeparator);
+}
+
+function normalizePathForComparison(path: string) {
+	return process.platform === "win32" ? path.toLowerCase() : path;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error ? signal.reason : new Error("Screenshot capture cancelled.");
+}
+
+function formatScreenshotText(page: DevToolsPage, screenshot: ScreenshotSaveResult) {
+	const pathLabel = screenshot.isDefaultPath ? "Saved to temp file" : "Saved to";
+	return [
+		`Captured PNG screenshot from ${page.title || page.url || page.id}.`,
+		`${pathLabel}: ${screenshot.savedPath}`,
+		`Bytes: ${screenshot.bytes}`,
+		`Use read({ path: ${JSON.stringify(screenshot.savedPath)} }) to inspect the saved screenshot if inline image content is not available.`,
+	].join("\n");
+}
+
 function renderToolCall(action: string) {
 	return () => new PiTextComponent(`Chrome DevTools: ${action}`);
 }
@@ -963,7 +1112,7 @@ function renderScreenshotResult(
 	options: ToolRenderResultOptions,
 	theme: RenderTheme,
 ): RenderComponent {
-	const output = formatCollapsibleOutput(textContent(result), options);
+	const output = formatCollapsibleOutput(screenshotTextContent(result), options);
 	return new PiTextComponent(output.text, theme, output.color);
 }
 
@@ -971,6 +1120,16 @@ function textContent(result: AgentToolResult<unknown>) {
 	return result.content
 		.flatMap((content) => (content.type === "text" ? [content.text] : []))
 		.join("\n");
+}
+
+function screenshotTextContent(result: AgentToolResult<unknown>) {
+	const text = textContent(result);
+	if (text.trim()) return text;
+
+	const details = result.details as { savedPath?: unknown; bytes?: unknown } | undefined;
+	if (typeof details?.savedPath !== "string") return text;
+	const bytes = typeof details.bytes === "number" ? ` (${details.bytes} bytes)` : "";
+	return `Saved screenshot to ${details.savedPath}${bytes}`;
 }
 
 function formatCollapsibleOutput(
@@ -984,11 +1143,15 @@ function formatCollapsibleOutput(
 }
 
 class PiTextComponent implements RenderComponent {
-	constructor(
-		private text = "",
-		private readonly theme?: RenderTheme,
-		private readonly color?: string,
-	) {}
+	private text: string;
+	private readonly theme?: RenderTheme;
+	private readonly color?: string;
+
+	constructor(text = "", theme?: RenderTheme, color?: string) {
+		this.text = text;
+		this.theme = theme;
+		this.color = color;
+	}
 
 	setText(text: string) {
 		this.text = text;

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { lstat, mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
 	defineTool,
 	type AgentToolResult,
@@ -251,7 +251,7 @@ const screenshotTool = defineTool({
 		savePath: Type.Optional(
 			Type.String({
 				description:
-					"Optional PNG file path to save the screenshot. Defaults to a unique temp file; relative paths resolve from the current working directory.",
+					"Optional PNG file path to save the screenshot. Defaults to a unique temp file; relative paths resolve from the current working directory. A single leading @ is stripped to match Pi file-mention paths.",
 			}),
 		),
 	}),
@@ -987,9 +987,9 @@ async function saveScreenshot(
 
 	await withFileMutationQueue(resolvedPath.path, async () => {
 		throwIfAborted(signal);
-		await mkdir(dirname(resolvedPath.path), { recursive: true });
-		await assertSafeScreenshotWritePath(resolvedPath);
-		await writeFile(resolvedPath.path, pngBytes, { signal });
+		await ensureSafeScreenshotParent(resolvedPath);
+		await assertSafeScreenshotTargetPath(resolvedPath);
+		await writeScreenshotAtomically(resolvedPath.path, pngBytes, signal);
 	});
 
 	return {
@@ -1042,7 +1042,56 @@ function hasParentPathSegment(path: string) {
 	return path.split(/[\\/]+/).some((part) => part === "..");
 }
 
-async function assertSafeScreenshotWritePath(resolvedPath: ResolvedScreenshotPath) {
+async function ensureSafeScreenshotParent(resolvedPath: ResolvedScreenshotPath) {
+	const parentPath = dirname(resolvedPath.path);
+	const rootPath = selectAllowedRoot(parentPath, resolvedPath.allowedRoots);
+	if (!rootPath) {
+		throw new Error(
+			"Screenshot savePath parent must stay inside the current working directory or OS temp directory.",
+		);
+	}
+
+	const realRootPath = await realpath(rootPath);
+	let currentPath = rootPath;
+	const parentSegments = relative(rootPath, parentPath)
+		.split(/[\\/]+/)
+		.filter((part) => part.length > 0);
+
+	for (const segment of parentSegments) {
+		currentPath = join(currentPath, segment);
+		await ensureSafeDirectorySegment(currentPath, realRootPath);
+	}
+}
+
+function selectAllowedRoot(path: string, roots: readonly string[]) {
+	const matchingRoots = roots.filter((root) => isPathInsideRoot(path, root));
+	matchingRoots.sort(
+		(left, right) =>
+			normalizePathForComparison(resolve(right)).length -
+			normalizePathForComparison(resolve(left)).length,
+	);
+	return matchingRoots[0];
+}
+
+async function ensureSafeDirectorySegment(path: string, realRootPath: string) {
+	const existingDirectory = await lstat(path).catch(async (error: unknown) => {
+		if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+		await mkdir(path).catch((mkdirError: unknown) => {
+			if (!isNodeError(mkdirError) || mkdirError.code !== "EEXIST") throw mkdirError;
+		});
+		return lstat(path);
+	});
+
+	if (existingDirectory.isSymbolicLink()) {
+		throw new Error("Screenshot savePath parent directories must not contain symbolic links.");
+	}
+	if (!existingDirectory.isDirectory()) {
+		throw new Error("Screenshot savePath parent must be a directory.");
+	}
+	await assertPathWithinRealRoot(path, realRootPath);
+}
+
+async function assertSafeScreenshotTargetPath(resolvedPath: ResolvedScreenshotPath) {
 	const existingTarget = await lstat(resolvedPath.path).catch((error: unknown) => {
 		if (isNodeError(error) && error.code === "ENOENT") return undefined;
 		throw error;
@@ -1050,16 +1099,45 @@ async function assertSafeScreenshotWritePath(resolvedPath: ResolvedScreenshotPat
 	if (existingTarget?.isSymbolicLink()) {
 		throw new Error("Screenshot savePath must not point to a symbolic link.");
 	}
+	if (existingTarget?.isDirectory()) {
+		throw new Error("Screenshot savePath must point to a file, not a directory.");
+	}
 
-	const [realParent, realAllowedRoots] = await Promise.all([
-		realpath(dirname(resolvedPath.path)),
-		Promise.all(resolvedPath.allowedRoots.map(realpathOrResolvedPath)),
-	]);
+	const realAllowedRoots = await Promise.all(resolvedPath.allowedRoots.map(realpathOrResolvedPath));
+	const realParent = await realpath(dirname(resolvedPath.path));
 	const realTargetPath = join(realParent, basename(resolvedPath.path));
 	if (!realAllowedRoots.some((root) => isPathInsideRoot(realTargetPath, root))) {
 		throw new Error(
 			"Screenshot savePath resolves outside the current working directory or OS temp directory.",
 		);
+	}
+}
+
+async function assertPathWithinRealRoot(path: string, realRootPath: string) {
+	const realPath = await realpath(path);
+	if (!isPathInsideRoot(realPath, realRootPath)) {
+		throw new Error(
+			"Screenshot savePath parent resolves outside the current working directory or OS temp directory.",
+		);
+	}
+}
+
+async function writeScreenshotAtomically(
+	path: string,
+	pngBytes: Buffer,
+	signal: AbortSignal | undefined,
+) {
+	const tempFile = join(
+		dirname(path),
+		`.${basename(path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+	);
+	try {
+		await writeFile(tempFile, pngBytes, { flag: "wx", signal });
+		throwIfAborted(signal);
+		await rename(tempFile, path);
+	} catch (error) {
+		await rm(tempFile, { force: true }).catch(() => undefined);
+		throw error;
 	}
 }
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -251,7 +251,7 @@ const screenshotTool = defineTool({
 		savePath: Type.Optional(
 			Type.String({
 				description:
-					"Optional PNG file path to save the screenshot. Defaults to a unique temp file; relative paths resolve from the current working directory. A single leading @ is stripped to match Pi file-mention paths.",
+					"Screenshot is always saved as a PNG file. Optional output path; omitted defaults to a unique temp file. Relative paths resolve from the current working directory. A single leading @ is stripped to match Pi file-mention paths. Existing regular files are replaced.",
 			}),
 		),
 	}),
@@ -989,7 +989,7 @@ async function saveScreenshot(
 		throwIfAborted(signal);
 		await ensureSafeScreenshotParent(resolvedPath);
 		await assertSafeScreenshotTargetPath(resolvedPath);
-		await writeScreenshotAtomically(resolvedPath.path, pngBytes, signal);
+		await writeScreenshotFileSafely(resolvedPath, pngBytes, signal);
 	});
 
 	return {
@@ -1122,23 +1122,51 @@ async function assertPathWithinRealRoot(path: string, realRootPath: string) {
 	}
 }
 
-async function writeScreenshotAtomically(
-	path: string,
+async function writeScreenshotFileSafely(
+	resolvedPath: ResolvedScreenshotPath,
 	pngBytes: Buffer,
 	signal: AbortSignal | undefined,
 ) {
 	const tempFile = join(
-		dirname(path),
-		`.${basename(path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+		dirname(resolvedPath.path),
+		`.${basename(resolvedPath.path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
 	);
 	try {
 		await writeFile(tempFile, pngBytes, { flag: "wx", signal });
 		throwIfAborted(signal);
-		await rename(tempFile, path);
+		await replaceScreenshotFile(resolvedPath, tempFile, signal);
 	} catch (error) {
 		await rm(tempFile, { force: true }).catch(() => undefined);
 		throw error;
 	}
+}
+
+async function replaceScreenshotFile(
+	resolvedPath: ResolvedScreenshotPath,
+	tempFile: string,
+	signal: AbortSignal | undefined,
+) {
+	try {
+		await rename(tempFile, resolvedPath.path);
+		return;
+	} catch (error) {
+		if (!shouldRetryRenameAfterRemovingDestination(error)) throw error;
+	}
+
+	// Some Windows filesystems reject renaming over an existing file. Revalidate before
+	// removing the destination so the fallback still refuses directories and symlinks.
+	await assertSafeScreenshotTargetPath(resolvedPath);
+	throwIfAborted(signal);
+	await rm(resolvedPath.path, { force: true });
+	await rename(tempFile, resolvedPath.path);
+}
+
+function shouldRetryRenameAfterRemovingDestination(error: unknown) {
+	return (
+		process.platform === "win32" &&
+		isNodeError(error) &&
+		["EACCES", "EEXIST", "EPERM"].includes(error.code ?? "")
+	);
 }
 
 async function realpathOrResolvedPath(path: string) {

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1102,6 +1102,9 @@ async function assertSafeScreenshotTargetPath(resolvedPath: ResolvedScreenshotPa
 	if (existingTarget?.isDirectory()) {
 		throw new Error("Screenshot savePath must point to a file, not a directory.");
 	}
+	if (existingTarget && !existingTarget.isFile()) {
+		throw new Error("Screenshot savePath may only replace regular files.");
+	}
 
 	const realAllowedRoots = await Promise.all(resolvedPath.allowedRoots.map(realpathOrResolvedPath));
 	const realParent = await realpath(dirname(resolvedPath.path));


### PR DESCRIPTION
## Summary
- add optional `savePath` to `chrome_devtools_screenshot` and always write captured PNGs to disk
- report saved path, byte count, and read-tool hint while preserving inline image content
- document screenshot file behavior and archive the completed implementation plan

Part of #89 (screenshot capture improvements).

## Verification
- Node mocked-CDP harness for schema, default temp save, explicit savePath, path rejection, symlink rejection, image content, PNG signature, and concurrent writes
- `npm --workspace @narumitw/pi-chrome-devtools run check`
- `npm run check`
- `just pack-chrome-devtools`
- `git diff --check`