### PR TITLE
fix(pi-goal): release stale tool block on clear

### DIFF
--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -86,7 +86,7 @@ While a goal is active, `pi-goal` injects persistence rules and exposes `goal_co
 
 ## 🛑 Interruption and queued-input behavior
 
-On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input). On `/goal clear`, it only clears goal state and pending continuation markers; it does not abort the current turn. Retryable provider interruptions and overflow compaction retries stay active while Pi retries; no extra continuation is queued.
+On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input), `/goal resume`, or `/goal clear`. On `/goal clear`, it clears goal state, pending continuation markers, and any stale tool-call block; it does not abort the current turn. Retryable provider interruptions and overflow compaction retries stay active while Pi retries; no extra continuation is queued.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -293,6 +293,10 @@ export default function goal(pi: ExtensionAPI) {
 
 	pi.on("tool_call", () => {
 		if (!staleGoalToolCallsBlocked) return;
+		if (!activeGoal || activeGoal.status !== "paused") {
+			clearStaleGoalToolCallBlock();
+			return;
+		}
 		return {
 			block: true,
 			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
@@ -439,6 +443,7 @@ function clearGoal(ctx: StatusContext) {
 		ctx.ui.notify("No active goal.", "info");
 		cancelContinuationPending();
 		clearGoalRecovery();
+		clearStaleGoalToolCallBlock();
 		clearPersistedGoal(ctx.cwd);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		return;
@@ -1004,6 +1009,7 @@ function loadGoalFromSession(ctx: StatusContext): ActiveGoal | undefined {
 function clearActiveGoal(ctx: StatusContext) {
 	cancelContinuationPending();
 	clearGoalRecovery();
+	clearStaleGoalToolCallBlock();
 	activeGoal = undefined;
 	clearPersistedGoal(ctx.cwd);
 	ctx.ui.setStatus(STATUS_KEY, undefined);

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -282,6 +282,42 @@ test("clear removes goal state without aborting or blocking stale tools", async 
 	assert.match(staleCompletion.content?.[0]?.text ?? "", /no active goal/i);
 });
 
+test("clear releases stale tool-call block from a paused goal", async () => {
+	let pauseAborts = 0;
+	const paused = await startGoalForTest({ abort: () => pauseAborts++ });
+	await paused.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		paused.ctx,
+	);
+
+	await paused.mock.commands.get("goal")?.handler("pause", paused.ctx);
+
+	assert.equal(pauseAborts, 1);
+	assert.equal(lastGoalStatus(paused.mock), "paused");
+	assert.deepEqual(
+		paused.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "t-paused", input: {} },
+			paused.ctx,
+		),
+		{
+			block: true,
+			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
+		},
+	);
+
+	await paused.mock.commands.get("goal")?.handler("clear", paused.ctx);
+
+	assert.equal(lastGoalStatus(paused.mock), null);
+	assert.equal(paused.statuses.get("goal"), undefined);
+	assert.equal(
+		paused.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "t-after-clear", input: {} },
+			paused.ctx,
+		),
+		undefined,
+	);
+});
+
 test("agent_end keeps retryable interruptions active but pauses non-retryable errors", async () => {
 	assert.equal(
 		isRetryableGoalInterruption({


### PR DESCRIPTION
## Summary
- clear stale goal tool-call blocking when `/goal clear` removes the active goal
- self-heal stale blocking if a tool call arrives without a paused active goal
- document clear/resume as unblock paths

## Verification
- `npm run check`
- `git diff --check`