### PR TITLE
feat(btw): add thinking-level config

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -30,6 +30,7 @@
 - Symptom: pi-goal compaction/retry hooks can mis-handle continuation state if a fresh continuation reuses a cancelled marker. Cause: markers based only on goal id and iteration collide after compaction cancellation. Fix: include a unique nonce in continuation markers.
 - Symptom: Pi compaction event docs may mention `reason`/`willRetry` while project target typings lack them. Cause: local/global `@earendil-works/pi-coding-agent` version skew. Fix: run `npm install`, verify target version, and treat compaction event fields as optional.
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
+- Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
 
 ## TASTE
 

--- a/docs/plans/archived/2026-07-10_pi-btw-thinking-level-config-plan.md
+++ b/docs/plans/archived/2026-07-10_pi-btw-thinking-level-config-plan.md
@@ -1,0 +1,67 @@
+## Goal
+
+Add a user-level `pi-btw.json` setting that lets `/btw` either inherit Pi's current thinking level or request a fixed level for side-question model calls, without changing the main session's thinking level.
+
+Success means users can place this file at `$PI_CODING_AGENT_DIR/pi-btw.json` (normally `~/.pi/agent/pi-btw.json`):
+
+```json
+{
+  "thinkingLevel": "high"
+}
+```
+
+A missing file, an empty object, or an omitted `thinkingLevel` must use the level returned by `pi.getThinkingLevel()` at `/btw` invocation time.
+
+## Context
+
+- Pi's public term is **thinking level**: core settings use `defaultThinkingLevel`, while extensions read the effective runtime value through `pi.getThinkingLevel()`.
+- `pi-btw` currently calls the provider-level `complete()` API without a thinking option. It therefore does not explicitly inherit the current Pi level today. This change preserves the no-config UX while making inheritance real.
+- The provider-neutral pi-ai option is named `reasoning`, so the extension should translate its user-facing `thinkingLevel` setting into that internal option through `completeSimple()`.
+- For the repository's current Pi target, accepted levels are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. `max` is out of scope until the target Pi/pi-ai types support it consistently.
+
+## Architecture
+
+- Config path: `join(getAgentDir(), "pi-btw.json")`; this uses Pi's existing agent-directory resolution, including its existing `PI_CODING_AGENT_DIR` support, without adding any pi-btw environment variable.
+- Config shape: `{ "thinkingLevel"?: BtwThinkingLevel }`; omission means inherit. No separate `"inherit"` sentinel is needed.
+- If `pi-btw.json` does not exist, do not create it or warn; silently inherit the current Pi thinking level and leave the filesystem unchanged.
+- Load the small config file on each valid `/btw` invocation so edits apply to the next question without `/reload`.
+- Resolution precedence: valid config override → current `pi.getThinkingLevel()`.
+- Convert effective `off` to an omitted `reasoning` option; pass all other effective levels as `reasoning` to `completeSimple()`, which owns provider-specific mapping and capability clamping.
+- Invalid JSON or an invalid `thinkingLevel` should produce a warning and fall back to the current Pi level rather than blocking the side question.
+
+## Non-Goals
+
+- Do not add project-local `.pi/pi-btw.json` precedence in this version.
+- Do not add `/btw` subcommands, command-line overrides, or a settings UI.
+- Do not change the selected model or mutate the main session's thinking level.
+- Do not auto-create or write `pi-btw.json`, and do not add environment variables, custom thinking-token budgets, or release/version changes.
+
+## Assumptions
+
+- `pi-btw.json` is a user-global extension config, consistent with the requested filename and other package configs under the Pi agent directory.
+- Unknown JSON keys may be ignored for forward compatibility, but a present invalid `thinkingLevel` invalidates that override and triggers fallback.
+
+## Plan
+
+- [x] Added config-contract tests in `extensions/pi-btw/test/btw.test.ts`; the initial `npm test` failed on the new missing exports before implementation.
+- [x] Replaced the compatibility loader with a `completeSimple` loader; preference, fallback, and missing-export behavior pass under `npm test`.
+- [x] Added exported normalization, file-loading, and effective-level helpers using `getAgentDir()` and `pi-btw.json`; tests use isolated temporary paths.
+- [x] Resolved the effective thinking level inside the validated `/btw` command path; tests prove factory/invalid command paths do not read the level and helper tests prove inheritance and override precedence.
+- [x] Routed side questions through `completeSimple()` with provider-neutral reasoning options; captured-call tests cover every supported level, auth environment, headers, and `off` omission, while source inspection confirms no `pi.setThinkingLevel()` call.
+- [x] Added warning-and-inherit behavior for malformed, wrong-type, unsupported, and unreadable settings; missing settings remain silent and uncreated in tests.
+- [x] Documented the complete `pi-btw.json` contract in `extensions/pi-btw/README.md`.
+- [x] Ran `npm run check` successfully and inspected `just pack-btw`; the dry run contains only `LICENSE`, `README.md`, `package.json`, and `src/btw.ts`. An interactive smoke test was not required because the provider call and command-independent config flow are covered without external credentials.
+
+## Risks
+
+- Inheriting a high current level can make quick side questions slower or more expensive than the provider default used by the current implementation; the fixed config, including `off` or `low`, is the escape hatch and must be documented.
+- Calling raw `complete()` with a generic field would behave inconsistently across providers; using `completeSimple()` is required for provider-neutral translation.
+- A configured level may exceed the selected model's capabilities; pi-ai should clamp it, and documentation must describe the value as a requested level rather than a guarantee.
+
+## Completion Checklist
+
+- [x] No config and `{}` both use the current runtime Pi thinking level, with a missing config left uncreated, verified by `missing pi-btw settings inherit silently without creating a file` and `pi-btw settings override the current runtime thinking level` tests.
+- [x] Every documented fixed level overrides inheritance only for the side call, verified by captured `completeSimple()` options and the absence of `pi.setThinkingLevel()` in `extensions/pi-btw/src/btw.ts`.
+- [x] `off` omits provider reasoning and invalid config warns then inherits, verified by `side-question completion maps thinking levels into provider-neutral options` and invalid-settings tests.
+- [x] Config location and behavior are documented in `extensions/pi-btw/README.md`, with no new environment variable, verified against `BTW_SETTINGS_FILE`, `BTW_THINKING_LEVELS`, and accepted-value tests.
+- [x] Repository verification passed with `npm run check`; package inspection passed with `just pack-btw` and four intended tarball files.

--- a/extensions/pi-btw/README.md
+++ b/extensions/pi-btw/README.md
@@ -11,6 +11,7 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 - Adds a `/btw <question>` command to Pi.
 - Answers side questions in a temporary, scrollable UI.
 - Uses the current session branch as context.
+- Inherits Pi's current thinking level or uses a fixed level from `pi-btw.json`.
 - Does not append the side question or answer to the main conversation.
 - Works as an independently installable npm Pi extension package.
 
@@ -50,6 +51,36 @@ Long answers open in a pager-style view. Use `↑`/`↓` or `k`/`j` to scroll by
 `PgUp`/`PgDn`, `Shift+Space`/`Space`, or `Ctrl+B`/`Ctrl+F` to scroll by page,
 `Ctrl+U`/`Ctrl+D` to scroll by half page, and `Home`/`End` to jump. Close with
 `q`, `Esc`, `Enter`, or `Ctrl+C`.
+
+## ⚙️ Thinking level
+
+Pi calls its reasoning setting the **thinking level**. By default, `/btw` inherits the
+current runtime level, including changes made through `/settings` or `Shift+Tab`. It does
+not read or change `defaultThinkingLevel` directly.
+
+To request a fixed level for side questions, create:
+
+```text
+$PI_CODING_AGENT_DIR/pi-btw.json
+```
+
+The normal location is `~/.pi/agent/pi-btw.json`. `PI_CODING_AGENT_DIR` is an existing Pi
+setting; pi-btw does not add any environment variables.
+
+```json
+{
+  "thinkingLevel": "low"
+}
+```
+
+Supported values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. The selected
+value affects only `/btw` requests and does not change the main session. Pi's provider
+layer may clamp a requested level when the active model does not support it.
+
+The settings file is optional and is never created automatically. A missing file, `{}`,
+or an omitted `thinkingLevel` silently inherits the current Pi level. The file is read for
+each `/btw` invocation, so edits apply to the next side question without `/reload`. Invalid
+or unreadable settings produce a warning and fall back to the current Pi level.
 
 ## 🧠 Why use pi-btw?
 

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -1,48 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import type {
 	Api,
 	AssistantMessage,
 	Context,
 	Model,
-	ProviderStreamOptions,
+	ProviderEnv,
+	ProviderHeaders,
+	SimpleStreamOptions,
 	UserMessage,
 } from "@earendil-works/pi-ai";
-// pi-ai 0.79 exports complete from the root; 0.80 moved it to the compat subpath.
-type CompleteFunction = <TApi extends Api>(
+// pi-ai 0.79 exports completeSimple from the root; 0.80 moved it to the compat subpath.
+type CompleteSimpleFunction = <TApi extends Api>(
 	model: Model<TApi>,
 	context: Context,
-	options?: ProviderStreamOptions,
+	options?: SimpleStreamOptions,
 ) => Promise<AssistantMessage>;
 
-function hasComplete(value: unknown): value is { complete: CompleteFunction } {
+function hasCompleteSimple(value: unknown): value is { completeSimple: CompleteSimpleFunction } {
 	return (
 		typeof value === "object" &&
 		value !== null &&
-		typeof Reflect.get(value, "complete") === "function"
+		typeof Reflect.get(value, "completeSimple") === "function"
 	);
 }
 
 type ModuleImporter = (moduleId: string) => Promise<unknown>;
 
-export async function loadComplete(
+export async function loadCompleteSimple(
 	importModule: ModuleImporter = (moduleId) => import(moduleId),
-): Promise<CompleteFunction> {
+): Promise<CompleteSimpleFunction> {
 	let importError: unknown;
 	for (const moduleId of ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]) {
 		try {
 			const module = await importModule(moduleId);
-			if (hasComplete(module)) return module.complete;
+			if (hasCompleteSimple(module)) return module.completeSimple;
 		} catch (error: unknown) {
 			importError = error;
 		}
 	}
 
-	throw new Error("@earendil-works/pi-ai does not export complete", { cause: importError });
+	throw new Error("@earendil-works/pi-ai does not export completeSimple", {
+		cause: importError,
+	});
 }
 
-const complete = await loadComplete();
+const completeSimple = await loadCompleteSimple();
 import {
 	BorderedLoader,
 	DynamicBorder,
+	getAgentDir,
 	getMarkdownTheme,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
@@ -62,6 +69,134 @@ const MAX_CONTEXT_CHARS = 40_000;
 const ANSWER_CHROME_LINES = 4;
 // Pi renders a spacer above the custom editor and a two-line built-in footer below it.
 const ANSWER_RESERVED_APP_LINES = 3;
+export const BTW_SETTINGS_FILE = "pi-btw.json";
+export const BTW_THINKING_LEVELS = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+] as const;
+
+export type BtwThinkingLevel = (typeof BTW_THINKING_LEVELS)[number];
+
+export interface BtwSettings {
+	thinkingLevel?: BtwThinkingLevel;
+}
+
+export type BtwSettingsLoadResult =
+	| { kind: "missing" }
+	| { kind: "invalid"; reason: string }
+	| { kind: "loaded"; settings: BtwSettings };
+
+interface LoadBtwThinkingLevelOptions {
+	settingsPath?: string;
+	warn?: (message: string) => void;
+}
+
+interface SideQuestionAuth {
+	apiKey: string;
+	headers?: ProviderHeaders;
+	env?: ProviderEnv;
+}
+
+interface CompleteSideQuestionOptions {
+	model: Model<Api>;
+	question: string;
+	conversationContext: string;
+	thinkingLevel: BtwThinkingLevel;
+	auth: SideQuestionAuth;
+	signal?: AbortSignal;
+	completeSimple?: CompleteSimpleFunction;
+}
+
+export function normalizeBtwSettings(value: unknown): BtwSettings | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	if (!Object.hasOwn(value, "thinkingLevel")) return {};
+
+	const thinkingLevel = Reflect.get(value, "thinkingLevel");
+	return isBtwThinkingLevel(thinkingLevel) ? { thinkingLevel } : undefined;
+}
+
+export async function readBtwSettings(
+	settingsPath = join(getAgentDir(), BTW_SETTINGS_FILE),
+): Promise<BtwSettingsLoadResult> {
+	let contents: string;
+	try {
+		contents = await readFile(settingsPath, "utf8");
+	} catch (error: unknown) {
+		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
+		return { kind: "invalid", reason: `${settingsPath}: ${formatError(error)}` };
+	}
+
+	try {
+		const settings = normalizeBtwSettings(JSON.parse(contents) as unknown);
+		if (settings) return { kind: "loaded", settings };
+		return { kind: "invalid", reason: `${settingsPath}: invalid settings shape` };
+	} catch (error: unknown) {
+		return { kind: "invalid", reason: `${settingsPath}: ${formatError(error)}` };
+	}
+}
+
+export async function loadBtwThinkingLevel(
+	currentThinkingLevel: BtwThinkingLevel,
+	options: LoadBtwThinkingLevelOptions = {},
+): Promise<BtwThinkingLevel> {
+	const settings = await readBtwSettings(options.settingsPath);
+	if (settings.kind === "missing") return currentThinkingLevel;
+	if (settings.kind === "loaded") {
+		return settings.settings.thinkingLevel ?? currentThinkingLevel;
+	}
+
+	options.warn?.(
+		`pi-btw settings ignored: ${settings.reason}; expected { "thinkingLevel"?: "${BTW_THINKING_LEVELS.join('" | "')}" }. Using current Pi thinking level.`,
+	);
+	return currentThinkingLevel;
+}
+
+export async function completeSideQuestion({
+	model,
+	question,
+	conversationContext,
+	thinkingLevel,
+	auth,
+	signal,
+	completeSimple: runCompleteSimple = completeSimple,
+}: CompleteSideQuestionOptions): Promise<AssistantMessage> {
+	const userMessage: UserMessage = {
+		role: "user",
+		content: [
+			{
+				type: "text",
+				text: buildUserPrompt(question, conversationContext),
+			},
+		],
+		timestamp: Date.now(),
+	};
+	const streamOptions: SimpleStreamOptions = {
+		apiKey: auth.apiKey,
+		headers: auth.headers,
+		env: auth.env,
+		signal,
+	};
+	if (thinkingLevel !== "off") streamOptions.reasoning = thinkingLevel;
+
+	return runCompleteSimple(model, { systemPrompt: SYSTEM_PROMPT, messages: [userMessage] }, streamOptions);
+}
+
+function isBtwThinkingLevel(value: unknown): value is BtwThinkingLevel {
+	return BTW_THINKING_LEVELS.includes(value as BtwThinkingLevel);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
 const SYSTEM_PROMPT = `You answer quick side questions for a coding-agent user.
 
 Use the provided conversation context only as background. Answer the user's side question directly and concisely. Do not claim to have changed files, run tools, or affected the main task. If the context is insufficient, say what is unknown and give the best next step.`;
@@ -105,7 +240,10 @@ export default function btw(pi: ExtensionAPI) {
 				return;
 			}
 
-			const answer = await askSideQuestion(question, ctx);
+			const thinkingLevel = await loadBtwThinkingLevel(pi.getThinkingLevel(), {
+				warn: (message) => ctx.ui.notify(message, "warning"),
+			});
+			const answer = await askSideQuestion(question, thinkingLevel, ctx);
 			if (answer === undefined) {
 				ctx.ui.notify("Cancelled", "info");
 				return;
@@ -118,6 +256,7 @@ export default function btw(pi: ExtensionAPI) {
 
 async function askSideQuestion(
 	question: string,
+	thinkingLevel: BtwThinkingLevel,
 	ctx: ExtensionCommandContext,
 ): Promise<string | undefined> {
 	return ctx.ui.custom<string | undefined>((tui, theme, _keybindings, done) => {
@@ -131,22 +270,14 @@ async function askSideQuestion(
 			}
 
 			const conversationContext = buildConversationContext(ctx.sessionManager.getBranch());
-			const userMessage: UserMessage = {
-				role: "user",
-				content: [
-					{
-						type: "text",
-						text: buildUserPrompt(question, conversationContext),
-					},
-				],
-				timestamp: Date.now(),
-			};
-
-			const response = await complete(
-				ctx.model!,
-				{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
-				{ apiKey: auth.apiKey, headers: auth.headers, signal: loader.signal },
-			);
+			const response = await completeSideQuestion({
+				model: ctx.model!,
+				question,
+				conversationContext,
+				thinkingLevel,
+				auth: { apiKey: auth.apiKey, headers: auth.headers, env: auth.env },
+				signal: loader.signal,
+			});
 
 			if (response.stopReason === "aborted") {
 				return undefined;

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -5,8 +5,6 @@ import type {
 	AssistantMessage,
 	Context,
 	Model,
-	ProviderEnv,
-	ProviderHeaders,
 	SimpleStreamOptions,
 	UserMessage,
 } from "@earendil-works/pi-ai";
@@ -97,8 +95,8 @@ interface LoadBtwThinkingLevelOptions {
 
 interface SideQuestionAuth {
 	apiKey: string;
-	headers?: ProviderHeaders;
-	env?: ProviderEnv;
+	headers?: Record<string, string>;
+	env?: Record<string, string>;
 }
 
 interface CompleteSideQuestionOptions {

--- a/extensions/pi-btw/test/btw.test.ts
+++ b/extensions/pi-btw/test/btw.test.ts
@@ -1,49 +1,195 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import btw, {
+	BTW_SETTINGS_FILE,
 	buildConversationContext,
 	buildUserPrompt,
-	loadComplete,
+	completeSideQuestion,
+	loadBtwThinkingLevel,
+	loadCompleteSimple,
+	normalizeBtwSettings,
+	readBtwSettings,
 	sanitizeSingleLine,
 } from "../src/btw.js";
 
-test("loadComplete prefers compat and falls back to the root module", async () => {
-	const compatComplete = async () => ({ source: "compat" });
-	const rootComplete = async () => ({ source: "root" });
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+async function withTempSettings(run: (settingsPath: string) => Promise<void>): Promise<void> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-btw-test-"));
+	try {
+		await run(join(directory, BTW_SETTINGS_FILE));
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+test("loadCompleteSimple prefers compat and falls back to the root module", async () => {
+	const compatCompleteSimple = async () => ({ source: "compat" });
+	const rootCompleteSimple = async () => ({ source: "root" });
 	const preferredImports: string[] = [];
-	const preferred = await loadComplete(async (moduleId) => {
+	const preferred = await loadCompleteSimple(async (moduleId) => {
 		preferredImports.push(moduleId);
-		return moduleId.endsWith("/compat") ? { complete: compatComplete } : { complete: rootComplete };
+		return moduleId.endsWith("/compat")
+			? { completeSimple: compatCompleteSimple }
+			: { completeSimple: rootCompleteSimple };
 	});
 
-	assert.equal(preferred, compatComplete);
+	assert.equal(preferred, compatCompleteSimple);
 	assert.deepEqual(preferredImports, ["@earendil-works/pi-ai/compat"]);
 
 	const fallbackImports: string[] = [];
-	const fallback = await loadComplete(async (moduleId) => {
+	const fallback = await loadCompleteSimple(async (moduleId) => {
 		fallbackImports.push(moduleId);
 		if (moduleId.endsWith("/compat")) throw new Error("missing compat export");
-		return { complete: rootComplete };
+		return { completeSimple: rootCompleteSimple };
 	});
 
-	assert.equal(fallback, rootComplete);
+	assert.equal(fallback, rootCompleteSimple);
 	assert.deepEqual(fallbackImports, ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]);
 });
 
-test("loadComplete reports when neither module exports complete", async () => {
+test("loadCompleteSimple reports when neither module exports completeSimple", async () => {
 	await assert.rejects(
-		loadComplete(async (moduleId) => {
+		loadCompleteSimple(async (moduleId) => {
 			if (moduleId.endsWith("/compat")) throw new Error("missing compat export");
 			return {};
 		}),
-		/@earendil-works\/pi-ai does not export complete/,
+		/@earendil-works\/pi-ai does not export completeSimple/,
 	);
 });
 
-test("btw command validates usage before asking a side question", async () => {
+test("normalizeBtwSettings accepts omission and every supported thinking level", () => {
+	assert.deepEqual(normalizeBtwSettings({}), {});
+	assert.deepEqual(normalizeBtwSettings({ futureOption: true }), {});
+
+	for (const thinkingLevel of THINKING_LEVELS) {
+		assert.deepEqual(normalizeBtwSettings({ thinkingLevel }), { thinkingLevel });
+	}
+
+	assert.equal(normalizeBtwSettings(null), undefined);
+	assert.equal(normalizeBtwSettings([]), undefined);
+	assert.equal(normalizeBtwSettings({ thinkingLevel: null }), undefined);
+	assert.equal(normalizeBtwSettings({ thinkingLevel: "max" }), undefined);
+	assert.equal(normalizeBtwSettings({ thinkingLevel: "huge" }), undefined);
+});
+
+test("missing pi-btw settings inherit silently without creating a file", async () => {
+	await withTempSettings(async (settingsPath) => {
+		assert.deepEqual(await readBtwSettings(settingsPath), { kind: "missing" });
+
+		const warnings: string[] = [];
+		assert.equal(
+			await loadBtwThinkingLevel("high", {
+				settingsPath,
+				warn: (message) => warnings.push(message),
+			}),
+			"high",
+		);
+		assert.deepEqual(warnings, []);
+		await assert.rejects(readFile(settingsPath, "utf8"), (error: unknown) => {
+			return (error as NodeJS.ErrnoException).code === "ENOENT";
+		});
+	});
+});
+
+test("pi-btw settings override the current runtime thinking level", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await writeFile(settingsPath, "{}\n", "utf8");
+		assert.equal(await loadBtwThinkingLevel("medium", { settingsPath }), "medium");
+
+		for (const thinkingLevel of THINKING_LEVELS) {
+			await writeFile(settingsPath, `${JSON.stringify({ thinkingLevel })}\n`, "utf8");
+			assert.equal(await loadBtwThinkingLevel("medium", { settingsPath }), thinkingLevel);
+		}
+	});
+});
+
+test("invalid pi-btw settings warn and fall back to the runtime level", async () => {
+	await withTempSettings(async (settingsPath) => {
+		for (const contents of ["{not-json", '{"thinkingLevel":42}\n', '{"thinkingLevel":"huge"}\n']) {
+			await writeFile(settingsPath, contents, "utf8");
+			const warnings: string[] = [];
+			assert.equal(
+				await loadBtwThinkingLevel("low", {
+					settingsPath,
+					warn: (message) => warnings.push(message),
+				}),
+				"low",
+			);
+			assert.equal(warnings.length, 1);
+			assert.match(warnings[0] ?? "", /pi-btw settings ignored/);
+			assert.match(warnings[0] ?? "", /thinkingLevel/);
+			assert.match(warnings[0] ?? "", new RegExp(BTW_SETTINGS_FILE));
+		}
+
+		await rm(settingsPath, { force: true });
+		await mkdir(settingsPath);
+		const warnings: string[] = [];
+		assert.equal(
+			await loadBtwThinkingLevel("medium", {
+				settingsPath,
+				warn: (message) => warnings.push(message),
+			}),
+			"medium",
+		);
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0] ?? "", /pi-btw settings ignored/);
+	});
+});
+
+test("side-question completion maps thinking levels into provider-neutral options", async () => {
+	for (const thinkingLevel of THINKING_LEVELS) {
+		let capturedContext: unknown;
+		let capturedOptions: Record<string, unknown> | undefined;
+		const response = { role: "assistant", stopReason: "stop", content: [] };
+		const result = await completeSideQuestion({
+			completeSimple: (async (
+				_model: Model<Api>,
+				context: Context,
+				options?: SimpleStreamOptions,
+			) => {
+				capturedContext = context;
+				capturedOptions = options as Record<string, unknown>;
+				return response as never;
+			}) as never,
+			model: { id: "test-model" } as never,
+			question: "Why?",
+			conversationContext: "User: context",
+			thinkingLevel,
+			auth: {
+				apiKey: "test-key",
+				headers: { "x-test": "yes" },
+				env: { TEST_ENV: "yes" },
+			},
+		});
+
+		assert.equal(result, response);
+		assert.match(JSON.stringify(capturedContext), /<side_question>\\nWhy\?/);
+		assert.equal(capturedOptions?.apiKey, "test-key");
+		assert.deepEqual(capturedOptions?.headers, { "x-test": "yes" });
+		assert.deepEqual(capturedOptions?.env, { TEST_ENV: "yes" });
+		if (thinkingLevel === "off") {
+			assert.equal(Object.hasOwn(capturedOptions ?? {}, "reasoning"), false);
+		} else {
+			assert.equal(capturedOptions?.reasoning, thinkingLevel);
+		}
+	}
+});
+
+test("btw command validates usage before reading the runtime thinking level", async () => {
 	const mock = createMockPi();
+	let thinkingLevelReads = 0;
+	mock.rawPi.getThinkingLevel = () => {
+		thinkingLevelReads += 1;
+		return "medium";
+	};
 	btw(mock.pi);
+	assert.equal(thinkingLevelReads, 0);
 
 	const command = mock.commands.get("btw");
 	assert.ok(command);
@@ -61,6 +207,7 @@ test("btw command validates usage before asking a side question", async () => {
 	assert.equal(emptyQuestion.notifications[0]?.level, "warning");
 	assert.match(emptyQuestion.notifications[0]?.message ?? "", /Usage: \/btw/);
 	assert.equal(nonInteractive.notifications[0]?.level, "error");
+	assert.equal(thinkingLevelReads, 0);
 });
 
 test("buildConversationContext formats user, assistant, and tool content", () => {


### PR DESCRIPTION
## Summary

- add optional `pi-btw.json` configuration for a fixed `/btw` thinking level
- inherit Pi's current runtime thinking level when the file or field is absent, without creating config files or changing the main session
- use provider-neutral `completeSimple()` reasoning options and fall back with a warning for invalid settings
- document the config contract and cover supported levels, compatibility loading, and error paths

## Testing

- `npm run check`
- `just pack-btw`