### PR TITLE
fix: guard codex usage timers against stale ctx

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -22,6 +22,7 @@
 - Symptom: Chrome DevTools `/json/new` may reject unsafe `GET`. Cause: modern Chrome expects `PUT` for target creation. Fix: use `PUT /json/new?${encodeURIComponent(url)}`.
 - Symptom: Telegram bot polling can replay stale queued messages or conflict across Pi processes. Cause: `getUpdates` is a single bot-token queue controlled by offsets. Fix: discard pending updates on startup with an offset and run one active polling Pi per bot token.
 - For pi-sync on Cloudflare R2, keep session-token support for temporary credentials but retry once without the token when R2 static keys reject `X-Amz-Security-Token`.
+- Symptom: Pi extension async/timer/command continuations can crash after reload or session replacement. Cause: captured `ExtensionContext` becomes stale. Fix: pass plain data into delayed callbacks, catch stale-context errors, and scope cleanup to the failing ctx/request.
 
 ## TASTE
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -260,51 +260,56 @@ export default function codexUsage(pi: ExtensionAPI) {
 	pi.registerCommand(COMMAND_NAME, {
 		description: "Show Codex ChatGPT subscription usage and rate-limit windows",
 		handler: async (args, ctx) => {
-			const options = parseArgs(args);
-			if (!options.ok) {
-				ctx.ui.notify(options.error, "warning");
-				return;
-			}
-
-			if (options.value.clearStatusline) {
-				clearUsageStatusline(ctx);
-				ctx.ui.notify("Codex usage statusline cleared.", "info");
-				return;
-			}
-
-			const cached = cache && Date.now() - cache.createdAt < CACHE_TTL_MS ? cache : undefined;
-			if (cached && !options.value.refresh) {
-				if (options.value.statusline) {
-					setUsageStatusline(ctx, cached.report, {
-						autoRefresh: isOpenAICodexModel(ctx.model),
-						model: ctx.model,
-					});
-				}
-				showReport(ctx, cached.report, true);
-				return;
-			}
-
-			let keepStatusline = false;
-			const statuslineStarted =
-				options.value.statusline && setStatuslineValue(ctx, "📊 checking");
 			try {
-				const result = await queryUsage(ctx, options.value);
-				if (!result.ok) {
-					ctx.ui.notify(formatQueryErrors(result.errors), "error");
+				const options = parseArgs(args);
+				if (!options.ok) {
+					ctx.ui.notify(options.error, "warning");
 					return;
 				}
 
-				cache = { createdAt: Date.now(), report: result.report };
-				if (options.value.statusline) {
-					setUsageStatusline(ctx, result.report, {
-						autoRefresh: isOpenAICodexModel(ctx.model),
-						model: ctx.model,
-					});
-					keepStatusline = true;
+				if (options.value.clearStatusline) {
+					clearUsageStatusline(ctx);
+					ctx.ui.notify("Codex usage statusline cleared.", "info");
+					return;
 				}
-				showReport(ctx, result.report, false);
-			} finally {
-				if (statuslineStarted && !keepStatusline) setStatuslineValue(ctx, undefined);
+
+				const cached = cache && Date.now() - cache.createdAt < CACHE_TTL_MS ? cache : undefined;
+				if (cached && !options.value.refresh) {
+					if (options.value.statusline) {
+						setUsageStatusline(ctx, cached.report, {
+							autoRefresh: isOpenAICodexModel(ctx.model),
+							model: ctx.model,
+						});
+					}
+					showReport(ctx, cached.report, true);
+					return;
+				}
+
+				let keepStatusline = false;
+				const statuslineStarted =
+					options.value.statusline && setStatuslineValue(ctx, "📊 checking");
+				try {
+					const result = await queryUsage(ctx, options.value);
+					if (!result.ok) {
+						ctx.ui.notify(formatQueryErrors(result.errors), "error");
+						return;
+					}
+
+					cache = { createdAt: Date.now(), report: result.report };
+					if (options.value.statusline) {
+						setUsageStatusline(ctx, result.report, {
+							autoRefresh: isOpenAICodexModel(ctx.model),
+							model: ctx.model,
+						});
+						keepStatusline = true;
+					}
+					showReport(ctx, result.report, false);
+				} finally {
+					if (statuslineStarted && !keepStatusline) setStatuslineValue(ctx, undefined);
+				}
+			} catch (error) {
+				if (handleStaleContextError(ctx, error)) return;
+				throw error;
 			}
 		},
 	});

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -144,6 +144,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	let statuslineRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	let statuslineRequestId = 0;
 	let sessionActive = false;
+	let activeStatuslineContext: ExtensionContext | undefined;
 
 	const clearStatuslineTimers = () => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
@@ -152,15 +153,18 @@ export default function codexUsage(pi: ExtensionAPI) {
 		statuslineRefreshTimer = undefined;
 	};
 
-	const handleStaleContextError = (error: unknown): boolean => {
+	const handleStaleContextError = (ctx: ExtensionContext, error: unknown): boolean => {
 		if (!isStaleExtensionContextError(error)) return false;
-		statuslineRequestId += 1;
-		clearStatuslineTimers();
+		if (ctx === activeStatuslineContext) {
+			statuslineRequestId += 1;
+			clearStatuslineTimers();
+			activeStatuslineContext = undefined;
+		}
 		return true;
 	};
 
-	const rethrowUnlessStaleContextError = (error: unknown) => {
-		if (!handleStaleContextError(error)) throw error;
+	const rethrowUnlessStaleContextError = (ctx: ExtensionContext) => (error: unknown) => {
+		if (!handleStaleContextError(ctx, error)) throw error;
 	};
 
 	const setStatuslineValue = (ctx: ExtensionContext, value: string | undefined): boolean => {
@@ -168,7 +172,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 			ctx.ui.setStatus(STATUS_KEY, value);
 			return true;
 		} catch (error) {
-			if (handleStaleContextError(error)) return false;
+			if (handleStaleContextError(ctx, error)) return false;
 			throw error;
 		}
 	};
@@ -176,6 +180,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	const clearUsageStatusline = (ctx: ExtensionContext) => {
 		statuslineRequestId += 1;
 		clearStatuslineTimers();
+		activeStatuslineContext = undefined;
 		setStatuslineValue(ctx, undefined);
 	};
 
@@ -197,7 +202,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 			statuslineRefreshTimer = undefined;
 			if (!sessionActive || requestId !== statuslineRequestId) return;
 			void refreshCurrentCodexUsageStatusline(ctx, true, model).catch(
-				rethrowUnlessStaleContextError,
+				rethrowUnlessStaleContextError(ctx),
 			);
 		}, CACHE_TTL_MS);
 		statuslineRefreshTimer.unref?.();
@@ -208,6 +213,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 		report: CodexUsageReport,
 		options: { autoRefresh: boolean; model: CodexUsageModel | undefined },
 	) => {
+		activeStatuslineContext = ctx;
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
 		statuslineClearTimer = undefined;
 		if (!setStatuslineValue(ctx, formatCodexUsageStatusline(report, options.model))) return;
@@ -221,6 +227,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 		model?: CodexUsageModel,
 	) => {
 		if (!sessionActive) return;
+		activeStatuslineContext = ctx;
 		const selectedModel = model ?? ctx.model;
 		if (!isOpenAICodexModel(selectedModel)) {
 			clearUsageStatusline(ctx);
@@ -304,7 +311,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 		sessionActive = true;
 		if (isOpenAICodexModel(ctx.model)) {
 			void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model).catch(
-				rethrowUnlessStaleContextError,
+				rethrowUnlessStaleContextError(ctx),
 			);
 		} else {
 			clearUsageStatusline(ctx);
@@ -314,7 +321,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	pi.on("session_tree", (_event, ctx) => {
 		if (isOpenAICodexModel(ctx.model)) {
 			void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model).catch(
-				rethrowUnlessStaleContextError,
+				rethrowUnlessStaleContextError(ctx),
 			);
 		} else {
 			clearUsageStatusline(ctx);
@@ -324,7 +331,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	pi.on("model_select", (event, ctx) => {
 		if (isOpenAICodexModel(event.model)) {
 			void refreshCurrentCodexUsageStatusline(ctx, false, event.model).catch(
-				rethrowUnlessStaleContextError,
+				rethrowUnlessStaleContextError(ctx),
 			);
 		} else {
 			clearUsageStatusline(ctx);

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -213,10 +213,10 @@ export default function codexUsage(pi: ExtensionAPI) {
 		report: CodexUsageReport,
 		options: { autoRefresh: boolean; model: CodexUsageModel | undefined },
 	) => {
+		if (!setStatuslineValue(ctx, formatCodexUsageStatusline(report, options.model))) return;
 		activeStatuslineContext = ctx;
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
 		statuslineClearTimer = undefined;
-		if (!setStatuslineValue(ctx, formatCodexUsageStatusline(report, options.model))) return;
 		if (options.autoRefresh) scheduleStatuslineRefresh(ctx, options.model);
 		else scheduleTemporaryStatuslineClear(ctx);
 	};
@@ -247,8 +247,9 @@ export default function codexUsage(pi: ExtensionAPI) {
 		if (!sessionActive || requestId !== statuslineRequestId) return;
 
 		if (!result.ok) {
-			setStatuslineValue(ctx, "📊 usage error");
-			scheduleStatuslineRefresh(ctx, selectedModel);
+			if (setStatuslineValue(ctx, "📊 usage error")) {
+				scheduleStatuslineRefresh(ctx, selectedModel);
+			}
 			return;
 		}
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -159,6 +159,10 @@ export default function codexUsage(pi: ExtensionAPI) {
 		return true;
 	};
 
+	const rethrowUnlessStaleContextError = (error: unknown) => {
+		if (!handleStaleContextError(error)) throw error;
+	};
+
 	const setStatuslineValue = (ctx: ExtensionContext, value: string | undefined): boolean => {
 		try {
 			ctx.ui.setStatus(STATUS_KEY, value);
@@ -192,9 +196,9 @@ export default function codexUsage(pi: ExtensionAPI) {
 		statuslineRefreshTimer = setTimeout(() => {
 			statuslineRefreshTimer = undefined;
 			if (!sessionActive || requestId !== statuslineRequestId) return;
-			void refreshCurrentCodexUsageStatusline(ctx, true, model).catch((error: unknown) => {
-				if (!handleStaleContextError(error)) throw error;
-			});
+			void refreshCurrentCodexUsageStatusline(ctx, true, model).catch(
+				rethrowUnlessStaleContextError,
+			);
 		}, CACHE_TTL_MS);
 		statuslineRefreshTimer.unref?.();
 	};
@@ -227,7 +231,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 		statuslineRequestId = requestId;
 		const cached = cache && Date.now() - cache.createdAt < CACHE_TTL_MS ? cache : undefined;
 		if (cached && !force) {
-			setUsageStatusline(ctx, cached.report, { autoRefresh: true, model });
+			setUsageStatusline(ctx, cached.report, { autoRefresh: true, model: selectedModel });
 			return;
 		}
 
@@ -298,18 +302,30 @@ export default function codexUsage(pi: ExtensionAPI) {
 
 	pi.on("session_start", (_event, ctx) => {
 		sessionActive = true;
-		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model);
-		else clearUsageStatusline(ctx);
+		if (isOpenAICodexModel(ctx.model)) {
+			void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model).catch(
+				rethrowUnlessStaleContextError,
+			);
+		} else {
+			clearUsageStatusline(ctx);
+		}
 	});
 
 	pi.on("session_tree", (_event, ctx) => {
-		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model);
-		else clearUsageStatusline(ctx);
+		if (isOpenAICodexModel(ctx.model)) {
+			void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model).catch(
+				rethrowUnlessStaleContextError,
+			);
+		} else {
+			clearUsageStatusline(ctx);
+		}
 	});
 
 	pi.on("model_select", (event, ctx) => {
 		if (isOpenAICodexModel(event.model)) {
-			void refreshCurrentCodexUsageStatusline(ctx, false, event.model);
+			void refreshCurrentCodexUsageStatusline(ctx, false, event.model).catch(
+				rethrowUnlessStaleContextError,
+			);
 		} else {
 			clearUsageStatusline(ctx);
 		}

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -143,6 +143,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	let statuslineClearTimer: ReturnType<typeof setTimeout> | undefined;
 	let statuslineRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	let statuslineRequestId = 0;
+	let sessionActive = false;
 
 	const clearStatuslineTimers = () => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
@@ -151,25 +152,49 @@ export default function codexUsage(pi: ExtensionAPI) {
 		statuslineRefreshTimer = undefined;
 	};
 
+	const handleStaleContextError = (error: unknown): boolean => {
+		if (!isStaleExtensionContextError(error)) return false;
+		statuslineRequestId += 1;
+		clearStatuslineTimers();
+		return true;
+	};
+
+	const setStatuslineValue = (ctx: ExtensionContext, value: string | undefined): boolean => {
+		try {
+			ctx.ui.setStatus(STATUS_KEY, value);
+			return true;
+		} catch (error) {
+			if (handleStaleContextError(error)) return false;
+			throw error;
+		}
+	};
+
 	const clearUsageStatusline = (ctx: ExtensionContext) => {
 		statuslineRequestId += 1;
 		clearStatuslineTimers();
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+		setStatuslineValue(ctx, undefined);
 	};
 
 	const scheduleTemporaryStatuslineClear = (ctx: ExtensionContext) => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
+		const requestId = statuslineRequestId;
 		statuslineClearTimer = setTimeout(() => {
-			ctx.ui.setStatus(STATUS_KEY, undefined);
 			statuslineClearTimer = undefined;
+			if (!sessionActive || requestId !== statuslineRequestId) return;
+			setStatuslineValue(ctx, undefined);
 		}, CACHE_TTL_MS);
 		statuslineClearTimer.unref?.();
 	};
 
-	const scheduleStatuslineRefresh = (ctx: ExtensionContext) => {
+	const scheduleStatuslineRefresh = (ctx: ExtensionContext, model: CodexUsageModel | undefined) => {
 		if (statuslineRefreshTimer) clearTimeout(statuslineRefreshTimer);
+		const requestId = statuslineRequestId;
 		statuslineRefreshTimer = setTimeout(() => {
-			void refreshCurrentCodexUsageStatusline(ctx, true);
+			statuslineRefreshTimer = undefined;
+			if (!sessionActive || requestId !== statuslineRequestId) return;
+			void refreshCurrentCodexUsageStatusline(ctx, true, model).catch((error: unknown) => {
+				if (!handleStaleContextError(error)) throw error;
+			});
 		}, CACHE_TTL_MS);
 		statuslineRefreshTimer.unref?.();
 	};
@@ -181,17 +206,19 @@ export default function codexUsage(pi: ExtensionAPI) {
 	) => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
 		statuslineClearTimer = undefined;
-		ctx.ui.setStatus(STATUS_KEY, formatCodexUsageStatusline(report, options.model));
-		if (options.autoRefresh) scheduleStatuslineRefresh(ctx);
+		if (!setStatuslineValue(ctx, formatCodexUsageStatusline(report, options.model))) return;
+		if (options.autoRefresh) scheduleStatuslineRefresh(ctx, options.model);
 		else scheduleTemporaryStatuslineClear(ctx);
 	};
 
 	const refreshCurrentCodexUsageStatusline = async (
 		ctx: ExtensionContext,
 		force: boolean,
-		model = ctx.model,
+		model?: CodexUsageModel,
 	) => {
-		if (!isOpenAICodexModel(model)) {
+		if (!sessionActive) return;
+		const selectedModel = model ?? ctx.model;
+		if (!isOpenAICodexModel(selectedModel)) {
 			clearUsageStatusline(ctx);
 			return;
 		}
@@ -204,22 +231,18 @@ export default function codexUsage(pi: ExtensionAPI) {
 			return;
 		}
 
-		ctx.ui.setStatus(STATUS_KEY, "📊 checking");
+		if (!setStatuslineValue(ctx, "📊 checking")) return;
 		const result = await queryUsage(ctx, { timeoutMs: DEFAULT_TIMEOUT_MS });
-		if (requestId !== statuslineRequestId) return;
-		if (!isOpenAICodexModel(ctx.model)) {
-			clearUsageStatusline(ctx);
-			return;
-		}
+		if (!sessionActive || requestId !== statuslineRequestId) return;
 
 		if (!result.ok) {
-			ctx.ui.setStatus(STATUS_KEY, "📊 usage error");
-			scheduleStatuslineRefresh(ctx);
+			setStatuslineValue(ctx, "📊 usage error");
+			scheduleStatuslineRefresh(ctx, selectedModel);
 			return;
 		}
 
 		cache = { createdAt: Date.now(), report: result.report };
-		setUsageStatusline(ctx, result.report, { autoRefresh: true, model });
+		setUsageStatusline(ctx, result.report, { autoRefresh: true, model: selectedModel });
 	};
 
 	pi.registerCommand(COMMAND_NAME, {
@@ -274,12 +297,13 @@ export default function codexUsage(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false);
+		sessionActive = true;
+		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model);
 		else clearUsageStatusline(ctx);
 	});
 
 	pi.on("session_tree", (_event, ctx) => {
-		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false);
+		if (isOpenAICodexModel(ctx.model)) void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model);
 		else clearUsageStatusline(ctx);
 	});
 
@@ -291,7 +315,10 @@ export default function codexUsage(pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => clearUsageStatusline(ctx));
+	pi.on("session_shutdown", (_event, ctx) => {
+		sessionActive = false;
+		clearUsageStatusline(ctx);
+	});
 }
 
 export function parseArgs(
@@ -342,6 +369,13 @@ function isOpenAICodexModel(model: Pick<PiModel, "provider"> | undefined): boole
 	return model?.provider === CODEX_PROVIDER_ID;
 }
 
+export function isStaleExtensionContextError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		error.message.includes("This extension ctx is stale after session replacement or reload")
+	);
+}
+
 async function queryUsage(
 	ctx: ExtensionContext,
 	options: Pick<QueryUsageOptions, "timeoutMs">,
@@ -352,6 +386,7 @@ async function queryUsage(
 		const report = await queryViaPiAuth(ctx, options.timeoutMs);
 		return { ok: true, report };
 	} catch (cause) {
+		if (isStaleExtensionContextError(cause)) throw cause;
 		errors.push({ source: "pi-auth", message: errorMessage(cause), cause });
 	}
 
@@ -359,6 +394,7 @@ async function queryUsage(
 		const report = await queryViaCodexAppServer(options.timeoutMs);
 		return { ok: true, report };
 	} catch (cause) {
+		if (isStaleExtensionContextError(cause)) throw cause;
 		errors.push({ source: "codex-app-server", message: errorMessage(cause), cause });
 	}
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -285,7 +285,8 @@ export default function codexUsage(pi: ExtensionAPI) {
 			}
 
 			let keepStatusline = false;
-			if (options.value.statusline) ctx.ui.setStatus(STATUS_KEY, "📊 checking");
+			const statuslineStarted =
+				options.value.statusline && setStatuslineValue(ctx, "📊 checking");
 			try {
 				const result = await queryUsage(ctx, options.value);
 				if (!result.ok) {
@@ -303,7 +304,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 				}
 				showReport(ctx, result.report, false);
 			} finally {
-				if (options.value.statusline && !keepStatusline) ctx.ui.setStatus(STATUS_KEY, undefined);
+				if (statuslineStarted && !keepStatusline) setStatuslineValue(ctx, undefined);
 			}
 		},
 	});

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -229,6 +229,27 @@ test("stale command statusline writes are ignored", async (t) => {
 	await command.handler("", ctx);
 });
 
+test("stale command query failures are ignored", async () => {
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const command = mock.commands.get("codex-status");
+	assert.ok(command);
+	const staleError = new Error("This extension ctx is stale after session replacement or reload.");
+	const model = { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", provider: "openai-codex" };
+	const { ctx } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => {
+				throw staleError;
+			},
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+
+	await command.handler("", ctx);
+});
+
 test("stale command statusline writes do not cancel newer session refresh timers", async (t) => {
 	// Node pairs clearTimeout with mocked setTimeout; clearTimeout is not a valid apis entry.
 	t.mock.timers.enable({ apis: ["setTimeout"] });

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -81,6 +81,7 @@ test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => 
 });
 
 test("scheduled statusline refresh ignores stale extension contexts", async (t) => {
+	// Node pairs clearTimeout with mocked setTimeout; clearTimeout is not a valid apis entry.
 	t.mock.timers.enable({ apis: ["setTimeout"] });
 	const originalFetch = globalThis.fetch;
 	t.after(() => {
@@ -111,12 +112,14 @@ test("scheduled statusline refresh ignores stale extension contexts", async (t) 
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
 
+	let staleModelRegistryReads = 0;
 	const staleError = new Error(
 		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
 	);
 	Object.defineProperty(ctx, "modelRegistry", {
 		configurable: true,
 		get() {
+			staleModelRegistryReads += 1;
 			throw staleError;
 		},
 	});
@@ -124,6 +127,68 @@ test("scheduled statusline refresh ignores stale extension contexts", async (t) 
 	t.mock.timers.tick(5 * 60 * 1000);
 	await Promise.resolve();
 	await Promise.resolve();
+	assert.equal(staleModelRegistryReads, 1);
+});
+
+test("stale refresh errors do not cancel newer session refresh timers", async (t) => {
+	// Node pairs clearTimeout with mocked setTimeout; clearTimeout is not a valid apis entry.
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	let fetches = 0;
+	globalThis.fetch = async () => {
+		fetches += 1;
+		return new Response(
+			JSON.stringify({
+				plan_type: "pro_lite",
+				rate_limit: { primary_window: { used_percent: fetches === 1 ? 25 : 50 } },
+			}),
+			{ status: 200 },
+		);
+	};
+
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const model = { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", provider: "openai-codex" };
+	let rejectOldAuth: (error: Error) => void = () => undefined;
+	const oldAuth = new Promise<never>((_resolve, reject) => {
+		rejectOldAuth = reject;
+	});
+	const staleError = new Error(
+		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+	);
+	const { ctx: oldCtx } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: () => oldAuth,
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+	const { ctx: newCtx, statuses } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-token" }),
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, oldCtx);
+	mock.events.get("session_start")?.[0]?.({}, newCtx);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+
+	rejectOldAuth(staleError);
+	await Promise.resolve();
+	await Promise.resolve();
+
+	t.mock.timers.tick(5 * 60 * 1000);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(statuses.get("codex-usage"), "📊 codex 50% 5h");
 });
 
 test("isStaleExtensionContextError recognizes Pi stale-context failures", () => {

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -191,6 +191,63 @@ test("stale refresh errors do not cancel newer session refresh timers", async (t
 	assert.equal(statuses.get("codex-usage"), "📊 codex 50% 5h");
 });
 
+test("stale command statusline writes do not cancel newer session refresh timers", async (t) => {
+	// Node pairs clearTimeout with mocked setTimeout; clearTimeout is not a valid apis entry.
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	let fetches = 0;
+	globalThis.fetch = async () => {
+		fetches += 1;
+		return new Response(
+			JSON.stringify({
+				plan_type: "pro_lite",
+				rate_limit: { primary_window: { used_percent: fetches === 1 ? 25 : 50 } },
+			}),
+			{ status: 200 },
+		);
+	};
+
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const command = mock.commands.get("codex-status");
+	assert.ok(command);
+	const model = { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", provider: "openai-codex" };
+	const { ctx: newCtx, statuses } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-token" }),
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, newCtx);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+
+	const staleError = new Error(
+		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+	);
+	const { ctx: staleCtx } = createMockContext({
+		model,
+		ui: {
+			notify: () => undefined,
+			setStatus: () => {
+				throw staleError;
+			},
+		},
+	});
+
+	await command.handler("", staleCtx);
+	t.mock.timers.tick(5 * 60 * 1000);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(statuses.get("codex-usage"), "📊 codex 50% 5h");
+});
+
 test("isStaleExtensionContextError recognizes Pi stale-context failures", () => {
 	assert.equal(
 		isStaleExtensionContextError(

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexUsage, {
 	type CodexUsageReport,
 	formatCodexUsageReport,
 	formatCodexUsageStatusline,
+	isStaleExtensionContextError,
 	normalizeAppServerResponse,
 	normalizeBackendPayload,
 	parseArgs,
@@ -77,6 +78,62 @@ test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => 
 	assert.equal(report.snapshots.length, 1);
 	assert.equal(report.snapshots[0]?.primary?.usedPercent, 40);
 	assert.equal(report.snapshots[0]?.secondary?.windowMinutes, 10080);
+});
+
+test("scheduled statusline refresh ignores stale extension contexts", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = async () =>
+		new Response(
+			JSON.stringify({
+				plan_type: "pro_lite",
+				rate_limit: { primary_window: { used_percent: 25 } },
+			}),
+			{ status: 200 },
+		);
+
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const model = { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", provider: "openai-codex" };
+	const { ctx, statuses } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-token" }),
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+
+	const staleError = new Error(
+		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+	);
+	Object.defineProperty(ctx, "modelRegistry", {
+		configurable: true,
+		get() {
+			throw staleError;
+		},
+	});
+
+	t.mock.timers.tick(5 * 60 * 1000);
+	await Promise.resolve();
+	await Promise.resolve();
+});
+
+test("isStaleExtensionContextError recognizes Pi stale-context failures", () => {
+	assert.equal(
+		isStaleExtensionContextError(
+			new Error("This extension ctx is stale after session replacement or reload."),
+		),
+		true,
+	);
+	assert.equal(isStaleExtensionContextError(new Error("network failed")), false);
 });
 
 test("formatters render report text and model-specific statusline buckets", () => {

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -191,6 +191,44 @@ test("stale refresh errors do not cancel newer session refresh timers", async (t
 	assert.equal(statuses.get("codex-usage"), "📊 codex 50% 5h");
 });
 
+test("stale command statusline writes are ignored", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = async () =>
+		new Response(
+			JSON.stringify({
+				plan_type: "pro_lite",
+				rate_limit: { primary_window: { used_percent: 25 } },
+			}),
+			{ status: 200 },
+		);
+
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const command = mock.commands.get("codex-status");
+	assert.ok(command);
+	const staleError = new Error("This extension ctx is stale after session replacement or reload.");
+	const model = { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", provider: "openai-codex" };
+	const { ctx } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-token" }),
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+		ui: {
+			notify: () => undefined,
+			setStatus: () => {
+				throw staleError;
+			},
+		},
+	});
+
+	await command.handler("", ctx);
+});
+
 test("stale command statusline writes do not cancel newer session refresh timers", async (t) => {
 	// Node pairs clearTimeout with mocked setTimeout; clearTimeout is not a valid apis entry.
 	t.mock.timers.enable({ apis: ["setTimeout"] });


### PR DESCRIPTION
## Summary

This supersedes #97 and fixes the `pi-codex-usage` stale `ExtensionContext` crash reported in #100.

Root cause: the statusline auto-refresh timer could keep a captured `ExtensionContext` after `/reload`, session replacement, fork, or session switch. When that timer later fired, it could read stale context state such as `ctx.model` / `ctx.modelRegistry` and Pi would throw an uncaught stale-context exception.

Changes:

- pass the selected Codex model into scheduled/cached refreshes so timer callbacks do not need to read `ctx.model`
- guard timer callbacks, fire-and-forget event refreshes, and `/codex-status` statusline writes against stale-context failures
- scope stale-context cleanup to the context/request that failed so an old refresh cannot cancel a newer session's refresh timer
- avoid scheduling another refresh when writing the error statusline already proved the context is stale
- add regression coverage for stale timer refreshes, stale command writes, and old refreshes racing with newer sessions

## Verification

- npm run check

Fixes #100
Refs #97, #98
