### PR TITLE
feat(subagents): guide self-directed fan-out

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -51,27 +51,42 @@ Execution modes:
 
 ## 🧭 Proactive use
 
-The `subagent` tool now advertises concise prompt guidance so the main Pi agent can choose it
-without an explicit user request when delegation is a good fit.
+The `subagent` tool advertises concise prompt guidance so the main Pi agent can decide
+whether to spawn 0, 1, or multiple subagents without an explicit user-specified count.
 
-Use `subagent` proactively for:
+Count-selection guidance:
 
-- Independent read-only research, broad codebase reconnaissance, or high-volume command output
-  that would clutter the main context.
-- Parallel multi-domain investigation where each branch can return a concise summary.
-- Independent review or verification after implementation, especially with the read-only
-  `reviewer` agent.
+- Use **no subagent** for simple answers, quick targeted edits, latency-sensitive one-step work, or
+  tasks that need frequent user back-and-forth.
+- Use **one subagent** for isolated research, high-volume command output, planning, or independent
+  review/verification after implementation.
+- Prefer **2–4 parallel read-only subagents** when a broad task naturally splits into independent
+  branches that can each return a concise summary.
+- Exceed 4 tasks only when the branches are clearly distinct and worth the extra cost, while staying
+  within the existing hard max of 8 parallel tasks.
+- Do not parallelize implementation that may edit the same files or shared state; serialize
+  write-heavy work instead.
+- Do not use project-local agents unless the user explicitly opts into them with
+  `agentScope: "project"` or `"both"`; keep confirmation enabled for untrusted repositories.
 
-Do not use `subagent` for:
+Examples where the main agent chooses the count:
 
-- Simple answers, quick targeted edits, latency-sensitive one-step work, or tasks that need
-  frequent user back-and-forth.
-- Parallel implementation that may edit the same files or shared state; serialize write-heavy work
-  instead.
-- Project-local agents unless the user explicitly opts into them with `agentScope: "project"` or
-  `"both"`; keep confirmation enabled for untrusted repositories.
+No subagent for a known-file edit:
 
-Good delegation example:
+```txt
+Rename one symbol in src/foo.ts.
+```
+
+One subagent for an independent review:
+
+```json
+{
+  "agent": "reviewer",
+  "task": "Review the current changes for release blockers. Do not edit files. Report PASS/FAIL/PARTIAL with evidence."
+}
+```
+
+Two to four parallel subagents for broad independent reconnaissance:
 
 ```json
 {
@@ -83,6 +98,10 @@ Good delegation example:
     {
       "agent": "scout",
       "task": "Research auth-related tests. Report coverage gaps. Do not edit files."
+    },
+    {
+      "agent": "scout",
+      "task": "Research API entry points that depend on auth. Report integration risks. Do not edit files."
     }
   ],
   "aggregator": {
@@ -91,9 +110,6 @@ Good delegation example:
   }
 }
 ```
-
-Bad delegation example: do not spawn a worker just to rename one symbol in a known file; edit it
-directly in the main conversation.
 
 ## 🚀 Examples
 

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -770,11 +770,14 @@ export default function (pi: ExtensionAPI) {
 			'To enable project-local agents in .pi/agents, set agentScope: "both" (or "project").',
 		].join(" "),
 		promptSnippet:
-			"Delegate independent research, review, verification, or multi-step work to isolated Pi subagents.",
+			"Decide whether to spawn 0, 1, or multiple subagents for independent research, review, verification, or multi-step work in isolated Pi processes.",
 		promptGuidelines: [
-			"Use subagent for independent read-only research, broad codebase reconnaissance, high-volume command output, multi-domain parallel investigation, or an independent reviewer after implementation.",
-			"Use subagent parallel mode when work splits into independent tasks; prefer read-only agents such as scout or reviewer for fan-out and serialize write-heavy implementation that touches the same files.",
-			"Do not use subagent for simple answers, quick targeted edits, latency-sensitive one-step work, or tasks requiring frequent user back-and-forth.",
+			"Use subagent only when delegation fits; the main agent should decide how many subagents to spawn from task shape instead of waiting for the user to specify a count.",
+			"Use no subagent for simple answers, quick targeted edits, latency-sensitive one-step work, or tasks requiring frequent user back-and-forth.",
+			"Use one subagent for isolated research, broad command output, planning, or independent review/verification that benefits from a separate context.",
+			"Use subagent parallel mode with 2-4 parallel read-only subagents when work has broad independent branches; prefer scout or reviewer for fan-out and add an aggregator when synthesis helps.",
+			"Use more than 4 subagent tasks only when clearly justified by distinct independent branches, and stay within the existing hard max 8 parallel tasks.",
+			"Do not use subagent parallel mode for write-heavy implementation touching the same files or shared state; serialize those changes in the main agent or one worker.",
 			'Do not use subagent with project-local agents unless the user explicitly wants project agents or sets agentScope to "project" or "both"; keep confirmation enabled for untrusted repositories.',
 			"When using subagent, write self-contained tasks with file paths, context, expected output, and whether the subagent may edit files.",
 		],

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -14,11 +14,22 @@ import subagents, {
 	uniqueToolNames,
 } from "../src/subagents.js";
 
-test("subagents registers delegation tool and configuration command", () => {
+test("subagents registers self-directed fan-out guidance and configuration command", () => {
 	const mock = createMockPi();
 	subagents(mock.pi);
 
-	assert.equal(mock.tools[0]?.name, "subagent");
+	const tool = mock.tools[0];
+	assert.equal(tool?.name, "subagent");
+	assert.match(String(tool?.promptSnippet), /decide whether to spawn 0, 1, or multiple subagents/i);
+
+	const promptGuidelines = tool?.promptGuidelines;
+	assert.ok(Array.isArray(promptGuidelines));
+	const guidanceText = promptGuidelines.join("\n");
+	assert.match(guidanceText, /decide how many subagents to spawn/i);
+	assert.match(guidanceText, /no subagent/i);
+	assert.match(guidanceText, /one subagent/i);
+	assert.match(guidanceText, /2-4 parallel read-only subagents/i);
+	assert.match(guidanceText, /hard max 8/i);
 	assert.ok(mock.commands.has("subagents:config"));
 });
 


### PR DESCRIPTION
## Summary
- strengthen pi-subagents prompt metadata so the main agent chooses 0, 1, or multiple subagents from task shape
- document count-selection guidance and examples for no subagent, one reviewer, and 2-4 read-only fan-out
- add tests asserting the registered tool exposes self-directed fan-out guidance

## Verification
- npm run typecheck: passed
- npm run pack:subagents: passed; dry-run contents inspected
- subagents compiled test: passed
- npm test: currently fails in unrelated pi-github-pr test `queued branch refresh does not run after session shutdown`; pi-subagents tests pass
- npm run check: currently fails at the same unrelated pi-github-pr test after biome, boundaries, and typecheck pass

Runtime limits unchanged: max 8 parallel tasks, concurrency 4.