### PR TITLE
fix(github-pr): target count queries to PR host

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -18,6 +18,7 @@
 - `node-domexception` deprecation comes via `@google/genai -> google-auth-library -> gaxios -> node-fetch -> fetch-blob`; use the root npm override to `npm:@profoundlogic/node-domexception`.
 - New filesystem-writing Pi tools need a pre-review edge-case pass: workspace containment, absolute/`..` paths, symlink loops/escapes, duplicate paths, cancellation, process errors, protocol errors, and edit ordering.
 - New extension package source may match the root `.gitignore` `src/` rule; stage intended `extensions/<pkg>/src/*.ts` with `git add -f`.
+- Symptom: `npm test --workspace @narumitw/<extension>` fails with “Missing script: test”. Cause: extension packages do not define workspace test scripts; root `npm test` compiles and runs all extension tests. Fix: run `npm test` from the repository root.
 - When PR comments expose one class of bug, stop patching comment-by-comment and do a holistic pass over adjacent Modules before pushing again.
 - Symptom: PR status shows no issue comments but inline review comments exist. Cause: `gh pr view --json comments,reviews` omits pull review comment bodies. Fix: use `gh api repos/OWNER/REPO/pulls/NUMBER/comments` plus issue comments/reviews when actual PR review comments are needed.
 - Symptom: Chrome DevTools `/json/new` may reject unsafe `GET`. Cause: modern Chrome expects `PUT` for target creation. Fix: use `PUT /json/new?${encodeURIComponent(url)}`.

--- a/docs/plans/archived/2026-06-25_github-pr-ghes-host-plan.md
+++ b/docs/plans/archived/2026-06-25_github-pr-ghes-host-plan.md
@@ -1,0 +1,24 @@
+## Goal
+
+Make `pi-github-pr` work with GitHub Enterprise Server without requiring users to set `GH_HOST`, while keeping github.com behavior unchanged.
+
+## Context
+
+`extensions/pi-github-pr/src/github-pr.ts` runs `gh pr view`, then runs `gh api graphql` for comment/review counts. `gh pr view` can infer the host from the current repository, but `gh api graphql` defaults to `github.com` unless `--hostname` or `GH_HOST` is provided. The PR URL returned by `gh pr view` already contains the host.
+
+## Plan
+
+- [x] Extend `parsePrCoordinates` in `extensions/pi-github-pr/src/github-pr.ts` to return the PR URL hostname along with owner, repo name, and number; verified by `npm test` covering `https://github.example.com/org/repo/pull/123` and expecting `--hostname github.example.com`.
+- [x] Pass `--hostname <hostname>` to the `gh api graphql` call in `runGhPrCountQuery` so count queries target the same host as the PR URL; verified with `npm test` that mocked `gh api graphql` args include `--hostname` for both github.com and enterprise URLs.
+- [x] Update `extensions/pi-github-pr/README.md` to say GitHub Enterprise works through `gh auth login --hostname <host>` and no manual `GH_HOST` is required; verified by reading the Prerequisites and Known limits sections.
+- [x] Run package checks for the extension; verified with `npm run check --workspace @narumitw/pi-github-pr`.
+
+## Risks
+
+- Mitigated: installed `gh api --help | rg -- '--hostname'` reports `--hostname string       The GitHub hostname for the request (default "github.com")`.
+
+## Completion Checklist
+
+- [x] `gh api graphql` uses the PR URL host instead of defaulting to `github.com`, verified by unit-test expected exec args in `extensions/pi-github-pr/test/github-pr.test.ts` and `npm test`.
+- [x] GitHub Enterprise usage is documented, verified by `extensions/pi-github-pr/README.md` mentioning `gh auth login --hostname <host>` and no `GH_HOST` requirement.
+- [x] The extension still passes its checks, verified by `npm run check --workspace @narumitw/pi-github-pr` and full `npm run check`.

--- a/extensions/pi-github-pr/README.md
+++ b/extensions/pi-github-pr/README.md
@@ -55,9 +55,11 @@ Install and authenticate GitHub CLI yourself:
 ```bash
 brew install gh
 gh auth login
+# For GitHub Enterprise Server:
+gh auth login --hostname github.example.com
 ```
 
-The extension shells out to `gh pr view`; GitHub Enterprise hosts and credential storage are delegated to `gh`.
+The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`. It uses the PR URL host for follow-up API calls, so no manual `GH_HOST` is required.
 
 ## 💬 Behavior
 
@@ -71,7 +73,7 @@ The extension runs passively:
 
 ## Known limits
 
-- Requires `gh`; there is no direct GitHub API or `GITHUB_TOKEN` fallback.
+- Requires `gh`; there is no direct GitHub API, `GITHUB_TOKEN` fallback, or manual `GH_HOST` requirement.
 - Only the current branch PR is shown; there is no command or tool for arbitrary PR lookup.
 - Comment count uses `gh pr view` comments and reviews, not precise unresolved review-thread counts.
 - It does not read PR comment bodies, review bodies, inline diff comments, or unresolved review-thread text.

--- a/extensions/pi-github-pr/README.md
+++ b/extensions/pi-github-pr/README.md
@@ -56,10 +56,10 @@ Install and authenticate GitHub CLI yourself:
 brew install gh
 gh auth login
 # For GitHub Enterprise Server (include the port if your URL uses one):
-gh auth login --hostname github.example.com
+gh auth login --hostname github.example.com:8443
 ```
 
-The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`. It uses the PR URL host for follow-up API calls, so no manual `GH_HOST` is required.
+The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`. It uses the PR URL host (including any port) for follow-up API calls, so no manual `GH_HOST` is required.
 
 ## 💬 Behavior
 

--- a/extensions/pi-github-pr/README.md
+++ b/extensions/pi-github-pr/README.md
@@ -55,7 +55,7 @@ Install and authenticate GitHub CLI yourself:
 ```bash
 brew install gh
 gh auth login
-# For GitHub Enterprise Server:
+# For GitHub Enterprise Server (include the port if your URL uses one):
 gh auth login --hostname github.example.com
 ```
 

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -307,12 +307,14 @@ async function runGhPrCountQuery(
 	pr: JsonRecord,
 	signal?: AbortSignal,
 ): Promise<Pick<JsonRecord, "comments" | "reviews">> {
-	const { owner, name, number } = parsePrCoordinates(pr);
+	const { hostname, owner, name, number } = parsePrCoordinates(pr);
 	const result = await execGh(
 		pi,
 		[
 			"api",
 			"graphql",
+			"--hostname",
+			hostname,
 			"-f",
 			`query=${GH_PR_COUNT_QUERY}`,
 			"-F",
@@ -392,7 +394,9 @@ function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-function parsePrCoordinates(pr: JsonRecord): { owner: string; name: string; number: number } {
+function parsePrCoordinates(
+	pr: JsonRecord,
+): { hostname: string; owner: string; name: string; number: number } {
 	const number = requiredNumber(pr.number, "number");
 	const url = optionalString(pr.url);
 	if (!url) throw new Error("Missing PR url");
@@ -407,7 +411,7 @@ function parsePrCoordinates(pr: JsonRecord): { owner: string; name: string; numb
 	const match = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/?$/.exec(parsed.pathname);
 	if (!match) throw new Error(`Unsupported PR url: ${url}`);
 
-	return { owner: match[1], name: match[2], number };
+	return { hostname: parsed.hostname, owner: match[1], name: match[2], number };
 }
 
 function arrayValue(value: unknown): unknown[] {

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -411,7 +411,7 @@ function parsePrCoordinates(
 	const match = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/?$/.exec(parsed.pathname);
 	if (!match) throw new Error(`Unsupported PR url: ${url}`);
 
-	return { hostname: parsed.hostname, owner: match[1], name: match[2], number };
+	return { hostname: parsed.host, owner: match[1], name: match[2], number };
 }
 
 function arrayValue(value: unknown): unknown[] {

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -307,14 +307,14 @@ async function runGhPrCountQuery(
 	pr: JsonRecord,
 	signal?: AbortSignal,
 ): Promise<Pick<JsonRecord, "comments" | "reviews">> {
-	const { hostname, owner, name, number } = parsePrCoordinates(pr);
+	const { host, owner, name, number } = parsePrCoordinates(pr);
 	const result = await execGh(
 		pi,
 		[
 			"api",
 			"graphql",
 			"--hostname",
-			hostname,
+			host,
 			"-f",
 			`query=${GH_PR_COUNT_QUERY}`,
 			"-F",
@@ -396,7 +396,7 @@ function formatError(error: unknown): string {
 
 function parsePrCoordinates(
 	pr: JsonRecord,
-): { hostname: string; owner: string; name: string; number: number } {
+): { host: string; owner: string; name: string; number: number } {
 	const number = requiredNumber(pr.number, "number");
 	const url = optionalString(pr.url);
 	if (!url) throw new Error("Missing PR url");
@@ -411,7 +411,7 @@ function parsePrCoordinates(
 	const match = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/?$/.exec(parsed.pathname);
 	if (!match) throw new Error(`Unsupported PR url: ${url}`);
 
-	return { hostname: parsed.host, owner: match[1], name: match[2], number };
+	return { host: parsed.host, owner: match[1], name: match[2], number };
 }
 
 function arrayValue(value: unknown): unknown[] {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -155,9 +155,16 @@ test("runGhPrView calls gh pr view for the current branch and reports actionable
 		options: { cwd: "/repo", signal: undefined, timeout: 10_000 },
 	});
 	assert.deepEqual(calls[1]?.options, { cwd: "/repo", signal: undefined, timeout: 10_000 });
-	assert.deepEqual(calls[1]?.args.slice(0, 4), ["api", "graphql", "-f", calls[1]?.args[3]]);
-	assert.match(calls[1]?.args[3] ?? "", /^query=\s*query PullRequestCounts/);
-	assert.deepEqual(calls[1]?.args.slice(4), [
+	assert.deepEqual(calls[1]?.args.slice(0, 6), [
+		"api",
+		"graphql",
+		"--hostname",
+		"github.com",
+		"-f",
+		calls[1]?.args[5],
+	]);
+	assert.match(calls[1]?.args[5] ?? "", /^query=\s*query PullRequestCounts/);
+	assert.deepEqual(calls[1]?.args.slice(6), [
 		"-F",
 		"owner=narumiruna",
 		"-F",
@@ -250,6 +257,37 @@ test("runGhPrView calls gh pr view for the current branch and reports actionable
 		),
 		/gh pr view failed/,
 	);
+});
+
+test("runGhPrView sends gh api graphql to the enterprise PR hostname", async () => {
+	const calls: ExecCall[] = [];
+	const pi = {
+		exec: async (command, args, options) => {
+			calls.push({ command, args, options });
+			return okResult(
+				args[0] === "pr"
+					? { ...samplePr, url: "https://github.example.com/org/repo/pull/123" }
+					: sampleCounts,
+			);
+		},
+	} satisfies { exec: ExecFunction };
+
+	await runGhPrView(pi, "/repo");
+
+	assert.deepEqual(calls[1]?.args.slice(0, 4), [
+		"api",
+		"graphql",
+		"--hostname",
+		"github.example.com",
+	]);
+	assert.deepEqual(calls[1]?.args.slice(6), [
+		"-F",
+		"owner=org",
+		"-F",
+		"name=repo",
+		"-F",
+		"number=123",
+	]);
 });
 
 test("lifecycle refresh sets and clears only statusline output", async () => {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -259,14 +259,14 @@ test("runGhPrView calls gh pr view for the current branch and reports actionable
 	);
 });
 
-test("runGhPrView sends gh api graphql to the enterprise PR hostname", async () => {
+test("runGhPrView sends gh api graphql to the enterprise PR host", async () => {
 	const calls: ExecCall[] = [];
 	const pi = {
 		exec: async (command, args, options) => {
 			calls.push({ command, args, options });
 			return okResult(
 				args[0] === "pr"
-					? { ...samplePr, url: "https://github.example.com/org/repo/pull/123" }
+					? { ...samplePr, url: "https://github.example.com:8443/org/repo/pull/123" }
 					: sampleCounts,
 			);
 		},
@@ -278,7 +278,7 @@ test("runGhPrView sends gh api graphql to the enterprise PR hostname", async () 
 		"api",
 		"graphql",
 		"--hostname",
-		"github.example.com",
+		"github.example.com:8443",
 	]);
 	assert.deepEqual(calls[1]?.args.slice(6), [
 		"-F",


### PR DESCRIPTION
## Summary
- pass the PR URL hostname to `gh api graphql --hostname` for comment/review counts
- add GitHub Enterprise host coverage in tests
- document GHES auth without requiring manual `GH_HOST`

## Tests
- `npm run check --workspace @narumitw/pi-github-pr`
- `npm test`
- `npm run check`