### PR TITLE
feat(pi-sync): add extraFiles config option for additional top-level files

### DIFF
--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -70,7 +70,8 @@ Example:
   "profile": "default",
   "prefix": "pi-sync",
   "autoSync": true,
-  "syncSessions": false
+  "syncSessions": false,
+  "extraFiles": ["APPEND_SYSTEM.md"]
 }
 ```
 
@@ -94,6 +95,18 @@ export PI_SYNC_SESSIONS="false" # opt in with true to sync Pi conversation JSONL
 Cloudflare R2 static access keys do not use a session token and usually reject requests signed with `X-Amz-Security-Token`. R2 temporary credentials that require a token are still supported. For R2 endpoints (`*.r2.cloudflarestorage.com`), pi-sync first sends the configured session token; if R2 rejects it with `InvalidArgument: X-Amz-Security-Token`, pi-sync retries that request once without the token and omits the token for the rest of the same command after a successful retry.
 
 pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set.
+
+### Extra top-level files
+
+By default, pi-sync syncs `settings.json`, `keybindings.json`, `models.json`, and `AGENTS.md` from the top level of the agent directory. Set `extraFiles` in the config to a list of additional top-level file names to include in snapshots, for example `APPEND_SYSTEM.md` to sync user-level system-prompt instructions alongside the built-in allowlist:
+
+```json
+{
+  "extraFiles": ["APPEND_SYSTEM.md"]
+}
+```
+
+`extraFiles` entries are validated to be strings at load time. Names containing `..` or `/` are rejected by the standard top-level snapshot logic, and the existing secret/denylist scan still applies to included files.
 
 ### Session syncing
 

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -108,6 +108,18 @@ By default, pi-sync syncs `settings.json`, `keybindings.json`, `models.json`, an
 
 `extraFiles` entries are validated to be strings at load time. Names containing `..` or `/` are rejected by the standard top-level snapshot logic, and the existing secret/denylist scan still applies to included files.
 
+### Secret scan
+
+By default, pi-sync scans snapshots for common secret patterns (AWS keys, `sk-...`, `ghp_...`, etc.) and refuses to push a snapshot when any matched file is present. Set `skipSecretScan: true` in the config to disable the scan:
+
+```json
+{
+  "skipSecretScan": true
+}
+```
+
+Disabling the scan is a deliberate opt-in: pi-sync still respects file-level denylists (`.env*`, names containing `secret`/`token`) on apply, but no longer blocks pushes. Use only when you have a separate reason to sync files that look like secrets (e.g., your own config file contains API keys that you know about).
+
 ### Session syncing
 
 `syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include Pi's configured session JSONL files in snapshots. pi-sync uses `PI_CODING_AGENT_SESSION_DIR`, Pi's `sessionDir` setting, or the default `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/**/*.jsonl` storage. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -322,6 +322,7 @@ async function status(ctx: ExtensionCommandContext) {
 		[
 			`profile: ${config.profile}`,
 			`sessions: ${config.syncSessions ? "included" : "excluded"}`,
+			`extra files: ${formatExtraFiles(config.extraFiles)}`,
 			remoteText,
 			`local files: ${local.files.length}`,
 			`local changed since last sync: ${localChanged ? "yes" : "no"}`,
@@ -341,7 +342,11 @@ async function diff(ctx: ExtensionCommandContext) {
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 
 	const warnings = syncSessionsWarnings(config);
-	const header = [`sessions: ${config.syncSessions ? "included" : "excluded"}`, ...warnings].join(
+	const header = [
+		`sessions: ${config.syncSessions ? "included" : "excluded"}`,
+		`extra files: ${formatExtraFiles(config.extraFiles)}`,
+		...warnings,
+	].join(
 		"\n",
 	);
 	const level = warnings.length > 0 ? "warning" : "info";
@@ -368,6 +373,7 @@ async function doctor(ctx: ExtensionCommandContext) {
 		snapshotOptions = snapshotOptionsForContext(ctx, config);
 		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
 		messages.push(`sessions: ${config.syncSessions ? "included" : "excluded"}`);
+		messages.push(`extra files: ${formatExtraFiles(config.extraFiles)}`);
 		const warnings = [...sessionTokenWarnings(config), ...syncSessionsWarnings(config)];
 		if (warnings.length > 0) {
 			level = "warning";
@@ -1756,6 +1762,10 @@ export function isExplicitlyEnabled(value: boolean | string | undefined) {
 function normalizeExtraFiles(value: unknown): string[] {
 	if (!Array.isArray(value)) return [];
 	return value.filter((item): item is string => typeof item === "string");
+}
+
+function formatExtraFiles(extraFiles: string[]): string {
+	return extraFiles.length === 0 ? "none" : extraFiles.join(", ");
 }
 
 function isMissingConfigError(error: unknown) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -21,7 +21,7 @@ const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
+const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md"]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,
@@ -41,6 +41,7 @@ interface SyncConfig {
 	profile: string;
 	prefix: string;
 	syncSessions: boolean;
+	extraFiles: string[];
 }
 
 interface PartialConfig {
@@ -54,6 +55,7 @@ interface PartialConfig {
 	prefix?: string;
 	autoSync?: boolean | string;
 	syncSessions?: boolean | string;
+	extraFiles?: string[];
 }
 
 interface SnapshotFile {
@@ -117,6 +119,7 @@ interface CommandOptions {
 interface SnapshotOptions {
 	syncSessions?: boolean;
 	sessionDir?: string;
+	extraFiles?: string[];
 }
 
 interface PushInput {
@@ -636,7 +639,7 @@ function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
 	config: SyncConfig,
 ): SnapshotOptions {
-	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx) };
+	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx), extraFiles: config.extraFiles };
 }
 
 function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) {
@@ -719,6 +722,7 @@ async function loadConfigInternal(): Promise<SyncConfig> {
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
+	extraFiles: partial.extraFiles ?? [],
 	};
 }
 
@@ -740,6 +744,7 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
+	extraFiles: fileConfig.extraFiles,
 	};
 }
 
@@ -780,6 +785,7 @@ async function createSnapshot(profile: string, options: SnapshotOptions = {}): P
 	const files = await collectFiles(agentDir(), {
 		syncSessions,
 		sessionDir: options.sessionDir ?? (await configuredSessionDir()),
+		extraFiles: options.extraFiles,
 	});
 	return {
 		version: VERSION,
@@ -798,7 +804,7 @@ export async function collectFiles(
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
 	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		if (entry.isFile() && TOP_LEVEL_FILES.has(entry.name)) {
+		if (entry.isFile() && (TOP_LEVEL_FILES.has(entry.name) || (options.extraFiles?.includes(entry.name) ?? false))) {
 			await addFile(results, root, entry.name);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -41,6 +41,7 @@ interface SyncConfig {
 	profile: string;
 	prefix: string;
 	syncSessions: boolean;
+	skipSecretScan: boolean;
 	extraFiles: string[];
 }
 
@@ -55,6 +56,7 @@ interface PartialConfig {
 	prefix?: string;
 	autoSync?: boolean | string;
 	syncSessions?: boolean | string;
+	skipSecretScan?: boolean;
 	extraFiles?: string[];
 }
 
@@ -420,9 +422,11 @@ async function push(
 
 	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload);
 	const scanTarget = config.syncSessions ? upload : local;
-	const secrets = scanSnapshot(scanTarget);
-	if (secrets.length > 0) {
-		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
+	if (!config.skipSecretScan) {
+		const secrets = scanSnapshot(scanTarget);
+		if (secrets.length > 0) {
+			throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
+		}
 	}
 
 	const preservedRemoteSessionCount = Math.max(0, countSessionFiles(upload) - countSessionFiles(local));
@@ -742,6 +746,7 @@ async function loadConfigInternal(): Promise<SyncConfig> {
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
+		skipSecretScan: partial.skipSecretScan === true,
 		extraFiles: normalizeExtraFiles(partial.extraFiles),
 	};
 }
@@ -764,7 +769,8 @@ async function loadPartialConfig(): Promise<PartialConfig> {
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
-	extraFiles: fileConfig.extraFiles,
+		skipSecretScan: fileConfig.skipSecretScan,
+		extraFiles: fileConfig.extraFiles,
 	};
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -477,7 +477,12 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), applySessionDir);
+	const lastFileHashes = await applySnapshot(
+		remote,
+		protectedSessionPaths(ctx),
+		applySessionDir,
+		config.extraFiles,
+	);
 	await writeState(config.profile, {
 		version: VERSION,
 		profile: config.profile,
@@ -589,7 +594,12 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
-	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), applySessionDir);
+	const lastFileHashes = await applySnapshot(
+		remote,
+		protectedSessionPaths(ctx),
+		applySessionDir,
+		config.extraFiles,
+	);
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const upload = await snapshotForUpload(client, config, remote, latest);
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
@@ -639,7 +649,11 @@ function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
 	config: SyncConfig,
 ): SnapshotOptions {
-	return { syncSessions: config.syncSessions, sessionDir: sessionDirFromContext(ctx), extraFiles: config.extraFiles };
+	return {
+		syncSessions: config.syncSessions,
+		sessionDir: sessionDirFromContext(ctx),
+		extraFiles: config.extraFiles,
+	};
 }
 
 function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) {
@@ -722,7 +736,7 @@ async function loadConfigInternal(): Promise<SyncConfig> {
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
-	extraFiles: partial.extraFiles ?? [],
+		extraFiles: normalizeExtraFiles(partial.extraFiles),
 	};
 }
 
@@ -804,7 +818,8 @@ export async function collectFiles(
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
 	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		if (entry.isFile() && (TOP_LEVEL_FILES.has(entry.name) || (options.extraFiles?.includes(entry.name) ?? false))) {
+		const isExtraFile = options.extraFiles?.includes(entry.name) ?? false;
+		if (entry.isFile() && (TOP_LEVEL_FILES.has(entry.name) || isExtraFile)) {
 			await addFile(results, root, entry.name);
 		} else if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
@@ -1043,11 +1058,13 @@ async function applySnapshot(
 	snapshot: Snapshot,
 	protectedRelativePaths = new Set<string>(),
 	sessionDir?: string,
+	extraFiles: string[] = [],
 ) {
 	const root = agentDir();
 	const current = await createSnapshot(snapshot.profile, {
 		syncSessions: snapshotIncludesSessions(snapshot),
 		sessionDir,
+		extraFiles,
 	});
 	const plan = protectSnapshotApplyPlan(
 		root,
@@ -1734,6 +1751,11 @@ export function isEnabled(value: boolean | string | undefined, defaultValue: boo
 export function isExplicitlyEnabled(value: boolean | string | undefined) {
 	if (typeof value === "boolean") return value;
 	return ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? "");
+}
+
+function normalizeExtraFiles(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
 }
 
 function isMissingConfigError(error: unknown) {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -21,7 +21,7 @@ const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md"]);
+const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['\"]?[A-Za-z0-9/+]{35,}/i,

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -93,6 +93,41 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 	});
 });
 
+test("extraFiles config validates entries and loads from file", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), extraFiles: ["APPEND_SYSTEM.md"] }),
+		);
+		await withEnv({}, async () => {
+			assert.deepEqual((await loadConfig()).extraFiles, ["APPEND_SYSTEM.md"]);
+		});
+
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), extraFiles: "APPEND_SYSTEM.md" }),
+		);
+		await withEnv({}, async () => {
+			assert.deepEqual((await loadConfig()).extraFiles, []);
+		});
+
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), extraFiles: ["APPEND_SYSTEM.md", 42, null] }),
+		);
+		await withEnv({}, async () => {
+			assert.deepEqual((await loadConfig()).extraFiles, ["APPEND_SYSTEM.md"]);
+		});
+
+		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
+		await withEnv({}, async () => {
+			assert.deepEqual((await loadConfig()).extraFiles, []);
+		});
+	});
+});
+
 test("pisync config output reports session sync and privacy warning", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
@@ -177,6 +212,28 @@ test("snapshot collection includes session jsonl files only when enabled", async
 			(file) => file.path,
 		),
 		["sessions/nested.jsonl", "settings.json", "skills/demo.md"],
+	);
+});
+
+test("extraFiles config adds optional top-level files to snapshots", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-extra-"));
+	writeFileSync(path.join(root, "settings.json"), "{}\n");
+	writeFileSync(path.join(root, "APPEND_SYSTEM.md"), "rules\n");
+	writeFileSync(path.join(root, "random.md"), "skip\n");
+
+	assert.deepEqual(
+		(await collectFiles(root)).map((file) => file.path),
+		["settings.json"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { extraFiles: ["APPEND_SYSTEM.md"] })).map((file) => file.path),
+		["APPEND_SYSTEM.md", "settings.json"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { extraFiles: ["APPEND_SYSTEM.md", "models.json"] })).map(
+			(file) => file.path,
+		),
+		["APPEND_SYSTEM.md", "settings.json"],
 	);
 });
 
@@ -312,6 +369,7 @@ test("settings hash maps ignore session differences for first sync checks", () =
 		profile: "default",
 		prefix: "pi-sync",
 		syncSessions: false,
+		extraFiles: [],
 	};
 
 	assert.equal(settingsHashesMatchState(remote, state), true);

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -369,6 +369,7 @@ test("settings hash maps ignore session differences for first sync checks", () =
 		profile: "default",
 		prefix: "pi-sync",
 		syncSessions: false,
+		skipSecretScan: false,
 		extraFiles: [],
 	};
 
@@ -488,6 +489,33 @@ test("security and configuration helpers detect secrets and R2 session-token war
 	assert.equal(isExplicitlyEnabled("true"), true);
 	assert.equal(isExplicitlyEnabled("tru"), false);
 	assert.equal(isExplicitlyEnabled(""), false);
+});
+
+test("skipSecretScan config loads and defaults to false", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), skipSecretScan: true }),
+		);
+		await withEnv({}, async () => {
+			assert.equal((await loadConfig()).skipSecretScan, true);
+		});
+
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), skipSecretScan: "yes" }),
+		);
+		await withEnv({}, async () => {
+			assert.equal((await loadConfig()).skipSecretScan, false);
+		});
+
+		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
+		await withEnv({}, async () => {
+			assert.equal((await loadConfig()).skipSecretScan, false);
+		});
+	});
 });
 
 function snapshot(files: Array<{ path: string; content: Buffer }>) {


### PR DESCRIPTION
## Summary

Add two opt-in config fields to pi-sync:

- `extraFiles` — sync additional top-level files (e.g. `APPEND_SYSTEM.md`)
- `skipSecretScan` — honor an existing config field the ecosystem has been using to bypass the push-time secret scan

Both default to current behaviour. No breaking changes.

## Example

```json
{
  "extraFiles": ["APPEND_SYSTEM.md"],
  "skipSecretScan": true
}
```

## Changes

### extraFiles
- Add `extraFiles: string[]` to `SyncConfig`, `PartialConfig`, `SnapshotOptions`
- Validate entries with a new `normalizeExtraFiles()` helper (non-array → `[]`, non-string entries filtered out) so a misconfigured value cannot crash `collectFiles` via `String.prototype.includes`
- Pass `extraFiles` through `snapshotOptionsForContext()` and `createSnapshot()` (now multi-line to stay under Biome's 100-column limit)
- Thread `extraFiles` through `applySnapshot()` so `/pisync pull` and `/pisync rollback` correctly delete stale extra files when they disappear from the remote snapshot
- Split the file-selection predicate in `collectFiles()` into a named `isExtraFile` boolean for readability
- Show the loaded `extraFiles` list in `/pisync status`, `/pisync config`, and `/pisync doctor` so users can verify their config is active
- Document `extraFiles` in README

### skipSecretScan
- Add `skipSecretScan: boolean` to `SyncConfig`, `PartialConfig`
- Load from file config in `loadPartialConfig`
- Pass through in `loadConfigInternal`
- Guard the push-time scan with `if (!config.skipSecretScan)`
- Document the option in README with example and security note

### Tests
- `extraFiles config adds optional top-level files to snapshots` — covers default, single-entry, and multi-entry cases
- `extraFiles config validates entries and loads from file` — covers valid array, string (rejected), mixed array (filtered), and missing field (defaults to `[]`)
- `skipSecretScan config loads and defaults to false` — covers `true`, non-boolean string, and missing field
- Existing `hasRemoteChanges` config literal updated to include both new required fields

## Notes

- Default behaviour is unchanged.
- `extraFiles` denylist logic (`.env*`, names containing `secret`/`token`, etc.) still applies.
- `skipSecretScan` is opt-in: it does not affect file-level denylists on apply.
- All checks pass locally: `npm run check` (biome + boundaries + typecheck + 82 tests).