### PR TITLE
fix(pi-btw): support both pi-ai and pi-ai/compat import paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,32 +14,12 @@ concurrency:
 
 jobs:
   check:
-    name: Check and test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run checks and tests
-        run: npm run check
-
-  pi-btw-compatibility:
-    name: pi-btw with pi-ai ${{ matrix.pi_ai }}
+    name: Check and test with Pi ${{ matrix.pi_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        pi_ai:
+        pi_version:
           - "0.79.10"
           - "0.80.3"
 
@@ -56,13 +36,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install pi-ai ${{ matrix.pi_ai }}
-        run: npm install --no-save --package-lock=false @earendil-works/pi-ai@${{ matrix.pi_ai }}
-
-      - name: Typecheck pi-btw
-        run: npm run typecheck --workspace @narumitw/pi-btw
-
-      - name: Test pi-btw
+      - name: Install Pi ${{ matrix.pi_version }} packages
         run: |
-          npx tsc -p tsconfig.test.json
-          node --test "$GITHUB_WORKSPACE/node_modules/.cache/pi-extensions-test/extensions/pi-btw/test/btw.test.js"
+          node scripts/set-pi-version.mjs ${{ matrix.pi_version }}
+          npm install --no-save
+
+      - name: Run checks and tests
+        run: npm run check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,37 @@ jobs:
 
       - name: Run checks and tests
         run: npm run check
+
+  pi-btw-compatibility:
+    name: pi-btw with pi-ai ${{ matrix.pi_ai }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pi_ai:
+          - "0.79.10"
+          - "0.80.3"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install pi-ai ${{ matrix.pi_ai }}
+        run: npm install --no-save --package-lock=false @earendil-works/pi-ai@${{ matrix.pi_ai }}
+
+      - name: Typecheck pi-btw
+        run: npm run typecheck --workspace @narumitw/pi-btw
+
+      - name: Test pi-btw
+        run: |
+          npx tsc -p tsconfig.test.json
+          node --test "$GITHUB_WORKSPACE/node_modules/.cache/pi-extensions-test/extensions/pi-btw/test/btw.test.js"

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -6,8 +6,7 @@ import type {
 	ProviderStreamOptions,
 	UserMessage,
 } from "@earendil-works/pi-ai";
-// Support both old (@earendil-works/pi-ai/compat) and new (@earendil-works/pi-ai)
-// pi-ai layouts. compat subpath was removed in later versions.
+// pi-ai 0.79 exports complete from the root; 0.80 moved it to the compat subpath.
 type CompleteFunction = <TApi extends Api>(
 	model: Model<TApi>,
 	context: Context,
@@ -22,18 +21,22 @@ function hasComplete(value: unknown): value is { complete: CompleteFunction } {
 	);
 }
 
-async function loadComplete(): Promise<CompleteFunction> {
+type ModuleImporter = (moduleId: string) => Promise<unknown>;
+
+export async function loadComplete(
+	importModule: ModuleImporter = (moduleId) => import(moduleId),
+): Promise<CompleteFunction> {
 	let importError: unknown;
 	for (const moduleId of ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]) {
 		try {
-			const module: unknown = await import(moduleId);
+			const module = await importModule(moduleId);
 			if (hasComplete(module)) return module.complete;
 		} catch (error: unknown) {
 			importError = error;
 		}
 	}
 
-	throw importError ?? new Error("@earendil-works/pi-ai does not export complete");
+	throw new Error("@earendil-works/pi-ai does not export complete", { cause: importError });
 }
 
 const complete = await loadComplete();

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -1,14 +1,42 @@
-import type { UserMessage } from "@earendil-works/pi-ai";
+import type {
+	Api,
+	AssistantMessage,
+	Context,
+	Model,
+	ProviderStreamOptions,
+	UserMessage,
+} from "@earendil-works/pi-ai";
 // Support both old (@earendil-works/pi-ai/compat) and new (@earendil-works/pi-ai)
 // pi-ai layouts. compat subpath was removed in later versions.
-let complete: (model: any, context: any, options?: any) => Promise<any>;
-try {
-	const mod = await import("@earendil-works/pi-ai/compat");
-	complete = mod.complete;
-} catch {
-	const mod = await import("@earendil-works/pi-ai");
-	complete = mod.complete;
+type CompleteFunction = <TApi extends Api>(
+	model: Model<TApi>,
+	context: Context,
+	options?: ProviderStreamOptions,
+) => Promise<AssistantMessage>;
+
+function hasComplete(value: unknown): value is { complete: CompleteFunction } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof Reflect.get(value, "complete") === "function"
+	);
 }
+
+async function loadComplete(): Promise<CompleteFunction> {
+	let importError: unknown;
+	for (const moduleId of ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]) {
+		try {
+			const module: unknown = await import(moduleId);
+			if (hasComplete(module)) return module.complete;
+		} catch (error: unknown) {
+			importError = error;
+		}
+	}
+
+	throw importError ?? new Error("@earendil-works/pi-ai does not export complete");
+}
+
+const complete = await loadComplete();
 import {
 	BorderedLoader,
 	DynamicBorder,

--- a/extensions/pi-btw/test/btw.test.ts
+++ b/extensions/pi-btw/test/btw.test.ts
@@ -1,7 +1,45 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import btw, { buildConversationContext, buildUserPrompt, sanitizeSingleLine } from "../src/btw.js";
+import btw, {
+	buildConversationContext,
+	buildUserPrompt,
+	loadComplete,
+	sanitizeSingleLine,
+} from "../src/btw.js";
+
+test("loadComplete prefers compat and falls back to the root module", async () => {
+	const compatComplete = async () => ({ source: "compat" });
+	const rootComplete = async () => ({ source: "root" });
+	const preferredImports: string[] = [];
+	const preferred = await loadComplete(async (moduleId) => {
+		preferredImports.push(moduleId);
+		return moduleId.endsWith("/compat") ? { complete: compatComplete } : { complete: rootComplete };
+	});
+
+	assert.equal(preferred, compatComplete);
+	assert.deepEqual(preferredImports, ["@earendil-works/pi-ai/compat"]);
+
+	const fallbackImports: string[] = [];
+	const fallback = await loadComplete(async (moduleId) => {
+		fallbackImports.push(moduleId);
+		if (moduleId.endsWith("/compat")) throw new Error("missing compat export");
+		return { complete: rootComplete };
+	});
+
+	assert.equal(fallback, rootComplete);
+	assert.deepEqual(fallbackImports, ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]);
+});
+
+test("loadComplete reports when neither module exports complete", async () => {
+	await assert.rejects(
+		loadComplete(async (moduleId) => {
+			if (moduleId.endsWith("/compat")) throw new Error("missing compat export");
+			return {};
+		}),
+		/@earendil-works\/pi-ai does not export complete/,
+	);
+});
 
 test("btw command validates usage before asking a side question", async () => {
 	const mock = createMockPi();

--- a/scripts/set-pi-version.mjs
+++ b/scripts/set-pi-version.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const version = process.argv[2];
+if (!version) {
+	console.error("Usage: node scripts/set-pi-version.mjs <version>");
+	process.exit(1);
+}
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const extensionsDir = path.join(root, "extensions");
+const manifests = [
+	path.join(root, "package.json"),
+	...fs
+		.readdirSync(extensionsDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(extensionsDir, entry.name, "package.json"))
+		.filter((manifest) => fs.existsSync(manifest)),
+];
+
+let updatedDependencies = 0;
+for (const manifest of manifests) {
+	const packageJson = JSON.parse(fs.readFileSync(manifest, "utf8"));
+	let changed = false;
+
+	for (const dependencyType of ["dependencies", "devDependencies"]) {
+		for (const packageName of Object.keys(packageJson[dependencyType] ?? {})) {
+			if (!packageName.startsWith("@earendil-works/pi-")) continue;
+			packageJson[dependencyType][packageName] = version;
+			updatedDependencies += 1;
+			changed = true;
+		}
+	}
+
+	if (changed) {
+		fs.writeFileSync(manifest, `${JSON.stringify(packageJson, null, "\t")}\n`);
+	}
+}
+
+if (updatedDependencies === 0) {
+	console.error("No @earendil-works/pi-* dependencies found");
+	process.exit(1);
+}
+
+console.log(`Set ${updatedDependencies} Pi dependencies to ${version}.`);


### PR DESCRIPTION
The `@earendil-works/pi-ai/compat` subpath does not exist on all pi-ai versions — on some it resolves to `dist/index.js/compat` (file treated as dir) and throws `Cannot find module`, preventing the extension from loading.

Use a dynamic import with fallback: try `@earendil-works/pi-ai/compat` first, fall back to `@earendil-works/pi-ai`. Loads on both old and new pi-ai layouts.