### PR TITLE
docs: add Google GenAI to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm scope](https://img.shields.io/badge/npm-@narumitw-blue)](https://www.npmjs.com/org/narumitw) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Production-ready, independently installable [Pi](https://pi.dev) extension packages for the Pi coding agent. This monorepo provides native Pi tools and commands for configurable LSP diagnostics and source fixes, Chrome DevTools automation, Codex account switching and usage status, Firecrawl web scraping, GitHub PR status, goal-driven task completion, read-only plan mode, pause-and-explain interruptions, retry handling, R2/S3 settings sync, terminal statuslines, delegated subagents, and keep-awake automation.
+Production-ready, independently installable [Pi](https://pi.dev) extension packages for the Pi coding agent. This monorepo provides native Pi tools and commands for configurable LSP diagnostics and source fixes, Chrome DevTools automation, Codex account switching and usage status, Firecrawl web scraping, Google GenAI grounding, GitHub PR status, goal-driven task completion, read-only plan mode, pause-and-explain interruptions, retry handling, R2/S3 settings sync, terminal statuslines, delegated subagents, and keep-awake automation.
 
 ## 📦 Pi extension packages
 
@@ -18,6 +18,7 @@ Install only the Pi extensions you need. Each package is published under the `@n
 | [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) | 🔥 Firecrawl-powered web scraping, crawling, URL discovery, and web search tools for research workflows. | `pi install npm:@narumitw/pi-firecrawl` |
 | [`@narumitw/pi-github-pr`](./extensions/pi-github-pr) | 🔎 Passive current-branch GitHub PR checks, review, and comment counts in the statusline. | `pi install npm:@narumitw/pi-github-pr` |
 | [`@narumitw/pi-goal`](./extensions/pi-goal) | 🎯 `/goal` mode that keeps the agent working until a verifiable task is complete. | `pi install npm:@narumitw/pi-goal` |
+| [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) | 🔎 Google GenAI Interactions grounding tools for Google Search, Maps, and URL context. | `pi install npm:@narumitw/pi-google-genai` |
 | [`@narumitw/pi-lsp`](./extensions/pi-lsp) | 🧠 Configurable language-server diagnostics and source-fix tools routed by file extension. | `pi install npm:@narumitw/pi-lsp` |
 | [`@narumitw/pi-plan-mode`](./extensions/pi-plan-mode) | 🧭 Codex-like read-only `/plan` collaboration mode with safe exploration and implementation-ready plans. | `pi install npm:@narumitw/pi-plan-mode` |
 | [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for provider responses that fail with `Unknown error (no error details in response)`. | `pi install npm:@narumitw/pi-retry` |
@@ -64,6 +65,10 @@ Use [`@narumitw/pi-chrome-devtools`](./extensions/pi-chrome-devtools) when you w
 ### 🔎 Web scraping, crawling, and research
 
 Use [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) to give Pi native Firecrawl tools for scraping markdown or HTML, mapping URLs, crawling websites, and searching the web from inside an agent workflow.
+
+### 🔎 Google GenAI grounding
+
+Use [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) to give Pi Google Search, Google Maps, and URL-context grounding through Gemini Interactions with Pi Google auth or a private `google-genai.json` key.
 
 ### 🔐 Codex subscription accounts
 
@@ -130,6 +135,7 @@ pi -e ./extensions/pi-codex-usage
 pi -e ./extensions/pi-firecrawl
 pi -e ./extensions/pi-github-pr
 pi -e ./extensions/pi-goal
+pi -e ./extensions/pi-google-genai
 pi -e ./extensions/pi-lsp
 pi -e ./extensions/pi-plan-mode
 pi -e ./extensions/pi-retry
@@ -150,6 +156,7 @@ npm run pack:codex-usage
 npm run pack:firecrawl
 npm run pack:github-pr
 npm run pack:goal
+npm run pack:google-genai
 npm run pack:lsp
 npm run pack:plan-mode
 npm run pack:retry
@@ -183,6 +190,7 @@ extensions/
 ├── pi-firecrawl/
 ├── pi-github-pr/
 ├── pi-goal/
+├── pi-google-genai/
 ├── pi-lsp/
 ├── pi-plan-mode/
 ├── pi-retry/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) to give Pi native Fire
 
 ### 🔎 Google GenAI grounding
 
-Use [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) to give Pi Google Search, Google Maps, and URL-context grounding through Gemini Interactions with Pi Google auth or a private `google-genai.json` key.
+Use [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) to give Pi Google Search, Google Maps, and URL-context grounding through Gemini Interactions with Pi Google auth or a private `google-genai.json` config.
 
 ### 🔐 Codex subscription accounts
 


### PR DESCRIPTION
## Summary
- add @narumitw/pi-google-genai to the root package table
- add Google GenAI grounding use case, local try command, pack command, and tree entry

## Verification
- npm run biome:check
- commit hook: npm typecheck