### PR TITLE
feat: standardize extension config filenames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Run commands from the repository root unless noted otherwise.
 - TypeScript uses `module`/`moduleResolution: NodeNext`, `target: ES2022`, `strict: true`, and `noEmit: true`.
 - Biome is authoritative: tabs, 100-column line width, double quotes, semicolons, and recommended lint rules.
 - Keep extension packages small and self-contained. Add dependencies only when they solve a current extension need.
-- Name an active extension's general user config `<unscoped-package-name>.json`; use the same basename for project overrides. Use variants such as `.local`, credential vaults, or state filenames only when they communicate a concrete security or storage semantic.
+- Name an active extension-managed user JSON file `<unscoped-package-name>.json`; use the same basename for project overrides. Credential sensitivity changes permissions and migration handling, not the basename. Use variants such as `.local` or state filenames only when they communicate a concrete storage semantic.
 - When adding an extension, include the source in `pi.extensions`, package publish `files`, and root workspace-aware scripts/recipes if users need them.
 - When a source file exceeds 1,000 lines, it must be reviewed for decomposition. Split it along clear responsibility boundaries when doing so improves cohesion, maintainability, or testability. Do not split files mechanically solely to satisfy the line limit. Generated, vendored, migration, snapshot, and primarily declarative files may be exempt.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Run commands from the repository root unless noted otherwise.
 - TypeScript uses `module`/`moduleResolution: NodeNext`, `target: ES2022`, `strict: true`, and `noEmit: true`.
 - Biome is authoritative: tabs, 100-column line width, double quotes, semicolons, and recommended lint rules.
 - Keep extension packages small and self-contained. Add dependencies only when they solve a current extension need.
+- Name an active extension's general user config `<unscoped-package-name>.json`; use the same basename for project overrides. Use variants such as `.local`, credential vaults, or state filenames only when they communicate a concrete security or storage semantic.
 - When adding an extension, include the source in `pi.extensions`, package publish `files`, and root workspace-aware scripts/recipes if users need them.
 - When a source file exceeds 1,000 lines, it must be reviewed for decomposition. Split it along clear responsibility boundaries when doing so improves cohesion, maintainability, or testability. Do not split files mechanically solely to satisfy the line limit. Generated, vendored, migration, snapshot, and primarily declarative files may be exempt.
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -19,6 +19,7 @@
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.
 - Keep package metadata and CI/bump/publish workflows pinned to npm 11.16.0; npm 12.0 resolves shrinkwrapped overrides differently, prunes alternate-Pi installs, and cannot resolve its published provenance `sigstore`. Regenerate the lockfile when intentionally changing npm major versions.
 - New filesystem-writing Pi tools need a pre-review edge-case pass: workspace containment, absolute/`..` paths, symlink loops/escapes, duplicate paths, cancellation, process errors, protocol errors, and edit ordering.
+- Config filename migrations should validate but copy the original JSON bytes, not normalized settings, so unknown forward-compatible fields survive; before deleting legacy files, recheck that their contents did not change.
 - New extension package source may match the root `.gitignore` `src/` rule; stage intended `extensions/<pkg>/src/*.ts` with `git add -f`. Biome also honors that ignore, so format/check changed source explicitly with `--vcs-use-ignore-file=false`.
 - Symptom: `npm test --workspace @narumitw/<extension>` fails with “Missing script: test”. Cause: extension packages do not define workspace test scripts; root `npm test` compiles and runs all extension tests. Fix: run `npm test` from the repository root.
 - When PR comments expose one class of bug, stop patching comment-by-comment and do a holistic pass over adjacent Modules before pushing again.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -19,7 +19,7 @@
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.
 - Keep package metadata and CI/bump/publish workflows pinned to npm 11.16.0; npm 12.0 resolves shrinkwrapped overrides differently, prunes alternate-Pi installs, and cannot resolve its published provenance `sigstore`. Regenerate the lockfile when intentionally changing npm major versions.
 - New filesystem-writing Pi tools need a pre-review edge-case pass: workspace containment, absolute/`..` paths, symlink loops/escapes, duplicate paths, cancellation, process errors, protocol errors, and edit ordering.
-- New extension package source may match the root `.gitignore` `src/` rule; stage intended `extensions/<pkg>/src/*.ts` with `git add -f`.
+- New extension package source may match the root `.gitignore` `src/` rule; stage intended `extensions/<pkg>/src/*.ts` with `git add -f`. Biome also honors that ignore, so format/check changed source explicitly with `--vcs-use-ignore-file=false`.
 - Symptom: `npm test --workspace @narumitw/<extension>` fails with “Missing script: test”. Cause: extension packages do not define workspace test scripts; root `npm test` compiles and runs all extension tests. Fix: run `npm test` from the repository root.
 - When PR comments expose one class of bug, stop patching comment-by-comment and do a holistic pass over adjacent Modules before pushing again.
 - Symptom: PR status shows no issue comments but inline review comments exist. Cause: `gh pr view --json comments,reviews` omits pull review comment bodies. Fix: use `gh api repos/OWNER/REPO/pulls/NUMBER/comments` plus issue comments/reviews when actual PR review comments are needed.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Use [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) to give Pi Googl
 
 ### 🔐 Codex subscription accounts
 
-Use [`@narumitw/pi-codex-accounts`](./extensions/pi-codex-accounts) to keep multiple ChatGPT Codex subscription accounts in a private `codex-accounts.json` file and switch the active account with `/codex-account`. It does not add provider aliases or change Pi's built-in `/login` provider list.
+Use [`@narumitw/pi-codex-accounts`](./extensions/pi-codex-accounts) to keep multiple ChatGPT Codex subscription accounts in a private `pi-codex-accounts.json` file and switch the active account with `/codex-account`. It does not add provider aliases or change Pi's built-in `/login` provider list.
 
 ### 📊 Codex usage status
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pi -e npm:@narumitw/pi-goal -e npm:@narumitw/pi-statusline -e npm:@narumitw/pi-l
 
 ### 🧠 Shared language-server workflows
 
-Use [`@narumitw/pi-lsp`](./extensions/pi-lsp) to let Pi run configurable Language Server Protocol servers through one shared runner. Configure servers in `.pi/lsp.json`, `~/.pi/agent/lsp.json`, or `PI_LSP_CONFIG` with simple `{ command, extensions }` entries, then use Pi tools for diagnostics and source code actions. The older split packages [`@narumitw/pi-biome-lsp`](./extensions/deprecated/pi-biome-lsp) and [`@narumitw/pi-python-lsp`](./extensions/deprecated/pi-python-lsp) are deprecated, kept for reference, and excluded from active workspace scripts.
+Use [`@narumitw/pi-lsp`](./extensions/pi-lsp) to let Pi run configurable Language Server Protocol servers through one shared runner. Configure servers in `.pi/pi-lsp.json`, `~/.pi/agent/pi-lsp.json`, or `PI_LSP_CONFIG` with simple `{ command, extensions }` entries, then use Pi tools for diagnostics and source code actions. The older split packages [`@narumitw/pi-biome-lsp`](./extensions/deprecated/pi-biome-lsp) and [`@narumitw/pi-python-lsp`](./extensions/deprecated/pi-python-lsp) are deprecated, kept for reference, and excluded from active workspace scripts.
 
 ### 🧬 JavaScript and TypeScript coding with Biome
 
@@ -69,7 +69,7 @@ Use [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) to give Pi native Fire
 
 ### 🔎 Google GenAI grounding
 
-Use [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) to give Pi Google Search, Google Maps, and URL-context grounding through Gemini Interactions with Pi Google auth or a private `google-genai.json` config.
+Use [`@narumitw/pi-google-genai`](./extensions/pi-google-genai) to give Pi Google Search, Google Maps, and URL-context grounding through Gemini Interactions with Pi Google auth or a private `pi-google-genai.json` config.
 
 ### 🔐 Codex subscription accounts
 

--- a/docs/plans/archived/2026-07-13_extension-config-filenames-plan.md
+++ b/docs/plans/archived/2026-07-13_extension-config-filenames-plan.md
@@ -4,26 +4,26 @@ Unify active extension config filenames as `<unscoped-package-name>.json` while 
 
 ## Non-Goals
 
-- Do not rename `pi-sync.local.json`, `codex-accounts.json`, state/lock/snapshot files, Pi core config files, or deprecated-extension config files.
+- Do not rename `pi-sync.local.json`, state/lock/snapshot files, Pi core config files, or deprecated-extension config files.
 - Do not change JSON schemas, environment variables, commands, or tools.
 
 ## Plan
 
-- [x] Add isolated migration tests for `pi-lsp`, `pi-plan-mode`, `pi-google-genai`, `pi-statusline`, and `pi-subagents`, and confirm they fail against the old filenames. Evidence: initial `npm test` failed on missing migration notice fields and missing subagent migration exports.
-- [x] Implement package-local safe migration and canonical read/write paths for the five extensions, including new-file precedence, invalid-file behavior, migration fallback, and once-per-session notices where context is available. Evidence: migration, invalid-file, precedence, and dangling-symlink fallback tests pass in `npm test`.
+- [x] Add isolated migration tests for `pi-lsp`, `pi-plan-mode`, `pi-google-genai`, `pi-statusline`, `pi-subagents`, and `pi-codex-accounts`, and confirm they fail against the old filenames. Evidence: red test runs failed on the old paths, missing migration behavior, and missing notice fields.
+- [x] Implement package-local safe migration and canonical read/write paths for six extensions, including `pi-codex-accounts`, with new-file precedence, invalid-file behavior, migration fallback, and once-per-session notices where context is available. Evidence: migration, invalid-file, precedence, dangling-symlink fallback, credential permission, and legacy-lock tests pass in `npm test`.
 - [x] Preserve Google GenAI `0600` permissions and make project-scoped legacy LSP config fallback-only rather than mutating the working tree. Evidence: Google mode assertions and LSP project-path existence assertions pass.
 - [x] Update package/root documentation and repository guidance with the canonical naming rule, compatibility notes, and explicit exceptions. Evidence: package READMEs, root `README.md`, and `AGENTS.md` updated.
-- [x] Run formatting, targeted tests, `npm run check`, legacy-name searches, and relevant package dry runs. Evidence: `npm run check` passed 364 tests; all five `just pack-*` dry runs passed; legacy search returned only compatibility code/tests/docs.
+- [x] Run formatting, targeted tests, `npm run check`, legacy-name searches, and relevant package dry runs. Evidence: `npm run check` passed 367 tests; all six `just pack-*` dry runs passed; legacy search returned only compatibility code/tests/docs.
 
 ## Risks
 
 - Migration races or I/O errors could lose the only valid config; install the canonical file exclusively and remove legacy only after success.
-- Google GenAI config may contain an API key; preserve private permissions and never include config values in warnings.
+- Google GenAI and Codex Accounts files contain credentials; preserve private permissions and never include config values in warnings.
 - Project LSP config may be tracked by Git; never auto-rename `.pi/lsp.json`.
 
 ## Completion Checklist
 
-- [x] All five canonical paths and compatibility behaviors are verified by source, docs, and 364 passing tests.
-- [x] LSP project config remains unmodified and Google GenAI permissions remain `0600`, verified by migration tests.
-- [x] Naming guidance and exceptions are documented; `git diff --name-only` shows no pi-sync, credential-vault, state, or deprecated-extension changes.
-- [x] `npm run check`, legacy-name audit, and all five package dry runs pass.
+- [x] All six canonical paths and compatibility behaviors are verified by source, docs, and 367 passing tests.
+- [x] LSP project config remains unmodified and Google GenAI/Codex Accounts permissions remain `0600`, verified by migration tests.
+- [x] Naming guidance and exceptions are documented; `git diff --name-only` shows no pi-sync, state, or deprecated-extension changes.
+- [x] `npm run check`, legacy-name audit, and all six package dry runs pass.

--- a/docs/plans/archived/2026-07-13_extension-config-filenames-plan.md
+++ b/docs/plans/archived/2026-07-13_extension-config-filenames-plan.md
@@ -1,0 +1,29 @@
+## Goal
+
+Unify active extension config filenames as `<unscoped-package-name>.json` while safely preserving phase-1 compatibility for existing users.
+
+## Non-Goals
+
+- Do not rename `pi-sync.local.json`, `codex-accounts.json`, state/lock/snapshot files, Pi core config files, or deprecated-extension config files.
+- Do not change JSON schemas, environment variables, commands, or tools.
+
+## Plan
+
+- [x] Add isolated migration tests for `pi-lsp`, `pi-plan-mode`, `pi-google-genai`, `pi-statusline`, and `pi-subagents`, and confirm they fail against the old filenames. Evidence: initial `npm test` failed on missing migration notice fields and missing subagent migration exports.
+- [x] Implement package-local safe migration and canonical read/write paths for the five extensions, including new-file precedence, invalid-file behavior, migration fallback, and once-per-session notices where context is available. Evidence: migration, invalid-file, precedence, and dangling-symlink fallback tests pass in `npm test`.
+- [x] Preserve Google GenAI `0600` permissions and make project-scoped legacy LSP config fallback-only rather than mutating the working tree. Evidence: Google mode assertions and LSP project-path existence assertions pass.
+- [x] Update package/root documentation and repository guidance with the canonical naming rule, compatibility notes, and explicit exceptions. Evidence: package READMEs, root `README.md`, and `AGENTS.md` updated.
+- [x] Run formatting, targeted tests, `npm run check`, legacy-name searches, and relevant package dry runs. Evidence: `npm run check` passed 364 tests; all five `just pack-*` dry runs passed; legacy search returned only compatibility code/tests/docs.
+
+## Risks
+
+- Migration races or I/O errors could lose the only valid config; install the canonical file exclusively and remove legacy only after success.
+- Google GenAI config may contain an API key; preserve private permissions and never include config values in warnings.
+- Project LSP config may be tracked by Git; never auto-rename `.pi/lsp.json`.
+
+## Completion Checklist
+
+- [x] All five canonical paths and compatibility behaviors are verified by source, docs, and 364 passing tests.
+- [x] LSP project config remains unmodified and Google GenAI permissions remain `0600`, verified by migration tests.
+- [x] Naming guidance and exceptions are documented; `git diff --name-only` shows no pi-sync, credential-vault, state, or deprecated-extension changes.
+- [x] `npm run check`, legacy-name audit, and all five package dry runs pass.

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -141,7 +141,7 @@ PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mo
 
 The custom command is parsed with shell-like quoting and is run directly without a shell. `PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
 
-Deprecated: `PI_CAFFEINATE_ICON` still works for now. If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json`:
+Deprecated: `PI_CAFFEINATE_ICON` still works for now. If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline.json`:
 
 ```json
 {
@@ -151,7 +151,7 @@ Deprecated: `PI_CAFFEINATE_ICON` still works for now. If you use `@narumitw/pi-s
 }
 ```
 
-Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the compatibility window. In `pi-statusline-settings.json`, use an empty string to show the caffeinate status without an icon.
+Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the compatibility window. In `pi-statusline.json`, use an empty string to show the caffeinate status without an icon.
 
 ## 🧠 Why use pi-caffeinate?
 

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -453,7 +453,7 @@ function warnDeprecatedIcon(ctx: ExtensionContext) {
 	if (state.iconWarningShown || !process.env.PI_CAFFEINATE_ICON?.trim()) return;
 	state.iconWarningShown = true;
 	ctx.ui.notify(
-		"PI_CAFFEINATE_ICON is deprecated but still works for now. If you use @narumitw/pi-statusline, move it to pi-statusline-settings.json (extensionStatusIcons.caffeinate).",
+		"PI_CAFFEINATE_ICON is deprecated but still works for now. If you use @narumitw/pi-statusline, move it to pi-statusline.json (extensionStatusIcons.caffeinate).",
 		"warning",
 	);
 }

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -12,7 +12,7 @@ It keeps using Pi's built-in `openai-codex` provider. It does **not** add provid
 - Adds `/codex-account [name]` for switching the active self-managed Codex account.
 - Adds `/codex-logout <name>` for deleting one self-managed account.
 - Adds `(default pi login)` in the selector to clear the active self-managed account and return to Pi's normal `openai-codex` auth.
-- Stores credentials in `~/.pi/agent/codex-accounts.json` with private file permissions.
+- Stores credentials in `~/.pi/agent/pi-codex-accounts.json` with private file permissions.
 - Sets only the runtime API key for Pi's native `openai-codex` provider.
 - Leaves your selected `/model` unchanged, matching Pi's built-in `/login` behavior, except it may select `openai-codex/gpt-5.5` when the current model is `unknown/unknown`.
 - Shows `codex:<name>` in the statusline only while the current model provider is `openai-codex`.
@@ -66,6 +66,9 @@ Remove one self-managed account:
 ```
 
 ## 🔐 Auth behavior
+
+The canonical credential file is `~/.pi/agent/pi-codex-accounts.json`. A legacy-only `codex-accounts.json` is migrated under the existing credential-file lock, copied with `0600` permissions, and removed only after the canonical file is installed. If both files exist, the canonical file takes precedence and the legacy file is retained.
+
 
 When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider.
 

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -1,5 +1,14 @@
 import { randomUUID } from "node:crypto";
-import { chmodSync, linkSync, lstatSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	closeSync,
+	linkSync,
+	lstatSync,
+	openSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import {
 	FileAuthStorageBackend,
@@ -367,8 +376,23 @@ function defaultAccountsPath(): string {
 		const notices: string[] = [];
 		const permissionError = enforcePrivateFilePermissions(canonicalPath);
 		if (permissionError) notices.push(permissionError);
-		if (pathEntryExists(legacyPath)) {
-			notices.push(`${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} takes precedence.`);
+		if (readableFileExists(canonicalPath)) {
+			if (pathEntryExists(legacyPath)) {
+				notices.push(
+					`${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} takes precedence.`,
+				);
+			}
+			pendingAccountsMigrationNotice = notices.length > 0 ? notices.join("\n") : undefined;
+			return canonicalPath;
+		}
+		if (readableFileExists(legacyPath)) {
+			const legacyPermissionError = enforcePrivateFilePermissions(legacyPath);
+			if (legacyPermissionError) notices.push(legacyPermissionError);
+			notices.push(
+				`${CODEX_ACCOUNTS_FILE} is unusable; ${LEGACY_CODEX_ACCOUNTS_FILE} will be used for this session.`,
+			);
+			pendingAccountsMigrationNotice = notices.join("\n");
+			return legacyPath;
 		}
 		pendingAccountsMigrationNotice = notices.length > 0 ? notices.join("\n") : undefined;
 		return canonicalPath;
@@ -440,6 +464,19 @@ function pathEntryExists(filePath: string): boolean {
 		return true;
 	} catch {
 		return false;
+	}
+}
+
+function readableFileExists(filePath: string): boolean {
+	let descriptor: number | undefined;
+	try {
+		if (!statSync(filePath).isFile()) return false;
+		descriptor = openSync(filePath, "r");
+		return true;
+	} catch {
+		return false;
+	} finally {
+		if (descriptor !== undefined) closeSync(descriptor);
 	}
 }
 

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -1,4 +1,6 @@
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { chmodSync, linkSync, lstatSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
 	FileAuthStorageBackend,
 	getAgentDir,
@@ -15,12 +17,14 @@ import {
 
 export const CODEX_PROVIDER_ID = "openai-codex";
 export const DEFAULT_CODEX_MODEL_ID = "gpt-5.5";
-export const CODEX_ACCOUNTS_FILE = "codex-accounts.json";
+export const CODEX_ACCOUNTS_FILE = "pi-codex-accounts.json";
+const LEGACY_CODEX_ACCOUNTS_FILE = "codex-accounts.json";
 export const CODEX_ACCOUNTS_STATUS_KEY = "codex-accounts";
 export const DEFAULT_PI_LOGIN_LABEL = "(default pi login)";
 export const FAIL_CLOSED_API_KEY = "pi-codex-accounts-refresh-failed";
 
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
+let pendingAccountsMigrationNotice: string | undefined;
 const ACCOUNT_NAME_RE = /^[A-Za-z0-9._-]{1,64}$/;
 
 type RuntimeAuthStorage = {
@@ -129,6 +133,7 @@ export default function codexAccounts(
 	dependencies: CodexAccountsDependencies = {},
 ) {
 	const store = dependencies.store ?? new CodexAccountStore();
+	let migrationNotice = dependencies.store ? undefined : consumeAccountsMigrationNotice();
 	const oauthProvider = dependencies.oauthProvider ?? openaiCodexOAuthProvider;
 	// Pi's extension loader only exposes pi-ai's root, compat, and OAuth entry points.
 	// Keep cleanup injectable until the WebSocket API is available through a loader-safe export.
@@ -233,6 +238,10 @@ export default function codexAccounts(
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
+		if (migrationNotice) {
+			ctx.ui.notify(migrationNotice, "warning");
+			migrationNotice = undefined;
+		}
 		await sync(ctx);
 	});
 
@@ -349,7 +358,95 @@ export function isOpenAICodexModel(model: Pick<NonNullable<ExtensionContext["mod
 }
 
 function defaultAccountsPath(): string {
-	return join(getAgentDir(), CODEX_ACCOUNTS_FILE);
+	const agentDir = getAgentDir();
+	const canonicalPath = join(agentDir, CODEX_ACCOUNTS_FILE);
+	const legacyPath = join(agentDir, LEGACY_CODEX_ACCOUNTS_FILE);
+	pendingAccountsMigrationNotice = undefined;
+
+	if (pathEntryExists(canonicalPath)) {
+		const notices: string[] = [];
+		const permissionError = enforcePrivateFilePermissions(canonicalPath);
+		if (permissionError) notices.push(permissionError);
+		if (pathEntryExists(legacyPath)) {
+			notices.push(`${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} takes precedence.`);
+		}
+		pendingAccountsMigrationNotice = notices.length > 0 ? notices.join("\n") : undefined;
+		return canonicalPath;
+	}
+	if (!pathEntryExists(legacyPath)) return canonicalPath;
+
+	try {
+		return new FileAuthStorageBackend(legacyPath).withLock((current) => {
+			const contents = current ?? "{}";
+			const permissionError = enforcePrivateFilePermissions(legacyPath);
+			if (permissionError) throw new Error(permissionError);
+			try {
+				installPrivateFileExclusively(canonicalPath, contents);
+			} catch (error) {
+				if (pathEntryExists(canonicalPath)) {
+					pendingAccountsMigrationNotice = `${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} was created concurrently.`;
+					return { result: canonicalPath };
+				}
+				throw error;
+			}
+			try {
+				rmSync(legacyPath);
+				pendingAccountsMigrationNotice = `Codex accounts migrated from ${LEGACY_CODEX_ACCOUNTS_FILE} to ${CODEX_ACCOUNTS_FILE}.`;
+			} catch (error) {
+				pendingAccountsMigrationNotice = `Codex accounts migrated to ${CODEX_ACCOUNTS_FILE}, but ${LEGACY_CODEX_ACCOUNTS_FILE} could not be removed: ${errorMessage(error)}.`;
+			}
+			return { result: canonicalPath };
+		});
+	} catch (error) {
+		if (pathEntryExists(canonicalPath)) {
+			pendingAccountsMigrationNotice = `${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} was created concurrently.`;
+			return canonicalPath;
+		}
+		pendingAccountsMigrationNotice = `Codex accounts migration failed: ${errorMessage(error)}. The legacy file will be used for this session.`;
+		return legacyPath;
+	}
+}
+
+function enforcePrivateFilePermissions(filePath: string): string | undefined {
+	try {
+		if (lstatSync(filePath).isDirectory()) {
+			return `Codex accounts path is a directory and permissions were not changed: ${filePath}`;
+		}
+		chmodSync(filePath, 0o600);
+		return undefined;
+	} catch (error) {
+		return `Failed to enforce 0600 permissions for ${filePath}: ${errorMessage(error)}`;
+	}
+}
+
+function installPrivateFileExclusively(filePath: string, contents: string): void {
+	const tempFile = join(dirname(filePath), `.${CODEX_ACCOUNTS_FILE}.${randomUUID()}.tmp`);
+	try {
+		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		chmodSync(tempFile, 0o600);
+		linkSync(tempFile, filePath);
+	} finally {
+		try {
+			rmSync(tempFile, { force: true });
+		} catch {
+			// Preserve the migration result if best-effort temp cleanup fails.
+		}
+	}
+}
+
+function pathEntryExists(filePath: string): boolean {
+	try {
+		lstatSync(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function consumeAccountsMigrationNotice(): string | undefined {
+	const notice = pendingAccountsMigrationNotice;
+	pendingAccountsMigrationNotice = undefined;
+	return notice;
 }
 
 function parseStoredData(raw: string | undefined): CodexAccountsData {
@@ -359,7 +456,7 @@ function parseStoredData(raw: string | undefined): CodexAccountsData {
 	try {
 		parsed = JSON.parse(raw) as unknown;
 	} catch {
-		throw new Error("Invalid Codex accounts JSON. Fix or remove codex-accounts.json.");
+		throw new Error(`Invalid Codex accounts JSON. Fix or remove ${CODEX_ACCOUNTS_FILE}.`);
 	}
 
 	if (!isRecord(parsed)) throw new Error("Invalid Codex accounts data: expected an object.");

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -5,6 +5,7 @@ import {
 	linkSync,
 	lstatSync,
 	openSync,
+	readFileSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -400,18 +401,27 @@ function defaultAccountsPath(): string {
 	if (!pathEntryExists(legacyPath)) return canonicalPath;
 
 	try {
-		return new FileAuthStorageBackend(legacyPath).withLock((current) => {
-			const contents = current ?? "{}";
+		return new FileAuthStorageBackend(legacyPath).withLock(() => {
+			const contents = readFileSync(legacyPath, "utf8");
 			const permissionError = enforcePrivateFilePermissions(legacyPath);
 			if (permissionError) throw new Error(permissionError);
+			let installedIdentity: FileIdentity;
 			try {
-				installPrivateFileExclusively(canonicalPath, contents);
+				installedIdentity = installPrivateFileExclusively(canonicalPath, contents);
 			} catch (error) {
 				if (pathEntryExists(canonicalPath)) {
 					pendingAccountsMigrationNotice = `${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} was created concurrently.`;
 					return { result: canonicalPath };
 				}
 				throw error;
+			}
+			if (!fileContentsEqual(legacyPath, contents)) {
+				if (removeFileIfIdentityMatches(canonicalPath, installedIdentity, contents)) {
+					pendingAccountsMigrationNotice = `${LEGACY_CODEX_ACCOUNTS_FILE} changed during migration; the stale ${CODEX_ACCOUNTS_FILE} snapshot was removed and the legacy file will be used for this session.`;
+					return { result: legacyPath };
+				}
+				pendingAccountsMigrationNotice = `${LEGACY_CODEX_ACCOUNTS_FILE} changed during migration, but ${CODEX_ACCOUNTS_FILE} was replaced concurrently and takes precedence.`;
+				return { result: canonicalPath };
 			}
 			try {
 				rmSync(legacyPath);
@@ -443,18 +453,46 @@ function enforcePrivateFilePermissions(filePath: string): string | undefined {
 	}
 }
 
-function installPrivateFileExclusively(filePath: string, contents: string): void {
+type FileIdentity = { dev: number; ino: number };
+
+function installPrivateFileExclusively(filePath: string, contents: string): FileIdentity {
 	const tempFile = join(dirname(filePath), `.${CODEX_ACCOUNTS_FILE}.${randomUUID()}.tmp`);
 	try {
 		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
 		chmodSync(tempFile, 0o600);
+		const identity = lstatSync(tempFile);
 		linkSync(tempFile, filePath);
+		return { dev: identity.dev, ino: identity.ino };
 	} finally {
 		try {
 			rmSync(tempFile, { force: true });
 		} catch {
 			// Preserve the migration result if best-effort temp cleanup fails.
 		}
+	}
+}
+
+function removeFileIfIdentityMatches(
+	filePath: string,
+	expected: FileIdentity,
+	expectedContents: string,
+) {
+	try {
+		const current = lstatSync(filePath);
+		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		if (readFileSync(filePath, "utf8") !== expectedContents) return false;
+		rmSync(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function fileContentsEqual(filePath: string, expected: string) {
+	try {
+		return readFileSync(filePath, "utf8") === expected;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, stat } from "node:fs/promises";
+import { access, chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexAccounts, {
+	CODEX_ACCOUNTS_FILE,
 	CODEX_ACCOUNTS_STATUS_KEY,
 	CODEX_PROVIDER_ID,
 	CodexAccountStore,
@@ -55,7 +56,7 @@ test("parseAccountName accepts small account labels and rejects unsafe names", (
 
 test("store writes private account files and redacts invalid JSON", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-"));
-	const file = join(dir, "codex-accounts.json");
+	const file = join(dir, "pi-codex-accounts.json");
 	const store = new CodexAccountStore(new FileAuthStorageBackend(file));
 
 	await store.write({ active: "work", accounts: { work: validCred("work") } });
@@ -69,6 +70,95 @@ test("store writes private account files and redacts invalid JSON", async () => 
 		assert.doesNotMatch(error.message, /secret-token/);
 		return true;
 	});
+});
+
+test("default store migrates credentials to the canonical package filename", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		const raw = JSON.stringify({
+			active: "work",
+			accounts: { work: validCred("work") },
+			futureOption: true,
+		});
+		await writeFile(legacyPath, raw, { mode: 0o644 });
+		await chmod(legacyPath, 0o644);
+
+		const mock = createMockPi();
+		codexAccounts(mock.pi);
+		assert.equal(CODEX_ACCOUNTS_FILE, "pi-codex-accounts.json");
+		assert.equal(await readFile(canonicalPath, "utf8"), raw);
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		await assert.rejects(access(legacyPath));
+
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		assert.match(context.notifications[0]?.message ?? "", /migrated/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("migration preserves malformed credential data without leaking tokens", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-invalid-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		await writeFile(legacyPath, '{"accounts":{"work":{"access":"secret-token"}}', {
+			mode: 0o600,
+		});
+		const store = new CodexAccountStore();
+
+		await assert.rejects(store.readAsync(), (error) => {
+			assert.ok(error instanceof Error);
+			assert.match(error.message, /pi-codex-accounts\.json/);
+			assert.doesNotMatch(error.message, /secret-token/);
+			return true;
+		});
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		await assert.rejects(access(legacyPath));
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("canonical Codex accounts file wins without deleting the legacy file", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-precedence-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		await writeFile(
+			legacyPath,
+			JSON.stringify({ active: "old", accounts: { old: validCred("old") } }),
+			{ mode: 0o600 },
+		);
+		await writeFile(
+			canonicalPath,
+			JSON.stringify({ active: "new", accounts: { new: validCred("new") } }),
+			{ mode: 0o644 },
+		);
+		await chmod(canonicalPath, 0o644);
+
+		const store = new CodexAccountStore();
+		assert.equal(store.read().active, "new");
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		assert.equal((await stat(legacyPath)).isFile(), true);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
 });
 
 test("ensureActiveCodexAuth clears runtime auth when no self-managed account is active", async () => {

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { access, chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -154,6 +154,30 @@ test("canonical Codex accounts file wins without deleting the legacy file", asyn
 		assert.equal(store.read().active, "new");
 		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
 		assert.equal((await stat(legacyPath)).isFile(), true);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("default store falls back to legacy credentials for a broken canonical symlink", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-broken-canonical-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		await writeFile(
+			legacyPath,
+			JSON.stringify({ active: "legacy", accounts: { legacy: validCred("legacy") } }),
+			{ mode: 0o600 },
+		);
+		await symlink("missing-target", canonicalPath);
+
+		const store = new CodexAccountStore();
+		assert.equal(store.read().active, "legacy");
+		assert.equal((await stat(legacyPath)).mode & 0o777, 0o600);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/extensions/pi-google-genai/README.md
+++ b/extensions/pi-google-genai/README.md
@@ -9,7 +9,7 @@
 - `google_search` for Google Search grounding.
 - `google_maps` for Google Maps/place grounding.
 - `google_url_context` for asking about specific `http://` or `https://` URLs.
-- Uses Pi auth for Google (`/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`) unless `google-genai.json` contains a literal `apiKey`.
+- Uses Pi auth for Google (`/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`) unless `pi-google-genai.json` contains a literal `apiKey`.
 - Lets `/google-genai tools` persist which of the three tools are active.
 - Truncates large outputs and writes the full raw interaction response to a private temp file only when truncation happens.
 
@@ -36,7 +36,7 @@ pi -e ./extensions/pi-google-genai
 Config lives at:
 
 ```text
-${PI_CODING_AGENT_DIR:-~/.pi/agent}/google-genai.json
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-google-genai.json
 ```
 
 Example:
@@ -53,12 +53,14 @@ Example:
 
 The file is written as `0600`.
 
-Timeout precedence is: per-call `timeoutMs` parameter, `google-genai.json` `timeoutMs`, then
+Compatibility: a valid legacy `google-genai.json` is migrated automatically to `pi-google-genai.json` while preserving private permissions. If both files exist, the new filename takes precedence.
+
+Timeout precedence is: per-call `timeoutMs` parameter, `pi-google-genai.json` `timeoutMs`, then
 the 60000ms default. Timeout values must be integer milliseconds from 1 to 2147483647.
 
 ### 🔐 Auth precedence
 
-1. Literal `apiKey` in `google-genai.json`.
+1. Literal `apiKey` in `pi-google-genai.json`.
 2. Pi Google auth via `/login google`, `auth.json`, runtime key, or `GEMINI_API_KEY`.
 3. Missing-auth tool error.
 

--- a/extensions/pi-google-genai/src/config.ts
+++ b/extensions/pi-google-genai/src/config.ts
@@ -4,6 +4,7 @@ import {
 	chmod,
 	link,
 	mkdir,
+	lstat,
 	readFile,
 	rename,
 	rm,
@@ -180,6 +181,7 @@ async function prepareGoogleGenaiConfigPath(canonicalPath: string, warnings: str
 	const legacyPath = join(dirname(canonicalPath), LEGACY_CONFIG_FILE_NAME);
 	if (await exists(canonicalPath)) {
 		if (await exists(legacyPath)) {
+			await ensureConfigPermissions(legacyPath, warnings);
 			warnings.push(
 				`${LEGACY_CONFIG_FILE_NAME} ignored because ${CONFIG_FILE_NAME} takes precedence.`,
 			);
@@ -196,11 +198,21 @@ async function prepareGoogleGenaiConfigPath(canonicalPath: string, warnings: str
 		return legacyPath;
 	}
 	try {
-		await installPrivateConfigExclusively(canonicalPath, `${JSON.stringify(legacy, null, "\t")}\n`);
+		const installedContents = `${JSON.stringify(legacy, null, "\t")}\n`;
+		const installedIdentity = await installPrivateConfigExclusively(
+			canonicalPath,
+			installedContents,
+		);
 		await chmod(canonicalPath, 0o600);
 		if (!(await jsonFileEquals(legacyPath, legacy))) {
+			if (await removeFileIfIdentityMatches(canonicalPath, installedIdentity)) {
+				warnings.push(
+					`${LEGACY_CONFIG_FILE_NAME} changed during migration; the stale ${CONFIG_FILE_NAME} snapshot was removed and the legacy file was used for this session.`,
+				);
+				return legacyPath;
+			}
 			warnings.push(
-				`Google GenAI config migrated to ${CONFIG_FILE_NAME}, but ${LEGACY_CONFIG_FILE_NAME} changed during migration and was retained.`,
+				`${LEGACY_CONFIG_FILE_NAME} changed during migration, but ${CONFIG_FILE_NAME} was replaced concurrently and takes precedence.`,
 			);
 			return canonicalPath;
 		}
@@ -239,14 +251,32 @@ async function jsonFileEquals(filePath: string, expected: object) {
 	}
 }
 
-async function installPrivateConfigExclusively(filePath: string, contents: string) {
+type FileIdentity = Pick<Awaited<ReturnType<typeof lstat>>, "dev" | "ino">;
+
+async function installPrivateConfigExclusively(
+	filePath: string,
+	contents: string,
+): Promise<FileIdentity> {
 	const tempFile = join(dirname(filePath), `.${CONFIG_FILE_NAME}.${randomUUID()}.tmp`);
 	try {
 		await writeFile(tempFile, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
 		await chmod(tempFile, 0o600);
+		const identity = await lstat(tempFile);
 		await link(tempFile, filePath);
+		return { dev: identity.dev, ino: identity.ino };
 	} finally {
 		await rm(tempFile, { force: true }).catch(() => undefined);
+	}
+}
+
+async function removeFileIfIdentityMatches(filePath: string, expected: FileIdentity) {
+	try {
+		const current = await lstat(filePath);
+		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		await rm(filePath);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-google-genai/src/config.ts
+++ b/extensions/pi-google-genai/src/config.ts
@@ -1,4 +1,15 @@
-import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import {
+	access,
+	chmod,
+	link,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -7,8 +18,13 @@ export const DEFAULT_MODEL = "gemini-3.5-flash";
 export const DEFAULT_API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions";
 export const DEFAULT_TIMEOUT_MS = 60_000;
 export const MAX_TIMEOUT_MS = 2_147_483_647;
-export const GOOGLE_GENAI_TOOL_NAMES = ["google_search", "google_maps", "google_url_context"] as const;
-const CONFIG_FILE_NAME = "google-genai.json";
+export const GOOGLE_GENAI_TOOL_NAMES = [
+	"google_search",
+	"google_maps",
+	"google_url_context",
+] as const;
+const CONFIG_FILE_NAME = "pi-google-genai.json";
+const LEGACY_CONFIG_FILE_NAME = "google-genai.json";
 export type GoogleGenaiToolName = (typeof GOOGLE_GENAI_TOOL_NAMES)[number];
 export interface GoogleGenaiConfig {
 	apiKey?: string;
@@ -35,11 +51,12 @@ export function normalizeGoogleGenaiSettings(value: unknown): GoogleGenaiConfig 
 export async function loadGoogleGenaiConfig(): Promise<LoadedGoogleGenaiConfig> {
 	const path = googleGenaiConfigPath();
 	const warnings: string[] = [];
-	await ensureConfigPermissions(path, warnings);
-	const raw = await readJsonIfExists(path, warnings);
+	const readPath = await prepareGoogleGenaiConfigPath(path, warnings);
+	await ensureConfigPermissions(readPath, warnings);
+	const raw = await readJsonIfExists(readPath, warnings);
 	const configLoaded = isObject(raw);
 	if (raw !== undefined && !configLoaded) {
-		warnings.push("google-genai.json must contain a JSON object; ignoring config.");
+		warnings.push(`${CONFIG_FILE_NAME} must contain a JSON object; ignoring config.`);
 	}
 	const normalized = normalizeConfigWithWarnings(configLoaded ? raw : undefined);
 	return {
@@ -57,7 +74,7 @@ export async function resolveGoogleGenaiAuth(
 	if (config.apiKey) {
 		if (isUnsupportedConfigApiKey(config.apiKey)) {
 			throw new Error(
-				"Interpolation and command syntax are not supported in google-genai.json apiKey. Use a literal key, /login google, or GEMINI_API_KEY.",
+				`Interpolation and command syntax are not supported in ${CONFIG_FILE_NAME} apiKey. Use a literal key, /login google, or GEMINI_API_KEY.`,
 			);
 		}
 		return config.apiKey;
@@ -92,7 +109,10 @@ export function assertSafeApiUrl(apiUrl: string) {
 	}
 }
 
-function normalizeConfigWithWarnings(value: unknown): { config: GoogleGenaiConfig; warnings: string[] } {
+function normalizeConfigWithWarnings(value: unknown): {
+	config: GoogleGenaiConfig;
+	warnings: string[];
+} {
 	const input = value && typeof value === "object" && !Array.isArray(value) ? value : {};
 	const raw = input as Record<string, unknown>;
 	const warnings: string[] = [];
@@ -112,7 +132,7 @@ function normalizeConfigWithWarnings(value: unknown): { config: GoogleGenaiConfi
 function normalizeTools(value: unknown, warnings: string[]) {
 	if (value === undefined) return [...GOOGLE_GENAI_TOOL_NAMES];
 	if (!Array.isArray(value)) {
-		warnings.push("google-genai.json tools must be an array; defaulting to all tools enabled.");
+		warnings.push(`${CONFIG_FILE_NAME} tools must be an array; defaulting to all tools enabled.`);
 		return [...GOOGLE_GENAI_TOOL_NAMES];
 	}
 	const selected: GoogleGenaiToolName[] = [];
@@ -145,13 +165,85 @@ function normalizeConfigTimeout(value: unknown, warnings: string[]) {
 	if (value === undefined) return undefined;
 	if (isValidTimeoutMs(value)) return value;
 	warnings.push(
-		`google-genai.json timeoutMs must be an integer from 1 to ${MAX_TIMEOUT_MS} milliseconds; ignoring value.`,
+		`${CONFIG_FILE_NAME} timeoutMs must be an integer from 1 to ${MAX_TIMEOUT_MS} milliseconds; ignoring value.`,
 	);
 	return undefined;
 }
 
 function isValidTimeoutMs(value: unknown): value is number {
-	return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= MAX_TIMEOUT_MS;
+	return (
+		typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= MAX_TIMEOUT_MS
+	);
+}
+
+async function prepareGoogleGenaiConfigPath(canonicalPath: string, warnings: string[]) {
+	const legacyPath = join(dirname(canonicalPath), LEGACY_CONFIG_FILE_NAME);
+	if (await exists(canonicalPath)) {
+		if (await exists(legacyPath)) {
+			warnings.push(
+				`${LEGACY_CONFIG_FILE_NAME} ignored because ${CONFIG_FILE_NAME} takes precedence.`,
+			);
+		}
+		return canonicalPath;
+	}
+	if (!(await exists(legacyPath))) return canonicalPath;
+
+	await ensureConfigPermissions(legacyPath, warnings);
+	const legacyWarnings: string[] = [];
+	const legacy = await readJsonIfExists(legacyPath, legacyWarnings);
+	if (!isObject(legacy)) {
+		warnings.push(...legacyWarnings);
+		if (legacy !== undefined) {
+			warnings.push(`${LEGACY_CONFIG_FILE_NAME} must contain a JSON object; ignoring config.`);
+		}
+		return legacyPath;
+	}
+	try {
+		await installPrivateConfigExclusively(canonicalPath, `${JSON.stringify(legacy, null, "\t")}\n`);
+		await chmod(canonicalPath, 0o600);
+		try {
+			await rm(legacyPath);
+			warnings.push(
+				`Google GenAI config migrated from ${LEGACY_CONFIG_FILE_NAME} to ${CONFIG_FILE_NAME}.`,
+			);
+		} catch (error) {
+			warnings.push(
+				`Google GenAI config migrated to ${CONFIG_FILE_NAME}, but ${LEGACY_CONFIG_FILE_NAME} could not be removed: ${formatError(error)}.`,
+			);
+		}
+		return canonicalPath;
+	} catch (error) {
+		if (await exists(canonicalPath)) {
+			warnings.push(
+				`${LEGACY_CONFIG_FILE_NAME} ignored because ${CONFIG_FILE_NAME} was created concurrently.`,
+			);
+			return canonicalPath;
+		}
+		warnings.push(
+			`Google GenAI config migration failed: ${formatError(error)}. The legacy file was used for this session.`,
+		);
+		return legacyPath;
+	}
+}
+
+async function installPrivateConfigExclusively(filePath: string, contents: string) {
+	const tempFile = join(dirname(filePath), `.${CONFIG_FILE_NAME}.${randomUUID()}.tmp`);
+	try {
+		await writeFile(tempFile, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		await chmod(tempFile, 0o600);
+		await link(tempFile, filePath);
+	} finally {
+		await rm(tempFile, { force: true }).catch(() => undefined);
+	}
+}
+
+async function exists(path: string) {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 async function readJsonIfExists(path: string, warnings: string[]) {
@@ -159,7 +251,9 @@ async function readJsonIfExists(path: string, warnings: string[]) {
 		return JSON.parse(await readFile(path, "utf8"));
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		warnings.push(`Failed to read ${path}: ${error instanceof Error ? error.message : String(error)}`);
+		warnings.push(
+			`Failed to read ${path}: ${error instanceof Error ? error.message : String(error)}`,
+		);
 		return undefined;
 	}
 }
@@ -169,7 +263,9 @@ export async function writeGoogleGenaiConfig(config: GoogleGenaiConfig) {
 	await mkdir(dirname(path), { recursive: true });
 	const tempFile = `${path}.${process.pid}.${Date.now()}.tmp`;
 	try {
-		await writeFile(tempFile, `${JSON.stringify(cleanObject(config), null, "\t")}\n`, { mode: 0o600 });
+		await writeFile(tempFile, `${JSON.stringify(cleanObject(config), null, "\t")}\n`, {
+			mode: 0o600,
+		});
 		await chmod(tempFile, 0o600);
 		await rename(tempFile, path);
 		await chmod(path, 0o600);
@@ -179,13 +275,19 @@ export async function writeGoogleGenaiConfig(config: GoogleGenaiConfig) {
 	}
 }
 
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}
+
 async function ensureConfigPermissions(path: string, warnings: string[]) {
 	try {
 		const current = await stat(path);
 		if ((current.mode & 0o777) !== 0o600) await chmod(path, 0o600);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		warnings.push(`Failed to enforce 0600 permissions for ${path}: ${error instanceof Error ? error.message : String(error)}`);
+		warnings.push(
+			`Failed to enforce 0600 permissions for ${path}: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
 }
 

--- a/extensions/pi-google-genai/src/config.ts
+++ b/extensions/pi-google-genai/src/config.ts
@@ -205,7 +205,9 @@ async function prepareGoogleGenaiConfigPath(canonicalPath: string, warnings: str
 		);
 		await chmod(canonicalPath, 0o600);
 		if (!(await jsonFileEquals(legacyPath, legacy))) {
-			if (await removeFileIfIdentityMatches(canonicalPath, installedIdentity)) {
+			if (
+				await removeFileIfIdentityMatches(canonicalPath, installedIdentity, installedContents)
+			) {
 				warnings.push(
 					`${LEGACY_CONFIG_FILE_NAME} changed during migration; the stale ${CONFIG_FILE_NAME} snapshot was removed and the legacy file was used for this session.`,
 				);
@@ -269,10 +271,15 @@ async function installPrivateConfigExclusively(
 	}
 }
 
-async function removeFileIfIdentityMatches(filePath: string, expected: FileIdentity) {
+async function removeFileIfIdentityMatches(
+	filePath: string,
+	expected: FileIdentity,
+	expectedContents: string,
+) {
 	try {
 		const current = await lstat(filePath);
 		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		if ((await readFile(filePath, "utf8")) !== expectedContents) return false;
 		await rm(filePath);
 		return true;
 	} catch {

--- a/extensions/pi-google-genai/src/config.ts
+++ b/extensions/pi-google-genai/src/config.ts
@@ -11,7 +11,7 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 export const DEFAULT_MODEL = "gemini-3.5-flash";
@@ -56,7 +56,7 @@ export async function loadGoogleGenaiConfig(): Promise<LoadedGoogleGenaiConfig> 
 	const raw = await readJsonIfExists(readPath, warnings);
 	const configLoaded = isObject(raw);
 	if (raw !== undefined && !configLoaded) {
-		warnings.push(`${CONFIG_FILE_NAME} must contain a JSON object; ignoring config.`);
+		warnings.push(`${basename(readPath)} must contain a JSON object; ignoring config.`);
 	}
 	const normalized = normalizeConfigWithWarnings(configLoaded ? raw : undefined);
 	return {
@@ -193,14 +193,17 @@ async function prepareGoogleGenaiConfigPath(canonicalPath: string, warnings: str
 	const legacy = await readJsonIfExists(legacyPath, legacyWarnings);
 	if (!isObject(legacy)) {
 		warnings.push(...legacyWarnings);
-		if (legacy !== undefined) {
-			warnings.push(`${LEGACY_CONFIG_FILE_NAME} must contain a JSON object; ignoring config.`);
-		}
 		return legacyPath;
 	}
 	try {
 		await installPrivateConfigExclusively(canonicalPath, `${JSON.stringify(legacy, null, "\t")}\n`);
 		await chmod(canonicalPath, 0o600);
+		if (!(await jsonFileEquals(legacyPath, legacy))) {
+			warnings.push(
+				`Google GenAI config migrated to ${CONFIG_FILE_NAME}, but ${LEGACY_CONFIG_FILE_NAME} changed during migration and was retained.`,
+			);
+			return canonicalPath;
+		}
 		try {
 			await rm(legacyPath);
 			warnings.push(
@@ -223,6 +226,16 @@ async function prepareGoogleGenaiConfigPath(canonicalPath: string, warnings: str
 			`Google GenAI config migration failed: ${formatError(error)}. The legacy file was used for this session.`,
 		);
 		return legacyPath;
+	}
+}
+
+async function jsonFileEquals(filePath: string, expected: object) {
+	try {
+		return (
+			JSON.stringify(JSON.parse(await readFile(filePath, "utf8"))) === JSON.stringify(expected)
+		);
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -143,7 +143,7 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext, pi: 
 
 async function initConfig(ctx: ExtensionCommandContext, pi: ExtensionAPI) {
 	if (!ctx.hasUI) {
-		ctx.ui.notify("/google-genai init requires interactive UI. Edit google-genai.json manually or use /login google.", "warning");
+		ctx.ui.notify("/google-genai init requires interactive UI. Edit pi-google-genai.json manually or use /login google.", "warning");
 		return;
 	}
 	const loaded = await loadGoogleGenaiConfig();

--- a/extensions/pi-google-genai/src/interaction-client.ts
+++ b/extensions/pi-google-genai/src/interaction-client.ts
@@ -64,7 +64,7 @@ function formatTimeoutError(timeoutMs: number, timeoutAdvice?: string) {
 		`Google GenAI request timed out after ${timeoutMs}ms.`,
 		"This is a timeout, not a no-results response.",
 		timeoutAdvice ?? "Try narrowing the query or splitting broad comparison/review queries.",
-		"To allow longer calls, set google-genai.json timeoutMs or the per-call timeoutMs parameter.",
+		"To allow longer calls, set pi-google-genai.json timeoutMs or the per-call timeoutMs parameter.",
 	].join(" ");
 }
 

--- a/extensions/pi-google-genai/src/tools.ts
+++ b/extensions/pi-google-genai/src/tools.ts
@@ -24,7 +24,7 @@ const SearchTypesParameter = Type.Optional(
 );
 const TimeoutMsParameter = Type.Optional(
 	Type.Integer({
-		description: `Per-call timeout in milliseconds. Overrides google-genai.json timeoutMs and the ${DEFAULT_TIMEOUT_MS}ms default. Must be an integer from 1 to ${MAX_TIMEOUT_MS}.`,
+		description: `Per-call timeout in milliseconds. Overrides pi-google-genai.json timeoutMs and the ${DEFAULT_TIMEOUT_MS}ms default. Must be an integer from 1 to ${MAX_TIMEOUT_MS}.`,
 		minimum: 1,
 		maximum: MAX_TIMEOUT_MS,
 	}),

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -120,11 +120,13 @@ test("config loading migrates to the canonical package filename with private per
 		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
 		await assert.rejects(stat(legacyPath));
 
-		await writeFile(legacyPath, JSON.stringify({ model: "old" }), { mode: 0o600 });
+		await writeFile(legacyPath, JSON.stringify({ model: "old" }), { mode: 0o644 });
+		await chmod(legacyPath, 0o644);
 		await writeFile(canonicalPath, JSON.stringify({ model: "new" }), { mode: 0o600 });
 		const preferred = await loadGoogleGenaiConfig();
 		assert.equal(preferred.config.model, "new");
 		assert.match(preferred.warnings.join("\n"), /ignored/i);
+		assert.equal((await stat(legacyPath)).mode & 0o777, 0o600);
 
 		await writeFile(canonicalPath, "invalid", { mode: 0o600 });
 		const invalidNew = await loadGoogleGenaiConfig();

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -1,5 +1,15 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	stat,
+	symlink,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -58,7 +68,7 @@ test("command parser and completions cover google-genai subcommands", () => {
 
 test("config loading defaults, normalizes tools, and rejects interpolation", async () => {
 	await withTempAgentDir(async (agentDir) => {
-		assert.equal(googleGenaiConfigPath(), join(agentDir, "google-genai.json"));
+		assert.equal(googleGenaiConfigPath(), join(agentDir, "pi-google-genai.json"));
 		const missingConfig = await loadGoogleGenaiConfig();
 		assert.deepEqual(missingConfig, {
 			config: {
@@ -67,7 +77,7 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 				timeoutMs: DEFAULT_TIMEOUT_MS,
 				tools: [...GOOGLE_GENAI_TOOL_NAMES],
 			},
-			path: join(agentDir, "google-genai.json"),
+			path: join(agentDir, "pi-google-genai.json"),
 			warnings: [],
 			configLoaded: false,
 		});
@@ -96,7 +106,49 @@ test("config loading defaults, normalizes tools, and rejects interpolation", asy
 	});
 });
 
-test("config loading validates google-genai.json timeoutMs", async () => {
+test("config loading migrates to the canonical package filename with private permissions", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		const legacyPath = join(agentDir, "google-genai.json");
+		const canonicalPath = join(agentDir, "pi-google-genai.json");
+		await mkdir(agentDir, { recursive: true });
+		await writeFile(legacyPath, JSON.stringify({ apiKey: "test-key", model: "legacy" }), {
+			mode: 0o600,
+		});
+		const migrated = await loadGoogleGenaiConfig();
+		assert.equal(migrated.config.model, "legacy");
+		assert.match(migrated.warnings.join("\n"), /migrated/i);
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		await assert.rejects(stat(legacyPath));
+
+		await writeFile(legacyPath, JSON.stringify({ model: "old" }), { mode: 0o600 });
+		await writeFile(canonicalPath, JSON.stringify({ model: "new" }), { mode: 0o600 });
+		const preferred = await loadGoogleGenaiConfig();
+		assert.equal(preferred.config.model, "new");
+		assert.match(preferred.warnings.join("\n"), /ignored/i);
+
+		await writeFile(canonicalPath, "invalid", { mode: 0o600 });
+		const invalidNew = await loadGoogleGenaiConfig();
+		assert.equal(invalidNew.configLoaded, false);
+		assert.match(invalidNew.warnings.join("\n"), /ignored/i);
+
+		await unlink(canonicalPath);
+		await writeFile(legacyPath, "invalid", { mode: 0o600 });
+		const invalidLegacy = await loadGoogleGenaiConfig();
+		assert.equal(invalidLegacy.configLoaded, false);
+		await assert.rejects(stat(canonicalPath));
+
+		await writeFile(legacyPath, JSON.stringify({ apiKey: "fallback-key", model: "fallback" }), {
+			mode: 0o600,
+		});
+		await symlink("missing-target", canonicalPath);
+		const fallback = await loadGoogleGenaiConfig();
+		assert.equal(fallback.config.model, "fallback");
+		assert.match(fallback.warnings.join("\n"), /migration failed/i);
+		assert.equal((await stat(legacyPath)).mode & 0o777, 0o600);
+	});
+});
+
+test("config loading validates pi-google-genai.json timeoutMs", async () => {
 	await withTempAgentDir(async () => {
 		await writeConfig({ timeoutMs: 45_000 });
 		let loaded = await loadGoogleGenaiConfig();
@@ -118,7 +170,7 @@ test("config loading validates google-genai.json timeoutMs", async () => {
 
 test("config loading repairs permissions and ignores invalid payloads", async () => {
 	await withTempAgentDir(async (agentDir) => {
-		const path = join(agentDir, "google-genai.json");
+		const path = join(agentDir, "pi-google-genai.json");
 		await mkdir(agentDir, { recursive: true });
 		await writeFile(path, '{"apiKey":"secret"', { mode: 0o644 });
 		await chmod(path, 0o644);
@@ -509,16 +561,16 @@ test("commands init, status, and tool selection merge config and preserve unrela
 		};
 
 		await command.handler("init", ctx);
-		const config = JSON.parse(await readFile(join(agentDir, "google-genai.json"), "utf8"));
+		const config = JSON.parse(await readFile(join(agentDir, "pi-google-genai.json"), "utf8"));
 		assert.equal(config.apiKey, "old-key");
 		assert.equal(config.model, "new-model");
 		assert.deepEqual(config.tools, ["google_search"]);
-		assert.equal((await stat(join(agentDir, "google-genai.json"))).mode & 0o777, 0o600);
+		assert.equal((await stat(join(agentDir, "pi-google-genai.json"))).mode & 0o777, 0o600);
 
 		await command.handler("tools", ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
 		assert.deepEqual(
-			JSON.parse(await readFile(join(agentDir, "google-genai.json"), "utf8")).tools,
+			JSON.parse(await readFile(join(agentDir, "pi-google-genai.json"), "utf8")).tools,
 			[],
 		);
 
@@ -649,7 +701,7 @@ async function writeConfig(value: unknown) {
 	assert.ok(agentDir);
 	await import("node:fs/promises").then(async (fs) => {
 		await fs.mkdir(agentDir, { recursive: true });
-		await fs.writeFile(join(agentDir, "google-genai.json"), JSON.stringify(value, null, "\t"));
+		await fs.writeFile(join(agentDir, "pi-google-genai.json"), JSON.stringify(value, null, "\t"));
 	});
 }
 

--- a/extensions/pi-google-genai/test/google-genai.test.ts
+++ b/extensions/pi-google-genai/test/google-genai.test.ts
@@ -137,6 +137,12 @@ test("config loading migrates to the canonical package filename with private per
 		assert.equal(invalidLegacy.configLoaded, false);
 		await assert.rejects(stat(canonicalPath));
 
+		await writeFile(legacyPath, "null", { mode: 0o600 });
+		const wrongShapeLegacy = await loadGoogleGenaiConfig();
+		assert.match(wrongShapeLegacy.warnings.join("\n"), /google-genai\.json must/);
+		assert.doesNotMatch(wrongShapeLegacy.warnings.join("\n"), /pi-google-genai\.json must/);
+		await assert.rejects(stat(canonicalPath));
+
 		await writeFile(legacyPath, JSON.stringify({ apiKey: "fallback-key", model: "fallback" }), {
 			mode: 0o600,
 		});

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -41,12 +41,14 @@ If no config is provided, pi-lsp ships compatible defaults for Biome, ty, and Ru
 Custom config can be supplied in one of these locations:
 
 1. `PI_LSP_CONFIG` as inline JSON or a path to a JSON file
-2. `<workspace>/.pi/lsp.json`
-3. `~/.pi/agent/lsp.json`
+2. `<workspace>/.pi/pi-lsp.json`
+3. `~/.pi/agent/pi-lsp.json`
 
 `PI_LSP_CONFIG` only accepts JSON or a JSON file path; JavaScript and TypeScript config files are not evaluated.
 
-`lsp.json` can be a plain object keyed by server name:
+Compatibility: a user-scoped legacy `lsp.json` is migrated automatically. A project-scoped legacy `.pi/lsp.json` remains readable with a warning but is not renamed automatically, so the extension never modifies a repository working tree. New paths take precedence when both names exist.
+
+`pi-lsp.json` can be a plain object keyed by server name:
 
 ```json
 {

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -1,5 +1,14 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, linkSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	linkSync,
+	lstatSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -109,8 +118,13 @@ function loadConfiguredConfig(cwd: string): LspConfig | undefined {
 
 	const legacyContents = readFileSync(legacyUserConfig, "utf8");
 	const legacy = normalizeConfig(JSON.parse(legacyContents), legacyUserConfig);
+	let installedIdentity: FileIdentity;
 	try {
-		installFileExclusively(userConfig, legacyContents);
+		installedIdentity = installFileExclusively(
+			userConfig,
+			legacyContents,
+			statSync(legacyUserConfig).mode & 0o777,
+		);
 	} catch (error) {
 		if (existsSync(userConfig)) {
 			pendingConfigNotice = "lsp.json ignored because pi-lsp.json was created concurrently.";
@@ -120,8 +134,13 @@ function loadConfiguredConfig(cwd: string): LspConfig | undefined {
 		return legacy;
 	}
 	if (!fileContentsEqual(legacyUserConfig, legacyContents)) {
-		pendingConfigNotice =
-			"LSP config migrated to pi-lsp.json, but lsp.json changed during migration and was retained.";
+		if (removeFileIfIdentityMatches(userConfig, installedIdentity)) {
+			pendingConfigNotice =
+				"lsp.json changed during migration; the stale pi-lsp.json snapshot was removed and the legacy file was used for this session.";
+		} else {
+			pendingConfigNotice =
+				"lsp.json changed during migration, but pi-lsp.json was replaced concurrently and takes precedence on the next load.";
+		}
 		return legacy;
 	}
 	try {
@@ -133,17 +152,33 @@ function loadConfiguredConfig(cwd: string): LspConfig | undefined {
 	return legacy;
 }
 
-function installFileExclusively(filePath: string, contents: string) {
+type FileIdentity = { dev: number; ino: number };
+
+function installFileExclusively(filePath: string, contents: string, mode: number): FileIdentity {
 	const tempFile = path.join(path.dirname(filePath), `.pi-lsp.json.${randomUUID()}.tmp`);
 	try {
-		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx", mode });
+		chmodSync(tempFile, mode);
+		const identity = lstatSync(tempFile);
 		linkSync(tempFile, filePath);
+		return { dev: identity.dev, ino: identity.ino };
 	} finally {
 		try {
 			rmSync(tempFile, { force: true });
 		} catch {
 			// Preserve the migration result if best-effort temp cleanup fails.
 		}
+	}
+}
+
+function removeFileIfIdentityMatches(filePath: string, expected: FileIdentity) {
+	try {
+		const current = lstatSync(filePath);
+		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		rmSync(filePath);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -79,6 +79,7 @@ export function loadConfig(cwd = process.cwd()): LspConfig {
 let pendingConfigNotice: string | undefined;
 
 function loadConfiguredConfig(cwd: string): LspConfig | undefined {
+	pendingConfigNotice = undefined;
 	const rawConfig = process.env.PI_LSP_CONFIG?.trim();
 	if (rawConfig) return parseConfigSource(rawConfig, cwd, "PI_LSP_CONFIG");
 
@@ -111,8 +112,16 @@ function loadConfiguredConfig(cwd: string): LspConfig | undefined {
 	try {
 		installFileExclusively(userConfig, legacyContents);
 	} catch (error) {
-		if (existsSync(userConfig)) return parseConfigFile(userConfig);
+		if (existsSync(userConfig)) {
+			pendingConfigNotice = "lsp.json ignored because pi-lsp.json was created concurrently.";
+			return parseConfigFile(userConfig);
+		}
 		pendingConfigNotice = `LSP config migration failed: ${formatError(error)}. The legacy file was used for this session.`;
+		return legacy;
+	}
+	if (!fileContentsEqual(legacyUserConfig, legacyContents)) {
+		pendingConfigNotice =
+			"LSP config migrated to pi-lsp.json, but lsp.json changed during migration and was retained.";
 		return legacy;
 	}
 	try {
@@ -130,7 +139,19 @@ function installFileExclusively(filePath: string, contents: string) {
 		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
 		linkSync(tempFile, filePath);
 	} finally {
-		rmSync(tempFile, { force: true });
+		try {
+			rmSync(tempFile, { force: true });
+		} catch {
+			// Preserve the migration result if best-effort temp cleanup fails.
+		}
+	}
+}
+
+function fileContentsEqual(filePath: string, expected: string) {
+	try {
+		return readFileSync(filePath, "utf8") === expected;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, linkSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -75,23 +76,80 @@ export function loadConfig(cwd = process.cwd()): LspConfig {
 	return configured ?? { servers: DEFAULT_SERVER_CONFIGS };
 }
 
+let pendingConfigNotice: string | undefined;
+
 function loadConfiguredConfig(cwd: string): LspConfig | undefined {
 	const rawConfig = process.env.PI_LSP_CONFIG?.trim();
 	if (rawConfig) return parseConfigSource(rawConfig, cwd, "PI_LSP_CONFIG");
 
-	const projectConfig = path.join(cwd, ".pi", "lsp.json");
-	if (existsSync(projectConfig)) return parseConfigFile(projectConfig);
+	const projectConfig = path.join(cwd, ".pi", "pi-lsp.json");
+	const legacyProjectConfig = path.join(cwd, ".pi", "lsp.json");
+	if (existsSync(projectConfig)) {
+		if (existsSync(legacyProjectConfig)) {
+			pendingConfigNotice = ".pi/lsp.json ignored because .pi/pi-lsp.json takes precedence.";
+		}
+		return parseConfigFile(projectConfig);
+	}
+	if (existsSync(legacyProjectConfig)) {
+		pendingConfigNotice =
+			"Using legacy .pi/lsp.json. Rename it to .pi/pi-lsp.json; the repository file was not modified automatically.";
+		return parseConfigFile(legacyProjectConfig);
+	}
 
-	const userConfig = path.join(getAgentDir(), "lsp.json");
-	if (existsSync(userConfig)) return parseConfigFile(userConfig);
+	const userConfig = path.join(getAgentDir(), "pi-lsp.json");
+	const legacyUserConfig = path.join(getAgentDir(), "lsp.json");
+	if (existsSync(userConfig)) {
+		if (existsSync(legacyUserConfig)) {
+			pendingConfigNotice = "lsp.json ignored because pi-lsp.json takes precedence.";
+		}
+		return parseConfigFile(userConfig);
+	}
+	if (!existsSync(legacyUserConfig)) return undefined;
 
-	return undefined;
+	const legacyContents = readFileSync(legacyUserConfig, "utf8");
+	const legacy = normalizeConfig(JSON.parse(legacyContents), legacyUserConfig);
+	try {
+		installFileExclusively(userConfig, legacyContents);
+	} catch (error) {
+		if (existsSync(userConfig)) return parseConfigFile(userConfig);
+		pendingConfigNotice = `LSP config migration failed: ${formatError(error)}. The legacy file was used for this session.`;
+		return legacy;
+	}
+	try {
+		rmSync(legacyUserConfig);
+		pendingConfigNotice = "LSP config migrated from lsp.json to pi-lsp.json.";
+	} catch (error) {
+		pendingConfigNotice = `LSP config migrated to pi-lsp.json, but lsp.json could not be removed: ${formatError(error)}.`;
+	}
+	return legacy;
+}
+
+function installFileExclusively(filePath: string, contents: string) {
+	const tempFile = path.join(path.dirname(filePath), `.pi-lsp.json.${randomUUID()}.tmp`);
+	try {
+		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		linkSync(tempFile, filePath);
+	} finally {
+		rmSync(tempFile, { force: true });
+	}
+}
+
+export function consumeLspConfigNotice() {
+	const notice = pendingConfigNotice;
+	pendingConfigNotice = undefined;
+	return notice;
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
 }
 
 function parseConfigSource(source: string, cwd: string, label: string): LspConfig {
 	if (source.startsWith("{")) return normalizeConfig(JSON.parse(source), label);
 	const expandedSource = expandHome(source);
-	const filePath = path.isAbsolute(expandedSource) ? expandedSource : path.resolve(cwd, expandedSource);
+	const filePath = path.isAbsolute(expandedSource)
+		? expandedSource
+		: path.resolve(cwd, expandedSource);
 	return parseConfigFile(filePath);
 }
 
@@ -115,7 +173,9 @@ function normalizeConfig(value: unknown, label: string): LspConfig {
 		const timeout = normalizeTimeout(value.timeout, label);
 		const servers = value.servers;
 		if (!isRecord(servers) || Array.isArray(servers)) {
-			throw new Error(`${label}.servers must be a JSON object mapping server names to LSP server config.`);
+			throw new Error(
+				`${label}.servers must be a JSON object mapping server names to LSP server config.`,
+			);
 		}
 		return { timeout, servers: normalizeServerMap(servers, `${label}.servers`) };
 	}
@@ -128,14 +188,13 @@ function normalizeConfig(value: unknown, label: string): LspConfig {
 }
 
 function normalizeServerMap(value: Record<string, unknown>, label: string) {
-	return Object.entries(value).map(([name, server]) => normalizeServer(name, server, `${label}.${name}`));
+	return Object.entries(value).map(([name, server]) =>
+		normalizeServer(name, server, `${label}.${name}`),
+	);
 }
 
 function isServerEntry(value: unknown) {
-	return (
-		isRecord(value) &&
-		(Array.isArray(value.command) || Array.isArray(value.extensions))
-	);
+	return isRecord(value) && (Array.isArray(value.command) || Array.isArray(value.extensions));
 }
 
 function normalizeServer(name: string, value: unknown, label: string): InternalLspServer {
@@ -198,7 +257,10 @@ const LANGUAGE_IDS: Record<string, string> = {
 };
 
 function commandFromEnvName(name: string): string {
-	return name.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase();
+	return name
+		.replace(/[^a-zA-Z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.toUpperCase();
 }
 
 function envName(name: string, suffix: "COMMAND") {

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -134,7 +134,7 @@ function loadConfiguredConfig(cwd: string): LspConfig | undefined {
 		return legacy;
 	}
 	if (!fileContentsEqual(legacyUserConfig, legacyContents)) {
-		if (removeFileIfIdentityMatches(userConfig, installedIdentity)) {
+		if (removeFileIfIdentityMatches(userConfig, installedIdentity, legacyContents)) {
 			pendingConfigNotice =
 				"lsp.json changed during migration; the stale pi-lsp.json snapshot was removed and the legacy file was used for this session.";
 		} else {
@@ -171,10 +171,15 @@ function installFileExclusively(filePath: string, contents: string, mode: number
 	}
 }
 
-function removeFileIfIdentityMatches(filePath: string, expected: FileIdentity) {
+function removeFileIfIdentityMatches(
+	filePath: string,
+	expected: FileIdentity,
+	expectedContents: string,
+) {
 	try {
 		const current = lstatSync(filePath);
 		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		if (readFileSync(filePath, "utf8") !== expectedContents) return false;
 		rmSync(filePath);
 		return true;
 	} catch {

--- a/extensions/pi-lsp/src/pi-lsp.ts
+++ b/extensions/pi-lsp/src/pi-lsp.ts
@@ -1,6 +1,6 @@
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { loadRuntime } from "./adapters.js";
+import { consumeLspConfigNotice, loadRuntime } from "./adapters.js";
 import { commandExists, commandFromEnv } from "./command.js";
 import { resolveRoot } from "./files.js";
 import { selectDiagnosticRoutes, selectFixRoute } from "./routes.js";
@@ -133,18 +133,35 @@ export default function lsp(pi: ExtensionAPI) {
 	pi.registerCommand("lsp", {
 		description: "Show shared LSP extension configuration",
 		handler: async (_args, ctx) => {
-			const { adapters } = loadRuntime(ctx.cwd);
-			ctx.ui.notify(buildStatusMessage(adapters, ctx.cwd), statusLevel(adapters, ctx.cwd));
+			try {
+				const { adapters } = loadRuntime(ctx.cwd);
+				const notice = consumeLspConfigNotice();
+				if (notice) ctx.ui.notify(notice, "warning");
+				ctx.ui.notify(buildStatusMessage(adapters, ctx.cwd), statusLevel(adapters, ctx.cwd));
+			} catch (error) {
+				ctx.ui.notify(`LSP config ignored: ${formatError(error)}`, "warning");
+			}
 		},
 	});
 
 	pi.on("session_start", (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		try {
+			loadRuntime(ctx.cwd);
+			const notice = consumeLspConfigNotice();
+			if (notice) ctx.ui.notify(notice, "warning");
+		} catch (error) {
+			ctx.ui.notify(`LSP config ignored: ${formatError(error)}`, "warning");
+		}
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
 }
 
 function textFromResult(result: { content?: Array<{ type?: string; text?: string }> }) {

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -5,6 +5,7 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
+	statSync,
 	symlinkSync,
 	unlinkSync,
 	writeFileSync,
@@ -76,8 +77,10 @@ test("LSP config uses canonical paths while preserving project legacy files", ()
 	try {
 		const userLegacy = path.join(agentDir, "lsp.json");
 		writeFileSync(userLegacy, JSON.stringify(config("user")));
+		chmodSync(userLegacy, 0o600);
 		assert.equal(loadConfig(project).servers[0]?.name, "user");
 		assert.equal(existsSync(path.join(agentDir, "pi-lsp.json")), true);
+		assert.equal(statSync(path.join(agentDir, "pi-lsp.json")).mode & 0o777, 0o600);
 		assert.equal(existsSync(userLegacy), false);
 
 		const projectLegacy = path.join(project, ".pi", "lsp.json");

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -1,9 +1,19 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createMockPi } from "../../../test/support.js";
+import { loadConfig } from "../src/adapters.js";
 import { commandExists, commandFromEnv, splitCommand } from "../src/command.js";
 import { collectSupportedFiles, directoryUri, resolveSupportedFile } from "../src/files.js";
 import lsp from "../src/pi-lsp.js";
@@ -50,6 +60,52 @@ test("command helpers split shell-like strings and honor environment overrides",
 	writeFileSync(executable, "#!/bin/sh\nexit 0\n");
 	chmodSync(executable, 0o755);
 	assert.equal(commandExists("./tool", root), true);
+});
+
+test("LSP config uses canonical paths while preserving project legacy files", () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-config-"));
+	const agentDir = path.join(root, "agent");
+	const project = path.join(root, "project");
+	mkdirSync(path.join(project, ".pi"), { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	const config = (name: string) => ({
+		servers: { [name]: { command: [name], extensions: [`.${name}`] } },
+	});
+	try {
+		const userLegacy = path.join(agentDir, "lsp.json");
+		writeFileSync(userLegacy, JSON.stringify(config("user")));
+		assert.equal(loadConfig(project).servers[0]?.name, "user");
+		assert.equal(existsSync(path.join(agentDir, "pi-lsp.json")), true);
+		assert.equal(existsSync(userLegacy), false);
+
+		const projectLegacy = path.join(project, ".pi", "lsp.json");
+		writeFileSync(projectLegacy, JSON.stringify(config("legacy-project")));
+		assert.equal(loadConfig(project).servers[0]?.name, "legacy-project");
+		assert.equal(existsSync(projectLegacy), true);
+		assert.equal(existsSync(path.join(project, ".pi", "pi-lsp.json")), false);
+
+		const projectCanonical = path.join(project, ".pi", "pi-lsp.json");
+		writeFileSync(projectCanonical, JSON.stringify(config("project")));
+		assert.equal(loadConfig(project).servers[0]?.name, "project");
+
+		writeFileSync(projectCanonical, "invalid");
+		assert.throws(() => loadConfig(project));
+		assert.equal(existsSync(projectLegacy), true);
+		unlinkSync(projectCanonical);
+		unlinkSync(projectLegacy);
+
+		writeFileSync(userLegacy, JSON.stringify(config("fallback")));
+		unlinkSync(path.join(agentDir, "pi-lsp.json"));
+		symlinkSync("missing-target", path.join(agentDir, "pi-lsp.json"));
+		assert.equal(loadConfig(project).servers[0]?.name, "fallback");
+		assert.equal(existsSync(userLegacy), true);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("text edit helpers apply reverse-sorted edits and detect overlaps", () => {

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -13,7 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createMockPi } from "../../../test/support.js";
-import { loadConfig } from "../src/adapters.js";
+import { consumeLspConfigNotice, loadConfig } from "../src/adapters.js";
 import { commandExists, commandFromEnv, splitCommand } from "../src/command.js";
 import { collectSupportedFiles, directoryUri, resolveSupportedFile } from "../src/files.js";
 import lsp from "../src/pi-lsp.js";
@@ -101,7 +101,12 @@ test("LSP config uses canonical paths while preserving project legacy files", ()
 		symlinkSync("missing-target", path.join(agentDir, "pi-lsp.json"));
 		assert.equal(loadConfig(project).servers[0]?.name, "fallback");
 		assert.equal(existsSync(userLegacy), true);
+
+		process.env.PI_LSP_CONFIG = JSON.stringify(config("explicit"));
+		assert.equal(loadConfig(project).servers[0]?.name, "explicit");
+		assert.equal(consumeLspConfigNotice(), undefined);
 	} finally {
+		delete process.env.PI_LSP_CONFIG;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { recursive: true, force: true });

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -85,7 +85,7 @@ You can also exit directly. Direct exit discards the latest proposed plan instea
 
 ## ⚙️ Thinking level
 
-Plan mode inherits Pi's current thinking level by default. To request a fixed level only while Plan mode is active, create `$PI_CODING_AGENT_DIR/plan-mode.json` (normally `~/.pi/agent/plan-mode.json`):
+Plan mode inherits Pi's current thinking level by default. To request a fixed level only while Plan mode is active, create `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`):
 
 ```json
 {
@@ -94,6 +94,8 @@ Plan mode inherits Pi's current thinking level by default. To request a fixed le
 ```
 
 Supported values are `inherit`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. The extension snapshots the prior level and restores it on exit only if the level still matches the value it applied; a manual change made during Plan mode is preserved. The settings file is optional, is read at session start, and never changes Pi's default setting. Invalid settings produce a warning and fall back to `inherit`.
+
+Compatibility: a valid legacy `plan-mode.json` is migrated automatically to `pi-plan-mode.json`. If both files exist, the new filename takes precedence.
 
 ## 🧠 Codex-like behavior
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -214,6 +214,7 @@ export default function planMode(pi: ExtensionAPI) {
 		else if (loadedSettings.kind === "invalid") {
 			ctx.ui.notify(`pi-plan-mode settings ignored: ${loadedSettings.reason}`, "warning");
 		}
+		if (loadedSettings.notice) ctx.ui.notify(loadedSettings.notice, "warning");
 		restoreState(ctx);
 		if (pi.getFlag("plan") === true) state.enabled = true;
 		if (state.enabled) {

--- a/extensions/pi-plan-mode/src/settings.ts
+++ b/extensions/pi-plan-mode/src/settings.ts
@@ -52,18 +52,30 @@ export async function readPlanModeSettings(
 			: canonical;
 	}
 
-	const legacy = await readSettingsFile(legacyPath);
+	const legacySnapshot = await readSettingsSnapshot(legacyPath);
+	const legacy = legacySnapshot.result;
 	const raced = await readSettingsFile(canonicalPath);
 	if (raced.kind !== "missing") return raced;
 	if (legacy.kind !== "loaded") return legacy;
 	try {
-		await installFileExclusively(canonicalPath, `${JSON.stringify(legacy.settings, null, "\t")}\n`);
+		await installFileExclusively(canonicalPath, legacySnapshot.contents ?? "");
 	} catch (error) {
 		const created = await readSettingsFile(canonicalPath);
-		if (created.kind !== "missing") return created;
+		if (created.kind !== "missing") {
+			return {
+				...created,
+				notice: `${LEGACY_PLAN_MODE_SETTINGS_FILE} ignored because ${PLAN_MODE_SETTINGS_FILE} was created concurrently.`,
+			};
+		}
 		return {
 			...legacy,
 			notice: `Plan-mode settings migration failed: ${formatError(error)}. The legacy file was used for this session.`,
+		};
+	}
+	if (!(await fileContentsEqual(legacyPath, legacySnapshot.contents ?? ""))) {
+		return {
+			...legacy,
+			notice: `Plan-mode settings migrated to ${PLAN_MODE_SETTINGS_FILE}, but ${LEGACY_PLAN_MODE_SETTINGS_FILE} changed during migration and was retained.`,
 		};
 	}
 	try {
@@ -91,20 +103,30 @@ async function installFileExclusively(filePath: string, contents: string) {
 }
 
 async function readSettingsFile(settingsPath: string): Promise<PlanModeSettingsLoadResult> {
+	return (await readSettingsSnapshot(settingsPath)).result;
+}
+
+async function readSettingsSnapshot(settingsPath: string): Promise<{
+	result: PlanModeSettingsLoadResult;
+	contents?: string;
+}> {
 	let contents: string;
 	try {
 		contents = await readFile(settingsPath, "utf8");
 	} catch (error: unknown) {
-		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
-		return { kind: "invalid", reason: formatError(error) };
+		if (isNodeError(error) && error.code === "ENOENT") return { result: { kind: "missing" } };
+		return { result: { kind: "invalid", reason: formatError(error) } };
 	}
 	try {
 		const settings = normalizePlanModeSettings(JSON.parse(contents) as unknown);
-		return settings
-			? { kind: "loaded", settings }
-			: { kind: "invalid", reason: "invalid settings shape" };
+		return {
+			contents,
+			result: settings
+				? { kind: "loaded", settings }
+				: { kind: "invalid", reason: "invalid settings shape" },
+		};
 	} catch (error: unknown) {
-		return { kind: "invalid", reason: formatError(error) };
+		return { contents, result: { kind: "invalid", reason: formatError(error) } };
 	}
 }
 
@@ -112,6 +134,14 @@ export function configuredThinkingLevel(
 	settings: PlanModeSettings,
 ): PlanModeFixedThinkingLevel | undefined {
 	return settings.thinkingLevel === "inherit" ? undefined : settings.thinkingLevel;
+}
+
+async function fileContentsEqual(path: string, expected: string) {
+	try {
+		return (await readFile(path, "utf8")) === expected;
+	} catch {
+		return false;
+	}
 }
 
 async function exists(path: string) {

--- a/extensions/pi-plan-mode/src/settings.ts
+++ b/extensions/pi-plan-mode/src/settings.ts
@@ -1,8 +1,10 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { access, link, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
-export const PLAN_MODE_SETTINGS_FILE = "plan-mode.json";
+export const PLAN_MODE_SETTINGS_FILE = "pi-plan-mode.json";
+const LEGACY_PLAN_MODE_SETTINGS_FILE = "plan-mode.json";
 export const PLAN_MODE_THINKING_LEVELS = [
 	"inherit",
 	"off",
@@ -20,9 +22,9 @@ export interface PlanModeSettings {
 	thinkingLevel: PlanModeThinkingLevel;
 }
 export type PlanModeSettingsLoadResult =
-	| { kind: "missing" }
-	| { kind: "invalid"; reason: string }
-	| { kind: "loaded"; settings: PlanModeSettings };
+	| { kind: "missing"; notice?: string }
+	| { kind: "invalid"; reason: string; notice?: string }
+	| { kind: "loaded"; settings: PlanModeSettings; notice?: string };
 
 export function normalizePlanModeSettings(value: unknown): PlanModeSettings | undefined {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
@@ -35,8 +37,60 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 }
 
 export async function readPlanModeSettings(
-	settingsPath = join(getAgentDir(), PLAN_MODE_SETTINGS_FILE),
+	settingsPath?: string,
 ): Promise<PlanModeSettingsLoadResult> {
+	if (settingsPath) return readSettingsFile(settingsPath);
+	const canonicalPath = join(getAgentDir(), PLAN_MODE_SETTINGS_FILE);
+	const canonical = await readSettingsFile(canonicalPath);
+	const legacyPath = join(getAgentDir(), LEGACY_PLAN_MODE_SETTINGS_FILE);
+	if (canonical.kind !== "missing") {
+		return (await exists(legacyPath))
+			? {
+					...canonical,
+					notice: `${LEGACY_PLAN_MODE_SETTINGS_FILE} ignored because ${PLAN_MODE_SETTINGS_FILE} takes precedence.`,
+				}
+			: canonical;
+	}
+
+	const legacy = await readSettingsFile(legacyPath);
+	const raced = await readSettingsFile(canonicalPath);
+	if (raced.kind !== "missing") return raced;
+	if (legacy.kind !== "loaded") return legacy;
+	try {
+		await installFileExclusively(canonicalPath, `${JSON.stringify(legacy.settings, null, "\t")}\n`);
+	} catch (error) {
+		const created = await readSettingsFile(canonicalPath);
+		if (created.kind !== "missing") return created;
+		return {
+			...legacy,
+			notice: `Plan-mode settings migration failed: ${formatError(error)}. The legacy file was used for this session.`,
+		};
+	}
+	try {
+		await rm(legacyPath);
+		return {
+			...legacy,
+			notice: `Plan-mode settings migrated from ${LEGACY_PLAN_MODE_SETTINGS_FILE} to ${PLAN_MODE_SETTINGS_FILE}.`,
+		};
+	} catch (error) {
+		return {
+			...legacy,
+			notice: `Plan-mode settings migrated to ${PLAN_MODE_SETTINGS_FILE}, but ${LEGACY_PLAN_MODE_SETTINGS_FILE} could not be removed: ${formatError(error)}.`,
+		};
+	}
+}
+
+async function installFileExclusively(filePath: string, contents: string) {
+	const tempFile = join(dirname(filePath), `.${PLAN_MODE_SETTINGS_FILE}.${randomUUID()}.tmp`);
+	try {
+		await writeFile(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		await link(tempFile, filePath);
+	} finally {
+		await rm(tempFile, { force: true }).catch(() => undefined);
+	}
+}
+
+async function readSettingsFile(settingsPath: string): Promise<PlanModeSettingsLoadResult> {
 	let contents: string;
 	try {
 		contents = await readFile(settingsPath, "utf8");
@@ -58,6 +112,15 @@ export function configuredThinkingLevel(
 	settings: PlanModeSettings,
 ): PlanModeFixedThinkingLevel | undefined {
 	return settings.thinkingLevel === "inherit" ? undefined : settings.thinkingLevel;
+}
+
+async function exists(path: string) {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/extensions/pi-plan-mode/src/settings.ts
+++ b/extensions/pi-plan-mode/src/settings.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { access, link, readFile, rm, writeFile } from "node:fs/promises";
+import { access, link, lstat, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
@@ -57,8 +57,12 @@ export async function readPlanModeSettings(
 	const raced = await readSettingsFile(canonicalPath);
 	if (raced.kind !== "missing") return raced;
 	if (legacy.kind !== "loaded") return legacy;
+	let installedIdentity: FileIdentity;
 	try {
-		await installFileExclusively(canonicalPath, legacySnapshot.contents ?? "");
+		installedIdentity = await installFileExclusively(
+			canonicalPath,
+			legacySnapshot.contents ?? "",
+		);
 	} catch (error) {
 		const created = await readSettingsFile(canonicalPath);
 		if (created.kind !== "missing") {
@@ -73,9 +77,16 @@ export async function readPlanModeSettings(
 		};
 	}
 	if (!(await fileContentsEqual(legacyPath, legacySnapshot.contents ?? ""))) {
+		const removed = await removeFileIfIdentityMatches(
+			canonicalPath,
+			installedIdentity,
+			legacySnapshot.contents ?? "",
+		);
 		return {
 			...legacy,
-			notice: `Plan-mode settings migrated to ${PLAN_MODE_SETTINGS_FILE}, but ${LEGACY_PLAN_MODE_SETTINGS_FILE} changed during migration and was retained.`,
+			notice: removed
+				? `${LEGACY_PLAN_MODE_SETTINGS_FILE} changed during migration; the stale ${PLAN_MODE_SETTINGS_FILE} snapshot was removed.`
+				: `${LEGACY_PLAN_MODE_SETTINGS_FILE} changed during migration, but ${PLAN_MODE_SETTINGS_FILE} was replaced concurrently and takes precedence on the next load.`,
 		};
 	}
 	try {
@@ -92,13 +103,33 @@ export async function readPlanModeSettings(
 	}
 }
 
-async function installFileExclusively(filePath: string, contents: string) {
+type FileIdentity = { dev: number; ino: number };
+
+async function installFileExclusively(filePath: string, contents: string): Promise<FileIdentity> {
 	const tempFile = join(dirname(filePath), `.${PLAN_MODE_SETTINGS_FILE}.${randomUUID()}.tmp`);
 	try {
 		await writeFile(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		const identity = await lstat(tempFile);
 		await link(tempFile, filePath);
+		return { dev: identity.dev, ino: identity.ino };
 	} finally {
 		await rm(tempFile, { force: true }).catch(() => undefined);
+	}
+}
+
+async function removeFileIfIdentityMatches(
+	filePath: string,
+	expected: FileIdentity,
+	expectedContents: string,
+) {
+	try {
+		const current = await lstat(filePath);
+		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		if ((await readFile(filePath, "utf8")) !== expectedContents) return false;
+		await rm(filePath);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -245,7 +245,7 @@ test("Plan-mode settings validate inherit and fixed thinking levels", async () =
 
 	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-test-"));
 	try {
-		const path = join(directory, "plan-mode.json");
+		const path = join(directory, "pi-plan-mode.json");
 		await writeFile(path, '{"thinkingLevel":"high"}');
 		assert.deepEqual(await readPlanModeSettings(path), {
 			kind: "loaded",
@@ -256,12 +256,65 @@ test("Plan-mode settings validate inherit and fixed thinking levels", async () =
 	}
 });
 
+test("Plan-mode settings migrate to the canonical package filename", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"high"}');
+		const loaded = await readPlanModeSettings();
+		assert.equal(loaded.kind, "loaded");
+		assert.match(loaded.notice ?? "", /migrated/i);
+		assert.deepEqual(JSON.parse(await readFile(join(directory, "pi-plan-mode.json"), "utf8")), {
+			thinkingLevel: "high",
+		});
+		await assert.rejects(access(join(directory, "plan-mode.json")));
+
+		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"low"}');
+		await writeFile(join(directory, "pi-plan-mode.json"), '{"thinkingLevel":"medium"}');
+		const preferred = await readPlanModeSettings();
+		assert.deepEqual(preferred.kind === "loaded" ? preferred.settings : undefined, {
+			thinkingLevel: "medium",
+		});
+		assert.match(preferred.notice ?? "", /ignored/i);
+
+		await writeFile(join(directory, "pi-plan-mode.json"), "invalid");
+		const invalid = await readPlanModeSettings();
+		assert.equal(invalid.kind, "invalid");
+		assert.equal(
+			await readFile(join(directory, "plan-mode.json"), "utf8"),
+			'{"thinkingLevel":"low"}',
+		);
+
+		await unlink(join(directory, "pi-plan-mode.json"));
+		await writeFile(join(directory, "plan-mode.json"), "invalid");
+		assert.equal((await readPlanModeSettings()).kind, "invalid");
+		await assert.rejects(access(join(directory, "pi-plan-mode.json")));
+
+		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"high"}');
+		await symlink("missing-target", join(directory, "pi-plan-mode.json"));
+		const fallback = await readPlanModeSettings();
+		assert.deepEqual(fallback.kind === "loaded" ? fallback.settings : undefined, {
+			thinkingLevel: "high",
+		});
+		assert.match(fallback.notice ?? "", /migration failed/i);
+		assert.equal(
+			await readFile(join(directory, "plan-mode.json"), "utf8"),
+			'{"thinkingLevel":"high"}',
+		);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
 test("missing settings reset a previously loaded fixed thinking level", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-reset-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = directory;
 	try {
-		const settingsPath = join(directory, "plan-mode.json");
+		const settingsPath = join(directory, "pi-plan-mode.json");
 		await writeFile(settingsPath, '{"thinkingLevel":"medium"}');
 		const mock = createMockPi({ activeTools: ["read"], thinkingLevel: "low" });
 		planMode(mock.pi);
@@ -550,7 +603,7 @@ test("Plan thinking level restores only while the extension owns the applied val
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = directory;
 	try {
-		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"medium"}');
+		await writeFile(join(directory, "pi-plan-mode.json"), '{"thinkingLevel":"medium"}');
 		const mock = createMockPi({ activeTools: ["read", "bash"], thinkingLevel: "low" });
 		planMode(mock.pi);
 		const context = createMockContext();
@@ -604,7 +657,7 @@ test("manual thinking changes survive active Plan-mode shutdown and resume", asy
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = directory;
 	try {
-		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"medium"}');
+		await writeFile(join(directory, "pi-plan-mode.json"), '{"thinkingLevel":"medium"}');
 		const mock = createMockPi({ activeTools: ["read"], thinkingLevel: "low" });
 		planMode(mock.pi);
 		const context = createMockContext();

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -261,12 +261,16 @@ test("Plan-mode settings migrate to the canonical package filename", async () =>
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = directory;
 	try {
-		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"high"}');
+		await writeFile(
+			join(directory, "plan-mode.json"),
+			'{"thinkingLevel":"high","futureOption":true}',
+		);
 		const loaded = await readPlanModeSettings();
 		assert.equal(loaded.kind, "loaded");
 		assert.match(loaded.notice ?? "", /migrated/i);
 		assert.deepEqual(JSON.parse(await readFile(join(directory, "pi-plan-mode.json"), "utf8")), {
 			thinkingLevel: "high",
+			futureOption: true,
 		});
 		await assert.rejects(access(join(directory, "plan-mode.json")));
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -53,7 +53,7 @@ Unset or invalid values fall back to `tokyo-night`. Both presets keep the same e
 
 ## ⚙️ Extension status icons
 
-Extension statuses use built-in icons by status key. Override or suppress them in `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline-settings.json`:
+Extension statuses use built-in icons by status key. Override or suppress them in `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline.json`:
 
 ```json
 {
@@ -69,6 +69,8 @@ Extension statuses use built-in icons by status key. Override or suppress them i
   }
 }
 ```
+
+Compatibility: a valid legacy `pi-statusline-settings.json` is migrated automatically to `pi-statusline.json`. If both files exist, the new filename takes precedence.
 
 - Exact status key: always wins, e.g. `"goal"` or `"foo:server"`.
 - Installed extension id: for installed packages, use the package name/source such as `"@vendor/pi-foo"`, `"npm:@vendor/pi-foo@1.2.3"`, `"pi-foo"`, or the derived key `"foo"`.

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, linkSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, linkSync, lstatSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import process from "node:process";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -59,8 +59,9 @@ export function readStatuslineSettings(settingsPath?: string): StatuslineSetting
 		pendingSettingsNotice = `${LEGACY_SETTINGS_FILE} is invalid and was ignored.`;
 		return legacy.settings;
 	}
+	let installedIdentity: FileIdentity;
 	try {
-		installFileExclusively(canonicalPath, legacy.contents ?? "");
+		installedIdentity = installFileExclusively(canonicalPath, legacy.contents ?? "");
 	} catch (error) {
 		if (existsSync(canonicalPath)) {
 			const canonical = readSettingsFileResult(canonicalPath);
@@ -74,7 +75,13 @@ export function readStatuslineSettings(settingsPath?: string): StatuslineSetting
 		return legacy.settings;
 	}
 	if (!fileContentsEqual(legacyPath, legacy.contents ?? "")) {
-		pendingSettingsNotice = `Statusline settings migrated to ${SETTINGS_FILE}, but ${LEGACY_SETTINGS_FILE} changed during migration and was retained.`;
+		pendingSettingsNotice = removeFileIfIdentityMatches(
+			canonicalPath,
+			installedIdentity,
+			legacy.contents ?? "",
+		)
+			? `${LEGACY_SETTINGS_FILE} changed during migration; the stale ${SETTINGS_FILE} snapshot was removed.`
+			: `${LEGACY_SETTINGS_FILE} changed during migration, but ${SETTINGS_FILE} was replaced concurrently and takes precedence on the next load.`;
 		return legacy.settings;
 	}
 	try {
@@ -86,17 +93,37 @@ export function readStatuslineSettings(settingsPath?: string): StatuslineSetting
 	return legacy.settings;
 }
 
-function installFileExclusively(filePath: string, contents: string) {
+type FileIdentity = { dev: number; ino: number };
+
+function installFileExclusively(filePath: string, contents: string): FileIdentity {
 	const tempFile = join(dirname(filePath), `.${SETTINGS_FILE}.${randomUUID()}.tmp`);
 	try {
 		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		const identity = lstatSync(tempFile);
 		linkSync(tempFile, filePath);
+		return { dev: identity.dev, ino: identity.ino };
 	} finally {
 		try {
 			rmSync(tempFile, { force: true });
 		} catch {
 			// Preserve the migration result if best-effort temp cleanup fails.
 		}
+	}
+}
+
+function removeFileIfIdentityMatches(
+	filePath: string,
+	expected: FileIdentity,
+	expectedContents: string,
+) {
+	try {
+		const current = lstatSync(filePath);
+		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		if (readFileSync(filePath, "utf8") !== expectedContents) return false;
+		rmSync(filePath);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -1,10 +1,12 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { existsSync, linkSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { SegmentName, StatuslineConfig, StatuslinePresetName } from "../presets/types.js";
 
-const SETTINGS_FILE = "pi-statusline-settings.json";
+const SETTINGS_FILE = "pi-statusline.json";
+const LEGACY_SETTINGS_FILE = "pi-statusline-settings.json";
 const DEFAULT_PRESET: StatuslinePresetName = "tokyo-night";
 const DEFAULT_SEGMENTS: SegmentName[] = [
 	"brand",
@@ -18,6 +20,7 @@ const DEFAULT_SEGMENTS: SegmentName[] = [
 	"cost",
 	"time",
 ];
+let pendingSettingsNotice: string | undefined;
 
 export interface StatuslineSettings {
 	extensionStatusIcons: Record<string, string>;
@@ -35,18 +38,80 @@ export function createDefaultConfig(): StatuslineConfig {
 	};
 }
 
-export function readStatuslineSettings(
-	settingsPath = join(getAgentDir(), SETTINGS_FILE),
-): StatuslineSettings {
+export function readStatuslineSettings(settingsPath?: string): StatuslineSettings {
+	if (settingsPath) return readSettingsFile(settingsPath);
+	const canonicalPath = join(getAgentDir(), SETTINGS_FILE);
+	const legacyPath = join(getAgentDir(), LEGACY_SETTINGS_FILE);
+	if (existsSync(canonicalPath)) {
+		const canonical = readSettingsFileResult(canonicalPath);
+		const notices: string[] = [];
+		if (!canonical.valid) notices.push(`${SETTINGS_FILE} is invalid and was ignored.`);
+		if (existsSync(legacyPath)) {
+			notices.push(`${LEGACY_SETTINGS_FILE} ignored because ${SETTINGS_FILE} takes precedence.`);
+		}
+		if (notices.length > 0) pendingSettingsNotice = notices.join("\n");
+		return canonical.settings;
+	}
+	if (!existsSync(legacyPath)) return { extensionStatusIcons: {} };
+	const legacy = readSettingsFileResult(legacyPath);
+	if (!legacy.valid) {
+		pendingSettingsNotice = `${LEGACY_SETTINGS_FILE} is invalid and was ignored.`;
+		return legacy.settings;
+	}
 	try {
-		return normalizeStatuslineSettings(JSON.parse(readFileSync(settingsPath, "utf8")));
+		installFileExclusively(canonicalPath, `${JSON.stringify(legacy.settings, null, "\t")}\n`);
+	} catch (error) {
+		if (existsSync(canonicalPath)) return readSettingsFile(canonicalPath);
+		pendingSettingsNotice = `Statusline settings migration failed: ${formatError(error)}. The legacy file was used for this session.`;
+		return legacy.settings;
+	}
+	try {
+		rmSync(legacyPath);
+		pendingSettingsNotice = `Statusline settings migrated from ${LEGACY_SETTINGS_FILE} to ${SETTINGS_FILE}.`;
+	} catch (error) {
+		pendingSettingsNotice = `Statusline settings migrated to ${SETTINGS_FILE}, but ${LEGACY_SETTINGS_FILE} could not be removed: ${formatError(error)}.`;
+	}
+	return legacy.settings;
+}
+
+function installFileExclusively(filePath: string, contents: string) {
+	const tempFile = join(dirname(filePath), `.${SETTINGS_FILE}.${randomUUID()}.tmp`);
+	try {
+		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		linkSync(tempFile, filePath);
+	} finally {
+		rmSync(tempFile, { force: true });
+	}
+}
+
+export function consumeStatuslineSettingsNotice() {
+	const notice = pendingSettingsNotice;
+	pendingSettingsNotice = undefined;
+	return notice;
+}
+
+function readSettingsFile(settingsPath: string): StatuslineSettings {
+	return readSettingsFileResult(settingsPath).settings;
+}
+
+function readSettingsFileResult(settingsPath: string): {
+	settings: StatuslineSettings;
+	valid: boolean;
+} {
+	try {
+		const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return { settings: { extensionStatusIcons: {} }, valid: false };
+		}
+		return { settings: normalizeStatuslineSettings(parsed), valid: true };
 	} catch {
-		return { extensionStatusIcons: {} };
+		return { settings: { extensionStatusIcons: {} }, valid: false };
 	}
 }
 
 export function normalizeStatuslineSettings(value: unknown): StatuslineSettings {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return { extensionStatusIcons: {} };
+	if (!value || typeof value !== "object" || Array.isArray(value))
+		return { extensionStatusIcons: {} };
 	const icons = (value as { extensionStatusIcons?: unknown }).extensionStatusIcons;
 	if (!icons || typeof icons !== "object" || Array.isArray(icons)) {
 		return { extensionStatusIcons: {} };
@@ -63,4 +128,8 @@ export function normalizeStatuslineSettings(value: unknown): StatuslineSettings 
 function readStatuslinePreset(): StatuslinePresetName {
 	const value = process.env.PI_STATUSLINE_PRESET?.trim().toLowerCase();
 	return value === "classic" || value === "tokyo-night" ? value : DEFAULT_PRESET;
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -40,6 +40,7 @@ export function createDefaultConfig(): StatuslineConfig {
 
 export function readStatuslineSettings(settingsPath?: string): StatuslineSettings {
 	if (settingsPath) return readSettingsFile(settingsPath);
+	pendingSettingsNotice = undefined;
 	const canonicalPath = join(getAgentDir(), SETTINGS_FILE);
 	const legacyPath = join(getAgentDir(), LEGACY_SETTINGS_FILE);
 	if (existsSync(canonicalPath)) {
@@ -59,10 +60,21 @@ export function readStatuslineSettings(settingsPath?: string): StatuslineSetting
 		return legacy.settings;
 	}
 	try {
-		installFileExclusively(canonicalPath, `${JSON.stringify(legacy.settings, null, "\t")}\n`);
+		installFileExclusively(canonicalPath, legacy.contents ?? "");
 	} catch (error) {
-		if (existsSync(canonicalPath)) return readSettingsFile(canonicalPath);
+		if (existsSync(canonicalPath)) {
+			const canonical = readSettingsFileResult(canonicalPath);
+			pendingSettingsNotice = [
+				...(!canonical.valid ? [`${SETTINGS_FILE} is invalid and was ignored.`] : []),
+				`${LEGACY_SETTINGS_FILE} ignored because ${SETTINGS_FILE} was created concurrently.`,
+			].join("\n");
+			return canonical.settings;
+		}
 		pendingSettingsNotice = `Statusline settings migration failed: ${formatError(error)}. The legacy file was used for this session.`;
+		return legacy.settings;
+	}
+	if (!fileContentsEqual(legacyPath, legacy.contents ?? "")) {
+		pendingSettingsNotice = `Statusline settings migrated to ${SETTINGS_FILE}, but ${LEGACY_SETTINGS_FILE} changed during migration and was retained.`;
 		return legacy.settings;
 	}
 	try {
@@ -80,7 +92,19 @@ function installFileExclusively(filePath: string, contents: string) {
 		writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
 		linkSync(tempFile, filePath);
 	} finally {
-		rmSync(tempFile, { force: true });
+		try {
+			rmSync(tempFile, { force: true });
+		} catch {
+			// Preserve the migration result if best-effort temp cleanup fails.
+		}
+	}
+}
+
+function fileContentsEqual(path: string, expected: string) {
+	try {
+		return readFileSync(path, "utf8") === expected;
+	} catch {
+		return false;
 	}
 }
 
@@ -97,13 +121,16 @@ function readSettingsFile(settingsPath: string): StatuslineSettings {
 function readSettingsFileResult(settingsPath: string): {
 	settings: StatuslineSettings;
 	valid: boolean;
+	contents?: string;
 } {
+	let contents: string;
 	try {
-		const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as unknown;
+		contents = readFileSync(settingsPath, "utf8");
+		const parsed = JSON.parse(contents) as unknown;
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-			return { settings: { extensionStatusIcons: {} }, valid: false };
+			return { settings: { extensionStatusIcons: {} }, valid: false, contents };
 		}
-		return { settings: normalizeStatuslineSettings(parsed), valid: true };
+		return { settings: normalizeStatuslineSettings(parsed), valid: true, contents };
 	} catch {
 		return { settings: { extensionStatusIcons: {} }, valid: false };
 	}

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -15,7 +15,7 @@ import {
 	renderStatusline,
 	type RuntimeState,
 } from "./render.js";
-import { createDefaultConfig } from "./settings.js";
+import { consumeStatuslineSettingsNotice, createDefaultConfig } from "./settings.js";
 
 const STATUSLINE_KEY = "statusline";
 const GIT_STATUS_REFRESH_INTERVAL_MS = 30_000;
@@ -162,6 +162,8 @@ export default function statusline(pi: ExtensionAPI) {
 	};
 
 	pi.on("session_start", (_event, ctx) => {
+		const settingsNotice = consumeStatuslineSettingsNotice();
+		if (settingsNotice) ctx.ui.notify(settingsNotice, "warning");
 		runtime.thinkingLevel = pi.getThinkingLevel();
 		installFooter(ctx);
 	});

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -403,7 +412,7 @@ test("git branch text includes compact status before PR link", () => {
 
 test("statusline settings load extension icon overrides", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-test-"));
-	const settingsPath = join(root, "pi-statusline-settings.json");
+	const settingsPath = join(root, "pi-statusline.json");
 
 	assert.deepEqual(readStatuslineSettings(settingsPath), { extensionStatusIcons: {} });
 
@@ -417,6 +426,50 @@ test("statusline settings load extension icon overrides", () => {
 
 	writeFileSync(settingsPath, "not json");
 	assert.deepEqual(readStatuslineSettings(settingsPath), { extensionStatusIcons: {} });
+});
+
+test("statusline settings migrate to the canonical package filename", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const legacyPath = join(root, "pi-statusline-settings.json");
+		const canonicalPath = join(root, "pi-statusline.json");
+		writeFileSync(legacyPath, JSON.stringify({ extensionStatusIcons: { goal: "🎯" } }));
+		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: { goal: "🎯" } });
+		assert.deepEqual(JSON.parse(readFileSync(canonicalPath, "utf8")), {
+			extensionStatusIcons: { goal: "🎯" },
+		});
+		assert.equal(existsSync(legacyPath), false);
+
+		writeFileSync(legacyPath, JSON.stringify({ extensionStatusIcons: { goal: "old" } }));
+		writeFileSync(canonicalPath, JSON.stringify({ extensionStatusIcons: { goal: "new" } }));
+		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: { goal: "new" } });
+		assert.equal(existsSync(legacyPath), true);
+
+		writeFileSync(canonicalPath, "invalid");
+		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: {} });
+		assert.equal(readFileSync(legacyPath, "utf8").includes("old"), true);
+
+		unlinkSync(canonicalPath);
+		writeFileSync(legacyPath, "invalid");
+		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: {} });
+		assert.equal(existsSync(canonicalPath), false);
+
+		writeFileSync(legacyPath, JSON.stringify({ extensionStatusIcons: { goal: "fallback" } }));
+		symlinkSync("missing-target", canonicalPath);
+		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: { goal: "fallback" } });
+		assert.equal(existsSync(legacyPath), true);
+		const mock = createMockPi();
+		statusline(mock.pi);
+		const context = createMockContext();
+		await emit(mock.events, "session_start", {}, context.ctx);
+		assert.match(context.notifications[0]?.message ?? "", /migration failed/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("extension status icons use config, leading emoji, defaults, and fallback", () => {
@@ -457,7 +510,7 @@ test("statusline render uses installed package id icon aliases from settings", a
 
 	try {
 		writeFileSync(
-			join(agentDir, "pi-statusline-settings.json"),
+			join(agentDir, "pi-statusline.json"),
 			JSON.stringify({ extensionStatusIcons: { "@vendor/pi-foo": "🧪" } }),
 		);
 		writeFileSync(

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { consumeStatuslineSettingsNotice } from "../src/settings.js";
 import type { ExtensionStatusIconAliasMap } from "../src/statusline.js";
 import statusline, {
 	buildExtensionStatusIconAliases,
@@ -435,10 +436,14 @@ test("statusline settings migrate to the canonical package filename", async () =
 	try {
 		const legacyPath = join(root, "pi-statusline-settings.json");
 		const canonicalPath = join(root, "pi-statusline.json");
-		writeFileSync(legacyPath, JSON.stringify({ extensionStatusIcons: { goal: "🎯" } }));
+		writeFileSync(
+			legacyPath,
+			JSON.stringify({ extensionStatusIcons: { goal: "🎯" }, futureOption: true }),
+		);
 		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: { goal: "🎯" } });
 		assert.deepEqual(JSON.parse(readFileSync(canonicalPath, "utf8")), {
 			extensionStatusIcons: { goal: "🎯" },
+			futureOption: true,
 		});
 		assert.equal(existsSync(legacyPath), false);
 
@@ -450,7 +455,10 @@ test("statusline settings migrate to the canonical package filename", async () =
 		writeFileSync(canonicalPath, "invalid");
 		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: {} });
 		assert.equal(readFileSync(legacyPath, "utf8").includes("old"), true);
-
+		unlinkSync(legacyPath);
+		writeFileSync(canonicalPath, JSON.stringify({ extensionStatusIcons: { goal: "fixed" } }));
+		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: { goal: "fixed" } });
+		assert.equal(consumeStatuslineSettingsNotice(), undefined);
 		unlinkSync(canonicalPath);
 		writeFileSync(legacyPath, "invalid");
 		assert.deepEqual(readStatuslineSettings(), { extensionStatusIcons: {} });

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -210,7 +210,7 @@ When `subagent_wait` starts while a turn is running, that wait consumes the turn
 
 The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history. Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
 
-Configure the runtime in `~/.pi/agent/pi-subagents-config.json`, then reload Pi:
+Configure the runtime in `~/.pi/agent/pi-subagents.json`, then reload Pi:
 
 ```json
 {
@@ -301,7 +301,9 @@ Built-in agents inherit the active/default Pi model instead of forcing a provide
 ## ⚙️ Configure agent tools
 
 Run `/subagents:config` in an interactive Pi session to edit the tools each subagent may use.
-The command stores settings in `~/.pi/agent/pi-subagents-config.json`.
+The command stores settings in `~/.pi/agent/pi-subagents.json`.
+
+Compatibility: a valid legacy `pi-subagents-config.json` is migrated automatically to `pi-subagents.json`. If both files exist, the new filename takes precedence.
 
 - Select an agent, then press Enter or Space to toggle tools.
 - Press `S` to save, or Esc to cancel and return to agent selection.

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -118,9 +119,69 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 	return settings;
 }
 
+const SETTINGS_FILE = "pi-subagents.json";
+const LEGACY_SETTINGS_FILE = "pi-subagents-config.json";
+let pendingSettingsNotice: string | undefined;
+
 export function readSubagentSettings(): SubagentSettings | undefined {
-	const configPath = path.join(getAgentDir(), "pi-subagents-config.json");
-	if (!fs.existsSync(configPath)) return undefined;
+	const canonicalPath = path.join(getAgentDir(), SETTINGS_FILE);
+	const legacyPath = path.join(getAgentDir(), LEGACY_SETTINGS_FILE);
+	if (fs.existsSync(canonicalPath)) {
+		const canonical = readSettingsFile(canonicalPath);
+		const notices: string[] = [];
+		if (!canonical) notices.push(`${SETTINGS_FILE} is invalid and was ignored.`);
+		if (fs.existsSync(legacyPath)) {
+			notices.push(`${LEGACY_SETTINGS_FILE} ignored because ${SETTINGS_FILE} takes precedence.`);
+		}
+		if (notices.length > 0) pendingSettingsNotice = notices.join("\n");
+		return canonical;
+	}
+	if (!fs.existsSync(legacyPath)) return undefined;
+	const legacy = readSettingsFile(legacyPath);
+	if (!legacy) {
+		pendingSettingsNotice = `${LEGACY_SETTINGS_FILE} is invalid and was ignored.`;
+		return undefined;
+	}
+	try {
+		installFileExclusively(canonicalPath, `${JSON.stringify(legacy, null, "\t")}\n`);
+	} catch (error) {
+		if (fs.existsSync(canonicalPath)) return readSettingsFile(canonicalPath);
+		pendingSettingsNotice = `Subagent settings migration failed: ${formatError(error)}. The legacy file was used for this session.`;
+		return legacy;
+	}
+	try {
+		fs.rmSync(legacyPath);
+		pendingSettingsNotice = `Subagent settings migrated from ${LEGACY_SETTINGS_FILE} to ${SETTINGS_FILE}.`;
+	} catch (error) {
+		pendingSettingsNotice = `Subagent settings migrated to ${SETTINGS_FILE}, but ${LEGACY_SETTINGS_FILE} could not be removed: ${formatError(error)}.`;
+	}
+	return legacy;
+}
+
+function installFileExclusively(filePath: string, contents: string) {
+	const tempFile = path.join(path.dirname(filePath), `.${SETTINGS_FILE}.${randomUUID()}.tmp`);
+	try {
+		fs.writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		fs.linkSync(tempFile, filePath);
+	} finally {
+		fs.rmSync(tempFile, { force: true });
+	}
+}
+
+export function consumeSubagentSettingsNotice() {
+	const notice = pendingSettingsNotice;
+	pendingSettingsNotice = undefined;
+	return notice;
+}
+
+export function saveSubagentConfig(settings: SubagentSettings): void {
+	const agentDir = getAgentDir();
+	fs.mkdirSync(agentDir, { recursive: true });
+	const configPath = path.join(agentDir, SETTINGS_FILE);
+	fs.writeFileSync(configPath, `${JSON.stringify(settings, null, "\t")}\n`, "utf-8");
+}
+
+function readSettingsFile(configPath: string): SubagentSettings | undefined {
 	try {
 		return normalizeSubagentSettings(JSON.parse(fs.readFileSync(configPath, "utf-8")));
 	} catch {
@@ -128,12 +189,8 @@ export function readSubagentSettings(): SubagentSettings | undefined {
 	}
 }
 
-export function saveSubagentConfig(settings: SubagentSettings): void {
-	const agentDir = getAgentDir();
-	fs.mkdirSync(agentDir, { recursive: true });
-
-	const configPath = path.join(agentDir, "pi-subagents-config.json");
-	fs.writeFileSync(configPath, `${JSON.stringify(settings, null, "\t")}\n`, "utf-8");
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
 }
 
 export function uniqueToolNames(tools: string[]): string[] {
@@ -153,7 +210,11 @@ export function resolveSubagentThinkingLevel(
 	topLevelThinkingLevel?: SubagentThinkingLevel,
 	localThinkingLevel?: SubagentThinkingLevel,
 ): SubagentThinkingLevel | undefined {
-	return localThinkingLevel ?? topLevelThinkingLevel ?? agents.find((agent) => agent.name === agentName)?.thinkingLevel;
+	return (
+		localThinkingLevel ??
+		topLevelThinkingLevel ??
+		agents.find((agent) => agent.name === agentName)?.thinkingLevel
+	);
 }
 
 export function hasAnyAgentOverride(config: SubagentAgentConfig): boolean {

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -144,8 +144,9 @@ export function readSubagentSettings(): SubagentSettings | undefined {
 		pendingSettingsNotice = `${LEGACY_SETTINGS_FILE} is invalid and was ignored.`;
 		return undefined;
 	}
+	let installedIdentity: FileIdentity;
 	try {
-		installFileExclusively(canonicalPath, legacySnapshot.contents ?? "");
+		installedIdentity = installFileExclusively(canonicalPath, legacySnapshot.contents ?? "");
 	} catch (error) {
 		if (fs.existsSync(canonicalPath)) {
 			const canonical = readSettingsFile(canonicalPath);
@@ -159,7 +160,13 @@ export function readSubagentSettings(): SubagentSettings | undefined {
 		return legacy;
 	}
 	if (!fileContentsEqual(legacyPath, legacySnapshot.contents ?? "")) {
-		pendingSettingsNotice = `Subagent settings migrated to ${SETTINGS_FILE}, but ${LEGACY_SETTINGS_FILE} changed during migration and was retained.`;
+		pendingSettingsNotice = removeFileIfIdentityMatches(
+			canonicalPath,
+			installedIdentity,
+			legacySnapshot.contents ?? "",
+		)
+			? `${LEGACY_SETTINGS_FILE} changed during migration; the stale ${SETTINGS_FILE} snapshot was removed.`
+			: `${LEGACY_SETTINGS_FILE} changed during migration, but ${SETTINGS_FILE} was replaced concurrently and takes precedence on the next load.`;
 		return legacy;
 	}
 	try {
@@ -171,17 +178,37 @@ export function readSubagentSettings(): SubagentSettings | undefined {
 	return legacy;
 }
 
-function installFileExclusively(filePath: string, contents: string) {
+type FileIdentity = { dev: number; ino: number };
+
+function installFileExclusively(filePath: string, contents: string): FileIdentity {
 	const tempFile = path.join(path.dirname(filePath), `.${SETTINGS_FILE}.${randomUUID()}.tmp`);
 	try {
 		fs.writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
+		const identity = fs.lstatSync(tempFile);
 		fs.linkSync(tempFile, filePath);
+		return { dev: identity.dev, ino: identity.ino };
 	} finally {
 		try {
 			fs.rmSync(tempFile, { force: true });
 		} catch {
 			// Preserve the migration result if best-effort temp cleanup fails.
 		}
+	}
+}
+
+function removeFileIfIdentityMatches(
+	filePath: string,
+	expected: FileIdentity,
+	expectedContents: string,
+) {
+	try {
+		const current = fs.lstatSync(filePath);
+		if (current.dev !== expected.dev || current.ino !== expected.ino) return false;
+		if (fs.readFileSync(filePath, "utf8") !== expectedContents) return false;
+		fs.rmSync(filePath);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -124,6 +124,7 @@ const LEGACY_SETTINGS_FILE = "pi-subagents-config.json";
 let pendingSettingsNotice: string | undefined;
 
 export function readSubagentSettings(): SubagentSettings | undefined {
+	pendingSettingsNotice = undefined;
 	const canonicalPath = path.join(getAgentDir(), SETTINGS_FILE);
 	const legacyPath = path.join(getAgentDir(), LEGACY_SETTINGS_FILE);
 	if (fs.existsSync(canonicalPath)) {
@@ -137,16 +138,28 @@ export function readSubagentSettings(): SubagentSettings | undefined {
 		return canonical;
 	}
 	if (!fs.existsSync(legacyPath)) return undefined;
-	const legacy = readSettingsFile(legacyPath);
+	const legacySnapshot = readSettingsSnapshot(legacyPath);
+	const legacy = legacySnapshot.settings;
 	if (!legacy) {
 		pendingSettingsNotice = `${LEGACY_SETTINGS_FILE} is invalid and was ignored.`;
 		return undefined;
 	}
 	try {
-		installFileExclusively(canonicalPath, `${JSON.stringify(legacy, null, "\t")}\n`);
+		installFileExclusively(canonicalPath, legacySnapshot.contents ?? "");
 	} catch (error) {
-		if (fs.existsSync(canonicalPath)) return readSettingsFile(canonicalPath);
+		if (fs.existsSync(canonicalPath)) {
+			const canonical = readSettingsFile(canonicalPath);
+			pendingSettingsNotice = [
+				...(!canonical ? [`${SETTINGS_FILE} is invalid and was ignored.`] : []),
+				`${LEGACY_SETTINGS_FILE} ignored because ${SETTINGS_FILE} was created concurrently.`,
+			].join("\n");
+			return canonical;
+		}
 		pendingSettingsNotice = `Subagent settings migration failed: ${formatError(error)}. The legacy file was used for this session.`;
+		return legacy;
+	}
+	if (!fileContentsEqual(legacyPath, legacySnapshot.contents ?? "")) {
+		pendingSettingsNotice = `Subagent settings migrated to ${SETTINGS_FILE}, but ${LEGACY_SETTINGS_FILE} changed during migration and was retained.`;
 		return legacy;
 	}
 	try {
@@ -164,7 +177,19 @@ function installFileExclusively(filePath: string, contents: string) {
 		fs.writeFileSync(tempFile, contents, { encoding: "utf8", flag: "wx" });
 		fs.linkSync(tempFile, filePath);
 	} finally {
-		fs.rmSync(tempFile, { force: true });
+		try {
+			fs.rmSync(tempFile, { force: true });
+		} catch {
+			// Preserve the migration result if best-effort temp cleanup fails.
+		}
+	}
+}
+
+function fileContentsEqual(filePath: string, expected: string) {
+	try {
+		return fs.readFileSync(filePath, "utf8") === expected;
+	} catch {
+		return false;
 	}
 }
 
@@ -178,14 +203,35 @@ export function saveSubagentConfig(settings: SubagentSettings): void {
 	const agentDir = getAgentDir();
 	fs.mkdirSync(agentDir, { recursive: true });
 	const configPath = path.join(agentDir, SETTINGS_FILE);
-	fs.writeFileSync(configPath, `${JSON.stringify(settings, null, "\t")}\n`, "utf-8");
+	const tempFile = path.join(agentDir, `.${SETTINGS_FILE}.${randomUUID()}.tmp`);
+	try {
+		fs.writeFileSync(tempFile, `${JSON.stringify(settings, null, "\t")}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+		});
+		fs.renameSync(tempFile, configPath);
+	} finally {
+		try {
+			fs.rmSync(tempFile, { force: true });
+		} catch {
+			// Preserve the save result if best-effort temp cleanup fails.
+		}
+	}
 }
 
 function readSettingsFile(configPath: string): SubagentSettings | undefined {
+	return readSettingsSnapshot(configPath).settings;
+}
+
+function readSettingsSnapshot(configPath: string): {
+	settings?: SubagentSettings;
+	contents?: string;
+} {
 	try {
-		return normalizeSubagentSettings(JSON.parse(fs.readFileSync(configPath, "utf-8")));
+		const contents = fs.readFileSync(configPath, "utf8");
+		return { settings: normalizeSubagentSettings(JSON.parse(contents)), contents };
 	} catch {
-		return undefined;
+		return {};
 	}
 }
 

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -69,8 +69,11 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
-		readSubagentSettings();
-		const notice = consumeSubagentSettingsNotice();
+		let notice = consumeSubagentSettingsNotice();
+		if (!notice) {
+			readSubagentSettings();
+			notice = consumeSubagentSettingsNotice();
+		}
 		if (notice) ctx.ui.notify(notice, "warning");
 	});
 

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -19,6 +19,7 @@ import { executeSubagent } from "./execution.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
 import type { SubagentDetails } from "./runner.js";
 import { registerStatefulSubagents } from "./stateful.js";
+import { consumeSubagentSettingsNotice, readSubagentSettings } from "./settings.js";
 
 export default function (pi: ExtensionAPI) {
 	pi.registerTool<typeof SubagentParams, SubagentDetails>({
@@ -67,6 +68,12 @@ export default function (pi: ExtensionAPI) {
 		if ((event.details as (SubagentDetails & { isError?: boolean }) | undefined)?.isError) return { isError: true };
 	});
 
+	pi.on("session_start", (_event, ctx) => {
+		readSubagentSettings();
+		const notice = consumeSubagentSettingsNotice();
+		if (notice) ctx.ui.notify(notice, "warning");
+	});
+
 	registerSubagentConfigCommand(pi);
 	registerStatefulSubagents(pi);
 }
@@ -75,7 +82,9 @@ export { buildPiArgs } from "./runner.js";
 export {
 	normalizeAgentSettings,
 	normalizeSubagentSettings,
+	readSubagentSettings,
 	resolveSubagentThinkingLevel,
+	saveSubagentConfig,
 	sameToolSet,
 	uniqueToolNames,
 } from "./settings.js";

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -1215,7 +1215,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 
 		writeFileSync(
-			path.join(dir, "pi-subagents-config.json"),
+			path.join(dir, "pi-subagents.json"),
 			JSON.stringify({ stateful: { enabled: false } }),
 		);
 		const disabled = createMockPi();

--- a/extensions/pi-subagents/test/in-process-transport.test.ts
+++ b/extensions/pi-subagents/test/in-process-transport.test.ts
@@ -402,7 +402,7 @@ test("registered detached spawn returns while running and publishes each in-proc
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-tools-"));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	writeFileSync(
-		path.join(agentDir, "pi-subagents-config.json"),
+		path.join(agentDir, "pi-subagents.json"),
 		JSON.stringify({ stateful: { transport: "in-process", persistence: false } }),
 	);
 	try {

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -14,6 +15,7 @@ import path from "node:path";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { discoverAgents, formatAgentList } from "../src/agents.js";
+import { consumeSubagentSettingsNotice } from "../src/settings.js";
 import subagents, {
 	buildPiArgs,
 	formatTokens,
@@ -224,12 +226,17 @@ test("subagent settings migrate and save to the canonical package filename", () 
 	try {
 		const legacyPath = path.join(directory, "pi-subagents-config.json");
 		const canonicalPath = path.join(directory, "pi-subagents.json");
-		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
-		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
-		assert.equal(existsSync(canonicalPath), true);
-		assert.equal(existsSync(legacyPath), false);
+		writeFileSync(
+			legacyPath,
+			JSON.stringify({ agents: { scout: { tools: ["read"] } }, futureOption: true }),
+		);
 		const migrationMock = createMockPi();
 		subagents(migrationMock.pi);
+		assert.deepEqual(JSON.parse(readFileSync(canonicalPath, "utf8")), {
+			agents: { scout: { tools: ["read"] } },
+			futureOption: true,
+		});
+		assert.equal(existsSync(legacyPath), false);
 		const migrationContext = createMockContext();
 		migrationMock.events.get("session_start")?.[0]?.({}, migrationContext.ctx);
 		assert.match(migrationContext.notifications[0]?.message ?? "", /migrated/i);
@@ -242,7 +249,10 @@ test("subagent settings migrate and save to the canonical package filename", () 
 		writeFileSync(canonicalPath, "invalid");
 		assert.equal(readSubagentSettings(), undefined);
 		assert.equal(readFileSync(legacyPath, "utf8").includes("bash"), true);
-
+		unlinkSync(legacyPath);
+		writeFileSync(canonicalPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
+		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		assert.equal(consumeSubagentSettingsNotice(), undefined);
 		unlinkSync(canonicalPath);
 		writeFileSync(legacyPath, "invalid");
 		assert.equal(readSubagentSettings(), undefined);
@@ -252,9 +262,10 @@ test("subagent settings migrate and save to the canonical package filename", () 
 		symlinkSync("missing-target", canonicalPath);
 		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
 		assert.equal(existsSync(legacyPath), true);
-		unlinkSync(canonicalPath);
 
 		saveSubagentConfig({ stateful: { enabled: false } });
+		assert.equal(lstatSync(canonicalPath).isSymbolicLink(), false);
+		assert.equal(existsSync(path.join(directory, "missing-target")), false);
 		assert.deepEqual(JSON.parse(readFileSync(canonicalPath, "utf8")), {
 			stateful: { enabled: false },
 		});

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -11,8 +20,10 @@ import subagents, {
 	formatUsageStats,
 	normalizeSubagentSettings,
 	parsePositiveInteger,
+	readSubagentSettings,
 	resolveSubagentThinkingLevel,
 	sameToolSet,
+	saveSubagentConfig,
 	uniqueToolNames,
 } from "../src/subagents.js";
 
@@ -204,6 +215,59 @@ test("subagent settings normalize known override fields only", () => {
 		},
 	);
 	assert.equal(normalizeSubagentSettings({ agents: [] }), undefined);
+});
+
+test("subagent settings migrate and save to the canonical package filename", () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const legacyPath = path.join(directory, "pi-subagents-config.json");
+		const canonicalPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
+		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		assert.equal(existsSync(canonicalPath), true);
+		assert.equal(existsSync(legacyPath), false);
+		const migrationMock = createMockPi();
+		subagents(migrationMock.pi);
+		const migrationContext = createMockContext();
+		migrationMock.events.get("session_start")?.[0]?.({}, migrationContext.ctx);
+		assert.match(migrationContext.notifications[0]?.message ?? "", /migrated/i);
+
+		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["bash"] } } }));
+		writeFileSync(canonicalPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
+		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		assert.equal(existsSync(legacyPath), true);
+
+		writeFileSync(canonicalPath, "invalid");
+		assert.equal(readSubagentSettings(), undefined);
+		assert.equal(readFileSync(legacyPath, "utf8").includes("bash"), true);
+
+		unlinkSync(canonicalPath);
+		writeFileSync(legacyPath, "invalid");
+		assert.equal(readSubagentSettings(), undefined);
+		assert.equal(existsSync(canonicalPath), false);
+
+		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
+		symlinkSync("missing-target", canonicalPath);
+		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		assert.equal(existsSync(legacyPath), true);
+		unlinkSync(canonicalPath);
+
+		saveSubagentConfig({ stateful: { enabled: false } });
+		assert.deepEqual(JSON.parse(readFileSync(canonicalPath, "utf8")), {
+			stateful: { enabled: false },
+		});
+		const ignoredMock = createMockPi();
+		subagents(ignoredMock.pi);
+		const ignoredContext = createMockContext();
+		ignoredMock.events.get("session_start")?.[0]?.({}, ignoredContext.ctx);
+		assert.match(ignoredContext.notifications[0]?.message ?? "", /ignored/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
 });
 
 test("subagent formatting and set helpers are deterministic", () => {


### PR DESCRIPTION
## Summary

- standardize active extension-managed JSON names on the unscoped npm package name
- safely migrate legacy user files with canonical-file precedence and session warnings
- keep project `.pi/lsp.json` fallback-only to avoid modifying repository working trees
- preserve `0600` permissions for Google GenAI and Codex Accounts credentials

## Canonical filenames

- `pi-lsp.json`
- `pi-plan-mode.json`
- `pi-google-genai.json`
- `pi-statusline.json`
- `pi-subagents.json`
- `pi-codex-accounts.json`

## Verification

- `npm run check` (367 tests)
- `just pack-codex-accounts`
- `just pack-lsp`
- `just pack-plan-mode`
- `just pack-google-genai`
- `just pack-statusline`
- `just pack-subagents`