### PR TITLE
fix: harden just recipe arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,24 +42,27 @@ npm-public package="@narumitw/pi-goal":
     npm access set status=public {{quote(package)}}
     npm view {{quote(package)}} version
 
+_validate-extension-name name:
+    @[[ {{quote(name)}} =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || { printf 'invalid extension name: %s\n' {{quote(name)}} >&2; exit 2; }
+
 # Preview the package that npm would publish
 # Usage: just pack subagents
-pack name:
+pack name: (_validate-extension-name name)
     name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; npm --workspace "$package" pack --dry-run
 
 # Try a package from this working tree as a temporary pi package
 # Usage: just try subagents
-try name:
+try name: (_validate-extension-name name)
     name={{quote(name)}}; pi -e "./extensions/pi-$name"
 
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents
-install name:
+install name: (_validate-extension-name name)
     name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else echo "$package is not published; installing local workspace package instead."; pi install "./extensions/pi-$name"; fi
 
 # Publish one package to npm, skipping if the current version already exists
 # Usage: just publish subagents
-publish name:
+publish name: (_validate-extension-name name)
     name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; version="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').version" "$name")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public; fi
 
 # Publish all extension packages to npm

--- a/justfile
+++ b/justfile
@@ -23,12 +23,12 @@ pre-commit:
 # Show npm account/registry/package visibility information for one package
 # Usage: just doctor @narumitw/pi-chrome-devtools
 doctor package="@narumitw/pi-chrome-devtools":
-    @echo "package: {{package}}"
-    npm whoami
+    @printf 'package: %s\n' {{quote(package)}}
+    npm whoami || true
     npm config get registry
-    npm access get status {{package}} || true
-    npm dist-tag ls {{package}} || true
-    npm view {{package}} version || true
+    npm access get status {{quote(package)}} || true
+    npm dist-tag ls {{quote(package)}} || true
+    npm view {{quote(package)}} version || true
 
 # Show npm visibility/version information for all extension packages
 doctor-all:
@@ -39,28 +39,28 @@ doctor-all:
 #   npm publish --workspace @narumitw/pi-subagents --access public
 # Usage for existing packages: just npm-public @narumitw/pi-goal
 npm-public package="@narumitw/pi-goal":
-    npm access set status=public {{package}}
-    npm view {{package}} version
+    npm access set status=public {{quote(package)}}
+    npm view {{quote(package)}} version
 
 # Preview the package that npm would publish
 # Usage: just pack subagents
 pack name:
-    package="$(node -p "require('./extensions/pi-{{name}}/package.json').name")"; npm --workspace "$package" pack --dry-run
+    name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; npm --workspace "$package" pack --dry-run
 
 # Try a package from this working tree as a temporary pi package
 # Usage: just try subagents
 try name:
-    pi -e ./extensions/pi-{{name}}
+    name={{quote(name)}}; pi -e "./extensions/pi-$name"
 
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents
 install name:
-    package="$(node -p "require('./extensions/pi-{{name}}/package.json').name")"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else echo "$package is not published; installing local workspace package instead."; pi install ./extensions/pi-{{name}}; fi
+    name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else echo "$package is not published; installing local workspace package instead."; pi install "./extensions/pi-$name"; fi
 
 # Publish one package to npm, skipping if the current version already exists
 # Usage: just publish subagents
 publish name:
-    package="$(node -p "require('./extensions/pi-{{name}}/package.json').name")"; version="$(node -p "require('./extensions/pi-{{name}}/package.json').version")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public; fi
+    name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; version="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').version" "$name")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public; fi
 
 # Publish all extension packages to npm
 publish-all:
@@ -241,4 +241,4 @@ publish-wait-what:
 # Bump one workspace package without creating a git tag
 # Usage: just bump @narumitw/pi-goal patch
 bump package part="patch":
-    npm --workspace {{package}} version {{part}} --no-git-tag-version
+    npm --workspace {{quote(package)}} version {{quote(part)}} --no-git-tag-version


### PR DESCRIPTION
## Summary
- keep `just doctor` diagnostics running when npm is logged out
- quote user-provided just recipe arguments
- pass extension names through shell variables before using them in paths

## Verification
- `git diff --check origin/main...HEAD`
- `just --list`
- `just --dry-run doctor 'x; echo PWN'`
- `just --dry-run pack "x'\''; echo PWN"`
- `just pack goal`
