### PR TITLE
fix(goal): guard stale completion calls

### DIFF
--- a/docs/plans/archived/2026-07-05_pi-goal-stale-completion-guard-plan.md
+++ b/docs/plans/archived/2026-07-05_pi-goal-stale-completion-guard-plan.md
@@ -1,0 +1,46 @@
+## Goal
+
+Add a stale-completion guard to `@narumitw/pi-goal` so `goal_complete` can only complete the exact active goal instance that was presented to the current turn.
+
+Success means an old, delayed, or replaced turn cannot mark a newer goal complete, while the current `/goal` completion flow and completion summary UX continue to work.
+
+## Context
+
+`extensions/pi-goal/src/goal.ts` currently stores an `ActiveGoal.id` and uses nonce-bearing continuation markers, but `goal_complete` only accepts `summary`. If a stale turn survives goal replacement or resume/clear races, the tool has no expected goal identifier to validate before mutating `activeGoal`.
+
+Codex avoids this class of bug in its state layer with expected-goal-id guarded updates in `third_party/codex/codex-rs/state/src/runtime/goals.rs`.
+
+## Architecture
+
+Keep the Pi extension self-contained. Add a required `goal_id` parameter to `goal_complete`, inject the current goal id into goal-mode prompts, and reject tool calls whose `goal_id` does not match the current `activeGoal.id`.
+
+The `summary` parameter remains for user-visible completion evidence; it is not used as a safety guard.
+
+## Non-Goals
+
+- Do not replace `goal_complete` with Codex-style `update_goal` in this slice.
+- Do not remove the current summary/evidence requirement.
+- Do not change goal persistence storage beyond storing any new compatibility metadata required by tests.
+
+## Plan
+
+- [x] Add focused failing tests in `extensions/pi-goal/test/goal.test.ts` for stale completion rejection after goal replacement, pause/resume, and clear; verify the tests fail before implementation with `npm test` from the repository root.
+- [x] Extend the `goal_complete` tool schema in `extensions/pi-goal/src/goal.ts` with required `goal_id` and validate it before summary validation or state mutation; verify stale calls return a warning result and leave `lastGoalStatus(mock)` unchanged with `npm test`.
+- [x] Inject the active goal id into `buildGoalSystemPrompt()`, `buildGoalPrompt()`, `buildResumePrompt()`, `buildObjectiveUpdatedPrompt()`, and `buildContinuePrompt()` as explicit completion-token guidance; verify prompt tests assert the goal id appears and XML escaping still passes with `npm test`.
+- [x] Update continuation/stale-tool-call guards so rejected stale `goal_complete` calls do not clear continuation state or unblock paused/stopped stale tool calls; verify with existing pause/clear stale-call tests plus the new stale completion tests.
+- [x] Update `extensions/pi-goal/README.md` completion documentation to explain that `goal_id` is a stale-turn guard and `summary` is completion evidence; verify README command/tool examples match the TypeScript tool schema by inspection.
+- [x] Run `npm run check` from the repository root and fix any formatting, type, or test failures.
+
+## Risks
+
+- Models may omit the new required `goal_id` until prompts are clear enough, causing false rejections.
+- Exposing raw goal ids in prompts can be confused with user objective data unless the prompt states that it is only a tool guard.
+- Existing sessions with active goals created before this change will need the prompt injection path to supply the id from persisted `ActiveGoal.id`.
+
+## Completion Checklist
+
+- [x] `goal_complete` requires and validates `goal_id`, verified by `extensions/pi-goal/src/goal.ts` schema and execution checks.
+- [x] Stale completion after replacement, pause/resume, or clear is rejected without completing the current goal, verified by targeted tests in `extensions/pi-goal/test/goal.test.ts`.
+- [x] Current-goal completion still succeeds with matching `goal_id` and non-empty non-contradictory summary, verified by updated success tests.
+- [x] Goal prompts consistently tell the model which `goal_id` to pass to `goal_complete`, verified by prompt snapshot/assertion tests.
+- [x] Repository verification passes with `npm run check`.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-goal)](https://www.npmjs.com/package/@narumitw/pi-goal) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds session-scoped `/goal` commands and a `goal_complete` tool for autonomous, verifiable task completion.
+`@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds session-scoped `/goal` commands and a `goal_complete({ goal_id, summary })` tool for autonomous, verifiable task completion.
 
 Goal mode uses Codex-like persistence instructions and keeps sending guarded continuation messages until the agent calls `goal_complete`, the user pauses or clears the goal, an interrupt/error pauses the goal, or an optional token budget is reached.
 
@@ -15,12 +15,13 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Supports optional token budgets such as `/goal --tokens 100k <goal>`.
 - Tracks `active`, `paused`, `budget_limited`, and `complete` states.
 - Stores goal state in the current Pi session, following Codex's thread-owned goal model instead of using a global per-directory goal.
-- Registers a `goal_complete` tool for explicit completion, and rejects plainly contradictory completion summaries such as “not complete” or “tests still fail”.
+- Registers a `goal_complete({ goal_id, summary })` tool for explicit completion, requiring the current goal id and rejecting missing/stale ids plus plainly contradictory summaries such as “not complete” or “tests still fail”.
 - Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle and no pending messages are queued.
 - Pauses and aborts queued goal work when the user pauses a goal or Pi reports a non-retryable aborted/errored assistant turn.
 - Keeps retryable provider interruptions and Pi compaction retries active without enqueueing duplicate goal continuations while Pi retries.
 - Preserves active goals across manual, threshold, and overflow compaction.
 - Guards auto-follow-ups so duplicate, replaced, paused, cleared, completed, or budget-limited goals are not continued.
+- Rotates the completion guard id when a goal is resumed or edited so delayed old turns cannot complete the newer goal instance.
 - Blocks stale tool calls after pause or non-retryable interruption.
 - Encourages requirement-by-requirement verification before the goal is marked complete.
 
@@ -82,7 +83,9 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 ## ✅ How completion works
 
-While a goal is active, `pi-goal` injects persistence rules and exposes `goal_complete`. If a turn ends before completion, it records usage and sends one guarded continuation only when no other messages are pending. Empty or plainly contradictory completion summaries are rejected as a state-safety guard, not as proof of completion.
+While a goal is active, `pi-goal` injects persistence rules, a `<goal_id>` stale-turn guard, and exposes `goal_complete`. To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence. Missing or stale `goal_id` values are rejected before summary validation, and paused goals cannot be completed until resumed. Empty or plainly contradictory summaries are also rejected; the summary is completion evidence, not the stale-turn safety token.
+
+If a turn ends before completion, `pi-goal` records usage and sends one guarded continuation only when no other messages are pending.
 
 ## 🛑 Interruption and queued-input behavior
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -28,6 +28,7 @@ interface ActiveGoal {
 
 interface GoalCompleteDetails {
 	goal: string;
+	goal_id: string;
 	summary: string;
 }
 
@@ -130,14 +131,20 @@ const goalCompleteTool = defineTool({
 	name: "goal_complete",
 	label: "Goal Complete",
 	description:
-		"Mark the active /goal as complete after all required work is done and verified. Do not use for partial progress, blockers, failing, or unverified work.",
-	promptSnippet: "Mark the active /goal as complete after fully finishing and verifying it",
+		"Mark the active /goal as complete after all required work is done and verified, using the current goal_id stale-turn guard. Do not use for partial progress, blockers, failing, or unverified work.",
+	promptSnippet:
+		"Mark the active /goal as complete after fully finishing and verifying it, with the current goal_id",
 	promptGuidelines: [
 		"When a /goal is active, keep working until the goal is complete; do not stop with only a plan or partial progress.",
 		"Before calling goal_complete, audit the active goal requirement by requirement against the current files, command output, tests, or external state.",
+		"Pass the exact goal_id shown in the current /goal prompt; never reuse a goal_id from an older, paused, replaced, or cleared turn.",
 		"Call goal_complete only after the requested goal is fully implemented, verified, and no known required work remains; otherwise keep working.",
 	],
 	parameters: Type.Object({
+		goal_id: Type.String({
+			description:
+				"The exact goal_id shown in the current active /goal prompt. Used only to reject stale completion calls from older turns.",
+		}),
 		summary: Type.String({
 			description:
 				"State what was completed and what evidence verified it. Do not use this tool to report partial progress, blockers, failures, or remaining work.",
@@ -146,7 +153,8 @@ const goalCompleteTool = defineTool({
 	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 		const completedGoal = activeGoal;
 		const goal = completedGoal?.text ?? "unknown goal";
-		const summary = params.summary.trim();
+		const requestedGoalId = typeof params.goal_id === "string" ? params.goal_id.trim() : "";
+		const summary = typeof params.summary === "string" ? params.summary.trim() : "";
 
 		if (!completedGoal) {
 			const rejection = "Goal completion rejected: no active goal.";
@@ -154,7 +162,28 @@ const goalCompleteTool = defineTool({
 
 			return {
 				content: [{ type: "text", text: rejection }],
-				details: { goal, summary } satisfies GoalCompleteDetails,
+				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
+			};
+		}
+
+		const staleGoalRejection = goalIdRejectionReason(completedGoal, requestedGoalId);
+		if (staleGoalRejection) {
+			const rejection = `Goal completion rejected: ${staleGoalRejection}.`;
+			ctx.ui.notify(rejection, "warning");
+
+			return {
+				content: [{ type: "text", text: rejection }],
+				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
+			};
+		}
+
+		if (completedGoal.status !== "active") {
+			const rejection = `Goal completion rejected: goal is ${completedGoal.status}, not active.`;
+			ctx.ui.notify(rejection, "warning");
+
+			return {
+				content: [{ type: "text", text: rejection }],
+				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
 			};
 		}
 
@@ -177,24 +206,22 @@ const goalCompleteTool = defineTool({
 						text: rejection,
 					},
 				],
-				details: { goal, summary } satisfies GoalCompleteDetails,
+				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
 			};
 		}
 
-		if (completedGoal) {
-			activeGoal = transitionGoal(completedGoal, "complete");
-			updateGoalUsage(activeGoal, ctx);
-			persistGoal(activeGoal);
-		}
+		activeGoal = transitionGoal(completedGoal, "complete");
+		updateGoalUsage(activeGoal, ctx);
+		persistGoal(activeGoal);
 
-		ctx.ui.setStatus(STATUS_KEY, completedGoal ? formatStatus(activeGoal) : undefined);
+		ctx.ui.setStatus(STATUS_KEY, formatStatus(activeGoal));
 		clearActiveGoal(ctx);
 		showCompletionStatus(ctx);
 		ctx.ui.notify(`Goal complete: ${goal}`, "info");
 
 		return {
 			content: [{ type: "text", text: `Goal complete: ${summary}` }],
-			details: { goal, summary } satisfies GoalCompleteDetails,
+			details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
 			terminate: true,
 		};
 	},
@@ -427,7 +454,7 @@ async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 	}
 	clearGoalRecovery();
 	clearStaleGoalToolCallBlock();
-	activeGoal = transitionGoal(activeGoal, "active");
+	activeGoal = transitionGoal(nextGoalInstance(activeGoal), "active");
 	persistGoal(activeGoal);
 	updateStatus(ctx, activeGoal);
 	if (activeGoal.status !== "active") {
@@ -474,7 +501,7 @@ async function editGoal(
 	cancelContinuationPending();
 	clearGoalRecovery();
 	activeGoal = normalizeGoalForBudget({
-		...activeGoal,
+		...nextGoalInstance(activeGoal),
 		text: objective,
 		status: editedGoalStatus(activeGoal.status),
 		tokenBudget: tokenBudget ?? activeGoal.tokenBudget,
@@ -519,6 +546,10 @@ function createGoal(text: string, tokenBudget: number | undefined, baselineToken
 
 function transitionGoal(goal: ActiveGoal, status: GoalStatus): ActiveGoal {
 	return normalizeGoalForBudget({ ...goal, status, updatedAt: Date.now() });
+}
+
+function nextGoalInstance(goal: ActiveGoal): ActiveGoal {
+	return { ...goal, id: randomUUID(), updatedAt: Date.now() };
 }
 
 function editedGoalStatus(status: GoalStatus): GoalStatus {
@@ -747,34 +778,42 @@ export function formatTokenCount(value: number) {
 
 function buildGoalPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatTokenCount(goal.tokenBudget)}.`;
-	return `Goal mode is active. Complete this goal fully:\n\n${goalObjectiveBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
+	return `Goal mode is active. Complete this goal fully:\n\n${goalContextBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
 }
 
 function buildObjectiveUpdatedPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatBudget(goal)} used.`;
-	return `The active /goal objective was updated. Continue working toward this goal:\n\n${goalObjectiveBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("the updated goal")}`;
+	return `The active /goal objective was updated. Continue working toward this goal:\n\n${goalContextBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("the updated goal")}`;
 }
 
 function buildResumePrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\nToken budget: ${formatBudget(goal)} used.`;
-	return `The user explicitly resumed the paused /goal. Continue working toward this goal:\n\n${goalObjectiveBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
+	return `The user explicitly resumed the paused /goal. Continue working toward this goal:\n\n${goalContextBlock(goal)}${budgetLine}\n\n${goalPersistenceRules("this goal")}`;
 }
 
 export function buildGoalSystemPrompt(goal: ActiveGoal) {
 	const budgetLine = goal.tokenBudget === undefined ? "" : `\n- Respect the goal token budget (${formatBudget(goal)} used).`;
-	return `Active /goal:\n${goalObjectiveBlock(goal)}\n\nGoal-mode rules:\n- Keep going until the active goal is completely resolved end-to-end.\n- Treat the current worktree, command output, tests, and external state as authoritative.\n- Do not redefine the goal into a smaller task; audit every requirement before completion.\n- Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps.\n- Autonomously perform implementation and verification with the available tools when they are needed to complete the goal.\n- Persevere through recoverable tool failures by trying reasonable alternatives instead of yielding early.\n- If the goal is not complete at the end of a turn, expect an automatic continuation and keep working from where you left off.\n- Only call the goal_complete tool after the goal is fully complete and verified.${budgetLine}`;
+	return `Active /goal:\n${goalContextBlock(goal)}\n\nGoal-mode rules:\n- Keep going until the active goal is completely resolved end-to-end.\n- Treat the current worktree, command output, tests, and external state as authoritative.\n- Do not redefine the goal into a smaller task; audit every requirement before completion.\n- Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps.\n- Autonomously perform implementation and verification with the available tools when they are needed to complete the goal.\n- Persevere through recoverable tool failures by trying reasonable alternatives instead of yielding early.\n- If the goal is not complete at the end of a turn, expect an automatic continuation and keep working from where you left off.\n- Only call the goal_complete tool after the goal is fully complete and verified, and pass this exact goal_id.${budgetLine}`;
 }
 
 function buildContinuePrompt(goal: ActiveGoal, marker: string) {
-	return `Continue the active /goal until it is complete:\n\n${goalObjectiveBlock(goal)}\n\nThis is automatic continuation #${goal.iteration}. Current files, command output, tests, and external state are authoritative; re-check them as needed. ${goalPersistenceRules("this goal")}\n\n${continuationMarkerComment(marker)}`;
+	return `Continue the active /goal until it is complete:\n\n${goalContextBlock(goal)}\n\nThis is automatic continuation #${goal.iteration}. Current files, command output, tests, and external state are authoritative; re-check them as needed. ${goalPersistenceRules("this goal")}\n\n${continuationMarkerComment(marker)}`;
+}
+
+function goalContextBlock(goal: ActiveGoal) {
+	return `${goalObjectiveBlock(goal)}\n\n${goalCompletionGuardBlock(goal)}`;
 }
 
 function goalObjectiveBlock(goal: ActiveGoal) {
 	return `<goal_objective>\n${escapeXmlText(goal.text)}\n</goal_objective>`;
 }
 
+function goalCompletionGuardBlock(goal: ActiveGoal) {
+	return `<goal_id>\n${escapeXmlText(goal.id)}\n</goal_id>\nThis goal_id is only the goal_complete tool stale-turn guard, not part of the objective. If and only if the goal is fully complete, pass this exact goal_id to goal_complete with the completion summary.`;
+}
+
 function goalPersistenceRules(goalLabel: string) {
-	return `Keep going until ${goalLabel} is completely resolved end-to-end. Do not redefine ${goalLabel} into a smaller task. Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps. Autonomously perform implementation and verification with the available tools when they are needed. Treat the current worktree, command output, tests, and external state as authoritative. If a tool call fails, try reasonable alternatives instead of yielding early. Before calling goal_complete, audit ${goalLabel} requirement by requirement against the verified current state. Only call the goal_complete tool after ${goalLabel} is fully complete and verified.`;
+	return `Keep going until ${goalLabel} is completely resolved end-to-end. Do not redefine ${goalLabel} into a smaller task. Do not stop at analysis, a plan, TODO list, partial fixes, or suggested next steps. Autonomously perform implementation and verification with the available tools when they are needed. Treat the current worktree, command output, tests, and external state as authoritative. If a tool call fails, try reasonable alternatives instead of yielding early. Before calling goal_complete, audit ${goalLabel} requirement by requirement against the verified current state. Only call the goal_complete tool after ${goalLabel} is fully complete and verified, and pass this exact goal_id. Never reuse a goal_id from an older, paused, replaced, or cleared turn.`;
 }
 
 function hasPendingMessages(ctx: StatusContext) {
@@ -817,6 +856,12 @@ function isPiOwnedCompactionRetry(event: unknown, goalId: string) {
 
 export function isContradictoryCompletionSummary(summary: string) {
 	return CONTRADICTORY_COMPLETION_PATTERNS.some((pattern) => pattern.test(summary));
+}
+
+function goalIdRejectionReason(goal: ActiveGoal, requestedGoalId: string) {
+	if (!requestedGoalId) return "missing goal_id";
+	if (requestedGoalId !== goal.id) return "goal_id does not match the active goal";
+	return undefined;
 }
 
 export function isRetryableGoalInterruption(assistant: AssistantMessageLike) {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -22,6 +22,11 @@ test("goal registers command, completion tool, and lifecycle hooks", () => {
 	assert.ok(mock.commands.has("goal"));
 	assert.equal(typeof mock.commands.get("goal")?.getArgumentCompletions, "function");
 	assert.equal(mock.tools[0]?.name, "goal_complete");
+	const toolParameters = mock.tools[0]?.parameters as
+		| { required?: string[]; properties?: Record<string, unknown> }
+		| undefined;
+	assert.deepEqual(toolParameters?.required, ["goal_id", "summary"]);
+	assert.ok(toolParameters?.properties?.goal_id);
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"agent_end",
 		"before_agent_start",
@@ -119,9 +124,9 @@ test("formatStatus reports active, paused, budget-limited, and empty states", ()
 	assert.equal(formatStatus({ ...activeGoal, status: "budget_limited" }), "budget 500/2k");
 });
 
-test("buildGoalSystemPrompt escapes objective XML and includes budget rules", () => {
+test("buildGoalSystemPrompt escapes objective XML and includes goal_id guard rules", () => {
 	const prompt = buildGoalSystemPrompt({
-		id: "g1",
+		id: "g<1&2>",
 		text: "fix <all> & verify",
 		status: "active",
 		startedAt: 0,
@@ -134,8 +139,75 @@ test("buildGoalSystemPrompt escapes objective XML and includes budget rules", ()
 	});
 
 	assert.match(prompt, /fix &lt;all&gt; &amp; verify/);
+	assert.match(prompt, /g&lt;1&amp;2&gt;/);
 	assert.match(prompt, /Respect the goal token budget \(250\/1k used\)/);
 	assert.match(prompt, /Only call the goal_complete tool after/);
+	assert.match(prompt, /pass this exact goal_id/);
+	assert.match(prompt, /stale-turn guard/);
+});
+
+test("goal prompts include the active goal_id guard", async () => {
+	const started = await startGoalForTest();
+	const initialGoal = requireLastGoal(started.mock);
+	assertPromptHasGoalId(started.mock.sentUserMessages[0]?.text ?? "", initialGoal.id);
+
+	const systemPrompt = started.mock.events.get("before_agent_start")?.[0]?.(
+		{ systemPrompt: "base" },
+		started.ctx,
+	) as { systemPrompt?: string } | undefined;
+	assertPromptHasGoalId(systemPrompt?.systemPrompt ?? "", initialGoal.id);
+
+	await started.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		started.ctx,
+	);
+	assertPromptHasGoalId(started.mock.sentUserMessages.at(-1)?.text ?? "", initialGoal.id);
+
+	await started.mock.commands.get("goal")?.handler("pause", started.ctx);
+	await started.mock.commands.get("goal")?.handler("resume", started.ctx);
+	const resumedGoal = requireLastGoal(started.mock);
+	assertPromptHasGoalId(started.mock.sentUserMessages.at(-1)?.text ?? "", resumedGoal.id);
+
+	await started.mock.commands.get("goal")?.handler("edit verify edited objective", started.ctx);
+	const editedGoal = requireLastGoal(started.mock);
+	assertPromptHasGoalId(started.mock.sentUserMessages.at(-1)?.text ?? "", editedGoal.id);
+});
+
+test("goal_complete requires current goal_id before validating summary", async () => {
+	const { mock, ctx } = await startGoalForTest();
+	const tool = mock.tools[0] as GoalTool;
+	const currentGoal = requireLastGoal(mock);
+
+	try {
+		const missingId = await tool.execute(
+			"call-missing-id",
+			{ summary: "Implemented and verified with npm test." },
+			new AbortController().signal,
+			() => undefined,
+			ctx,
+		);
+
+		assert.equal(missingId.terminate, undefined);
+		assert.match(missingId.content?.[0]?.text ?? "", /goal_id/i);
+		assert.equal(lastGoalStatus(mock), "active");
+
+		const staleId = await tool.execute(
+			"call-stale-id",
+			{ goal_id: "stale-goal", summary: "Not complete: tests still fail." },
+			new AbortController().signal,
+			() => undefined,
+			ctx,
+		);
+
+		assert.equal(staleId.terminate, undefined);
+		assert.match(staleId.content?.[0]?.text ?? "", /goal_id/i);
+		assert.doesNotMatch(staleId.content?.[0]?.text ?? "", /summary/i);
+		assert.doesNotMatch(staleId.content?.[0]?.text ?? "", new RegExp(escapeRegExp(currentGoal.id)));
+		assert.equal(requireLastGoal(mock).id, currentGoal.id);
+		assert.equal(lastGoalStatus(mock), "active");
+	} finally {
+		mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	}
 });
 
 test("goal_complete rejects contradictory summaries and accepts verified completion", async () => {
@@ -155,10 +227,11 @@ test("goal_complete rejects contradictory summaries and accepts verified complet
 
 	const { mock, ctx } = await startGoalForTest();
 	const tool = mock.tools[0] as GoalTool;
+	const goalId = requireLastGoal(mock).id;
 
 	const rejected = await tool.execute(
 		"call-1",
-		{ summary: "Not complete: tests still fail." },
+		{ goal_id: goalId, summary: "Not complete: tests still fail." },
 		new AbortController().signal,
 		() => undefined,
 		ctx,
@@ -170,7 +243,7 @@ test("goal_complete rejects contradictory summaries and accepts verified complet
 
 	const emptyRejected = await tool.execute(
 		"call-empty",
-		{ summary: "   " },
+		{ goal_id: goalId, summary: "   " },
 		new AbortController().signal,
 		() => undefined,
 		ctx,
@@ -182,7 +255,7 @@ test("goal_complete rejects contradictory summaries and accepts verified complet
 
 	const accepted = await tool.execute(
 		"call-2",
-		{ summary: "Implemented and verified with npm test." },
+		{ goal_id: goalId, summary: "Implemented and verified with npm test." },
 		new AbortController().signal,
 		() => undefined,
 		ctx,
@@ -193,7 +266,7 @@ test("goal_complete rejects contradictory summaries and accepts verified complet
 
 	const noActiveRejected = await tool.execute(
 		"call-no-active",
-		{ summary: "Implemented and verified with npm test." },
+		{ goal_id: goalId, summary: "Implemented and verified with npm test." },
 		new AbortController().signal,
 		() => undefined,
 		ctx,
@@ -203,6 +276,98 @@ test("goal_complete rejects contradictory summaries and accepts verified complet
 	assert.match(noActiveRejected.content?.[0]?.text ?? "", /no active goal/i);
 	assert.equal(lastGoalStatus(mock), null);
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+});
+
+test("goal_complete rejects stale goal_id after replacement, pause/resume, and clear", async () => {
+	const replaced = await startGoalForTest();
+	const replacementTool = replaced.mock.tools[0] as GoalTool;
+	const originalGoal = requireLastGoal(replaced.mock);
+
+	await replaced.mock.commands.get("goal")?.handler("ship replacement objective", replaced.ctx);
+	const replacementGoal = requireLastGoal(replaced.mock);
+	assert.notEqual(replacementGoal.id, originalGoal.id);
+
+	const staleReplacement = await replacementTool.execute(
+		"call-stale-replacement",
+		{ goal_id: originalGoal.id, summary: "Not complete: tests still fail." },
+		new AbortController().signal,
+		() => undefined,
+		replaced.ctx,
+	);
+
+	assert.equal(staleReplacement.terminate, undefined);
+	assert.match(staleReplacement.content?.[0]?.text ?? "", /goal_id/i);
+	assert.doesNotMatch(
+		staleReplacement.content?.[0]?.text ?? "",
+		new RegExp(escapeRegExp(replacementGoal.id)),
+	);
+	assert.equal(requireLastGoal(replaced.mock).id, replacementGoal.id);
+	assert.equal(lastGoalStatus(replaced.mock), "active");
+
+	const resumed = await startGoalForTest();
+	const resumeTool = resumed.mock.tools[0] as GoalTool;
+	const beforePauseGoal = requireLastGoal(resumed.mock);
+	await resumed.mock.commands.get("goal")?.handler("pause", resumed.ctx);
+
+	const stalePaused = await resumeTool.execute(
+		"call-stale-paused",
+		{ goal_id: beforePauseGoal.id, summary: "Not complete: tests still fail." },
+		new AbortController().signal,
+		() => undefined,
+		resumed.ctx,
+	);
+
+	assert.equal(stalePaused.terminate, undefined);
+	assert.match(stalePaused.content?.[0]?.text ?? "", /paused|not active/i);
+	assert.equal(lastGoalStatus(resumed.mock), "paused");
+	assert.deepEqual(
+		resumed.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "t-after-stale-complete", input: {} },
+			resumed.ctx,
+		),
+		{
+			block: true,
+			reason: "Blocked stale /goal tool call after the goal was paused or interrupted.",
+		},
+	);
+
+	await resumed.mock.commands.get("goal")?.handler("resume", resumed.ctx);
+	const afterResumeGoal = requireLastGoal(resumed.mock);
+	assert.notEqual(afterResumeGoal.id, beforePauseGoal.id);
+
+	const staleAfterResume = await resumeTool.execute(
+		"call-stale-after-resume",
+		{ goal_id: beforePauseGoal.id, summary: "Not complete: tests still fail." },
+		new AbortController().signal,
+		() => undefined,
+		resumed.ctx,
+	);
+
+	assert.equal(staleAfterResume.terminate, undefined);
+	assert.match(staleAfterResume.content?.[0]?.text ?? "", /goal_id/i);
+	assert.doesNotMatch(
+		staleAfterResume.content?.[0]?.text ?? "",
+		new RegExp(escapeRegExp(afterResumeGoal.id)),
+	);
+	assert.equal(requireLastGoal(resumed.mock).id, afterResumeGoal.id);
+	assert.equal(lastGoalStatus(resumed.mock), "active");
+
+	const cleared = await startGoalForTest();
+	const clearTool = cleared.mock.tools[0] as GoalTool;
+	const beforeClearGoal = requireLastGoal(cleared.mock);
+	await cleared.mock.commands.get("goal")?.handler("clear", cleared.ctx);
+
+	const staleAfterClear = await clearTool.execute(
+		"call-stale-after-clear",
+		{ goal_id: beforeClearGoal.id, summary: "Implemented and verified." },
+		new AbortController().signal,
+		() => undefined,
+		cleared.ctx,
+	);
+
+	assert.equal(staleAfterClear.terminate, undefined);
+	assert.match(staleAfterClear.content?.[0]?.text ?? "", /no active goal/i);
+	assert.equal(lastGoalStatus(cleared.mock), null);
 });
 
 test("pause aborts the current turn, blocks stale tools, and persists paused state", async () => {
@@ -242,6 +407,7 @@ test("pause aborts the current turn, blocks stale tools, and persists paused sta
 test("clear removes goal state without aborting or blocking stale tools", async () => {
 	let clearAborts = 0;
 	const cleared = await startGoalForTest({ abort: () => clearAborts++ });
+	const beforeClearGoal = requireLastGoal(cleared.mock);
 	await cleared.mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },
 		cleared.ctx,
@@ -272,7 +438,7 @@ test("clear removes goal state without aborting or blocking stale tools", async 
 	const tool = cleared.mock.tools[0] as GoalTool;
 	const staleCompletion = await tool.execute(
 		"call-after-clear",
-		{ summary: "Implemented and verified." },
+		{ goal_id: beforeClearGoal.id, summary: "Implemented and verified." },
 		new AbortController().signal,
 		() => undefined,
 		cleared.ctx,
@@ -612,6 +778,21 @@ type GoalTool = {
 	}>;
 };
 
+type StoredGoal = {
+	id: string;
+	status?: string;
+};
+
+function assertPromptHasGoalId(prompt: string, goalId: string) {
+	assert.match(prompt, new RegExp(`<goal_id>\\s*${escapeRegExp(goalId)}\\s*</goal_id>`));
+	assert.match(prompt, /pass this exact goal_id/);
+	assert.match(prompt, /stale-turn guard/);
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 async function startGoalForTest(overrides: Record<string, unknown> = {}) {
 	const mock = createMockPi();
 	goal(mock.pi);
@@ -621,8 +802,18 @@ async function startGoalForTest(overrides: Record<string, unknown> = {}) {
 	return { mock, ...context };
 }
 
-function lastGoalStatus(mock: ReturnType<typeof createMockPi>) {
+function requireLastGoal(mock: ReturnType<typeof createMockPi>) {
+	const goal = lastGoal(mock);
+	assert.ok(goal, "expected a persisted goal");
+	return goal;
+}
+
+function lastGoal(mock: ReturnType<typeof createMockPi>) {
 	const entry = mock.entries.filter((entry) => entry.customType === "goal-state").at(-1);
-	return ((entry?.data as { goal?: { status?: string } | null } | undefined)?.goal?.status ??
-		null) as string | null;
+	return ((entry?.data as { goal?: StoredGoal | null } | undefined)?.goal ??
+		null) as StoredGoal | null;
+}
+
+function lastGoalStatus(mock: ReturnType<typeof createMockPi>) {
+	return lastGoal(mock)?.status ?? null;
 }


### PR DESCRIPTION
## Summary
- require `goal_id` for `goal_complete` and reject missing/stale/non-active completions before mutating goal state
- inject the current `<goal_id>` guard into goal prompts and rotate ids on resume/edit
- add regression tests and archive the completed stale-completion plan

## Verification
- `npm run check`
- commit hook: Biome check and npm typecheck