### PR TITLE
docs: align README behavior and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install only the Pi extensions you need. Each package is published under the `@n
 | [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) | 🔎 Google GenAI grounding tools for Google Search, Maps, and URL context. | `pi install npm:@narumitw/pi-google-genai` |
 | [`@narumitw/pi-lsp`](./extensions/pi-lsp) | 🧠 Language-agnostic LSP diagnostics and code actions for TypeScript, JavaScript, Python, JSON, CSS, and more through configured language servers. | `pi install npm:@narumitw/pi-lsp` |
 | [`@narumitw/pi-plan-mode`](./extensions/pi-plan-mode) | 🧭 Codex-like read-only `/plan` collaboration mode with safe exploration and implementation-ready plans. | `pi install npm:@narumitw/pi-plan-mode` |
-| [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for provider responses that fail with `Unknown error (no error details in response)`. | `pi install npm:@narumitw/pi-retry` |
+| [`@narumitw/pi-retry`](./extensions/pi-retry) | 🔁 Retry support for unknown provider errors, retryable Codex backend failures, websocket limits, and stalled streams. | `pi install npm:@narumitw/pi-retry` |
 | [`@narumitw/pi-statusline`](./extensions/pi-statusline) | ✨ A rich Pi terminal statusline with model, tools, git branch/status, context usage, token totals, cost, and time. | `pi install npm:@narumitw/pi-statusline` |
 | [`@narumitw/pi-sync`](./extensions/pi-sync) | ☁️ Sync allowlisted Pi settings, skills, prompts, themes, extensions, and optional sessions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
 | [`@narumitw/pi-subagents`](./extensions/pi-subagents) | 🤖 Delegate work to specialized isolated subagents with single, parallel, and chained execution modes. | `pi install npm:@narumitw/pi-subagents` |

--- a/docs/plans/archived/2026-07-10_readme-audit-updates-plan.md
+++ b/docs/plans/archived/2026-07-10_readme-audit-updates-plan.md
@@ -1,0 +1,28 @@
+## Goal
+
+Resolve every README issue found in the repository audit so package descriptions match current behavior, compatibility policy, and documentation conventions.
+
+## Non-Goals
+
+- Change extension runtime behavior or package versions.
+- Rewrite deprecated package documentation beyond adding the missing deprecation notice.
+
+## Plan
+
+- [x] Update the root and `pi-retry` READMEs to document generic retryable Codex backend failures; verified against `extensions/pi-retry/src/retry.ts` and the passing generic retry regression test.
+- [x] Align the legacy settings filename removal policy in the caffeinate, Chrome DevTools, and Firecrawl READMEs with their runtime notices; verified README and runtime references say removal occurs in a future major release.
+- [x] Add the missing deprecation notice to `extensions/deprecated/pi-sidebar/README.md`; verified all five deprecated package READMEs identify their status within the first eight lines.
+- [x] Add npm one-off trial commands to the Google GenAI and LSP READMEs; verified both contain `pi -e npm:@narumitw/...` before their local-development examples.
+- [x] Run documentation consistency checks and the repository CI-equivalent check; validated 22 README files and completed `npm run check` with 242 passing tests.
+
+## Risks
+
+- Overstating retry matching could imply all Codex failures are retried; keep the wording limited to backend errors that explicitly say the request can be retried.
+- Compatibility wording must not promise removal before a major release.
+
+## Completion Checklist
+
+- [x] All audited README findings are resolved, verified by `git diff` across the eight listed README files.
+- [x] README links and referenced source/test paths pass the local validation script for 22 repository READMEs.
+- [x] Repository checks pass with `npm run check` (`242` tests passed).
+- [x] The completed plan is ready to archive under `docs/plans/archived/` with completion evidence recorded above.

--- a/extensions/deprecated/pi-sidebar/README.md
+++ b/extensions/deprecated/pi-sidebar/README.md
@@ -2,6 +2,8 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sidebar)](https://www.npmjs.com/package/@narumitw/pi-sidebar) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
+> Deprecated: this package is kept for reference under `extensions/deprecated/` and is no longer part of the active workspace package set.
+
 `@narumitw/pi-sidebar` is a native [Pi coding agent](https://pi.dev) extension that adds an opencode-inspired right sidebar overlay to Pi's interactive terminal UI.
 
 It keeps session state, model information, context usage, running tools, and recent activity visible while leaving the main editor focused.

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -115,8 +115,7 @@ Missing, invalid, or deleted settings default back to `display` mode on every su
 Compatibility: older versions used `pi-caffeinate-settings.json`. During the migration window, a
 legacy-only file is automatically migrated to `pi-caffeinate.json` with a warning. If both files
 exist, `pi-caffeinate.json` wins and the legacy file is ignored. The legacy filename is deprecated
-and planned for removal after at least one minor release cycle, preferably 4–8 weeks, or at the
-next major release.
+and will be removed in a future major release.
 
 ### Environment variables
 

--- a/extensions/pi-chrome-devtools/README.md
+++ b/extensions/pi-chrome-devtools/README.md
@@ -174,8 +174,7 @@ instead of enabling tools by itself. A valid saved selection is restored on Pi s
 Compatibility: older versions used `pi-chrome-devtools-settings.json`. During the migration
 window, a legacy-only file is automatically migrated to `pi-chrome-devtools.json` with a warning.
 If both files exist, `pi-chrome-devtools.json` wins and the legacy file is ignored. The legacy
-filename is deprecated and planned for removal after at least one minor release cycle, preferably
-4–8 weeks, or at the next major release.
+filename is deprecated and will be removed in a future major release.
 
 ## 🧠 Use cases
 

--- a/extensions/pi-firecrawl/README.md
+++ b/extensions/pi-firecrawl/README.md
@@ -111,8 +111,7 @@ instead of enabling tools by itself. A valid saved selection is restored on Pi s
 Compatibility: older versions used `pi-firecrawl-settings.json`. During the migration window,
 a legacy-only file is automatically migrated to `pi-firecrawl.json` with a warning. If both
 files exist, `pi-firecrawl.json` wins and the legacy file is ignored. The legacy filename is
-deprecated and planned for removal after at least one minor release cycle, preferably 4–8 weeks,
-or at the next major release.
+deprecated and will be removed in a future major release.
 
 ## 🚀 Examples
 

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -19,6 +19,12 @@
 pi install npm:@narumitw/pi-google-genai
 ```
 
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-google-genai
+```
+
 Try from this repository:
 
 ```bash

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -22,6 +22,12 @@ The extension is language-agnostic: servers are selected by config and file exte
 pi install npm:@narumitw/pi-lsp
 ```
 
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-lsp
+```
+
 Try this package locally from the repository root:
 
 ```bash

--- a/extensions/pi-retry/README.md
+++ b/extensions/pi-retry/README.md
@@ -2,15 +2,16 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-retry)](https://www.npmjs.com/package/@narumitw/pi-retry) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-retry` is a native [Pi coding agent](https://pi.dev) extension that treats provider responses containing `Unknown error (no error details in response)`, Codex `websocket_connection_limit_reached`, and stalled provider streams as retryable.
+`@narumitw/pi-retry` is a native [Pi coding agent](https://pi.dev) extension that treats provider responses containing `Unknown error (no error details in response)`, Codex backend errors that explicitly say the request can be retried, Codex `websocket_connection_limit_reached`, and stalled provider streams as retryable.
 
-Use it to make Pi sessions more resilient when an upstream AI provider returns a transient unknown error without useful details, Codex asks for a fresh websocket, or a provider stops streaming after Pi has sent a request.
+Use it to make Pi sessions more resilient when an upstream AI provider returns a transient unknown error without useful details, Codex reports an explicitly retryable backend failure or asks for a fresh websocket, or a provider stops streaming after Pi has sent a request.
 
 ## ✨ Features
 
 - Detects assistant messages that end with `stopReason: "error"`.
 - Matches the known provider error text `Unknown error (no error details in response)`.
 - Matches Codex `websocket_connection_limit_reached` after a websocket hits its 60-minute limit.
+- Matches Codex backend failures that explicitly include `You can retry your request`.
 - Appends Pi's retryable-provider-error hint.
 - Lets Pi's built-in retry path continue the turn.
 - Watches provider requests and assistant stream events for stalls.
@@ -40,7 +41,7 @@ pi -e ./extensions/pi-retry
 
 ## 🚀 What it does
 
-When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)` or Codex `websocket_connection_limit_reached`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
+When an assistant message ends with `stopReason: "error"` and the error message matches `Unknown error (no error details in response)`, Codex `websocket_connection_limit_reached`, or a Codex processing error that explicitly says `You can retry your request`, the extension appends Pi's retryable-provider-error hint so Pi's built-in retry path can continue the turn.
 
 After Pi sends a provider request, the extension also starts a stall watchdog. Provider responses and assistant stream events briefly refresh a `receiving` statusline item, so you can tell that data is still arriving while Pi shows its normal working indicator. If no provider response or assistant stream event is observed for 90s, it briefly shows `retrying`, calls `ctx.abort()`, and rewrites the resulting assistant abort/error as a retryable provider error.
 
@@ -56,7 +57,7 @@ Use `0`, `off`, or `false` to disable the watchdog. Retry attempts and backoff r
 ## 🧠 Use cases
 
 - Reduce manual restarts after transient provider failures.
-- Recover when Codex websocket sessions hit the 60-minute connection limit.
+- Recover from explicitly retryable Codex backend failures or websocket connection limits.
 - Improve reliability during long Pi coding agent sessions.
 - Keep tool-heavy implementation tasks moving when a provider returns an unknown error or stream stalls.
 - Pair with `@narumitw/pi-goal` for more robust autonomous task loops.


### PR DESCRIPTION
## Summary

- document all retry cases currently handled by pi-retry
- align legacy settings removal guidance with runtime notices
- add the missing sidebar deprecation notice and npm trial examples
- archive the completed README audit plan

## Verification

- `npm run check` (242 tests passed)
- validated local links and referenced paths across 22 repository README files
- `git diff --check`