### PR TITLE
chore(deps): update npm lockfile

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -16,7 +16,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"preset": "recommended"
 		}
 	},
 	"javascript": {

--- a/extensions/pi-btw/package.json
+++ b/extensions/pi-btw/package.json
@@ -28,7 +28,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-ai": "0.74.0",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@earendil-works/pi-tui": "0.79.8",

--- a/extensions/pi-caffeinate/package.json
+++ b/extensions/pi-caffeinate/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@types/node": "25.6.0",
 		"typescript": "6.0.3"

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -32,7 +32,7 @@
 		"typebox": "^1.3.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/extensions/pi-codex-usage/package.json
+++ b/extensions/pi-codex-usage/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@types/node": "25.6.0",
 		"typescript": "6.0.3"

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -32,7 +32,7 @@
 		"typebox": "^1.3.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/extensions/pi-github-pr/package.json
+++ b/extensions/pi-github-pr/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@types/node": "25.6.0",
 		"typescript": "6.0.3"

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -31,7 +31,7 @@
 		"typebox": "^1.3.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-ai": "0.79.8",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"

--- a/extensions/pi-lsp/package.json
+++ b/extensions/pi-lsp/package.json
@@ -35,7 +35,7 @@
 		"typebox": "^1.3.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@types/node": "25.6.0",
 		"typescript": "6.0.3"

--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -28,7 +28,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/extensions/pi-retry/package.json
+++ b/extensions/pi-retry/package.json
@@ -27,7 +27,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@earendil-works/pi-tui": "0.79.8",
 		"@types/node": "25.6.0",

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -38,7 +38,7 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-agent-core": "0.80.2",
 		"@earendil-works/pi-ai": "0.74.0",
 		"@earendil-works/pi-coding-agent": "0.79.8",

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/extensions/pi-wait-what/package.json
+++ b/extensions/pi-wait-what/package.json
@@ -32,7 +32,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"typescript": "6.0.3"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"extensions/*"
 			],
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.14",
+				"@biomejs/biome": "^2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "^25.6.0",
 				"typebox": "^1.3.2",
@@ -23,38 +23,11 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-ai": "0.74.0",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@earendil-works/pi-tui": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-btw/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-caffeinate": {
@@ -62,37 +35,10 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-caffeinate/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-caffeinate/node_modules/@types/node": {
@@ -113,36 +59,9 @@
 				"typebox": "^1.3.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-chrome-devtools/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-codex-usage": {
@@ -150,37 +69,10 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-codex-usage/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-codex-usage/node_modules/@types/node": {
@@ -201,36 +93,9 @@
 				"typebox": "^1.3.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-firecrawl/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-github-pr": {
@@ -238,37 +103,10 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-github-pr/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-github-pr/node_modules/@types/node": {
@@ -289,37 +127,10 @@
 				"typebox": "^1.3.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-ai": "0.79.8",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-goal/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-goal/node_modules/@earendil-works/pi-ai": {
@@ -363,37 +174,10 @@
 				"typebox": "^1.3.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-lsp/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-lsp/node_modules/@types/node": {
@@ -411,36 +195,9 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-plan-mode/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-retry": {
@@ -448,36 +205,9 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-retry/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-statusline": {
@@ -485,38 +215,11 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@earendil-works/pi-tui": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-statusline/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-statusline/node_modules/@types/node": {
@@ -537,7 +240,7 @@
 				"typebox": "^1.3.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-agent-core": "0.80.2",
 				"@earendil-works/pi-ai": "0.74.0",
 				"@earendil-works/pi-coding-agent": "0.79.8",
@@ -551,68 +254,14 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
-		"extensions/pi-subagents/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
-			}
-		},
 		"extensions/pi-sync": {
 			"name": "@narumitw/pi-sync",
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-sync/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-wait-what": {
@@ -620,39 +269,12 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.1",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
-			}
-		},
-		"extensions/pi-wait-what/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -1324,154 +946,6 @@
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
 			"integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
-			"integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
-			"integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
-			"integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
-			"integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
-			"integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
-			"integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
-			"integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
-			"integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
 			"cpu": [
 				"x64"
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,33 @@
 				"typescript": "6.0.3"
 			}
 		},
+		"extensions/pi-btw/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
 		"extensions/pi-caffeinate": {
 			"name": "@narumitw/pi-caffeinate",
 			"version": "0.9.2",
@@ -39,6 +66,43 @@
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-caffeinate/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
+		"extensions/pi-caffeinate/node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-chrome-devtools": {
@@ -54,6 +118,33 @@
 				"typescript": "6.0.3"
 			}
 		},
+		"extensions/pi-chrome-devtools/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
 		"extensions/pi-codex-usage": {
 			"name": "@narumitw/pi-codex-usage",
 			"version": "0.9.2",
@@ -63,6 +154,43 @@
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-codex-usage/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
+		"extensions/pi-codex-usage/node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-firecrawl": {
@@ -78,6 +206,33 @@
 				"typescript": "6.0.3"
 			}
 		},
+		"extensions/pi-firecrawl/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
 		"extensions/pi-github-pr": {
 			"name": "@narumitw/pi-github-pr",
 			"version": "0.9.2",
@@ -87,6 +242,43 @@
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-github-pr/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
+		"extensions/pi-github-pr/node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-goal": {
@@ -103,389 +295,31 @@
 				"typescript": "6.0.3"
 			}
 		},
-		"extensions/pi-goal/node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1048.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+		"extensions/pi-goal/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/credential-provider-node": "^3.972.42",
-				"@aws-sdk/eventstream-handler-node": "^3.972.16",
-				"@aws-sdk/middleware-eventstream": "^3.972.12",
-				"@aws-sdk/middleware-websocket": "^3.972.19",
-				"@aws-sdk/token-providers": "3.1048.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/fetch-http-handler": "^5.4.2",
-				"@smithy/node-http-handler": "^4.7.2",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
 			},
 			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/core": {
-			"version": "3.974.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
-			"integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@aws-sdk/xml-builder": "^3.972.31",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.24.6",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
+				"node": ">=14.21.3"
 			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.49",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
-			"integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
 			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.51",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
-			"integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/node-http-handler": "^4.7.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
-			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.56",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
-			"integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/credential-provider-env": "^3.972.49",
-				"@aws-sdk/credential-provider-http": "^3.972.51",
-				"@aws-sdk/credential-provider-login": "^3.972.55",
-				"@aws-sdk/credential-provider-process": "^3.972.49",
-				"@aws-sdk/credential-provider-sso": "^3.972.55",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/credential-provider-imds": "^4.3.7",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
-			"integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.58",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
-			"integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.49",
-				"@aws-sdk/credential-provider-http": "^3.972.51",
-				"@aws-sdk/credential-provider-ini": "^3.972.56",
-				"@aws-sdk/credential-provider-process": "^3.972.49",
-				"@aws-sdk/credential-provider-sso": "^3.972.55",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/credential-provider-imds": "^4.3.7",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.49",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
-			"integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
-			"integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/token-providers": "3.1074.0",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1074.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
-			"integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
-			"integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
-			"integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.18",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
-			"integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.31.tgz",
-			"integrity": "sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
-			"integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/node-http-handler": "^4.7.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
-			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.35",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1048.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/nested-clients": "^3.997.9",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/types": {
-			"version": "3.973.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
-			"integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-goal/node_modules/@earendil-works/pi-ai": {
@@ -521,94 +355,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"extensions/pi-goal/node_modules/@smithy/core": {
-			"version": "3.26.0",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
-			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
-			"integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@smithy/fetch-http-handler": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
-			"integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@smithy/node-http-handler": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@smithy/signature-v4": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
-			"integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@smithy/types": {
-			"version": "4.15.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"extensions/pi-lsp": {
 			"name": "@narumitw/pi-lsp",
 			"version": "0.9.2",
@@ -623,6 +369,43 @@
 				"typescript": "6.0.3"
 			}
 		},
+		"extensions/pi-lsp/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
+		"extensions/pi-lsp/node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
 		"extensions/pi-plan-mode": {
 			"name": "@narumitw/pi-plan-mode",
 			"version": "0.9.2",
@@ -631,6 +414,33 @@
 				"@biomejs/biome": "2.4.14",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-plan-mode/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-retry": {
@@ -643,6 +453,33 @@
 				"typescript": "6.0.3"
 			}
 		},
+		"extensions/pi-retry/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
 		"extensions/pi-statusline": {
 			"name": "@narumitw/pi-statusline",
 			"version": "0.9.2",
@@ -653,6 +490,43 @@
 				"@earendil-works/pi-tui": "0.79.8",
 				"@types/node": "25.6.0",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-statusline/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
+		"extensions/pi-statusline/node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-subagents": {
@@ -677,6 +551,33 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"extensions/pi-subagents/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
+			}
+		},
 		"extensions/pi-sync": {
 			"name": "@narumitw/pi-sync",
 			"version": "0.9.2",
@@ -685,6 +586,33 @@
 				"@biomejs/biome": "2.4.14",
 				"@earendil-works/pi-coding-agent": "0.79.8",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-sync/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"extensions/pi-wait-what": {
@@ -698,6 +626,33 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
+		"extensions/pi-wait-what/node_modules/@biomejs/biome": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -752,47 +707,6 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
@@ -830,100 +744,26 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1042.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1042.0.tgz",
-			"integrity": "sha512-uYJ/HDSQvorlgYqZSwRFGolEx5wygqyuBRfemXJ3Bla2yiRj9maSVOvWP88i/hDC2BKoH6NQw8GPB9Z4RYAnwQ==",
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/credential-provider-node": "^3.972.39",
-				"@aws-sdk/eventstream-handler-node": "^3.972.14",
-				"@aws-sdk/middleware-eventstream": "^3.972.10",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.38",
-				"@aws-sdk/middleware-websocket": "^3.972.16",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/token-providers": "3.1042.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.24",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.17",
-				"@smithy/eventstream-serde-browser": "^4.2.14",
-				"@smithy/eventstream-serde-config-resolver": "^4.3.14",
-				"@smithy/eventstream-serde-node": "^4.2.14",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.7",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
 				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.49",
-				"@smithy/util-defaults-mode-node": "^4.2.54",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -931,25 +771,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-			"integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+			"version": "3.974.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+			"integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.22",
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/types": "^3.973.13",
+				"@aws-sdk/xml-builder": "^3.972.31",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -957,16 +791,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
-			"integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+			"integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -974,47 +808,58 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
-			"integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+			"version": "3.972.51",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+			"integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
-			"integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/credential-provider-env": "^3.972.34",
-				"@aws-sdk/credential-provider-http": "^3.972.36",
-				"@aws-sdk/credential-provider-login": "^3.972.38",
-				"@aws-sdk/credential-provider-process": "^3.972.34",
-				"@aws-sdk/credential-provider-sso": "^3.972.38",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.56",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+			"integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/credential-provider-env": "^3.972.49",
+				"@aws-sdk/credential-provider-http": "^3.972.51",
+				"@aws-sdk/credential-provider-login": "^3.972.55",
+				"@aws-sdk/credential-provider-process": "^3.972.49",
+				"@aws-sdk/credential-provider-sso": "^3.972.55",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1022,19 +867,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
-			"integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+			"integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1042,23 +885,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.39",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
-			"integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+			"version": "3.972.58",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+			"integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.34",
-				"@aws-sdk/credential-provider-http": "^3.972.36",
-				"@aws-sdk/credential-provider-ini": "^3.972.38",
-				"@aws-sdk/credential-provider-process": "^3.972.34",
-				"@aws-sdk/credential-provider-sso": "^3.972.38",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/credential-provider-env": "^3.972.49",
+				"@aws-sdk/credential-provider-http": "^3.972.51",
+				"@aws-sdk/credential-provider-ini": "^3.972.56",
+				"@aws-sdk/credential-provider-process": "^3.972.49",
+				"@aws-sdk/credential-provider-sso": "^3.972.55",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1066,17 +908,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
-			"integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+			"integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1084,19 +925,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
-			"integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+			"integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/token-providers": "3.1041.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/token-providers": "3.1074.0",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1104,18 +944,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1041.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-			"integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+			"version": "3.1074.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+			"integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1123,18 +962,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
-			"integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+			"integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1142,15 +980,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.14",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
-			"integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
+			"integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1158,109 +996,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
-			"integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+			"version": "3.972.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
+			"integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
-			"integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
-			"integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.6",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1268,23 +1012,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
-			"integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.31.tgz",
+			"integrity": "sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-format-url": "^3.972.10",
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/eventstream-serde-browser": "^4.2.14",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1292,85 +1031,52 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.6",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
-			"integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+			"version": "3.997.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+			"integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.38",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.25",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.24",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.17",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.7",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.49",
-				"@smithy/util-defaults-mode-node": "^4.2.54",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.25",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
-			"integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+			"version": "3.996.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.37",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1378,17 +1084,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1042.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1042.0.tgz",
-			"integrity": "sha512-rOEGTVOrceb/1CfIWK0zl1v2WS70f/i5bDirLl5xdFAbVQ5znub6Ezf2ugmJEg+rionO0IkwbKX3Dh3T/oZjbA==",
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -1397,59 +1102,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"version": "3.973.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-arn-parser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.996.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-endpoints": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
-			"integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1457,9 +1116,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"version": "3.965.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+			"integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1467,57 +1126,16 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.24",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
-			"integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.38",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"aws-crt": ">=1.0.0"
-			},
-			"peerDependenciesMeta": {
-				"aws-crt": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+			"integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@nodable/entities": "2.1.0",
-				"@smithy/types": "^4.14.1",
-				"fast-xml-parser": "5.7.2",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1535,9 +1153,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1545,9 +1163,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
+			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -1561,14 +1179,162 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
+				"@biomejs/cli-darwin-arm64": "2.5.1",
+				"@biomejs/cli-darwin-x64": "2.5.1",
+				"@biomejs/cli-linux-arm64": "2.5.1",
+				"@biomejs/cli-linux-arm64-musl": "2.5.1",
+				"@biomejs/cli-linux-x64": "2.5.1",
+				"@biomejs/cli-linux-x64-musl": "2.5.1",
+				"@biomejs/cli-win32-arm64": "2.5.1",
+				"@biomejs/cli-win32-x64": "2.5.1"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
+			"integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-darwin-x64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
+			"integrity": "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-arm64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
+			"integrity": "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
+			"integrity": "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
+			"integrity": "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
+			"integrity": "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-win32-arm64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
+			"integrity": "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-win32-x64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
+			"integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
@@ -1613,6 +1379,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1630,6 +1399,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1647,6 +1419,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1664,6 +1439,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1723,391 +1501,6 @@
 				"node": ">=22.19.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1048.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/credential-provider-node": "^3.972.42",
-				"@aws-sdk/eventstream-handler-node": "^3.972.16",
-				"@aws-sdk/middleware-eventstream": "^3.972.12",
-				"@aws-sdk/middleware-websocket": "^3.972.19",
-				"@aws-sdk/token-providers": "3.1048.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/fetch-http-handler": "^5.4.2",
-				"@smithy/node-http-handler": "^4.7.2",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/core": {
-			"version": "3.974.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
-			"integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@aws-sdk/xml-builder": "^3.972.31",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.24.6",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.49",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
-			"integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.51",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
-			"integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/node-http-handler": "^4.7.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
-			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.56",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
-			"integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/credential-provider-env": "^3.972.49",
-				"@aws-sdk/credential-provider-http": "^3.972.51",
-				"@aws-sdk/credential-provider-login": "^3.972.55",
-				"@aws-sdk/credential-provider-process": "^3.972.49",
-				"@aws-sdk/credential-provider-sso": "^3.972.55",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/credential-provider-imds": "^4.3.7",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
-			"integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.58",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
-			"integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.49",
-				"@aws-sdk/credential-provider-http": "^3.972.51",
-				"@aws-sdk/credential-provider-ini": "^3.972.56",
-				"@aws-sdk/credential-provider-process": "^3.972.49",
-				"@aws-sdk/credential-provider-sso": "^3.972.55",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/credential-provider-imds": "^4.3.7",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.49",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
-			"integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
-			"integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/token-providers": "3.1074.0",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1074.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
-			"integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
-			"integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/nested-clients": "^3.997.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
-			"integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.18",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
-			"integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.31.tgz",
-			"integrity": "sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
-			"integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.23",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/node-http-handler": "^4.7.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
-			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.35",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1048.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/nested-clients": "^3.997.9",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/types": {
-			"version": "3.973.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
-			"integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
 		"node_modules/@earendil-works/pi-agent-core/node_modules/@earendil-works/pi-ai": {
 			"version": "0.80.2",
 			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
@@ -2132,94 +1525,6 @@
 			},
 			"engines": {
 				"node": ">=22.19.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/core": {
-			"version": "3.26.0",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
-			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
-			"integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/fetch-http-handler": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
-			"integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/node-http-handler": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/signature-v4": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
-			"integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.26.0",
-				"@smithy/types": "^4.15.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/types": {
-			"version": "4.15.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
@@ -4344,19 +3649,6 @@
 			"resolved": "extensions/pi-wait-what",
 			"link": true
 		},
-		"node_modules/@nodable/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/nodable"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -4422,13 +3714,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -4450,40 +3735,15 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.17",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
-			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.17",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4491,91 +3751,14 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+			"integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
-			"integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
-			"integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
-			"integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
-			"integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
-			"integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4583,46 +3766,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.17",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+			"integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
-			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4630,215 +3781,27 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
-			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.32",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
-			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-retry": {
-			"version": "4.5.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
-			"integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/service-error-classification": "^4.3.1",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/uuid": "^1.1.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.20",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
-			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
-			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
-			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/property-provider": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
-			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
-			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
-			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/service-error-classification": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
-			"integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.9",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
-			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4846,38 +3809,14 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+			"integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.13",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
-			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4885,65 +3824,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/url-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
-			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-base64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -4954,182 +3837,31 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.49",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
-			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.54",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
-			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-endpoints": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
-			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
-			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-retry": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
-			"integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/service-error-classification": "^4.3.1",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-stream": {
-			"version": "4.5.25",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
-			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/uuid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
@@ -5140,14 +3872,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "25.9.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+			"integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
+		},
+		"node_modules/@types/node/node_modules/undici-types": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -5363,44 +4102,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-xml-builder": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
-			"integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
-			}
-		},
-		"node_modules/fast-xml-parser": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.5",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.2.3"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
-			}
-		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -5425,14 +4126,6 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
-		"node_modules/fetch-blob/node_modules/node-domexception": {
-			"name": "@profoundlogic/node-domexception",
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@profoundlogic/node-domexception/-/node-domexception-1.0.2.tgz",
-			"integrity": "sha512-qeEIO+aJIGHxEwCtAHoPH8VrWFvWh3zFmr2/cb9gFGc6qyYW9r48Q2vg8YwME/PyIt98GaR42kPVUkN4n0a19A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -5447,9 +4140,9 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+			"integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5515,9 +4208,9 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.6.2",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+			"integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5644,6 +4337,16 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/marked": {
 			"version": "18.0.5",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -5673,6 +4376,14 @@
 			"engines": {
 				"node": ">= 0.4.0"
 			}
+		},
+		"node_modules/node-domexception": {
+			"name": "@profoundlogic/node-domexception",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@profoundlogic/node-domexception/-/node-domexception-1.0.2.tgz",
+			"integrity": "sha512-qeEIO+aJIGHxEwCtAHoPH8VrWFvWh3zFmr2/cb9gFGc6qyYW9r48Q2vg8YwME/PyIt98GaR42kPVUkN4n0a19A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/node-fetch": {
 			"version": "3.3.2",
@@ -5770,26 +4481,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/path-expression-matcher": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/protobufjs": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-			"integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
@@ -5800,7 +4495,6 @@
 				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",
@@ -5829,16 +4523,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/proxy-from-env": {
@@ -5891,9 +4575,9 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-			"integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5930,19 +4614,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/ts-algebra": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"pack:wait-what": "npm --workspace @narumitw/pi-wait-what pack --dry-run"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.14",
+		"@biomejs/biome": "^2.5.1",
 		"@earendil-works/pi-coding-agent": "0.79.8",
 		"@types/node": "^25.6.0",
 		"typebox": "^1.3.2",


### PR DESCRIPTION
## Summary
- update npm lockfile via `npm update`
- migrate Biome config for schema 2.5.1 and `preset: recommended`

## Verification
- `npm run check`
- `npm ls typebox --workspaces --include-workspace-root`
- `git diff --check`