### PR TITLE
fix(chrome-devtools): launch after retryable port conflicts

### DIFF
--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1266,9 +1266,9 @@ function shouldAutoLaunchAfterEndpointError(error: unknown) {
 	if (!canAutoLaunchBrowser()) return false;
 	if (isLaunchableEndpointError(error)) return true;
 
-	// If the user did not pin a port, non-retryable unexpected responses on the
-	// default port are conflicts we can avoid with a dynamic DevTools port.
-	return !state.portConfigured && error instanceof DevToolsEndpointError && !error.retryable;
+	// After the attach-first retry window is exhausted, anything unexpected on an
+	// unpinned default port is a conflict we can avoid with a dynamic DevTools port.
+	return !state.portConfigured && error instanceof DevToolsEndpointError;
 }
 
 function canAutoLaunchBrowser() {

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1266,8 +1266,8 @@ function shouldAutoLaunchAfterEndpointError(error: unknown) {
 	if (!canAutoLaunchBrowser()) return false;
 	if (isLaunchableEndpointError(error)) return true;
 
-	// After the attach-first retry window is exhausted, anything unexpected on an
-	// unpinned default port is a conflict we can avoid with a dynamic DevTools port.
+	// After the attach-first attempt (including its retry window, when applicable) fails, treat any
+	// DevTools endpoint error on an unpinned port as a conflict we can avoid with a dynamic port.
 	return !state.portConfigured && error instanceof DevToolsEndpointError;
 }
 


### PR DESCRIPTION
## Summary
- Treat exhausted retryable DevTools endpoint errors on the unpinned default port as conflicts that can be avoided by dynamic auto-launch.
- Keep the attach-first retry window before auto-launching, so temporary startup failures still get their grace period.

Follow-up to PR #93 review comment: https://github.com/narumiruna/pi-extensions/pull/93#discussion_r3406402066

## Verification
- npm run check --workspace @narumitw/pi-chrome-devtools
- npm run check