### PR TITLE
feat(statusline): support extension icon aliases

### DIFF
--- a/docs/plans/archived/2026-07-08_pi-statusline-third-party-extension-icons-plan.md
+++ b/docs/plans/archived/2026-07-08_pi-statusline-third-party-extension-icons-plan.md
@@ -1,0 +1,65 @@
+## Goal
+
+Resolve [issue #153](https://github.com/narumiruna/pi-extensions/issues/153) by letting `@narumitw/pi-statusline` apply `extensionStatusIcons` overrides to arbitrary installed extension ids, including third-party package ids such as `@scope/pi-example`, while preserving existing status-key overrides like `goal` and `caffeinate`.
+
+Success means users can configure icons by either the emitted status key or an installed extension package id/alias, and `pi-statusline` resolves the icon predictably for extension statuses shown in the footer.
+
+## Context
+
+`pi-statusline` currently formats statuses from `footerData.getExtensionStatuses()` and looks up `extensionStatusIcons` by the raw status key. That works for built-in/default keys but does not bridge package ids from Pi settings to status keys for third-party extensions.
+
+Repository evidence:
+
+- `extensions/pi-statusline/src/statusline.ts` already reads user/project settings in duplicate-extension detection via `readPackageSources()` and `packageNameForSource()`.
+- `formatExtensionStatus()` currently receives only the status key, value, theme, and icon config.
+- Existing tests cover exact-key overrides, leading emoji fallback, built-in defaults, and unknown fallback.
+
+## Architecture
+
+Add a small extension-id alias layer inside `pi-statusline`:
+
+1. Load installed package names from the same settings sources already inspected for duplicate extension detection.
+2. Derive status-key aliases from package names, e.g. `@scope/pi-foo` → aliases `@scope/pi-foo`, `pi-foo`, `foo`, with status key `foo`.
+3. Match package-derived status keys by exact key or delimiter-bound namespace prefix only, e.g. package `@scope/pi-foo` may match status keys `foo`, `foo:server`, or `foo/server`, but not `foobar`.
+4. When rendering a status key, resolve icons in this order:
+   - exact configured status key, preserving current behavior and empty-string suppression;
+   - configured installed package id/alias associated with that status key;
+   - leading emoji from the status text;
+   - built-in default icon;
+   - generic `🔌` fallback.
+
+## Non-Goals
+
+- Do not require third-party extensions to change their `ctx.ui.setStatus()` keys.
+- Do not add dependencies between `pi-statusline` and status-producing extensions.
+- Do not redesign the status settings file beyond `extensionStatusIcons`.
+- Do not add a UI editor for icon settings in this issue.
+
+## Assumptions
+
+- “Extension id” means the installed package id/name from Pi package settings, such as `@scope/pi-foo` or `npm:@scope/pi-foo@1.2.3`, not a new runtime id API exposed by Pi.
+- Third-party packages commonly emit a status key derived from their package basename, usually by dropping a leading `pi-` prefix.
+
+## Plan
+
+- [x] Add failing tests in `extensions/pi-statusline/test/statusline.test.ts` for third-party icon configuration by full package id, unscoped package name, `pi-`-stripped status key, and delimiter-bound namespaced status keys like `foo:server` and `foo/server`; verify the new tests fail with `npm test -- pi-statusline` or `npm test` before implementation.
+- [x] Extract installed-extension package discovery from duplicate detection in `extensions/pi-statusline/src/statusline.ts` into a reusable helper that returns package names from user and project settings; verify existing duplicate-extension tests still pass with `npm test -- pi-statusline` or `npm test`.
+- [x] Add a pure alias helper that maps package names to status keys and icon lookup aliases, including scoped npm packages, unscoped packages, local package names, names without a `pi-` prefix, and delimiter-bound namespace matches; verify with targeted unit tests for `@vendor/pi-foo`, `pi-foo`, `@vendor/foo`, versioned `npm:` specs, `foo:server`, `foo/server`, and non-match `foobar`.
+- [x] Thread the alias map through runtime/config rendering so `formatExtensionStatus()` can resolve exact status-key overrides before installed package-id aliases; verify with tests that exact key config wins over package-id config and `""` still suppresses icons.
+- [x] Preserve fallback behavior for statuses with no matching installed package or configured icon; verify existing unknown-status and leading-emoji tests remain unchanged.
+- [x] Update `extensions/pi-statusline/README.md` to document configuring icons by status key or installed extension id, including one third-party example; verify examples match the implemented alias precedence by inspection.
+- [x] Run `npm run check` from the repository root and fix formatting, type, boundary, or test failures.
+
+## Risks
+
+- Status keys are extension-chosen strings, so package-name aliasing is heuristic. Keep exact status-key overrides highest priority so users can always force the intended icon.
+- Multiple installed packages can derive the same status key. Do not apply package-id alias matches for ambiguous derived keys; document that exact status-key config disambiguates collisions.
+- Reading settings for aliases must not add heavy work to every render. Compute aliases during footer installation/session setup, like duplicate-extension detection.
+
+## Completion Checklist
+
+- [x] `extensionStatusIcons` supports exact status-key overrides, installed package id/alias overrides, and delimiter-bound namespaced status keys, verified by unit tests in `extensions/pi-statusline/test/statusline.test.ts`.
+- [x] Exact status-key overrides, including empty-string suppression, take precedence over package-id aliases, verified by a regression test.
+- [x] Existing leading emoji, built-in default icon, and generic fallback behavior remains unchanged, verified by existing and updated tests.
+- [x] README documents third-party extension icon configuration, verified by review of `extensions/pi-statusline/README.md`.
+- [x] Repository verification passes with `npm run check`.

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -64,14 +64,19 @@ Extension statuses use built-in icons by status key. Override or suppress them i
     "pisync": "☁️",
     "unknown-error-retry": "",
     "plan-mode": "📝",
-    "subagents": "🤖"
+    "subagents": "🤖",
+    "@vendor/pi-foo": "🧪"
   }
 }
 ```
 
+- Exact status key: always wins, e.g. `"goal"` or `"foo:server"`.
+- Installed extension id: for installed packages, use the package name/source such as `"@vendor/pi-foo"`, `"npm:@vendor/pi-foo@1.2.3"`, `"pi-foo"`, or the derived key `"foo"`.
+- Namespaced status keys: package `@vendor/pi-foo` can match `foo`, `foo:server`, and `foo/server`, but not fuzzy matches like `foobar`.
 - Missing key: use the built-in icon, or `🔌` for an unknown status key.
 - String value: use that string as the icon.
 - Empty string: show the status text without an icon.
+- If multiple installed packages derive the same key, use the exact status key to disambiguate.
 - `PI_STATUSLINE_PRESET` remains the only preset setting; this JSON file only controls extension status icons.
 
 During the `PI_CAFFEINATE_ICON` deprecation window, a leading emoji from `pi-caffeinate` is still used when JSON does not configure `caffeinate`. JSON wins when both are set.
@@ -102,6 +107,7 @@ Examples:
 - `🎯 active` for `goal: active` using the built-in `goal` icon.
 - `🔎 PR #123 checks passing` for `github-pr: PR #123 checks passing` using the built-in `github-pr` icon.
 - `☕ display` when JSON config sets `"caffeinate": "☕"`.
+- `🧪 running` for third-party status `foo:server` when an installed package is named `@vendor/pi-foo` and JSON config sets `"@vendor/pi-foo": "🧪"`.
 - `receiving` when JSON config sets `"unknown-error-retry": ""`.
 - `🔌 running` for an unknown extension status key with no configured icon.
 - `⚠️ dup biome-lsp` when local and npm installs register the same extension.

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -22,6 +22,7 @@ import type {
 } from "../presets/types.js";
 
 type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
+export type ExtensionStatusIconAliasMap = ReadonlyMap<string, readonly string[]>;
 
 interface RuntimeState {
 	turnCount: number;
@@ -31,6 +32,7 @@ interface RuntimeState {
 	isStreaming: boolean;
 	thinkingLevel: ThinkingLevel;
 	duplicateExtensions: string[];
+	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	gitStatus?: GitStatusSummary;
 	requestRender?: () => void;
 }
@@ -57,6 +59,8 @@ const DEFAULT_PRESET: StatuslinePresetName = "tokyo-night";
 const GIT_STATUS_REFRESH_INTERVAL_MS = 30_000;
 const GIT_STATUS_EVENT_DEBOUNCE_MS = 250;
 const GIT_STATUS_TIMEOUT_MS = 3_000;
+
+const EMPTY_EXTENSION_STATUS_ICON_ALIASES: ExtensionStatusIconAliasMap = new Map();
 
 const DEFAULT_EXTENSION_STATUS_ICONS: Record<string, string> = {
 	"chrome-devtools": "🌐",
@@ -106,6 +110,7 @@ export default function statusline(pi: ExtensionAPI) {
 		isStreaming: false,
 		thinkingLevel: "off",
 		duplicateExtensions: [],
+		extensionStatusIconAliases: EMPTY_EXTENSION_STATUS_ICON_ALIASES,
 	};
 
 	let sessionGeneration = 0;
@@ -188,9 +193,13 @@ export default function statusline(pi: ExtensionAPI) {
 		clearGitStatusDebounce();
 		activeGitStatusTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
 		runtime.gitStatus = undefined;
+		runtime.duplicateExtensions = [];
+		runtime.extensionStatusIconAliases = EMPTY_EXTENSION_STATUS_ICON_ALIASES;
 		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
 		if (!activeGitStatusTarget) return;
-		runtime.duplicateExtensions = findDuplicateExtensions(cwd);
+		const installedPackages = readInstalledExtensionPackages(cwd);
+		runtime.duplicateExtensions = findDuplicateExtensions(installedPackages);
+		runtime.extensionStatusIconAliases = buildExtensionStatusIconAliases(installedPackages);
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			runtime.requestRender = () => tui.requestRender();
 
@@ -216,6 +225,8 @@ export default function statusline(pi: ExtensionAPI) {
 						clearGitStatusDebounce();
 						pendingGitStatusRefresh = undefined;
 						runtime.gitStatus = undefined;
+						runtime.duplicateExtensions = [];
+						runtime.extensionStatusIconAliases = EMPTY_EXTENSION_STATUS_ICON_ALIASES;
 						runtime.requestRender = undefined;
 					}
 				},
@@ -246,6 +257,8 @@ export default function statusline(pi: ExtensionAPI) {
 		clearGitStatusDebounce();
 		pendingGitStatusRefresh = undefined;
 		runtime.gitStatus = undefined;
+		runtime.duplicateExtensions = [];
+		runtime.extensionStatusIconAliases = EMPTY_EXTENSION_STATUS_ICON_ALIASES;
 		ctx.ui.setFooter(undefined);
 		ctx.ui.setStatus(STATUSLINE_KEY, undefined);
 		runtime.requestRender = undefined;
@@ -631,7 +644,9 @@ function formatExtensionStatuses(
 				([key, value]) =>
 					key !== STATUSLINE_KEY && key !== GITHUB_PR_KEY && value.trim().length > 0,
 			)
-			.map(([key, value]) => formatExtensionStatus(key, value, theme, config)),
+			.map(([key, value]) =>
+				formatExtensionStatus(key, value, theme, config, runtime.extensionStatusIconAliases),
+			),
 	].slice(0, 5);
 
 	return visibleStatuses.join(separator);
@@ -642,12 +657,13 @@ export function formatExtensionStatus(
 	value: string,
 	theme: Theme,
 	config: Pick<StatuslineConfig, "extensionStatusIcons">,
+	extensionStatusIconAliases: ExtensionStatusIconAliasMap = EMPTY_EXTENSION_STATUS_ICON_ALIASES,
 ): string {
 	const status = splitExtensionStatusIcon(stripExtensionStatusPrefix(key, value));
 	const text = simplifyExtensionStatusText(status.text);
 	const color = extensionColor(key, value);
 	const textColor = color === "warning" ? "warning" : "muted";
-	const icon = extensionStatusIcon(key, status.icon, config.extensionStatusIcons);
+	const icon = extensionStatusIcon(key, status.icon, config.extensionStatusIcons, extensionStatusIconAliases);
 	const renderedText = theme.fg(textColor, text);
 	return icon ? `${theme.fg(color, icon)} ${renderedText}` : renderedText;
 }
@@ -656,9 +672,27 @@ function extensionStatusIcon(
 	key: string,
 	leadingIcon: string | undefined,
 	configuredIcons: Record<string, string>,
+	extensionStatusIconAliases: ExtensionStatusIconAliasMap,
 ) {
 	if (Object.hasOwn(configuredIcons, key)) return configuredIcons[key];
+	for (const alias of extensionStatusAliasesForKey(key, extensionStatusIconAliases)) {
+		if (Object.hasOwn(configuredIcons, alias)) return configuredIcons[alias];
+	}
 	return leadingIcon ?? DEFAULT_EXTENSION_STATUS_ICONS[key] ?? "🔌";
+}
+
+function extensionStatusAliasesForKey(
+	key: string,
+	extensionStatusIconAliases: ExtensionStatusIconAliasMap,
+): readonly string[] {
+	for (const [statusBase, aliases] of extensionStatusIconAliases) {
+		if (statusKeyMatchesStatusBase(key, statusBase)) return aliases;
+	}
+	return [];
+}
+
+function statusKeyMatchesStatusBase(key: string, statusBase: string): boolean {
+	return key === statusBase || key.startsWith(`${statusBase}:`) || key.startsWith(`${statusBase}/`);
 }
 
 export function wrapExtensionStatusline(status: string, width: number): string[] {
@@ -715,26 +749,100 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function findDuplicateExtensions(cwd: string): string[] {
-	const settingsFiles = [
+interface InstalledExtensionPackage {
+	packageName: string;
+	source: string;
+	identity: string;
+}
+
+function readInstalledExtensionPackages(cwd: string): InstalledExtensionPackage[] {
+	const packages: InstalledExtensionPackage[] = [];
+	const settingsFiles = extensionSettingsFiles(cwd);
+
+	for (const settingsFile of settingsFiles) {
+		const baseDirectory = dirname(settingsFile);
+		for (const rawSource of readPackageSources(settingsFile)) {
+			const source = rawSource.trim();
+			if (!source) continue;
+			const packageName = packageNameForSource(source, baseDirectory);
+			if (!packageName) continue;
+			packages.push({ packageName, source, identity: sourceIdentity(source, baseDirectory) });
+		}
+	}
+
+	return packages;
+}
+
+function extensionSettingsFiles(cwd: string): string[] {
+	return [
 		join(process.env.HOME ?? "", ".pi", "agent", "settings.json"),
 		join(cwd, ".pi", "settings.json"),
 	].filter((file) => existsSync(file));
+}
+
+function findDuplicateExtensions(installedPackages: readonly InstalledExtensionPackage[]): string[] {
 	const sourcesByPackage = new Map<string, Set<string>>();
 
-	for (const settingsFile of settingsFiles) {
-		for (const source of readPackageSources(settingsFile)) {
-			const packageName = packageNameForSource(source, dirname(settingsFile));
-			if (!packageName) continue;
-			const sources = sourcesByPackage.get(packageName) ?? new Set<string>();
-			sources.add(sourceIdentity(source, dirname(settingsFile)));
-			sourcesByPackage.set(packageName, sources);
-		}
+	for (const extensionPackage of installedPackages) {
+		const sources = sourcesByPackage.get(extensionPackage.packageName) ?? new Set<string>();
+		sources.add(extensionPackage.identity);
+		sourcesByPackage.set(extensionPackage.packageName, sources);
 	}
 
 	return [...sourcesByPackage.entries()]
 		.filter(([, sources]) => sources.size > 1)
 		.map(([packageName]) => packageName.replace(/^@[^/]+\//, "").replace(/^pi-/, ""));
+}
+
+export function buildExtensionStatusIconAliases(
+	installedPackages: readonly { packageName: string; source?: string }[],
+): Map<string, string[]> {
+	const packageAliasesByStatusBase = new Map<string, Map<string, string[]>>();
+
+	for (const extensionPackage of installedPackages) {
+		const candidate = extensionStatusIconAliasCandidate(extensionPackage.packageName, extensionPackage.source);
+		if (!candidate) continue;
+		const aliasesByPackage = packageAliasesByStatusBase.get(candidate.statusBase) ?? new Map<string, string[]>();
+		const existingAliases = aliasesByPackage.get(extensionPackage.packageName) ?? [];
+		aliasesByPackage.set(extensionPackage.packageName, uniqueStrings([...existingAliases, ...candidate.aliases]));
+		packageAliasesByStatusBase.set(candidate.statusBase, aliasesByPackage);
+	}
+
+	const aliases = new Map<string, string[]>();
+	for (const [statusBase, aliasesByPackage] of packageAliasesByStatusBase) {
+		if (aliasesByPackage.size === 1) aliases.set(statusBase, [...aliasesByPackage.values()][0] ?? []);
+	}
+	return aliases;
+}
+
+function extensionStatusIconAliasCandidate(
+	packageName: string,
+	source?: string,
+): { statusBase: string; aliases: string[] } | undefined {
+	const packageBase = packageBaseName(packageName);
+	const statusBase = statusBaseFromPackageBase(packageBase);
+	if (!statusBase) return undefined;
+
+	const sourceAliases = source?.startsWith("npm:") ? [source, `npm:${npmPackageName(source)}`] : [];
+	return {
+		statusBase,
+		aliases: uniqueStrings([...sourceAliases, packageName, packageBase, statusBase]),
+	};
+}
+
+function packageBaseName(packageName: string): string {
+	const slashIndex = packageName.lastIndexOf("/");
+	return slashIndex === -1 ? packageName : packageName.slice(slashIndex + 1);
+}
+
+function statusBaseFromPackageBase(packageBase: string): string {
+	return packageBase.startsWith("pi-") && packageBase.length > "pi-".length
+		? packageBase.slice("pi-".length)
+		: packageBase;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+	return [...new Set(values.filter((value) => value.length > 0))];
 }
 
 function readPackageSources(settingsFile: string): string[] {

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import statusline, {
+	buildExtensionStatusIconAliases,
 	contextColor,
 	extensionColor,
 	formatCount,
@@ -439,6 +440,167 @@ test("extension status icons use config, leading emoji, defaults, and fallback",
 	assert.equal(formatExtensionStatus("caffeinate", "☕ display", theme, config({})), "☕ display");
 	assert.equal(formatExtensionStatus("goal", "active", theme, config({ goal: "" })), "active");
 	assert.equal(formatExtensionStatus("unknown", "running", theme, config({})), "🔌 running");
+});
+
+test("statusline render uses installed package id icon aliases from settings", async () => {
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-alias-test-"));
+	const agentDir = join(root, "agent");
+	const cwd = join(root, "project");
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+
+	try {
+		writeFileSync(
+			join(agentDir, "pi-statusline-settings.json"),
+			JSON.stringify({ extensionStatusIcons: { "@vendor/pi-foo": "🧪" } }),
+		);
+		writeFileSync(
+			join(cwd, ".pi", "settings.json"),
+			JSON.stringify({ packages: ["npm:@vendor/pi-foo@1.2.3"] }),
+		);
+
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () => ({
+			stdout: "## main\n",
+			stderr: "",
+			code: 0,
+			killed: false,
+		});
+		statusline(mock.pi);
+		const context = createMockContext({ mode: "tui", cwd });
+
+		await emit(mock.events, "session_start", {}, context.ctx);
+		const footerFactory = context.footer as (
+			tui: { requestRender(): void },
+			theme: { fg(_color: string, text: string): string; bold(text: string): string },
+			footerData: {
+				getGitBranch(): string | null;
+				getExtensionStatuses(): ReadonlyMap<string, string>;
+				onBranchChange(callback: () => void): () => void;
+			},
+		) => { render(width: number): string[]; dispose(): void };
+		const footer = footerFactory(
+			{ requestRender() {} },
+			{ fg: (_color, text) => text, bold: (text) => text },
+			{
+				getGitBranch: () => "main",
+				getExtensionStatuses: () => new Map([["foo:server", "running"]]),
+				onBranchChange: () => () => undefined,
+			},
+		);
+
+		const lines = footer.render(120);
+		footer.dispose();
+
+		assert.ok(
+			lines.some((line) => line.includes("🧪 running")),
+			lines.join("\n"),
+		);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+});
+
+test("extension status icons use installed package id aliases without fuzzy matching", () => {
+	const theme = { fg: (_color: string, text: string) => text } as never;
+	const config = (extensionStatusIcons: Record<string, string>) => ({ extensionStatusIcons });
+	const aliases = buildExtensionStatusIconAliases([
+		{ packageName: "@vendor/pi-foo", source: "npm:@vendor/pi-foo@1.2.3" },
+		{ packageName: "@vendor/bar" },
+	]);
+
+	assert.deepEqual(
+		[...aliases],
+		[
+			[
+				"foo",
+				["npm:@vendor/pi-foo@1.2.3", "npm:@vendor/pi-foo", "@vendor/pi-foo", "pi-foo", "foo"],
+			],
+			["bar", ["@vendor/bar", "bar"]],
+		],
+	);
+	assert.equal(
+		formatExtensionStatus("foo", "running", theme, config({ "@vendor/pi-foo": "🧪" }), aliases),
+		"🧪 running",
+	);
+	assert.equal(
+		formatExtensionStatus("foo:server", "running", theme, config({ "pi-foo": "🧬" }), aliases),
+		"🧬 running",
+	);
+	assert.equal(
+		formatExtensionStatus(
+			"foo/server",
+			"running",
+			theme,
+			config({ "npm:@vendor/pi-foo@1.2.3": "📦" }),
+			aliases,
+		),
+		"📦 running",
+	);
+	assert.equal(
+		formatExtensionStatus("bar", "running", theme, config({ "@vendor/bar": "🍫" }), aliases),
+		"🍫 running",
+	);
+	assert.equal(
+		formatExtensionStatus("foobar", "running", theme, config({ "@vendor/pi-foo": "🧪" }), aliases),
+		"🔌 running",
+	);
+});
+
+test("extension status icon aliases preserve exact-key precedence and skip ambiguous packages", () => {
+	const theme = { fg: (_color: string, text: string) => text } as never;
+	const config = (extensionStatusIcons: Record<string, string>) => ({ extensionStatusIcons });
+	const aliases = buildExtensionStatusIconAliases([
+		{ packageName: "@first/pi-foo" },
+		{ packageName: "@second/pi-foo" },
+	]);
+
+	assert.deepEqual([...aliases], []);
+	assert.equal(
+		formatExtensionStatus(
+			"foo:server",
+			"running",
+			theme,
+			config({ "@first/pi-foo": "1️⃣", "foo:server": "✅" }),
+			aliases,
+		),
+		"✅ running",
+	);
+	assert.equal(
+		formatExtensionStatus(
+			"foo:server",
+			"running",
+			theme,
+			config({ "@first/pi-foo": "1️⃣" }),
+			aliases,
+		),
+		"🔌 running",
+	);
+
+	const unambiguousAliases = buildExtensionStatusIconAliases([{ packageName: "@vendor/pi-foo" }]);
+	assert.equal(
+		formatExtensionStatus(
+			"foo:server",
+			"running",
+			theme,
+			config({ "@vendor/pi-foo": "🧪", "foo:server": "" }),
+			unambiguousAliases,
+		),
+		"running",
+	);
+	assert.equal(
+		formatExtensionStatus(
+			"foo:server",
+			"running",
+			theme,
+			config({ "@vendor/pi-foo": "" }),
+			unambiguousAliases,
+		),
+		"running",
+	);
 });
 
 test("long extension status lines wrap to terminal width without ellipsis", () => {


### PR DESCRIPTION
## Summary
- support `extensionStatusIcons` lookup by installed package id/source aliases for third-party extensions
- match package-derived status keys exactly or by `:`/`/` namespace delimiters, without fuzzy matches
- keep exact status-key overrides and empty-string suppression highest priority

Closes #153

## Tests
- `npm run check`