### PR TITLE
fix: guard codex usage timers against stale ctx

### DIFF
--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -143,6 +143,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	let statuslineClearTimer: ReturnType<typeof setTimeout> | undefined;
 	let statuslineRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	let statuslineRequestId = 0;
+	let sessionActive = false;
 
 	const clearStatuslineTimers = () => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
@@ -151,25 +152,49 @@ export default function codexUsage(pi: ExtensionAPI) {
 		statuslineRefreshTimer = undefined;
 	};
 
+	const handleStaleContextError = (error: unknown): boolean => {
+		if (!isStaleExtensionContextError(error)) return false;
+		statuslineRequestId += 1;
+		clearStatuslineTimers();
+		return true;
+	};
+
+	const setStatuslineValue = (ctx: ExtensionContext, value: string | undefined): boolean => {
+		try {
+			ctx.ui.setStatus(STATUS_KEY, value);
+			return true;
+		} catch (error) {
+			if (handleStaleContextError(error)) return false;
+			throw error;
+		}
+	};
+
 	const clearUsageStatusline = (ctx: ExtensionContext) => {
 		statuslineRequestId += 1;
 		clearStatuslineTimers();
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+		setStatuslineValue(ctx, undefined);
 	};
 
 	const scheduleTemporaryStatuslineClear = (ctx: ExtensionContext) => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
+		const requestId = statuslineRequestId;
 		statuslineClearTimer = setTimeout(() => {
-			ctx.ui.setStatus(STATUS_KEY, undefined);
 			statuslineClearTimer = undefined;
+			if (!sessionActive || requestId !== statuslineRequestId) return;
+			setStatuslineValue(ctx, undefined);
 		}, CACHE_TTL_MS);
 		statuslineClearTimer.unref?.();
 	};
 
-	const scheduleStatuslineRefresh = (ctx: ExtensionContext) => {
+	const scheduleStatuslineRefresh = (ctx: ExtensionContext, model: CodexUsageModel | undefined) => {
 		if (statuslineRefreshTimer) clearTimeout(statuslineRefreshTimer);
+		const requestId = statuslineRequestId;
 		statuslineRefreshTimer = setTimeout(() => {
-			void refreshCurrentCodexUsageStatusline(ctx, true);
+			statuslineRefreshTimer = undefined;
+			if (!sessionActive || requestId !== statuslineRequestId) return;
+			void refreshCurrentCodexUsageStatusline(ctx, true, model).catch((error: unknown) => {
+				if (!handleStaleContextError(error)) throw error;
+			});
 		}, CACHE_TTL_MS);
 		statuslineRefreshTimer.unref?.();
 	};
@@ -181,17 +206,19 @@ export default function codexUsage(pi: ExtensionAPI) {
 	) => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
 		statuslineClearTimer = undefined;
-		ctx.ui.setStatus(STATUS_KEY, formatCodexUsageStatusline(report, options.model));
-		if (options.autoRefresh) scheduleStatuslineRefresh(ctx);
+		if (!setStatuslineValue(ctx, formatCodexUsageStatusline(report, options.model))) return;
+		if (options.autoRefresh) scheduleStatuslineRefresh(ctx, options.model);
 		else scheduleTemporaryStatuslineClear(ctx);
 	};
 
 	const refreshCurrentCodexUsageStatusline = async (
 		ctx: ExtensionContext,
 		force: boolean,
-		model = ctx.model,
+		model?: CodexUsageModel,
 	) => {
-		if (!isOpenAICodexModel(model)) {
+		if (!sessionActive) return;
+		const selectedModel = model ?? ctx.model;
+		if (!isOpenAICodexModel(selectedModel)) {
 			clearUsageStatusline(ctx);
 			return;
 		}
@@ -204,22 +231,18 @@ export default function codexUsage(pi: ExtensionAPI) {
 			return;
 		}
 
-		ctx.ui.setStatus(STATUS_KEY, "📊 checking");
+		if (!setStatuslineValue(ctx, "📊 checking")) return;
 		const result = await queryUsage(ctx, { timeoutMs: DEFAULT_TIMEOUT_MS });
-		if (requestId !== statuslineRequestId) return;
-		if (!isOpenAICodexModel(ctx.model)) {
-			clearUsageStatusline(ctx);
-			return;
-		}
+		if (!sessionActive || requestId !== statuslineRequestId) return;
 
 		if (!result.ok) {
-			ctx.ui.setStatus(STATUS_KEY, "📊 usage error");
-			scheduleStatuslineRefresh(ctx);
+			setStatuslineValue(ctx, "📊 usage error");
+			scheduleStatuslineRefresh(ctx, selectedModel);
 			return;
 		}
 
 		cache = { createdAt: Date.now(), report: result.report };
-		setUsageStatusline(ctx, result.report, { autoRefresh: true, model });
+		setUsageStatusline(ctx, result.report, { autoRefresh: true, model: selectedModel });
 	};
 
 	pi.registerCommand(COMMAND_NAME, {
@@ -274,12 +297,13 @@ export default function codexUsage(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false);
+		sessionActive = true;
+		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model);
 		else clearUsageStatusline(ctx);
 	});
 
 	pi.on("session_tree", (_event, ctx) => {
-		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false);
+		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model);
 		else clearUsageStatusline(ctx);
 	});
 
@@ -291,7 +315,10 @@ export default function codexUsage(pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => clearUsageStatusline(ctx));
+	pi.on("session_shutdown", (_event, ctx) => {
+		sessionActive = false;
+		clearUsageStatusline(ctx);
+	});
 }
 
 export function parseArgs(
@@ -342,6 +369,13 @@ function isOpenAICodexModel(model: Pick<PiModel, "provider"> | undefined): boole
 	return model?.provider === CODEX_PROVIDER_ID;
 }
 
+export function isStaleExtensionContextError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		error.message.includes("This extension ctx is stale after session replacement or reload")
+	);
+}
+
 async function queryUsage(
 	ctx: ExtensionContext,
 	options: Pick<QueryUsageOptions, "timeoutMs">,
@@ -352,6 +386,7 @@ async function queryUsage(
 		const report = await queryViaPiAuth(ctx, options.timeoutMs);
 		return { ok: true, report };
 	} catch (cause) {
+		if (isStaleExtensionContextError(cause)) throw cause;
 		errors.push({ source: "pi-auth", message: errorMessage(cause), cause });
 	}
 
@@ -359,6 +394,7 @@ async function queryUsage(
 		const report = await queryViaCodexAppServer(options.timeoutMs);
 		return { ok: true, report };
 	} catch (cause) {
+		if (isStaleExtensionContextError(cause)) throw cause;
 		errors.push({ source: "codex-app-server", message: errorMessage(cause), cause });
 	}
 

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexUsage, {
 	type CodexUsageReport,
 	formatCodexUsageReport,
 	formatCodexUsageStatusline,
+	isStaleExtensionContextError,
 	normalizeAppServerResponse,
 	normalizeBackendPayload,
 	parseArgs,
@@ -77,6 +78,62 @@ test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => 
 	assert.equal(report.snapshots.length, 1);
 	assert.equal(report.snapshots[0]?.primary?.usedPercent, 40);
 	assert.equal(report.snapshots[0]?.secondary?.windowMinutes, 10080);
+});
+
+test("scheduled statusline refresh ignores stale extension contexts", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = async () =>
+		new Response(
+			JSON.stringify({
+				plan_type: "pro_lite",
+				rate_limit: { primary_window: { used_percent: 25 } },
+			}),
+			{ status: 200 },
+		);
+
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const model = { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", provider: "openai-codex" };
+	const { ctx, statuses } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-token" }),
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+
+	const staleError = new Error(
+		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+	);
+	Object.defineProperty(ctx, "modelRegistry", {
+		configurable: true,
+		get() {
+			throw staleError;
+		},
+	});
+
+	t.mock.timers.tick(5 * 60 * 1000);
+	await Promise.resolve();
+	await Promise.resolve();
+});
+
+test("isStaleExtensionContextError recognizes Pi stale-context failures", () => {
+	assert.equal(
+		isStaleExtensionContextError(
+			new Error("This extension ctx is stale after session replacement or reload."),
+		),
+		true,
+	);
+	assert.equal(isStaleExtensionContextError(new Error("network failed")), false);
 });
 
 test("formatters render report text and model-specific statusline buckets", () => {


### PR DESCRIPTION
## Summary

- guard Codex usage statusline timers with a session-active/request-generation check
- pass the selected model into timer refreshes instead of reading `ctx.model` from stale timer callbacks
- swallow Pi stale-context errors from abandoned statusline timers while still rethrowing unrelated failures
- add a regression test for a scheduled refresh that fires after its captured context has become stale

## Why

Pi now throws when an extension uses an `ExtensionContext` captured before a reload or session replacement. The Codex usage statusline schedules a refresh timer that later calls `refreshCurrentCodexUsageStatusline(ctx, true)`. When that timer fires after `/reload`, `newSession`, `fork`, or `switchSession`, it can read a stale `ctx.model` / `ctx.modelRegistry` and crash Pi with an uncaught exception.

Observed downstream stack:

```text
pi exiting due to uncaughtException:
Error: This extension ctx is stale after session replacement or reload.
    at ExtensionRunner.assertActive (.../dist/core/extensions/runner.js:331:19)
    at get model (.../dist/core/extensions/runner.js:440:24)
    at refreshCurrentCodexUsageStatusline (.../@narumitw/pi-codex-usage/src/codex-usage.ts:192:15)
    at Timeout._onTimeout (.../@narumitw/pi-codex-usage/src/codex-usage.ts:172:12)
```

## Verification

- `npm run check`

Refs mifunedev/openharness#419

