### PR TITLE
feat(google-genai): make request timeouts configurable

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -34,6 +34,7 @@
 
 - Keep entries short and reusable.
 - Prefer status-producing extensions to publish text-only status values; keep extension icons in pi-statusline defaults/settings so styling and suppression stay centralized.
+- Prefer JSON config files over environment variables for user-facing settings, including token configuration when it is appropriate for the product. Add new environment variables only when they serve a clear purpose, such as secrets, deployment workflows, automation, or compatibility with existing integrations.
 - Keep `just` install recipes resilient by verifying registry visibility and falling back only when it solves the current install path.
 - New extension README files should mirror the existing style: emoji title, npm/Pi/license badges, Features, Install, Usage/What it does, Package layout, Keywords, and License.
 - New slash-command extensions should include argument autocomplete when the command has known subcommands, modes, or flags.

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -47,6 +47,15 @@ Example:
 
 The file is written as `0600`.
 
+Timeout precedence is: per-call `timeoutMs` parameter, `PI_GOOGLE_GENAI_TIMEOUT_MS`,
+`google-genai.json` `timeoutMs`, then the 30000ms default.
+
+Example environment override:
+
+```bash
+PI_GOOGLE_GENAI_TIMEOUT_MS=60000 pi -e ./extensions/pi-google-genai
+```
+
 ### 🔐 Auth precedence
 
 1. Literal `apiKey` in `google-genai.json`.
@@ -83,10 +92,15 @@ Parameters:
 
 - `query`: search question.
 - `searchTypes?`: optional array of `web_search` and/or `image_search`. Omit it for Google's default web search.
+- `timeoutMs?`: per-call timeout in milliseconds.
 
 #### Large / broad searches
 
-Very broad market-research queries can time out. Prefer several narrow searches over one big query.
+Very broad market-research, comparison, review, or search-result synthesis queries can time out. A
+timeout error means the request exceeded the configured duration; it is not a “no results found”
+response. Prefer several narrow searches over one big query, or raise
+`PI_GOOGLE_GENAI_TIMEOUT_MS`, config `timeoutMs`, or per-call `timeoutMs` when a broader call is
+genuinely needed.
 
 Instead of:
 
@@ -112,6 +126,7 @@ Parameters:
 
 - `query`: maps/place question.
 - `latitude?` and `longitude?`: optional pair for location-sensitive questions. If one is set, both are required. Latitude must be `-90..90`; longitude must be `-180..180`.
+- `timeoutMs?`: per-call timeout in milliseconds.
 
 ### 🔗 `google_url_context`
 
@@ -121,6 +136,7 @@ Parameters:
 
 - `prompt`: question or instruction.
 - `urls`: one or more `http://` or `https://` URLs.
+- `timeoutMs?`: per-call timeout in milliseconds.
 
 Use Firecrawl instead when you need raw HTML/markdown extraction, crawling, or URL discovery.
 

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -47,14 +47,8 @@ Example:
 
 The file is written as `0600`.
 
-Timeout precedence is: per-call `timeoutMs` parameter, `PI_GOOGLE_GENAI_TIMEOUT_MS`,
-`google-genai.json` `timeoutMs`, then the 30000ms default.
-
-Example environment override:
-
-```bash
-PI_GOOGLE_GENAI_TIMEOUT_MS=60000 pi -e ./extensions/pi-google-genai
-```
+Timeout precedence is: per-call `timeoutMs` parameter, `google-genai.json` `timeoutMs`, then
+the 30000ms default.
 
 ### 🔐 Auth precedence
 
@@ -98,9 +92,8 @@ Parameters:
 
 Very broad market-research, comparison, review, or search-result synthesis queries can time out. A
 timeout error means the request exceeded the configured duration; it is not a “no results found”
-response. Prefer several narrow searches over one big query, or raise
-`PI_GOOGLE_GENAI_TIMEOUT_MS`, config `timeoutMs`, or per-call `timeoutMs` when a broader call is
-genuinely needed.
+response. Prefer several narrow searches over one big query, or raise config `timeoutMs` or
+per-call `timeoutMs` when a broader call is genuinely needed.
 
 Instead of:
 

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -40,7 +40,7 @@ Example:
   "apiKey": "YOUR_GOOGLE_API_KEY",
   "model": "gemini-3.5-flash",
   "apiUrl": "https://generativelanguage.googleapis.com/v1beta/interactions",
-  "timeoutMs": 30000,
+  "timeoutMs": 60000,
   "tools": ["google_search", "google_maps", "google_url_context"]
 }
 ```
@@ -48,7 +48,7 @@ Example:
 The file is written as `0600`.
 
 Timeout precedence is: per-call `timeoutMs` parameter, `google-genai.json` `timeoutMs`, then
-the 30000ms default.
+the 60000ms default. Timeout values must be integer milliseconds from 1 to 2147483647.
 
 ### 🔐 Auth precedence
 

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -18,6 +18,7 @@ import { Type } from "typebox";
 export const DEFAULT_MODEL = "gemini-3.5-flash";
 export const DEFAULT_API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions";
 export const DEFAULT_TIMEOUT_MS = 30_000;
+export const GOOGLE_GENAI_TIMEOUT_ENV = "PI_GOOGLE_GENAI_TIMEOUT_MS";
 export const GOOGLE_GENAI_TOOL_NAMES = [
 	"google_search",
 	"google_maps",
@@ -41,6 +42,12 @@ const COMMAND_COMPLETIONS = [
 const SearchTypesParameter = Type.Optional(
 	Type.Array(Type.Union([Type.Literal("web_search"), Type.Literal("image_search")]), {
 		description: "Optional Google Search grounding types. Defaults to Google's web search.",
+	}),
+);
+const TimeoutMsParameter = Type.Optional(
+	Type.Number({
+		description: `Per-call timeout in milliseconds. Overrides ${GOOGLE_GENAI_TIMEOUT_ENV}, google-genai.json timeoutMs, and the ${DEFAULT_TIMEOUT_MS}ms default.`,
+		minimum: 1,
 	}),
 );
 
@@ -122,16 +129,19 @@ const googleSearchTool = defineTool({
 	parameters: Type.Object({
 		query: Type.String({ description: "Search question or query." }),
 		searchTypes: SearchTypesParameter,
+		timeoutMs: TimeoutMsParameter,
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const searchTypes = validateSearchTypes(params.searchTypes);
+		const timeoutMs = validateTimeoutMs(params.timeoutMs);
 		return withStatus(ctx, "search", () =>
 			callInteraction(
 				{
 					input: params.query,
 					tool: cleanObject({ type: "google_search", search_types: searchTypes }),
+					timeoutMs,
 					timeoutAdvice:
-						"Broad trend, multi-product, or market-research queries can time out; split them into smaller google_search calls before increasing timeoutMs.",
+						"Broad trend, comparison, review, or search-result synthesis queries can time out; narrow the query or split it into smaller google_search calls before increasing the timeout.",
 				},
 				ctx,
 				signal,
@@ -153,14 +163,17 @@ const googleMapsTool = defineTool({
 		query: Type.String({ description: "Maps-grounded question or place query." }),
 		latitude: Type.Optional(Type.Number({ description: "User latitude in degrees." })),
 		longitude: Type.Optional(Type.Number({ description: "User longitude in degrees." })),
+		timeoutMs: TimeoutMsParameter,
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const location = validateMapsLocation(params);
+		const timeoutMs = validateTimeoutMs(params.timeoutMs);
 		return withStatus(ctx, "maps", () =>
 			callInteraction(
 				{
 					input: params.query,
 					tool: cleanObject({ type: "google_maps", ...location }),
+					timeoutMs,
 				},
 				ctx,
 				signal,
@@ -184,14 +197,17 @@ const googleUrlContextTool = defineTool({
 			description: "One or more http:// or https:// URLs.",
 			minItems: 1,
 		}),
+		timeoutMs: TimeoutMsParameter,
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const urls = validateUrls(params.urls);
+		const timeoutMs = validateTimeoutMs(params.timeoutMs);
 		return withStatus(ctx, "url", () =>
 			callInteraction(
 				{
 					input: `${params.prompt}\n\nURLs:\n${urls.join("\n")}`,
 					tool: { type: "url_context" },
+					timeoutMs,
 				},
 				ctx,
 				signal,
@@ -316,6 +332,14 @@ export function validateSearchTypes(searchTypes: unknown): SearchType[] | undefi
 		}
 	}
 	return values as SearchType[];
+}
+
+export function validateTimeoutMs(timeoutMs: unknown): number | undefined {
+	if (timeoutMs === undefined) return undefined;
+	if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("timeoutMs must be a positive number of milliseconds.");
+	}
+	return timeoutMs;
 }
 
 export function validateMapsLocation(params: { latitude?: unknown; longitude?: unknown }) {
@@ -446,7 +470,7 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext, pi: 
 }
 
 async function callInteraction(
-	request: { input: string; tool: Record<string, unknown>; timeoutAdvice?: string },
+	request: { input: string; tool: Record<string, unknown>; timeoutMs?: number; timeoutAdvice?: string },
 	ctx: ExtensionContext,
 	signal: AbortSignal | undefined,
 ) {
@@ -459,7 +483,8 @@ async function callInteraction(
 		input: request.input,
 		tools: [request.tool],
 	};
-	const timeoutSignal = makeTimeoutSignal(signal, config.timeoutMs);
+	const timeoutMs = request.timeoutMs ?? config.timeoutMs;
+	const timeoutSignal = makeTimeoutSignal(signal, timeoutMs);
 	try {
 		const response = await fetch(config.apiUrl, {
 			method: "POST",
@@ -478,9 +503,7 @@ async function callInteraction(
 		return formatToolResult(payload, config.model);
 	} catch (error) {
 		if (timeoutSignal.isTimeout()) {
-			throw new Error(
-				`Google GenAI request timed out after ${config.timeoutMs}ms. ${request.timeoutAdvice ?? "Try a smaller request or increase timeoutMs."}`,
-			);
+			throw new Error(formatTimeoutError(timeoutMs, request.timeoutAdvice));
 		}
 		throw error;
 	} finally {
@@ -619,10 +642,12 @@ function normalizeConfigWithWarnings(value: unknown): { config: GoogleGenaiConfi
 	const raw = input as Record<string, unknown>;
 	const warnings: string[] = [];
 	const tools = normalizeTools(raw.tools, warnings);
+	const fileTimeoutMs = normalizeConfigTimeout(raw.timeoutMs, warnings);
+	const envTimeoutMs = normalizeEnvTimeout(warnings);
 	const config: GoogleGenaiConfig = {
 		model: normalizeString(raw.model) ?? DEFAULT_MODEL,
 		apiUrl: normalizeApiUrl(raw.apiUrl) ?? DEFAULT_API_URL,
-		timeoutMs: normalizeTimeout(raw.timeoutMs) ?? DEFAULT_TIMEOUT_MS,
+		timeoutMs: envTimeoutMs ?? fileTimeoutMs ?? DEFAULT_TIMEOUT_MS,
 		tools,
 	};
 	const apiKey = normalizeString(raw.apiKey);
@@ -662,8 +687,30 @@ function normalizeApiUrl(value: unknown) {
 	return url.replace(/\/+$/, "");
 }
 
-function normalizeTimeout(value: unknown) {
-	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+function normalizeConfigTimeout(value: unknown, warnings: string[]) {
+	if (value === undefined) return undefined;
+	const timeoutMs = parsePositiveTimeoutMs(value);
+	if (timeoutMs !== undefined) return timeoutMs;
+	warnings.push("google-genai.json timeoutMs must be a positive number of milliseconds; ignoring value.");
+	return undefined;
+}
+
+function normalizeEnvTimeout(warnings: string[]) {
+	const value = process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+	if (value === undefined || value.trim() === "") return undefined;
+	const timeoutMs = parsePositiveTimeoutMs(value);
+	if (timeoutMs !== undefined) return timeoutMs;
+	warnings.push(`${GOOGLE_GENAI_TIMEOUT_ENV} must be a positive number of milliseconds; ignoring value.`);
+	return undefined;
+}
+
+function parsePositiveTimeoutMs(value: unknown) {
+	if (typeof value === "number") {
+		return Number.isFinite(value) && value > 0 ? value : undefined;
+	}
+	if (typeof value !== "string") return undefined;
+	const parsed = Number(value.trim());
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 async function readJsonIfExists(path: string, warnings: string[]) {
@@ -722,6 +769,15 @@ function formatPersistedTools(tools: readonly GoogleGenaiToolName[]) {
 
 function isGoogleGenaiToolName(value: string): value is GoogleGenaiToolName {
 	return GOOGLE_GENAI_TOOL_NAMES.includes(value as GoogleGenaiToolName);
+}
+
+function formatTimeoutError(timeoutMs: number, timeoutAdvice?: string) {
+	return [
+		`Google GenAI request timed out after ${timeoutMs}ms.`,
+		"This is a timeout, not a no-results response.",
+		timeoutAdvice ?? "Try narrowing the query or splitting broad comparison/review queries.",
+		`To allow longer calls, set ${GOOGLE_GENAI_TIMEOUT_ENV}, google-genai.json timeoutMs, or the per-call timeoutMs parameter.`,
+	].join(" ");
 }
 
 function makeTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): FetchSignal {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -17,7 +17,8 @@ import { Type } from "typebox";
 
 export const DEFAULT_MODEL = "gemini-3.5-flash";
 export const DEFAULT_API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions";
-export const DEFAULT_TIMEOUT_MS = 30_000;
+export const DEFAULT_TIMEOUT_MS = 60_000;
+export const MAX_TIMEOUT_MS = 2_147_483_647;
 export const GOOGLE_GENAI_TOOL_NAMES = [
 	"google_search",
 	"google_maps",
@@ -44,9 +45,10 @@ const SearchTypesParameter = Type.Optional(
 	}),
 );
 const TimeoutMsParameter = Type.Optional(
-	Type.Number({
-		description: `Per-call timeout in milliseconds. Overrides google-genai.json timeoutMs and the ${DEFAULT_TIMEOUT_MS}ms default.`,
+	Type.Integer({
+		description: `Per-call timeout in milliseconds. Overrides google-genai.json timeoutMs and the ${DEFAULT_TIMEOUT_MS}ms default. Must be an integer from 1 to ${MAX_TIMEOUT_MS}.`,
 		minimum: 1,
+		maximum: MAX_TIMEOUT_MS,
 	}),
 );
 
@@ -335,8 +337,8 @@ export function validateSearchTypes(searchTypes: unknown): SearchType[] | undefi
 
 export function validateTimeoutMs(timeoutMs: unknown): number | undefined {
 	if (timeoutMs === undefined) return undefined;
-	if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-		throw new Error("timeoutMs must be a positive number of milliseconds.");
+	if (!isValidTimeoutMs(timeoutMs)) {
+		throw new Error(`timeoutMs must be an integer from 1 to ${MAX_TIMEOUT_MS} milliseconds.`);
 	}
 	return timeoutMs;
 }
@@ -687,9 +689,15 @@ function normalizeApiUrl(value: unknown) {
 
 function normalizeConfigTimeout(value: unknown, warnings: string[]) {
 	if (value === undefined) return undefined;
-	if (typeof value === "number" && Number.isFinite(value) && value > 0) return value;
-	warnings.push("google-genai.json timeoutMs must be a positive number of milliseconds; ignoring value.");
+	if (isValidTimeoutMs(value)) return value;
+	warnings.push(
+		`google-genai.json timeoutMs must be an integer from 1 to ${MAX_TIMEOUT_MS} milliseconds; ignoring value.`,
+	);
 	return undefined;
+}
+
+function isValidTimeoutMs(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= MAX_TIMEOUT_MS;
 }
 
 async function readJsonIfExists(path: string, warnings: string[]) {

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -18,7 +18,6 @@ import { Type } from "typebox";
 export const DEFAULT_MODEL = "gemini-3.5-flash";
 export const DEFAULT_API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions";
 export const DEFAULT_TIMEOUT_MS = 30_000;
-export const GOOGLE_GENAI_TIMEOUT_ENV = "PI_GOOGLE_GENAI_TIMEOUT_MS";
 export const GOOGLE_GENAI_TOOL_NAMES = [
 	"google_search",
 	"google_maps",
@@ -46,7 +45,7 @@ const SearchTypesParameter = Type.Optional(
 );
 const TimeoutMsParameter = Type.Optional(
 	Type.Number({
-		description: `Per-call timeout in milliseconds. Overrides ${GOOGLE_GENAI_TIMEOUT_ENV}, google-genai.json timeoutMs, and the ${DEFAULT_TIMEOUT_MS}ms default.`,
+		description: `Per-call timeout in milliseconds. Overrides google-genai.json timeoutMs and the ${DEFAULT_TIMEOUT_MS}ms default.`,
 		minimum: 1,
 	}),
 );
@@ -643,11 +642,10 @@ function normalizeConfigWithWarnings(value: unknown): { config: GoogleGenaiConfi
 	const warnings: string[] = [];
 	const tools = normalizeTools(raw.tools, warnings);
 	const fileTimeoutMs = normalizeConfigTimeout(raw.timeoutMs, warnings);
-	const envTimeoutMs = normalizeEnvTimeout(warnings);
 	const config: GoogleGenaiConfig = {
 		model: normalizeString(raw.model) ?? DEFAULT_MODEL,
 		apiUrl: normalizeApiUrl(raw.apiUrl) ?? DEFAULT_API_URL,
-		timeoutMs: envTimeoutMs ?? fileTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+		timeoutMs: fileTimeoutMs ?? DEFAULT_TIMEOUT_MS,
 		tools,
 	};
 	const apiKey = normalizeString(raw.apiKey);
@@ -689,28 +687,9 @@ function normalizeApiUrl(value: unknown) {
 
 function normalizeConfigTimeout(value: unknown, warnings: string[]) {
 	if (value === undefined) return undefined;
-	const timeoutMs = parsePositiveTimeoutMs(value);
-	if (timeoutMs !== undefined) return timeoutMs;
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) return value;
 	warnings.push("google-genai.json timeoutMs must be a positive number of milliseconds; ignoring value.");
 	return undefined;
-}
-
-function normalizeEnvTimeout(warnings: string[]) {
-	const value = process.env[GOOGLE_GENAI_TIMEOUT_ENV];
-	if (value === undefined || value.trim() === "") return undefined;
-	const timeoutMs = parsePositiveTimeoutMs(value);
-	if (timeoutMs !== undefined) return timeoutMs;
-	warnings.push(`${GOOGLE_GENAI_TIMEOUT_ENV} must be a positive number of milliseconds; ignoring value.`);
-	return undefined;
-}
-
-function parsePositiveTimeoutMs(value: unknown) {
-	if (typeof value === "number") {
-		return Number.isFinite(value) && value > 0 ? value : undefined;
-	}
-	if (typeof value !== "string") return undefined;
-	const parsed = Number(value.trim());
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 async function readJsonIfExists(path: string, warnings: string[]) {
@@ -776,7 +755,7 @@ function formatTimeoutError(timeoutMs: number, timeoutAdvice?: string) {
 		`Google GenAI request timed out after ${timeoutMs}ms.`,
 		"This is a timeout, not a no-results response.",
 		timeoutAdvice ?? "Try narrowing the query or splitting broad comparison/review queries.",
-		`To allow longer calls, set ${GOOGLE_GENAI_TIMEOUT_ENV}, google-genai.json timeoutMs, or the per-call timeoutMs parameter.`,
+		"To allow longer calls, set google-genai.json timeoutMs or the per-call timeoutMs parameter.",
 	].join(" ");
 }
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -10,7 +10,9 @@ import googleGenai, {
 	commandCompletions,
 	DEFAULT_API_URL,
 	DEFAULT_MODEL,
+	DEFAULT_TIMEOUT_MS,
 	formatToolResult,
+	GOOGLE_GENAI_TIMEOUT_ENV,
 	GOOGLE_GENAI_TOOL_NAMES,
 	googleGenaiConfigPath,
 	loadGoogleGenaiConfig,
@@ -33,6 +35,7 @@ test("google-genai registers three tools, command, and session hooks", () => {
 	assert.ok(mock.commands.has("google-genai"));
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"web_search"/);
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"image_search"/);
+	assert.match(JSON.stringify(mock.tools[0].parameters), /timeoutMs/);
 	assert.match(JSON.stringify(mock.tools[0].promptGuidelines), /split|narrow/i);
 	assert.match(JSON.stringify(mock.tools[2].parameters), /"minItems":1/);
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
@@ -58,7 +61,7 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 			config: {
 				model: DEFAULT_MODEL,
 				apiUrl: DEFAULT_API_URL,
-				timeoutMs: 30000,
+				timeoutMs: DEFAULT_TIMEOUT_MS,
 				tools: [...GOOGLE_GENAI_TOOL_NAMES],
 			},
 			path: join(agentDir, "google-genai.json"),
@@ -87,6 +90,23 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 			() => resolveGoogleGenaiAuth(loaded.config, authContext()),
 			/Interpolation/,
 		);
+	});
+});
+
+test("config loading supports PI_GOOGLE_GENAI_TIMEOUT_MS override", async () => {
+	await withTempAgentDir(async () => {
+		await writeConfig({ timeoutMs: 12_000 });
+
+		process.env[GOOGLE_GENAI_TIMEOUT_ENV] = "45000";
+		let loaded = await loadGoogleGenaiConfig();
+		assert.equal(loaded.config.timeoutMs, 45_000);
+		assert.deepEqual(loaded.warnings, []);
+
+		process.env[GOOGLE_GENAI_TIMEOUT_ENV] = "not-a-number";
+		loaded = await loadGoogleGenaiConfig();
+		assert.equal(loaded.config.timeoutMs, 12_000);
+		assert.match(loaded.warnings.join("\n"), /PI_GOOGLE_GENAI_TIMEOUT_MS/);
+		assert.match(loaded.warnings.join("\n"), /positive number of milliseconds/);
 	});
 });
 
@@ -200,6 +220,26 @@ test("tools surface successful non-JSON responses instead of dropping the body",
 	});
 });
 
+test("tools keep empty successful responses distinct from timeout errors", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi();
+		googleGenai(mock.pi);
+		const { ctx } = createMockContext({
+			modelRegistry: { getApiKeyForProvider: async () => "test-key" },
+		});
+		const previous = globalThis.fetch;
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ output_text: "" }))) as typeof fetch;
+		try {
+			const result = await executeTool(mock.tools[0], "call-empty", { query: "empty" }, ctx);
+			assert.equal(result.content[0].text, "No response received.");
+			assert.doesNotMatch(result.content[0].text, /timed out|no results found|not found/i);
+		} finally {
+			globalThis.fetch = previous;
+		}
+	});
+});
+
 test("tools reject insecure apiUrl before sending the API key", async () => {
 	await withTempAgentDir(async () => {
 		await writeConfig({ apiUrl: "http://example.test/interactions" });
@@ -249,7 +289,7 @@ test("tools allow local http apiUrl for proxies", async () => {
 
 test("tool requests report HTTP errors and time out", async () => {
 	await withTempAgentDir(async () => {
-		await writeConfig({ timeoutMs: 1 });
+		await writeConfig({ timeoutMs: 50_000 });
 		const mock = createMockPi();
 		googleGenai(mock.pi);
 		const { ctx } = createMockContext({
@@ -274,14 +314,45 @@ test("tool requests report HTTP errors and time out", async () => {
 				});
 				throw new Error("unreachable");
 			}) as typeof fetch;
+
+			process.env[GOOGLE_GENAI_TIMEOUT_ENV] = "1";
 			await assert.rejects(
 				() => executeTool(mock.tools[0], "call-timeout", { query: "slow" }, ctx),
-				/timed out after 1ms.*split/i,
+				(error) => {
+					assert.ok(error instanceof Error);
+					assert.match(error.message, /timed out after 1ms/);
+					assert.match(error.message, /timeout, not a no-results response/i);
+					assert.match(error.message, /narrow/i);
+					assert.match(error.message, /split/i);
+					assert.match(error.message, /PI_GOOGLE_GENAI_TIMEOUT_MS/);
+					assert.doesNotMatch(error.message, /not found|no results found/i);
+					return true;
+				},
+			);
+
+			delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+			await assert.rejects(
+				() =>
+					executeTool(mock.tools[0], "call-per-call-timeout", { query: "slow", timeoutMs: 1 }, ctx),
+				/timed out after 1ms/,
+			);
+			await assert.rejects(
+				() =>
+					executeTool(mock.tools[0], "call-invalid-timeout", { query: "slow", timeoutMs: 0 }, ctx),
+				/timeoutMs must be a positive number of milliseconds/,
 			);
 
 			let mapsTimeout: unknown;
 			try {
-				await executeTool(mock.tools[1], "call-timeout-maps", { query: "nearby" }, ctx);
+				await executeTool(
+					mock.tools[1],
+					"call-timeout-maps",
+					{
+						query: "nearby",
+						timeoutMs: 1,
+					},
+					ctx,
+				);
 			} catch (error) {
 				mapsTimeout = error;
 			}
@@ -511,14 +582,16 @@ test("session_start restores persisted tool selection and ignores unknown names"
 	});
 });
 
-test("normalize settings defaults missing tools to all enabled and allows empty selection", () => {
-	assert.deepEqual(normalizeGoogleGenaiSettings({}), {
-		model: DEFAULT_MODEL,
-		apiUrl: DEFAULT_API_URL,
-		timeoutMs: 30000,
-		tools: [...GOOGLE_GENAI_TOOL_NAMES],
+test("normalize settings defaults missing tools to all enabled and allows empty selection", async () => {
+	await withGoogleGenaiTimeoutEnv(undefined, async () => {
+		assert.deepEqual(normalizeGoogleGenaiSettings({}), {
+			model: DEFAULT_MODEL,
+			apiUrl: DEFAULT_API_URL,
+			timeoutMs: DEFAULT_TIMEOUT_MS,
+			tools: [...GOOGLE_GENAI_TOOL_NAMES],
+		});
+		assert.deepEqual(normalizeGoogleGenaiSettings({ tools: [] }).tools, []);
 	});
-	assert.deepEqual(normalizeGoogleGenaiSettings({ tools: [] }).tools, []);
 });
 
 interface TestToolDetails extends Record<string, unknown> {
@@ -545,14 +618,30 @@ async function executeTool(
 
 async function withTempAgentDir(fn: (agentDir: string) => Promise<void>) {
 	const previous = process.env.PI_CODING_AGENT_DIR;
+	const previousTimeout = process.env[GOOGLE_GENAI_TIMEOUT_ENV];
 	const agentDir = await mkdtemp(join(tmpdir(), "pi-google-genai-test-"));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
 	try {
 		await fn(agentDir);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;
+		if (previousTimeout === undefined) delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+		else process.env[GOOGLE_GENAI_TIMEOUT_ENV] = previousTimeout;
 		await rm(agentDir, { recursive: true, force: true });
+	}
+}
+
+async function withGoogleGenaiTimeoutEnv(value: string | undefined, fn: () => Promise<void>) {
+	const previous = process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+	if (value === undefined) delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+	else process.env[GOOGLE_GENAI_TIMEOUT_ENV] = value;
+	try {
+		await fn();
+	} finally {
+		if (previous === undefined) delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+		else process.env[GOOGLE_GENAI_TIMEOUT_ENV] = previous;
 	}
 }
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -15,11 +15,13 @@ import googleGenai, {
 	GOOGLE_GENAI_TOOL_NAMES,
 	googleGenaiConfigPath,
 	loadGoogleGenaiConfig,
+	MAX_TIMEOUT_MS,
 	normalizeGoogleGenaiSettings,
 	parseCommand,
 	resolveGoogleGenaiAuth,
 	validateMapsLocation,
 	validateSearchTypes,
+	validateTimeoutMs,
 	validateUrls,
 } from "../src/google-genai.js";
 
@@ -35,6 +37,8 @@ test("google-genai registers three tools, command, and session hooks", () => {
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"web_search"/);
 	assert.match(JSON.stringify(mock.tools[0].parameters), /"const":"image_search"/);
 	assert.match(JSON.stringify(mock.tools[0].parameters), /timeoutMs/);
+	assert.match(JSON.stringify(mock.tools[0].parameters), /"type":"integer"/);
+	assert.match(JSON.stringify(mock.tools[0].parameters), new RegExp(`"maximum":${MAX_TIMEOUT_MS}`));
 	assert.match(JSON.stringify(mock.tools[0].promptGuidelines), /split|narrow/i);
 	assert.match(JSON.stringify(mock.tools[2].parameters), /"minItems":1/);
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
@@ -103,7 +107,12 @@ test("config loading validates google-genai.json timeoutMs", async () => {
 		loaded = await loadGoogleGenaiConfig();
 		assert.equal(loaded.config.timeoutMs, DEFAULT_TIMEOUT_MS);
 		assert.match(loaded.warnings.join("\n"), /google-genai\.json timeoutMs/);
-		assert.match(loaded.warnings.join("\n"), /positive number of milliseconds/);
+		assert.match(loaded.warnings.join("\n"), /integer from 1/);
+
+		await writeConfig({ timeoutMs: MAX_TIMEOUT_MS + 1 });
+		loaded = await loadGoogleGenaiConfig();
+		assert.equal(loaded.config.timeoutMs, DEFAULT_TIMEOUT_MS);
+		assert.match(loaded.warnings.join("\n"), new RegExp(String(MAX_TIMEOUT_MS)));
 	});
 });
 
@@ -139,13 +148,18 @@ test("auth uses config apiKey before Pi google auth", async () => {
 	);
 });
 
-test("validators enforce search types, map coordinate pairs, and URL schemes", () => {
+test("validators enforce search types, timeout bounds, map coordinate pairs, and URL schemes", () => {
 	assert.deepEqual(validateSearchTypes(undefined), undefined);
 	assert.deepEqual(validateSearchTypes(["web_search", "image_search"]), [
 		"web_search",
 		"image_search",
 	]);
 	assert.throws(() => validateSearchTypes(["enterprise_web_search"]), /searchTypes/);
+	assert.equal(validateTimeoutMs(undefined), undefined);
+	assert.equal(validateTimeoutMs(MAX_TIMEOUT_MS), MAX_TIMEOUT_MS);
+	assert.throws(() => validateTimeoutMs(0), /integer from 1/);
+	assert.throws(() => validateTimeoutMs(1.5), /integer from 1/);
+	assert.throws(() => validateTimeoutMs(MAX_TIMEOUT_MS + 1), /integer from 1/);
 	assert.deepEqual(validateMapsLocation({}), {});
 	assert.deepEqual(validateMapsLocation({ latitude: 34.05, longitude: -118.24 }), {
 		latitude: 34.05,
@@ -335,7 +349,7 @@ test("tool requests report HTTP errors and time out", async () => {
 			await assert.rejects(
 				() =>
 					executeTool(mock.tools[0], "call-invalid-timeout", { query: "slow", timeoutMs: 0 }, ctx),
-				/timeoutMs must be a positive number of milliseconds/,
+				/integer from 1/,
 			);
 
 			let mapsTimeout: unknown;

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -12,7 +12,6 @@ import googleGenai, {
 	DEFAULT_MODEL,
 	DEFAULT_TIMEOUT_MS,
 	formatToolResult,
-	GOOGLE_GENAI_TIMEOUT_ENV,
 	GOOGLE_GENAI_TOOL_NAMES,
 	googleGenaiConfigPath,
 	loadGoogleGenaiConfig,
@@ -93,19 +92,17 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 	});
 });
 
-test("config loading supports PI_GOOGLE_GENAI_TIMEOUT_MS override", async () => {
+test("config loading validates google-genai.json timeoutMs", async () => {
 	await withTempAgentDir(async () => {
-		await writeConfig({ timeoutMs: 12_000 });
-
-		process.env[GOOGLE_GENAI_TIMEOUT_ENV] = "45000";
+		await writeConfig({ timeoutMs: 45_000 });
 		let loaded = await loadGoogleGenaiConfig();
 		assert.equal(loaded.config.timeoutMs, 45_000);
 		assert.deepEqual(loaded.warnings, []);
 
-		process.env[GOOGLE_GENAI_TIMEOUT_ENV] = "not-a-number";
+		await writeConfig({ timeoutMs: "not-a-number" });
 		loaded = await loadGoogleGenaiConfig();
-		assert.equal(loaded.config.timeoutMs, 12_000);
-		assert.match(loaded.warnings.join("\n"), /PI_GOOGLE_GENAI_TIMEOUT_MS/);
+		assert.equal(loaded.config.timeoutMs, DEFAULT_TIMEOUT_MS);
+		assert.match(loaded.warnings.join("\n"), /google-genai\.json timeoutMs/);
 		assert.match(loaded.warnings.join("\n"), /positive number of milliseconds/);
 	});
 });
@@ -289,7 +286,7 @@ test("tools allow local http apiUrl for proxies", async () => {
 
 test("tool requests report HTTP errors and time out", async () => {
 	await withTempAgentDir(async () => {
-		await writeConfig({ timeoutMs: 50_000 });
+		await writeConfig({ timeoutMs: 1 });
 		const mock = createMockPi();
 		googleGenai(mock.pi);
 		const { ctx } = createMockContext({
@@ -315,7 +312,6 @@ test("tool requests report HTTP errors and time out", async () => {
 				throw new Error("unreachable");
 			}) as typeof fetch;
 
-			process.env[GOOGLE_GENAI_TIMEOUT_ENV] = "1";
 			await assert.rejects(
 				() => executeTool(mock.tools[0], "call-timeout", { query: "slow" }, ctx),
 				(error) => {
@@ -324,13 +320,13 @@ test("tool requests report HTTP errors and time out", async () => {
 					assert.match(error.message, /timeout, not a no-results response/i);
 					assert.match(error.message, /narrow/i);
 					assert.match(error.message, /split/i);
-					assert.match(error.message, /PI_GOOGLE_GENAI_TIMEOUT_MS/);
+					assert.match(error.message, /google-genai\.json timeoutMs/);
 					assert.doesNotMatch(error.message, /not found|no results found/i);
 					return true;
 				},
 			);
 
-			delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
+			await writeConfig({ timeoutMs: 50_000 });
 			await assert.rejects(
 				() =>
 					executeTool(mock.tools[0], "call-per-call-timeout", { query: "slow", timeoutMs: 1 }, ctx),
@@ -582,16 +578,14 @@ test("session_start restores persisted tool selection and ignores unknown names"
 	});
 });
 
-test("normalize settings defaults missing tools to all enabled and allows empty selection", async () => {
-	await withGoogleGenaiTimeoutEnv(undefined, async () => {
-		assert.deepEqual(normalizeGoogleGenaiSettings({}), {
-			model: DEFAULT_MODEL,
-			apiUrl: DEFAULT_API_URL,
-			timeoutMs: DEFAULT_TIMEOUT_MS,
-			tools: [...GOOGLE_GENAI_TOOL_NAMES],
-		});
-		assert.deepEqual(normalizeGoogleGenaiSettings({ tools: [] }).tools, []);
+test("normalize settings defaults missing tools to all enabled and allows empty selection", () => {
+	assert.deepEqual(normalizeGoogleGenaiSettings({}), {
+		model: DEFAULT_MODEL,
+		apiUrl: DEFAULT_API_URL,
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+		tools: [...GOOGLE_GENAI_TOOL_NAMES],
 	});
+	assert.deepEqual(normalizeGoogleGenaiSettings({ tools: [] }).tools, []);
 });
 
 interface TestToolDetails extends Record<string, unknown> {
@@ -618,30 +612,14 @@ async function executeTool(
 
 async function withTempAgentDir(fn: (agentDir: string) => Promise<void>) {
 	const previous = process.env.PI_CODING_AGENT_DIR;
-	const previousTimeout = process.env[GOOGLE_GENAI_TIMEOUT_ENV];
 	const agentDir = await mkdtemp(join(tmpdir(), "pi-google-genai-test-"));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
-	delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
 	try {
 		await fn(agentDir);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;
-		if (previousTimeout === undefined) delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
-		else process.env[GOOGLE_GENAI_TIMEOUT_ENV] = previousTimeout;
 		await rm(agentDir, { recursive: true, force: true });
-	}
-}
-
-async function withGoogleGenaiTimeoutEnv(value: string | undefined, fn: () => Promise<void>) {
-	const previous = process.env[GOOGLE_GENAI_TIMEOUT_ENV];
-	if (value === undefined) delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
-	else process.env[GOOGLE_GENAI_TIMEOUT_ENV] = value;
-	try {
-		await fn();
-	} finally {
-		if (previous === undefined) delete process.env[GOOGLE_GENAI_TIMEOUT_ENV];
-		else process.env[GOOGLE_GENAI_TIMEOUT_ENV] = previous;
 	}
 }
 


### PR DESCRIPTION
## Summary
- add config-file timeout validation and per-call timeoutMs support for Google GenAI tools
- improve timeout diagnostics so they distinguish timeout from no results and suggest narrowing/splitting broad queries
- document timeout precedence in google-genai.json plus per-call overrides and add regression coverage
- record the repo preference for JSON config over new env vars in MEMORY.md

## Verification
- npm run check
- npm run biome:check