### PR TITLE
fix(goal): add command argument completions

### DIFF
--- a/docs/plans/archived/2026-06-22_pi-goal-autocomplete-plan.md
+++ b/docs/plans/archived/2026-06-22_pi-goal-autocomplete-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Fix issue #109 by adding tab autocomplete suggestions for `/goal` arguments, so users can discover static management subcommands (`pause`, `resume`, `clear`, `edit`, `status`) and the `--tokens` option from the Pi editor. Success means the `pi-goal` command registers argument completions, tests cover the suggestion behavior, and the workspace check passes.
+
+## Context
+
+`pi-goal` currently registers `/goal` with a description and handler only. Pi command registration supports `getArgumentCompletions(argumentPrefix)`, returning `AutocompleteItem[] | null`, which is enough for this issue without adding dependencies or a custom editor autocomplete provider.
+
+## Non-Goals
+
+- Do not autocomplete free-form goal objective text.
+- Do not add dynamic state-aware filtering such as hiding `resume` unless a goal is paused.
+- Do not add a new autocomplete provider; the command-level API is sufficient.
+
+## Assumptions
+
+- The issue is about `/goal` subcommand and option discovery, not shell-level completion outside Pi's TUI editor.
+- Static completions are acceptable for the first fix because every suggested item is already accepted by `parseCommand` or `parseObjective`.
+
+## Plan
+
+- [x] Add a small exported completion helper in `extensions/pi-goal/src/goal.ts` that returns matching `AutocompleteItem` objects for `/goal` argument prefixes; verified by `completeGoalArguments` unit tests for empty, partial, already-complete, edit-option, and objective-like prefixes.
+- [x] Wire the helper into `pi.registerCommand("goal", { getArgumentCompletions })` so Pi's built-in command autocomplete can show `/goal` suggestions; verified by `goal registers command...` asserting the registered command has a completion function.
+- [x] Cover expected suggestions in `extensions/pi-goal/test/goal.test.ts`: empty args include `pause`, `resume`, `clear`, `edit`, `status`, and `--tokens`; partial args such as `pa` return `pause`; non-matching or objective-like prefixes return `null`; verified by focused goal tests.
+- [x] Run the smallest relevant verification command for the package after code changes; verified with `node_modules/.bin/tsc -p tsconfig.test.json && node ./node_modules/.cache/pi-extensions-test/extensions/pi-goal/test/goal.test.js`.
+- [x] Run the repository gate if the focused test passes; verified with `npm run check`.
+
+## Risks
+
+- [x] Mitigated: `getArgumentCompletions` receives the full argument prefix, not just the current token; tests cover prefixes that include spaces such as `edit `.
+- [x] Mitigated: Returning noisy suggestions after users start typing an objective could be annoying; `completeGoalArguments` returns `null` for objective-like prefixes such as `ship objective` and `edit objective`.
+
+## Completion Checklist
+
+- [x] `/goal` registers `getArgumentCompletions`, verified by `extensions/pi-goal/test/goal.test.ts`.
+- [x] Static suggestions cover accepted subcommands and `--tokens`, verified by focused goal tests.
+- [x] No new dependency or custom autocomplete provider is added, verified by the diff.
+- [x] The fix passes `npm run check` from the repository root.

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -49,6 +49,12 @@ interface CommandResult {
 	tokenBudget?: number;
 }
 
+interface GoalArgumentCompletion {
+	value: string;
+	label: string;
+	description?: string;
+}
+
 interface StatusContext {
 	cwd: string;
 	ui: {
@@ -66,6 +72,19 @@ const GOAL_STATE_ENTRY_TYPE = "goal-state";
 const MAX_OBJECTIVE_LENGTH = 4_000;
 const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
 const CONTINUATION_MARKER_PREFIX = "pi-goal-continuation:";
+const GOAL_ARGUMENT_COMPLETIONS: readonly GoalArgumentCompletion[] = [
+	{ value: "pause", label: "pause", description: "Pause the active goal" },
+	{ value: "resume", label: "resume", description: "Resume a paused or budget-limited goal" },
+	{ value: "clear", label: "clear", description: "Clear the current goal" },
+	{ value: "edit", label: "edit", description: "Edit the current goal objective" },
+	{ value: "status", label: "status", description: "Show the current goal" },
+	{ value: "--tokens ", label: "--tokens", description: "Set a token budget before the goal" },
+];
+const EDIT_TOKEN_COMPLETION: GoalArgumentCompletion = {
+	value: "edit --tokens ",
+	label: "--tokens",
+	description: "Set a token budget before the updated goal",
+};
 const STATE_FILE = join(
 	process.env.PI_CODING_AGENT_DIR ?? join(process.env.HOME ?? ".", ".pi", "agent"),
 	"pi-goal-state.json",
@@ -123,6 +142,7 @@ export default function goal(pi: ExtensionAPI) {
 
 	pi.registerCommand("goal", {
 		description: "Run a goal to completion: /goal [--tokens 100k] <goal_to_complete>",
+		getArgumentCompletions: completeGoalArguments,
 		handler: async (args, ctx) => {
 			const result = parseCommand(args);
 			if (typeof result === "string") {
@@ -404,6 +424,25 @@ function updateGoalUsage(goal: ActiveGoal, ctx: StatusContext) {
 	goal.tokensUsed = Math.max(0, currentTokenTotal(ctx) - goal.baselineTokens);
 	goal.timeUsedSeconds = Math.max(0, Math.floor((Date.now() - goal.startedAt) / 1000));
 	goal.updatedAt = Date.now();
+}
+
+export function completeGoalArguments(argumentPrefix: string): GoalArgumentCompletion[] | null {
+	const prefix = argumentPrefix.trimStart();
+	if (prefix === "") return [...GOAL_ARGUMENT_COMPLETIONS];
+
+	const editOptionPrefix = /^edit\s+(\S*)$/.exec(prefix)?.[1];
+	if (editOptionPrefix !== undefined) {
+		return editOptionPrefix === "" || "--tokens".startsWith(editOptionPrefix)
+			? [EDIT_TOKEN_COMPLETION]
+			: null;
+	}
+
+	if (/\s/.test(prefix)) return null;
+
+	const matches = GOAL_ARGUMENT_COMPLETIONS.filter(
+		(item) => item.value.startsWith(prefix) || item.label.startsWith(prefix),
+	);
+	return matches.length > 0 ? [...matches] : null;
 }
 
 export function parseCommand(args: string): CommandResult | string {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -35,6 +35,17 @@ test("completeGoalArguments suggests /goal subcommands and token options", () =>
 		["pause", "resume", "clear", "edit", "status", "--tokens"],
 	);
 	assert.deepEqual(
+		completeGoalArguments("")?.map((item) => item.description),
+		[
+			"Pause the active goal",
+			"Resume a paused or budget-limited goal",
+			"Clear the current goal",
+			"Edit the current goal objective",
+			"Show the current goal",
+			"Set a token budget before the goal",
+		],
+	);
+	assert.deepEqual(
 		completeGoalArguments("pa")?.map((item) => item.value),
 		["pause"],
 	);

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { createMockPi } from "../../../test/support.js";
 import goal, {
 	buildGoalSystemPrompt,
+	completeGoalArguments,
 	findFinalAssistantMessage,
 	formatDuration,
 	formatStatus,
@@ -17,6 +18,7 @@ test("goal registers command, completion tool, and lifecycle hooks", () => {
 	goal(mock.pi);
 
 	assert.ok(mock.commands.has("goal"));
+	assert.equal(typeof mock.commands.get("goal")?.getArgumentCompletions, "function");
 	assert.equal(mock.tools[0]?.name, "goal_complete");
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"agent_end",
@@ -25,6 +27,35 @@ test("goal registers command, completion tool, and lifecycle hooks", () => {
 		"session_shutdown",
 		"session_start",
 	]);
+});
+
+test("completeGoalArguments suggests /goal subcommands and token options", () => {
+	assert.deepEqual(
+		completeGoalArguments("")?.map((item) => item.label),
+		["pause", "resume", "clear", "edit", "status", "--tokens"],
+	);
+	assert.deepEqual(
+		completeGoalArguments("pa")?.map((item) => item.value),
+		["pause"],
+	);
+	assert.deepEqual(
+		completeGoalArguments("pause")?.map((item) => item.value),
+		["pause"],
+	);
+	assert.deepEqual(
+		completeGoalArguments("--t")?.map((item) => item.value),
+		["--tokens "],
+	);
+	assert.deepEqual(
+		completeGoalArguments("edit ")?.map((item) => item.value),
+		["edit --tokens "],
+	);
+	assert.deepEqual(
+		completeGoalArguments("edit --t")?.map((item) => item.value),
+		["edit --tokens "],
+	);
+	assert.equal(completeGoalArguments("ship objective"), null);
+	assert.equal(completeGoalArguments("edit objective"), null);
 });
 
 test("parseCommand parses budgets, quoted objectives, and management commands", () => {


### PR DESCRIPTION
## Summary
- add `/goal` argument completions for management subcommands and `--tokens`
- avoid suggestions once users start typing free-form objectives
- archive the completed implementation plan

Fixes #109

## Tests
- `node_modules/.bin/tsc -p tsconfig.test.json && node ./node_modules/.cache/pi-extensions-test/extensions/pi-goal/test/goal.test.js`
- `npm run check`