### PR TITLE
fix(pi-goal): preserve goals through compaction retries

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -26,6 +26,8 @@
 - For pi-sync on Cloudflare R2, keep session-token support for temporary credentials but retry once without the token when R2 static keys reject `X-Amz-Security-Token`.
 - Symptom: Pi extension async/timer/command continuations can crash after reload or session replacement. Cause: captured `ExtensionContext` becomes stale. Fix: pass plain data into delayed callbacks, catch stale-context errors, and scope cleanup to the failing ctx/request.
 - Codex `websocket_connection_limit_reached` is a retryable fresh-websocket case, but Pi 0.79.8's auto-retry regex does not classify “connection limit”; pi-retry must add the `provider returned error` hint.
+- Symptom: pi-goal compaction/retry hooks can mis-handle continuation state if a fresh continuation reuses a cancelled marker. Cause: markers based only on goal id and iteration collide after compaction cancellation. Fix: include a unique nonce in continuation markers.
+- Symptom: Pi compaction event docs may mention `reason`/`willRetry` while project target typings lack them. Cause: local/global `@earendil-works/pi-coding-agent` version skew. Fix: run `npm install`, verify target version, and treat compaction event fields as optional.
 
 ## TASTE
 

--- a/docs/plans/2026-06-29_pi-goal-compaction-retry-plan.md
+++ b/docs/plans/2026-06-29_pi-goal-compaction-retry-plan.md
@@ -1,0 +1,59 @@
+## Goal
+
+Fix `@narumitw/pi-goal` so an active `/goal` survives Pi auto-compaction and provider retry paths without blocking the retry's tool calls. Success means issue #124's sequence no longer pauses the goal or enables stale-tool blocking, while real user pause and non-retryable errors still block stale tool calls.
+
+## Context
+
+Issue #124 is real, but the likely root cause is lifecycle ordering, not lost session state:
+
+1. Pi emits `agent_end` to extensions.
+2. `pi-goal` currently treats some context-overflow errors as non-retryable, pauses the goal, and enables stale tool-call blocking.
+3. Pi core then performs auto-compaction / retry.
+4. The retried assistant tool call is blocked by `pi-goal`.
+
+Goal state is stored in session custom entries and is still present after compaction, so the fix should focus on retry classification, compaction-aware continuation handling, and stale-block scope.
+
+## Architecture
+
+- Keep `/goal` state session-owned via `goal-state` custom entries.
+- Add a tiny in-memory recovery marker for Pi-owned recovery flows (`provider_retry` / `compaction_retry`) so `pi-goal` does not enqueue duplicate continuations while Pi core is retrying.
+- Treat stale tool-call blocking as a pause/interruption guard only; compaction and retry flows are not stale work.
+
+## Non-Goals
+
+- Do not change Pi core compaction behavior.
+- Do not change `goal_complete` acceptance rules beyond tests needed for this bug.
+- Do not add a new persistence format unless the existing `goal-state` custom entry is proven insufficient.
+
+## Plan
+
+- [x] Sync local dependencies to the repo lockfile before editing so compaction event types match the target package; verified with `npm install` and `npm ls @earendil-works/pi-coding-agent --depth=0` resolving `0.79.8` without `invalid` output.
+- [x] Update `extensions/pi-goal/src/goal.ts` retry classification to use Pi's context-overflow detector for assistant errors, falling back to the existing provider-retry regex for non-overflow transient failures; verified with unit cases where `prompt is too long...`, OpenRouter `maximum context length...`, and `context_length_exceeded` all keep the goal active.
+- [x] Extend `findFinalAssistantMessage()` / `AssistantMessageLike` only as far as needed for overflow detection (`provider`, `model`, `usage`, `timestamp`, `content`, `api` if required by the imported type); verified with existing `findFinalAssistantMessage` tests plus one assistant message containing usage.
+- [x] Add a small recovery marker in `extensions/pi-goal/src/goal.ts` so retryable `agent_end` clears pending goal continuation, persists active goal state, and returns without pause, abort, stale-block, or auto-continuation; verified with tests that retryable overflow and WebSocket errors keep `tool_call` unblocked and overflow does not call `abort()`.
+- [x] Register `session_before_compact` and `session_compact` hooks for active goals: persist latest goal state before compaction, cancel any pending continuation marker, mark overflow+retry compaction as Pi-owned recovery, and avoid sending a duplicate continuation when `willRetry` is true; verified by simulating both hook events in `extensions/pi-goal/test/goal.test.ts`.
+- [x] For manual/threshold compaction without Pi retry, enqueue at most one fresh goal continuation after compaction when the goal is still active and no messages are pending; verified the old pre-compaction continuation marker is consumed and only one post-compaction continuation can be sent.
+- [x] Keep stale tool blocking limited to `/goal pause` and non-retryable `pauseGoalAfterAgentEnd()`; verified `/goal clear`, retryable provider errors, and compaction hooks leave `tool_call` unblocked.
+- [x] Update `extensions/pi-goal/README.md` only for user-visible behavior: active goals survive Pi compaction/retry and stale tool blocking is reserved for pause/non-retryable interruption; verified the README does not claim goal state was previously lost.
+- [x] Run focused verification with `npm test -- --package pi-goal` and `npm run typecheck`; verified both commands pass.
+- [x] Run release/package verification with `npm run check` and `npm run pack:goal`; verified check passes and dry-run package contains only `LICENSE`, `README.md`, `package.json`, and `src/goal.ts`.
+
+## Risks
+
+- Mitigated: importing Pi overflow helpers required adding `@earendil-works/pi-ai` as a pi-goal dev dependency; verified with `npm run typecheck` plus `npm run pack:goal`.
+- Mitigated: Pi `0.79.8` compaction hook typings lack `reason` / `willRetry`, so the implementation uses optional field checks and a goal recovery marker fallback; verified by focused compaction tests.
+- Mitigated: duplicate continuation prevention is covered by a test that cancels a pre-compaction continuation, consumes its marker, and sends only one fresh continuation.
+
+## Rollback / Recovery
+
+- If the full recovery-state change misbehaves before release, revert the pi-goal source/test/README/package metadata changes and ship the smaller overflow-classification fix as a patch.
+- If a published patch regresses goal mode, publish a follow-up patch; npm unpublish is not a practical rollback path for users.
+
+## Completion Checklist
+
+- [x] Issue #124 reproduction is covered by `overflow compaction retry keeps the goal active and does not block retry tools` in `extensions/pi-goal/test/goal.test.ts`.
+- [x] Retryable provider errors keep active goal state and are verified by `agent_end keeps retryable interruptions active but pauses non-retryable errors` in `extensions/pi-goal/test/goal.test.ts`.
+- [x] User pause and non-retryable errors still block stale tool calls and are verified by `pause aborts the current turn...`, `stale goal tool calls...`, and the non-retryable branch of the agent-end test.
+- [x] Compaction hooks preserve active goal state and prevent duplicate continuations, verified by `overflow compaction retry...` and `manual compaction cancels stale continuation...` tests.
+- [x] Package metadata remains installable and minimal, verified by `npm run typecheck`, `npm test -- --package pi-goal`, `npm run check`, and `npm run pack:goal`.
+- [x] User-facing behavior is documented in `extensions/pi-goal/README.md` and verified by review of the changed Features and Interruption sections.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -18,9 +18,10 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Registers a `goal_complete` tool for explicit completion, and rejects plainly contradictory completion summaries such as “not complete” or “tests still fail”.
 - Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle and no pending messages are queued.
 - Pauses and aborts queued goal work when the user pauses a goal or Pi reports a non-retryable aborted/errored assistant turn.
-- Keeps retryable provider interruptions active without enqueueing duplicate goal continuations while Pi retries.
+- Keeps retryable provider interruptions and Pi compaction retries active without enqueueing duplicate goal continuations while Pi retries.
+- Preserves active goals across manual, threshold, and overflow compaction.
 - Guards auto-follow-ups so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
-- Blocks stale tool calls after pause/interruption.
+- Blocks stale tool calls after pause or non-retryable interruption.
 - Encourages requirement-by-requirement verification before the goal is marked complete.
 
 ## 📦 Install
@@ -85,7 +86,7 @@ While a goal is active, `pi-goal` injects persistence rules and exposes `goal_co
 
 ## 🛑 Interruption and queued-input behavior
 
-On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input). On `/goal clear`, it only clears goal state and pending continuation markers; it does not abort the current turn. Retryable provider interruptions stay active while Pi retries; no extra continuation is queued.
+On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input). On `/goal clear`, it only clears goal state and pending continuation markers; it does not abort the current turn. Retryable provider interruptions and overflow compaction retries stay active while Pi retries; no extra continuation is queued.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -32,6 +32,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.14",
+		"@earendil-works/pi-ai": "0.79.8",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -3,6 +3,11 @@ import { dirname, join } from "node:path";
 import process from "node:process";
 import { randomUUID } from "node:crypto";
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	isContextOverflow,
+	type AssistantMessage as PiAssistantMessage,
+	type Usage,
+} from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 
 type GoalStatus = "active" | "paused" | "budget_limited" | "complete";
@@ -33,10 +38,23 @@ interface ContinuationPending {
 	prompt: string;
 }
 
+type GoalRecoveryKind = "provider_retry" | "compaction_retry";
+
+interface GoalRecovery {
+	goalId: string;
+	kind: GoalRecoveryKind;
+}
+
 interface AssistantMessageLike {
 	role: "assistant";
 	stopReason?: AgentStopReason;
 	errorMessage?: string;
+	content?: PiAssistantMessage["content"];
+	api?: PiAssistantMessage["api"];
+	provider?: PiAssistantMessage["provider"];
+	model?: string;
+	usage?: Usage;
+	timestamp?: number;
 }
 
 interface GoalStateEntryData {
@@ -104,6 +122,7 @@ let activeGoal: ActiveGoal | undefined;
 let completionStatusTimer: NodeJS.Timeout | undefined;
 let extensionApi: ExtensionAPI | undefined;
 let continuationPending: ContinuationPending | undefined;
+let goalRecovery: GoalRecovery | undefined;
 let staleGoalToolCallsBlocked = false;
 const cancelledContinuationMarkers = new Set<string>();
 
@@ -221,6 +240,7 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx) => {
 		clearCompletionStatusTimer();
 		clearContinuationTracking();
+		clearGoalRecovery();
 		clearStaleGoalToolCallBlock();
 		activeGoal = loadGoalFromSession(ctx);
 		if (activeGoal) updateStatus(ctx, activeGoal);
@@ -230,9 +250,36 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (activeGoal) persistGoal(activeGoal);
 		clearContinuationTracking();
+		clearGoalRecovery();
 		clearStaleGoalToolCallBlock();
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		clearCompletionStatusTimer();
+	});
+
+	pi.on("session_before_compact", (_event, ctx) => {
+		if (!activeGoal || activeGoal.status !== "active") return;
+		updateGoalUsage(activeGoal, ctx);
+		cancelContinuationPending();
+		persistGoal(activeGoal);
+		updateStatus(ctx, activeGoal);
+	});
+
+	pi.on("session_compact", async (event, ctx) => {
+		if (!activeGoal || activeGoal.status !== "active") {
+			clearGoalRecovery();
+			return;
+		}
+
+		const restoredGoal = loadGoalFromSession(ctx);
+		if (restoredGoal?.id === activeGoal.id) activeGoal = restoredGoal;
+		updateGoalUsage(activeGoal, ctx);
+		persistGoal(activeGoal);
+		updateStatus(ctx, activeGoal);
+
+		const wasPiRetry = isPiOwnedCompactionRetry(event, activeGoal.id);
+		clearGoalRecoveryForGoal(activeGoal.id);
+		if (wasPiRetry || hasPendingMessages(ctx)) return;
+		await sendContinuationPrompt(pi, ctx, activeGoal);
 	});
 
 	pi.on("input", (event) => {
@@ -240,6 +287,7 @@ export default function goal(pi: ExtensionAPI) {
 			if (consumeCancelledContinuationPrompt(event.text)) return { action: "handled" as const };
 			return;
 		}
+		clearGoalRecovery();
 		clearStaleGoalToolCallBlock();
 	});
 
@@ -272,14 +320,21 @@ export default function goal(pi: ExtensionAPI) {
 
 		if (finalAssistant?.stopReason === "aborted" || finalAssistant?.stopReason === "error") {
 			if (isRetryableGoalInterruption(finalAssistant)) {
-				forgetContinuationPending();
+				goalRecovery = {
+					goalId,
+					kind: isGoalContextOverflow(finalAssistant) ? "compaction_retry" : "provider_retry",
+				};
+				cancelContinuationPending();
 				persistGoal(activeGoal);
 				updateStatus(ctx, activeGoal);
 				return;
 			}
+			clearGoalRecoveryForGoal(goalId);
 			pauseGoalAfterAgentEnd(ctx, activeGoal, finalAssistant);
 			return;
 		}
+
+		clearGoalRecoveryForGoal(goalId);
 
 		if (activeGoal.tokenBudget !== undefined && activeGoal.tokensUsed >= activeGoal.tokenBudget) {
 			cancelContinuationPending();
@@ -330,6 +385,7 @@ async function startGoal(
 	}
 
 	cancelContinuationPending();
+	clearGoalRecovery();
 	clearStaleGoalToolCallBlock();
 	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
 	persistGoal(activeGoal);
@@ -365,6 +421,7 @@ async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 		ctx.ui.notify(`Goal is ${activeGoal.status}; only paused or budget-limited goals can be resumed.`, "warning");
 		return;
 	}
+	clearGoalRecovery();
 	clearStaleGoalToolCallBlock();
 	activeGoal = transitionGoal(activeGoal, "active");
 	persistGoal(activeGoal);
@@ -381,6 +438,7 @@ function clearGoal(ctx: StatusContext) {
 	if (!activeGoal) {
 		ctx.ui.notify("No active goal.", "info");
 		cancelContinuationPending();
+		clearGoalRecovery();
 		clearPersistedGoal(ctx.cwd);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		return;
@@ -409,6 +467,7 @@ async function editGoal(
 
 	updateGoalUsage(activeGoal, ctx);
 	cancelContinuationPending();
+	clearGoalRecovery();
 	activeGoal = normalizeGoalForBudget({
 		...activeGoal,
 		text: objective,
@@ -733,8 +792,22 @@ function clearStaleGoalToolCallBlock() {
 	staleGoalToolCallsBlocked = false;
 }
 
-function forgetContinuationPending() {
-	continuationPending = undefined;
+function clearGoalRecovery() {
+	goalRecovery = undefined;
+}
+
+function clearGoalRecoveryForGoal(goalId: string) {
+	if (goalRecovery?.goalId === goalId) goalRecovery = undefined;
+}
+
+function isPiOwnedCompactionRetry(event: unknown, goalId: string) {
+	const compaction = event as { reason?: unknown; willRetry?: unknown };
+	if (compaction.willRetry === true) return true;
+	return (
+		goalRecovery?.goalId === goalId &&
+		goalRecovery.kind === "compaction_retry" &&
+		(compaction.reason === undefined || compaction.reason === "overflow")
+	);
 }
 
 export function isContradictoryCompletionSummary(summary: string) {
@@ -745,7 +818,42 @@ export function isRetryableGoalInterruption(assistant: AssistantMessageLike) {
 	if (assistant.stopReason !== "error") return false;
 	if (!assistant.errorMessage) return false;
 	if (NON_RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage)) return false;
-	return RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage);
+	return isGoalContextOverflow(assistant) || RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage);
+}
+
+function isGoalContextOverflow(assistant: AssistantMessageLike) {
+	return isContextOverflow(toPiAssistantMessage(assistant));
+}
+
+function toPiAssistantMessage(assistant: AssistantMessageLike): PiAssistantMessage {
+	return {
+		role: "assistant",
+		content: assistant.content ?? [],
+		api: assistant.api ?? "openai-responses",
+		provider: assistant.provider ?? "unknown",
+		model: assistant.model ?? "unknown",
+		usage: assistant.usage ?? zeroUsage(),
+		stopReason: assistant.stopReason ?? "error",
+		errorMessage: assistant.errorMessage,
+		timestamp: assistant.timestamp ?? Date.now(),
+	};
+}
+
+function zeroUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		},
+	};
 }
 
 function clearContinuationTracking() {
@@ -776,7 +884,7 @@ function markContinuationDelivered(prompt: string) {
 }
 
 function continuationMarker(goal: ActiveGoal) {
-	return `${goal.id}:${goal.iteration}`;
+	return `${goal.id}:${goal.iteration}:${randomUUID()}`;
 }
 
 function continuationMarkerComment(marker: string) {
@@ -801,17 +909,45 @@ export function findFinalAssistantMessage(messages: unknown[]): AssistantMessage
 		if (!message || typeof message !== "object") continue;
 		const candidate = message as Record<string, unknown>;
 		if (candidate.role !== "assistant") continue;
-		return {
+		const assistant: AssistantMessageLike = {
 			role: "assistant",
 			stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
 			errorMessage: typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
 		};
+		if (Array.isArray(candidate.content)) assistant.content = candidate.content as PiAssistantMessage["content"];
+		if (typeof candidate.api === "string") assistant.api = candidate.api;
+		if (typeof candidate.provider === "string") assistant.provider = candidate.provider;
+		if (typeof candidate.model === "string") assistant.model = candidate.model;
+		if (typeof candidate.timestamp === "number") assistant.timestamp = candidate.timestamp;
+		const usage = normalizeUsage(candidate.usage);
+		if (usage) assistant.usage = usage;
+		return assistant;
 	}
 	return undefined;
 }
 
 function isAgentStopReason(value: unknown): value is AgentStopReason {
 	return ["stop", "length", "toolUse", "error", "aborted"].includes(String(value));
+}
+
+function normalizeUsage(value: unknown): Usage | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const usage = value as Partial<Usage>;
+	if (typeof usage.input !== "number" || typeof usage.output !== "number") return undefined;
+	return {
+		input: usage.input,
+		output: usage.output,
+		cacheRead: usage.cacheRead ?? 0,
+		cacheWrite: usage.cacheWrite ?? 0,
+		totalTokens: usage.totalTokens ?? usage.input + usage.output + (usage.cacheRead ?? 0),
+		cost: {
+			input: usage.cost?.input ?? 0,
+			output: usage.cost?.output ?? 0,
+			cacheRead: usage.cost?.cacheRead ?? 0,
+			cacheWrite: usage.cost?.cacheWrite ?? 0,
+			total: usage.cost?.total ?? 0,
+		},
+	};
 }
 
 function escapeXmlText(value: string) {
@@ -867,6 +1003,7 @@ function loadGoalFromSession(ctx: StatusContext): ActiveGoal | undefined {
 
 function clearActiveGoal(ctx: StatusContext) {
 	cancelContinuationPending();
+	clearGoalRecovery();
 	activeGoal = undefined;
 	clearPersistedGoal(ctx.cwd);
 	ctx.ui.setStatus(STATUS_KEY, undefined);

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -26,6 +26,8 @@ test("goal registers command, completion tool, and lifecycle hooks", () => {
 		"agent_end",
 		"before_agent_start",
 		"input",
+		"session_before_compact",
+		"session_compact",
 		"session_shutdown",
 		"session_start",
 		"tool_call",
@@ -293,6 +295,31 @@ test("agent_end keeps retryable interruptions active but pauses non-retryable er
 		isRetryableGoalInterruption({
 			role: "assistant",
 			stopReason: "error",
+			errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+		}),
+		true,
+	);
+	assert.equal(
+		isRetryableGoalInterruption({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage:
+				"This endpoint's maximum context length is 128000 tokens. However, you requested about 140000 tokens.",
+		}),
+		true,
+	);
+	assert.equal(
+		isRetryableGoalInterruption({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: "context_length_exceeded",
+		}),
+		true,
+	);
+	assert.equal(
+		isRetryableGoalInterruption({
+			role: "assistant",
+			stopReason: "error",
 			errorMessage: "You have hit your ChatGPT usage limit.",
 		}),
 		false,
@@ -308,6 +335,13 @@ test("agent_end keeps retryable interruptions active but pauses non-retryable er
 
 	assert.equal(lastGoalStatus(retryable.mock), "active");
 	assert.equal(retryable.mock.sentUserMessages.length, 1);
+	assert.equal(
+		retryable.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "retry-tool", input: {} },
+			retryable.ctx,
+		),
+		undefined,
+	);
 
 	let aborts = 0;
 	const nonRetryable = await startGoalForTest({ abort: () => aborts++ });
@@ -336,6 +370,108 @@ test("agent_end keeps retryable interruptions active but pauses non-retryable er
 			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
 		},
 	);
+});
+
+test("overflow compaction retry keeps the goal active and does not block retry tools", async () => {
+	let aborts = 0;
+	const overflow = await startGoalForTest({ abort: () => aborts++ });
+
+	await overflow.mock.events.get("agent_end")?.[0]?.(
+		{
+			messages: [
+				{
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+				},
+			],
+		},
+		overflow.ctx,
+	);
+
+	assert.equal(aborts, 0);
+	assert.equal(lastGoalStatus(overflow.mock), "active");
+	assert.equal(overflow.mock.sentUserMessages.length, 1);
+	assert.equal(
+		overflow.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "read", toolCallId: "retry-tool", input: {} },
+			overflow.ctx,
+		),
+		undefined,
+	);
+
+	overflow.mock.events.get("session_before_compact")?.[0]?.({}, overflow.ctx);
+	await overflow.mock.events.get("session_compact")?.[0]?.({}, overflow.ctx);
+
+	assert.equal(lastGoalStatus(overflow.mock), "active");
+	assert.equal(overflow.mock.sentUserMessages.length, 1);
+	assert.equal(
+		overflow.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "post-compact-retry-tool", input: {} },
+			overflow.ctx,
+		),
+		undefined,
+	);
+});
+
+test("compaction with willRetry true does not enqueue a goal continuation", async () => {
+	const retrying = await startGoalForTest();
+
+	retrying.mock.events.get("session_before_compact")?.[0]?.(
+		{ reason: "overflow", willRetry: true },
+		retrying.ctx,
+	);
+	await retrying.mock.events.get("session_compact")?.[0]?.(
+		{ reason: "overflow", willRetry: true },
+		retrying.ctx,
+	);
+
+	assert.equal(lastGoalStatus(retrying.mock), "active");
+	assert.equal(retrying.mock.sentUserMessages.length, 1);
+});
+
+test("manual compaction cancels stale continuation and sends one fresh continuation", async () => {
+	const compacted = await startGoalForTest();
+	await compacted.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		compacted.ctx,
+	);
+	const staleContinuation = compacted.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.match(staleContinuation, /pi-goal-continuation/);
+
+	compacted.mock.events.get("session_before_compact")?.[0]?.(
+		{ reason: "threshold", willRetry: false },
+		compacted.ctx,
+	);
+	assert.deepEqual(
+		compacted.mock.events.get("input")?.[0]?.(
+			{ source: "extension", text: staleContinuation },
+			compacted.ctx,
+		),
+		{ action: "handled" },
+	);
+
+	await compacted.mock.events.get("session_compact")?.[0]?.(
+		{ reason: "threshold", willRetry: false },
+		compacted.ctx,
+	);
+	const freshContinuation = compacted.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.equal(compacted.mock.sentUserMessages.length, 3);
+	assert.match(freshContinuation, /pi-goal-continuation/);
+	assert.notEqual(freshContinuation, staleContinuation);
+	assert.equal(
+		compacted.mock.events.get("input")?.[0]?.(
+			{ source: "extension", text: freshContinuation },
+			compacted.ctx,
+		),
+		undefined,
+	);
+
+	await compacted.mock.events.get("session_compact")?.[0]?.(
+		{ reason: "threshold", willRetry: false },
+		compacted.ctx,
+	);
+	assert.equal(compacted.mock.sentUserMessages.length, 3);
 });
 
 test("stale goal tool calls are blocked after pause until a fresh non-goal prompt arrives", async () => {
@@ -374,6 +510,35 @@ test("findFinalAssistantMessage returns the last assistant with a known stop rea
 			{ role: "assistant", stopReason: "error", errorMessage: "bad" },
 		]),
 		{ role: "assistant", stopReason: "error", errorMessage: "bad" },
+	);
+	assert.deepEqual(
+		findFinalAssistantMessage([
+			{
+				role: "assistant",
+				stopReason: "error",
+				errorMessage: "context_length_exceeded",
+				provider: "openai",
+				model: "gpt-test",
+				usage: { input: 10, output: 2 },
+				timestamp: 123,
+			},
+		]),
+		{
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: "context_length_exceeded",
+			provider: "openai",
+			model: "gpt-test",
+			usage: {
+				input: 10,
+				output: 2,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 12,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: 123,
+		},
 	);
 	assert.equal(validateObjective(""), "Usage: /goal <goal_to_complete>");
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,8 +98,508 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.14",
+				"@earendil-works/pi-ai": "0.79.8",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/core": {
+			"version": "3.974.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+			"integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.13",
+				"@aws-sdk/xml-builder": "^3.972.31",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+			"integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.51",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+			"integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.56",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+			"integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/credential-provider-env": "^3.972.49",
+				"@aws-sdk/credential-provider-http": "^3.972.51",
+				"@aws-sdk/credential-provider-login": "^3.972.55",
+				"@aws-sdk/credential-provider-process": "^3.972.49",
+				"@aws-sdk/credential-provider-sso": "^3.972.55",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+			"integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.58",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+			"integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.49",
+				"@aws-sdk/credential-provider-http": "^3.972.51",
+				"@aws-sdk/credential-provider-ini": "^3.972.56",
+				"@aws-sdk/credential-provider-process": "^3.972.49",
+				"@aws-sdk/credential-provider-sso": "^3.972.55",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+			"integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+			"integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/token-providers": "3.1074.0",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1074.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+			"integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+			"integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
+			"integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
+			"integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.31.tgz",
+			"integrity": "sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+			"integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/types": {
+			"version": "3.973.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+			"integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-ai": {
+			"version": "0.79.8",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.8.tgz",
+			"integrity": "sha512-ZpSwaD7oNpsjn9vtEatZQNT9PSdDJXi6rFeY5Qv+OHQGFDKlmcrfJE4ypm4SAc/fBECPs4Rdi3l+YjVtXYrkKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@smithy/core": {
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+			"integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+			"integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@smithy/signature-v4": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+			"integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@smithy/types": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"extensions/pi-lsp": {
@@ -1773,7 +2273,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "./dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -1896,6 +2396,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1913,6 +2416,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1930,6 +2436,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1947,6 +2456,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1964,6 +2476,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3238,15 +3753,24 @@
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-			"integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
 				"ws": "^8.18.0",
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@narumitw/pi-btw": {
@@ -3317,6 +3841,26 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -4890,9 +5434,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/typebox": {
-			"version": "1.1.37",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.37.tgz",
-			"integrity": "sha512-jb7jp6KvOvvy5sd+11AfJ0/e0F0AS9RcOXd55oGi2ZnRHIGmFvrTaNF+ZidRmGBmmNTkM5KKl0Z37KzxJ+owEQ==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
 			"license": "MIT"
 		},
 		"node_modules/typescript": {


### PR DESCRIPTION
## Summary
- classify Pi context-overflow errors as retryable goal interruptions
- add compaction-aware goal recovery so Pi-owned retries do not get stale tool calls blocked or duplicate continuations
- document and test compaction/retry behavior for pi-goal

Fixes #124

## Verification
- npm install
- npm ls @earendil-works/pi-coding-agent --depth=0
- npm test -- --package pi-goal
- npm run typecheck
- npm run check
- npm run pack:goal
- git diff --check