### PR TITLE
feat: show clickable PR number after branch in statusline

### DIFF
--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -276,7 +276,9 @@ export function formatLinkedStatus(status: PullRequestStatus): string {
 }
 
 function osc8Link(url: string, text: string): string {
-	return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
+	const safeUrl = url.replace(/[\x00-\x1f\x7f]/g, "");
+	if (!/^https?:\/\//.test(safeUrl)) return text;
+	return `\x1b]8;;${safeUrl}\x07${text}\x1b]8;;\x07`;
 }
 
 function clearStatus(ctx: ExtensionContext) {

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -28,6 +28,7 @@ export interface CommentSummary {
 
 export interface PullRequestStatus {
 	number: number;
+	url: string;
 	isDraft: boolean;
 	review: ReviewSummary;
 	checks: CheckSummary;
@@ -111,6 +112,7 @@ export function normalizeGhPrView(value: unknown): PullRequestStatus {
 
 	return {
 		number: requiredNumber(pr.number, "number"),
+		url: optionalString(pr.url) ?? "",
 		isDraft: pr.isDraft === true,
 		review: summarizeReviews(pr.reviewDecision, latestReviews.length > 0 ? latestReviews : reviews),
 		checks: summarizeChecks(pr.statusCheckRollup),
@@ -263,7 +265,18 @@ function formatReviewCompact(status: PullRequestStatus): string {
 }
 
 function renderStatus(ctx: ExtensionContext, status: PullRequestStatus) {
-	ctx.ui.setStatus(STATUS_KEY, formatCompactStatus(status));
+	ctx.ui.setStatus(STATUS_KEY, formatLinkedStatus(status));
+}
+
+export function formatLinkedStatus(status: PullRequestStatus): string {
+	const text = formatCompactStatus(status);
+	if (!status.url) return text;
+	const label = `#${status.number}`;
+	return text.replace(label, osc8Link(status.url, label));
+}
+
+function osc8Link(url: string, text: string): string {
+	return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
 }
 
 function clearStatus(ctx: ExtensionContext) {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ExecResult } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import githubPr, { formatCompactStatus, normalizeGhPrView, runGhPrView } from "../src/github-pr.js";
+import githubPr, {
+	formatCompactStatus,
+	formatLinkedStatus,
+	normalizeGhPrView,
+	runGhPrView,
+} from "../src/github-pr.js";
 
 type ExecOptions = { cwd?: string; signal?: AbortSignal; timeout?: number };
 type ExecCall = { command: string; args: string[]; options?: ExecOptions };
@@ -68,6 +73,17 @@ test("normalizeGhPrView summarizes approved reviews, failing checks, and comment
 	assert.deepEqual(status.comments, { issue: 2, reviews: 3, total: 5 });
 	assert.deepEqual(status.review.approvedBy, ["alice"]);
 	assert.equal(formatCompactStatus(status), "PR #123: checks failing (1), approved, 5 comments");
+	assert.equal(
+		formatLinkedStatus(status),
+		`PR \x1b]8;;${samplePr.url}\x07#123\x1b]8;;\x07: checks failing (1), approved, 5 comments`,
+	);
+});
+
+test("formatLinkedStatus falls back to plain text when the PR url is missing", () => {
+	const status = normalizeGhPrView({ ...samplePr, url: undefined });
+
+	assert.equal(status.url, "");
+	assert.equal(formatLinkedStatus(status), formatCompactStatus(status));
 });
 
 test("normalizeGhPrView summarizes pending, changes-requested, draft, and commented reviews", () => {
@@ -254,7 +270,7 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	await sessionStart({}, context.ctx);
 	assert.equal(
 		context.statuses.get("github-pr"),
-		"PR #123: checks failing (1), approved, 5 comments",
+		`PR \x1b]8;;${samplePr.url}\x07#123\x1b]8;;\x07: checks failing (1), approved, 5 comments`,
 	);
 	assert.equal(context.widgets.size, 0);
 	assert.equal(context.notifications.length, 0);
@@ -263,7 +279,7 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	assert.equal(calls.length, 4);
 	assert.equal(
 		context.statuses.get("github-pr"),
-		"PR #123: checks failing (1), approved, 5 comments",
+		`PR \x1b]8;;${samplePr.url}\x07#123\x1b]8;;\x07: checks failing (1), approved, 5 comments`,
 	);
 
 	await sessionShutdown({}, context.ctx);

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -41,6 +41,7 @@ interface TokenTotals {
 }
 
 const STATUSLINE_KEY = "statusline";
+const GITHUB_PR_KEY = "github-pr";
 const SETTINGS_FILE = "pi-statusline-settings.json";
 const DEFAULT_PRESET: StatuslinePresetName = "tokyo-night";
 
@@ -276,8 +277,11 @@ function buildSegment(
 				thinkingColor(runtime.thinkingLevel),
 				"header",
 			);
-		case "branch":
-			return segment(name, `🌿 ${footerData.getGitBranch() ?? "no-git"}`, color, "git");
+		case "branch": {
+			const branch = footerData.getGitBranch();
+			const pr = branch ? prLinkFromStatuses(footerData.getExtensionStatuses()) : undefined;
+			return segment(name, pr ? `🌿 ${branch} (${pr})` : `🌿 ${branch ?? "no-git"}`, color, "git");
+		}
 		case "cwd":
 			return segment(name, `📁 ${basename(ctx.cwd) || ctx.cwd}`, color, "directory");
 		case "tools":
@@ -373,6 +377,19 @@ export function formatToolActivity(runtime: RuntimeState): string {
 	return "💤 idle";
 }
 
+export function prLinkFromStatuses(statuses: ReadonlyMap<string, string>): string | undefined {
+	const value = statuses.get(GITHUB_PR_KEY);
+	if (!value) return undefined;
+	// Extract the OSC 8 hyperlink span (the clickable "#123"); skip non-PR states
+	// like "PR gh missing" that carry no link. github-pr emits exactly one link, so the
+	// first OSC 8 span is the PR number.
+	const open = value.indexOf("\x1b]8;;");
+	if (open === -1) return undefined;
+	const closeMarker = "\x1b]8;;\x07";
+	const close = value.indexOf(closeMarker, open + 1);
+	return close === -1 ? undefined : value.slice(open, close + closeMarker.length);
+}
+
 function formatExtensionStatuses(
 	statuses: ReadonlyMap<string, string>,
 	theme: Theme,
@@ -383,7 +400,11 @@ function formatExtensionStatuses(
 	const visibleStatuses = [
 		...formatDuplicateExtensionStatus(runtime, theme),
 		...[...statuses.entries()]
-			.filter(([key, value]) => key !== STATUSLINE_KEY && value.trim().length > 0)
+			// github-pr is rendered inline in the branch segment, so skip it here to avoid duplication.
+			.filter(
+				([key, value]) =>
+					key !== STATUSLINE_KEY && key !== GITHUB_PR_KEY && value.trim().length > 0,
+			)
 			.map(([key, value]) => formatExtensionStatus(key, value, theme, config)),
 	].slice(0, 5);
 

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -12,6 +12,7 @@ import statusline, {
 	formatExtensionStatus,
 	formatToolActivity,
 	npmPackageName,
+	prLinkFromStatuses,
 	readStatuslineSettings,
 	shortenModel,
 	simplifyExtensionStatusText,
@@ -70,6 +71,16 @@ test("extension status helpers strip prefixes, icons, and simplify text", () => 
 	assert.equal(simplifyExtensionStatusText("ready, missing (details)"), "✓ ✗");
 	assert.equal(extensionColor("codex", "checking"), "accent");
 	assert.equal(extensionColor("lsp", "command missing"), "warning");
+});
+
+test("prLinkFromStatuses keeps the linked PR token and drops the tail and non-PR states", () => {
+	const link = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
+	assert.equal(
+		prLinkFromStatuses(new Map([["github-pr", `PR ${link}: checks failing (1), approved`]])),
+		link,
+	);
+	assert.equal(prLinkFromStatuses(new Map([["github-pr", "PR gh missing"]])), undefined);
+	assert.equal(prLinkFromStatuses(new Map()), undefined);
 });
 
 test("statusline settings load extension icon overrides", () => {


### PR DESCRIPTION
## What

Render the current PR number right after the git branch in **pi-statusline** as `🌿 <branch> (#123)`, where `#123` is a Cmd-clickable OSC 8 terminal hyperlink to the pull request.

## Why

The active PR is high-signal context while coding. Showing it inline next to the branch (and making it clickable) saves a trip to the browser, and reuses data the `pi-github-pr` extension already fetches.

## How

- **pi-github-pr**: `PullRequestStatus` now carries the PR `url`; the `#<number>` token in the status string is wrapped in an OSC 8 hyperlink (`\x1b]8;;URL\x07#123\x1b]8;;\x07`). `formatCompactStatus` stays plain (linking happens at render in `formatLinkedStatus`).
- **pi-statusline**: the branch segment extracts the linked token from the `github-pr` status and appends it as `(#123)`. The separate `github-pr` status line is suppressed to avoid duplication. The PR is only shown when a real git branch is present.

OSC 8 survives the footer's `truncateToWidth` / `wrapTextWithAnsi` rendering (verified). Clickability requires an OSC-8-capable terminal (iTerm2 / WezTerm / Kitty / Ghostty); other terminals show plain `#123`.

## Test

- `npm test` — 96 pass (added: missing-url fallback for `formatLinkedStatus`, OSC 8 extraction for `prLinkFromStatuses`).
- `npm run typecheck` — clean.
- `npx biome check` — clean.