### PR TITLE
fix(google-genai): guide broad search timeout recovery

### DIFF
--- a/docs/plans/archived/2026-07-05_google-genai-broad-search-timeout-plan.md
+++ b/docs/plans/archived/2026-07-05_google-genai-broad-search-timeout-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Make `pi-google-genai` recover better when Google Search grounding receives an overly broad query. Success means the model is guided to split market-research-style searches, timeout errors explain the likely cause and next step, and the README documents a small-query workflow.
+
+## Context
+
+`google_search` currently sends `query` to the Gemini Interactions API as-is with a default `timeoutMs` of 30 seconds. A query like `2026 AI coding assistant product trends agentic coding IDE local first developer tools web UI Cursor Claude Code GitHub Copilot` mixes trends, product comparison, feature areas, and current-year synthesis, so it can time out. The current timeout error only says the request timed out; it does not tell the user this may be a too-broad query rather than auth failure, sensitive content, or a broken tool.
+
+## Non-Goals
+
+- Do not add an automatic query planner or multi-search orchestration; that adds cost, latency, and source-selection complexity.
+- Do not raise the default `timeoutMs` as the main fix; narrower queries are cheaper and more reliable.
+- Do not add `@google/genai` or any new dependency.
+
+## Assumptions
+
+- The reported failure is most likely the 30-second timeout, not Google auth, content policy, or API schema breakage.
+- Pi reads `promptGuidelines` for registered tools, so a short guideline can influence model tool usage.
+
+## Plan
+
+- [x] Add a timeout-error unit test in `extensions/pi-google-genai/test/google-genai.test.ts` that expects the error to include the timeout duration and advice to split broad queries; verified the test failed before implementation with `npm test`.
+- [x] Update the timeout error in `extensions/pi-google-genai/src/google-genai.ts` to say broad trend, multi-product, or market-research queries should be split into smaller `google_search` calls before increasing `timeoutMs`; verified with `npm test`.
+- [x] Add a `googleSearchTool.promptGuidelines` rule that broad, multi-product, or trend-synthesis searches should be narrowed or split by product/topic first; verified in the tool-registration test that the guideline contains split/narrow wording, then ran `npm test`.
+- [x] Add a short “Large / broad searches” section to `extensions/pi-google-genai/README.md` with the bad example and suggested smaller searches for Cursor, Claude Code, GitHub Copilot, overall trends, and local-first tools; verified with `rg -n "Large|broad|Cursor|Claude Code|GitHub Copilot" extensions/pi-google-genai/README.md`.
+- [x] Run `npm run check` to verify Biome, boundary checks, typechecks, and tests.
+
+## Risks
+
+- A timeout can also be caused by temporary Google-side slowness. Phrase the message as a likely recovery path, not a definitive diagnosis.
+- Prompt guidelines do not prevent direct manual calls with broad queries, so the timeout hint is still required.
+
+## Completion Checklist
+
+- [x] `google_search` prompts the model to split or narrow broad multi-product research queries; verified by the tool-registration unit test in `npm test` and `npm run check`.
+- [x] Timeout errors include an actionable recovery step; verified by the timeout unit test in `npm test` and `npm run check`.
+- [x] README documents broad-query failure mode and split-query examples; verified by `rg -n "Large|broad|Cursor|Claude Code|GitHub Copilot" extensions/pi-google-genai/README.md`.
+- [x] Repository validation passes; verified by `npm run check`.

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -84,6 +84,26 @@ Parameters:
 - `query`: search question.
 - `searchTypes?`: optional array of `web_search` and/or `image_search`. Omit it for Google's default web search.
 
+#### Large / broad searches
+
+Very broad market-research queries can time out. Prefer several narrow searches over one big query.
+
+Instead of:
+
+```text
+2026 AI coding assistant product trends agentic coding IDE local first developer tools web UI Cursor Claude Code GitHub Copilot
+```
+
+Try:
+
+```text
+Cursor AI coding features 2026
+Claude Code features agentic coding
+GitHub Copilot coding agent features 2026
+AI coding assistant trends 2025 2026
+local first AI developer tools trends
+```
+
 ### 🗺️ `google_maps`
 
 Ask Google Maps-grounded questions.

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -116,6 +116,7 @@ const googleSearchTool = defineTool({
 	promptSnippet: "Search Google through Gemini grounding",
 	promptGuidelines: [
 		"Use google_search when the user asks for current public web or image-search-backed information.",
+		"Split or narrow broad trend, multi-product, or market-research questions before synthesizing.",
 		"If Google GenAI auth is missing, report the configuration error instead of retrying repeatedly.",
 	],
 	parameters: Type.Object({
@@ -129,6 +130,8 @@ const googleSearchTool = defineTool({
 				{
 					input: params.query,
 					tool: cleanObject({ type: "google_search", search_types: searchTypes }),
+					timeoutAdvice:
+						"Broad trend, multi-product, or market-research queries can time out; split them into smaller google_search calls before increasing timeoutMs.",
 				},
 				ctx,
 				signal,
@@ -443,7 +446,7 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext, pi: 
 }
 
 async function callInteraction(
-	request: { input: string; tool: Record<string, unknown> },
+	request: { input: string; tool: Record<string, unknown>; timeoutAdvice?: string },
 	ctx: ExtensionContext,
 	signal: AbortSignal | undefined,
 ) {
@@ -475,7 +478,9 @@ async function callInteraction(
 		return formatToolResult(payload, config.model);
 	} catch (error) {
 		if (timeoutSignal.isTimeout()) {
-			throw new Error(`Google GenAI request timed out after ${config.timeoutMs}ms.`);
+			throw new Error(
+				`Google GenAI request timed out after ${config.timeoutMs}ms. ${request.timeoutAdvice ?? "Try a smaller request or increase timeoutMs."}`,
+			);
 		}
 		throw error;
 	} finally {

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -33,6 +33,7 @@ test("google-genai registers three tools, command, and session hooks", () => {
 	assert.ok(mock.commands.has("google-genai"));
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"web_search"/);
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"image_search"/);
+	assert.match(JSON.stringify(mock.tools[0].promptGuidelines), /split|narrow/i);
 	assert.match(JSON.stringify(mock.tools[2].parameters), /"minItems":1/);
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
 });
@@ -275,8 +276,18 @@ test("tool requests report HTTP errors and time out", async () => {
 			}) as typeof fetch;
 			await assert.rejects(
 				() => executeTool(mock.tools[0], "call-timeout", { query: "slow" }, ctx),
-				/timed out/,
+				/timed out after 1ms.*split/i,
 			);
+
+			let mapsTimeout: unknown;
+			try {
+				await executeTool(mock.tools[1], "call-timeout-maps", { query: "nearby" }, ctx);
+			} catch (error) {
+				mapsTimeout = error;
+			}
+			assert.ok(mapsTimeout instanceof Error);
+			assert.match(mapsTimeout.message, /timed out after 1ms/);
+			assert.doesNotMatch(mapsTimeout.message, /google_search/);
 		} finally {
 			globalThis.fetch = previous;
 		}


### PR DESCRIPTION
## Summary
- guide google_search to split broad trend/multi-product searches before synthesis
- add actionable timeout guidance for broad market-research queries
- document narrower query examples for AI coding assistant trend searches

## Tests
- npm run check