### PR TITLE
fix(goal): isolate runtime state per factory invocation

### DIFF
--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -33,11 +33,12 @@ import {
 
 type AgentStopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 
-// This module intentionally retains the shared lifecycle state machine: every
-// Pi hook and goal tool coordinates the same goal, continuation, retry, stale-
-// turn guard, and budget single-flight state. Pure command, prompt, accounting,
-// and persistence logic lives in focused modules; splitting the remaining
-// handlers would create ambiguous mutable-state ownership.
+// Per-factory GoalRuntime owns mutable goal/continuation/budget/recovery state
+// so concurrent in-process AgentSessions cannot clobber each other. Pure helpers
+// live at module scope (single source of truth). registerGoalRuntime still keeps
+// the orchestration handlers together so mutable ownership does not fragment
+// across files; a file-size split is deferred until that ownership boundary is
+// stable under isolation tests.
 
 interface GoalCompleteDetails {
 	goal: string;
@@ -128,6 +129,7 @@ const RETRYABLE_GOAL_ERROR_PATTERNS = [
 	/timed? out|timeout|terminated|websocket.?(?:closed|error)|ended without|stream ended before message_stop|http2 request did not get a response|retry delay/i,
 	/context[_\s-]*length[_\s-]*exceeded|input exceeds the context window/i,
 ] as const;
+
 interface GoalRuntime {
 	readonly pi: ExtensionAPI;
 	activeGoal?: ActiveGoal;
@@ -376,16 +378,16 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 					pauseGoal(ctx);
 					return;
 				case "resume":
-					await resumeGoal(pi, ctx);
+					await resumeGoal(runtime.pi, ctx);
 					return;
 				case "clear":
 					clearGoal(ctx);
 					return;
 				case "edit":
-					await editGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
+					await editGoal(result.objective ?? "", result.tokenBudget, runtime.pi, ctx);
 					return;
 				case "start":
-					await startGoal(result.objective ?? "", result.tokenBudget, pi, ctx);
+					await startGoal(result.objective ?? "", result.tokenBudget, runtime.pi, ctx);
 					return;
 			}
 		},
@@ -401,7 +403,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		if (runtime.activeGoal) {
 			if (runtime.activeGoal.status === "active") {
 				updateGoalUsage(runtime.activeGoal, ctx);
-				if (limitActiveGoalForBudget(pi, ctx, false)) return;
+				if (limitActiveGoalForBudget(ctx, false)) return;
 			}
 			persistGoal(runtime.activeGoal);
 			updateStatus(ctx, runtime.activeGoal);
@@ -431,7 +433,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		cancelContinuationWork();
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
-		if (limitActiveGoalForBudget(pi, ctx, false)) return { cancel: true as const };
+		if (limitActiveGoalForBudget(ctx, false)) return { cancel: true as const };
 	});
 
 	pi.on("session_compact", (event, ctx) => {
@@ -445,7 +447,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		updateGoalUsage(runtime.activeGoal, ctx);
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
-		if (limitActiveGoalForBudget(pi, ctx, false)) return;
+		if (limitActiveGoalForBudget(ctx, false)) return;
 
 		const wasPiRetry = isPiOwnedCompactionRetry(event, runtime.activeGoal.id);
 		clearGoalRecoveryForGoal(runtime.activeGoal.id);
@@ -454,7 +456,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		// Manual compaction does not emit agent_settled. This common dispatcher is
 		// therefore the narrow fallback; threshold compaction leaves the intent for
 		// agent_settled when Pi is still busy.
-		dispatchContinuationIfSettled(pi, ctx);
+		dispatchContinuationIfSettled(ctx);
 	});
 
 	pi.on("input", (event) => {
@@ -504,7 +506,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 			runtime.budgetWrapUp?.goalId === runtime.activeGoal.id &&
 			!runtime.budgetWrapUp.delivered
 		) {
-			queueBudgetWrapUp(pi, ctx, runtime.activeGoal);
+			queueBudgetWrapUp(ctx, runtime.activeGoal);
 			return;
 		}
 		if (runtime.activeGoal?.status !== "active") return;
@@ -514,7 +516,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		updateGoalUsage(runtime.activeGoal, ctx);
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
-		limitActiveGoalForBudget(pi, ctx, true);
+		limitActiveGoalForBudget(ctx, true);
 	});
 
 	pi.on("before_agent_start", (event) => {
@@ -555,7 +557,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 
 		if (finalAssistant?.stopReason === "error") {
 			if (isRetryableGoalInterruption(finalAssistant)) {
-				if (limitActiveGoalForBudget(pi, ctx, false)) return;
+				if (limitActiveGoalForBudget(ctx, false)) return;
 				runtime.goalRecovery = {
 					goalId,
 					kind: isGoalContextOverflow(finalAssistant) ? "compaction_retry" : "provider_retry",
@@ -577,7 +579,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 
 		clearGoalRecoveryForGoal(goalId);
 
-		if (limitActiveGoalForBudget(pi, ctx, false)) return;
+		if (limitActiveGoalForBudget(ctx, false)) return;
 
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
@@ -588,7 +590,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 	});
 
 	pi.on("agent_settled", (_event, ctx) => {
-		dispatchContinuationIfSettled(pi, ctx);
+		dispatchContinuationIfSettled(ctx);
 	});
 
 	async function startGoal(
@@ -819,53 +821,6 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		ctx.ui.notify(goalSummary(runtime.activeGoal), "info");
 	}
 
-	function createGoal(
-		text: string,
-		tokenBudget: number | undefined,
-		baselineTokens: number,
-	): ActiveGoal {
-		const now = Date.now();
-		return {
-			id: randomUUID(),
-			text,
-			status: "active",
-			startedAt: now,
-			updatedAt: now,
-			iteration: 0,
-			tokenBudget,
-			tokensUsed: 0,
-			timeUsedSeconds: 0,
-			baselineTokens,
-			activeStartedAt: now,
-		};
-	}
-
-	function transitionGoal(goal: ActiveGoal, requestedStatus: GoalStatus): ActiveGoal {
-		const now = Date.now();
-		const status =
-			requestedStatus === "active" &&
-			goal.tokenBudget !== undefined &&
-			goal.tokensUsed >= goal.tokenBudget
-				? "budget_limited"
-				: requestedStatus;
-		const next = { ...goal, status, updatedAt: now };
-		checkpointGoalActiveTime(next, now, status === "active");
-		return next;
-	}
-
-	function nextGoalInstance(goal: ActiveGoal): ActiveGoal {
-		return { ...goal, id: randomUUID(), updatedAt: Date.now() };
-	}
-
-	function editedGoalStatus(status: GoalStatus): GoalStatus {
-		if (status === "paused" || status === "blocked" || status === "usage_limited") return status;
-		return "active";
-	}
-
-	function incrementGoal(goal: ActiveGoal): ActiveGoal {
-		return { ...goal, iteration: goal.iteration + 1, updatedAt: Date.now() };
-	}
-
 	function stopGoalAfterAgentEnd(
 		ctx: StatusContext,
 		goal: ActiveGoal,
@@ -903,27 +858,6 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		);
 	}
 
-	async function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-		return sendPrompt(pi, ctx, buildGoalPrompt(goal));
-	}
-
-	async function sendObjectiveUpdatedPrompt(
-		pi: ExtensionAPI,
-		ctx: StatusContext,
-		goal: ActiveGoal,
-	) {
-		return sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
-	}
-
-	async function sendResumePrompt(
-		pi: ExtensionAPI,
-		ctx: StatusContext,
-		goal: ActiveGoal,
-		stoppedStatus: GoalStatus,
-	) {
-		return sendPrompt(pi, ctx, buildResumePrompt(goal, stoppedStatus));
-	}
-
 	function requestContinuation(goal: ActiveGoal) {
 		if (hasContinuationWorkForGoal(goal.id)) return false;
 		const marker = continuationMarker(goal);
@@ -936,7 +870,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		return true;
 	}
 
-	function dispatchContinuationIfSettled(pi: ExtensionAPI, ctx: StatusContext) {
+	function dispatchContinuationIfSettled(ctx: StatusContext) {
 		const intent = runtime.continuationIntent;
 		if (!intent) return false;
 		if (
@@ -952,7 +886,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		runtime.continuationIntent = undefined;
 		runtime.continuationDelivery = intent;
 		try {
-			pi.sendUserMessage(intent.prompt);
+			runtime.pi.sendUserMessage(intent.prompt);
 			return true;
 		} catch (error) {
 			if (runtime.continuationDelivery?.marker === intent.marker)
@@ -972,86 +906,13 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		);
 	}
 
-	async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
-		try {
-			const sent = ctx.isIdle?.()
-				? (pi.sendUserMessage(prompt) as void | Promise<void>)
-				: (pi.sendUserMessage(prompt, { deliverAs: "followUp" }) as void | Promise<void>);
-			await sent;
-			return true;
-		} catch (error) {
-			ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
-			return false;
-		}
-	}
-
 	function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
 		clearCompletionStatusTimer();
 		ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
 	}
 
-	function formatStatus(goal: ActiveGoal | undefined) {
-		if (!goal) return undefined;
-		if (goal.status === "complete") return "complete";
-		if (goal.status === "paused") return "paused";
-		if (goal.status === "blocked") return "blocked";
-		if (goal.status === "usage_limited") return "usage";
-		if (goal.status === "budget_limited") return `budget ${formatBudget(goal)}`;
-		if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)}`;
-		return `active ${formatDuration(goal.timeUsedSeconds)}`;
-	}
-
-	function formatBudget(goal: ActiveGoal) {
-		return `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget ?? 0)}`;
-	}
-
-	function goalSummary(goal: ActiveGoal) {
-		return [
-			`Goal: ${goal.text}`,
-			`Status: ${goal.status}`,
-			`Iteration: ${goal.iteration}`,
-			`Active elapsed: ${formatDuration(goal.timeUsedSeconds)}`,
-			`Tokens: ${goal.tokenBudget === undefined ? formatTokenCount(goal.tokensUsed) : formatBudget(goal)}`,
-			`Commands: ${goalCommandHint(goal.status)}`,
-		].join("\n");
-	}
-
-	function goalCommandHint(status: GoalStatus) {
-		if (status === "active") return "/goal edit <objective>, /goal pause, /goal clear";
-		if (isResumableGoalStatus(status)) {
-			return "/goal edit <objective>, /goal resume, /goal clear";
-		}
-		return "/goal edit <objective>, /goal clear";
-	}
-
-	function hasPendingMessages(ctx: StatusContext) {
-		return ctx.hasPendingMessages?.() ?? false;
-	}
-
-	function abortCurrentTurn(ctx: StatusContext) {
-		try {
-			ctx.abort?.();
-		} catch {
-			// Best effort: stale goal guards still prevent follow-on tool calls.
-		}
-	}
-
 	function blockStaleGoalToolCalls() {
 		runtime.staleGoalToolCallsBlocked = true;
-	}
-
-	function blocksStaleGoalToolCalls(status: GoalStatus) {
-		return status === "paused" || status === "blocked" || status === "usage_limited";
-	}
-
-	function isResumableGoalStatus(status: GoalStatus) {
-		return blocksStaleGoalToolCalls(status) || status === "budget_limited";
-	}
-
-	function stoppedStatusLabel(status: GoalStatus) {
-		if (status === "usage_limited") return "usage-limited";
-		if (status === "budget_limited") return "budget-limited";
-		return status;
 	}
 
 	function clearStaleGoalToolCallBlock() {
@@ -1083,14 +944,14 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		);
 	}
 
-	function queueBudgetWrapUp(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	function queueBudgetWrapUp(ctx: StatusContext, goal: ActiveGoal) {
 		if (!runtime.budgetWrapUp || runtime.budgetWrapUp.goalId !== goal.id) {
 			runtime.budgetWrapUp = { goalId: goal.id, delivered: false };
 		}
 		if (runtime.budgetWrapUp.delivered) return true;
 		runtime.budgetWrapUp.delivered = true;
 		try {
-			pi.sendMessage(
+			runtime.pi.sendMessage(
 				{
 					customType: BUDGET_WRAP_UP_MESSAGE_TYPE,
 					content: BUDGET_WRAP_UP_PROMPT,
@@ -1107,7 +968,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		}
 	}
 
-	function limitActiveGoalForBudget(pi: ExtensionAPI, ctx: StatusContext, sendWrapUp: boolean) {
+	function limitActiveGoalForBudget(ctx: StatusContext, sendWrapUp: boolean) {
 		const goal = runtime.activeGoal;
 		if (
 			goal?.status !== "active" ||
@@ -1124,7 +985,7 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
 		ctx.ui.notify(`Goal token budget reached: ${formatBudget(runtime.activeGoal)}`, "warning");
-		if (sendWrapUp) queueBudgetWrapUp(pi, ctx, runtime.activeGoal);
+		if (sendWrapUp) queueBudgetWrapUp(ctx, runtime.activeGoal);
 		return true;
 	}
 
@@ -1140,75 +1001,6 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 			runtime.goalRecovery.kind === "compaction_retry" &&
 			(compaction.reason === undefined || compaction.reason === "overflow")
 		);
-	}
-
-	function isContradictoryCompletionSummary(summary: string) {
-		return CONTRADICTORY_COMPLETION_PATTERNS.some((pattern) => pattern.test(summary));
-	}
-
-	function goalIdRejectionReason(goal: ActiveGoal, requestedGoalId: string) {
-		if (!requestedGoalId) return "missing goal_id";
-		if (requestedGoalId !== goal.id) return "goal_id does not match the active goal";
-		return undefined;
-	}
-
-	function isUsageLimitedGoalInterruption(assistant: AssistantMessageLike) {
-		const errorMessage = assistant.errorMessage;
-		return (
-			assistant.stopReason === "error" &&
-			typeof errorMessage === "string" &&
-			USAGE_LIMIT_GOAL_ERROR_PATTERNS.some((pattern) => pattern.test(errorMessage))
-		);
-	}
-
-	function isRetryableGoalInterruption(assistant: AssistantMessageLike) {
-		if (assistant.stopReason !== "error") return false;
-		if (!assistant.errorMessage) return false;
-		if (
-			isUsageLimitedGoalInterruption(assistant) ||
-			NON_RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage)
-		) {
-			return false;
-		}
-		return (
-			isGoalContextOverflow(assistant) ||
-			RETRYABLE_GOAL_ERROR_PATTERNS.some((pattern) => pattern.test(assistant.errorMessage ?? ""))
-		);
-	}
-
-	function isGoalContextOverflow(assistant: AssistantMessageLike) {
-		return isContextOverflow(toPiAssistantMessage(assistant));
-	}
-
-	function toPiAssistantMessage(assistant: AssistantMessageLike): PiAssistantMessage {
-		return {
-			role: "assistant",
-			content: assistant.content ?? [],
-			api: assistant.api ?? "openai-responses",
-			provider: assistant.provider ?? "unknown",
-			model: assistant.model ?? "unknown",
-			usage: assistant.usage ?? zeroUsage(),
-			stopReason: assistant.stopReason ?? "error",
-			errorMessage: assistant.errorMessage,
-			timestamp: assistant.timestamp ?? Date.now(),
-		};
-	}
-
-	function zeroUsage(): Usage {
-		return {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 0,
-			cost: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				total: 0,
-			},
-		};
 	}
 
 	function clearContinuationTracking() {
@@ -1246,87 +1038,6 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 			return;
 		}
 		if (runtime.continuationDelivery?.marker === marker) runtime.continuationDelivery = undefined;
-	}
-
-	function continuationMarker(goal: ActiveGoal) {
-		return `${goal.id}:${goal.iteration}:${randomUUID()}`;
-	}
-
-	function continuationMarkerComment(marker: string) {
-		return `<!-- ${CONTINUATION_MARKER_PREFIX}${marker} -->`;
-	}
-
-	function escapeRegExpText(value: string) {
-		return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	}
-
-	const CONTINUATION_MARKER_PATTERN = new RegExp(
-		`<!--\\s*${escapeRegExpText(CONTINUATION_MARKER_PREFIX)}([^\\s>]+)\\s*-->`,
-	);
-
-	function extractContinuationMarker(prompt: string) {
-		return CONTINUATION_MARKER_PATTERN.exec(prompt)?.[1];
-	}
-
-	function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {
-		for (let i = messages.length - 1; i >= 0; i--) {
-			const message = messages[i];
-			if (!message || typeof message !== "object") continue;
-			const candidate = message as Record<string, unknown>;
-			if (candidate.role !== "assistant") continue;
-			const assistant: AssistantMessageLike = {
-				role: "assistant",
-				stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
-				errorMessage:
-					typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
-			};
-			if (Array.isArray(candidate.content))
-				assistant.content = candidate.content as PiAssistantMessage["content"];
-			if (typeof candidate.api === "string") assistant.api = candidate.api;
-			if (typeof candidate.provider === "string") assistant.provider = candidate.provider;
-			if (typeof candidate.model === "string") assistant.model = candidate.model;
-			if (typeof candidate.timestamp === "number") assistant.timestamp = candidate.timestamp;
-			const usage = normalizeUsage(candidate.usage);
-			if (usage) assistant.usage = usage;
-			return assistant;
-		}
-		return undefined;
-	}
-
-	function isAgentStopReason(value: unknown): value is AgentStopReason {
-		return ["stop", "length", "toolUse", "error", "aborted"].includes(String(value));
-	}
-
-	function normalizeUsage(value: unknown): Usage | undefined {
-		if (!value || typeof value !== "object") return undefined;
-		const usage = value as Partial<Usage>;
-		if (typeof usage.input !== "number" || typeof usage.output !== "number") return undefined;
-		return {
-			input: nonNegativeFiniteNumber(usage.input),
-			output: nonNegativeFiniteNumber(usage.output),
-			cacheRead: nonNegativeFiniteNumber(usage.cacheRead),
-			cacheWrite: nonNegativeFiniteNumber(usage.cacheWrite),
-			totalTokens: assistantUsageTokens(usage),
-			cost: {
-				input: usage.cost?.input ?? 0,
-				output: usage.cost?.output ?? 0,
-				cacheRead: usage.cost?.cacheRead ?? 0,
-				cacheWrite: usage.cost?.cacheWrite ?? 0,
-				total: usage.cost?.total ?? 0,
-			},
-		};
-	}
-
-	function escapeXmlText(value: string) {
-		return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-	}
-
-	function formatError(error: unknown) {
-		return truncateNotification(error instanceof Error ? error.message : String(error));
-	}
-
-	function truncateNotification(value: string) {
-		return value.length > 160 ? `${value.slice(0, 157)}...` : value;
 	}
 
 	function persistGoal(goal: ActiveGoal) {
@@ -1369,8 +1080,85 @@ function registerGoalRuntime(pi: ExtensionAPI) {
 	}
 }
 
-export default function goal(pi: ExtensionAPI) {
-	registerGoalRuntime(pi);
+function createGoal(
+	text: string,
+	tokenBudget: number | undefined,
+	baselineTokens: number,
+): ActiveGoal {
+	const now = Date.now();
+	return {
+		id: randomUUID(),
+		text,
+		status: "active",
+		startedAt: now,
+		updatedAt: now,
+		iteration: 0,
+		tokenBudget,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		baselineTokens,
+		activeStartedAt: now,
+	};
+}
+
+function transitionGoal(goal: ActiveGoal, requestedStatus: GoalStatus): ActiveGoal {
+	const now = Date.now();
+	const status =
+		requestedStatus === "active" &&
+		goal.tokenBudget !== undefined &&
+		goal.tokensUsed >= goal.tokenBudget
+			? "budget_limited"
+			: requestedStatus;
+	const next = { ...goal, status, updatedAt: now };
+	checkpointGoalActiveTime(next, now, status === "active");
+	return next;
+}
+
+function nextGoalInstance(goal: ActiveGoal): ActiveGoal {
+	return { ...goal, id: randomUUID(), updatedAt: Date.now() };
+}
+
+function editedGoalStatus(status: GoalStatus): GoalStatus {
+	if (status === "paused" || status === "blocked" || status === "usage_limited") return status;
+	return "active";
+}
+
+function incrementGoal(goal: ActiveGoal): ActiveGoal {
+	return { ...goal, iteration: goal.iteration + 1, updatedAt: Date.now() };
+}
+
+async function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+	return sendPrompt(pi, ctx, buildGoalPrompt(goal));
+}
+
+async function sendObjectiveUpdatedPrompt(
+	pi: ExtensionAPI,
+	ctx: StatusContext,
+	goal: ActiveGoal,
+) {
+	return sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
+}
+
+async function sendResumePrompt(
+	pi: ExtensionAPI,
+	ctx: StatusContext,
+	goal: ActiveGoal,
+	stoppedStatus: GoalStatus,
+) {
+	return sendPrompt(pi, ctx, buildResumePrompt(goal, stoppedStatus));
+}
+
+async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
+	try {
+		const sent = ctx.isIdle?.()
+			? (pi.sendUserMessage(prompt) as void | Promise<void>)
+			: (pi.sendUserMessage(prompt, { deliverAs: "followUp" }) as void | Promise<void>);
+		await sent;
+		return true;
+	} catch (error) {
+		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
+		return false;
+	}
 }
 
 export function formatStatus(goal: ActiveGoal | undefined) {
@@ -1379,17 +1167,68 @@ export function formatStatus(goal: ActiveGoal | undefined) {
 	if (goal.status === "paused") return "paused";
 	if (goal.status === "blocked") return "blocked";
 	if (goal.status === "usage_limited") return "usage";
-	if (goal.status === "budget_limited") {
-		return `budget ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget ?? 0)}`;
-	}
-	if (goal.tokenBudget !== undefined) {
-		return `active ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`;
-	}
+	if (goal.status === "budget_limited") return `budget ${formatBudget(goal)}`;
+	if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)}`;
 	return `active ${formatDuration(goal.timeUsedSeconds)}`;
+}
+
+function formatBudget(goal: ActiveGoal) {
+	return `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget ?? 0)}`;
+}
+
+function goalSummary(goal: ActiveGoal) {
+	return [
+		`Goal: ${goal.text}`,
+		`Status: ${goal.status}`,
+		`Iteration: ${goal.iteration}`,
+		`Active elapsed: ${formatDuration(goal.timeUsedSeconds)}`,
+		`Tokens: ${goal.tokenBudget === undefined ? formatTokenCount(goal.tokensUsed) : formatBudget(goal)}`,
+		`Commands: ${goalCommandHint(goal.status)}`,
+	].join("\n");
+}
+
+function goalCommandHint(status: GoalStatus) {
+	if (status === "active") return "/goal edit <objective>, /goal pause, /goal clear";
+	if (isResumableGoalStatus(status)) {
+		return "/goal edit <objective>, /goal resume, /goal clear";
+	}
+	return "/goal edit <objective>, /goal clear";
+}
+
+function hasPendingMessages(ctx: StatusContext) {
+	return ctx.hasPendingMessages?.() ?? false;
+}
+
+function abortCurrentTurn(ctx: StatusContext) {
+	try {
+		ctx.abort?.();
+	} catch {
+		// Best effort: stale goal guards still prevent follow-on tool calls.
+	}
+}
+
+function blocksStaleGoalToolCalls(status: GoalStatus) {
+	return status === "paused" || status === "blocked" || status === "usage_limited";
+}
+
+function isResumableGoalStatus(status: GoalStatus) {
+	return blocksStaleGoalToolCalls(status) || status === "budget_limited";
+}
+
+function stoppedStatusLabel(status: GoalStatus) {
+	if (status === "usage_limited") return "usage-limited";
+	if (status === "budget_limited") return "budget-limited";
+	return status;
 }
 
 export function isContradictoryCompletionSummary(summary: string) {
 	return CONTRADICTORY_COMPLETION_PATTERNS.some((pattern) => pattern.test(summary));
+}
+
+function goalIdRejectionReason(goal: ActiveGoal, requestedGoalId: string) {
+	if (!requestedGoalId) return "missing goal_id";
+	if (requestedGoalId !== goal.id) return "goal_id does not match the active goal";
+	return undefined;
 }
 
 export function isUsageLimitedGoalInterruption(assistant: AssistantMessageLike) {
@@ -1411,34 +1250,60 @@ export function isRetryableGoalInterruption(assistant: AssistantMessageLike) {
 		return false;
 	}
 	return (
-		isGoalContextOverflowForExport(assistant) ||
+		isGoalContextOverflow(assistant) ||
 		RETRYABLE_GOAL_ERROR_PATTERNS.some((pattern) => pattern.test(assistant.errorMessage ?? ""))
 	);
 }
 
-function isGoalContextOverflowForExport(assistant: AssistantMessageLike) {
-	return isContextOverflow({
+function isGoalContextOverflow(assistant: AssistantMessageLike) {
+	return isContextOverflow(toPiAssistantMessage(assistant));
+}
+
+function toPiAssistantMessage(assistant: AssistantMessageLike): PiAssistantMessage {
+	return {
 		role: "assistant",
 		content: assistant.content ?? [],
 		api: assistant.api ?? "openai-responses",
 		provider: assistant.provider ?? "unknown",
 		model: assistant.model ?? "unknown",
-		usage: assistant.usage ?? zeroUsageForExport(),
+		usage: assistant.usage ?? zeroUsage(),
 		stopReason: assistant.stopReason ?? "error",
 		errorMessage: assistant.errorMessage,
 		timestamp: assistant.timestamp ?? Date.now(),
-	});
+	};
 }
 
-function zeroUsageForExport(): Usage {
+function zeroUsage(): Usage {
 	return {
 		input: 0,
 		output: 0,
 		cacheRead: 0,
 		cacheWrite: 0,
 		totalTokens: 0,
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		},
 	};
+}
+
+function continuationMarker(goal: ActiveGoal) {
+	return `${goal.id}:${goal.iteration}:${randomUUID()}`;
+}
+
+function escapeRegExpText(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const CONTINUATION_MARKER_PATTERN = new RegExp(
+	`<!--\\s*${escapeRegExpText(CONTINUATION_MARKER_PREFIX)}([^\\s>]+)\\s*-->`,
+);
+
+function extractContinuationMarker(prompt: string) {
+	return CONTINUATION_MARKER_PATTERN.exec(prompt)?.[1];
 }
 
 export function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {
@@ -1449,30 +1314,28 @@ export function findFinalAssistantMessage(messages: unknown[]): AssistantMessage
 		if (candidate.role !== "assistant") continue;
 		const assistant: AssistantMessageLike = {
 			role: "assistant",
-			stopReason: isAgentStopReasonForExport(candidate.stopReason)
-				? candidate.stopReason
-				: undefined,
-			errorMessage: typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
+			stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
+			errorMessage:
+				typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
 		};
-		if (Array.isArray(candidate.content)) {
+		if (Array.isArray(candidate.content))
 			assistant.content = candidate.content as PiAssistantMessage["content"];
-		}
 		if (typeof candidate.api === "string") assistant.api = candidate.api;
 		if (typeof candidate.provider === "string") assistant.provider = candidate.provider;
 		if (typeof candidate.model === "string") assistant.model = candidate.model;
 		if (typeof candidate.timestamp === "number") assistant.timestamp = candidate.timestamp;
-		const usage = normalizeUsageForExport(candidate.usage);
+		const usage = normalizeUsage(candidate.usage);
 		if (usage) assistant.usage = usage;
 		return assistant;
 	}
 	return undefined;
 }
 
-function isAgentStopReasonForExport(value: unknown): value is AgentStopReason {
+function isAgentStopReason(value: unknown): value is AgentStopReason {
 	return ["stop", "length", "toolUse", "error", "aborted"].includes(String(value));
 }
 
-function normalizeUsageForExport(value: unknown): Usage | undefined {
+function normalizeUsage(value: unknown): Usage | undefined {
 	if (!value || typeof value !== "object") return undefined;
 	const usage = value as Partial<Usage>;
 	if (typeof usage.input !== "number" || typeof usage.output !== "number") return undefined;
@@ -1492,16 +1355,30 @@ function normalizeUsageForExport(value: unknown): Usage | undefined {
 	};
 }
 
+function formatError(error: unknown) {
+	return truncateNotification(error instanceof Error ? error.message : String(error));
+}
+
+function truncateNotification(value: string) {
+	return value.length > 160 ? `${value.slice(0, 157)}...` : value;
+}
+
+export default function goal(pi: ExtensionAPI) {
+	registerGoalRuntime(pi);
+}
+
 export {
 	assistantUsageTokens,
 	cumulativeAssistantTokens,
 	formatDuration,
 	formatTokenCount,
 } from "./accounting.js";
+
 export {
 	completeGoalArguments,
 	parseCommand,
 	parseTokenBudget,
 	validateObjective,
 } from "./command.js";
+
 export { buildGoalSystemPrompt } from "./prompts.js";

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -1131,11 +1131,7 @@ async function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: Active
 	return sendPrompt(pi, ctx, buildGoalPrompt(goal));
 }
 
-async function sendObjectiveUpdatedPrompt(
-	pi: ExtensionAPI,
-	ctx: StatusContext,
-	goal: ActiveGoal,
-) {
+async function sendObjectiveUpdatedPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
 	return sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
 }
 
@@ -1315,8 +1311,7 @@ export function findFinalAssistantMessage(messages: unknown[]): AssistantMessage
 		const assistant: AssistantMessageLike = {
 			role: "assistant",
 			stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
-			errorMessage:
-				typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
+			errorMessage: typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
 		};
 		if (Array.isArray(candidate.content))
 			assistant.content = candidate.content as PiAssistantMessage["content"];

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -1,29 +1,21 @@
 import { randomUUID } from "node:crypto";
-import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	isContextOverflow,
 	type AssistantMessage as PiAssistantMessage,
 	type Usage,
 } from "@earendil-works/pi-ai";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
 	assistantUsageTokens,
 	checkpointGoalActiveTime,
-	cumulativeAssistantTokens,
 	currentTokenTotal,
 	formatDuration,
 	formatTokenCount,
-	isNonNegativeFiniteNumber,
 	nonNegativeFiniteNumber,
-	normalizeTokenBudget,
 	updateGoalUsage,
 } from "./accounting.js";
-import {
-	completeGoalArguments,
-	parseCommand,
-	parseTokenBudget,
-	validateObjective,
-} from "./command.js";
+import { completeGoalArguments, parseCommand, validateObjective } from "./command.js";
 import {
 	type ActiveGoal,
 	clearLegacyPersistedGoal,
@@ -136,222 +128,233 @@ const RETRYABLE_GOAL_ERROR_PATTERNS = [
 	/timed? out|timeout|terminated|websocket.?(?:closed|error)|ended without|stream ended before message_stop|http2 request did not get a response|retry delay/i,
 	/context[_\s-]*length[_\s-]*exceeded|input exceeds the context window/i,
 ] as const;
-let activeGoal: ActiveGoal | undefined;
-let completionStatusTimer: NodeJS.Timeout | undefined;
-let extensionApi: ExtensionAPI | undefined;
-let continuationIntent: ContinuationTicket | undefined;
-let continuationDelivery: ContinuationTicket | undefined;
-let goalRecovery: GoalRecovery | undefined;
-let budgetWrapUp: BudgetWrapUp | undefined;
-let staleGoalToolCallsBlocked = false;
-const cancelledContinuationMarkers = new Set<string>();
+interface GoalRuntime {
+	readonly pi: ExtensionAPI;
+	activeGoal?: ActiveGoal;
+	completionStatusTimer?: NodeJS.Timeout;
+	continuationIntent?: ContinuationTicket;
+	continuationDelivery?: ContinuationTicket;
+	goalRecovery?: GoalRecovery;
+	budgetWrapUp?: BudgetWrapUp;
+	staleGoalToolCallsBlocked: boolean;
+	cancelledContinuationMarkers: Set<string>;
+}
 
-const goalCompleteTool = defineTool({
-	name: "goal_complete",
-	label: "Goal Complete",
-	description:
-		"Mark the active /goal as complete after all required work is done and verified, using the current goal_id stale-turn guard. Do not use for partial progress, blockers, failing, or unverified work.",
-	promptSnippet:
-		"Mark the active /goal as complete after fully finishing and verifying it, with the current goal_id",
-	promptGuidelines: [
-		"When a /goal is active, keep working until the goal is complete; do not stop with only a plan or partial progress.",
-		"Before calling goal_complete, audit the active goal requirement by requirement against the current files, command output, tests, or external state.",
-		"Pass the exact goal_id shown in the current /goal prompt; never reuse a goal_id from an older, stopped, replaced, or cleared turn.",
-		"Call goal_complete only after the requested goal is fully implemented, verified, and no known required work remains; otherwise keep working.",
-	],
-	parameters: Type.Object({
-		goal_id: Type.String({
-			description:
-				"The exact goal_id shown in the current active /goal prompt. Used only to reject stale completion calls from older turns.",
+function createGoalRuntime(pi: ExtensionAPI): GoalRuntime {
+	return {
+		pi,
+		staleGoalToolCallsBlocked: false,
+		cancelledContinuationMarkers: new Set(),
+	};
+}
+
+function registerGoalRuntime(pi: ExtensionAPI) {
+	const runtime = createGoalRuntime(pi);
+
+	const goalCompleteTool = defineTool({
+		name: "goal_complete",
+		label: "Goal Complete",
+		description:
+			"Mark the active /goal as complete after all required work is done and verified, using the current goal_id stale-turn guard. Do not use for partial progress, blockers, failing, or unverified work.",
+		promptSnippet:
+			"Mark the active /goal as complete after fully finishing and verifying it, with the current goal_id",
+		promptGuidelines: [
+			"When a /goal is active, keep working until the goal is complete; do not stop with only a plan or partial progress.",
+			"Before calling goal_complete, audit the active goal requirement by requirement against the current files, command output, tests, or external state.",
+			"Pass the exact goal_id shown in the current /goal prompt; never reuse a goal_id from an older, stopped, replaced, or cleared turn.",
+			"Call goal_complete only after the requested goal is fully implemented, verified, and no known required work remains; otherwise keep working.",
+		],
+		parameters: Type.Object({
+			goal_id: Type.String({
+				description:
+					"The exact goal_id shown in the current active /goal prompt. Used only to reject stale completion calls from older turns.",
+			}),
+			summary: Type.String({
+				description:
+					"State what was completed and what evidence verified it. Do not use this tool to report partial progress, blockers, failures, or remaining work.",
+			}),
 		}),
-		summary: Type.String({
-			description:
-				"State what was completed and what evidence verified it. Do not use this tool to report partial progress, blockers, failures, or remaining work.",
-		}),
-	}),
-	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		const completedGoal = activeGoal;
-		const goal = completedGoal?.text ?? "unknown goal";
-		const requestedGoalId = typeof params.goal_id === "string" ? params.goal_id.trim() : "";
-		const summary = typeof params.summary === "string" ? params.summary.trim() : "";
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const completedGoal = runtime.activeGoal;
+			const goal = completedGoal?.text ?? "unknown goal";
+			const requestedGoalId = typeof params.goal_id === "string" ? params.goal_id.trim() : "";
+			const summary = typeof params.summary === "string" ? params.summary.trim() : "";
 
-		if (!completedGoal) {
-			const rejection = "Goal completion rejected: no active goal.";
-			ctx.ui.notify(rejection, "warning");
+			if (!completedGoal) {
+				const rejection = "Goal completion rejected: no active goal.";
+				ctx.ui.notify(rejection, "warning");
 
-			return {
-				content: [{ type: "text", text: rejection }],
-				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
-			};
-		}
+				return {
+					content: [{ type: "text", text: rejection }],
+					details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
+				};
+			}
 
-		const completingDuringBudgetWrapUp =
-			completedGoal.status === "budget_limited" &&
-			budgetWrapUp?.goalId === completedGoal.id &&
-			budgetWrapUp.delivered;
-		const staleGoalRejection = goalIdRejectionReason(completedGoal, requestedGoalId);
-		if (staleGoalRejection) {
-			const rejection = `Goal completion rejected: ${staleGoalRejection}.`;
-			ctx.ui.notify(rejection, "warning");
-			if (completingDuringBudgetWrapUp) {
+			const completingDuringBudgetWrapUp =
+				completedGoal.status === "budget_limited" &&
+				runtime.budgetWrapUp?.goalId === completedGoal.id &&
+				runtime.budgetWrapUp.delivered;
+			const staleGoalRejection = goalIdRejectionReason(completedGoal, requestedGoalId);
+			if (staleGoalRejection) {
+				const rejection = `Goal completion rejected: ${staleGoalRejection}.`;
+				ctx.ui.notify(rejection, "warning");
+				if (completingDuringBudgetWrapUp) {
+					updateGoalUsage(completedGoal, ctx);
+					persistGoal(completedGoal);
+					updateStatus(ctx, completedGoal);
+					clearBudgetWrapUp();
+				}
+
+				return {
+					content: [{ type: "text", text: rejection }],
+					details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
+					terminate: completingDuringBudgetWrapUp || undefined,
+				};
+			}
+			if (completedGoal.status !== "active" && !completingDuringBudgetWrapUp) {
+				const rejection = `Goal completion rejected: goal is ${completedGoal.status}, not active.`;
+				ctx.ui.notify(rejection, "warning");
+
+				return {
+					content: [{ type: "text", text: rejection }],
+					details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
+				};
+			}
+
+			const rejectionReason = !summary
+				? "summary is empty"
+				: isContradictoryCompletionSummary(summary)
+					? "summary says the goal is not complete"
+					: undefined;
+			if (rejectionReason) {
 				updateGoalUsage(completedGoal, ctx);
 				persistGoal(completedGoal);
 				updateStatus(ctx, completedGoal);
-				clearBudgetWrapUp();
+				const rejection = `Goal completion rejected: ${rejectionReason}.`;
+				ctx.ui.notify(rejection, "warning");
+				if (completingDuringBudgetWrapUp) clearBudgetWrapUp();
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: rejection,
+						},
+					],
+					details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
+					terminate: completingDuringBudgetWrapUp || undefined,
+				};
 			}
 
+			runtime.activeGoal = transitionGoal(completedGoal, "complete");
+			updateGoalUsage(runtime.activeGoal, ctx);
+			persistGoal(runtime.activeGoal);
+
+			ctx.ui.setStatus(STATUS_KEY, formatStatus(runtime.activeGoal));
+			clearActiveGoal(ctx);
+			showCompletionStatus(ctx);
+			ctx.ui.notify(`Goal complete: ${goal}`, "info");
+
 			return {
-				content: [{ type: "text", text: rejection }],
+				content: [{ type: "text", text: `Goal complete: ${summary}` }],
 				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
-				terminate: completingDuringBudgetWrapUp || undefined,
+				terminate: true,
 			};
-		}
-		if (completedGoal.status !== "active" && !completingDuringBudgetWrapUp) {
-			const rejection = `Goal completion rejected: goal is ${completedGoal.status}, not active.`;
-			ctx.ui.notify(rejection, "warning");
+		},
+	});
+
+	const goalBlockedTool = defineTool({
+		name: "goal_blocked",
+		label: "Goal Blocked",
+		description:
+			"Stop the active /goal only at a true impasse after the same blocker recurs for at least three consecutive goal turns, with the current goal_id and concrete evidence that user or external action is required. Do not use for ordinary clarification, uncertainty, or recoverable failures.",
+		promptSnippet:
+			"Mark the active /goal blocked only after the same blocker recurs for three consecutive goal turns",
+		promptGuidelines: [
+			"Use goal_blocked only for a true impasse after the same blocker recurs for at least three consecutive goal turns and concrete evidence shows user or external action is required.",
+			"After a blocked goal is resumed, start a fresh three-turn blocker audit before using goal_blocked again.",
+			"Do not use goal_blocked for ordinary clarification, incomplete work, uncertainty, difficult tasks, or recoverable tool/provider failures.",
+			"Pass goal_blocked the exact current goal_id; never reuse a goal_id from an older, stopped, replaced, or cleared goal turn.",
+		],
+		parameters: Type.Object({
+			goal_id: Type.String({
+				description: "The exact goal_id shown in the current active /goal prompt.",
+			}),
+			reason: Type.String({
+				minLength: 1,
+				maxLength: MAX_BLOCKER_REASON_LENGTH,
+				description: "The specific user or external action required to unblock the goal.",
+			}),
+			evidence: Type.String({
+				minLength: 1,
+				maxLength: MAX_BLOCKER_EVIDENCE_LENGTH,
+				description: "Concrete evidence from the repeated attempts that proves the impasse.",
+			}),
+			repeated_turns: Type.Integer({
+				minimum: 3,
+				description: "Number of separate turns spent trying to resolve this same blocker.",
+			}),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const blockedGoal = runtime.activeGoal;
+			const goal = blockedGoal?.text ?? "unknown goal";
+			const requestedGoalId = typeof params.goal_id === "string" ? params.goal_id.trim() : "";
+			const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+			const evidence = typeof params.evidence === "string" ? params.evidence.trim() : "";
+			const repeatedTurns =
+				typeof params.repeated_turns === "number" ? params.repeated_turns : Number.NaN;
+			const reject = (rejectionReason: string) => {
+				const rejection = `goal_blocked rejected: ${rejectionReason}.`;
+				ctx.ui.notify(rejection, "warning");
+				return {
+					content: [{ type: "text" as const, text: rejection }],
+					details: {
+						goal,
+						goal_id: requestedGoalId,
+						reason: reason.slice(0, MAX_BLOCKER_REASON_LENGTH),
+						evidence: evidence.slice(0, MAX_BLOCKER_EVIDENCE_LENGTH),
+						repeated_turns: Number.isFinite(repeatedTurns) ? repeatedTurns : 0,
+					} satisfies GoalBlockedDetails,
+				};
+			};
+
+			if (!blockedGoal) return reject("no active goal");
+			const staleGoalRejection = goalIdRejectionReason(blockedGoal, requestedGoalId);
+			if (staleGoalRejection) return reject(staleGoalRejection);
+			if (blockedGoal.status !== "active") {
+				return reject(`goal is ${blockedGoal.status}, not active`);
+			}
+			if (!reason) return reject("reason is empty");
+			if (reason.length > MAX_BLOCKER_REASON_LENGTH) return reject("reason is too long");
+			if (!evidence) return reject("evidence is empty");
+			if (evidence.length > MAX_BLOCKER_EVIDENCE_LENGTH) return reject("evidence is too long");
+			if (!Number.isInteger(repeatedTurns)) return reject("repeated_turns must be a whole number");
+			if (repeatedTurns < 3) return reject("repeated_turns must be at least 3");
+
+			updateGoalUsage(blockedGoal, ctx);
+			cancelContinuationWork();
+			clearBudgetWrapUp();
+			clearGoalRecoveryForGoal(blockedGoal.id);
+			blockStaleGoalToolCalls();
+			runtime.activeGoal = transitionGoal(blockedGoal, "blocked");
+			persistGoal(runtime.activeGoal);
+			updateStatus(ctx, runtime.activeGoal);
+			ctx.ui.notify(`Goal blocked: ${truncateNotification(reason)}`, "warning");
 
 			return {
-				content: [{ type: "text", text: rejection }],
-				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
-			};
-		}
-
-		const rejectionReason = !summary
-			? "summary is empty"
-			: isContradictoryCompletionSummary(summary)
-				? "summary says the goal is not complete"
-				: undefined;
-		if (rejectionReason) {
-			updateGoalUsage(completedGoal, ctx);
-			persistGoal(completedGoal);
-			updateStatus(ctx, completedGoal);
-			const rejection = `Goal completion rejected: ${rejectionReason}.`;
-			ctx.ui.notify(rejection, "warning");
-			if (completingDuringBudgetWrapUp) clearBudgetWrapUp();
-
-			return {
-				content: [
-					{
-						type: "text",
-						text: rejection,
-					},
-				],
-				details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
-				terminate: completingDuringBudgetWrapUp || undefined,
-			};
-		}
-
-		activeGoal = transitionGoal(completedGoal, "complete");
-		updateGoalUsage(activeGoal, ctx);
-		persistGoal(activeGoal);
-
-		ctx.ui.setStatus(STATUS_KEY, formatStatus(activeGoal));
-		clearActiveGoal(ctx);
-		showCompletionStatus(ctx);
-		ctx.ui.notify(`Goal complete: ${goal}`, "info");
-
-		return {
-			content: [{ type: "text", text: `Goal complete: ${summary}` }],
-			details: { goal, goal_id: requestedGoalId, summary } satisfies GoalCompleteDetails,
-			terminate: true,
-		};
-	},
-});
-
-const goalBlockedTool = defineTool({
-	name: "goal_blocked",
-	label: "Goal Blocked",
-	description:
-		"Stop the active /goal only at a true impasse after the same blocker recurs for at least three consecutive goal turns, with the current goal_id and concrete evidence that user or external action is required. Do not use for ordinary clarification, uncertainty, or recoverable failures.",
-	promptSnippet:
-		"Mark the active /goal blocked only after the same blocker recurs for three consecutive goal turns",
-	promptGuidelines: [
-		"Use goal_blocked only for a true impasse after the same blocker recurs for at least three consecutive goal turns and concrete evidence shows user or external action is required.",
-		"After a blocked goal is resumed, start a fresh three-turn blocker audit before using goal_blocked again.",
-		"Do not use goal_blocked for ordinary clarification, incomplete work, uncertainty, difficult tasks, or recoverable tool/provider failures.",
-		"Pass goal_blocked the exact current goal_id; never reuse a goal_id from an older, stopped, replaced, or cleared goal turn.",
-	],
-	parameters: Type.Object({
-		goal_id: Type.String({
-			description: "The exact goal_id shown in the current active /goal prompt.",
-		}),
-		reason: Type.String({
-			minLength: 1,
-			maxLength: MAX_BLOCKER_REASON_LENGTH,
-			description: "The specific user or external action required to unblock the goal.",
-		}),
-		evidence: Type.String({
-			minLength: 1,
-			maxLength: MAX_BLOCKER_EVIDENCE_LENGTH,
-			description: "Concrete evidence from the repeated attempts that proves the impasse.",
-		}),
-		repeated_turns: Type.Integer({
-			minimum: 3,
-			description: "Number of separate turns spent trying to resolve this same blocker.",
-		}),
-	}),
-	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-		const blockedGoal = activeGoal;
-		const goal = blockedGoal?.text ?? "unknown goal";
-		const requestedGoalId = typeof params.goal_id === "string" ? params.goal_id.trim() : "";
-		const reason = typeof params.reason === "string" ? params.reason.trim() : "";
-		const evidence = typeof params.evidence === "string" ? params.evidence.trim() : "";
-		const repeatedTurns =
-			typeof params.repeated_turns === "number" ? params.repeated_turns : Number.NaN;
-		const reject = (rejectionReason: string) => {
-			const rejection = `goal_blocked rejected: ${rejectionReason}.`;
-			ctx.ui.notify(rejection, "warning");
-			return {
-				content: [{ type: "text" as const, text: rejection }],
+				content: [{ type: "text", text: `Goal blocked: ${reason}` }],
 				details: {
 					goal,
 					goal_id: requestedGoalId,
-					reason: reason.slice(0, MAX_BLOCKER_REASON_LENGTH),
-					evidence: evidence.slice(0, MAX_BLOCKER_EVIDENCE_LENGTH),
-					repeated_turns: Number.isFinite(repeatedTurns) ? repeatedTurns : 0,
+					reason,
+					evidence,
+					repeated_turns: repeatedTurns,
 				} satisfies GoalBlockedDetails,
+				terminate: true,
 			};
-		};
+		},
+	});
 
-		if (!blockedGoal) return reject("no active goal");
-		const staleGoalRejection = goalIdRejectionReason(blockedGoal, requestedGoalId);
-		if (staleGoalRejection) return reject(staleGoalRejection);
-		if (blockedGoal.status !== "active") {
-			return reject(`goal is ${blockedGoal.status}, not active`);
-		}
-		if (!reason) return reject("reason is empty");
-		if (reason.length > MAX_BLOCKER_REASON_LENGTH) return reject("reason is too long");
-		if (!evidence) return reject("evidence is empty");
-		if (evidence.length > MAX_BLOCKER_EVIDENCE_LENGTH) return reject("evidence is too long");
-		if (!Number.isInteger(repeatedTurns)) return reject("repeated_turns must be a whole number");
-		if (repeatedTurns < 3) return reject("repeated_turns must be at least 3");
-
-		updateGoalUsage(blockedGoal, ctx);
-		cancelContinuationWork();
-		clearBudgetWrapUp();
-		clearGoalRecoveryForGoal(blockedGoal.id);
-		blockStaleGoalToolCalls();
-		activeGoal = transitionGoal(blockedGoal, "blocked");
-		persistGoal(activeGoal);
-		updateStatus(ctx, activeGoal);
-		ctx.ui.notify(`Goal blocked: ${truncateNotification(reason)}`, "warning");
-
-		return {
-			content: [{ type: "text", text: `Goal blocked: ${reason}` }],
-			details: {
-				goal,
-				goal_id: requestedGoalId,
-				reason,
-				evidence,
-				repeated_turns: repeatedTurns,
-			} satisfies GoalBlockedDetails,
-			terminate: true,
-		};
-	},
-});
-
-export default function goal(pi: ExtensionAPI) {
-	extensionApi = pi;
 	pi.registerTool(goalCompleteTool);
 	pi.registerTool(goalBlockedTool);
 
@@ -394,21 +397,21 @@ export default function goal(pi: ExtensionAPI) {
 		clearGoalRecovery();
 		clearBudgetWrapUp();
 		clearStaleGoalToolCallBlock();
-		activeGoal = loadGoalFromSession(ctx);
-		if (activeGoal) {
-			if (activeGoal.status === "active") {
-				updateGoalUsage(activeGoal, ctx);
+		runtime.activeGoal = loadGoalFromSession(ctx);
+		if (runtime.activeGoal) {
+			if (runtime.activeGoal.status === "active") {
+				updateGoalUsage(runtime.activeGoal, ctx);
 				if (limitActiveGoalForBudget(pi, ctx, false)) return;
 			}
-			persistGoal(activeGoal);
-			updateStatus(ctx, activeGoal);
+			persistGoal(runtime.activeGoal);
+			updateStatus(ctx, runtime.activeGoal);
 		} else ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
-		if (activeGoal) {
-			updateGoalUsage(activeGoal, ctx, false);
-			persistGoal(activeGoal);
+		if (runtime.activeGoal) {
+			updateGoalUsage(runtime.activeGoal, ctx, false);
+			persistGoal(runtime.activeGoal);
 		}
 		clearContinuationTracking();
 		clearGoalRecovery();
@@ -419,35 +422,35 @@ export default function goal(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_before_compact", (event, ctx) => {
-		if (activeGoal?.status === "budget_limited") {
+		if (runtime.activeGoal?.status === "budget_limited") {
 			if ((event as { willRetry?: boolean }).willRetry === true) return { cancel: true as const };
 			return;
 		}
-		if (!activeGoal || activeGoal.status !== "active") return;
-		updateGoalUsage(activeGoal, ctx);
+		if (runtime.activeGoal?.status !== "active") return;
+		updateGoalUsage(runtime.activeGoal, ctx);
 		cancelContinuationWork();
-		persistGoal(activeGoal);
-		updateStatus(ctx, activeGoal);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
 		if (limitActiveGoalForBudget(pi, ctx, false)) return { cancel: true as const };
 	});
 
 	pi.on("session_compact", (event, ctx) => {
-		if (!activeGoal || activeGoal.status !== "active") {
+		if (runtime.activeGoal?.status !== "active") {
 			clearGoalRecovery();
 			return;
 		}
 
 		const restoredGoal = loadGoalFromSession(ctx);
-		if (restoredGoal?.id === activeGoal.id) activeGoal = restoredGoal;
-		updateGoalUsage(activeGoal, ctx);
-		persistGoal(activeGoal);
-		updateStatus(ctx, activeGoal);
+		if (restoredGoal?.id === runtime.activeGoal.id) runtime.activeGoal = restoredGoal;
+		updateGoalUsage(runtime.activeGoal, ctx);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
 		if (limitActiveGoalForBudget(pi, ctx, false)) return;
 
-		const wasPiRetry = isPiOwnedCompactionRetry(event, activeGoal.id);
-		clearGoalRecoveryForGoal(activeGoal.id);
+		const wasPiRetry = isPiOwnedCompactionRetry(event, runtime.activeGoal.id);
+		clearGoalRecoveryForGoal(runtime.activeGoal.id);
 		if (wasPiRetry) return;
-		requestContinuation(activeGoal);
+		requestContinuation(runtime.activeGoal);
 		// Manual compaction does not emit agent_settled. This common dispatcher is
 		// therefore the narrow fallback; threshold compaction leaves the intent for
 		// agent_settled when Pi is still busy.
@@ -472,8 +475,8 @@ export default function goal(pi: ExtensionAPI) {
 
 	pi.on("tool_call", (event, ctx) => {
 		if (
-			activeGoal?.status === "budget_limited" &&
-			budgetWrapUp?.goalId === activeGoal.id &&
+			runtime.activeGoal?.status === "budget_limited" &&
+			runtime.budgetWrapUp?.goalId === runtime.activeGoal.id &&
 			event.toolName !== "goal_complete"
 		) {
 			// A blocked tool result would normally trigger another model call. Abort the
@@ -484,8 +487,8 @@ export default function goal(pi: ExtensionAPI) {
 				reason: "Goal token budget is exhausted; only goal_complete is allowed during wrap-up.",
 			};
 		}
-		if (!staleGoalToolCallsBlocked) return;
-		if (!activeGoal || !blocksStaleGoalToolCalls(activeGoal.status)) {
+		if (!runtime.staleGoalToolCallsBlocked) return;
+		if (!runtime.activeGoal || !blocksStaleGoalToolCalls(runtime.activeGoal.status)) {
 			clearStaleGoalToolCallBlock();
 			return;
 		}
@@ -497,72 +500,75 @@ export default function goal(pi: ExtensionAPI) {
 
 	pi.on("tool_execution_end", (_event, ctx) => {
 		if (
-			activeGoal?.status === "budget_limited" &&
-			budgetWrapUp?.goalId === activeGoal.id &&
-			!budgetWrapUp.delivered
+			runtime.activeGoal?.status === "budget_limited" &&
+			runtime.budgetWrapUp?.goalId === runtime.activeGoal.id &&
+			!runtime.budgetWrapUp.delivered
 		) {
-			queueBudgetWrapUp(pi, ctx, activeGoal);
+			queueBudgetWrapUp(pi, ctx, runtime.activeGoal);
 			return;
 		}
-		if (!activeGoal || activeGoal.status !== "active") return;
+		if (runtime.activeGoal?.status !== "active") return;
 
 		// AgentSession persists assistant message_end before tool execution events,
 		// so the completed assistant call's usage is authoritative at this boundary.
-		updateGoalUsage(activeGoal, ctx);
-		persistGoal(activeGoal);
-		updateStatus(ctx, activeGoal);
+		updateGoalUsage(runtime.activeGoal, ctx);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
 		limitActiveGoalForBudget(pi, ctx, true);
 	});
 
 	pi.on("before_agent_start", (event) => {
 		markContinuationStarted(event.prompt);
-		if (!activeGoal || activeGoal.status !== "active") return;
+		if (runtime.activeGoal?.status !== "active") return;
 
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n${buildGoalSystemPrompt(activeGoal)}`,
+			systemPrompt: `${event.systemPrompt}\n\n${buildGoalSystemPrompt(runtime.activeGoal)}`,
 		};
 	});
 
 	pi.on("agent_end", (event, ctx) => {
-		if (!activeGoal) return;
-		if (activeGoal.status === "budget_limited" && budgetWrapUp?.goalId === activeGoal.id) {
-			updateGoalUsage(activeGoal, ctx);
-			persistGoal(activeGoal);
-			updateStatus(ctx, activeGoal);
+		if (!runtime.activeGoal) return;
+		if (
+			runtime.activeGoal.status === "budget_limited" &&
+			runtime.budgetWrapUp?.goalId === runtime.activeGoal.id
+		) {
+			updateGoalUsage(runtime.activeGoal, ctx);
+			persistGoal(runtime.activeGoal);
+			updateStatus(ctx, runtime.activeGoal);
 			clearBudgetWrapUp();
 			return;
 		}
-		if (activeGoal.status !== "active") return;
+		if (runtime.activeGoal.status !== "active") return;
 
-		const goalId = activeGoal.id;
+		const goalId = runtime.activeGoal.id;
 		const alreadyAwaitingContinuation = hasContinuationWorkForGoal(goalId);
 		const finalAssistant = findFinalAssistantMessage(event.messages);
 
-		if (!alreadyAwaitingContinuation) activeGoal = incrementGoal(activeGoal);
-		updateGoalUsage(activeGoal, ctx);
+		if (!alreadyAwaitingContinuation) runtime.activeGoal = incrementGoal(runtime.activeGoal);
+		updateGoalUsage(runtime.activeGoal, ctx);
 
 		if (finalAssistant?.stopReason === "aborted") {
 			clearGoalRecoveryForGoal(goalId);
-			stopGoalAfterAgentEnd(ctx, activeGoal, finalAssistant, "paused");
+			stopGoalAfterAgentEnd(ctx, runtime.activeGoal, finalAssistant, "paused");
 			return;
 		}
 
 		if (finalAssistant?.stopReason === "error") {
 			if (isRetryableGoalInterruption(finalAssistant)) {
 				if (limitActiveGoalForBudget(pi, ctx, false)) return;
-				goalRecovery = {
+				runtime.goalRecovery = {
 					goalId,
 					kind: isGoalContextOverflow(finalAssistant) ? "compaction_retry" : "provider_retry",
 				};
 				cancelContinuationWork();
-				persistGoal(activeGoal);
-				updateStatus(ctx, activeGoal);
+				persistGoal(runtime.activeGoal);
+				updateStatus(ctx, runtime.activeGoal);
 				return;
 			}
 			clearGoalRecoveryForGoal(goalId);
 			stopGoalAfterAgentEnd(
 				ctx,
-				activeGoal,
+				runtime.activeGoal,
 				finalAssistant,
 				isUsageLimitedGoalInterruption(finalAssistant) ? "usage_limited" : "blocked",
 			);
@@ -573,10 +579,10 @@ export default function goal(pi: ExtensionAPI) {
 
 		if (limitActiveGoalForBudget(pi, ctx, false)) return;
 
-		persistGoal(activeGoal);
-		updateStatus(ctx, activeGoal);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
 
-		const currentGoal = activeGoal;
+		const currentGoal = runtime.activeGoal;
 		if (!currentGoal || currentGoal.id !== goalId || currentGoal.status !== "active") return;
 		requestContinuation(currentGoal);
 	});
@@ -584,371 +590,787 @@ export default function goal(pi: ExtensionAPI) {
 	pi.on("agent_settled", (_event, ctx) => {
 		dispatchContinuationIfSettled(pi, ctx);
 	});
-}
 
-async function startGoal(
-	objective: string,
-	tokenBudget: number | undefined,
-	pi: ExtensionAPI,
-	ctx: StatusContext,
-) {
-	const validationError = validateObjective(objective);
-	if (validationError) {
-		ctx.ui.notify(validationError, "warning");
-		return;
-	}
-
-	const existingGoal = activeGoal?.status !== "complete" ? activeGoal : undefined;
-	if (existingGoal) {
-		const shouldReplace = await ctx.ui.confirm(
-			"Replace goal?",
-			`Current goal: ${existingGoal.text}\n\nNew goal: ${objective}`,
-		);
-		if (!shouldReplace) {
-			ctx.ui.notify(`Goal kept: ${existingGoal.text}`, "info");
+	async function startGoal(
+		objective: string,
+		tokenBudget: number | undefined,
+		pi: ExtensionAPI,
+		ctx: StatusContext,
+	) {
+		const validationError = validateObjective(objective);
+		if (validationError) {
+			ctx.ui.notify(validationError, "warning");
 			return;
 		}
-	}
 
-	cancelContinuationWork();
-	clearGoalRecovery();
-	clearBudgetWrapUp();
-	clearStaleGoalToolCallBlock();
-	activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-	const startedGoal = activeGoal;
-	const sent = await sendGoalPrompt(pi, ctx, startedGoal);
-	if (!sent) {
-		if (activeGoal?.id === startedGoal.id) {
-			if (existingGoal) {
-				updateGoalUsage(existingGoal, ctx);
-				if (existingGoal.status === "active") {
-					abortCurrentTurn(ctx);
-					activeGoal = transitionGoal(existingGoal, "paused");
-					blockStaleGoalToolCalls();
-				} else {
-					activeGoal = existingGoal;
-					if (blocksStaleGoalToolCalls(activeGoal.status)) blockStaleGoalToolCalls();
-					else clearStaleGoalToolCallBlock();
-				}
-				persistGoal(activeGoal);
-				updateStatus(ctx, activeGoal);
-			} else {
-				clearActiveGoal(ctx);
+		const existingGoal = runtime.activeGoal?.status !== "complete" ? runtime.activeGoal : undefined;
+		if (existingGoal) {
+			const shouldReplace = await ctx.ui.confirm(
+				"Replace goal?",
+				`Current goal: ${existingGoal.text}\n\nNew goal: ${objective}`,
+			);
+			if (!shouldReplace) {
+				ctx.ui.notify(`Goal kept: ${existingGoal.text}`, "info");
+				return;
 			}
 		}
-		return;
-	}
-	ctx.ui.notify(existingGoal ? `Goal replaced: ${objective}` : `Goal started: ${objective}`, "info");
-}
 
-function pauseGoal(ctx: StatusContext) {
-	if (!activeGoal) {
-		ctx.ui.notify("No active goal.", "info");
-		return;
-	}
-	if (activeGoal.status !== "active") {
-		ctx.ui.notify(`Goal is ${activeGoal.status}; only active goals can be paused.`, "warning");
-		return;
-	}
-	updateGoalUsage(activeGoal, ctx);
-	cancelContinuationWork();
-	clearBudgetWrapUp();
-	blockStaleGoalToolCalls();
-	abortCurrentTurn(ctx);
-	activeGoal = transitionGoal(activeGoal, "paused");
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-	ctx.ui.notify(`Goal paused: ${activeGoal.text}`, "info");
-}
-
-async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
-	if (!activeGoal) {
-		ctx.ui.notify("No active goal.", "info");
-		return;
-	}
-	if (!isResumableGoalStatus(activeGoal.status)) {
-		ctx.ui.notify(
-			`Goal is ${activeGoal.status}; only paused, blocked, usage-limited, or budget-limited goals can be resumed.`,
-			"warning",
-		);
-		return;
-	}
-	if (
-		activeGoal.tokenBudget !== undefined &&
-		activeGoal.tokensUsed >= activeGoal.tokenBudget
-	) {
-		ctx.ui.notify(`Goal token budget is still reached: ${formatBudget(activeGoal)}`, "warning");
-		return;
-	}
-	const stoppedGoal = activeGoal;
-	const stoppedStatus = stoppedGoal.status;
-	cancelContinuationWork();
-	clearGoalRecovery();
-	clearBudgetWrapUp();
-	clearStaleGoalToolCallBlock();
-	activeGoal = transitionGoal(nextGoalInstance(activeGoal), "active");
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-	if (activeGoal.status !== "active") {
-		ctx.ui.notify(`Goal token budget is still reached: ${formatBudget(activeGoal)}`, "warning");
-		return;
-	}
-	const resumedGoal = activeGoal;
-	const sent = await sendResumePrompt(pi, ctx, resumedGoal, stoppedStatus);
-	if (!sent) {
-		if (activeGoal?.id === resumedGoal.id && activeGoal.status === "active") {
-			activeGoal = stoppedGoal;
-			persistGoal(activeGoal);
-			updateStatus(ctx, activeGoal);
-			if (blocksStaleGoalToolCalls(activeGoal.status)) blockStaleGoalToolCalls();
-		}
-		return;
-	}
-	ctx.ui.notify(
-		`Goal resumed from ${stoppedStatusLabel(stoppedStatus)}: ${resumedGoal.text}`,
-		"info",
-	);
-}
-
-function clearGoal(ctx: StatusContext) {
-	if (!activeGoal) {
-		ctx.ui.notify("No active goal.", "info");
 		cancelContinuationWork();
 		clearGoalRecovery();
 		clearBudgetWrapUp();
 		clearStaleGoalToolCallBlock();
-		clearPersistedGoal(ctx.cwd);
-		ctx.ui.setStatus(STATUS_KEY, undefined);
-		return;
-	}
-
-	const stoppedGoal = activeGoal.text;
-	clearActiveGoal(ctx);
-	ctx.ui.notify(`Goal cleared: ${stoppedGoal}`, "warning");
-}
-
-async function editGoal(
-	objective: string,
-	tokenBudget: number | undefined,
-	pi: ExtensionAPI,
-	ctx: StatusContext,
-) {
-	const validationError = validateObjective(objective);
-	if (validationError) {
-		ctx.ui.notify(validationError, "warning");
-		return;
-	}
-	if (!activeGoal) {
-		ctx.ui.notify("No active goal. Use /goal <objective> to start one.", "warning");
-		return;
-	}
-
-	updateGoalUsage(activeGoal, ctx);
-	const previousGoal = { ...activeGoal };
-	cancelContinuationWork();
-	clearGoalRecovery();
-	clearBudgetWrapUp();
-	const previousStatus = activeGoal.status;
-	activeGoal = transitionGoal(
-		{
-			...nextGoalInstance(activeGoal),
-			text: objective,
-			tokenBudget: tokenBudget ?? activeGoal.tokenBudget,
-		},
-		editedGoalStatus(previousStatus),
-	);
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-	if (activeGoal.status === "active") {
-		clearStaleGoalToolCallBlock();
-		const editedGoal = activeGoal;
-		const sent = await sendObjectiveUpdatedPrompt(pi, ctx, editedGoal);
+		runtime.activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+		const startedGoal = runtime.activeGoal;
+		const sent = await sendGoalPrompt(pi, ctx, startedGoal);
 		if (!sent) {
-			if (activeGoal?.id === editedGoal.id) {
-				if (previousStatus === "active") {
-					abortCurrentTurn(ctx);
-					activeGoal = transitionGoal(previousGoal, "paused");
-					blockStaleGoalToolCalls();
+			if (runtime.activeGoal?.id === startedGoal.id) {
+				if (existingGoal) {
+					updateGoalUsage(existingGoal, ctx);
+					if (existingGoal.status === "active") {
+						abortCurrentTurn(ctx);
+						runtime.activeGoal = transitionGoal(existingGoal, "paused");
+						blockStaleGoalToolCalls();
+					} else {
+						runtime.activeGoal = existingGoal;
+						if (blocksStaleGoalToolCalls(runtime.activeGoal.status)) blockStaleGoalToolCalls();
+						else clearStaleGoalToolCallBlock();
+					}
+					persistGoal(runtime.activeGoal);
+					updateStatus(ctx, runtime.activeGoal);
 				} else {
-					activeGoal = previousGoal;
-					if (blocksStaleGoalToolCalls(activeGoal.status)) blockStaleGoalToolCalls();
-					else clearStaleGoalToolCallBlock();
+					clearActiveGoal(ctx);
 				}
-				persistGoal(activeGoal);
-				updateStatus(ctx, activeGoal);
 			}
 			return;
 		}
-	} else if (blocksStaleGoalToolCalls(activeGoal.status)) {
-		blockStaleGoalToolCalls();
-	} else {
-		clearStaleGoalToolCallBlock();
-	}
-	ctx.ui.notify(`Goal updated: ${objective}`, "info");
-}
-
-function showGoal(ctx: StatusContext) {
-	if (!activeGoal) {
-		ctx.ui.notify("Usage: /goal <objective>\nNo goal is currently set.", "info");
-		ctx.ui.setStatus(STATUS_KEY, undefined);
-		return;
-	}
-	updateGoalUsage(activeGoal, ctx);
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-	ctx.ui.notify(goalSummary(activeGoal), "info");
-}
-
-function createGoal(text: string, tokenBudget: number | undefined, baselineTokens: number): ActiveGoal {
-	const now = Date.now();
-	return {
-		id: randomUUID(),
-		text,
-		status: "active",
-		startedAt: now,
-		updatedAt: now,
-		iteration: 0,
-		tokenBudget,
-		tokensUsed: 0,
-		timeUsedSeconds: 0,
-		baselineTokens,
-		activeStartedAt: now,
-	};
-}
-
-function transitionGoal(goal: ActiveGoal, requestedStatus: GoalStatus): ActiveGoal {
-	const now = Date.now();
-	const status =
-		requestedStatus === "active" &&
-		goal.tokenBudget !== undefined &&
-		goal.tokensUsed >= goal.tokenBudget
-			? "budget_limited"
-			: requestedStatus;
-	const next = { ...goal, status, updatedAt: now };
-	checkpointGoalActiveTime(next, now, status === "active");
-	return next;
-}
-
-function nextGoalInstance(goal: ActiveGoal): ActiveGoal {
-	return { ...goal, id: randomUUID(), updatedAt: Date.now() };
-}
-
-function editedGoalStatus(status: GoalStatus): GoalStatus {
-	if (status === "paused" || status === "blocked" || status === "usage_limited") return status;
-	return "active";
-}
-
-function incrementGoal(goal: ActiveGoal): ActiveGoal {
-	return { ...goal, iteration: goal.iteration + 1, updatedAt: Date.now() };
-}
-
-function stopGoalAfterAgentEnd(
-	ctx: StatusContext,
-	goal: ActiveGoal,
-	assistant: AssistantMessageLike,
-	status: "paused" | "blocked" | "usage_limited",
-) {
-	cancelContinuationWork();
-	clearBudgetWrapUp();
-	blockStaleGoalToolCalls();
-	abortCurrentTurn(ctx);
-	activeGoal = transitionGoal(goal, status);
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-
-	const details = assistant.errorMessage ? ` (${truncateNotification(assistant.errorMessage)})` : "";
-	if (status === "paused") {
-		ctx.ui.notify(`Goal paused after interruption${details}. Run /goal resume to continue.`, "warning");
-		return;
-	}
-	if (status === "usage_limited") {
 		ctx.ui.notify(
-			`Goal stopped after provider usage limit${details}. Run /goal resume when usage is available.`,
+			existingGoal ? `Goal replaced: ${objective}` : `Goal started: ${objective}`,
+			"info",
+		);
+	}
+
+	function pauseGoal(ctx: StatusContext) {
+		if (!runtime.activeGoal) {
+			ctx.ui.notify("No active goal.", "info");
+			return;
+		}
+		if (runtime.activeGoal.status !== "active") {
+			ctx.ui.notify(
+				`Goal is ${runtime.activeGoal.status}; only active goals can be paused.`,
+				"warning",
+			);
+			return;
+		}
+		updateGoalUsage(runtime.activeGoal, ctx);
+		cancelContinuationWork();
+		clearBudgetWrapUp();
+		blockStaleGoalToolCalls();
+		abortCurrentTurn(ctx);
+		runtime.activeGoal = transitionGoal(runtime.activeGoal, "paused");
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+		ctx.ui.notify(`Goal paused: ${runtime.activeGoal.text}`, "info");
+	}
+
+	async function resumeGoal(pi: ExtensionAPI, ctx: StatusContext) {
+		if (!runtime.activeGoal) {
+			ctx.ui.notify("No active goal.", "info");
+			return;
+		}
+		if (!isResumableGoalStatus(runtime.activeGoal.status)) {
+			ctx.ui.notify(
+				`Goal is ${runtime.activeGoal.status}; only paused, blocked, usage-limited, or budget-limited goals can be resumed.`,
+				"warning",
+			);
+			return;
+		}
+		if (
+			runtime.activeGoal.tokenBudget !== undefined &&
+			runtime.activeGoal.tokensUsed >= runtime.activeGoal.tokenBudget
+		) {
+			ctx.ui.notify(
+				`Goal token budget is still reached: ${formatBudget(runtime.activeGoal)}`,
+				"warning",
+			);
+			return;
+		}
+		const stoppedGoal = runtime.activeGoal;
+		const stoppedStatus = stoppedGoal.status;
+		cancelContinuationWork();
+		clearGoalRecovery();
+		clearBudgetWrapUp();
+		clearStaleGoalToolCallBlock();
+		runtime.activeGoal = transitionGoal(nextGoalInstance(runtime.activeGoal), "active");
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+		if (runtime.activeGoal.status !== "active") {
+			ctx.ui.notify(
+				`Goal token budget is still reached: ${formatBudget(runtime.activeGoal)}`,
+				"warning",
+			);
+			return;
+		}
+		const resumedGoal = runtime.activeGoal;
+		const sent = await sendResumePrompt(pi, ctx, resumedGoal, stoppedStatus);
+		if (!sent) {
+			if (runtime.activeGoal?.id === resumedGoal.id && runtime.activeGoal.status === "active") {
+				runtime.activeGoal = stoppedGoal;
+				persistGoal(runtime.activeGoal);
+				updateStatus(ctx, runtime.activeGoal);
+				if (blocksStaleGoalToolCalls(runtime.activeGoal.status)) blockStaleGoalToolCalls();
+			}
+			return;
+		}
+		ctx.ui.notify(
+			`Goal resumed from ${stoppedStatusLabel(stoppedStatus)}: ${resumedGoal.text}`,
+			"info",
+		);
+	}
+
+	function clearGoal(ctx: StatusContext) {
+		if (!runtime.activeGoal) {
+			ctx.ui.notify("No active goal.", "info");
+			cancelContinuationWork();
+			clearGoalRecovery();
+			clearBudgetWrapUp();
+			clearStaleGoalToolCallBlock();
+			clearPersistedGoal(ctx.cwd);
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+
+		const stoppedGoal = runtime.activeGoal.text;
+		clearActiveGoal(ctx);
+		ctx.ui.notify(`Goal cleared: ${stoppedGoal}`, "warning");
+	}
+
+	async function editGoal(
+		objective: string,
+		tokenBudget: number | undefined,
+		pi: ExtensionAPI,
+		ctx: StatusContext,
+	) {
+		const validationError = validateObjective(objective);
+		if (validationError) {
+			ctx.ui.notify(validationError, "warning");
+			return;
+		}
+		if (!runtime.activeGoal) {
+			ctx.ui.notify("No active goal. Use /goal <objective> to start one.", "warning");
+			return;
+		}
+
+		updateGoalUsage(runtime.activeGoal, ctx);
+		const previousGoal = { ...runtime.activeGoal };
+		cancelContinuationWork();
+		clearGoalRecovery();
+		clearBudgetWrapUp();
+		const previousStatus = runtime.activeGoal.status;
+		runtime.activeGoal = transitionGoal(
+			{
+				...nextGoalInstance(runtime.activeGoal),
+				text: objective,
+				tokenBudget: tokenBudget ?? runtime.activeGoal.tokenBudget,
+			},
+			editedGoalStatus(previousStatus),
+		);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+		const editedGoal = runtime.activeGoal;
+		if (!editedGoal) return;
+		if (editedGoal.status === "active") {
+			clearStaleGoalToolCallBlock();
+			const sent = await sendObjectiveUpdatedPrompt(pi, ctx, editedGoal);
+			if (!sent) {
+				if (runtime.activeGoal?.id === editedGoal.id) {
+					if (previousStatus === "active") {
+						abortCurrentTurn(ctx);
+						runtime.activeGoal = transitionGoal(previousGoal, "paused");
+						blockStaleGoalToolCalls();
+					} else {
+						runtime.activeGoal = previousGoal;
+						if (blocksStaleGoalToolCalls(runtime.activeGoal.status)) blockStaleGoalToolCalls();
+						else clearStaleGoalToolCallBlock();
+					}
+					persistGoal(runtime.activeGoal);
+					updateStatus(ctx, runtime.activeGoal);
+				}
+				return;
+			}
+		} else if (blocksStaleGoalToolCalls(editedGoal.status)) {
+			blockStaleGoalToolCalls();
+		} else {
+			clearStaleGoalToolCallBlock();
+		}
+		ctx.ui.notify(`Goal updated: ${objective}`, "info");
+	}
+
+	function showGoal(ctx: StatusContext) {
+		if (!runtime.activeGoal) {
+			ctx.ui.notify("Usage: /goal <objective>\nNo goal is currently set.", "info");
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+		updateGoalUsage(runtime.activeGoal, ctx);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+		ctx.ui.notify(goalSummary(runtime.activeGoal), "info");
+	}
+
+	function createGoal(
+		text: string,
+		tokenBudget: number | undefined,
+		baselineTokens: number,
+	): ActiveGoal {
+		const now = Date.now();
+		return {
+			id: randomUUID(),
+			text,
+			status: "active",
+			startedAt: now,
+			updatedAt: now,
+			iteration: 0,
+			tokenBudget,
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			baselineTokens,
+			activeStartedAt: now,
+		};
+	}
+
+	function transitionGoal(goal: ActiveGoal, requestedStatus: GoalStatus): ActiveGoal {
+		const now = Date.now();
+		const status =
+			requestedStatus === "active" &&
+			goal.tokenBudget !== undefined &&
+			goal.tokensUsed >= goal.tokenBudget
+				? "budget_limited"
+				: requestedStatus;
+		const next = { ...goal, status, updatedAt: now };
+		checkpointGoalActiveTime(next, now, status === "active");
+		return next;
+	}
+
+	function nextGoalInstance(goal: ActiveGoal): ActiveGoal {
+		return { ...goal, id: randomUUID(), updatedAt: Date.now() };
+	}
+
+	function editedGoalStatus(status: GoalStatus): GoalStatus {
+		if (status === "paused" || status === "blocked" || status === "usage_limited") return status;
+		return "active";
+	}
+
+	function incrementGoal(goal: ActiveGoal): ActiveGoal {
+		return { ...goal, iteration: goal.iteration + 1, updatedAt: Date.now() };
+	}
+
+	function stopGoalAfterAgentEnd(
+		ctx: StatusContext,
+		goal: ActiveGoal,
+		assistant: AssistantMessageLike,
+		status: "paused" | "blocked" | "usage_limited",
+	) {
+		cancelContinuationWork();
+		clearBudgetWrapUp();
+		blockStaleGoalToolCalls();
+		abortCurrentTurn(ctx);
+		runtime.activeGoal = transitionGoal(goal, status);
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+
+		const details = assistant.errorMessage
+			? ` (${truncateNotification(assistant.errorMessage)})`
+			: "";
+		if (status === "paused") {
+			ctx.ui.notify(
+				`Goal paused after interruption${details}. Run /goal resume to continue.`,
+				"warning",
+			);
+			return;
+		}
+		if (status === "usage_limited") {
+			ctx.ui.notify(
+				`Goal stopped after provider usage limit${details}. Run /goal resume when usage is available.`,
+				"warning",
+			);
+			return;
+		}
+		ctx.ui.notify(
+			`Goal blocked after agent error${details}. Resolve the blocker or run /goal resume to retry.`,
 			"warning",
 		);
-		return;
 	}
-	ctx.ui.notify(
-		`Goal blocked after agent error${details}. Resolve the blocker or run /goal resume to retry.`,
-		"warning",
-	);
-}
 
-async function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	return sendPrompt(pi, ctx, buildGoalPrompt(goal));
-}
-
-async function sendObjectiveUpdatedPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	return sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
-}
-
-async function sendResumePrompt(
-	pi: ExtensionAPI,
-	ctx: StatusContext,
-	goal: ActiveGoal,
-	stoppedStatus: GoalStatus,
-) {
-	return sendPrompt(pi, ctx, buildResumePrompt(goal, stoppedStatus));
-}
-
-function requestContinuation(goal: ActiveGoal) {
-	if (hasContinuationWorkForGoal(goal.id)) return false;
-	const marker = continuationMarker(goal);
-	continuationIntent = {
-		goalId: goal.id,
-		iteration: goal.iteration,
-		marker,
-		prompt: buildContinuePrompt(goal, marker),
-	};
-	return true;
-}
-
-function dispatchContinuationIfSettled(pi: ExtensionAPI, ctx: StatusContext) {
-	const intent = continuationIntent;
-	if (!intent) return false;
-	if (!activeGoal || activeGoal.id !== intent.goalId || activeGoal.status !== "active") {
-		continuationIntent = undefined;
-		return false;
+	async function sendGoalPrompt(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+		return sendPrompt(pi, ctx, buildGoalPrompt(goal));
 	}
-	if (ctx.isIdle?.() !== true || hasPendingMessages(ctx)) return false;
 
-	continuationIntent = undefined;
-	continuationDelivery = intent;
-	try {
-		pi.sendUserMessage(intent.prompt);
+	async function sendObjectiveUpdatedPrompt(
+		pi: ExtensionAPI,
+		ctx: StatusContext,
+		goal: ActiveGoal,
+	) {
+		return sendPrompt(pi, ctx, buildObjectiveUpdatedPrompt(goal));
+	}
+
+	async function sendResumePrompt(
+		pi: ExtensionAPI,
+		ctx: StatusContext,
+		goal: ActiveGoal,
+		stoppedStatus: GoalStatus,
+	) {
+		return sendPrompt(pi, ctx, buildResumePrompt(goal, stoppedStatus));
+	}
+
+	function requestContinuation(goal: ActiveGoal) {
+		if (hasContinuationWorkForGoal(goal.id)) return false;
+		const marker = continuationMarker(goal);
+		runtime.continuationIntent = {
+			goalId: goal.id,
+			iteration: goal.iteration,
+			marker,
+			prompt: buildContinuePrompt(goal, marker),
+		};
 		return true;
-	} catch (error) {
-		if (continuationDelivery?.marker === intent.marker) continuationDelivery = undefined;
-		if (activeGoal?.id === intent.goalId && activeGoal.status === "active") {
-			continuationIntent = intent;
+	}
+
+	function dispatchContinuationIfSettled(pi: ExtensionAPI, ctx: StatusContext) {
+		const intent = runtime.continuationIntent;
+		if (!intent) return false;
+		if (
+			!runtime.activeGoal ||
+			runtime.activeGoal.id !== intent.goalId ||
+			runtime.activeGoal.status !== "active"
+		) {
+			runtime.continuationIntent = undefined;
+			return false;
 		}
-		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
-		return false;
+		if (ctx.isIdle?.() !== true || hasPendingMessages(ctx)) return false;
+
+		runtime.continuationIntent = undefined;
+		runtime.continuationDelivery = intent;
+		try {
+			pi.sendUserMessage(intent.prompt);
+			return true;
+		} catch (error) {
+			if (runtime.continuationDelivery?.marker === intent.marker)
+				runtime.continuationDelivery = undefined;
+			if (runtime.activeGoal?.id === intent.goalId && runtime.activeGoal.status === "active") {
+				runtime.continuationIntent = intent;
+			}
+			ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
+			return false;
+		}
 	}
-}
 
-function hasContinuationWorkForGoal(goalId: string) {
-	return continuationIntent?.goalId === goalId || continuationDelivery?.goalId === goalId;
-}
+	function hasContinuationWorkForGoal(goalId: string) {
+		return (
+			runtime.continuationIntent?.goalId === goalId ||
+			runtime.continuationDelivery?.goalId === goalId
+		);
+	}
 
-async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
-	try {
-		const sent = ctx.isIdle?.()
-			? (pi.sendUserMessage(prompt) as void | Promise<void>)
-			: (pi.sendUserMessage(prompt, { deliverAs: "followUp" }) as void | Promise<void>);
-		await sent;
+	async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
+		try {
+			const sent = ctx.isIdle?.()
+				? (pi.sendUserMessage(prompt) as void | Promise<void>)
+				: (pi.sendUserMessage(prompt, { deliverAs: "followUp" }) as void | Promise<void>);
+			await sent;
+			return true;
+		} catch (error) {
+			ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
+			return false;
+		}
+	}
+
+	function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
+		clearCompletionStatusTimer();
+		ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
+	}
+
+	function formatStatus(goal: ActiveGoal | undefined) {
+		if (!goal) return undefined;
+		if (goal.status === "complete") return "complete";
+		if (goal.status === "paused") return "paused";
+		if (goal.status === "blocked") return "blocked";
+		if (goal.status === "usage_limited") return "usage";
+		if (goal.status === "budget_limited") return `budget ${formatBudget(goal)}`;
+		if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)}`;
+		return `active ${formatDuration(goal.timeUsedSeconds)}`;
+	}
+
+	function formatBudget(goal: ActiveGoal) {
+		return `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget ?? 0)}`;
+	}
+
+	function goalSummary(goal: ActiveGoal) {
+		return [
+			`Goal: ${goal.text}`,
+			`Status: ${goal.status}`,
+			`Iteration: ${goal.iteration}`,
+			`Active elapsed: ${formatDuration(goal.timeUsedSeconds)}`,
+			`Tokens: ${goal.tokenBudget === undefined ? formatTokenCount(goal.tokensUsed) : formatBudget(goal)}`,
+			`Commands: ${goalCommandHint(goal.status)}`,
+		].join("\n");
+	}
+
+	function goalCommandHint(status: GoalStatus) {
+		if (status === "active") return "/goal edit <objective>, /goal pause, /goal clear";
+		if (isResumableGoalStatus(status)) {
+			return "/goal edit <objective>, /goal resume, /goal clear";
+		}
+		return "/goal edit <objective>, /goal clear";
+	}
+
+	function hasPendingMessages(ctx: StatusContext) {
+		return ctx.hasPendingMessages?.() ?? false;
+	}
+
+	function abortCurrentTurn(ctx: StatusContext) {
+		try {
+			ctx.abort?.();
+		} catch {
+			// Best effort: stale goal guards still prevent follow-on tool calls.
+		}
+	}
+
+	function blockStaleGoalToolCalls() {
+		runtime.staleGoalToolCallsBlocked = true;
+	}
+
+	function blocksStaleGoalToolCalls(status: GoalStatus) {
+		return status === "paused" || status === "blocked" || status === "usage_limited";
+	}
+
+	function isResumableGoalStatus(status: GoalStatus) {
+		return blocksStaleGoalToolCalls(status) || status === "budget_limited";
+	}
+
+	function stoppedStatusLabel(status: GoalStatus) {
+		if (status === "usage_limited") return "usage-limited";
+		if (status === "budget_limited") return "budget-limited";
+		return status;
+	}
+
+	function clearStaleGoalToolCallBlock() {
+		runtime.staleGoalToolCallsBlocked = false;
+	}
+
+	function clearGoalRecovery() {
+		runtime.goalRecovery = undefined;
+	}
+
+	function clearBudgetWrapUp() {
+		runtime.budgetWrapUp = undefined;
+	}
+
+	function keepBudgetWrapUpMessage(message: unknown) {
+		if (!message || typeof message !== "object") return true;
+		const candidate = message as {
+			role?: unknown;
+			customType?: unknown;
+			details?: { goalId?: unknown };
+		};
+		if (candidate.role !== "custom" || candidate.customType !== BUDGET_WRAP_UP_MESSAGE_TYPE) {
+			return true;
+		}
+		return (
+			typeof candidate.details?.goalId === "string" &&
+			candidate.details.goalId === runtime.budgetWrapUp?.goalId &&
+			candidate.details.goalId === runtime.activeGoal?.id
+		);
+	}
+
+	function queueBudgetWrapUp(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
+		if (!runtime.budgetWrapUp || runtime.budgetWrapUp.goalId !== goal.id) {
+			runtime.budgetWrapUp = { goalId: goal.id, delivered: false };
+		}
+		if (runtime.budgetWrapUp.delivered) return true;
+		runtime.budgetWrapUp.delivered = true;
+		try {
+			pi.sendMessage(
+				{
+					customType: BUDGET_WRAP_UP_MESSAGE_TYPE,
+					content: BUDGET_WRAP_UP_PROMPT,
+					display: true,
+					details: { goalId: goal.id },
+				},
+				{ deliverAs: "steer" },
+			);
+			return true;
+		} catch (error) {
+			runtime.budgetWrapUp.delivered = false;
+			ctx.ui.notify(`Goal budget wrap-up failed: ${formatError(error)}`, "error");
+			return false;
+		}
+	}
+
+	function limitActiveGoalForBudget(pi: ExtensionAPI, ctx: StatusContext, sendWrapUp: boolean) {
+		const goal = runtime.activeGoal;
+		if (
+			goal?.status !== "active" ||
+			goal.tokenBudget === undefined ||
+			goal.tokensUsed < goal.tokenBudget
+		) {
+			return false;
+		}
+
+		cancelContinuationWork();
+		clearGoalRecoveryForGoal(goal.id);
+		clearBudgetWrapUp();
+		runtime.activeGoal = transitionGoal(goal, "budget_limited");
+		persistGoal(runtime.activeGoal);
+		updateStatus(ctx, runtime.activeGoal);
+		ctx.ui.notify(`Goal token budget reached: ${formatBudget(runtime.activeGoal)}`, "warning");
+		if (sendWrapUp) queueBudgetWrapUp(pi, ctx, runtime.activeGoal);
 		return true;
-	} catch (error) {
-		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
-		return false;
+	}
+
+	function clearGoalRecoveryForGoal(goalId: string) {
+		if (runtime.goalRecovery?.goalId === goalId) runtime.goalRecovery = undefined;
+	}
+
+	function isPiOwnedCompactionRetry(event: unknown, goalId: string) {
+		const compaction = event as { reason?: unknown; willRetry?: unknown };
+		if (compaction.willRetry === true) return true;
+		return (
+			runtime.goalRecovery?.goalId === goalId &&
+			runtime.goalRecovery.kind === "compaction_retry" &&
+			(compaction.reason === undefined || compaction.reason === "overflow")
+		);
+	}
+
+	function isContradictoryCompletionSummary(summary: string) {
+		return CONTRADICTORY_COMPLETION_PATTERNS.some((pattern) => pattern.test(summary));
+	}
+
+	function goalIdRejectionReason(goal: ActiveGoal, requestedGoalId: string) {
+		if (!requestedGoalId) return "missing goal_id";
+		if (requestedGoalId !== goal.id) return "goal_id does not match the active goal";
+		return undefined;
+	}
+
+	function isUsageLimitedGoalInterruption(assistant: AssistantMessageLike) {
+		const errorMessage = assistant.errorMessage;
+		return (
+			assistant.stopReason === "error" &&
+			typeof errorMessage === "string" &&
+			USAGE_LIMIT_GOAL_ERROR_PATTERNS.some((pattern) => pattern.test(errorMessage))
+		);
+	}
+
+	function isRetryableGoalInterruption(assistant: AssistantMessageLike) {
+		if (assistant.stopReason !== "error") return false;
+		if (!assistant.errorMessage) return false;
+		if (
+			isUsageLimitedGoalInterruption(assistant) ||
+			NON_RETRYABLE_GOAL_ERROR_RE.test(assistant.errorMessage)
+		) {
+			return false;
+		}
+		return (
+			isGoalContextOverflow(assistant) ||
+			RETRYABLE_GOAL_ERROR_PATTERNS.some((pattern) => pattern.test(assistant.errorMessage ?? ""))
+		);
+	}
+
+	function isGoalContextOverflow(assistant: AssistantMessageLike) {
+		return isContextOverflow(toPiAssistantMessage(assistant));
+	}
+
+	function toPiAssistantMessage(assistant: AssistantMessageLike): PiAssistantMessage {
+		return {
+			role: "assistant",
+			content: assistant.content ?? [],
+			api: assistant.api ?? "openai-responses",
+			provider: assistant.provider ?? "unknown",
+			model: assistant.model ?? "unknown",
+			usage: assistant.usage ?? zeroUsage(),
+			stopReason: assistant.stopReason ?? "error",
+			errorMessage: assistant.errorMessage,
+			timestamp: assistant.timestamp ?? Date.now(),
+		};
+	}
+
+	function zeroUsage(): Usage {
+		return {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				total: 0,
+			},
+		};
+	}
+
+	function clearContinuationTracking() {
+		runtime.continuationIntent = undefined;
+		runtime.continuationDelivery = undefined;
+		runtime.cancelledContinuationMarkers.clear();
+	}
+
+	function cancelContinuationWork() {
+		if (runtime.continuationDelivery)
+			rememberCancelledContinuationMarker(runtime.continuationDelivery.marker);
+		runtime.continuationIntent = undefined;
+		runtime.continuationDelivery = undefined;
+	}
+
+	function rememberCancelledContinuationMarker(marker: string) {
+		runtime.cancelledContinuationMarkers.add(marker);
+		if (runtime.cancelledContinuationMarkers.size <= MAX_CANCELLED_CONTINUATION_PROMPTS) return;
+		const oldest = runtime.cancelledContinuationMarkers.values().next().value;
+		if (oldest) runtime.cancelledContinuationMarkers.delete(oldest);
+	}
+
+	function consumeCancelledContinuationPrompt(prompt: string) {
+		const marker = extractContinuationMarker(prompt);
+		return marker ? runtime.cancelledContinuationMarkers.delete(marker) : false;
+	}
+
+	function markContinuationStarted(prompt: string) {
+		const marker = extractContinuationMarker(prompt);
+		if (!marker) {
+			// A user, retry, or another extension started newer work. Cancel both an
+			// unsent intent and a delivery that may have lost the non-atomic idle race;
+			// the newer work's agent_end will record a fresh intent.
+			cancelContinuationWork();
+			return;
+		}
+		if (runtime.continuationDelivery?.marker === marker) runtime.continuationDelivery = undefined;
+	}
+
+	function continuationMarker(goal: ActiveGoal) {
+		return `${goal.id}:${goal.iteration}:${randomUUID()}`;
+	}
+
+	function continuationMarkerComment(marker: string) {
+		return `<!-- ${CONTINUATION_MARKER_PREFIX}${marker} -->`;
+	}
+
+	function escapeRegExpText(value: string) {
+		return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	}
+
+	const CONTINUATION_MARKER_PATTERN = new RegExp(
+		`<!--\\s*${escapeRegExpText(CONTINUATION_MARKER_PREFIX)}([^\\s>]+)\\s*-->`,
+	);
+
+	function extractContinuationMarker(prompt: string) {
+		return CONTINUATION_MARKER_PATTERN.exec(prompt)?.[1];
+	}
+
+	function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const message = messages[i];
+			if (!message || typeof message !== "object") continue;
+			const candidate = message as Record<string, unknown>;
+			if (candidate.role !== "assistant") continue;
+			const assistant: AssistantMessageLike = {
+				role: "assistant",
+				stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
+				errorMessage:
+					typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
+			};
+			if (Array.isArray(candidate.content))
+				assistant.content = candidate.content as PiAssistantMessage["content"];
+			if (typeof candidate.api === "string") assistant.api = candidate.api;
+			if (typeof candidate.provider === "string") assistant.provider = candidate.provider;
+			if (typeof candidate.model === "string") assistant.model = candidate.model;
+			if (typeof candidate.timestamp === "number") assistant.timestamp = candidate.timestamp;
+			const usage = normalizeUsage(candidate.usage);
+			if (usage) assistant.usage = usage;
+			return assistant;
+		}
+		return undefined;
+	}
+
+	function isAgentStopReason(value: unknown): value is AgentStopReason {
+		return ["stop", "length", "toolUse", "error", "aborted"].includes(String(value));
+	}
+
+	function normalizeUsage(value: unknown): Usage | undefined {
+		if (!value || typeof value !== "object") return undefined;
+		const usage = value as Partial<Usage>;
+		if (typeof usage.input !== "number" || typeof usage.output !== "number") return undefined;
+		return {
+			input: nonNegativeFiniteNumber(usage.input),
+			output: nonNegativeFiniteNumber(usage.output),
+			cacheRead: nonNegativeFiniteNumber(usage.cacheRead),
+			cacheWrite: nonNegativeFiniteNumber(usage.cacheWrite),
+			totalTokens: assistantUsageTokens(usage),
+			cost: {
+				input: usage.cost?.input ?? 0,
+				output: usage.cost?.output ?? 0,
+				cacheRead: usage.cost?.cacheRead ?? 0,
+				cacheWrite: usage.cost?.cacheWrite ?? 0,
+				total: usage.cost?.total ?? 0,
+			},
+		};
+	}
+
+	function escapeXmlText(value: string) {
+		return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+	}
+
+	function formatError(error: unknown) {
+		return truncateNotification(error instanceof Error ? error.message : String(error));
+	}
+
+	function truncateNotification(value: string) {
+		return value.length > 160 ? `${value.slice(0, 157)}...` : value;
+	}
+
+	function persistGoal(goal: ActiveGoal) {
+		runtime.pi.appendEntry<GoalStateEntryData>(GOAL_STATE_ENTRY_TYPE, { goal });
+	}
+
+	function clearPersistedGoal(cwd: string) {
+		runtime.pi.appendEntry<GoalStateEntryData>(GOAL_STATE_ENTRY_TYPE, { goal: null });
+		clearLegacyPersistedGoal(cwd);
+	}
+
+	function clearActiveGoal(ctx: StatusContext) {
+		cancelContinuationWork();
+		clearGoalRecovery();
+		clearBudgetWrapUp();
+		clearStaleGoalToolCallBlock();
+		runtime.activeGoal = undefined;
+		clearPersistedGoal(ctx.cwd);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
+
+	function showCompletionStatus(ctx: StatusContext) {
+		clearCompletionStatusTimer();
+		ctx.ui.setStatus(STATUS_KEY, "complete");
+		runtime.completionStatusTimer = setTimeout(() => {
+			runtime.completionStatusTimer = undefined;
+			try {
+				ctx.ui.setStatus(STATUS_KEY, undefined);
+			} catch {
+				// The completion status is best-effort; the captured ctx may be stale after
+				// session replacement or reload before this timer fires.
+			}
+		}, 8_000);
+	}
+
+	function clearCompletionStatusTimer() {
+		if (!runtime.completionStatusTimer) return;
+		clearTimeout(runtime.completionStatusTimer);
+		runtime.completionStatusTimer = undefined;
 	}
 }
 
-function updateStatus(ctx: StatusContext, goal: ActiveGoal) {
-	clearCompletionStatusTimer();
-	ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
+export default function goal(pi: ExtensionAPI) {
+	registerGoalRuntime(pi);
 }
 
 export function formatStatus(goal: ActiveGoal | undefined) {
@@ -957,161 +1379,17 @@ export function formatStatus(goal: ActiveGoal | undefined) {
 	if (goal.status === "paused") return "paused";
 	if (goal.status === "blocked") return "blocked";
 	if (goal.status === "usage_limited") return "usage";
-	if (goal.status === "budget_limited") return `budget ${formatBudget(goal)}`;
-	if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)}`;
+	if (goal.status === "budget_limited") {
+		return `budget ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget ?? 0)}`;
+	}
+	if (goal.tokenBudget !== undefined) {
+		return `active ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`;
+	}
 	return `active ${formatDuration(goal.timeUsedSeconds)}`;
-}
-
-function formatBudget(goal: ActiveGoal) {
-	return `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget ?? 0)}`;
-}
-
-function goalSummary(goal: ActiveGoal) {
-	return [
-		`Goal: ${goal.text}`,
-		`Status: ${goal.status}`,
-		`Iteration: ${goal.iteration}`,
-		`Active elapsed: ${formatDuration(goal.timeUsedSeconds)}`,
-		`Tokens: ${goal.tokenBudget === undefined ? formatTokenCount(goal.tokensUsed) : formatBudget(goal)}`,
-		`Commands: ${goalCommandHint(goal.status)}`,
-	].join("\n");
-}
-
-function goalCommandHint(status: GoalStatus) {
-	if (status === "active") return "/goal edit <objective>, /goal pause, /goal clear";
-	if (isResumableGoalStatus(status)) {
-		return "/goal edit <objective>, /goal resume, /goal clear";
-	}
-	return "/goal edit <objective>, /goal clear";
-}
-
-function hasPendingMessages(ctx: StatusContext) {
-	return ctx.hasPendingMessages?.() ?? false;
-}
-
-function abortCurrentTurn(ctx: StatusContext) {
-	try {
-		ctx.abort?.();
-	} catch {
-		// Best effort: stale goal guards still prevent follow-on tool calls.
-	}
-}
-
-function blockStaleGoalToolCalls() {
-	staleGoalToolCallsBlocked = true;
-}
-
-function blocksStaleGoalToolCalls(status: GoalStatus) {
-	return status === "paused" || status === "blocked" || status === "usage_limited";
-}
-
-function isResumableGoalStatus(status: GoalStatus) {
-	return blocksStaleGoalToolCalls(status) || status === "budget_limited";
-}
-
-function stoppedStatusLabel(status: GoalStatus) {
-	if (status === "usage_limited") return "usage-limited";
-	if (status === "budget_limited") return "budget-limited";
-	return status;
-}
-
-function clearStaleGoalToolCallBlock() {
-	staleGoalToolCallsBlocked = false;
-}
-
-function clearGoalRecovery() {
-	goalRecovery = undefined;
-}
-
-function clearBudgetWrapUp() {
-	budgetWrapUp = undefined;
-}
-
-function keepBudgetWrapUpMessage(message: unknown) {
-	if (!message || typeof message !== "object") return true;
-	const candidate = message as {
-		role?: unknown;
-		customType?: unknown;
-		details?: { goalId?: unknown };
-	};
-	if (candidate.role !== "custom" || candidate.customType !== BUDGET_WRAP_UP_MESSAGE_TYPE) {
-		return true;
-	}
-	return (
-		typeof candidate.details?.goalId === "string" &&
-		candidate.details.goalId === budgetWrapUp?.goalId &&
-		candidate.details.goalId === activeGoal?.id
-	);
-}
-
-function queueBudgetWrapUp(pi: ExtensionAPI, ctx: StatusContext, goal: ActiveGoal) {
-	if (!budgetWrapUp || budgetWrapUp.goalId !== goal.id) {
-		budgetWrapUp = { goalId: goal.id, delivered: false };
-	}
-	if (budgetWrapUp.delivered) return true;
-	budgetWrapUp.delivered = true;
-	try {
-		pi.sendMessage(
-			{
-				customType: BUDGET_WRAP_UP_MESSAGE_TYPE,
-				content: BUDGET_WRAP_UP_PROMPT,
-				display: true,
-				details: { goalId: goal.id },
-			},
-			{ deliverAs: "steer" },
-		);
-		return true;
-	} catch (error) {
-		budgetWrapUp.delivered = false;
-		ctx.ui.notify(`Goal budget wrap-up failed: ${formatError(error)}`, "error");
-		return false;
-	}
-}
-
-function limitActiveGoalForBudget(pi: ExtensionAPI, ctx: StatusContext, sendWrapUp: boolean) {
-	const goal = activeGoal;
-	if (
-		!goal ||
-		goal.status !== "active" ||
-		goal.tokenBudget === undefined ||
-		goal.tokensUsed < goal.tokenBudget
-	) {
-		return false;
-	}
-
-	cancelContinuationWork();
-	clearGoalRecoveryForGoal(goal.id);
-	clearBudgetWrapUp();
-	activeGoal = transitionGoal(goal, "budget_limited");
-	persistGoal(activeGoal);
-	updateStatus(ctx, activeGoal);
-	ctx.ui.notify(`Goal token budget reached: ${formatBudget(activeGoal)}`, "warning");
-	if (sendWrapUp) queueBudgetWrapUp(pi, ctx, activeGoal);
-	return true;
-}
-
-function clearGoalRecoveryForGoal(goalId: string) {
-	if (goalRecovery?.goalId === goalId) goalRecovery = undefined;
-}
-
-function isPiOwnedCompactionRetry(event: unknown, goalId: string) {
-	const compaction = event as { reason?: unknown; willRetry?: unknown };
-	if (compaction.willRetry === true) return true;
-	return (
-		goalRecovery?.goalId === goalId &&
-		goalRecovery.kind === "compaction_retry" &&
-		(compaction.reason === undefined || compaction.reason === "overflow")
-	);
 }
 
 export function isContradictoryCompletionSummary(summary: string) {
 	return CONTRADICTORY_COMPLETION_PATTERNS.some((pattern) => pattern.test(summary));
-}
-
-function goalIdRejectionReason(goal: ActiveGoal, requestedGoalId: string) {
-	if (!requestedGoalId) return "missing goal_id";
-	if (requestedGoalId !== goal.id) return "goal_id does not match the active goal";
-	return undefined;
 }
 
 export function isUsageLimitedGoalInterruption(assistant: AssistantMessageLike) {
@@ -1133,100 +1411,34 @@ export function isRetryableGoalInterruption(assistant: AssistantMessageLike) {
 		return false;
 	}
 	return (
-		isGoalContextOverflow(assistant) ||
+		isGoalContextOverflowForExport(assistant) ||
 		RETRYABLE_GOAL_ERROR_PATTERNS.some((pattern) => pattern.test(assistant.errorMessage ?? ""))
 	);
 }
 
-function isGoalContextOverflow(assistant: AssistantMessageLike) {
-	return isContextOverflow(toPiAssistantMessage(assistant));
-}
-
-function toPiAssistantMessage(assistant: AssistantMessageLike): PiAssistantMessage {
-	return {
+function isGoalContextOverflowForExport(assistant: AssistantMessageLike) {
+	return isContextOverflow({
 		role: "assistant",
 		content: assistant.content ?? [],
 		api: assistant.api ?? "openai-responses",
 		provider: assistant.provider ?? "unknown",
 		model: assistant.model ?? "unknown",
-		usage: assistant.usage ?? zeroUsage(),
+		usage: assistant.usage ?? zeroUsageForExport(),
 		stopReason: assistant.stopReason ?? "error",
 		errorMessage: assistant.errorMessage,
 		timestamp: assistant.timestamp ?? Date.now(),
-	};
+	});
 }
 
-function zeroUsage(): Usage {
+function zeroUsageForExport(): Usage {
 	return {
 		input: 0,
 		output: 0,
 		cacheRead: 0,
 		cacheWrite: 0,
 		totalTokens: 0,
-		cost: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			total: 0,
-		},
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
-}
-
-function clearContinuationTracking() {
-	continuationIntent = undefined;
-	continuationDelivery = undefined;
-	cancelledContinuationMarkers.clear();
-}
-
-function cancelContinuationWork() {
-	if (continuationDelivery) rememberCancelledContinuationMarker(continuationDelivery.marker);
-	continuationIntent = undefined;
-	continuationDelivery = undefined;
-}
-
-function rememberCancelledContinuationMarker(marker: string) {
-	cancelledContinuationMarkers.add(marker);
-	if (cancelledContinuationMarkers.size <= MAX_CANCELLED_CONTINUATION_PROMPTS) return;
-	const oldest = cancelledContinuationMarkers.values().next().value;
-	if (oldest) cancelledContinuationMarkers.delete(oldest);
-}
-
-function consumeCancelledContinuationPrompt(prompt: string) {
-	const marker = extractContinuationMarker(prompt);
-	return marker ? cancelledContinuationMarkers.delete(marker) : false;
-}
-
-function markContinuationStarted(prompt: string) {
-	const marker = extractContinuationMarker(prompt);
-	if (!marker) {
-		// A user, retry, or another extension started newer work. Cancel both an
-		// unsent intent and a delivery that may have lost the non-atomic idle race;
-		// the newer work's agent_end will record a fresh intent.
-		cancelContinuationWork();
-		return;
-	}
-	if (continuationDelivery?.marker === marker) continuationDelivery = undefined;
-}
-
-function continuationMarker(goal: ActiveGoal) {
-	return `${goal.id}:${goal.iteration}:${randomUUID()}`;
-}
-
-function continuationMarkerComment(marker: string) {
-	return `<!-- ${CONTINUATION_MARKER_PREFIX}${marker} -->`;
-}
-
-function escapeRegExpText(value: string) {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-const CONTINUATION_MARKER_PATTERN = new RegExp(
-	`<!--\\s*${escapeRegExpText(CONTINUATION_MARKER_PREFIX)}([^\\s>]+)\\s*-->`,
-);
-
-function extractContinuationMarker(prompt: string) {
-	return CONTINUATION_MARKER_PATTERN.exec(prompt)?.[1];
 }
 
 export function findFinalAssistantMessage(messages: unknown[]): AssistantMessageLike | undefined {
@@ -1237,26 +1449,30 @@ export function findFinalAssistantMessage(messages: unknown[]): AssistantMessage
 		if (candidate.role !== "assistant") continue;
 		const assistant: AssistantMessageLike = {
 			role: "assistant",
-			stopReason: isAgentStopReason(candidate.stopReason) ? candidate.stopReason : undefined,
+			stopReason: isAgentStopReasonForExport(candidate.stopReason)
+				? candidate.stopReason
+				: undefined,
 			errorMessage: typeof candidate.errorMessage === "string" ? candidate.errorMessage : undefined,
 		};
-		if (Array.isArray(candidate.content)) assistant.content = candidate.content as PiAssistantMessage["content"];
+		if (Array.isArray(candidate.content)) {
+			assistant.content = candidate.content as PiAssistantMessage["content"];
+		}
 		if (typeof candidate.api === "string") assistant.api = candidate.api;
 		if (typeof candidate.provider === "string") assistant.provider = candidate.provider;
 		if (typeof candidate.model === "string") assistant.model = candidate.model;
 		if (typeof candidate.timestamp === "number") assistant.timestamp = candidate.timestamp;
-		const usage = normalizeUsage(candidate.usage);
+		const usage = normalizeUsageForExport(candidate.usage);
 		if (usage) assistant.usage = usage;
 		return assistant;
 	}
 	return undefined;
 }
 
-function isAgentStopReason(value: unknown): value is AgentStopReason {
+function isAgentStopReasonForExport(value: unknown): value is AgentStopReason {
 	return ["stop", "length", "toolUse", "error", "aborted"].includes(String(value));
 }
 
-function normalizeUsage(value: unknown): Usage | undefined {
+function normalizeUsageForExport(value: unknown): Usage | undefined {
 	if (!value || typeof value !== "object") return undefined;
 	const usage = value as Partial<Usage>;
 	if (typeof usage.input !== "number" || typeof usage.output !== "number") return undefined;
@@ -1276,62 +1492,16 @@ function normalizeUsage(value: unknown): Usage | undefined {
 	};
 }
 
-function escapeXmlText(value: string) {
-	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-function formatError(error: unknown) {
-	return truncateNotification(error instanceof Error ? error.message : String(error));
-}
-
-function truncateNotification(value: string) {
-	return value.length > 160 ? `${value.slice(0, 157)}...` : value;
-}
-
-function persistGoal(goal: ActiveGoal) {
-	extensionApi?.appendEntry<GoalStateEntryData>(GOAL_STATE_ENTRY_TYPE, { goal });
-}
-
-function clearPersistedGoal(cwd: string) {
-	extensionApi?.appendEntry<GoalStateEntryData>(GOAL_STATE_ENTRY_TYPE, { goal: null });
-	clearLegacyPersistedGoal(cwd);
-}
-
-function clearActiveGoal(ctx: StatusContext) {
-	cancelContinuationWork();
-	clearGoalRecovery();
-	clearBudgetWrapUp();
-	clearStaleGoalToolCallBlock();
-	activeGoal = undefined;
-	clearPersistedGoal(ctx.cwd);
-	ctx.ui.setStatus(STATUS_KEY, undefined);
-}
-
-function showCompletionStatus(ctx: StatusContext) {
-	clearCompletionStatusTimer();
-	ctx.ui.setStatus(STATUS_KEY, "complete");
-	completionStatusTimer = setTimeout(() => {
-		completionStatusTimer = undefined;
-		try {
-			ctx.ui.setStatus(STATUS_KEY, undefined);
-		} catch {
-			// The completion status is best-effort; the captured ctx may be stale after
-			// session replacement or reload before this timer fires.
-		}
-	}, 8_000);
-}
-
-function clearCompletionStatusTimer() {
-	if (!completionStatusTimer) return;
-	clearTimeout(completionStatusTimer);
-	completionStatusTimer = undefined;
-}
-
 export {
 	assistantUsageTokens,
 	cumulativeAssistantTokens,
 	formatDuration,
 	formatTokenCount,
 } from "./accounting.js";
-export { completeGoalArguments, parseCommand, parseTokenBudget, validateObjective } from "./command.js";
+export {
+	completeGoalArguments,
+	parseCommand,
+	parseTokenBudget,
+	validateObjective,
+} from "./command.js";
 export { buildGoalSystemPrompt } from "./prompts.js";

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -98,6 +98,7 @@ test("child session initialization does not erase or reroute the parent goal", a
 		data: { goal: rootGoal },
 	});
 	const rootCompletion = requireGoalTool(root, "goal_complete");
+	const rootEntriesBeforeChild = root.entries.length;
 
 	const child = createMockPi();
 	goal(child.pi);
@@ -105,6 +106,12 @@ test("child session initialization does not erase or reroute the parent goal", a
 		sessionManager: { getBranch: () => [], getEntries: () => [] },
 	});
 	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+
+	// Empty-child startup must not claim the parent goal or append any snapshot of it.
+	assert.equal(lastGoalStatus(child), null);
+	assert.equal(child.entries.filter((entry) => entry.customType === "goal-state").length, 0);
+	assert.equal(requireLastGoal(root).id, rootGoal.id);
+	assert.equal(lastGoalStatus(root), "active");
 
 	const result = await rootCompletion.execute(
 		"root-completion",
@@ -117,10 +124,54 @@ test("child session initialization does not erase or reroute the parent goal", a
 	assert.equal(result.content?.[0]?.text, "Goal complete: Verified parent completion.");
 	assert.equal(result.terminate, true);
 	assert.equal(result.details?.goal, rootGoal.text);
-	assert.deepEqual(root.entries.filter((entry) => entry.customType === "goal-state").at(-1)?.data, {
-		goal: null,
-	});
-	assert.equal(child.entries.filter((entry) => entry.customType === "goal-state").length, 0);
+	assert.equal(result.details?.goal_id, rootGoal.id);
+
+	const rootGoalStates = root.entries
+		.slice(rootEntriesBeforeChild)
+		.filter((entry) => entry.customType === "goal-state")
+		.map((entry) => entry.data as { goal?: StoredGoal | null });
+	assert.equal(rootGoalStates.length, 2);
+	assert.equal(rootGoalStates[0]?.goal?.status, "complete");
+	assert.equal(rootGoalStates[0]?.goal?.id, rootGoal.id);
+	assert.equal(rootGoalStates[0]?.goal?.text, rootGoal.text);
+	assert.deepEqual(rootGoalStates[1], { goal: null });
+	assert.equal(lastGoalStatus(root), null);
+
+	const childGoalStates = child.entries.filter((entry) => entry.customType === "goal-state");
+	assert.equal(childGoalStates.length, 0);
+	assert.equal(
+		childGoalStates.some(
+			(entry) => (entry.data as { goal?: StoredGoal | null } | undefined)?.goal?.id === rootGoal.id,
+		),
+		false,
+	);
+});
+
+test("independent goal instances keep distinct concurrent active goals", async () => {
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	await child.commands.get("goal")?.handler("child objective", childContext.ctx);
+
+	const rootGoal = requireLastGoal(root);
+	const childGoal = requireLastGoal(child);
+	assert.notEqual(rootGoal.id, childGoal.id);
+	assert.equal(rootGoal.text, "root objective");
+	assert.equal(childGoal.text, "child objective");
+	assert.equal(lastGoalStatus(root), "active");
+	assert.equal(lastGoalStatus(child), "active");
+	assert.match(String(rootContext.statuses.get("goal")), /^active /);
+	assert.match(String(childContext.statuses.get("goal")), /^active /);
+
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
 });
 
 test("independent goal instances keep completion local", async () => {
@@ -138,7 +189,8 @@ test("independent goal instances keep completion local", async () => {
 
 	const rootGoal = requireLastGoal(root);
 	const childGoal = requireLastGoal(child);
-	assert.notEqual(rootGoal.id, childGoal.id);
+	const rootEntriesBefore = root.entries.length;
+	const childEntriesBefore = child.entries.length;
 
 	const result = await requireGoalTool(root, "goal_complete").execute(
 		"root-completion",
@@ -149,9 +201,28 @@ test("independent goal instances keep completion local", async () => {
 	);
 
 	assert.equal(result.terminate, true);
+	assert.equal(result.details?.goal, rootGoal.text);
+	assert.equal(result.details?.goal_id, rootGoal.id);
+
+	const rootCompletion = findPersistedGoal(root, "complete");
+	assert.ok(rootCompletion);
+	assert.equal(rootCompletion.id, rootGoal.id);
+	assert.equal(rootCompletion.text, rootGoal.text);
+	assert.deepEqual(lastGoal(root), null);
 	assert.equal(lastGoalStatus(root), null);
+
+	const rootGoalStates = root.entries
+		.slice(rootEntriesBefore)
+		.filter((entry) => entry.customType === "goal-state")
+		.map((entry) => entry.data as { goal?: StoredGoal | null });
+	assert.equal(rootGoalStates.length, 2);
+	assert.equal(rootGoalStates[0]?.goal?.status, "complete");
+	assert.deepEqual(rootGoalStates[1], { goal: null });
+
+	assert.equal(child.entries.length, childEntriesBefore);
 	assert.equal(lastGoalStatus(child), "active");
 	assert.equal(requireLastGoal(child).id, childGoal.id);
+	assert.equal(requireLastGoal(child).text, childGoal.text);
 	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
 	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
 });
@@ -175,15 +246,128 @@ test("tool lifecycle persistence stays on the owning goal instance", async () =>
 	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
 	await child.commands.get("goal")?.handler("child objective", childContext.ctx);
 
+	const rootGoal = requireLastGoal(root);
+	const childGoal = requireLastGoal(child);
 	const rootEntriesBefore = root.entries.length;
 	const childEntriesBefore = child.entries.length;
+
 	root.events.get("tool_execution_end")?.[0]?.({}, rootContext.ctx);
 	assert.equal(root.entries.length, rootEntriesBefore + 1);
 	assert.equal(child.entries.length, childEntriesBefore);
+	const rootUpdated = requireLastGoal(root);
+	assert.equal(rootUpdated.id, rootGoal.id);
+	assert.equal(rootUpdated.text, "root objective");
+	assert.equal(rootUpdated.status, "active");
+	assert.equal(requireLastGoal(child).id, childGoal.id);
+	assert.equal(requireLastGoal(child).text, "child objective");
 
 	child.events.get("tool_execution_end")?.[0]?.({}, childContext.ctx);
 	assert.equal(root.entries.length, rootEntriesBefore + 1);
 	assert.equal(child.entries.length, childEntriesBefore + 1);
+	const childUpdated = requireLastGoal(child);
+	assert.equal(childUpdated.id, childGoal.id);
+	assert.equal(childUpdated.text, "child objective");
+	assert.equal(childUpdated.status, "active");
+	assert.equal(requireLastGoal(root).id, rootGoal.id);
+	assert.equal(requireLastGoal(root).text, "root objective");
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+});
+
+test("goal_blocked ownership stays on the root instance after child start", async () => {
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+	const rootGoal = requireLastGoal(root);
+	const rootBlocker = requireGoalTool(root, "goal_blocked");
+	const rootEntriesBeforeChild = root.entries.length;
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	assert.equal(lastGoalStatus(child), null);
+
+	const result = await rootBlocker.execute(
+		"root-block",
+		{
+			goal_id: rootGoal.id,
+			reason: "Need offline hardware access that remains unavailable",
+			evidence: "Attempted recovery three times with the same USB failure",
+			repeated_turns: 3,
+		},
+		new AbortController().signal,
+		() => undefined,
+		rootContext.ctx,
+	);
+
+	assert.equal(result.terminate, true);
+	assert.equal(result.details?.goal, rootGoal.text);
+	assert.equal(result.details?.goal_id, rootGoal.id);
+	assert.match(result.content?.[0]?.text ?? "", /Goal blocked:/i);
+
+	const rootBlocked = findPersistedGoal(root, "blocked");
+	assert.ok(rootBlocked);
+	assert.equal(rootBlocked.id, rootGoal.id);
+	assert.equal(rootBlocked.text, rootGoal.text);
+	assert.equal(lastGoalStatus(root), "blocked");
+	assert.ok(root.entries.length > rootEntriesBeforeChild);
+	assert.equal(child.entries.filter((entry) => entry.customType === "goal-state").length, 0);
+	assert.equal(lastGoalStatus(child), null);
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+});
+
+test("continuation and budget messages stay on the owning runtime API", async () => {
+	const rootBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 0 })];
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext({
+		sessionManager: { getBranch: () => rootBranch, getEntries: () => rootBranch },
+	});
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("--tokens 1 root objective", rootContext.ctx);
+	const rootGoal = requireLastGoal(root);
+	const rootUserMessagesBefore = root.sentUserMessages.length;
+	const rootCustomMessagesBefore = root.sentMessages.length;
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	const childUserMessagesBefore = child.sentUserMessages.length;
+	const childCustomMessagesBefore = child.sentMessages.length;
+
+	// Parent agent_end after an incomplete stop must enqueue and later dispatch continuation
+	// against the parent API only, even after a sibling factory started.
+	await root.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		rootContext.ctx,
+	);
+	root.events.get("agent_settled")?.[0]?.({}, rootContext.ctx);
+	assert.ok(root.sentUserMessages.length > rootUserMessagesBefore);
+	assert.match(
+		root.sentUserMessages.at(-1)?.text ?? "",
+		new RegExp(`<!-- pi-goal-continuation:${rootGoal.id}:`),
+	);
+	assert.equal(child.sentUserMessages.length, childUserMessagesBefore);
+
+	// Parent tool activity that crosses the token budget must wrap up through the parent API.
+	rootBranch.push(assistantUsageEntry({ totalTokens: 5 }));
+	root.events.get("tool_execution_end")?.[0]?.({}, rootContext.ctx);
+	assert.equal(lastGoalStatus(root), "budget_limited");
+	assert.ok(root.sentMessages.length > rootCustomMessagesBefore);
+	const wrapUp = root.sentMessages.at(-1)?.message as {
+		customType?: string;
+		details?: { goalId?: string };
+	};
+	assert.equal(wrapUp?.customType, "goal-budget-wrap-up");
+	assert.equal(wrapUp?.details?.goalId, rootGoal.id);
+	assert.equal(child.sentMessages.length, childCustomMessagesBefore);
+	assert.equal(lastGoalStatus(child), null);
+
 	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
 	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
 });
@@ -195,12 +379,18 @@ test("child shutdown does not clear the parent goal", async () => {
 	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
 	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
 	const rootGoal = requireLastGoal(root);
+	const rootEntriesBeforeChild = root.entries.length;
 
 	const child = createMockPi();
 	goal(child.pi);
 	const childContext = createMockContext();
 	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
 	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+
+	assert.equal(requireLastGoal(root).id, rootGoal.id);
+	assert.equal(lastGoalStatus(root), "active");
+	assert.equal(lastGoalStatus(child), null);
+	assert.equal(child.entries.filter((entry) => entry.customType === "goal-state").length, 0);
 
 	const result = await requireGoalTool(root, "goal_complete").execute(
 		"root-completion-after-child-shutdown",
@@ -211,6 +401,17 @@ test("child shutdown does not clear the parent goal", async () => {
 	);
 
 	assert.equal(result.terminate, true);
+	assert.equal(result.details?.goal, rootGoal.text);
+	assert.equal(result.details?.goal_id, rootGoal.id);
+
+	const rootGoalStates = root.entries
+		.slice(rootEntriesBeforeChild)
+		.filter((entry) => entry.customType === "goal-state")
+		.map((entry) => entry.data as { goal?: StoredGoal | null });
+	assert.equal(rootGoalStates.length, 2);
+	assert.equal(rootGoalStates[0]?.goal?.status, "complete");
+	assert.equal(rootGoalStates[0]?.goal?.id, rootGoal.id);
+	assert.deepEqual(rootGoalStates[1], { goal: null });
 	assert.equal(lastGoalStatus(root), null);
 	assert.equal(child.entries.length, 0);
 	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
@@ -2175,7 +2376,13 @@ test("findFinalAssistantMessage returns the last assistant with a known stop rea
 type GoalTool = {
 	execute: (...args: unknown[]) => Promise<{
 		content?: Array<{ type: string; text: string }>;
-		details?: { goal?: string };
+		details?: {
+			goal?: string;
+			goal_id?: string;
+			reason?: string;
+			evidence?: string;
+			repeated_turns?: number;
+		};
 		terminate?: boolean;
 	}>;
 };

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -81,6 +81,141 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 	]);
 });
 
+test("child session initialization does not erase or reroute the parent goal", async () => {
+	const rootBranch: Array<Record<string, unknown>> = [];
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext({
+		sessionManager: { getBranch: () => rootBranch, getEntries: () => rootBranch },
+	});
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("parent objective", rootContext.ctx);
+
+	const rootGoal = requireLastGoal(root);
+	rootBranch.push({
+		type: "custom",
+		customType: "goal-state",
+		data: { goal: rootGoal },
+	});
+	const rootCompletion = requireGoalTool(root, "goal_complete");
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext({
+		sessionManager: { getBranch: () => [], getEntries: () => [] },
+	});
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+
+	const result = await rootCompletion.execute(
+		"root-completion",
+		{ goal_id: rootGoal.id, summary: "Verified parent completion." },
+		new AbortController().signal,
+		() => undefined,
+		rootContext.ctx,
+	);
+
+	assert.equal(result.content?.[0]?.text, "Goal complete: Verified parent completion.");
+	assert.equal(result.terminate, true);
+	assert.equal(result.details?.goal, rootGoal.text);
+	assert.deepEqual(root.entries.filter((entry) => entry.customType === "goal-state").at(-1)?.data, {
+		goal: null,
+	});
+	assert.equal(child.entries.filter((entry) => entry.customType === "goal-state").length, 0);
+});
+
+test("independent goal instances keep completion local", async () => {
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	await child.commands.get("goal")?.handler("child objective", childContext.ctx);
+
+	const rootGoal = requireLastGoal(root);
+	const childGoal = requireLastGoal(child);
+	assert.notEqual(rootGoal.id, childGoal.id);
+
+	const result = await requireGoalTool(root, "goal_complete").execute(
+		"root-completion",
+		{ goal_id: rootGoal.id, summary: "Root work verified." },
+		new AbortController().signal,
+		() => undefined,
+		rootContext.ctx,
+	);
+
+	assert.equal(result.terminate, true);
+	assert.equal(lastGoalStatus(root), null);
+	assert.equal(lastGoalStatus(child), "active");
+	assert.equal(requireLastGoal(child).id, childGoal.id);
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+});
+
+test("tool lifecycle persistence stays on the owning goal instance", async () => {
+	const rootBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 1 })];
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext({
+		sessionManager: { getBranch: () => rootBranch, getEntries: () => rootBranch },
+	});
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+
+	const childBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 2 })];
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext({
+		sessionManager: { getBranch: () => childBranch, getEntries: () => childBranch },
+	});
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	await child.commands.get("goal")?.handler("child objective", childContext.ctx);
+
+	const rootEntriesBefore = root.entries.length;
+	const childEntriesBefore = child.entries.length;
+	root.events.get("tool_execution_end")?.[0]?.({}, rootContext.ctx);
+	assert.equal(root.entries.length, rootEntriesBefore + 1);
+	assert.equal(child.entries.length, childEntriesBefore);
+
+	child.events.get("tool_execution_end")?.[0]?.({}, childContext.ctx);
+	assert.equal(root.entries.length, rootEntriesBefore + 1);
+	assert.equal(child.entries.length, childEntriesBefore + 1);
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+});
+
+test("child shutdown does not clear the parent goal", async () => {
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+	const rootGoal = requireLastGoal(root);
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+
+	const result = await requireGoalTool(root, "goal_complete").execute(
+		"root-completion-after-child-shutdown",
+		{ goal_id: rootGoal.id, summary: "Root work verified after child shutdown." },
+		new AbortController().signal,
+		() => undefined,
+		rootContext.ctx,
+	);
+
+	assert.equal(result.terminate, true);
+	assert.equal(lastGoalStatus(root), null);
+	assert.equal(child.entries.length, 0);
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+});
+
 test("completeGoalArguments suggests /goal subcommands and token options", () => {
 	assert.deepEqual(
 		completeGoalArguments("")?.map((item) => item.label),
@@ -2040,6 +2175,7 @@ test("findFinalAssistantMessage returns the last assistant with a known stop rea
 type GoalTool = {
 	execute: (...args: unknown[]) => Promise<{
 		content?: Array<{ type: string; text: string }>;
+		details?: { goal?: string };
 		terminate?: boolean;
 	}>;
 };

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -320,7 +320,7 @@ test("goal_blocked ownership stays on the root instance after child start", asyn
 	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
 });
 
-test("continuation and budget messages stay on the owning runtime API", async () => {
+test("pending continuation and budget state survive later child startup", async () => {
 	const rootBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 0 })];
 	const root = createMockPi();
 	goal(root.pi);
@@ -331,42 +331,177 @@ test("continuation and budget messages stay on the owning runtime API", async ()
 	await root.commands.get("goal")?.handler("--tokens 1 root objective", rootContext.ctx);
 	const rootGoal = requireLastGoal(root);
 	const rootUserMessagesBefore = root.sentUserMessages.length;
-	const rootCustomMessagesBefore = root.sentMessages.length;
 
-	const child = createMockPi();
-	goal(child.pi);
-	const childContext = createMockContext();
-	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
-	const childUserMessagesBefore = child.sentUserMessages.length;
-	const childCustomMessagesBefore = child.sentMessages.length;
-
-	// Parent agent_end after an incomplete stop must enqueue and later dispatch continuation
-	// against the parent API only, even after a sibling factory started.
+	// Record the parent continuation before the child starts. Child session_start must not
+	// clear an already-pending continuation or reroute its eventual delivery.
 	await root.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },
 		rootContext.ctx,
 	);
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
 	root.events.get("agent_settled")?.[0]?.({}, rootContext.ctx);
-	assert.ok(root.sentUserMessages.length > rootUserMessagesBefore);
-	assert.match(
-		root.sentUserMessages.at(-1)?.text ?? "",
-		new RegExp(`<!-- pi-goal-continuation:${rootGoal.id}:`),
-	);
-	assert.equal(child.sentUserMessages.length, childUserMessagesBefore);
+	assert.equal(root.sentUserMessages.length, rootUserMessagesBefore + 1);
+	const staleContinuation = root.sentUserMessages.at(-1)?.text ?? "";
+	assert.match(staleContinuation, new RegExp(`<!-- pi-goal-continuation:${rootGoal.id}:`));
+	assert.equal(child.sentUserMessages.length, 0);
 
-	// Parent tool activity that crosses the token budget must wrap up through the parent API.
+	// Establish the parent budget wrap-up before another child starts. Its context marker
+	// must remain authorized by the parent runtime after that later child session_start.
 	rootBranch.push(assistantUsageEntry({ totalTokens: 5 }));
 	root.events.get("tool_execution_end")?.[0]?.({}, rootContext.ctx);
 	assert.equal(lastGoalStatus(root), "budget_limited");
-	assert.ok(root.sentMessages.length > rootCustomMessagesBefore);
 	const wrapUp = root.sentMessages.at(-1)?.message as {
 		customType?: string;
 		details?: { goalId?: string };
 	};
 	assert.equal(wrapUp?.customType, "goal-budget-wrap-up");
 	assert.equal(wrapUp?.details?.goalId, rootGoal.id);
-	assert.equal(child.sentMessages.length, childCustomMessagesBefore);
+
+	const laterChild = createMockPi();
+	goal(laterChild.pi);
+	const laterChildContext = createMockContext();
+	laterChild.events.get("session_start")?.[0]?.({}, laterChildContext.ctx);
+	const contextMessages = [
+		{ role: "custom", customType: wrapUp.customType, details: wrapUp.details },
+		{ role: "user", content: "continue" },
+	];
+	assert.equal(
+		root.events.get("context")?.[0]?.({ messages: contextMessages }, rootContext.ctx),
+		undefined,
+	);
+	assert.equal(child.sentMessages.length, 0);
+	assert.equal(laterChild.sentMessages.length, 0);
 	assert.equal(lastGoalStatus(child), null);
+	assert.equal(lastGoalStatus(laterChild), null);
+	assert.deepEqual(
+		root.events.get("input")?.[0]?.(
+			{ source: "extension", text: staleContinuation },
+			rootContext.ctx,
+		),
+		{ action: "handled" },
+	);
+	assert.equal(
+		laterChild.events.get("input")?.[0]?.(
+			{ source: "extension", text: staleContinuation },
+			laterChildContext.ctx,
+		),
+		undefined,
+	);
+
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+	laterChild.events.get("session_shutdown")?.[0]?.({}, laterChildContext.ctx);
+});
+
+test("stale tool guard survives later child startup", async () => {
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+	await root.commands.get("goal")?.handler("pause", rootContext.ctx);
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	const rootToolCall = root.events.get("tool_call")?.[0];
+	assert.deepEqual(
+		rootToolCall?.({ toolName: "bash", toolCallId: "root-stale", input: {} }, rootContext.ctx),
+		{ block: true, reason: STALE_GOAL_TOOL_REASON },
+	);
+	assert.equal(
+		child.events.get("tool_call")?.[0]?.(
+			{ toolName: "bash", toolCallId: "child-fresh", input: {} },
+			childContext.ctx,
+		),
+		undefined,
+	);
+
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+	assert.deepEqual(
+		rootToolCall?.(
+			{ toolName: "bash", toolCallId: "root-stale-after-shutdown", input: {} },
+			rootContext.ctx,
+		),
+		{ block: true, reason: STALE_GOAL_TOOL_REASON },
+	);
+	assert.equal(lastGoalStatus(root), "paused");
+	assert.equal(lastGoalStatus(child), null);
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+});
+
+test("pending compaction recovery survives later child startup", async () => {
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+	const rootGoal = requireLastGoal(root);
+	const rootUserMessagesBefore = root.sentUserMessages.length;
+
+	await root.events.get("agent_end")?.[0]?.(
+		{
+			messages: [
+				{
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+				},
+			],
+		},
+		rootContext.ctx,
+	);
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	const retryPrompt = root.events.get("before_agent_start")?.[0]?.(
+		{ prompt: "retry", systemPrompt: "base" },
+		rootContext.ctx,
+	) as { systemPrompt?: string } | undefined;
+	assert.match(retryPrompt?.systemPrompt ?? "", new RegExp(rootGoal.id));
+
+	root.events.get("session_before_compact")?.[0]?.({}, rootContext.ctx);
+	await root.events.get("session_compact")?.[0]?.({}, rootContext.ctx);
+	await root.events.get("agent_settled")?.[0]?.({}, rootContext.ctx);
+	assert.equal(root.sentUserMessages.length, rootUserMessagesBefore);
+	assert.equal(child.sentUserMessages.length, 0);
+	assert.equal(lastGoalStatus(root), "active");
+	assert.equal(lastGoalStatus(child), null);
+
+	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
+	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
+});
+
+test("completion status timer survives later child startup", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const root = createMockPi();
+	goal(root.pi);
+	const rootContext = createMockContext();
+	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
+	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
+	const rootGoal = requireLastGoal(root);
+	await requireGoalTool(root, "goal_complete").execute(
+		"root-completion",
+		{ goal_id: rootGoal.id, summary: "Root work verified." },
+		new AbortController().signal,
+		() => undefined,
+		rootContext.ctx,
+	);
+	assert.equal(rootContext.statuses.get("goal"), "complete");
+
+	const child = createMockPi();
+	goal(child.pi);
+	const childContext = createMockContext();
+	child.events.get("session_start")?.[0]?.({}, childContext.ctx);
+	t.mock.timers.tick(8_000);
+	assert.equal(rootContext.statuses.get("goal"), undefined);
+	assert.equal(childContext.statuses.get("goal"), undefined);
 
 	root.events.get("session_shutdown")?.[0]?.({}, rootContext.ctx);
 	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);


### PR DESCRIPTION
## Summary

`pi-goal` stored mutable goal state, the owning `ExtensionAPI`, timers, continuation/recovery/budget state, and tool closures in module-level variables. Pi can invoke the same extension factory more than once in a single process when an in-process child session is created. Because JavaScript module state is shared, the parent and child instances read and wrote the same registry.

The observed failure was triggered by `@tintinweb/pi-subagents@0.13.0`, whose child sessions inherit extensions by default. An empty child session's `session_start` set the shared `activeGoal` to `undefined` and replaced the shared `extensionApi`. The parent kept running, but goal snapshots stopped and its final `goal_complete` failed with `no active goal` even though the parent session still had an active persisted `goal-state`.

## Fix

- **Per-factory `GoalRuntime`**: Every `goal(pi)` invocation now owns its active goal, timers, continuation/recovery/budget state, stale-tool guards, and cancelled-continuation markers.
- **Per-runtime tools**: `goal_complete` and `goal_blocked` are created inside the factory and close over only that runtime.
- **Isolated persistence**: All `appendEntry`, `sendUserMessage`, and `sendMessage` calls go through `runtime.pi`.
- **Single pure-helper surface**: Pure helpers (`formatStatus`, interruption classifiers, `findFinalAssistantMessage`, etc.) live once at module scope — no more nested duplicates or `*ForExport` copies.

## Tests

Isolation coverage verifies:

- Parent goal survives an empty-child `session_start` and can still complete.
- Completion writes ordered `complete` then `null` tombstone; child receives no parent entries.
- Root and child can hold distinct concurrent active goals.
- `goal_blocked` ownership and `tool_execution_end` persistence stay on the owning instance.
- Continuation and budget wrap-up messages route through the owning runtime API.
- Child shutdown cannot clear or disable parent state.

No deferred items (rehydration, `session_tree`, persistence rewrite, new modules, README changes) are included; the fix scope is limited to `goal.ts` and `goal.test.ts`.

## Verification

```
npm --workspace @narumitw/pi-goal run typecheck   :heavy_check_mark:
npm test                                           329/329 pass
npm --workspace @narumitw/pi-goal run test:runtime :heavy_check_mark:
npm run check                                      :heavy_check_mark:
npm run pack:goal                                  :heavy_check_mark:
```
