### PR TITLE
feat: add recipe to try all extensions

### DIFF
--- a/justfile
+++ b/justfile
@@ -55,6 +55,10 @@ pack name: (_validate-extension-name name)
 try name: (_validate-extension-name name)
     name={{quote(name)}}; pi -e "./extensions/pi-$name"
 
+# Start a fresh Pi session with every local extension loaded
+try-all:
+    args=(); for dir in ./extensions/pi-*; do args+=(-e "$dir"); done; pi -ne "${args[@]}"
+
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents
 install name: (_validate-extension-name name)


### PR DESCRIPTION
## Summary

- add a `try-all` recipe for starting a fresh Pi session
- discover and load every local extension under `extensions/pi-*`

## Testing

- `just --dry-run try-all`
- `npm run check`