### PR TITLE
feat(subagents): add thinking level control

### DIFF
--- a/docs/plans/archived/2026-07-08_pi-subagents-thinking-level-plan.md
+++ b/docs/plans/archived/2026-07-08_pi-subagents-thinking-level-plan.md
@@ -1,0 +1,56 @@
+## Goal
+
+Resolve [issue #147](https://github.com/narumiruna/pi-extensions/issues/147) by adding explicit thinking-level control to `@narumitw/pi-subagents` subprocess invocations.
+
+Success means a caller can request Pi thinking levels (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`) for single, parallel, chain, and aggregator subagents, and tests prove the chosen level is passed to the spawned `pi --thinking <level>` command without breaking existing model, tool, timeout, or project-agent behavior.
+
+## Context
+
+`extensions/pi-subagents/src/subagents.ts` currently starts workers as `pi --mode json -p --no-session`, optionally adding `--model`, `--tools`, `--no-tools`, and `--append-system-prompt`. Pi CLI supports `--thinking <level>` and `--model <pattern>:<thinking>`, but the extension has no first-class `thinkingLevel` parameter or agent default.
+
+Existing agent definitions/config support `model`, `tools`, and `timeoutMs`; the `/subagents:config` UI only edits tools but intentionally preserves other config fields when saving.
+
+## Architecture
+
+Add a small, validated `ThinkingLevel` union inside `pi-subagents` and thread it through the same places that already carry timeout/model overrides:
+
+- tool call params: top-level `thinkingLevel` plus per task/chain step/aggregator `thinkingLevel`;
+- agent defaults: custom-agent frontmatter `thinkingLevel` and config-file override `agents.<name>.thinkingLevel`;
+- subprocess launch: pass the resolved value as `--thinking <level>`.
+
+Suggested precedence: local item `thinkingLevel` > top-level `thinkingLevel` > resolved agent default `thinkingLevel` > omit `--thinking` and preserve current Pi subprocess defaults/model-suffix behavior.
+
+Keep `model: sonnet:high` working as it does today. If both `model` contains a thinking suffix and an explicit `thinkingLevel` is resolved, pass both `--model` and `--thinking`; Pi's CLI should treat `--thinking` as the explicit override.
+
+## Non-Goals
+
+- Do not make subagents implicitly inherit the parent session's current thinking level in this slice; omitted `thinkingLevel` should preserve existing subprocess defaults.
+- Do not redesign `/subagents:config` into a full model/timeout/thinking editor; only preserve and normalize the new field like the existing non-UI `model` and `timeoutMs` settings.
+- Do not add provider/model capability detection in the extension; Pi already clamps unsupported thinking levels at model resolution time.
+
+## Plan
+
+- [x] Add failing tests in `extensions/pi-subagents/test/subagents.test.ts` for accepted `thinkingLevel` values in the tool schema and config normalization; verify initial failures with `npm test` from the repository root.
+- [x] Extract a small subprocess-argument helper from `runSingleAgent()` in `extensions/pi-subagents/src/subagents.ts` so tests can assert generated Pi args without spawning a subprocess; verify existing args for `--mode json -p --no-session`, `--model`, `--tools`, `--no-tools`, and `--append-system-prompt` remain unchanged with targeted tests.
+- [x] Add `thinkingLevel` to `TaskItem`, `ChainItem`, `AggregatorItem`, and top-level `SubagentParams` using an enum schema for `off|minimal|low|medium|high|xhigh`; verify schema tests cover the field descriptions and invalid values are rejected by TypeScript/schema validation paths.
+- [x] Extend `AgentConfig`, `SubagentAgentConfig`, `discoverAgents()`, `normalizeAgentSettings()`, and `hasAnyAgentOverride()` to support `thinkingLevel`; verify custom-agent frontmatter and config override tests cover valid values, invalid config rejection, null clearing, and preservation when `/subagents:config` saves tool defaults.
+- [x] Resolve the final thinking level in each execution path (`single`, `parallel`, `chain`, `aggregator`) with precedence local item > top-level > agent default; verify argument-helper tests cover each mode and precedence branch.
+- [x] Pass the resolved thinking level to `runSingleAgent()` and add `--thinking <level>` only when a value is resolved; verify tests assert no `--thinking` is emitted when omitted, preserving current behavior.
+- [x] Include the requested `thinkingLevel` in `SingleResult` details and optionally render it beside model/usage so users can confirm what was requested; verify renderer or details tests cover at least the details field.
+- [x] Update `extensions/pi-subagents/README.md` with tool examples, custom-agent frontmatter, runtime-limit/config notes if needed, and the exact supported levels; verify examples match the TypeScript schema by inspection.
+- [x] Run `npm run check` from the repository root and fix formatting, type, or test failures.
+
+## Risks
+
+- Adding too many override locations can make precedence confusing; keep the documented order explicit and covered by tests.
+- If Pi CLI behavior changes for `--model foo:high` plus `--thinking low`, this extension should still pass explicit arguments predictably and let Pi own model capability clamping.
+- `/subagents:config` only edits tools, so users who want persistent thinking defaults must edit `pi-subagents-config.json` or agent frontmatter manually until a broader config UI exists.
+
+## Completion Checklist
+
+- [x] `subagent` accepts `thinkingLevel` at top level, per task, per chain step, and per aggregator, verified by schema/assertion tests in `extensions/pi-subagents/test/subagents.test.ts`.
+- [x] Custom agents and config overrides can set or clear default `thinkingLevel`, verified by discovery/normalization tests.
+- [x] Spawned Pi subprocess args include `--thinking <level>` for resolved values and omit it otherwise, verified by argument-helper tests.
+- [x] Existing model/tool/timeout/project-agent behavior remains unchanged, verified by existing tests plus new regression assertions.
+- [x] README documents the feature and supported levels, verified by review of `extensions/pi-subagents/README.md`.
+- [x] Repository verification passes with `npm run check`.

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -14,7 +14,7 @@ Use it to split research, planning, implementation, and review work across focus
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides `/subagents:config` to persist per-agent tool allow-lists.
-- Supports per-task `cwd`, hard subprocess `timeoutMs`, abort propagation, and streaming progress.
+- Supports per-task `cwd`, hard subprocess `timeoutMs`, `thinkingLevel`, abort propagation, and streaming progress.
 - Publishes transient runtime status through Pi's generic extension status API while subagents are running.
 - Returns complete worker output in tool details and a concise result for the main agent.
 
@@ -48,6 +48,12 @@ Execution modes:
 - **parallel** — run multiple `{ agent, task }` jobs independently.
 - **parallel + aggregator** — run parallel jobs, then pass all outputs into one fan-in agent.
 - **chain** — run sequential steps, passing prior output with `{previous}`.
+
+Common controls:
+
+- `cwd` — run a job from a different working directory.
+- `timeoutMs` — set a hard subprocess timeout.
+- `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, or `xhigh` thinking for the spawned Pi process.
 
 ## 🧭 Proactive use
 
@@ -122,7 +128,7 @@ Run one read-only reconnaissance agent:
 }
 ```
 
-Run multiple agents in parallel:
+Run multiple agents in parallel with a shared thinking level and one per-task override:
 
 ```json
 {
@@ -130,14 +136,16 @@ Run multiple agents in parallel:
     {
       "agent": "scout",
       "task": "Map package metadata files",
-      "timeoutMs": 30000
+      "timeoutMs": 30000,
+      "thinkingLevel": "low"
     },
     {
       "agent": "reviewer",
       "task": "Review TypeScript config consistency"
     }
   ],
-  "timeoutMs": 120000
+  "timeoutMs": 120000,
+  "thinkingLevel": "medium"
 }
 ```
 
@@ -212,6 +220,7 @@ name: api-reviewer
 description: Review API changes for compatibility and tests
 tools: read, grep, find, ls, bash
 model: sonnet
+thinkingLevel: high
 ---
 
 You are an API review subagent. Do not edit files. Check compatibility,
@@ -220,13 +229,17 @@ test coverage, and migration risks. Report PASS/FAIL/PARTIAL with evidence.
 
 By default, `subagent` loads user agents only. Set `agentScope` to `"project"` or `"both"` to load project-local agents. Interactive sessions ask for confirmation before using project agents unless `confirmProjectAgents` is disabled.
 
-## ⏱️ Runtime limits
+## ⏱️ Runtime limits and thinking levels
 
 Each subprocess has a hard timeout to avoid runaway workers.
 
 - Set `timeoutMs` on the top-level call to apply a default for all jobs.
 - Set `timeoutMs` on a task, chain step, or aggregator to override it locally.
 - If omitted, the default is `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset.
+
+Set `thinkingLevel` to pass Pi's `--thinking <level>` to a subprocess. Supported values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+
+Thinking-level precedence is: task/chain step/aggregator `thinkingLevel` → top-level `thinkingLevel` → agent default from config or frontmatter → Pi subprocess default. Omit `thinkingLevel` to preserve existing behavior. Pi still owns model capability clamping, so unsupported thinking levels are handled by the spawned Pi process.
 
 On timeout, the extension sends `SIGTERM`, escalates to `SIGKILL` after a short grace period, and returns any partial messages or stderr collected so far.
 

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -4,7 +4,16 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
+
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly ThinkingLevel[];
+
+export type SubagentThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+export function isThinkingLevel(value: unknown): value is SubagentThinkingLevel {
+	return typeof value === "string" && THINKING_LEVELS.includes(value as SubagentThinkingLevel);
+}
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -15,6 +24,7 @@ export interface AgentConfig {
 	description: string;
 	tools?: string[];
 	model?: string;
+	thinkingLevel?: SubagentThinkingLevel;
 	timeoutMs?: number;
 	systemPrompt: string;
 	source: AgentSource;
@@ -24,6 +34,7 @@ export interface AgentConfig {
 export interface SubagentAgentConfig {
 	tools?: string[];
 	model?: string | null;
+	thinkingLevel?: SubagentThinkingLevel | null;
 	timeoutMs?: number | null;
 }
 
@@ -146,6 +157,7 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 			description: frontmatter.description,
 			tools: tools && tools.length > 0 ? tools : undefined,
 			model: frontmatter.model,
+			thinkingLevel: isThinkingLevel(frontmatter.thinkingLevel) ? frontmatter.thinkingLevel : undefined,
 			systemPrompt: body,
 			source,
 			filePath,
@@ -216,6 +228,9 @@ export function discoverAgents(
 		if (hasOwn(override, "tools")) nextAgent.tools = override.tools;
 		if (hasOwn(override, "model")) {
 			nextAgent.model = override.model === null ? undefined : override.model;
+		}
+		if (hasOwn(override, "thinkingLevel")) {
+			nextAgent.thinkingLevel = override.thinkingLevel === null ? undefined : override.thinkingLevel;
 		}
 		if (hasOwn(override, "timeoutMs")) {
 			nextAgent.timeoutMs = override.timeoutMs === null ? undefined : override.timeoutMs;

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -39,12 +39,15 @@ import {
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import {
+	THINKING_LEVELS,
 	type AgentConfig,
 	type AgentScope,
 	type AgentSource,
 	type SubagentAgentConfig,
 	type SubagentSettings,
+	type SubagentThinkingLevel,
 	discoverAgents,
+	isThinkingLevel,
 } from "./agents.js";
 
 const MAX_PARALLEL_TASKS = 8;
@@ -132,6 +135,7 @@ export function formatUsageStats(
 		turns?: number;
 	},
 	model?: string,
+	thinkingLevel?: SubagentThinkingLevel,
 ): string {
 	const parts: string[] = [];
 	if (usage.turns) parts.push(`${usage.turns} turn${usage.turns > 1 ? "s" : ""}`);
@@ -144,6 +148,7 @@ export function formatUsageStats(
 		parts.push(`ctx:${formatTokens(usage.contextTokens)}`);
 	}
 	if (model) parts.push(model);
+	if (thinkingLevel) parts.push(`thinking:${thinkingLevel}`);
 	return parts.join(" ");
 }
 
@@ -234,6 +239,7 @@ interface SingleResult {
 	stderr: string;
 	usage: UsageStats;
 	model?: string;
+	thinkingLevel?: SubagentThinkingLevel;
 	stopReason?: string;
 	errorMessage?: string;
 	step?: number;
@@ -326,6 +332,25 @@ async function writePromptToTempFile(agentName: string, prompt: string): Promise
 	return { dir: tmpDir, filePath };
 }
 
+export function buildPiArgs(options: {
+	model?: string;
+	thinkingLevel?: SubagentThinkingLevel;
+	tools?: string[];
+	systemPromptPath?: string;
+	task: string;
+}): string[] {
+	const args: string[] = ["--mode", "json", "-p", "--no-session"];
+	if (options.model) args.push("--model", options.model);
+	if (options.thinkingLevel) args.push("--thinking", options.thinkingLevel);
+	if (Array.isArray(options.tools)) {
+		if (options.tools.length > 0) args.push("--tools", options.tools.join(","));
+		else args.push("--no-tools");
+	}
+	if (options.systemPromptPath) args.push("--append-system-prompt", options.systemPromptPath);
+	args.push(`Task: ${options.task}`);
+	return args;
+}
+
 function getPiInvocation(args: string[]): { command: string; args: string[] } {
 	const currentScript = process.argv[1];
 	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
@@ -378,6 +403,7 @@ async function runSingleAgent(
 	cwd: string | undefined,
 	step: number | undefined,
 	signal: AbortSignal | undefined,
+	thinkingLevel: SubagentThinkingLevel | undefined,
 	timeoutMs: number,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
@@ -394,16 +420,10 @@ async function runSingleAgent(
 			messages: [],
 			stderr: `Unknown agent: "${agentName}". Available agents: ${available}.`,
 			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+			thinkingLevel,
 			step,
 			finalOutput: "",
 		};
-	}
-
-	const args: string[] = ["--mode", "json", "-p", "--no-session"];
-	if (agent.model) args.push("--model", agent.model);
-	if (Array.isArray(agent.tools)) {
-		if (agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
-		else args.push("--no-tools");
 	}
 
 	let tmpPromptDir: string | null = null;
@@ -418,6 +438,7 @@ async function runSingleAgent(
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
 		model: agent.model ?? undefined,
+		thinkingLevel,
 		step,
 		timeoutMs,
 	};
@@ -437,10 +458,15 @@ async function runSingleAgent(
 			const tmp = await writePromptToTempFile(agent.name, agent.systemPrompt);
 			tmpPromptDir = tmp.dir;
 			tmpPromptPath = tmp.filePath;
-			args.push("--append-system-prompt", tmpPromptPath);
 		}
 
-		args.push(`Task: ${task}`);
+		const args = buildPiArgs({
+			model: agent.model,
+			thinkingLevel,
+			tools: agent.tools,
+			systemPromptPath: tmpPromptPath ?? undefined,
+			task,
+		});
 		let wasAborted = false;
 		let timedOut = false;
 
@@ -568,11 +594,16 @@ const TimeoutMs = Type.Number({
 	minimum: 1,
 });
 
+const ThinkingLevelSchema = StringEnum(THINKING_LEVELS, {
+	description: "Pi thinking level for the subagent process: off, minimal, low, medium, high, or xhigh.",
+});
+
 const TaskItem = Type.Object({
 	agent: Type.String({ description: "Name of the agent to invoke" }),
 	task: Type.String({ description: "Task to delegate to the agent" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
 	timeoutMs: Type.Optional(TimeoutMs),
+	thinkingLevel: Type.Optional(ThinkingLevelSchema),
 });
 
 const ChainItem = Type.Object({
@@ -580,6 +611,7 @@ const ChainItem = Type.Object({
 	task: Type.String({ description: "Task with optional {previous} placeholder for prior output" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
 	timeoutMs: Type.Optional(TimeoutMs),
+	thinkingLevel: Type.Optional(ThinkingLevelSchema),
 });
 
 const AggregatorItem = Type.Object({
@@ -587,6 +619,7 @@ const AggregatorItem = Type.Object({
 	task: Type.String({ description: "Fan-in task. Use {previous} to include all parallel outputs." }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the aggregator process" })),
 	timeoutMs: Type.Optional(TimeoutMs),
+	thinkingLevel: Type.Optional(ThinkingLevelSchema),
 });
 
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
@@ -606,6 +639,7 @@ const SubagentParams = Type.Object({
 	),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process (single mode)" })),
 	timeoutMs: Type.Optional(TimeoutMs),
+	thinkingLevel: Type.Optional(ThinkingLevelSchema),
 });
 
 // ---- Settings helpers ----
@@ -641,6 +675,12 @@ export function normalizeAgentSettings(value: unknown): SubagentAgentConfig | un
 	if (hasOwn(value, "model")) {
 		if (value.model !== null && typeof value.model !== "string") return undefined;
 		config.model = value.model;
+		hasKnownField = true;
+	}
+
+	if (hasOwn(value, "thinkingLevel")) {
+		if (value.thinkingLevel !== null && !isThinkingLevel(value.thinkingLevel)) return undefined;
+		config.thinkingLevel = value.thinkingLevel;
 		hasKnownField = true;
 	}
 
@@ -696,8 +736,22 @@ export function sameToolSet(left: string[], right: string[]): boolean {
 	return [...leftSet].every((tool) => rightSet.has(tool));
 }
 
+export function resolveSubagentThinkingLevel(
+	agents: readonly Pick<AgentConfig, "name" | "thinkingLevel">[],
+	agentName: string,
+	topLevelThinkingLevel?: SubagentThinkingLevel,
+	localThinkingLevel?: SubagentThinkingLevel,
+): SubagentThinkingLevel | undefined {
+	return localThinkingLevel ?? topLevelThinkingLevel ?? agents.find((agent) => agent.name === agentName)?.thinkingLevel;
+}
+
 function hasAnyAgentOverride(config: SubagentAgentConfig): boolean {
-	return hasOwn(config, "tools") || hasOwn(config, "model") || hasOwn(config, "timeoutMs");
+	return (
+		hasOwn(config, "tools") ||
+		hasOwn(config, "model") ||
+		hasOwn(config, "thinkingLevel") ||
+		hasOwn(config, "timeoutMs")
+	);
 }
 
 // ---- Tool toggle component ----
@@ -794,6 +848,8 @@ export default function (pi: ExtensionAPI) {
 				params.timeoutMs ??
 				agents.find((agent) => agent.name === agentName)?.timeoutMs ??
 				DEFAULT_TIMEOUT_MS;
+			const resolveThinkingLevel = (agentName: string, localThinkingLevel?: SubagentThinkingLevel) =>
+				resolveSubagentThinkingLevel(agents, agentName, params.thinkingLevel, localThinkingLevel);
 
 			const hasChain = (params.chain?.length ?? 0) > 0;
 			const hasTasks = (params.tasks?.length ?? 0) > 0;
@@ -887,6 +943,7 @@ export default function (pi: ExtensionAPI) {
 							step.cwd,
 							i + 1,
 							signal,
+							resolveThinkingLevel(step.agent, step.thinkingLevel),
 							resolveTimeoutMs(step.agent, step.timeoutMs),
 							chainUpdate,
 							makeDetails("chain"),
@@ -942,6 +999,7 @@ export default function (pi: ExtensionAPI) {
 							messages: [],
 							stderr: "",
 							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+							thinkingLevel: resolveThinkingLevel(params.tasks[i].agent, params.tasks[i].thinkingLevel),
 							finalOutput: "",
 						};
 					}
@@ -973,6 +1031,7 @@ export default function (pi: ExtensionAPI) {
 							t.cwd,
 							undefined,
 							signal,
+							resolveThinkingLevel(t.agent, t.thinkingLevel),
 							resolveTimeoutMs(t.agent, t.timeoutMs),
 							// Per-task update callback
 							(partial) => {
@@ -1006,6 +1065,7 @@ export default function (pi: ExtensionAPI) {
 							aggregator.cwd,
 							undefined,
 							signal,
+							resolveThinkingLevel(aggregator.agent, aggregator.thinkingLevel),
 							resolveTimeoutMs(aggregator.agent, aggregator.timeoutMs),
 							(partial) => {
 								status.update(fanInStatus(aggregator.agent));
@@ -1063,6 +1123,7 @@ export default function (pi: ExtensionAPI) {
 						params.cwd,
 						undefined,
 						signal,
+						resolveThinkingLevel(params.agent, params.thinkingLevel),
 						resolveTimeoutMs(params.agent, params.timeoutMs),
 						onUpdate,
 						makeDetails("single"),
@@ -1206,7 +1267,7 @@ export default function (pi: ExtensionAPI) {
 							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
 						}
 					}
-					const usageStr = formatUsageStats(r.usage, r.model);
+					const usageStr = formatUsageStats(r.usage, r.model, r.thinkingLevel);
 					if (usageStr) {
 						container.addChild(new Spacer(1));
 						container.addChild(new Text(theme.fg("dim", usageStr), 0, 0));
@@ -1222,7 +1283,7 @@ export default function (pi: ExtensionAPI) {
 					text += `\n${renderDisplayItems(displayItems, COLLAPSED_ITEM_COUNT)}`;
 					if (displayItems.length > COLLAPSED_ITEM_COUNT) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
 				}
-				const usageStr = formatUsageStats(r.usage, r.model);
+				const usageStr = formatUsageStats(r.usage, r.model, r.thinkingLevel);
 				if (usageStr) text += `\n${theme.fg("dim", usageStr)}`;
 				return new Text(text, 0, 0);
 			}
@@ -1291,7 +1352,7 @@ export default function (pi: ExtensionAPI) {
 							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
 						}
 
-						const stepUsage = formatUsageStats(r.usage, r.model);
+						const stepUsage = formatUsageStats(r.usage, r.model, r.thinkingLevel);
 						if (stepUsage) container.addChild(new Text(theme.fg("dim", stepUsage), 0, 0));
 					}
 
@@ -1383,7 +1444,7 @@ export default function (pi: ExtensionAPI) {
 							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
 						}
 
-						const taskUsage = formatUsageStats(r.usage, r.model);
+						const taskUsage = formatUsageStats(r.usage, r.model, r.thinkingLevel);
 						if (taskUsage) container.addChild(new Text(theme.fg("dim", taskUsage), 0, 0));
 					}
 
@@ -1416,7 +1477,7 @@ export default function (pi: ExtensionAPI) {
 							container.addChild(new Spacer(1));
 							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
 						}
-						const fanInUsage = formatUsageStats(aggregator.usage, aggregator.model);
+						const fanInUsage = formatUsageStats(aggregator.usage, aggregator.model, aggregator.thinkingLevel);
 						if (fanInUsage) container.addChild(new Text(theme.fg("dim", fanInUsage), 0, 0));
 					}
 

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -3,16 +3,34 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import { discoverAgents, formatAgentList } from "../src/agents.js";
 import subagents, {
+	buildPiArgs,
 	formatTokens,
 	formatUsageStats,
 	normalizeSubagentSettings,
 	parsePositiveInteger,
+	resolveSubagentThinkingLevel,
 	sameToolSet,
 	uniqueToolNames,
 } from "../src/subagents.js";
+
+type SchemaObject = {
+	properties?: Record<string, SchemaObject>;
+	items?: SchemaObject;
+	enum?: string[];
+	description?: string;
+};
+
+type SubagentTool = {
+	execute: (...args: unknown[]) => Promise<{
+		details?: {
+			results: Array<{ thinkingLevel?: string }>;
+			aggregator?: { thinkingLevel?: string };
+		};
+	}>;
+};
 
 test("subagents registers self-directed fan-out guidance and configuration command", () => {
 	const mock = createMockPi();
@@ -30,6 +48,24 @@ test("subagents registers self-directed fan-out guidance and configuration comma
 	assert.match(guidanceText, /one subagent/i);
 	assert.match(guidanceText, /2-4 parallel read-only subagents/i);
 	assert.match(guidanceText, /hard max 8/i);
+
+	const parameters = tool?.parameters as SchemaObject | undefined;
+	const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh"];
+	assert.deepEqual(parameters?.properties?.thinkingLevel?.enum, thinkingLevels);
+	assert.doesNotMatch(parameters?.properties?.thinkingLevel?.enum?.join(",") ?? "", /huge/);
+	assert.match(parameters?.properties?.thinkingLevel?.description ?? "", /off.*minimal.*xhigh/);
+	assert.deepEqual(
+		parameters?.properties?.tasks?.items?.properties?.thinkingLevel?.enum,
+		thinkingLevels,
+	);
+	assert.deepEqual(
+		parameters?.properties?.chain?.items?.properties?.thinkingLevel?.enum,
+		thinkingLevels,
+	);
+	assert.deepEqual(
+		parameters?.properties?.aggregator?.properties?.thinkingLevel?.enum,
+		thinkingLevels,
+	);
 	assert.ok(mock.commands.has("subagents:config"));
 });
 
@@ -45,19 +81,30 @@ test("discoverAgents includes built-ins and lets project agents override by name
 			"description: Project-specific scout",
 			"tools: read,bash",
 			"model: gpt-test",
+			"thinkingLevel: high",
 			"---",
 			"Project scout prompt.",
 		].join("\n"),
 	);
 
-	const result = discoverAgents(cwd, "project", { agents: { scout: { timeoutMs: 1234 } } });
+	const baseResult = discoverAgents(cwd, "project");
+	const baseScout = baseResult.agents.find((agent) => agent.name === "scout");
+	assert.equal(baseScout?.thinkingLevel, "high");
+
+	const result = discoverAgents(cwd, "project", {
+		agents: { scout: { timeoutMs: 1234, thinkingLevel: "low" } },
+	});
 	const scout = result.agents.find((agent) => agent.name === "scout");
 
 	assert.equal(result.projectAgentsDir, agentsDir);
 	assert.equal(scout?.source, "project");
 	assert.deepEqual(scout?.tools, ["read", "bash"]);
 	assert.equal(scout?.model, "gpt-test");
+	assert.equal(scout?.thinkingLevel, "low");
 	assert.equal(scout?.timeoutMs, 1234);
+
+	const cleared = discoverAgents(cwd, "project", { agents: { scout: { thinkingLevel: null } } });
+	assert.equal(cleared.agents.find((agent) => agent.name === "scout")?.thinkingLevel, undefined);
 	assert.ok(result.agents.some((agent) => agent.name === "worker" && agent.source === "built-in"));
 });
 
@@ -73,11 +120,18 @@ test("subagent settings normalize known override fields only", () => {
 	assert.deepEqual(
 		normalizeSubagentSettings({
 			agents: {
-				scout: { tools: ["read"], model: null, timeoutMs: 1 },
+				scout: { tools: ["read"], model: null, timeoutMs: 1, thinkingLevel: "medium" },
+				clearThinking: { thinkingLevel: null },
 				bad: { tools: [1] },
+				badThinking: { thinkingLevel: "huge" },
 			},
 		}),
-		{ agents: { scout: { tools: ["read"], model: null, timeoutMs: 1 } } },
+		{
+			agents: {
+				scout: { tools: ["read"], model: null, timeoutMs: 1, thinkingLevel: "medium" },
+				clearThinking: { thinkingLevel: null },
+			},
+		},
 	);
 	assert.equal(normalizeSubagentSettings({ agents: [] }), undefined);
 });
@@ -93,6 +147,115 @@ test("subagent formatting and set helpers are deterministic", () => {
 		),
 		"2 turns ↑1.5k ↓20 $0.0123 gpt",
 	);
+	assert.equal(
+		formatUsageStats(
+			{ input: 1500, output: 20, cacheRead: 0, cacheWrite: 0, cost: 0.0123, turns: 2 },
+			"gpt",
+			"high",
+		),
+		"2 turns ↑1.5k ↓20 $0.0123 gpt thinking:high",
+	);
 	assert.deepEqual(uniqueToolNames(["read", "read", "bash"]), ["read", "bash"]);
 	assert.equal(sameToolSet(["read", "bash"], ["bash", "read"]), true);
+});
+
+test("subagent thinking levels resolve by local, top-level, then agent default", () => {
+	const agents = [{ name: "scout", thinkingLevel: "low" }, { name: "reviewer" }] as const;
+
+	assert.equal(resolveSubagentThinkingLevel(agents, "scout", "medium", "high"), "high");
+	assert.equal(resolveSubagentThinkingLevel(agents, "scout", "medium"), "medium");
+	assert.equal(resolveSubagentThinkingLevel(agents, "scout"), "low");
+	assert.equal(resolveSubagentThinkingLevel(agents, "reviewer"), undefined);
+	assert.equal(resolveSubagentThinkingLevel(agents, "missing", "minimal"), "minimal");
+});
+
+test("buildPiArgs passes thinking only when requested", () => {
+	assert.deepEqual(buildPiArgs({ task: "do it" }), [
+		"--mode",
+		"json",
+		"-p",
+		"--no-session",
+		"Task: do it",
+	]);
+	assert.deepEqual(
+		buildPiArgs({
+			model: "sonnet",
+			thinkingLevel: "high",
+			tools: ["read", "bash"],
+			systemPromptPath: "/tmp/prompt.md",
+			task: "review code",
+		}),
+		[
+			"--mode",
+			"json",
+			"-p",
+			"--no-session",
+			"--model",
+			"sonnet",
+			"--thinking",
+			"high",
+			"--tools",
+			"read,bash",
+			"--append-system-prompt",
+			"/tmp/prompt.md",
+			"Task: review code",
+		],
+	);
+	assert.deepEqual(buildPiArgs({ thinkingLevel: "off", tools: [], task: "no tools" }), [
+		"--mode",
+		"json",
+		"-p",
+		"--no-session",
+		"--thinking",
+		"off",
+		"--no-tools",
+		"Task: no tools",
+	]);
+});
+
+test("subagent execute resolves thinking level in single, chain, parallel, and aggregator modes", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools[0] as SubagentTool;
+	const { ctx } = createMockContext();
+	const signal = new AbortController().signal;
+
+	const single = await tool.execute(
+		"single",
+		{ agent: "missing", task: "single", thinkingLevel: "medium" },
+		signal,
+		() => undefined,
+		ctx,
+	);
+	assert.equal(single.details?.results[0]?.thinkingLevel, "medium");
+
+	const chain = await tool.execute(
+		"chain",
+		{
+			thinkingLevel: "low",
+			chain: [{ agent: "missing", task: "chain", thinkingLevel: "high" }],
+		},
+		signal,
+		() => undefined,
+		ctx,
+	);
+	assert.equal(chain.details?.results[0]?.thinkingLevel, "high");
+
+	const parallel = await tool.execute(
+		"parallel",
+		{
+			thinkingLevel: "minimal",
+			tasks: [
+				{ agent: "missing", task: "inherits top level" },
+				{ agent: "missing", task: "local override", thinkingLevel: "off" },
+			],
+			aggregator: { agent: "missing", task: "aggregate", thinkingLevel: "xhigh" },
+		},
+		signal,
+		() => undefined,
+		ctx,
+	);
+	assert.equal(parallel.details?.results[0]?.thinkingLevel, "minimal");
+	assert.equal(parallel.details?.results[1]?.thinkingLevel, "off");
+	assert.equal(parallel.details?.aggregator?.thinkingLevel, "xhigh");
 });


### PR DESCRIPTION
## Summary
- add validated `thinkingLevel` support for single, parallel, chain, and aggregator subagent calls
- support agent frontmatter/config defaults and pass resolved values as `--thinking <level>`
- expose requested thinking levels in results/usage and document supported levels

Closes #147

## Tests
- `npm run check`