### PR TITLE
feat(caffeinate): add quiet mode

### DIFF
--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -14,7 +14,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 - Supports macOS, Windows, WSL, and Linux.
 - Defaults to display-awake mode on every supported OS: prevent system sleep and keep the screen/display awake.
 - Provides a single `/caffeinate` command with menu-based controls and direct subcommands.
-- Persists the selected keep-awake mode in a small JSON settings file.
+- Persists the selected keep-awake mode and optional quiet mode in a small JSON settings file.
 - Allows a custom inhibitor command through environment configuration.
 - Emits plain status text; `@narumitw/pi-statusline` can add or suppress the status icon from JSON config.
 - Fails safely when no supported inhibitor is available.
@@ -77,7 +77,7 @@ Keeps the system awake while allowing normal display sleep. If an inhibitor is c
 /caffeinate status
 ```
 
-Shows whether an inhibitor is active, unavailable, disabled, or idle. The status includes the current mode and settings file path.
+Shows whether an inhibitor is active, unavailable, disabled, or idle. The status includes the current mode, quiet mode, and settings file path.
 
 ```text
 /caffeinate mode
@@ -93,7 +93,7 @@ Releases any active inhibitor until Pi starts another agent run.
 
 ## ⚙️ Configuration
 
-### Persisted mode
+### Persisted settings
 
 `/caffeinate sleep` and `/caffeinate display` save the selected mode to:
 
@@ -106,11 +106,18 @@ Example:
 ```json
 {
   "mode": "display",
+  "quiet": true,
   "updatedAt": 1791763200000
 }
 ```
 
-Missing, invalid, or deleted settings default back to `display` mode on every supported OS.
+Set `"quiet": true` to hide the routine `Keeping computer awake (...)` and
+`Released pi-caffeinate (agent finished)` lifecycle notifications. Quiet mode does not hide
+warnings, status updates, or feedback from `/caffeinate` commands such as `status`, mode changes,
+help, and manual stop. It defaults to `false` when omitted.
+
+Missing, invalid, or deleted settings default back to `display` mode with quiet mode disabled on
+every supported OS.
 
 Compatibility: older versions used `pi-caffeinate-settings.json`. During the migration window, a
 legacy-only file is automatically migrated to `pi-caffeinate.json` with a warning. If both files

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -114,7 +114,8 @@ Example:
 Set `"quiet": true` to hide the routine `Keeping computer awake (...)` and
 `Released pi-caffeinate (agent finished)` lifecycle notifications. Quiet mode does not hide
 warnings, status updates, or feedback from `/caffeinate` commands such as `status`, mode changes,
-help, and manual stop. It defaults to `false` when omitted.
+help, and manual stop. It defaults to `false` when omitted. The file is read at startup and on
+`/reload`; run `/reload` after editing it in a running Pi session before using mode commands.
 
 Missing, invalid, or deleted settings default back to `display` mode with quiet mode disabled on
 every supported OS.

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -56,6 +56,7 @@ interface CaffeinateState {
 	available: boolean;
 	disabled: boolean;
 	mode: CaffeinateMode;
+	quiet: boolean;
 	settingsLoaded: boolean;
 	settingsError?: string;
 	settingsNotice?: string;
@@ -67,6 +68,7 @@ const state: CaffeinateState = {
 	available: true,
 	disabled: isDisabled(),
 	mode: DEFAULT_MODE,
+	quiet: false,
 	settingsLoaded: false,
 	iconWarningShown: false,
 };
@@ -83,12 +85,14 @@ export default function caffeinate(pi: ExtensionAPI) {
 	pi.on("agent_start", async (_event, ctx) => {
 		await ensureSettingsLoaded(ctx);
 		state.activeTurns += 1;
-		startInhibitor(ctx);
+		startInhibitor(ctx, { notify: !state.quiet });
 	});
 
 	pi.on("agent_end", (_event, ctx) => {
 		state.activeTurns = Math.max(0, state.activeTurns - 1);
-		if (state.activeTurns === 0) stopInhibitor(ctx, "agent finished");
+		if (state.activeTurns === 0) {
+			stopInhibitor(ctx, "agent finished", { notify: !state.quiet });
+		}
 		updateStatus(ctx);
 	});
 
@@ -195,7 +199,7 @@ async function setMode(ctx: ExtensionContext, mode: CaffeinateMode) {
 
 	let saved = true;
 	try {
-		await saveSettings({ mode, updatedAt: Date.now() });
+		await saveSettings({ mode, quiet: state.quiet, updatedAt: Date.now() });
 	} catch (error) {
 		saved = false;
 		state.settingsError = `settings save failed: ${formatError(error)}`;
@@ -204,7 +208,7 @@ async function setMode(ctx: ExtensionContext, mode: CaffeinateMode) {
 
 	if (state.process && previousMode !== mode && !state.command?.custom) {
 		stopInhibitor(ctx, "mode changed", { notify: false });
-		startInhibitor(ctx);
+		startInhibitor(ctx, { notify: !state.quiet });
 	}
 
 	ctx.ui.notify(
@@ -261,7 +265,7 @@ function buildCommandGuide() {
 	].join("\n");
 }
 
-function startInhibitor(ctx: ExtensionContext) {
+function startInhibitor(ctx: ExtensionContext, options: { notify?: boolean } = {}) {
 	if (state.disabled || state.process) {
 		updateStatus(ctx);
 		return;
@@ -293,6 +297,7 @@ function startInhibitor(ctx: ExtensionContext) {
 				if (state.process !== child) return;
 				state.process = undefined;
 				state.startedAt = undefined;
+				state.available = false;
 				state.lastError = `${command.description} exited unexpectedly (${exit}).`;
 				ctx.ui.notify(state.lastError, "warning");
 				updateStatus(ctx);
@@ -303,7 +308,9 @@ function startInhibitor(ctx: ExtensionContext) {
 		state.command = command;
 		state.available = true;
 		state.lastError = undefined;
-		ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
+		if (options.notify !== false) {
+			ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
+		}
 		updateStatus(ctx);
 	} catch (error) {
 		state.process = undefined;
@@ -348,6 +355,7 @@ function describeState() {
 	const customCommand = hasCustomCommand();
 	const lines = [
 		`Mode: ${formatMode(state.mode)}${customCommand ? " (overridden by custom command)" : ""}`,
+		`Quiet mode: ${state.quiet ? "enabled" : "disabled"}`,
 		`Settings: ${settingsFilePath()}`,
 	];
 
@@ -394,6 +402,7 @@ async function loadSettingsIntoState(ctx: ExtensionContext) {
 	if (state.disabled) {
 		state.settingsLoaded = true;
 		state.settingsError = undefined;
+		state.quiet = false;
 		return;
 	}
 
@@ -407,10 +416,12 @@ async function loadSettingsIntoState(ctx: ExtensionContext) {
 
 	if (settings.kind === "loaded") {
 		state.mode = settings.settings.mode;
+		state.quiet = settings.settings.quiet;
 		return;
 	}
 
 	state.mode = DEFAULT_MODE;
+	state.quiet = false;
 	if (settings.kind === "invalid") {
 		state.settingsError = settings.reason;
 		ctx.ui.notify(

--- a/extensions/pi-caffeinate/src/settings.ts
+++ b/extensions/pi-caffeinate/src/settings.ts
@@ -11,6 +11,7 @@ export type CaffeinateMode = "sleep" | "display";
 
 export interface CaffeinateSettings {
 	mode: CaffeinateMode;
+	quiet: boolean;
 	updatedAt: number;
 }
 
@@ -59,7 +60,10 @@ async function readSettingsFile(filePath: string): Promise<SettingsLoadResult> {
 	try {
 		const settings = normalizeCaffeinateSettings(JSON.parse(text) as unknown);
 		if (settings) return { kind: "loaded", settings };
-		return { kind: "invalid", reason: `${filePath}: expected { "mode": "sleep" | "display" }` };
+		return {
+			kind: "invalid",
+			reason: `${filePath}: expected { "mode": "sleep" | "display", optional "quiet": boolean }`,
+		};
 	} catch (error) {
 		return { kind: "invalid", reason: `${filePath}: ${formatError(error)}` };
 	}
@@ -108,10 +112,11 @@ async function fileExists(filePath: string) {
 
 export function normalizeCaffeinateSettings(value: unknown): CaffeinateSettings | undefined {
 	if (!value || typeof value !== "object") return undefined;
-	const settings = value as { mode?: unknown; updatedAt?: unknown };
+	const settings = value as { mode?: unknown; quiet?: unknown; updatedAt?: unknown };
 	if (!isCaffeinateMode(settings.mode)) return undefined;
+	if (settings.quiet !== undefined && typeof settings.quiet !== "boolean") return undefined;
 	if (settings.updatedAt !== undefined && typeof settings.updatedAt !== "number") return undefined;
-	return { mode: settings.mode, updatedAt: settings.updatedAt ?? 0 };
+	return { mode: settings.mode, quiet: settings.quiet ?? false, updatedAt: settings.updatedAt ?? 0 };
 }
 
 function isCaffeinateMode(value: unknown): value is CaffeinateMode {

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -122,7 +122,28 @@ test("caffeinate loads the new settings file without a migration warning", async
 
 		await mock.commands.get("caffeinate")?.handler("status", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /Mode: system-awake/);
+		assert.match(notifications.at(-1)?.message ?? "", /Quiet mode: disabled/);
 		assert.match(notifications.at(-1)?.message ?? "", /Settings: .*pi-caffeinate\.json/);
+	});
+});
+
+test("session reload applies manual quiet mode changes", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, "display");
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		const { ctx, notifications } = createMockContext();
+
+		caffeinateModule.default(mock.pi);
+		const sessionStart = mock.events.get("session_start")?.[0];
+		await sessionStart?.({ reason: "startup" }, ctx);
+		await mock.commands.get("caffeinate")?.handler("status", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /Quiet mode: disabled/);
+
+		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
+		await sessionStart?.({ reason: "reload" }, ctx);
+		await mock.commands.get("caffeinate")?.handler("status", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /Quiet mode: enabled/);
 	});
 });
 
@@ -410,7 +431,8 @@ function longRunningCustomCommand() {
 }
 
 function customNodeCommand(script: string) {
-	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+	const executable = process.execPath.replaceAll("\\", "/");
+	return `${JSON.stringify(executable)} -e ${JSON.stringify(script)}`;
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2_000) {

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -56,8 +56,23 @@ test("splitCommand handles quotes and escaped spaces", () => {
 	]);
 });
 
-test("normalizeCaffeinateSettings accepts only known modes", () => {
-	assert.deepEqual(normalizeCaffeinateSettings({ mode: "sleep" }), { mode: "sleep", updatedAt: 0 });
+test("normalizeCaffeinateSettings accepts quiet booleans and defaults quiet to false", () => {
+	assert.deepEqual(normalizeCaffeinateSettings({ mode: "sleep" }), {
+		mode: "sleep",
+		quiet: false,
+		updatedAt: 0,
+	});
+	assert.deepEqual(normalizeCaffeinateSettings({ mode: "display", quiet: true }), {
+		mode: "display",
+		quiet: true,
+		updatedAt: 0,
+	});
+	assert.deepEqual(normalizeCaffeinateSettings({ mode: "display", quiet: false }), {
+		mode: "display",
+		quiet: false,
+		updatedAt: 0,
+	});
+	assert.equal(normalizeCaffeinateSettings({ mode: "display", quiet: "yes" }), undefined);
 	assert.equal(normalizeCaffeinateSettings({ mode: "display", updatedAt: "now" }), undefined);
 	assert.equal(normalizeCaffeinateSettings({ mode: "screen" }), undefined);
 });
@@ -241,19 +256,104 @@ test("caffeinate ignores invalid legacy settings without creating the new file",
 	});
 });
 
-test("caffeinate saves mode only to the new settings file", async () => {
+test("caffeinate saves mode only to the new settings file and preserves quiet mode", async () => {
 	await withTempAgentDir(async (agentDir) => {
-		writeSettings(agentDir, NEW_SETTINGS_FILE, "display");
+		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
 		writeSettings(agentDir, LEGACY_SETTINGS_FILE, "display");
 		const caffeinateModule = await importFreshCaffeinate();
 		const mock = createMockPi();
-		const { ctx } = createMockContext();
+		const { ctx, notifications } = createMockContext();
 
 		caffeinateModule.default(mock.pi);
 		await mock.commands.get("caffeinate")?.handler("sleep", ctx);
 
-		assert.equal(readSettings(agentDir, NEW_SETTINGS_FILE).mode, "sleep");
+		const savedSettings = readSettings(agentDir, NEW_SETTINGS_FILE);
+		assert.equal(savedSettings.mode, "sleep");
+		assert.equal(savedSettings.quiet, true);
+		assert.equal(typeof savedSettings.updatedAt, "number");
 		assert.equal(readSettings(agentDir, LEGACY_SETTINGS_FILE).mode, "display");
+		assert.match(notifications.at(-1)?.message ?? "", /mode set to system-awake and saved/);
+	});
+});
+
+test("quiet mode keeps lifecycle and status active without routine notifications", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
+		process.env.PI_CAFFEINATE_COMMAND = longRunningCustomCommand();
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		const { ctx, notifications, statuses } = createMockContext();
+
+		caffeinateModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.events.get("agent_start")?.[0]?.({}, ctx);
+		const activeStatus = statuses.get("caffeinate");
+		await mock.events.get("agent_end")?.[0]?.({}, ctx);
+
+		assert.equal(notifications.length, 0);
+		assert.equal(activeStatus, "custom");
+		assert.equal(statuses.get("caffeinate"), undefined);
+	});
+});
+
+test("quiet mode preserves explicit command feedback", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
+		process.env.PI_CAFFEINATE_COMMAND = longRunningCustomCommand();
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		const { ctx, notifications } = createMockContext();
+
+		caffeinateModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.events.get("agent_start")?.[0]?.({}, ctx);
+		await mock.commands.get("caffeinate")?.handler("status", ctx);
+		await mock.commands.get("caffeinate")?.handler("stop", ctx);
+
+		assert.match(notifications[0]?.message ?? "", /Quiet mode: enabled/);
+		assert.match(notifications[1]?.message ?? "", /Released pi-caffeinate \(manual stop\)/);
+	});
+});
+
+test("quiet mode preserves inhibitor failure warnings", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
+		process.env.PI_CAFFEINATE_COMMAND = customNodeCommand("setTimeout(()=>process.exit(7),20)");
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		const { ctx, notifications, statuses } = createMockContext();
+
+		caffeinateModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.events.get("agent_start")?.[0]?.({}, ctx);
+		await waitFor(() => notifications.length > 0 && statuses.get("caffeinate") === "unavailable");
+
+		assert.equal(notifications.length, 1);
+		assert.equal(notifications[0]?.level, "warning");
+		assert.match(notifications[0]?.message ?? "", /exited unexpectedly \(code 7\)/);
+		assert.equal(statuses.get("caffeinate"), "unavailable");
+	});
+});
+
+test("default settings keep routine lifecycle notifications", async () => {
+	await withTempAgentDir(async () => {
+		process.env.PI_CAFFEINATE_COMMAND = longRunningCustomCommand();
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		const { ctx, notifications } = createMockContext();
+
+		caffeinateModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.events.get("agent_start")?.[0]?.({}, ctx);
+		await mock.events.get("agent_end")?.[0]?.({}, ctx);
+
+		assert.deepEqual(
+			notifications.map(({ message, level }) => ({ message, level })),
+			[
+				{ message: "Keeping computer awake (custom).", level: "info" },
+				{ message: "Released pi-caffeinate (agent finished).", level: "info" },
+			],
+		);
 	});
 });
 
@@ -269,10 +369,12 @@ async function withTempAgentDir<T>(fn: (agentDir: string) => Promise<T>) {
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	const previousDisabled = process.env.PI_CAFFEINATE_DISABLED;
 	const previousIcon = process.env.PI_CAFFEINATE_ICON;
+	const previousCommand = process.env.PI_CAFFEINATE_COMMAND;
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-caffeinate-settings-"));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	delete process.env.PI_CAFFEINATE_DISABLED;
 	delete process.env.PI_CAFFEINATE_ICON;
+	delete process.env.PI_CAFFEINATE_COMMAND;
 	try {
 		return await fn(agentDir);
 	} finally {
@@ -282,17 +384,39 @@ async function withTempAgentDir<T>(fn: (agentDir: string) => Promise<T>) {
 		else process.env.PI_CAFFEINATE_DISABLED = previousDisabled;
 		if (previousIcon === undefined) delete process.env.PI_CAFFEINATE_ICON;
 		else process.env.PI_CAFFEINATE_ICON = previousIcon;
+		if (previousCommand === undefined) delete process.env.PI_CAFFEINATE_COMMAND;
+		else process.env.PI_CAFFEINATE_COMMAND = previousCommand;
 		rmSync(agentDir, { recursive: true, force: true });
 	}
 }
 
-function writeSettings(agentDir: string, fileName: string, mode: string) {
-	writeFileSync(path.join(agentDir, fileName), JSON.stringify({ mode, updatedAt: 1 }));
+function writeSettings(agentDir: string, fileName: string, mode: string, quiet?: boolean) {
+	writeFileSync(
+		path.join(agentDir, fileName),
+		JSON.stringify({ mode, ...(quiet === undefined ? {} : { quiet }), updatedAt: 1 }),
+	);
 }
 
 function readSettings(agentDir: string, fileName: string) {
 	return JSON.parse(readFileSync(path.join(agentDir, fileName), "utf8")) as {
 		mode: string;
+		quiet?: boolean;
 		updatedAt: number;
 	};
+}
+
+function longRunningCustomCommand() {
+	return customNodeCommand("setInterval(()=>{},1000)");
+}
+
+function customNodeCommand(script: string) {
+	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
 }


### PR DESCRIPTION
## Summary

- add an optional `quiet` setting to `pi-caffeinate.json`, defaulting to `false`
- suppress routine inhibitor start and agent-finished notifications while preserving warnings, status updates, and explicit command feedback
- preserve quiet mode when saving mode changes and report it from `/caffeinate status`
- document the setting and cover default, quiet, warning, status, command, save, and migration behavior

## Testing

- `npm run check`

Closes #194
