### PR TITLE
fix(caffeinate): simplify status wording

### DIFF
--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -144,7 +144,7 @@ Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the co
 
 AI coding agents often run tool-heavy tasks that take several minutes. `pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
 
-The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend. Use sleep-only mode when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
+The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend. Use `/caffeinate sleep` (shown as `system-awake` in status output) when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
 
 ## 🗂️ Package layout
 

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -319,7 +319,7 @@ function startInhibitor(ctx: ExtensionContext) {
 			updateStatus(ctx);
 		});
 
-		ctx.ui.notify(`Keeping computer awake with ${command.description}.`, "info");
+		ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
 		updateStatus(ctx);
 	} catch (error) {
 		state.process = undefined;
@@ -580,11 +580,11 @@ function statusLevel() {
 
 function statusModeLabel() {
 	if (state.command?.custom) return "custom";
-	return state.mode === "sleep" ? "sleep" : "display";
+	return formatMode(state.mode);
 }
 
 export function formatMode(mode: CaffeinateMode) {
-	return mode === "sleep" ? "sleep-only" : "display-awake";
+	return mode === "sleep" ? "system-awake" : "display-awake";
 }
 
 async function ensureSettingsLoaded(ctx: ExtensionContext) {
@@ -696,7 +696,7 @@ function warnDeprecatedIcon(ctx: ExtensionContext) {
 	if (state.iconWarningShown || !process.env.PI_CAFFEINATE_ICON?.trim()) return;
 	state.iconWarningShown = true;
 	ctx.ui.notify(
-		'PI_CAFFEINATE_ICON is deprecated and still works for now. If you use @narumitw/pi-statusline, move this icon to pi-statusline-settings.json: { "extensionStatusIcons": { "caffeinate": "..." } }.',
+		"PI_CAFFEINATE_ICON is deprecated but still works for now. If you use @narumitw/pi-statusline, move it to pi-statusline-settings.json (extensionStatusIcons.caffeinate).",
 		"warning",
 	);
 }

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -70,12 +70,14 @@ test("session start warns for deprecated PI_CAFFEINATE_ICON", async (t) => {
 
 	assert.equal(notifications.length, 1);
 	assert.match(notifications[0]?.message ?? "", /PI_CAFFEINATE_ICON is deprecated/);
+	assert.match(notifications[0]?.message ?? "", /still works for now/);
 	assert.match(notifications[0]?.message ?? "", /If you use @narumitw\/pi-statusline/);
 });
 
-test("windowsInhibitorScript uses unsigned flags and releases on exit", () => {
+test("windowsInhibitorScript flags and formatMode labels are user-facing", () => {
 	assert.match(windowsInhibitorScript("sleep"), /\[uint32\]'0x80000001'/);
 	assert.match(windowsInhibitorScript("display"), /\[uint32\]'0x80000003'/);
 	assert.match(windowsInhibitorScript("display"), /\[uint32\]'0x80000000'/);
+	assert.equal(formatMode("sleep"), "system-awake");
 	assert.equal(formatMode("display"), "display-awake");
 });


### PR DESCRIPTION
## Summary
- rename the system-only keep-awake label to `system-awake`
- shorten the active keep-awake and deprecated icon messages
- update caffeinate docs and tests

## Tests
- npm run check