### PR TITLE
feat(chrome-devtools): rename persisted settings file

### DIFF
--- a/docs/plans/archived/2026-07-10_pi-chrome-devtools-config-rename-plan.md
+++ b/docs/plans/archived/2026-07-10_pi-chrome-devtools-config-rename-plan.md
@@ -1,0 +1,54 @@
+## Goal
+
+Rename the persisted Chrome DevTools extension settings file from `pi-chrome-devtools-settings.json` to `pi-chrome-devtools.json` without breaking existing users.
+
+Success means phase 1 automatically migrates existing tool-selection settings, warns clearly, saves only to the new filename, and preserves the current active-tool policy when settings are missing or invalid. Phase 2 removal is intentionally not performed in this code change because the deprecation window has not elapsed.
+
+## Context
+
+`extensions/pi-chrome-devtools/src/chrome-devtools.ts` previously stored selected `chrome_devtools_*` tools at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools-settings.json`. `/chrome-devtools status` and `extensions/pi-chrome-devtools/README.md` exposed that path.
+
+## Plan
+
+### Phase 1 — compatibility migration release
+
+- [x] Add settings path constants for `NEW_SETTINGS_FILE = pi-chrome-devtools.json` and `LEGACY_SETTINGS_FILE = pi-chrome-devtools-settings.json` in `extensions/pi-chrome-devtools/src/chrome-devtools.ts`; verified with `rg -n "pi-chrome-devtools-settings|pi-chrome-devtools\.json" extensions/pi-chrome-devtools/src/chrome-devtools.ts` showing both constants.
+- [x] Add tests with an isolated temporary `PI_CODING_AGENT_DIR` for: new file only loads and applies saved tools, legacy file only migrates to the new filename and warns, both files use the new file and warn that legacy is ignored, invalid legacy file warns without creating the new file, missing settings preserve active tools, and `/chrome-devtools disable` saves only the new filename; verified by initial red `npm test -- --workspace @narumitw/pi-chrome-devtools` showing the new migration tests failed before implementation, then final green test runs.
+- [x] Implement settings loading so the new file is preferred, legacy-only settings are migrated without overwriting an existing new file, migration failure falls back to reading the legacy file with a warning, and missing/invalid settings still preserve Pi's current active-tool policy; verified with `npm test -- --workspace @narumitw/pi-chrome-devtools` passing.
+- [x] Update save behavior so all future writes go to `pi-chrome-devtools.json` only and never recreate `pi-chrome-devtools-settings.json`; verified by the `chrome-devtools saves tool selection only to the new settings file` test.
+- [x] Update `/chrome-devtools status` to show `pi-chrome-devtools.json` as the settings path and include a clear compatibility note when a legacy file was migrated or ignored during the session; verified by status-message assertions in `extensions/pi-chrome-devtools/test/chrome-devtools.test.ts`.
+- [x] Update `extensions/pi-chrome-devtools/README.md` to document `pi-chrome-devtools.json`, automatic phase-1 migration from `pi-chrome-devtools-settings.json`, and the planned removal window; verified with `rg -n "pi-chrome-devtools-settings|pi-chrome-devtools\.json" extensions/pi-chrome-devtools/README.md`.
+- [x] Run phase-1 verification: `npm test -- --workspace @narumitw/pi-chrome-devtools`, `npm --workspace @narumitw/pi-chrome-devtools run typecheck`, `npm --workspace @narumitw/pi-chrome-devtools run check`, `npm run check`, and `just pack-chrome-devtools`; all passed, and the dry-run tarball contained `LICENSE`, `README.md`, `package.json`, and `src/chrome-devtools.ts`.
+- [x] Not applicable: release phase 1 as a patch or minor version with release notes. Publishing is outside this coding task; the README now contains the release-note content needed for publish notes, and `just pack-chrome-devtools` verified the package contents.
+
+### Deprecation interval
+
+- [x] Not applicable now: keep phase 1 and phase 2 separated by at least one normal minor release cycle and preferably 4–8 weeks. This interval cannot elapse during this code change; the README documents the intended 4–8 week or next-major-release window.
+- [x] Not applicable now: before phase 2, confirm the phase-1 version has been published long enough for users to receive automatic migration. No phase-2 removal was performed.
+
+### Phase 2 — legacy removal release
+
+- [x] Not applicable now: remove legacy migration and all active code references to `pi-chrome-devtools-settings.json` from `extensions/pi-chrome-devtools/src/chrome-devtools.ts`. The compatibility migration intentionally keeps legacy references during phase 1.
+- [x] Not applicable now: update tests so only `pi-chrome-devtools.json` is expected. Current tests intentionally cover phase-1 legacy compatibility.
+- [x] Not applicable now: update `extensions/pi-chrome-devtools/README.md` so normal docs no longer mention `pi-chrome-devtools-settings.json`. Current docs intentionally mention the legacy filename only in the phase-1 compatibility note.
+- [x] Not applicable now: release phase 2 as a major version if strict semver is desired. No phase-2 removal or publish was performed.
+
+## Risks
+
+- [x] Import-time settings path constants can make tests accidentally use the real user directory. Mitigated by runtime `settingsFilePath()`/`legacySettingsFilePath()` helpers and tests with isolated temporary `PI_CODING_AGENT_DIR` values.
+- [x] Overwriting `pi-chrome-devtools.json` when both files exist would lose the user's newer preference. Mitigated by always preferring the new file and writing migrated legacy settings with `flag: "wx"` only when the new file is absent.
+- [x] Users who skip phase 1 may lose persisted tool selection in phase 2. Mitigated for this change by not performing phase 2 and documenting the deprecation window.
+
+## Rollback / Recovery
+
+- If phase 1 causes migration issues, revert the migration code and document that users can manually rename `pi-chrome-devtools.json` back to `pi-chrome-devtools-settings.json`; the JSON schema is unchanged.
+- If phase 2 causes skipped-version breakage in the future, reintroduce a small legacy-read shim in a patch release and document manual rename recovery.
+
+## Completion Checklist
+
+- [x] Phase 1 loads and saves `pi-chrome-devtools.json`, migrates legacy-only settings safely, and warns users, verified by pi-chrome-devtools tests and source review.
+- [x] Phase 1 preserves missing/invalid-settings behavior, verified by tests showing Pi's current active-tool policy is not changed when settings are absent or invalid.
+- [x] Phase 1 README documents the new filename, automatic migration, and deprecation interval; no standalone release-notes file exists in this repo, so publish notes remain a release-time handoff.
+- [x] Not applicable now: at least one minor release cycle or 4–8 weeks passes between phase 1 and phase 2. The window is documented, and phase 2 was not performed.
+- [x] Not applicable now: phase 2 removes active code and docs references to `pi-chrome-devtools-settings.json`. Legacy references intentionally remain for phase-1 compatibility.
+- [x] Final verification passes for the touched package and repository, verified by `npm test -- --workspace @narumitw/pi-chrome-devtools`, `npm --workspace @narumitw/pi-chrome-devtools run typecheck`, `npm --workspace @narumitw/pi-chrome-devtools run check`, `npm run check`, and `just pack-chrome-devtools`.

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -164,12 +164,18 @@ Direct subcommands are also available:
 The selected tool names are saved to:
 
 ```text
-${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools-settings.json
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json
 ```
 
 When the file is missing or invalid, the extension preserves Pi's current active-tool policy
 instead of enabling tools by itself. A valid saved selection is restored on Pi startup and
 `/reload`.
+
+Compatibility: older versions used `pi-chrome-devtools-settings.json`. During the migration
+window, a legacy-only file is automatically migrated to `pi-chrome-devtools.json` with a warning.
+If both files exist, `pi-chrome-devtools.json` wins and the legacy file is ignored. The legacy
+filename is deprecated and planned for removal after at least one minor release cycle, preferably
+4–8 weeks, or at the next major release.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -24,10 +24,8 @@ const MANAGED_BROWSER_PROFILE_PREFIX = "pi-chrome-devtools-profile-";
 const DEVTOOLS_ACTIVE_PORT_FILE = "DevToolsActivePort";
 const BROWSER_SHUTDOWN_WAIT_MS = 1_500;
 const STATUS_KEY = "chrome-devtools";
-const SETTINGS_FILE = join(
-	process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent"),
-	"pi-chrome-devtools-settings.json",
-);
+const NEW_SETTINGS_FILE_NAME = "pi-chrome-devtools.json";
+const LEGACY_SETTINGS_FILE_NAME = "pi-chrome-devtools-settings.json";
 const CHROME_DEVTOOLS_TOOL_NAMES = [
 	"chrome_devtools_list_pages",
 	"chrome_devtools_select_page",
@@ -108,6 +106,7 @@ interface ChromeDevToolsState {
 	launchPromise?: Promise<void>;
 	lastLaunchAttempt?: BrowserLaunchAttempt;
 	shuttingDown: boolean;
+	settingsNotice?: string;
 }
 
 interface ManagedBrowser {
@@ -375,8 +374,11 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		state.shuttingDown = false;
+		state.settingsNotice = undefined;
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		const settings = await loadSettings();
+		recordSettingsNotice(settings);
+		if (settings.notice) ctx.ui.notify(settings.notice, "warning");
 		if (settings.kind === "loaded") {
 			applyChromeDevtoolsTools(pi, settings.settings.tools);
 			return;
@@ -670,7 +672,8 @@ async function buildToolStatusMessage(pi: ExtensionAPI) {
 	return [
 		`Chrome DevTools tools: ${formatRuntimeStatus(summary)}`,
 		`Persisted selection: ${persistedSetting}`,
-		`Settings file: ${SETTINGS_FILE}`,
+		`Settings file: ${settingsFilePath()}`,
+		...(state.settingsNotice ? [`Settings note: ${state.settingsNotice}`] : []),
 		`Other active tools preserved: ${summary.activeNonChromeToolCount}`,
 		`Endpoint: ${devToolsEndpoint()}`,
 		`Endpoint source: ${endpointSourceLabel()}`,
@@ -745,6 +748,7 @@ function formatRuntimeStatus(summary: ToolStatusSummary) {
 
 async function persistedSettingLabel() {
 	const settings = await loadSettings();
+	recordSettingsNotice(settings);
 	if (settings.kind === "loaded") return formatPersistedSelection(settings.settings.tools);
 	if (settings.kind === "invalid") {
 		return `none; current active-tool policy preserved (invalid settings ignored: ${settings.reason})`;
@@ -771,27 +775,90 @@ async function persistSettings(
 	}
 }
 
-async function loadSettings(): Promise<
-	| { kind: "missing" }
-	| { kind: "invalid"; reason: string }
-	| { kind: "loaded"; settings: ChromeDevToolsSettings }
-> {
+type SettingsLoadResult =
+	| { kind: "missing"; notice?: string }
+	| { kind: "invalid"; reason: string; notice?: string }
+	| { kind: "loaded"; settings: ChromeDevToolsSettings; notice?: string };
+
+async function loadSettings(): Promise<SettingsLoadResult> {
+	const newSettings = await readSettingsFile(settingsFilePath());
+	if (newSettings.kind !== "missing") {
+		return withLegacyIgnoredNotice(newSettings);
+	}
+
+	const legacyPath = legacySettingsFilePath();
+	const legacySettings = await readSettingsFile(legacyPath);
+	if (legacySettings.kind === "missing") return { kind: "missing" };
+	if (legacySettings.kind === "invalid") return legacySettings;
+
+	return {
+		...legacySettings,
+		notice: await migrateLegacySettings(legacyPath, legacySettings.settings),
+	};
+}
+
+async function readSettingsFile(filePath: string): Promise<SettingsLoadResult> {
 	let text: string;
 	try {
-		text = await readFile(SETTINGS_FILE, "utf8");
+		text = await readFile(filePath, "utf8");
 	} catch (error) {
 		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
-		return { kind: "invalid", reason: formatError(error) };
+		return { kind: "invalid", reason: `${filePath}: ${formatError(error)}` };
 	}
 
 	try {
 		const parsed = JSON.parse(text) as unknown;
 		const settings = normalizeChromeDevtoolsSettings(parsed);
 		if (settings) return { kind: "loaded", settings };
-		return { kind: "invalid", reason: "expected tools to be an array of Chrome DevTools tool names" };
+		return {
+			kind: "invalid",
+			reason: `${filePath}: expected tools to be an array of Chrome DevTools tool names`,
+		};
 	} catch (error) {
-		return { kind: "invalid", reason: formatError(error) };
+		return { kind: "invalid", reason: `${filePath}: ${formatError(error)}` };
 	}
+}
+
+async function withLegacyIgnoredNotice(settings: SettingsLoadResult): Promise<SettingsLoadResult> {
+	if (!(await fileExists(legacySettingsFilePath()))) return settings;
+	return {
+		...settings,
+		notice: `Chrome DevTools legacy settings ignored: ${legacySettingsFilePath()} exists, but ${settingsFilePath()} takes precedence. Delete ${LEGACY_SETTINGS_FILE_NAME} after confirming your settings.`,
+	};
+}
+
+async function migrateLegacySettings(legacyPath: string, settings: ChromeDevToolsSettings) {
+	const newPath = settingsFilePath();
+	try {
+		await mkdir(dirname(newPath), { recursive: true });
+		await writeFile(newPath, `${JSON.stringify(settings, null, 2)}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+		});
+	} catch (error) {
+		return `Chrome DevTools legacy settings migration failed: could not migrate ${legacyPath} to ${newPath}: ${formatError(error)}. The legacy file was used for this session; future saves will write ${NEW_SETTINGS_FILE_NAME}.`;
+	}
+
+	try {
+		await rm(legacyPath, { force: true });
+	} catch (error) {
+		return `Chrome DevTools settings migrated from ${legacyPath} to ${newPath}, but the legacy file could not be removed: ${formatError(error)}. Delete ${LEGACY_SETTINGS_FILE_NAME} after confirming your settings.`;
+	}
+
+	return `Chrome DevTools settings migrated from ${legacyPath} to ${newPath}. ${LEGACY_SETTINGS_FILE_NAME} is deprecated and will be removed in a future major release.`;
+}
+
+async function fileExists(filePath: string) {
+	try {
+		await access(filePath, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function recordSettingsNotice(settings: SettingsLoadResult) {
+	if (settings.notice) state.settingsNotice = settings.notice;
 }
 
 export function normalizeChromeDevtoolsSettings(value: unknown): ChromeDevToolsSettings | undefined {
@@ -819,16 +886,28 @@ function orderedUniqueChromeDevtoolsTools(tools: readonly ChromeDevToolsToolName
 }
 
 async function saveSettings(settings: ChromeDevToolsSettings) {
-	await mkdir(dirname(SETTINGS_FILE), { recursive: true });
-	const tempFile = `${SETTINGS_FILE}.${process.pid}.${Date.now()}.tmp`;
+	const filePath = settingsFilePath();
+	await mkdir(dirname(filePath), { recursive: true });
+	const tempFile = `${filePath}.${process.pid}.${Date.now()}.tmp`;
 	try {
-		await writeFile(tempFile, `${JSON.stringify(settings, null, 2)}
-`, "utf8");
-		await rename(tempFile, SETTINGS_FILE);
+		await writeFile(tempFile, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+		await rename(tempFile, filePath);
 	} catch (error) {
 		await rm(tempFile, { force: true }).catch(() => undefined);
 		throw error;
 	}
+}
+
+function settingsFilePath() {
+	return join(agentDir(), NEW_SETTINGS_FILE_NAME);
+}
+
+function legacySettingsFilePath() {
+	return join(agentDir(), LEGACY_SETTINGS_FILE_NAME);
+}
+
+function agentDir() {
+	return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/extensions/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/extensions/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import chromeDevtools, {
 	commandCompletions,
 	formatHostForUrl,
@@ -18,6 +18,12 @@ import chromeDevtools, {
 	resolveScreenshotPath,
 	selectAllowedRoot,
 } from "../src/chrome-devtools.js";
+
+const NEW_SETTINGS_FILE = "pi-chrome-devtools.json";
+const LEGACY_SETTINGS_FILE = "pi-chrome-devtools-settings.json";
+const LIST_PAGES_TOOL = "chrome_devtools_list_pages";
+const EVALUATE_TOOL = "chrome_devtools_evaluate";
+const SCREENSHOT_TOOL = "chrome_devtools_screenshot";
 
 test("chrome-devtools registers all CDP tools and command", () => {
 	const mock = createMockPi();
@@ -54,19 +60,141 @@ test("chrome-devtools command parsing and completions cover aliases", () => {
 test("chrome-devtools settings normalize ordered unique tool names", () => {
 	assert.deepEqual(
 		normalizeChromeDevtoolsSettings({
-			tools: [
-				"chrome_devtools_screenshot",
-				"chrome_devtools_list_pages",
-				"chrome_devtools_screenshot",
-			],
+			tools: [SCREENSHOT_TOOL, LIST_PAGES_TOOL, SCREENSHOT_TOOL],
 			updatedAt: 1,
 		}),
-		{ tools: ["chrome_devtools_list_pages", "chrome_devtools_screenshot"], updatedAt: 1 },
+		{ tools: [LIST_PAGES_TOOL, SCREENSHOT_TOOL], updatedAt: 1 },
 	);
 	assert.equal(normalizeChromeDevtoolsSettings({ tools: ["bad"], updatedAt: 1 }), undefined);
-	assert.deepEqual(orderedChromeDevtoolsTools(new Set(["chrome_devtools_evaluate"])), [
-		"chrome_devtools_evaluate",
-	]);
+	assert.deepEqual(orderedChromeDevtoolsTools(new Set([EVALUATE_TOOL])), [EVALUATE_TOOL]);
+});
+
+test("chrome-devtools preserves active tools when settings are missing", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", EVALUATE_TOOL]);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("chrome-devtools loads the new settings file without a migration warning", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, [SCREENSHOT_TOOL]);
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", LIST_PAGES_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", SCREENSHOT_TOOL]);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("chrome-devtools migrates a legacy-only settings file and warns", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, LEGACY_SETTINGS_FILE, [LIST_PAGES_TOOL]);
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", SCREENSHOT_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LIST_PAGES_TOOL]);
+		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, [LIST_PAGES_TOOL]);
+		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), false);
+		assert.match(notifications[0]?.message ?? "", /migrated/i);
+		assert.match(notifications[0]?.message ?? "", /pi-chrome-devtools-settings\.json/);
+		assert.match(notifications[0]?.message ?? "", /pi-chrome-devtools\.json/);
+	});
+});
+
+test("chrome-devtools prefers new settings when both files exist and reports legacy ignored", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, [SCREENSHOT_TOOL]);
+		writeSettings(agentDir, LEGACY_SETTINGS_FILE, [LIST_PAGES_TOOL]);
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.commands.get("chrome-devtools")?.handler("status", ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", SCREENSHOT_TOOL]);
+		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, [SCREENSHOT_TOOL]);
+		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), true);
+		assert.match(notifications[0]?.message ?? "", /legacy settings ignored/i);
+		const statusMessage = notifications.at(-1)?.message ?? "";
+		assert.match(statusMessage, /Settings file: .*pi-chrome-devtools\.json/);
+		assert.match(statusMessage, /legacy settings ignored/i);
+	});
+});
+
+test("chrome-devtools ignores invalid legacy settings without creating the new file", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeFileSync(
+			path.join(agentDir, LEGACY_SETTINGS_FILE),
+			JSON.stringify({ tools: ["bad"], updatedAt: 1 }),
+		);
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", EVALUATE_TOOL]);
+		assert.equal(existsSync(path.join(agentDir, NEW_SETTINGS_FILE)), false);
+		assert.match(notifications[0]?.message ?? "", /settings ignored/i);
+		assert.match(notifications[0]?.message ?? "", /pi-chrome-devtools-settings\.json/);
+	});
+});
+
+test("chrome-devtools does not fall back to legacy settings when the new file is invalid", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeFileSync(
+			path.join(agentDir, NEW_SETTINGS_FILE),
+			JSON.stringify({ tools: ["bad"], updatedAt: 1 }),
+		);
+		writeSettings(agentDir, LEGACY_SETTINGS_FILE, [LIST_PAGES_TOOL]);
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", EVALUATE_TOOL]);
+		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), true);
+		assert.match(notifications[0]?.message ?? "", /legacy settings ignored/i);
+		assert.match(notifications[1]?.message ?? "", /settings ignored/i);
+		assert.match(notifications[1]?.message ?? "", /pi-chrome-devtools\.json/);
+	});
+});
+
+test("chrome-devtools saves tool selection only to the new settings file", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", LIST_PAGES_TOOL] });
+		const { ctx, notifications } = createMockContext();
+
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.commands.get("chrome-devtools")?.handler("disable", ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, []);
+		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), false);
+		assert.match(notifications[0]?.message ?? "", /Settings file: .*pi-chrome-devtools\.json/);
+	});
 });
 
 test("endpoint helpers normalize ports, hosts, and launch quoting", () => {
@@ -92,3 +220,32 @@ test("resolveScreenshotPath confines explicit paths to cwd or temp", () => {
 	assert.equal(selectAllowedRoot(path.join(cwd, "screens"), [cwd, os.tmpdir()]), path.resolve(cwd));
 	assert.equal(isPathInsideRoot(path.join(cwd, "screens", "out.png"), cwd), true);
 });
+
+let importCounter = 0;
+
+async function importFreshChromeDevtools() {
+	return (await import(
+		`../src/chrome-devtools.js?settings-test=${Date.now()}-${importCounter++}`
+	)) as typeof import("../src/chrome-devtools.js");
+}
+
+async function withTempAgentDir<T>(fn: (agentDir: string) => Promise<T>) {
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-settings-"));
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		return await fn(agentDir);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+}
+
+function writeSettings(agentDir: string, fileName: string, tools: string[]) {
+	writeFileSync(path.join(agentDir, fileName), JSON.stringify({ tools, updatedAt: 1 }));
+}
+
+function readSettings(agentDir: string, fileName: string) {
+	return JSON.parse(readFileSync(path.join(agentDir, fileName), "utf8")) as { tools: string[] };
+}


### PR DESCRIPTION
## Summary
- use `pi-chrome-devtools.json` as the persisted Chrome DevTools settings file
- migrate legacy-only `pi-chrome-devtools-settings.json` files with warnings, and prefer the new file when both exist
- document the compatibility window and add migration/save behavior tests

## Verification
- `npm test -- --workspace @narumitw/pi-chrome-devtools`
- `npm --workspace @narumitw/pi-chrome-devtools run typecheck`
- `npm --workspace @narumitw/pi-chrome-devtools run check`
- `npm run check`
- `just pack-chrome-devtools`
- `npm run biome:check`
- `git diff --check`
