### PR TITLE
fix(goal): continue only after agent settles

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,7 +12,7 @@
 - ty/ruff LSP servers may request `workspace/configuration`; respond with per-item empty config objects or diagnostic requests can hang.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
-- Symptom: extension accept/execute actions from `agent_end` may not trigger a new turn. Cause: `pi.sendMessage({ triggerTurn: true })` only triggers when idle, and `sendUserMessage(..., { deliverAs: "followUp" })` can miss the current drain point late in `agent_end`. Fix: avoid starting new user turns from `agent_end`; let the user submit normally or schedule work after the agent is truly idle.
+- Symptom: extension actions from `agent_end` may not trigger a new turn. Cause: follow-ups can miss the late drain point. Fix: on Pi 0.80.6+, record intent in `agent_end` and dispatch from `agent_settled`; standalone manual compaction does not emit `agent_settled`, so use a narrowly idle-gated `session_compact` fallback when needed.
 - Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.

--- a/docs/plans/2026-07-05_pi-goal-continuation-prompt-hardening-plan.md
+++ b/docs/plans/2026-07-05_pi-goal-continuation-prompt-hardening-plan.md
@@ -1,0 +1,52 @@
+## Goal
+
+Harden `pi-goal` continuation and goal-mode prompts with Codex-style objective fidelity, evidence-based completion audit, and blocked-audit guidance.
+
+Success means an active goal is less likely to be narrowed, prematurely marked complete, or abandoned at a plan/TODO; tests prove the prompt contains the required guardrails without breaking continuation markers or objective escaping.
+
+## Context
+
+`extensions/pi-goal/src/goal.ts` currently builds compact prompts in `goalPersistenceRules()`, `buildGoalSystemPrompt()`, and `buildContinuePrompt()`. Codex's `third_party/codex/codex-rs/ext/goal/templates/goals/continuation.md` is stronger: it treats the objective as user-provided data, preserves full scope, requires requirement-by-requirement evidence, and defines strict blocked behavior.
+
+## Architecture
+
+Keep prompt construction in `extensions/pi-goal/src/goal.ts` unless the file becomes unwieldy. Prefer small helper functions or constants for reusable prompt sections:
+
+- objective trust boundary;
+- work-from-evidence rule;
+- fidelity/no-scope-shrinking rule;
+- completion audit rule;
+- blocked audit rule if `blocked` status/tool is implemented first.
+
+This plan can land before or after stopped statuses. If stopped statuses are not implemented yet, include blocked-audit wording as future-facing guidance only where it does not reference unavailable tools.
+
+## Non-Goals
+
+- Do not copy Codex templates verbatim if shorter Pi-specific wording is clearer.
+- Do not change `/goal` command semantics in this slice.
+- Do not add new status states unless executing the stopped-statuses plan at the same time.
+
+## Plan
+
+- [ ] Add failing prompt tests in `extensions/pi-goal/test/goal.test.ts` that assert continuation/system prompts include objective trust-boundary language, no-scope-shrinking language, evidence-based completion audit language, and current authoritative-state language; verify initial failures with `npm test`.
+- [ ] Refactor prompt builders in `extensions/pi-goal/src/goal.ts` into concise reusable sections without changing public command behavior; verify existing parser/status tests still pass with `npm test`.
+- [ ] Update `buildContinuePrompt()` to include Codex-style guidance that the full objective persists across turns, completion must be proven requirement by requirement, and weak/indirect evidence is not enough; verify prompt tests assert these phrases and the continuation marker remains parseable.
+- [ ] Update `buildGoalSystemPrompt()`, `buildGoalPrompt()`, `buildResumePrompt()`, and `buildObjectiveUpdatedPrompt()` so first turn, resumed turn, edited objective turn, and automatic continuation share the same completion standard; verify tests cover each builder.
+- [ ] If the stopped-statuses plan is already implemented, add blocked-audit prompt language that references the chosen blocked tool/status and the three-turn repeated-blocker threshold; otherwise add a TODO-free neutral warning not to stop merely because work is hard or uncertain; verify tests match the implemented branch.
+- [ ] Update `extensions/pi-goal/README.md` completion/interruption sections to describe the stronger audit behavior and clarify that prompt wording is a guardrail, not a proof of completion; verify README examples remain concise.
+- [ ] Run `npm run check` from the repository root and fix any formatting, type, or test failures.
+
+## Risks
+
+- Longer prompts consume more tokens and can make every goal turn more expensive.
+- Overly broad prompt text may conflict with existing global/developer instructions unless it stays scoped to goal behavior.
+- If blocked guidance references unavailable tools, the model may try to call tools that do not exist.
+
+## Completion Checklist
+
+- [ ] Continuation prompts preserve full-objective fidelity and evidence-based completion audit language, verified by prompt tests in `extensions/pi-goal/test/goal.test.ts`.
+- [ ] First-turn, resume, edit, and system prompt builders share the hardened completion standard, verified by tests for each builder.
+- [ ] Continuation marker cancellation/delivery still works with the longer prompt, verified by existing continuation-marker tests.
+- [ ] Objective XML escaping remains correct for adversarial objective text, verified by prompt escaping tests.
+- [ ] README documents the hardened completion behavior, verified by review of `extensions/pi-goal/README.md`.
+- [ ] Repository verification passes with `npm run check`.

--- a/docs/plans/2026-07-05_pi-goal-stopped-statuses-plan.md
+++ b/docs/plans/2026-07-05_pi-goal-stopped-statuses-plan.md
@@ -1,0 +1,58 @@
+## Goal
+
+Add Codex-inspired stopped statuses to `@narumitw/pi-goal`: `blocked` for true impasses and `usage_limited` for provider/account quota limits.
+
+Success means users can distinguish intentional pause, model-reported blocker, usage-limit stop, budget-limit stop, and completion; `/goal resume` can restart resumable stopped states safely.
+
+## Context
+
+`pi-goal` currently has `active`, `paused`, `budget_limited`, and `complete`. Non-retryable aborted/error turns are generally paused, and there is no model-facing way to stop an active goal as blocked. Codex uses `blocked` and `usage_limited` in `third_party/codex/codex-rs/protocol/src/protocol.rs` and `third_party/codex/codex-rs/ext/goal/src/tool.rs`, with prompt rules requiring repeated blocker evidence before `blocked`.
+
+## Architecture
+
+Extend the local goal state machine in `extensions/pi-goal/src/goal.ts` without adding Codex's SQLite store. Add a small model-facing blocked tool or status-update helper that can only mark the current matching goal `blocked`; keep `goal_complete` dedicated to successful completion.
+
+Suggested status semantics:
+
+- `paused`: user-initiated pause or user abort/interruption.
+- `blocked`: model or non-usage terminal error indicates work cannot proceed without user/external action.
+- `usage_limited`: provider/account usage limit stops the goal.
+- `budget_limited`: user-configured goal token budget is exhausted.
+- `complete`: goal is achieved and verified.
+
+## Non-Goals
+
+- Do not implement exact Codex SDK logical goal streams.
+- Do not persist a global per-directory goal database.
+- Do not make `blocked` a substitute for ordinary clarification; the prompt/tool contract must preserve strict blocker semantics.
+
+## Unknowns
+
+- Whether to name the new model-facing blocked tool `goal_blocked` or to introduce a broader `goal_update` tool. Resolve during implementation by choosing the smaller API that keeps `goal_complete` backward-compatible.
+
+## Plan
+
+- [ ] Add failing tests in `extensions/pi-goal/test/goal.test.ts` for `blocked` and `usage_limited` formatting, `/goal resume` eligibility, stale tool-call blocking after stopped states, and usage-limit classification; verify initial failures with `npm test`.
+- [ ] Extend `GoalStatus`, `isGoal()`, `formatStatus()`, `goalSummary()`, and `goalCommandHint()` in `extensions/pi-goal/src/goal.ts` to support `blocked` and `usage_limited`; verify formatting tests cover active/paused/blocked/usage_limited/budget_limited/complete.
+- [ ] Update command behavior so `/goal resume` accepts `paused`, `blocked`, `usage_limited`, and budget-limited goals when budget allows, while `/goal pause` remains active-only; verify command tests assert accepted and rejected statuses.
+- [ ] Add a model-facing blocker path, either `goal_blocked({ goal_id, reason, evidence, repeated_turns })` or `goal_update({ goal_id, status: "blocked", ... })`, that rejects stale ids, empty evidence, and `repeated_turns < 3`; verify with tool execution tests.
+- [ ] Split interruption classification so user aborts stay `paused`, provider/account quota messages become `usage_limited`, and non-retryable agent errors become `blocked` with a clear notification; verify with targeted `agent_end` tests for each stop reason.
+- [ ] Update stale tool-call blocking to apply to stopped states caused by in-flight work (`paused`, `blocked`, `usage_limited`) until a fresh user prompt, resume, or clear; verify existing stale-call tests plus new blocked/usage-limited cases.
+- [ ] Update `extensions/pi-goal/README.md` statusline states, command descriptions, and interruption behavior for `blocked` and `usage_limited`; verify examples align with `formatStatus()` output.
+- [ ] Run `npm run check` from the repository root and fix any formatting, type, or test failures.
+
+## Risks
+
+- A model-facing blocked tool may be overused unless the prompt and tool schema are strict.
+- Automatically mapping generic errors to `blocked` could surprise users who expect `/goal resume` after transient provider issues; tests should preserve retryable interruption behavior.
+- Statusline consumers may need to tolerate new plain-text values such as `blocked` and `usage`.
+
+## Completion Checklist
+
+- [ ] `pi-goal` state supports `blocked` and `usage_limited`, verified by TypeScript type checks and `isGoal()` persistence tests.
+- [ ] Users can resume `paused`, `blocked`, and `usage_limited` goals with `/goal resume`, verified by command tests.
+- [ ] The model can mark a current goal blocked only with matching goal id and sufficient blocker evidence, verified by tool tests.
+- [ ] Usage-limit interruptions produce `usage_limited` instead of generic `paused`, verified by `agent_end` interruption tests.
+- [ ] Retryable provider/context-overflow interruptions remain active and do not become stopped states, verified by existing retry tests.
+- [ ] README and statusline examples document all stopped statuses, verified by review of `extensions/pi-goal/README.md`.
+- [ ] Repository verification passes with `npm run check`.

--- a/docs/plans/2026-07-10_pi-goal-budget-accounting-plan.md
+++ b/docs/plans/2026-07-10_pi-goal-budget-accounting-plan.md
@@ -1,0 +1,58 @@
+## Goal
+
+Make `pi-goal` token and elapsed-time accounting accurate enough to enforce user budgets and explain exhaustion. Success means the extension uses a documented total-token definition, excludes paused wall-clock time, detects exhaustion at the earliest reliable lifecycle boundary, and gives the model one bounded wrap-up instruction without declaring completion.
+
+## Context
+
+`currentTokenTotal()` currently sums only assistant `input` and `output`, although Pi usage also exposes `cacheRead`, `cacheWrite`, and `totalTokens`. Elapsed time is currently `Date.now() - startedAt`, so paused time is counted. Budget status is checked only in `agent_end`, while current Codex accounts at tool and turn boundaries and injects a budget-limit wrap-up item.
+
+This plan depends on the idle-continuation plan so exhaustion can cancel continuation intent safely. It should land before prompt hardening.
+
+## Architecture
+
+Define one compatibility helper for cumulative assistant token usage:
+
+1. use finite, non-negative `usage.totalTokens` when present;
+2. otherwise use the Pi-compatible fallback established by local usage typings/tests;
+3. never double-count cache fields already included in `totalTokens`.
+
+Change elapsed time from wall-clock-since-creation to an accumulated active duration with a persisted active-start timestamp. Settle active duration whenever the goal stops, pauses, is edited into a stopped state, completes, or shuts down; restart the clock only when it becomes active.
+
+At the earliest public Pi hook where assistant usage is persisted, transition once to `budget_limited`, cancel continuation intent, and inject one model-visible but non-user-authored wrap-up message when a turn is still running. Retain `agent_end` as the final fallback check.
+
+## Unknowns
+
+- Whether `tool_execution_end` always sees the current assistant usage persisted in `ctx.sessionManager` for every supported provider. Resolve with a focused lifecycle probe before choosing `tool_execution_end`, `tool_result`, or an agent-level fallback as the primary boundary.
+- Whether `cacheWrite` is included in Pi's `totalTokens` fallback semantics. Resolve from the installed `@earendil-works/pi-ai` type/docs and encode the decision in tests and README wording.
+
+## Plan
+
+- [ ] Inspect the installed Pi usage type and lifecycle ordering to define total-token and tool-boundary semantics; record the chosen formula and hook in comments/tests, and verify with source references plus a mock lifecycle probe.
+- [ ] Add failing tests for `totalTokens`, missing-`totalTokens` fallback, cached-token-heavy usage, malformed/negative usage, branch changes, and baseline subtraction; verify failures with `npm test` before implementation.
+- [ ] Replace `currentTokenTotal()` with a typed cumulative usage helper that follows the documented formula and clamps invalid deltas; verify all accounting cases with focused tests.
+- [ ] Extend persisted goal state with backward-compatible active-time fields, migrate older session entries during normalization, and settle/restart active duration on every status transition; verify tests for pause waiting, resume, edit, completion, reload, and legacy entries using a fake clock.
+- [ ] Add the earliest reliable budget check after completed tool activity while retaining an `agent_end` fallback; verify a multi-tool turn reaches `budget_limited` once and cannot schedule another continuation.
+- [ ] Add a single-flight budget wrap-up message that tells the model to stop substantive work, summarize progress/blockers, and not call `goal_complete` unless evidence already proves completion; verify only one message is injected across parallel tools and repeated lifecycle events.
+- [ ] Ensure increasing the budget through `/goal edit --tokens ...` can reactivate only according to the stopped-status transition rules, while an unchanged exhausted budget remains `budget_limited`; verify command and stale-goal-ID tests.
+- [ ] Update status and README wording to define counted tokens, active elapsed time, possible one-turn overshoot, and budget-limit wrap-up semantics; verify examples match formatter tests.
+- [ ] Run `npm run check`; verify formatting, boundary checks, typechecks, and all tests pass.
+
+## Risks
+
+- Changing token semantics can exhaust existing budgets sooner after reload.
+- Provider usage fields may not be uniform; an incorrect fallback could double-count cached tokens.
+- Parallel tools can race to emit duplicate wrap-up messages without a goal-ID-scoped single-flight guard.
+- Persisted-state evolution must remain readable by the current release during rollback.
+
+## Rollback / Recovery
+
+Keep old persisted fields readable and make new fields optional during normalization. If tool-boundary usage is not reliable on a supported provider, retain corrected token totals and active-time accounting while falling back to the final `agent_end` budget check.
+
+## Completion Checklist
+
+- [ ] Total-token semantics are documented and verified by direct, fallback, cached, invalid, and baseline accounting tests.
+- [ ] Paused time is excluded and legacy goal entries remain readable, verified by fake-clock and migration tests.
+- [ ] Budget exhaustion transitions once at the earliest reliable boundary and cancels continuation, verified by parallel-tool and turn-end tests.
+- [ ] The model receives at most one non-completion wrap-up instruction, verified by repeated-event tests.
+- [ ] Resume/edit behavior for exhausted budgets is verified by command and stale-ID tests.
+- [ ] Documentation and repository checks are verified by README review and a passing `npm run check`.

--- a/docs/plans/2026-07-10_pi-goal-codex-alignment-plan.md
+++ b/docs/plans/2026-07-10_pi-goal-codex-alignment-plan.md
@@ -1,0 +1,55 @@
+## Goal
+
+Bring `@narumitw/pi-goal` closer to the current Codex Goal contract without porting Codex's SQLite runtime. Success means continuation starts only from a safe idle boundary, stopped outcomes are distinguishable and resumable, budget usage is trustworthy, and every goal prompt applies the same evidence-based completion standard.
+
+## Context
+
+This is the entry plan for the improvement program. Execute the linked plans as separate, reviewable slices in this order:
+
+1. [Idle continuation](./archived/2026-07-10_pi-goal-idle-continuation-plan.md) — completed
+2. [Stopped statuses](./2026-07-05_pi-goal-stopped-statuses-plan.md)
+3. [Budget accounting](./2026-07-10_pi-goal-budget-accounting-plan.md)
+4. [Prompt hardening](./2026-07-05_pi-goal-continuation-prompt-hardening-plan.md)
+
+The order is intentional: prompt text must describe states and controls that already exist, while accounting and continuation changes should land before wording claims Codex-like behavior.
+
+## Architecture
+
+Keep the implementation as a Pi extension with session-entry persistence and one `/goal` command. Preserve the UUID stale-turn guard and nonce-based continuation cancellation. Use Pi's settled/idle lifecycle for scheduling, add Codex-inspired stopped states locally, and define token/elapsed usage in extension-owned state rather than introducing a global database.
+
+## Non-Goals
+
+- Do not port Codex's SQLite goal store, app-server RPC API, analytics, or TUI.
+- Do not modify `third_party/codex`.
+- Do not remove `goal_complete({ goal_id, summary })` or weaken its stale-turn checks.
+- Do not claim exact Codex parity where Pi lacks a hidden-context or runtime-reservation API.
+- Do not update the external article unless its source is later added to this repository.
+
+## Plan
+
+- [x] Executed the idle-continuation plan: ordinary continuation now leaves `agent_end` and starts only after Pi is settled; verified by focused tests, the real `AgentSession` runtime smoke, `npm run check`, and `just pack-goal`.
+- [ ] Execute the stopped-statuses plan so `paused`, `blocked`, `usage_limited`, `budget_limited`, and `complete` have distinct transitions and resume behavior; verify with its state, tool, and interruption tests.
+- [ ] Execute the budget-accounting plan so cached/total tokens, active elapsed time, tool-boundary exhaustion, and wrap-up behavior have documented semantics; verify with its accounting tests.
+- [ ] Execute the prompt-hardening plan after stopped statuses exist so kickoff, resume, edit, system, continuation, blocker, and budget prompts all match implemented behavior; verify with prompt snapshots/assertions.
+- [ ] Reconcile `extensions/pi-goal/README.md` with the final command surface, all statuses, interruption semantics, token definition, visible-versus-hidden continuation limitation, and completion contract; verify every documented command and status against source tests.
+- [ ] Run the CI-equivalent gate and package preview after all slices land; verify with `npm run check` and `just pack-goal`, then inspect that the tarball contains only `src`, `README.md`, `LICENSE`, and package metadata.
+
+## Risks
+
+- Moving continuation later can expose missed wake-ups unless every active, eligible goal reaches a settled callback.
+- New stopped states change statusline text consumed by other extensions.
+- Counting provider `totalTokens` can make existing budgets exhaust sooner than users expect.
+- Stronger prompts increase recurring context cost; keep shared sections concise and tested.
+
+## Rollback / Recovery
+
+Land each linked plan as an independent change. If a slice regresses runtime behavior, revert that slice while preserving earlier completed slices. Keep persisted-state readers backward-compatible throughout so rollback does not make existing sessions unreadable.
+
+## Completion Checklist
+
+- [x] Safe continuation is verified by the completed and archived idle-continuation plan, 211 passing repository tests, and the four-scenario runtime smoke.
+- [ ] Distinct stopped statuses are verified by the completed and archived stopped-statuses plan plus state-transition tests.
+- [ ] Correct token and active-time accounting is verified by the completed and archived budget-accounting plan plus boundary tests.
+- [ ] Consistent evidence-based prompts are verified by the completed and archived prompt-hardening plan plus prompt assertions.
+- [ ] Public documentation and package contents are verified by README review, `npm run check`, and `just pack-goal` output.
+- [ ] All linked plans are archived under `docs/plans/archived/` only after their own completion evidence is recorded.

--- a/docs/plans/archived/2026-07-10_pi-goal-idle-continuation-plan.md
+++ b/docs/plans/archived/2026-07-10_pi-goal-idle-continuation-plan.md
@@ -1,0 +1,55 @@
+## Goal
+
+Move `pi-goal` automatic continuation from the fragile `agent_end` follow-up path to Pi's fully settled idle boundary. Success means an eligible active goal starts exactly one continuation after retries, compaction, and queued messages settle, while pause, clear, replacement, completion, pending work, and stale prompts cannot restart it.
+
+## Context
+
+`extensions/pi-goal/src/goal.ts` previously classified outcomes and sent the next prompt from `agent_end`. Pi `0.80.6` exposes `agent_settled` after retry, compaction, steering, and follow-up work has drained. Current Codex similarly waits for a thread-idle lifecycle and uses an atomic idle-turn gate.
+
+Pi extensions cannot reproduce Codex's hidden context or core turn reservation, so this implementation uses the strongest safe behavior available through public Pi APIs and documents the remaining race.
+
+## Architecture
+
+The implemented responsibilities are split as follows:
+
+- `agent_end`: records usage, classifies retryable/non-retryable outcomes, updates budget/state, and creates a plain in-memory continuation intent.
+- `agent_settled`: re-reads the current goal and intent, requires `ctx.isIdle()`, rejects pending messages, and dispatches one immediate continuation.
+- compaction hooks: cancel stale intent/delivery; Pi-owned retries defer to the retry, while non-retrying compaction creates one fresh intent.
+- `session_compact`: uses the same single-flight dispatcher as a narrow fallback because manual compaction does not emit `agent_settled`.
+
+Goal ID, iteration, and nonce form each continuation ticket. Intent and accepted delivery are tracked separately so repeated settled events are idempotent and newer work can cancel a delivery that lost Pi's non-atomic idle race.
+
+## Resolved Unknowns
+
+- Pi `0.80.6` emits `agent_settled` after complete agent runs, including queued follow-up work, but not after standalone manual compaction. Verified from the installed runtime and `npm run test:runtime --workspace @narumitw/pi-goal`; the implementation retains only the shared idle-gated `session_compact` fallback.
+- Pi extensions still cannot atomically reserve an idle turn. If another extension wins after the idle check, its `before_agent_start` cancels both the old intent and accepted delivery, and its eventual `agent_end` creates a fresh continuation. This residual race is documented in the README.
+
+## Plan
+
+- [x] Added failing tests in `extensions/pi-goal/test/goal.test.ts` for intent-only `agent_end`, exactly-once `agent_settled`, and repeated settled events; the pre-implementation run failed six goal tests and the final focused run passed.
+- [x] Added race tests for pending messages, retryable and non-retryable errors, overflow retry, manual compaction, pause, clear, replacement, completion, budget exhaustion, failed dispatch, and a delivery that loses the start race; verified by the passing goal tests in `npm test`.
+- [x] Replaced `ContinuationPending` with separate single-flight intent and delivery tickets keyed by goal ID, iteration, and nonce; existing and new marker-cancellation tests pass.
+- [x] Removed ordinary continuation sending from `agent_end`; source inspection with `rg -n 'agent_end|deliverAs: "followUp"|sendUserMessage' extensions/pi-goal/src/goal.ts` shows `agent_end` only records intent and the settled dispatcher sends the continuation without follow-up options.
+- [x] Registered `agent_settled` with current-goal, active-status, idle, pending-message, and single-flight gates; focused tests cover each rejection and successful dispatch path.
+- [x] Reworked compaction so Pi-owned retries create no continuation and non-retrying compaction creates at most one fresh ticket; unit and real-runtime manual-compaction checks pass.
+- [x] Substituted a non-interactive SDK runtime smoke for the prohibited interactive TUI command. `npm run test:runtime --workspace @narumitw/pi-goal` exercises normal continuation, queued user input, pause during streaming, and manual compaction against a real Pi `AgentSession`; all four scenarios pass.
+- [x] Updated `extensions/pi-goal/README.md` with the Pi `0.80.6` requirement, settled lifecycle, pending-message priority, manual-compaction fallback, cancellation semantics, and atomic-reservation limitation.
+- [x] Ran `npm run check`; Biome, extension boundaries, all workspace typechecks, and 211 tests passed.
+
+## Risks
+
+- Missed settled wake-ups are mitigated by focused tests and the real-runtime smoke; manual compaction has a verified narrow fallback.
+- Pi's public API cannot provide Codex's atomic idle reservation. The accepted limitation is documented, and newer work cancels stale delivery state so the goal can recover on its next `agent_end`.
+- `agent_settled` requires Pi `0.80.6` or newer. Package development dependencies and README now state that compatibility floor.
+
+## Rollback / Recovery
+
+The implementation retains isolated intent, delivery, and dispatch helpers. A regression can be rolled back by reverting this plan's source, test, README, and Pi development-dependency changes together; persisted goal entries are unchanged and remain backward-compatible.
+
+## Completion Checklist
+
+- [x] No normal continuation is sent from `agent_end`, verified by source inspection and focused tests.
+- [x] Exactly-one settled continuation is verified by repeated-event, failed-dispatch, and lost-start-race tests.
+- [x] Pending messages, pause, clear, replacement, completion, budget exhaustion, errors, and compaction cannot launch stale work, verified by targeted tests.
+- [x] Supported Pi runtime behavior is verified by `npm run test:runtime --workspace @narumitw/pi-goal`, covering normal, interrupted, queued-input, and manual-compaction flows.
+- [x] Documentation and repository checks are verified by README review, `npm run check`, and `just pack-goal`; the dry-run tarball contains only `LICENSE`, `README.md`, `package.json`, and `src/goal.ts`.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds session-scoped `/goal` commands and a `goal_complete({ goal_id, summary })` tool for autonomous, verifiable task completion.
 
-Goal mode uses Codex-like persistence instructions and keeps sending guarded continuation messages until the agent calls `goal_complete`, the user pauses or clears the goal, an interrupt/error pauses the goal, or an optional token budget is reached.
+Goal mode uses Codex-like persistence instructions and sends guarded continuation messages from Pi's fully settled idle boundary until the agent calls `goal_complete`, the user pauses or clears the goal, an interrupt/error pauses the goal, or an optional token budget is reached.
 
 ## ✨ Features
 
@@ -16,7 +16,8 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Tracks `active`, `paused`, `budget_limited`, and `complete` states.
 - Stores goal state in the current Pi session, following Codex's thread-owned goal model instead of using a global per-directory goal.
 - Registers a `goal_complete({ goal_id, summary })` tool for explicit completion, requiring the current goal id and rejecting missing/stale ids plus plainly contradictory summaries such as “not complete” or “tests still fail”.
-- Automatically prompts the agent to continue if an active turn ends early, directly triggering the next turn when Pi is idle and no pending messages are queued.
+- Records continuation intent when an active turn ends early, then directly triggers exactly one next turn only after Pi reports the agent fully settled, idle, and free of pending messages.
+- Lets retry, compaction, steering, follow-up, and other queued work settle before automatic goal continuation.
 - Pauses and aborts queued goal work when the user pauses a goal or Pi reports a non-retryable aborted/errored assistant turn.
 - Keeps retryable provider interruptions and Pi compaction retries active without enqueueing duplicate goal continuations while Pi retries.
 - Preserves active goals across manual, threshold, and overflow compaction.
@@ -26,6 +27,8 @@ Goal mode uses Codex-like persistence instructions and keeps sending guarded con
 - Encourages requirement-by-requirement verification before the goal is marked complete.
 
 ## 📦 Install
+
+Requires Pi `0.80.6` or newer for the `agent_settled` lifecycle event.
 
 ```bash
 pi install npm:@narumitw/pi-goal
@@ -85,11 +88,13 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 While a goal is active, `pi-goal` injects persistence rules, a `<goal_id>` stale-turn guard, and exposes `goal_complete`. To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence. Missing or stale `goal_id` values are rejected before summary validation, and paused goals cannot be completed until resumed. Empty or plainly contradictory summaries are also rejected; the summary is completion evidence, not the stale-turn safety token.
 
-If a turn ends before completion, `pi-goal` records usage and sends one guarded continuation only when no other messages are pending.
+If a turn ends before completion, `pi-goal` records usage and creates one continuation intent. It dispatches that continuation only from Pi's `agent_settled` lifecycle after retries, automatic compaction, steering, and follow-up work have drained, `ctx.isIdle()` is true, and no messages are pending. Repeated settled events cannot dispatch the same intent twice.
+
+Manual compaction does not emit `agent_settled`, so its completion hook uses the same single-flight dispatcher as a narrow idle-only fallback. Pi extensions cannot reserve an idle turn atomically like Codex core; another extension can still win the race after the idle check, and its newer turn supersedes the old continuation intent.
 
 ## 🛑 Interruption and queued-input behavior
 
-On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input), `/goal resume`, or `/goal clear`. On `/goal clear`, it clears goal state, pending continuation markers, and any stale tool-call block; it does not abort the current turn. Retryable provider interruptions and overflow compaction retries stay active while Pi retries; no extra continuation is queued.
+On user pause, abort, or non-retryable error, `pi-goal` pauses the goal, cancels pending continuation intent or delivery, aborts stale work, and blocks stale tool calls until the next user prompt (non-extension input), `/goal resume`, or `/goal clear`. On `/goal clear`, it clears goal state, continuation intent and markers, and any stale tool-call block; it does not abort the current turn. Retryable provider interruptions and overflow compaction retries stay active while Pi retries; no extra continuation is queued. User and extension work that starts before settlement supersedes the older continuation intent, and pending messages always take priority.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -25,6 +25,7 @@
 	"scripts": {
 		"check": "biome check . && npm run typecheck",
 		"format": "biome check --write .",
+		"test:runtime": "node ./test/goal-runtime-smoke.mjs",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -32,8 +33,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.2",
-		"@earendil-works/pi-ai": "0.80.3",
-		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@earendil-works/pi-ai": "0.80.6",
+		"@earendil-works/pi-coding-agent": "0.80.6",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -32,7 +32,7 @@ interface GoalCompleteDetails {
 	summary: string;
 }
 
-interface ContinuationPending {
+interface ContinuationTicket {
 	goalId: string;
 	iteration: number;
 	marker: string;
@@ -122,7 +122,8 @@ const STATE_FILE = join(
 let activeGoal: ActiveGoal | undefined;
 let completionStatusTimer: NodeJS.Timeout | undefined;
 let extensionApi: ExtensionAPI | undefined;
-let continuationPending: ContinuationPending | undefined;
+let continuationIntent: ContinuationTicket | undefined;
+let continuationDelivery: ContinuationTicket | undefined;
 let goalRecovery: GoalRecovery | undefined;
 let staleGoalToolCallsBlocked = false;
 const cancelledContinuationMarkers = new Set<string>();
@@ -286,12 +287,12 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("session_before_compact", (_event, ctx) => {
 		if (!activeGoal || activeGoal.status !== "active") return;
 		updateGoalUsage(activeGoal, ctx);
-		cancelContinuationPending();
+		cancelContinuationWork();
 		persistGoal(activeGoal);
 		updateStatus(ctx, activeGoal);
 	});
 
-	pi.on("session_compact", async (event, ctx) => {
+	pi.on("session_compact", (event, ctx) => {
 		if (!activeGoal || activeGoal.status !== "active") {
 			clearGoalRecovery();
 			return;
@@ -305,8 +306,12 @@ export default function goal(pi: ExtensionAPI) {
 
 		const wasPiRetry = isPiOwnedCompactionRetry(event, activeGoal.id);
 		clearGoalRecoveryForGoal(activeGoal.id);
-		if (wasPiRetry || hasPendingMessages(ctx)) return;
-		await sendContinuationPrompt(pi, ctx, activeGoal);
+		if (wasPiRetry) return;
+		requestContinuation(activeGoal);
+		// Manual compaction does not emit agent_settled. This common dispatcher is
+		// therefore the narrow fallback; threshold compaction leaves the intent for
+		// agent_settled when Pi is still busy.
+		dispatchContinuationIfSettled(pi, ctx);
 	});
 
 	pi.on("input", (event) => {
@@ -331,7 +336,7 @@ export default function goal(pi: ExtensionAPI) {
 	});
 
 	pi.on("before_agent_start", (event) => {
-		markContinuationDelivered(event.prompt);
+		markContinuationStarted(event.prompt);
 		if (!activeGoal || activeGoal.status !== "active") return;
 
 		return {
@@ -339,14 +344,14 @@ export default function goal(pi: ExtensionAPI) {
 		};
 	});
 
-	pi.on("agent_end", async (event, ctx) => {
+	pi.on("agent_end", (event, ctx) => {
 		if (!activeGoal || activeGoal.status !== "active") return;
 
 		const goalId = activeGoal.id;
-		const hadPendingContinuation = continuationPending?.goalId === goalId;
+		const alreadyAwaitingContinuation = hasContinuationWorkForGoal(goalId);
 		const finalAssistant = findFinalAssistantMessage(event.messages);
 
-		if (!hadPendingContinuation) activeGoal = incrementGoal(activeGoal);
+		if (!alreadyAwaitingContinuation) activeGoal = incrementGoal(activeGoal);
 		updateGoalUsage(activeGoal, ctx);
 
 		if (finalAssistant?.stopReason === "aborted" || finalAssistant?.stopReason === "error") {
@@ -355,7 +360,7 @@ export default function goal(pi: ExtensionAPI) {
 					goalId,
 					kind: isGoalContextOverflow(finalAssistant) ? "compaction_retry" : "provider_retry",
 				};
-				cancelContinuationPending();
+				cancelContinuationWork();
 				persistGoal(activeGoal);
 				updateStatus(ctx, activeGoal);
 				return;
@@ -368,7 +373,7 @@ export default function goal(pi: ExtensionAPI) {
 		clearGoalRecoveryForGoal(goalId);
 
 		if (activeGoal.tokenBudget !== undefined && activeGoal.tokensUsed >= activeGoal.tokenBudget) {
-			cancelContinuationPending();
+			cancelContinuationWork();
 			activeGoal = transitionGoal(activeGoal, "budget_limited");
 			persistGoal(activeGoal);
 			updateStatus(ctx, activeGoal);
@@ -379,15 +384,13 @@ export default function goal(pi: ExtensionAPI) {
 		persistGoal(activeGoal);
 		updateStatus(ctx, activeGoal);
 
-		if (hadPendingContinuation) {
-			if (hasPendingMessages(ctx)) return;
-			if (continuationPending?.goalId === goalId) continuationPending = undefined;
-		}
-
 		const currentGoal = activeGoal;
 		if (!currentGoal || currentGoal.id !== goalId || currentGoal.status !== "active") return;
-		if (hasPendingMessages(ctx)) return;
-		await sendContinuationPrompt(pi, ctx, currentGoal);
+		requestContinuation(currentGoal);
+	});
+
+	pi.on("agent_settled", (_event, ctx) => {
+		dispatchContinuationIfSettled(pi, ctx);
 	});
 }
 
@@ -415,7 +418,7 @@ async function startGoal(
 		}
 	}
 
-	cancelContinuationPending();
+	cancelContinuationWork();
 	clearGoalRecovery();
 	clearStaleGoalToolCallBlock();
 	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
@@ -434,7 +437,7 @@ function pauseGoal(ctx: StatusContext) {
 		ctx.ui.notify(`Goal is ${activeGoal.status}; only active goals can be paused.`, "warning");
 		return;
 	}
-	cancelContinuationPending();
+	cancelContinuationWork();
 	blockStaleGoalToolCalls();
 	abortCurrentTurn(ctx);
 	activeGoal = transitionGoal(activeGoal, "paused");
@@ -468,7 +471,7 @@ async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
 function clearGoal(ctx: StatusContext) {
 	if (!activeGoal) {
 		ctx.ui.notify("No active goal.", "info");
-		cancelContinuationPending();
+		cancelContinuationWork();
 		clearGoalRecovery();
 		clearStaleGoalToolCallBlock();
 		clearPersistedGoal(ctx.cwd);
@@ -498,7 +501,7 @@ async function editGoal(
 	}
 
 	updateGoalUsage(activeGoal, ctx);
-	cancelContinuationPending();
+	cancelContinuationWork();
 	clearGoalRecovery();
 	activeGoal = normalizeGoalForBudget({
 		...nextGoalInstance(activeGoal),
@@ -576,7 +579,7 @@ function pauseGoalAfterAgentEnd(
 	goal: ActiveGoal,
 	assistant: AssistantMessageLike,
 ) {
-	cancelContinuationPending();
+	cancelContinuationWork();
 	blockStaleGoalToolCalls();
 	abortCurrentTurn(ctx);
 	activeGoal = transitionGoal(goal, "paused");
@@ -702,16 +705,44 @@ async function sendResumePrompt(pi: ExtensionAPI, ctx: StatusContext, goal: Acti
 	return sendPrompt(pi, ctx, buildResumePrompt(goal));
 }
 
-async function sendContinuationPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	if (continuationPending?.goalId === goal.id) return false;
-	if (hasPendingMessages(ctx)) return false;
-
+function requestContinuation(goal: ActiveGoal) {
+	if (hasContinuationWorkForGoal(goal.id)) return false;
 	const marker = continuationMarker(goal);
-	const prompt = buildContinuePrompt(goal, marker);
-	continuationPending = { goalId: goal.id, iteration: goal.iteration, marker, prompt };
-	const sent = await sendPrompt(pi, ctx, prompt);
-	if (!sent && continuationPending?.marker === marker) continuationPending = undefined;
-	return sent;
+	continuationIntent = {
+		goalId: goal.id,
+		iteration: goal.iteration,
+		marker,
+		prompt: buildContinuePrompt(goal, marker),
+	};
+	return true;
+}
+
+function dispatchContinuationIfSettled(pi: ExtensionAPI, ctx: StatusContext) {
+	const intent = continuationIntent;
+	if (!intent) return false;
+	if (!activeGoal || activeGoal.id !== intent.goalId || activeGoal.status !== "active") {
+		continuationIntent = undefined;
+		return false;
+	}
+	if (ctx.isIdle?.() !== true || hasPendingMessages(ctx)) return false;
+
+	continuationIntent = undefined;
+	continuationDelivery = intent;
+	try {
+		pi.sendUserMessage(intent.prompt);
+		return true;
+	} catch (error) {
+		if (continuationDelivery?.marker === intent.marker) continuationDelivery = undefined;
+		if (activeGoal?.id === intent.goalId && activeGoal.status === "active") {
+			continuationIntent = intent;
+		}
+		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
+		return false;
+	}
+}
+
+function hasContinuationWorkForGoal(goalId: string) {
+	return continuationIntent?.goalId === goalId || continuationDelivery?.goalId === goalId;
 }
 
 async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
@@ -907,13 +938,15 @@ function zeroUsage(): Usage {
 }
 
 function clearContinuationTracking() {
-	continuationPending = undefined;
+	continuationIntent = undefined;
+	continuationDelivery = undefined;
 	cancelledContinuationMarkers.clear();
 }
 
-function cancelContinuationPending() {
-	if (continuationPending) rememberCancelledContinuationMarker(continuationPending.marker);
-	continuationPending = undefined;
+function cancelContinuationWork() {
+	if (continuationDelivery) rememberCancelledContinuationMarker(continuationDelivery.marker);
+	continuationIntent = undefined;
+	continuationDelivery = undefined;
 }
 
 function rememberCancelledContinuationMarker(marker: string) {
@@ -928,9 +961,16 @@ function consumeCancelledContinuationPrompt(prompt: string) {
 	return marker ? cancelledContinuationMarkers.delete(marker) : false;
 }
 
-function markContinuationDelivered(prompt: string) {
+function markContinuationStarted(prompt: string) {
 	const marker = extractContinuationMarker(prompt);
-	if (marker && continuationPending?.marker === marker) continuationPending = undefined;
+	if (!marker) {
+		// A user, retry, or another extension started newer work. Cancel both an
+		// unsent intent and a delivery that may have lost the non-atomic idle race;
+		// the newer work's agent_end will record a fresh intent.
+		cancelContinuationWork();
+		return;
+	}
+	if (continuationDelivery?.marker === marker) continuationDelivery = undefined;
 }
 
 function continuationMarker(goal: ActiveGoal) {
@@ -1052,7 +1092,7 @@ function loadGoalFromSession(ctx: StatusContext): ActiveGoal | undefined {
 }
 
 function clearActiveGoal(ctx: StatusContext) {
-	cancelContinuationPending();
+	cancelContinuationWork();
 	clearGoalRecovery();
 	clearStaleGoalToolCallBlock();
 	activeGoal = undefined;

--- a/extensions/pi-goal/test/goal-runtime-smoke.mjs
+++ b/extensions/pi-goal/test/goal-runtime-smoke.mjs
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	createFauxCore,
+	fauxAssistantMessage,
+	fauxToolCall,
+} from "@earendil-works/pi-ai/providers/faux";
+import {
+	AuthStorage,
+	createAgentSession,
+	DefaultResourceLoader,
+	ModelRegistry,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+const extensionPath = resolve(import.meta.dirname, "../src/goal.ts");
+
+async function createHarness(responses, fauxOptions = {}, prepareSession) {
+	const root = await mkdtemp(join(tmpdir(), "pi-goal-runtime-"));
+	const agentDir = join(root, "agent");
+	const cwd = join(root, "workspace");
+	await mkdir(cwd, { recursive: true });
+
+	const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	const faux = createFauxCore({
+		api: `pi-goal-faux-${crypto.randomUUID()}`,
+		provider: `pi-goal-faux-${crypto.randomUUID()}`,
+		...fauxOptions,
+	});
+	const provider = faux.getModel().provider;
+	modelRegistry.registerProvider(provider, {
+		api: faux.api,
+		apiKey: "runtime-smoke",
+		baseUrl: "http://localhost",
+		streamSimple: faux.streamSimple,
+		models: faux.models.map((model) => ({
+			id: model.id,
+			name: model.name,
+			api: model.api,
+			baseUrl: model.baseUrl,
+			reasoning: model.reasoning,
+			input: model.input,
+			cost: model.cost,
+			contextWindow: model.contextWindow,
+			maxTokens: model.maxTokens,
+		})),
+	});
+	const model = modelRegistry.find(provider, faux.getModel().id);
+	assert.ok(model, "expected registered faux model");
+	faux.setResponses(responses);
+
+	const settingsManager = SettingsManager.inMemory({
+		compaction: { enabled: false },
+		retry: { enabled: false },
+	});
+	const lifecycleEvents = [];
+	const resourceLoader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		settingsManager,
+		additionalExtensionPaths: [extensionPath],
+		extensionFactories: [
+			{
+				name: "runtime-smoke-observer",
+				factory: (pi) => {
+					pi.on("session_start", () => lifecycleEvents.push("session_start"));
+					pi.on("session_before_compact", () => lifecycleEvents.push("session_before_compact"));
+					pi.on("session_compact", (_event, ctx) =>
+						lifecycleEvents.push(
+							`session_compact:idle=${ctx.isIdle()}:pending=${ctx.hasPendingMessages()}`,
+						),
+					);
+					pi.on("agent_settled", () => lifecycleEvents.push("agent_settled"));
+				},
+			},
+		],
+	});
+	await resourceLoader.reload();
+	const sessionManager = SessionManager.inMemory(cwd);
+	prepareSession?.(sessionManager);
+	const result = await createAgentSession({
+		cwd,
+		agentDir,
+		authStorage,
+		modelRegistry,
+		model,
+		resourceLoader,
+		sessionManager,
+		settingsManager,
+		noTools: "builtin",
+	});
+	assert.deepEqual(result.extensionsResult.errors, []);
+	await result.session.bindExtensions({});
+	return {
+		extensions: result.extensionsResult.extensions.map((extension) => ({
+			path: extension.path,
+			handlers: [...extension.handlers.keys()],
+		})),
+		faux,
+		lifecycleEvents,
+		session: result.session,
+		async cleanup() {
+			result.session.dispose();
+			await rm(root, { recursive: true, force: true });
+		},
+	};
+}
+
+function completionResponse(context) {
+	const goalId = /<goal_id>\s*([^<\s]+)\s*<\/goal_id>/.exec(context.systemPrompt ?? "")?.[1];
+	assert.ok(goalId, "expected goal id in continuation system prompt");
+	return fauxAssistantMessage(
+		fauxToolCall("goal_complete", {
+			goal_id: goalId,
+			summary: "Runtime smoke completed and verified.",
+		}),
+	);
+}
+
+function userMessageText(message) {
+	if (message.role !== "user") return "";
+	if (typeof message.content === "string") return message.content;
+	if (!Array.isArray(message.content)) return "";
+	return message.content
+		.filter((part) => part?.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function persistedGoalStatus(session) {
+	const entry = session.sessionManager
+		.getBranch()
+		.filter((candidate) => candidate.type === "custom" && candidate.customType === "goal-state")
+		.at(-1);
+	return entry?.data?.goal?.status ?? null;
+}
+
+async function waitFor(predicate, description, timeoutMs = 10_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${description}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+async function normalContinuationScenario() {
+	const harness = await createHarness([
+		fauxAssistantMessage("First pass stopped without completion."),
+		completionResponse,
+	]);
+	const events = [];
+	const unsubscribe = harness.session.subscribe((event) => events.push(event.type));
+	try {
+		await harness.session.prompt("/goal runtime continuation smoke");
+		await waitFor(() => harness.faux.state.callCount === 2, "settled continuation");
+		await harness.session.agent.waitForIdle();
+		assert.equal(events.filter((type) => type === "agent_settled").length, 2);
+		assert.equal(persistedGoalStatus(harness.session), null);
+		assert.ok(
+			harness.session.messages
+				.map(userMessageText)
+				.some((text) => text.includes("pi-goal-continuation:")),
+		);
+	} finally {
+		unsubscribe();
+		await harness.cleanup();
+	}
+}
+
+async function queuedInputScenario() {
+	const observedPrompts = [];
+	const harness = await createHarness(
+		[
+			(context) => {
+				observedPrompts.push(context.messages.map(userMessageText).filter(Boolean).at(-1) ?? "");
+				return fauxAssistantMessage("x".repeat(120));
+			},
+			(context) => {
+				observedPrompts.push(context.messages.map(userMessageText).filter(Boolean).at(-1) ?? "");
+				return fauxAssistantMessage("Queued request handled.");
+			},
+			(context) => {
+				observedPrompts.push(context.messages.map(userMessageText).filter(Boolean).at(-1) ?? "");
+				return completionResponse(context);
+			},
+		],
+		{ tokensPerSecond: 200, tokenSize: { min: 1, max: 1 } },
+	);
+	try {
+		await harness.session.prompt("/goal queued work smoke");
+		await waitFor(() => harness.session.isStreaming, "initial turn streaming");
+		await harness.session.prompt("queued user work", { streamingBehavior: "followUp" });
+		await waitFor(() => harness.faux.state.callCount === 3, "continuation after queued input");
+		await harness.session.agent.waitForIdle();
+		const queuedIndex = observedPrompts.findIndex((text) => text.includes("queued user work"));
+		const continuationIndex = observedPrompts.findIndex((text) =>
+			text.includes("pi-goal-continuation:"),
+		);
+		assert.ok(queuedIndex >= 0, "expected queued work to reach the model");
+		assert.ok(continuationIndex > queuedIndex, "continuation must yield to queued work");
+	} finally {
+		await harness.cleanup();
+	}
+}
+
+async function pauseScenario() {
+	const harness = await createHarness([fauxAssistantMessage("x".repeat(200))], {
+		tokensPerSecond: 100,
+		tokenSize: { min: 1, max: 1 },
+	});
+	try {
+		await harness.session.prompt("/goal interrupt runtime smoke");
+		await waitFor(() => harness.session.isStreaming, "goal turn streaming");
+		await harness.session.prompt("/goal pause");
+		await waitFor(() => !harness.session.isStreaming, "goal turn abort");
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		assert.equal(harness.faux.state.callCount, 1);
+		assert.equal(persistedGoalStatus(harness.session), "paused");
+		assert.equal(
+			harness.session.messages
+				.map(userMessageText)
+				.filter((text) => text.includes("pi-goal-continuation:")).length,
+			0,
+		);
+	} finally {
+		await harness.cleanup();
+	}
+}
+
+async function manualCompactionScenario() {
+	const now = Date.now();
+	const harness = await createHarness(
+		[fauxAssistantMessage("Compacted prior work."), completionResponse],
+		{},
+		(sessionManager) => {
+			sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: `Old request ${"x".repeat(100_000)}` }],
+				timestamp: now - 4_000,
+			});
+			sessionManager.appendMessage(fauxAssistantMessage(`Old result ${"y".repeat(100_000)}`));
+			sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "Recent request" }],
+				timestamp: now - 2_000,
+			});
+			sessionManager.appendMessage(fauxAssistantMessage("Recent result"));
+			sessionManager.appendCustomEntry("goal-state", {
+				goal: {
+					id: crypto.randomUUID(),
+					text: "finish after manual compaction",
+					status: "active",
+					startedAt: now - 1_000,
+					updatedAt: now - 1_000,
+					iteration: 1,
+					tokensUsed: 0,
+					timeUsedSeconds: 1,
+					baselineTokens: 0,
+				},
+			});
+		},
+	);
+	const events = [];
+	const unsubscribe = harness.session.subscribe((event) => events.push(event));
+	try {
+		await harness.session.compact("Summarize for the runtime smoke test.");
+		await waitFor(
+			() => harness.faux.state.callCount === 2,
+			`manual-compaction continuation (${JSON.stringify({
+				callCount: harness.faux.state.callCount,
+				goalStatus: persistedGoalStatus(harness.session),
+				isIdle: harness.session.isIdle,
+				events: events.map((event) => event.type),
+				extensions: harness.extensions,
+				lifecycleEvents: harness.lifecycleEvents,
+			})})`,
+		);
+		await harness.session.agent.waitForIdle();
+		assert.equal(persistedGoalStatus(harness.session), null);
+		assert.ok(
+			harness.session.messages
+				.map(userMessageText)
+				.some((text) => text.includes("pi-goal-continuation:")),
+		);
+	} finally {
+		unsubscribe();
+		await harness.cleanup();
+	}
+}
+
+await normalContinuationScenario();
+await queuedInputScenario();
+await pauseScenario();
+await manualCompactionScenario();
+console.log("pi-goal runtime smoke: normal, queued input, pause, and manual compaction passed");

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -29,6 +29,7 @@ test("goal registers command, completion tool, and lifecycle hooks", () => {
 	assert.ok(toolParameters?.properties?.goal_id);
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"agent_end",
+		"agent_settled",
 		"before_agent_start",
 		"input",
 		"session_before_compact",
@@ -161,6 +162,8 @@ test("goal prompts include the active goal_id guard", async () => {
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },
 		started.ctx,
 	);
+	assert.equal(started.mock.sentUserMessages.length, 1);
+	await started.mock.events.get("agent_settled")?.[0]?.({}, started.ctx);
 	assertPromptHasGoalId(started.mock.sentUserMessages.at(-1)?.text ?? "", initialGoal.id);
 
 	await started.mock.commands.get("goal")?.handler("pause", started.ctx);
@@ -370,6 +373,114 @@ test("goal_complete rejects stale goal_id after replacement, pause/resume, and c
 	assert.equal(lastGoalStatus(cleared.mock), null);
 });
 
+test("agent_settled dispatches one idle continuation after agent_end records intent", async () => {
+	const settled = await startGoalForTest();
+
+	await settled.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		settled.ctx,
+	);
+	assert.equal(settled.mock.sentUserMessages.length, 1);
+
+	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
+	assert.equal(settled.mock.sentUserMessages.length, 2);
+	assert.equal(settled.mock.sentUserMessages.at(-1)?.options, undefined);
+	assert.match(settled.mock.sentUserMessages.at(-1)?.text ?? "", /automatic continuation #1/i);
+
+	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
+	assert.equal(settled.mock.sentUserMessages.length, 2);
+});
+
+test("agent_settled retains intent until idle and pending-message gates allow dispatch", async () => {
+	let idle = false;
+	let pending = true;
+	const settled = await startGoalForTest({
+		isIdle: () => idle,
+		hasPendingMessages: () => pending,
+	});
+
+	await settled.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		settled.ctx,
+	);
+	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
+	assert.equal(settled.mock.sentUserMessages.length, 1);
+
+	idle = true;
+	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
+	assert.equal(settled.mock.sentUserMessages.length, 1);
+
+	pending = false;
+	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
+	assert.equal(settled.mock.sentUserMessages.length, 2);
+});
+
+test("failed settled dispatch retains intent for a later idle retry", async () => {
+	const retried = await startGoalForTest();
+	await retried.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		retried.ctx,
+	);
+
+	const sendUserMessage = retried.mock.rawPi.sendUserMessage.bind(retried.mock.rawPi);
+	retried.mock.rawPi.sendUserMessage = () => {
+		throw new Error("runtime unavailable");
+	};
+	await retried.mock.events.get("agent_settled")?.[0]?.({}, retried.ctx);
+	assert.equal(retried.mock.sentUserMessages.length, 1);
+	assert.match(retried.notifications.at(-1)?.message ?? "", /runtime unavailable/i);
+
+	retried.mock.rawPi.sendUserMessage = sendUserMessage;
+	await retried.mock.events.get("agent_settled")?.[0]?.({}, retried.ctx);
+	assert.equal(retried.mock.sentUserMessages.length, 2);
+});
+
+test("new work supersedes an older continuation intent before it settles", async () => {
+	const superseded = await startGoalForTest();
+	await superseded.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		superseded.ctx,
+	);
+
+	superseded.mock.events.get("before_agent_start")?.[0]?.(
+		{ prompt: "queued user work", systemPrompt: "base" },
+		superseded.ctx,
+	);
+	await superseded.mock.events.get("agent_settled")?.[0]?.({}, superseded.ctx);
+
+	assert.equal(superseded.mock.sentUserMessages.length, 1);
+});
+
+test("newer work supersedes an accepted continuation delivery that lost the start race", async () => {
+	const raced = await startGoalForTest();
+	await raced.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		raced.ctx,
+	);
+	await raced.mock.events.get("agent_settled")?.[0]?.({}, raced.ctx);
+	const staleContinuation = raced.mock.sentUserMessages.at(-1)?.text ?? "";
+
+	raced.mock.events.get("before_agent_start")?.[0]?.(
+		{ prompt: "newer extension work", systemPrompt: "base" },
+		raced.ctx,
+	);
+	assert.deepEqual(
+		raced.mock.events.get("input")?.[0]?.(
+			{ source: "extension", text: staleContinuation },
+			raced.ctx,
+		),
+		{ action: "handled" },
+	);
+
+	await raced.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		raced.ctx,
+	);
+	await raced.mock.events.get("agent_settled")?.[0]?.({}, raced.ctx);
+	assert.equal(raced.mock.sentUserMessages.length, 3);
+	assert.notEqual(raced.mock.sentUserMessages.at(-1)?.text, staleContinuation);
+});
+
 test("pause aborts the current turn, blocks stale tools, and persists paused state", async () => {
 	let pauseAborts = 0;
 	const paused = await startGoalForTest({ abort: () => pauseAborts++ });
@@ -377,6 +488,7 @@ test("pause aborts the current turn, blocks stale tools, and persists paused sta
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },
 		paused.ctx,
 	);
+	await paused.mock.events.get("agent_settled")?.[0]?.({}, paused.ctx);
 	const staleContinuation = paused.mock.sentUserMessages.at(-1)?.text ?? "";
 	assert.match(staleContinuation, /pi-goal-continuation/);
 
@@ -412,6 +524,7 @@ test("clear removes goal state without aborting or blocking stale tools", async 
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },
 		cleared.ctx,
 	);
+	await cleared.mock.events.get("agent_settled")?.[0]?.({}, cleared.ctx);
 	const staleContinuation = cleared.mock.sentUserMessages.at(-1)?.text ?? "";
 	assert.match(staleContinuation, /pi-goal-continuation/);
 
@@ -484,6 +597,68 @@ test("clear releases stale tool-call block from a paused goal", async () => {
 	);
 });
 
+test("state changes between agent_end and agent_settled cancel stale continuation intent", async () => {
+	for (const action of ["pause", "clear", "replace", "complete"] as const) {
+		let aborts = 0;
+		const changed = await startGoalForTest({ abort: () => aborts++ });
+		const originalGoal = requireLastGoal(changed.mock);
+		await changed.mock.events.get("agent_end")?.[0]?.(
+			{ messages: [{ role: "assistant", stopReason: "stop" }] },
+			changed.ctx,
+		);
+
+		if (action === "pause" || action === "clear") {
+			await changed.mock.commands.get("goal")?.handler(action, changed.ctx);
+		} else if (action === "replace") {
+			await changed.mock.commands.get("goal")?.handler("replacement objective", changed.ctx);
+		} else {
+			await (changed.mock.tools[0] as GoalTool).execute(
+				"complete-before-settled",
+				{ goal_id: originalGoal.id, summary: "Implemented and verified." },
+				new AbortController().signal,
+				() => undefined,
+				changed.ctx,
+			);
+		}
+
+		const messagesBeforeSettled = changed.mock.sentUserMessages.length;
+		await changed.mock.events.get("agent_settled")?.[0]?.({}, changed.ctx);
+		assert.equal(
+			changed.mock.sentUserMessages.length,
+			messagesBeforeSettled,
+			`${action} must not dispatch the stale continuation`,
+		);
+	}
+});
+
+test("budget exhaustion between agent_end and agent_settled cancels continuation intent", async () => {
+	const branch = [
+		{
+			type: "message",
+			message: { role: "assistant", usage: { input: 0, output: 0 } },
+		},
+	];
+	const budgeted = await startGoalForTest(
+		{
+			sessionManager: { getBranch: () => branch, getEntries: () => [] },
+		},
+		"--tokens 1 finish",
+	);
+
+	branch.push({
+		type: "message",
+		message: { role: "assistant", usage: { input: 1, output: 0 } },
+	});
+	await budgeted.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		budgeted.ctx,
+	);
+	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
+
+	await budgeted.mock.events.get("agent_settled")?.[0]?.({}, budgeted.ctx);
+	assert.equal(budgeted.mock.sentUserMessages.length, 1);
+});
+
 test("agent_end keeps retryable interruptions active but pauses non-retryable errors", async () => {
 	assert.equal(
 		isRetryableGoalInterruption({
@@ -536,6 +711,7 @@ test("agent_end keeps retryable interruptions active but pauses non-retryable er
 	);
 
 	assert.equal(lastGoalStatus(retryable.mock), "active");
+	await retryable.mock.events.get("agent_settled")?.[0]?.({}, retryable.ctx);
 	assert.equal(retryable.mock.sentUserMessages.length, 1);
 	assert.equal(
 		retryable.mock.events.get("tool_call")?.[0]?.(
@@ -562,6 +738,8 @@ test("agent_end keeps retryable interruptions active but pauses non-retryable er
 
 	assert.equal(aborts, 1);
 	assert.equal(lastGoalStatus(nonRetryable.mock), "paused");
+	await nonRetryable.mock.events.get("agent_settled")?.[0]?.({}, nonRetryable.ctx);
+	assert.equal(nonRetryable.mock.sentUserMessages.length, 1);
 	assert.deepEqual(
 		nonRetryable.mock.events.get("tool_call")?.[0]?.(
 			{ toolName: "bash", toolCallId: "t1", input: {} },
@@ -630,6 +808,7 @@ test("overflow compaction retry keeps the goal active and does not block retry t
 
 	overflow.mock.events.get("session_before_compact")?.[0]?.({}, overflow.ctx);
 	await overflow.mock.events.get("session_compact")?.[0]?.({}, overflow.ctx);
+	await overflow.mock.events.get("agent_settled")?.[0]?.({}, overflow.ctx);
 
 	assert.equal(lastGoalStatus(overflow.mock), "active");
 	assert.equal(overflow.mock.sentUserMessages.length, 1);
@@ -653,17 +832,20 @@ test("compaction with willRetry true does not enqueue a goal continuation", asyn
 		{ reason: "overflow", willRetry: true },
 		retrying.ctx,
 	);
+	await retrying.mock.events.get("agent_settled")?.[0]?.({}, retrying.ctx);
 
 	assert.equal(lastGoalStatus(retrying.mock), "active");
 	assert.equal(retrying.mock.sentUserMessages.length, 1);
 });
 
 test("manual compaction cancels stale continuation and sends one fresh continuation", async () => {
-	const compacted = await startGoalForTest();
+	let idle = true;
+	const compacted = await startGoalForTest({ isIdle: () => idle });
 	await compacted.mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },
 		compacted.ctx,
 	);
+	await compacted.mock.events.get("agent_settled")?.[0]?.({}, compacted.ctx);
 	const staleContinuation = compacted.mock.sentUserMessages.at(-1)?.text ?? "";
 	assert.match(staleContinuation, /pi-goal-continuation/);
 
@@ -679,10 +861,15 @@ test("manual compaction cancels stale continuation and sends one fresh continuat
 		{ action: "handled" },
 	);
 
+	idle = false;
 	await compacted.mock.events.get("session_compact")?.[0]?.(
 		{ reason: "threshold", willRetry: false },
 		compacted.ctx,
 	);
+	assert.equal(compacted.mock.sentUserMessages.length, 2);
+
+	idle = true;
+	await compacted.mock.events.get("agent_settled")?.[0]?.({}, compacted.ctx);
 	const freshContinuation = compacted.mock.sentUserMessages.at(-1)?.text ?? "";
 	assert.equal(compacted.mock.sentUserMessages.length, 3);
 	assert.match(freshContinuation, /pi-goal-continuation/);
@@ -793,12 +980,12 @@ function escapeRegExp(value: string) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-async function startGoalForTest(overrides: Record<string, unknown> = {}) {
+async function startGoalForTest(overrides: Record<string, unknown> = {}, command = "finish") {
 	const mock = createMockPi();
 	goal(mock.pi);
 	const context = createMockContext(overrides);
 	mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	await mock.commands.get("goal")?.handler("finish", context.ctx);
+	await mock.commands.get("goal")?.handler(command, context.ctx);
 	return { mock, ...context };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,9 +113,2000 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.2",
-				"@earendil-works/pi-ai": "0.80.3",
-				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@earendil-works/pi-ai": "0.80.6",
+				"@earendil-works/pi-coding-agent": "0.80.6",
 				"typescript": "6.0.3"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-ai": {
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+			"integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+			"integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+			"dev": true,
+			"hasShrinkwrap": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.80.6",
+				"@earendil-works/pi-ai": "^0.80.6",
+				"@earendil-works/pi-tui": "^0.80.6",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"semver": "7.8.0",
+				"typebox": "1.1.38",
+				"undici": "8.5.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "0.3.9"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+			"version": "3.974.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-login": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-ini": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.80.6",
+				"ignore": "7.0.5",
+				"typebox": "1.1.38",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "./dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"extensions/pi-goal/node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		},
 		"extensions/pi-google-genai": {
@@ -937,6 +2928,7 @@
 			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
 			"integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
 			"dev": true,
+			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-agent-core": "^0.80.3",
@@ -2188,14 +4180,6 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob/node_modules/node-domexception": {
-			"name": "@profoundlogic/node-domexception",
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@profoundlogic/node-domexception/-/node-domexception-1.0.2.tgz",
-			"integrity": "sha512-qeEIO+aJIGHxEwCtAHoPH8VrWFvWh3zFmr2/cb9gFGc6qyYW9r48Q2vg8YwME/PyIt98GaR42kPVUkN4n0a19A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2492,6 +4476,27 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
 			"version": "3.3.2",


### PR DESCRIPTION
## Summary

- defer automatic goal continuation until Pi emits `agent_settled`, with idle, pending-message, goal-state, and single-flight guards
- separate continuation intent from delivery so pause, replacement, completion, compaction, and newer work cancel stale prompts safely
- add focused race coverage and a real `AgentSession` runtime smoke for normal continuation, queued input, interruption, and manual compaction
- require Pi 0.80.6 for the settled lifecycle, document the remaining non-atomic idle race, archive the completed implementation plan, and record the remaining Codex-alignment roadmap

## Testing

- `npm run test:runtime --workspace @narumitw/pi-goal`
- `npm run check` (211 tests passed)
- `just pack-goal`
- `git diff --check main...HEAD`
