### PR TITLE
fix(codex-accounts): reset stale auth connections

### DIFF
--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -17,6 +17,7 @@ It keeps using Pi's built-in `openai-codex` provider. It does **not** add provid
 - Leaves your selected `/model` unchanged, matching Pi's built-in `/login` behavior, except it may select `openai-codex/gpt-5.5` when the current model is `unknown/unknown`.
 - Shows `codex:<name>` in the statusline only while the current model provider is `openai-codex`.
 - Fails closed if an active self-managed account cannot refresh, so Pi does not silently fall back to a different Codex account.
+- Closes the current session's cached Codex WebSocket when auth changes, preventing a reused connection from staying on the previous account.
 
 ## 📦 Install
 
@@ -71,6 +72,8 @@ When an active self-managed account is set, the extension applies that account's
 When no self-managed account is active, the extension removes its runtime override and Pi uses its normal `openai-codex` auth resolution. That means existing `/login openai-codex`, `auth.json`, or environment behavior still works.
 
 If the active self-managed account refresh fails, the extension keeps a non-empty failing runtime key in place. This prevents accidental fallback to a different Codex account.
+
+Account switches and token refreshes also close any cached Codex WebSocket for the current Pi session. The next request reconnects with the newly selected credentials; repeated pre-turn checks, including turns started after compaction, keep the connection when auth is unchanged.
 
 ## 🚧 Limitations
 

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -7,6 +7,7 @@ import {
 	type ExtensionCommandContext,
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { closeOpenAICodexWebSocketSessions } from "@earendil-works/pi-ai/api/openai-codex-responses";
 import {
 	openaiCodexOAuthProvider,
 	type OAuthCredentials,
@@ -73,10 +74,12 @@ export type CommandArgumentCompletion = {
 export type CodexAccountsDependencies = {
 	store?: CodexAccountStore;
 	oauthProvider?: CodexOAuthProvider;
+	closeWebSocketSessions?: (sessionId?: string) => void;
 };
 
 export class CodexAccountStore {
 	private readonly backend: AuthStorageBackend;
+	private operationTail: Promise<void> = Promise.resolve();
 
 	constructor(backend: AuthStorageBackend = new FileAuthStorageBackend(defaultAccountsPath())) {
 		this.backend = backend;
@@ -91,15 +94,30 @@ export class CodexAccountStore {
 	}
 
 	async write(data: CodexAccountsData): Promise<void> {
-		const next = stringifyStoredData(data);
-		await this.backend.withLockAsync(async () => ({ result: undefined, next }));
+		await this.updateAsync(async () => data);
 	}
 
 	async update(mutator: (data: CodexAccountsData) => CodexAccountsData): Promise<CodexAccountsData> {
-		return this.backend.withLockAsync(async (current) => {
-			const nextData = mutator(parseStoredData(current));
-			return { result: nextData, next: stringifyStoredData(nextData) };
+		return this.updateAsync(async (data) => mutator(data));
+	}
+
+	async updateAsync(
+		mutator: (data: CodexAccountsData) => Promise<CodexAccountsData>,
+	): Promise<CodexAccountsData> {
+		const previous = this.operationTail;
+		let release: () => void = () => undefined;
+		this.operationTail = new Promise<void>((resolve) => {
+			release = resolve;
 		});
+		await previous;
+		try {
+			return await this.backend.withLockAsync(async (current) => {
+				const nextData = await mutator(parseStoredData(current));
+				return { result: nextData, next: stringifyStoredData(nextData) };
+			});
+		} finally {
+			release();
+		}
 	}
 
 	async writeRawForTest(raw: string): Promise<void> {
@@ -113,9 +131,19 @@ export default function codexAccounts(
 ) {
 	const store = dependencies.store ?? new CodexAccountStore();
 	const oauthProvider = dependencies.oauthProvider ?? openaiCodexOAuthProvider;
+	const closeWebSocketSessions =
+		dependencies.closeWebSocketSessions ?? closeOpenAICodexWebSocketSessions;
+	let appliedAuthIdentity: string | undefined;
+	let authIdentityInitialized = false;
 
 	const sync = async (ctx: ExtensionContext, model = ctx.model) => {
 		const result = await ensureActiveCodexAuth(ctx, store, { oauthProvider });
+		const authIdentity = await getActiveAuthIdentity(store, result);
+		if (!authIdentityInitialized || appliedAuthIdentity !== authIdentity) {
+			closeWebSocketSessions(ctx.sessionManager.getSessionId());
+			authIdentityInitialized = true;
+			appliedAuthIdentity = authIdentity;
+		}
 		updateStatus(ctx, result, model);
 		return result;
 	};
@@ -159,7 +187,7 @@ export default function codexAccounts(
 			}
 
 			if (isDefaultPiLoginArg(trimmed)) {
-				await clearActiveAccount(ctx, store);
+				await clearActiveAccount(ctx, store, sync);
 				return;
 			}
 
@@ -184,21 +212,22 @@ export default function codexAccounts(
 				return;
 			}
 
-			const data = await store.readAsync();
-			if (!data.accounts[parsedName.name]) {
+			let removed = false;
+			let removedActive = false;
+			await store.update((data) => {
+				if (!data.accounts[parsedName.name]) return data;
+				removed = true;
+				removedActive = data.active === parsedName.name;
+				const accounts = { ...data.accounts };
+				delete accounts[parsedName.name];
+				return { active: removedActive ? undefined : data.active, accounts };
+			});
+			if (!removed) {
 				ctx.ui.notify(`Codex account "${parsedName.name}" was not found.`, "warning");
 				return;
 			}
 
-			const accounts = { ...data.accounts };
-			delete accounts[parsedName.name];
-			const next = { active: data.active === parsedName.name ? undefined : data.active, accounts };
-			await store.write(next);
-
-			if (next.active === undefined) {
-				clearRuntimeCodexAuth(ctx);
-				updateStatus(ctx, { status: "inactive" });
-			}
+			if (removedActive) await sync(ctx);
 			ctx.ui.notify(`Removed Codex account "${parsedName.name}".`, "info");
 		},
 	});
@@ -254,19 +283,37 @@ export async function ensureActiveCodexAuth(
 
 	const oauthProvider = options.oauthProvider ?? openaiCodexOAuthProvider;
 	if (credential.expires <= (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
-		try {
-			const refreshed = normalizeCredential(await oauthProvider.refreshToken(credential));
-			await store.update((current) => ({
-				...current,
-				accounts: { ...current.accounts, [active]: refreshed },
-			}));
-			credential = refreshed;
-		} catch (error) {
+		let refreshError: unknown;
+		const current = await store.updateAsync(async (latest) => {
+			if (latest.active !== active || !latest.accounts[active]) return latest;
+			const latestCredential = latest.accounts[active];
+			if (latestCredential.expires > (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
+				credential = latestCredential;
+				return latest;
+			}
+			try {
+				const refreshed = normalizeCredential(
+					await oauthProvider.refreshToken(latestCredential),
+				);
+				credential = refreshed;
+				return {
+					...latest,
+					accounts: { ...latest.accounts, [active]: refreshed },
+				};
+			} catch (error) {
+				refreshError = error;
+				return latest;
+			}
+		});
+		if (current.active !== active) {
+			return ensureActiveCodexAuth(ctx, store, options);
+		}
+		if (refreshError !== undefined) {
 			setRuntimeCodexApiKey(ctx, FAIL_CLOSED_API_KEY);
 			return {
 				status: "error",
 				accountName: active,
-				message: redactTokenText(errorMessage(error)),
+				message: redactTokenText(errorMessage(refreshError)),
 			};
 		}
 	}
@@ -433,7 +480,7 @@ async function showAccountSelector(
 	const selected = await ctx.ui.select("Select Codex account:", [DEFAULT_PI_LOGIN_LABEL, ...names]);
 	if (!selected) return;
 	if (selected === DEFAULT_PI_LOGIN_LABEL) {
-		await clearActiveAccount(ctx, store);
+		await clearActiveAccount(ctx, store, sync);
 		return;
 	}
 	await activateStoredAccount(ctx, store, selected, sync);
@@ -445,20 +492,27 @@ async function activateStoredAccount(
 	name: string,
 	sync: (ctx: ExtensionContext) => Promise<EnsureActiveCodexAuthResult>,
 ): Promise<void> {
-	const data = await store.readAsync();
-	if (!data.accounts[name]) {
+	let activated = false;
+	await store.update((data) => {
+		if (!data.accounts[name]) return data;
+		activated = true;
+		return { ...data, active: name };
+	});
+	if (!activated) {
 		ctx.ui.notify(`Codex account "${name}" was not found.`, "warning");
 		return;
 	}
-	await store.write({ ...data, active: name });
 	const result = await sync(ctx);
 	ctx.ui.notify(formatActivatedMessage("Activated", name, result), result.status === "error" ? "error" : "info");
 }
 
-async function clearActiveAccount(ctx: ExtensionCommandContext, store: CodexAccountStore): Promise<void> {
+async function clearActiveAccount(
+	ctx: ExtensionCommandContext,
+	store: CodexAccountStore,
+	sync: (ctx: ExtensionContext) => Promise<EnsureActiveCodexAuthResult>,
+): Promise<void> {
 	await store.update((data) => ({ ...data, active: undefined }));
-	clearRuntimeCodexAuth(ctx);
-	updateStatus(ctx, { status: "inactive" });
+	await sync(ctx);
 	ctx.ui.notify("Using default Pi Codex login.", "info");
 }
 
@@ -491,6 +545,16 @@ function formatActivatedMessage(
 		return `${action} Codex account "${name}", but refresh failed; Codex requests will fail closed: ${result.message}`;
 	}
 	return `${action} Codex account "${name}".`;
+}
+
+async function getActiveAuthIdentity(
+	store: CodexAccountStore,
+	result: EnsureActiveCodexAuthResult,
+): Promise<string> {
+	if (result.status === "inactive") return "default";
+	if (result.status === "error") return `error:${result.accountName}`;
+	const data = await store.readAsync();
+	return `${result.accountName}:${data.accounts[result.accountName]?.access ?? "missing"}`;
 }
 
 function updateStatus(

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -138,6 +138,40 @@ test("ensureActiveCodexAuth refreshes near-expired active accounts", async () =>
 	assert.equal((await store.readAsync()).accounts.work?.access, "access-new");
 });
 
+test("concurrent auth checks refresh an expiring account only once", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({
+		active: "work",
+		accounts: { work: { access: "old", refresh: "refresh-old", expires: 0 } },
+	});
+	let refreshCalls = 0;
+	const oauthProvider = {
+		async refreshToken() {
+			refreshCalls += 1;
+			await Promise.resolve();
+			return validCred("new");
+		},
+		getApiKey: (credential: { access: string }) => credential.access,
+	};
+	const runtimeKeys: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: (_provider: string, key: string) => runtimeKeys.push(key),
+				removeRuntimeApiKey: () => undefined,
+			},
+		},
+	});
+
+	await Promise.all([
+		ensureActiveCodexAuth(ctx, store, { oauthProvider }),
+		ensureActiveCodexAuth(ctx, store, { oauthProvider }),
+	]);
+
+	assert.equal(refreshCalls, 1);
+	assert.deepEqual(runtimeKeys, ["access-new", "access-new"]);
+});
+
 test("ensureActiveCodexAuth fails closed when active account refresh fails", async () => {
 	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
 	await store.write({
@@ -350,6 +384,61 @@ test("codex-account can switch accounts or return to default Pi login", async ()
 	assert.deepEqual(runtimeCalls.at(-1), `remove:${CODEX_PROVIDER_ID}`);
 });
 
+test("codex-account default does not let an in-flight refresh restore the previous account", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({
+		active: "work",
+		accounts: {
+			work: { ...validCred("work"), expires: 0 },
+			home: validCred("home"),
+		},
+	});
+	let releaseRefresh: (() => void) | undefined;
+	const refreshStarted = new Promise<void>((resolve) => {
+		releaseRefresh = resolve;
+	});
+	let signalRefreshStarted: (() => void) | undefined;
+	const refreshEntered = new Promise<void>((resolve) => {
+		signalRefreshStarted = resolve;
+	});
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		oauthProvider: {
+			async login() {
+				throw new Error("unexpected login");
+			},
+			async refreshToken() {
+				signalRefreshStarted?.();
+				await refreshStarted;
+				return validCred("work-refreshed");
+			},
+			getApiKey: (credential) => credential.access,
+		},
+	});
+	const command = mock.commands.get("codex-account");
+	assert.ok(command);
+	const runtimeCalls: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: (provider: string, key: string) =>
+					runtimeCalls.push(`set:${provider}:${key}`),
+				removeRuntimeApiKey: (provider: string) => runtimeCalls.push(`remove:${provider}`),
+			},
+		},
+	});
+
+	const startup = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await refreshEntered;
+	const switching = command.handler("default", ctx);
+	releaseRefresh?.();
+	await Promise.all([startup, switching]);
+
+	assert.equal((await store.readAsync()).active, undefined);
+	assert.equal(runtimeCalls.at(-1), `remove:${CODEX_PROVIDER_ID}`);
+});
+
 test("codex-account selector includes default Pi login", async () => {
 	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
 	await store.write({ active: "work", accounts: { work: validCred("work") } });
@@ -409,6 +498,92 @@ test("codex-logout deletes accounts and clears active runtime auth", async () =>
 	assert.equal(data.active, undefined);
 	assert.equal(data.accounts.work, undefined);
 	assert.deepEqual(runtimeCalls.at(-1), `remove:${CODEX_PROVIDER_ID}`);
+});
+
+test("logging out another account does not overwrite an in-flight token refresh", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({
+		active: "work",
+		accounts: {
+			work: { ...validCred("work"), expires: 0 },
+			home: validCred("home"),
+		},
+	});
+	let releaseRefresh: (() => void) | undefined;
+	const refreshBlocked = new Promise<void>((resolve) => {
+		releaseRefresh = resolve;
+	});
+	let signalRefreshStarted: (() => void) | undefined;
+	const refreshStarted = new Promise<void>((resolve) => {
+		signalRefreshStarted = resolve;
+	});
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		oauthProvider: {
+			async login() {
+				throw new Error("unexpected login");
+			},
+			async refreshToken() {
+				signalRefreshStarted?.();
+				await refreshBlocked;
+				return validCred("refreshed");
+			},
+			getApiKey: (credential) => credential.access,
+		},
+		closeWebSocketSessions: () => undefined,
+	});
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: () => undefined,
+				removeRuntimeApiKey: () => undefined,
+			},
+		},
+	});
+
+	const startup = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await refreshStarted;
+	const command = mock.commands.get("codex-logout");
+	assert.ok(command);
+	const logout = command.handler("home", ctx);
+	releaseRefresh?.();
+	await Promise.all([startup, logout]);
+
+	const data = await store.readAsync();
+	assert.equal(data.accounts.home, undefined);
+	assert.equal(data.accounts.work?.access, "access-refreshed");
+});
+
+test("account changes close cached Codex WebSockets while unchanged compaction checks do not", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({
+		active: "work",
+		accounts: { work: validCred("work"), home: validCred("home") },
+	});
+	const closedSessions: Array<string | undefined> = [];
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		closeWebSocketSessions: (sessionId) => closedSessions.push(sessionId),
+	});
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: () => undefined,
+				removeRuntimeApiKey: () => undefined,
+			},
+		},
+	});
+
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("before_agent_start")?.[0]?.({}, ctx);
+	assert.equal(closedSessions.length, 1);
+
+	const command = mock.commands.get("codex-account");
+	assert.ok(command);
+	await command.handler("home", ctx);
+	assert.equal(closedSessions.length, 2);
 });
 
 test("status is visible only while the selected model is openai-codex", async () => {

--- a/test/support.ts
+++ b/test/support.ts
@@ -156,6 +156,7 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 		reload: overrides.reload ?? (async () => undefined),
 		getContextUsage: overrides.getContextUsage ?? (() => undefined),
 		sessionManager: overrides.sessionManager ?? {
+			getSessionId: () => "test-session",
 			getBranch: () => [],
 			getEntries: () => [],
 		},


### PR DESCRIPTION
## Summary
- close cached Codex WebSockets when the selected account or access token changes
- serialize credential refreshes and prevent stale refreshes from restoring a previous account
- keep unchanged pre-turn and post-compaction auth checks connection-stable
- add regression coverage and document reconnect behavior

## Verification
- `npm run check`
- `just pack-codex-accounts`
- `git diff --check`