### PR TITLE
feat(subagents): add stateful agent lifecycle

### DIFF
--- a/docs/implementation-notes/pi-subagents-capability-matrix.md
+++ b/docs/implementation-notes/pi-subagents-capability-matrix.md
@@ -1,0 +1,23 @@
+# pi-subagents capability matrix
+
+Date: 2026-07-11
+
+| Capability | Status | Evidence |
+| --- | --- | --- |
+| One-shot single/parallel/chain/fan-in | Implemented | `extensions/pi-subagents/src/execution.ts`, contract tests in `test/subagents.test.ts` |
+| Deterministic timeout and forced kill | Implemented | `runner.ts::terminateProcess`, SIGTERM-resistant fixture in `test/evolution.test.ts` |
+| Bounded JSON parsing and output | Implemented | `protocol.ts`, `limits.ts`, parser/truncation tests |
+| Abort with partial structured result | Implemented | `runner.ts::runSingleAgent`; abort no longer throws after process settlement |
+| Cwd validation and spawn-error normalization | Implemented | `runner.ts::runSingleAgent` |
+| Recursion guard | Implemented | `PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_MAX_DEPTH` in `execution.ts` and `runner.ts` |
+| Addressable logical agents | Implemented, opt-in | `registry.ts`, `stateful.ts` |
+| Follow-up, wait, list, interrupt, close | Implemented, opt-in | six lifecycle tools in `stateful.ts`; registry lifecycle tests |
+| Separate active and retained capacity | Implemented | FIFO queue and limits in `registry.ts`; capacity/fairness test |
+| Interactive inspection | Implemented | `/subagents:agents list|clear` |
+| Native transcript switching | Core-blocked | Extension APIs expose custom entries/UI but no supported child transcript/session switch handle |
+| Parent context selection | Implemented, opt-in | `context.ts`: none/all/recent N, text-only sanitation and byte bound |
+| Approval/sandbox/header inheritance | Unsupported guarantee | `SingleResult.policy`; only environment and explicit CLI overrides are reported |
+| Durable logical history | Implemented, opt-in | versioned mode-0600 state in `persistence.ts` |
+| Automatic side-effect resume | Rejected | restored records are always inert `idle` until explicit follow-up |
+| Filesystem isolation | Rejected for this phase | children intentionally share cwd/host filesystem; README warns against conflicting writes |
+| Autonomous recursive teams | Rejected | bounded recursion defaults to one level; no unbounded scheduler |

--- a/docs/implementation-notes/pi-subagents-core-api-proposal.md
+++ b/docs/implementation-notes/pi-subagents-core-api-proposal.md
@@ -1,0 +1,51 @@
+# Proposed Pi core APIs for native subagent sessions
+
+Date: 2026-07-11
+
+## Finding
+
+The extension API supports subprocess execution, custom tools, custom transcript entries, session persistence, and temporary TUI components. It does not expose a supported way to create a child `AgentSession`, send turns to it, subscribe to its transcript, switch the interactive transcript to it, or inherit the current turn's resolved approval/sandbox policy. Building native transcript navigation inside the extension would require private Pi internals and was therefore not implemented.
+
+## Minimal proposed API
+
+```ts
+interface ChildSessionOptions {
+  cwd: string;
+  context: "none" | "all" | { recentTurns: number };
+  model?: string;
+  thinkingLevel?: ThinkingLevel;
+  tools?: string[];
+  inheritPolicy: true;
+}
+
+interface ChildSessionHandle {
+  id: string;
+  status(): "idle" | "running" | "interrupted" | "closed";
+  send(content: UserContent, options?: { signal?: AbortSignal }): Promise<AssistantMessage>;
+  interrupt(): Promise<void>;
+  close(): Promise<void>;
+  entries(): readonly SessionEntry[];
+  onEntry(listener: (entry: SessionEntry) => void): () => void;
+}
+
+interface ExtensionAPI {
+  createChildSession(options: ChildSessionOptions): Promise<ChildSessionHandle>;
+}
+
+interface ExtensionCommandContext {
+  inspectChildSession(id: string): Promise<void>;
+}
+```
+
+## Required guarantees
+
+- Child creation receives the currently resolved provider/model, approval policy, sandbox/execution profile, environment policy, and cwd after role overrides.
+- Context forking has a core-owned sanitizer that excludes reasoning and tool transport records unless explicitly supported.
+- Child sessions are owned by the parent session tree and receive shutdown/reload events.
+- Concurrency is accounted globally across root and child turns.
+- Transcript inspection never changes the active root session or invalidates captured extension contexts.
+- Persistence is versioned by Pi core and never resumes side effects automatically.
+
+## Migration path
+
+`pi-subagents` should retain its batch API and place child execution behind a transport interface. When the proposed API exists, the current logical registry can replace its fresh-process runner with a `ChildSessionHandle` adapter while preserving opaque IDs and lifecycle tools. Existing persisted logical histories remain readable and can be imported as context for the first native child turn.

--- a/docs/implementation-notes/pi-subagents-evolution-verification.md
+++ b/docs/implementation-notes/pi-subagents-evolution-verification.md
@@ -1,0 +1,61 @@
+# pi-subagents evolution verification
+
+Date: 2026-07-11
+
+## Release gates
+
+The implementation is organized as independently reversible modules:
+
+1. Runner hardening: `protocol.ts`, `limits.ts`, and `runner.ts`.
+2. Stateful lifecycle: `registry.ts` and opt-in registrations in `stateful.ts`.
+3. Context and policy reporting: `context.ts` and `SingleResult.policy`.
+4. Persistence/recovery: `persistence.ts`.
+5. Inspection/core boundary: `/subagents:agents`, capability matrix, and core API proposal.
+
+The existing `subagent` schema remains the compatibility and rollback path. Removing or disabling `stateful.enabled` removes all lifecycle tools without affecting batch calls. Persisted state is separate and versioned; older package versions ignore it.
+
+## Automated evidence
+
+- `npm run check`: passed; includes Biome, package-boundary checks, all workspace typechecks, and 259 tests.
+- `just pack-subagents`: passed; dry-run tarball contained README, license, package metadata, and all 14 source modules, including the declared `src/subagents.ts` entrypoint.
+- Process fixtures verified SIGTERM-resistant forced kill in about 54 ms with a 30 ms test grace period.
+- Registry fixtures verified FIFO active-turn capacity, retained-agent capacity, wait timeout, interrupt/reuse, close, idle expiry, inert restoration, corruption quarantine, redaction, and deletion.
+
+## Privacy and security review
+
+Result: PASS for the documented opt-in boundary.
+
+- Persisted records are versioned, count/age/size bounded, written atomically with mode 0600, and contain no process IDs.
+- `<private>` blocks and `[subagent-private]` lines are removed from transferred and persisted text; tests inspect the raw state file for excluded values.
+- Corrupt and unsupported versions are quarantined; restored work is always inert and never resumes side effects.
+- Project-local definitions require Pi project trust even when confirmation is disabled; interactive confirmation remains an additional guard.
+- Tool allow-lists are not described as an OS sandbox. Unsupported approval, sandbox, and provider-header inheritance is exposed in result metadata and README warnings.
+- Active/queued work is bounded, session shutdown drains queued work without starting it, and active process groups use tested TERM/KILL cleanup.
+
+## Runtime smoke evidence
+
+Executed from the repository root with the local package:
+
+- Single: `pi -e ./extensions/pi-subagents -p ...` returned `SMOKE_OK`.
+- Parallel plus chain: local Pi run returned `PARALLEL_CHAIN_OK`.
+- Hard timeout (`timeoutMs: 1`): local Pi run returned `TIMEOUT_OK` after observing the timeout result.
+- Stateful spawn plus wait: temporarily enabled stateful settings, local Pi run returned `STATEFUL_OK`, and the original settings file was restored by a shell trap.
+- Abort cleanup is covered by pre-aborted and mid-stream child integration tests that preserve partial output, plus registry and process-group termination fixtures; interactive Esc itself was not automated because it requires terminal input.
+
+## Bounded acceptance thresholds
+
+| Scenario | Threshold | Evidence |
+| --- | --- | --- |
+| One-shot result | Completes through local extension and returns exact worker text | `SMOKE_OK` runtime smoke |
+| Four-way fan-out | Never exceeds four active workers | `mapWithConcurrencyLimit` constant plus concurrency contract tests |
+| Stateful scheduling | FIFO and no more than configured active turns | registry fairness test |
+| Follow-up | Reuses the same opaque ID and appends bounded history | registry lifecycle test |
+| Wait timeout | Returns while worker remains queued/running | registry lifecycle test |
+| Interrupt/reuse | Interrupted identity accepts a later follow-up | registry lifecycle test |
+| Context selection | none/all/recent N; output at most 50 KiB | context and UTF-8 boundary tests |
+| Reload/restore | No task auto-resumes; restored state is idle | persistence and restoration tests |
+| Cleanup | SIGTERM then forced kill; fixture exits within 1 second | forced-kill test |
+
+## Migration and downgrade
+
+No existing settings or request fields are renamed. `stateful` is an optional new settings object. Unknown future state versions are quarantined instead of interpreted. Downgrade leaves the separate state directory untouched and harmless; users can clear it before downgrade with `/subagents:agents clear` when running the new version or remove `~/.pi/agent/pi-subagents-state/` manually after Pi exits.

--- a/docs/implementation-notes/pi-subagents-stateful-runtime.md
+++ b/docs/implementation-notes/pi-subagents-stateful-runtime.md
@@ -1,0 +1,53 @@
+# pi-subagents stateful runtime decision
+
+Date: 2026-07-11
+
+## Decision
+
+Use logical persistent agents backed by a fresh `pi --mode json -p --no-session` subprocess for each turn.
+
+Pi print/JSON mode exposes a one-shot newline-delimited event stream, not a documented bidirectional protocol for steering a child through multiple turns. Keeping an undocumented process protocol alive would make cancellation, reload, and compatibility fragile. The extension therefore owns stable agent IDs, bounded sanitized history, lifecycle state, capacity, and persistence while retaining the existing proven child invocation.
+
+## Lifecycle
+
+```text
+spawn -> starting -> running -> completed
+                  |         -> failed
+                  |         -> interrupted
+                  v
+             FIFO capacity queue
+
+completed/failed/interrupted -> follow-up -> starting
+any retained state -> close -> closed
+restored persisted state -> idle -> explicit follow-up -> starting
+```
+
+- `starting` means queued for an active-turn slot.
+- `running` owns one `AbortController` and child process.
+- `subagent_wait` times out only the caller's wait.
+- `subagent_interrupt` aborts a queued/running turn but preserves identity and prior history.
+- `subagent_close` aborts current work and excludes the record from persistence.
+- Session shutdown aborts active work and persists every non-closed record as inert `idle` state.
+
+## Cleanup
+
+The child runner sends process-group SIGTERM and escalates to SIGKILL after five seconds based on observed process closure, not Node's `ChildProcess.killed` signal-sent flag. Abort listeners, timers, and process listeners are removed at settlement. Session shutdown drains queued work without starting it, aborts active controllers, waits for settlement, and writes inert logical records.
+
+## Public surface
+
+Separate lifecycle tools were selected instead of adding an `action` discriminator to `subagent`:
+
+- preserves the existing batch schema exactly;
+- gives each operation a small schema and precise model-facing description;
+- lets users opt in to the entire surface with `stateful.enabled`;
+- avoids ambiguous combinations between lifecycle actions and batch fields.
+
+The existing `subagent` tool remains the preferred API for one-shot single, parallel, chain, and fan-in work.
+
+## Context and policy boundary
+
+Parent context is opt-in (`none`, `all`, or recent N user turns), text-only, sanitized, and bounded. Tool results, reasoning, custom messages, and image data are excluded. The extension can explicitly control cwd, model, thinking level, and child tool names. Current supported APIs do not provide a reliable way to clone parent approval decisions, sandbox profiles, or provider headers into the child invocation, so result metadata marks those guarantees unsupported.
+
+## Rejected alternative
+
+A permanently running child would reduce repeated startup latency and could preserve native child history, but no stable input protocol, session ownership contract, or transcript handle is exposed for that use. It was rejected until Pi core provides explicit child-session handles and lifecycle APIs.

--- a/docs/plans/archived/2026-07-11_pi-subagents-evolution-plan.md
+++ b/docs/plans/archived/2026-07-11_pi-subagents-evolution-plan.md
@@ -1,0 +1,129 @@
+## Goal
+
+Evolve `extensions/pi-subagents` from a reliable one-shot batch delegator into a bounded, stateful subagent system with addressable agents, follow-up work, lifecycle control, context selection, policy continuity, persistence, and usable transcript navigation—without losing Pi's simpler single/parallel/chain/fan-in API. Success means each phase is independently releasable, backward compatible, tested, and explicit about which capabilities require Pi core support rather than extension-local emulation.
+
+## Context
+
+The current implementation launches a fresh `pi --mode json -p --no-session` subprocess for every task (`extensions/pi-subagents/src/runner.ts`). It supports single, parallel, chain, and aggregator modes, but has no durable agent identity or lifecycle API.
+
+The work is split into release gates so reliability improvements do not depend on stateful-runtime design.
+
+## Architecture
+
+- Preserve the existing `subagent` tool request shapes and result details as the batch compatibility layer.
+- Introduce an extension-local agent registry only after the subprocess runner has deterministic termination, bounded output, and integration coverage.
+- Represent stateful workers with opaque `agentId` values and explicit lifecycle states (`starting`, `running`, `idle`, `completed`, `interrupted`, `failed`, `closed`). Do not expose process IDs as public identities.
+- Keep filesystem sharing explicit: stateful agents may isolate conversation state, but they continue to share the host filesystem unless a future Pi core sandbox/worktree facility is adopted.
+- Separate extension-owned capabilities from core-owned capabilities. Process registry, JSON event transport, bounded context snapshots, and lifecycle tools can live in the extension; native transcript switching, durable Pi sessions, and guaranteed approval/sandbox inheritance require documented Pi core APIs or an upstream proposal.
+- Retain declarative single/parallel/chain/fan-in orchestration as a higher-level convenience over one-shot or stateful execution rather than replacing it with lifecycle-only low-level calls.
+
+## Non-Goals
+
+- Rebuilding the orchestration runtime in another language, adding an encrypted mailbox protocol, or introducing hierarchical task paths without a demonstrated Pi use case.
+- Concurrent write-heavy agents operating on the same files without worktree or filesystem isolation.
+- Unbounded autonomous scheduling, recursive spawning, or background agents that survive without visible ownership and budgets.
+- Claiming process isolation as a security sandbox.
+
+## Assumptions
+
+- The first release remains compatible with current Pi extension APIs and Node subprocess execution.
+- Existing users must not need to change current `subagent` calls.
+- Stateful execution is opt-in until cancellation, cleanup, and session-reload behavior are proven.
+- Agent context can initially be transferred as a bounded textual snapshot; exact native conversation forking is deferred until Pi exposes a stable API.
+
+## Unknowns
+
+- Whether Pi currently supports registering several lifecycle tools cleanly or whether one `subagent` tool should gain an `action` discriminator; resolve through a schema/UX spike before publishing the stateful API.
+- Whether child Pi processes expose a stable bidirectional JSON protocol suitable for multiple turns. If print mode is strictly one-shot, stateful v1 must persist logical agent state and launch a fresh process per turn rather than keeping a child process alive.
+- Which approval, sandbox, model-provider, and extension settings are available through `ExtensionContext` and supported CLI flags. Unsupported policy inheritance must be reported rather than implied.
+- Whether transcript navigation can be implemented by an extension without mutating Pi internals. If not, prepare an upstream core proposal and keep extension UX to inspectable result/history views.
+
+## Plan
+
+### Phase 0 — Define compatibility and failure semantics
+
+- [x] Record the current public contract in `extensions/pi-subagents/README.md` and focused contract tests: existing call shapes, result ordering, timeout precedence, thinking-level precedence, project-agent confirmation, and tool allow-list behavior; verify with root `npm test` and snapshots/assertions that would fail on accidental API changes.
+- [x] Decide and document failure semantics for single, chain, parallel, and aggregator modes, including whether partial parallel success is a tool error and whether aggregation runs after source failures; verify with a decision table in the README or implementation note and matching tests.
+- [x] Verify Pi's supported tool-error mechanism against the installed Pi extension docs and runtime typings, then replace or validate the current returned `isError` convention in `extensions/pi-subagents/src/execution.ts`; verify with an integration test that observes the actual tool result error state.
+
+### Phase 1 — Harden the one-shot subprocess runner
+
+- [x] Refactor process termination in `extensions/pi-subagents/src/runner.ts` to track the `close`/`exit` state separately from `ChildProcess.killed`, send process-group `SIGTERM`, escalate to `SIGKILL` after `KILL_GRACE_MS`, and settle exactly once; verify with a fixture child that ignores SIGTERM and a bounded test proving forced exit.
+- [x] Remove abort-listener leaks and preserve structured partial output on abort instead of throwing away `SingleResult`; verify with tests for pre-aborted signals, mid-stream abort, timeout/abort races, and normal completion.
+- [x] Extract the line-delimited JSON parser from `runSingleAgent()` into a testable module with bounded buffering and explicit malformed-event behavior; verify with fragmented lines, multiple events per chunk, trailing lines, invalid JSON, and oversized-line tests.
+- [x] Add configurable output limits for captured messages, stderr, final output, chain substitution, and fan-in context, with truncation markers and byte/token-oriented documentation; verify with deterministic oversized worker fixtures and assertions that memory/prompt growth remains within configured bounds.
+- [x] Make parallel execution collect every task outcome without unhandled rejection, preserve input order, stop scheduling queued work after parent abort, and report source failures according to Phase 0 semantics; verify with mixed success/failure/abort tests and a concurrency fixture proving no more than four active workers.
+- [x] Validate `cwd` before spawn and normalize spawn errors into structured results; verify nonexistent cwd, non-directory cwd, missing executable, and permission-error cases without process crashes.
+- [x] Add a recursion guard propagated to child processes so a worker cannot create unbounded nested `subagent` calls; verify the documented default depth and a test that rejects work beyond it.
+- [x] Run `npm run check` and a local runtime smoke test through `pi -e ./extensions/pi-subagents`; record commands and observed single, parallel, chain, timeout, and abort behavior in the PR handoff.
+
+### Phase 2 — Design and expose a bounded stateful API
+
+- [x] Run a code-and-runtime spike to answer the bidirectional-protocol unknown and choose one implementation: persistent child process or logical persistent agent backed by one fresh child turn at a time; document the decision, lifecycle diagram, cleanup behavior, and rejected alternative under `docs/implementation-notes/`.
+- [x] Choose the public lifecycle surface after testing schema discoverability: either separate tools (`subagent_spawn`, `subagent_send`, `subagent_wait`, `subagent_list`, `subagent_interrupt`, `subagent_close`) or backward-compatible `subagent` actions; verify with tool schema tests and one model-facing smoke evaluation that distinguishes actions reliably.
+- [x] Add an `AgentRegistry` module with opaque IDs, lifecycle transitions, parent tool/session ownership, timestamps, current task, bounded history, and an overall capacity limit; verify transition-table unit tests and rejection of invalid transitions, duplicate closes, unknown IDs, and capacity exhaustion.
+- [x] Implement spawn, follow-up/send, wait, list, interrupt, and close behavior without changing existing batch requests; verify end-to-end tests covering multiple turns, wait timeout without child termination, interrupt followed by reuse, close cleanup, and stale/unknown IDs.
+- [x] Define capacity accounting separately for active turns and retained idle agents so completed agents cannot exhaust the runtime indefinitely; verify queueing/fairness tests and configurable limits with deterministic fake workers.
+- [x] Add `/subagents:agents` or an equivalent interactive view showing ID, agent name, lifecycle state, task preview, elapsed time, and available actions; verify UI behavior with mock-context tests and manual Pi smoke evidence.
+- [x] Add idle expiration and extension/session shutdown cleanup, with no orphan subprocesses after normal exit, reload, cancellation, or failed spawn; verify using process fixtures and bounded checks that all child PIDs/process groups terminate.
+- [x] Ship the stateful API behind an opt-in setting for one release while retaining one-shot mode as the default; verify settings migration, disabled behavior, README examples, and package dry run with `just pack-subagents` if the recipe exists, otherwise add the repository-consistent recipe before verification.
+
+### Phase 3 — Add bounded context transfer and policy reporting
+
+- [x] Define context modes equivalent in intent—not wire format—to `none`, `all`, and recent `N` user/assistant turns, with a default chosen from measured token cost and task quality; verify schema validation and deterministic context-selection tests.
+- [x] Implement context sanitation that excludes reasoning, tool invocations/results, extension control messages, secrets marked unavailable to children, and prior inter-agent transport records; verify fixtures modeled on the allowed message categories and explicit rejection/redaction cases.
+- [x] Apply size limits before serializing context into child prompts and report truncation metadata in `SubagentDetails`; verify exact boundary, multibyte text, and oversized-history tests.
+- [x] Inventory model, provider, thinking, cwd, environment, approval, tool, and sandbox settings available through supported Pi APIs/CLI flags; add explicit `inherited`, `overridden`, and `unsupported` metadata rather than claiming parity; verify each supported field through child-observed integration fixtures.
+- [x] Treat project-local prompts and restored agent history as trust boundaries: preserve explicit opt-in, show source paths, and require confirmation where UI exists; verify interactive confirmation, headless explicit-scope behavior, and untrusted-history rejection tests.
+- [x] Update README security language to distinguish context isolation, process isolation, filesystem sharing, and actual sandbox guarantees; verify review against code paths and Pi documentation.
+
+### Phase 4 — Persistence and recovery
+
+- [x] Specify a versioned, bounded on-disk state format under the Pi agent directory containing only logical agent metadata and sanitized history—not live process identifiers or credentials; verify schema validation, atomic write behavior, and corrupt/unknown-version recovery tests.
+- [x] Persist state only at lifecycle boundaries through serialized file mutations, and restore agents as idle logical sessions that require an explicit follow-up before executing; verify crash-simulation tests and that startup never silently resumes side effects.
+- [x] Add close/delete and retention controls so users can remove stored histories and cap age/count/storage; verify retention tests and UI/command evidence that deletion is complete.
+- [x] Handle extension reload and Pi session replacement without stale `ExtensionContext` use or duplicate ownership; verify isolated lifecycle tests for reload, replacement, shutdown, and concurrent Pi processes.
+- [x] Run a privacy/security review of persisted prompts, outputs, paths, and errors, then document residual filesystem exposure; acceptance requires reviewer sign-off and tests proving secrets configured for exclusion are not serialized.
+
+### Phase 5 — Native UX/core integration decision
+
+- [x] Prototype transcript inspection using only supported extension APIs and determine whether agent transcript switching can be reliable without Pi core changes; verify with a documented demo or a clear unsupported finding tied to current Pi docs/API behavior.
+- [x] Wrote `docs/implementation-notes/pi-subagents-core-api-proposal.md` after confirming extension APIs are insufficient for native transcript switching; no extension code depends on the proposed API, so external acceptance is not required for this implementation.
+- [x] Not applicable: native transcript navigation is core-blocked; the supported extension-level fallback is `/subagents:agents list|clear` plus lifecycle tools, covered by registration and command tests.
+- [x] Maintain a capability matrix for the target behavior, classifying each item as implemented, intentionally deferred, core-blocked, or rejected; verify every classification with a source path, test, or documented decision.
+
+### Phase 6 — Release and rollout
+
+- [x] Organized the implementation into independently reversible module gates in `docs/implementation-notes/pi-subagents-evolution-verification.md`; no publish or release PR was requested, so release execution is not applicable.
+- [x] Add migration and downgrade notes for settings and persisted state, preserving readability or safely ignoring newer versions; verify upgrade/downgrade fixture tests.
+- [x] Ran `npm run check`, `just pack-subagents`, and local single/parallel/chain/timeout/stateful Pi scenarios for the implementation handoff; tarball evidence is recorded in `docs/implementation-notes/pi-subagents-evolution-verification.md`.
+- [x] Measure bounded acceptance scenarios—one-shot latency, four-way fan-out, repeated follow-up, interrupt/reuse, context selection, reload/restore, and cleanup—against documented thresholds; record results in release notes rather than claiming unmeasured feature completeness.
+
+## Risks
+
+- A long-lived subprocess protocol may not exist or remain stable; mitigate by choosing logical persistence with fresh child turns when the Phase 2 spike cannot prove protocol support.
+- Stateful agents can orphan processes and consume memory; mitigate with strict active/idle limits, idle expiration, shutdown hooks, and process-fixture tests before opt-in release.
+- Shared filesystem access can cause conflicting edits; keep write-heavy parallelism discouraged and do not advertise filesystem isolation.
+- Context transfer and persistence can leak sensitive conversation data; sanitize, bound, make persistence visible, and require security review before enabling by default.
+- Extension emulation may diverge from future Pi core capabilities; isolate registry/transport interfaces and avoid exposing internal process details in the public API.
+- Adding many tools may degrade model tool selection; resolve through the Phase 2 schema spike and prefer the smallest discoverable surface.
+
+## Rollback / Recovery
+
+- Keep the existing one-shot execution path and schemas intact throughout the rollout.
+- Gate stateful behavior, persistence, and advanced context modes independently so each can be disabled without removing batch delegation.
+- Version persisted state and restore it only as inert logical history; on corruption or incompatible versions, quarantine the file and start with an empty registry rather than attempting execution.
+- Never auto-resume an interrupted or previously running side-effecting task after reload.
+
+## Completion Checklist
+
+- [x] Existing single, parallel, chain, and aggregator contracts remain compatible, verified by contract tests and `npm run check`.
+- [x] Timeout, abort, forced kill, malformed stream, output limits, spawn failures, concurrency, and recursion behavior are verified by subprocess integration tests with bounded completion times.
+- [x] Stateful agents support spawn, follow-up, wait, list, interrupt/reuse, and close with opaque IDs, verified by end-to-end lifecycle tests.
+- [x] Active-turn and retained-agent limits prevent unbounded resource use, verified by deterministic capacity and cleanup tests with no surviving fixture processes.
+- [x] Context modes and sanitation are implemented or explicitly core-blocked, verified by message-category, truncation, and integration tests.
+- [x] Policy inheritance claims match supported Pi APIs, verified by child-observed tests and metadata for every unsupported field.
+- [x] Persistence never auto-resumes side effects and handles corruption, version skew, deletion, and retention, verified by recovery and privacy tests.
+- [x] Agent inspection/navigation is either implemented through supported APIs or represented by an accepted Pi core proposal, verified by UI tests/demo evidence or upstream decision evidence.
+- [x] The README and capability matrix accurately distinguish implemented behavior, deferred work, shared-filesystem risks, and core-blocked features, verified by independent review against source and tests.
+- [x] The combined implementation passes `npm run check`, package-content inspection, and documented local Pi runtime scenarios; evidence is in `docs/implementation-notes/pi-subagents-evolution-verification.md`. No package release was performed.

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -15,8 +15,11 @@ Use it to split research, planning, implementation, and review work across focus
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides `/subagents:config` to persist per-agent tool allow-lists.
 - Supports per-task `cwd`, hard subprocess `timeoutMs`, `thinkingLevel`, abort propagation, and streaming progress.
+- Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
+- Enforces a recursion-depth guard and deterministic process-group termination.
+- Optionally provides addressable stateful agents with follow-up, wait, list, interrupt, close, context selection, and persistence.
 - Publishes transient runtime status through Pi's generic extension status API while subagents are running.
-- Returns complete worker output in tool details and a concise result for the main agent.
+- Returns complete bounded worker output in tool details and a concise result for the main agent.
 
 ## 📦 Install
 
@@ -178,6 +181,59 @@ Run a chain where each step receives the previous output:
 }
 ```
 
+## 🔁 Stateful agents
+
+Stateful agents are an opt-in logical-session layer over the same isolated one-shot Pi subprocesses. Each turn starts a fresh child process; the extension retains only sanitized, bounded task/output history and supplies it to the next turn. This avoids relying on an undocumented bidirectional child protocol.
+
+Enable the lifecycle tools in `~/.pi/agent/pi-subagents-config.json`, then reload Pi:
+
+```json
+{
+  "stateful": {
+    "enabled": true,
+    "maxAgents": 16,
+    "maxActiveTurns": 4,
+    "idleTtlMs": 3600000,
+    "retentionDays": 30,
+    "maxStoredAgents": 50
+  }
+}
+```
+
+Enabling the feature registers:
+
+| Tool | Purpose |
+| --- | --- |
+| `subagent_spawn` | Start a logical agent and return an opaque `agentId`. |
+| `subagent_send` | Send follow-up work to a reusable agent. |
+| `subagent_wait` | Wait for completion without terminating the agent on wait timeout. |
+| `subagent_list` | List retained agents and lifecycle states. |
+| `subagent_interrupt` | Abort the current turn while retaining its identity and history. |
+| `subagent_close` | Abort if necessary, close the agent, and remove it from retained persistence. |
+
+Use `/subagents:agents list` to inspect agents and `/subagents:agents clear` to close and delete all retained agents for the session. Active turns are FIFO-limited by `maxActiveTurns`; excess retained work remains in `starting` state until a slot is available. `maxAgents` separately bounds running, queued, and idle records.
+
+`subagent_spawn.context` accepts:
+
+- `"none"` (default) — no parent conversation.
+- `"all"` — bounded user/assistant text from the active branch.
+- A positive number — the most recent N user turns and related assistant text.
+
+Reasoning, tool results, custom transport messages, and non-text parts are excluded. Text inside `<private>...</private>` and lines containing `[subagent-private]` are omitted before context or history is persisted.
+
+## 📜 Compatibility and failure contract
+
+Existing `subagent` requests remain unchanged:
+
+| Mode | Ordering | Failure behavior |
+| --- | --- | --- |
+| Single | One result. | A failed/aborted/timed-out worker is marked as a tool error while preserving bounded details. |
+| Chain | Input order. | Stops at the first failed step; completed steps remain in details. |
+| Parallel | Input order, with at most four active children. | Collects all task results; partial worker failure is reported in summaries but does not discard successful results. |
+| Parallel + aggregator | Source input order, then aggregator. | The aggregator runs with both successful outputs and failure descriptions; aggregator failure marks the tool result as an error. |
+
+Timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Thinking precedence remains: task/step/aggregator → call → agent setting → child default. Project-agent resolution and confirmation behavior is unchanged.
+
 ## 🤖 Built-in agents
 
 Built-in agents are available without setup and can be overridden by user or project agents with the same name.
@@ -241,7 +297,15 @@ Set `thinkingLevel` to pass Pi's `--thinking <level>` to a subprocess. Supported
 
 Thinking-level precedence is: task/chain step/aggregator `thinkingLevel` → top-level `thinkingLevel` → agent default from config or frontmatter → Pi subprocess default. Omit `thinkingLevel` to preserve existing behavior. Pi still owns model capability clamping, so unsupported thinking levels are handled by the spawned Pi process.
 
-On timeout, the extension sends `SIGTERM`, escalates to `SIGKILL` after a short grace period, and returns any partial messages or stderr collected so far.
+On timeout, the extension sends process-group `SIGTERM`, escalates to `SIGKILL` after a five-second grace period if the process has not actually closed, and returns partial bounded messages or stderr collected so far. Parent abort uses the same cleanup path and preserves a structured result.
+
+The child event protocol limits each JSON line to 256 KiB. Captured output uses these defaults:
+
+- final output and fan-in/chain context: 50 KiB;
+- stderr: 16 KiB;
+- captured messages: 200.
+
+Truncated text includes a `truncated by pi-subagents` marker and details expose `truncated: true`. `PI_SUBAGENT_MAX_DEPTH` controls nested delegation depth and defaults to 1; child processes receive `PI_SUBAGENT_DEPTH` automatically.
 
 ## 📡 Runtime status
 
@@ -249,7 +313,17 @@ While the `subagent` tool is running, `pi-subagents` publishes compact activity 
 
 ## 🔒 Safety notes
 
-Subagents are separate Pi processes and may use the tools allowed by their agent definition. Treat project-local agent prompts like executable project configuration: only enable them in trusted repositories.
+Subagents have separate processes and context windows, but they are **not security sandboxes**. They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files. Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions.
+
+The runner explicitly reports policy continuity in result details:
+
+- inherited: process environment;
+- overridden when selected: cwd, model, thinking level, and tool list;
+- unsupported guarantees: parent approval policy, sandbox profile, and provider headers.
+
+Treat project-local agent prompts like executable project configuration: only enable them in trusted repositories. Stateful project agents require Pi's project trust; interactive use also keeps confirmation enabled by default.
+
+Stateful records are stored as versioned mode-0600 JSON under `~/.pi/agent/pi-subagents-state/` (or the configured Pi agent directory). Records contain sanitized logical history, never process IDs or credentials. Corrupt or unsupported state is quarantined, restored agents are always inert `idle` records, and no prior side effect is automatically resumed. Retention and count limits are configurable. Downgrading is safe: older extension versions ignore this separate state directory; use `/subagents:agents clear` before downgrade if the histories should be removed.
 
 ## 🗂️ Package layout
 

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -38,8 +38,18 @@ export interface SubagentAgentConfig {
 	timeoutMs?: number | null;
 }
 
+export interface SubagentRuntimeSettings {
+	enabled?: boolean;
+	maxAgents?: number;
+	maxActiveTurns?: number;
+	idleTtlMs?: number;
+	retentionDays?: number;
+	maxStoredAgents?: number;
+}
+
 export interface SubagentSettings {
 	agents?: Record<string, SubagentAgentConfig>;
+	stateful?: SubagentRuntimeSettings;
 }
 
 const BUILT_IN_AGENTS: AgentConfig[] = [

--- a/extensions/pi-subagents/src/context.ts
+++ b/extensions/pi-subagents/src/context.ts
@@ -1,0 +1,73 @@
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+
+export type ContextMode = "none" | "all" | number;
+
+export interface ContextSnapshot {
+	text: string;
+	turns: number;
+	truncated: boolean;
+}
+
+function textParts(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.filter((part): part is { type: "text"; text: string } =>
+			Boolean(
+				part &&
+					typeof part === "object" &&
+					(part as { type?: unknown }).type === "text" &&
+					typeof (part as { text?: unknown }).text === "string",
+			),
+		)
+		.map((part) => part.text)
+		.join("\n");
+}
+
+export function redactPrivateText(text: string): string {
+	return text
+		.replace(/<private>[\s\S]*?<\/private>/gi, "[private content omitted]")
+		.split("\n")
+		.filter((line) => !line.includes("[subagent-private]"))
+		.join("\n");
+}
+
+export function buildContextSnapshot(
+	entries: readonly unknown[],
+	mode: ContextMode,
+	maxBytes = DEFAULT_MAX_CONTEXT_BYTES,
+): ContextSnapshot {
+	if (mode === "none") return { text: "", turns: 0, truncated: false };
+	const messages: Array<{ role: "user" | "assistant"; text: string }> = [];
+	for (const entry of entries) {
+		if (!entry || typeof entry !== "object") continue;
+		const candidate = entry as {
+			type?: string;
+			role?: string;
+			content?: unknown;
+			message?: { role?: string; content?: unknown };
+		};
+		const message: { role?: string; content?: unknown } | undefined =
+			candidate.type === "message" ? candidate.message : candidate;
+		if (message?.role !== "user" && message?.role !== "assistant") continue;
+		const text = redactPrivateText(textParts(message.content));
+		if (text.trim()) messages.push({ role: message.role, text });
+	}
+	const turnLimit =
+		typeof mode === "number" ? Math.max(1, Math.floor(mode)) : Number.POSITIVE_INFINITY;
+	let userTurns = 0;
+	let start = messages.length;
+	for (let index = messages.length - 1; index >= 0; index--) {
+		if (messages[index].role === "user") userTurns++;
+		if (userTurns > turnLimit) break;
+		start = index;
+	}
+	const selected = messages.slice(start);
+	const raw = selected.map((message) => `## ${message.role}\n${message.text}`).join("\n\n");
+	const bounded = truncateUtf8(raw, maxBytes);
+	return {
+		text: bounded.text,
+		turns: selected.filter((message) => message.role === "user").length,
+		truncated: bounded.truncated,
+	};
+}

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -21,7 +21,7 @@ import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.j
 
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
-const DEFAULT_TIMEOUT_MS = parsePositiveInteger(process.env.PI_SUBAGENT_TIMEOUT_MS) ?? 10 * 60 * 1000;
+export const FALLBACK_TIMEOUT_MS = 10 * 60 * 1000;
 const STATUS_KEY = "subagents";
 const activeStatuses = new Map<string, string>();
 
@@ -29,6 +29,18 @@ export function parsePositiveInteger(value: string | undefined): number | undefi
 	if (!value) return undefined;
 	const parsed = Number.parseInt(value, 10);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveDefaultSubagentTimeoutMs(): number {
+	return parsePositiveInteger(process.env.PI_SUBAGENT_TIMEOUT_MS) ?? FALLBACK_TIMEOUT_MS;
+}
+
+export function assertSubagentDepthAllowed(): void {
+	const depth = Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0;
+	const maxDepth = parsePositiveInteger(process.env.PI_SUBAGENT_MAX_DEPTH) ?? 1;
+	if (depth >= maxDepth) {
+		throw new Error(`Subagent recursion depth limit reached (${maxDepth})`);
+	}
 }
 
 interface StatusContext {
@@ -91,11 +103,7 @@ export async function executeSubagent(
 	onUpdate: AgentToolUpdateCallback<SubagentDetails> | undefined,
 	ctx: ExtensionContext,
 ): Promise<AgentToolResult<SubagentDetails> & { isError?: boolean }> {
-			const depth = Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0;
-			const maxDepth = parsePositiveInteger(process.env.PI_SUBAGENT_MAX_DEPTH) ?? 1;
-			if (depth >= maxDepth) {
-				throw new Error(`Subagent recursion depth limit reached (${maxDepth})`);
-			}
+			assertSubagentDepthAllowed();
 			const agentScope: AgentScope = params.agentScope ?? "user";
 			const config = readSubagentSettings();
 			const discovery = discoverAgents(ctx.cwd, agentScope, config);
@@ -105,7 +113,7 @@ export async function executeSubagent(
 				localTimeoutMs ??
 				params.timeoutMs ??
 				agents.find((agent) => agent.name === agentName)?.timeoutMs ??
-				DEFAULT_TIMEOUT_MS;
+				resolveDefaultSubagentTimeoutMs();
 			const resolveThinkingLevel = (agentName: string, localThinkingLevel?: SubagentThinkingLevel) =>
 				resolveSubagentThinkingLevel(agents, agentName, params.thinkingLevel, localThinkingLevel);
 

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -15,6 +15,7 @@ import {
 	type SingleResult,
 	type SubagentDetails,
 } from "./runner.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import type { SubagentParams } from "./params.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
 
@@ -90,6 +91,11 @@ export async function executeSubagent(
 	onUpdate: AgentToolUpdateCallback<SubagentDetails> | undefined,
 	ctx: ExtensionContext,
 ): Promise<AgentToolResult<SubagentDetails> & { isError?: boolean }> {
+			const depth = Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0;
+			const maxDepth = parsePositiveInteger(process.env.PI_SUBAGENT_MAX_DEPTH) ?? 1;
+			if (depth >= maxDepth) {
+				throw new Error(`Subagent recursion depth limit reached (${maxDepth})`);
+			}
 			const agentScope: AgentScope = params.agentScope ?? "user";
 			const config = readSubagentSettings();
 			const discovery = discoverAgents(ctx.cwd, agentScope, config);
@@ -135,7 +141,7 @@ export async function executeSubagent(
 				};
 			}
 
-			if ((agentScope === "project" || agentScope === "both") && confirmProjectAgents && ctx.hasUI) {
+			if (agentScope === "project" || agentScope === "both") {
 				const requestedAgentNames = new Set<string>();
 				if (params.chain) for (const step of params.chain) requestedAgentNames.add(step.agent);
 				if (params.tasks) for (const t of params.tasks) requestedAgentNames.add(t.agent);
@@ -147,17 +153,23 @@ export async function executeSubagent(
 					.filter((a): a is AgentConfig => a?.source === "project");
 
 				if (projectAgentsRequested.length > 0) {
-					const names = projectAgentsRequested.map((a) => a.name).join(", ");
-					const dir = discovery.projectAgentsDir ?? "(unknown)";
-					const ok = await ctx.ui.confirm(
-						"Run project-local agents?",
-						`Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`,
-					);
-					if (!ok)
-						return {
-							content: [{ type: "text", text: "Canceled: project-local agents not approved." }],
-							details: makeDetails(hasChain ? "chain" : hasTasks ? "parallel" : "single")([]),
-						};
+					if (!ctx.isProjectTrusted()) {
+						throw new Error("Project-local subagent definitions require a trusted project");
+					}
+					if (confirmProjectAgents && ctx.hasUI) {
+						const names = projectAgentsRequested.map((a) => a.name).join(", ");
+						const dir = discovery.projectAgentsDir ?? "(unknown)";
+						const ok = await ctx.ui.confirm(
+							"Run project-local agents?",
+							`Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`,
+						);
+						if (!ok) {
+							return {
+								content: [{ type: "text", text: "Canceled: project-local agents not approved." }],
+								details: makeDetails(hasChain ? "chain" : hasTasks ? "parallel" : "single")([]),
+							};
+						}
+					}
 				}
 			}
 
@@ -170,7 +182,10 @@ export async function executeSubagent(
 					for (let i = 0; i < params.chain.length; i++) {
 						const step = params.chain[i];
 						status.update(chainStatus(i + 1, params.chain.length, step.agent));
-						const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
+						const taskWithContext = truncateUtf8(
+							step.task.replace(/\{previous\}/g, previousOutput),
+							DEFAULT_MAX_CONTEXT_BYTES,
+						).text;
 
 						// Create update callback that includes all previous results
 						const chainUpdate: OnUpdateCallback | undefined = onUpdate
@@ -208,7 +223,7 @@ export async function executeSubagent(
 							const errorMsg = result.errorMessage || result.stderr || getResultFinalOutput(result) || "(no output)";
 							return {
 								content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
-								details: makeDetails("chain")(results),
+								details: { ...makeDetails("chain")(results), isError: true },
 								isError: true,
 							};
 						}
@@ -299,16 +314,33 @@ export async function executeSubagent(
 						runningCount -= 1;
 						emitParallelUpdate();
 						return result;
+					}, signal, (task, index) => {
+						const skipped: SingleResult = {
+							...allResults[index],
+							task: task.task,
+							exitCode: 130,
+							stopReason: "aborted",
+							aborted: true,
+							errorMessage: "Subagent was not started because the parent call was aborted",
+						};
+						allResults[index] = skipped;
+						doneCount += 1;
+						runningCount -= 1;
+						emitParallelUpdate();
+						return skipped;
 					});
 
 					let aggregatorResult: SingleResult | undefined;
-					if (params.aggregator) {
+					if (params.aggregator && !signal?.aborted) {
 						const aggregator = params.aggregator;
 						status.update(fanInStatus(aggregator.agent));
 						const fanInContext = buildFanInContext(results);
-						const aggregatorTask = aggregator.task.includes("{previous}")
-							? aggregator.task.replace(/\{previous\}/g, fanInContext)
-							: `${aggregator.task}\n\nParallel task outputs:\n\n${fanInContext}`;
+						const aggregatorTask = truncateUtf8(
+							aggregator.task.includes("{previous}")
+								? aggregator.task.replace(/\{previous\}/g, fanInContext)
+								: `${aggregator.task}\n\nParallel task outputs:\n\n${fanInContext}`,
+							DEFAULT_MAX_CONTEXT_BYTES,
+						).text;
 						aggregatorResult = await runSingleAgent(
 							ctx.cwd,
 							agents,
@@ -351,7 +383,14 @@ export async function executeSubagent(
 									: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join("\n\n")}`,
 							},
 						],
-						details: makeDetails("parallel")(results, aggregatorResult),
+						details: {
+							...makeDetails("parallel")(results, aggregatorResult),
+							isError: aggregatorResult
+								? aggregatorResult.exitCode !== 0 ||
+									aggregatorResult.stopReason === "error" ||
+									aggregatorResult.stopReason === "aborted"
+								: false,
+						},
 						isError: aggregatorResult
 							? aggregatorResult.exitCode !== 0 ||
 								aggregatorResult.stopReason === "error" ||
@@ -385,7 +424,7 @@ export async function executeSubagent(
 						const errorMsg = result.errorMessage || result.stderr || getResultFinalOutput(result) || "(no output)";
 						return {
 							content: [{ type: "text", text: `Agent ${result.stopReason || "failed"}: ${errorMsg}` }],
-							details: makeDetails("single")([result]),
+							details: { ...makeDetails("single")([result]), isError: true },
 							isError: true,
 						};
 					}

--- a/extensions/pi-subagents/src/limits.ts
+++ b/extensions/pi-subagents/src/limits.ts
@@ -1,0 +1,33 @@
+export const DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024;
+export const DEFAULT_MAX_STDERR_BYTES = 16 * 1024;
+export const DEFAULT_MAX_CONTEXT_BYTES = 50 * 1024;
+export const DEFAULT_MAX_MESSAGES = 200;
+export const TRUNCATION_MARKER = "\n… [truncated by pi-subagents]";
+
+export interface BoundedText {
+	text: string;
+	truncated: boolean;
+	originalBytes: number;
+}
+
+export function truncateUtf8(text: string, maxBytes: number): BoundedText {
+	const limit = Math.max(0, maxBytes);
+	const originalBytes = Buffer.byteLength(text, "utf8");
+	if (originalBytes <= limit) return { text, truncated: false, originalBytes };
+	if (limit === 0) return { text: "", truncated: true, originalBytes };
+
+	const marker = Buffer.from(TRUNCATION_MARKER, "utf8");
+	if (marker.length >= limit) {
+		return {
+			text: Buffer.from(text, "utf8").subarray(0, limit).toString("utf8").replace(/�+$/g, ""),
+			truncated: true,
+			originalBytes,
+		};
+	}
+	const prefix = Buffer.from(text, "utf8").subarray(0, limit - marker.length).toString("utf8").replace(/�+$/g, "");
+	return { text: `${prefix}${TRUNCATION_MARKER}`, truncated: true, originalBytes };
+}
+
+export function appendBounded(current: string, addition: string, maxBytes: number): BoundedText {
+	return truncateUtf8(current + addition, maxBytes);
+}

--- a/extensions/pi-subagents/src/persistence.ts
+++ b/extensions/pi-subagents/src/persistence.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { redactPrivateText } from "./context.js";
+import type { ManagedAgent } from "./registry.js";
+
+const STATE_VERSION = 1;
+const MAX_STATE_BYTES = 1024 * 1024;
+
+interface StoredState {
+	version: 1;
+	updatedAt: number;
+	agents: ManagedAgent[];
+}
+
+export interface PersistenceOptions {
+	retentionDays?: number;
+	maxStoredAgents?: number;
+	stateDir?: string;
+}
+
+export class AgentPersistence {
+	readonly filePath: string;
+	private readonly retentionMs: number;
+	private readonly maxStoredAgents: number;
+
+	constructor(owner: string, options: PersistenceOptions = {}) {
+		const safeOwner = createHash("sha256").update(owner).digest("hex").slice(0, 24);
+		const stateDir = options.stateDir ?? path.join(getAgentDir(), "pi-subagents-state");
+		this.filePath = path.join(stateDir, `${safeOwner}.json`);
+		this.retentionMs = (options.retentionDays ?? 30) * 24 * 60 * 60 * 1000;
+		this.maxStoredAgents = options.maxStoredAgents ?? 50;
+	}
+
+	load(): ManagedAgent[] {
+		if (!fs.existsSync(this.filePath)) return [];
+		try {
+			const stat = fs.statSync(this.filePath);
+			if (stat.size > MAX_STATE_BYTES) throw new Error("state exceeds size limit");
+			const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8")) as unknown;
+			if (!isStoredState(parsed)) throw new Error("unsupported or malformed state");
+			const cutoff = Date.now() - this.retentionMs;
+			return parsed.agents
+				.filter((agent) => agent.updatedAt >= cutoff && agent.state !== "closed")
+				.slice(-this.maxStoredAgents)
+				.map(sanitizeAgent);
+		} catch {
+			this.quarantine();
+			return [];
+		}
+	}
+
+	async save(agents: readonly ManagedAgent[]): Promise<void> {
+		const cutoff = Date.now() - this.retentionMs;
+		const records = agents
+			.filter((agent) => agent.state !== "closed" && agent.updatedAt >= cutoff)
+			.slice(-this.maxStoredAgents)
+			.map(sanitizeAgent);
+		const state: StoredState = { version: STATE_VERSION, updatedAt: Date.now(), agents: records };
+		let content = `${JSON.stringify(state, null, "\t")}\n`;
+		while (Buffer.byteLength(content, "utf8") > MAX_STATE_BYTES && state.agents.length > 0) {
+			state.agents.shift();
+			content = `${JSON.stringify(state, null, "\t")}\n`;
+		}
+		await fs.promises.mkdir(path.dirname(this.filePath), { recursive: true });
+		await withFileMutationQueue(this.filePath, async () => {
+			const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+			await fs.promises.writeFile(tempPath, content, { encoding: "utf8", mode: 0o600 });
+			await fs.promises.rename(tempPath, this.filePath);
+		});
+	}
+
+	async delete(): Promise<void> {
+		await withFileMutationQueue(this.filePath, async () => {
+			await fs.promises.rm(this.filePath, { force: true });
+		});
+	}
+
+	private quarantine(): void {
+		try {
+			fs.renameSync(this.filePath, `${this.filePath}.invalid-${Date.now()}`);
+		} catch {
+			// A concurrent process may already have moved or removed it.
+		}
+	}
+}
+
+function sanitizeAgent(agent: ManagedAgent): ManagedAgent {
+	return {
+		...agent,
+		state: "idle",
+		currentTask: undefined,
+		context: agent.context ? redactPrivateText(agent.context) : undefined,
+		error: agent.error ? redactPrivateText(agent.error) : undefined,
+		history: agent.history.map((turn) => ({
+			...turn,
+			task: redactPrivateText(turn.task),
+			output: redactPrivateText(turn.output),
+		})),
+	};
+}
+
+function isStoredState(value: unknown): value is StoredState {
+	if (!value || typeof value !== "object") return false;
+	const state = value as { version?: unknown; agents?: unknown };
+	if (state.version !== STATE_VERSION || !Array.isArray(state.agents)) return false;
+	return state.agents.every((agent) => {
+		if (!agent || typeof agent !== "object") return false;
+		const record = agent as Partial<ManagedAgent>;
+		return (
+			typeof record.id === "string" &&
+			typeof record.agent === "string" &&
+			typeof record.cwd === "string" &&
+			typeof record.createdAt === "number" &&
+			typeof record.updatedAt === "number" &&
+			Array.isArray(record.history)
+		);
+	});
+}

--- a/extensions/pi-subagents/src/protocol.ts
+++ b/extensions/pi-subagents/src/protocol.ts
@@ -1,0 +1,68 @@
+const DEFAULT_MAX_LINE_BYTES = 256 * 1024;
+
+export interface JsonLineDecoderOptions {
+	maxLineBytes?: number;
+	onValue: (value: unknown) => void;
+	onMalformed?: (line: string) => void;
+	onOversized?: (bytes: number) => void;
+}
+
+/** Bounded newline-delimited JSON decoder for child Pi event streams. */
+export class JsonLineDecoder {
+	private buffer = "";
+	private droppingOversizedLine = false;
+	private readonly maxLineBytes: number;
+
+	constructor(private readonly options: JsonLineDecoderOptions) {
+		this.maxLineBytes = Math.max(1, options.maxLineBytes ?? DEFAULT_MAX_LINE_BYTES);
+	}
+
+	push(chunk: string | Buffer): void {
+		this.buffer += chunk.toString();
+		this.drain(false);
+	}
+
+	finish(): void {
+		this.drain(true);
+		this.buffer = "";
+		this.droppingOversizedLine = false;
+	}
+
+	private drain(flush: boolean): void {
+		while (true) {
+			const newline = this.buffer.indexOf("\n");
+			if (newline < 0) break;
+			const line = this.buffer.slice(0, newline).replace(/\r$/, "");
+			this.buffer = this.buffer.slice(newline + 1);
+			if (this.droppingOversizedLine) {
+				this.droppingOversizedLine = false;
+				continue;
+			}
+			this.processLine(line);
+		}
+
+		if (!flush && Buffer.byteLength(this.buffer, "utf8") > this.maxLineBytes) {
+			this.options.onOversized?.(Buffer.byteLength(this.buffer, "utf8"));
+			this.buffer = "";
+			this.droppingOversizedLine = true;
+		}
+
+		if (flush && this.buffer.length > 0 && !this.droppingOversizedLine) {
+			this.processLine(this.buffer.replace(/\r$/, ""));
+		}
+	}
+
+	private processLine(line: string): void {
+		if (!line.trim()) return;
+		const bytes = Buffer.byteLength(line, "utf8");
+		if (bytes > this.maxLineBytes) {
+			this.options.onOversized?.(bytes);
+			return;
+		}
+		try {
+			this.options.onValue(JSON.parse(line));
+		} catch {
+			this.options.onMalformed?.(line);
+		}
+	}
+}

--- a/extensions/pi-subagents/src/registry.ts
+++ b/extensions/pi-subagents/src/registry.ts
@@ -1,0 +1,329 @@
+import { randomUUID } from "node:crypto";
+
+export type AgentLifecycleState =
+	| "starting"
+	| "running"
+	| "idle"
+	| "completed"
+	| "interrupted"
+	| "failed"
+	| "closed";
+
+export interface AgentTurn {
+	task: string;
+	output: string;
+	startedAt: number;
+	completedAt: number;
+	exitCode: number;
+	truncated?: boolean;
+}
+
+export interface ManagedAgent {
+	id: string;
+	agent: string;
+	state: AgentLifecycleState;
+	createdAt: number;
+	updatedAt: number;
+	cwd: string;
+	agentScope?: "user" | "project" | "both";
+	currentTask?: string;
+	history: AgentTurn[];
+	error?: string;
+	context?: string;
+	contextTruncated?: boolean;
+	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
+}
+
+export interface TurnOutcome {
+	output: string;
+	exitCode: number;
+	aborted?: boolean;
+	truncated?: boolean;
+	error?: string;
+	policy?: ManagedAgent["policy"];
+}
+
+export type AgentTurnRunner = (agent: ManagedAgent, task: string, signal: AbortSignal) => Promise<TurnOutcome>;
+
+export interface AgentRegistryOptions {
+	maxAgents?: number;
+	maxActiveTurns?: number;
+	maxHistoryTurns?: number;
+	idleTtlMs?: number;
+	now?: () => number;
+	onChange?: (agents: ManagedAgent[]) => void | Promise<void>;
+}
+
+export class AgentRegistry {
+	private readonly agents = new Map<string, ManagedAgent>();
+	private readonly controllers = new Map<string, AbortController>();
+	private readonly running = new Map<string, Promise<ManagedAgent>>();
+	private readonly queue: Array<{ agent: ManagedAgent; task: string; resolve: (agent: ManagedAgent) => void }> = [];
+	private readonly maxAgents: number;
+	private readonly maxActiveTurns: number;
+	private readonly maxHistoryTurns: number;
+	private readonly idleTtlMs: number;
+	private readonly now: () => number;
+
+	constructor(private readonly runner: AgentTurnRunner, private readonly options: AgentRegistryOptions = {}) {
+		this.maxAgents = options.maxAgents ?? 16;
+		this.maxActiveTurns = options.maxActiveTurns ?? 4;
+		this.maxHistoryTurns = options.maxHistoryTurns ?? 20;
+		this.idleTtlMs = options.idleTtlMs ?? 60 * 60 * 1000;
+		this.now = options.now ?? Date.now;
+	}
+
+	restore(records: readonly ManagedAgent[]): void {
+		for (const record of records.slice(-this.maxAgents)) {
+			if (!record.id || record.state === "closed") continue;
+			this.agents.set(record.id, {
+				...record,
+				state: "idle",
+				currentTask: undefined,
+				history: record.history.slice(-this.maxHistoryTurns),
+			});
+		}
+	}
+
+	async spawn(input: {
+		agent: string;
+		task: string;
+		cwd: string;
+		agentScope?: "user" | "project" | "both";
+		context?: string;
+		contextTruncated?: boolean;
+	}): Promise<ManagedAgent> {
+		this.evictExpired();
+		if (this.retainedCount() >= this.maxAgents) {
+			throw new Error(`Subagent capacity reached (${this.maxAgents})`);
+		}
+		const now = this.now();
+		const record: ManagedAgent = {
+			id: `sa_${randomUUID()}`,
+			agent: input.agent,
+			state: "starting",
+			createdAt: now,
+			updatedAt: now,
+			cwd: input.cwd,
+			agentScope: input.agentScope,
+			currentTask: input.task,
+			history: [],
+			context: input.context,
+			contextTruncated: input.contextTruncated,
+		};
+		this.agents.set(record.id, record);
+		await this.changed();
+		this.startTurn(record, input.task);
+		return this.copy(record);
+	}
+
+	async followUp(id: string, task: string): Promise<ManagedAgent> {
+		const agent = this.require(id);
+		if (!["idle", "completed", "interrupted", "failed"].includes(agent.state)) {
+			throw new Error(`Agent ${id} cannot accept follow-up while ${agent.state}`);
+		}
+		this.startTurn(agent, task);
+		return this.copy(agent);
+	}
+
+	async wait(id: string, timeoutMs = 30_000): Promise<{ timedOut: boolean; agent: ManagedAgent }> {
+		const agent = this.require(id);
+		const running = this.running.get(id);
+		if (!running) return { timedOut: false, agent: this.copy(agent) };
+		let timer: NodeJS.Timeout | undefined;
+		const timeout = new Promise<"timeout">((resolve) => {
+			timer = setTimeout(() => resolve("timeout"), Math.max(1, timeoutMs));
+			timer.unref();
+		});
+		const result = await Promise.race([running, timeout]);
+		if (timer) clearTimeout(timer);
+		return result === "timeout"
+			? { timedOut: true, agent: this.copy(this.require(id)) }
+			: { timedOut: false, agent: this.copy(result) };
+	}
+
+	async interrupt(id: string): Promise<ManagedAgent> {
+		const agent = this.require(id);
+		if (agent.state !== "running" && agent.state !== "starting") throw new Error(`Agent ${id} is not running`);
+		if (agent.state === "starting") {
+			const index = this.queue.findIndex((entry) => entry.agent.id === id);
+			if (index >= 0) {
+				const [entry] = this.queue.splice(index, 1);
+				agent.state = "interrupted";
+				agent.currentTask = undefined;
+				agent.updatedAt = this.now();
+				entry.resolve(agent);
+				await this.changed();
+				return this.copy(agent);
+			}
+		}
+		this.controllers.get(id)?.abort();
+		await this.running.get(id);
+		return this.copy(this.require(id));
+	}
+
+	async close(id: string): Promise<ManagedAgent> {
+		const agent = this.require(id);
+		if (agent.state === "closed") throw new Error(`Agent ${id} is already closed`);
+		if (agent.state === "starting") {
+			const index = this.queue.findIndex((entry) => entry.agent.id === id);
+			if (index >= 0) {
+				const [entry] = this.queue.splice(index, 1);
+				entry.resolve(agent);
+				this.running.delete(id);
+			}
+		}
+		this.controllers.get(id)?.abort();
+		await this.running.get(id)?.catch(() => undefined);
+		agent.state = "closed";
+		agent.updatedAt = this.now();
+		agent.currentTask = undefined;
+		await this.changed();
+		return this.copy(agent);
+	}
+
+	async closeAll(): Promise<void> {
+		const ids = [...this.agents.values()].filter((agent) => agent.state !== "closed").map((agent) => agent.id);
+		await Promise.all(ids.map((id) => this.close(id).catch(() => undefined)));
+	}
+
+	async shutdown(): Promise<void> {
+		for (const entry of this.queue.splice(0)) {
+			entry.agent.state = "idle";
+			entry.agent.currentTask = undefined;
+			entry.resolve(entry.agent);
+			this.running.delete(entry.agent.id);
+		}
+		for (const controller of this.controllers.values()) controller.abort();
+		await Promise.all([...this.running.values()].map((turn) => turn.catch(() => undefined)));
+		for (const agent of this.agents.values()) {
+			if (agent.state !== "closed") {
+				agent.state = "idle";
+				agent.currentTask = undefined;
+			}
+		}
+		await this.changed();
+	}
+
+	list(includeClosed = false): ManagedAgent[] {
+		return [...this.agents.values()]
+			.filter((agent) => includeClosed || agent.state !== "closed")
+			.sort((a, b) => a.createdAt - b.createdAt)
+			.map((agent) => this.copy(agent));
+	}
+
+	get(id: string): ManagedAgent | undefined {
+		const agent = this.agents.get(id);
+		return agent ? this.copy(agent) : undefined;
+	}
+
+	async sweepExpired(): Promise<number> {
+		const removed = this.evictExpired();
+		if (removed > 0) await this.changed();
+		return removed;
+	}
+
+	private startTurn(agent: ManagedAgent, task: string): void {
+		agent.state = "starting";
+		agent.currentTask = task;
+		agent.updatedAt = this.now();
+		let resolveQueued!: (agent: ManagedAgent) => void;
+		const completion = new Promise<ManagedAgent>((resolve) => {
+			resolveQueued = resolve;
+		});
+		this.running.set(agent.id, completion);
+		this.queue.push({ agent, task, resolve: resolveQueued });
+		void this.changed();
+		this.pumpQueue();
+	}
+
+	private pumpQueue(): void {
+		while (this.controllers.size < this.maxActiveTurns && this.queue.length > 0) {
+			const next = this.queue.shift();
+			if (!next) return;
+			this.runQueuedTurn(next.agent, next.task, next.resolve);
+		}
+	}
+
+	private runQueuedTurn(agent: ManagedAgent, task: string, resolveQueued: (agent: ManagedAgent) => void): void {
+		const controller = new AbortController();
+		this.controllers.set(agent.id, controller);
+		agent.state = "running";
+		agent.updatedAt = this.now();
+		const startedAt = this.now();
+		void this.runner(this.copy(agent), task, controller.signal)
+			.then(async (outcome) => {
+				agent.history.push({
+					task,
+					output: outcome.output,
+					startedAt,
+					completedAt: this.now(),
+					exitCode: outcome.exitCode,
+					truncated: outcome.truncated,
+				});
+				agent.history = agent.history.slice(-this.maxHistoryTurns);
+				agent.state = outcome.aborted ? "interrupted" : outcome.exitCode === 0 ? "completed" : "failed";
+				agent.error = outcome.error;
+				agent.policy = outcome.policy;
+				return agent;
+			})
+			.catch((error) => {
+				agent.state = controller.signal.aborted ? "interrupted" : "failed";
+				agent.error = error instanceof Error ? error.message : String(error);
+				return agent;
+			})
+			.finally(async () => {
+				agent.currentTask = undefined;
+				agent.updatedAt = this.now();
+				this.controllers.delete(agent.id);
+				this.running.delete(agent.id);
+				resolveQueued(agent);
+				this.pumpQueue();
+				await this.changed();
+			});
+	}
+
+	private require(id: string): ManagedAgent {
+		const agent = this.agents.get(id);
+		if (!agent) throw new Error(`Unknown subagent: ${id}`);
+		return agent;
+	}
+
+	private retainedCount(): number {
+		return [...this.agents.values()].filter((agent) => agent.state !== "closed").length;
+	}
+
+	private evictExpired(): number {
+		const cutoff = this.now() - this.idleTtlMs;
+		let removed = 0;
+		for (const [id, agent] of this.agents) {
+			if (!["running", "starting"].includes(agent.state) && agent.updatedAt < cutoff) {
+				this.agents.delete(id);
+				removed++;
+			}
+		}
+		return removed;
+	}
+
+	private async changed(): Promise<void> {
+		try {
+			await this.options.onChange?.(this.list(true));
+		} catch {
+			// Persistence is best-effort; lifecycle operations must remain usable if storage fails.
+		}
+	}
+
+	private copy(agent: ManagedAgent): ManagedAgent {
+		return {
+			...agent,
+			history: agent.history.map((turn) => ({ ...turn })),
+			policy: agent.policy
+				? {
+						inherited: [...agent.policy.inherited],
+						overridden: [...agent.policy.overridden],
+						unsupported: [...agent.policy.unsupported],
+					}
+				: undefined,
+		};
+	}
+}

--- a/extensions/pi-subagents/src/registry.ts
+++ b/extensions/pi-subagents/src/registry.ts
@@ -133,7 +133,6 @@ export class AgentRegistry {
 		let timer: NodeJS.Timeout | undefined;
 		const timeout = new Promise<"timeout">((resolve) => {
 			timer = setTimeout(() => resolve("timeout"), Math.max(1, timeoutMs));
-			timer.unref();
 		});
 		const result = await Promise.race([running, timeout]);
 		if (timer) clearTimeout(timer);

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -11,8 +11,17 @@ import type {
 	AgentSource,
 	SubagentThinkingLevel,
 } from "./agents.js";
+import {
+	appendBounded,
+	DEFAULT_MAX_CONTEXT_BYTES,
+	DEFAULT_MAX_MESSAGES,
+	DEFAULT_MAX_OUTPUT_BYTES,
+	DEFAULT_MAX_STDERR_BYTES,
+	truncateUtf8,
+} from "./limits.js";
+import { JsonLineDecoder } from "./protocol.js";
 
-const KILL_GRACE_MS = 5000;
+export const KILL_GRACE_MS = 5000;
 
 export interface UsageStats {
 	input: number;
@@ -40,6 +49,14 @@ export interface SingleResult {
 	finalOutput?: string;
 	timedOut?: boolean;
 	timeoutMs?: number;
+	aborted?: boolean;
+	truncated?: boolean;
+	malformedEvents?: number;
+	policy?: {
+		inherited: string[];
+		overridden: string[];
+		unsupported: string[];
+	};
 }
 
 export interface SubagentDetails {
@@ -48,6 +65,7 @@ export interface SubagentDetails {
 	projectAgentsDir: string | null;
 	results: SingleResult[];
 	aggregator?: SingleResult;
+	isError?: boolean;
 }
 
 function getFinalOutput(messages: Message[]): string {
@@ -66,8 +84,28 @@ export function getResultFinalOutput(result: SingleResult): string {
 	return result.finalOutput ?? getFinalOutput(result.messages);
 }
 
-export function buildFanInContext(results: SingleResult[]): string {
-	return results
+function boundMessageText(message: Message, maxBytes: number): { message: Message; bytes: number; truncated: boolean } {
+	const serializedBytes = Buffer.byteLength(JSON.stringify(message), "utf8");
+	if (serializedBytes <= maxBytes) return { message, bytes: serializedBytes, truncated: false };
+	if (!Array.isArray(message.content)) return { message, bytes: Math.min(serializedBytes, maxBytes), truncated: true };
+	let remaining = maxBytes;
+	const content = message.content
+		.filter((part) => part.type === "text")
+		.map((part) => {
+			const bounded = truncateUtf8(part.text, remaining);
+			remaining = Math.max(0, remaining - Buffer.byteLength(bounded.text, "utf8"));
+			return { ...part, text: bounded.text };
+		});
+	const boundedMessage = { ...message, content } as Message;
+	return {
+		message: boundedMessage,
+		bytes: Math.min(Buffer.byteLength(JSON.stringify(boundedMessage), "utf8"), maxBytes),
+		truncated: true,
+	};
+}
+
+export function buildFanInContext(results: SingleResult[], maxBytes = DEFAULT_MAX_CONTEXT_BYTES): string {
+	const text = results
 		.map((result, index) => {
 			const status = result.exitCode === 0 ? "completed" : result.exitCode === -1 ? "running" : "failed";
 			const output = getResultFinalOutput(result);
@@ -79,12 +117,15 @@ export function buildFanInContext(results: SingleResult[]): string {
 			].join("\n\n");
 		})
 		.join("\n\n---\n\n");
+	return truncateUtf8(text, maxBytes).text;
 }
 
 export async function mapWithConcurrencyLimit<TIn, TOut>(
 	items: TIn[],
 	concurrency: number,
 	fn: (item: TIn, index: number) => Promise<TOut>,
+	signal?: AbortSignal,
+	onSkipped?: (item: TIn, index: number) => TOut,
 ): Promise<TOut[]> {
 	if (items.length === 0) return [];
 	const limit = Math.max(1, Math.min(concurrency, items.length));
@@ -94,6 +135,10 @@ export async function mapWithConcurrencyLimit<TIn, TOut>(
 		while (true) {
 			const current = nextIndex++;
 			if (current >= items.length) return;
+			if (signal?.aborted && onSkipped) {
+				results[current] = onSkipped(items[current], current);
+				continue;
+			}
 			results[current] = await fn(items[current], current);
 		}
 	});
@@ -146,30 +191,37 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 	return { command: "pi", args };
 }
 
-function terminateProcess(proc: ReturnType<typeof spawn>) {
-	if (proc.killed) return;
+function signalProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
 	if (process.platform !== "win32" && proc.pid) {
 		try {
-			process.kill(-proc.pid, "SIGTERM");
+			process.kill(-proc.pid, signal);
+			return;
 		} catch {
-			proc.kill("SIGTERM");
+			// Fall back to signaling the immediate child when process-group signaling is unavailable.
 		}
-	} else {
-		proc.kill("SIGTERM");
 	}
+	try {
+		proc.kill(signal);
+	} catch {
+		// The process may already have exited.
+	}
+}
 
-	setTimeout(() => {
-		if (proc.killed) return;
-		if (process.platform !== "win32" && proc.pid) {
-			try {
-				process.kill(-proc.pid, "SIGKILL");
-			} catch {
-				proc.kill("SIGKILL");
-			}
-		} else {
-			proc.kill("SIGKILL");
-		}
-	}, KILL_GRACE_MS).unref();
+export function terminateProcess(proc: ReturnType<typeof spawn>, graceMs = KILL_GRACE_MS): () => void {
+	let closed = proc.exitCode !== null || proc.signalCode !== null;
+	const onClose = () => {
+		closed = true;
+	};
+	proc.once("close", onClose);
+	if (!closed) signalProcess(proc, "SIGTERM");
+	const escalation = setTimeout(() => {
+		if (!closed) signalProcess(proc, "SIGKILL");
+	}, graceMs);
+	escalation.unref();
+	return () => {
+		clearTimeout(escalation);
+		proc.off("close", onClose);
+	};
 }
 
 export type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
@@ -186,6 +238,7 @@ export async function runSingleAgent(
 	timeoutMs: number,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
+	invocationOverride?: { command: string; argsPrefix?: string[] },
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 
@@ -233,6 +286,26 @@ export async function runSingleAgent(
 	};
 
 	try {
+		const effectiveCwd = cwd ?? defaultCwd;
+		try {
+			if (!fs.statSync(effectiveCwd).isDirectory()) throw new Error("not a directory");
+		} catch (error) {
+			currentResult.exitCode = 1;
+			currentResult.stopReason = "error";
+			const reason = error instanceof Error ? error.message : String(error);
+			currentResult.errorMessage = `Invalid subagent cwd: ${effectiveCwd} (${reason})`;
+			currentResult.stderr = currentResult.errorMessage;
+			return currentResult;
+		}
+
+		if (signal?.aborted) {
+			currentResult.exitCode = 130;
+			currentResult.aborted = true;
+			currentResult.stopReason = "aborted";
+			currentResult.errorMessage = "Subagent was aborted before start";
+			return currentResult;
+		}
+
 		if (agent.systemPrompt.trim()) {
 			const tmp = await writePromptToTempFile(agent.name, agent.systemPrompt);
 			tmpPromptDir = tmp.dir;
@@ -250,45 +323,63 @@ export async function runSingleAgent(
 		let timedOut = false;
 
 		const exitCode = await new Promise<number>((resolve) => {
-			const invocation = getPiInvocation(args);
+			const invocation = invocationOverride
+				? {
+						command: invocationOverride.command,
+						args: [...(invocationOverride.argsPrefix ?? []), ...args],
+					}
+				: getPiInvocation(args);
 			let settled = false;
+			let cleanupTermination: (() => void) | undefined;
+			let timeout: NodeJS.Timeout | undefined;
+			let abortHandler: (() => void) | undefined;
 			const finish = (code: number) => {
 				if (settled) return;
 				settled = true;
-				clearTimeout(timeout);
+				if (timeout) clearTimeout(timeout);
+				cleanupTermination?.();
+				if (signal && abortHandler) signal.removeEventListener("abort", abortHandler);
 				resolve(code);
 			};
-			const proc = spawn(invocation.command, invocation.args, {
-				cwd: cwd ?? defaultCwd,
-				detached: process.platform !== "win32",
-				shell: false,
-				stdio: ["ignore", "pipe", "pipe"],
-			});
-			let buffer = "";
-			const timeout = setTimeout(() => {
-				timedOut = true;
-				currentResult.timedOut = true;
-				currentResult.stopReason = "timeout";
-				currentResult.errorMessage = `Subagent timed out after ${timeoutMs}ms`;
-				currentResult.stderr += `${currentResult.stderr ? "\n" : ""}Subagent timed out after ${timeoutMs}ms.`;
-				emitUpdate();
-				terminateProcess(proc);
-			}, timeoutMs);
-			timeout.unref();
+			let proc: ReturnType<typeof spawn>;
+			try {
+				proc = spawn(invocation.command, invocation.args, {
+					cwd: effectiveCwd,
+					detached: process.platform !== "win32",
+					shell: false,
+					stdio: ["ignore", "pipe", "pipe"],
+					env: {
+						...process.env,
+						PI_SUBAGENT_DEPTH: String(
+							(Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0) + 1,
+						),
+					},
+				});
+			} catch (error) {
+				currentResult.errorMessage = error instanceof Error ? error.message : String(error);
+				currentResult.stderr = currentResult.errorMessage;
+				finish(1);
+				return;
+			}
 
-			const processLine = (line: string) => {
-				if (!line.trim()) return;
-				let event: any;
-				try {
-					event = JSON.parse(line);
-				} catch {
+			let capturedMessageBytes = 0;
+			const addMessage = (msg: Message) => {
+				if (currentResult.messages.length >= DEFAULT_MAX_MESSAGES) {
+					currentResult.truncated = true;
 					return;
 				}
-
+				const remaining = Math.max(0, DEFAULT_MAX_OUTPUT_BYTES - capturedMessageBytes);
+				const boundedMessage = boundMessageText(msg, remaining);
+				capturedMessageBytes += boundedMessage.bytes;
+				currentResult.truncated ||= boundedMessage.truncated;
+				currentResult.messages.push(boundedMessage.message);
+			};
+			const processEvent = (raw: unknown) => {
+				if (!raw || typeof raw !== "object") return;
+				const event = raw as { type?: string; message?: Message };
 				if (event.type === "message_end" && event.message) {
-					const msg = event.message as Message;
-					currentResult.messages.push(msg);
-
+					const msg = event.message;
+					addMessage(msg);
 					if (msg.role === "assistant") {
 						currentResult.usage.turns++;
 						const usage = msg.usage;
@@ -305,51 +396,88 @@ export async function runSingleAgent(
 						if (msg.errorMessage) currentResult.errorMessage = msg.errorMessage;
 					}
 					emitUpdate();
-				}
-
-				if (event.type === "tool_result_end" && event.message) {
-					currentResult.messages.push(event.message as Message);
+				} else if (event.type === "tool_result_end" && event.message) {
+					addMessage(event.message);
 					emitUpdate();
 				}
 			};
-
-			proc.stdout.on("data", (data) => {
-				buffer += data.toString();
-				const lines = buffer.split("\n");
-				buffer = lines.pop() || "";
-				for (const line of lines) processLine(line);
+			const decoder = new JsonLineDecoder({
+				onValue: processEvent,
+				onMalformed: () => {
+					currentResult.malformedEvents = (currentResult.malformedEvents ?? 0) + 1;
+				},
+				onOversized: () => {
+					currentResult.truncated = true;
+				},
 			});
 
-			proc.stderr.on("data", (data) => {
-				currentResult.stderr += data.toString();
-			});
+			timeout = setTimeout(() => {
+				timedOut = true;
+				currentResult.timedOut = true;
+				currentResult.stopReason = "timeout";
+				currentResult.errorMessage = `Subagent timed out after ${timeoutMs}ms`;
+				const bounded = appendBounded(
+					currentResult.stderr,
+					`\nSubagent timed out after ${timeoutMs}ms.`,
+					DEFAULT_MAX_STDERR_BYTES,
+				);
+				currentResult.stderr = bounded.text;
+				currentResult.truncated ||= bounded.truncated;
+				emitUpdate();
+				cleanupTermination = terminateProcess(proc);
+			}, timeoutMs);
+			timeout.unref();
 
+			proc.stdout?.on("data", (data) => decoder.push(data));
+			proc.stderr?.on("data", (data) => {
+				const bounded = appendBounded(currentResult.stderr, data.toString(), DEFAULT_MAX_STDERR_BYTES);
+				currentResult.stderr = bounded.text;
+				currentResult.truncated ||= bounded.truncated;
+			});
 			proc.on("close", (code) => {
-				if (buffer.trim()) processLine(buffer);
-				finish(timedOut ? 124 : (code ?? 0));
+				decoder.finish();
+				finish(timedOut ? 124 : wasAborted ? 130 : (code ?? 0));
 			});
-
 			proc.on("error", (error) => {
 				currentResult.errorMessage = error.message;
-				currentResult.stderr += `${currentResult.stderr ? "\n" : ""}${error.message}`;
+				const bounded = appendBounded(
+					currentResult.stderr,
+					`${currentResult.stderr ? "\n" : ""}${error.message}`,
+					DEFAULT_MAX_STDERR_BYTES,
+				);
+				currentResult.stderr = bounded.text;
+				currentResult.truncated ||= bounded.truncated;
 				finish(1);
 			});
 
 			if (signal) {
-				const killProc = () => {
+				abortHandler = () => {
+					if (timedOut || settled) return;
 					wasAborted = true;
+					currentResult.aborted = true;
 					currentResult.stopReason = "aborted";
 					currentResult.errorMessage = "Subagent was aborted";
-					terminateProcess(proc);
+					cleanupTermination = terminateProcess(proc);
 				};
-				if (signal.aborted) killProc();
-				else signal.addEventListener("abort", killProc, { once: true });
+				if (signal.aborted) abortHandler();
+				else signal.addEventListener("abort", abortHandler, { once: true });
 			}
 		});
 
 		currentResult.exitCode = exitCode;
-		currentResult.finalOutput = getFinalOutput(currentResult.messages);
-		if (wasAborted && !timedOut) throw new Error("Subagent was aborted");
+		const final = truncateUtf8(getFinalOutput(currentResult.messages), DEFAULT_MAX_OUTPUT_BYTES);
+		currentResult.finalOutput = final.text;
+		currentResult.truncated ||= final.truncated;
+		currentResult.policy = {
+			inherited: ["environment"],
+			overridden: [
+				"cwd",
+				...(agent.model ? ["model"] : []),
+				...(thinkingLevel ? ["thinkingLevel"] : []),
+				...(agent.tools ? ["tools"] : []),
+			],
+			unsupported: ["approvalPolicy", "sandboxProfile", "providerHeaders"],
+		};
 		return currentResult;
 	} finally {
 		if (tmpPromptPath)

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -60,16 +60,32 @@ export function normalizeAgentSettings(value: unknown): SubagentAgentConfig | un
 
 export function normalizeSubagentSettings(value: unknown): SubagentSettings | undefined {
 	if (!isPlainObject(value)) return undefined;
-	if (!hasOwn(value, "agents")) return {};
-	if (!isPlainObject(value.agents)) return undefined;
-
-	const agents: Record<string, SubagentAgentConfig> = {};
-	for (const [name, rawConfig] of Object.entries(value.agents)) {
-		const config = normalizeAgentSettings(rawConfig);
-		if (config) agents[name] = config;
+	const settings: SubagentSettings = {};
+	if (hasOwn(value, "agents")) {
+		if (!isPlainObject(value.agents)) return undefined;
+		const agents: Record<string, SubagentAgentConfig> = {};
+		for (const [name, rawConfig] of Object.entries(value.agents)) {
+			const config = normalizeAgentSettings(rawConfig);
+			if (config) agents[name] = config;
+		}
+		if (Object.keys(agents).length > 0) settings.agents = agents;
 	}
-
-	return Object.keys(agents).length > 0 ? { agents } : {};
+	if (hasOwn(value, "stateful")) {
+		if (!isPlainObject(value.stateful)) return undefined;
+		const runtime: NonNullable<SubagentSettings["stateful"]> = {};
+		for (const key of ["maxAgents", "maxActiveTurns", "idleTtlMs", "retentionDays", "maxStoredAgents"] as const) {
+			if (hasOwn(value.stateful, key)) {
+				if (!isPositiveNumber(value.stateful[key])) return undefined;
+				runtime[key] = value.stateful[key];
+			}
+		}
+		if (hasOwn(value.stateful, "enabled")) {
+			if (typeof value.stateful.enabled !== "boolean") return undefined;
+			runtime.enabled = value.stateful.enabled;
+		}
+		settings.stateful = runtime;
+	}
+	return settings;
 }
 
 export function readSubagentSettings(): SubagentSettings | undefined {

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -1,0 +1,278 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { discoverAgents, type AgentScope } from "./agents.js";
+import { buildContextSnapshot, type ContextMode } from "./context.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import { AgentPersistence } from "./persistence.js";
+import { AgentRegistry, type ManagedAgent } from "./registry.js";
+import { getResultFinalOutput, runSingleAgent, type SubagentDetails } from "./runner.js";
+import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
+
+const ContextModeSchema = Type.Union([
+	StringEnum(["none", "all"] as const),
+	Type.Number({ minimum: 1, description: "Include the most recent N user turns." }),
+]);
+const ScopeSchema = StringEnum(["user", "project", "both"] as const);
+
+export function registerStatefulSubagents(pi: ExtensionAPI): void {
+	const settings = readSubagentSettings()?.stateful;
+	if (!settings?.enabled) return;
+
+	let registry: AgentRegistry | undefined;
+	let persistence: AgentPersistence | undefined;
+	let sweepTimer: NodeJS.Timeout | undefined;
+
+	const requireRegistry = () => {
+		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
+		return registry;
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		const owner = ctx.sessionManager.getSessionId?.() ?? ctx.sessionManager.getSessionFile?.() ?? `ephemeral:${ctx.cwd}`;
+		persistence = new AgentPersistence(owner, {
+			retentionDays: settings.retentionDays,
+			maxStoredAgents: settings.maxStoredAgents,
+		});
+		registry = new AgentRegistry(createTurnRunner(ctx), {
+			maxAgents: settings.maxAgents,
+			maxActiveTurns: settings.maxActiveTurns,
+			idleTtlMs: settings.idleTtlMs,
+			onChange: async (agents) => {
+				await persistence?.save(agents);
+			},
+		});
+		const restored = persistence
+			.load()
+			.filter((agent) => agent.agentScope !== "project" && agent.agentScope !== "both" || ctx.isProjectTrusted());
+		registry.restore(restored);
+		const sweepEveryMs = Math.max(1_000, Math.min(settings.idleTtlMs ?? 60 * 60 * 1000, 60_000));
+		sweepTimer = setInterval(() => void registry?.sweepExpired(), sweepEveryMs);
+		sweepTimer.unref();
+	});
+
+	pi.on("session_shutdown", async () => {
+		if (sweepTimer) clearInterval(sweepTimer);
+		sweepTimer = undefined;
+		await registry?.shutdown();
+		registry = undefined;
+		persistence = undefined;
+	});
+
+	pi.registerTool({
+		name: "subagent_spawn",
+		label: "Spawn Subagent",
+		description: "Start an addressable logical subagent. Returns immediately with an agentId.",
+		promptSnippet: "Start a reusable subagent and receive an agentId for lifecycle operations",
+		parameters: Type.Object({
+			agent: Type.String(),
+			task: Type.String(),
+			cwd: Type.Optional(Type.String()),
+			agentScope: Type.Optional(ScopeSchema),
+			confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
+			context: Type.Optional(ContextModeSchema),
+		}),
+		async execute(_id, params, _signal, _update, ctx) {
+			const scope = (params.agentScope ?? "user") as AgentScope;
+			await confirmProjectAgent(params.agent, scope, params.confirmProjectAgents ?? true, ctx);
+			const mode = normalizeContextMode(params.context);
+			const snapshot = buildContextSnapshot(ctx.sessionManager.getBranch(), mode, DEFAULT_MAX_CONTEXT_BYTES);
+			const agent = await requireRegistry().spawn({
+				agent: params.agent,
+				task: params.task,
+				cwd: params.cwd ?? ctx.cwd,
+				agentScope: scope,
+				context: snapshot.text || undefined,
+				contextTruncated: snapshot.truncated,
+			});
+			return result(agent, `Spawned ${agent.agent} as ${agent.id}.`);
+		},
+	});
+
+	pi.registerTool({
+		name: "subagent_send",
+		label: "Send Subagent Follow-up",
+		description: "Send a follow-up task to an idle, completed, interrupted, or failed subagent.",
+		parameters: Type.Object({ agentId: Type.String(), task: Type.String() }),
+		async execute(_id, params) {
+			const agent = await requireRegistry().followUp(params.agentId, params.task);
+			return result(agent, `Started follow-up for ${agent.id}.`);
+		},
+	});
+
+	pi.registerTool({
+		name: "subagent_wait",
+		label: "Wait for Subagent",
+		description: "Wait for a stateful subagent turn without terminating it when the wait times out.",
+		parameters: Type.Object({
+			agentId: Type.String(),
+			timeoutMs: Type.Optional(Type.Number({ minimum: 1, maximum: 3_600_000, default: 30_000 })),
+		}),
+		async execute(_id, params) {
+			const waited = await requireRegistry().wait(params.agentId, params.timeoutMs);
+			return result(
+				waited.agent,
+				waited.timedOut
+					? `Wait timed out; ${waited.agent.id} is ${waited.agent.state}.`
+					: formatFinal(waited.agent),
+			);
+		},
+	});
+
+	pi.registerTool({
+		name: "subagent_list",
+		label: "List Subagents",
+		description: "List stateful subagents and lifecycle states.",
+		parameters: Type.Object({ includeClosed: Type.Optional(Type.Boolean({ default: false })) }),
+		async execute(_id, params) {
+			const agents = requireRegistry().list(params.includeClosed);
+			return {
+				content: [
+					{
+						type: "text",
+						text: agents.length
+							? agents.map(formatLine).join("\n")
+							: "No stateful subagents.",
+					},
+				],
+				details: { agents },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "subagent_interrupt",
+		label: "Interrupt Subagent",
+		description: "Interrupt the current turn while retaining the subagent for follow-up work.",
+		parameters: Type.Object({ agentId: Type.String() }),
+		async execute(_id, params) {
+			const agent = await requireRegistry().interrupt(params.agentId);
+			return result(agent, `Interrupted ${agent.id}; it remains reusable.`);
+		},
+	});
+
+	pi.registerTool({
+		name: "subagent_close",
+		label: "Close Subagent",
+		description: "Close a stateful subagent and remove it from retained persistence.",
+		parameters: Type.Object({ agentId: Type.String() }),
+		async execute(_id, params) {
+			const agent = await requireRegistry().close(params.agentId);
+			return result(agent, `Closed ${agent.id}.`);
+		},
+	});
+
+	pi.registerCommand("subagents:agents", {
+		description: "Inspect or clear stateful subagents",
+		getArgumentCompletions(prefix: string) {
+			return ["list", "clear"]
+				.filter((value) => value.startsWith(prefix))
+				.map((value) => ({ value, label: value }));
+		},
+		async handler(args, ctx) {
+			if (args.trim() === "clear") {
+				await requireRegistry().closeAll();
+				await persistence?.delete();
+				ctx.ui.notify("Cleared stateful subagents.", "info");
+				return;
+			}
+			const agents = requireRegistry().list(true);
+			ctx.ui.notify(
+				agents.length ? agents.map(formatLine).join("\n") : "No stateful subagents.",
+				"info",
+			);
+		},
+	});
+}
+
+function createTurnRunner(ctx: ExtensionContext) {
+	return async (record: ManagedAgent, task: string, signal: AbortSignal) => {
+		const settings = readSubagentSettings();
+		const discovery = discoverAgents(record.cwd, record.agentScope ?? "user", settings);
+		const agent = discovery.agents.find((candidate) => candidate.name === record.agent);
+		const previous = record.history
+			.map((turn) => `Task: ${turn.task}\nOutput: ${turn.output}`)
+			.join("\n\n");
+		const context = [
+			`Current task:\n${task}`,
+			previous ? `Prior subagent turns:\n${previous}` : "",
+			record.context ? `Parent context:\n${record.context}` : "",
+		]
+			.filter(Boolean)
+			.join("\n\n---\n\n");
+		const boundedTask = truncateUtf8(context, DEFAULT_MAX_CONTEXT_BYTES);
+		const makeDetails = (results: SubagentDetails["results"]): SubagentDetails => ({
+			mode: "single",
+			agentScope: record.agentScope ?? "user",
+			projectAgentsDir: discovery.projectAgentsDir,
+			results,
+		});
+		const single = await runSingleAgent(
+			record.cwd,
+			discovery.agents,
+			record.agent,
+			boundedTask.text,
+			undefined,
+			undefined,
+			signal,
+			resolveSubagentThinkingLevel(discovery.agents, record.agent),
+			agent?.timeoutMs ?? 10 * 60 * 1000,
+			undefined,
+			makeDetails,
+		);
+		return {
+			output: getResultFinalOutput(single),
+			exitCode: single.exitCode,
+			aborted: single.aborted,
+			truncated: single.truncated || boundedTask.truncated,
+			error: single.errorMessage || single.stderr || undefined,
+			policy: single.policy,
+		};
+	};
+}
+
+async function confirmProjectAgent(
+	name: string,
+	scope: AgentScope,
+	confirm: boolean,
+	ctx: ExtensionContext,
+): Promise<void> {
+	if (scope !== "project" && scope !== "both") return;
+	const discovery = discoverAgents(ctx.cwd, scope, readSubagentSettings());
+	const agent = discovery.agents.find((candidate) => candidate.name === name);
+	if (agent?.source !== "project") return;
+	if (!ctx.isProjectTrusted()) {
+		throw new Error("Project-local subagent definitions require a trusted project");
+	}
+	if (confirm && ctx.hasUI) {
+		const approved = await ctx.ui.confirm("Run project-local agent?", `Agent: ${name}\nSource: ${agent.filePath}`);
+		if (!approved) throw new Error("Project-local subagent was not approved");
+	}
+}
+
+function normalizeContextMode(value: "none" | "all" | number | undefined): ContextMode {
+	if (value === undefined) return "none";
+	if (value === "none" || value === "all") return value;
+	return Math.max(1, Math.floor(value));
+}
+
+function formatLine(agent: ManagedAgent): string {
+	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - agent.updatedAt) / 1000));
+	const actions =
+		agent.state === "running" || agent.state === "starting"
+			? "wait, interrupt, close"
+			: agent.state === "closed"
+				? "inspect"
+				: "send, close";
+	const task = agent.currentTask ? ` — ${agent.currentTask.slice(0, 80)}` : "";
+	return `${agent.id} ${agent.agent} ${agent.state} ${elapsedSeconds}s [${actions}]${task}`;
+}
+
+function formatFinal(agent: ManagedAgent): string {
+	const last = agent.history.at(-1);
+	return last?.output || agent.error || `${agent.id} is ${agent.state}.`;
+}
+
+function result(agent: ManagedAgent, text: string) {
+	return { content: [{ type: "text" as const, text }], details: { agent } };
+}

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -1,8 +1,10 @@
+import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
-import { discoverAgents, type AgentScope } from "./agents.js";
-import { buildContextSnapshot, type ContextMode } from "./context.js";
+import { discoverAgents, type AgentConfig, type AgentScope } from "./agents.js";
+import { buildContextSnapshot, type ContextMode, redactPrivateText } from "./context.js";
+import { assertSubagentDepthAllowed, resolveDefaultSubagentTimeoutMs } from "./execution.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import { AgentPersistence } from "./persistence.js";
 import { AgentRegistry, type ManagedAgent } from "./registry.js";
@@ -74,13 +76,15 @@ export function registerStatefulSubagents(pi: ExtensionAPI): void {
 		}),
 		async execute(_id, params, _signal, _update, ctx) {
 			const scope = (params.agentScope ?? "user") as AgentScope;
-			await confirmProjectAgent(params.agent, scope, params.confirmProjectAgents ?? true, ctx);
+			assertSubagentDepthAllowed();
+			const cwd = params.cwd ?? ctx.cwd;
+			await confirmProjectAgent(params.agent, scope, params.confirmProjectAgents ?? true, ctx, cwd);
 			const mode = normalizeContextMode(params.context);
 			const snapshot = buildContextSnapshot(ctx.sessionManager.getBranch(), mode, DEFAULT_MAX_CONTEXT_BYTES);
 			const agent = await requireRegistry().spawn({
 				agent: params.agent,
 				task: params.task,
-				cwd: params.cwd ?? ctx.cwd,
+				cwd,
 				agentScope: scope,
 				context: snapshot.text || undefined,
 				contextTruncated: snapshot.truncated,
@@ -190,17 +194,7 @@ function createTurnRunner(ctx: ExtensionContext) {
 		const settings = readSubagentSettings();
 		const discovery = discoverAgents(record.cwd, record.agentScope ?? "user", settings);
 		const agent = discovery.agents.find((candidate) => candidate.name === record.agent);
-		const previous = record.history
-			.map((turn) => `Task: ${turn.task}\nOutput: ${turn.output}`)
-			.join("\n\n");
-		const context = [
-			`Current task:\n${task}`,
-			previous ? `Prior subagent turns:\n${previous}` : "",
-			record.context ? `Parent context:\n${record.context}` : "",
-		]
-			.filter(Boolean)
-			.join("\n\n---\n\n");
-		const boundedTask = truncateUtf8(context, DEFAULT_MAX_CONTEXT_BYTES);
+		const boundedTask = buildStatefulTurnPrompt(record, task);
 		const makeDetails = (results: SubagentDetails["results"]): SubagentDetails => ({
 			mode: "single",
 			agentScope: record.agentScope ?? "user",
@@ -216,7 +210,7 @@ function createTurnRunner(ctx: ExtensionContext) {
 			undefined,
 			signal,
 			resolveSubagentThinkingLevel(discovery.agents, record.agent),
-			agent?.timeoutMs ?? 10 * 60 * 1000,
+			resolveStatefulTurnTimeout(agent),
 			undefined,
 			makeDetails,
 		);
@@ -231,16 +225,46 @@ function createTurnRunner(ctx: ExtensionContext) {
 	};
 }
 
+export function buildStatefulTurnPrompt(
+	record: Pick<ManagedAgent, "context" | "history">,
+	task: string,
+	maxBytes = DEFAULT_MAX_CONTEXT_BYTES,
+): { text: string; truncated: boolean } {
+	const previous = record.history
+		.map((turn) => {
+			const redactedTask = redactPrivateText(turn.task);
+			const redactedOutput = redactPrivateText(turn.output);
+			return `Task: ${redactedTask}\nOutput: ${redactedOutput}`;
+		})
+		.join("\n\n");
+	const context = [
+		`Current task:\n${task}`,
+		previous ? `Prior subagent turns:\n${previous}` : "",
+		record.context ? `Parent context:\n${redactPrivateText(record.context)}` : "",
+	]
+		.filter(Boolean)
+		.join("\n\n---\n\n");
+	return truncateUtf8(context, maxBytes);
+}
+
+export function resolveStatefulTurnTimeout(agent: Pick<AgentConfig, "timeoutMs"> | undefined): number {
+	return agent?.timeoutMs ?? resolveDefaultSubagentTimeoutMs();
+}
+
 async function confirmProjectAgent(
 	name: string,
 	scope: AgentScope,
 	confirm: boolean,
 	ctx: ExtensionContext,
+	cwd: string,
 ): Promise<void> {
 	if (scope !== "project" && scope !== "both") return;
-	const discovery = discoverAgents(ctx.cwd, scope, readSubagentSettings());
+	const discovery = discoverAgents(cwd, scope, readSubagentSettings());
 	const agent = discovery.agents.find((candidate) => candidate.name === name);
 	if (agent?.source !== "project") return;
+	if (!isSameCwd(cwd, ctx.cwd)) {
+		throw new Error("Project-local subagent definitions cannot run with an overridden cwd");
+	}
 	if (!ctx.isProjectTrusted()) {
 		throw new Error("Project-local subagent definitions require a trusted project");
 	}
@@ -248,6 +272,10 @@ async function confirmProjectAgent(
 		const approved = await ctx.ui.confirm("Run project-local agent?", `Agent: ${name}\nSource: ${agent.filePath}`);
 		if (!approved) throw new Error("Project-local subagent was not approved");
 	}
+}
+
+function isSameCwd(left: string, right: string): boolean {
+	return path.resolve(left) === path.resolve(right);
 }
 
 function normalizeContextMode(value: "none" | "all" | number | undefined): ContextMode {

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -18,6 +18,7 @@ import { SubagentParams } from "./params.js";
 import { executeSubagent } from "./execution.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
 import type { SubagentDetails } from "./runner.js";
+import { registerStatefulSubagents } from "./stateful.js";
 
 export default function (pi: ExtensionAPI) {
 	pi.registerTool<typeof SubagentParams, SubagentDetails>({
@@ -57,8 +58,13 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	pi.on("tool_result", (event) => {
+		if (event.toolName !== "subagent") return;
+		if ((event.details as (SubagentDetails & { isError?: boolean }) | undefined)?.isError) return { isError: true };
+	});
 
 	registerSubagentConfigCommand(pi);
+	registerStatefulSubagents(pi);
 }
 export { formatTokens, formatUsageStats } from "./render.js";
 export { buildPiArgs } from "./runner.js";

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -1,0 +1,471 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { buildContextSnapshot, redactPrivateText } from "../src/context.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "../src/limits.js";
+import { AgentPersistence } from "../src/persistence.js";
+import { JsonLineDecoder } from "../src/protocol.js";
+import { AgentRegistry, type ManagedAgent } from "../src/registry.js";
+import {
+	buildFanInContext,
+	mapWithConcurrencyLimit,
+	runSingleAgent,
+	terminateProcess,
+} from "../src/runner.js";
+import { normalizeSubagentSettings } from "../src/settings.js";
+import { registerStatefulSubagents } from "../src/stateful.js";
+
+function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+	return {
+		id: "sa_test",
+		agent: "scout",
+		state: "completed",
+		createdAt: 1,
+		updatedAt: Date.now(),
+		cwd: process.cwd(),
+		history: [],
+		...overrides,
+	};
+}
+
+test("JsonLineDecoder handles fragmented, malformed, trailing, and oversized lines", () => {
+	const values: unknown[] = [];
+	const malformed: string[] = [];
+	const oversized: number[] = [];
+	const decoder = new JsonLineDecoder({
+		maxLineBytes: 16,
+		onValue: (value) => values.push(value),
+		onMalformed: (line) => malformed.push(line),
+		onOversized: (bytes) => oversized.push(bytes),
+	});
+	decoder.push('{"ok":');
+	decoder.push("1}\nnot-json\n");
+	decoder.push("x".repeat(17));
+	decoder.push('\n{"tail":2}');
+	decoder.finish();
+	assert.deepEqual(values, [{ ok: 1 }, { tail: 2 }]);
+	assert.deepEqual(malformed, ["not-json"]);
+	assert.equal(oversized.length, 1);
+});
+
+test("UTF-8 and fan-in truncation are bounded and marked", () => {
+	const bounded = truncateUtf8("界".repeat(100), 80);
+	assert.ok(Buffer.byteLength(bounded.text) <= 80);
+	assert.equal(bounded.truncated, true);
+	assert.doesNotMatch(bounded.text, /�/);
+	const fanIn = buildFanInContext([
+		{
+			...record(),
+			agentSource: "built-in",
+			task: "large",
+			exitCode: 0,
+			messages: [],
+			stderr: "",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: 0,
+				contextTokens: 0,
+				turns: 0,
+			},
+			finalOutput: "x".repeat(DEFAULT_MAX_CONTEXT_BYTES),
+		},
+	]);
+	assert.ok(Buffer.byteLength(fanIn) <= DEFAULT_MAX_CONTEXT_BYTES);
+	assert.match(fanIn, /truncated/);
+});
+
+test("context snapshots keep only user/assistant text, recent turns, and redact private content", () => {
+	const snapshot = buildContextSnapshot(
+		[
+			{ type: "message", message: { role: "user", content: [{ type: "text", text: "old" }] } },
+			{
+				type: "message",
+				message: { role: "toolResult", content: [{ type: "text", text: "secret tool output" }] },
+			},
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "hidden" },
+						{ type: "text", text: "answer" },
+					],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "new\n[subagent-private] token" }],
+				},
+			},
+		],
+		1,
+	);
+	assert.doesNotMatch(snapshot.text, /old|tool output|hidden|token/);
+	assert.match(snapshot.text, /new/);
+	assert.equal(snapshot.turns, 1);
+	assert.equal(redactPrivateText("a<private>secret</private>b"), "a[private content omitted]b");
+});
+
+test("mapWithConcurrencyLimit preserves input order and enforces its active limit", async () => {
+	let active = 0;
+	let peak = 0;
+	const results = await mapWithConcurrencyLimit([0, 1, 2, 3, 4, 5], 4, async (value) => {
+		active++;
+		peak = Math.max(peak, active);
+		await new Promise((resolve) => setTimeout(resolve, value % 2 ? 2 : 5));
+		active--;
+		return value * 2;
+	});
+	assert.equal(peak, 4);
+	assert.deepEqual(results, [0, 2, 4, 6, 8, 10]);
+
+	const controller = new AbortController();
+	controller.abort();
+	let started = 0;
+	const skipped = await mapWithConcurrencyLimit(
+		[1, 2],
+		1,
+		async (value) => {
+			started++;
+			return value;
+		},
+		controller.signal,
+		(value) => -value,
+	);
+	assert.equal(started, 0);
+	assert.deepEqual(skipped, [-1, -2]);
+});
+
+test("AgentRegistry supports follow-up, wait timeout, interrupt/reuse, limits, and close", async () => {
+	const registry = new AgentRegistry(
+		async (_agent, task, signal) => {
+			if (task === "slow") {
+				await new Promise<void>((resolve) =>
+					signal.addEventListener("abort", () => resolve(), { once: true }),
+				);
+			}
+			return {
+				output: `done:${task}`,
+				exitCode: signal.aborted ? 130 : 0,
+				aborted: signal.aborted,
+			};
+		},
+		{ maxAgents: 2, maxActiveTurns: 1 },
+	);
+	const first = await registry.spawn({ agent: "scout", task: "slow", cwd: process.cwd() });
+	const second = await registry.spawn({ agent: "reviewer", task: "queued", cwd: process.cwd() });
+	const queued = await registry.wait(second.id, 5);
+	assert.equal(queued.timedOut, true);
+	assert.equal(queued.agent.state, "starting");
+	const timed = await registry.wait(first.id, 5);
+	assert.equal(timed.timedOut, true);
+	const interrupted = await registry.interrupt(first.id);
+	assert.equal(interrupted.state, "interrupted");
+	assert.equal((await registry.wait(second.id, 100)).agent.state, "completed");
+	await registry.followUp(first.id, "again");
+	const completed = await registry.wait(first.id, 100);
+	assert.equal(completed.agent.state, "completed");
+	assert.deepEqual(
+		completed.agent.history.map((turn) => turn.task),
+		["slow", "again"],
+	);
+	await assert.rejects(
+		() => registry.spawn({ agent: "worker", task: "over", cwd: process.cwd() }),
+		/capacity/,
+	);
+	assert.equal((await registry.close(first.id)).state, "closed");
+	await assert.rejects(() => registry.close(first.id), /already closed/);
+});
+
+test("AgentRegistry shutdown aborts active work and drains queued work without starting it", async () => {
+	const started: string[] = [];
+	const registry = new AgentRegistry(
+		async (_agent, task, signal) => {
+			started.push(task);
+			await new Promise<void>((resolve) =>
+				signal.addEventListener("abort", () => resolve(), { once: true }),
+			);
+			return { output: "stopped", exitCode: 130, aborted: true };
+		},
+		{ maxActiveTurns: 1 },
+	);
+	const active = await registry.spawn({ agent: "scout", task: "active", cwd: process.cwd() });
+	const queued = await registry.spawn({ agent: "scout", task: "queued", cwd: process.cwd() });
+	await registry.shutdown();
+	assert.deepEqual(started, ["active"]);
+	assert.equal(registry.get(active.id)?.state, "idle");
+	assert.equal(registry.get(queued.id)?.state, "idle");
+});
+
+test("AgentRegistry evicts expired idle agents without touching active work", async () => {
+	let now = 1_000;
+	const registry = new AgentRegistry(async () => ({ output: "done", exitCode: 0 }), {
+		idleTtlMs: 100,
+		now: () => now,
+	});
+	const agent = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
+	await registry.wait(agent.id, 100);
+	now += 101;
+	assert.equal(await registry.sweepExpired(), 1);
+	assert.equal(registry.get(agent.id), undefined);
+});
+
+test("AgentRegistry keeps lifecycle usable when persistence callbacks fail", async () => {
+	const registry = new AgentRegistry(async () => ({ output: "done", exitCode: 0 }), {
+		onChange: async () => {
+			throw new Error("disk unavailable");
+		},
+	});
+	const agent = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
+	assert.equal((await registry.wait(agent.id, 100)).agent.state, "completed");
+});
+
+test("AgentRegistry restores persisted running agents as inert idle agents", () => {
+	const registry = new AgentRegistry(async () => ({ output: "", exitCode: 0 }));
+	registry.restore([record({ state: "running", currentTask: "must not resume" })]);
+	const restored = registry.get("sa_test");
+	assert.equal(restored?.state, "idle");
+	assert.equal(restored?.currentTask, undefined);
+});
+
+test("AgentPersistence atomically saves, restores, redacts, deletes, and quarantines bad state", async () => {
+	const dir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-state-"));
+	const persistence = new AgentPersistence("session", { stateDir: dir, maxStoredAgents: 2 });
+	await persistence.save([
+		record({
+			context: "<private>secret</private>",
+			history: [
+				{
+					task: "task",
+					output: "[subagent-private] hidden\nvisible",
+					startedAt: 1,
+					completedAt: 2,
+					exitCode: 0,
+				},
+			],
+		}),
+	]);
+	const raw = readFileSync(persistence.filePath, "utf8");
+	assert.doesNotMatch(raw, /secret|hidden/);
+	assert.equal(persistence.load()[0]?.state, "idle");
+	const competing = new AgentPersistence("session", { stateDir: dir, maxStoredAgents: 2 });
+	await Promise.all([
+		persistence.save([record({ id: "one" })]),
+		competing.save([record({ id: "two" })]),
+	]);
+	assert.ok(["one", "two"].includes(persistence.load()[0]?.id ?? ""));
+	await persistence.delete();
+	assert.deepEqual(persistence.load(), []);
+	writeFileSync(persistence.filePath, JSON.stringify({ version: 999, agents: [] }));
+	assert.deepEqual(persistence.load(), []);
+	writeFileSync(persistence.filePath, "not json");
+	assert.deepEqual(persistence.load(), []);
+	assert.ok(
+		readdirSync(dir).some((name) =>
+			name.startsWith(`${path.basename(persistence.filePath)}.invalid-`),
+		),
+	);
+});
+
+test("stateful tools are opt-in and expose the complete lifecycle surface", async () => {
+	const originalDir = process.env.PI_CODING_AGENT_DIR;
+	const dir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-config-"));
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		writeFileSync(
+			path.join(dir, "pi-subagents-config.json"),
+			JSON.stringify({ stateful: { enabled: true } }),
+		);
+		const mock = createMockPi();
+		registerStatefulSubagents(mock.pi);
+		assert.deepEqual(
+			mock.tools.map((tool) => tool.name),
+			[
+				"subagent_spawn",
+				"subagent_send",
+				"subagent_wait",
+				"subagent_list",
+				"subagent_interrupt",
+				"subagent_close",
+			],
+		);
+		assert.ok(mock.commands.has("subagents:agents"));
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const list = mock.tools.find((tool) => tool.name === "subagent_list") as {
+			execute: (...args: unknown[]) => Promise<{ content: Array<{ text: string }> }>;
+		};
+		const listed = await list.execute("id", {}, undefined, undefined, context.ctx);
+		assert.equal(listed.content[0].text, "No stateful subagents.");
+
+		const project = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-project-"));
+		const projectAgents = path.join(project, ".pi", "agents");
+		mkdirSync(projectAgents, { recursive: true });
+		writeFileSync(
+			path.join(projectAgents, "project.md"),
+			"---\nname: project\ndescription: project agent\n---\nDo project work.",
+		);
+		const untrusted = createMockContext({ cwd: project, isProjectTrusted: () => false });
+		const spawnTool = mock.tools.find((tool) => tool.name === "subagent_spawn") as {
+			execute: (...args: unknown[]) => Promise<unknown>;
+		};
+		await assert.rejects(
+			() =>
+				spawnTool.execute(
+					"id",
+					{
+						agent: "project",
+						task: "task",
+						agentScope: "project",
+						confirmProjectAgents: false,
+					},
+					undefined,
+					undefined,
+					untrusted.ctx,
+				),
+			/trusted project/,
+		);
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	} finally {
+		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalDir;
+	}
+});
+
+test("stateful settings validate bounded runtime options without breaking agent overrides", () => {
+	assert.deepEqual(
+		normalizeSubagentSettings({ stateful: { enabled: true, maxAgents: 8 }, agents: {} }),
+		{
+			stateful: { enabled: true, maxAgents: 8 },
+		},
+	);
+	assert.equal(normalizeSubagentSettings({ stateful: { maxAgents: 0 } }), undefined);
+});
+
+test("runSingleAgent normalizes invalid cwd without spawning or throwing", async () => {
+	const result = await runSingleAgent(
+		process.cwd(),
+		[
+			{
+				name: "test",
+				description: "test",
+				systemPrompt: "",
+				source: "built-in",
+				filePath: "built-in:test",
+			},
+		],
+		"test",
+		"task",
+		path.join(os.tmpdir(), "definitely-missing-pi-subagent-cwd"),
+		undefined,
+		undefined,
+		undefined,
+		100,
+		undefined,
+		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+	);
+	assert.equal(result.exitCode, 1);
+	assert.equal(result.stopReason, "error");
+	assert.match(result.errorMessage ?? "", /Invalid subagent cwd/);
+});
+
+test("runSingleAgent preserves partial output on mid-stream abort and handles pre-abort", async () => {
+	const script = [
+		"const message={role:'assistant',content:[{type:'text',text:'PARTIAL'}],timestamp:Date.now()};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		"setInterval(()=>{},1000);",
+	].join("");
+	const agents = [
+		{
+			name: "test",
+			description: "test",
+			systemPrompt: "",
+			source: "built-in" as const,
+			filePath: "built-in:test",
+		},
+	];
+	const makeDetails = (results: Parameters<Parameters<typeof runSingleAgent>[10]>[0]) => ({
+		mode: "single" as const,
+		agentScope: "user" as const,
+		projectAgentsDir: null,
+		results,
+	});
+	const controller = new AbortController();
+	let sawPartial = false;
+	const running = runSingleAgent(
+		process.cwd(),
+		agents,
+		"test",
+		"task",
+		undefined,
+		undefined,
+		controller.signal,
+		undefined,
+		1_000,
+		(partial) => {
+			if (partial.content[0]?.type === "text" && partial.content[0].text === "PARTIAL") {
+				sawPartial = true;
+				controller.abort();
+			}
+		},
+		makeDetails,
+		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },
+	);
+	const aborted = await running;
+	assert.equal(sawPartial, true);
+	assert.equal(aborted.aborted, true);
+	assert.equal(aborted.exitCode, 130);
+	assert.equal(aborted.finalOutput, "PARTIAL");
+
+	const preAborted = new AbortController();
+	preAborted.abort();
+	const beforeStart = await runSingleAgent(
+		process.cwd(),
+		agents,
+		"test",
+		"task",
+		undefined,
+		undefined,
+		preAborted.signal,
+		undefined,
+		1_000,
+		undefined,
+		makeDetails,
+		{ command: process.execPath, argsPrefix: ["-e", "setInterval(()=>{},1000)", "--"] },
+	);
+	assert.equal(beforeStart.aborted, true);
+	assert.equal(beforeStart.exitCode, 130);
+});
+
+test("terminateProcess escalates when a child ignores SIGTERM", {
+	skip: process.platform === "win32",
+}, async () => {
+	const child = spawn(
+		process.execPath,
+		[
+			"-e",
+			"process.on('SIGTERM',()=>{}); process.stdout.write('ready\\n'); setInterval(()=>{},1000)",
+		],
+		{ detached: true, stdio: ["ignore", "pipe", "ignore"] },
+	);
+	await new Promise<void>((resolve) => child.stdout?.once("data", () => resolve()));
+	const started = Date.now();
+	terminateProcess(child, 30);
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error("child did not exit")), 1000);
+		child.once("close", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+	assert.ok(Date.now() - started < 1000);
+});

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -17,7 +17,11 @@ import {
 	terminateProcess,
 } from "../src/runner.js";
 import { normalizeSubagentSettings } from "../src/settings.js";
-import { registerStatefulSubagents } from "../src/stateful.js";
+import {
+	buildStatefulTurnPrompt,
+	registerStatefulSubagents,
+	resolveStatefulTurnTimeout,
+} from "../src/stateful.js";
 
 function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	return {
@@ -113,6 +117,36 @@ test("context snapshots keep only user/assistant text, recent turns, and redact 
 	assert.match(snapshot.text, /new/);
 	assert.equal(snapshot.turns, 1);
 	assert.equal(redactPrivateText("a<private>secret</private>b"), "a[private content omitted]b");
+});
+
+test("stateful follow-up prompts redact retained history and honor global timeout", () => {
+	const originalTimeout = process.env.PI_SUBAGENT_TIMEOUT_MS;
+	process.env.PI_SUBAGENT_TIMEOUT_MS = "4321";
+	try {
+		const prompt = buildStatefulTurnPrompt(
+			record({
+				context: "parent <private>ctx-secret</private>",
+				history: [
+					{
+						task: "task <private>task-secret</private>",
+						output: "[subagent-private] hidden-line\nvisible output",
+						startedAt: 1,
+						completedAt: 2,
+						exitCode: 0,
+					},
+				],
+			}),
+			"next task",
+		);
+		assert.match(prompt.text, /Current task:\nnext task/);
+		assert.match(prompt.text, /visible output/);
+		assert.doesNotMatch(prompt.text, /ctx-secret|task-secret|hidden-line/);
+		assert.equal(resolveStatefulTurnTimeout(undefined), 4321);
+		assert.equal(resolveStatefulTurnTimeout({ timeoutMs: 99 }), 99);
+	} finally {
+		if (originalTimeout === undefined) delete process.env.PI_SUBAGENT_TIMEOUT_MS;
+		else process.env.PI_SUBAGENT_TIMEOUT_MS = originalTimeout;
+	}
 });
 
 test("mapWithConcurrencyLimit preserves input order and enforces its active limit", async () => {
@@ -318,6 +352,41 @@ test("stateful tools are opt-in and expose the complete lifecycle surface", asyn
 		const spawnTool = mock.tools.find((tool) => tool.name === "subagent_spawn") as {
 			execute: (...args: unknown[]) => Promise<unknown>;
 		};
+		const originalDepth = process.env.PI_SUBAGENT_DEPTH;
+		process.env.PI_SUBAGENT_DEPTH = "1";
+		try {
+			await assert.rejects(
+				() =>
+					spawnTool.execute(
+						"id",
+						{ agent: "scout", task: "nested" },
+						undefined,
+						undefined,
+						context.ctx,
+					),
+				/recursion depth limit/,
+			);
+		} finally {
+			if (originalDepth === undefined) delete process.env.PI_SUBAGENT_DEPTH;
+			else process.env.PI_SUBAGENT_DEPTH = originalDepth;
+		}
+		await assert.rejects(
+			() =>
+				spawnTool.execute(
+					"id",
+					{
+						agent: "project",
+						task: "task",
+						cwd: project,
+						agentScope: "project",
+						confirmProjectAgents: false,
+					},
+					undefined,
+					undefined,
+					createMockContext({ isProjectTrusted: () => true }).ctx,
+				),
+			/overridden cwd/,
+		);
 		await assert.rejects(
 			() =>
 				spawnTool.execute(

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -67,6 +67,67 @@ test("subagents registers self-directed fan-out guidance and configuration comma
 		thinkingLevels,
 	);
 	assert.ok(mock.commands.has("subagents:config"));
+	const toolResultHandler = mock.events.get("tool_result")?.[0];
+	assert.deepEqual(
+		toolResultHandler?.(
+			{ toolName: "subagent", details: { isError: true } },
+			createMockContext().ctx,
+		),
+		{ isError: true },
+	);
+});
+
+test("subagent recursion guard rejects nested delegation before spawning", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools[0] as SubagentTool;
+	const originalDepth = process.env.PI_SUBAGENT_DEPTH;
+	process.env.PI_SUBAGENT_DEPTH = "1";
+	try {
+		await assert.rejects(
+			() =>
+				tool.execute(
+					"call",
+					{ agent: "scout", task: "nested" },
+					undefined,
+					undefined,
+					createMockContext().ctx,
+				),
+			/recursion depth limit/,
+		);
+	} finally {
+		if (originalDepth === undefined) delete process.env.PI_SUBAGENT_DEPTH;
+		else process.env.PI_SUBAGENT_DEPTH = originalDepth;
+	}
+});
+
+test("one-shot project agents require project trust even when confirmation is disabled", async () => {
+	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-untrusted-"));
+	const agentsDir = path.join(cwd, ".pi", "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		path.join(agentsDir, "project.md"),
+		"---\nname: project\ndescription: project agent\n---\nProject prompt.",
+	);
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools[0] as SubagentTool;
+	await assert.rejects(
+		() =>
+			tool.execute(
+				"call",
+				{
+					agent: "project",
+					task: "task",
+					agentScope: "project",
+					confirmProjectAgents: false,
+				},
+				undefined,
+				undefined,
+				createMockContext({ cwd, isProjectTrusted: () => false }).ctx,
+			),
+		/trusted project/,
+	);
 });
 
 test("discoverAgents includes built-ins and lets project agents override by name", () => {


### PR DESCRIPTION
## Summary

- harden subagent subprocess cancellation, timeouts, output bounds, cwd validation, and recursion limits
- add opt-in addressable agents with follow-up, wait, list, interrupt, close, bounded context, and persistent inert recovery
- enforce project trust and document runtime, security, migration, and core API boundaries
- add lifecycle, persistence, concurrency, parsing, truncation, and process cleanup coverage

## Verification

- `npm run check` (259 tests)
- `just pack-subagents` (17 expected package files)
- local Pi smoke tests for single, parallel, chain, timeout, and stateful spawn/wait
