### PR TITLE
feat(statusline): centralize extension status icons

### DIFF
--- a/docs/plans/archived/2026-06-19_status-emoji-config-plan.md
+++ b/docs/plans/archived/2026-06-19_status-emoji-config-plan.md
@@ -1,0 +1,84 @@
+## Goal
+
+Move status emoji ownership out of producer extensions and into `@narumitw/pi-statusline`. Success means active extensions publish plain status text, while `pi-statusline` can centrally choose, override, or suppress per-extension status icons from JSON config.
+
+## Context
+
+Current status icons are split across extensions: `pi-caffeinate` has `PI_CAFFEINATE_ICON`, while `pi-goal`, `pi-sync`, `pi-plan-mode`, `pi-retry`, `pi-subagents`, `pi-firecrawl`, `pi-chrome-devtools`, and `pi-codex-usage` embed emoji in status strings. `pi-statusline` already parses a leading emoji from extension status text and falls back to `🔌` when none exists.
+
+## Architecture
+
+`pi-statusline` becomes the presentation owner for extension status icons. Producer extensions call `ctx.ui.setStatus()` with plain text only. `pi-statusline` reads `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json` and applies icons by Pi status key.
+
+Proposed config shape:
+
+```json
+{
+  "extensionStatusIcons": {
+    "caffeinate": "☕",
+    "goal": "🎯",
+    "pisync": "☁️",
+    "unknown-error-retry": "",
+    "plan-mode": "📝",
+    "subagents": "🤖"
+  }
+}
+```
+
+Semantics:
+
+- Missing key: use `pi-statusline`'s built-in icon for that status key, or `🔌` for unknown keys.
+- String value: use that exact string as the icon.
+- Empty string: render the status text with no icon.
+- `PI_STATUSLINE_PRESET` remains the only preset configuration path.
+- During the deprecation phase, if JSON does not configure `caffeinate`, `pi-statusline` may still use the leading emoji emitted by `PI_CAFFEINATE_ICON` for compatibility.
+
+Precedence during the deprecation phase:
+
+1. JSON `extensionStatusIcons[key]`, including `""`.
+2. A leading emoji already present in the producer status text, for `PI_CAFFEINATE_ICON` compatibility.
+3. `pi-statusline`'s built-in default icon map.
+4. Unknown-key fallback `🔌`.
+
+## Non-Goals
+
+- Do not add per-state icons such as separate `retryingIcon` and `receivingIcon` in this phase.
+- Do not add settings loaders to every producer extension.
+- Do not change `pi-statusline`'s main statusline segment emoji, only extension status icons.
+- Do not include deprecated extensions in the first pass.
+
+## Assumptions
+
+- It is acceptable that users without `pi-statusline` see plain status text instead of emoji-prefixed status text, except `pi-caffeinate` during the deprecation phase.
+- `PI_CAFFEINATE_ICON` remains as a deprecated compatibility path for at least one release cycle because it is a documented feature.
+- `pi-statusline-settings.json` is local config only unless a separate future change teaches `pi-sync` to sync extension config files.
+
+## Plan
+
+- [x] Add a `pi-statusline-settings.json` loader in `extensions/pi-statusline/src/statusline.ts` that reads from `getAgentDir()`, validates `extensionStatusIcons`, and ignores invalid fields; verify with focused `extensions/pi-statusline/test/statusline.test.ts` cases for missing, valid, and invalid config.
+- [x] Add a built-in extension icon map in `pi-statusline` keyed by status key (`caffeinate`, `goal`, `pisync`, `unknown-error-retry`, `plan-mode`, `subagents`, `firecrawl`, `chrome-devtools`, `codex-usage`, `lsp`) and update `formatExtensionStatus()` so JSON overrides, `""` suppression, leading-emoji compatibility, default icons, and unknown-key fallback work; verify with tests for each precedence branch.
+- [x] Remove producer-owned emoji from active extensions except the deprecated `PI_CAFFEINATE_ICON` compatibility path by changing status strings in `pi-goal`, `pi-sync`, `pi-plan-mode`, `pi-retry`, `pi-subagents`, `pi-firecrawl`, `pi-chrome-devtools`, and `pi-codex-usage` to plain text; verify with `rg -n "setStatus\([^\n]*(🎯|📝|🔁|📥|🔄|🧑|🔥|🌐|📊)" extensions/*/src` returning no active producer hits outside `pi-statusline`.
+- [x] Keep `PI_CAFFEINATE_ICON` in `pi-caffeinate` as a deprecated compatibility path that warns once per session when set and explains the `pi-statusline-settings.json` replacement; verify with `extensions/pi-caffeinate/test/caffeinate.test.ts`.
+- [x] Update affected tests to assert plain producer statuses, deprecated `PI_CAFFEINATE_ICON` behavior, and centralized `pi-statusline` icon rendering; verify with `npm test -- --workspace @narumitw/pi-statusline`, `npm test -- --workspace @narumitw/pi-caffeinate`, and the touched package tests or `npm test`.
+- [x] Update READMEs for `pi-statusline` and affected producer extensions: document `pi-statusline-settings.json`, mark `PI_CAFFEINATE_ICON` as deprecated rather than removed, and show `""` for no icon; verify with `rg -n "PI_CAFFEINATE_ICON|deprecated|pi-statusline-settings|extensionStatusIcons|status icon" README.md extensions/*/README.md`.
+- [x] Run full verification after implementation; verify with `npm run check`.
+
+## Risks
+
+- Removing `PI_CAFFEINATE_ICON` immediately would be a breaking change; mitigate by keeping it for at least one release cycle with a deprecation warning and README migration guidance to `pi-statusline-settings.json`.
+- Some status keys are less obvious than package names (`pisync`, `unknown-error-retry`); mitigate with a documented default map and examples.
+- Empty icon rendering can accidentally leave extra spacing; mitigate with explicit `pi-statusline` tests for no-icon output.
+
+## Completion Checklist
+
+- [x] Producer extensions emit plain status text except deprecated `PI_CAFFEINATE_ICON`, verified by source grep and updated package tests.
+- [x] `pi-statusline` owns default, custom, suppressed, and compatibility leading-emoji extension status icons, verified by `extensions/pi-statusline/test/statusline.test.ts`.
+- [x] JSON config behavior and `PI_CAFFEINATE_ICON` deprecation/migration are documented, verified by README grep and source review.
+- [x] The repo passes `npm run check` after all changes.
+
+## Completion Evidence
+
+- `npm test -- --workspace @narumitw/pi-statusline`, `npm test -- --workspace @narumitw/pi-caffeinate`, `npm test -- --workspace @narumitw/pi-goal`, and `npm test -- --workspace @narumitw/pi-codex-usage` passed after the status icon changes.
+- `npm run check` passed after all implementation and docs updates.
+- `rg -n "setStatus\([^\n]*(🎯|📝|🔁|📥|🔄|🧑|🔥|🌐|📊)" extensions/*/src` returned no producer status hits; remaining status emoji are centralized in `pi-statusline` or its main statusline segments.
+- README docs now cover `pi-statusline-settings.json`, `extensionStatusIcons`, empty-string icon suppression, and `PI_CAFFEINATE_ICON` deprecation.

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -128,7 +128,7 @@ PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mo
 
 The custom command is parsed with shell-like quoting and is run directly without a shell. `PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
 
-Deprecated: `PI_CAFFEINATE_ICON` still works for one release cycle, but status icons are now owned by `@narumitw/pi-statusline`. Configure the icon in `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json` instead:
+Deprecated: `PI_CAFFEINATE_ICON` still works for now. If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json`:
 
 ```json
 {
@@ -138,7 +138,7 @@ Deprecated: `PI_CAFFEINATE_ICON` still works for one release cycle, but status i
 }
 ```
 
-Use an empty string to show the caffeinate status without an icon.
+Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the compatibility window. In `pi-statusline-settings.json`, use an empty string to show the caffeinate status without an icon.
 
 ## 🧠 Why use pi-caffeinate?
 

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -16,7 +16,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 - Provides a single `/caffeinate` command with menu-based controls and direct subcommands.
 - Persists the selected keep-awake mode in a small JSON settings file.
 - Allows a custom inhibitor command through environment configuration.
-- Allows a custom status icon through environment configuration.
+- Emits plain status text; `@narumitw/pi-statusline` can add or suppress the status icon from JSON config.
 - Fails safely when no supported inhibitor is available.
 
 ## 📦 Install
@@ -128,11 +128,17 @@ PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mo
 
 The custom command is parsed with shell-like quoting and is run directly without a shell. `PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
 
-Customise the status bar icon (default: `💊`):
+Deprecated: `PI_CAFFEINATE_ICON` still works for one release cycle, but status icons are now owned by `@narumitw/pi-statusline`. Configure the icon in `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json` instead:
 
-```bash
-PI_CAFFEINATE_ICON='☕️' pi
+```json
+{
+  "extensionStatusIcons": {
+    "caffeinate": "☕️"
+  }
+}
 ```
+
+Use an empty string to show the caffeinate status without an icon.
 
 ## 🧠 Why use pi-caffeinate?
 

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -696,7 +696,7 @@ function warnDeprecatedIcon(ctx: ExtensionContext) {
 	if (state.iconWarningShown || !process.env.PI_CAFFEINATE_ICON?.trim()) return;
 	state.iconWarningShown = true;
 	ctx.ui.notify(
-		'PI_CAFFEINATE_ICON is deprecated. Configure { "extensionStatusIcons": { "caffeinate": "..." } } in pi-statusline-settings.json instead.',
+		'PI_CAFFEINATE_ICON is deprecated and still works for now. If you use @narumitw/pi-statusline, move this icon to pi-statusline-settings.json: { "extensionStatusIcons": { "caffeinate": "..." } }.',
 		"warning",
 	);
 }

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -61,6 +61,7 @@ interface CaffeinateState {
 	mode: CaffeinateMode;
 	settingsLoaded: boolean;
 	settingsError?: string;
+	iconWarningShown: boolean;
 }
 
 interface CaffeinateSettings {
@@ -74,10 +75,13 @@ const state: CaffeinateState = {
 	disabled: isDisabled(),
 	mode: DEFAULT_MODE,
 	settingsLoaded: false,
+	iconWarningShown: false,
 };
 
 export default function caffeinate(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
+		state.iconWarningShown = false;
+		warnDeprecatedIcon(ctx);
 		await loadSettingsIntoState(ctx);
 		updateStatus(ctx);
 	});
@@ -527,12 +531,12 @@ function updateStatus(ctx: ExtensionContext) {
 	}
 
 	if (state.process) {
-		ctx.ui.setStatus(STATUS_KEY, `${getIcon()} ${statusModeLabel()}`);
+		ctx.ui.setStatus(STATUS_KEY, withDeprecatedIcon(statusModeLabel()));
 		return;
 	}
 
 	if (!state.available) {
-		ctx.ui.setStatus(STATUS_KEY, `${getIcon()} unavailable`);
+		ctx.ui.setStatus(STATUS_KEY, withDeprecatedIcon("unavailable"));
 		return;
 	}
 
@@ -683,6 +687,16 @@ function hasCustomCommand() {
 	return Boolean(process.env.PI_CAFFEINATE_COMMAND?.trim());
 }
 
-function getIcon() {
-	return process.env.PI_CAFFEINATE_ICON?.trim() ?? "💊";
+function withDeprecatedIcon(text: string) {
+	const icon = process.env.PI_CAFFEINATE_ICON?.trim();
+	return icon ? `${icon} ${text}` : text;
+}
+
+function warnDeprecatedIcon(ctx: ExtensionContext) {
+	if (state.iconWarningShown || !process.env.PI_CAFFEINATE_ICON?.trim()) return;
+	state.iconWarningShown = true;
+	ctx.ui.notify(
+		'PI_CAFFEINATE_ICON is deprecated. Configure { "extensionStatusIcons": { "caffeinate": "..." } } in pi-statusline-settings.json instead.',
+		"warning",
+	);
 }

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -70,6 +70,7 @@ test("session start warns for deprecated PI_CAFFEINATE_ICON", async (t) => {
 
 	assert.equal(notifications.length, 1);
 	assert.match(notifications[0]?.message ?? "", /PI_CAFFEINATE_ICON is deprecated/);
+	assert.match(notifications[0]?.message ?? "", /If you use @narumitw\/pi-statusline/);
 });
 
 test("windowsInhibitorScript uses unsigned flags and releases on exit", () => {

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import caffeinate, {
 	commandCompletions,
 	formatMode,
@@ -51,6 +51,25 @@ test("normalizeCaffeinateSettings accepts only known modes", () => {
 	assert.deepEqual(normalizeCaffeinateSettings({ mode: "sleep" }), { mode: "sleep", updatedAt: 0 });
 	assert.equal(normalizeCaffeinateSettings({ mode: "display", updatedAt: "now" }), undefined);
 	assert.equal(normalizeCaffeinateSettings({ mode: "screen" }), undefined);
+});
+
+test("session start warns for deprecated PI_CAFFEINATE_ICON", async (t) => {
+	const original = process.env.PI_CAFFEINATE_ICON;
+	t.after(() => {
+		if (original === undefined) delete process.env.PI_CAFFEINATE_ICON;
+		else process.env.PI_CAFFEINATE_ICON = original;
+	});
+	process.env.PI_CAFFEINATE_ICON = "☕";
+
+	const mock = createMockPi();
+	caffeinate(mock.pi);
+	const { ctx, notifications } = createMockContext();
+	const handler = mock.events.get("session_start")?.[0];
+
+	await handler?.({}, ctx);
+
+	assert.equal(notifications.length, 1);
+	assert.match(notifications[0]?.message ?? "", /PI_CAFFEINATE_ICON is deprecated/);
 });
 
 test("windowsInhibitorScript uses unsigned flags and releases on exit", () => {

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -193,7 +193,7 @@ const listPagesTool = defineTool({
 	renderCall: renderToolCall("list pages"),
 	renderResult: renderTextResult,
 	async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🌐 list pages", async () => {
+		return withStatus(ctx, "list pages", async () => {
 			const pages = await listPages();
 			return textResult(JSON.stringify(pages.map(formatPage), null, 2), { pages });
 		});
@@ -211,7 +211,7 @@ const selectPageTool = defineTool({
 	renderCall: renderToolCall("select page"),
 	renderResult: renderTextResult,
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🌐 select page", async () => {
+		return withStatus(ctx, "select page", async () => {
 			const page = await getPage(params.pageId);
 			state.activePageId = page.id;
 			return textResult(`Selected page ${page.id}: ${page.title}\n${page.url}`, {
@@ -236,7 +236,7 @@ const navigateTool = defineTool({
 	renderCall: renderToolCall("navigate"),
 	renderResult: renderTextResult,
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🌐 navigate", async () => {
+		return withStatus(ctx, "navigate", async () => {
 			const { created, page } = await resolvePageForNavigation(params.pageId);
 			const result = await withCdp(page, async (client) => {
 				await client.send("Page.enable");
@@ -271,7 +271,7 @@ const evaluateTool = defineTool({
 	renderCall: renderToolCall("evaluate"),
 	renderResult: renderTextResult,
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🌐 evaluate", async () => {
+		return withStatus(ctx, "evaluate", async () => {
 			const page = await resolvePage(params.pageId);
 			const result = await withCdp(page, (client) =>
 				client.send("Runtime.evaluate", {
@@ -309,7 +309,7 @@ const screenshotTool = defineTool({
 	renderCall: renderToolCall("screenshot"),
 	renderResult: renderScreenshotResult,
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🌐 screenshot", async () => {
+		return withStatus(ctx, "screenshot", async () => {
 			const page = await resolvePage(params.pageId);
 			const result = await withCdp(page, async (client) => {
 				throwIfAborted(signal);

--- a/extensions/pi-codex-usage/README.md
+++ b/extensions/pi-codex-usage/README.md
@@ -66,11 +66,11 @@ information on rate limits and credits
 When the selected Pi model provider is `openai-codex`, `pi-codex-usage` refreshes a compact statusline item automatically:
 
 ```text
-📊 codex 59% 5h 61% wk
-📊 codex spark 100% 5h 100% wk
+codex 59% 5h 61% wk
+codex spark 100% 5h 100% wk
 ```
 
-The statusline value uses the cached usage snapshot and refreshes every five minutes while the current model remains `openai-codex`.
+`@narumitw/pi-statusline` adds the default `📊` icon unless configured otherwise. The statusline value uses the cached usage snapshot and refreshes every five minutes while the current model remains `openai-codex`.
 When the selected model has its own returned usage bucket, such as `gpt-5.3-codex-spark`, the statusline switches to that bucket instead of the default `codex` bucket.
 Switching away from an OpenAI Codex model clears the item.
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -242,12 +242,12 @@ export default function codexUsage(pi: ExtensionAPI) {
 			return;
 		}
 
-		if (!setStatuslineValue(ctx, "📊 checking")) return;
+		if (!setStatuslineValue(ctx, "checking")) return;
 		const result = await queryUsage(ctx, { timeoutMs: DEFAULT_TIMEOUT_MS });
 		if (!sessionActive || requestId !== statuslineRequestId) return;
 
 		if (!result.ok) {
-			if (setStatuslineValue(ctx, "📊 usage error")) {
+			if (setStatuslineValue(ctx, "usage error")) {
 				scheduleStatuslineRefresh(ctx, selectedModel);
 			}
 			return;
@@ -287,7 +287,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 
 				let keepStatusline = false;
 				const statuslineStarted =
-					options.value.statusline && setStatuslineValue(ctx, "📊 checking");
+					options.value.statusline && setStatuslineValue(ctx, "checking");
 				try {
 					const result = await queryUsage(ctx, options.value);
 					if (!result.ok) {
@@ -891,9 +891,9 @@ export function formatCodexUsageStatusline(
 	model?: CodexUsageModel,
 ): string {
 	const snapshot = selectSnapshotForModel(report, model);
-	if (!snapshot) return "📊 usage unavailable";
+	if (!snapshot) return "usage unavailable";
 
-	const parts = [`📊 ${formatStatuslinePrefix(snapshot)}`];
+	const parts = [formatStatuslinePrefix(snapshot)];
 	if (snapshot.primary) parts.push(`${formatRemainingPercent(snapshot.primary)} 5h`);
 	if (snapshot.secondary) parts.push(`${formatRemainingPercent(snapshot.secondary)} wk`);
 	if (parts.length === 1 && snapshot.credits) parts.push(formatCredits(snapshot.credits));

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -110,7 +110,7 @@ test("scheduled statusline refresh ignores stale extension contexts", async (t) 
 
 	mock.events.get("session_start")?.[0]?.({}, ctx);
 	await new Promise<void>((resolve) => setImmediate(resolve));
-	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+	assert.equal(statuses.get("codex-usage"), "codex 75% 5h");
 
 	let staleModelRegistryReads = 0;
 	const staleError = new Error(
@@ -180,7 +180,7 @@ test("stale refresh errors do not cancel newer session refresh timers", async (t
 	mock.events.get("session_start")?.[0]?.({}, oldCtx);
 	mock.events.get("session_start")?.[0]?.({}, newCtx);
 	await new Promise<void>((resolve) => setImmediate(resolve));
-	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+	assert.equal(statuses.get("codex-usage"), "codex 75% 5h");
 
 	rejectOldAuth(staleError);
 	await Promise.resolve();
@@ -188,7 +188,7 @@ test("stale refresh errors do not cancel newer session refresh timers", async (t
 
 	t.mock.timers.tick(5 * 60 * 1000);
 	await new Promise<void>((resolve) => setImmediate(resolve));
-	assert.equal(statuses.get("codex-usage"), "📊 codex 50% 5h");
+	assert.equal(statuses.get("codex-usage"), "codex 50% 5h");
 });
 
 test("stale command statusline writes are ignored", async (t) => {
@@ -286,7 +286,7 @@ test("stale command statusline writes do not cancel newer session refresh timers
 
 	mock.events.get("session_start")?.[0]?.({}, newCtx);
 	await new Promise<void>((resolve) => setImmediate(resolve));
-	assert.equal(statuses.get("codex-usage"), "📊 codex 75% 5h");
+	assert.equal(statuses.get("codex-usage"), "codex 75% 5h");
 
 	const staleError = new Error(
 		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
@@ -304,7 +304,7 @@ test("stale command statusline writes do not cancel newer session refresh timers
 	await command.handler("", staleCtx);
 	t.mock.timers.tick(5 * 60 * 1000);
 	await new Promise<void>((resolve) => setImmediate(resolve));
-	assert.equal(statuses.get("codex-usage"), "📊 codex 50% 5h");
+	assert.equal(statuses.get("codex-usage"), "codex 50% 5h");
 });
 
 test("isStaleExtensionContextError recognizes Pi stale-context failures", () => {
@@ -334,7 +334,7 @@ test("formatters render report text and model-specific statusline buckets", () =
 			name: "GPT-5.3 Codex Spark",
 			provider: "openai-codex",
 		}),
-		"📊 codex spark 90% 5h",
+		"codex spark 90% 5h",
 	);
-	assert.equal(formatCodexUsageStatusline(report), "📊 codex 40% 5h 20% wk");
+	assert.equal(formatCodexUsageStatusline(report), "codex 40% 5h 20% wk");
 });

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -140,7 +140,7 @@ const scrapeTool = defineTool({
 		location: Type.Optional(Type.Any({ description: "Firecrawl location options." })),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🔥 scrape", async () => {
+		return withStatus(ctx, "scrape", async () => {
 			const payload = await firecrawlRequest("POST", "/scrape", cleanObject(params), signal);
 			return jsonResult(payload);
 		});
@@ -178,7 +178,7 @@ const crawlTool = defineTool({
 		webhook: Type.Optional(Type.Any({ description: "Firecrawl webhook configuration." })),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🔥 crawl", async () => {
+		return withStatus(ctx, "crawl", async () => {
 			const payload = await firecrawlRequest("POST", "/crawl", cleanObject(params), signal);
 			return jsonResult(payload);
 		});
@@ -194,7 +194,7 @@ const crawlStatusTool = defineTool({
 		id: Type.String({ description: "Crawl job id returned by firecrawl_crawl." }),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🔥 crawl status", async () => {
+		return withStatus(ctx, "crawl status", async () => {
 			const payload = await firecrawlRequest(
 				"GET",
 				`/crawl/${encodeURIComponent(params.id)}`,
@@ -226,7 +226,7 @@ const mapTool = defineTool({
 		limit: Type.Optional(Type.Number({ description: "Maximum number of URLs to return." })),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🔥 map", async () => {
+		return withStatus(ctx, "map", async () => {
 			const payload = await firecrawlRequest("POST", "/map", cleanObject(params), signal);
 			return jsonResult(payload);
 		});
@@ -250,7 +250,7 @@ const searchTool = defineTool({
 		),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-		return withStatus(ctx, "🔥 search", async () => {
+		return withStatus(ctx, "search", async () => {
 			const payload = await firecrawlRequest("POST", "/search", cleanObject(params), signal);
 			return jsonResult(payload);
 		});

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -69,13 +69,13 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 ## 📊 Statusline states
 
-`pi-goal` writes compact status strings for statusline extensions:
+`pi-goal` writes compact plain status strings for statusline extensions. `@narumitw/pi-statusline` adds the default `🎯` icon unless configured otherwise:
 
-- `🎯 active 3m` — an active goal without a token budget.
-- `🎯 active 18k/100k` — an active goal with token usage and budget.
-- `🎯 paused` — auto-continuation is paused.
-- `🎯 budget 100k/100k` — the token budget was reached; auto-continuation stops.
-- `🎯 complete` — shown briefly after `goal_complete` succeeds.
+- `active 3m` — an active goal without a token budget.
+- `active 18k/100k` — an active goal with token usage and budget.
+- `paused` — auto-continuation is paused.
+- `budget 100k/100k` — the token budget was reached; auto-continuation stops.
+- `complete` — shown briefly after `goal_complete` succeeds.
 
 ## ✅ How completion works
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -527,11 +527,11 @@ function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
 
 export function formatStatus(goal: ActiveGoal | undefined) {
 	if (!goal) return undefined;
-	if (goal.status === "complete") return "🎯 complete";
-	if (goal.status === "paused") return "🎯 paused";
-	if (goal.status === "budget_limited") return `🎯 budget ${formatBudget(goal)}`;
-	if (goal.tokenBudget !== undefined) return `🎯 active ${formatBudget(goal)}`;
-	return `🎯 active ${formatDuration(goal.timeUsedSeconds)}`;
+	if (goal.status === "complete") return "complete";
+	if (goal.status === "paused") return "paused";
+	if (goal.status === "budget_limited") return `budget ${formatBudget(goal)}`;
+	if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)}`;
+	return `active ${formatDuration(goal.timeUsedSeconds)}`;
 }
 
 function formatBudget(goal: ActiveGoal) {
@@ -731,7 +731,7 @@ function clearActiveGoal(ctx: StatusContext) {
 
 function showCompletionStatus(ctx: StatusContext) {
 	clearCompletionStatusTimer();
-	ctx.ui.setStatus(STATUS_KEY, "🎯 complete");
+	ctx.ui.setStatus(STATUS_KEY, "complete");
 	completionStatusTimer = setTimeout(() => {
 		completionStatusTimer = undefined;
 		try {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -67,9 +67,9 @@ test("formatStatus reports active, paused, budget-limited, and empty states", ()
 	} as const;
 
 	assert.equal(formatStatus(undefined), undefined);
-	assert.equal(formatStatus(activeGoal), "🎯 active 500/2k");
-	assert.equal(formatStatus({ ...activeGoal, status: "paused" }), "🎯 paused");
-	assert.equal(formatStatus({ ...activeGoal, status: "budget_limited" }), "🎯 budget 500/2k");
+	assert.equal(formatStatus(activeGoal), "active 500/2k");
+	assert.equal(formatStatus({ ...activeGoal, status: "paused" }), "paused");
+	assert.equal(formatStatus({ ...activeGoal, status: "budget_limited" }), "budget 500/2k");
 });
 
 test("buildGoalSystemPrompt escapes objective XML and includes budget rules", () => {

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -16,7 +16,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finish with `<proposed_plan>` only when decision-complete.
 - Adds a required `plan_mode_question` tool so the agent can ask structured Plan-mode questions before finalizing a plan.
 - Detects proposed plan blocks and prompts you to implement, stay in Plan mode, or exit and discard the plan.
-- Shows Plan mode state in Pi's statusline as `📝 plan active` or `📝 plan ready`.
+- Shows Plan mode state in Pi's statusline as `plan active` or `plan ready`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
 - Persists Plan mode state in the Pi session so resume restores the mode.
 
 ## 📦 Install
@@ -79,8 +79,8 @@ After a proposed plan is detected, `/plan` lets you choose whether to implement 
 
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 
-- `📝 plan active`: Plan mode is enabled and still gathering context or drafting a plan.
-- `📝 plan ready`: A `<proposed_plan>` was detected and remains ready until you implement it, continue planning, or exit Plan mode.
+- `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
+- `plan ready`: A `<proposed_plan>` was detected and remains ready until you implement it, continue planning, or exit Plan mode.
 
 You can also exit directly. Direct exit discards the latest proposed plan instead of treating it as an implementation request:
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -644,8 +644,8 @@ export default function planMode(pi: ExtensionAPI) {
 
 	function formatStatus() {
 		if (!state.enabled) return undefined;
-		if (state.awaitingAction || state.latestPlan) return "📝 plan ready";
-		return "📝 plan active";
+		if (state.awaitingAction || state.latestPlan) return "plan ready";
+		return "plan active";
 	}
 
 	function clearUi(ctx: ExtensionContext) {

--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -14,8 +14,8 @@ Use it to make Pi sessions more resilient when an upstream AI provider returns a
 - Lets Pi's built-in retry path continue the turn.
 - Watches provider requests and assistant stream events for stalls.
 - Aborts and rewrites watchdog-triggered aborts as retryable provider errors.
-- Shows `📥 receiving` in the statusline while provider/stream events are arriving.
-- Shows `🔁 retrying` when a matching error or stall triggers retry.
+- Shows `receiving` in the statusline while provider/stream events are arriving.
+- Shows `retrying` when a matching error or stall triggers retry; `@narumitw/pi-statusline` adds the default `🔁` icon unless configured otherwise.
 - Supports `--retry-stall-timeout-ms <ms>` and `PI_RETRY_STALL_TIMEOUT_MS=<ms>`.
 - Works as a small, focused npm Pi extension package.
 
@@ -41,7 +41,7 @@ pi -e ./extensions/pi-retry
 
 When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
 
-After Pi sends a provider request, the extension also starts a stall watchdog. Provider responses and assistant stream events briefly refresh a `📥 receiving` statusline item, so you can tell that data is still arriving while Pi shows its normal working indicator. If no provider response or assistant stream event is observed for 90s, it briefly shows `🔁 retrying`, calls `ctx.abort()`, and rewrites the resulting assistant abort/error as a retryable provider error.
+After Pi sends a provider request, the extension also starts a stall watchdog. Provider responses and assistant stream events briefly refresh a `receiving` statusline item, so you can tell that data is still arriving while Pi shows its normal working indicator. If no provider response or assistant stream event is observed for 90s, it briefly shows `retrying`, calls `ctx.abort()`, and rewrites the resulting assistant abort/error as a retryable provider error.
 
 Configure the watchdog with:
 

--- a/extensions/pi-retry/src/retry.ts
+++ b/extensions/pi-retry/src/retry.ts
@@ -73,11 +73,11 @@ export default function retry(pi: ExtensionAPI) {
 	};
 
 	const showRetryStatus = (ctx: StatusContext) => {
-		setTransientStatus(ctx, "retry", "🔁 retrying", STATUS_VISIBLE_MS);
+		setTransientStatus(ctx, "retry", "retrying", STATUS_VISIBLE_MS);
 	};
 
 	const showIncomingStatus = (ctx: StatusContext) => {
-		setTransientStatus(ctx, "incoming", "📥 receiving", INCOMING_STATUS_VISIBLE_MS);
+		setTransientStatus(ctx, "incoming", "receiving", INCOMING_STATUS_VISIBLE_MS);
 	};
 
 	const clearIncomingStatus = (ctx: StatusContext) => {

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -11,7 +11,7 @@ Use it to monitor model selection, thinking level, git branch, working directory
 - Replaces the default Pi footer with a compact preset-based statusline.
 - Shows model, thinking level, git branch, project directory, active tool, context usage, tokens, cost, and clock.
 - Displays compact statuses published through Pi's generic extension status API.
-- Preserves extension-provided status icons when the status text starts with one.
+- Owns extension status icons through optional JSON config, including per-extension icon suppression with `""`.
 - Warns when the same extension package is installed from multiple sources.
 - Uses emoji-labeled segments for readability in both classic and Tokyo Night presets.
 - Adapts to terminal width and truncates safely.
@@ -49,7 +49,31 @@ Supported presets:
 - `tokyo-night` — the default, inspired by the [Starship Tokyo Night preset](https://starship.rs/presets/tokyo-night), using `░▒▓` / `` powerline blocks and the Tokyo Night color ramp.
 - `classic` — a compact Pi-themed statusline with left-aligned `•` separators.
 
-Unset or invalid values fall back to `tokyo-night`. Both presets keep the same emoji-labeled information and preserve extension-provided status icons.
+Unset or invalid values fall back to `tokyo-night`. Both presets keep the same emoji-labeled information.
+
+## ⚙️ Extension status icons
+
+Extension statuses use built-in icons by status key. Override or suppress them in `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json`:
+
+```json
+{
+  "extensionStatusIcons": {
+    "caffeinate": "☕",
+    "goal": "🎯",
+    "pisync": "☁️",
+    "unknown-error-retry": "",
+    "plan-mode": "📝",
+    "subagents": "🤖"
+  }
+}
+```
+
+- Missing key: use the built-in icon, or `🔌` for an unknown status key.
+- String value: use that string as the icon.
+- Empty string: show the status text without an icon.
+- `PI_STATUSLINE_PRESET` remains the only preset setting; this JSON file only controls extension status icons.
+
+During the `PI_CAFFEINATE_ICON` deprecation window, a leading emoji from `pi-caffeinate` is still used when JSON does not configure `caffeinate`. JSON wins when both are set.
 
 ## 👀 What it shows
 
@@ -68,14 +92,14 @@ The default `tokyo-night` statusline uses a Starship-inspired `░▒▓` / `
 
 Statuses from other extensions appear on their own compact line below the main statusline and use each preset's separator.
 
-`pi-statusline` is extension-agnostic: it consumes Pi's generic extension status API and does not import or depend on status-producing extensions. If an extension wants a custom icon, it should include that icon at the start of its status text, for example `ctx.ui.setStatus("goal", "🎯 active")`. Statuses without a leading icon use the generic `🔌` icon.
+`pi-statusline` is extension-agnostic: it consumes Pi's generic extension status API and does not import or depend on status-producing extensions.
 
 Examples:
 
-- `🔌 active` for a plain status such as `goal: active`.
-- `🎯 active` when the producing extension sets `🎯 active`.
-- `🐍 ty ✓ ruff ✓` when the producing extension sets a Python status with a leading icon.
-- `🧪 running` when any extension publishes an activity status with its own icon.
+- `🎯 active` for `goal: active` using the built-in `goal` icon.
+- `☕ display` when JSON config sets `"caffeinate": "☕"`.
+- `receiving` when JSON config sets `"unknown-error-retry": ""`.
+- `🔌 running` for an unknown extension status key with no configured icon.
 - `⚠️ dup biome-lsp` when local and npm installs register the same extension.
 
 ## 🧠 Use cases

--- a/extensions/pi-statusline/presets/types.ts
+++ b/extensions/pi-statusline/presets/types.ts
@@ -26,6 +26,7 @@ export interface StatuslineConfig {
 	separator: SeparatorName;
 	showLabels: boolean;
 	segments: SegmentName[];
+	extensionStatusIcons: Record<string, string>;
 }
 
 export interface RenderSegment {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import process from "node:process";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -40,7 +41,25 @@ interface TokenTotals {
 }
 
 const STATUSLINE_KEY = "statusline";
+const SETTINGS_FILE = "pi-statusline-settings.json";
 const DEFAULT_PRESET: StatuslinePresetName = "tokyo-night";
+
+const DEFAULT_EXTENSION_STATUS_ICONS: Record<string, string> = {
+	"chrome-devtools": "🌐",
+	"codex-usage": "📊",
+	caffeinate: "💊",
+	firecrawl: "🔥",
+	goal: "🎯",
+	lsp: "🧰",
+	"plan-mode": "📝",
+	pisync: "🔄",
+	subagents: "🧑‍🤝‍🧑",
+	"unknown-error-retry": "🔁",
+};
+
+interface StatuslineSettings {
+	extensionStatusIcons: Record<string, string>;
+}
 
 const DEFAULT_SEGMENTS: SegmentName[] = [
 	"brand",
@@ -173,6 +192,28 @@ function createDefaultConfig(): StatuslineConfig {
 		separator: "dot",
 		showLabels: false,
 		segments: [...DEFAULT_SEGMENTS],
+		extensionStatusIcons: readStatuslineSettings().extensionStatusIcons,
+	};
+}
+
+export function readStatuslineSettings(settingsPath = join(getAgentDir(), SETTINGS_FILE)): StatuslineSettings {
+	try {
+		return normalizeStatuslineSettings(JSON.parse(readFileSync(settingsPath, "utf8")));
+	} catch {
+		return { extensionStatusIcons: {} };
+	}
+}
+
+export function normalizeStatuslineSettings(value: unknown): StatuslineSettings {
+	if (!value || typeof value !== "object") return { extensionStatusIcons: {} };
+	const icons = (value as { extensionStatusIcons?: unknown }).extensionStatusIcons;
+	if (!icons || typeof icons !== "object" || Array.isArray(icons)) {
+		return { extensionStatusIcons: {} };
+	}
+	return {
+		extensionStatusIcons: Object.fromEntries(
+			Object.entries(icons).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+		),
 	};
 }
 
@@ -351,18 +392,34 @@ function formatExtensionStatuses(
 		...formatDuplicateExtensionStatus(runtime, theme),
 		...[...statuses.entries()]
 			.filter(([key, value]) => key !== STATUSLINE_KEY && value.trim().length > 0)
-			.map(([key, value]) => formatExtensionStatus(key, value, theme)),
+			.map(([key, value]) => formatExtensionStatus(key, value, theme, config)),
 	].slice(0, 5);
 
 	return visibleStatuses.join(separator);
 }
 
-function formatExtensionStatus(key: string, value: string, theme: Theme): string {
+export function formatExtensionStatus(
+	key: string,
+	value: string,
+	theme: Theme,
+	config: Pick<StatuslineConfig, "extensionStatusIcons">,
+): string {
 	const status = splitExtensionStatusIcon(stripExtensionStatusPrefix(key, value));
 	const text = truncateToWidth(simplifyExtensionStatusText(status.text), 22, "…");
 	const color = extensionColor(key, value);
 	const textColor = color === "warning" ? "warning" : "muted";
-	return `${theme.fg(color, status.icon)} ${theme.fg(textColor, text)}`;
+	const icon = extensionStatusIcon(key, status.icon, config.extensionStatusIcons);
+	const renderedText = theme.fg(textColor, text);
+	return icon ? `${theme.fg(color, icon)} ${renderedText}` : renderedText;
+}
+
+function extensionStatusIcon(
+	key: string,
+	leadingIcon: string | undefined,
+	configuredIcons: Record<string, string>,
+) {
+	if (Object.hasOwn(configuredIcons, key)) return configuredIcons[key];
+	return leadingIcon ?? DEFAULT_EXTENSION_STATUS_ICONS[key] ?? "🔌";
 }
 
 function formatDuplicateExtensionStatus(runtime: RuntimeState, theme: Theme): string[] {
@@ -373,13 +430,13 @@ function formatDuplicateExtensionStatus(runtime: RuntimeState, theme: Theme): st
 	return [`${theme.fg("warning", "⚠️")} ${theme.fg("warning", `dup ${names}${suffix}`)}`];
 }
 
-export function splitExtensionStatusIcon(value: string): { icon: string; text: string } {
+export function splitExtensionStatusIcon(value: string): { icon?: string; text: string } {
 	const trimmed = value.trim();
 	const [firstToken, ...restTokens] = trimmed.split(/\s+/);
 	if (firstToken && isEmojiOnlyToken(firstToken)) {
 		return { icon: firstToken, text: restTokens.join(" ") };
 	}
-	return { icon: "🔌", text: trimmed };
+	return { text: trimmed };
 }
 
 function isEmojiOnlyToken(value: string): boolean {

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { createMockPi } from "../../../test/support.js";
 import statusline, {
 	contextColor,
 	extensionColor,
 	formatCount,
+	formatExtensionStatus,
 	formatToolActivity,
 	npmPackageName,
+	readStatuslineSettings,
 	shortenModel,
 	simplifyExtensionStatusText,
 	splitExtensionStatusIcon,
@@ -58,11 +63,43 @@ test("extension status helpers strip prefixes, icons, and simplify text", () => 
 		icon: "🔥",
 		text: "running crawl",
 	});
-	assert.deepEqual(splitExtensionStatusIcon("plain status"), { icon: "🔌", text: "plain status" });
+	assert.deepEqual(splitExtensionStatusIcon("plain status"), { text: "plain status" });
 	assert.equal(stripExtensionStatusPrefix("firecrawl", "firecrawl: ready"), "ready");
 	assert.equal(simplifyExtensionStatusText("ready, missing (details)"), "✓ ✗");
 	assert.equal(extensionColor("codex", "checking"), "accent");
 	assert.equal(extensionColor("lsp", "command missing"), "warning");
+});
+
+test("statusline settings load extension icon overrides", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-test-"));
+	const settingsPath = join(root, "pi-statusline-settings.json");
+
+	assert.deepEqual(readStatuslineSettings(settingsPath), { extensionStatusIcons: {} });
+
+	writeFileSync(
+		settingsPath,
+		JSON.stringify({ extensionStatusIcons: { goal: "", caffeinate: "☕", bad: 1 } }),
+	);
+	assert.deepEqual(readStatuslineSettings(settingsPath), {
+		extensionStatusIcons: { goal: "", caffeinate: "☕" },
+	});
+
+	writeFileSync(settingsPath, "not json");
+	assert.deepEqual(readStatuslineSettings(settingsPath), { extensionStatusIcons: {} });
+});
+
+test("extension status icons use config, leading emoji, defaults, and fallback", () => {
+	const theme = { fg: (_color: string, text: string) => text } as never;
+	const config = (extensionStatusIcons: Record<string, string>) => ({ extensionStatusIcons });
+
+	assert.equal(formatExtensionStatus("goal", "active", theme, config({})), "🎯 active");
+	assert.equal(
+		formatExtensionStatus("caffeinate", "☕ display", theme, config({ caffeinate: "🍵" })),
+		"🍵 display",
+	);
+	assert.equal(formatExtensionStatus("caffeinate", "☕ display", theme, config({})), "☕ display");
+	assert.equal(formatExtensionStatus("goal", "active", theme, config({ goal: "" })), "active");
+	assert.equal(formatExtensionStatus("unknown", "running", theme, config({})), "🔌 running");
 });
 
 test("statusline compact formatting helpers", () => {

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -99,19 +99,19 @@ function publishSubagentStatus(ctx: StatusContext) {
 }
 
 function singleStatus(agent: string): string {
-	return `🧑‍🤝‍🧑 ${agent}`;
+	return `${agent}`;
 }
 
 function chainStatus(step: number, total: number, agent?: string): string {
-	return `🧑‍🤝‍🧑 chain ${step}/${total}${agent ? ` ${agent}` : ""}`;
+	return `chain ${step}/${total}${agent ? ` ${agent}` : ""}`;
 }
 
 function parallelStatus(done: number, total: number, running: number): string {
-	return `🧑‍🤝‍🧑 parallel ${done}/${total} done${running > 0 ? ` ${running} running` : ""}`;
+	return `parallel ${done}/${total} done${running > 0 ? ` ${running} running` : ""}`;
 }
 
 function fanInStatus(agent: string): string {
-	return `🧑‍🤝‍🧑 fan-in ${agent}`;
+	return `fan-in ${agent}`;
 }
 
 export function formatTokens(count: number): string {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -299,7 +299,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 }
 
 async function status(ctx: ExtensionCommandContext) {
-	ctx.ui.setStatus(STATUS_KEY, "🔄 checking");
+	ctx.ui.setStatus(STATUS_KEY, "checking");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
@@ -330,7 +330,7 @@ async function status(ctx: ExtensionCommandContext) {
 }
 
 async function diff(ctx: ExtensionCommandContext) {
-	ctx.ui.setStatus(STATUS_KEY, "🔄 diff");
+	ctx.ui.setStatus(STATUS_KEY, "diff");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
@@ -395,7 +395,7 @@ async function push(
 	options: CommandOptions,
 	input?: PushInput,
 ) {
-	ctx.ui.setStatus(STATUS_KEY, "🔄 pushing");
+	ctx.ui.setStatus(STATUS_KEY, "pushing");
 	const config = input?.config ?? (await loadConfig());
 	const client = input?.client ?? new S3Client(config);
 	const state = input?.state ?? (await readState(config.profile));
@@ -446,7 +446,7 @@ async function push(
 }
 
 async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
-	ctx.ui.setStatus(STATUS_KEY, "🔄 pulling");
+	ctx.ui.setStatus(STATUS_KEY, "pulling");
 	const config = await loadConfig();
 	const client = new S3Client(config);
 	const state = await readState(config.profile);


### PR DESCRIPTION
## Summary
- add `pi-statusline-settings.json` `extensionStatusIcons` support for default, custom, suppressed, and leading-emoji compatibility icons
- move active producer extension statuses to plain text
- keep `PI_CAFFEINATE_ICON` as a deprecated compatibility path with a warning
- document the JSON config and archive the completed plan

## Verification
- `npm test -- --workspace @narumitw/pi-statusline`
- `npm test -- --workspace @narumitw/pi-caffeinate`
- `npm test -- --workspace @narumitw/pi-goal`
- `npm test -- --workspace @narumitw/pi-codex-usage`
- `npm run check`
- `git diff --check`
- `rg -n "setStatus\([^\n]*(🎯|📝|🔁|📥|🔄|🧑|🔥|🌐|📊)" extensions/*/src` returned no producer status hits