### PR TITLE
fix(pi-sync): cover append system file sync

### DIFF
--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -14,6 +14,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
   - `keybindings.json`
   - `models.json`
   - `AGENTS.md`
+  - `APPEND_SYSTEM.md`
   - `skills/`, `prompts/`, `themes/`, and `extensions/`
   - optionally denylist-filtered `sessions/**/*.jsonl` when `syncSessions` is enabled
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
@@ -70,7 +71,8 @@ Example:
   "profile": "default",
   "prefix": "pi-sync",
   "autoSync": true,
-  "syncSessions": false
+  "syncSessions": false,
+  "extraFiles": []
 }
 ```
 
@@ -88,6 +90,8 @@ export PI_SYNC_PREFIX="pi-sync"
 export PI_SYNC_AUTO_SYNC="true"
 export PI_SYNC_SESSIONS="false" # opt in with true to sync Pi conversation JSONL files
 ```
+
+Set `extraFiles` to additional top-level file names to include beyond the default allowlist.
 
 `PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, assumed roles, or S3-compatible providers that issue short-lived credentials.
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -91,7 +91,7 @@ export PI_SYNC_AUTO_SYNC="true"
 export PI_SYNC_SESSIONS="false" # opt in with true to sync Pi conversation JSONL files
 ```
 
-Set `extraFiles` to additional top-level file names to include beyond the default allowlist.
+Set `extraFiles` to additional top-level file names to include beyond the default allowlist. Machines without a matching `extraFiles` entry preserve those remote files but do not apply or delete them locally.
 
 `PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, assumed roles, or S3-compatible providers that issue short-lived credentials.
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -580,7 +580,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 		await push(ctx, options);
 		return;
 	}
-	if (syncPolicyChanged(state, config)) {
+	if (shouldRefreshSyncedState(remote, state, config)) {
 		await writeState(config.profile, {
 			version: VERSION,
 			profile: config.profile,
@@ -1494,6 +1494,14 @@ function snapshotsMatch(left: Snapshot, right: Snapshot) {
 
 function syncPolicyChanged(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
 	return (state.syncSessions ?? false) !== config.syncSessions || extraFilesChanged(state, config);
+}
+
+function shouldRefreshSyncedState(
+	remote: Snapshot,
+	state: SyncState,
+	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+) {
+	return remote.id !== state.lastAppliedSnapshot || syncPolicyChanged(state, config);
 }
 
 function extraFilesChanged(state: SyncState, config: Pick<SyncConfig, "extraFiles">) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1269,6 +1269,7 @@ function isSafeSnapshotPath(normalized: string) {
 		normalized !== "." &&
 		normalized !== ".." &&
 		!normalized.startsWith("../") &&
+		!normalized.includes("\\") &&
 		!path.posix.isAbsolute(normalized) &&
 		path.posix.normalize(normalized) === normalized &&
 		!isDeniedPath(normalized)
@@ -1891,6 +1892,7 @@ function normalizeExtraFiles(value: unknown) {
 				item !== "" &&
 				!item.includes("/") &&
 				!item.includes("\\") &&
+				!TOP_LEVEL_FILES.has(item) &&
 				!isDeniedPath(item) &&
 				!TOP_LEVEL_DIRS.has(lower) &&
 				lower !== "sessions"

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac, randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, type Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -860,16 +860,17 @@ export async function collectFiles(
 	options: SnapshotOptions = {},
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
-	const extraFiles = extraFileNamesByLower(options.extraFiles);
-	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		const extraFileName = extraFiles.get(entry.name.toLowerCase());
+	const entries = await fs.readdir(root, { withFileTypes: true });
+	for (const entry of entries) {
 		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
 			await addFile(results, root, entry.name);
-		} else if (entry.isFile() && extraFileName) {
-			await addFile(results, root, entry.name, extraFileName);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
 		}
+	}
+	for (const extraFileName of normalizeExtraFiles(options.extraFiles)) {
+		const entry = selectExtraFileEntry(entries, extraFileName);
+		if (entry) await addFile(results, root, entry.name, extraFileName);
 	}
 	if (options.syncSessions) {
 		try {
@@ -976,7 +977,7 @@ export function filterSnapshotForConfigPolicy(
 	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
 	options: { regenerateId?: boolean } = {},
 ) {
-	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
+	const extraFiles = extraFileNames(config.extraFiles);
 	const filtered = {
 		...snapshot,
 		syncSessions: config.syncSessions ? snapshot.syncSessions : false,
@@ -1001,7 +1002,7 @@ function isConfiguredSnapshotPath(
 ) {
 	const normalized = toPosix(relativePath);
 	if (isSessionPath(normalized)) return config.syncSessions;
-	if (!normalized.includes("/")) return TOP_LEVEL_FILES.has(normalized) || extraFiles.has(normalized);
+	if (!normalized.includes("/")) return TOP_LEVEL_FILES.has(normalized) || extraFiles.has(normalized.toLowerCase());
 	return TOP_LEVEL_DIRS.has(normalized.slice(0, normalized.indexOf("/")));
 }
 
@@ -1393,7 +1394,7 @@ function fileHashMap(snapshot: Snapshot) {
 }
 
 function stateHashMapForConfig(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
-	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
+	const extraFiles = extraFileNames(config.extraFiles);
 	return Object.fromEntries(
 		Object.entries(state.lastFileHashes).filter(([filePath]) =>
 			isConfiguredSnapshotPath(filePath, config, extraFiles),
@@ -1928,8 +1929,17 @@ function normalizeExtraFiles(value: unknown) {
 		});
 }
 
-function extraFileNamesByLower(value: unknown) {
-	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
+function extraFileNames(value: unknown) {
+	return new Set(normalizeExtraFiles(value).map((fileName) => fileName.toLowerCase()));
+}
+
+function selectExtraFileEntry(entries: Dirent[], fileName: string) {
+	const exact = entries.find((entry) => entry.isFile() && entry.name === fileName);
+	if (exact) return exact;
+	const lower = fileName.toLowerCase();
+	return entries
+		.filter((entry) => entry.isFile() && entry.name.toLowerCase() === lower)
+		.sort((left, right) => left.name.localeCompare(right.name))[0];
 }
 
 function hasEnv(name: string) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -920,11 +920,13 @@ async function addFile(
 
 export function isDeniedPath(relativePath: string) {
 	const normalized = toPosix(relativePath);
-	const base = path.posix.basename(normalized).toLowerCase();
+	const lower = normalized.toLowerCase();
+	const segments = lower.split("/");
+	const base = path.posix.basename(lower);
 	return (
-		normalized.includes("/node_modules/") ||
-		normalized.includes("/.git/") ||
-		normalized.includes("/.pisync/") ||
+		segments.includes("node_modules") ||
+		segments.includes(".git") ||
+		segments.includes(".pisync") ||
 		base === ".env" ||
 		base.startsWith(".env.") ||
 		base.endsWith(".env") ||
@@ -977,14 +979,12 @@ export function filterSnapshotForConfigPolicy(
 	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
 	options: { regenerateId?: boolean } = {},
 ) {
-	const extraFiles = extraFileNames(config.extraFiles);
+	const extraFilePaths = extraFilePathsByLower(config.extraFiles);
+	const extraFiles = new Set(extraFilePaths.keys());
 	const filtered = {
 		...snapshot,
 		syncSessions: config.syncSessions ? snapshot.syncSessions : false,
-		files: snapshot.files.filter((file) => {
-			const normalized = toPosix(file.path);
-			return isSafeSnapshotPath(file.path) && isConfiguredSnapshotPath(normalized, config, extraFiles);
-		}),
+		files: canonicalizeSnapshotFilesForConfig(snapshot.files, config, extraFiles, extraFilePaths),
 	};
 	if (!options.regenerateId || snapshotsMatch(snapshot, filtered)) return filtered;
 	return {
@@ -1004,6 +1004,61 @@ function isConfiguredSnapshotPath(
 	if (isSessionPath(normalized)) return config.syncSessions;
 	if (!normalized.includes("/")) return TOP_LEVEL_FILES.has(normalized) || extraFiles.has(normalized.toLowerCase());
 	return TOP_LEVEL_DIRS.has(normalized.slice(0, normalized.indexOf("/")));
+}
+
+function canonicalizeSnapshotFilesForConfig(
+	files: SnapshotFile[],
+	config: Pick<SyncConfig, "syncSessions">,
+	extraFiles: Set<string>,
+	extraFilePaths: Map<string, string>,
+) {
+	const configuredFiles: SnapshotFile[] = [];
+	const extraCandidates = new Map<
+		string,
+		{ exact: boolean; file: SnapshotFile; originalPath: string }
+	>();
+	for (const file of files) {
+		const normalized = toPosix(file.path);
+		if (!isSafeSnapshotPath(file.path) || !isConfiguredSnapshotPath(normalized, config, extraFiles)) {
+			continue;
+		}
+		const extraPath = configuredExtraPath(normalized, extraFilePaths);
+		if (!extraPath) {
+			configuredFiles.push(normalized === file.path ? file : { ...file, path: normalized });
+			continue;
+		}
+		const candidate = {
+			exact: normalized === extraPath,
+			file: { ...file, path: extraPath },
+			originalPath: normalized,
+		};
+		const current = extraCandidates.get(extraPath.toLowerCase());
+		if (!current || isPreferredExtraCandidate(candidate, current)) {
+			extraCandidates.set(extraPath.toLowerCase(), candidate);
+		}
+	}
+	return [
+		...configuredFiles,
+		...[...extraCandidates.values()].map((candidate) => candidate.file),
+	].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function configuredExtraPath(relativePath: string, extraFilePaths: Map<string, string>) {
+	const normalized = toPosix(relativePath);
+	if (normalized.includes("/") || TOP_LEVEL_FILES.has(normalized)) return undefined;
+	return extraFilePaths.get(normalized.toLowerCase());
+}
+
+function canonicalSnapshotPathForConfig(relativePath: string, extraFilePaths: Map<string, string>) {
+	return configuredExtraPath(relativePath, extraFilePaths) ?? toPosix(relativePath);
+}
+
+function isPreferredExtraCandidate(
+	left: { exact: boolean; originalPath: string },
+	right: { exact: boolean; originalPath: string },
+) {
+	if (left.exact !== right.exact) return left.exact;
+	return left.originalPath.localeCompare(right.originalPath) < 0;
 }
 
 export function snapshotWithoutSessions(snapshot: Snapshot) {
@@ -1394,11 +1449,12 @@ function fileHashMap(snapshot: Snapshot) {
 }
 
 function stateHashMapForConfig(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
-	const extraFiles = extraFileNames(config.extraFiles);
+	const extraFilePaths = extraFilePathsByLower(config.extraFiles);
+	const extraFiles = new Set(extraFilePaths.keys());
 	return Object.fromEntries(
-		Object.entries(state.lastFileHashes).filter(([filePath]) =>
-			isConfiguredSnapshotPath(filePath, config, extraFiles),
-		),
+		Object.entries(state.lastFileHashes)
+			.filter(([filePath]) => isConfiguredSnapshotPath(filePath, config, extraFiles))
+			.map(([filePath, hash]) => [canonicalSnapshotPathForConfig(filePath, extraFilePaths), hash]),
 	);
 }
 
@@ -1929,8 +1985,8 @@ function normalizeExtraFiles(value: unknown) {
 		});
 }
 
-function extraFileNames(value: unknown) {
-	return new Set(normalizeExtraFiles(value).map((fileName) => fileName.toLowerCase()));
+function extraFilePathsByLower(value: unknown) {
+	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
 }
 
 function selectExtraFileEntry(entries: Dirent[], fileName: string) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -21,7 +21,13 @@ const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md"]);
+const TOP_LEVEL_FILES = new Set([
+	"settings.json",
+	"keybindings.json",
+	"models.json",
+	"AGENTS.md",
+	"APPEND_SYSTEM.md",
+]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,
@@ -55,7 +61,7 @@ interface PartialConfig {
 	prefix?: string;
 	autoSync?: boolean | string;
 	syncSessions?: boolean | string;
-	extraFiles?: string[];
+	extraFiles?: unknown;
 }
 
 interface SnapshotFile {
@@ -272,6 +278,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 		prefix: DEFAULT_PREFIX,
 		autoSync: true,
 		syncSessions: false,
+		extraFiles: [],
 	};
 	await writeJson(configPath, sample);
 	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /pisync doctor.`, "info");
@@ -294,6 +301,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
 			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
 			`syncSessions: ${syncSessions ? "enabled" : "disabled"}`,
+			`extraFiles: ${normalizeExtraFiles(partial.extraFiles).join(", ") || "none"}`,
 			`local config: ${localConfigPath()}`,
 			...warnings,
 		].join("\n"),
@@ -477,7 +485,10 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), applySessionDir);
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), {
+		sessionDir: applySessionDir,
+		extraFiles: config.extraFiles,
+	});
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
@@ -589,7 +600,10 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), applySessionDir);
+	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), {
+		sessionDir: applySessionDir,
+		extraFiles: config.extraFiles,
+	});
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const upload = await snapshotForUpload(client, config, remote, latest);
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
@@ -639,7 +653,11 @@ function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
 	config: SyncConfig,
 ): SnapshotOptions {
-	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx), extraFiles: config.extraFiles };
+	return {
+		syncSessions: config.syncSessions,
+		sessionDir: sessionDirFromContext(ctx),
+		extraFiles: config.extraFiles,
+	};
 }
 
 function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) {
@@ -722,7 +740,7 @@ async function loadConfigInternal(): Promise<SyncConfig> {
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
-	extraFiles: partial.extraFiles ?? [],
+		extraFiles: normalizeExtraFiles(partial.extraFiles),
 	};
 }
 
@@ -744,7 +762,7 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
-	extraFiles: fileConfig.extraFiles,
+		extraFiles: fileConfig.extraFiles,
 	};
 }
 
@@ -803,8 +821,10 @@ export async function collectFiles(
 	options: SnapshotOptions = {},
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
+	const extraFiles = new Set(normalizeExtraFiles(options.extraFiles));
 	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		if (entry.isFile() && (TOP_LEVEL_FILES.has(entry.name) || (options.extraFiles?.includes(entry.name) ?? false))) {
+		const isTopLevelFile = TOP_LEVEL_FILES.has(entry.name) || extraFiles.has(entry.name);
+		if (entry.isFile() && isTopLevelFile) {
 			await addFile(results, root, entry.name);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
@@ -1042,12 +1062,14 @@ async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
 async function applySnapshot(
 	snapshot: Snapshot,
 	protectedRelativePaths = new Set<string>(),
-	sessionDir?: string,
+	options: Pick<SnapshotOptions, "sessionDir" | "extraFiles"> = {},
 ) {
 	const root = agentDir();
+	const { sessionDir } = options;
 	const current = await createSnapshot(snapshot.profile, {
 		syncSessions: snapshotIncludesSessions(snapshot),
 		sessionDir,
+		extraFiles: options.extraFiles,
 	});
 	const plan = protectSnapshotApplyPlan(
 		root,
@@ -1719,6 +1741,13 @@ export function isCloudflareR2Endpoint(endpoint: string | undefined) {
 function normalizeOptionalString(value: string | undefined) {
 	const normalized = value?.trim();
 	return normalized ? normalized : undefined;
+}
+
+function normalizeExtraFiles(value: unknown) {
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+		.map((item) => item.trim());
 }
 
 function hasEnv(name: string) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -21,7 +21,7 @@ const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
+const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md"]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,
@@ -41,6 +41,7 @@ interface SyncConfig {
 	profile: string;
 	prefix: string;
 	syncSessions: boolean;
+	extraFiles: string[];
 }
 
 interface PartialConfig {
@@ -54,6 +55,7 @@ interface PartialConfig {
 	prefix?: string;
 	autoSync?: boolean | string;
 	syncSessions?: boolean | string;
+	extraFiles?: string[];
 }
 
 interface SnapshotFile {
@@ -117,6 +119,7 @@ interface CommandOptions {
 interface SnapshotOptions {
 	syncSessions?: boolean;
 	sessionDir?: string;
+	extraFiles?: string[];
 }
 
 interface PushInput {
@@ -636,7 +639,7 @@ function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
 	config: SyncConfig,
 ): SnapshotOptions {
-	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx) };
+	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx), extraFiles: config.extraFiles };
 }
 
 function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) {
@@ -719,6 +722,7 @@ async function loadConfigInternal(): Promise<SyncConfig> {
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
+	extraFiles: partial.extraFiles ?? [],
 	};
 }
 
@@ -740,6 +744,7 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
+	extraFiles: fileConfig.extraFiles,
 	};
 }
 
@@ -780,6 +785,7 @@ async function createSnapshot(profile: string, options: SnapshotOptions = {}): P
 	const files = await collectFiles(agentDir(), {
 		syncSessions,
 		sessionDir: options.sessionDir ?? (await configuredSessionDir()),
+		extraFiles: options.extraFiles,
 	});
 	return {
 		version: VERSION,
@@ -798,7 +804,7 @@ export async function collectFiles(
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
 	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
+		if (entry.isFile() && (TOP_LEVEL_FILES.has(entry.name) || (options.extraFiles?.includes(entry.name) ?? false))) {
 			await addFile(results, root, entry.name);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1867,7 +1867,16 @@ function normalizeExtraFiles(value: unknown) {
 	const files = value
 		.filter((item): item is string => typeof item === "string")
 		.map((item) => item.trim())
-		.filter((item) => item !== "" && !item.includes("/") && !item.includes("\\"));
+		.filter((item) => {
+			const lower = item.toLowerCase();
+			return (
+				item !== "" &&
+				!item.includes("/") &&
+				!item.includes("\\") &&
+				!TOP_LEVEL_DIRS.has(lower) &&
+				lower !== "sessions"
+			);
+		});
 	return [...new Set(files)];
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -479,7 +479,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
 
 	const localChanged = hasLocalChanges(local, state, config);
-	const remoteChanged = hasRemoteChanges(remote, state, config);
+	const remoteChanged = hasRemoteChanges(remote, state, config, protectedSessionPaths(ctx));
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
 		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
 	}
@@ -530,7 +530,9 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
 	const localChanged = hasLocalChanges(local, state, config);
-	const remoteChanged = remote ? hasRemoteChanges(remote, state, config) : false;
+	const remoteChanged = remote
+		? hasRemoteChanges(remote, state, config, protectedSessionPaths(ctx))
+		: false;
 	const firstSync = !state.lastAppliedSnapshot;
 
 	if (firstSync && remote && remote.files.length > 0 && local.files.length > 0) {
@@ -1364,7 +1366,7 @@ export async function addTopLevelCaseVariantDeletes(
 	const deletes = new Set(plan.deletes);
 	for (const entry of entries) {
 		const canonicalPath = topLevelPaths.get(entry.name.toLowerCase());
-		if (canonicalPath && entry.name !== canonicalPath) {
+		if (canonicalPath && entry.name !== canonicalPath && (entry.isFile() || entry.isSymbolicLink())) {
 			deletes.add(safeJoin(root, entry.name));
 		}
 	}
@@ -1485,9 +1487,14 @@ function remoteChangedSinceState(
 	return config.syncSessions && state.syncSessions !== true && latest.value?.syncSessions === true;
 }
 
-export function hasRemoteChanges(remote: Snapshot, state: SyncState, config: SyncConfig) {
+export function hasRemoteChanges(
+	remote: Snapshot,
+	state: SyncState,
+	config: SyncConfig,
+	ignoredPaths = new Set<string>(),
+) {
 	if (remote.id === state.lastAppliedSnapshot && !syncPolicyChanged(state, config)) return false;
-	return !snapshotHashesMatchState(filterSnapshotForConfigPolicy(remote, config), state, config);
+	return !snapshotHashesMatchState(filterSnapshotForConfigPolicy(remote, config), state, config, ignoredPaths);
 }
 
 function remoteIdentity(remote: RemoteObject<LatestPointer>) {
@@ -1520,12 +1527,23 @@ function snapshotHashesMatchState(
 	snapshot: Snapshot,
 	state: SyncState,
 	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+	ignoredPaths = new Set<string>(),
 ) {
-	return sameHashes(fileHashMap(snapshot), stateHashMapForConfig(state, config));
+	return sameHashes(
+		withoutHashPaths(fileHashMap(snapshot), ignoredPaths),
+		withoutHashPaths(stateHashMapForConfig(state, config), ignoredPaths),
+	);
 }
 
 function snapshotsMatch(left: Snapshot, right: Snapshot) {
 	return left.syncSessions === right.syncSessions && sameHashes(fileHashMap(left), fileHashMap(right));
+}
+
+function withoutHashPaths(hashes: Record<string, string>, ignoredPaths: Set<string>) {
+	if (ignoredPaths.size === 0) return hashes;
+	return Object.fromEntries(
+		Object.entries(hashes).filter(([filePath]) => !ignoredPaths.has(toPosix(filePath))),
+	);
 }
 
 function syncPolicyChanged(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -103,6 +103,7 @@ interface SyncState {
 	lastRemoteEtag?: string;
 	lastFileHashes: Record<string, string>;
 	syncSessions?: boolean;
+	extraFiles?: string[];
 }
 
 interface LockFile {
@@ -248,7 +249,7 @@ async function autoPushSessions(ctx: ExtensionContext) {
 		await withLock("auto-session-push", async () => {
 			const state = await readState(config.profile);
 			const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
-			if (!hasLocalChanges(local, state)) return;
+			if (!hasLocalChanges(local, state, config)) return;
 			await push(ctx, AUTO_SYNC_OPTIONS, { config, state, local });
 		});
 	} catch (error) {
@@ -316,7 +317,7 @@ async function status(ctx: ExtensionCommandContext) {
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const state = await readState(config.profile);
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	const localChanged = hasLocalChanges(local, state);
+	const localChanged = hasLocalChanges(local, state, config);
 
 	let remoteText = "remote: empty";
 	let remoteChanged = remoteChangedSinceState(latest, state, config);
@@ -418,7 +419,7 @@ async function push(
 		const remoteForConflict = remoteForUpload
 			? filterSnapshotForConfigPolicy(remoteForUpload, config)
 			: undefined;
-		if (!remoteForConflict || !settingsHashesMatchState(remoteForConflict, state)) {
+		if (!remoteForConflict || !snapshotHashesMatchState(remoteForConflict, state, config)) {
 			throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
 		}
 	}
@@ -430,7 +431,7 @@ async function push(
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
 
-	const preservedRemoteFileCount = countPreservedRemoteFiles(local, upload);
+	const preservedRemoteFileCount = config.syncSessions ? 0 : countPreservedRemoteFiles(local, upload);
 	if (
 		!options.yes &&
 		!(await ctx.ui.confirm(
@@ -452,6 +453,7 @@ async function push(
 		lastRemoteEtag: undefined,
 		lastFileHashes: fileHashMap(local),
 		syncSessions: config.syncSessions,
+		extraFiles: config.extraFiles,
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
@@ -468,7 +470,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const remote = await readRemoteSnapshot(client, config);
 	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
 
-	const localChanged = hasLocalChanges(local, state);
+	const localChanged = hasLocalChanges(local, state, config);
 	const remoteChanged = hasRemoteChanges(remote, state, config);
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
 		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
@@ -499,6 +501,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		lastRemoteEtag: undefined,
 		lastFileHashes,
 		syncSessions: config.syncSessions,
+		extraFiles: config.extraFiles,
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
@@ -518,7 +521,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const state = await readState(config.profile);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
-	const localChanged = hasLocalChanges(local, state);
+	const localChanged = hasLocalChanges(local, state, config);
 	const remoteChanged = remote ? hasRemoteChanges(remote, state, config) : false;
 	const firstSync = !state.lastAppliedSnapshot;
 
@@ -540,6 +543,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			lastRemoteEtag: undefined,
 			lastFileHashes: fileHashMap(remote),
 			syncSessions: config.syncSessions,
+			extraFiles: config.extraFiles,
 		});
 		if (!options.silent) ctx.ui.notify("pi-sync state initialized; local settings already match remote.", "info");
 		return;
@@ -554,6 +558,17 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	if (localChanged || !remote) {
 		await push(ctx, options);
 		return;
+	}
+	if (syncPolicyChanged(state, config)) {
+		await writeState(config.profile, {
+			version: VERSION,
+			profile: config.profile,
+			lastAppliedSnapshot: remote.id,
+			lastRemoteEtag: undefined,
+			lastFileHashes: fileHashMap(remote),
+			syncSessions: config.syncSessions,
+			extraFiles: config.extraFiles,
+		});
 	}
 	if (!options.silent) ctx.ui.notify("pi-sync is already up to date.", "info");
 }
@@ -589,6 +604,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const remote = filterSnapshotForConfigPolicy(
 		config.syncSessions ? decoded : snapshotWithoutSessions(decoded),
 		config,
+		{ regenerateId: true },
 	);
 
 	if (
@@ -626,6 +642,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		lastRemoteEtag: undefined,
 		lastFileHashes,
 		syncSessions: config.syncSessions,
+		extraFiles: config.extraFiles,
 	});
 	ctx.ui.notify(`Rolled back to ${target}; latest: ${pointer.snapshot}. Backup: ${backup}`, "info");
 	await maybeReload(ctx);
@@ -939,12 +956,20 @@ function snapshotIncludesSessions(snapshot: Snapshot) {
 export function filterSnapshotForConfigPolicy(
 	snapshot: Snapshot,
 	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+	options: { regenerateId?: boolean } = {},
 ) {
 	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
-	return {
+	const filtered = {
 		...snapshot,
 		syncSessions: config.syncSessions ? snapshot.syncSessions : false,
 		files: snapshot.files.filter((file) => isConfiguredSnapshotPath(file.path, config, extraFiles)),
+	};
+	if (!options.regenerateId || snapshotHashesMatch(snapshot, filtered)) return filtered;
+	return {
+		...filtered,
+		id: snapshotId(),
+		createdAt: new Date().toISOString(),
+		machine: os.hostname(),
 	};
 }
 
@@ -994,7 +1019,11 @@ async function readRemoteSnapshotForSettingsOnlyUpload(
 	latest: RemoteObject<LatestPointer>,
 	state: SyncState,
 ) {
-	if (latest.missing || !latest.value || latest.value.snapshot === state.lastAppliedSnapshot) {
+	if (
+		latest.missing ||
+		!latest.value ||
+		(latest.value.snapshot === state.lastAppliedSnapshot && !syncPolicyChanged(state, config))
+	) {
 		return undefined;
 	}
 	return readRemoteSnapshotRaw(client, config);
@@ -1291,8 +1320,8 @@ function formatPushSummary(
 	].join("\n");
 }
 
-function hasLocalChanges(local: Snapshot, state: SyncState) {
-	return !sameHashes(fileHashMap(local), state.lastFileHashes);
+function hasLocalChanges(local: Snapshot, state: SyncState, config: SyncConfig) {
+	return !sameHashes(fileHashMap(local), stateHashMapForConfig(state, config));
 }
 
 function remoteChangedSinceState(
@@ -1302,14 +1331,12 @@ function remoteChangedSinceState(
 ) {
 	if (latest.missing) return Boolean(state.lastAppliedSnapshot);
 	if (latest.value?.snapshot !== state.lastAppliedSnapshot) return true;
+	if (extraFilesChanged(state, config)) return true;
 	return config.syncSessions && state.syncSessions !== true && latest.value?.syncSessions === true;
 }
 
 export function hasRemoteChanges(remote: Snapshot, state: SyncState, config: SyncConfig) {
-	if (remote.id !== state.lastAppliedSnapshot) {
-		return config.syncSessions || !settingsHashesMatchState(remote, state);
-	}
-	return config.syncSessions && state.syncSessions !== true && snapshotIncludesSessions(remote);
+	return !snapshotHashesMatchState(filterSnapshotForConfigPolicy(remote, config), state, config);
 }
 
 function remoteIdentity(remote: RemoteObject<LatestPointer>) {
@@ -1326,6 +1353,42 @@ function sameHashes(left: Record<string, string>, right: Record<string, string>)
 
 function fileHashMap(snapshot: Snapshot) {
 	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
+}
+
+function stateHashMapForConfig(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
+	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
+	return Object.fromEntries(
+		Object.entries(state.lastFileHashes).filter(([filePath]) =>
+			isConfiguredSnapshotPath(filePath, config, extraFiles),
+		),
+	);
+}
+
+function snapshotHashesMatchState(
+	snapshot: Snapshot,
+	state: SyncState,
+	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+) {
+	return sameHashes(fileHashMap(snapshot), stateHashMapForConfig(state, config));
+}
+
+function snapshotHashesMatch(left: Snapshot, right: Snapshot) {
+	return left.syncSessions === right.syncSessions && sameHashes(fileHashMap(left), fileHashMap(right));
+}
+
+function syncPolicyChanged(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
+	return (state.syncSessions ?? false) !== config.syncSessions || extraFilesChanged(state, config);
+}
+
+function extraFilesChanged(state: SyncState, config: Pick<SyncConfig, "extraFiles">) {
+	return !sameStringSet(normalizeExtraFiles(state.extraFiles), normalizeExtraFiles(config.extraFiles));
+}
+
+function sameStringSet(left: string[], right: string[]) {
+	const leftSet = new Set(left);
+	const rightSet = new Set(right);
+	if (leftSet.size !== rightSet.size) return false;
+	return [...leftSet].every((item) => rightSet.has(item));
 }
 
 function countPreservedRemoteFiles(local: Snapshot, upload: Snapshot) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -420,7 +420,9 @@ async function push(
 			? filterSnapshotForConfigPolicy(remoteForUpload, config)
 			: undefined;
 		if (!remoteForConflict || !snapshotHashesMatchState(remoteForConflict, state, config)) {
-			throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
+			throw new Error(
+				"Remote or sync policy changed since last sync. Run /pisync pull first or /pisync push --force.",
+			);
 		}
 	}
 
@@ -1860,9 +1862,11 @@ function normalizeOptionalString(value: string | undefined) {
 
 function normalizeExtraFiles(value: unknown) {
 	if (!Array.isArray(value)) return [];
-	return value
-		.filter((item): item is string => typeof item === "string" && item.trim() !== "")
-		.map((item) => item.trim());
+	const files = value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter((item) => item !== "" && !item.includes("/") && !item.includes("\\"));
+	return [...new Set(files)];
 }
 
 function hasEnv(name: string) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -21,7 +21,7 @@ const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md"]);
+const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -550,6 +550,19 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 		if (!options.silent) ctx.ui.notify("pi-sync state initialized; local settings already match remote.", "info");
 		return;
 	}
+	if (localChanged && remoteChanged && remote && snapshotsMatch(local, remote)) {
+		await writeState(config.profile, {
+			version: VERSION,
+			profile: config.profile,
+			lastAppliedSnapshot: remote.id,
+			lastRemoteEtag: undefined,
+			lastFileHashes: fileHashMap(remote),
+			syncSessions: config.syncSessions,
+			extraFiles: config.extraFiles,
+		});
+		if (!options.silent) ctx.ui.notify("pi-sync is already up to date.", "info");
+		return;
+	}
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
 		throw new Error("Both local and remote changed. Run /pisync diff and resolve with push --force or pull --force.");
 	}
@@ -969,7 +982,7 @@ export function filterSnapshotForConfigPolicy(
 			return isSafeSnapshotPath(normalized) && isConfiguredSnapshotPath(normalized, config, extraFiles);
 		}),
 	};
-	if (!options.regenerateId || snapshotHashesMatch(snapshot, filtered)) return filtered;
+	if (!options.regenerateId || snapshotsMatch(snapshot, filtered)) return filtered;
 	return {
 		...filtered,
 		id: snapshotId(),
@@ -1344,6 +1357,7 @@ function remoteChangedSinceState(
 }
 
 export function hasRemoteChanges(remote: Snapshot, state: SyncState, config: SyncConfig) {
+	if (remote.id === state.lastAppliedSnapshot && !syncPolicyChanged(state, config)) return false;
 	return !snapshotHashesMatchState(filterSnapshotForConfigPolicy(remote, config), state, config);
 }
 
@@ -1380,7 +1394,7 @@ function snapshotHashesMatchState(
 	return sameHashes(fileHashMap(snapshot), stateHashMapForConfig(state, config));
 }
 
-function snapshotHashesMatch(left: Snapshot, right: Snapshot) {
+function snapshotsMatch(left: Snapshot, right: Snapshot) {
 	return left.syncSessions === right.syncSessions && sameHashes(fileHashMap(left), fileHashMap(right));
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -529,7 +529,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const firstSync = !state.lastAppliedSnapshot;
 
 	if (firstSync && remote && local.files.length > 0) {
-		if (!sameHashes(settingsHashMap(local), settingsHashMap(remote))) {
+		if (!canPullRemoteSettingsOnFirstSync(local, remote)) {
 			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
 		}
 		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
@@ -909,7 +909,7 @@ async function addFile(
 	relativePath: string,
 	snapshotPath = relativePath,
 ) {
-	if (isDeniedPath(snapshotPath)) return;
+	if (!isSafeSnapshotPath(snapshotPath)) return;
 	const absolutePath = safeJoin(root, relativePath);
 	const content = await fs.readFile(absolutePath);
 	results.push({ path: snapshotPath, contentBase64: content.toString("base64"), sha256: sha256(content) });
@@ -1447,6 +1447,13 @@ export function settingsHashesMatchState(remote: Snapshot, state: SyncState) {
 	return sameHashes(settingsHashMap(remote), settingsHashMapFromState(state));
 }
 
+export function canPullRemoteSettingsOnFirstSync(local: Snapshot, remote: Snapshot) {
+	const remoteSettings = settingsHashMap(remote);
+	return Object.entries(settingsHashMap(local)).every(
+		([filePath, hash]) => remoteSettings[filePath] === hash,
+	);
+}
+
 export function canPullRemoteSessionsOnFirstSync(local: Snapshot, remote: Snapshot) {
 	const localSessions = sessionHashMap(local);
 	const remoteSessions = sessionHashMap(remote);
@@ -1887,21 +1894,26 @@ function normalizeOptionalString(value: string | undefined) {
 
 function normalizeExtraFiles(value: unknown) {
 	if (!Array.isArray(value)) return [];
-	const files = value
+	const seen = new Set<string>();
+	return value
 		.filter((item): item is string => typeof item === "string")
 		.map((item) => item.trim())
 		.filter((item) => {
 			const lower = item.toLowerCase();
-			return (
-				item !== "" &&
-				!item.includes("/") &&
-				!item.includes("\\") &&
-				!TOP_LEVEL_FILE_NAMES.has(lower) &&
-				!isDeniedPath(item) &&
-				!RESERVED_TOP_LEVEL_NAMES.has(lower)
-			);
+			if (
+				item === "" ||
+				item.includes("/") ||
+				item.includes("\\") ||
+				TOP_LEVEL_FILE_NAMES.has(lower) ||
+				isDeniedPath(item) ||
+				RESERVED_TOP_LEVEL_NAMES.has(lower) ||
+				seen.has(lower)
+			) {
+				return false;
+			}
+			seen.add(lower);
+			return true;
 		});
-	return [...new Set(files)];
 }
 
 function hasEnv(name: string) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -979,7 +979,7 @@ export function filterSnapshotForConfigPolicy(
 		syncSessions: config.syncSessions ? snapshot.syncSessions : false,
 		files: snapshot.files.filter((file) => {
 			const normalized = toPosix(file.path);
-			return isSafeSnapshotPath(normalized) && isConfiguredSnapshotPath(normalized, config, extraFiles);
+			return isSafeSnapshotPath(file.path) && isConfiguredSnapshotPath(normalized, config, extraFiles);
 		}),
 	};
 	if (!options.regenerateId || snapshotsMatch(snapshot, filtered)) return filtered;
@@ -1071,7 +1071,7 @@ export function mergeRemotePreservedFiles(
 		const normalized = toPosix(file.path);
 		return (
 			!paths.has(normalized) &&
-			isSafeSnapshotPath(normalized) &&
+			isSafeSnapshotPath(file.path) &&
 			!normalized.includes("/") &&
 			!TOP_LEVEL_FILES.has(normalized) &&
 			!extraFiles.has(normalized)
@@ -1092,7 +1092,7 @@ export function mergeRemotePreservedFiles(
 export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
 	const remoteSessions = remote.files.filter((file) => {
 		const normalized = toPosix(file.path);
-		return isSessionFilePath(normalized) && isSafeSnapshotPath(normalized);
+		return isSessionFilePath(normalized) && isSafeSnapshotPath(file.path);
 	});
 	if (remoteSessions.length === 0 && !snapshotIncludesSessions(remote)) return local;
 	return {
@@ -1195,7 +1195,7 @@ export function preflightSnapshotApply(
 
 	for (const file of snapshot.files) {
 		const normalized = toPosix(file.path);
-		if (!isSafeSnapshotPath(normalized)) {
+		if (!isSafeSnapshotPath(file.path)) {
 			throw new Error(`Unsafe path in snapshot: ${file.path}`);
 		}
 		if (isSessionPath(normalized) && !isSessionFilePath(normalized)) {
@@ -1263,13 +1263,14 @@ export function appliedFileHashMap(
 	return hashes;
 }
 
-function isSafeSnapshotPath(normalized: string) {
+function isSafeSnapshotPath(relativePath: string) {
+	if (relativePath.includes("\\")) return false;
+	const normalized = toPosix(relativePath);
 	return (
 		Boolean(normalized) &&
 		normalized !== "." &&
 		normalized !== ".." &&
 		!normalized.startsWith("../") &&
-		!normalized.includes("\\") &&
 		!path.posix.isAbsolute(normalized) &&
 		path.posix.normalize(normalized) === normalized &&
 		!isDeniedPath(normalized)

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -29,6 +29,8 @@ const TOP_LEVEL_FILES = new Set([
 	"APPEND_SYSTEM.md",
 ]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
+const TOP_LEVEL_FILE_NAMES = new Set([...TOP_LEVEL_FILES].map((name) => name.toLowerCase()));
+const RESERVED_TOP_LEVEL_NAMES = new Set([...TOP_LEVEL_DIRS, "sessions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,
 	/(ANTHROPIC|OPENAI|GEMINI|GOOGLE|FIRECRAWL|GITHUB|CLOUDFLARE|R2|S3)_[A-Z0-9_]*(KEY|TOKEN|SECRET)\s*[=:]\s*['\"]?[^\s'\"]{12,}/i,
@@ -427,13 +429,12 @@ async function push(
 	}
 
 	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload);
-	const scanTarget = config.syncSessions ? upload : local;
-	const secrets = scanSnapshot(scanTarget);
+	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
 
-	const preservedRemoteFileCount = config.syncSessions ? 0 : countPreservedRemoteFiles(local, upload);
+	const preservedRemoteFileCount = countPreservedRemoteFiles(local, upload);
 	if (
 		!options.yes &&
 		!(await ctx.ui.confirm(
@@ -1069,11 +1070,13 @@ export function mergeRemotePreservedFiles(
 	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
 	const remoteExtras = remote.files.filter((file) => {
 		const normalized = toPosix(file.path);
+		const lower = normalized.toLowerCase();
 		return (
 			!paths.has(normalized) &&
 			isSafeSnapshotPath(file.path) &&
 			!normalized.includes("/") &&
-			!TOP_LEVEL_FILES.has(normalized) &&
+			!TOP_LEVEL_FILE_NAMES.has(lower) &&
+			!RESERVED_TOP_LEVEL_NAMES.has(lower) &&
 			!extraFiles.has(normalized)
 		);
 	});
@@ -1893,10 +1896,9 @@ function normalizeExtraFiles(value: unknown) {
 				item !== "" &&
 				!item.includes("/") &&
 				!item.includes("\\") &&
-				!TOP_LEVEL_FILES.has(item) &&
+				!TOP_LEVEL_FILE_NAMES.has(lower) &&
 				!isDeniedPath(item) &&
-				!TOP_LEVEL_DIRS.has(lower) &&
-				lower !== "sessions"
+				!RESERVED_TOP_LEVEL_NAMES.has(lower)
 			);
 		});
 	return [...new Set(files)];

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -964,7 +964,10 @@ export function filterSnapshotForConfigPolicy(
 	const filtered = {
 		...snapshot,
 		syncSessions: config.syncSessions ? snapshot.syncSessions : false,
-		files: snapshot.files.filter((file) => isConfiguredSnapshotPath(file.path, config, extraFiles)),
+		files: snapshot.files.filter((file) => {
+			const normalized = toPosix(file.path);
+			return isSafeSnapshotPath(normalized) && isConfiguredSnapshotPath(normalized, config, extraFiles);
+		}),
 	};
 	if (!options.regenerateId || snapshotHashesMatch(snapshot, filtered)) return filtered;
 	return {
@@ -1074,9 +1077,10 @@ export function mergeRemotePreservedFiles(
 }
 
 export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
-	const remoteSessions = remote.files.filter(
-		(file) => isSessionFilePath(file.path) && !isDeniedPath(file.path),
-	);
+	const remoteSessions = remote.files.filter((file) => {
+		const normalized = toPosix(file.path);
+		return isSessionFilePath(normalized) && isSafeSnapshotPath(normalized);
+	});
 	if (remoteSessions.length === 0 && !snapshotIncludesSessions(remote)) return local;
 	return {
 		...local,
@@ -1873,6 +1877,7 @@ function normalizeExtraFiles(value: unknown) {
 				item !== "" &&
 				!item.includes("/") &&
 				!item.includes("\\") &&
+				!isDeniedPath(item) &&
 				!TOP_LEVEL_DIRS.has(lower) &&
 				lower !== "sessions"
 			);

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1249,6 +1249,8 @@ export function appliedFileHashMap(
 function isSafeSnapshotPath(normalized: string) {
 	return (
 		Boolean(normalized) &&
+		normalized !== "." &&
+		normalized !== ".." &&
 		!normalized.startsWith("../") &&
 		!path.posix.isAbsolute(normalized) &&
 		path.posix.normalize(normalized) === normalized &&

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1257,11 +1257,15 @@ async function applySnapshot(
 		sessionDir,
 		extraFiles: options.extraFiles,
 	});
-	const plan = protectSnapshotApplyPlan(
+	const plan = await addTopLevelCaseVariantDeletes(
 		root,
-		preflightSnapshotApply(root, snapshot, current, { sessionDir }),
-		protectedRelativePaths,
-		sessionDir,
+		protectSnapshotApplyPlan(
+			root,
+			preflightSnapshotApply(root, snapshot, current, { sessionDir }),
+			protectedRelativePaths,
+			sessionDir,
+		),
+		snapshot,
 	);
 	await preflightSnapshotMutations(root, plan, sessionDir);
 	for (const target of plan.deletes) {
@@ -1333,6 +1337,38 @@ export function protectSnapshotApplyPlan(
 		writes: plan.writes.filter((item) => !protectedTargets.has(item.target)),
 		deletes: plan.deletes.filter((target) => !protectedTargets.has(target)),
 	};
+}
+
+export async function addTopLevelCaseVariantDeletes(
+	root: string,
+	plan: SnapshotApplyPlan,
+	snapshot: Pick<Snapshot, "files">,
+): Promise<SnapshotApplyPlan> {
+	const topLevelPaths = new Map<string, string>();
+	for (const file of snapshot.files) {
+		const normalized = toPosix(file.path);
+		if (!normalized.includes("/") && isSafeSnapshotPath(file.path)) {
+			topLevelPaths.set(normalized.toLowerCase(), normalized);
+		}
+	}
+	if (topLevelPaths.size === 0) return plan;
+
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(root, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return plan;
+		throw error;
+	}
+
+	const deletes = new Set(plan.deletes);
+	for (const entry of entries) {
+		const canonicalPath = topLevelPaths.get(entry.name.toLowerCase());
+		if (canonicalPath && entry.name !== canonicalPath) {
+			deletes.add(safeJoin(root, entry.name));
+		}
+	}
+	return { ...plan, deletes: [...deletes] };
 }
 
 export function appliedFileHashMap(

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -415,7 +415,10 @@ async function push(
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const remoteForUpload = await readRemoteSnapshotForSettingsOnlyUpload(client, config, latest, state);
 	if (remoteChangedSinceState(latest, state, config) && !options.force) {
-		if (!remoteForUpload || !settingsHashesMatchState(remoteForUpload, state)) {
+		const remoteForConflict = remoteForUpload
+			? filterSnapshotForConfigPolicy(remoteForUpload, config)
+			: undefined;
+		if (!remoteForConflict || !settingsHashesMatchState(remoteForConflict, state)) {
 			throw new Error("Remote changed since last sync. Run /pisync pull first or /pisync push --force.");
 		}
 	}
@@ -427,12 +430,12 @@ async function push(
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
 
-	const preservedRemoteSessionCount = Math.max(0, countSessionFiles(upload) - countSessionFiles(local));
+	const preservedRemoteFileCount = countPreservedRemoteFiles(local, upload);
 	if (
 		!options.yes &&
 		!(await ctx.ui.confirm(
 			snapshotIncludesSessions(upload) ? "Push pi settings and sessions?" : "Push pi settings?",
-			formatPushSummary(upload, latest, preservedRemoteSessionCount),
+			formatPushSummary(upload, latest, preservedRemoteFileCount),
 		))
 	) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -583,7 +586,10 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const snapshot = await client.getBuffer(snapshotKey(config, target));
 	if (!snapshot.value) throw new Error(`Snapshot not found: ${target}`);
 	const decoded = await decodeSnapshot(snapshot.value);
-	const remote = config.syncSessions ? decoded : snapshotWithoutSessions(decoded);
+	const remote = filterSnapshotForConfigPolicy(
+		config.syncSessions ? decoded : snapshotWithoutSessions(decoded),
+		config,
+	);
 
 	if (
 		!options.yes &&
@@ -930,16 +936,27 @@ function snapshotIncludesSessions(snapshot: Snapshot) {
 	return snapshot.syncSessions === true || snapshot.files.some((file) => isSessionPath(file.path));
 }
 
-function filterSnapshotForSessionPolicy(
-	snapshot: Snapshot | undefined,
-	syncSessions: boolean,
-): Snapshot | undefined {
-	if (!snapshot || syncSessions) return snapshot;
+export function filterSnapshotForConfigPolicy(
+	snapshot: Snapshot,
+	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+) {
+	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
 	return {
 		...snapshot,
-		syncSessions: false,
-		files: snapshot.files.filter((file) => !isSessionPath(file.path)),
+		syncSessions: config.syncSessions ? snapshot.syncSessions : false,
+		files: snapshot.files.filter((file) => isConfiguredSnapshotPath(file.path, config, extraFiles)),
 	};
+}
+
+function isConfiguredSnapshotPath(
+	relativePath: string,
+	config: Pick<SyncConfig, "syncSessions">,
+	extraFiles: Set<string>,
+) {
+	const normalized = toPosix(relativePath);
+	if (isSessionPath(normalized)) return config.syncSessions;
+	if (!normalized.includes("/")) return TOP_LEVEL_FILES.has(normalized) || extraFiles.has(normalized);
+	return TOP_LEVEL_DIRS.has(normalized.slice(0, normalized.indexOf("/")));
 }
 
 export function snapshotWithoutSessions(snapshot: Snapshot) {
@@ -977,8 +994,9 @@ async function readRemoteSnapshotForSettingsOnlyUpload(
 	latest: RemoteObject<LatestPointer>,
 	state: SyncState,
 ) {
-	if (config.syncSessions || latest.missing || !latest.value) return undefined;
-	if (!latest.value.syncSessions && latest.value.snapshot === state.lastAppliedSnapshot) return undefined;
+	if (latest.missing || !latest.value || latest.value.snapshot === state.lastAppliedSnapshot) {
+		return undefined;
+	}
 	return readRemoteSnapshotRaw(client, config);
 }
 
@@ -989,11 +1007,39 @@ async function snapshotForUpload(
 	latest: RemoteObject<LatestPointer>,
 	remote?: Snapshot,
 ) {
-	if (config.syncSessions || latest.missing || !latest.value || latest.value.syncSessions === false) {
-		return local;
-	}
+	if (latest.missing || !latest.value) return local;
 	const snapshot = remote ?? (await readRemoteSnapshotRaw(client, config));
-	return snapshot ? mergeRemoteSessionFiles(local, snapshot) : local;
+	return snapshot ? mergeRemotePreservedFiles(local, snapshot, config) : local;
+}
+
+export function mergeRemotePreservedFiles(
+	local: Snapshot,
+	remote: Snapshot,
+	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+) {
+	const withSessions = config.syncSessions ? local : mergeRemoteSessionFiles(local, remote);
+	const paths = new Set(withSessions.files.map((file) => file.path));
+	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
+	const remoteExtras = remote.files.filter((file) => {
+		const normalized = toPosix(file.path);
+		return (
+			!paths.has(normalized) &&
+			isSafeSnapshotPath(normalized) &&
+			!normalized.includes("/") &&
+			!TOP_LEVEL_FILES.has(normalized) &&
+			!extraFiles.has(normalized)
+		);
+	});
+	if (remoteExtras.length === 0) return withSessions;
+	return {
+		...withSessions,
+		id: snapshotId(),
+		createdAt: new Date().toISOString(),
+		machine: os.hostname(),
+		files: [...withSessions.files, ...remoteExtras].sort((left, right) =>
+			left.path.localeCompare(right.path),
+		),
+	};
 }
 
 export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
@@ -1036,7 +1082,8 @@ async function uploadSnapshot(
 }
 
 async function readRemoteSnapshot(client: S3Client, config: SyncConfig) {
-	return filterSnapshotForSessionPolicy(await readRemoteSnapshotRaw(client, config), config.syncSessions);
+	const snapshot = await readRemoteSnapshotRaw(client, config);
+	return snapshot ? filterSnapshotForConfigPolicy(snapshot, config) : undefined;
 }
 
 async function readRemoteSnapshotRaw(client: S3Client, config: SyncConfig) {
@@ -1100,13 +1147,7 @@ export function preflightSnapshotApply(
 
 	for (const file of snapshot.files) {
 		const normalized = toPosix(file.path);
-		if (
-			!normalized ||
-			normalized.startsWith("../") ||
-			path.posix.isAbsolute(normalized) ||
-			path.posix.normalize(normalized) !== normalized ||
-			isDeniedPath(normalized)
-		) {
+		if (!isSafeSnapshotPath(normalized)) {
 			throw new Error(`Unsafe path in snapshot: ${file.path}`);
 		}
 		if (isSessionPath(normalized) && !isSessionFilePath(normalized)) {
@@ -1174,6 +1215,16 @@ export function appliedFileHashMap(
 	return hashes;
 }
 
+function isSafeSnapshotPath(normalized: string) {
+	return (
+		Boolean(normalized) &&
+		!normalized.startsWith("../") &&
+		!path.posix.isAbsolute(normalized) &&
+		path.posix.normalize(normalized) === normalized &&
+		!isDeniedPath(normalized)
+	);
+}
+
 function decodeBase64Strict(value: string, filePath: string) {
 	if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value) || value.length % 4 !== 0) {
 		throw new Error(`Invalid base64 content in snapshot file: ${filePath}`);
@@ -1229,13 +1280,13 @@ function formatSnapshotOnlyDiff(title: string, snapshot: Snapshot) {
 function formatPushSummary(
 	local: Snapshot,
 	latest: RemoteObject<LatestPointer>,
-	preservedRemoteSessionCount = 0,
+	preservedRemoteFileCount = 0,
 ) {
 	return [
 		`Upload ${local.files.length} files from ${agentDir()}.`,
 		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
-		preservedRemoteSessionCount > 0
-			? `Possible secrets in local files were scanned before this prompt; ${preservedRemoteSessionCount} preserved remote session file(s) were not rescanned.`
+		preservedRemoteFileCount > 0
+			? `Possible secrets in local files were scanned before this prompt; ${preservedRemoteFileCount} preserved remote file(s) were not rescanned.`
 			: "Possible secrets were scanned before this prompt.",
 	].join("\n");
 }
@@ -1277,8 +1328,9 @@ function fileHashMap(snapshot: Snapshot) {
 	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
 }
 
-function countSessionFiles(snapshot: Snapshot) {
-	return snapshot.files.filter((file) => isSessionPath(file.path)).length;
+function countPreservedRemoteFiles(local: Snapshot, upload: Snapshot) {
+	const localPaths = new Set(local.files.map((file) => file.path));
+	return upload.files.filter((file) => !localPaths.has(file.path)).length;
 }
 
 export function settingsHashMap(snapshot: Snapshot) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -29,7 +29,8 @@ const TOP_LEVEL_FILES = new Set([
 	"APPEND_SYSTEM.md",
 ]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
-const TOP_LEVEL_FILE_NAMES = new Set([...TOP_LEVEL_FILES].map((name) => name.toLowerCase()));
+const TOP_LEVEL_FILE_PATHS = new Map([...TOP_LEVEL_FILES].map((name) => [name.toLowerCase(), name]));
+const TOP_LEVEL_FILE_NAMES = new Set(TOP_LEVEL_FILE_PATHS.keys());
 const RESERVED_TOP_LEVEL_NAMES = new Set([...TOP_LEVEL_DIRS, "sessions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,
@@ -416,7 +417,9 @@ async function push(
 	const local = input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	const remoteForUpload = await readRemoteSnapshotForUpload(client, config, latest, state);
+	const remoteForUpload = options.force
+		? undefined
+		: await readRemoteSnapshotForUpload(client, config, latest, state);
 	if (remoteChangedSinceState(latest, state, config) && !options.force) {
 		const remoteForConflict = remoteForUpload
 			? filterSnapshotForConfigPolicy(remoteForUpload, config)
@@ -428,8 +431,10 @@ async function push(
 		}
 	}
 
-	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload);
-	const secrets = scanSnapshot(local);
+	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload, {
+		preserveRemote: !options.force,
+	});
+	const secrets = scanSnapshot(upload);
 	if (secrets.length > 0) {
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
@@ -528,7 +533,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	const remoteChanged = remote ? hasRemoteChanges(remote, state, config) : false;
 	const firstSync = !state.lastAppliedSnapshot;
 
-	if (firstSync && remote && local.files.length > 0) {
+	if (firstSync && remote && remote.files.length > 0 && local.files.length > 0) {
 		if (!canPullRemoteSettingsOnFirstSync(local, remote)) {
 			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
 		}
@@ -643,7 +648,9 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		extraFiles: config.extraFiles,
 	});
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	const upload = await snapshotForUpload(client, config, remote, latest);
+	const upload = await snapshotForUpload(client, config, remote, latest, undefined, {
+		ignoreUnreadableRemote: true,
+	});
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
 	if (upload.id !== decoded.id) {
 		await client.putBuffer(snapshotKey(config, upload.id), encoded, "application/gzip");
@@ -862,14 +869,16 @@ export async function collectFiles(
 	const results: SnapshotFile[] = [];
 	const entries = await fs.readdir(root, { withFileTypes: true });
 	for (const entry of entries) {
-		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
-			await addFile(results, root, entry.name);
-		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
+		if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
 		}
 	}
+	for (const fileName of TOP_LEVEL_FILES) {
+		const entry = selectTopLevelFileEntry(entries, fileName);
+		if (entry) await addFile(results, root, entry.name, fileName);
+	}
 	for (const extraFileName of normalizeExtraFiles(options.extraFiles)) {
-		const entry = selectExtraFileEntry(entries, extraFileName);
+		const entry = selectTopLevelFileEntry(entries, extraFileName);
 		if (entry) await addFile(results, root, entry.name, extraFileName);
 	}
 	if (options.syncSessions) {
@@ -1002,7 +1011,10 @@ function isConfiguredSnapshotPath(
 ) {
 	const normalized = toPosix(relativePath);
 	if (isSessionPath(normalized)) return config.syncSessions;
-	if (!normalized.includes("/")) return TOP_LEVEL_FILES.has(normalized) || extraFiles.has(normalized.toLowerCase());
+	if (!normalized.includes("/")) {
+		const lower = normalized.toLowerCase();
+		return TOP_LEVEL_FILE_NAMES.has(lower) || extraFiles.has(lower);
+	}
 	return TOP_LEVEL_DIRS.has(normalized.slice(0, normalized.indexOf("/")));
 }
 
@@ -1022,19 +1034,19 @@ function canonicalizeSnapshotFilesForConfig(
 		if (!isSafeSnapshotPath(file.path) || !isConfiguredSnapshotPath(normalized, config, extraFiles)) {
 			continue;
 		}
-		const extraPath = configuredExtraPath(normalized, extraFilePaths);
-		if (!extraPath) {
+		const topLevelPath = canonicalTopLevelFilePath(normalized, extraFilePaths);
+		if (!topLevelPath) {
 			configuredFiles.push(normalized === file.path ? file : { ...file, path: normalized });
 			continue;
 		}
 		const candidate = {
-			exact: normalized === extraPath,
-			file: { ...file, path: extraPath },
+			exact: normalized === topLevelPath,
+			file: { ...file, path: topLevelPath },
 			originalPath: normalized,
 		};
-		const current = extraCandidates.get(extraPath.toLowerCase());
+		const current = extraCandidates.get(topLevelPath.toLowerCase());
 		if (!current || isPreferredExtraCandidate(candidate, current)) {
-			extraCandidates.set(extraPath.toLowerCase(), candidate);
+			extraCandidates.set(topLevelPath.toLowerCase(), candidate);
 		}
 	}
 	return [
@@ -1043,14 +1055,15 @@ function canonicalizeSnapshotFilesForConfig(
 	].sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function configuredExtraPath(relativePath: string, extraFilePaths: Map<string, string>) {
+function canonicalTopLevelFilePath(relativePath: string, extraFilePaths: Map<string, string>) {
 	const normalized = toPosix(relativePath);
-	if (normalized.includes("/") || TOP_LEVEL_FILES.has(normalized)) return undefined;
-	return extraFilePaths.get(normalized.toLowerCase());
+	if (normalized.includes("/")) return undefined;
+	const lower = normalized.toLowerCase();
+	return TOP_LEVEL_FILE_PATHS.get(lower) ?? extraFilePaths.get(lower);
 }
 
 function canonicalSnapshotPathForConfig(relativePath: string, extraFilePaths: Map<string, string>) {
-	return configuredExtraPath(relativePath, extraFilePaths) ?? toPosix(relativePath);
+	return canonicalTopLevelFilePath(relativePath, extraFilePaths) ?? toPosix(relativePath);
 }
 
 function isPreferredExtraCandidate(
@@ -1112,9 +1125,18 @@ async function snapshotForUpload(
 	local: Snapshot,
 	latest: RemoteObject<LatestPointer>,
 	remote?: Snapshot,
+	options: { preserveRemote?: boolean; ignoreUnreadableRemote?: boolean } = {},
 ) {
-	if (latest.missing || !latest.value) return local;
-	const snapshot = remote ?? (await readRemoteSnapshotRaw(client, config));
+	if (options.preserveRemote === false || latest.missing || !latest.value) return local;
+	let snapshot = remote;
+	if (!snapshot) {
+		try {
+			snapshot = await readRemoteSnapshotRaw(client, config);
+		} catch (error) {
+			if (options.ignoreUnreadableRemote) return local;
+			throw error;
+		}
+	}
 	return snapshot ? mergeRemotePreservedFiles(local, snapshot, config) : local;
 }
 
@@ -1407,7 +1429,7 @@ function formatPushSummary(
 		`Upload ${local.files.length} files from ${agentDir()}.`,
 		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
 		preservedRemoteFileCount > 0
-			? `Possible secrets in local files were scanned before this prompt; ${preservedRemoteFileCount} preserved remote file(s) were not rescanned.`
+			? `Possible secrets in all uploaded files were scanned before this prompt, including ${preservedRemoteFileCount} preserved remote file(s).`
 			: "Possible secrets were scanned before this prompt.",
 	].join("\n");
 }
@@ -1989,7 +2011,7 @@ function extraFilePathsByLower(value: unknown) {
 	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
 }
 
-function selectExtraFileEntry(entries: Dirent[], fileName: string) {
+function selectTopLevelFileEntry(entries: Dirent[], fileName: string) {
 	const exact = entries.find((entry) => entry.isFile() && entry.name === fileName);
 	if (exact) return exact;
 	const lower = fileName.toLowerCase();

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -434,7 +434,7 @@ async function push(
 	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload, {
 		preserveRemote: !options.force,
 	});
-	const secrets = scanSnapshot(upload);
+	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
 		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
 	}
@@ -1429,7 +1429,7 @@ function formatPushSummary(
 		`Upload ${local.files.length} files from ${agentDir()}.`,
 		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
 		preservedRemoteFileCount > 0
-			? `Possible secrets in all uploaded files were scanned before this prompt, including ${preservedRemoteFileCount} preserved remote file(s).`
+			? `Possible secrets in locally managed files were scanned before this prompt; ${preservedRemoteFileCount} preserved remote file(s) were not rescanned.`
 			: "Possible secrets were scanned before this prompt.",
 	].join("\n");
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -416,7 +416,7 @@ async function push(
 	const local = input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	const remoteForUpload = await readRemoteSnapshotForSettingsOnlyUpload(client, config, latest, state);
+	const remoteForUpload = await readRemoteSnapshotForUpload(client, config, latest, state);
 	if (remoteChangedSinceState(latest, state, config) && !options.force) {
 		const remoteForConflict = remoteForUpload
 			? filterSnapshotForConfigPolicy(remoteForUpload, config)
@@ -860,11 +860,13 @@ export async function collectFiles(
 	options: SnapshotOptions = {},
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
-	const extraFiles = new Set(normalizeExtraFiles(options.extraFiles));
+	const extraFiles = extraFileNamesByLower(options.extraFiles);
 	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		const isTopLevelFile = TOP_LEVEL_FILES.has(entry.name) || extraFiles.has(entry.name);
-		if (entry.isFile() && isTopLevelFile) {
+		const extraFileName = extraFiles.get(entry.name.toLowerCase());
+		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
 			await addFile(results, root, entry.name);
+		} else if (entry.isFile() && extraFileName) {
+			await addFile(results, root, entry.name, extraFileName);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
 		}
@@ -1032,7 +1034,7 @@ export function scanSnapshot(snapshot: Snapshot) {
 	return findings;
 }
 
-async function readRemoteSnapshotForSettingsOnlyUpload(
+async function readRemoteSnapshotForUpload(
 	client: S3Client,
 	config: SyncConfig,
 	latest: RemoteObject<LatestPointer>,
@@ -1067,18 +1069,26 @@ export function mergeRemotePreservedFiles(
 ) {
 	const withSessions = config.syncSessions ? local : mergeRemoteSessionFiles(local, remote);
 	const paths = new Set(withSessions.files.map((file) => file.path));
-	const extraFiles = new Set(normalizeExtraFiles(config.extraFiles));
+	const pathNames = new Set(withSessions.files.map((file) => file.path.toLowerCase()));
+	const extraFileNames = new Set(normalizeExtraFiles(config.extraFiles).map((file) => file.toLowerCase()));
+	const seenRemoteExtraNames = new Set<string>();
 	const remoteExtras = remote.files.filter((file) => {
 		const normalized = toPosix(file.path);
 		const lower = normalized.toLowerCase();
-		return (
-			!paths.has(normalized) &&
-			isSafeSnapshotPath(file.path) &&
-			!normalized.includes("/") &&
-			!TOP_LEVEL_FILE_NAMES.has(lower) &&
-			!RESERVED_TOP_LEVEL_NAMES.has(lower) &&
-			!extraFiles.has(normalized)
-		);
+		if (
+			paths.has(normalized) ||
+			pathNames.has(lower) ||
+			!isSafeSnapshotPath(file.path) ||
+			normalized.includes("/") ||
+			TOP_LEVEL_FILE_NAMES.has(lower) ||
+			RESERVED_TOP_LEVEL_NAMES.has(lower) ||
+			extraFileNames.has(lower) ||
+			seenRemoteExtraNames.has(lower)
+		) {
+			return false;
+		}
+		seenRemoteExtraNames.add(lower);
+		return true;
 	});
 	if (remoteExtras.length === 0) return withSessions;
 	return {
@@ -1902,6 +1912,8 @@ function normalizeExtraFiles(value: unknown) {
 			const lower = item.toLowerCase();
 			if (
 				item === "" ||
+				item === "." ||
+				item === ".." ||
 				item.includes("/") ||
 				item.includes("\\") ||
 				TOP_LEVEL_FILE_NAMES.has(lower) ||
@@ -1914,6 +1926,10 @@ function normalizeExtraFiles(value: unknown) {
 			seen.add(lower);
 			return true;
 		});
+}
+
+function extraFileNamesByLower(value: unknown) {
+	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
 }
 
 function hasEnv(name: string) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -291,11 +291,14 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 		extraFiles: ["CONFIGURED.md"],
 	};
 
-	assert.deepEqual(
-		filterSnapshotForConfigPolicy(remote, config)
-			.files.map((file) => file.path)
-			.sort(),
-		["CONFIGURED.md", "settings.json"],
+	const filtered = filterSnapshotForConfigPolicy(remote, config);
+	assert.deepEqual(filtered.files.map((file) => file.path).sort(), [
+		"CONFIGURED.md",
+		"settings.json",
+	]);
+	assert.notEqual(
+		filterSnapshotForConfigPolicy(remote, config, { regenerateId: true }).id,
+		remote.id,
 	);
 	assert.deepEqual(
 		filterSnapshotForConfigPolicy(remote, { ...config, syncSessions: true })
@@ -313,6 +316,22 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 			extraFiles: ["CONFIGURED.md", "LOCAL.md"],
 		}).files.map((file) => file.path),
 		["sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.equal(
+		hasRemoteChanges(
+			filtered,
+			{
+				version: 1,
+				profile: "default",
+				lastAppliedSnapshot: remote.id,
+				lastFileHashes: Object.fromEntries(
+					snapshot([settings]).files.map((file) => [file.path, file.sha256]),
+				),
+				extraFiles: [],
+			},
+			config,
+		),
+		true,
 	);
 });
 
@@ -380,6 +399,7 @@ test("settings hash maps ignore session differences for first sync checks", () =
 
 	assert.equal(settingsHashesMatchState(remote, state), true);
 	assert.equal(hasRemoteChanges(remote, state, config), false);
+	assert.equal(hasRemoteChanges(remote, state, { ...config, syncSessions: true }), true);
 	assert.equal(
 		hasRemoteChanges(
 			snapshot([{ path: "settings.json", content: Buffer.from("changed") }]),

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -86,6 +86,8 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 					"nested\\x",
 					"skills",
 					"SESSIONS",
+					"settings.json",
+					"AGENTS.md",
 					".env",
 					"pi-sync.local.json",
 					"secret.txt",
@@ -245,6 +247,11 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 	);
 	assert.throws(
 		() => preflightSnapshotApply(root, snapshot([{ path: "..", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(root, snapshot([{ path: "sessions\\bad.jsonl", content }]), current),
 		/Unsafe path/,
 	);
 	assert.throws(

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -506,6 +506,27 @@ test("protected session apply plans keep the live session file", () => {
 		hashes["settings.json"],
 		remote.files.find((file) => file.path === "settings.json")?.sha256,
 	);
+	assert.equal(
+		hasRemoteChanges(
+			remote,
+			{
+				version: 1,
+				profile: "default",
+				lastAppliedSnapshot: remote.id,
+				lastFileHashes: hashes,
+				syncSessions: true,
+				extraFiles: [],
+			},
+			{
+				...requiredConfig(),
+				region: "auto",
+				profile: "default",
+				prefix: "pi-sync",
+				syncSessions: true,
+			},
+		),
+		false,
+	);
 });
 
 test("session backups include session jsonl files when enabled", async () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -77,7 +77,10 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 		});
 		writeFileSync(
 			path.join(agentDir, "pi-sync.local.json"),
-			JSON.stringify({ ...requiredConfig(), extraFiles: ["LOCAL.md", 1, ""] }),
+			JSON.stringify({
+				...requiredConfig(),
+				extraFiles: ["LOCAL.md", "LOCAL.md", "skills/demo.md", "nested\\x", 1, ""],
+			}),
 		);
 		await withEnv({}, async () => {
 			assert.deepEqual((await loadConfig()).extraFiles, ["LOCAL.md"]);

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -357,6 +357,16 @@ test("snapshot apply deletes stale top-level case variants", async () => {
 
 	const withCaseDeletes = await addTopLevelCaseVariantDeletes(root, plan, remote);
 	assert.deepEqual(withCaseDeletes.deletes, [path.join(root, "append_system.md")]);
+
+	const directoryRoot = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-dir-"));
+	mkdirSync(path.join(directoryRoot, "append_system.md"));
+	const directoryPlan = preflightSnapshotApply(directoryRoot, remote, current);
+	const withoutDirectoryDelete = await addTopLevelCaseVariantDeletes(
+		directoryRoot,
+		directoryPlan,
+		remote,
+	);
+	assert.deepEqual(withoutDirectoryDelete.deletes, []);
 });
 
 test("unconfigured extra top-level files are filtered locally and preserved on upload", () => {
@@ -635,24 +645,31 @@ test("protected session apply plans keep the live session file", () => {
 		hashes["settings.json"],
 		remote.files.find((file) => file.path === "settings.json")?.sha256,
 	);
+	const config = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncSessions: true,
+	};
+	const protectedState = {
+		version: 1,
+		profile: "default",
+		lastAppliedSnapshot: remote.id,
+		lastFileHashes: hashes,
+		syncSessions: true,
+		extraFiles: [],
+	};
+	assert.equal(hasRemoteChanges(remote, protectedState, config), false);
+
+	const advancedRemote = { ...remote, id: "advanced" };
+	assert.equal(hasRemoteChanges(advancedRemote, protectedState, config), true);
 	assert.equal(
 		hasRemoteChanges(
-			remote,
-			{
-				version: 1,
-				profile: "default",
-				lastAppliedSnapshot: remote.id,
-				lastFileHashes: hashes,
-				syncSessions: true,
-				extraFiles: [],
-			},
-			{
-				...requiredConfig(),
-				region: "auto",
-				profile: "default",
-				prefix: "pi-sync",
-				syncSessions: true,
-			},
+			advancedRemote,
+			protectedState,
+			config,
+			new Set(["sessions/--project--/live.jsonl"]),
 		),
 		false,
 	);

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -10,6 +10,7 @@ import sync, {
 	appliedFileHashMap,
 	backupLocal,
 	canPullRemoteSessionsOnFirstSync,
+	canPullRemoteSettingsOnFirstSync,
 	collectFiles,
 	encodeKey,
 	filterSnapshotForConfigPolicy,
@@ -82,6 +83,7 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 				extraFiles: [
 					"LOCAL.md",
 					"LOCAL.md",
+					"local.md",
 					"skills/demo.md",
 					"nested\\x",
 					"skills",
@@ -189,6 +191,7 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	writeFileSync(path.join(root, "LOCAL.md"), "local\n");
 	writeFileSync(path.join(root, "settings.json"), "{}\n");
 	writeFileSync(path.join(root, "skills", "demo.md"), "demo\n");
+	if (path.sep === "/") writeFileSync(path.join(root, "skills", "foo\\bar.md"), "skip\n");
 	writeFileSync(path.join(root, "sessions", "--project--", "session.jsonl"), "{}\n");
 	writeFileSync(path.join(root, "sessions", "--project--", "notes.txt"), "skip\n");
 	writeFileSync(path.join(root, "sessions", "token-project", "session.jsonl"), "skip\n");
@@ -457,13 +460,28 @@ test("settings hash maps ignore session differences for first sync checks", () =
 	);
 });
 
-test("first sync only auto-pulls remote sessions when local sessions are not at risk", () => {
+test("first sync only auto-pulls remote files when local files are not at risk", () => {
+	const settings = { path: "settings.json", content: Buffer.from("settings") };
+	const appendSystem = { path: "APPEND_SYSTEM.md", content: Buffer.from("append") };
+	const changedSettings = { path: "settings.json", content: Buffer.from("changed") };
 	const remoteOnly = snapshot([
 		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("r") },
 	]);
 	const shared = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("same") };
 	const changed = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("changed") };
 
+	assert.equal(
+		canPullRemoteSettingsOnFirstSync(snapshot([settings]), snapshot([settings, appendSystem])),
+		true,
+	);
+	assert.equal(
+		canPullRemoteSettingsOnFirstSync(snapshot([settings]), snapshot([changedSettings])),
+		false,
+	);
+	assert.equal(
+		canPullRemoteSettingsOnFirstSync(snapshot([appendSystem]), snapshot([settings])),
+		false,
+	);
 	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([]), remoteOnly), true);
 	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), snapshot([shared])), true);
 	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), remoteOnly), false);

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -94,6 +94,9 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 					"append_system.md",
 					".",
 					"..",
+					".git",
+					"node_modules",
+					".pisync",
 					".env",
 					"pi-sync.local.json",
 					"secret.txt",
@@ -178,6 +181,9 @@ test("path and key helpers normalize safe names and reject escapes", () => {
 	assert.equal(safeJoin(root, "skills/demo.md"), path.join(root, "skills", "demo.md"));
 	assert.throws(() => safeJoin(root, "../escape"), /Unsafe path/);
 	assert.equal(isDeniedPath("skills/.env.local"), true);
+	assert.equal(isDeniedPath(".git"), true);
+	assert.equal(isDeniedPath("node_modules"), true);
+	assert.equal(isDeniedPath(".pisync"), true);
 	assert.equal(isDeniedPath("skills/demo.md"), false);
 	assert.equal(encodeKey("a b/c+d"), "a%20b/c%2Bd");
 	assert.equal(posixJoin("/prefix/", "profile", "/latest.json"), "prefix/profile/latest.json");
@@ -370,12 +376,35 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 			.sort(),
 		["CONFIGURED.md", "sessions/--project--/session.jsonl", "settings.json"],
 	);
-	assert.deepEqual(
-		filterSnapshotForConfigPolicy(snapshot([{ path: "local.md", content: Buffer.from("local") }]), {
+	const lowerCaseRemoteExtra = filterSnapshotForConfigPolicy(
+		snapshot([{ path: "local.md", content: Buffer.from("local") }]),
+		{
 			...config,
 			extraFiles: ["LOCAL.md"],
-		}).files.map((file) => file.path),
-		["local.md"],
+		},
+	);
+	assert.deepEqual(
+		lowerCaseRemoteExtra.files.map((file) => file.path),
+		["LOCAL.md"],
+	);
+	assert.equal(
+		hasRemoteChanges(
+			lowerCaseRemoteExtra,
+			{
+				version: 1,
+				profile: "default",
+				lastAppliedSnapshot: lowerCaseRemoteExtra.id,
+				lastFileHashes: Object.fromEntries(
+					snapshot([{ path: "local.md", content: Buffer.from("local") }]).files.map((file) => [
+						file.path,
+						file.sha256,
+					]),
+				),
+				extraFiles: ["LOCAL.md"],
+			},
+			{ ...config, extraFiles: ["LOCAL.md"] },
+		),
+		false,
 	);
 	assert.deepEqual(
 		mergeRemotePreservedFiles(snapshot([settings]), remote, config).files.map((file) => file.path),

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -79,7 +79,16 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 			path.join(agentDir, "pi-sync.local.json"),
 			JSON.stringify({
 				...requiredConfig(),
-				extraFiles: ["LOCAL.md", "LOCAL.md", "skills/demo.md", "nested\\x", 1, ""],
+				extraFiles: [
+					"LOCAL.md",
+					"LOCAL.md",
+					"skills/demo.md",
+					"nested\\x",
+					"skills",
+					"SESSIONS",
+					1,
+					"",
+				],
 			}),
 		);
 		await withEnv({}, async () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -65,6 +65,22 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 			assert.equal((await loadConfig()).syncSessions, true);
 		});
 
+		rmSync(path.join(agentDir, "pi-sync.local.json"));
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), extraFiles: "APPEND_SYSTEM.md" }),
+		);
+		await withEnv({}, async () => {
+			assert.deepEqual((await loadConfig()).extraFiles, []);
+		});
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), extraFiles: ["LOCAL.md", 1, ""] }),
+		);
+		await withEnv({}, async () => {
+			assert.deepEqual((await loadConfig()).extraFiles, ["LOCAL.md"]);
+		});
+
 		const customAgentDir = path.join(agentDir, "custom-agent");
 		mkdirSync(customAgentDir, { recursive: true });
 		writeFileSync(
@@ -147,6 +163,8 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	mkdirSync(path.join(root, "skills"), { recursive: true });
 	mkdirSync(path.join(root, "sessions", "--project--"), { recursive: true });
 	mkdirSync(path.join(root, "sessions", "token-project"), { recursive: true });
+	writeFileSync(path.join(root, "APPEND_SYSTEM.md"), "append\n");
+	writeFileSync(path.join(root, "LOCAL.md"), "local\n");
 	writeFileSync(path.join(root, "settings.json"), "{}\n");
 	writeFileSync(path.join(root, "skills", "demo.md"), "demo\n");
 	writeFileSync(path.join(root, "sessions", "--project--", "session.jsonl"), "{}\n");
@@ -157,17 +175,21 @@ test("snapshot collection includes session jsonl files only when enabled", async
 
 	assert.deepEqual(
 		(await collectFiles(root)).map((file) => file.path),
-		["settings.json", "skills/demo.md"],
+		["APPEND_SYSTEM.md", "settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { extraFiles: ["LOCAL.md"] })).map((file) => file.path),
+		["APPEND_SYSTEM.md", "LOCAL.md", "settings.json", "skills/demo.md"],
 	);
 	assert.deepEqual(
 		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
-		["sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
+		["APPEND_SYSTEM.md", "sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
 	);
 	assert.deepEqual(
 		(await collectFiles(root, { syncSessions: true, sessionDir: customSessionDir })).map(
 			(file) => file.path,
 		),
-		["sessions/custom.jsonl", "settings.json", "skills/demo.md"],
+		["APPEND_SYSTEM.md", "sessions/custom.jsonl", "settings.json", "skills/demo.md"],
 	);
 	const nestedSessionDir = path.join(root, "sessions", "work");
 	mkdirSync(nestedSessionDir, { recursive: true });
@@ -176,7 +198,7 @@ test("snapshot collection includes session jsonl files only when enabled", async
 		(await collectFiles(root, { syncSessions: true, sessionDir: nestedSessionDir })).map(
 			(file) => file.path,
 		),
-		["sessions/nested.jsonl", "settings.json", "skills/demo.md"],
+		["APPEND_SYSTEM.md", "sessions/nested.jsonl", "settings.json", "skills/demo.md"],
 	);
 });
 
@@ -453,6 +475,7 @@ function requiredConfig() {
 		bucket: "pi-sync-test",
 		accessKeyId: "access-key",
 		secretAccessKey: "secret-key",
+		extraFiles: [],
 	};
 }
 

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -213,6 +213,13 @@ test("snapshot collection includes session jsonl files only when enabled", async
 		(await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] })).map((file) => file.path),
 		["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
 	);
+	writeFileSync(path.join(root, "LOCAL-CASE.md"), "local exact case\n");
+	if (readdirSync(root).includes("LOCAL-CASE.md")) {
+		assert.deepEqual(
+			(await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] })).map((file) => file.path),
+			["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
+		);
+	}
 	assert.deepEqual(
 		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
 		["APPEND_SYSTEM.md", "sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
@@ -362,6 +369,13 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 			.files.map((file) => file.path)
 			.sort(),
 		["CONFIGURED.md", "sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.deepEqual(
+		filterSnapshotForConfigPolicy(snapshot([{ path: "local.md", content: Buffer.from("local") }]), {
+			...config,
+			extraFiles: ["LOCAL.md"],
+		}).files.map((file) => file.path),
+		["local.md"],
 	);
 	assert.deepEqual(
 		mergeRemotePreservedFiles(snapshot([settings]), remote, config).files.map((file) => file.path),

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -87,7 +87,9 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 					"skills",
 					"SESSIONS",
 					"settings.json",
+					"Settings.json",
 					"AGENTS.md",
+					"append_system.md",
 					".env",
 					"pi-sync.local.json",
 					"secret.txt",
@@ -313,8 +315,18 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 	const configured = { path: "CONFIGURED.md", content: Buffer.from("configured") };
 	const session = { path: "sessions/--project--/session.jsonl", content: Buffer.from("session") };
 	const unsafeSession = { path: "sessions/../evil.jsonl", content: Buffer.from("evil") };
+	const reservedExtra = { path: "skills", content: Buffer.from("reserved") };
+	const builtInCaseExtra = { path: "Settings.json", content: Buffer.from("duplicate") };
 	const remote = {
-		...snapshot([custom, configured, session, unsafeSession, settings]),
+		...snapshot([
+			custom,
+			configured,
+			session,
+			unsafeSession,
+			reservedExtra,
+			builtInCaseExtra,
+			settings,
+		]),
 		syncSessions: true,
 	};
 	const config = {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -227,9 +227,17 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	);
 	writeFileSync(path.join(root, "LOCAL-CASE.md"), "local exact case\n");
 	if (readdirSync(root).includes("LOCAL-CASE.md")) {
+		const exactCaseFiles = await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] });
 		assert.deepEqual(
-			(await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] })).map((file) => file.path),
+			exactCaseFiles.map((file) => file.path),
 			["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
+		);
+		assert.equal(
+			Buffer.from(
+				exactCaseFiles.find((file) => file.path === "LOCAL-CASE.md")?.contentBase64 ?? "",
+				"base64",
+			).toString("utf8"),
+			"local exact case\n",
 		);
 	}
 	assert.deepEqual(

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -86,6 +86,10 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 					"nested\\x",
 					"skills",
 					"SESSIONS",
+					".env",
+					"pi-sync.local.json",
+					"secret.txt",
+					"token.json",
 					1,
 					"",
 				],
@@ -301,7 +305,11 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 	const custom = { path: "LOCAL.md", content: Buffer.from("custom") };
 	const configured = { path: "CONFIGURED.md", content: Buffer.from("configured") };
 	const session = { path: "sessions/--project--/session.jsonl", content: Buffer.from("session") };
-	const remote = { ...snapshot([custom, configured, session, settings]), syncSessions: true };
+	const unsafeSession = { path: "sessions/../evil.jsonl", content: Buffer.from("evil") };
+	const remote = {
+		...snapshot([custom, configured, session, unsafeSession, settings]),
+		syncSessions: true,
+	};
 	const config = {
 		...requiredConfig(),
 		region: "auto",

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -211,6 +211,12 @@ test("snapshot collection includes session jsonl files only when enabled", async
 		(await collectFiles(root)).map((file) => file.path),
 		["APPEND_SYSTEM.md", "settings.json", "skills/demo.md"],
 	);
+	const caseRoot = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-case-"));
+	writeFileSync(path.join(caseRoot, "append_system.md"), "append\n");
+	assert.deepEqual(
+		(await collectFiles(caseRoot)).map((file) => file.path),
+		["APPEND_SYSTEM.md"],
+	);
 	assert.deepEqual(
 		(await collectFiles(root, { extraFiles: ["LOCAL.md"] })).map((file) => file.path),
 		["APPEND_SYSTEM.md", "LOCAL.md", "settings.json", "skills/demo.md"],
@@ -366,6 +372,13 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 		"CONFIGURED.md",
 		"settings.json",
 	]);
+	assert.deepEqual(
+		filterSnapshotForConfigPolicy(
+			snapshot([{ path: "append_system.md", content: Buffer.from("append") }]),
+			config,
+		).files.map((file) => file.path),
+		["APPEND_SYSTEM.md"],
+	);
 	assert.notEqual(
 		filterSnapshotForConfigPolicy(remote, config, { regenerateId: true }).id,
 		remote.id,

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -227,6 +227,14 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 		/Unsafe path/,
 	);
 	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: ".", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: "..", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
 		() =>
 			preflightSnapshotApply(
 				root,

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -12,12 +12,14 @@ import sync, {
 	canPullRemoteSessionsOnFirstSync,
 	collectFiles,
 	encodeKey,
+	filterSnapshotForConfigPolicy,
 	hasRemoteChanges,
 	isCloudflareR2Endpoint,
 	isDeniedPath,
 	isEnabled,
 	isExplicitlyEnabled,
 	loadConfig,
+	mergeRemotePreservedFiles,
 	mergeRemoteSessionFiles,
 	parseOptions,
 	posixJoin,
@@ -271,6 +273,46 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 				current,
 			),
 		/Unsafe session path/,
+	);
+});
+
+test("unconfigured extra top-level files are filtered locally and preserved on upload", () => {
+	const settings = { path: "settings.json", content: Buffer.from("settings") };
+	const custom = { path: "LOCAL.md", content: Buffer.from("custom") };
+	const configured = { path: "CONFIGURED.md", content: Buffer.from("configured") };
+	const session = { path: "sessions/--project--/session.jsonl", content: Buffer.from("session") };
+	const remote = { ...snapshot([custom, configured, session, settings]), syncSessions: true };
+	const config = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncSessions: false,
+		extraFiles: ["CONFIGURED.md"],
+	};
+
+	assert.deepEqual(
+		filterSnapshotForConfigPolicy(remote, config)
+			.files.map((file) => file.path)
+			.sort(),
+		["CONFIGURED.md", "settings.json"],
+	);
+	assert.deepEqual(
+		filterSnapshotForConfigPolicy(remote, { ...config, syncSessions: true })
+			.files.map((file) => file.path)
+			.sort(),
+		["CONFIGURED.md", "sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.deepEqual(
+		mergeRemotePreservedFiles(snapshot([settings]), remote, config).files.map((file) => file.path),
+		["LOCAL.md", "sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.deepEqual(
+		mergeRemotePreservedFiles(snapshot([settings]), remote, {
+			...config,
+			extraFiles: ["CONFIGURED.md", "LOCAL.md"],
+		}).files.map((file) => file.path),
+		["sessions/--project--/session.jsonl", "settings.json"],
 	);
 });
 

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -92,6 +92,8 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 					"Settings.json",
 					"AGENTS.md",
 					"append_system.md",
+					".",
+					"..",
 					".env",
 					"pi-sync.local.json",
 					"secret.txt",
@@ -189,6 +191,7 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	mkdirSync(path.join(root, "sessions", "token-project"), { recursive: true });
 	writeFileSync(path.join(root, "APPEND_SYSTEM.md"), "append\n");
 	writeFileSync(path.join(root, "LOCAL.md"), "local\n");
+	writeFileSync(path.join(root, "local-case.md"), "local case\n");
 	writeFileSync(path.join(root, "settings.json"), "{}\n");
 	writeFileSync(path.join(root, "skills", "demo.md"), "demo\n");
 	if (path.sep === "/") writeFileSync(path.join(root, "skills", "foo\\bar.md"), "skip\n");
@@ -205,6 +208,10 @@ test("snapshot collection includes session jsonl files only when enabled", async
 	assert.deepEqual(
 		(await collectFiles(root, { extraFiles: ["LOCAL.md"] })).map((file) => file.path),
 		["APPEND_SYSTEM.md", "LOCAL.md", "settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] })).map((file) => file.path),
+		["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
 	);
 	assert.deepEqual(
 		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
@@ -366,6 +373,14 @@ test("unconfigured extra top-level files are filtered locally and preserved on u
 			extraFiles: ["CONFIGURED.md", "LOCAL.md"],
 		}).files.map((file) => file.path),
 		["sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.deepEqual(
+		mergeRemotePreservedFiles(
+			snapshot([settings, { path: "local.md", content: Buffer.from("local") }]),
+			remote,
+			config,
+		).files.map((file) => file.path),
+		["local.md", "sessions/--project--/session.jsonl", "settings.json"],
 	);
 	assert.equal(
 		hasRemoteChanges(

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { gunzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import sync, {
+	addTopLevelCaseVariantDeletes,
 	appliedFileHashMap,
 	backupLocal,
 	canPullRemoteSessionsOnFirstSync,
@@ -344,6 +345,18 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 			),
 		/Unsafe session path/,
 	);
+});
+
+test("snapshot apply deletes stale top-level case variants", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-"));
+	writeFileSync(path.join(root, "append_system.md"), "old\n");
+	const remote = snapshot([{ path: "APPEND_SYSTEM.md", content: Buffer.from("new\n") }]);
+	const current = snapshot([{ path: "APPEND_SYSTEM.md", content: Buffer.from("old\n") }]);
+	const plan = preflightSnapshotApply(root, remote, current);
+	assert.deepEqual(plan.deletes, []);
+
+	const withCaseDeletes = await addTopLevelCaseVariantDeletes(root, plan, remote);
+	assert.deepEqual(withCaseDeletes.deletes, [path.join(root, "append_system.md")]);
 });
 
 test("unconfigured extra top-level files are filtered locally and preserved on upload", () => {


### PR DESCRIPTION
## Summary
- sync APPEND_SYSTEM.md by default and document extra top-level files
- normalize extraFiles before snapshot collection
- pass extraFiles into pull/rollback apply snapshots and add regression coverage

## Verification
- npm run check

Closes #107.