### PR TITLE
fix(pi-retry): retry Codex websocket connection limit

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -23,6 +23,7 @@
 - Symptom: Telegram bot polling can replay stale queued messages or conflict across Pi processes. Cause: `getUpdates` is a single bot-token queue controlled by offsets. Fix: discard pending updates on startup with an offset and run one active polling Pi per bot token.
 - For pi-sync on Cloudflare R2, keep session-token support for temporary credentials but retry once without the token when R2 static keys reject `X-Amz-Security-Token`.
 - Symptom: Pi extension async/timer/command continuations can crash after reload or session replacement. Cause: captured `ExtensionContext` becomes stale. Fix: pass plain data into delayed callbacks, catch stale-context errors, and scope cleanup to the failing ctx/request.
+- Codex `websocket_connection_limit_reached` is a retryable fresh-websocket case, but Pi 0.79.8's auto-retry regex does not classify “connection limit”; pi-retry must add the `provider returned error` hint.
 
 ## TASTE
 

--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -2,14 +2,15 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-retry)](https://www.npmjs.com/package/@narumitw/pi-retry) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-retry` is a native [Pi coding agent](https://pi.dev) extension that treats provider responses containing `Unknown error (no error details in response)` and stalled provider streams as retryable.
+`@narumitw/pi-retry` is a native [Pi coding agent](https://pi.dev) extension that treats provider responses containing `Unknown error (no error details in response)`, Codex `websocket_connection_limit_reached`, and stalled provider streams as retryable.
 
-Use it to make Pi sessions more resilient when an upstream AI provider returns a transient unknown error without useful details or stops streaming after Pi has sent a request.
+Use it to make Pi sessions more resilient when an upstream AI provider returns a transient unknown error without useful details, Codex asks for a fresh websocket, or a provider stops streaming after Pi has sent a request.
 
 ## ✨ Features
 
 - Detects assistant messages that end with `stopReason: "error"`.
 - Matches the known provider error text `Unknown error (no error details in response)`.
+- Matches Codex `websocket_connection_limit_reached` after a websocket hits its 60-minute limit.
 - Appends Pi's retryable-provider-error hint.
 - Lets Pi's built-in retry path continue the turn.
 - Watches provider requests and assistant stream events for stalls.
@@ -39,7 +40,7 @@ pi -e ./extensions/pi-retry
 
 ## 🚀 What it does
 
-When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
+When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)` or Codex `websocket_connection_limit_reached`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
 
 After Pi sends a provider request, the extension also starts a stall watchdog. Provider responses and assistant stream events briefly refresh a `receiving` statusline item, so you can tell that data is still arriving while Pi shows its normal working indicator. If no provider response or assistant stream event is observed for 90s, it briefly shows `retrying`, calls `ctx.abort()`, and rewrites the resulting assistant abort/error as a retryable provider error.
 
@@ -55,6 +56,7 @@ Use `0`, `off`, or `false` to disable the watchdog. Retry attempts and backoff r
 ## 🧠 Use cases
 
 - Reduce manual restarts after transient provider failures.
+- Recover when Codex websocket sessions hit the 60-minute connection limit.
 - Improve reliability during long Pi coding agent sessions.
 - Keep tool-heavy implementation tasks moving when a provider returns an unknown error or stream stalls.
 - Pair with `@narumitw/pi-goal` for more robust autonomous task loops.

--- a/extensions/pi-retry/package.json
+++ b/extensions/pi-retry/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-retry",
 	"version": "0.6.0",
-	"description": "Public pi extension that retries empty-detail provider errors and stalled streams.",
+	"description": "Public pi extension that retries empty-detail, Codex websocket-limit, and stalled provider errors."
 	"type": "module",
 	"license": "MIT",
 	"private": false,

--- a/extensions/pi-retry/package.json
+++ b/extensions/pi-retry/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-retry",
 	"version": "0.6.0",
-	"description": "Public pi extension that retries empty-detail, Codex websocket-limit, and stalled provider errors."
+	"description": "Public pi extension that retries empty-detail, Codex websocket-limit, and stalled provider errors.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,

--- a/extensions/pi-retry/src/retry.ts
+++ b/extensions/pi-retry/src/retry.ts
@@ -1,8 +1,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const UNKNOWN_NO_DETAILS_RE = /Unknown error \(no error details in response\)/i;
+const CODEX_WEBSOCKET_CONNECTION_LIMIT_RE =
+	/websocket[_\s-]*connection[_\s-]*limit[_\s-]*reached|create a new websocket connection to continue/i;
 const RETRYABLE_HINT = "provider returned error";
 const UNKNOWN_ERROR_TAG = "[unknown-error-retry]";
+const CODEX_WEBSOCKET_CONNECTION_LIMIT_TAG = "[codex-websocket-limit-retry]";
 const STALL_WATCHDOG_TAG = "[stall-watchdog-retry]";
 const STATUS_KEY = "unknown-error-retry";
 const STATUS_VISIBLE_MS = 8_000;
@@ -190,24 +193,37 @@ export default function retry(pi: ExtensionAPI) {
 
 		if (message.stopReason !== "error") return;
 		if (typeof message.errorMessage !== "string") return;
-		if (!UNKNOWN_NO_DETAILS_RE.test(message.errorMessage)) return;
+
+		const matchedError = UNKNOWN_NO_DETAILS_RE.test(message.errorMessage)
+			? {
+					tag: UNKNOWN_ERROR_TAG,
+					label: "empty-detail provider failure",
+					notification:
+						"Matched provider 'Unknown error (no error details in response)'; letting pi auto-retry this turn.",
+				}
+			: CODEX_WEBSOCKET_CONNECTION_LIMIT_RE.test(message.errorMessage)
+				? {
+						tag: CODEX_WEBSOCKET_CONNECTION_LIMIT_TAG,
+						label: "Codex websocket connection limit",
+						notification:
+							"Matched Codex websocket connection limit; letting pi auto-retry with a fresh websocket.",
+					}
+				: undefined;
+		if (!matchedError) return;
 
 		// Avoid appending the hint repeatedly if a resumed/replayed message already has it.
-		if (message.errorMessage.includes(UNKNOWN_ERROR_TAG)) return;
+		if (message.errorMessage.includes(matchedError.tag)) return;
 
 		// pi already has agent-level auto-retry for transient provider errors, but its
-		// matcher does not classify this empty-detail "Unknown error" message as retryable.
+		// matcher does not classify a few provider-specific messages as retryable.
 		// Adding this hint before the message is finalized makes pi's built-in auto-retry
 		// path pick it up, remove the failed assistant message from live agent state, and
 		// call agent.continue() with the normal retry settings/backoff.
-		const errorMessage = `${message.errorMessage}\n\n${UNKNOWN_ERROR_TAG} ${RETRYABLE_HINT}; treating empty-detail provider failure as retryable.`;
+		const errorMessage = `${message.errorMessage}\n\n${matchedError.tag} ${RETRYABLE_HINT}; treating ${matchedError.label} as retryable.`;
 
 		if (ctx.hasUI) {
 			showRetryStatus(ctx);
-			ctx.ui.notify?.(
-				"Matched provider 'Unknown error (no error details in response)'; letting pi auto-retry this turn.",
-				"warning",
-			);
+			ctx.ui.notify?.(matchedError.notification, "warning");
 		}
 
 		return {

--- a/extensions/pi-retry/test/retry.test.ts
+++ b/extensions/pi-retry/test/retry.test.ts
@@ -47,3 +47,31 @@ test("message_end appends pi retry hint for unknown provider errors once", () =>
 		undefined,
 	);
 });
+
+test("message_end appends pi retry hint for Codex websocket connection limits once", () => {
+	const mock = createMockPi();
+	retry(mock.pi);
+	const handler = mock.events.get("message_end")?.[0];
+	assert.ok(handler);
+
+	const event = {
+		message: {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage:
+				'Codex error: {"type":"error","error":{"code":"websocket_connection_limit_reached","message":"Responses websocket connection limit reached (60 minutes). Create a new websocket connection to continue."},"status":400}',
+		},
+	};
+	const result = handler(event, createMockContext({ hasUI: false }).ctx);
+	assert.ok(result && typeof result === "object" && "message" in result);
+	const retryResult = result as { message: { errorMessage: string } };
+
+	assert.match(
+		retryResult.message.errorMessage,
+		/\[codex-websocket-limit-retry\] provider returned error/,
+	);
+	assert.equal(
+		handler({ message: retryResult.message }, createMockContext({ hasUI: false }).ctx),
+		undefined,
+	);
+});


### PR DESCRIPTION
## Summary
- Treat Codex websocket_connection_limit_reached errors as retryable in pi-retry
- Update pi-retry docs and package metadata

## Verification
- npm run check
- npm run pack:retry