### PR TITLE
fix(subagents): streamline orchestration results

### DIFF
--- a/docs/plans/archived/2026-07-12_pi-subagents-orchestration-ux-plan.md
+++ b/docs/plans/archived/2026-07-12_pi-subagents-orchestration-ux-plan.md
@@ -1,0 +1,59 @@
+## Goal
+
+Improve `pi-subagents` orchestration UX so one-shot parallel requests select the blocking batch API, shared-workspace conflicts produce actionable recovery, and an explicit `subagent_wait` does not also surface a redundant asynchronous completion for the same turn. Success means the observed “spawn three trivial workers” flow completes with one parallel call and one synthesized root response, while detached sidecar workflows retain reliable completion delivery.
+
+## Context
+
+A recent request to run three agents used repeated `subagent_spawn` calls instead of `subagent` parallel mode. The second shared-workspace spawn failed because `scout` is conservatively write-capable through `bash`; two unnecessary worktrees were then created. Although three waits returned the results, the already-scheduled detached completion messages appeared after the root response and caused duplicate follow-up turns.
+
+The current safety guard is correct to treat shell-capable agents as write-capable. This plan improves API selection, diagnostics, and completion consumption rather than weakening that guard or claiming prompt-level read-only intent is a filesystem sandbox.
+
+## Architecture
+
+Keep the existing split between blocking batch jobs and reusable detached agents:
+
+- `subagent` remains the preferred API for independent one-shot single/parallel/chain/fan-in work.
+- `subagent_spawn` remains the reusable background API for work that benefits from overlap, retained history, or addressable lifecycle controls.
+- Add per-agent-turn completion-consumption bookkeeping at the stateful orchestration boundary. A wait registered before settlement consumes that turn’s completion through the wait result, so the same completion is not also injected asynchronously. Without a registered waiter, detached delivery remains unchanged.
+- Keep shared-workspace write detection conservative. Improve the rejection text with safe, context-specific alternatives instead of inferring “read-only” from natural-language task text.
+
+## Non-Goals
+
+- Do not remove or weaken shared-workspace write-conflict protection.
+- Do not add an untrusted `readOnly` flag that grants concurrency while shell-capable agents can still write.
+- Do not make model-generated numbers cryptographically random; callers needing randomness must request a concrete system randomness source and range.
+- Do not replace detached agents with batch workers for reusable, follow-up, mailbox, or background-sidecar workflows.
+
+## Unknowns
+
+- [x] Pi custom messages cannot be retracted safely after settlement, so deduplication is guaranteed only for waits registered while the turn is `starting` or `running`; the README documents late-wait behavior.
+- [x] Completion suppression belongs in the transport-neutral extension integration layer: `src/stateful.ts` tracks active waiters while `AgentRegistry` retains its one-completion-per-turn contract.
+
+## Plan
+
+- [x] Add regression tests reproducing the observed API-selection and lifecycle problems in `extensions/pi-subagents/test/subagents.test.ts`, `evolution.test.ts`, and/or `in-process-transport.test.ts`: one-shot parallel guidance must prefer `subagent` parallel mode, a second write-capable shared spawn must return actionable alternatives, and a wait registered before settlement must yield exactly one root-visible result; verify the focused tests fail before implementation with the repository’s compiled Node test command or `npm test`.
+- [x] Trace completion ordering across `src/stateful.ts`, `src/registry.ts`, and both transports, recording whether wait registration can be associated with a specific agent turn before `onTurnComplete`; verify with deterministic tests covering completion-before-wait, wait-before-completion, timeout, abort, follow-up turns, and multiple simultaneous waiters.
+- [x] Revise the `subagent` and `subagent_spawn` prompt snippets/guidelines in `src/subagents.ts` and `src/stateful.ts` so explicit multi-agent one-shot work selects one blocking parallel call, while detached spawn is reserved for reusable or genuinely overlapping work; verify exact prompt contracts in `extensions/pi-subagents/test/subagents.test.ts`.
+- [x] Make shared-workspace conflict errors in `src/stateful.ts` identify the active agent and explain safe next actions: use `subagent` parallel mode for one-shot independent work, wait/close the active detached agent, use `allowConcurrentWrites` only when overlapping writes are knowingly safe, or use `worktree` only when repository isolation is actually needed; verify assertions for spawn and follow-up conflicts without relaxing `isWriteCapable` behavior.
+- [x] Implement per-turn completion consumption so a wait registered before settlement receives the terminal result without a duplicate `pi-subagent-completion` injection; preserve asynchronous delivery when no waiter consumes the result and preserve one completion per later follow-up turn. Verify race, timeout, abort, multiple-waiter, subprocess, and in-process cases with deterministic tests.
+- [x] Ensure orchestration recovery treats a successfully waited completion as observed and does not schedule an extra synthesis continuation, while unobserved detached completions still recover an idle root exactly once; verify existing orchestration tests plus new wait/delivery interaction tests.
+- [x] Update `extensions/pi-subagents/README.md` with a concise decision table for batch parallel versus detached spawn, explain conservative shell/write detection, describe wait-based completion consumption, and show system-randomness wording for tasks where actual randomness matters; verify published package contents with `just pack-subagents`.
+- [x] Run a Pi JSON smoke test for the original scenario using three one-shot agents and assert one batch tool call, three ordered results, one root synthesis, no worktrees, and no trailing completion turns; also smoke-test a genuine detached no-wait workflow to confirm asynchronous completion still arrives.
+- [x] Run `npm run check` and `just pack-subagents`, inspect the intended diff and tarball; `npm run check` passed all 322 tests and `just pack-subagents` contained all 23 expected package files.
+
+## Risks
+
+- Suppressing completion too broadly could make detached results invisible. Bind consumption to an exact agent turn and retain asynchronous delivery unless a waiter was registered before that turn settled.
+- Completion and timeout races could either duplicate or lose output. Define settlement as the single ownership decision point and cover both event orders deterministically.
+- Stronger prompt guidance cannot force every model to choose the right API. Actionable runtime errors and duplicate-delivery prevention must remain correct when guidance is ignored.
+- More verbose conflict errors could overwhelm tool output. Keep the first sentence diagnostic and the alternatives bounded.
+
+## Completion Checklist
+
+- [x] One-shot multi-agent selection is verified by prompt-contract tests and a Pi smoke trace showing one `subagent` parallel call.
+- [x] Shared-workspace safety remains conservative and is verified by existing write-conflict tests plus actionable-error assertions.
+- [x] Wait-before-completion produces one root-visible result with no trailing custom completion, verified for subprocess and in-process transports.
+- [x] Detached no-wait completion and idle-root recovery still occur exactly once, verified by lifecycle regression tests and a smoke trace.
+- [x] Timeout, abort, completion-before-wait, follow-up, and simultaneous-waiter behavior is verified by deterministic tests with no lost terminal output.
+- [x] Documentation and publish contents are verified by `just pack-subagents`.
+- [x] Repository CI-equivalent validation is verified by a passing `npm run check`.

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -48,6 +48,14 @@ pi -e ./extensions/pi-subagents
 - `subagent` — delegate blocking single, parallel, fan-in, or chained batch work.
 - `subagent_spawn` and related lifecycle tools — start reusable detached work, return immediately, and receive bounded completion messages automatically.
 
+Choose the API by lifecycle:
+
+| Need | Use |
+| --- | --- |
+| One or more independent, one-shot results needed before the root responds | One blocking `subagent` call (`tasks` for parallel work) |
+| Reusable history, follow-ups, mailboxes, or work that overlaps useful root work | `subagent_spawn` and lifecycle tools |
+| One simple or critical-path action the root can perform directly | No subagent |
+
 Execution modes:
 
 - **single** — run one `{ agent, task }` job.
@@ -138,6 +146,8 @@ Run one read-only reconnaissance agent:
 }
 ```
 
+For genuinely random values, specify the range, duplicate policy, and a system randomness source instead of relying on model sampling, for example: `Use Python secrets to return 10 integers from 0 through 999; duplicates are allowed.`
+
 Run multiple agents in parallel with a shared thinking level and one per-task override:
 
 ```json
@@ -195,6 +205,8 @@ Stateful lifecycle tools are available by default. `subagent_spawn` is detached:
 Detached work has a root-coordination invariant: the main agent should continue useful non-overlapping work when available, or call `subagent_wait` when coordination is the only useful next action. If it yields while current delegated work is still live or awaiting synthesis, the extension schedules one idle-gated recovery continuation for that orchestration revision. A completion, close, interruption, new root turn, session replacement, or shutdown revises or clears that ephemeral state. Recovery is bounded and does not internally wait forever or persist across sessions.
 
 A single detached agent is justified only by a concrete isolation or specialization benefit such as independent review, bounded context/output, a distinct model/tool profile, or workspace isolation. Simple work that the main agent can perform directly should not be delegated.
+
+When `subagent_wait` starts while a turn is running, that wait consumes the turn's completion: the terminal output is returned by the tool and is not also injected as a duplicate asynchronous completion. Multiple active waiters may all receive the terminal result. A timed-out or aborted wait does not consume it, so later settlement still delivers the normal asynchronous completion. If a turn has already settled and queued its completion before a wait starts, the queued message cannot be retracted safely.
 
 The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history. Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
 
@@ -255,7 +267,9 @@ Stateful execution uses a transport boundary:
 
 No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used. Approval policy, sandbox profile, provider-header hooks, extension state, global scheduling, and parent/child transcript switching are not inherited or provided by the in-process transport.
 
-Write-capable agents share the workspace by default. Concurrent write-capable starts in the same cwd are rejected unless `allowConcurrentWrites` is explicitly set. Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; this requires a clean repository and the worktree is removed on close or session shutdown. Isolated worktree agents are intentionally not restored after shutdown.
+Write-capable agents share the workspace by default. Concurrent write-capable starts in the same cwd are rejected unless `allowConcurrentWrites` is explicitly set. Classification is intentionally conservative: an agent with `bash`, `write`, or `edit` is write-capable even when its task prompt says “read only,” because prompt wording is not a filesystem sandbox. For independent one-shot work, use batch parallel mode. Otherwise wait for or close the active agent, explicitly accept safe overlap with `allowConcurrentWrites`, or use an isolated worktree when repository isolation is actually needed.
+
+Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; this requires a clean repository and the worktree is removed on close or session shutdown. Isolated worktree agents are intentionally not restored after shutdown.
 
 ## 📜 Compatibility and failure contract
 

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -56,6 +56,7 @@ export function registerStatefulSubagents(
 	const parentRuntime: ParentRuntimeSnapshot = { model: undefined, thinkingLevel: "off" };
 	const orchestration = new RootOrchestrationState();
 	const cancelledRecoveryNonces = new Set<string>();
+	const completionWaiters = new Map<string, number>();
 
 	const requireRegistry = () => {
 		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
@@ -108,7 +109,9 @@ export function registerStatefulSubagents(
 			onTurnComplete: (completion) => {
 				if (generation !== runtimeGeneration) return;
 				orchestration.complete(completion.agent.id);
-				sendDetachedCompletion(pi, completion);
+				if (!completionWaiters.has(completion.agent.id)) {
+					sendDetachedCompletion(pi, completion);
+				}
 			},
 		});
 		const restored = sessionPersistence
@@ -184,6 +187,7 @@ export function registerStatefulSubagents(
 		}
 		isolatedAgents.clear();
 		seenMessageIds.clear();
+		completionWaiters.clear();
 		let cleanupError: unknown;
 		try {
 			await workspaceManager.cleanupAll();
@@ -210,6 +214,7 @@ export function registerStatefulSubagents(
 		promptGuidelines: [
 			"Do not delegate simple or critical-path work that the main agent can perform directly.",
 			"A single detached subagent is appropriate only for a concrete isolation or specialization benefit such as independent review, bounded context/output, a distinct model/tool profile, or workspace isolation.",
+			"Use one blocking subagent parallel call for multiple independent one-shot tasks; do not use repeated detached spawns when no reuse or overlap is needed.",
 			"After spawning, continue useful non-overlapping local work when available; otherwise call subagent_wait rather than yielding while delegated work remains unresolved.",
 			"Consume available completion messages and synthesize their results before finishing; interrupt or close agents that are no longer needed.",
 			"Detached completion is delivered automatically. Do not poll, wait forever, or spawn additional agents without a distinct need.",
@@ -396,14 +401,23 @@ export function registerStatefulSubagents(
 			timeoutMs: Type.Optional(Type.Number({ minimum: 1, maximum: 3_600_000, default: 30_000 })),
 		}),
 		async execute(_id, params, signal) {
-			const waited = await requireRegistry().wait(params.agentId, params.timeoutMs, signal);
-			if (!waited.timedOut) orchestration.observe(waited.agent.id);
-			return result(
-				waited.agent,
-				waited.timedOut
-					? `Wait timed out; ${waited.agent.id} is ${waited.agent.state}.`
-					: formatFinal(waited.agent),
-			);
+			const existing = requireRegistry().get(params.agentId);
+			const registered = existing?.state === "starting" || existing?.state === "running";
+			if (registered) {
+				completionWaiters.set(params.agentId, (completionWaiters.get(params.agentId) ?? 0) + 1);
+			}
+			try {
+				const waited = await requireRegistry().wait(params.agentId, params.timeoutMs, signal);
+				if (!waited.timedOut) orchestration.observe(waited.agent.id);
+				return result(
+					waited.agent,
+					waited.timedOut
+						? `Wait timed out; ${waited.agent.id} is ${waited.agent.state}.`
+						: formatFinal(waited.agent),
+				);
+			} finally {
+				if (registered) decrementWaiter(completionWaiters, params.agentId);
+			}
 		},
 	});
 
@@ -545,7 +559,8 @@ export function assertNoSharedWriteConflict(
 		const activeConfig = agents.find((agent) => agent.name === active.agent);
 		if (isWriteCapable(activeConfig?.tools)) {
 			throw new Error(
-				`Write-capable subagent ${active.id} is already active in shared workspace ${cwd}`,
+				`Write-capable subagent ${active.id} is already active in shared workspace ${cwd}. ` +
+					"For independent one-shot work, use subagent parallel mode. Otherwise wait or close the active agent; set allowConcurrentWrites only when overlapping writes are knowingly safe, or use workspaceMode worktree when repository isolation is needed.",
 			);
 		}
 	}
@@ -569,6 +584,12 @@ export function assertFollowUpWriteAllowed(
 export function isWriteCapable(tools: string[] | undefined): boolean {
 	if (!tools) return true;
 	return tools.some((tool) => ["bash", "write", "edit"].includes(tool));
+}
+
+function decrementWaiter(waiters: Map<string, number>, agentId: string): void {
+	const count = waiters.get(agentId);
+	if (count === undefined || count <= 1) waiters.delete(agentId);
+	else waiters.set(agentId, count - 1);
 }
 
 async function confirmProjectAgent(

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -37,6 +37,7 @@ export default function (pi: ExtensionAPI) {
 			"Use subagent only when delegation fits; the main agent should decide how many subagents to spawn from task shape instead of waiting for the user to specify a count.",
 			"Use no subagent for simple answers, quick targeted edits, latency-sensitive one-step work, tasks requiring frequent user back-and-forth, or critical-path work needed for the main agent's next action.",
 			"A single blocking subagent call should be used only when independent context, high-volume output isolation, or an external review is worth waiting for; otherwise do the task in the main agent.",
+			"For one-shot parallel work, use a single subagent call with tasks instead of repeated subagent_spawn calls, even when the user explicitly requests multiple agents.",
 			"When subagent_spawn is available, use it only when detached delegation has a concrete parallel, isolation, or specialization benefit; otherwise keep the work in the main agent.",
 			"After detached spawn, continue useful non-overlapping work when available, or call subagent_wait when coordination is the only useful next action; do not yield permanently while delegated work remains unresolved.",
 			"Consume detached completion messages and synthesize their results before finishing; interrupt or close agents that are no longer needed.",

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -1019,7 +1019,14 @@ test("shared-workspace write classification and follow-up guards are conservativ
 	const followUp = record({ agent: "worker", cwd: process.cwd(), state: "completed" });
 	assert.throws(
 		() => assertFollowUpWriteAllowed(registry, followUp, false, false),
-		/already active in shared workspace/,
+		(error: unknown) => {
+			assert.match(String(error), /already active in shared workspace/);
+			assert.match(String(error), /subagent parallel mode/);
+			assert.match(String(error), /wait or close/);
+			assert.match(String(error), /allowConcurrentWrites/);
+			assert.match(String(error), /worktree/);
+			return true;
+		},
 	);
 	assert.doesNotThrow(() => assertFollowUpWriteAllowed(registry, followUp, true, false));
 	assert.doesNotThrow(() => assertFollowUpWriteAllowed(registry, followUp, false, true));

--- a/extensions/pi-subagents/test/in-process-transport.test.ts
+++ b/extensions/pi-subagents/test/in-process-transport.test.ts
@@ -482,7 +482,10 @@ test("registered detached spawn returns while running and publishes each in-proc
 		mock.sentUserMessages.length = 1;
 		mock.events.get("before_agent_start")?.[0]?.({}, context.ctx);
 		await execute("subagent_send", { agentId, task: "second" });
-		await execute("subagent_wait", { agentId, timeoutMs: 100 });
+		await Promise.all([
+			execute("subagent_wait", { agentId, timeoutMs: 100 }),
+			execute("subagent_wait", { agentId, timeoutMs: 100 }),
+		]);
 		child.waitForNextAbort();
 		await execute("subagent_send", { agentId, task: "interrupt me" });
 		await execute("subagent_interrupt", { agentId });
@@ -495,7 +498,11 @@ test("registered detached spawn returns while running and publishes each in-proc
 		assert.equal(created[0].parentRuntime.thinkingLevel, "high");
 		assert.equal(child.disposals, 1);
 		await new Promise((resolve) => setImmediate(resolve));
-		assert.equal(mock.sentMessages.length, 4);
+		assert.equal(
+			mock.sentMessages.length,
+			2,
+			"active waits consume completion without suppressing unwaited turns",
+		);
 		const firstCompletion = mock.sentMessages[0] as {
 			message: { customType: string; content: string; details: { agentId: string; state: string } };
 			options: { deliverAs: string; triggerTurn: boolean };

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -46,6 +46,7 @@ test("subagents registers self-directed fan-out guidance and configuration comma
 	assert.match(guidanceText, /decide how many subagents to spawn/i);
 	assert.match(guidanceText, /no subagent/i);
 	assert.match(guidanceText, /blocking subagent/i);
+	assert.match(guidanceText, /one-shot.*parallel.*single.*subagent.*call/i);
 	assert.match(guidanceText, /critical-path/i);
 	assert.match(guidanceText, /subagent_spawn.*parallel, isolation, or specialization benefit/i);
 	assert.match(


### PR DESCRIPTION
## Summary

- guide one-shot parallel work toward a single blocking `subagent` call
- avoid duplicate asynchronous completions when an active `subagent_wait` consumes the result
- make shared-workspace conflicts actionable and document lifecycle choices

## Verification

- `npm run check` (322 tests)
- `just pack-subagents` (23 files)
- Pi JSON smoke: one parallel call, three ordered outputs, one root synthesis
- subprocess wait smoke: no duplicate completion
- detached no-wait smoke: asynchronous completion preserved