### PR TITLE
fix(statusline): wrap long extension statuses

### DIFF
--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -14,7 +14,7 @@ Use it to monitor model selection, thinking level, git branch, working directory
 - Owns extension status icons through optional JSON config, including per-extension icon suppression with `""`.
 - Warns when the same extension package is installed from multiple sources.
 - Uses emoji-labeled segments for readability in both classic and Tokyo Night presets.
-- Adapts to terminal width and truncates safely.
+- Adapts to terminal width and wraps long extension status lines safely.
 - Requires no configuration, with optional preset selection through `PI_STATUSLINE_PRESET`.
 
 ## 📦 Install
@@ -91,7 +91,7 @@ The default `tokyo-night` statusline uses a Starship-inspired `░▒▓` / `
 - 💸 estimated cost.
 - 🕒 clock.
 
-Statuses from other extensions appear on their own compact line below the main statusline and use each preset's separator.
+Statuses from other extensions appear below the main statusline, use each preset's separator, and wrap onto additional footer lines when they exceed the terminal width.
 
 `pi-statusline` is extension-agnostic: it consumes Pi's generic extension status API and does not import or depend on status-producing extensions.
 

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -9,7 +9,7 @@ import type {
 	Theme,
 	ThemeColor,
 } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { classicExtensionSeparator, renderClassicStatusline } from "../presets/classic.js";
 import { renderTokyoNightStatusline, tokyoNightExtensionSeparator } from "../presets/tokyo-night.js";
 import type {
@@ -113,14 +113,7 @@ export default function statusline(pi: ExtensionAPI) {
 				invalidate() {},
 				render(width: number): string[] {
 					const lines = [renderStatusline(width, ctx, footerData, theme, config, runtime)];
-					const extensionStatusLine = renderExtensionStatusline(
-						width,
-						footerData,
-						theme,
-						config,
-						runtime,
-					);
-					if (extensionStatusLine) lines.push(extensionStatusLine);
+					lines.push(...renderExtensionStatusline(width, footerData, theme, config, runtime));
 					return lines;
 				},
 			};
@@ -256,11 +249,9 @@ function renderExtensionStatusline(
 	theme: Theme,
 	config: StatuslineConfig,
 	runtime: RuntimeState,
-): string | undefined {
+): string[] {
 	const status = formatExtensionStatuses(footerData.getExtensionStatuses(), theme, config, runtime);
-	if (!status) return undefined;
-
-	return truncateToWidth(status, width, "");
+	return wrapExtensionStatusline(status, width);
 }
 
 function buildSegment(
@@ -406,7 +397,7 @@ export function formatExtensionStatus(
 	config: Pick<StatuslineConfig, "extensionStatusIcons">,
 ): string {
 	const status = splitExtensionStatusIcon(stripExtensionStatusPrefix(key, value));
-	const text = truncateToWidth(simplifyExtensionStatusText(status.text), 22, "…");
+	const text = simplifyExtensionStatusText(status.text);
 	const color = extensionColor(key, value);
 	const textColor = color === "warning" ? "warning" : "muted";
 	const icon = extensionStatusIcon(key, status.icon, config.extensionStatusIcons);
@@ -421,6 +412,11 @@ function extensionStatusIcon(
 ) {
 	if (Object.hasOwn(configuredIcons, key)) return configuredIcons[key];
 	return leadingIcon ?? DEFAULT_EXTENSION_STATUS_ICONS[key] ?? "🔌";
+}
+
+export function wrapExtensionStatusline(status: string, width: number): string[] {
+	if (!status || width <= 0) return [];
+	return wrapTextWithAnsi(status, width);
 }
 
 function formatDuplicateExtensionStatus(runtime: RuntimeState, theme: Theme): string[] {

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockPi } from "../../../test/support.js";
 import statusline, {
 	contextColor,
@@ -16,6 +17,7 @@ import statusline, {
 	simplifyExtensionStatusText,
 	splitExtensionStatusIcon,
 	stripExtensionStatusPrefix,
+	wrapExtensionStatusline,
 } from "../src/statusline.js";
 
 test("statusline registers lifecycle handlers without reading thinking level at load time", () => {
@@ -98,12 +100,33 @@ test("extension status icons use config, leading emoji, defaults, and fallback",
 		"🔎 PR #123 checks passing",
 	);
 	assert.equal(
+		formatExtensionStatus(
+			"github-pr",
+			"PR #123: checks pending (12), changes requested, 45 comments",
+			theme,
+			config({}),
+		),
+		"🔎 PR #123: checks pending (12) changes requested 45 comments",
+	);
+	assert.equal(
 		formatExtensionStatus("caffeinate", "☕ display", theme, config({ caffeinate: "🍵" })),
 		"🍵 display",
 	);
 	assert.equal(formatExtensionStatus("caffeinate", "☕ display", theme, config({})), "☕ display");
 	assert.equal(formatExtensionStatus("goal", "active", theme, config({ goal: "" })), "active");
 	assert.equal(formatExtensionStatus("unknown", "running", theme, config({})), "🔌 running");
+});
+
+test("long extension status lines wrap to terminal width without ellipsis", () => {
+	const lines = wrapExtensionStatusline(
+		"🔎 PR #123: checks pending (12) changes requested 45 comments",
+		30,
+	);
+
+	assert.ok(lines.length > 1);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 30));
+	assert.equal(lines.join(" ").includes("…"), false);
+	assert.match(lines.join(" "), /45 comments/);
 });
 
 test("statusline compact formatting helpers", () => {


### PR DESCRIPTION
## Summary
- remove the fixed 22-column truncation from extension status entries
- wrap long extension status output onto additional footer lines instead of adding an ellipsis
- document and test the wrapping behavior

## Verification
- npm run check
- just pack-statusline

Stacked on #116 so this PR only contains the statusline wrapping change.