### PR TITLE
docs: remember command autocomplete preference

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -30,4 +30,5 @@
 - Keep entries short and reusable.
 - Keep `just` install recipes resilient by verifying registry visibility and falling back only when it solves the current install path.
 - New extension README files should mirror the existing style: emoji title, npm/Pi/license badges, Features, Install, Usage/What it does, Package layout, Keywords, and License.
+- New slash-command extensions should include argument autocomplete when the command has known subcommands, modes, or flags.
 - Earendil Works acquired the Pi tooling from mariozechner; prefer `@earendil-works/*` Pi packages because `@mariozechner/pi-*` packages are deprecated and should not be used for new extension work.


### PR DESCRIPTION
## Summary
- Add a reusable MEMORY.md taste note to include argument autocomplete for new slash-command extensions when subcommands, modes, or flags are known.

## Tests
- Not run (documentation-only change).