### PR TITLE
fix(github-pr): sanitize OSC 8 link output

### DIFF
--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -275,10 +275,22 @@ export function formatLinkedStatus(status: PullRequestStatus): string {
 	return text.replace(label, osc8Link(status.url, label));
 }
 
+function stripTerminalControlChars(value: string): string {
+	return value.replace(/[\x00-\x1f\x7f]/g, "");
+}
+
 function osc8Link(url: string, text: string): string {
-	const safeUrl = url.replace(/[\x00-\x1f\x7f]/g, "");
-	if (!/^https?:\/\//.test(safeUrl)) return text;
-	return `\x1b]8;;${safeUrl}\x07${text}\x1b]8;;\x07`;
+	const safeText = stripTerminalControlChars(text);
+
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return safeText;
+
+		const safeUrl = stripTerminalControlChars(parsed.toString());
+		return `\x1b]8;;${safeUrl}\x07${safeText}\x1b]8;;\x07`;
+	} catch {
+		return safeText;
+	}
 }
 
 function clearStatus(ctx: ExtensionContext) {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -86,6 +86,31 @@ test("formatLinkedStatus falls back to plain text when the PR url is missing", (
 	assert.equal(formatLinkedStatus(status), formatCompactStatus(status));
 });
 
+test("formatLinkedStatus rejects invalid and non-http PR urls", () => {
+	const status = normalizeGhPrView(samplePr);
+
+	for (const url of ["not a url", "javascript:alert(1)"]) {
+		const candidate = { ...status, url };
+		assert.equal(formatLinkedStatus(candidate), formatCompactStatus(candidate));
+	}
+});
+
+test("formatLinkedStatus strips terminal controls from OSC 8 url and text", () => {
+	const status = normalizeGhPrView({ ...samplePr, url: `${samplePr.url}\x1b` });
+	const unsafeNumber = { toString: () => "12\x1b\n3" } as unknown as number;
+	const rendered = formatLinkedStatus({ ...status, number: unsafeNumber });
+
+	const controls = [...rendered]
+		.filter((char) => {
+			const code = char.charCodeAt(0);
+			return code <= 0x1f || code === 0x7f;
+		})
+		.join("");
+	assert.equal(controls, "\x1b\x07\x1b\x07");
+	assert.ok(rendered.includes("#123"));
+	assert.ok(!rendered.includes("#12\x1b\n3"));
+});
+
 test("normalizeGhPrView summarizes pending, changes-requested, draft, and commented reviews", () => {
 	const changesRequested = normalizeGhPrView({
 		...samplePr,


### PR DESCRIPTION
## Summary
- sanitize OSC 8 link text and URL before writing terminal output
- validate PR URLs with URL and allow only http(s), falling back to plain text otherwise
- cover invalid URLs and terminal control characters in github-pr tests

## Tests
- npm run check