### PR TITLE
feat: add Google GenAI extension

### DIFF
--- a/docs/plans/2026-07-04_google-genai-extension-plan.md
+++ b/docs/plans/2026-07-04_google-genai-extension-plan.md
@@ -1,0 +1,80 @@
+## Goal
+
+Add a new `@narumitw/pi-google-genai` Pi extension package that exposes Google GenAI grounding through three LLM tools: `google_search`, `google_maps`, and `google_url_context`. Success means the tools call the Gemini Interactions API with `~/.pi/agent/google-genai.json` config or Pi's built-in Google auth, return compact answer text with sources plus normalized details, are documented, tested without live network calls, and pass repository checks.
+
+## Context
+
+The extension is one package with three tools, not three packages. The tools share the same Gemini Interactions endpoint, API key resolution, model setting, fetch helper, response parser, truncation, source formatting, and error handling.
+
+Configuration is user-level at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/google-genai.json` and is always written with `0600` permissions:
+
+```json
+{
+	"apiKey": "YOUR_GOOGLE_API_KEY",
+	"model": "gemini-3.5-flash",
+	"apiUrl": "https://generativelanguage.googleapis.com/v1beta/interactions",
+	"timeoutMs": 30000,
+	"tools": ["google_search", "google_maps", "google_url_context"]
+}
+```
+
+Auth precedence is config literal `apiKey` first, then Pi auth for provider `google` through `/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`, then a clear missing-auth error. Config `apiKey` is literal only for the first version; `$GEMINI_API_KEY`, `${GEMINI_API_KEY}`, `!command`, and Pi's internal `resolveConfigValue` syntax are intentionally out of scope.
+
+## Architecture
+
+- Create `extensions/pi-google-genai` with the standard package layout: `src/google-genai.ts`, `test/google-genai.test.ts`, `package.json`, `tsconfig.json`, `README.md`, and `LICENSE`.
+- Register exactly three tools:
+  - `google_search`: accepts `query` and optional `searchTypes` limited to `web_search` and `image_search`; default omits `search_types` so Google uses web search.
+  - `google_maps`: accepts `query` plus optional `latitude` and `longitude`; coordinates must be provided as a pair and pass range checks.
+  - `google_url_context`: accepts `prompt` plus `urls`, only allows `http://` and `https://`, sends `tools: [{ "type": "url_context" }]`, and uses a single string input containing the prompt and URL list.
+- Use Node `fetch` directly against the configured Interactions API URL; do not add `@google/genai` until file upload, live sessions, Vertex auth, batch/video operations, or other SDK-heavy features are added.
+- Keep one shared helper for request construction, timeout/abort, status updates, JSON parsing, source extraction, output truncation, and result formatting.
+- Tool content includes answer text and a compact `Sources:` section with at most 10 sources. Details contain normalized metadata only: model, output text, sources, tool steps, truncation state, and `fullResponsePath` when present.
+- If tool content is truncated, write the full raw interaction JSON to a temp file with `0600` permissions and include the file path in content/details. Do not store raw interaction JSON in session `details`.
+- Add `/google-genai init|status|help|config|tools|enable|disable` command modes with argument completions. `/google-genai init` asks for API key and model, merges with existing config, preserves existing API key/model on empty input, writes defaults for `apiUrl`, `timeoutMs`, and all tools, and never prints secrets.
+- `/google-genai tools|enable|disable` uses `pi.getActiveTools()` / `pi.setActiveTools()` to manage only the three Google GenAI tool names while preserving unrelated tools; selected tool names persist in the same `google-genai.json`. Missing `tools` means all three enabled; unknown names are ignored with a warning.
+
+## Non-Goals
+
+- Do not implement Pi `resolveConfigValue`, `$ENV` interpolation, or `!command` secret lookup in `google-genai.json`.
+- Do not add `@google/genai` as a direct dependency in the first version.
+- Do not create separate packages for search, maps, and URL context.
+- Do not store raw interaction JSON in session details or print resolved API keys in command output, tool content, test fixtures, or docs.
+- Do not add deprecated Google Maps `enable_widget` support.
+- Do not add per-tool model overrides; use config `model` only.
+
+## Plan
+
+- [x] Add `extensions/pi-google-genai/package.json`, `tsconfig.json`, `LICENSE`, and README scaffolding for `@narumitw/pi-google-genai`; verify with `npm --workspace @narumitw/pi-google-genai run typecheck` after source exists.
+- [x] Add root package/recipe wiring for the new workspace (`pack:google-genai` script plus `just pack-google-genai`, `try-google-genai`, `install-google-genai`, and `publish-google-genai` aliases); verify with `npm run check:boundaries` and `just --list | grep google-genai`.
+- [x] Implement config loading in `src/google-genai.ts` to read `${PI_CODING_AGENT_DIR:-~/.pi/agent}/google-genai.json`, default `model` to `gemini-3.5-flash`, default `apiUrl` to the official Interactions endpoint, default `timeoutMs` to `30000`, default missing `tools` to all enabled, reject config `apiKey` values starting with `$` or `!`, normalize known tools, ignore unknown tool names with warning metadata, and never log the key; verify with unit tests.
+- [x] Implement config writing for `/google-genai init` and tool selection to create parent directories, merge/update existing config, preserve existing API key/model on empty input, write `0600`, and repair config permissions with `chmod 0600`; verify with unit tests using a temporary `PI_CODING_AGENT_DIR`.
+- [x] Implement auth resolution so tools use config literal `apiKey` before `ctx.modelRegistry.getApiKeyForProvider("google")`, with no direct `process.env.GEMINI_API_KEY` read; verify with unit tests for config key, Pi auth fallback, missing auth, and rejected interpolation.
+- [x] Implement a shared `callInteraction()` helper using `fetch` with `x-goog-api-key`, JSON content type, abort signal, configurable timeout, non-2xx error messages, and interaction response normalization; verify with mocked `globalThis.fetch` tests covering request body, headers, success text extraction, annotations/source extraction, HTTP error, timeout, and aborted signal passthrough.
+- [x] Implement `google_search` with `query` and optional `searchTypes` mapped to the Interactions `google_search` tool; verify with unit tests that the request uses `tools: [{ type: "google_search" }]` and includes `search_types` only when supplied.
+- [x] Implement `google_maps` with `query`, optional paired/range-checked `latitude` and `longitude`, and no `enable_widget`; verify with unit tests for coordinates present, coordinates omitted, invalid half-pair/range errors, and place citation details from response annotations.
+- [x] Implement `google_url_context` with `prompt` and `urls`, only allow `http`/`https`, include URLs in one string input, and use `tools: [{ type: "url_context" }]`; verify with unit tests for request shape, invalid URL rejection, and URL context result details.
+- [x] Format tool output as answer text plus at most 10 `Sources:` entries, truncate content to Pi defaults, and write full raw interaction JSON to a `0600` temp file only when truncated; verify with unit tests for source limit, truncation notice, file permissions, and normalized details without `rawInteraction`.
+- [x] Register `/google-genai` command modes for `init`, `status`/`config`, `help`, `tools`, `enable`, and `disable`, including command completions; verify with command-handler unit tests using fake UI and active-tool state.
+- [x] Document install, `/login google`, config, init/status/help/tools commands, API key precedence, literal-only config `apiKey`, tool usage, manual live smoke tests, and no-SDK-first rationale in `extensions/pi-google-genai/README.md`; verify by README review and package dry-run.
+- [x] Run `npm run check`; verify Biome, boundary check, workspace typechecks, and tests pass.
+- [x] Run `just pack-google-genai`; verify the tarball contains `src`, `README.md`, `LICENSE`, and `package.json`, and no test files or secrets.
+
+## Risks
+
+- The Interactions API is preview/beta and may change. Keep request/response parsing small and tolerant instead of wrapping every field in rigid SDK-like types.
+- `gemini-3.5-flash` availability depends on Google's API. Keep it configurable and test request construction with mocks rather than requiring a live API key.
+- Google Maps and URL context response shapes may include partial/error statuses. Return raw relevant normalized `details` so the LLM can report source failures instead of hiding them.
+- `setActiveTools()` is global to the current Pi session. Patch only Google GenAI tool names and preserve unrelated active tools to avoid clobbering other extensions.
+
+## Completion Checklist
+
+- [x] `@narumitw/pi-google-genai` exists as an active workspace with correct `pi.extensions` entry and publish `files`; verified by `npm query .workspace --json` and package review.
+- [x] The extension registers exactly `google_search`, `google_maps`, and `google_url_context`; verified by unit tests against a fake `ExtensionAPI`.
+- [x] API key resolution uses literal config key before Pi auth provider `google`, rejects interpolation in config, and reports missing auth clearly; verified by config/auth unit tests.
+- [x] `/google-genai init` merges config, preserves existing values on empty input, writes `0600`, and never prints secrets; verified by command/config unit tests.
+- [x] `/google-genai tools|enable|disable` manages only Google GenAI tools, allows `tools: []`, persists to `google-genai.json`, and restores on `session_start`; verified by command and session-start unit tests.
+- [x] Each tool sends the expected Interactions request body and returns normalized text, compact sources, truncation behavior, and metadata without live network calls; verified by mocked-fetch unit tests.
+- [x] README documents config path, API key precedence including `/login google`, three tools, tool-selection commands, live smoke tests, and why `@google/genai` is not a dependency yet; verified in `extensions/pi-google-genai/README.md`.
+- [x] Repository validation passes; verified by `npm run check`.
+- [x] Package dry-run passes with expected contents; verified by `just pack-google-genai`.

--- a/extensions/pi-google-genai/LICENSE
+++ b/extensions/pi-google-genai/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-google-genai` exposes Google GenAI Interactions grounding tools to Pi.
 
-## Features
+## ✨ Features
 
 - `google_search` for Google Search grounding.
 - `google_maps` for Google Maps/place grounding.
@@ -13,7 +13,7 @@
 - Lets `/google-genai tools` persist which of the three tools are active.
 - Truncates large outputs and writes the full raw interaction response to a private temp file only when truncation happens.
 
-## Install
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-google-genai
@@ -25,7 +25,7 @@ Try from this repository:
 pi -e ./extensions/pi-google-genai
 ```
 
-## Configuration
+## ⚙️ Configuration
 
 Config lives at:
 
@@ -47,7 +47,7 @@ Example:
 
 The file is written as `0600`.
 
-### Auth precedence
+### 🔐 Auth precedence
 
 1. Literal `apiKey` in `google-genai.json`.
 2. Pi Google auth via `/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`.
@@ -55,7 +55,7 @@ The file is written as `0600`.
 
 `apiKey` in this config is literal only. `$GEMINI_API_KEY`, `${GEMINI_API_KEY}`, and `!command` are not resolved here. Use Pi `/login google` or `GEMINI_API_KEY` for that behavior.
 
-## Command
+## 💬 Command
 
 ```text
 /google-genai init
@@ -73,9 +73,9 @@ The file is written as `0600`.
 - `enable`: enable all three tools.
 - `disable`: disable all three tools. The slash command remains available so you can re-enable them.
 
-## Tools
+## 🛠️ Tools
 
-### `google_search`
+### 🔎 `google_search`
 
 Search Google through Gemini grounding.
 
@@ -84,7 +84,7 @@ Parameters:
 - `query`: search question.
 - `searchTypes?`: optional array of `web_search` and/or `image_search`. Omit it for Google's default web search.
 
-### `google_maps`
+### 🗺️ `google_maps`
 
 Ask Google Maps-grounded questions.
 
@@ -93,7 +93,7 @@ Parameters:
 - `query`: maps/place question.
 - `latitude?` and `longitude?`: optional pair for location-sensitive questions. If one is set, both are required. Latitude must be `-90..90`; longitude must be `-180..180`.
 
-### `google_url_context`
+### 🔗 `google_url_context`
 
 Ask Gemini to use specific URLs as context.
 
@@ -104,7 +104,7 @@ Parameters:
 
 Use Firecrawl instead when you need raw HTML/markdown extraction, crawling, or URL discovery.
 
-## Manual live smoke test
+## 🧪 Manual live smoke test
 
 Automated tests mock Google. Before publishing, you can manually try:
 
@@ -121,11 +121,11 @@ Use google_maps to find Italian restaurants near latitude 34.050481 longitude -1
 Use google_url_context to summarize https://ai.google.dev/gemini-api/docs/interactions.
 ```
 
-## Why no `@google/genai` dependency yet?
+## 🪶 Why no `@google/genai` dependency yet?
 
 The first version only needs one POST to the Interactions API, so native `fetch` is enough. Add `@google/genai` later when the extension needs SDK-heavy features such as file upload, live sessions, Vertex/Enterprise auth, batch/video operations, or file-search store management.
 
-## Package layout
+## 📁 Package layout
 
 ```txt
 extensions/pi-google-genai/
@@ -137,10 +137,10 @@ extensions/pi-google-genai/
 └── package.json
 ```
 
-## Keywords
+## 🏷️ Keywords
 
 `pi-package`, `pi-extension`, `google`, `gemini`, `genai`, `search`, `maps`
 
-## License
+## 📄 License
 
 MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -1,0 +1,146 @@
+# 🔎 pi-google-genai — Google GenAI grounding tools for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-google-genai)](https://www.npmjs.com/package/@narumitw/pi-google-genai) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-google-genai` exposes Google GenAI Interactions grounding tools to Pi.
+
+## Features
+
+- `google_search` for Google Search grounding.
+- `google_maps` for Google Maps/place grounding.
+- `google_url_context` for asking about specific `http://` or `https://` URLs.
+- Uses Pi auth for Google (`/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`) unless `google-genai.json` contains a literal `apiKey`.
+- Lets `/google-genai tools` persist which of the three tools are active.
+- Truncates large outputs and writes the full raw interaction response to a private temp file only when truncation happens.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-google-genai
+```
+
+Try from this repository:
+
+```bash
+pi -e ./extensions/pi-google-genai
+```
+
+## Configuration
+
+Config lives at:
+
+```text
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/google-genai.json
+```
+
+Example:
+
+```json
+{
+  "apiKey": "YOUR_GOOGLE_API_KEY",
+  "model": "gemini-3.5-flash",
+  "apiUrl": "https://generativelanguage.googleapis.com/v1beta/interactions",
+  "timeoutMs": 30000,
+  "tools": ["google_search", "google_maps", "google_url_context"]
+}
+```
+
+The file is written as `0600`.
+
+### Auth precedence
+
+1. Literal `apiKey` in `google-genai.json`.
+2. Pi Google auth via `/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`.
+3. Missing-auth tool error.
+
+`apiKey` in this config is literal only. `$GEMINI_API_KEY`, `${GEMINI_API_KEY}`, and `!command` are not resolved here. Use Pi `/login google` or `GEMINI_API_KEY` for that behavior.
+
+## Command
+
+```text
+/google-genai init
+/google-genai status
+/google-genai config
+/google-genai help
+/google-genai tools
+/google-genai enable
+/google-genai disable
+```
+
+- `init`: interactively creates or updates config. API key may be blank; blank keeps an existing key or uses Pi auth fallback.
+- `status` / `config`: shows config path, model, API URL, timeout, auth source, and enabled tools. It never prints the key.
+- `tools`: select which Google GenAI tools are active and persist the selection.
+- `enable`: enable all three tools.
+- `disable`: disable all three tools. The slash command remains available so you can re-enable them.
+
+## Tools
+
+### `google_search`
+
+Search Google through Gemini grounding.
+
+Parameters:
+
+- `query`: search question.
+- `searchTypes?`: optional array of `web_search` and/or `image_search`. Omit it for Google's default web search.
+
+### `google_maps`
+
+Ask Google Maps-grounded questions.
+
+Parameters:
+
+- `query`: maps/place question.
+- `latitude?` and `longitude?`: optional pair for location-sensitive questions. If one is set, both are required. Latitude must be `-90..90`; longitude must be `-180..180`.
+
+### `google_url_context`
+
+Ask Gemini to use specific URLs as context.
+
+Parameters:
+
+- `prompt`: question or instruction.
+- `urls`: one or more `http://` or `https://` URLs.
+
+Use Firecrawl instead when you need raw HTML/markdown extraction, crawling, or URL discovery.
+
+## Manual live smoke test
+
+Automated tests mock Google. Before publishing, you can manually try:
+
+```bash
+export GEMINI_API_KEY=your-key
+pi -e ./extensions/pi-google-genai
+```
+
+Then ask Pi to use:
+
+```text
+Use google_search to answer: Who won Euro 2024?
+Use google_maps to find Italian restaurants near latitude 34.050481 longitude -118.248526.
+Use google_url_context to summarize https://ai.google.dev/gemini-api/docs/interactions.
+```
+
+## Why no `@google/genai` dependency yet?
+
+The first version only needs one POST to the Interactions API, so native `fetch` is enough. Add `@google/genai` later when the extension needs SDK-heavy features such as file upload, live sessions, Vertex/Enterprise auth, batch/video operations, or file-search store management.
+
+## Package layout
+
+```txt
+extensions/pi-google-genai/
+├── src/google-genai.ts
+├── test/google-genai.test.ts
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+## Keywords
+
+`pi-package`, `pi-extension`, `google`, `gemini`, `genai`, `search`, `maps`
+
+## License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-google-genai/package.json
+++ b/extensions/pi-google-genai/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@narumitw/pi-google-genai",
+	"version": "0.10.0",
+	"description": "Pi extension that exposes Google GenAI search, maps, and URL context grounding tools.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"google",
+		"gemini",
+		"genai",
+		"search",
+		"maps"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/google-genai.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"typebox": "^1.3.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.2",
+		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/node": "26.1.0",
+		"typescript": "6.0.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "extensions/pi-google-genai"
+	}
+}

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -268,12 +268,16 @@ export async function loadGoogleGenaiConfig(): Promise<LoadedGoogleGenaiConfig> 
 	const warnings: string[] = [];
 	await ensureConfigPermissions(path, warnings);
 	const raw = await readJsonIfExists(path, warnings);
-	const normalized = normalizeConfigWithWarnings(raw);
+	const configLoaded = isObject(raw);
+	if (raw !== undefined && !configLoaded) {
+		warnings.push("google-genai.json must contain a JSON object; ignoring config.");
+	}
+	const normalized = normalizeConfigWithWarnings(configLoaded ? raw : undefined);
 	return {
 		config: normalized.config,
 		path,
 		warnings: [...warnings, ...normalized.warnings],
-		configLoaded: raw !== undefined,
+		configLoaded,
 	};
 }
 
@@ -591,7 +595,7 @@ function assertSafeApiUrl(apiUrl: string) {
 	try {
 		parsed = new URL(apiUrl);
 	} catch {
-		throw new Error(`Google GenAI apiUrl must be a valid HTTPS URL: ${apiUrl}`);
+		throw new Error(`Google GenAI apiUrl must be a valid URL: ${apiUrl}`);
 	}
 	const localHttp =
 		parsed.protocol === "http:" &&

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -66,6 +66,7 @@ export interface LoadedGoogleGenaiConfig {
 	config: GoogleGenaiConfig;
 	path: string;
 	warnings: string[];
+	configLoaded: boolean;
 }
 
 interface GoogleGenaiSource {
@@ -210,7 +211,7 @@ export default function googleGenai(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		const loaded = await loadGoogleGenaiConfig();
-		applyGoogleToolSelection(pi, loaded.config.tools);
+		if (loaded.configLoaded) applyGoogleToolSelection(pi, loaded.config.tools);
 		if (loaded.warnings.length > 0) ctx.ui.notify(loaded.warnings.join("\n"), "warning");
 	});
 
@@ -266,7 +267,12 @@ export async function loadGoogleGenaiConfig(): Promise<LoadedGoogleGenaiConfig> 
 	await ensureConfigPermissions(path, warnings);
 	const raw = await readJsonIfExists(path, warnings);
 	const normalized = normalizeConfigWithWarnings(raw);
-	return { config: normalized.config, path, warnings: [...warnings, ...normalized.warnings] };
+	return {
+		config: normalized.config,
+		path,
+		warnings: [...warnings, ...normalized.warnings],
+		configLoaded: raw !== undefined,
+	};
 }
 
 export async function resolveGoogleGenaiAuth(

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -599,7 +599,9 @@ function assertSafeApiUrl(apiUrl: string) {
 		throw new Error(`Google GenAI apiUrl must be a valid URL: ${apiUrl}`);
 	}
 	const localHttp =
-		parsed.protocol === "http:" && ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname);
+		parsed.protocol === "http:" &&
+		["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname);
+	if (parsed.protocol !== "https:" && !localHttp) {
 		throw new Error(
 			`Google GenAI apiUrl must use https:// to protect the API key (http://localhost is allowed for local proxies): ${apiUrl}`,
 		);

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -405,7 +405,8 @@ export function buildStatusMessage(loaded: LoadedGoogleGenaiConfig, authSource: 
 		`apiUrl: ${config.apiUrl}`,
 		`timeoutMs: ${config.timeoutMs}`,
 		`auth: ${authSource}`,
-		`tools: ${formatPersistedTools(config.tools)}`,
+		`configLoaded: ${loaded.configLoaded ? "yes" : "no"}`,
+		`persisted tools: ${loaded.configLoaded ? formatPersistedTools(config.tools) : "none"}`,
 		...(warnings.length > 0 ? ["warnings:", ...warnings.map((warning) => `- ${warning}`)] : []),
 	].join("\n");
 }

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -599,9 +599,7 @@ function assertSafeApiUrl(apiUrl: string) {
 		throw new Error(`Google GenAI apiUrl must be a valid URL: ${apiUrl}`);
 	}
 	const localHttp =
-		parsed.protocol === "http:" &&
-		["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
-	if (parsed.protocol !== "https:" && !localHttp) {
+		parsed.protocol === "http:" && ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname);
 		throw new Error(
 			`Google GenAI apiUrl must use https:// to protect the API key (http://localhost is allowed for local proxies): ${apiUrl}`,
 		);

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -216,8 +216,9 @@ export default function googleGenai(pi: ExtensionAPI) {
 		if (loaded.warnings.length > 0) ctx.ui.notify(loaded.warnings.join("\n"), "warning");
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
+	pi.on("session_shutdown", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		await cleanupRawResponseDirectory();
 	});
 }
 
@@ -896,6 +897,17 @@ function rawResponseDirectory() {
 			throw error;
 		});
 	return rawResponseDirectoryPromise;
+}
+
+async function cleanupRawResponseDirectory() {
+	const directoryPromise = rawResponseDirectoryPromise;
+	rawResponseDirectoryPromise = undefined;
+	if (!directoryPromise) return;
+	try {
+		await rm(await directoryPromise, { recursive: true, force: true });
+	} catch {
+		// Best-effort temp cleanup; avoid making session shutdown fail.
+	}
 }
 
 function asArray(value: unknown): unknown[] {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -272,7 +272,7 @@ export async function resolveGoogleGenaiAuth(
 	ctx: Pick<ExtensionContext, "modelRegistry">,
 ) {
 	if (config.apiKey) {
-		if (config.apiKey.startsWith("$") || config.apiKey.startsWith("!")) {
+		if (isUnsupportedConfigApiKey(config.apiKey)) {
 			throw new Error(
 				"Interpolation and command syntax are not supported in google-genai.json apiKey. Use a literal key, /login google, or GEMINI_API_KEY.",
 			);
@@ -433,6 +433,7 @@ async function callInteraction(
 ) {
 	const loaded = await loadGoogleGenaiConfig();
 	const { config } = loaded;
+	assertSafeApiUrl(config.apiUrl);
 	const apiKey = await resolveGoogleGenaiAuth(config, ctx);
 	const body: InteractionRequest = {
 		model: config.model,
@@ -539,7 +540,11 @@ async function selectTools(ctx: ExtensionCommandContext, pi: ExtensionAPI) {
 }
 
 function authSource(config: GoogleGenaiConfig, ctx: ExtensionCommandContext) {
-	if (config.apiKey) return "config apiKey";
+	if (config.apiKey) {
+		return isUnsupportedConfigApiKey(config.apiKey)
+			? "invalid config apiKey (interpolation unsupported)"
+			: "config apiKey";
+	}
 	const status = ctx.modelRegistry.getProviderAuthStatus("google");
 	if (status.configured || status.source) {
 		return status.label ? `Pi auth/google (${status.label})` : "Pi auth/google";
@@ -565,6 +570,26 @@ function currentGoogleTools(pi: ExtensionAPI) {
 
 function orderedGoogleTools(tools: Set<GoogleGenaiToolName>) {
 	return GOOGLE_GENAI_TOOL_NAMES.filter((toolName) => tools.has(toolName));
+}
+
+function isUnsupportedConfigApiKey(apiKey: string) {
+	return apiKey.startsWith("$") || apiKey.startsWith("!");
+}
+
+function assertSafeApiUrl(apiUrl: string) {
+	let parsed: URL;
+	try {
+		parsed = new URL(apiUrl);
+	} catch {
+		throw new Error(`Google GenAI apiUrl must be a valid HTTPS URL: ${apiUrl}`);
+	}
+	const localHttp =
+		parsed.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
+	if (parsed.protocol !== "https:" && !localHttp) {
+		throw new Error(
+			`Google GenAI apiUrl must use https:// to protect the API key (http://localhost is allowed for local proxies): ${apiUrl}`,
+		);
+	}
 }
 
 function normalizeConfigWithWarnings(value: unknown): { config: GoogleGenaiConfig; warnings: string[] } {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -539,7 +539,7 @@ function authSource(config: GoogleGenaiConfig, ctx: ExtensionCommandContext) {
 	if (status.configured || status.source) {
 		return status.label ? `Pi auth/google (${status.label})` : "Pi auth/google";
 	}
-	return Promise.resolve("missing");
+	return "missing";
 }
 
 async function saveToolSelection(tools: GoogleGenaiToolName[]) {
@@ -627,8 +627,16 @@ async function readJsonIfExists(path: string, warnings: string[]) {
 async function writeGoogleGenaiConfig(config: GoogleGenaiConfig) {
 	const path = googleGenaiConfigPath();
 	await mkdir(dirname(path), { recursive: true });
-	await writeFile(path, `${JSON.stringify(cleanObject(config), null, "\t")}\n`, { mode: 0o600 });
-	await chmod(path, 0o600);
+	const tempFile = `${path}.${process.pid}.${Date.now()}.tmp`;
+	try {
+		await writeFile(tempFile, `${JSON.stringify(cleanObject(config), null, "\t")}\n`, { mode: 0o600 });
+		await chmod(tempFile, 0o600);
+		await rename(tempFile, path);
+		await chmod(path, 0o600);
+	} catch (error) {
+		await rm(tempFile, { force: true }).catch(() => undefined);
+		throw error;
+	}
 }
 
 async function ensureConfigPermissions(path: string, warnings: string[]) {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -1,0 +1,858 @@
+import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	defineTool,
+	formatSize,
+	truncateHead,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+export const DEFAULT_MODEL = "gemini-3.5-flash";
+export const DEFAULT_API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions";
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const GOOGLE_GENAI_TOOL_NAMES = [
+	"google_search",
+	"google_maps",
+	"google_url_context",
+] as const;
+
+const STATUS_KEY = "google-genai";
+const CONFIG_FILE_NAME = "google-genai.json";
+const SEARCH_TYPES = ["web_search", "image_search"] as const;
+const SOURCE_LIMIT = 10;
+const COMMAND_COMPLETIONS = [
+	{ value: "init", label: "init", description: "Create or update Google GenAI config" },
+	{ value: "status", label: "status", description: "Show Google GenAI config status" },
+	{ value: "config", label: "config", description: "Show Google GenAI config status" },
+	{ value: "help", label: "help", description: "Show Google GenAI command usage" },
+	{ value: "tools", label: "tools", description: "Select Google GenAI tools" },
+	{ value: "enable", label: "enable", description: "Enable all Google GenAI tools" },
+	{ value: "disable", label: "disable", description: "Disable all Google GenAI tools" },
+];
+
+const SearchTypesParameter = Type.Optional(
+	Type.Array(Type.String({ description: "Search type: web_search or image_search." }), {
+		description: "Optional Google Search grounding types. Defaults to Google's web search.",
+	}),
+);
+
+type GoogleGenaiToolName = (typeof GOOGLE_GENAI_TOOL_NAMES)[number];
+type SearchType = (typeof SEARCH_TYPES)[number];
+type CommandAction =
+	| "status"
+	| "init"
+	| "help"
+	| "tools"
+	| "enable"
+	| "disable"
+	| "unknown";
+
+export interface GoogleGenaiConfig {
+	apiKey?: string;
+	model: string;
+	apiUrl: string;
+	timeoutMs: number;
+	tools: GoogleGenaiToolName[];
+}
+
+export interface LoadedGoogleGenaiConfig {
+	config: GoogleGenaiConfig;
+	path: string;
+	warnings: string[];
+}
+
+interface GoogleGenaiSource {
+	type: string;
+	title?: string;
+	name?: string;
+	url?: string;
+	status?: string;
+	placeId?: string;
+}
+
+interface GoogleGenaiDetails {
+	model: string;
+	outputText: string;
+	sources: GoogleGenaiSource[];
+	toolSteps: unknown[];
+	truncated: boolean;
+	truncation?: {
+		truncatedBy: "lines" | "bytes" | null;
+		totalLines: number;
+		totalBytes: number;
+		outputLines: number;
+		outputBytes: number;
+	};
+	fullResponsePath?: string;
+}
+
+interface InteractionRequest {
+	model: string;
+	input: string;
+	tools: Array<Record<string, unknown>>;
+}
+
+interface FetchSignal {
+	signal: AbortSignal;
+	cleanup(): void;
+	isTimeout(): boolean;
+}
+
+const googleSearchTool = defineTool({
+	name: "google_search",
+	label: "Google GenAI: Search",
+	description: `Search Google through Gemini Interactions grounding. Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}.`,
+	promptSnippet: "Search Google through Gemini grounding",
+	promptGuidelines: [
+		"Use google_search when the user asks for current public web or image-search-backed information.",
+		"If Google GenAI auth is missing, report the configuration error instead of retrying repeatedly.",
+	],
+	parameters: Type.Object({
+		query: Type.String({ description: "Search question or query." }),
+		searchTypes: SearchTypesParameter,
+	}),
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		const searchTypes = validateSearchTypes(params.searchTypes);
+		return withStatus(ctx, "search", () =>
+			callInteraction(
+				{
+					input: params.query,
+					tool: cleanObject({ type: "google_search", search_types: searchTypes }),
+				},
+				ctx,
+				signal,
+			),
+		);
+	},
+});
+
+const googleMapsTool = defineTool({
+	name: "google_maps",
+	label: "Google GenAI: Maps",
+	description: `Ask Google Maps-grounded questions through Gemini Interactions. Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}.`,
+	promptSnippet: "Ask Google Maps-grounded questions",
+	promptGuidelines: [
+		"Use google_maps for place, nearby, route, and local-business questions that benefit from Google Maps grounding.",
+		"Provide both latitude and longitude when the user's current location matters; omit both for general place questions.",
+	],
+	parameters: Type.Object({
+		query: Type.String({ description: "Maps-grounded question or place query." }),
+		latitude: Type.Optional(Type.Number({ description: "User latitude in degrees." })),
+		longitude: Type.Optional(Type.Number({ description: "User longitude in degrees." })),
+	}),
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		const location = validateMapsLocation(params);
+		return withStatus(ctx, "maps", () =>
+			callInteraction(
+				{
+					input: params.query,
+					tool: cleanObject({ type: "google_maps", ...location }),
+				},
+				ctx,
+				signal,
+			),
+		);
+	},
+});
+
+const googleUrlContextTool = defineTool({
+	name: "google_url_context",
+	label: "Google GenAI: URL Context",
+	description: `Ask Gemini to use specific http/https URLs as context. Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}.`,
+	promptSnippet: "Ask Gemini to use specific URL context",
+	promptGuidelines: [
+		"Use google_url_context when the user provides specific URLs and asks about their contents.",
+		"Use firecrawl tools instead when the user needs raw HTML, markdown extraction, or site crawling.",
+	],
+	parameters: Type.Object({
+		prompt: Type.String({ description: "Question or instruction for the provided URLs." }),
+		urls: Type.Array(Type.String({ description: "HTTP or HTTPS URL to fetch as context." }), {
+			description: "One or more http:// or https:// URLs.",
+		}),
+	}),
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		const urls = validateUrls(params.urls);
+		return withStatus(ctx, "url", () =>
+			callInteraction(
+				{
+					input: `${params.prompt}\n\nURLs:\n${urls.join("\n")}`,
+					tool: { type: "url_context" },
+				},
+				ctx,
+				signal,
+			),
+		);
+	},
+});
+
+export default function googleGenai(pi: ExtensionAPI) {
+	pi.registerTool(googleSearchTool);
+	pi.registerTool(googleMapsTool);
+	pi.registerTool(googleUrlContextTool);
+
+	pi.registerCommand("google-genai", {
+		description: "Configure Google GenAI grounding tools",
+		getArgumentCompletions: commandCompletions,
+		handler: async (args, ctx) => {
+			await handleCommand(args, ctx, pi);
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		const loaded = await loadGoogleGenaiConfig();
+		applyGoogleToolSelection(pi, loaded.config.tools);
+		if (loaded.warnings.length > 0) ctx.ui.notify(loaded.warnings.join("\n"), "warning");
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}
+
+export function googleGenaiConfigPath() {
+	return join(process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent"), CONFIG_FILE_NAME);
+}
+
+export function parseCommand(rawArgs: string): CommandAction {
+	const [command = ""] = splitArgs(rawArgs);
+	switch (command) {
+		case "":
+		case "status":
+		case "config":
+			return "status";
+		case "init":
+			return "init";
+		case "help":
+			return "help";
+		case "tools":
+		case "toggle":
+		case "select":
+			return "tools";
+		case "enable":
+		case "on":
+			return "enable";
+		case "disable":
+		case "off":
+			return "disable";
+		default:
+			return "unknown";
+	}
+}
+
+export function commandCompletions(prefix: string) {
+	if (/\s/.test(prefix.trimStart())) return null;
+	const token = prefix.trimStart();
+	const matches = COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(token));
+	return matches.length > 0 ? matches : null;
+}
+
+export function normalizeGoogleGenaiSettings(value: unknown): GoogleGenaiConfig {
+	return normalizeConfigWithWarnings(value).config;
+}
+
+export async function loadGoogleGenaiConfig(): Promise<LoadedGoogleGenaiConfig> {
+	const path = googleGenaiConfigPath();
+	const warnings: string[] = [];
+	const raw = await readJsonIfExists(path, warnings);
+	if (raw !== undefined) await ensureConfigPermissions(path, warnings);
+	const normalized = normalizeConfigWithWarnings(raw);
+	return { config: normalized.config, path, warnings: [...warnings, ...normalized.warnings] };
+}
+
+export async function resolveGoogleGenaiAuth(
+	config: Pick<GoogleGenaiConfig, "apiKey">,
+	ctx: Pick<ExtensionContext, "modelRegistry">,
+) {
+	if (config.apiKey) {
+		if (config.apiKey.startsWith("$") || config.apiKey.startsWith("!")) {
+			throw new Error(
+				"Interpolation and command syntax are not supported in google-genai.json apiKey. Use a literal key, /login google, or GEMINI_API_KEY.",
+			);
+		}
+		return config.apiKey;
+	}
+
+	const apiKey = await ctx.modelRegistry.getApiKeyForProvider("google");
+	if (apiKey) return apiKey;
+
+	throw new Error(
+		`Missing Google GenAI API key. Run /google-genai init, run /login google, or set GEMINI_API_KEY. Config path: ${googleGenaiConfigPath()}`,
+	);
+}
+
+export function validateSearchTypes(searchTypes: unknown): SearchType[] | undefined {
+	if (searchTypes === undefined) return undefined;
+	if (!Array.isArray(searchTypes)) throw new Error("searchTypes must be an array.");
+	const values = [...new Set(searchTypes)];
+	for (const value of values) {
+		if (!SEARCH_TYPES.includes(value as SearchType)) {
+			throw new Error(`searchTypes supports only: ${SEARCH_TYPES.join(", ")}.`);
+		}
+	}
+	return values as SearchType[];
+}
+
+export function validateMapsLocation(params: { latitude?: unknown; longitude?: unknown }) {
+	const hasLatitude = params.latitude !== undefined;
+	const hasLongitude = params.longitude !== undefined;
+	if (hasLatitude !== hasLongitude) {
+		throw new Error("latitude and longitude must be provided together.");
+	}
+	if (!hasLatitude) return {};
+	if (typeof params.latitude !== "number" || !Number.isFinite(params.latitude)) {
+		throw new Error("latitude must be a finite number.");
+	}
+	if (typeof params.longitude !== "number" || !Number.isFinite(params.longitude)) {
+		throw new Error("longitude must be a finite number.");
+	}
+	if (params.latitude < -90 || params.latitude > 90) {
+		throw new Error("latitude must be between -90 and 90.");
+	}
+	if (params.longitude < -180 || params.longitude > 180) {
+		throw new Error("longitude must be between -180 and 180.");
+	}
+	return { latitude: params.latitude, longitude: params.longitude };
+}
+
+export function validateUrls(urls: unknown): string[] {
+	if (!Array.isArray(urls) || urls.length === 0) {
+		throw new Error("urls must contain at least one http:// or https:// URL.");
+	}
+	return urls.map((url) => {
+		if (typeof url !== "string" || !url.trim()) {
+			throw new Error("urls must contain non-empty strings.");
+		}
+		let parsed: URL;
+		try {
+			parsed = new URL(url.trim());
+		} catch {
+			throw new Error(`Invalid URL: ${url}`);
+		}
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			throw new Error(`Only http:// and https:// URLs are supported: ${url}`);
+		}
+		return url.trim();
+	});
+}
+
+export async function formatToolResult(raw: unknown, model: string) {
+	const outputText = extractOutputText(raw).trim() || "No response received.";
+	const sources = extractSources(raw);
+	const toolSteps = extractToolSteps(raw);
+	const text = formatContent(outputText, sources);
+	const truncation = truncateHead(text, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+	const details: GoogleGenaiDetails = {
+		model,
+		outputText,
+		sources,
+		toolSteps,
+		truncated: truncation.truncated,
+	};
+
+	let content = truncation.content;
+	if (truncation.truncated) {
+		if (sources.length > 0 && !content.includes("\nSources:")) {
+			content += `\n\n${formatSourcesSection(sources)}`;
+		}
+		const fullResponsePath = await writeRawResponse(raw);
+		details.fullResponsePath = fullResponsePath;
+		details.truncation = {
+			truncatedBy: truncation.truncatedBy,
+			totalLines: truncation.totalLines,
+			totalBytes: truncation.totalBytes,
+			outputLines: truncation.outputLines,
+			outputBytes: truncation.outputBytes,
+		};
+		content += `\n\n[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full response saved to: ${fullResponsePath}]`;
+	}
+
+	return { content: [{ type: "text" as const, text: content }], details };
+}
+
+export function buildStatusMessage(loaded: LoadedGoogleGenaiConfig, authSource: string) {
+	const { config, path, warnings } = loaded;
+	return [
+		"Google GenAI config:",
+		`path: ${path}`,
+		`model: ${config.model}`,
+		`apiUrl: ${config.apiUrl}`,
+		`timeoutMs: ${config.timeoutMs}`,
+		`auth: ${authSource}`,
+		`tools: ${formatPersistedTools(config.tools)}`,
+		...(warnings.length > 0 ? ["warnings:", ...warnings.map((warning) => `- ${warning}`)] : []),
+	].join("\n");
+}
+
+async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext, pi: ExtensionAPI) {
+	const action = parseCommand(rawArgs);
+	switch (action) {
+		case "status":
+			await showStatus(ctx);
+			return;
+		case "init":
+			await initConfig(ctx, pi);
+			return;
+		case "help":
+			ctx.ui.notify(helpText(), "info");
+			return;
+		case "tools":
+			await selectTools(ctx, pi);
+			return;
+		case "enable":
+			await saveToolSelection([...GOOGLE_GENAI_TOOL_NAMES]);
+			applyGoogleToolSelection(pi, [...GOOGLE_GENAI_TOOL_NAMES]);
+			ctx.ui.notify("Enabled all Google GenAI tools.", "info");
+			return;
+		case "disable":
+			await saveToolSelection([]);
+			applyGoogleToolSelection(pi, []);
+			ctx.ui.notify("Disabled all Google GenAI tools. Use /google-genai enable to restore them.", "info");
+			return;
+		case "unknown":
+			ctx.ui.notify(helpText(), "warning");
+			return;
+	}
+}
+
+async function callInteraction(
+	request: { input: string; tool: Record<string, unknown> },
+	ctx: ExtensionContext,
+	signal: AbortSignal | undefined,
+) {
+	const loaded = await loadGoogleGenaiConfig();
+	const { config } = loaded;
+	const apiKey = await resolveGoogleGenaiAuth(config, ctx);
+	const body: InteractionRequest = {
+		model: config.model,
+		input: request.input,
+		tools: [request.tool],
+	};
+	const timeoutSignal = makeTimeoutSignal(signal, config.timeoutMs);
+	try {
+		const response = await fetch(config.apiUrl, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-goog-api-key": apiKey,
+			},
+			body: JSON.stringify(body),
+			signal: timeoutSignal.signal,
+		});
+		const responseText = await response.text();
+		const payload = parseJsonResponse(responseText);
+		if (!response.ok) {
+			throw new Error(`Google GenAI request failed (${response.status}): ${errorMessage(payload)}`);
+		}
+		return formatToolResult(payload, config.model);
+	} catch (error) {
+		if (timeoutSignal.isTimeout()) {
+			throw new Error(`Google GenAI request timed out after ${config.timeoutMs}ms.`);
+		}
+		throw error;
+	} finally {
+		timeoutSignal.cleanup();
+	}
+}
+
+async function initConfig(ctx: ExtensionCommandContext, pi: ExtensionAPI) {
+	if (!ctx.hasUI) {
+		ctx.ui.notify("/google-genai init requires interactive UI. Edit google-genai.json manually or use /login google.", "warning");
+		return;
+	}
+	const loaded = await loadGoogleGenaiConfig();
+	const apiKey = await ctx.ui.input(
+		"Google GenAI API key (leave blank to keep existing/use /login google/GEMINI_API_KEY):",
+	);
+	if (apiKey === undefined) {
+		ctx.ui.notify("Cancelled", "info");
+		return;
+	}
+	const model = await ctx.ui.input("Google GenAI model:", loaded.config.model);
+	if (model === undefined) {
+		ctx.ui.notify("Cancelled", "info");
+		return;
+	}
+
+	const next: GoogleGenaiConfig = {
+		...loaded.config,
+		apiKey: apiKey.trim() || loaded.config.apiKey,
+		model: model.trim() || loaded.config.model || DEFAULT_MODEL,
+		apiUrl: loaded.config.apiUrl || DEFAULT_API_URL,
+		timeoutMs: loaded.config.timeoutMs || DEFAULT_TIMEOUT_MS,
+		tools: loaded.config.tools ?? [...GOOGLE_GENAI_TOOL_NAMES],
+	};
+	await writeGoogleGenaiConfig(next);
+	applyGoogleToolSelection(pi, next.tools);
+	ctx.ui.notify(`Saved Google GenAI config to ${googleGenaiConfigPath()}.`, "info");
+}
+
+async function showStatus(ctx: ExtensionCommandContext) {
+	const loaded = await loadGoogleGenaiConfig();
+	ctx.ui.notify(buildStatusMessage(loaded, await authSource(loaded.config, ctx)), "info");
+}
+
+async function selectTools(ctx: ExtensionCommandContext, pi: ExtensionAPI) {
+	if (!ctx.hasUI) {
+		ctx.ui.notify("/google-genai tools requires interactive UI.", "warning");
+		return;
+	}
+
+	let selected = new Set(currentGoogleTools(pi));
+	while (true) {
+		const rows = [
+			...GOOGLE_GENAI_TOOL_NAMES.map((toolName) => `${selected.has(toolName) ? "[x]" : "[ ]"} ${toolName}`),
+			"Enable all Google GenAI tools",
+			"Disable all Google GenAI tools",
+			"Done",
+		];
+		const choice = await ctx.ui.select(
+			`Google GenAI tools (${selected.size}/${GOOGLE_GENAI_TOOL_NAMES.length})`,
+			rows,
+		);
+		if (!choice || choice === "Done") return;
+		if (choice === "Enable all Google GenAI tools") {
+			selected = new Set(GOOGLE_GENAI_TOOL_NAMES);
+		} else if (choice === "Disable all Google GenAI tools") {
+			selected = new Set();
+		} else {
+			const toolName = GOOGLE_GENAI_TOOL_NAMES.find((name) => choice.endsWith(name));
+			if (!toolName) continue;
+			if (selected.has(toolName)) selected.delete(toolName);
+			else selected.add(toolName);
+		}
+		const ordered = orderedGoogleTools(selected);
+		applyGoogleToolSelection(pi, ordered);
+		await saveToolSelection(ordered);
+	}
+}
+
+function authSource(config: GoogleGenaiConfig, ctx: ExtensionCommandContext) {
+	if (config.apiKey) return "config apiKey";
+	const status = ctx.modelRegistry.getProviderAuthStatus("google");
+	if (status.configured || status.source) {
+		return status.label ? `Pi auth/google (${status.label})` : "Pi auth/google";
+	}
+	return Promise.resolve("missing");
+}
+
+async function saveToolSelection(tools: GoogleGenaiToolName[]) {
+	const loaded = await loadGoogleGenaiConfig();
+	await writeGoogleGenaiConfig({ ...loaded.config, tools });
+}
+
+function applyGoogleToolSelection(pi: ExtensionAPI, selectedTools: readonly GoogleGenaiToolName[]) {
+	const active = pi.getActiveTools();
+	const nonGoogle = active.filter((toolName) => !isGoogleGenaiToolName(toolName));
+	pi.setActiveTools([...nonGoogle, ...selectedTools]);
+}
+
+function currentGoogleTools(pi: ExtensionAPI) {
+	const active = new Set(pi.getActiveTools());
+	return GOOGLE_GENAI_TOOL_NAMES.filter((toolName) => active.has(toolName));
+}
+
+function orderedGoogleTools(tools: Set<GoogleGenaiToolName>) {
+	return GOOGLE_GENAI_TOOL_NAMES.filter((toolName) => tools.has(toolName));
+}
+
+function normalizeConfigWithWarnings(value: unknown): { config: GoogleGenaiConfig; warnings: string[] } {
+	const input = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+	const raw = input as Record<string, unknown>;
+	const warnings: string[] = [];
+	const tools = normalizeTools(raw.tools, warnings);
+	const config: GoogleGenaiConfig = {
+		model: normalizeString(raw.model) ?? DEFAULT_MODEL,
+		apiUrl: normalizeApiUrl(raw.apiUrl) ?? DEFAULT_API_URL,
+		timeoutMs: normalizeTimeout(raw.timeoutMs) ?? DEFAULT_TIMEOUT_MS,
+		tools,
+	};
+	const apiKey = normalizeString(raw.apiKey);
+	if (apiKey) config.apiKey = apiKey;
+	return { config, warnings };
+}
+
+function normalizeTools(value: unknown, warnings: string[]) {
+	if (value === undefined) return [...GOOGLE_GENAI_TOOL_NAMES];
+	if (!Array.isArray(value)) {
+		warnings.push("google-genai.json tools must be an array; defaulting to all tools enabled.");
+		return [...GOOGLE_GENAI_TOOL_NAMES];
+	}
+	const selected: GoogleGenaiToolName[] = [];
+	const unknown: string[] = [];
+	for (const item of value) {
+		if (typeof item !== "string") continue;
+		if (isGoogleGenaiToolName(item)) {
+			if (!selected.includes(item)) selected.push(item);
+		} else {
+			unknown.push(item);
+		}
+	}
+	if (unknown.length > 0) {
+		warnings.push(`Ignoring unknown Google GenAI tool name(s): ${unknown.join(", ")}.`);
+	}
+	return GOOGLE_GENAI_TOOL_NAMES.filter((toolName) => selected.includes(toolName));
+}
+
+function normalizeString(value: unknown) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeApiUrl(value: unknown) {
+	const url = normalizeString(value);
+	if (!url) return undefined;
+	return url.replace(/\/+$/, "");
+}
+
+function normalizeTimeout(value: unknown) {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+async function readJsonIfExists(path: string, warnings: string[]) {
+	try {
+		return JSON.parse(await readFile(path, "utf8"));
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		warnings.push(`Failed to read ${path}: ${error instanceof Error ? error.message : String(error)}`);
+		return undefined;
+	}
+}
+
+async function writeGoogleGenaiConfig(config: GoogleGenaiConfig) {
+	const path = googleGenaiConfigPath();
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, `${JSON.stringify(cleanObject(config), null, "\t")}\n`, { mode: 0o600 });
+	await chmod(path, 0o600);
+}
+
+async function ensureConfigPermissions(path: string, warnings: string[]) {
+	try {
+		const current = await stat(path);
+		if ((current.mode & 0o777) !== 0o600) await chmod(path, 0o600);
+	} catch (error) {
+		warnings.push(`Failed to enforce 0600 permissions for ${path}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+function cleanObject<T>(value: T): T {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const result: Record<string, unknown> = {};
+	for (const [key, item] of Object.entries(value)) {
+		if (item !== undefined) result[key] = item;
+	}
+	return result as T;
+}
+
+function splitArgs(rawArgs: string) {
+	return rawArgs.trim().split(/\s+/).filter(Boolean);
+}
+
+function formatPersistedTools(tools: readonly GoogleGenaiToolName[]) {
+	if (tools.length === GOOGLE_GENAI_TOOL_NAMES.length) return "all enabled";
+	if (tools.length === 0) return "all disabled";
+	return `${tools.length}/${GOOGLE_GENAI_TOOL_NAMES.length} selected: ${tools.join(", ")}`;
+}
+
+function isGoogleGenaiToolName(value: string): value is GoogleGenaiToolName {
+	return GOOGLE_GENAI_TOOL_NAMES.includes(value as GoogleGenaiToolName);
+}
+
+function makeTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): FetchSignal {
+	const controller = new AbortController();
+	let timedOut = false;
+	const abortFromParent = () => controller.abort(signal?.reason);
+	if (signal?.aborted) abortFromParent();
+	else signal?.addEventListener("abort", abortFromParent, { once: true });
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		controller.abort(new Error(`Timed out after ${timeoutMs}ms`));
+	}, timeoutMs);
+	return {
+		signal: controller.signal,
+		cleanup() {
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", abortFromParent);
+		},
+		isTimeout: () => timedOut,
+	};
+}
+
+function parseJsonResponse(text: string) {
+	if (!text) return {};
+	try {
+		return JSON.parse(text);
+	} catch {
+		return { text };
+	}
+}
+
+function errorMessage(payload: unknown) {
+	if (payload && typeof payload === "object") {
+		const error = (payload as { error?: { message?: unknown }; message?: unknown }).error;
+		if (typeof error?.message === "string") return error.message;
+		const message = (payload as { message?: unknown }).message;
+		if (typeof message === "string") return message;
+	}
+	return typeof payload === "string" ? payload : JSON.stringify(payload);
+}
+
+function extractOutputText(raw: unknown): string {
+	if (!raw || typeof raw !== "object") return "";
+	const object = raw as { output_text?: unknown; outputText?: unknown; steps?: unknown };
+	if (typeof object.output_text === "string") return object.output_text;
+	if (typeof object.outputText === "string") return object.outputText;
+	const lines: string[] = [];
+	for (const step of asArray(object.steps)) {
+		if (!isObject(step) || step.type !== "model_output") continue;
+		for (const block of asArray(step.content)) {
+			if (isObject(block) && block.type === "text" && typeof block.text === "string") {
+				lines.push(block.text);
+			}
+		}
+	}
+	return lines.join("\n");
+}
+
+function extractSources(raw: unknown): GoogleGenaiSource[] {
+	const sources: GoogleGenaiSource[] = [];
+	if (!raw || typeof raw !== "object") return sources;
+	const steps = asArray((raw as { steps?: unknown }).steps);
+
+	for (const step of steps) {
+		if (!isObject(step)) continue;
+		if (step.type === "model_output") {
+			for (const block of asArray(step.content)) {
+				if (!isObject(block)) continue;
+				for (const annotation of asArray(block.annotations)) addAnnotationSource(sources, annotation);
+			}
+		} else if (step.type === "google_maps_result") {
+			for (const result of asArray(step.result)) {
+				if (!isObject(result)) continue;
+				for (const place of asArray(result.places)) {
+					if (!isObject(place)) continue;
+					addSource(sources, {
+						type: "place",
+						name: stringValue(place.name),
+						url: stringValue(place.url),
+						placeId: stringValue(place.place_id),
+					});
+				}
+			}
+		} else if (step.type === "url_context_result") {
+			for (const result of asArray(step.result)) {
+				if (!isObject(result)) continue;
+				addSource(sources, {
+					type: "url_context",
+					url: stringValue(result.url),
+					status: stringValue(result.status),
+				});
+			}
+		}
+	}
+	return sources;
+}
+
+function addAnnotationSource(sources: GoogleGenaiSource[], annotation: unknown) {
+	if (!isObject(annotation) || typeof annotation.type !== "string") return;
+	if (annotation.type === "url_citation") {
+		addSource(sources, {
+			type: "url",
+			title: stringValue(annotation.title),
+			url: stringValue(annotation.url),
+		});
+	} else if (annotation.type === "place_citation") {
+		addSource(sources, {
+			type: "place",
+			name: stringValue(annotation.name),
+			url: stringValue(annotation.url),
+			placeId: stringValue(annotation.place_id),
+		});
+	} else if (annotation.type === "file_citation") {
+		addSource(sources, {
+			type: "file",
+			title: stringValue(annotation.file_name),
+			url: stringValue(annotation.document_uri),
+		});
+	}
+}
+
+function addSource(sources: GoogleGenaiSource[], source: GoogleGenaiSource) {
+	if (!source.url && !source.name && !source.title) return;
+	const key = `${source.type}\0${source.url ?? ""}\0${source.name ?? ""}\0${source.title ?? ""}`;
+	if (sources.some((existing) => `${existing.type}\0${existing.url ?? ""}\0${existing.name ?? ""}\0${existing.title ?? ""}` === key)) return;
+	sources.push(source);
+}
+
+function extractToolSteps(raw: unknown) {
+	if (!raw || typeof raw !== "object") return [];
+	return asArray((raw as { steps?: unknown }).steps)
+		.filter((step) => isObject(step) && step.type !== "model_output")
+		.map((step) => cleanObject(step));
+}
+
+function formatContent(outputText: string, sources: GoogleGenaiSource[]) {
+	if (sources.length === 0) return outputText;
+	return [outputText, "", formatSourcesSection(sources)].join("\n");
+}
+
+function formatSourcesSection(sources: GoogleGenaiSource[]) {
+	const visibleSources = sources.slice(0, SOURCE_LIMIT);
+	return [
+		"Sources:",
+		...visibleSources.map((source, index) => `${index + 1}. ${formatSource(source)}`),
+	].join("\n");
+}
+
+function formatSource(source: GoogleGenaiSource) {
+	const label = source.title ?? source.name ?? source.url ?? source.type;
+	const url = source.url && source.url !== label ? ` — ${source.url}` : "";
+	const status = source.status ? ` (${source.status})` : "";
+	return `${label}${url}${status}`;
+}
+
+async function writeRawResponse(raw: unknown) {
+	const directory = await mkdtemp(join(tmpdir(), "pi-google-genai-"));
+	const path = join(directory, "interaction.json");
+	await writeFile(path, `${JSON.stringify(raw, null, "\t")}\n`, { mode: 0o600 });
+	await chmod(path, 0o600);
+	return path;
+}
+
+function asArray(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown) {
+	return typeof value === "string" && value ? value : undefined;
+}
+
+async function withStatus<T>(ctx: ExtensionContext, status: string, fn: () => Promise<T>) {
+	ctx.ui.setStatus(STATUS_KEY, status);
+	try {
+		return await fn();
+	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
+}
+
+function helpText() {
+	return [
+		"Google GenAI commands:",
+		"/google-genai init - create or update config",
+		"/google-genai status|config - show config and auth status",
+		"/google-genai tools - select enabled Google GenAI tools",
+		"/google-genai enable - enable all Google GenAI tools",
+		"/google-genai disable - disable all Google GenAI tools",
+		"Auth: config apiKey, /login google, or GEMINI_API_KEY.",
+	].join("\n");
+}

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -179,6 +179,7 @@ const googleUrlContextTool = defineTool({
 		prompt: Type.String({ description: "Question or instruction for the provided URLs." }),
 		urls: Type.Array(Type.String({ description: "HTTP or HTTPS URL to fetch as context." }), {
 			description: "One or more http:// or https:// URLs.",
+			minItems: 1,
 		}),
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -742,7 +743,7 @@ function parseJsonResponse(text: string) {
 	try {
 		return JSON.parse(text);
 	} catch {
-		return { text };
+		return { message: text, output_text: text };
 	}
 }
 

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -38,7 +38,7 @@ const COMMAND_COMPLETIONS = [
 ];
 
 const SearchTypesParameter = Type.Optional(
-	Type.Array(Type.String({ description: "Search type: web_search or image_search." }), {
+	Type.Array(Type.Union([Type.Literal("web_search"), Type.Literal("image_search")]), {
 		description: "Optional Google Search grounding types. Defaults to Google's web search.",
 	}),
 );
@@ -104,6 +104,8 @@ interface FetchSignal {
 	cleanup(): void;
 	isTimeout(): boolean;
 }
+
+let rawResponsePathPromise: Promise<string> | undefined;
 
 const googleSearchTool = defineTool({
 	name: "google_search",
@@ -868,11 +870,18 @@ function formatSource(source: GoogleGenaiSource) {
 }
 
 async function writeRawResponse(raw: unknown) {
-	const directory = await mkdtemp(join(tmpdir(), "pi-google-genai-"));
-	const path = join(directory, "interaction.json");
+	const path = await rawResponsePath();
 	await writeFile(path, `${JSON.stringify(raw, null, "\t")}\n`, { mode: 0o600 });
 	await chmod(path, 0o600);
 	return path;
+}
+
+function rawResponsePath() {
+	rawResponsePathPromise ??= mkdtemp(join(tmpdir(), "pi-google-genai-")).then(async (directory) => {
+		await chmod(directory, 0o700);
+		return join(directory, "interaction.json");
+	});
+	return rawResponsePathPromise;
 }
 
 function asArray(value: unknown): unknown[] {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -106,7 +107,7 @@ interface FetchSignal {
 	isTimeout(): boolean;
 }
 
-let rawResponsePathPromise: Promise<string> | undefined;
+let rawResponseDirectoryPromise: Promise<string> | undefined;
 
 const googleSearchTool = defineTool({
 	name: "google_search",
@@ -592,7 +593,8 @@ function assertSafeApiUrl(apiUrl: string) {
 		throw new Error(`Google GenAI apiUrl must be a valid HTTPS URL: ${apiUrl}`);
 	}
 	const localHttp =
-		parsed.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
+		parsed.protocol === "http:" &&
+		["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname);
 	if (parsed.protocol !== "https:" && !localHttp) {
 		throw new Error(
 			`Google GenAI apiUrl must use https:// to protect the API key (http://localhost is allowed for local proxies): ${apiUrl}`,
@@ -876,23 +878,24 @@ function formatSource(source: GoogleGenaiSource) {
 }
 
 async function writeRawResponse(raw: unknown) {
-	const path = await rawResponsePath();
+	const directory = await rawResponseDirectory();
+	const path = join(directory, `interaction-${Date.now()}-${randomUUID()}.json`);
 	await writeFile(path, `${JSON.stringify(raw, null, "\t")}\n`, { mode: 0o600 });
 	await chmod(path, 0o600);
 	return path;
 }
 
-function rawResponsePath() {
-	rawResponsePathPromise ??= mkdtemp(join(tmpdir(), "pi-google-genai-"))
+function rawResponseDirectory() {
+	rawResponseDirectoryPromise ??= mkdtemp(join(tmpdir(), "pi-google-genai-"))
 		.then(async (directory) => {
 			await chmod(directory, 0o700);
-			return join(directory, "interaction.json");
+			return directory;
 		})
 		.catch((error) => {
-			rawResponsePathPromise = undefined;
+			rawResponseDirectoryPromise = undefined;
 			throw error;
 		});
-	return rawResponsePathPromise;
+	return rawResponseDirectoryPromise;
 }
 
 function asArray(value: unknown): unknown[] {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -877,10 +877,15 @@ async function writeRawResponse(raw: unknown) {
 }
 
 function rawResponsePath() {
-	rawResponsePathPromise ??= mkdtemp(join(tmpdir(), "pi-google-genai-")).then(async (directory) => {
-		await chmod(directory, 0o700);
-		return join(directory, "interaction.json");
-	});
+	rawResponsePathPromise ??= mkdtemp(join(tmpdir(), "pi-google-genai-"))
+		.then(async (directory) => {
+			await chmod(directory, 0o700);
+			return join(directory, "interaction.json");
+		})
+		.catch((error) => {
+			rawResponsePathPromise = undefined;
+			throw error;
+		});
 	return rawResponsePathPromise;
 }
 

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -7,6 +7,7 @@ import {
 	defineTool,
 	formatSize,
 	truncateHead,
+	truncateLine,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ExtensionContext,
@@ -260,8 +261,8 @@ export function normalizeGoogleGenaiSettings(value: unknown): GoogleGenaiConfig 
 export async function loadGoogleGenaiConfig(): Promise<LoadedGoogleGenaiConfig> {
 	const path = googleGenaiConfigPath();
 	const warnings: string[] = [];
+	await ensureConfigPermissions(path, warnings);
 	const raw = await readJsonIfExists(path, warnings);
-	if (raw !== undefined) await ensureConfigPermissions(path, warnings);
 	const normalized = normalizeConfigWithWarnings(raw);
 	return { config: normalized.config, path, warnings: [...warnings, ...normalized.warnings] };
 }
@@ -356,22 +357,26 @@ export async function formatToolResult(raw: unknown, model: string) {
 		truncated: truncation.truncated,
 	};
 
-	let content = truncation.content;
-	if (truncation.truncated) {
-		if (sources.length > 0 && !content.includes("\nSources:")) {
-			content += `\n\n${formatSourcesSection(sources)}`;
-		}
-		const fullResponsePath = await writeRawResponse(raw);
-		details.fullResponsePath = fullResponsePath;
-		details.truncation = {
-			truncatedBy: truncation.truncatedBy,
-			totalLines: truncation.totalLines,
-			totalBytes: truncation.totalBytes,
-			outputLines: truncation.outputLines,
-			outputBytes: truncation.outputBytes,
-		};
-		content += `\n\n[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full response saved to: ${fullResponsePath}]`;
+	if (!truncation.truncated) {
+		return { content: [{ type: "text" as const, text: truncation.content }], details };
 	}
+
+	const fullResponsePath = await writeRawResponse(raw);
+	details.fullResponsePath = fullResponsePath;
+	details.truncation = {
+		truncatedBy: truncation.truncatedBy,
+		totalLines: truncation.totalLines,
+		totalBytes: truncation.totalBytes,
+		outputLines: truncation.outputLines,
+		outputBytes: truncation.outputBytes,
+	};
+	const footer = `[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full response saved to: ${fullResponsePath}]`;
+	const suffix = joinBlocks([sources.length > 0 ? formatSourcesSection(sources) : "", footer]);
+	const truncatedOutput = truncateHead(outputText, {
+		maxLines: Math.max(0, DEFAULT_MAX_LINES - countLines(suffix) - 1),
+		maxBytes: Math.max(0, DEFAULT_MAX_BYTES - Buffer.byteLength(suffix, "utf8") - 2),
+	});
+	const content = joinBlocks([truncatedOutput.content, suffix]);
 
 	return { content: [{ type: "text" as const, text: content }], details };
 }
@@ -644,6 +649,7 @@ async function ensureConfigPermissions(path: string, warnings: string[]) {
 		const current = await stat(path);
 		if ((current.mode & 0o777) !== 0o600) await chmod(path, 0o600);
 	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
 		warnings.push(`Failed to enforce 0600 permissions for ${path}: ${error instanceof Error ? error.message : String(error)}`);
 	}
 }
@@ -805,16 +811,28 @@ function extractToolSteps(raw: unknown) {
 }
 
 function formatContent(outputText: string, sources: GoogleGenaiSource[]) {
-	if (sources.length === 0) return outputText;
-	return [outputText, "", formatSourcesSection(sources)].join("\n");
+	return joinBlocks([outputText, sources.length > 0 ? formatSourcesSection(sources) : ""]);
 }
 
 function formatSourcesSection(sources: GoogleGenaiSource[]) {
 	const visibleSources = sources.slice(0, SOURCE_LIMIT);
 	return [
 		"Sources:",
-		...visibleSources.map((source, index) => `${index + 1}. ${formatSource(source)}`),
+		...visibleSources.map((source, index) =>
+			truncateLine(`${index + 1}. ${formatSource(source)}`).text,
+		),
 	].join("\n");
+}
+
+function joinBlocks(blocks: string[]) {
+	return blocks.filter(Boolean).join("\n\n");
+}
+
+function countLines(content: string) {
+	if (!content) return 0;
+	const lines = content.split("\n");
+	if (content.endsWith("\n")) lines.pop();
+	return lines.length;
 }
 
 function formatSource(source: GoogleGenaiSource) {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -595,7 +595,7 @@ function assertSafeApiUrl(apiUrl: string) {
 	}
 	const localHttp =
 		parsed.protocol === "http:" &&
-		["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname);
+		["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
 	if (parsed.protocol !== "https:" && !localHttp) {
 		throw new Error(
 			`Google GenAI apiUrl must use https:// to protect the API key (http://localhost is allowed for local proxies): ${apiUrl}`,

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -84,18 +84,23 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 	});
 });
 
-test("config loading repairs permissions even when JSON is invalid", async () => {
+test("config loading repairs permissions and ignores invalid payloads", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		const path = join(agentDir, "google-genai.json");
 		await mkdir(agentDir, { recursive: true });
 		await writeFile(path, '{"apiKey":"secret"', { mode: 0o644 });
 		await chmod(path, 0o644);
 
-		const loaded = await loadGoogleGenaiConfig();
+		let loaded = await loadGoogleGenaiConfig();
 
 		assert.match(loaded.warnings.join("\n"), /Failed to read/);
 		assert.equal(loaded.configLoaded, false);
 		assert.equal((await stat(path)).mode & 0o777, 0o600);
+
+		await writeConfig(null);
+		loaded = await loadGoogleGenaiConfig();
+		assert.equal(loaded.configLoaded, false);
+		assert.match(loaded.warnings.join("\n"), /must contain a JSON object/);
 	});
 });
 
@@ -184,6 +189,11 @@ test("tools reject insecure apiUrl before sending the API key", async () => {
 			await assert.rejects(
 				() => executeTool(mock.tools[0], "call-insecure", { query: "bad" }, ctx),
 				/must use https:\/\//,
+			);
+			await writeConfig({ apiUrl: "not a url" });
+			await assert.rejects(
+				() => executeTool(mock.tools[0], "call-invalid-url", { query: "bad" }, ctx),
+				/must be a valid URL/,
 			);
 			assert.equal(fetchCalls, 0);
 		} finally {
@@ -432,13 +442,21 @@ test("status reports unsupported config apiKey interpolation as invalid", async 
 	});
 });
 
-test("session_start preserves active tools when config is missing", async () => {
+test("session_start preserves active tools when config is missing or invalid", async () => {
 	await withTempAgentDir(async () => {
-		const mock = createMockPi({ activeTools: ["read"] });
+		let mock = createMockPi({ activeTools: ["read"] });
 		googleGenai(mock.pi);
-		const { ctx } = createMockContext();
-		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		let context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+
+		await writeConfig(null);
+		mock = createMockPi({ activeTools: ["read"] });
+		googleGenai(mock.pi);
+		context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+		assert.match(context.notifications[0].message, /must contain a JSON object/);
 	});
 });
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -161,6 +161,32 @@ test("tools send expected interaction requests and format sources", async () => 
 	});
 });
 
+test("tools reject insecure apiUrl before sending the API key", async () => {
+	await withTempAgentDir(async () => {
+		await writeConfig({ apiUrl: "http://example.test/interactions" });
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const previous = globalThis.fetch;
+		let fetchCalls = 0;
+		globalThis.fetch = (async () => {
+			fetchCalls += 1;
+			return new Response("{}");
+		}) as typeof fetch;
+		try {
+			await assert.rejects(
+				() => executeTool(mock.tools[0], "call-insecure", { query: "bad" }, ctx),
+				/must use https:\/\//,
+			);
+			assert.equal(fetchCalls, 0);
+		} finally {
+			globalThis.fetch = previous;
+		}
+	});
+});
+
 test("tool requests report HTTP errors and time out", async () => {
 	await withTempAgentDir(async () => {
 		await writeConfig({ timeoutMs: 1 });
@@ -333,6 +359,31 @@ test("commands init, status, and tool selection merge config and preserve unrela
 		await command.handler("status", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /auth: config apiKey/);
 		assert.match(buildStatusMessage(await loadGoogleGenaiConfig(), "config apiKey"), /apiUrl:/);
+	});
+});
+
+test("status reports unsupported config apiKey interpolation as invalid", async () => {
+	await withTempAgentDir(async () => {
+		await writeConfig({ apiKey: "$GEMINI_API_KEY" });
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const command = mock.commands.get("google-genai");
+		assert.ok(command);
+		const notifications: Array<{ message: string; level?: string }> = [];
+		await command.handler("status", {
+			hasUI: true,
+			ui: {
+				notify(message: string, level?: string) {
+					notifications.push({ message, level });
+				},
+				setStatus() {},
+			},
+			modelRegistry: { getProviderAuthStatus: () => ({ configured: true, source: "env" }) },
+		});
+
+		const message = notifications.at(-1)?.message ?? "";
+		assert.match(message, /auth: invalid config apiKey/);
+		assert.doesNotMatch(message, /auth: config apiKey/);
 	});
 });
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -52,7 +52,8 @@ test("command parser and completions cover google-genai subcommands", () => {
 test("config loading defaults, normalizes tools, and rejects interpolation", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		assert.equal(googleGenaiConfigPath(), join(agentDir, "google-genai.json"));
-		assert.deepEqual(await loadGoogleGenaiConfig(), {
+		const missingConfig = await loadGoogleGenaiConfig();
+		assert.deepEqual(missingConfig, {
 			config: {
 				model: DEFAULT_MODEL,
 				apiUrl: DEFAULT_API_URL,
@@ -63,6 +64,9 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 			warnings: [],
 			configLoaded: false,
 		});
+		const missingStatus = buildStatusMessage(missingConfig, "missing");
+		assert.match(missingStatus, /configLoaded: no/);
+		assert.match(missingStatus, /persisted tools: none/);
 
 		await writeConfig({
 			apiKey: "$GEMINI_API_KEY",

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -338,6 +338,23 @@ test("formatToolResult limits sources, truncates content, and writes raw respons
 	});
 });
 
+test("session_shutdown removes truncated raw response temp directory", async () => {
+	await withTempAgentDir(async () => {
+		const result = await formatToolResult({ output_text: "x".repeat(60_000) }, "gemini-test");
+		const fullResponsePath = result.details.fullResponsePath;
+		assert.ok(fullResponsePath);
+		const directory = dirname(fullResponsePath);
+		assert.equal((await stat(directory)).mode & 0o777, 0o700);
+
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext();
+		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+
+		await assert.rejects(() => stat(directory), { code: "ENOENT" });
+	});
+});
+
 test("commands init, status, and tool selection merge config and preserve unrelated tools", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		await writeConfig({ apiKey: "old-key", model: "old-model", tools: ["google_search"] });

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -60,6 +60,7 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 			},
 			path: join(agentDir, "google-genai.json"),
 			warnings: [],
+			configLoaded: false,
 		});
 
 		await writeConfig({
@@ -74,6 +75,7 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 		assert.equal(loaded.config.model, "custom-model");
 		assert.equal(loaded.config.apiUrl, "https://proxy.test/interactions");
 		assert.equal(loaded.config.timeoutMs, 12);
+		assert.equal(loaded.configLoaded, true);
 		assert.match(loaded.warnings.join("\n"), /unknown/);
 		await assert.rejects(
 			() => resolveGoogleGenaiAuth(loaded.config, authContext()),
@@ -92,6 +94,7 @@ test("config loading repairs permissions even when JSON is invalid", async () =>
 		const loaded = await loadGoogleGenaiConfig();
 
 		assert.match(loaded.warnings.join("\n"), /Failed to read/);
+		assert.equal(loaded.configLoaded, false);
 		assert.equal((await stat(path)).mode & 0o777, 0o600);
 	});
 });
@@ -390,6 +393,16 @@ test("status reports unsupported config apiKey interpolation as invalid", async 
 		const message = notifications.at(-1)?.message ?? "";
 		assert.match(message, /auth: invalid config apiKey/);
 		assert.doesNotMatch(message, /auth: config apiKey/);
+	});
+});
+
+test("session_start preserves active tools when config is missing", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["read"] });
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
 	});
 });
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -31,6 +31,8 @@ test("google-genai registers three tools, command, and session hooks", () => {
 		["google_search", "google_maps", "google_url_context"],
 	);
 	assert.ok(mock.commands.has("google-genai"));
+	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"web_search"/);
+	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"image_search"/);
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
 });
 
@@ -307,6 +309,10 @@ test("formatToolResult limits sources, truncates content, and writes raw respons
 		assert.ok(result.details.fullResponsePath);
 		assert.equal((await stat(result.details.fullResponsePath)).mode & 0o777, 0o600);
 		assert.match(await readFile(result.details.fullResponsePath, "utf8"), /output_text/);
+		assert.equal(
+			(await formatToolResult(raw, "gemini-test")).details.fullResponsePath,
+			result.details.fullResponsePath,
+		);
 	});
 });
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -439,7 +439,7 @@ async function executeTool(
 
 async function withTempAgentDir(fn: (agentDir: string) => Promise<void>) {
 	const previous = process.env.PI_CODING_AGENT_DIR;
-	const agentDir = join(tmpdir(), `pi-google-genai-test-${Date.now()}-${Math.random()}`);
+	const agentDir = await mkdtemp(join(tmpdir(), "pi-google-genai-test-"));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	try {
 		await fn(agentDir);

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -33,6 +33,7 @@ test("google-genai registers three tools, command, and session hooks", () => {
 	assert.ok(mock.commands.has("google-genai"));
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"web_search"/);
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"image_search"/);
+	assert.match(JSON.stringify(mock.tools[2].parameters), /"minItems":1/);
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
 });
 
@@ -168,6 +169,29 @@ test("tools send expected interaction requests and format sources", async () => 
 			assert.match(result.content[0].text, /Sources:/);
 			assert.equal(result.details.sources[0].url, "https://example.test/euro");
 		});
+	});
+});
+
+test("tools surface successful non-JSON responses instead of dropping the body", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const previous = globalThis.fetch;
+		globalThis.fetch = (async () =>
+			new Response("plain text response", {
+				status: 200,
+				headers: { "content-type": "text/plain" },
+			})) as typeof fetch;
+		try {
+			const result = await executeTool(mock.tools[0], "call-text", { query: "text" }, ctx);
+			assert.equal(result.content[0].text, "plain text response");
+			assert.equal(result.details.outputText, "plain text response");
+		} finally {
+			globalThis.fetch = previous;
+		}
 	});
 });
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
@@ -192,6 +192,22 @@ test("tools reject insecure apiUrl before sending the API key", async () => {
 	});
 });
 
+test("tools allow local http apiUrl for proxies", async () => {
+	await withTempAgentDir(async () => {
+		await writeConfig({ apiUrl: "http://[::1]:1234/interactions" });
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const fetchCalls: Array<{ url: string; init: RequestInit & { body?: string } }> = [];
+		await withMockFetch(fetchCalls, async () => {
+			await executeTool(mock.tools[0], "call-local", { query: "ok" }, ctx);
+			assert.equal(fetchCalls[0].url, "http://[::1]:1234/interactions");
+		});
+	});
+});
+
 test("tool requests report HTTP errors and time out", async () => {
 	await withTempAgentDir(async () => {
 		await writeConfig({ timeoutMs: 1 });
@@ -312,9 +328,12 @@ test("formatToolResult limits sources, truncates content, and writes raw respons
 		assert.ok(result.details.fullResponsePath);
 		assert.equal((await stat(result.details.fullResponsePath)).mode & 0o777, 0o600);
 		assert.match(await readFile(result.details.fullResponsePath, "utf8"), /output_text/);
+		const second = await formatToolResult(raw, "gemini-test");
+		assert.ok(second.details.fullResponsePath);
+		assert.notEqual(second.details.fullResponsePath, result.details.fullResponsePath);
 		assert.equal(
-			(await formatToolResult(raw, "gemini-test")).details.fullResponsePath,
-			result.details.fullResponsePath,
+			dirname(second.details.fullResponsePath),
+			dirname(result.details.fullResponsePath),
 		);
 	});
 });

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+import { readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import googleGenai, {
+	buildStatusMessage,
+	commandCompletions,
+	DEFAULT_API_URL,
+	DEFAULT_MODEL,
+	formatToolResult,
+	GOOGLE_GENAI_TOOL_NAMES,
+	googleGenaiConfigPath,
+	loadGoogleGenaiConfig,
+	normalizeGoogleGenaiSettings,
+	parseCommand,
+	resolveGoogleGenaiAuth,
+	validateMapsLocation,
+	validateSearchTypes,
+	validateUrls,
+} from "../src/google-genai.js";
+
+test("google-genai registers three tools, command, and session hooks", () => {
+	const mock = createMockPi();
+	googleGenai(mock.pi);
+
+	assert.deepEqual(
+		mock.tools.map((tool) => tool.name),
+		["google_search", "google_maps", "google_url_context"],
+	);
+	assert.ok(mock.commands.has("google-genai"));
+	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+});
+
+test("command parser and completions cover google-genai subcommands", () => {
+	assert.equal(parseCommand(""), "status");
+	assert.equal(parseCommand("config"), "status");
+	assert.equal(parseCommand("on"), "enable");
+	assert.equal(parseCommand("off"), "disable");
+	assert.equal(parseCommand("wat"), "unknown");
+	assert.deepEqual(commandCompletions("to"), [
+		{ value: "tools", label: "tools", description: "Select Google GenAI tools" },
+	]);
+	assert.equal(commandCompletions("tools now"), null);
+});
+
+test("config loading defaults, normalizes tools, and rejects interpolation", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		assert.equal(googleGenaiConfigPath(), join(agentDir, "google-genai.json"));
+		assert.deepEqual(await loadGoogleGenaiConfig(), {
+			config: {
+				model: DEFAULT_MODEL,
+				apiUrl: DEFAULT_API_URL,
+				timeoutMs: 30000,
+				tools: [...GOOGLE_GENAI_TOOL_NAMES],
+			},
+			path: join(agentDir, "google-genai.json"),
+			warnings: [],
+		});
+
+		await writeConfig({
+			apiKey: "$GEMINI_API_KEY",
+			model: "custom-model",
+			apiUrl: "https://proxy.test/interactions",
+			timeoutMs: 12,
+			tools: ["google_maps", "unknown", "google_search", "google_maps"],
+		});
+		const loaded = await loadGoogleGenaiConfig();
+		assert.deepEqual(loaded.config.tools, ["google_search", "google_maps"]);
+		assert.equal(loaded.config.model, "custom-model");
+		assert.equal(loaded.config.apiUrl, "https://proxy.test/interactions");
+		assert.equal(loaded.config.timeoutMs, 12);
+		assert.match(loaded.warnings.join("\n"), /unknown/);
+		await assert.rejects(
+			() => resolveGoogleGenaiAuth(loaded.config, authContext()),
+			/Interpolation/,
+		);
+	});
+});
+
+test("auth uses config apiKey before Pi google auth", async () => {
+	assert.equal(
+		await resolveGoogleGenaiAuth({ apiKey: "config-key" }, authContext("pi-key")),
+		"config-key",
+	);
+	assert.equal(await resolveGoogleGenaiAuth({}, authContext("pi-key")), "pi-key");
+	await assert.rejects(
+		() => resolveGoogleGenaiAuth({}, authContext(undefined)),
+		/Missing Google GenAI API key/,
+	);
+});
+
+test("validators enforce search types, map coordinate pairs, and URL schemes", () => {
+	assert.deepEqual(validateSearchTypes(undefined), undefined);
+	assert.deepEqual(validateSearchTypes(["web_search", "image_search"]), [
+		"web_search",
+		"image_search",
+	]);
+	assert.throws(() => validateSearchTypes(["enterprise_web_search"]), /searchTypes/);
+	assert.deepEqual(validateMapsLocation({}), {});
+	assert.deepEqual(validateMapsLocation({ latitude: 34.05, longitude: -118.24 }), {
+		latitude: 34.05,
+		longitude: -118.24,
+	});
+	assert.throws(() => validateMapsLocation({ latitude: 34 }), /latitude and longitude/);
+	assert.throws(() => validateMapsLocation({ latitude: 91, longitude: 1 }), /latitude/);
+	assert.throws(() => validateMapsLocation({ latitude: 1, longitude: 181 }), /longitude/);
+	assert.deepEqual(validateUrls(["https://example.com", "http://example.com"]), [
+		"https://example.com",
+		"http://example.com",
+	]);
+	assert.throws(() => validateUrls(["file:///etc/passwd"]), /http/);
+});
+
+test("tools send expected interaction requests and format sources", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["read"] });
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const fetchCalls: Array<{ url: string; init: RequestInit & { body?: string } }> = [];
+		await withMockFetch(fetchCalls, async () => {
+			const result = await executeTool(
+				mock.tools[0],
+				"call-1",
+				{
+					query: "Who won Euro 2024?",
+					searchTypes: ["image_search"],
+				},
+				ctx,
+			);
+
+			assert.equal(fetchCalls[0].url, DEFAULT_API_URL);
+			assert.equal(new Headers(fetchCalls[0].init.headers).get("x-goog-api-key"), "test-key");
+			assert.deepEqual(JSON.parse(fetchCalls[0].init.body ?? "{}"), {
+				model: DEFAULT_MODEL,
+				input: "Who won Euro 2024?",
+				tools: [{ type: "google_search", search_types: ["image_search"] }],
+			});
+			assert.match(result.content[0].text, /Spain won/);
+			assert.match(result.content[0].text, /Sources:/);
+			assert.equal(result.details.sources[0].url, "https://example.test/euro");
+		});
+	});
+});
+
+test("tool requests report HTTP errors and time out", async () => {
+	await withTempAgentDir(async () => {
+		await writeConfig({ timeoutMs: 1 });
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const previous = globalThis.fetch;
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ error: { message: "bad request" } }), {
+				status: 400,
+			})) as typeof fetch;
+		try {
+			await assert.rejects(
+				() => executeTool(mock.tools[0], "call-http", { query: "bad" }, ctx),
+				/bad request/,
+			);
+
+			globalThis.fetch = (async (_url: string, init: RequestInit) => {
+				await new Promise((_resolve, reject) => {
+					init.signal?.addEventListener("abort", () => reject(new Error("aborted by timeout")), {
+						once: true,
+					});
+				});
+				throw new Error("unreachable");
+			}) as typeof fetch;
+			await assert.rejects(
+				() => executeTool(mock.tools[0], "call-timeout", { query: "slow" }, ctx),
+				/timed out/,
+			);
+		} finally {
+			globalThis.fetch = previous;
+		}
+	});
+});
+
+test("maps and url-context tools validate inputs and request shapes", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const fetchCalls: Array<{ url: string; init: RequestInit & { body?: string } }> = [];
+		await withMockFetch(fetchCalls, async () => {
+			const maps = await executeTool(
+				mock.tools[1],
+				"call-2",
+				{ query: "Italian nearby", latitude: 34.050481, longitude: -118.248526 },
+				ctx,
+			);
+			assert.deepEqual(JSON.parse(fetchCalls[0].init.body ?? "{}").tools, [
+				{ type: "google_maps", latitude: 34.050481, longitude: -118.248526 },
+			]);
+			assert.equal(maps.details.sources[1].type, "place");
+
+			await assert.rejects(
+				() => executeTool(mock.tools[1], "call-3", { query: "bad", latitude: 1 }, ctx),
+				/latitude and longitude/,
+			);
+
+			await executeTool(
+				mock.tools[2],
+				"call-4",
+				{ prompt: "Summarize", urls: ["https://example.test/doc"] },
+				ctx,
+			);
+			assert.deepEqual(JSON.parse(fetchCalls[1].init.body ?? "{}"), {
+				model: DEFAULT_MODEL,
+				input: "Summarize\n\nURLs:\nhttps://example.test/doc",
+				tools: [{ type: "url_context" }],
+			});
+			await assert.rejects(
+				() =>
+					executeTool(
+						mock.tools[2],
+						"call-5",
+						{ prompt: "Summarize", urls: ["ftp://example.test/doc"] },
+						ctx,
+					),
+				/http/,
+			);
+		});
+	});
+});
+
+test("formatToolResult limits sources, truncates content, and writes raw response only when truncated", async () => {
+	await withTempAgentDir(async () => {
+		const raw = {
+			output_text: `${"x".repeat(60_000)}`,
+			steps: [
+				{
+					type: "model_output",
+					content: Array.from({ length: 12 }, (_, index) => ({
+						type: "text",
+						text: "x",
+						annotations: [
+							{
+								type: "url_citation",
+								title: `Source ${index}`,
+								url: `https://example.test/${index}`,
+							},
+						],
+					})),
+				},
+			],
+		};
+
+		const result = await formatToolResult(raw, "gemini-test");
+		const text = result.content[0].text;
+		assert.match(text, /Output truncated/);
+		assert.equal((text.match(/^\d+\./gm) ?? []).length, 10);
+		assert.equal(result.details.sources.length, 12);
+		assert.equal("rawInteraction" in result.details, false);
+		assert.ok(result.details.fullResponsePath);
+		assert.equal((await stat(result.details.fullResponsePath)).mode & 0o777, 0o600);
+		assert.match(await readFile(result.details.fullResponsePath, "utf8"), /output_text/);
+	});
+});
+
+test("commands init, status, and tool selection merge config and preserve unrelated tools", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		await writeConfig({ apiKey: "old-key", model: "old-model", tools: ["google_search"] });
+		const mock = createMockPi({ activeTools: ["read", "google_search"] });
+		googleGenai(mock.pi);
+		const command = mock.commands.get("google-genai");
+		assert.ok(command);
+		const inputs = ["", "new-model"];
+		const selections = ["[x] google_search", "Done"];
+		const notifications: Array<{ message: string; level?: string }> = [];
+		const ctx = {
+			hasUI: true,
+			ui: {
+				notify(message: string, level?: string) {
+					notifications.push({ message, level });
+				},
+				input: async () => inputs.shift(),
+				select: async () => selections.shift() ?? "Done",
+				setStatus() {},
+			},
+			modelRegistry: { getApiKeyForProvider: async () => "pi-key" },
+		};
+
+		await command.handler("init", ctx);
+		const config = JSON.parse(await readFile(join(agentDir, "google-genai.json"), "utf8"));
+		assert.equal(config.apiKey, "old-key");
+		assert.equal(config.model, "new-model");
+		assert.deepEqual(config.tools, ["google_search"]);
+		assert.equal((await stat(join(agentDir, "google-genai.json"))).mode & 0o777, 0o600);
+
+		await command.handler("tools", ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+		assert.deepEqual(
+			JSON.parse(await readFile(join(agentDir, "google-genai.json"), "utf8")).tools,
+			[],
+		);
+
+		await command.handler("enable", ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"read",
+			"google_search",
+			"google_maps",
+			"google_url_context",
+		]);
+		await command.handler("disable", ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+		await command.handler("status", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /auth: config apiKey/);
+		assert.match(buildStatusMessage(await loadGoogleGenaiConfig(), "config apiKey"), /apiUrl:/);
+	});
+});
+
+test("session_start restores persisted tool selection and ignores unknown names", async () => {
+	await withTempAgentDir(async () => {
+		await writeConfig({ tools: ["google_maps", "bad"] });
+		const mock = createMockPi({ activeTools: ["read", ...GOOGLE_GENAI_TOOL_NAMES] });
+		googleGenai(mock.pi);
+		const { ctx, notifications } = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "google_maps"]);
+		assert.match(notifications[0].message, /unknown/);
+	});
+});
+
+test("normalize settings defaults missing tools to all enabled and allows empty selection", () => {
+	assert.deepEqual(normalizeGoogleGenaiSettings({}), {
+		model: DEFAULT_MODEL,
+		apiUrl: DEFAULT_API_URL,
+		timeoutMs: 30000,
+		tools: [...GOOGLE_GENAI_TOOL_NAMES],
+	});
+	assert.deepEqual(normalizeGoogleGenaiSettings({ tools: [] }).tools, []);
+});
+
+interface TestToolDetails extends Record<string, unknown> {
+	sources: Array<{ type?: string; url?: string }>;
+	fullResponsePath?: string;
+}
+
+type ToolExecute = (
+	toolCallId: string,
+	params: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+	onUpdate: undefined,
+	ctx: unknown,
+) => Promise<{ content: Array<{ type: "text"; text: string }>; details: TestToolDetails }>;
+
+async function executeTool(
+	tool: { [key: string]: unknown },
+	toolCallId: string,
+	params: Record<string, unknown>,
+	ctx: unknown,
+) {
+	return (tool.execute as ToolExecute)(toolCallId, params, undefined, undefined, ctx);
+}
+
+async function withTempAgentDir(fn: (agentDir: string) => Promise<void>) {
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = join(tmpdir(), `pi-google-genai-test-${Date.now()}-${Math.random()}`);
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		await fn(agentDir);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+}
+
+async function writeConfig(value: unknown) {
+	const agentDir = process.env.PI_CODING_AGENT_DIR;
+	assert.ok(agentDir);
+	await import("node:fs/promises").then(async (fs) => {
+		await fs.mkdir(agentDir, { recursive: true });
+		await fs.writeFile(join(agentDir, "google-genai.json"), JSON.stringify(value, null, "\t"));
+	});
+}
+
+function authContext(apiKey?: string) {
+	return {
+		modelRegistry: {
+			getApiKeyForProvider: async () => apiKey,
+		},
+	} as never;
+}
+
+async function withMockFetch(
+	calls: Array<{ url: string; init: RequestInit & { body?: string } }>,
+	fn: () => Promise<void>,
+) {
+	const previous = globalThis.fetch;
+	globalThis.fetch = (async (url: string, init: RequestInit & { body?: string }) => {
+		calls.push({ url, init });
+		return new Response(
+			JSON.stringify({
+				output_text: "Spain won UEFA Euro 2024.",
+				steps: [
+					{
+						type: "model_output",
+						content: [
+							{
+								type: "text",
+								text: "Spain won UEFA Euro 2024.",
+								annotations: [
+									{
+										type: "url_citation",
+										title: "Euro 2024 final",
+										url: "https://example.test/euro",
+									},
+								],
+							},
+						],
+					},
+					{
+						type: "google_maps_result",
+						result: [{ places: [{ name: "Place", url: "https://maps.example/place" }] }],
+					},
+					{
+						type: "url_context_result",
+						result: [{ url: "https://example.test/doc", status: "success" }],
+					},
+				],
+			}),
+			{ status: 200, headers: { "content-type": "application/json" } },
+		);
+	}) as typeof fetch;
+	try {
+		await fn();
+	} finally {
+		globalThis.fetch = previous;
+	}
+}

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { readFile, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import googleGenai, {
 	buildStatusMessage,
@@ -76,6 +77,20 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 			() => resolveGoogleGenaiAuth(loaded.config, authContext()),
 			/Interpolation/,
 		);
+	});
+});
+
+test("config loading repairs permissions even when JSON is invalid", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		const path = join(agentDir, "google-genai.json");
+		await mkdir(agentDir, { recursive: true });
+		await writeFile(path, '{"apiKey":"secret"', { mode: 0o644 });
+		await chmod(path, 0o644);
+
+		const loaded = await loadGoogleGenaiConfig();
+
+		assert.match(loaded.warnings.join("\n"), /Failed to read/);
+		assert.equal((await stat(path)).mode & 0o777, 0o600);
 	});
 });
 
@@ -258,6 +273,8 @@ test("formatToolResult limits sources, truncates content, and writes raw respons
 		const result = await formatToolResult(raw, "gemini-test");
 		const text = result.content[0].text;
 		assert.match(text, /Output truncated/);
+		assert.ok(countLines(text) <= DEFAULT_MAX_LINES);
+		assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
 		assert.equal((text.match(/^\d+\./gm) ?? []).length, 10);
 		assert.equal(result.details.sources.length, 12);
 		assert.equal("rawInteraction" in result.details, false);
@@ -374,6 +391,13 @@ async function withTempAgentDir(fn: (agentDir: string) => Promise<void>) {
 		else process.env.PI_CODING_AGENT_DIR = previous;
 		await rm(agentDir, { recursive: true, force: true });
 	}
+}
+
+function countLines(content: string) {
+	if (!content) return 0;
+	const lines = content.split("\n");
+	if (content.endsWith("\n")) lines.pop();
+	return lines.length;
 }
 
 async function writeConfig(value: unknown) {

--- a/extensions/pi-google-genai/tsconfig.json
+++ b/extensions/pi-google-genai/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -91,6 +91,9 @@ pack-firecrawl:
 pack-github-pr:
     just pack github-pr
 
+pack-google-genai:
+    just pack google-genai
+
 pack-goal:
     just pack goal
 
@@ -136,6 +139,9 @@ try-firecrawl:
 
 try-github-pr:
     just try github-pr
+
+try-google-genai:
+    just try google-genai
 
 try-goal:
     just try goal
@@ -183,6 +189,9 @@ install-firecrawl:
 install-github-pr:
     just install github-pr
 
+install-google-genai:
+    just install google-genai
+
 install-goal:
     just install goal
 
@@ -228,6 +237,9 @@ publish-firecrawl:
 
 publish-github-pr:
     just publish github-pr
+
+publish-google-genai:
+    just publish google-genai
 
 publish-goal:
     just publish goal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,7 +1465,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,20 @@
 				"typescript": "6.0.3"
 			}
 		},
+		"extensions/pi-google-genai": {
+			"name": "@narumitw/pi-google-genai",
+			"version": "0.10.0",
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "^1.3.3"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.2",
+				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/node": "26.1.0",
+				"typescript": "6.0.3"
+			}
+		},
 		"extensions/pi-lsp": {
 			"name": "@narumitw/pi-lsp",
 			"version": "0.10.0",
@@ -2966,6 +2980,10 @@
 		},
 		"node_modules/@narumitw/pi-goal": {
 			"resolved": "extensions/pi-goal",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-google-genai": {
+			"resolved": "extensions/pi-google-genai",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-lsp": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"pack:codex-usage": "npm --workspace @narumitw/pi-codex-usage pack --dry-run",
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:github-pr": "npm --workspace @narumitw/pi-github-pr pack --dry-run",
+		"pack:google-genai": "npm --workspace @narumitw/pi-google-genai pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
 		"pack:lsp": "npm --workspace @narumitw/pi-lsp pack --dry-run",
 		"pack:plan-mode": "npm --workspace @narumitw/pi-plan-mode pack --dry-run",


### PR DESCRIPTION
## Summary
- add @narumitw/pi-google-genai with google_search, google_maps, and google_url_context tools
- add config/auth handling, command modes, tool selection persistence, response formatting, and mocked-fetch tests
- wire package scripts/just recipes and document install/config/smoke tests

## Verification
- npm run check
- just pack-google-genai