### PR TITLE
feat(sync): support optional session syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install only the Pi extensions you need. Each package is published under the `@n
 | [`@narumitw/pi-lsp`](./extensions/pi-lsp) | 🧠 Configurable language-server diagnostics and source-fix tools routed by file extension. | `pi install npm:@narumitw/pi-lsp` |
 | [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for provider responses that fail with `Unknown error (no error details in response)`. | `pi install npm:@narumitw/pi-retry` |
 | [`@narumitw/pi-statusline`](./extensions/pi-statusline) | ✨ A rich Pi terminal statusline with model, tools, git branch, context usage, token totals, cost, and time. | `pi install npm:@narumitw/pi-statusline` |
-| [`@narumitw/pi-sync`](./extensions/pi-sync) | ☁️ Sync allowlisted Pi settings, skills, prompts, themes, and extensions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
+| [`@narumitw/pi-sync`](./extensions/pi-sync) | ☁️ Sync allowlisted Pi settings, skills, prompts, themes, extensions, and optional sessions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
 | [`@narumitw/pi-subagents`](./extensions/pi-subagents) | 🤖 Delegate work to specialized isolated subagents with single, parallel, and chained execution modes. | `pi install npm:@narumitw/pi-subagents` |
 
 ## 🚀 Quick start

--- a/docs/plans/archived/2026-06-19_pi-sync-session-sync-plan.md
+++ b/docs/plans/archived/2026-06-19_pi-sync-session-sync-plan.md
@@ -1,6 +1,6 @@
 ## Goal
 
-Add opt-in Pi conversation/session syncing to `@narumitw/pi-sync` for issue #99. Success means users can sync Pi JSONL sessions under `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/` through the existing R2/S3 snapshot flow, with privacy warnings, backups, conflict protection, tests, and docs.
+Add opt-in Pi conversation/session syncing to `@narumitw/pi-sync` for issue #99. Success means users can sync Pi JSONL sessions from Pi's configured session directory through the existing R2/S3 snapshot flow, with privacy warnings, backups, conflict protection, tests, and docs.
 
 ## Context
 
@@ -8,7 +8,7 @@ Issue #99 asks for `pi-sync` to support synced sessions/conversations. Current d
 
 ## Architecture
 
-Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` config flag, defaulting to `false`, that extends the collected file set with denylist-filtered session JSONL files only. Honor `PI_CODING_AGENT_DIR`, preserve remote session entries during settings-only operations, and protect the current live session JSONL during destructive applies. Do not add real-time collaborative editing; this remains file snapshot sync.
+Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` config flag, defaulting to `false`, that extends the collected file set with denylist-filtered session JSONL files only. Honor `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, Pi `sessionDir`, and the session manager's custom directory, preserve remote session entries during settings-only operations, and protect the current live session JSONL during destructive applies. Do not add real-time collaborative editing; this remains file snapshot sync.
 
 ## Non-Goals
 
@@ -32,6 +32,7 @@ Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` conf
 - [x] Preserve remote session state for opted-out clients: settings-only pushes/rollbacks keep valid remote session JSONL entries, preserve empty session-aware snapshots, avoid rescanning preserved remote sessions, and ignore session-only remote advances when settings hashes match; verified by `settings-only uploads preserve remote session files` and `settings hash maps ignore session differences for first sync checks` in `npm test`.
 - [x] Update `extensions/pi-sync/README.md` to document `syncSessions`, `PI_SYNC_SESSIONS`, `PI_CODING_AGENT_DIR`, denylisted session paths, privacy risks, non-real-time behavior, conflict expectations, and the recovery path from `${PI_CODING_AGENT_DIR:-~/.pi/agent}/.pisync/backups/`; verified by README review and `rg -n "syncSessions|PI_SYNC_SESSIONS|PI_CODING_AGENT_DIR|sessions" extensions/pi-sync/README.md`.
 - [x] Run package checks for the smallest affected surface and final PR verification; verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, `npm test -- --workspace @narumitw/pi-sync`, `npm run check`, `npm run pack:sync`, and GitHub `Check and test` passing.
+- [x] Address latest PR review feedback on configured session directories: external session roots preflight against the session root, incoming `settings.json` `sessionDir` decides the apply root unless CLI/env overrides it, nested configured session directories are not widened to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions`, `PI_CODING_AGENT_DIR` supports `~` and ignores empty values, `snapshotOptionsForContext` passes only snapshot fields, session apply preflight avoids the old current×remote nested scan, and startup session pulls warn that Pi has already selected the current session. Verified by `npm test -- --workspace @narumitw/pi-sync`, `npm run check`, and `npm run pack:sync` on 2026-06-19 after commit `26748e3`.
 
 ## Risks
 

--- a/docs/plans/archived/2026-06-19_pi-sync-session-sync-plan.md
+++ b/docs/plans/archived/2026-06-19_pi-sync-session-sync-plan.md
@@ -1,18 +1,18 @@
 ## Goal
 
-Add opt-in Pi conversation/session syncing to `@narumitw/pi-sync` for issue #99. Success means users can sync Pi JSONL sessions under `~/.pi/agent/sessions/` through the existing R2/S3 snapshot flow, with privacy warnings, backups, conflict protection, tests, and docs.
+Add opt-in Pi conversation/session syncing to `@narumitw/pi-sync` for issue #99. Success means users can sync Pi JSONL sessions under `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/` through the existing R2/S3 snapshot flow, with privacy warnings, backups, conflict protection, tests, and docs.
 
 ## Context
 
-Issue #99 asks for `pi-sync` to support synced sessions/conversations. Current docs explicitly said pi-sync did not sync Pi sessions. Pi stores sessions as JSONL under `~/.pi/agent/sessions/--<cwd>--/<timestamp>_<uuid>.jsonl`; session files are user data and may include prompts, tool output, paths, screenshots, or secrets.
+Issue #99 asks for `pi-sync` to support synced sessions/conversations. Current docs explicitly said pi-sync did not sync Pi sessions. Pi stores sessions as JSONL under `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/--<cwd>--/<timestamp>_<uuid>.jsonl`; session files are user data and may include prompts, tool output, paths, screenshots, or secrets.
 
 ## Architecture
 
-Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` config flag, defaulting to `false`, that extends the collected file set with session JSONL files only. Do not add real-time collaborative editing; this remains file snapshot sync.
+Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` config flag, defaulting to `false`, that extends the collected file set with denylist-filtered session JSONL files only. Honor `PI_CODING_AGENT_DIR`, preserve remote session entries during settings-only operations, and protect the current live session JSONL during destructive applies. Do not add real-time collaborative editing; this remains file snapshot sync.
 
 ## Non-Goals
 
-- Do not sync `auth.json`, OAuth state, npm caches, `.pisync`, `.env*`, or arbitrary files under `~/.pi/agent`.
+- Do not sync `auth.json`, OAuth state, npm caches, `.pisync`, `.env*`, or arbitrary files under `${PI_CODING_AGENT_DIR:-~/.pi/agent}`.
 - Do not support concurrent live editing of the same session file from multiple machines.
 - Do not add a new storage backend or database.
 
@@ -25,29 +25,30 @@ Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` conf
 
 - [x] Confirm the exact Pi session file shape and resume behavior against local Pi docs and one sample file; verified by `docs/sessions.md`, `docs/session-format.md`, `find ~/.pi/agent/sessions -name '*.jsonl' | head -5`, and a sample JSONL header showing `type: "session", version: 3`.
 - [x] Add `syncSessions?: boolean | string` config parsing to `extensions/pi-sync/src/sync.ts`, default `false`, with env override `PI_SYNC_SESSIONS`; verified by `syncSessions config defaults off and supports file plus env overrides` in `npm test`.
-- [x] Extend snapshot collection so `sessions/**/*.jsonl` is included only when `syncSessions` is enabled, while denying non-JSONL files, symlink escapes, `.pisync`, `.env*`, token/secret paths, and `node_modules`; verified by `snapshot collection includes session jsonl files only when enabled` and `snapshot preflight validates checksums, duplicate session paths, and deletes stale files` in `npm test`.
-- [x] Keep pull/rollback safety for sessions by reusing the current backup and preflight apply path, and add regression coverage for duplicate session paths, checksum mismatch, and local backup creation before applying a session snapshot; verified by `snapshot preflight validates checksums, duplicate session paths, and deletes stale files` and `session backups include session jsonl files when enabled` in `npm test`.
+- [x] Extend snapshot collection so `sessions/**/*.jsonl` is included only when `syncSessions` is enabled, while honoring `PI_CODING_AGENT_DIR` and denying non-JSONL files, symlink escapes, `.pisync`, `.env*`, token/secret paths, and `node_modules`; verified by `snapshot collection includes session jsonl files only when enabled`, `syncSessions config defaults off and supports file plus env overrides`, and `snapshot preflight validates checksums, duplicate session paths, and deletes stale files` in `npm test`.
+- [x] Keep pull/rollback safety for sessions by reusing the current backup and preflight apply path, protecting the current live session JSONL, and recording hashes for files actually applied; verified by `snapshot preflight validates checksums, duplicate session paths, and deletes stale files`, `protected session apply plans keep the live session file`, and `session backups include session jsonl files when enabled` in `npm test`.
 - [x] Update `/pisync config`, `/pisync doctor`, `/pisync status`, and `/pisync diff` output to show whether sessions are included and to warn that session contents may contain sensitive data; verified by `pisync config output reports session sync and privacy warning` in `npm test` and source review of `status`, `diff`, and `doctor` output.
-- [x] Decide whether auto-sync should push on `session_shutdown` when `autoSync` and `syncSessions` are enabled; implemented a quiet shutdown push guarded by `autoSync`, `syncSessions`, local-change detection, and the existing lock, with async shutdown support grounded in Pi extension docs and the `auto-commit-on-exit.ts` example.
-- [x] Update `extensions/pi-sync/README.md` to document `syncSessions`, `PI_SYNC_SESSIONS`, privacy risks, non-real-time behavior, conflict expectations, and the recovery path from `~/.pi/agent/.pisync/backups/`; verified by README review and `rg -n "syncSessions|PI_SYNC_SESSIONS|sessions" extensions/pi-sync/README.md`.
-- [x] Run package checks for the smallest affected surface; verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, and `npm run pack:sync`.
+- [x] Decide whether auto-sync should push on `session_shutdown` when `autoSync` and `syncSessions` are enabled; implemented a quiet shutdown push guarded by `autoSync`, `syncSessions`, local-change detection, non-reload shutdown, event-shape safety, and the existing lock, with async shutdown support grounded in Pi extension docs and the `auto-commit-on-exit.ts` example.
+- [x] Preserve remote session state for opted-out clients: settings-only pushes/rollbacks keep valid remote session JSONL entries, preserve empty session-aware snapshots, avoid rescanning preserved remote sessions, and ignore session-only remote advances when settings hashes match; verified by `settings-only uploads preserve remote session files` and `settings hash maps ignore session differences for first sync checks` in `npm test`.
+- [x] Update `extensions/pi-sync/README.md` to document `syncSessions`, `PI_SYNC_SESSIONS`, `PI_CODING_AGENT_DIR`, denylisted session paths, privacy risks, non-real-time behavior, conflict expectations, and the recovery path from `${PI_CODING_AGENT_DIR:-~/.pi/agent}/.pisync/backups/`; verified by README review and `rg -n "syncSessions|PI_SYNC_SESSIONS|PI_CODING_AGENT_DIR|sessions" extensions/pi-sync/README.md`.
+- [x] Run package checks for the smallest affected surface and final PR verification; verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, `npm test -- --workspace @narumitw/pi-sync`, `npm run check`, `npm run pack:sync`, and GitHub `Check and test` passing.
 
 ## Risks
 
 - [x] Session files can contain secrets; mitigated with default-off config, secret scanning, command warnings, and README privacy docs.
-- [x] Same session edited on two machines can still conflict; mitigated by existing remote-change checks and README snapshot/conflict docs.
-- [x] Session trees can be large; mitigated by including only `.jsonl` and relying on gzip snapshots.
+- [x] Same session edited on two machines can still conflict; mitigated by existing remote-change checks, first-sync session conflict guards, live-session protection, and README snapshot/conflict docs.
+- [x] Session trees can be large; mitigated by including only denylist-filtered `.jsonl`, avoiding unnecessary remote snapshot downloads when possible, and relying on gzip snapshots.
 
 ## Rollback / Recovery
 
 - Disable with `syncSessions: false` or `PI_SYNC_SESSIONS=false`.
-- Recover overwritten local session files from `~/.pi/agent/.pisync/backups/<snapshot>.json.gz` or by pulling an older remote snapshot with `/pisync rollback <snapshot-id>`.
+- Recover overwritten local session files from `${PI_CODING_AGENT_DIR:-~/.pi/agent}/.pisync/backups/<snapshot>.json.gz` or by pulling an older remote snapshot with `/pisync rollback <snapshot-id>`.
 - If the feature regresses, revert the `syncSessions` collection/config changes; existing settings-only sync continues to read old snapshots because they omit session files.
 
 ## Completion Checklist
 
 - [x] Session sync is opt-in and default-off, verified by config unit tests and `/pisync config` output test.
-- [x] Only `sessions/**/*.jsonl` is synced when enabled, verified by collection/filter tests and preflight rejection of non-JSONL session paths.
-- [x] Pull and rollback protect local session data with backups and preflight validation, verified by backup and preflight tests.
-- [x] User-facing docs explain privacy, non-real-time behavior, conflicts, env/config settings, and recovery, verified in `extensions/pi-sync/README.md`.
-- [x] The implementation passes the affected package checks and package dry run, verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, and `npm run pack:sync`.
+- [x] Only denylist-filtered `sessions/**/*.jsonl` is synced when enabled, verified by collection/filter tests and preflight rejection of non-JSONL session paths.
+- [x] Pull and rollback protect local session data with backups, live-session protection, and preflight validation, verified by backup and preflight tests.
+- [x] User-facing docs explain privacy, non-real-time behavior, conflicts, env/config settings, `PI_CODING_AGENT_DIR`, and recovery, verified in `extensions/pi-sync/README.md`.
+- [x] The implementation passes the affected package checks, package dry run, and PR CI, verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, `npm test -- --workspace @narumitw/pi-sync`, `npm run check`, `npm run pack:sync`, and GitHub `Check and test` passing.

--- a/docs/plans/archived/2026-06-19_pi-sync-session-sync-plan.md
+++ b/docs/plans/archived/2026-06-19_pi-sync-session-sync-plan.md
@@ -1,0 +1,53 @@
+## Goal
+
+Add opt-in Pi conversation/session syncing to `@narumitw/pi-sync` for issue #99. Success means users can sync Pi JSONL sessions under `~/.pi/agent/sessions/` through the existing R2/S3 snapshot flow, with privacy warnings, backups, conflict protection, tests, and docs.
+
+## Context
+
+Issue #99 asks for `pi-sync` to support synced sessions/conversations. Current docs explicitly said pi-sync did not sync Pi sessions. Pi stores sessions as JSONL under `~/.pi/agent/sessions/--<cwd>--/<timestamp>_<uuid>.jsonl`; session files are user data and may include prompts, tool output, paths, screenshots, or secrets.
+
+## Architecture
+
+Keep the existing S3/R2 snapshot model and local lock. Add a `syncSessions` config flag, defaulting to `false`, that extends the collected file set with session JSONL files only. Do not add real-time collaborative editing; this remains file snapshot sync.
+
+## Non-Goals
+
+- Do not sync `auth.json`, OAuth state, npm caches, `.pisync`, `.env*`, or arbitrary files under `~/.pi/agent`.
+- Do not support concurrent live editing of the same session file from multiple machines.
+- Do not add a new storage backend or database.
+
+## Assumptions
+
+- “Synchronous conversations” in issue #99 means Pi session/conversation files, not live multi-user chat.
+- Opt-in is required because sessions are more sensitive than settings.
+
+## Plan
+
+- [x] Confirm the exact Pi session file shape and resume behavior against local Pi docs and one sample file; verified by `docs/sessions.md`, `docs/session-format.md`, `find ~/.pi/agent/sessions -name '*.jsonl' | head -5`, and a sample JSONL header showing `type: "session", version: 3`.
+- [x] Add `syncSessions?: boolean | string` config parsing to `extensions/pi-sync/src/sync.ts`, default `false`, with env override `PI_SYNC_SESSIONS`; verified by `syncSessions config defaults off and supports file plus env overrides` in `npm test`.
+- [x] Extend snapshot collection so `sessions/**/*.jsonl` is included only when `syncSessions` is enabled, while denying non-JSONL files, symlink escapes, `.pisync`, `.env*`, token/secret paths, and `node_modules`; verified by `snapshot collection includes session jsonl files only when enabled` and `snapshot preflight validates checksums, duplicate session paths, and deletes stale files` in `npm test`.
+- [x] Keep pull/rollback safety for sessions by reusing the current backup and preflight apply path, and add regression coverage for duplicate session paths, checksum mismatch, and local backup creation before applying a session snapshot; verified by `snapshot preflight validates checksums, duplicate session paths, and deletes stale files` and `session backups include session jsonl files when enabled` in `npm test`.
+- [x] Update `/pisync config`, `/pisync doctor`, `/pisync status`, and `/pisync diff` output to show whether sessions are included and to warn that session contents may contain sensitive data; verified by `pisync config output reports session sync and privacy warning` in `npm test` and source review of `status`, `diff`, and `doctor` output.
+- [x] Decide whether auto-sync should push on `session_shutdown` when `autoSync` and `syncSessions` are enabled; implemented a quiet shutdown push guarded by `autoSync`, `syncSessions`, local-change detection, and the existing lock, with async shutdown support grounded in Pi extension docs and the `auto-commit-on-exit.ts` example.
+- [x] Update `extensions/pi-sync/README.md` to document `syncSessions`, `PI_SYNC_SESSIONS`, privacy risks, non-real-time behavior, conflict expectations, and the recovery path from `~/.pi/agent/.pisync/backups/`; verified by README review and `rg -n "syncSessions|PI_SYNC_SESSIONS|sessions" extensions/pi-sync/README.md`.
+- [x] Run package checks for the smallest affected surface; verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, and `npm run pack:sync`.
+
+## Risks
+
+- [x] Session files can contain secrets; mitigated with default-off config, secret scanning, command warnings, and README privacy docs.
+- [x] Same session edited on two machines can still conflict; mitigated by existing remote-change checks and README snapshot/conflict docs.
+- [x] Session trees can be large; mitigated by including only `.jsonl` and relying on gzip snapshots.
+
+## Rollback / Recovery
+
+- Disable with `syncSessions: false` or `PI_SYNC_SESSIONS=false`.
+- Recover overwritten local session files from `~/.pi/agent/.pisync/backups/<snapshot>.json.gz` or by pulling an older remote snapshot with `/pisync rollback <snapshot-id>`.
+- If the feature regresses, revert the `syncSessions` collection/config changes; existing settings-only sync continues to read old snapshots because they omit session files.
+
+## Completion Checklist
+
+- [x] Session sync is opt-in and default-off, verified by config unit tests and `/pisync config` output test.
+- [x] Only `sessions/**/*.jsonl` is synced when enabled, verified by collection/filter tests and preflight rejection of non-JSONL session paths.
+- [x] Pull and rollback protect local session data with backups and preflight validation, verified by backup and preflight tests.
+- [x] User-facing docs explain privacy, non-real-time behavior, conflicts, env/config settings, and recovery, verified in `extensions/pi-sync/README.md`.
+- [x] The implementation passes the affected package checks and package dry run, verified by `npm --workspace @narumitw/pi-sync run typecheck`, `npm --workspace @narumitw/pi-sync run check`, `npm test`, and `npm run pack:sync`.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -97,7 +97,7 @@ pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TO
 
 ### Session syncing
 
-`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `~/.pi/agent/sessions/**/*.jsonl` in snapshots. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
+`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/**/*.jsonl` in snapshots. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
 
 Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -103,7 +103,7 @@ Session sync is snapshot-based, not live collaboration. If the same session chan
 
 When both `autoSync` and `syncSessions` are enabled, pi-sync syncs on startup and attempts a quiet session push on shutdown when local files changed. If the remote changed first, the shutdown push is skipped with a warning instead of overwriting it.
 
-Session files can contain prompts, model output, tool results, file paths, images, and secrets. Use trusted R2/S3 storage, keep credentials local, and recover local files from `~/.pi/agent/.pisync/backups/` if a pull or rollback overwrites something unexpectedly.
+Session files can contain prompts, model output, tool results, file paths, images, and secrets. Use trusted R2/S3 storage, keep credentials local, and recover local files from `${PI_CODING_AGENT_DIR:-~/.pi/agent}/.pisync/backups/` if a pull or rollback overwrites something unexpectedly.
 
 ## 🚀 Usage
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-sync` is a native [Pi coding agent](https://pi.dev) extension that syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage.
 
-It syncs automatically by default when Pi starts, then uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups. Cross-machine pushes use a best-effort remote re-read guard because R2 rejected conditional `latest.json` writes during testing.
+It syncs automatically by default when Pi starts, then uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups. Conversation/session syncing is opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets. Cross-machine pushes use a best-effort remote re-read guard because R2 rejected conditional `latest.json` writes during testing.
 
 ## ✨ Features
 
@@ -15,6 +15,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
   - `models.json`
   - `AGENTS.md`
   - `skills/`, `prompts/`, `themes/`, and `extensions/`
+  - optionally `sessions/**/*.jsonl` when `syncSessions` is enabled
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
 - Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
@@ -66,7 +67,8 @@ Example:
   "secretAccessKey": "<secret-access-key>",
   "profile": "default",
   "prefix": "pi-sync",
-  "autoSync": true
+  "autoSync": true,
+  "syncSessions": false
 }
 ```
 
@@ -82,6 +84,7 @@ export PI_SYNC_SESSION_TOKEN="..." # optional, for temporary credentials that re
 export PI_SYNC_PROFILE="default"
 export PI_SYNC_PREFIX="pi-sync"
 export PI_SYNC_AUTO_SYNC="true"
+export PI_SYNC_SESSIONS="false" # opt in with true to sync Pi conversation JSONL files
 ```
 
 `PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, assumed roles, or S3-compatible providers that issue short-lived credentials.
@@ -89,6 +92,16 @@ export PI_SYNC_AUTO_SYNC="true"
 Cloudflare R2 static access keys do not use a session token and usually reject requests signed with `X-Amz-Security-Token`. R2 temporary credentials that require a token are still supported. For R2 endpoints (`*.r2.cloudflarestorage.com`), pi-sync first sends the configured session token; if R2 rejects it with `InvalidArgument: X-Amz-Security-Token`, pi-sync retries that request once without the token and omits the token for the rest of the same command after a successful retry.
 
 pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set.
+
+### Session syncing
+
+`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `~/.pi/agent/sessions/**/*.jsonl` in snapshots. Only JSONL session files are included; other session-directory files are ignored.
+
+Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
+
+When both `autoSync` and `syncSessions` are enabled, pi-sync syncs on startup and attempts a quiet session push on shutdown when local files changed. If the remote changed first, the shutdown push is skipped with a warning instead of overwriting it.
+
+Session files can contain prompts, model output, tool results, file paths, images, and secrets. Use trusted R2/S3 storage, keep credentials local, and recover local files from `~/.pi/agent/.pisync/backups/` if a pull or rollback overwrites something unexpectedly.
 
 ## 🚀 Usage
 
@@ -157,7 +170,7 @@ Before updating `latest.json`, pi-sync re-reads the current pointer and rejects 
 ## 🛡️ Safety notes
 
 - pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
-- pi-sync does not sync Pi sessions, OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
+- pi-sync does not sync Pi sessions unless `syncSessions`/`PI_SYNC_SESSIONS` is enabled. It never syncs OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
 - If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/pisync unlock --stale` is intended for locks whose process is gone or invalid.
 - If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
 - Pull and rollback create backups before writing local files, then preflight deletes and writes before mutating the local settings tree.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -15,7 +15,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
   - `models.json`
   - `AGENTS.md`
   - `skills/`, `prompts/`, `themes/`, and `extensions/`
-  - optionally `sessions/**/*.jsonl` when `syncSessions` is enabled
+  - optionally denylist-filtered `sessions/**/*.jsonl` when `syncSessions` is enabled
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
 - Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
@@ -95,7 +95,7 @@ pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TO
 
 ### Session syncing
 
-`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `~/.pi/agent/sessions/**/*.jsonl` in snapshots. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files are ignored.
+`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `~/.pi/agent/sessions/**/*.jsonl` in snapshots. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
 
 Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
 
@@ -170,7 +170,7 @@ Before updating `latest.json`, pi-sync re-reads the current pointer and rejects 
 ## 🛡️ Safety notes
 
 - pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
-- pi-sync does not sync Pi sessions unless `syncSessions`/`PI_SYNC_SESSIONS` is enabled. It never syncs OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
+- With `syncSessions`/`PI_SYNC_SESSIONS` disabled, pi-sync does not collect or apply local Pi sessions, though settings-only pushes may preserve session files already present in remote snapshots. It never syncs OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
 - If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/pisync unlock --stale` is intended for locks whose process is gone or invalid.
 - If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
 - Pull and rollback create backups before writing local files, then preflight deletes and writes before mutating the local settings tree.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -101,7 +101,7 @@ pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TO
 
 Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
 
-When both `autoSync` and `syncSessions` are enabled, pi-sync syncs on startup and attempts a quiet session push on shutdown when local files changed. If the remote changed first, the shutdown push is skipped with a warning instead of overwriting it.
+When both `autoSync` and `syncSessions` are enabled, pi-sync syncs on startup and attempts a quiet session push on shutdown when local files changed. Startup session pulls happen after Pi has already selected the current session, so restart Pi or resume a pulled session to use newly synced conversations. If the remote changed first, the shutdown push is skipped with a warning instead of overwriting it.
 
 Session files can contain prompts, model output, tool results, file paths, images, and secrets. Use trusted R2/S3 storage, keep credentials local, and recover local files from `${PI_CODING_AGENT_DIR:-~/.pi/agent}/.pisync/backups/` if a pull or rollback overwrites something unexpectedly.
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -56,6 +56,8 @@ Then edit:
 ~/.pi/agent/pi-sync.local.json
 ```
 
+If `PI_CODING_AGENT_DIR` is set, pi-sync uses that directory instead of `~/.pi/agent` for config, state, backups, and synced files.
+
 Example:
 
 ```json

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -97,7 +97,7 @@ pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TO
 
 ### Session syncing
 
-`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/**/*.jsonl` in snapshots. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
+`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include Pi's configured session JSONL files in snapshots. pi-sync uses `PI_CODING_AGENT_SESSION_DIR`, Pi's `sessionDir` setting, or the default `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/**/*.jsonl` storage. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
 
 Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -95,7 +95,7 @@ pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TO
 
 ### Session syncing
 
-`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `~/.pi/agent/sessions/**/*.jsonl` in snapshots. Only JSONL session files are included; other session-directory files are ignored.
+`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include `~/.pi/agent/sessions/**/*.jsonl` in snapshots. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files are ignored.
 
 Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -153,8 +153,8 @@ export default function sync(pi: ExtensionAPI) {
 		await autoSync(ctx);
 	});
 
-	pi.on("session_shutdown", async (_event, ctx) => {
-		await autoPushSessions(ctx);
+	pi.on("session_shutdown", async (event, ctx) => {
+		if (event.reason !== "reload") await autoPushSessions(ctx);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 }
@@ -398,23 +398,24 @@ async function push(
 	const client = input?.client ?? new S3Client(config);
 	const state = input?.state ?? (await readState(config.profile));
 	const local = input?.local ?? (await createSnapshot(config.profile, config));
-	const secrets = scanSnapshot(local);
-	if (secrets.length > 0) {
-		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
-	}
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	if (remoteChangedSinceState(latest, state, config) && !options.force) {
 		throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
 	}
 
-	if (!options.yes && !(await ctx.ui.confirm("Push pi settings?", formatPushSummary(local, latest)))) {
+	const upload = await snapshotForUpload(client, config, local, latest);
+	const secrets = scanSnapshot(upload);
+	if (secrets.length > 0) {
+		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
+	}
+
+	if (!options.yes && !(await ctx.ui.confirm("Push pi settings?", formatPushSummary(upload, latest)))) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		ctx.ui.notify("Push cancelled.", "info");
 		return;
 	}
 
-	const upload = await snapshotForUpload(client, config, local, latest);
 	const pointer = await uploadSnapshot(client, config, upload, latest, options.force);
 	await updateHistory(client, config, pointer);
 	await writeState(config.profile, {
@@ -484,6 +485,9 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
 		}
 		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
+			if (!canPullRemoteSessionsOnFirstSync(local, remote)) {
+				throw new Error("Remote settings match, but local and remote Pi sessions differ. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+			}
 			await pull(ctx, options);
 			return;
 		}
@@ -561,12 +565,12 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
-		lastAppliedSnapshot: remote.id,
+		lastAppliedSnapshot: pointer.snapshot,
 		lastRemoteEtag: undefined,
 		lastFileHashes: fileHashMap(remote),
 		syncSessions: config.syncSessions,
 	});
-	ctx.ui.notify(`Rolled back to ${remote.id}. Backup: ${backup}`, "info");
+	ctx.ui.notify(`Rolled back to ${target}; latest: ${pointer.snapshot}. Backup: ${backup}`, "info");
 	await maybeReload(ctx);
 }
 
@@ -781,9 +785,9 @@ function filterSnapshotForSessionPolicy(
 	};
 }
 
-function snapshotWithoutSessions(snapshot: Snapshot) {
+export function snapshotWithoutSessions(snapshot: Snapshot) {
 	const files = snapshot.files.filter((file) => !isSessionPath(file.path));
-	if (files.length === snapshot.files.length) return snapshot;
+	if (files.length === snapshot.files.length && snapshot.syncSessions !== true) return snapshot;
 	return {
 		...snapshot,
 		id: snapshotId(),
@@ -1058,6 +1062,18 @@ export function settingsHashMap(snapshot: Snapshot) {
 			.filter((file) => !isSessionPath(file.path))
 			.map((file) => [file.path, file.sha256]),
 	);
+}
+
+export function sessionHashMap(snapshot: Snapshot) {
+	return Object.fromEntries(
+		snapshot.files.filter((file) => isSessionPath(file.path)).map((file) => [file.path, file.sha256]),
+	);
+}
+
+export function canPullRemoteSessionsOnFirstSync(local: Snapshot, remote: Snapshot) {
+	const localSessions = sessionHashMap(local);
+	const remoteSessions = sessionHashMap(remote);
+	return Object.entries(localSessions).every(([filePath, hash]) => remoteSessions[filePath] === hash);
 }
 
 async function readState(profile: string): Promise<SyncState> {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -964,7 +964,8 @@ export function preflightSnapshotApply(
 			!normalized ||
 			normalized.startsWith("../") ||
 			path.posix.isAbsolute(normalized) ||
-			path.posix.normalize(normalized) !== normalized
+			path.posix.normalize(normalized) !== normalized ||
+			isDeniedPath(normalized)
 		) {
 			throw new Error(`Unsafe path in snapshot: ${file.path}`);
 		}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -843,13 +843,17 @@ async function snapshotForUpload(
 	latest: RemoteObject<LatestPointer>,
 	remote?: Snapshot,
 ) {
-	if (config.syncSessions || latest.missing || !latest.value) return local;
+	if (config.syncSessions || latest.missing || !latest.value || latest.value.syncSessions !== true) {
+		return local;
+	}
 	const snapshot = remote ?? (await readRemoteSnapshotRaw(client, config));
 	return snapshot ? mergeRemoteSessionFiles(local, snapshot) : local;
 }
 
 export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
-	const remoteSessions = remote.files.filter((file) => isSessionPath(file.path));
+	const remoteSessions = remote.files.filter(
+		(file) => isSessionFilePath(file.path) && !isDeniedPath(file.path),
+	);
 	if (remoteSessions.length === 0) return local;
 	return {
 		...local,
@@ -1084,8 +1088,10 @@ function remoteChangedSinceState(
 	return config.syncSessions && state.syncSessions !== true && latest.value?.syncSessions === true;
 }
 
-function hasRemoteChanges(remote: Snapshot, state: SyncState, config: SyncConfig) {
-	if (remote.id !== state.lastAppliedSnapshot) return true;
+export function hasRemoteChanges(remote: Snapshot, state: SyncState, config: SyncConfig) {
+	if (remote.id !== state.lastAppliedSnapshot) {
+		return config.syncSessions || !settingsHashesMatchState(remote, state);
+	}
 	return config.syncSessions && state.syncSessions !== true && snapshotIncludesSessions(remote);
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1468,7 +1468,7 @@ function usage() {
 	return [
 		"Usage: /pisync <command>",
 		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json when PI_CODING_AGENT_DIR is set).",
 	].join("\n");
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -400,17 +400,28 @@ async function push(
 	const local = input?.local ?? (await createSnapshot(config.profile, config));
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
+	const remoteForUpload = await readRemoteSnapshotForSettingsOnlyUpload(client, config, latest, state);
 	if (remoteChangedSinceState(latest, state, config) && !options.force) {
-		throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
+		if (!remoteForUpload || !settingsHashesMatchState(remoteForUpload, state)) {
+			throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
+		}
 	}
 
-	const upload = await snapshotForUpload(client, config, local, latest);
-	const secrets = scanSnapshot(upload);
+	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload);
+	const scanTarget = config.syncSessions ? upload : local;
+	const secrets = scanSnapshot(scanTarget);
 	if (secrets.length > 0) {
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
 
-	if (!options.yes && !(await ctx.ui.confirm("Push pi settings?", formatPushSummary(upload, latest)))) {
+	const preservedRemoteSessionCount = Math.max(0, countSessionFiles(upload) - countSessionFiles(local));
+	if (
+		!options.yes &&
+		!(await ctx.ui.confirm(
+			"Push pi settings?",
+			formatPushSummary(upload, latest, preservedRemoteSessionCount),
+		))
+	) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		ctx.ui.notify("Push cancelled.", "info");
 		return;
@@ -814,15 +825,27 @@ export function scanSnapshot(snapshot: Snapshot) {
 	return findings;
 }
 
+async function readRemoteSnapshotForSettingsOnlyUpload(
+	client: S3Client,
+	config: SyncConfig,
+	latest: RemoteObject<LatestPointer>,
+	state: SyncState,
+) {
+	if (config.syncSessions || latest.missing || !latest.value) return undefined;
+	if (!latest.value.syncSessions && latest.value.snapshot === state.lastAppliedSnapshot) return undefined;
+	return readRemoteSnapshotRaw(client, config);
+}
+
 async function snapshotForUpload(
 	client: S3Client,
 	config: SyncConfig,
 	local: Snapshot,
 	latest: RemoteObject<LatestPointer>,
+	remote?: Snapshot,
 ) {
 	if (config.syncSessions || latest.missing || !latest.value) return local;
-	const remote = await readRemoteSnapshotRaw(client, config);
-	return remote ? mergeRemoteSessionFiles(local, remote) : local;
+	const snapshot = remote ?? (await readRemoteSnapshotRaw(client, config));
+	return snapshot ? mergeRemoteSessionFiles(local, snapshot) : local;
 }
 
 export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
@@ -1013,11 +1036,17 @@ function formatSnapshotOnlyDiff(title: string, snapshot: Snapshot) {
 	return [`${title}: ${snapshot.id}`, ...snapshot.files.map((file) => `+ ${file.path}`)].join("\n");
 }
 
-function formatPushSummary(local: Snapshot, latest: RemoteObject<LatestPointer>) {
+function formatPushSummary(
+	local: Snapshot,
+	latest: RemoteObject<LatestPointer>,
+	preservedRemoteSessionCount = 0,
+) {
 	return [
 		`Upload ${local.files.length} files from ${agentDir()}.`,
 		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
-		"Possible secrets were scanned before this prompt.",
+		preservedRemoteSessionCount > 0
+			? `Possible secrets in local files were scanned before this prompt; ${preservedRemoteSessionCount} preserved remote session file(s) were not rescanned.`
+			: "Possible secrets were scanned before this prompt.",
 	].join("\n");
 }
 
@@ -1056,6 +1085,10 @@ function fileHashMap(snapshot: Snapshot) {
 	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
 }
 
+function countSessionFiles(snapshot: Snapshot) {
+	return snapshot.files.filter((file) => isSessionPath(file.path)).length;
+}
+
 export function settingsHashMap(snapshot: Snapshot) {
 	return Object.fromEntries(
 		snapshot.files
@@ -1068,6 +1101,16 @@ export function sessionHashMap(snapshot: Snapshot) {
 	return Object.fromEntries(
 		snapshot.files.filter((file) => isSessionPath(file.path)).map((file) => [file.path, file.sha256]),
 	);
+}
+
+export function settingsHashMapFromState(state: SyncState) {
+	return Object.fromEntries(
+		Object.entries(state.lastFileHashes).filter(([filePath]) => !isSessionPath(filePath)),
+	);
+}
+
+export function settingsHashesMatchState(remote: Snapshot, state: SyncState) {
+	return sameHashes(settingsHashMap(remote), settingsHashMapFromState(state));
 }
 
 export function canPullRemoteSessionsOnFirstSync(local: Snapshot, remote: Snapshot) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -116,6 +116,7 @@ interface CommandOptions {
 
 interface SnapshotOptions {
 	syncSessions?: boolean;
+	sessionDir?: string;
 }
 
 interface PushInput {
@@ -237,7 +238,7 @@ async function autoPushSessions(ctx: ExtensionContext) {
 		if (!config.syncSessions) return;
 		await withLock("auto-session-push", async () => {
 			const state = await readState(config.profile);
-			const local = await createSnapshot(config.profile, config);
+			const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 			if (!hasLocalChanges(local, state)) return;
 			await push(ctx, AUTO_SYNC_OPTIONS, { config, state, local });
 		});
@@ -301,7 +302,7 @@ async function status(ctx: ExtensionCommandContext) {
 	ctx.ui.setStatus(STATUS_KEY, "🔄 checking");
 	const config = await loadConfig();
 	const client = new S3Client(config);
-	const local = await createSnapshot(config.profile, config);
+	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const state = await readState(config.profile);
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const localChanged = hasLocalChanges(local, state);
@@ -332,7 +333,7 @@ async function diff(ctx: ExtensionCommandContext) {
 	ctx.ui.setStatus(STATUS_KEY, "🔄 diff");
 	const config = await loadConfig();
 	const client = new S3Client(config);
-	const local = await createSnapshot(config.profile, config);
+	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 
@@ -361,7 +362,7 @@ async function doctor(ctx: ExtensionCommandContext) {
 	try {
 		const config = await loadConfig();
 		profile = config.profile;
-		snapshotOptions = config;
+		snapshotOptions = snapshotOptionsForContext(ctx, config);
 		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
 		messages.push(`sessions: ${config.syncSessions ? "included" : "excluded"}`);
 		const warnings = [...sessionTokenWarnings(config), ...syncSessionsWarnings(config)];
@@ -398,7 +399,7 @@ async function push(
 	const config = input?.config ?? (await loadConfig());
 	const client = input?.client ?? new S3Client(config);
 	const state = input?.state ?? (await readState(config.profile));
-	const local = input?.local ?? (await createSnapshot(config.profile, config));
+	const local = input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const remoteForUpload = await readRemoteSnapshotForSettingsOnlyUpload(client, config, latest, state);
@@ -449,7 +450,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
-	const local = await createSnapshot(config.profile, config);
+	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
 	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
 
@@ -471,8 +472,8 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		return;
 	}
 
-	const backup = await backupLocal(config.profile, config);
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx));
+	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), sessionDirFromContext(ctx));
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
@@ -492,7 +493,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
-	const local = await createSnapshot(config.profile, config);
+	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
 	const localChanged = hasLocalChanges(local, state);
 	const remoteChanged = remote ? hasRemoteChanges(remote, state, config) : false;
@@ -577,8 +578,8 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		return;
 	}
 
-	const backup = await backupLocal(config.profile, config);
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx));
+	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), sessionDirFromContext(ctx));
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const upload = await snapshotForUpload(client, config, remote, latest);
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
@@ -618,10 +619,24 @@ function protectedSessionPaths(ctx: ExtensionCommandContext | ExtensionContext) 
 	const getSessionFile = ctx.sessionManager.getSessionFile;
 	if (typeof getSessionFile !== "function") return new Set<string>();
 	const sessionFile = getSessionFile.call(ctx.sessionManager) as string | undefined;
-	if (!sessionFile) return new Set<string>();
-	const relativePath = toPosix(path.relative(agentDir(), sessionFile));
-	if (!isSessionFilePath(relativePath) || relativePath.startsWith("../")) return new Set<string>();
-	return new Set([relativePath]);
+	const snapshotPath = sessionFile
+		? sessionSnapshotPathFromAbsolute(sessionFile, sessionDirFromContext(ctx))
+		: undefined;
+	return snapshotPath ? new Set([snapshotPath]) : new Set<string>();
+}
+
+function snapshotOptionsForContext(
+	ctx: ExtensionCommandContext | ExtensionContext,
+	config: SyncConfig,
+): SnapshotOptions {
+	return { ...config, sessionDir: sessionDirFromContext(ctx) };
+}
+
+function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) {
+	const getSessionDir = ctx.sessionManager.getSessionDir;
+	return typeof getSessionDir === "function"
+		? (getSessionDir.call(ctx.sessionManager) as string | undefined)
+		: undefined;
 }
 
 async function maybeReload(ctx: ExtensionCommandContext | ExtensionContext) {
@@ -714,9 +729,20 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 	};
 }
 
+async function configuredSessionDir() {
+	if (process.env.PI_CODING_AGENT_SESSION_DIR) {
+		return expandHome(process.env.PI_CODING_AGENT_SESSION_DIR);
+	}
+	const settings = await readJsonIfExists<{ sessionDir?: string }>(path.join(agentDir(), "settings.json"));
+	return settings?.sessionDir ? expandHome(settings.sessionDir) : undefined;
+}
+
 async function createSnapshot(profile: string, options: SnapshotOptions = {}): Promise<Snapshot> {
 	const syncSessions = Boolean(options.syncSessions);
-	const files = await collectFiles(agentDir(), { syncSessions });
+	const files = await collectFiles(agentDir(), {
+		syncSessions,
+		sessionDir: options.sessionDir ?? (await configuredSessionDir()),
+	});
 	return {
 		version: VERSION,
 		id: snapshotId(),
@@ -738,8 +764,16 @@ export async function collectFiles(
 			await addFile(results, root, entry.name);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
-		} else if (entry.isDirectory() && entry.name === "sessions" && options.syncSessions) {
-			await collectDirectory(results, root, entry.name, { sessionsOnly: true });
+		}
+	}
+	if (options.syncSessions) {
+		try {
+			await collectDirectory(results, sessionStorageRoot(root, options.sessionDir), "", {
+				sessionsOnly: true,
+				virtualPrefix: "sessions",
+			});
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 		}
 	}
 	return results.sort((left, right) => left.path.localeCompare(right.path));
@@ -749,25 +783,33 @@ async function collectDirectory(
 	results: SnapshotFile[],
 	root: string,
 	relativeDirectory: string,
-	options: { sessionsOnly?: boolean } = {},
+	options: { sessionsOnly?: boolean; virtualPrefix?: string } = {},
 ) {
 	const absoluteDirectory = path.join(root, relativeDirectory);
 	for (const entry of await fs.readdir(absoluteDirectory, { withFileTypes: true })) {
-		const relativePath = posixJoin(relativeDirectory, entry.name);
-		if (isDeniedPath(relativePath)) continue;
+		const relativePath = relativeDirectory ? posixJoin(relativeDirectory, entry.name) : entry.name;
+		const snapshotPath = options.virtualPrefix
+			? posixJoin(options.virtualPrefix, relativePath)
+			: relativePath;
+		if (isDeniedPath(snapshotPath)) continue;
 		if (entry.isDirectory()) {
 			await collectDirectory(results, root, relativePath, options);
-		} else if (entry.isFile() && (!options.sessionsOnly || isSessionFilePath(relativePath))) {
-			await addFile(results, root, relativePath);
+		} else if (entry.isFile() && (!options.sessionsOnly || isSessionFilePath(snapshotPath))) {
+			await addFile(results, root, relativePath, snapshotPath);
 		}
 	}
 }
 
-async function addFile(results: SnapshotFile[], root: string, relativePath: string) {
-	if (isDeniedPath(relativePath)) return;
+async function addFile(
+	results: SnapshotFile[],
+	root: string,
+	relativePath: string,
+	snapshotPath = relativePath,
+) {
+	if (isDeniedPath(snapshotPath)) return;
 	const absolutePath = safeJoin(root, relativePath);
 	const content = await fs.readFile(absolutePath);
-	results.push({ path: relativePath, contentBase64: content.toString("base64"), sha256: sha256(content) });
+	results.push({ path: snapshotPath, contentBase64: content.toString("base64"), sha256: sha256(content) });
 }
 
 export function isDeniedPath(relativePath: string) {
@@ -793,6 +835,34 @@ function isSessionPath(relativePath: string) {
 function isSessionFilePath(relativePath: string) {
 	const normalized = toPosix(relativePath);
 	return isSessionPath(normalized) && normalized.endsWith(".jsonl");
+}
+
+function sessionStorageRoot(root: string, configuredSessionDir?: string) {
+	const defaultRoot = path.resolve(root, "sessions");
+	if (!configuredSessionDir) return defaultRoot;
+	const resolved = path.resolve(expandHome(configuredSessionDir));
+	return isPathInside(defaultRoot, resolved) ? defaultRoot : resolved;
+}
+
+function sessionSnapshotPathFromAbsolute(sessionFile: string, configuredSessionDir?: string) {
+	const relativePath = toPosix(path.relative(sessionStorageRoot(agentDir(), configuredSessionDir), sessionFile));
+	if (!relativePath || relativePath.startsWith("../") || path.posix.isAbsolute(relativePath)) {
+		return undefined;
+	}
+	const snapshotPath = posixJoin("sessions", relativePath);
+	return isSessionFilePath(snapshotPath) ? snapshotPath : undefined;
+}
+
+function snapshotTarget(root: string, relativePath: string, configuredSessionDir?: string) {
+	if (isSessionPath(relativePath)) {
+		return safeJoin(sessionStorageRoot(root, configuredSessionDir), relativePath.slice("sessions/".length));
+	}
+	return safeJoin(root, relativePath);
+}
+
+function isPathInside(parent: string, child: string) {
+	const relativePath = path.relative(parent, child);
+	return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
 function snapshotIncludesSessions(snapshot: Snapshot) {
@@ -928,15 +998,21 @@ async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
 	return parsed;
 }
 
-async function applySnapshot(snapshot: Snapshot, protectedRelativePaths = new Set<string>()) {
+async function applySnapshot(
+	snapshot: Snapshot,
+	protectedRelativePaths = new Set<string>(),
+	sessionDir?: string,
+) {
 	const root = agentDir();
 	const current = await createSnapshot(snapshot.profile, {
 		syncSessions: snapshotIncludesSessions(snapshot),
+		sessionDir,
 	});
 	const plan = protectSnapshotApplyPlan(
 		root,
-		preflightSnapshotApply(root, snapshot, current),
+		preflightSnapshotApply(root, snapshot, current, { sessionDir }),
 		protectedRelativePaths,
+		sessionDir,
 	);
 	await preflightSnapshotMutations(root, plan);
 	for (const target of plan.deletes) {
@@ -952,6 +1028,7 @@ export function preflightSnapshotApply(
 	root: string,
 	snapshot: Snapshot,
 	current: Snapshot,
+	options: { sessionDir?: string } = {},
 ): SnapshotApplyPlan {
 	const seenPaths = new Set<string>();
 	const remotePaths = new Set<string>();
@@ -976,7 +1053,7 @@ export function preflightSnapshotApply(
 		seenPaths.add(normalized);
 		remotePaths.add(normalized);
 
-		const target = safeJoin(root, normalized);
+		const target = snapshotTarget(root, normalized, options.sessionDir);
 		const content = decodeBase64Strict(file.contentBase64, normalized);
 		if (sha256(content) !== file.sha256) throw new Error(`Checksum mismatch in snapshot file: ${normalized}`);
 		writes.push({ target, content });
@@ -985,9 +1062,13 @@ export function preflightSnapshotApply(
 	const deletePaths = new Set<string>();
 	for (const file of current.files) {
 		const normalized = toPosix(file.path);
-		if (!remotePaths.has(normalized)) deletePaths.add(safeJoin(root, normalized));
+		if (!remotePaths.has(normalized)) {
+			deletePaths.add(snapshotTarget(root, normalized, options.sessionDir));
+		}
 		for (const remotePath of remotePaths) {
-			if (normalized.startsWith(`${remotePath}/`)) deletePaths.add(safeJoin(root, remotePath));
+			if (normalized.startsWith(`${remotePath}/`)) {
+				deletePaths.add(snapshotTarget(root, remotePath, options.sessionDir));
+			}
 		}
 	}
 	deletes.push(...deletePaths);
@@ -999,10 +1080,11 @@ export function protectSnapshotApplyPlan(
 	root: string,
 	plan: SnapshotApplyPlan,
 	protectedRelativePaths: Set<string>,
+	sessionDir?: string,
 ): SnapshotApplyPlan {
 	if (protectedRelativePaths.size === 0) return plan;
 	const protectedTargets = new Set(
-		[...protectedRelativePaths].map((relativePath) => safeJoin(root, relativePath)),
+		[...protectedRelativePaths].map((relativePath) => snapshotTarget(root, relativePath, sessionDir)),
 	);
 	return {
 		writes: plan.writes.filter((item) => !protectedTargets.has(item.target)),
@@ -1340,6 +1422,12 @@ function pointerFor(config: SyncConfig, snapshot: Snapshot, checksum: string): L
 
 function agentDir() {
 	return process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), ".pi", "agent");
+}
+
+function expandHome(value: string) {
+	return value === "~" || value.startsWith("~/")
+		? path.join(os.homedir(), value.slice(2))
+		: value;
 }
 
 function stateDir() {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -843,7 +843,7 @@ async function snapshotForUpload(
 	latest: RemoteObject<LatestPointer>,
 	remote?: Snapshot,
 ) {
-	if (config.syncSessions || latest.missing || !latest.value || latest.value.syncSessions !== true) {
+	if (config.syncSessions || latest.missing || !latest.value || latest.value.syncSessions === false) {
 		return local;
 	}
 	const snapshot = remote ?? (await readRemoteSnapshotRaw(client, config));
@@ -854,7 +854,7 @@ export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
 	const remoteSessions = remote.files.filter(
 		(file) => isSessionFilePath(file.path) && !isDeniedPath(file.path),
 	);
-	if (remoteSessions.length === 0) return local;
+	if (remoteSessions.length === 0 && !snapshotIncludesSessions(remote)) return local;
 	return {
 		...local,
 		id: snapshotId(),
@@ -1318,7 +1318,7 @@ function pointerFor(config: SyncConfig, snapshot: Snapshot, checksum: string): L
 }
 
 function agentDir() {
-	return path.join(os.homedir(), ".pi", "agent");
+	return process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), ".pi", "agent");
 }
 
 function stateDir() {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -40,6 +40,7 @@ interface SyncConfig {
 	sessionToken?: string;
 	profile: string;
 	prefix: string;
+	syncSessions: boolean;
 }
 
 interface PartialConfig {
@@ -52,6 +53,7 @@ interface PartialConfig {
 	profile?: string;
 	prefix?: string;
 	autoSync?: boolean | string;
+	syncSessions?: boolean | string;
 }
 
 interface SnapshotFile {
@@ -66,6 +68,7 @@ interface Snapshot {
 	createdAt: string;
 	machine: string;
 	profile: string;
+	syncSessions?: boolean;
 	files: SnapshotFile[];
 }
 
@@ -109,6 +112,10 @@ interface CommandOptions {
 	args: string[];
 }
 
+interface SnapshotOptions {
+	syncSessions?: boolean;
+}
+
 const AUTO_SYNC_OPTIONS: CommandOptions = {
 	yes: true,
 	force: false,
@@ -132,7 +139,8 @@ export default function sync(pi: ExtensionAPI) {
 		await autoSync(ctx);
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
+	pi.on("session_shutdown", async (_event, ctx) => {
+		await autoPushSessions(ctx);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 }
@@ -204,6 +212,27 @@ async function autoSync(ctx: ExtensionContext) {
 	}
 }
 
+async function autoPushSessions(ctx: ExtensionContext) {
+	try {
+		const partial = await loadPartialConfig();
+		if (!isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true)) return;
+		if (!isEnabled(partial.syncSessions, false)) return;
+		await ensureStateDir();
+		const config = await loadConfig();
+		if (!config.syncSessions) return;
+		await withLock("auto-session-push", async () => {
+			const state = await readState(config.profile);
+			const local = await createSnapshot(config.profile, config);
+			if (!hasLocalChanges(local, state)) return;
+			await push(ctx, AUTO_SYNC_OPTIONS);
+		});
+	} catch (error) {
+		if (isMissingConfigError(error)) return;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.notify(`pi-sync session push skipped: ${errorMessage(error)}`, "warning");
+	}
+}
+
 async function initConfig(ctx: ExtensionCommandContext) {
 	const configPath = localConfigPath();
 	try {
@@ -223,6 +252,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 		profile: DEFAULT_PROFILE,
 		prefix: DEFAULT_PREFIX,
 		autoSync: true,
+		syncSessions: false,
 	};
 	await writeJson(configPath, sample);
 	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /pisync doctor.`, "info");
@@ -230,7 +260,8 @@ async function initConfig(ctx: ExtensionCommandContext) {
 
 async function showConfig(ctx: ExtensionCommandContext) {
 	const partial = await loadPartialConfig();
-	const warnings = sessionTokenWarnings(partial);
+	const syncSessions = isEnabled(partial.syncSessions, false);
+	const warnings = [...sessionTokenWarnings(partial), ...syncSessionsWarnings({ syncSessions })];
 	ctx.ui.notify(
 		[
 			"pi-sync config:",
@@ -243,6 +274,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 			`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
 			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
 			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
+			`syncSessions: ${syncSessions ? "enabled" : "disabled"}`,
 			`local config: ${localConfigPath()}`,
 			...warnings,
 		].join("\n"),
@@ -254,7 +286,7 @@ async function status(ctx: ExtensionCommandContext) {
 	ctx.ui.setStatus(STATUS_KEY, "🔄 checking");
 	const config = await loadConfig();
 	const client = new S3Client(config);
-	const local = await createSnapshot(config.profile);
+	const local = await createSnapshot(config.profile, config);
 	const state = await readState(config.profile);
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const localChanged = hasLocalChanges(local, state);
@@ -266,16 +298,19 @@ async function status(ctx: ExtensionCommandContext) {
 		remoteText = `remote: ${latest.value.snapshot} from ${latest.value.machine} at ${latest.value.createdAt}`;
 	}
 
+	const warnings = syncSessionsWarnings(config);
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	ctx.ui.notify(
 		[
 			`profile: ${config.profile}`,
+			`sessions: ${config.syncSessions ? "included" : "excluded"}`,
 			remoteText,
 			`local files: ${local.files.length}`,
 			`local changed since last sync: ${localChanged ? "yes" : "no"}`,
 			`remote changed since last sync: ${remoteChanged ? "yes" : "no"}`,
+			...warnings,
 		].join("\n"),
-		localChanged || remoteChanged ? "warning" : "info",
+		localChanged || remoteChanged || warnings.length > 0 ? "warning" : "info",
 	);
 }
 
@@ -283,26 +318,39 @@ async function diff(ctx: ExtensionCommandContext) {
 	ctx.ui.setStatus(STATUS_KEY, "🔄 diff");
 	const config = await loadConfig();
 	const client = new S3Client(config);
-	const local = await createSnapshot(config.profile);
+	const local = await createSnapshot(config.profile, config);
 	const remote = await readRemoteSnapshot(client, config);
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 
+	const warnings = syncSessionsWarnings(config);
+	const header = [`sessions: ${config.syncSessions ? "included" : "excluded"}`, ...warnings].join(
+		"\n",
+	);
+	const level = warnings.length > 0 ? "warning" : "info";
 	if (!remote) {
-		ctx.ui.notify(formatSnapshotOnlyDiff("Remote is empty. Local push would upload", local), "info");
+		ctx.ui.notify(
+			`${header}\n\n${formatSnapshotOnlyDiff("Remote is empty. Local push would upload", local)}`,
+			level,
+		);
 		return;
 	}
 
-	ctx.ui.notify(formatDiff(local, remote), "info");
+	ctx.ui.notify(`${header}\n\n${formatDiff(local, remote)}`, level);
 }
 
 async function doctor(ctx: ExtensionCommandContext) {
 	const messages: string[] = [];
 	let level: "info" | "warning" = "info";
+	let snapshotOptions: SnapshotOptions = {};
+	let profile = DEFAULT_PROFILE;
 
 	try {
 		const config = await loadConfig();
+		profile = config.profile;
+		snapshotOptions = config;
 		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
-		const warnings = sessionTokenWarnings(config);
+		messages.push(`sessions: ${config.syncSessions ? "included" : "excluded"}`);
+		const warnings = [...sessionTokenWarnings(config), ...syncSessionsWarnings(config)];
 		if (warnings.length > 0) {
 			level = "warning";
 			messages.push(...warnings);
@@ -312,7 +360,7 @@ async function doctor(ctx: ExtensionCommandContext) {
 		messages.push(`config: ${errorMessage(error)}`);
 	}
 
-	const local = await createSnapshot(DEFAULT_PROFILE);
+	const local = await createSnapshot(profile, snapshotOptions);
 	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
 		level = "warning";
@@ -332,7 +380,7 @@ async function push(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
-	const local = await createSnapshot(config.profile);
+	const local = await createSnapshot(config.profile, config);
 	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
@@ -369,7 +417,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
-	const local = await createSnapshot(config.profile);
+	const local = await createSnapshot(config.profile, config);
 	const remote = await readRemoteSnapshot(client, config);
 	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
 
@@ -385,7 +433,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		return;
 	}
 
-	const backup = await backupLocal(config.profile);
+	const backup = await backupLocal(config.profile, config);
 	await applySnapshot(remote);
 	await writeState(config.profile, {
 		version: VERSION,
@@ -405,7 +453,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);
-	const local = await createSnapshot(config.profile);
+	const local = await createSnapshot(config.profile, config);
 	const remote = await readRemoteSnapshot(client, config);
 	const localChanged = hasLocalChanges(local, state);
 	const remoteChanged = remote ? remote.id !== state.lastAppliedSnapshot : false;
@@ -466,14 +514,14 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const client = new S3Client(config);
 	const snapshot = await client.getBuffer(snapshotKey(config, target));
 	if (!snapshot.value) throw new Error(`Snapshot not found: ${target}`);
-	const remote = await decodeSnapshot(snapshot.value);
+	const remote = filterSnapshotForSessionPolicy(await decodeSnapshot(snapshot.value), config.syncSessions);
 
 	if (!options.yes && !(await ctx.ui.confirm("Rollback pi settings?", formatSnapshotOnlyDiff("Rollback would apply", remote)))) {
 		ctx.ui.notify("Rollback cancelled.", "info");
 		return;
 	}
 
-	const backup = await backupLocal(config.profile);
+	const backup = await backupLocal(config.profile, config);
 	await applySnapshot(remote);
 	const pointer = pointerFor(config, remote, sha256(snapshot.value));
 	await client.putJson(latestKey(config), pointer);
@@ -541,7 +589,7 @@ async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
 	}
 }
 
-async function loadConfig(): Promise<SyncConfig> {
+async function loadConfigInternal(): Promise<SyncConfig> {
 	const partial = await loadPartialConfig();
 	const endpoint = partial.endpoint;
 	const bucket = partial.bucket;
@@ -568,7 +616,12 @@ async function loadConfig(): Promise<SyncConfig> {
 		sessionToken: partial.sessionToken,
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
+		syncSessions: isEnabled(partial.syncSessions, false),
 	};
+}
+
+export async function loadConfig(): Promise<SyncConfig> {
+	return loadConfigInternal();
 }
 
 async function loadPartialConfig(): Promise<PartialConfig> {
@@ -584,41 +637,54 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		profile: process.env.PI_SYNC_PROFILE ?? fileConfig.profile,
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
+		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
 	};
 }
 
-async function createSnapshot(profile: string): Promise<Snapshot> {
-	const files = await collectFiles(agentDir());
+async function createSnapshot(profile: string, options: SnapshotOptions = {}): Promise<Snapshot> {
+	const syncSessions = Boolean(options.syncSessions);
+	const files = await collectFiles(agentDir(), { syncSessions });
 	return {
 		version: VERSION,
 		id: snapshotId(),
 		createdAt: new Date().toISOString(),
 		machine: os.hostname(),
 		profile,
+		syncSessions,
 		files,
 	};
 }
 
-async function collectFiles(root: string): Promise<SnapshotFile[]> {
+export async function collectFiles(
+	root: string,
+	options: SnapshotOptions = {},
+): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
 	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
 		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
 			await addFile(results, root, entry.name);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
+		} else if (entry.isDirectory() && entry.name === "sessions" && options.syncSessions) {
+			await collectDirectory(results, root, entry.name, { sessionsOnly: true });
 		}
 	}
 	return results.sort((left, right) => left.path.localeCompare(right.path));
 }
 
-async function collectDirectory(results: SnapshotFile[], root: string, relativeDirectory: string) {
+async function collectDirectory(
+	results: SnapshotFile[],
+	root: string,
+	relativeDirectory: string,
+	options: { sessionsOnly?: boolean } = {},
+) {
 	const absoluteDirectory = path.join(root, relativeDirectory);
 	for (const entry of await fs.readdir(absoluteDirectory, { withFileTypes: true })) {
 		const relativePath = posixJoin(relativeDirectory, entry.name);
 		if (isDeniedPath(relativePath)) continue;
 		if (entry.isDirectory()) {
-			await collectDirectory(results, root, relativePath);
-		} else if (entry.isFile()) {
+			await collectDirectory(results, root, relativePath, options);
+		} else if (entry.isFile() && (!options.sessionsOnly || isSessionFilePath(relativePath))) {
 			await addFile(results, root, relativePath);
 		}
 	}
@@ -645,6 +711,28 @@ export function isDeniedPath(relativePath: string) {
 		base.includes("token") ||
 		base === "pi-sync.local.json"
 	);
+}
+
+function isSessionPath(relativePath: string) {
+	return toPosix(relativePath).startsWith("sessions/");
+}
+
+function isSessionFilePath(relativePath: string) {
+	const normalized = toPosix(relativePath);
+	return isSessionPath(normalized) && normalized.endsWith(".jsonl");
+}
+
+function snapshotIncludesSessions(snapshot: Snapshot) {
+	return snapshot.syncSessions === true || snapshot.files.some((file) => isSessionPath(file.path));
+}
+
+function filterSnapshotForSessionPolicy(snapshot: Snapshot, syncSessions: boolean): Snapshot {
+	if (syncSessions) return snapshot;
+	return {
+		...snapshot,
+		syncSessions: false,
+		files: snapshot.files.filter((file) => !isSessionPath(file.path)),
+	};
 }
 
 export function scanSnapshot(snapshot: Snapshot) {
@@ -691,7 +779,7 @@ async function readRemoteSnapshot(client: S3Client, config: SyncConfig) {
 	const object = await client.getBuffer(snapshotKey(config, latest.value.snapshot));
 	if (!object.value) throw new Error(`Remote latest points to missing snapshot: ${latest.value.snapshot}`);
 	if (sha256(object.value) !== latest.value.sha256) throw new Error("Remote snapshot checksum mismatch.");
-	return decodeSnapshot(object.value);
+	return filterSnapshotForSessionPolicy(await decodeSnapshot(object.value), config.syncSessions);
 }
 
 async function encodeSnapshot(snapshot: Snapshot) {
@@ -707,7 +795,9 @@ async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
 
 async function applySnapshot(snapshot: Snapshot) {
 	const root = agentDir();
-	const current = await createSnapshot(snapshot.profile);
+	const current = await createSnapshot(snapshot.profile, {
+		syncSessions: snapshotIncludesSessions(snapshot),
+	});
 	const plan = preflightSnapshotApply(root, snapshot, current);
 	await preflightSnapshotMutations(root, plan);
 	for (const target of plan.deletes) {
@@ -728,6 +818,9 @@ export function preflightSnapshotApply(root: string, snapshot: Snapshot, current
 		const normalized = toPosix(file.path);
 		if (!normalized || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
 			throw new Error(`Unsafe path in snapshot: ${file.path}`);
+		}
+		if (isSessionPath(normalized) && !isSessionFilePath(normalized)) {
+			throw new Error(`Unsafe session path in snapshot: ${file.path}`);
 		}
 		if (seenPaths.has(normalized)) throw new Error(`Duplicate path in snapshot: ${normalized}`);
 		seenPaths.add(normalized);
@@ -759,8 +852,8 @@ function decodeBase64Strict(value: string, filePath: string) {
 	return Buffer.from(value, "base64");
 }
 
-async function backupLocal(profile: string) {
-	const snapshot = await createSnapshot(profile);
+export async function backupLocal(profile: string, options: SnapshotOptions = {}) {
+	const snapshot = await createSnapshot(profile, options);
 	const backupDirectory = path.join(stateDir(), "backups");
 	await fs.mkdir(backupDirectory, { recursive: true });
 	const backupPath = path.join(backupDirectory, `${snapshot.id}.json.gz`);
@@ -1158,7 +1251,7 @@ function usage() {
 	return [
 		"Usage: /pisync <command>",
 		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN (ignored for R2)/region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN/region/profile/prefix/sessions, or edit ~/.pi/agent/pi-sync.local.json.",
 	].join("\n");
 }
 
@@ -1211,6 +1304,13 @@ export function sessionTokenWarnings(config: { endpoint?: string; sessionToken?:
 	if (!isCloudflareR2Endpoint(config.endpoint) || !config.sessionToken) return [];
 	return [
 		"session token: configured for Cloudflare R2; if R2 rejects X-Amz-Security-Token, pi-sync retries once without it. R2 static access keys usually do not need a session token.",
+	];
+}
+
+function syncSessionsWarnings(config: { syncSessions?: boolean }) {
+	if (!config.syncSessions) return [];
+	return [
+		"sessions: enabled; Pi session JSONL can contain prompts, tool output, file paths, images, and secrets. Sync sessions only to storage you trust.",
 	];
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -473,7 +473,8 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	}
 
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), sessionDirFromContext(ctx));
+	const applySessionDir = await sessionDirForApply(ctx, remote);
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), applySessionDir);
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
@@ -485,6 +486,11 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
 		ctx.ui.notify(`Pulled ${remote.files.length} files from ${remote.id}. Backup: ${backup}`, "info");
+	} else if (options.auto && config.syncSessions && snapshotIncludesSessions(remote)) {
+		ctx.ui.notify(
+			"Pulled Pi sessions after startup selected the current session. Restart Pi or resume a pulled session to use newly synced conversations.",
+			"warning",
+		);
 	}
 	if (options.reload) await maybeReload(ctx);
 }
@@ -579,7 +585,8 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	}
 
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), sessionDirFromContext(ctx));
+	const applySessionDir = await sessionDirForApply(ctx, remote);
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), applySessionDir);
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const upload = await snapshotForUpload(client, config, remote, latest);
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
@@ -629,13 +636,20 @@ function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
 	config: SyncConfig,
 ): SnapshotOptions {
-	return { ...config, sessionDir: sessionDirFromContext(ctx) };
+	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx) };
 }
 
 function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) {
-	const getSessionDir = ctx.sessionManager.getSessionDir;
+	const manager = ctx.sessionManager as typeof ctx.sessionManager & {
+		usesDefaultSessionDir?: () => boolean;
+	};
+	const usesDefaultSessionDir = manager.usesDefaultSessionDir;
+	if (typeof usesDefaultSessionDir === "function" && usesDefaultSessionDir.call(manager)) {
+		return undefined;
+	}
+	const getSessionDir = manager.getSessionDir;
 	return typeof getSessionDir === "function"
-		? (getSessionDir.call(ctx.sessionManager) as string | undefined)
+		? (getSessionDir.call(manager) as string | undefined)
 		: undefined;
 }
 
@@ -730,11 +744,35 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 }
 
 async function configuredSessionDir() {
-	if (process.env.PI_CODING_AGENT_SESSION_DIR) {
-		return expandHome(process.env.PI_CODING_AGENT_SESSION_DIR);
-	}
+	const envSessionDir = normalizeOptionalString(process.env.PI_CODING_AGENT_SESSION_DIR);
+	if (envSessionDir) return expandHome(envSessionDir);
 	const settings = await readJsonIfExists<{ sessionDir?: string }>(path.join(agentDir(), "settings.json"));
 	return settings?.sessionDir ? expandHome(settings.sessionDir) : undefined;
+}
+
+async function sessionDirForApply(ctx: ExtensionCommandContext | ExtensionContext, snapshot: Snapshot) {
+	const contextSessionDir = sessionDirFromContext(ctx);
+	const envSessionDir = normalizeOptionalString(process.env.PI_CODING_AGENT_SESSION_DIR);
+	if (envSessionDir) return contextSessionDir ?? expandHome(envSessionDir);
+
+	const localSessionDir = await configuredSessionDir();
+	if (contextSessionDir && path.resolve(contextSessionDir) !== path.resolve(localSessionDir ?? "")) {
+		return contextSessionDir;
+	}
+	return sessionDirFromSnapshot(snapshot) ?? contextSessionDir;
+}
+
+function sessionDirFromSnapshot(snapshot: Snapshot) {
+	const settingsFile = snapshot.files.find((file) => file.path === "settings.json");
+	if (!settingsFile) return undefined;
+	try {
+		const settings = JSON.parse(
+			decodeBase64Strict(settingsFile.contentBase64, settingsFile.path).toString("utf8"),
+		) as { sessionDir?: string };
+		return settings.sessionDir ? expandHome(settings.sessionDir) : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 async function createSnapshot(profile: string, options: SnapshotOptions = {}): Promise<Snapshot> {
@@ -838,10 +876,7 @@ function isSessionFilePath(relativePath: string) {
 }
 
 function sessionStorageRoot(root: string, configuredSessionDir?: string) {
-	const defaultRoot = path.resolve(root, "sessions");
-	if (!configuredSessionDir) return defaultRoot;
-	const resolved = path.resolve(expandHome(configuredSessionDir));
-	return isPathInside(defaultRoot, resolved) ? defaultRoot : resolved;
+	return configuredSessionDir ? path.resolve(expandHome(configuredSessionDir)) : path.resolve(root, "sessions");
 }
 
 function sessionSnapshotPathFromAbsolute(sessionFile: string, configuredSessionDir?: string) {
@@ -1014,7 +1049,7 @@ async function applySnapshot(
 		protectedRelativePaths,
 		sessionDir,
 	);
-	await preflightSnapshotMutations(root, plan);
+	await preflightSnapshotMutations(root, plan, sessionDir);
 	for (const target of plan.deletes) {
 		await fs.rm(target, { force: true, recursive: true });
 	}
@@ -1065,8 +1100,8 @@ export function preflightSnapshotApply(
 		if (!remotePaths.has(normalized)) {
 			deletePaths.add(snapshotTarget(root, normalized, options.sessionDir));
 		}
-		for (const remotePath of remotePaths) {
-			if (normalized.startsWith(`${remotePath}/`)) {
+		for (const remotePath of parentPaths(normalized)) {
+			if (remotePaths.has(remotePath)) {
 				deletePaths.add(snapshotTarget(root, remotePath, options.sessionDir));
 			}
 		}
@@ -1421,7 +1456,8 @@ function pointerFor(config: SyncConfig, snapshot: Snapshot, checksum: string): L
 }
 
 function agentDir() {
-	return process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), ".pi", "agent");
+	const configured = normalizeOptionalString(process.env.PI_CODING_AGENT_DIR);
+	return configured ? expandHome(configured) : path.join(os.homedir(), ".pi", "agent");
 }
 
 function expandHome(value: string) {
@@ -1482,14 +1518,21 @@ async function writeJson(filePath: string, value: unknown) {
 async function preflightSnapshotMutations(
 	root: string,
 	plan: { deletes: string[]; writes: Array<{ target: string; content: Buffer }> },
+	sessionDir?: string,
 ) {
 	const deletePaths = new Set(plan.deletes);
 	for (const target of plan.deletes) {
-		await assertNoSymlinkParents(root, target);
+		await assertNoSymlinkParents(rootForTarget(root, target, sessionDir), target);
 	}
 	for (const item of plan.writes) {
-		await prepareSnapshotWrite(root, item.target, deletePaths);
+		await prepareSnapshotWrite(rootForTarget(root, item.target, sessionDir), item.target, deletePaths);
 	}
+}
+
+function rootForTarget(root: string, target: string, sessionDir?: string) {
+	const sessionRoot = sessionDir ? sessionStorageRoot(root, sessionDir) : undefined;
+	if (sessionRoot && isPathInside(sessionRoot, target)) return sessionRoot;
+	return root;
 }
 
 async function prepareSnapshotWrite(root: string, target: string, deletePaths: Set<string>) {
@@ -1594,6 +1637,16 @@ export function encodeKey(key: string) {
 
 export function posixJoin(...parts: string[]) {
 	return parts.map((part) => trimSlashes(part)).filter(Boolean).join("/");
+}
+
+function parentPaths(relativePath: string) {
+	const results: string[] = [];
+	let index = relativePath.lastIndexOf("/");
+	while (index > 0) {
+		results.push(relativePath.slice(0, index));
+		index = relativePath.lastIndexOf("/", index - 1);
+	}
+	return results;
 }
 
 function toPosix(value: string) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -79,6 +79,7 @@ interface LatestPointer {
 	sha256: string;
 	createdAt: string;
 	machine: string;
+	syncSessions?: boolean;
 }
 
 interface RemoteObject<T> {
@@ -93,6 +94,7 @@ interface SyncState {
 	lastAppliedSnapshot?: string;
 	lastRemoteEtag?: string;
 	lastFileHashes: Record<string, string>;
+	syncSessions?: boolean;
 }
 
 interface LockFile {
@@ -114,6 +116,18 @@ interface CommandOptions {
 
 interface SnapshotOptions {
 	syncSessions?: boolean;
+}
+
+interface PushInput {
+	config: SyncConfig;
+	state: SyncState;
+	local: Snapshot;
+	client?: S3Client;
+}
+
+interface SnapshotApplyPlan {
+	writes: Array<{ target: string; content: Buffer }>;
+	deletes: string[];
 }
 
 const AUTO_SYNC_OPTIONS: CommandOptions = {
@@ -216,7 +230,7 @@ async function autoPushSessions(ctx: ExtensionContext) {
 	try {
 		const partial = await loadPartialConfig();
 		if (!isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true)) return;
-		if (!isEnabled(partial.syncSessions, false)) return;
+		if (!isExplicitlyEnabled(partial.syncSessions)) return;
 		await ensureStateDir();
 		const config = await loadConfig();
 		if (!config.syncSessions) return;
@@ -224,7 +238,7 @@ async function autoPushSessions(ctx: ExtensionContext) {
 			const state = await readState(config.profile);
 			const local = await createSnapshot(config.profile, config);
 			if (!hasLocalChanges(local, state)) return;
-			await push(ctx, AUTO_SYNC_OPTIONS);
+			await push(ctx, AUTO_SYNC_OPTIONS, { config, state, local });
 		});
 	} catch (error) {
 		if (isMissingConfigError(error)) return;
@@ -260,7 +274,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 
 async function showConfig(ctx: ExtensionCommandContext) {
 	const partial = await loadPartialConfig();
-	const syncSessions = isEnabled(partial.syncSessions, false);
+	const syncSessions = isExplicitlyEnabled(partial.syncSessions);
 	const warnings = [...sessionTokenWarnings(partial), ...syncSessionsWarnings({ syncSessions })];
 	ctx.ui.notify(
 		[
@@ -292,9 +306,8 @@ async function status(ctx: ExtensionCommandContext) {
 	const localChanged = hasLocalChanges(local, state);
 
 	let remoteText = "remote: empty";
-	let remoteChanged = false;
+	let remoteChanged = remoteChangedSinceState(latest, state, config);
 	if (!latest.missing && latest.value) {
-		remoteChanged = latest.value.snapshot !== state.lastAppliedSnapshot;
 		remoteText = `remote: ${latest.value.snapshot} from ${latest.value.machine} at ${latest.value.createdAt}`;
 	}
 
@@ -375,19 +388,23 @@ async function doctor(ctx: ExtensionCommandContext) {
 	ctx.ui.notify(messages.join("\n"), level);
 }
 
-async function push(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
+async function push(
+	ctx: ExtensionCommandContext | ExtensionContext,
+	options: CommandOptions,
+	input?: PushInput,
+) {
 	ctx.ui.setStatus(STATUS_KEY, "🔄 pushing");
-	const config = await loadConfig();
-	const client = new S3Client(config);
-	const state = await readState(config.profile);
-	const local = await createSnapshot(config.profile, config);
+	const config = input?.config ?? (await loadConfig());
+	const client = input?.client ?? new S3Client(config);
+	const state = input?.state ?? (await readState(config.profile));
+	const local = input?.local ?? (await createSnapshot(config.profile, config));
 	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	if (remoteChangedSinceState(latest, state) && !options.force) {
+	if (remoteChangedSinceState(latest, state, config) && !options.force) {
 		throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
 	}
 
@@ -397,7 +414,8 @@ async function push(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		return;
 	}
 
-	const pointer = await uploadSnapshot(client, config, local, latest, options.force);
+	const upload = await snapshotForUpload(client, config, local, latest);
+	const pointer = await uploadSnapshot(client, config, upload, latest, options.force);
 	await updateHistory(client, config, pointer);
 	await writeState(config.profile, {
 		version: VERSION,
@@ -405,10 +423,11 @@ async function push(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		lastAppliedSnapshot: pointer.snapshot,
 		lastRemoteEtag: undefined,
 		lastFileHashes: fileHashMap(local),
+		syncSessions: config.syncSessions,
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
-		ctx.ui.notify(`Pushed ${local.files.length} files as ${pointer.snapshot}.`, "info");
+		ctx.ui.notify(`Pushed ${upload.files.length} files as ${pointer.snapshot}.`, "info");
 	}
 }
 
@@ -422,7 +441,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
 
 	const localChanged = hasLocalChanges(local, state);
-	const remoteChanged = remote.id !== state.lastAppliedSnapshot;
+	const remoteChanged = hasRemoteChanges(remote, state, config);
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
 		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
 	}
@@ -434,13 +453,14 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	}
 
 	const backup = await backupLocal(config.profile, config);
-	await applySnapshot(remote);
+	await applySnapshot(remote, protectedSessionPaths(ctx));
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
 		lastAppliedSnapshot: remote.id,
 		lastRemoteEtag: undefined,
 		lastFileHashes: fileHashMap(remote),
+		syncSessions: config.syncSessions,
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
@@ -456,7 +476,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const local = await createSnapshot(config.profile, config);
 	const remote = await readRemoteSnapshot(client, config);
 	const localChanged = hasLocalChanges(local, state);
-	const remoteChanged = remote ? remote.id !== state.lastAppliedSnapshot : false;
+	const remoteChanged = remote ? hasRemoteChanges(remote, state, config) : false;
 	const firstSync = !state.lastAppliedSnapshot;
 
 	if (firstSync && remote && local.files.length > 0) {
@@ -469,6 +489,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			lastAppliedSnapshot: remote.id,
 			lastRemoteEtag: undefined,
 			lastFileHashes: fileHashMap(remote),
+			syncSessions: config.syncSessions,
 		});
 		if (!options.silent) ctx.ui.notify("pi-sync state initialized; local settings already match remote.", "info");
 		return;
@@ -514,7 +535,8 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const client = new S3Client(config);
 	const snapshot = await client.getBuffer(snapshotKey(config, target));
 	if (!snapshot.value) throw new Error(`Snapshot not found: ${target}`);
-	const remote = filterSnapshotForSessionPolicy(await decodeSnapshot(snapshot.value), config.syncSessions);
+	const decoded = await decodeSnapshot(snapshot.value);
+	const remote = config.syncSessions ? decoded : snapshotWithoutSessions(decoded);
 
 	if (!options.yes && !(await ctx.ui.confirm("Rollback pi settings?", formatSnapshotOnlyDiff("Rollback would apply", remote)))) {
 		ctx.ui.notify("Rollback cancelled.", "info");
@@ -522,8 +544,12 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	}
 
 	const backup = await backupLocal(config.profile, config);
-	await applySnapshot(remote);
-	const pointer = pointerFor(config, remote, sha256(snapshot.value));
+	await applySnapshot(remote, protectedSessionPaths(ctx));
+	const encoded = remote.id === decoded.id ? snapshot.value : await encodeSnapshot(remote);
+	if (remote.id !== decoded.id) {
+		await client.putBuffer(snapshotKey(config, remote.id), encoded, "application/gzip");
+	}
+	const pointer = pointerFor(config, remote, sha256(encoded));
 	await client.putJson(latestKey(config), pointer);
 	await updateHistory(client, config, pointer);
 	await writeState(config.profile, {
@@ -532,6 +558,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		lastAppliedSnapshot: remote.id,
 		lastRemoteEtag: undefined,
 		lastFileHashes: fileHashMap(remote),
+		syncSessions: config.syncSessions,
 	});
 	ctx.ui.notify(`Rolled back to ${remote.id}. Backup: ${backup}`, "info");
 	await maybeReload(ctx);
@@ -549,6 +576,16 @@ async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
 	}
 	await fs.rm(lockPath(), { force: true });
 	ctx.ui.notify("Removed stale pi-sync lock.", "info");
+}
+
+function protectedSessionPaths(ctx: ExtensionCommandContext | ExtensionContext) {
+	const getSessionFile = ctx.sessionManager.getSessionFile;
+	if (typeof getSessionFile !== "function") return new Set<string>();
+	const sessionFile = getSessionFile.call(ctx.sessionManager) as string | undefined;
+	if (!sessionFile) return new Set<string>();
+	const relativePath = toPosix(path.relative(agentDir(), sessionFile));
+	if (!isSessionFilePath(relativePath) || relativePath.startsWith("../")) return new Set<string>();
+	return new Set([relativePath]);
 }
 
 async function maybeReload(ctx: ExtensionCommandContext | ExtensionContext) {
@@ -616,7 +653,7 @@ async function loadConfigInternal(): Promise<SyncConfig> {
 		sessionToken: partial.sessionToken,
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
-		syncSessions: isEnabled(partial.syncSessions, false),
+		syncSessions: isExplicitlyEnabled(partial.syncSessions),
 	};
 }
 
@@ -726,12 +763,28 @@ function snapshotIncludesSessions(snapshot: Snapshot) {
 	return snapshot.syncSessions === true || snapshot.files.some((file) => isSessionPath(file.path));
 }
 
-function filterSnapshotForSessionPolicy(snapshot: Snapshot, syncSessions: boolean): Snapshot {
-	if (syncSessions) return snapshot;
+function filterSnapshotForSessionPolicy(
+	snapshot: Snapshot | undefined,
+	syncSessions: boolean,
+): Snapshot | undefined {
+	if (!snapshot || syncSessions) return snapshot;
 	return {
 		...snapshot,
 		syncSessions: false,
 		files: snapshot.files.filter((file) => !isSessionPath(file.path)),
+	};
+}
+
+function snapshotWithoutSessions(snapshot: Snapshot) {
+	const files = snapshot.files.filter((file) => !isSessionPath(file.path));
+	if (files.length === snapshot.files.length) return snapshot;
+	return {
+		...snapshot,
+		id: snapshotId(),
+		createdAt: new Date().toISOString(),
+		machine: os.hostname(),
+		syncSessions: false,
+		files,
 	};
 }
 
@@ -749,6 +802,29 @@ export function scanSnapshot(snapshot: Snapshot) {
 		}
 	}
 	return findings;
+}
+
+async function snapshotForUpload(
+	client: S3Client,
+	config: SyncConfig,
+	local: Snapshot,
+	latest: RemoteObject<LatestPointer>,
+) {
+	if (config.syncSessions || latest.missing || !latest.value?.syncSessions) return local;
+	const remote = await readRemoteSnapshotRaw(client, config);
+	return remote ? mergeRemoteSessionFiles(local, remote) : local;
+}
+
+export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
+	const remoteSessions = remote.files.filter((file) => isSessionPath(file.path));
+	if (remoteSessions.length === 0) return local;
+	return {
+		...local,
+		syncSessions: true,
+		files: [...local.files.filter((file) => !isSessionPath(file.path)), ...remoteSessions].sort(
+			(left, right) => left.path.localeCompare(right.path),
+		),
+	};
 }
 
 async function uploadSnapshot(
@@ -774,12 +850,16 @@ async function uploadSnapshot(
 }
 
 async function readRemoteSnapshot(client: S3Client, config: SyncConfig) {
+	return filterSnapshotForSessionPolicy(await readRemoteSnapshotRaw(client, config), config.syncSessions);
+}
+
+async function readRemoteSnapshotRaw(client: S3Client, config: SyncConfig) {
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	if (latest.missing || !latest.value) return undefined;
 	const object = await client.getBuffer(snapshotKey(config, latest.value.snapshot));
 	if (!object.value) throw new Error(`Remote latest points to missing snapshot: ${latest.value.snapshot}`);
 	if (sha256(object.value) !== latest.value.sha256) throw new Error("Remote snapshot checksum mismatch.");
-	return filterSnapshotForSessionPolicy(await decodeSnapshot(object.value), config.syncSessions);
+	return decodeSnapshot(object.value);
 }
 
 async function encodeSnapshot(snapshot: Snapshot) {
@@ -793,12 +873,16 @@ async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
 	return parsed;
 }
 
-async function applySnapshot(snapshot: Snapshot) {
+async function applySnapshot(snapshot: Snapshot, protectedRelativePaths = new Set<string>()) {
 	const root = agentDir();
 	const current = await createSnapshot(snapshot.profile, {
 		syncSessions: snapshotIncludesSessions(snapshot),
 	});
-	const plan = preflightSnapshotApply(root, snapshot, current);
+	const plan = protectSnapshotApplyPlan(
+		root,
+		preflightSnapshotApply(root, snapshot, current),
+		protectedRelativePaths,
+	);
 	await preflightSnapshotMutations(root, plan);
 	for (const target of plan.deletes) {
 		await fs.rm(target, { force: true, recursive: true });
@@ -808,7 +892,11 @@ async function applySnapshot(snapshot: Snapshot) {
 	}
 }
 
-export function preflightSnapshotApply(root: string, snapshot: Snapshot, current: Snapshot) {
+export function preflightSnapshotApply(
+	root: string,
+	snapshot: Snapshot,
+	current: Snapshot,
+): SnapshotApplyPlan {
 	const seenPaths = new Set<string>();
 	const remotePaths = new Set<string>();
 	const writes: Array<{ target: string; content: Buffer }> = [];
@@ -843,6 +931,21 @@ export function preflightSnapshotApply(root: string, snapshot: Snapshot, current
 	deletes.push(...deletePaths);
 
 	return { writes, deletes };
+}
+
+export function protectSnapshotApplyPlan(
+	root: string,
+	plan: SnapshotApplyPlan,
+	protectedRelativePaths: Set<string>,
+): SnapshotApplyPlan {
+	if (protectedRelativePaths.size === 0) return plan;
+	const protectedTargets = new Set(
+		[...protectedRelativePaths].map((relativePath) => safeJoin(root, relativePath)),
+	);
+	return {
+		writes: plan.writes.filter((item) => !protectedTargets.has(item.target)),
+		deletes: plan.deletes.filter((target) => !protectedTargets.has(target)),
+	};
 }
 
 function decodeBase64Strict(value: string, filePath: string) {
@@ -909,9 +1012,19 @@ function hasLocalChanges(local: Snapshot, state: SyncState) {
 	return !sameHashes(fileHashMap(local), state.lastFileHashes);
 }
 
-function remoteChangedSinceState(latest: RemoteObject<LatestPointer>, state: SyncState) {
+function remoteChangedSinceState(
+	latest: RemoteObject<LatestPointer>,
+	state: SyncState,
+	config: SyncConfig,
+) {
 	if (latest.missing) return Boolean(state.lastAppliedSnapshot);
-	return latest.value?.snapshot !== state.lastAppliedSnapshot;
+	if (latest.value?.snapshot !== state.lastAppliedSnapshot) return true;
+	return config.syncSessions && state.syncSessions !== true && latest.value?.syncSessions === true;
+}
+
+function hasRemoteChanges(remote: Snapshot, state: SyncState, config: SyncConfig) {
+	if (remote.id !== state.lastAppliedSnapshot) return true;
+	return config.syncSessions && state.syncSessions !== true && snapshotIncludesSessions(remote);
 }
 
 function remoteIdentity(remote: RemoteObject<LatestPointer>) {
@@ -1098,6 +1211,7 @@ function pointerFor(config: SyncConfig, snapshot: Snapshot, checksum: string): L
 		sha256: checksum,
 		createdAt: snapshot.createdAt,
 		machine: snapshot.machine,
+		syncSessions: snapshotIncludesSessions(snapshot),
 	};
 }
 
@@ -1251,7 +1365,7 @@ function usage() {
 	return [
 		"Usage: /pisync <command>",
 		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN/region/profile/prefix/sessions, or edit ~/.pi/agent/pi-sync.local.json.",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json.",
 	].join("\n");
 }
 
@@ -1345,6 +1459,11 @@ export function isEnabled(value: boolean | string | undefined, defaultValue: boo
 	if (value === undefined) return defaultValue;
 	if (typeof value === "boolean") return value;
 	return !["0", "false", "no", "off"].includes(value.trim().toLowerCase());
+}
+
+export function isExplicitlyEnabled(value: boolean | string | undefined) {
+	if (typeof value === "boolean") return value;
+	return ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? "");
 }
 
 function isMissingConfigError(error: unknown) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -480,8 +480,12 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const firstSync = !state.lastAppliedSnapshot;
 
 	if (firstSync && remote && local.files.length > 0) {
-		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
+		if (!sameHashes(settingsHashMap(local), settingsHashMap(remote))) {
 			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+		}
+		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
+			await pull(ctx, options);
+			return;
 		}
 		await writeState(config.profile, {
 			version: VERSION,
@@ -545,11 +549,13 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 
 	const backup = await backupLocal(config.profile, config);
 	await applySnapshot(remote, protectedSessionPaths(ctx));
-	const encoded = remote.id === decoded.id ? snapshot.value : await encodeSnapshot(remote);
-	if (remote.id !== decoded.id) {
-		await client.putBuffer(snapshotKey(config, remote.id), encoded, "application/gzip");
+	const latest = await client.getJson<LatestPointer>(latestKey(config));
+	const upload = await snapshotForUpload(client, config, remote, latest);
+	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
+	if (upload.id !== decoded.id) {
+		await client.putBuffer(snapshotKey(config, upload.id), encoded, "application/gzip");
 	}
-	const pointer = pointerFor(config, remote, sha256(encoded));
+	const pointer = pointerFor(config, upload, sha256(encoded));
 	await client.putJson(latestKey(config), pointer);
 	await updateHistory(client, config, pointer);
 	await writeState(config.profile, {
@@ -810,7 +816,7 @@ async function snapshotForUpload(
 	local: Snapshot,
 	latest: RemoteObject<LatestPointer>,
 ) {
-	if (config.syncSessions || latest.missing || !latest.value?.syncSessions) return local;
+	if (config.syncSessions || latest.missing || !latest.value) return local;
 	const remote = await readRemoteSnapshotRaw(client, config);
 	return remote ? mergeRemoteSessionFiles(local, remote) : local;
 }
@@ -820,6 +826,9 @@ export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
 	if (remoteSessions.length === 0) return local;
 	return {
 		...local,
+		id: snapshotId(),
+		createdAt: new Date().toISOString(),
+		machine: os.hostname(),
 		syncSessions: true,
 		files: [...local.files.filter((file) => !isSessionPath(file.path)), ...remoteSessions].sort(
 			(left, right) => left.path.localeCompare(right.path),
@@ -1041,6 +1050,14 @@ function sameHashes(left: Record<string, string>, right: Record<string, string>)
 
 function fileHashMap(snapshot: Snapshot) {
 	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
+}
+
+export function settingsHashMap(snapshot: Snapshot) {
+	return Object.fromEntries(
+		snapshot.files
+			.filter((file) => !isSessionPath(file.path))
+			.map((file) => [file.path, file.sha256]),
+	);
 }
 
 async function readState(profile: string): Promise<SyncState> {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -154,7 +154,8 @@ export default function sync(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", async (event, ctx) => {
-		if (event.reason !== "reload") await autoPushSessions(ctx);
+		const reason = typeof event === "object" && event ? (event as { reason?: string }).reason : undefined;
+		if (reason !== "reload") await autoPushSessions(ctx);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -419,7 +419,7 @@ async function push(
 	if (
 		!options.yes &&
 		!(await ctx.ui.confirm(
-			"Push pi settings?",
+			snapshotIncludesSessions(upload) ? "Push pi settings and sessions?" : "Push pi settings?",
 			formatPushSummary(upload, latest, preservedRemoteSessionCount),
 		))
 	) {
@@ -459,7 +459,13 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
 	}
 
-	if (!options.yes && !(await ctx.ui.confirm("Pull pi settings?", formatDiff(local, remote)))) {
+	if (
+		!options.yes &&
+		!(await ctx.ui.confirm(
+			snapshotIncludesSessions(remote) ? "Pull pi settings and sessions?" : "Pull pi settings?",
+			formatDiff(local, remote),
+		))
+	) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		ctx.ui.notify("Pull cancelled.", "info");
 		return;
@@ -558,7 +564,15 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const decoded = await decodeSnapshot(snapshot.value);
 	const remote = config.syncSessions ? decoded : snapshotWithoutSessions(decoded);
 
-	if (!options.yes && !(await ctx.ui.confirm("Rollback pi settings?", formatSnapshotOnlyDiff("Rollback would apply", remote)))) {
+	if (
+		!options.yes &&
+		!(await ctx.ui.confirm(
+			snapshotIncludesSessions(remote)
+				? "Rollback pi settings and sessions?"
+				: "Rollback pi settings?",
+			formatSnapshotOnlyDiff("Rollback would apply", remote),
+		))
+	) {
 		ctx.ui.notify("Rollback cancelled.", "info");
 		return;
 	}
@@ -946,7 +960,12 @@ export function preflightSnapshotApply(
 
 	for (const file of snapshot.files) {
 		const normalized = toPosix(file.path);
-		if (!normalized || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
+		if (
+			!normalized ||
+			normalized.startsWith("../") ||
+			path.posix.isAbsolute(normalized) ||
+			path.posix.normalize(normalized) !== normalized
+		) {
 			throw new Error(`Unsafe path in snapshot: ${file.path}`);
 		}
 		if (isSessionPath(normalized) && !isSessionFilePath(normalized)) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -465,13 +465,13 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	}
 
 	const backup = await backupLocal(config.profile, config);
-	await applySnapshot(remote, protectedSessionPaths(ctx));
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx));
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
 		lastAppliedSnapshot: remote.id,
 		lastRemoteEtag: undefined,
-		lastFileHashes: fileHashMap(remote),
+		lastFileHashes,
 		syncSessions: config.syncSessions,
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -563,7 +563,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	}
 
 	const backup = await backupLocal(config.profile, config);
-	await applySnapshot(remote, protectedSessionPaths(ctx));
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx));
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const upload = await snapshotForUpload(client, config, remote, latest);
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
@@ -578,7 +578,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		profile: config.profile,
 		lastAppliedSnapshot: pointer.snapshot,
 		lastRemoteEtag: undefined,
-		lastFileHashes: fileHashMap(remote),
+		lastFileHashes,
 		syncSessions: config.syncSessions,
 	});
 	ctx.ui.notify(`Rolled back to ${target}; latest: ${pointer.snapshot}. Backup: ${backup}`, "info");
@@ -926,6 +926,7 @@ async function applySnapshot(snapshot: Snapshot, protectedRelativePaths = new Se
 	for (const item of plan.writes) {
 		await fs.writeFile(item.target, item.content);
 	}
+	return appliedFileHashMap(snapshot, current, protectedRelativePaths);
 }
 
 export function preflightSnapshotApply(
@@ -982,6 +983,25 @@ export function protectSnapshotApplyPlan(
 		writes: plan.writes.filter((item) => !protectedTargets.has(item.target)),
 		deletes: plan.deletes.filter((target) => !protectedTargets.has(target)),
 	};
+}
+
+export function appliedFileHashMap(
+	snapshot: Snapshot,
+	current: Snapshot,
+	protectedRelativePaths: Set<string>,
+) {
+	const hashes = fileHashMap(snapshot);
+	if (protectedRelativePaths.size === 0) return hashes;
+	const currentHashes = fileHashMap(current);
+	for (const relativePath of protectedRelativePaths) {
+		const normalized = toPosix(relativePath);
+		if (currentHashes[normalized]) {
+			hashes[normalized] = currentHashes[normalized];
+		} else {
+			delete hashes[normalized];
+		}
+	}
+	return hashes;
 }
 
 function decodeBase64Strict(value: string, filePath: string) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -12,6 +12,7 @@ import sync, {
 	canPullRemoteSessionsOnFirstSync,
 	collectFiles,
 	encodeKey,
+	hasRemoteChanges,
 	isCloudflareR2Endpoint,
 	isDeniedPath,
 	isEnabled,
@@ -200,9 +201,20 @@ test("settings-only uploads preserve remote session files", () => {
 		path: "sessions/--project--/session.jsonl",
 		content: Buffer.from("remote"),
 	};
+	const invalidSession = {
+		path: "sessions/--project--/notes.txt",
+		content: Buffer.from("skip"),
+	};
+	const deniedSession = {
+		path: "sessions/--project--/token.jsonl",
+		content: Buffer.from("skip"),
+	};
 	const local = snapshot([settings]);
 
-	const merged = mergeRemoteSessionFiles(local, snapshot([remoteSession]));
+	const merged = mergeRemoteSessionFiles(
+		local,
+		snapshot([remoteSession, invalidSession, deniedSession]),
+	);
 
 	assert.notEqual(merged.id, local.id);
 	assert.deepEqual(
@@ -223,12 +235,28 @@ test("settings hash maps ignore session differences for first sync checks", () =
 	]);
 
 	assert.deepEqual(settingsHashMap(local), settingsHashMap(remote));
+	const state = {
+		version: 1,
+		profile: "default",
+		lastAppliedSnapshot: "old",
+		lastFileHashes: Object.fromEntries(local.files.map((file) => [file.path, file.sha256])),
+	};
+	const config = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncSessions: false,
+	};
+
+	assert.equal(settingsHashesMatchState(remote, state), true);
+	assert.equal(hasRemoteChanges(remote, state, config), false);
 	assert.equal(
-		settingsHashesMatchState(remote, {
-			version: 1,
-			profile: "default",
-			lastFileHashes: Object.fromEntries(local.files.map((file) => [file.path, file.sha256])),
-		}),
+		hasRemoteChanges(
+			snapshot([{ path: "settings.json", content: Buffer.from("changed") }]),
+			state,
+			config,
+		),
 		true,
 	);
 });

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -181,6 +181,10 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 			),
 		/Unsafe path/,
 	);
+	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: ".env", content }]), current),
+		/Unsafe path/,
+	);
 	const sessionSnapshot = snapshot([{ path: "sessions/--project--/session.jsonl", content }]);
 	assert.throws(
 		() =>
@@ -420,13 +424,18 @@ function requiredConfig() {
 
 async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
 	const previousHome = process.env.HOME;
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	const home = mkdtempSync(path.join(os.tmpdir(), "pi-sync-home-"));
+	const agentDir = path.join(home, ".pi", "agent");
 	process.env.HOME = home;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
 	try {
-		return await fn(path.join(home, ".pi", "agent"));
+		return await fn(agentDir);
 	} finally {
 		if (previousHome === undefined) delete process.env.HOME;
 		else process.env.HOME = previousHome;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(home, { recursive: true, force: true });
 	}
 }

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -8,6 +8,7 @@ import { gunzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import sync, {
 	backupLocal,
+	canPullRemoteSessionsOnFirstSync,
 	collectFiles,
 	encodeKey,
 	isCloudflareR2Endpoint,
@@ -25,6 +26,7 @@ import sync, {
 	scanSnapshot,
 	sessionTokenWarnings,
 	settingsHashMap,
+	snapshotWithoutSessions,
 	splitArgs,
 } from "../src/sync.js";
 
@@ -219,6 +221,34 @@ test("settings hash maps ignore session differences for first sync checks", () =
 	]);
 
 	assert.deepEqual(settingsHashMap(local), settingsHashMap(remote));
+});
+
+test("first sync only auto-pulls remote sessions when local sessions are not at risk", () => {
+	const remoteOnly = snapshot([
+		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("r") },
+	]);
+	const shared = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("same") };
+	const changed = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("changed") };
+
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([]), remoteOnly), true);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), snapshot([shared])), true);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), remoteOnly), false);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([changed]), snapshot([shared])), false);
+});
+
+test("snapshotWithoutSessions clears session opt-in even when no session files exist", () => {
+	const source = {
+		...snapshot([{ path: "settings.json", content: Buffer.from("{}") }]),
+		syncSessions: true,
+	};
+	const filtered = snapshotWithoutSessions(source);
+
+	assert.equal(filtered.syncSessions, false);
+	assert.notEqual(filtered.id, source.id);
+	assert.deepEqual(
+		filtered.files.map((file) => file.path),
+		["settings.json"],
+	);
 });
 
 test("protected session apply plans keep the live session file", () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { gunzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import sync, {
+	appliedFileHashMap,
 	backupLocal,
 	canPullRemoteSessionsOnFirstSync,
 	collectFiles,
@@ -281,6 +282,25 @@ test("protected session apply plans keep the live session file", () => {
 		[path.join(root, "settings.json")],
 	);
 	assert.deepEqual(plan.deletes, [old]);
+
+	const current = snapshot([
+		{ path: "sessions/--project--/live.jsonl", content: Buffer.from("local") },
+		{ path: "sessions/--project--/old.jsonl", content: Buffer.from("old") },
+	]);
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("{}") },
+		{ path: "sessions/--project--/live.jsonl", content: Buffer.from("remote") },
+	]);
+	const hashes = appliedFileHashMap(remote, current, new Set(["sessions/--project--/live.jsonl"]));
+
+	assert.equal(
+		hashes["sessions/--project--/live.jsonl"],
+		current.files.find((file) => file.path === "sessions/--project--/live.jsonl")?.sha256,
+	);
+	assert.equal(
+		hashes["settings.json"],
+		remote.files.find((file) => file.path === "settings.json")?.sha256,
+	);
 });
 
 test("session backups include session jsonl files when enabled", async () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -24,6 +24,7 @@ import sync, {
 	safeName,
 	scanSnapshot,
 	sessionTokenWarnings,
+	settingsHashMap,
 	splitArgs,
 } from "../src/sync.js";
 
@@ -195,14 +196,29 @@ test("settings-only uploads preserve remote session files", () => {
 		path: "sessions/--project--/session.jsonl",
 		content: Buffer.from("remote"),
 	};
+	const local = snapshot([settings]);
 
-	const merged = mergeRemoteSessionFiles(snapshot([settings]), snapshot([remoteSession]));
+	const merged = mergeRemoteSessionFiles(local, snapshot([remoteSession]));
 
+	assert.notEqual(merged.id, local.id);
 	assert.deepEqual(
 		merged.files.map((file) => file.path),
 		["sessions/--project--/session.jsonl", "settings.json"],
 	);
 	assert.equal(merged.syncSessions, true);
+});
+
+test("settings hash maps ignore session differences for first sync checks", () => {
+	const local = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "sessions/--project--/local.jsonl", content: Buffer.from("local") },
+	]);
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("remote") },
+	]);
+
+	assert.deepEqual(settingsHashMap(local), settingsHashMap(remote));
 });
 
 test("protected session apply plans keep the live session file", () => {
@@ -297,6 +313,7 @@ async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
 	} finally {
 		if (previousHome === undefined) delete process.env.HOME;
 		else process.env.HOME = previousHome;
+		rmSync(home, { recursive: true, force: true });
 	}
 }
 

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -13,10 +13,13 @@ import sync, {
 	isCloudflareR2Endpoint,
 	isDeniedPath,
 	isEnabled,
+	isExplicitlyEnabled,
 	loadConfig,
+	mergeRemoteSessionFiles,
 	parseOptions,
 	posixJoin,
 	preflightSnapshotApply,
+	protectSnapshotApplyPlan,
 	safeJoin,
 	safeName,
 	scanSnapshot,
@@ -45,6 +48,15 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 		});
 		await withEnv({ PI_SYNC_SESSIONS: "false" }, async () => {
 			assert.equal((await loadConfig()).syncSessions, false);
+		});
+		await withEnv({ PI_SYNC_SESSIONS: "" }, async () => {
+			assert.equal((await loadConfig()).syncSessions, false);
+		});
+		await withEnv({ PI_SYNC_SESSIONS: "tru" }, async () => {
+			assert.equal((await loadConfig()).syncSessions, false);
+		});
+		await withEnv({ PI_SYNC_SESSIONS: "yes" }, async () => {
+			assert.equal((await loadConfig()).syncSessions, true);
 		});
 
 		rmSync(path.join(agentDir, "pi-sync.local.json"));
@@ -177,6 +189,45 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 	);
 });
 
+test("settings-only uploads preserve remote session files", () => {
+	const settings = { path: "settings.json", content: Buffer.from("local") };
+	const remoteSession = {
+		path: "sessions/--project--/session.jsonl",
+		content: Buffer.from("remote"),
+	};
+
+	const merged = mergeRemoteSessionFiles(snapshot([settings]), snapshot([remoteSession]));
+
+	assert.deepEqual(
+		merged.files.map((file) => file.path),
+		["sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.equal(merged.syncSessions, true);
+});
+
+test("protected session apply plans keep the live session file", () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-protect-"));
+	const live = path.join(root, "sessions", "--project--", "live.jsonl");
+	const old = path.join(root, "sessions", "--project--", "old.jsonl");
+	const plan = protectSnapshotApplyPlan(
+		root,
+		{
+			writes: [
+				{ target: live, content: Buffer.from("remote") },
+				{ target: path.join(root, "settings.json"), content: Buffer.from("{}") },
+			],
+			deletes: [live, old],
+		},
+		new Set(["sessions/--project--/live.jsonl"]),
+	);
+
+	assert.deepEqual(
+		plan.writes.map((item) => item.target),
+		[path.join(root, "settings.json")],
+	);
+	assert.deepEqual(plan.deletes, [old]);
+});
+
 test("session backups include session jsonl files when enabled", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(path.join(agentDir, "sessions", "--project--"), { recursive: true });
@@ -208,6 +259,9 @@ test("security and configuration helpers detect secrets and R2 session-token war
 	);
 	assert.equal(isEnabled("off", true), false);
 	assert.equal(isEnabled(undefined, true), true);
+	assert.equal(isExplicitlyEnabled("true"), true);
+	assert.equal(isExplicitlyEnabled("tru"), false);
+	assert.equal(isExplicitlyEnabled(""), false);
 });
 
 function snapshot(files: Array<{ path: string; content: Buffer }>) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -142,6 +142,8 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	writeFileSync(path.join(root, "sessions", "--project--", "session.jsonl"), "{}\n");
 	writeFileSync(path.join(root, "sessions", "--project--", "notes.txt"), "skip\n");
 	writeFileSync(path.join(root, "sessions", "token-project", "session.jsonl"), "skip\n");
+	const customSessionDir = mkdtempSync(path.join(os.tmpdir(), "pi-sync-sessions-"));
+	writeFileSync(path.join(customSessionDir, "custom.jsonl"), "{}\n");
 
 	assert.deepEqual(
 		(await collectFiles(root)).map((file) => file.path),
@@ -150,6 +152,12 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	assert.deepEqual(
 		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
 		["sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { syncSessions: true, sessionDir: customSessionDir })).map(
+			(file) => file.path,
+		),
+		["sessions/custom.jsonl", "settings.json", "skills/demo.md"],
 	);
 });
 
@@ -186,6 +194,13 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 		/Unsafe path/,
 	);
 	const sessionSnapshot = snapshot([{ path: "sessions/--project--/session.jsonl", content }]);
+	const customSessionDir = mkdtempSync(path.join(os.tmpdir(), "pi-sync-session-apply-"));
+	assert.deepEqual(
+		preflightSnapshotApply(root, sessionSnapshot, snapshot([]), {
+			sessionDir: customSessionDir,
+		}).writes.map((item) => item.target),
+		[path.join(customSessionDir, "--project--", "session.jsonl")],
+	);
 	assert.throws(
 		() =>
 			preflightSnapshotApply(
@@ -425,10 +440,12 @@ function requiredConfig() {
 async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
 	const previousHome = process.env.HOME;
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
 	const home = mkdtempSync(path.join(os.tmpdir(), "pi-sync-home-"));
 	const agentDir = path.join(home, ".pi", "agent");
 	process.env.HOME = home;
 	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env.PI_CODING_AGENT_SESSION_DIR;
 	try {
 		return await fn(agentDir);
 	} finally {
@@ -436,6 +453,8 @@ async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
 		else process.env.HOME = previousHome;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		if (previousSessionDir === undefined) delete process.env.PI_CODING_AGENT_SESSION_DIR;
+		else process.env.PI_CODING_AGENT_SESSION_DIR = previousSessionDir;
 		rmSync(home, { recursive: true, force: true });
 	}
 }
@@ -453,6 +472,7 @@ async function withEnv<T>(env: Record<string, string>, fn: () => Promise<T>) {
 		"PI_SYNC_PREFIX",
 		"PI_SYNC_AUTO_SYNC",
 		"PI_CODING_AGENT_DIR",
+		"PI_CODING_AGENT_SESSION_DIR",
 		"R2_ENDPOINT",
 		"R2_BUCKET",
 		"AWS_ACCESS_KEY_ID",

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -25,6 +25,7 @@ import sync, {
 	safeName,
 	scanSnapshot,
 	sessionTokenWarnings,
+	settingsHashesMatchState,
 	settingsHashMap,
 	snapshotWithoutSessions,
 	splitArgs,
@@ -221,6 +222,14 @@ test("settings hash maps ignore session differences for first sync checks", () =
 	]);
 
 	assert.deepEqual(settingsHashMap(local), settingsHashMap(remote));
+	assert.equal(
+		settingsHashesMatchState(remote, {
+			version: 1,
+			profile: "default",
+			lastFileHashes: Object.fromEntries(local.files.map((file) => [file.path, file.sha256])),
+		}),
+		true,
+	);
 });
 
 test("first sync only auto-pulls remote sessions when local sessions are not at risk", () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -65,6 +65,16 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 			assert.equal((await loadConfig()).syncSessions, true);
 		});
 
+		const customAgentDir = path.join(agentDir, "custom-agent");
+		mkdirSync(customAgentDir, { recursive: true });
+		writeFileSync(
+			path.join(customAgentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), profile: "custom" }),
+		);
+		await withEnv({ PI_CODING_AGENT_DIR: customAgentDir }, async () => {
+			assert.equal((await loadConfig()).profile, "custom");
+		});
+
 		rmSync(path.join(agentDir, "pi-sync.local.json"));
 		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
 		await withEnv({}, async () => {
@@ -222,6 +232,14 @@ test("settings-only uploads preserve remote session files", () => {
 		["sessions/--project--/session.jsonl", "settings.json"],
 	);
 	assert.equal(merged.syncSessions, true);
+
+	const emptySessionSet = mergeRemoteSessionFiles(local, { ...snapshot([]), syncSessions: true });
+	assert.notEqual(emptySessionSet.id, local.id);
+	assert.deepEqual(
+		emptySessionSet.files.map((file) => file.path),
+		["settings.json"],
+	);
+	assert.equal(emptySessionSet.syncSessions, true);
 });
 
 test("settings hash maps ignore session differences for first sync checks", () => {
@@ -416,6 +434,7 @@ async function withEnv<T>(env: Record<string, string>, fn: () => Promise<T>) {
 		"PI_SYNC_PROFILE",
 		"PI_SYNC_PREFIX",
 		"PI_SYNC_AUTO_SYNC",
+		"PI_CODING_AGENT_DIR",
 		"R2_ENDPOINT",
 		"R2_BUCKET",
 		"AWS_ACCESS_KEY_ID",

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -172,6 +172,15 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 		() => preflightSnapshotApply(root, snapshot([{ path: "../bad", content }]), current),
 		/Unsafe path/,
 	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				snapshot([{ path: "sessions/../settings.json", content }]),
+				current,
+			),
+		/Unsafe path/,
+	);
 	const sessionSnapshot = snapshot([{ path: "sessions/--project--/session.jsonl", content }]);
 	assert.throws(
 		() =>

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -1,15 +1,19 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { gunzipSync } from "node:zlib";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import sync, {
+	backupLocal,
+	collectFiles,
 	encodeKey,
 	isCloudflareR2Endpoint,
 	isDeniedPath,
 	isEnabled,
+	loadConfig,
 	parseOptions,
 	posixJoin,
 	preflightSnapshotApply,
@@ -26,6 +30,49 @@ test("sync registers pisync command and session lifecycle hooks", () => {
 
 	assert.ok(mock.commands.has("pisync"));
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+});
+
+test("syncSessions config defaults off and supports file plus env overrides", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), syncSessions: true }),
+		);
+
+		await withEnv({}, async () => {
+			assert.equal((await loadConfig()).syncSessions, true);
+		});
+		await withEnv({ PI_SYNC_SESSIONS: "false" }, async () => {
+			assert.equal((await loadConfig()).syncSessions, false);
+		});
+
+		rmSync(path.join(agentDir, "pi-sync.local.json"));
+		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
+		await withEnv({}, async () => {
+			assert.equal((await loadConfig()).syncSessions, false);
+		});
+	});
+});
+
+test("pisync config output reports session sync and privacy warning", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), syncSessions: true }),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await withEnv({}, async () => {
+			await mock.commands.get("pisync")?.handler("config", ctx);
+		});
+
+		assert.match(notifications[0]?.message ?? "", /syncSessions: enabled/);
+		assert.match(notifications[0]?.message ?? "", /session JSONL can contain/);
+	});
 });
 
 test("argument and option helpers parse quoted command lines", () => {
@@ -57,13 +104,34 @@ test("path and key helpers normalize safe names and reject escapes", () => {
 	assert.equal(safeName("team/prod"), "team_prod");
 });
 
-test("snapshot preflight validates checksums, duplicate paths, and deletes stale files", () => {
+test("snapshot collection includes session jsonl files only when enabled", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-"));
+	mkdirSync(path.join(root, "skills"), { recursive: true });
+	mkdirSync(path.join(root, "sessions", "--project--"), { recursive: true });
+	mkdirSync(path.join(root, "sessions", "token-project"), { recursive: true });
+	writeFileSync(path.join(root, "settings.json"), "{}\n");
+	writeFileSync(path.join(root, "skills", "demo.md"), "demo\n");
+	writeFileSync(path.join(root, "sessions", "--project--", "session.jsonl"), "{}\n");
+	writeFileSync(path.join(root, "sessions", "--project--", "notes.txt"), "skip\n");
+	writeFileSync(path.join(root, "sessions", "token-project", "session.jsonl"), "skip\n");
+
+	assert.deepEqual(
+		(await collectFiles(root)).map((file) => file.path),
+		["settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
+		["sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
+	);
+});
+
+test("snapshot preflight validates checksums, duplicate session paths, and deletes stale files", () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-"));
 	const content = Buffer.from("hello");
 	const remote = snapshot([{ path: "settings.json", content }]);
 	const current = snapshot([
 		{ path: "settings.json", content },
-		{ path: "skills/old.md", content: Buffer.from("old") },
+		{ path: "sessions/--project--/old.jsonl", content: Buffer.from("old") },
 	]);
 
 	const plan = preflightSnapshotApply(root, remote, current);
@@ -71,20 +139,59 @@ test("snapshot preflight validates checksums, duplicate paths, and deletes stale
 		plan.writes.map((item) => item.target),
 		[path.join(root, "settings.json")],
 	);
-	assert.deepEqual(plan.deletes, [path.join(root, "skills", "old.md")]);
+	assert.deepEqual(plan.deletes, [path.join(root, "sessions", "--project--", "old.jsonl")]);
 	assert.throws(
 		() => preflightSnapshotApply(root, snapshot([{ path: "../bad", content }]), current),
 		/Unsafe path/,
+	);
+	const sessionSnapshot = snapshot([{ path: "sessions/--project--/session.jsonl", content }]);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				{ ...sessionSnapshot, files: [sessionSnapshot.files[0], sessionSnapshot.files[0]] },
+				current,
+			),
+		/Duplicate path/,
 	);
 	assert.throws(
 		() =>
 			preflightSnapshotApply(
 				root,
-				{ ...remote, files: [remote.files[0], remote.files[0]] },
+				{
+					...sessionSnapshot,
+					files: [{ ...sessionSnapshot.files[0], sha256: "bad" }],
+				},
 				current,
 			),
-		/Duplicate path/,
+		/Checksum mismatch/,
 	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				snapshot([{ path: "sessions/--project--/notes.txt", content }]),
+				current,
+			),
+		/Unsafe session path/,
+	);
+});
+
+test("session backups include session jsonl files when enabled", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "sessions", "--project--"), { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), "{}\n");
+		writeFileSync(path.join(agentDir, "sessions", "--project--", "session.jsonl"), "{}\n");
+
+		const backupPath = await backupLocal("default", { syncSessions: true });
+		const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
+
+		assert.ok(
+			backup.files.some(
+				(file: { path: string }) => file.path === "sessions/--project--/session.jsonl",
+			),
+		);
+	});
 });
 
 test("security and configuration helpers detect secrets and R2 session-token warnings", () => {
@@ -116,4 +223,58 @@ function snapshot(files: Array<{ path: string; content: Buffer }>) {
 			sha256: createHash("sha256").update(file.content).digest("hex"),
 		})),
 	};
+}
+
+function requiredConfig() {
+	return {
+		endpoint: "https://example.r2.cloudflarestorage.com",
+		bucket: "pi-sync-test",
+		accessKeyId: "access-key",
+		secretAccessKey: "secret-key",
+	};
+}
+
+async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
+	const previousHome = process.env.HOME;
+	const home = mkdtempSync(path.join(os.tmpdir(), "pi-sync-home-"));
+	process.env.HOME = home;
+	try {
+		return await fn(path.join(home, ".pi", "agent"));
+	} finally {
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+	}
+}
+
+async function withEnv<T>(env: Record<string, string>, fn: () => Promise<T>) {
+	const keys = [
+		"PI_SYNC_ENDPOINT",
+		"PI_SYNC_BUCKET",
+		"PI_SYNC_ACCESS_KEY_ID",
+		"PI_SYNC_SECRET_ACCESS_KEY",
+		"PI_SYNC_SESSIONS",
+		"PI_SYNC_SESSION_TOKEN",
+		"PI_SYNC_REGION",
+		"PI_SYNC_PROFILE",
+		"PI_SYNC_PREFIX",
+		"PI_SYNC_AUTO_SYNC",
+		"R2_ENDPOINT",
+		"R2_BUCKET",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+	];
+	const previous = new Map(keys.map((key) => [key, process.env[key]]));
+	for (const key of keys) delete process.env[key];
+	Object.assign(process.env, env);
+	try {
+		return await fn();
+	} finally {
+		for (const key of keys) {
+			const value = previous.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
 }

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -75,6 +75,16 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 			assert.equal((await loadConfig()).profile, "custom");
 		});
 
+		const tildeAgentDir = path.join(path.dirname(agentDir), "agent-tilde");
+		mkdirSync(tildeAgentDir, { recursive: true });
+		writeFileSync(
+			path.join(tildeAgentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), profile: "tilde" }),
+		);
+		await withEnv({ PI_CODING_AGENT_DIR: "~/.pi/agent-tilde" }, async () => {
+			assert.equal((await loadConfig()).profile, "tilde");
+		});
+
 		rmSync(path.join(agentDir, "pi-sync.local.json"));
 		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
 		await withEnv({}, async () => {
@@ -158,6 +168,15 @@ test("snapshot collection includes session jsonl files only when enabled", async
 			(file) => file.path,
 		),
 		["sessions/custom.jsonl", "settings.json", "skills/demo.md"],
+	);
+	const nestedSessionDir = path.join(root, "sessions", "work");
+	mkdirSync(nestedSessionDir, { recursive: true });
+	writeFileSync(path.join(nestedSessionDir, "nested.jsonl"), "{}\n");
+	assert.deepEqual(
+		(await collectFiles(root, { syncSessions: true, sessionDir: nestedSessionDir })).map(
+			(file) => file.path,
+		),
+		["sessions/nested.jsonl", "settings.json", "skills/demo.md"],
 	);
 });
 


### PR DESCRIPTION
## Summary
- add opt-in `syncSessions` / `PI_SYNC_SESSIONS` support for Pi session JSONL snapshots
- include session privacy warnings in config/status/doctor/diff and docs
- add session snapshot filtering, backups/preflight coverage, and shutdown auto-push when enabled

Closes #99

## Verification
- npm run check
- npm run pack:sync