### PR TITLE
fix(pi-goal): guard goal continuation state

### DIFF
--- a/docs/plans/archived/2026-06-25_pi-goal-minimal-fix-plan.md
+++ b/docs/plans/archived/2026-06-25_pi-goal-minimal-fix-plan.md
@@ -1,0 +1,54 @@
+## Goal
+
+Fix issue #115's minimal verified failures in `@narumitw/pi-goal`: contradictory `goal_complete` calls must not clear active goals, paused/cleared goals must stop queued goal work as far as the extension can control, and retryable provider interruptions must not make goal status lie as `paused` while Pi is already retrying.
+
+## Context
+
+The downloaded issue logs in `data/*.html` show three concrete failures:
+
+- `goal_complete` was accepted even when the tool summary said the goal was not completed.
+- WebSocket/provider errors changed the goal state to `paused`, then the same goal work continued with tool calls seconds later.
+- Goal continuation produced many short incomplete turns; that loop is expected only while the goal remains active, but it becomes confusing when stale turns survive pause/error handling.
+
+## Architecture
+
+Keep queue ownership in Pi core. `pi-goal` should only own a small goal-state guard:
+
+- active goal state and continuation marker tracking
+- completion-tool validation
+- pause/clear abort requests
+- stale goal-turn tool blocking after a goal is paused or cleared
+- retryable-error classification only where needed to avoid false `paused` state
+
+## Non-Goals
+
+- Do not build a general message queue manager in `pi-goal`.
+- Do not change `pi-retry` unless a narrow retry-classification bug is found during implementation.
+- Do not attempt to prove arbitrary user-goal completion inside the extension; only block self-contradictory completion reports.
+
+## Plan
+
+- [x] Add regression tests in `extensions/pi-goal/test/goal.test.ts` for `goal_complete` summaries that contain clear incompletion language; verify the tool does not clear goal state, does not return `terminate: true`, and leaves status active with `npm test`.
+- [x] Implement a small `isContradictoryCompletionSummary(summary)` guard in `extensions/pi-goal/src/goal.ts` that rejects direct contradictions like `not complete`, `still failing`, or `tests still fail`; verify the new regression test passes and normal positive summaries still terminate.
+- [x] Add tests for `/goal pause` and `/goal clear` while a goal is active; verify `ctx.abort()` is called once, continuation markers are cancelled, and status becomes `paused` or undefined with `npm test`.
+- [x] Call `ctx.abort()` from `pauseGoal`, `clearGoal`, and non-retryable `pauseGoalAfterAgentEnd`; verify the abort-count tests pass and no existing command tests regress.
+- [x] Add a focused retryable-interruption classifier for provider errors that Pi is likely retrying (`WebSocket closed`, SSE/header timeout, context-window overflow with compaction/retry hints, or existing `provider returned error` retry hints); verify with unit tests that usage-limit/auth-limit messages remain non-retryable.
+- [x] In `agent_end`, keep retryable interruptions active without sending a new goal continuation prompt, and only pause on user aborts or non-retryable errors; verify with tests that retryable errors do not append `goal-state: paused` and non-retryable errors still do.
+- [x] Add a stale-goal tool-call guard: after pause/clear/non-retryable error, block tool calls from the cancelled goal turn until a new non-goal user prompt or `/goal resume` clears the guard; verify with a test that stale `tool_call` returns `{ block: true }` while a fresh user prompt is not blocked.
+- [x] Update `extensions/pi-goal/README.md` to describe the guarded completion behavior, abort-on-pause/clear behavior, and retryable interruption behavior; verify package docs still match `pi-goal` commands.
+- [x] Run `npm --workspace @narumitw/pi-goal run typecheck` and `npm test`; fix only failures caused by this change.
+
+## Risks
+
+- Summary-text validation can false-positive on legitimate completions that mention earlier incomplete states; keep the phrase list narrow and document that this is only a state-safety guard, not a completion verifier.
+- Retryable-error classification can leave a goal active without Pi actually retrying; keep the classifier conservative and prefer existing retry hints when available.
+- Tool-call blocking can block legitimate user work if not reset on fresh non-goal prompts; include reset tests.
+
+## Completion Checklist
+
+- [x] Contradictory `goal_complete` no longer clears active goals, verified by `npm test` regression coverage.
+- [x] `/goal pause`, `/goal clear`, and non-retryable error pause request abort and cancel stale continuations, verified by `npm test`.
+- [x] Retryable provider interruptions do not mark active goals as paused or enqueue duplicate goal continuations, verified by `npm test`.
+- [x] Stale tool calls after a cancelled goal turn are blocked without blocking fresh user prompts, verified by `npm test`.
+- [x] `extensions/pi-goal/README.md` documents the corrected behavior, verified by review of the README diff.
+- [x] `@narumitw/pi-goal` typechecks, verified by `npm --workspace @narumitw/pi-goal run typecheck`.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -15,10 +15,11 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Supports optional token budgets such as `/goal --tokens 100k <goal>`.
 - Tracks `active`, `paused`, `budget_limited`, and `complete` states.
 - Stores goal state in the current Pi session, following Codex's thread-owned goal model instead of using a global per-directory goal.
-- Registers a `goal_complete` tool for explicit completion.
+- Registers a `goal_complete` tool for explicit completion, and rejects plainly contradictory completion summaries such as “not complete” or “tests still fail”.
 - Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle and no pending messages are queued.
-- Pauses instead of auto-continuing when Pi reports an aborted or errored assistant turn.
-- Guards auto-follow-ups so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
+- Pauses and aborts queued goal work when the user pauses/clears a goal or Pi reports a non-retryable aborted/errored assistant turn.
+- Keeps retryable provider interruptions active without enqueueing duplicate goal continuations while Pi retries.
+- Guards auto-follow-ups and stale tool calls so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
 - Encourages requirement-by-requirement verification before the goal is marked complete.
 
 ## 📦 Install
@@ -79,17 +80,11 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 ## ✅ How completion works
 
-The extension registers a `goal_complete` tool. While a goal is active, the system prompt uses Codex-like persistence rules: keep going until the goal is resolved end-to-end, treat current files, command output, tests, and external state as authoritative, avoid redefining the goal into a smaller task, and call `goal_complete` only after requirement-by-requirement verification.
-
-If an agent turn ends before `goal_complete` is called, the extension records elapsed time and token usage, checks the budget, verifies that the same goal id is still active, and sends a continuation prompt only when no user or extension messages are already pending. When Pi is already idle, this directly triggers the next turn; otherwise it is queued as a follow-up until the agent finishes current work. A continuation-pending guard prevents repeated end events from enqueueing duplicate continuations.
+While a goal is active, `pi-goal` injects persistence rules and exposes `goal_complete`. If a turn ends before completion, it records usage and sends one guarded continuation only when no other messages are pending. Empty or plainly contradictory completion summaries are rejected as a state-safety guard, not as proof of completion.
 
 ## 🛑 Interruption and queued-input behavior
 
-When Pi reports the final assistant message with `stopReason: "aborted"` or `stopReason: "error"`, `pi-goal` records usage, changes the goal to `paused`, and does not auto-continue. Run `/goal resume` to continue after reviewing the interruption or error.
-
-If user or extension messages are already queued at the end of a goal turn, those messages take priority and `pi-goal` skips that automatic continuation. Active goal instructions are still injected into the next agent turn, and normal continuation can resume after pending work finishes.
-
-Queued automatic continuation prompts are tracked by goal id and iteration. If a queued continuation is invalidated by `/goal pause`, `/goal clear`, `/goal edit`, replacement, or completion before delivery, the extension handles that stale prompt instead of letting it restart old goal work.
+On user pause/clear, abort, or non-retryable error, `pi-goal` pauses or clears the goal, aborts stale work, and blocks cancelled-goal tool calls until the next user prompt (non-extension input). Retryable provider interruptions stay active while Pi retries; no extra continuation is queued.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -64,6 +64,7 @@ interface StatusContext {
 	};
 	isIdle?: () => boolean;
 	hasPendingMessages?: () => boolean;
+	abort?: () => void;
 	sessionManager?: unknown;
 }
 
@@ -72,6 +73,15 @@ const GOAL_STATE_ENTRY_TYPE = "goal-state";
 const MAX_OBJECTIVE_LENGTH = 4_000;
 const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
 const CONTINUATION_MARKER_PREFIX = "pi-goal-continuation:";
+const CONTRADICTORY_COMPLETION_PATTERNS = [
+	/(?<!could\s)\bnot\s+(?:yet\s+)?(?:complete|completed|done|finished)\b/i,
+	/\bstill\s+(?:incomplete|failing|failing\s+tests?|fails?)\b/i,
+	/\btests?\s+(?:still\s+)?fail(?:ing)?\b/i,
+] as const;
+const NON_RETRYABLE_GOAL_ERROR_RE =
+	/usage[_\s-]*limit|chatgpt usage limit|multi-auth rotation failed|credentials tried|unauthori[sz]ed|invalid api key/i;
+const RETRYABLE_GOAL_ERROR_RE =
+	/websocket closed|sse response headers timed out|headers timed out|context[_\s-]*length[_\s-]*exceeded|input exceeds the context window|provider returned error/i;
 const GOAL_ARGUMENT_COMPLETIONS: readonly GoalArgumentCompletion[] = [
 	{ value: "pause", label: "pause", description: "Pause the active goal" },
 	{ value: "resume", label: "resume", description: "Resume a paused or budget-limited goal" },
@@ -94,34 +104,69 @@ let activeGoal: ActiveGoal | undefined;
 let completionStatusTimer: NodeJS.Timeout | undefined;
 let extensionApi: ExtensionAPI | undefined;
 let continuationPending: ContinuationPending | undefined;
+let staleGoalToolCallsBlocked = false;
 const cancelledContinuationMarkers = new Set<string>();
 
 const goalCompleteTool = defineTool({
 	name: "goal_complete",
 	label: "Goal Complete",
 	description:
-		"Mark the active /goal as complete. Only call this after the requested goal is fully done and verified.",
+		"Mark the active /goal as complete after all required work is done and verified. Do not use for partial progress, blockers, failing, or unverified work.",
 	promptSnippet: "Mark the active /goal as complete after fully finishing and verifying it",
 	promptGuidelines: [
 		"When a /goal is active, keep working until the goal is complete; do not stop with only a plan or partial progress.",
 		"Before calling goal_complete, audit the active goal requirement by requirement against the current files, command output, tests, or external state.",
-		"Call goal_complete only after the requested goal is fully implemented, verified, and no known required work remains.",
+		"Call goal_complete only after the requested goal is fully implemented, verified, and no known required work remains; otherwise keep working.",
 	],
 	parameters: Type.Object({
 		summary: Type.String({
-			description: "Concise summary of what was completed and how it was verified.",
+			description:
+				"State what was completed and what evidence verified it. Do not use this tool to report partial progress, blockers, failures, or remaining work.",
 		}),
 	}),
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 		const completedGoal = activeGoal;
+		const goal = completedGoal?.text ?? "unknown goal";
+		const summary = params.summary.trim();
+
+		if (!completedGoal) {
+			const rejection = "Goal completion rejected: no active goal.";
+			ctx.ui.notify(rejection, "warning");
+
+			return {
+				content: [{ type: "text", text: rejection }],
+				details: { goal, summary } satisfies GoalCompleteDetails,
+			};
+		}
+
+		const rejectionReason = !summary
+			? "summary is empty"
+			: isContradictoryCompletionSummary(summary)
+				? "summary says the goal is not complete"
+				: undefined;
+		if (rejectionReason) {
+			updateGoalUsage(completedGoal, ctx);
+			persistGoal(completedGoal);
+			updateStatus(ctx, completedGoal);
+			const rejection = `Goal completion rejected: ${rejectionReason}.`;
+			ctx.ui.notify(rejection, "warning");
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: rejection,
+					},
+				],
+				details: { goal, summary } satisfies GoalCompleteDetails,
+			};
+		}
+
 		if (completedGoal) {
 			activeGoal = transitionGoal(completedGoal, "complete");
 			updateGoalUsage(activeGoal, ctx);
 			persistGoal(activeGoal);
 		}
-
-		const goal = completedGoal?.text ?? "unknown goal";
-		const summary = params.summary.trim();
 
 		ctx.ui.setStatus(STATUS_KEY, completedGoal ? formatStatus(activeGoal) : undefined);
 		clearActiveGoal(ctx);
@@ -176,6 +221,7 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx) => {
 		clearCompletionStatusTimer();
 		clearContinuationTracking();
+		clearStaleGoalToolCallBlock();
 		activeGoal = loadGoalFromSession(ctx);
 		if (activeGoal) updateStatus(ctx, activeGoal);
 		else ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -184,13 +230,25 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (activeGoal) persistGoal(activeGoal);
 		clearContinuationTracking();
+		clearStaleGoalToolCallBlock();
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		clearCompletionStatusTimer();
 	});
 
 	pi.on("input", (event) => {
-		if (event.source !== "extension") return;
-		if (consumeCancelledContinuationPrompt(event.text)) return { action: "handled" as const };
+		if (event.source === "extension") {
+			if (consumeCancelledContinuationPrompt(event.text)) return { action: "handled" as const };
+			return;
+		}
+		clearStaleGoalToolCallBlock();
+	});
+
+	pi.on("tool_call", () => {
+		if (!staleGoalToolCallsBlocked) return;
+		return {
+			block: true,
+			reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+		};
 	});
 
 	pi.on("before_agent_start", (event) => {
@@ -213,6 +271,12 @@ export default function goal(pi: ExtensionAPI) {
 		updateGoalUsage(activeGoal, ctx);
 
 		if (finalAssistant?.stopReason === "aborted" || finalAssistant?.stopReason === "error") {
+			if (isRetryableGoalInterruption(finalAssistant)) {
+				forgetContinuationPending();
+				persistGoal(activeGoal);
+				updateStatus(ctx, activeGoal);
+				return;
+			}
 			pauseGoalAfterAgentEnd(ctx, activeGoal, finalAssistant);
 			return;
 		}
@@ -266,6 +330,7 @@ async function startGoal(
 	}
 
 	cancelContinuationPending();
+	clearStaleGoalToolCallBlock();
 	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
@@ -283,6 +348,8 @@ function pauseGoal(ctx: StatusContext) {
 		return;
 	}
 	cancelContinuationPending();
+	blockStaleGoalToolCalls();
+	abortCurrentTurn(ctx);
 	activeGoal = transitionGoal(activeGoal, "paused");
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
@@ -298,6 +365,7 @@ async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 		ctx.ui.notify(`Goal is ${activeGoal.status}; only paused or budget-limited goals can be resumed.`, "warning");
 		return;
 	}
+	clearStaleGoalToolCallBlock();
 	activeGoal = transitionGoal(activeGoal, "active");
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
@@ -319,6 +387,8 @@ function clearGoal(ctx: StatusContext) {
 	}
 
 	const stoppedGoal = activeGoal.text;
+	blockStaleGoalToolCalls();
+	abortCurrentTurn(ctx);
 	clearActiveGoal(ctx);
 	ctx.ui.notify(`Goal cleared: ${stoppedGoal}`, "warning");
 }
@@ -351,7 +421,10 @@ async function editGoal(
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
 	ctx.ui.notify(`Goal updated: ${objective}`, "info");
-	if (activeGoal.status === "active") await sendObjectiveUpdatedPrompt(pi, ctx, activeGoal);
+	if (activeGoal.status === "active") {
+		clearStaleGoalToolCallBlock();
+		await sendObjectiveUpdatedPrompt(pi, ctx, activeGoal);
+	}
 }
 
 function showGoal(ctx: StatusContext) {
@@ -411,6 +484,8 @@ function pauseGoalAfterAgentEnd(
 	assistant: AssistantMessageLike,
 ) {
 	cancelContinuationPending();
+	blockStaleGoalToolCalls();
+	abortCurrentTurn(ctx);
 	activeGoal = transitionGoal(goal, "paused");
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
@@ -642,6 +717,37 @@ function goalPersistenceRules(goalLabel: string) {
 
 function hasPendingMessages(ctx: StatusContext) {
 	return ctx.hasPendingMessages?.() ?? false;
+}
+
+function abortCurrentTurn(ctx: StatusContext) {
+	try {
+		ctx.abort?.();
+	} catch {
+		// Best effort: stale goal guards still prevent follow-on tool calls.
+	}
+}
+
+function blockStaleGoalToolCalls() {
+	staleGoalToolCallsBlocked = true;
+}
+
+function clearStaleGoalToolCallBlock() {
+	staleGoalToolCallsBlocked = false;
+}
+
+function forgetContinuationPending() {
+	continuationPending = undefined;
+}
+
+export function isContradictoryCompletionSummary(summary: string) {
+	return CONTRADICTORY_COMPLETION_PATTERNS.some((pattern) => pattern.test(summary));
+}
+
+export function isRetryableGoalInterruption(assistant: AssistantMessageLike) {
+	if (assistant.stopReason !== "error") return false;
+	if (!assistant.errorMessage) return false;
+	if (NON_RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage)) return false;
+	return RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage);
 }
 
 function clearContinuationTracking() {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import goal, {
 	buildGoalSystemPrompt,
 	completeGoalArguments,
@@ -8,6 +8,8 @@ import goal, {
 	formatDuration,
 	formatStatus,
 	formatTokenCount,
+	isContradictoryCompletionSummary,
+	isRetryableGoalInterruption,
 	parseCommand,
 	parseTokenBudget,
 	validateObjective,
@@ -26,6 +28,7 @@ test("goal registers command, completion tool, and lifecycle hooks", () => {
 		"input",
 		"session_shutdown",
 		"session_start",
+		"tool_call",
 	]);
 });
 
@@ -133,6 +136,205 @@ test("buildGoalSystemPrompt escapes objective XML and includes budget rules", ()
 	assert.match(prompt, /Only call the goal_complete tool after/);
 });
 
+test("goal_complete rejects contradictory summaries and accepts verified completion", async () => {
+	assert.equal(isContradictoryCompletionSummary("Not complete: tests still fail."), true);
+	assert.equal(isContradictoryCompletionSummary("Tests still fail."), true);
+	assert.equal(isContradictoryCompletionSummary("Implemented and verified with npm test."), false);
+	assert.equal(isContradictoryCompletionSummary("Remaining tasks: none."), false);
+	assert.equal(
+		isContradictoryCompletionSummary("Could not complete earlier, but now fixed and verified."),
+		false,
+	);
+	assert.equal(isContradictoryCompletionSummary("Was failing before, now passes."), false);
+	assert.equal(
+		isContradictoryCompletionSummary("Coverage was below threshold, now passes."),
+		false,
+	);
+
+	const { mock, ctx } = await startGoalForTest();
+	const tool = mock.tools[0] as GoalTool;
+
+	const rejected = await tool.execute(
+		"call-1",
+		{ summary: "Not complete: tests still fail." },
+		new AbortController().signal,
+		() => undefined,
+		ctx,
+	);
+
+	assert.equal(rejected.terminate, undefined);
+	assert.match(rejected.content?.[0]?.text ?? "", /rejected/i);
+	assert.equal(lastGoalStatus(mock), "active");
+
+	const emptyRejected = await tool.execute(
+		"call-empty",
+		{ summary: "   " },
+		new AbortController().signal,
+		() => undefined,
+		ctx,
+	);
+
+	assert.equal(emptyRejected.terminate, undefined);
+	assert.match(emptyRejected.content?.[0]?.text ?? "", /summary is empty/i);
+	assert.equal(lastGoalStatus(mock), "active");
+
+	const accepted = await tool.execute(
+		"call-2",
+		{ summary: "Implemented and verified with npm test." },
+		new AbortController().signal,
+		() => undefined,
+		ctx,
+	);
+
+	assert.equal(accepted.terminate, true);
+	assert.equal(lastGoalStatus(mock), null);
+
+	const noActiveRejected = await tool.execute(
+		"call-no-active",
+		{ summary: "Implemented and verified with npm test." },
+		new AbortController().signal,
+		() => undefined,
+		ctx,
+	);
+
+	assert.equal(noActiveRejected.terminate, undefined);
+	assert.match(noActiveRejected.content?.[0]?.text ?? "", /no active goal/i);
+	assert.equal(lastGoalStatus(mock), null);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+});
+
+test("pause and clear abort the current turn and persist stopped goal state", async () => {
+	let pauseAborts = 0;
+	const paused = await startGoalForTest({ abort: () => pauseAborts++ });
+	await paused.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		paused.ctx,
+	);
+	const staleContinuation = paused.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.match(staleContinuation, /pi-goal-continuation/);
+
+	await paused.mock.commands.get("goal")?.handler("pause", paused.ctx);
+
+	assert.equal(pauseAborts, 1);
+	assert.equal(lastGoalStatus(paused.mock), "paused");
+	assert.equal(paused.statuses.get("goal"), "paused");
+	assert.deepEqual(
+		paused.mock.events.get("input")?.[0]?.(
+			{ source: "extension", text: staleContinuation },
+			paused.ctx,
+		),
+		{ action: "handled" },
+	);
+
+	let clearAborts = 0;
+	const cleared = await startGoalForTest({ abort: () => clearAborts++ });
+	await cleared.mock.commands.get("goal")?.handler("clear", cleared.ctx);
+
+	assert.equal(clearAborts, 1);
+	assert.equal(lastGoalStatus(cleared.mock), null);
+	assert.equal(cleared.statuses.get("goal"), undefined);
+});
+
+test("agent_end keeps retryable interruptions active but pauses non-retryable errors", async () => {
+	assert.equal(
+		isRetryableGoalInterruption({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: "WebSocket closed 1000",
+		}),
+		true,
+	);
+	assert.equal(
+		isRetryableGoalInterruption({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: "You have hit your ChatGPT usage limit.",
+		}),
+		false,
+	);
+
+	const retryable = await startGoalForTest();
+	await retryable.mock.events.get("agent_end")?.[0]?.(
+		{
+			messages: [{ role: "assistant", stopReason: "error", errorMessage: "WebSocket closed 1000" }],
+		},
+		retryable.ctx,
+	);
+
+	assert.equal(lastGoalStatus(retryable.mock), "active");
+	assert.equal(retryable.mock.sentUserMessages.length, 1);
+
+	let aborts = 0;
+	const nonRetryable = await startGoalForTest({ abort: () => aborts++ });
+	await nonRetryable.mock.events.get("agent_end")?.[0]?.(
+		{
+			messages: [
+				{
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "You have hit your ChatGPT usage limit.",
+				},
+			],
+		},
+		nonRetryable.ctx,
+	);
+
+	assert.equal(aborts, 1);
+	assert.equal(lastGoalStatus(nonRetryable.mock), "paused");
+	assert.deepEqual(
+		nonRetryable.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "t1", input: {} },
+			nonRetryable.ctx,
+		),
+		{
+			block: true,
+			reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+		},
+	);
+});
+
+test("stale goal tool calls are blocked until a fresh non-goal prompt arrives", async () => {
+	const paused = await startGoalForTest();
+	await paused.mock.commands.get("goal")?.handler("pause", paused.ctx);
+
+	const pauseToolCall = paused.mock.events.get("tool_call")?.[0];
+	assert.deepEqual(pauseToolCall?.({ toolName: "bash", toolCallId: "t1", input: {} }, paused.ctx), {
+		block: true,
+		reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+	});
+
+	paused.mock.events.get("input")?.[0]?.(
+		{ source: "extension", text: "unrelated extension message" },
+		paused.ctx,
+	);
+	assert.deepEqual(pauseToolCall?.({ toolName: "bash", toolCallId: "t2", input: {} }, paused.ctx), {
+		block: true,
+		reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+	});
+
+	paused.mock.events.get("input")?.[0]?.(
+		{ source: "interactive", text: "what happened?" },
+		paused.ctx,
+	);
+	assert.equal(
+		pauseToolCall?.({ toolName: "bash", toolCallId: "t3", input: {} }, paused.ctx),
+		undefined,
+	);
+
+	const cleared = await startGoalForTest();
+	await cleared.mock.commands.get("goal")?.handler("clear", cleared.ctx);
+	assert.deepEqual(
+		cleared.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "edit", toolCallId: "t3", input: {} },
+			cleared.ctx,
+		),
+		{
+			block: true,
+			reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+		},
+	);
+});
+
 test("findFinalAssistantMessage returns the last assistant with a known stop reason", () => {
 	assert.deepEqual(
 		findFinalAssistantMessage([
@@ -143,3 +345,25 @@ test("findFinalAssistantMessage returns the last assistant with a known stop rea
 	);
 	assert.equal(validateObjective(""), "Usage: /goal <goal_to_complete>");
 });
+
+type GoalTool = {
+	execute: (...args: unknown[]) => Promise<{
+		content?: Array<{ type: string; text: string }>;
+		terminate?: boolean;
+	}>;
+};
+
+async function startGoalForTest(overrides: Record<string, unknown> = {}) {
+	const mock = createMockPi();
+	goal(mock.pi);
+	const context = createMockContext(overrides);
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("goal")?.handler("finish", context.ctx);
+	return { mock, ...context };
+}
+
+function lastGoalStatus(mock: ReturnType<typeof createMockPi>) {
+	const entry = mock.entries.filter((entry) => entry.customType === "goal-state").at(-1);
+	return ((entry?.data as { goal?: { status?: string } | null } | undefined)?.goal?.status ??
+		null) as string | null;
+}


### PR DESCRIPTION
## Summary
- reject self-contradictory goal_complete summaries so unfinished goals stay active
- abort and block stale goal work after pause/clear/non-retryable errors
- keep retryable provider interruptions active without enqueueing duplicate continuations
- document and test the corrected pi-goal behavior

## Verification
- npm run check

Closes #115