### PR TITLE
chore: update npm dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/extensions/pi-btw/package.json
+++ b/extensions/pi-btw/package.json
@@ -28,10 +28,10 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-ai": "0.74.0",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@earendil-works/pi-tui": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-ai": "0.80.3",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@earendil-works/pi-tui": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -1,4 +1,4 @@
-import { complete, type UserMessage } from "@earendil-works/pi-ai";
+import { complete, type UserMessage } from "@earendil-works/pi-ai/compat";
 import {
 	BorderedLoader,
 	DynamicBorder,

--- a/extensions/pi-caffeinate/package.json
+++ b/extensions/pi-caffeinate/package.json
@@ -29,9 +29,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@types/node": "25.6.0",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/node": "26.1.0",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -29,11 +29,11 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typebox": "^1.3.2"
+		"typebox": "^1.3.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-codex-accounts/package.json
+++ b/extensions/pi-codex-accounts/package.json
@@ -34,9 +34,9 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-ai": "0.74.0",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-ai": "0.80.3",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-codex-usage/package.json
+++ b/extensions/pi-codex-usage/package.json
@@ -29,9 +29,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@types/node": "25.6.0",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/node": "26.1.0",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -29,11 +29,11 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typebox": "^1.3.2"
+		"typebox": "^1.3.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-github-pr/package.json
+++ b/extensions/pi-github-pr/package.json
@@ -29,9 +29,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@types/node": "25.6.0",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/node": "26.1.0",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -28,12 +28,12 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typebox": "^1.3.2"
+		"typebox": "^1.3.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-ai": "0.79.8",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-ai": "0.80.3",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-lsp/package.json
+++ b/extensions/pi-lsp/package.json
@@ -32,12 +32,12 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typebox": "^1.3.2"
+		"typebox": "^1.3.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@types/node": "25.6.0",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/node": "26.1.0",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -28,8 +28,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-retry/package.json
+++ b/extensions/pi-retry/package.json
@@ -27,8 +27,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -29,10 +29,10 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@earendil-works/pi-tui": "0.79.8",
-		"@types/node": "25.6.0",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@earendil-works/pi-tui": "0.80.3",
+		"@types/node": "26.1.0",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typebox": "^1.3.2"
+		"typebox": "^1.3.3"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-agent-core": "*",
@@ -38,11 +38,11 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-agent-core": "0.80.2",
-		"@earendil-works/pi-ai": "0.74.0",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@earendil-works/pi-tui": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-agent-core": "0.80.3",
+		"@earendil-works/pi-ai": "0.80.3",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@earendil-works/pi-tui": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -29,8 +29,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-wait-what/package.json
+++ b/extensions/pi-wait-what/package.json
@@ -32,8 +32,8 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
 				"extensions/*"
 			],
 			"devDependencies": {
-				"@biomejs/biome": "^2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@types/node": "^25.6.0",
-				"typebox": "^1.3.2",
+				"@biomejs/biome": "^2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/node": "^26.1.0",
+				"typebox": "^1.3.3",
 				"typescript": "^6.0.3"
 			}
 		},
@@ -23,38 +23,11 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-ai": "0.74.0",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@earendil-works/pi-tui": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-ai": "0.80.3",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@earendil-works/pi-tui": "0.80.3",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-btw/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"extensions/pi-caffeinate": {
@@ -62,47 +35,10 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@types/node": "25.6.0",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/node": "26.1.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-caffeinate/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
-		"extensions/pi-caffeinate/node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-chrome-devtools": {
@@ -110,39 +46,12 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"dependencies": {
-				"typebox": "^1.3.2"
+				"typebox": "^1.3.3"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-chrome-devtools/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"extensions/pi-codex-accounts": {
@@ -150,9 +59,9 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-ai": "0.74.0",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-ai": "0.80.3",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
 			},
 			"peerDependencies": {
@@ -160,79 +69,15 @@
 				"@earendil-works/pi-coding-agent": "*"
 			}
 		},
-		"extensions/pi-codex-accounts/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
 		"extensions/pi-codex-usage": {
 			"name": "@narumitw/pi-codex-usage",
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@types/node": "25.6.0",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/node": "26.1.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-codex-usage/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
-		"extensions/pi-codex-usage/node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-firecrawl": {
@@ -240,39 +85,12 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"dependencies": {
-				"typebox": "^1.3.2"
+				"typebox": "^1.3.3"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-firecrawl/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"extensions/pi-github-pr": {
@@ -280,47 +98,10 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@types/node": "25.6.0",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/node": "26.1.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-github-pr/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
-		"extensions/pi-github-pr/node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-goal": {
@@ -328,124 +109,27 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"dependencies": {
-				"typebox": "^1.3.2"
+				"typebox": "^1.3.3"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-ai": "0.79.8",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-ai": "0.80.3",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
 			}
-		},
-		"extensions/pi-goal/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
-		"extensions/pi-goal/node_modules/@earendil-works/pi-ai": {
-			"version": "0.79.8",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.8.tgz",
-			"integrity": "sha512-ZpSwaD7oNpsjn9vtEatZQNT9PSdDJXi6rFeY5Qv+OHQGFDKlmcrfJE4ypm4SAc/fBECPs4Rdi3l+YjVtXYrkKw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "0.91.1",
-				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
-				"@google/genai": "1.52.0",
-				"@mistralai/mistralai": "2.2.6",
-				"@opentelemetry/api": "1.9.0",
-				"@smithy/node-http-handler": "4.7.3",
-				"http-proxy-agent": "7.0.2",
-				"https-proxy-agent": "7.0.6",
-				"openai": "6.26.0",
-				"partial-json": "0.1.7",
-				"typebox": "1.1.38"
-			},
-			"bin": {
-				"pi-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=22.19.0"
-			}
-		},
-		"extensions/pi-goal/node_modules/@earendil-works/pi-ai/node_modules/typebox": {
-			"version": "1.1.38",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"extensions/pi-lsp": {
 			"name": "@narumitw/pi-lsp",
 			"version": "0.9.2",
 			"license": "MIT",
 			"dependencies": {
-				"typebox": "^1.3.2"
+				"typebox": "^1.3.3"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@types/node": "25.6.0",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/node": "26.1.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-lsp/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
-		"extensions/pi-lsp/node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-plan-mode": {
@@ -453,36 +137,9 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-plan-mode/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"extensions/pi-retry": {
@@ -490,36 +147,9 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-retry/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"extensions/pi-statusline": {
@@ -527,48 +157,11 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@earendil-works/pi-tui": "0.79.8",
-				"@types/node": "25.6.0",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@earendil-works/pi-tui": "0.80.3",
+				"@types/node": "26.1.0",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-statusline/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
-		"extensions/pi-statusline/node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.19.0"
 			}
 		},
 		"extensions/pi-subagents": {
@@ -576,14 +169,14 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"dependencies": {
-				"typebox": "^1.3.2"
+				"typebox": "^1.3.3"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-agent-core": "0.80.2",
-				"@earendil-works/pi-ai": "0.74.0",
-				"@earendil-works/pi-coding-agent": "0.79.8",
-				"@earendil-works/pi-tui": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-agent-core": "0.80.3",
+				"@earendil-works/pi-ai": "0.80.3",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@earendil-works/pi-tui": "0.80.3",
 				"typescript": "6.0.3"
 			},
 			"peerDependencies": {
@@ -593,68 +186,14 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
-		"extensions/pi-subagents/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
-			}
-		},
 		"extensions/pi-sync": {
 			"name": "@narumitw/pi-sync",
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
-			}
-		},
-		"extensions/pi-sync/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"extensions/pi-wait-what": {
@@ -662,39 +201,12 @@
 			"version": "0.9.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.1",
-				"@earendil-works/pi-coding-agent": "0.79.8",
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
 				"typescript": "6.0.3"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
-			}
-		},
-		"extensions/pi-wait-what/node_modules/@biomejs/biome": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-			"integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
-			},
-			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.1",
-				"@biomejs/cli-darwin-x64": "2.5.1",
-				"@biomejs/cli-linux-arm64": "2.5.1",
-				"@biomejs/cli-linux-arm64-musl": "2.5.1",
-				"@biomejs/cli-linux-x64": "2.5.1",
-				"@biomejs/cli-linux-x64-musl": "2.5.1",
-				"@biomejs/cli-win32-arm64": "2.5.1",
-				"@biomejs/cli-win32-x64": "2.5.1"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -1214,7 +726,7 @@
 				"@biomejs/cli-win32-x64": "2.5.2"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-darwin-arm64": {
+		"node_modules/@biomejs/cli-darwin-arm64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
 			"integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
@@ -1231,7 +743,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-darwin-x64": {
+		"node_modules/@biomejs/cli-darwin-x64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
 			"integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
@@ -1248,7 +760,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-arm64": {
+		"node_modules/@biomejs/cli-linux-arm64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
 			"integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
@@ -1265,7 +777,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-arm64-musl": {
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
 			"integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
@@ -1282,7 +794,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64": {
+		"node_modules/@biomejs/cli-linux-x64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
 			"integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
@@ -1299,7 +811,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64-musl": {
+		"node_modules/@biomejs/cli-linux-x64-musl": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
 			"integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
@@ -1316,7 +828,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-win32-arm64": {
+		"node_modules/@biomejs/cli-win32-arm64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
 			"integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
@@ -1333,7 +845,7 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/biome/node_modules/@biomejs/cli-win32-x64": {
+		"node_modules/@biomejs/cli-win32-x64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
 			"integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
@@ -1350,150 +862,14 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
-			"integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
-			"integrity": "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
-			"integrity": "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
-			"integrity": "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
-			"integrity": "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
-			"integrity": "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
-			"integrity": "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
-			"integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
 		"node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
-			"integrity": "sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+			"integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.2",
+				"@earendil-works/pi-ai": "^0.80.3",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -1502,7 +878,14 @@
 				"node": ">=22.19.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/@earendil-works/pi-ai": {
+		"node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-ai": {
 			"version": "0.80.3",
 			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
 			"integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
@@ -1528,50 +911,24 @@
 				"node": ">=22.19.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
+		"node_modules/@earendil-works/pi-ai/node_modules/typebox": {
 			"version": "1.1.38",
 			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
 			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.74.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
-			"integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.91.1",
-				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"typebox": "^1.1.24",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"pi-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.79.8",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.8.tgz",
-			"integrity": "sha512-wr9oTS/yrwURDXnYrONQgFgV7QDlwslXL/rvKU5X7TRtrGxIhippsRApXqYlRwSeMjb2YzgHMfZ/kAhOqrzoFQ==",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
+			"integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
 			"dev": true,
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.79.8",
-				"@earendil-works/pi-ai": "^0.79.8",
-				"@earendil-works/pi-tui": "^0.79.8",
+				"@earendil-works/pi-agent-core": "^0.80.3",
+				"@earendil-works/pi-ai": "^0.80.3",
+				"@earendil-works/pi-tui": "^0.80.3",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -2061,12 +1418,12 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.79.8",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.8.tgz",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.79.8",
+				"@earendil-works/pi-ai": "^0.80.3",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -2076,8 +1433,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.79.8",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.8.tgz",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2101,8 +1458,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.79.8",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.8.tgz",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3520,9 +2877,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.79.8",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.8.tgz",
-			"integrity": "sha512-QerB+0wUc6eEO8MwvzOQGtzcsbwo6y8VvdxYU6vGcakz6ofJZWhrmwrknp1dCGx3bEtCf+siUIxEzkqvFCzIsg==",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+			"integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3853,29 +3210,15 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@tootallnate/quickjs-emscripten": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/node": {
-			"version": "25.9.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-			"integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
+				"undici-types": "~8.3.0"
 			}
-		},
-		"node_modules/@types/node/node_modules/undici-types": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -3892,19 +3235,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/ast-types": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/base64-js": {
@@ -3927,16 +3257,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/basic-ftp": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			}
 		},
 		"node_modules/bignumber.js": {
 			"version": "9.3.1",
@@ -3961,19 +3281,6 @@
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"dev": true,
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
@@ -4003,21 +3310,6 @@
 				}
 			}
 		},
-		"node_modules/degenerator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ast-types": "^0.13.4",
-				"escodegen": "^2.1.0",
-				"esprima": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -4026,62 +3318,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/escodegen": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/extend": {
@@ -4171,31 +3407,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/get-uri": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"basic-ftp": "^5.0.2",
-				"data-uri-to-buffer": "^6.0.2",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/google-auth-library": {
 			"version": "10.9.0",
 			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
@@ -4262,16 +3473,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/ip-address": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -4326,16 +3527,6 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/marked": {
 			"version": "18.0.5",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -4355,16 +3546,6 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/netmask": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
 		},
 		"node_modules/node-domexception": {
 			"name": "@profoundlogic/node-domexception",
@@ -4429,40 +3610,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pac-proxy-agent": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/quickjs-emscripten": "^0.23.0",
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"get-uri": "^6.0.1",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.6",
-				"pac-resolver": "^7.0.1",
-				"socks-proxy-agent": "^8.0.5"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-resolver": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"degenerator": "^5.0.0",
-				"netmask": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/partial-json": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
@@ -4494,33 +3641,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/proxy-agent": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"http-proxy-agent": "^7.0.1",
-				"https-proxy-agent": "^7.0.6",
-				"lru-cache": "^7.14.1",
-				"pac-proxy-agent": "^7.1.0",
-				"proxy-from-env": "^1.1.0",
-				"socks-proxy-agent": "^8.0.5"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/retry": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -4551,58 +3671,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^10.1.1",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/ts-algebra": {
 			"version": "2.0.0",
@@ -4638,20 +3706,10 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
-		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
 		"pack:wait-what": "npm --workspace @narumitw/pi-wait-what pack --dry-run"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.1",
-		"@earendil-works/pi-coding-agent": "0.79.8",
-		"@types/node": "^25.6.0",
-		"typebox": "^1.3.2",
+		"@biomejs/biome": "^2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/node": "^26.1.0",
+		"typebox": "^1.3.3",
 		"typescript": "^6.0.3"
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary
- update active workspace npm dependencies to current latest versions
- update Biome schema for 2.5.2
- switch pi-btw to pi-ai compat import required by pi-ai 0.80.3

## Verification
- npm run check
- npm outdated --workspaces --include-workspace-root