### PR TITLE
feat(statusline): show compact git status

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -28,6 +28,7 @@
 - Codex `websocket_connection_limit_reached` is a retryable fresh-websocket case, but Pi 0.79.8's auto-retry regex does not classify “connection limit”; pi-retry must add the `provider returned error` hint.
 - Symptom: pi-goal compaction/retry hooks can mis-handle continuation state if a fresh continuation reuses a cancelled marker. Cause: markers based only on goal id and iteration collide after compaction cancellation. Fix: include a unique nonce in continuation markers.
 - Symptom: Pi compaction event docs may mention `reason`/`willRetry` while project target typings lack them. Cause: local/global `@earendil-works/pi-coding-agent` version skew. Fix: run `npm install`, verify target version, and treat compaction event fields as optional.
+- `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 
 ## TASTE
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install only the Pi extensions you need. Each package is published under the `@n
 | [`@narumitw/pi-lsp`](./extensions/pi-lsp) | 🧠 Language-agnostic LSP diagnostics and code actions for TypeScript, JavaScript, Python, JSON, CSS, and more through configured language servers. | `pi install npm:@narumitw/pi-lsp` |
 | [`@narumitw/pi-plan-mode`](./extensions/pi-plan-mode) | 🧭 Codex-like read-only `/plan` collaboration mode with safe exploration and implementation-ready plans. | `pi install npm:@narumitw/pi-plan-mode` |
 | [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for provider responses that fail with `Unknown error (no error details in response)`. | `pi install npm:@narumitw/pi-retry` |
-| [`@narumitw/pi-statusline`](./extensions/pi-statusline) | ✨ A rich Pi terminal statusline with model, tools, git branch, context usage, token totals, cost, and time. | `pi install npm:@narumitw/pi-statusline` |
+| [`@narumitw/pi-statusline`](./extensions/pi-statusline) | ✨ A rich Pi terminal statusline with model, tools, git branch/status, context usage, token totals, cost, and time. | `pi install npm:@narumitw/pi-statusline` |
 | [`@narumitw/pi-sync`](./extensions/pi-sync) | ☁️ Sync allowlisted Pi settings, skills, prompts, themes, extensions, and optional sessions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
 | [`@narumitw/pi-subagents`](./extensions/pi-subagents) | 🤖 Delegate work to specialized isolated subagents with single, parallel, and chained execution modes. | `pi install npm:@narumitw/pi-subagents` |
 | [`@narumitw/pi-wait-what`](./extensions/pi-wait-what) | 🤔 `/wait-what` pause command for asking the agent to explain surprising actions before continuing. | `pi install npm:@narumitw/pi-wait-what` |

--- a/docs/plans/archived/2026-07-06_pi-statusline-git-status-plan.md
+++ b/docs/plans/archived/2026-07-06_pi-statusline-git-status-plan.md
@@ -1,0 +1,34 @@
+## Goal
+
+Add compact Git status information to `@narumitw/pi-statusline` so the branch segment can show ahead/behind, staged, modified, untracked, and conflict counts without slowing footer rendering.
+
+## Context
+
+`pi-statusline` currently uses Pi's footer data provider for `getGitBranch()` only. Pi's footer API does not expose full `git status`, so the extension must run and cache `git status --porcelain=v1 --branch` itself.
+
+## Assumptions
+
+- Clean repositories should not show an extra clean marker.
+- Compact tokens are `⇡N`, `⇣N`, `+N`, `~N`, `?N`, and `!N` for ahead, behind, staged, modified, untracked, and conflicts.
+- Git status refresh should be event-driven plus a low-frequency 30s poll.
+
+## Plan
+
+- [x] Add parser/formatter tests in `extensions/pi-statusline/test/statusline.test.ts` for porcelain v1 branch status, dirty counts, clean output, and branch text with PR links; verified red first with `npm test` failing on missing `formatGitBranchText`, `formatGitStatusSummary`, and `parseGitStatusPorcelain` exports.
+- [x] Implement git status parsing and compact formatting in `extensions/pi-statusline/src/statusline.ts`; verified by `npm test` passing parser/formatter tests.
+- [x] Add asynchronous cached refresh logic in `extensions/pi-statusline/src/statusline.ts` that runs on session start, branch change, tool/turn completion, and every 30 seconds without running git commands during render; verified by tests for non-TUI skip, cached render, stale-event ignore, plus final reviewer PASS.
+- [x] Update `extensions/pi-statusline/README.md` to document compact git status tokens; verified the README includes all six token meanings.
+- [x] Run package-level and repository checks relevant to the change (`npm test`, `npm run typecheck`, and `npm run biome:check`); verified by `npm run check` passing, including Biome, boundary checks, typecheck, and 156 tests.
+
+## Risks
+
+- Running `git status` too often could make the TUI feel sluggish in large repositories; mitigate by caching, avoiding render-time commands, and using a 30s poll plus event refreshes.
+- Async refreshes can outlive a session reload; mitigate with generation checks and by clearing timers on footer disposal/session shutdown.
+
+## Completion Checklist
+
+- [x] The branch segment shows no extra clean marker for clean repositories, verified by `git status formatter omits clean markers` in `npm test`.
+- [x] Dirty repositories render compact tokens for ahead/behind, staged, modified, untracked, and conflicts, verified by `git status parser and formatter produce compact dirty tokens` in `npm test`.
+- [x] Footer rendering does not execute git commands synchronously, verified by `statusline renders cached git status without executing git during render` in `npm test` and final reviewer PASS.
+- [x] Git status documentation is present in `extensions/pi-statusline/README.md`, verified by token descriptions for `⇡`, `⇣`, `+`, `~`, `?`, and `!`.
+- [x] The change passes `npm test`, `npm run typecheck`, and `npm run biome:check`, verified by `npm run check` passing with 156 tests.

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -1,5 +1,5 @@
 import { watch, type FSWatcher } from "node:fs";
-import { resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 import type { ExecResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 export type ReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "UNKNOWN";
@@ -148,7 +148,11 @@ async function createBranchWatcher(
 		const gitHead = result.stdout.trim();
 		if (!gitHead) return undefined;
 
-		const watcher = watch(resolve(cwd, gitHead), { persistent: false }, onChange);
+		const headPath = resolve(cwd, gitHead);
+		const headFileName = basename(headPath);
+		const watcher = watch(dirname(headPath), { persistent: false }, (_event, fileName) => {
+			if (!fileName || fileName.toString() === headFileName) onChange();
+		});
 		watcher.on("error", () => watcher.close());
 		return watcher;
 	} catch {

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -9,7 +9,7 @@ Use it to monitor model selection, thinking level, git branch, working directory
 ## ✨ Features
 
 - Replaces the default Pi footer with a compact preset-based statusline.
-- Shows model, thinking level, git branch, project directory, active tool, context usage, tokens, cost, and clock.
+- Shows model, thinking level, git branch/status, project directory, active tool, context usage, tokens, cost, and clock.
 - Displays compact statuses published through Pi's generic extension status API.
 - Owns extension status icons through optional JSON config, including per-extension icon suppression with `""`.
 - Warns when the same extension package is installed from multiple sources.
@@ -84,12 +84,14 @@ The default `tokyo-night` statusline uses a Starship-inspired `░▒▓` / `
 - 🤖 current model.
 - 🧠 thinking level.
 - 📁 current project directory.
-- 🌿 git branch.
+- 🌿 git branch, with compact git status tokens when dirty or ahead/behind.
 - ⚙ active or last tool.
 - 🪟 context usage percentage.
 - 🔢 token totals.
 - 💸 estimated cost.
 - 🕒 clock.
+
+Git status tokens are hidden for clean repositories. When present, they mean `⇡` ahead, `⇣` behind, `+` staged, `~` modified/deleted in the worktree, `?` untracked, and `!` conflicts. Example: `🌿 main ⇡1 +2 ~1 ?3`.
 
 Statuses from other extensions appear below the main statusline, use each preset's separator, and wrap onto additional footer lines when they exceed the terminal width.
 

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -31,7 +31,17 @@ interface RuntimeState {
 	isStreaming: boolean;
 	thinkingLevel: ThinkingLevel;
 	duplicateExtensions: string[];
+	gitStatus?: GitStatusSummary;
 	requestRender?: () => void;
+}
+
+export interface GitStatusSummary {
+	ahead: number;
+	behind: number;
+	staged: number;
+	modified: number;
+	untracked: number;
+	conflicts: number;
 }
 
 interface TokenTotals {
@@ -44,6 +54,9 @@ const STATUSLINE_KEY = "statusline";
 const GITHUB_PR_KEY = "github-pr";
 const SETTINGS_FILE = "pi-statusline-settings.json";
 const DEFAULT_PRESET: StatuslinePresetName = "tokyo-night";
+const GIT_STATUS_REFRESH_INTERVAL_MS = 30_000;
+const GIT_STATUS_EVENT_DEBOUNCE_MS = 250;
+const GIT_STATUS_TIMEOUT_MS = 3_000;
 
 const DEFAULT_EXTENSION_STATUS_ICONS: Record<string, string> = {
 	"chrome-devtools": "🌐",
@@ -95,21 +108,106 @@ export default function statusline(pi: ExtensionAPI) {
 		duplicateExtensions: [],
 	};
 
+	let sessionGeneration = 0;
+	let activeGitStatusTarget: { cwd: string; generation: number } | undefined;
+	let gitStatusRefreshInFlight = false;
+	let gitStatusDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let pendingGitStatusRefresh: { cwd: string; generation: number } | undefined;
+
 	const refresh = () => runtime.requestRender?.();
 
+	const setGitStatus = (summary: GitStatusSummary | undefined) => {
+		if (gitStatusSummaryEqual(runtime.gitStatus, summary)) return;
+		runtime.gitStatus = summary;
+		refresh();
+	};
+
+	const clearGitStatusDebounce = () => {
+		if (!gitStatusDebounceTimer) return;
+		clearTimeout(gitStatusDebounceTimer);
+		gitStatusDebounceTimer = undefined;
+	};
+
+	const isActiveGitStatusTarget = (cwd: string, generation: number) =>
+		activeGitStatusTarget?.cwd === cwd &&
+		activeGitStatusTarget.generation === generation &&
+		generation === sessionGeneration;
+
+	const refreshGitStatus = (cwd: string, generation = sessionGeneration) => {
+		if (!isActiveGitStatusTarget(cwd, generation)) return;
+		if (gitStatusRefreshInFlight) {
+			pendingGitStatusRefresh = { cwd, generation };
+			return;
+		}
+
+		gitStatusRefreshInFlight = true;
+		void (async () => {
+			try {
+				const summary = await readGitStatus(pi, cwd);
+				if (isActiveGitStatusTarget(cwd, generation)) setGitStatus(summary);
+			} catch {
+				if (isActiveGitStatusTarget(cwd, generation)) setGitStatus(undefined);
+			} finally {
+				gitStatusRefreshInFlight = false;
+				const pending = pendingGitStatusRefresh;
+				pendingGitStatusRefresh = undefined;
+				if (pending && isActiveGitStatusTarget(pending.cwd, pending.generation)) {
+					refreshGitStatus(pending.cwd, pending.generation);
+				}
+			}
+		})();
+	};
+
+	const scheduleGitStatusRefresh = (cwd: string, generation = sessionGeneration) => {
+		if (!isActiveGitStatusTarget(cwd, generation)) return;
+		clearGitStatusDebounce();
+		gitStatusDebounceTimer = setTimeout(() => {
+			gitStatusDebounceTimer = undefined;
+			refreshGitStatus(cwd, generation);
+		}, GIT_STATUS_EVENT_DEBOUNCE_MS);
+	};
+
+	const scheduleGitStatusRefreshForContext = (ctx: ExtensionContext) => {
+		if (!activeGitStatusTarget || activeGitStatusTarget.cwd !== ctx.cwd) return;
+		scheduleGitStatusRefresh(activeGitStatusTarget.cwd, activeGitStatusTarget.generation);
+	};
+
 	const installFooter = (ctx: ExtensionContext) => {
+		const generation = ++sessionGeneration;
+		const cwd = ctx.cwd;
+		clearGitStatusDebounce();
+		activeGitStatusTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
+		runtime.gitStatus = undefined;
 		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
-		runtime.duplicateExtensions = findDuplicateExtensions(ctx.cwd);
+		if (!activeGitStatusTarget) return;
+		runtime.duplicateExtensions = findDuplicateExtensions(cwd);
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			runtime.requestRender = () => tui.requestRender();
 
-			const branchUnsubscribe = footerData.onBranchChange(() => tui.requestRender());
-			const clock = setInterval(() => tui.requestRender(), 30_000);
+			const refreshFooterGitStatus = () => refreshGitStatus(cwd, generation);
+			const branchUnsubscribe = footerData.onBranchChange(() => {
+				runtime.gitStatus = undefined;
+				clearGitStatusDebounce();
+				refreshFooterGitStatus();
+				tui.requestRender();
+			});
+			const clock = setInterval(() => {
+				clearGitStatusDebounce();
+				refreshFooterGitStatus();
+				tui.requestRender();
+			}, GIT_STATUS_REFRESH_INTERVAL_MS);
 
 			return {
 				dispose() {
 					branchUnsubscribe();
 					clearInterval(clock);
+					if (isActiveGitStatusTarget(cwd, generation)) {
+						activeGitStatusTarget = undefined;
+						clearGitStatusDebounce();
+						pendingGitStatusRefresh = undefined;
+						runtime.gitStatus = undefined;
+						runtime.requestRender = undefined;
+					}
 				},
 				invalidate() {},
 				render(width: number): string[] {
@@ -119,6 +217,7 @@ export default function statusline(pi: ExtensionAPI) {
 				},
 			};
 		});
+		refreshGitStatus(cwd, generation);
 	};
 
 	pi.on("session_start", (_event, ctx) => {
@@ -132,6 +231,11 @@ export default function statusline(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
+		sessionGeneration += 1;
+		activeGitStatusTarget = undefined;
+		clearGitStatusDebounce();
+		pendingGitStatusRefresh = undefined;
+		runtime.gitStatus = undefined;
 		ctx.ui.setFooter(undefined);
 		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
 		runtime.requestRender = undefined;
@@ -149,8 +253,9 @@ export default function statusline(pi: ExtensionAPI) {
 		refresh();
 	});
 
-	pi.on("agent_end", () => {
+	pi.on("agent_end", (_event, ctx) => {
 		runtime.isStreaming = false;
+		scheduleGitStatusRefreshForContext(ctx);
 		refresh();
 	});
 
@@ -160,7 +265,10 @@ export default function statusline(pi: ExtensionAPI) {
 		refresh();
 	});
 
-	pi.on("turn_end", () => refresh());
+	pi.on("turn_end", (_event, ctx) => {
+		scheduleGitStatusRefreshForContext(ctx);
+		refresh();
+	});
 
 	pi.on("tool_execution_start", (event) => {
 		const currentCount = runtime.activeTools.get(event.toolName) ?? 0;
@@ -169,12 +277,13 @@ export default function statusline(pi: ExtensionAPI) {
 		refresh();
 	});
 
-	pi.on("tool_execution_end", (event) => {
+	pi.on("tool_execution_end", (event, ctx) => {
 		const currentCount = runtime.activeTools.get(event.toolName) ?? 0;
 		if (currentCount <= 1) runtime.activeTools.delete(event.toolName);
 		else runtime.activeTools.set(event.toolName, currentCount - 1);
 
 		runtime.lastCompletedTool = event.toolName;
+		scheduleGitStatusRefreshForContext(ctx);
 		refresh();
 	});
 }
@@ -280,7 +389,7 @@ function buildSegment(
 		case "branch": {
 			const branch = footerData.getGitBranch();
 			const pr = branch ? prLinkFromStatuses(footerData.getExtensionStatuses()) : undefined;
-			return segment(name, pr ? `🌿 ${branch} (${pr})` : `🌿 ${branch ?? "no-git"}`, color, "git");
+			return segment(name, formatGitBranchText(branch, runtime.gitStatus, pr), color, "git");
 		}
 		case "cwd":
 			return segment(name, `📁 ${basename(ctx.cwd) || ctx.cwd}`, color, "directory");
@@ -388,6 +497,113 @@ export function prLinkFromStatuses(statuses: ReadonlyMap<string, string>): strin
 	const closeMarker = "\x1b]8;;\x07";
 	const close = value.indexOf(closeMarker, open + 1);
 	return close === -1 ? undefined : value.slice(open, close + closeMarker.length);
+}
+
+async function readGitStatus(
+	pi: ExtensionAPI,
+	cwd: string,
+): Promise<GitStatusSummary | undefined> {
+	const result = await pi.exec(
+		"git",
+		["--no-optional-locks", "status", "--porcelain=v1", "--branch", "--untracked-files=normal"],
+		{
+			cwd,
+			timeout: GIT_STATUS_TIMEOUT_MS,
+		},
+	);
+	if (result.code !== 0 || result.killed) return undefined;
+	return parseGitStatusPorcelain(result.stdout);
+}
+
+export function parseGitStatusPorcelain(output: string): GitStatusSummary {
+	const summary: GitStatusSummary = {
+		ahead: 0,
+		behind: 0,
+		staged: 0,
+		modified: 0,
+		untracked: 0,
+		conflicts: 0,
+	};
+
+	for (const line of output.split(/\r?\n/)) {
+		if (!line) continue;
+		if (line.startsWith("## ")) {
+			const ahead = line.match(/\bahead (\d+)/u);
+			const behind = line.match(/\bbehind (\d+)/u);
+			summary.ahead = ahead ? Number(ahead[1]) : 0;
+			summary.behind = behind ? Number(behind[1]) : 0;
+			continue;
+		}
+
+		const indexStatus = line[0] ?? " ";
+		const worktreeStatus = line[1] ?? " ";
+		if (indexStatus === "?" && worktreeStatus === "?") {
+			summary.untracked += 1;
+			continue;
+		}
+		if (isConflictStatus(indexStatus, worktreeStatus)) {
+			summary.conflicts += 1;
+			continue;
+		}
+		if (isChangedStatus(indexStatus)) summary.staged += 1;
+		if (isChangedStatus(worktreeStatus)) summary.modified += 1;
+	}
+
+	return summary;
+}
+
+function isConflictStatus(indexStatus: string, worktreeStatus: string): boolean {
+	return (
+		(indexStatus === "D" && worktreeStatus === "D") ||
+		(indexStatus === "A" && worktreeStatus === "A") ||
+		indexStatus === "U" ||
+		worktreeStatus === "U"
+	);
+}
+
+function isChangedStatus(status: string): boolean {
+	return status !== " " && status !== "?" && status !== "!";
+}
+
+export function formatGitStatusSummary(summary: GitStatusSummary | undefined): string {
+	if (!summary) return "";
+	const tokens = [
+		["⇡", summary.ahead],
+		["⇣", summary.behind],
+		["+", summary.staged],
+		["~", summary.modified],
+		["?", summary.untracked],
+		["!", summary.conflicts],
+	] as const;
+	return tokens
+		.filter(([, count]) => count > 0)
+		.map(([prefix, count]) => `${prefix}${formatCount(count)}`)
+		.join(" ");
+}
+
+export function formatGitBranchText(
+	branch: string | null,
+	status: GitStatusSummary | undefined,
+	pr?: string,
+): string {
+	if (!branch) return "🌿 no-git";
+	const suffixes = [formatGitStatusSummary(status), pr ? `(${pr})` : ""].filter(Boolean);
+	return suffixes.length > 0 ? `🌿 ${branch} ${suffixes.join(" ")}` : `🌿 ${branch}`;
+}
+
+function gitStatusSummaryEqual(
+	left: GitStatusSummary | undefined,
+	right: GitStatusSummary | undefined,
+): boolean {
+	if (!left || !right) return left === right;
+	return (
+		left.ahead === right.ahead &&
+		left.behind === right.behind &&
+		left.staged === right.staged &&
+		left.modified === right.modified &&
+		left.untracked === right.untracked &&
+		left.conflicts === right.conflicts
+	);
 }
 
 function formatExtensionStatuses(

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -109,10 +109,13 @@ export default function statusline(pi: ExtensionAPI) {
 	};
 
 	let sessionGeneration = 0;
+	let gitStatusRequestId = 0;
 	let activeGitStatusTarget: { cwd: string; generation: number } | undefined;
 	let gitStatusRefreshInFlight = false;
 	let gitStatusDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-	let pendingGitStatusRefresh: { cwd: string; generation: number } | undefined;
+	let pendingGitStatusRefresh:
+		| { cwd: string; generation: number; requestId: number }
+		| undefined;
 
 	const refresh = () => runtime.requestRender?.();
 
@@ -133,10 +136,13 @@ export default function statusline(pi: ExtensionAPI) {
 		activeGitStatusTarget.generation === generation &&
 		generation === sessionGeneration;
 
-	const refreshGitStatus = (cwd: string, generation = sessionGeneration) => {
-		if (!isActiveGitStatusTarget(cwd, generation)) return;
+	const isCurrentGitStatusRequest = (cwd: string, generation: number, requestId: number) =>
+		isActiveGitStatusTarget(cwd, generation) && requestId === gitStatusRequestId;
+
+	const runGitStatusRefresh = (cwd: string, generation: number, requestId: number) => {
+		if (!isCurrentGitStatusRequest(cwd, generation, requestId)) return;
 		if (gitStatusRefreshInFlight) {
-			pendingGitStatusRefresh = { cwd, generation };
+			pendingGitStatusRefresh = { cwd, generation, requestId };
 			return;
 		}
 
@@ -144,26 +150,30 @@ export default function statusline(pi: ExtensionAPI) {
 		void (async () => {
 			try {
 				const summary = await readGitStatus(pi, cwd);
-				if (isActiveGitStatusTarget(cwd, generation)) setGitStatus(summary);
+				if (isCurrentGitStatusRequest(cwd, generation, requestId)) setGitStatus(summary);
 			} catch {
-				if (isActiveGitStatusTarget(cwd, generation)) setGitStatus(undefined);
+				if (isCurrentGitStatusRequest(cwd, generation, requestId)) setGitStatus(undefined);
 			} finally {
 				gitStatusRefreshInFlight = false;
 				const pending = pendingGitStatusRefresh;
 				pendingGitStatusRefresh = undefined;
-				if (pending && isActiveGitStatusTarget(pending.cwd, pending.generation)) {
-					refreshGitStatus(pending.cwd, pending.generation);
-				}
+				if (pending) runGitStatusRefresh(pending.cwd, pending.generation, pending.requestId);
 			}
 		})();
 	};
 
+	const refreshGitStatus = (cwd: string, generation = sessionGeneration) => {
+		if (!isActiveGitStatusTarget(cwd, generation)) return;
+		runGitStatusRefresh(cwd, generation, ++gitStatusRequestId);
+	};
+
 	const scheduleGitStatusRefresh = (cwd: string, generation = sessionGeneration) => {
 		if (!isActiveGitStatusTarget(cwd, generation)) return;
+		const requestId = ++gitStatusRequestId;
 		clearGitStatusDebounce();
 		gitStatusDebounceTimer = setTimeout(() => {
 			gitStatusDebounceTimer = undefined;
-			refreshGitStatus(cwd, generation);
+			runGitStatusRefresh(cwd, generation, requestId);
 		}, GIT_STATUS_EVENT_DEBOUNCE_MS);
 	};
 

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -32,6 +32,25 @@ async function emit(
 	for (const handler of events.get(name) ?? []) await handler(...args);
 }
 
+type ExecResult = { stdout: string; stderr: string; code: number; killed: boolean };
+
+function deferred<T>() {
+	let resolveValue: ((value: T) => void) | undefined;
+	const promise = new Promise<T>((resolve) => {
+		resolveValue = resolve;
+	});
+	return {
+		promise,
+		resolve(value: T) {
+			resolveValue?.(value);
+		},
+	};
+}
+
+async function flushAsync() {
+	await new Promise((resolve) => setImmediate(resolve));
+}
+
 test("statusline registers lifecycle handlers without reading thinking level at load time", () => {
 	const mock = createMockPi();
 	mock.rawPi.getThinkingLevel = () => {
@@ -160,6 +179,119 @@ test("statusline stops git refreshes after its footer is disposed", async () => 
 	async function execGitStatus() {
 		execCalls += 1;
 		return { stdout: "## main\n", stderr: "", code: 0, killed: false };
+	}
+});
+
+test("statusline does not render stale in-flight git status after a branch change", async () => {
+	const mock = createMockPi();
+	const firstStatus = deferred<ExecResult>();
+	const secondStatus = deferred<ExecResult>();
+	const execResults = [firstStatus.promise, secondStatus.promise];
+	let execCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+
+	await emit(mock.events, "session_start", {}, context.ctx);
+	let branchChange: (() => void) | undefined;
+	const footerFactory = context.footer as (
+		tui: { requestRender(): void },
+		theme: { fg(_color: string, text: string): string; bold(text: string): string },
+		footerData: {
+			getGitBranch(): string | null;
+			getExtensionStatuses(): ReadonlyMap<string, string>;
+			onBranchChange(callback: () => void): () => void;
+		},
+	) => { dispose(): void; render(width: number): string[] };
+	const footer = footerFactory(
+		{ requestRender() {} },
+		{ fg: (_color, text) => text, bold: (text) => text },
+		{
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange(callback) {
+				branchChange = callback;
+				return () => {
+					branchChange = undefined;
+				};
+			},
+		},
+	);
+
+	assert.equal(execCalls, 1);
+	assert.ok(branchChange);
+	branchChange();
+	firstStatus.resolve({ stdout: "## main\n M stale.ts\n", stderr: "", code: 0, killed: false });
+	await flushAsync();
+
+	assert.equal(execCalls, 2);
+	assert.equal(footer.render(120).join("\n").includes("~1"), false);
+
+	secondStatus.resolve({ stdout: "## main\n?? fresh.ts\n", stderr: "", code: 0, killed: false });
+	await flushAsync();
+
+	assert.match(footer.render(120).join("\n"), /\?1/u);
+	footer.dispose();
+
+	async function execGitStatus() {
+		const result = execResults[execCalls];
+		execCalls += 1;
+		if (!result) throw new Error("unexpected git status refresh");
+		return result;
+	}
+});
+
+test("statusline invalidates in-flight git status while a debounced refresh is pending", async () => {
+	const mock = createMockPi();
+	const firstStatus = deferred<ExecResult>();
+	const secondStatus = deferred<ExecResult>();
+	const execResults = [firstStatus.promise, secondStatus.promise];
+	let execCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+
+	await emit(mock.events, "session_start", {}, context.ctx);
+	const footerFactory = context.footer as (
+		tui: { requestRender(): void },
+		theme: { fg(_color: string, text: string): string; bold(text: string): string },
+		footerData: {
+			getGitBranch(): string | null;
+			getExtensionStatuses(): ReadonlyMap<string, string>;
+			onBranchChange(callback: () => void): () => void;
+		},
+	) => { dispose(): void; render(width: number): string[] };
+	const footer = footerFactory(
+		{ requestRender() {} },
+		{ fg: (_color, text) => text, bold: (text) => text },
+		{
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+
+	assert.equal(execCalls, 1);
+	await emit(mock.events, "tool_execution_end", { toolName: "write" }, context.ctx);
+	firstStatus.resolve({ stdout: "## main\n M stale.ts\n", stderr: "", code: 0, killed: false });
+	await flushAsync();
+
+	assert.equal(execCalls, 1);
+	assert.equal(footer.render(120).join("\n").includes("~1"), false);
+
+	await new Promise((resolve) => setTimeout(resolve, 300));
+	assert.equal(execCalls, 2);
+	secondStatus.resolve({ stdout: "## main\n?? fresh.ts\n", stderr: "", code: 0, killed: false });
+	await flushAsync();
+
+	assert.match(footer.render(120).join("\n"), /\?1/u);
+	footer.dispose();
+
+	async function execGitStatus() {
+		const result = execResults[execCalls];
+		execCalls += 1;
+		if (!result) throw new Error("unexpected git status refresh");
+		return result;
 	}
 });
 

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -4,14 +4,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import statusline, {
 	contextColor,
 	extensionColor,
 	formatCount,
 	formatExtensionStatus,
+	formatGitBranchText,
+	formatGitStatusSummary,
 	formatToolActivity,
 	npmPackageName,
+	parseGitStatusPorcelain,
 	prLinkFromStatuses,
 	readStatuslineSettings,
 	shortenModel,
@@ -20,6 +23,14 @@ import statusline, {
 	stripExtensionStatusPrefix,
 	wrapExtensionStatusline,
 } from "../src/statusline.js";
+
+async function emit(
+	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
+	name: string,
+	...args: unknown[]
+) {
+	for (const handler of events.get(name) ?? []) await handler(...args);
+}
 
 test("statusline registers lifecycle handlers without reading thinking level at load time", () => {
 	const mock = createMockPi();
@@ -30,6 +41,126 @@ test("statusline registers lifecycle handlers without reading thinking level at 
 	assert.doesNotThrow(() => statusline(mock.pi));
 	assert.ok(mock.events.has("session_start"));
 	assert.ok(mock.events.has("tool_execution_start"));
+});
+
+test("statusline skips git status refreshes outside TUI mode", async () => {
+	const mock = createMockPi();
+	let execCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
+	statusline(mock.pi);
+	const { ctx } = createMockContext({ mode: "print" });
+
+	await emit(mock.events, "session_start", {}, ctx);
+	await emit(mock.events, "tool_execution_end", { toolName: "write" }, ctx);
+
+	assert.equal(execCalls, 0);
+
+	async function execGitStatus() {
+		execCalls += 1;
+		return { stdout: "## main\n", stderr: "", code: 0, killed: false };
+	}
+});
+
+test("statusline renders cached git status without executing git during render", async () => {
+	const mock = createMockPi();
+	let execCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+
+	await emit(mock.events, "session_start", {}, context.ctx);
+	const footerFactory = context.footer as (
+		tui: { requestRender(): void },
+		theme: { fg(_color: string, text: string): string; bold(text: string): string },
+		footerData: {
+			getGitBranch(): string | null;
+			getExtensionStatuses(): ReadonlyMap<string, string>;
+			onBranchChange(callback: () => void): () => void;
+		},
+	) => { render(width: number): string[]; dispose(): void };
+	const footer = footerFactory(
+		{ requestRender() {} },
+		{ fg: (_color, text) => text, bold: (text) => text },
+		{
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	const callsBeforeRender = execCalls;
+
+	footer.render(120);
+	footer.dispose();
+
+	assert.equal(execCalls, callsBeforeRender);
+	assert.equal(callsBeforeRender, 1);
+
+	async function execGitStatus() {
+		execCalls += 1;
+		return { stdout: "## main\n M changed.ts\n", stderr: "", code: 0, killed: false };
+	}
+});
+
+test("statusline ignores stale git refresh events from a previous cwd", async () => {
+	const mock = createMockPi();
+	const cwdCalls: string[] = [];
+	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
+	statusline(mock.pi);
+	const oldCwd = join(tmpdir(), "stale-a");
+	const newCwd = join(tmpdir(), "current-b");
+	const oldContext = createMockContext({ mode: "tui", cwd: oldCwd });
+	const newContext = createMockContext({ mode: "tui", cwd: newCwd });
+
+	await emit(mock.events, "session_start", {}, oldContext.ctx);
+	await emit(mock.events, "session_shutdown", {}, oldContext.ctx);
+	await emit(mock.events, "session_start", {}, newContext.ctx);
+	await emit(mock.events, "tool_execution_end", { toolName: "write" }, oldContext.ctx);
+	await new Promise((resolve) => setTimeout(resolve, 300));
+
+	assert.deepEqual(cwdCalls, [oldCwd, newCwd]);
+
+	async function execGitStatus(_command: string, _args: string[], options?: { cwd?: string }) {
+		cwdCalls.push(options?.cwd ?? "");
+		return { stdout: "## main\n", stderr: "", code: 0, killed: false };
+	}
+});
+
+test("statusline stops git refreshes after its footer is disposed", async () => {
+	const mock = createMockPi();
+	let execCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+
+	await emit(mock.events, "session_start", {}, context.ctx);
+	const footerFactory = context.footer as (
+		tui: { requestRender(): void },
+		theme: { fg(_color: string, text: string): string; bold(text: string): string },
+		footerData: {
+			getGitBranch(): string | null;
+			getExtensionStatuses(): ReadonlyMap<string, string>;
+			onBranchChange(callback: () => void): () => void;
+		},
+	) => { dispose(): void; render(width: number): string[] };
+	const footer = footerFactory(
+		{ requestRender() {} },
+		{ fg: (_color, text) => text, bold: (text) => text },
+		{
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	footer.dispose();
+	await emit(mock.events, "tool_execution_end", { toolName: "write" }, context.ctx);
+	await new Promise((resolve) => setTimeout(resolve, 300));
+
+	assert.equal(execCalls, 1);
+
+	async function execGitStatus() {
+		execCalls += 1;
+		return { stdout: "## main\n", stderr: "", code: 0, killed: false };
+	}
 });
 
 test("formatToolActivity prioritizes active tools, streaming, completed tools, and idle", () => {
@@ -81,6 +212,56 @@ test("prLinkFromStatuses keeps the linked PR token and drops the tail and non-PR
 	);
 	assert.equal(prLinkFromStatuses(new Map([["github-pr", "PR gh missing"]])), undefined);
 	assert.equal(prLinkFromStatuses(new Map()), undefined);
+});
+
+test("git status parser and formatter produce compact dirty tokens", () => {
+	const summary = parseGitStatusPorcelain(`## main...origin/main [ahead 2, behind 1]
+M  staged-modified.ts
+A  staged-added.ts
+ M modified.ts
+ D deleted.ts
+?? new-file.ts
+UU conflicted.ts
+`);
+
+	assert.deepEqual(summary, {
+		ahead: 2,
+		behind: 1,
+		staged: 2,
+		modified: 2,
+		untracked: 1,
+		conflicts: 1,
+	});
+	assert.equal(formatGitStatusSummary(summary), "⇡2 ⇣1 +2 ~2 ?1 !1");
+});
+
+test("git status formatter omits clean markers", () => {
+	const summary = parseGitStatusPorcelain("## main...origin/main\n");
+
+	assert.deepEqual(summary, {
+		ahead: 0,
+		behind: 0,
+		staged: 0,
+		modified: 0,
+		untracked: 0,
+		conflicts: 0,
+	});
+	assert.equal(formatGitStatusSummary(summary), "");
+	assert.equal(formatGitBranchText("main", summary), "🌿 main");
+});
+
+test("git branch text includes compact status before PR link", () => {
+	const link = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
+
+	assert.equal(
+		formatGitBranchText(
+			"feature",
+			{ ahead: 1, behind: 0, staged: 3, modified: 0, untracked: 2, conflicts: 0 },
+			link,
+		),
+		`🌿 feature ⇡1 +3 ?2 (${link})`,
+	);
+	assert.equal(formatGitBranchText(null, undefined), "🌿 no-git");
 });
 
 test("statusline settings load extension icon overrides", () => {


### PR DESCRIPTION
## Summary
- Add cached compact git status tokens to the pi-statusline branch segment
- Refresh git status on branch/session/tool/turn events plus low-frequency polling without running git during render
- Document token meanings and add parser/lifecycle regression tests

## Tests
- npm run check