### PR TITLE
feat(btw): support model selection in config

### DIFF
--- a/extensions/pi-btw/README.md
+++ b/extensions/pi-btw/README.md
@@ -11,6 +11,7 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 - Adds a `/btw <question>` command to Pi.
 - Answers side questions in a temporary, scrollable UI.
 - Uses the current session branch as context.
+- Uses Pi's current model or an independent model selected in `pi-btw.json`.
 - Inherits Pi's current thinking level or uses a fixed level from `pi-btw.json`.
 - Does not append the side question or answer to the main conversation.
 - Works as an independently installable npm Pi extension package.
@@ -52,13 +53,10 @@ Long answers open in a pager-style view. Use `↑`/`↓` or `k`/`j` to scroll by
 `Ctrl+U`/`Ctrl+D` to scroll by half page, and `Home`/`End` to jump. Close with
 `q`, `Esc`, `Enter`, or `Ctrl+C`.
 
-## ⚙️ Thinking level
+## ⚙️ Model and thinking level
 
-Pi calls its reasoning setting the **thinking level**. By default, `/btw` inherits the
-current runtime level, including changes made through `/settings` or `Shift+Tab`. It does
-not read or change `defaultThinkingLevel` directly.
-
-To request a fixed level for side questions, create:
+By default, `/btw` uses the current session model. To use an independent model for side
+questions, create:
 
 ```text
 $PI_CODING_AGENT_DIR/pi-btw.json
@@ -69,18 +67,29 @@ setting; pi-btw does not add any environment variables.
 
 ```json
 {
+  "model": "anthropic/claude-sonnet-4-5",
   "thinkingLevel": "low"
 }
 ```
 
-Supported values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. The selected
-value affects only `/btw` requests and does not change the main session. Pi's provider
-layer may clamp a requested level when the active model does not support it.
+The `model` value uses `provider/model-id` format. Only the first `/` is the separator, so
+model IDs may contain additional slashes, such as `openrouter/anthropic/claude-sonnet`.
+The configured model must exist in Pi's model registry and have usable credentials. If it
+cannot be found or authenticated, pi-btw warns and falls back to the current session model.
+If neither model is available, `/btw` reports an error and stops. This selection affects only
+`/btw`; it does not change the main session model.
 
-The settings file is optional and is never created automatically. A missing file, `{}`,
-or an omitted `thinkingLevel` silently inherits the current Pi level. The file is read for
+Pi calls its reasoning setting the **thinking level**. By default, `/btw` inherits the
+current runtime level, including changes made through `/settings` or `Shift+Tab`. It does
+not read or change `defaultThinkingLevel` directly. Supported fixed values are `off`,
+`minimal`, `low`, `medium`, `high`, and `xhigh`. The selected value applies to the model
+actually used by `/btw` and does not change the main session. Pi's provider layer may clamp
+a requested level when that model does not support it.
+
+The settings file is optional and is never created automatically. A missing file, `{}`, or
+omitted fields silently inherit the current Pi model and thinking level. The file is read for
 each `/btw` invocation, so edits apply to the next side question without `/reload`. Invalid
-or unreadable settings produce a warning and fall back to the current Pi level.
+or unreadable settings produce a warning and fall back to the current Pi defaults.
 
 ## 🧠 Why use pi-btw?
 

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -95,7 +95,7 @@ interface LoadBtwThinkingLevelOptions {
 }
 
 interface SideQuestionAuth {
-	apiKey: string;
+	apiKey?: string;
 	headers?: Record<string, string>;
 	env?: Record<string, string>;
 }
@@ -179,8 +179,8 @@ export async function resolveBtwModel({
 				: `falling back to ${fallback}`;
 			try {
 				const auth = await modelRegistry.getApiKeyAndHeaders(configuredModel);
-				if (auth.ok && auth.apiKey) return { model: configuredModel, auth: withApiKey(auth) };
-				const reason = auth.ok ? "has no API key" : auth.error;
+				if (auth.ok && hasRequestAuth(auth)) return { model: configuredModel, auth };
+				const reason = auth.ok ? "has no request credentials" : auth.error;
 				warn?.(
 					`pi-btw model ${settings.model} is unavailable (${reason}); ${fallbackAction}.`,
 				);
@@ -196,19 +196,19 @@ export async function resolveBtwModel({
 	if (!currentModel) return undefined;
 	try {
 		const auth = await modelRegistry.getApiKeyAndHeaders(currentModel);
-		if (auth.ok && auth.apiKey) return { model: currentModel, auth: withApiKey(auth) };
+		if (auth.ok && hasRequestAuth(auth)) return { model: currentModel, auth };
 	} catch {
 		// The caller reports the final lack of an available model.
 	}
 	return undefined;
 }
 
-function withApiKey(auth: {
-	apiKey?: string;
-	headers?: Record<string, string>;
-	env?: Record<string, string>;
-}): SideQuestionAuth {
-	return { apiKey: auth.apiKey!, headers: auth.headers, env: auth.env };
+function hasRequestAuth(auth: SideQuestionAuth): boolean {
+	return Boolean(
+		auth.apiKey ||
+			(auth.headers && Object.keys(auth.headers).length > 0) ||
+			(auth.env && Object.keys(auth.env).length > 0),
+	);
 }
 
 export async function readBtwSettings(
@@ -335,19 +335,18 @@ export default function btw(pi: ExtensionAPI) {
 				ctx.ui.notify(`pi-btw settings ignored: ${settingsResult.reason}`, "warning");
 			}
 
-			const selected = await resolveBtwModel({
-				settings,
-				currentModel: ctx.model,
-				modelRegistry: ctx.modelRegistry,
-				warn: (message) => ctx.ui.notify(message, "warning"),
-			});
-			if (!selected) {
+			const resolution = await resolveBtwModelWithLoader(settings, ctx);
+			if (resolution.kind === "cancelled") {
+				ctx.ui.notify("Cancelled", "info");
+				return;
+			}
+			if (resolution.kind === "unavailable") {
 				ctx.ui.notify("No available model for /btw", "error");
 				return;
 			}
 
 			const thinkingLevel = settings.thinkingLevel ?? pi.getThinkingLevel();
-			const answer = await askSideQuestion(question, selected, thinkingLevel, ctx);
+			const answer = await askSideQuestion(question, resolution.selected, thinkingLevel, ctx);
 			if (answer === undefined) {
 				ctx.ui.notify("Cancelled", "info");
 				return;
@@ -355,6 +354,39 @@ export default function btw(pi: ExtensionAPI) {
 
 			await showAnswer(question, answer, ctx);
 		},
+	});
+}
+
+type ModelResolutionOutcome =
+	| { kind: "cancelled" }
+	| { kind: "unavailable" }
+	| { kind: "selected"; selected: ResolvedBtwModel };
+
+async function resolveBtwModelWithLoader(
+	settings: BtwSettings,
+	ctx: ExtensionCommandContext,
+): Promise<ModelResolutionOutcome> {
+	return ctx.ui.custom<ModelResolutionOutcome>((tui, theme, _keybindings, done) => {
+		const loader = new BorderedLoader(tui, theme, "Resolving /btw model credentials...");
+		let cancelled = false;
+		loader.onAbort = () => {
+			cancelled = true;
+			done({ kind: "cancelled" });
+		};
+
+		resolveBtwModel({
+			settings,
+			currentModel: ctx.model,
+			modelRegistry: ctx.modelRegistry,
+			warn: (message) => {
+				if (!cancelled) ctx.ui.notify(message, "warning");
+			},
+		}).then((selected) => {
+			if (cancelled) return;
+			done(selected ? { kind: "selected", selected } : { kind: "unavailable" });
+		});
+
+		return loader;
 	});
 }
 

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -80,6 +80,7 @@ export const BTW_THINKING_LEVELS = [
 export type BtwThinkingLevel = (typeof BTW_THINKING_LEVELS)[number];
 
 export interface BtwSettings {
+	model?: string;
 	thinkingLevel?: BtwThinkingLevel;
 }
 
@@ -99,6 +100,26 @@ interface SideQuestionAuth {
 	env?: Record<string, string>;
 }
 
+interface BtwModelRegistry {
+	find(provider: string, modelId: string): Model<Api> | undefined;
+	getApiKeyAndHeaders(model: Model<Api>): Promise<
+		| { ok: true; apiKey?: string; headers?: Record<string, string>; env?: Record<string, string> }
+		| { ok: false; error: string }
+	>;
+}
+
+interface ResolveBtwModelOptions {
+	settings: BtwSettings;
+	currentModel: Model<Api> | undefined;
+	modelRegistry: BtwModelRegistry;
+	warn?: (message: string) => void;
+}
+
+interface ResolvedBtwModel {
+	model: Model<Api>;
+	auth: SideQuestionAuth;
+}
+
 interface CompleteSideQuestionOptions {
 	model: Model<Api>;
 	question: string;
@@ -111,10 +132,83 @@ interface CompleteSideQuestionOptions {
 
 export function normalizeBtwSettings(value: unknown): BtwSettings | undefined {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-	if (!Object.hasOwn(value, "thinkingLevel")) return {};
 
-	const thinkingLevel = Reflect.get(value, "thinkingLevel");
-	return isBtwThinkingLevel(thinkingLevel) ? { thinkingLevel } : undefined;
+	const settings: BtwSettings = {};
+	if (Object.hasOwn(value, "model")) {
+		const model = Reflect.get(value, "model");
+		if (typeof model !== "string" || !parseBtwModelReference(model)) return undefined;
+		settings.model = model;
+	}
+	if (Object.hasOwn(value, "thinkingLevel")) {
+		const thinkingLevel = Reflect.get(value, "thinkingLevel");
+		if (!isBtwThinkingLevel(thinkingLevel)) return undefined;
+		settings.thinkingLevel = thinkingLevel;
+	}
+	return settings;
+}
+
+export function parseBtwModelReference(
+	reference: string,
+): { provider: string; modelId: string } | undefined {
+	if (/\s/.test(reference)) return undefined;
+	const separator = reference.indexOf("/");
+	if (separator <= 0 || separator === reference.length - 1) return undefined;
+	return { provider: reference.slice(0, separator), modelId: reference.slice(separator + 1) };
+}
+
+export async function resolveBtwModel({
+	settings,
+	currentModel,
+	modelRegistry,
+	warn,
+}: ResolveBtwModelOptions): Promise<ResolvedBtwModel | undefined> {
+	if (settings.model) {
+		const fallback = currentModel
+			? `${currentModel.provider}/${currentModel.id}`
+			: "the current model";
+		const reference = parseBtwModelReference(settings.model)!;
+		const configuredModel = modelRegistry.find(reference.provider, reference.modelId);
+		if (!configuredModel) {
+			warn?.(`pi-btw model ${settings.model} was not found; falling back to ${fallback}.`);
+		} else {
+			const sameAsCurrent =
+				configuredModel === currentModel ||
+				(configuredModel.provider === currentModel?.provider && configuredModel.id === currentModel.id);
+			const fallbackAction = sameAsCurrent
+				? "no distinct current model is available"
+				: `falling back to ${fallback}`;
+			try {
+				const auth = await modelRegistry.getApiKeyAndHeaders(configuredModel);
+				if (auth.ok && auth.apiKey) return { model: configuredModel, auth: withApiKey(auth) };
+				const reason = auth.ok ? "has no API key" : auth.error;
+				warn?.(
+					`pi-btw model ${settings.model} is unavailable (${reason}); ${fallbackAction}.`,
+				);
+			} catch (error: unknown) {
+				warn?.(
+					`pi-btw model ${settings.model} credentials failed (${formatError(error)}); ${fallbackAction}.`,
+				);
+			}
+			if (sameAsCurrent) return undefined;
+		}
+	}
+
+	if (!currentModel) return undefined;
+	try {
+		const auth = await modelRegistry.getApiKeyAndHeaders(currentModel);
+		if (auth.ok && auth.apiKey) return { model: currentModel, auth: withApiKey(auth) };
+	} catch {
+		// The caller reports the final lack of an available model.
+	}
+	return undefined;
+}
+
+function withApiKey(auth: {
+	apiKey?: string;
+	headers?: Record<string, string>;
+	env?: Record<string, string>;
+}): SideQuestionAuth {
+	return { apiKey: auth.apiKey!, headers: auth.headers, env: auth.env };
 }
 
 export async function readBtwSettings(
@@ -148,7 +242,7 @@ export async function loadBtwThinkingLevel(
 	}
 
 	options.warn?.(
-		`pi-btw settings ignored: ${settings.reason}; expected { "thinkingLevel"?: "${BTW_THINKING_LEVELS.join('" | "')}" }. Using current Pi thinking level.`,
+		`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id" and thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}". Using current Pi thinking level.`,
 	);
 	return currentThinkingLevel;
 }
@@ -233,15 +327,27 @@ export default function btw(pi: ExtensionAPI) {
 				return;
 			}
 
-			if (!ctx.model) {
-				ctx.ui.notify("No model selected", "error");
+			const settingsResult = await readBtwSettings();
+			let settings: BtwSettings = {};
+			if (settingsResult.kind === "loaded") {
+				settings = settingsResult.settings;
+			} else if (settingsResult.kind === "invalid") {
+				ctx.ui.notify(`pi-btw settings ignored: ${settingsResult.reason}`, "warning");
+			}
+
+			const selected = await resolveBtwModel({
+				settings,
+				currentModel: ctx.model,
+				modelRegistry: ctx.modelRegistry,
+				warn: (message) => ctx.ui.notify(message, "warning"),
+			});
+			if (!selected) {
+				ctx.ui.notify("No available model for /btw", "error");
 				return;
 			}
 
-			const thinkingLevel = await loadBtwThinkingLevel(pi.getThinkingLevel(), {
-				warn: (message) => ctx.ui.notify(message, "warning"),
-			});
-			const answer = await askSideQuestion(question, thinkingLevel, ctx);
+			const thinkingLevel = settings.thinkingLevel ?? pi.getThinkingLevel();
+			const answer = await askSideQuestion(question, selected, thinkingLevel, ctx);
 			if (answer === undefined) {
 				ctx.ui.notify("Cancelled", "info");
 				return;
@@ -254,26 +360,26 @@ export default function btw(pi: ExtensionAPI) {
 
 async function askSideQuestion(
 	question: string,
+	selected: ResolvedBtwModel,
 	thinkingLevel: BtwThinkingLevel,
 	ctx: ExtensionCommandContext,
 ): Promise<string | undefined> {
 	return ctx.ui.custom<string | undefined>((tui, theme, _keybindings, done) => {
-		const loader = new BorderedLoader(tui, theme, `Answering /btw with ${ctx.model!.id}...`);
+		const loader = new BorderedLoader(
+			tui,
+			theme,
+			`Answering /btw with ${selected.model.provider}/${selected.model.id}...`,
+		);
 		loader.onAbort = () => done(undefined);
 
 		const ask = async () => {
-			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model!);
-			if (!auth.ok || !auth.apiKey) {
-				throw new Error(auth.ok ? `No API key for ${ctx.model!.provider}` : auth.error);
-			}
-
 			const conversationContext = buildConversationContext(ctx.sessionManager.getBranch());
 			const response = await completeSideQuestion({
-				model: ctx.model!,
+				model: selected.model,
 				question,
 				conversationContext,
 				thinkingLevel,
-				auth: { apiKey: auth.apiKey, headers: auth.headers, env: auth.env },
+				auth: selected.auth,
 				signal: loader.signal,
 			});
 

--- a/extensions/pi-btw/test/btw.test.ts
+++ b/extensions/pi-btw/test/btw.test.ts
@@ -130,6 +130,27 @@ test("resolveBtwModel selects configured model and its credentials", async () =>
 	assert.deepEqual(warnings, []);
 });
 
+test("resolveBtwModel accepts header-only and environment-only configured auth", async () => {
+	for (const auth of [
+		{ ok: true as const, headers: { Authorization: "Bearer test" } },
+		{ ok: true as const, env: { PROVIDER_TOKEN: "test" } },
+	]) {
+		const configuredModel = { provider: "custom", id: "side" } as Model<Api>;
+		const result = await resolveBtwModel({
+			settings: { model: "custom/side" },
+			currentModel: undefined,
+			modelRegistry: {
+				find: () => configuredModel,
+				getApiKeyAndHeaders: async () => auth,
+			} as never,
+		});
+
+		assert.equal(result?.model, configuredModel);
+		assert.deepEqual(result?.auth.headers, auth.headers);
+		assert.deepEqual(result?.auth.env, auth.env);
+	}
+});
+
 test("resolveBtwModel inherits current model when no model is configured", async () => {
 	const currentModel = { provider: "current", id: "main" } as Model<Api>;
 	const result = await resolveBtwModel({

--- a/extensions/pi-btw/test/btw.test.ts
+++ b/extensions/pi-btw/test/btw.test.ts
@@ -13,7 +13,9 @@ import btw, {
 	loadBtwThinkingLevel,
 	loadCompleteSimple,
 	normalizeBtwSettings,
+	parseBtwModelReference,
 	readBtwSettings,
+	resolveBtwModel,
 	sanitizeSingleLine,
 } from "../src/btw.js";
 
@@ -63,19 +65,159 @@ test("loadCompleteSimple reports when neither module exports completeSimple", as
 	);
 });
 
-test("normalizeBtwSettings accepts omission and every supported thinking level", () => {
+test("normalizeBtwSettings accepts optional model and thinking level", () => {
 	assert.deepEqual(normalizeBtwSettings({}), {});
 	assert.deepEqual(normalizeBtwSettings({ futureOption: true }), {});
+	assert.deepEqual(normalizeBtwSettings({ model: "anthropic/claude-sonnet-4-5" }), {
+		model: "anthropic/claude-sonnet-4-5",
+	});
+	assert.deepEqual(normalizeBtwSettings({ model: "openrouter/anthropic/claude-sonnet" }), {
+		model: "openrouter/anthropic/claude-sonnet",
+	});
 
 	for (const thinkingLevel of THINKING_LEVELS) {
 		assert.deepEqual(normalizeBtwSettings({ thinkingLevel }), { thinkingLevel });
+		assert.deepEqual(normalizeBtwSettings({ model: "test/model", thinkingLevel }), {
+			model: "test/model",
+			thinkingLevel,
+		});
 	}
 
 	assert.equal(normalizeBtwSettings(null), undefined);
 	assert.equal(normalizeBtwSettings([]), undefined);
+	assert.equal(normalizeBtwSettings({ model: "" }), undefined);
+	assert.equal(normalizeBtwSettings({ model: "model-without-provider" }), undefined);
+	assert.equal(normalizeBtwSettings({ model: "/model" }), undefined);
+	assert.equal(normalizeBtwSettings({ model: "provider/" }), undefined);
+	assert.equal(normalizeBtwSettings({ model: " provider/model" }), undefined);
+	assert.equal(normalizeBtwSettings({ model: "provider/model " }), undefined);
+	assert.equal(normalizeBtwSettings({ model: "provider/\nmodel" }), undefined);
 	assert.equal(normalizeBtwSettings({ thinkingLevel: null }), undefined);
 	assert.equal(normalizeBtwSettings({ thinkingLevel: "max" }), undefined);
 	assert.equal(normalizeBtwSettings({ thinkingLevel: "huge" }), undefined);
+});
+
+test("parseBtwModelReference splits only the first slash", () => {
+	assert.deepEqual(parseBtwModelReference("openrouter/anthropic/claude-sonnet"), {
+		provider: "openrouter",
+		modelId: "anthropic/claude-sonnet",
+	});
+	assert.equal(parseBtwModelReference("invalid"), undefined);
+});
+
+test("resolveBtwModel selects configured model and its credentials", async () => {
+	const currentModel = { provider: "current", id: "main" } as Model<Api>;
+	const configuredModel = { provider: "openrouter", id: "anthropic/claude" } as Model<Api>;
+	const credentialReads: Model<Api>[] = [];
+	const warnings: string[] = [];
+	const result = await resolveBtwModel({
+		settings: { model: "openrouter/anthropic/claude", thinkingLevel: "low" },
+		currentModel,
+		modelRegistry: {
+			find: (provider: string, modelId: string) =>
+				provider === "openrouter" && modelId === "anthropic/claude" ? configuredModel : undefined,
+			getApiKeyAndHeaders: async (model: Model<Api>) => {
+				credentialReads.push(model);
+				return { ok: true as const, apiKey: "configured-key", headers: { test: "yes" } };
+			},
+		} as never,
+		warn: (message) => warnings.push(message),
+	});
+
+	assert.equal(result?.model, configuredModel);
+	assert.equal(result?.auth.apiKey, "configured-key");
+	assert.deepEqual(credentialReads, [configuredModel]);
+	assert.deepEqual(warnings, []);
+});
+
+test("resolveBtwModel inherits current model when no model is configured", async () => {
+	const currentModel = { provider: "current", id: "main" } as Model<Api>;
+	const result = await resolveBtwModel({
+		settings: { thinkingLevel: "high" },
+		currentModel,
+		modelRegistry: {
+			find: () => undefined,
+			getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "current-key" }),
+		} as never,
+	});
+
+	assert.equal(result?.model, currentModel);
+	assert.equal(result?.auth.apiKey, "current-key");
+});
+
+test("resolveBtwModel warns and falls back for unavailable configured models", async () => {
+	const currentModel = { provider: "current", id: "main" } as Model<Api>;
+	for (const configuredAuth of [
+		{ ok: true as const, apiKey: undefined },
+		{ ok: false as const, error: "credential command failed" },
+	]) {
+		const configuredModel = { provider: "other", id: "side" } as Model<Api>;
+		const warnings: string[] = [];
+		const result = await resolveBtwModel({
+			settings: { model: "other/side" },
+			currentModel,
+			modelRegistry: {
+				find: () => configuredModel,
+				getApiKeyAndHeaders: async (model: Model<Api>) =>
+					model === configuredModel ? configuredAuth : { ok: true as const, apiKey: "current-key" },
+			} as never,
+			warn: (message) => warnings.push(message),
+		});
+
+		assert.equal(result?.model, currentModel);
+		assert.equal(result?.auth.apiKey, "current-key");
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0] ?? "", /other\/side/);
+		assert.match(warnings[0] ?? "", /current\/main/);
+	}
+
+	const warnings: string[] = [];
+	const missing = await resolveBtwModel({
+		settings: { model: "missing/model" },
+		currentModel,
+		modelRegistry: {
+			find: () => undefined,
+			getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "current-key" }),
+		} as never,
+		warn: (message) => warnings.push(message),
+	});
+	assert.equal(missing?.model, currentModel);
+	assert.match(warnings[0] ?? "", /not found/);
+});
+
+test("resolveBtwModel does not retry credentials when configured and current models are identical", async () => {
+	const model = { provider: "same", id: "model" } as Model<Api>;
+	let credentialReads = 0;
+	const result = await resolveBtwModel({
+		settings: { model: "same/model" },
+		currentModel: model,
+		modelRegistry: {
+			find: () => model,
+			getApiKeyAndHeaders: async () => {
+				credentialReads += 1;
+				throw new Error("credential command failed");
+			},
+		} as never,
+	});
+
+	assert.equal(result, undefined);
+	assert.equal(credentialReads, 1);
+});
+
+test("resolveBtwModel returns undefined when neither configured nor current model is usable", async () => {
+	const warnings: string[] = [];
+	const result = await resolveBtwModel({
+		settings: { model: "missing/model" },
+		currentModel: undefined,
+		modelRegistry: {
+			find: () => undefined,
+			getApiKeyAndHeaders: async () => ({ ok: false as const, error: "unused" }),
+		} as never,
+		warn: (message) => warnings.push(message),
+	});
+
+	assert.equal(result, undefined);
+	assert.equal(warnings.length, 1);
 });
 
 test("missing pi-btw settings inherit silently without creating a file", async () => {


### PR DESCRIPTION
## Summary

- allow `pi-btw.json` to select an independent `provider/model-id` for side questions
- fall back to the current session model when the configured model is missing or unauthenticated
- preserve independent thinking-level selection, hot reload settings per invocation, and show the effective model in the loader
- document the config contract and add regression coverage for parsing, credentials, fallback, and edge cases

## Verification

- `npm run check`
- `just pack-btw`
- `git diff --check`