### PR TITLE
fix(pi-goal): avoid aborting on goal clear

### DIFF
--- a/docs/plans/archived/2026-06-26_pi-goal-clear-semantics-plan.md
+++ b/docs/plans/archived/2026-06-26_pi-goal-clear-semantics-plan.md
@@ -1,0 +1,31 @@
+## Goal
+
+Make `/goal clear` in `@narumitw/pi-goal` mean “clear goal bookkeeping” only: remove the current goal state, statusline value, persisted/session state, and pending continuation tracking without aborting the active agent turn. Keep abort/interrupt behavior on `/goal pause`.
+
+## Context
+
+Current `clearGoal()` called `blockStaleGoalToolCalls()` and `abortCurrentTurn(ctx)` before clearing state. That made `/goal clear` behave like cancel/stop, while third-party references separate clear/state reset from interrupt/pause.
+
+## Non-Goals
+
+- Do not add `/goal stop` in this change.
+- Do not change `/goal pause`, `/goal resume`, token budgets, or `goal_complete` semantics beyond preserving the new clear behavior.
+
+## Plan
+
+- [x] Update `extensions/pi-goal/src/goal.ts` so `clearGoal()` only clears active/persisted goal state, status, and pending continuations; verified by inspecting `clearGoal()` and confirming it no longer calls `abortCurrentTurn(ctx)` or `blockStaleGoalToolCalls()`.
+- [x] Update `extensions/pi-goal/test/goal.test.ts` so pause still aborts and blocks stale tool calls, while clear does not abort and does not enable stale-tool-call blocking; verified with `npm test` and `npm run check`.
+- [x] Update `extensions/pi-goal/README.md` wording so `/goal clear` is documented as state clearing only and `/goal pause` owns aborting/stopping goal work; verified with `rg -n "pause/clear|paused or cleared|cancelled-goal|cancels the current goal" extensions/pi-goal/README.md extensions/pi-goal/src/goal.ts extensions/pi-goal/test/goal.test.ts` returning no output.
+- [x] Run the smallest useful project checks for this TypeScript extension; verified with `npm test`, `npm run typecheck`, and `npm run check` from the repository root.
+
+## Risks
+
+- Mitigated: An in-flight assistant turn may continue after `/goal clear`; the updated test verifies stale `goal_complete` calls reject with “no active goal”.
+
+## Completion Checklist
+
+- [x] `/goal clear` no longer aborts the active turn, verified by the updated clear test expecting zero abort calls and `npm run check` passing.
+- [x] `/goal clear` still clears goal state/status/persistence/pending continuation, verified by tests checking null goal state, cleared status, and cancelled continuation handling.
+- [x] `/goal pause` still aborts and blocks stale tool calls, verified by updated pause tests and `npm run check` passing.
+- [x] Documentation matches behavior, verified by `extensions/pi-goal/README.md` review and grep for obsolete “pause/clear”, “paused or cleared”, “cancelled-goal”, and “cancels the current goal” wording returning no output.
+- [x] TypeScript/tests pass, verified by `npm test`, `npm run typecheck`, and `npm run check`.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -17,9 +17,10 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Stores goal state in the current Pi session, following Codex's thread-owned goal model instead of using a global per-directory goal.
 - Registers a `goal_complete` tool for explicit completion, and rejects plainly contradictory completion summaries such as “not complete” or “tests still fail”.
 - Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle and no pending messages are queued.
-- Pauses and aborts queued goal work when the user pauses/clears a goal or Pi reports a non-retryable aborted/errored assistant turn.
+- Pauses and aborts queued goal work when the user pauses a goal or Pi reports a non-retryable aborted/errored assistant turn.
 - Keeps retryable provider interruptions active without enqueueing duplicate goal continuations while Pi retries.
-- Guards auto-follow-ups and stale tool calls so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
+- Guards auto-follow-ups so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
+- Blocks stale tool calls after pause/interruption.
 - Encourages requirement-by-requirement verification before the goal is marked complete.
 
 ## 📦 Install
@@ -56,9 +57,9 @@ pi -e ./extensions/pi-goal
 - `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters.
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
 - `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. Active goals stay active, paused goals stay paused, and budget-limited goals remain budget-limited if their budget is still exhausted.
-- `/goal pause` stops prompt injection and auto-continuation without forgetting the goal.
+- `/goal pause` stops prompt injection and auto-continuation, aborts the current turn, and keeps the goal for later resume.
 - `/goal resume` resumes a paused or budget-limited goal when the token budget allows it, then queues a resume prompt so work continues.
-- `/goal clear` cancels the current goal and also removes any legacy persisted state for the current working directory.
+- `/goal clear` clears the current goal state, status, pending continuation, and legacy persisted state for the current working directory without aborting any in-flight agent turn.
 
 Goal objectives are limited to 4,000 characters. Put longer instructions in a file and reference the file path from `/goal`.
 
@@ -84,7 +85,7 @@ While a goal is active, `pi-goal` injects persistence rules and exposes `goal_co
 
 ## 🛑 Interruption and queued-input behavior
 
-On user pause/clear, abort, or non-retryable error, `pi-goal` pauses or clears the goal, aborts stale work, and blocks cancelled-goal tool calls until the next user prompt (non-extension input). Retryable provider interruptions stay active while Pi retries; no extra continuation is queued.
+On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input). On `/goal clear`, it only clears goal state and pending continuation markers; it does not abort the current turn. Retryable provider interruptions stay active while Pi retries; no extra continuation is queued.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -247,7 +247,7 @@ export default function goal(pi: ExtensionAPI) {
 		if (!staleGoalToolCallsBlocked) return;
 		return {
 			block: true,
-			reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
 		};
 	});
 
@@ -387,8 +387,6 @@ function clearGoal(ctx: StatusContext) {
 	}
 
 	const stoppedGoal = activeGoal.text;
-	blockStaleGoalToolCalls();
-	abortCurrentTurn(ctx);
 	clearActiveGoal(ctx);
 	ctx.ui.notify(`Goal cleared: ${stoppedGoal}`, "warning");
 }

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -203,7 +203,7 @@ test("goal_complete rejects contradictory summaries and accepts verified complet
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 });
 
-test("pause and clear abort the current turn and persist stopped goal state", async () => {
+test("pause aborts the current turn, blocks stale tools, and persists paused state", async () => {
 	let pauseAborts = 0;
 	const paused = await startGoalForTest({ abort: () => pauseAborts++ });
 	await paused.mock.events.get("agent_end")?.[0]?.(
@@ -225,14 +225,59 @@ test("pause and clear abort the current turn and persist stopped goal state", as
 		),
 		{ action: "handled" },
 	);
+	assert.deepEqual(
+		paused.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "t1", input: {} },
+			paused.ctx,
+		),
+		{
+			block: true,
+			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
+		},
+	);
+});
 
+test("clear removes goal state without aborting or blocking stale tools", async () => {
 	let clearAborts = 0;
 	const cleared = await startGoalForTest({ abort: () => clearAborts++ });
+	await cleared.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		cleared.ctx,
+	);
+	const staleContinuation = cleared.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.match(staleContinuation, /pi-goal-continuation/);
+
 	await cleared.mock.commands.get("goal")?.handler("clear", cleared.ctx);
 
-	assert.equal(clearAborts, 1);
+	assert.equal(clearAborts, 0);
 	assert.equal(lastGoalStatus(cleared.mock), null);
 	assert.equal(cleared.statuses.get("goal"), undefined);
+	assert.deepEqual(
+		cleared.mock.events.get("input")?.[0]?.(
+			{ source: "extension", text: staleContinuation },
+			cleared.ctx,
+		),
+		{ action: "handled" },
+	);
+	assert.equal(
+		cleared.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "edit", toolCallId: "t-clear", input: {} },
+			cleared.ctx,
+		),
+		undefined,
+	);
+
+	const tool = cleared.mock.tools[0] as GoalTool;
+	const staleCompletion = await tool.execute(
+		"call-after-clear",
+		{ summary: "Implemented and verified." },
+		new AbortController().signal,
+		() => undefined,
+		cleared.ctx,
+	);
+
+	assert.equal(staleCompletion.terminate, undefined);
+	assert.match(staleCompletion.content?.[0]?.text ?? "", /no active goal/i);
 });
 
 test("agent_end keeps retryable interruptions active but pauses non-retryable errors", async () => {
@@ -288,19 +333,19 @@ test("agent_end keeps retryable interruptions active but pauses non-retryable er
 		),
 		{
 			block: true,
-			reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
 		},
 	);
 });
 
-test("stale goal tool calls are blocked until a fresh non-goal prompt arrives", async () => {
+test("stale goal tool calls are blocked after pause until a fresh non-goal prompt arrives", async () => {
 	const paused = await startGoalForTest();
 	await paused.mock.commands.get("goal")?.handler("pause", paused.ctx);
 
 	const pauseToolCall = paused.mock.events.get("tool_call")?.[0];
 	assert.deepEqual(pauseToolCall?.({ toolName: "bash", toolCallId: "t1", input: {} }, paused.ctx), {
 		block: true,
-		reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+		reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
 	});
 
 	paused.mock.events.get("input")?.[0]?.(
@@ -309,7 +354,7 @@ test("stale goal tool calls are blocked until a fresh non-goal prompt arrives", 
 	);
 	assert.deepEqual(pauseToolCall?.({ toolName: "bash", toolCallId: "t2", input: {} }, paused.ctx), {
 		block: true,
-		reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
+		reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
 	});
 
 	paused.mock.events.get("input")?.[0]?.(
@@ -319,19 +364,6 @@ test("stale goal tool calls are blocked until a fresh non-goal prompt arrives", 
 	assert.equal(
 		pauseToolCall?.({ toolName: "bash", toolCallId: "t3", input: {} }, paused.ctx),
 		undefined,
-	);
-
-	const cleared = await startGoalForTest();
-	await cleared.mock.commands.get("goal")?.handler("clear", cleared.ctx);
-	assert.deepEqual(
-		cleared.mock.events.get("tool_call")?.[0]?.(
-			{ toolName: "edit", toolCallId: "t3", input: {} },
-			cleared.ctx,
-		),
-		{
-			block: true,
-			reason: "Blocked stale /goal tool call after the goal was paused or cleared.",
-		},
 	);
 });
 


### PR DESCRIPTION
## Summary
- Make `/goal clear` clear goal bookkeeping without aborting the in-flight turn
- Keep stale tool-call blocking tied to pause/interruption
- Update tests, README, and archive the implementation plan

## Tests
- npm test
- npm run typecheck
- npm run check
- npm run biome:check