### PR TITLE
feat: add extension command autocomplete

### DIFF
--- a/docs/plans/archived/2026-06-22_extension-command-autocomplete-plan.md
+++ b/docs/plans/archived/2026-06-22_extension-command-autocomplete-plan.md
@@ -1,0 +1,44 @@
+## Goal
+
+Add Pi command-level argument autocomplete for `/pisync` first, then make the same small fix for other active extension commands where static subcommands or flags exist. Success means commands register `getArgumentCompletions`, suggestions use the `/goal` shape (`value`, command-token `label`, optional `description`), tests cover prefix behavior, and `npm run check` passes.
+
+## Context
+
+Pi already supports command argument completion through `registerCommand(..., { getArgumentCompletions(prefix) })`; no custom autocomplete provider is needed.
+
+Current active command status:
+
+- Done: `/goal`.
+- Missing and useful: `/pisync`, `/codex-status`, `/plan`.
+- Already present but worth auditing against `/goal` behavior: `/caffeinate`, `/firecrawl`, `/chrome-devtools`.
+- Skip: `/btw` and `/wait-what` are free-form text; `/lsp` and `/subagents:config` have no useful static args.
+
+## Non-Goals
+
+- Do not autocomplete dynamic remote data such as R2 buckets, snapshot ids, sessions, model ids, files, or agents.
+- Do not autocomplete free-form prompts, questions, or goal/objective text.
+- Do not add a shared package/helper just for a few static arrays; each extension is independently published.
+
+## Plan
+
+- [x] Add `completeSyncArguments(argumentPrefix)` in `extensions/pi-sync/src/sync.ts` and wire it into `/pisync`; suggested subcommands (`help`, `init`, `config`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, `unlock`) and only useful accepted flags (`--yes`, `-y`, `--force`, `--stale`) for matching subcommands; verified with `extensions/pi-sync/test/sync.test.ts` and `npm run check`.
+- [x] Cover `/pisync` completion edge cases in `extensions/pi-sync/test/sync.test.ts`: empty args, partial subcommand, command plus trailing space, flag prefix after `push`/`pull`/`sync`, `rollback <snapshot> --y`, `unlock --s`, and objective-like/unknown prefixes returning `null`; verified with `npm test` and `npm run check`.
+- [x] Audit existing autocomplete helpers in `pi-caffeinate`, `pi-firecrawl`, and `pi-chrome-devtools`; preserved trailing spaces with `trimStart()` instead of `trim()` and moved descriptive text from `label` to `description`; verified with updated package tests and `npm run check`.
+- [x] Add tiny static completions for `/codex-status` options (`--refresh`, `--no-statusline`, `--clear-statusline`, `--timeout`) in `extensions/pi-codex-usage/src/codex-usage.ts`; verified with completion tests and `npm run check`.
+- [x] Add tiny static completions for `/plan` management tokens (`exit`, `off`, `tools`) while returning `null` after free-form prompt-like text; verified with plan-mode tests and `npm run check`.
+- [x] Run `npm test` after the focused changes, then `npm run check` from the repository root; both passed.
+- [x] Not applicable: skipped interactive Pi TUI smoke-test because `npm run check` verifies command registration and completion helpers non-interactively.
+
+## Risks
+
+- [x] Mitigated: `getArgumentCompletions` receives the full argument prefix, not just the current token; tests preserve trailing spaces.
+- [x] Mitigated: over-completing free-form commands is worse than no completion; helpers return `null` once user text is likely not a command token.
+- [x] Mitigated: `/pisync rollback` snapshot ids are dynamic; completion suggests only `--yes` flags around snapshot text, not fake ids.
+
+## Completion Checklist
+
+- [x] `/pisync` registers `getArgumentCompletions`, verified by `extensions/pi-sync/test/sync.test.ts`.
+- [x] Static suggestions only include accepted commands/options, verified by unit tests against parser behavior.
+- [x] Existing autocomplete commands are not noisier after completed commands, verified by updated tests where touched.
+- [x] `/codex-status` and `/plan` are completed with tests, verified by `extensions/pi-codex-usage/test/codex-usage.test.ts` and `extensions/pi-plan-mode/test/plan-mode.test.ts`.
+- [x] The full repository gate passes with `npm run check`.

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -19,12 +19,12 @@ const SETTINGS_FILE = join(
 	"pi-caffeinate-settings.json",
 );
 const COMMAND_COMPLETIONS = [
-	{ value: "display", label: "Keep system and display awake" },
-	{ value: "sleep", label: "Keep system awake; allow display sleep" },
-	{ value: "status", label: "Show current status" },
-	{ value: "mode", label: "Choose keep-awake mode" },
-	{ value: "stop", label: "Release inhibitor for now" },
-	{ value: "help", label: "Show command help" },
+	{ value: "display", label: "display", description: "Keep system and display awake" },
+	{ value: "sleep", label: "sleep", description: "Keep system awake; allow display sleep" },
+	{ value: "status", label: "status", description: "Show current status" },
+	{ value: "mode", label: "mode", description: "Choose keep-awake mode" },
+	{ value: "stop", label: "stop", description: "Release inhibitor for now" },
+	{ value: "help", label: "help", description: "Show command help" },
 ];
 const MENU_OPTIONS = {
 	display: "Keep system and display awake",
@@ -246,8 +246,8 @@ export function parseCommand(args: string): CommandAction | "unknown" {
 }
 
 export function commandCompletions(prefix: string) {
-	const normalized = prefix.trim().toLowerCase();
-	if (normalized.includes(" ")) return null;
+	const normalized = prefix.trimStart().toLowerCase();
+	if (/\s/.test(normalized)) return null;
 
 	const matches = COMMAND_COMPLETIONS.filter((completion) =>
 		completion.value.startsWith(normalized),

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -33,7 +33,10 @@ test("parseCommand accepts documented commands and aliases", () => {
 });
 
 test("commandCompletions filters single-token prefixes", () => {
-	assert.deepEqual(commandCompletions("sta"), [{ value: "status", label: "Show current status" }]);
+	assert.deepEqual(commandCompletions("sta"), [
+		{ value: "status", label: "status", description: "Show current status" },
+	]);
+	assert.equal(commandCompletions("status "), null);
 	assert.equal(commandCompletions("status now"), null);
 });
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -36,13 +36,13 @@ const CHROME_DEVTOOLS_TOOL_NAMES = [
 	"chrome_devtools_screenshot",
 ] as const;
 const COMMAND_COMPLETIONS = [
-	{ value: "help", label: "Show command usage" },
-	{ value: "quickstart", label: "Show endpoint and launch help" },
-	{ value: "status", label: "Show tool and settings status" },
-	{ value: "tools", label: "Select Chrome DevTools tools" },
-	{ value: "toggle", label: "Select Chrome DevTools tools" },
-	{ value: "enable", label: "Enable all Chrome DevTools tools" },
-	{ value: "disable", label: "Disable all Chrome DevTools tools" },
+	{ value: "help", label: "help", description: "Show command usage" },
+	{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
+	{ value: "status", label: "status", description: "Show tool and settings status" },
+	{ value: "tools", label: "tools", description: "Select Chrome DevTools tools" },
+	{ value: "toggle", label: "toggle", description: "Select Chrome DevTools tools" },
+	{ value: "enable", label: "enable", description: "Enable all Chrome DevTools tools" },
+	{ value: "disable", label: "disable", description: "Disable all Chrome DevTools tools" },
 ];
 const MENU_OPTIONS = {
 	quickstart: "Quick start / endpoint help",
@@ -467,8 +467,8 @@ export function parseCommand(args: string): CommandAction | "unknown" {
 }
 
 export function commandCompletions(prefix: string) {
-	const normalized = prefix.trim().toLowerCase();
-	if (normalized.includes(" ")) return null;
+	const normalized = prefix.trimStart().toLowerCase();
+	if (/\s/.test(normalized)) return null;
 
 	const matches = COMMAND_COMPLETIONS.filter((completion) =>
 		completion.value.startsWith(normalized),

--- a/extensions/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/extensions/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -45,8 +45,9 @@ test("chrome-devtools command parsing and completions cover aliases", () => {
 	assert.equal(parseCommand("off"), "disable");
 	assert.equal(parseCommand("wat"), "unknown");
 	assert.deepEqual(commandCompletions("qui"), [
-		{ value: "quickstart", label: "Show endpoint and launch help" },
+		{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
 	]);
+	assert.equal(commandCompletions("quickstart "), null);
 	assert.equal(commandCompletions("quick start"), null);
 });
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -18,6 +18,23 @@ const LIMIT_VALUE_COLUMN = 29;
 const MAX_ERROR_BODY_CHARS = 600;
 const RESET_FOREGROUND = "\x1b[39m";
 
+interface CommandArgumentCompletion {
+	value: string;
+	label: string;
+	description?: string;
+}
+
+const COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
+	{ value: "--refresh", label: "--refresh", description: "Refresh usage instead of cached data" },
+	{ value: "--no-statusline", label: "--no-statusline", description: "Do not update the statusline" },
+	{
+		value: "--clear-statusline",
+		label: "--clear-statusline",
+		description: "Clear the usage statusline",
+	},
+	{ value: "--timeout ", label: "--timeout", description: "Set query timeout in seconds" },
+];
+
 type UsageSource = "pi-auth" | "codex-app-server";
 type PiModel = NonNullable<ExtensionContext["model"]>;
 export type CodexUsageModel = Pick<PiModel, "id" | "name" | "provider">;
@@ -259,6 +276,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 
 	pi.registerCommand(COMMAND_NAME, {
 		description: "Show Codex ChatGPT subscription usage and rate-limit windows",
+		getArgumentCompletions: completeCodexStatusArguments,
 		handler: async (args, ctx) => {
 			try {
 				const options = parseArgs(args);
@@ -349,6 +367,25 @@ export default function codexUsage(pi: ExtensionAPI) {
 		sessionActive = false;
 		clearUsageStatusline(ctx);
 	});
+}
+
+export function completeCodexStatusArguments(
+	argumentPrefix: string,
+): CommandArgumentCompletion[] | null {
+	const prefix = argumentPrefix.trimStart();
+	if (prefix === "") return [...COMMAND_COMPLETIONS];
+
+	const trailingSpace = /\s$/.test(prefix);
+	const tokens = prefix.trimEnd().split(/\s+/).filter(Boolean);
+	const previous = tokens.at(-1);
+	if (previous === "--timeout" && trailingSpace) return null;
+	if (!trailingSpace && tokens.at(-2) === "--timeout") return null;
+
+	const current = trailingSpace ? "" : (previous ?? "");
+	if (current && !current.startsWith("-")) return null;
+
+	const matches = COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(current));
+	return matches.length > 0 ? [...matches] : null;
 }
 
 export function parseArgs(

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -384,8 +384,14 @@ export function completeCodexStatusArguments(
 	const current = trailingSpace ? "" : (previous ?? "");
 	if (current && !current.startsWith("-")) return null;
 
+	const currentRaw = trailingSpace ? "" : (prefix.match(/\S+$/)?.[0] ?? "");
+	const completionPrefix = trailingSpace
+		? prefix
+		: prefix.slice(0, prefix.length - currentRaw.length);
 	const matches = COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(current));
-	return matches.length > 0 ? [...matches] : null;
+	return matches.length > 0
+		? matches.map((item) => ({ ...item, value: `${completionPrefix}${item.value}` }))
+		: null;
 }
 
 export function parseArgs(

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexUsage, {
 	type CodexUsageReport,
+	completeCodexStatusArguments,
 	formatCodexUsageReport,
 	formatCodexUsageStatusline,
 	isStaleExtensionContextError,
@@ -16,12 +17,30 @@ test("codex-usage registers command and statusline lifecycle hooks", () => {
 	codexUsage(mock.pi);
 
 	assert.ok(mock.commands.has("codex-status"));
+	assert.equal(typeof mock.commands.get("codex-status")?.getArgumentCompletions, "function");
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"model_select",
 		"session_shutdown",
 		"session_start",
 		"session_tree",
 	]);
+});
+
+test("completeCodexStatusArguments suggests accepted options", () => {
+	assert.deepEqual(
+		completeCodexStatusArguments("")?.map((item) => item.label),
+		["--refresh", "--no-statusline", "--clear-statusline", "--timeout"],
+	);
+	assert.deepEqual(
+		completeCodexStatusArguments("--r")?.map((item) => item.value),
+		["--refresh"],
+	);
+	assert.deepEqual(
+		completeCodexStatusArguments("--timeout 2 --n")?.map((item) => item.value),
+		["--no-statusline"],
+	);
+	assert.equal(completeCodexStatusArguments("--timeout "), null);
+	assert.equal(completeCodexStatusArguments("wat"), null);
 });
 
 test("parseArgs handles refresh, statusline, clear, and timeout options", () => {

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -37,7 +37,11 @@ test("completeCodexStatusArguments suggests accepted options", () => {
 	);
 	assert.deepEqual(
 		completeCodexStatusArguments("--timeout 2 --n")?.map((item) => item.value),
-		["--no-statusline"],
+		["--timeout 2 --no-statusline"],
+	);
+	assert.deepEqual(
+		completeCodexStatusArguments("--refresh --c")?.map((item) => item.value),
+		["--refresh --clear-statusline"],
 	);
 	assert.equal(completeCodexStatusArguments("--timeout "), null);
 	assert.equal(completeCodexStatusArguments("wat"), null);

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -22,14 +22,14 @@ const FIRECRAWL_TOOL_NAMES = [
 	"firecrawl_search",
 ] as const;
 const COMMAND_COMPLETIONS = [
-	{ value: "help", label: "Show command usage" },
-	{ value: "config", label: "Show configuration quick start" },
-	{ value: "quickstart", label: "Show configuration quick start" },
-	{ value: "status", label: "Show tool and settings status" },
-	{ value: "tools", label: "Select Firecrawl tools" },
-	{ value: "toggle", label: "Select Firecrawl tools" },
-	{ value: "enable", label: "Enable all Firecrawl tools" },
-	{ value: "disable", label: "Disable all Firecrawl tools" },
+	{ value: "help", label: "help", description: "Show command usage" },
+	{ value: "config", label: "config", description: "Show configuration quick start" },
+	{ value: "quickstart", label: "quickstart", description: "Show configuration quick start" },
+	{ value: "status", label: "status", description: "Show tool and settings status" },
+	{ value: "tools", label: "tools", description: "Select Firecrawl tools" },
+	{ value: "toggle", label: "toggle", description: "Select Firecrawl tools" },
+	{ value: "enable", label: "enable", description: "Enable all Firecrawl tools" },
+	{ value: "disable", label: "disable", description: "Disable all Firecrawl tools" },
 ];
 const MENU_OPTIONS = {
 	config: "Configuration quick start",
@@ -362,8 +362,8 @@ export function parseCommand(args: string): CommandAction | "unknown" {
 }
 
 export function commandCompletions(prefix: string) {
-	const normalized = prefix.trim().toLowerCase();
-	if (normalized.includes(" ")) return null;
+	const normalized = prefix.trimStart().toLowerCase();
+	if (/\s/.test(normalized)) return null;
 
 	const matches = COMMAND_COMPLETIONS.filter((completion) =>
 		completion.value.startsWith(normalized),

--- a/extensions/pi-firecrawl/test/firecrawl.test.ts
+++ b/extensions/pi-firecrawl/test/firecrawl.test.ts
@@ -40,8 +40,9 @@ test("firecrawl command parsing and completions cover aliases", () => {
 	assert.equal(parseCommand("off"), "disable");
 	assert.equal(parseCommand("wat"), "unknown");
 	assert.deepEqual(commandCompletions("con"), [
-		{ value: "config", label: "Show configuration quick start" },
+		{ value: "config", label: "config", description: "Show configuration quick start" },
 	]);
+	assert.equal(commandCompletions("config "), null);
 	assert.equal(commandCompletions("config now"), null);
 });
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -14,6 +14,12 @@ const TOOL_SELECTOR_PAGE_SIZE = 10;
 const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/i;
 const PROPOSED_PLAN_BLOCK_PATTERN = /<proposed_plan>\s*[\s\S]*?\s*<\/proposed_plan>/gi;
 
+interface CommandArgumentCompletion {
+	value: string;
+	label: string;
+	description?: string;
+}
+
 interface PlanModeState {
 	enabled: boolean;
 	latestPlan?: string;
@@ -72,6 +78,12 @@ type PlanModeQuestionDetails = {
 	questions: PlanModeQuestion[];
 	answers?: PlanModeQuestionAnswer[];
 };
+
+const PLAN_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
+	{ value: "exit", label: "exit", description: "Leave Plan mode" },
+	{ value: "off", label: "off", description: "Leave Plan mode" },
+	{ value: "tools", label: "tools", description: "Select tools allowed in Plan mode" },
+];
 
 const PLAN_MODE_QUESTION_PARAMS = {
 	type: "object",
@@ -228,6 +240,7 @@ export default function planMode(pi: ExtensionAPI) {
 
 	pi.registerCommand("plan", {
 		description: "Enter or manage Codex-like Plan mode",
+		getArgumentCompletions: completePlanArguments,
 		handler: async (args, ctx) => {
 			const prompt = args.trim();
 			const command = prompt.toLowerCase();
@@ -682,6 +695,15 @@ export default function planMode(pi: ExtensionAPI) {
 
 function isBuiltinTool(tool: ToolInfo) {
 	return tool.sourceInfo.source === "builtin";
+}
+
+export function completePlanArguments(argumentPrefix: string): CommandArgumentCompletion[] | null {
+	const prefix = argumentPrefix.trimStart().toLowerCase();
+	if (prefix === "") return [...PLAN_COMMAND_COMPLETIONS];
+	if (/\s/.test(prefix)) return null;
+
+	const matches = PLAN_COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(prefix));
+	return matches.length > 0 ? [...matches] : null;
 }
 
 export function canSelectToolInPlanMode(tool: ToolInfo) {

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { builtinTool, createMockPi, extensionTool } from "../../../test/support.js";
 import planMode, {
 	canSelectToolInPlanMode,
+	completePlanArguments,
 	extractProposedPlan,
 	isSafeCommand,
 	latestAssistantText,
@@ -20,8 +21,23 @@ test("plan-mode registers flag, question tool, command, and safety hooks", () =>
 	assert.ok(mock.flags.has("plan"));
 	assert.equal(mock.tools[0]?.name, "plan_mode_question");
 	assert.ok(mock.commands.has("plan"));
+	assert.equal(typeof mock.commands.get("plan")?.getArgumentCompletions, "function");
 	assert.ok(mock.events.has("tool_call"));
 	assert.ok(mock.events.has("before_agent_start"));
+});
+
+test("completePlanArguments suggests management tokens only", () => {
+	assert.deepEqual(
+		completePlanArguments("")?.map((item) => item.label),
+		["exit", "off", "tools"],
+	);
+	assert.deepEqual(
+		completePlanArguments("to")?.map((item) => item.value),
+		["tools"],
+	);
+	assert.equal(completePlanArguments("tools "), null);
+	assert.equal(completePlanArguments("write a plan"), null);
+	assert.equal(completePlanArguments("unknown"), null);
 });
 
 test("tool selection allows safe built-ins and non-built-ins only", () => {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -126,6 +126,12 @@ interface CommandOptions {
 	args: string[];
 }
 
+interface CommandArgumentCompletion {
+	value: string;
+	label: string;
+	description?: string;
+}
+
 interface SnapshotOptions {
 	syncSessions?: boolean;
 	sessionDir?: string;
@@ -153,10 +159,45 @@ const AUTO_SYNC_OPTIONS: CommandOptions = {
 	auto: true,
 	args: [],
 };
+const YES_FLAG_COMPLETIONS: readonly CommandArgumentCompletion[] = [
+	{ value: "--yes", label: "--yes", description: "Skip confirmation prompts" },
+	{ value: "-y", label: "-y", description: "Skip confirmation prompts" },
+];
+const SYNC_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
+	{ value: "help", label: "help", description: "Show command usage" },
+	{ value: "init", label: "init", description: "Create local config template" },
+	{ value: "config", label: "config", description: "Show resolved configuration" },
+	{ value: "status", label: "status", description: "Show sync status" },
+	{ value: "diff", label: "diff", description: "Show local/remote diff" },
+	{ value: "doctor", label: "doctor", description: "Check config, secrets, and lock state" },
+	{ value: "push", label: "push", description: "Upload local settings" },
+	{ value: "pull", label: "pull", description: "Apply remote settings" },
+	{ value: "sync", label: "sync", description: "Push or pull as needed" },
+	{ value: "history", label: "history", description: "Show recent remote snapshots" },
+	{ value: "rollback", label: "rollback", description: "Apply a previous snapshot" },
+	{ value: "unlock", label: "unlock", description: "Remove a stale local lock" },
+];
+const SYNC_FLAG_COMPLETIONS: Record<string, readonly CommandArgumentCompletion[]> = {
+	push: [
+		...YES_FLAG_COMPLETIONS,
+		{ value: "--force", label: "--force", description: "Overwrite visible remote changes" },
+	],
+	pull: [
+		...YES_FLAG_COMPLETIONS,
+		{ value: "--force", label: "--force", description: "Overwrite local changes" },
+	],
+	sync: [
+		...YES_FLAG_COMPLETIONS,
+		{ value: "--force", label: "--force", description: "Resolve conflicts by forcing action" },
+	],
+	rollback: YES_FLAG_COMPLETIONS,
+	unlock: [{ value: "--stale", label: "--stale", description: "Remove only a stale lock" }],
+};
 
 export default function sync(pi: ExtensionAPI) {
 	pi.registerCommand("pisync", {
 		description: "Sync Pi settings through Cloudflare R2 or S3-compatible storage",
+		getArgumentCompletions: completeSyncArguments,
 		handler: async (args, ctx) => {
 			await handleCommand(args, ctx);
 		},
@@ -1941,6 +1982,37 @@ export function parseOptions(args: string[]): CommandOptions {
 		auto: false,
 		args: args.filter((arg) => !arg.startsWith("-")),
 	};
+}
+
+export function completeSyncArguments(argumentPrefix: string): CommandArgumentCompletion[] | null {
+	const prefix = argumentPrefix.trimStart();
+	if (prefix === "") return [...SYNC_COMMAND_COMPLETIONS];
+
+	const trailingSpace = /\s$/.test(prefix);
+	const tokens = splitArgs(prefix);
+	if (tokens.length === 0) return [...SYNC_COMMAND_COMPLETIONS];
+
+	const [command] = tokens;
+	if (tokens.length === 1 && !trailingSpace) {
+		const matches = SYNC_COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(command));
+		return matches.length > 0 ? [...matches] : null;
+	}
+
+	const flagCompletions = SYNC_FLAG_COMPLETIONS[command];
+	if (!flagCompletions) return null;
+
+	const args = tokens.slice(1);
+	const completedArgs = trailingSpace ? args : args.slice(0, -1);
+	const completedValues = completedArgs.filter((arg) => !arg.startsWith("-"));
+	if (command === "rollback" ? completedValues.length > 1 : completedValues.length > 0) {
+		return null;
+	}
+
+	const current = trailingSpace ? "" : (args.at(-1) ?? "");
+	if (current && !current.startsWith("-")) return null;
+
+	const matches = flagCompletions.filter((item) => item.value.startsWith(current));
+	return matches.length > 0 ? [...matches] : null;
 }
 
 function usage() {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -2011,8 +2011,14 @@ export function completeSyncArguments(argumentPrefix: string): CommandArgumentCo
 	const current = trailingSpace ? "" : (args.at(-1) ?? "");
 	if (current && !current.startsWith("-")) return null;
 
+	const currentRaw = trailingSpace ? "" : (prefix.match(/\S+$/)?.[0] ?? "");
+	const completionPrefix = trailingSpace
+		? prefix
+		: prefix.slice(0, prefix.length - currentRaw.length);
 	const matches = flagCompletions.filter((item) => item.value.startsWith(current));
-	return matches.length > 0 ? [...matches] : null;
+	return matches.length > 0
+		? matches.map((item) => ({ ...item, value: `${completionPrefix}${item.value}` }))
+		: null;
 }
 
 function usage() {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -13,6 +13,7 @@ import sync, {
 	canPullRemoteSessionsOnFirstSync,
 	canPullRemoteSettingsOnFirstSync,
 	collectFiles,
+	completeSyncArguments,
 	encodeKey,
 	filterSnapshotForConfigPolicy,
 	hasRemoteChanges,
@@ -42,7 +43,55 @@ test("sync registers pisync command and session lifecycle hooks", () => {
 	sync(mock.pi);
 
 	assert.ok(mock.commands.has("pisync"));
+	assert.equal(typeof mock.commands.get("pisync")?.getArgumentCompletions, "function");
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+});
+
+test("completeSyncArguments suggests commands and useful flags", () => {
+	assert.deepEqual(
+		completeSyncArguments("")?.map((item) => item.label),
+		[
+			"help",
+			"init",
+			"config",
+			"status",
+			"diff",
+			"doctor",
+			"push",
+			"pull",
+			"sync",
+			"history",
+			"rollback",
+			"unlock",
+		],
+	);
+	assert.deepEqual(
+		completeSyncArguments("pu")?.map((item) => item.value),
+		["push", "pull"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("push ")?.map((item) => item.value),
+		["--yes", "-y", "--force"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("pull --f")?.map((item) => item.value),
+		["--force"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("sync -")?.map((item) => item.value),
+		["--yes", "-y", "--force"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("rollback 2026-06-22 --y")?.map((item) => item.value),
+		["--yes"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("unlock --s")?.map((item) => item.value),
+		["--stale"],
+	);
+	assert.equal(completeSyncArguments("status "), null);
+	assert.equal(completeSyncArguments("push snapshot"), null);
+	assert.equal(completeSyncArguments("wat"), null);
 });
 
 test("syncSessions config defaults off and supports file plus env overrides", async () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -71,23 +71,27 @@ test("completeSyncArguments suggests commands and useful flags", () => {
 	);
 	assert.deepEqual(
 		completeSyncArguments("push ")?.map((item) => item.value),
-		["--yes", "-y", "--force"],
+		["push --yes", "push -y", "push --force"],
 	);
 	assert.deepEqual(
 		completeSyncArguments("pull --f")?.map((item) => item.value),
-		["--force"],
+		["pull --force"],
 	);
 	assert.deepEqual(
 		completeSyncArguments("sync -")?.map((item) => item.value),
-		["--yes", "-y", "--force"],
+		["sync --yes", "sync -y", "sync --force"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("push --yes --f")?.map((item) => item.value),
+		["push --yes --force"],
 	);
 	assert.deepEqual(
 		completeSyncArguments("rollback 2026-06-22 --y")?.map((item) => item.value),
-		["--yes"],
+		["rollback 2026-06-22 --yes"],
 	);
 	assert.deepEqual(
 		completeSyncArguments("unlock --s")?.map((item) => item.value),
-		["--stale"],
+		["unlock --stale"],
 	);
 	assert.equal(completeSyncArguments("status "), null);
 	assert.equal(completeSyncArguments("push snapshot"), null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,7 +1762,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"


### PR DESCRIPTION
## Summary
- add /pisync argument completions for subcommands and accepted flags
- add static completions for /codex-status and /plan
- align existing command completions to token labels/descriptions and trailing-space null behavior
- archive the completed implementation plan

## Tests
- npm test
- npm run check