### PR TITLE
feat(codex-usage): show usage limit reset credits

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -42,6 +42,7 @@
 
 ## TASTE
 
+- Prefer writing a repository plan before starting non-trivial implementation work; keep it executable, verify it, and archive it when complete.
 - Keep entries short and reusable.
 - Prefer status-producing extensions to publish text-only status values; keep extension icons in pi-statusline defaults/settings so styling and suppression stay centralized.
 - Prefer JSON config files over environment variables for user-facing settings, including token configuration when it is appropriate for the product. Add new environment variables only when they serve a clear purpose, such as secrets, deployment workflows, automation, or compatibility with existing integrations.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -17,6 +17,7 @@
 - Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.
+- Symptom: a primary Codex window can reset a week later while displaying “5h”. Cause: `primary`/`secondary` are positions, not guaranteed durations. Fix: derive window labels from `windowMinutes`, retaining positional fallbacks only when duration is absent.
 - Keep package metadata and CI/bump/publish workflows pinned to npm 11.16.0; npm 12.0 resolves shrinkwrapped overrides differently, prunes alternate-Pi installs, and cannot resolve its published provenance `sigstore`. Regenerate the lockfile when intentionally changing npm major versions.
 - New filesystem-writing Pi tools need a pre-review edge-case pass: workspace containment, absolute/`..` paths, symlink loops/escapes, duplicate paths, cancellation, process errors, protocol errors, and edit ordering.
 - New extension package source may match the root `.gitignore` `src/` rule; stage intended `extensions/<pkg>/src/*.ts` with `git add -f`.

--- a/docs/plans/archived/2026-07-13_codex-usage-api-update-plan.md
+++ b/docs/plans/archived/2026-07-13_codex-usage-api-update-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Research the current Codex rate-limit usage contracts and update `pi-codex-usage` so its direct Pi-auth and Codex app-server paths preserve and display newly exposed usage data without regressing older payloads.
+
+## Context
+
+- Current upstream evidence is `third_party/codex` at `2f7d89b1419bf7064346855b0acde23514b1ebc5` (2026-07-13), plus the current Codex app-server documentation resolved through Context7.
+- The `/wham/usage` URL and existing rate-limit fields remain compatible.
+- Since the extension's original May implementation, Codex added `rate_limit_reset_credits.available_count` to the backend usage response (`bef99f86`, 2026-06-15), exposed it as `rateLimitResetCredits` from `account/rateLimits/read`, and added optional reset-credit detail rows (`58ec5283`, 2026-07-06).
+
+## Non-Goals
+
+- Do not add reset-credit redemption; Codex requires a separate idempotent consume flow and a post-consume refetch.
+- Do not add the separate `account/usage/read` token-activity report to this rate-limit status command.
+
+## Plan
+
+- [x] Compare `pi-codex-usage` direct/backend and app-server schemas with current `third_party/codex` and current Codex docs; verify changes through upstream source, generated protocol types, tests, and commit history.
+- [x] Add failing normalization and formatting tests for snake_case backend reset-credit summaries, camelCase app-server summaries/details, and reset-credit-only responses; verify the initial red state with `npm test` type errors for the missing contract.
+- [x] Extend `extensions/pi-codex-usage/src/types.ts` and `src/normalize.ts` to normalize the new fields while tolerating absent or malformed optional reset-credit metadata; verified by 13 focused passing tests.
+- [x] Update `extensions/pi-codex-usage/src/format.ts` and public exports so `/codex-status` reports available usage-limit resets without expanding the compact statusline; verified by formatter assertions and package typecheck.
+- [x] Update `extensions/pi-codex-usage/README.md` to document the upstream API change and visible behavior; examples and limitations now match implementation.
+- [x] Run package formatting/typechecking, focused tests, the repository CI-equivalent gate when possible, and the `just pack-codex-usage` dry run; package checks, focused tests, boundaries, and pack passed. The full gate is blocked by unrelated `pi-goal`/`pi-plan-mode` type errors and a concurrently created untracked `otel/` worktree with a nested Biome root.
+- [x] Audit the final diff against this plan, then archive this completed plan under `docs/plans/archived/`; tracked edits are limited to `pi-codex-usage`, this plan, and the requested durable memory preference.
+
+## Risks
+
+- Mitigated: optional reset-credit detail data can be absent, capped, or malformed; normalization treats `availableCount` as authoritative, skips unusable detail rows, and accepts count-only reports.
+- Accepted: the direct Pi-auth path sees the summary embedded in `/wham/usage`, while detailed rows are currently supplied by the app-server's additional lookup; the command intentionally displays the authoritative count only.
+- Accepted baseline: repository-wide tests expose unrelated Pi dependency compatibility errors in `pi-goal` and `pi-plan-mode`; focused compilation and tests prove this package's behavior.
+
+## Completion Checklist
+
+- [x] Direct `/wham/usage` reset-credit summaries and app-server `rateLimitResetCredits` responses are covered by 13 passing deterministic focused tests.
+- [x] `/codex-status` displays the authoritative available reset count, while existing model-specific statusline output remains unchanged, as verified by formatter tests.
+- [x] Package typecheck, explicit formatting/lint, focused tests, boundary check, and `just pack-codex-usage` pass; repository-wide baseline failures are recorded above.
+- [x] README claims match the implemented query, fallback, cache, and reset-credit behavior.
+- [x] Intended tracked paths are limited to `pi-codex-usage`, this archived plan, and `MEMORY.md`; `git status --short` separately shows the concurrent untracked `otel/` worktree, which was not modified.

--- a/docs/plans/archived/2026-07-13_codex-usage-reset-credit-edge-cases-plan.md
+++ b/docs/plans/archived/2026-07-13_codex-usage-reset-credit-edge-cases-plan.md
@@ -1,0 +1,35 @@
+## Goal
+
+Harden PR #200's Codex reset-credit normalization against malformed optional backend/app-server collections while preserving strict handling of the required primary usage snapshot and the authoritative reset count.
+
+## Context
+
+The focused edge-case audit found two plausible boundary failures in `extensions/pi-codex-usage/src/normalize.ts`:
+
+- A malformed entry inside optional `additional_rate_limits` or `rateLimitsByLimitId` can currently throw and discard otherwise valid primary/reset usage data.
+- A non-empty app-server reset-credit detail array containing only malformed rows is normalized as `credits: []`, which incorrectly conflates unusable details with the protocol's meaningful “details fetched and no rows returned” state.
+
+## Non-Goals
+
+- Do not make the required primary rate-limit snapshot lenient; malformed primary data should continue to fail the source so query fallback/error reporting remains accurate.
+- Do not add reset redemption or display individual reset-credit details.
+
+## Plan
+
+- [x] Add focused failing tests for malformed optional backend/app-server bucket entries and malformed-only reset-credit details; the initial focused run failed in all three identified cases.
+- [x] Add non-throwing normalization only around optional additional buckets, preserving strict primary snapshot normalization; focused strictness and malformed-collection tests pass.
+- [x] Preserve `credits: []` only for a truly empty detail array and omit `credits` when a non-empty detail array yields no valid rows; mixed arrays retain valid details capped by the authoritative count, without undefined optional properties.
+- [x] Run package check, explicit changed-file Biome check, focused tests, boundary check, package dry-run, and the repository gate where possible; local scoped checks passed and both remote CI matrix jobs passed.
+- [x] Audit the PR diff, update the archived plan with evidence, commit the hardening change, push PR #200, and verify CI/review state; commit `f127198` is pushed and both Pi 0.79.10/latest jobs passed.
+
+## Risks
+
+- Mitigated: validation failures are caught only for optional additional buckets; dedicated tests prove malformed required primary snapshots still throw.
+- Mitigated: detail rows are optional, filtered, and capped to `availableCount`, which remains authoritative.
+
+## Completion Checklist
+
+- [x] Malformed optional bucket entries no longer discard valid primary/reset usage, proven by deterministic tests.
+- [x] Empty and malformed-only reset-credit detail arrays retain distinct normalized meanings, proven by deterministic tests.
+- [x] Existing direct/app-server normalization, formatter, lifecycle, and statusline tests remain green in the 17-test focused suite.
+- [x] PR #200 contains hardening commit `f127198` with passing Pi 0.79.10/latest CI; unrelated `otel/` worktree content remains excluded.

--- a/extensions/pi-codex-usage/README.md
+++ b/extensions/pi-codex-usage/README.md
@@ -9,8 +9,9 @@ Use it when you want a quick Codex-style usage summary without leaving Pi or req
 ## ✨ Features
 
 - Adds a `/codex-status` command to Pi.
-- Shows Codex plan, 5-hour and weekly usage windows, reset times, and credits.
+- Shows Codex plan, 5-hour and weekly usage windows, reset times, credits, and earned usage-limit resets.
 - Displays additional usage buckets when the Codex backend returns them.
+- Reads the authoritative available reset count from the current Codex usage contract.
 - Automatically shows a compact statusline item while the current Pi model uses `openai-codex`.
 - Uses Pi's own OpenAI Codex subscription auth first.
 - Falls back to `codex app-server --listen stdio://` only when Pi auth is unavailable.
@@ -59,6 +60,8 @@ information on rate limits and credits
   GPT-5.3-Codex-Spark limit:
   5h limit:                    [████████████████████] 100% left (resets 19:16)
   Weekly limit:                [████████████████████] 100% left (resets 00:10 on 21 May)
+
+  Usage limit resets:          2 available
 ```
 
 ## 📊 Statusline behavior
@@ -85,6 +88,8 @@ Use `/codex-status --no-statusline` for a one-off notification without updating 
 
 This means Codex CLI is optional. Users who already use a Pi OpenAI Codex model or have logged in to Pi with ChatGPT Plus/Pro subscription auth can use the direct Pi-auth path.
 
+The direct `/wham/usage` response can include the snake_case `rate_limit_reset_credits` summary. Current Codex app-server responses expose the same authoritative count as camelCase `rateLimitResetCredits` and may also include capped detail rows. The extension accepts both forms and keeps the compact statusline focused on rate-limit windows.
+
 The extension does not read Pi or Codex auth files directly, and it does not expose bearer tokens in error messages.
 
 ## 🚧 Limitations
@@ -92,6 +97,7 @@ The extension does not read Pi or Codex auth files directly, and it does not exp
 - OpenAI API keys are not ChatGPT Codex subscription auth and do not expose this quota.
 - Usage data is a snapshot. Statusline and command results are cached for five minutes unless `--refresh` is used.
 - The fallback path requires Codex CLI to be installed and logged in.
+- `/codex-status` reports earned usage-limit resets but does not redeem them.
 
 ## 🗂️ Package layout
 

--- a/extensions/pi-codex-usage/README.md
+++ b/extensions/pi-codex-usage/README.md
@@ -9,7 +9,8 @@ Use it when you want a quick Codex-style usage summary without leaving Pi or req
 ## ✨ Features
 
 - Adds a `/codex-status` command to Pi.
-- Shows Codex plan, 5-hour and weekly usage windows, reset times, credits, and earned usage-limit resets.
+- Shows Codex usage windows, reset times, credits, and earned usage-limit resets.
+- Labels each window from its reported duration (for example, 5-hour or weekly).
 - Displays additional usage buckets when the Codex backend returns them.
 - Reads the authoritative available reset count from the current Codex usage contract.
 - Automatically shows a compact statusline item while the current Pi model uses `openai-codex`.
@@ -73,7 +74,7 @@ codex 59% 5h 61% wk
 codex spark 100% 5h 100% wk
 ```
 
-`@narumitw/pi-statusline` adds the default `📊` icon unless configured otherwise. The statusline value uses the cached usage snapshot and refreshes every five minutes while the current model remains `openai-codex`.
+`@narumitw/pi-statusline` adds the default `📊` icon unless configured otherwise. The statusline value uses the cached usage snapshot and refreshes every five minutes while the current model remains `openai-codex`. Window labels come from the duration reported by Codex, with 5-hour/weekly fallbacks for older responses that omit it.
 When the selected model has its own returned usage bucket, such as `gpt-5.3-codex-spark`, the statusline switches to that bucket instead of the default `codex` bucket.
 Switching away from an OpenAI Codex model clears the item.
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -1,19 +1,6 @@
-import type {
-	ExtensionAPI,
-	ExtensionCommandContext,
-	ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
-import {
-	formatCodexUsageReport,
-	formatCodexUsageStatusline,
-	formatQueryErrors,
-	showReport,
-} from "./format.js";
-import {
-	isOpenAICodexModel,
-	isStaleExtensionContextError,
-	queryUsage,
-} from "./query.js";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { formatCodexUsageStatusline, formatQueryErrors, showReport } from "./format.js";
+import { isOpenAICodexModel, isStaleExtensionContextError, queryUsage } from "./query.js";
 import type {
 	CachedReport,
 	CodexUsageModel,
@@ -34,7 +21,11 @@ interface CommandArgumentCompletion {
 
 const COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 	{ value: "--refresh", label: "--refresh", description: "Refresh usage instead of cached data" },
-	{ value: "--no-statusline", label: "--no-statusline", description: "Do not update the statusline" },
+	{
+		value: "--no-statusline",
+		label: "--no-statusline",
+		description: "Do not update the statusline",
+	},
 	{
 		value: "--clear-statusline",
 		label: "--clear-statusline",
@@ -192,8 +183,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 				}
 
 				let keepStatusline = false;
-				const statuslineStarted =
-					options.value.statusline && setStatuslineValue(ctx, "checking");
+				const statuslineStarted = options.value.statusline && setStatuslineValue(ctx, "checking");
 				try {
 					const result = await queryUsage(ctx, options.value);
 					if (!result.ok) {
@@ -333,6 +323,8 @@ export type {
 	CodexUsageModel,
 	CodexUsageReport,
 	NormalizedCredits,
+	NormalizedRateLimitResetCredit,
+	NormalizedRateLimitResetCredits,
 	NormalizedRateLimitSnapshot,
 	NormalizedRateLimitWindow,
 } from "./types.js";

--- a/extensions/pi-codex-usage/src/format.ts
+++ b/extensions/pi-codex-usage/src/format.ts
@@ -38,6 +38,13 @@ export function formatCodexUsageReport(report: CodexUsageReport, _cacheAgeMs?: n
 		}
 	}
 
+	if (report.resetCredits) {
+		if (report.snapshots.length > 0) lines.push("");
+		lines.push(
+			`  ${"Usage limit resets:".padEnd(LIMIT_VALUE_COLUMN)}${report.resetCredits.availableCount} available`,
+		);
+	}
+
 	return lines.join("\n");
 }
 
@@ -220,37 +227,6 @@ export function formatQueryErrors(errors: UsageQueryError[]): string {
 		"Tip: use a Pi OpenAI Codex model or run /login for OpenAI ChatGPT Plus/Pro. If Pi auth is unavailable, install Codex CLI and run codex login for the fallback.",
 	);
 	return lines.join("\n");
-}
-
-function formatPlanType(planType: string): string {
-	const key = planType
-		.replace(/([a-z])([A-Z])/g, "$1_$2")
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "_");
-	if (key === "pro_lite" || key === "prolite") return "Pro Lite";
-	if (key === "team" || key === "self_serve_business_usage_based" || key === "business") {
-		return "Business";
-	}
-	if (key === "enterprise_cbp_usage_based") return "Enterprise";
-
-	const normalized = planType
-		.replace(/([a-z])([A-Z])/g, "$1 $2")
-		.replace(/[_-]+/g, " ")
-		.trim();
-	if (!normalized) return planType;
-	return normalized
-		.split(/\s+/)
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-		.join(" ");
-}
-
-function formatDuration(milliseconds: number): string {
-	const seconds = Math.max(0, Math.round(milliseconds / 1000));
-	if (seconds < 60) return `${seconds}s`;
-	const minutes = Math.round(seconds / 60);
-	if (minutes < 60) return `${minutes}m`;
-	const hours = Math.round(minutes / 60);
-	return `${hours}h`;
 }
 
 function formatNumber(value: number, fallback: string): string {

--- a/extensions/pi-codex-usage/src/format.ts
+++ b/extensions/pi-codex-usage/src/format.ts
@@ -31,8 +31,8 @@ export function formatCodexUsageReport(report: CodexUsageReport, _cacheAgeMs?: n
 		if (!isPrimaryCodexSnapshot(snapshot)) {
 			lines.push(`  ${label} limit:`);
 		}
-		if (snapshot.primary) lines.push(formatWindowLine("5h limit:", snapshot.primary));
-		if (snapshot.secondary) lines.push(formatWindowLine("Weekly limit:", snapshot.secondary));
+		if (snapshot.primary) lines.push(formatWindowLine(snapshot.primary, "5h"));
+		if (snapshot.secondary) lines.push(formatWindowLine(snapshot.secondary, "weekly"));
 		if (!snapshot.primary && !snapshot.secondary) {
 			lines.push("  Limits unavailable for this account");
 		}
@@ -56,8 +56,16 @@ export function formatCodexUsageStatusline(
 	if (!snapshot) return "usage unavailable";
 
 	const parts = [formatStatuslinePrefix(snapshot)];
-	if (snapshot.primary) parts.push(`${formatRemainingPercent(snapshot.primary)} 5h`);
-	if (snapshot.secondary) parts.push(`${formatRemainingPercent(snapshot.secondary)} wk`);
+	if (snapshot.primary) {
+		parts.push(
+			`${formatRemainingPercent(snapshot.primary)} ${formatWindowLabel(snapshot.primary, "5h", true)}`,
+		);
+	}
+	if (snapshot.secondary) {
+		parts.push(
+			`${formatRemainingPercent(snapshot.secondary)} ${formatWindowLabel(snapshot.secondary, "weekly", true)}`,
+		);
+	}
 	if (parts.length === 1 && snapshot.credits) parts.push(formatCredits(snapshot.credits));
 	return parts.join(" ");
 }
@@ -178,8 +186,32 @@ function isPrimaryCodexSnapshot(snapshot: NormalizedRateLimitSnapshot): boolean 
 	);
 }
 
-function formatWindowLine(label: string, window: NormalizedRateLimitWindow): string {
+function formatWindowLine(
+	window: NormalizedRateLimitWindow,
+	fallback: "5h" | "weekly",
+): string {
+	const label = `${formatWindowLabel(window, fallback, false)} limit:`;
 	return `  ${label.padEnd(LIMIT_VALUE_COLUMN)}${formatWindow(window)}`;
+}
+
+function formatWindowLabel(
+	window: NormalizedRateLimitWindow,
+	fallback: "5h" | "weekly",
+	compact: boolean,
+): string {
+	const minutes = window.windowMinutes;
+	if (!minutes || !Number.isFinite(minutes) || minutes <= 0) {
+		return compact && fallback === "weekly" ? "wk" : capitalize(fallback);
+	}
+	if (minutes === 10_080) return compact ? "wk" : "Weekly";
+	if (minutes % 10_080 === 0) return `${minutes / 10_080}w`;
+	if (minutes % 1_440 === 0) return `${minutes / 1_440}d`;
+	if (minutes % 60 === 0) return `${minutes / 60}h`;
+	return `${minutes}m`;
+}
+
+function capitalize(value: string): string {
+	return `${value[0]?.toUpperCase() ?? ""}${value.slice(1)}`;
 }
 
 function formatWindow(window: NormalizedRateLimitWindow): string {

--- a/extensions/pi-codex-usage/src/normalize.ts
+++ b/extensions/pi-codex-usage/src/normalize.ts
@@ -1,14 +1,19 @@
 import type {
 	AppServerCreditsSnapshot,
+	AppServerRateLimitResetCredit,
+	AppServerRateLimitResetCredits,
 	AppServerRateLimitResponse,
 	AppServerRateLimitSnapshot,
 	AppServerWindowSnapshot,
 	BackendAdditionalRateLimit,
 	BackendCreditsSnapshot,
 	BackendRateLimitDetails,
+	BackendRateLimitResetCredits,
 	BackendWindowSnapshot,
 	CodexUsageReport,
 	NormalizedCredits,
+	NormalizedRateLimitResetCredit,
+	NormalizedRateLimitResetCredits,
 	NormalizedRateLimitSnapshot,
 	NormalizedRateLimitWindow,
 	RateLimitStatusPayload,
@@ -45,11 +50,12 @@ export function normalizeBackendPayload(
 		if (snapshot) snapshots.push(snapshot);
 	}
 
-	if (snapshots.length === 0) {
-		throw new Error("Codex usage endpoint returned no displayable rate-limit windows.");
+	const resetCredits = normalizeBackendRateLimitResetCredits(payload.rate_limit_reset_credits);
+	if (snapshots.length === 0 && !resetCredits) {
+		throw new Error("Codex usage endpoint returned no displayable usage data.");
 	}
 
-	return { source, capturedAt, planType, snapshots };
+	return { source, capturedAt, planType, snapshots, resetCredits };
 }
 
 function normalizeBackendSnapshot(
@@ -95,6 +101,14 @@ function normalizeBackendCredits(value: unknown): NormalizedCredits | undefined 
 	return { hasCredits, unlimited, balance: asString(credits.balance) };
 }
 
+function normalizeBackendRateLimitResetCredits(
+	value: unknown,
+): NormalizedRateLimitResetCredits | undefined {
+	const resetCredits = asObject(value) as BackendRateLimitResetCredits | undefined;
+	const availableCount = asNonnegativeInteger(resetCredits?.available_count);
+	return availableCount === undefined ? undefined : { availableCount };
+}
+
 export function normalizeAppServerResponse(
 	response: AppServerRateLimitResponse,
 	capturedAt: number,
@@ -116,12 +130,19 @@ export function normalizeAppServerResponse(
 		}
 	}
 
-	if (snapshots.length === 0) {
-		throw new Error("codex app-server returned no displayable rate-limit windows.");
+	const resetCredits = normalizeAppServerRateLimitResetCredits(response.rateLimitResetCredits);
+	if (snapshots.length === 0 && !resetCredits) {
+		throw new Error("codex app-server returned no displayable usage data.");
 	}
 
 	const planType = asAppServerPlanType(response.rateLimits);
-	return { source: "codex-app-server", capturedAt, planType, snapshots };
+	return {
+		source: "codex-app-server",
+		capturedAt,
+		planType,
+		snapshots,
+		resetCredits,
+	};
 }
 
 function asAppServerPlanType(raw: unknown): string | undefined {
@@ -172,6 +193,38 @@ function normalizeAppServerCredits(value: unknown): NormalizedCredits | undefine
 	return { hasCredits, unlimited, balance: asString(credits.balance) };
 }
 
+function normalizeAppServerRateLimitResetCredits(
+	value: unknown,
+): NormalizedRateLimitResetCredits | undefined {
+	const resetCredits = asObject(value) as AppServerRateLimitResetCredits | undefined;
+	const availableCount = asNonnegativeInteger(resetCredits?.availableCount);
+	if (availableCount === undefined) return undefined;
+
+	const credits = Array.isArray(resetCredits?.credits)
+		? resetCredits.credits
+				.map(normalizeAppServerRateLimitResetCredit)
+				.filter((credit): credit is NormalizedRateLimitResetCredit => credit !== undefined)
+		: undefined;
+	return credits ? { availableCount, credits } : { availableCount };
+}
+
+function normalizeAppServerRateLimitResetCredit(
+	value: unknown,
+): NormalizedRateLimitResetCredit | undefined {
+	const credit = asObject(value) as AppServerRateLimitResetCredit | undefined;
+	const id = asString(credit?.id);
+	if (!id) return undefined;
+	return {
+		id,
+		resetType: asString(credit?.resetType),
+		status: asString(credit?.status),
+		grantedAt: asNumber(credit?.grantedAt),
+		expiresAt: asNumber(credit?.expiresAt),
+		title: asString(credit?.title),
+		description: asString(credit?.description),
+	};
+}
+
 function mergeSnapshot(
 	left: NormalizedRateLimitSnapshot,
 	right: NormalizedRateLimitSnapshot,
@@ -186,9 +239,13 @@ function mergeSnapshot(
 }
 
 function assertObject(value: unknown, description: string): Record<string, unknown> {
-	if (!value || typeof value !== "object" || Array.isArray(value)) {
-		throw new Error(`${description} was not an object.`);
-	}
+	const object = asObject(value);
+	if (!object) throw new Error(`${description} was not an object.`);
+	return object;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 	return value as Record<string, unknown>;
 }
 
@@ -207,4 +264,10 @@ function asNumber(value: unknown): number | undefined {
 
 function asBoolean(value: unknown): boolean | undefined {
 	return typeof value === "boolean" ? value : undefined;
+}
+
+function asNonnegativeInteger(value: unknown): number | undefined {
+	const parsed = asNumber(value);
+	if (parsed === undefined || !Number.isSafeInteger(parsed)) return undefined;
+	return Math.max(0, parsed);
 }

--- a/extensions/pi-codex-usage/src/normalize.ts
+++ b/extensions/pi-codex-usage/src/normalize.ts
@@ -34,20 +34,22 @@ export function normalizeBackendPayload(
 		? payload.additional_rate_limits
 		: [];
 	for (const item of additional) {
-		const additionalLimit = assertObject(
-			item,
-			"additional rate limit",
-		) as BackendAdditionalRateLimit;
+		const additionalLimit = asObject(item) as BackendAdditionalRateLimit | undefined;
+		if (!additionalLimit) continue;
 		const limitId =
 			asString(additionalLimit.metered_feature) ?? asString(additionalLimit.limit_name);
 		if (!limitId) continue;
-		const snapshot = normalizeBackendSnapshot(
-			limitId,
-			asString(additionalLimit.limit_name),
-			additionalLimit.rate_limit,
-			undefined,
-		);
-		if (snapshot) snapshots.push(snapshot);
+		try {
+			const snapshot = normalizeBackendSnapshot(
+				limitId,
+				asString(additionalLimit.limit_name),
+				additionalLimit.rate_limit,
+				undefined,
+			);
+			if (snapshot) snapshots.push(snapshot);
+		} catch {
+			// Optional additional buckets must not hide otherwise usable primary/reset usage.
+		}
 	}
 
 	const resetCredits = normalizeBackendRateLimitResetCredits(payload.rate_limit_reset_credits);
@@ -114,8 +116,14 @@ export function normalizeAppServerResponse(
 	capturedAt: number,
 ): CodexUsageReport {
 	const snapshots: NormalizedRateLimitSnapshot[] = [];
-	const addSnapshot = (raw: unknown, fallbackId: string) => {
-		const snapshot = normalizeAppServerSnapshot(raw, fallbackId);
+	const addSnapshot = (raw: unknown, fallbackId: string, optional = false) => {
+		let snapshot: NormalizedRateLimitSnapshot | undefined;
+		try {
+			snapshot = normalizeAppServerSnapshot(raw, fallbackId);
+		} catch (error) {
+			if (optional) return;
+			throw error;
+		}
 		if (!snapshot) return;
 		const existingIndex = snapshots.findIndex((item) => item.limitId === snapshot.limitId);
 		if (existingIndex >= 0)
@@ -124,9 +132,10 @@ export function normalizeAppServerResponse(
 	};
 
 	addSnapshot(response.rateLimits, "codex");
-	if (response.rateLimitsByLimitId && typeof response.rateLimitsByLimitId === "object") {
-		for (const [limitId, raw] of Object.entries(response.rateLimitsByLimitId)) {
-			addSnapshot(raw, limitId);
+	const snapshotsByLimitId = asObject(response.rateLimitsByLimitId);
+	if (snapshotsByLimitId) {
+		for (const [limitId, raw] of Object.entries(snapshotsByLimitId)) {
+			if (limitId) addSnapshot(raw, limitId, true);
 		}
 	}
 
@@ -200,12 +209,17 @@ function normalizeAppServerRateLimitResetCredits(
 	const availableCount = asNonnegativeInteger(resetCredits?.availableCount);
 	if (availableCount === undefined) return undefined;
 
-	const credits = Array.isArray(resetCredits?.credits)
-		? resetCredits.credits
-				.map(normalizeAppServerRateLimitResetCredit)
-				.filter((credit): credit is NormalizedRateLimitResetCredit => credit !== undefined)
-		: undefined;
-	return credits ? { availableCount, credits } : { availableCount };
+	const rawCredits = resetCredits?.credits;
+	if (!Array.isArray(rawCredits)) return { availableCount };
+
+	const credits = rawCredits
+		.map(normalizeAppServerRateLimitResetCredit)
+		.filter((credit): credit is NormalizedRateLimitResetCredit => credit !== undefined)
+		.slice(0, availableCount);
+	if (rawCredits.length > 0 && credits.length === 0 && availableCount > 0) {
+		return { availableCount };
+	}
+	return { availableCount, credits };
 }
 
 function normalizeAppServerRateLimitResetCredit(
@@ -214,15 +228,21 @@ function normalizeAppServerRateLimitResetCredit(
 	const credit = asObject(value) as AppServerRateLimitResetCredit | undefined;
 	const id = asString(credit?.id);
 	if (!id) return undefined;
-	return {
-		id,
-		resetType: asString(credit?.resetType),
-		status: asString(credit?.status),
-		grantedAt: asNumber(credit?.grantedAt),
-		expiresAt: asNumber(credit?.expiresAt),
-		title: asString(credit?.title),
-		description: asString(credit?.description),
-	};
+
+	const normalized: NormalizedRateLimitResetCredit = { id };
+	const resetType = asString(credit?.resetType);
+	const status = asString(credit?.status);
+	const grantedAt = asNumber(credit?.grantedAt);
+	const expiresAt = asNumber(credit?.expiresAt);
+	const title = asString(credit?.title);
+	const description = asString(credit?.description);
+	if (resetType !== undefined) normalized.resetType = resetType;
+	if (status !== undefined) normalized.status = status;
+	if (grantedAt !== undefined) normalized.grantedAt = grantedAt;
+	if (expiresAt !== undefined) normalized.expiresAt = expiresAt;
+	if (title !== undefined) normalized.title = title;
+	if (description !== undefined) normalized.description = description;
+	return normalized;
 }
 
 function mergeSnapshot(

--- a/extensions/pi-codex-usage/src/types.ts
+++ b/extensions/pi-codex-usage/src/types.ts
@@ -31,6 +31,22 @@ export type CodexUsageReport = {
 	capturedAt: number;
 	planType?: string;
 	snapshots: NormalizedRateLimitSnapshot[];
+	resetCredits?: NormalizedRateLimitResetCredits;
+};
+
+export type NormalizedRateLimitResetCredits = {
+	availableCount: number;
+	credits?: NormalizedRateLimitResetCredit[];
+};
+
+export type NormalizedRateLimitResetCredit = {
+	id: string;
+	resetType?: string;
+	status?: string;
+	grantedAt?: number;
+	expiresAt?: number;
+	title?: string;
+	description?: string;
 };
 
 export type NormalizedRateLimitSnapshot = {
@@ -58,6 +74,11 @@ export type RateLimitStatusPayload = {
 	rate_limit?: unknown;
 	additional_rate_limits?: unknown;
 	credits?: unknown;
+	rate_limit_reset_credits?: unknown;
+};
+
+export type BackendRateLimitResetCredits = {
+	available_count?: unknown;
 };
 
 export type BackendRateLimitDetails = {
@@ -86,6 +107,22 @@ export type BackendCreditsSnapshot = {
 export type AppServerRateLimitResponse = {
 	rateLimits?: unknown;
 	rateLimitsByLimitId?: unknown;
+	rateLimitResetCredits?: unknown;
+};
+
+export type AppServerRateLimitResetCredits = {
+	availableCount?: unknown;
+	credits?: unknown;
+};
+
+export type AppServerRateLimitResetCredit = {
+	id?: unknown;
+	resetType?: unknown;
+	status?: unknown;
+	grantedAt?: unknown;
+	expiresAt?: unknown;
+	title?: unknown;
+	description?: unknown;
 };
 
 export type AppServerRateLimitSnapshot = {

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -67,6 +67,7 @@ test("normalizeBackendPayload keeps primary and additional rate limits", () => {
 				primary_window: { used_percent: 25, limit_window_seconds: 18000, reset_at: 1 },
 			},
 			credits: { has_credits: true, unlimited: false, balance: "12" },
+			rate_limit_reset_credits: { available_count: 3 },
 			additional_rate_limits: [
 				{
 					limit_name: "GPT-5.3 Codex Spark",
@@ -84,6 +85,22 @@ test("normalizeBackendPayload keeps primary and additional rate limits", () => {
 	assert.equal(report.snapshots.length, 2);
 	assert.equal(report.snapshots[0]?.primary?.windowMinutes, 300);
 	assert.equal(report.snapshots[1]?.limitId, "gpt-5.3-codex-spark");
+	assert.deepEqual(report.resetCredits, { availableCount: 3 });
+});
+
+test("normalizeBackendPayload accepts a reset-credit-only usage response", () => {
+	const report = normalizeBackendPayload(
+		{
+			plan_type: "plus",
+			rate_limit_reset_credits: { available_count: "2" },
+		},
+		1500,
+		"pi-auth",
+	);
+
+	assert.deepEqual(report.snapshots, []);
+	assert.deepEqual(report.resetCredits, { availableCount: 2 });
+	assert.match(formatCodexUsageReport(report), /Usage limit resets:\s+2 available/);
 });
 
 test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => {
@@ -93,6 +110,20 @@ test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => 
 			rateLimitsByLimitId: {
 				codex: { limitId: "codex", secondary: { usedPercent: 20, windowDurationMins: 10080 } },
 			},
+			rateLimitResetCredits: {
+				availableCount: 2,
+				credits: [
+					{
+						id: "reset-1",
+						resetType: "codexRateLimits",
+						status: "available",
+						grantedAt: 1_781_654_400,
+						expiresAt: 1_784_246_400,
+						title: "Full reset (Weekly + 5 hr)",
+						description: "Ready to redeem",
+					},
+				],
+			},
 		},
 		2000,
 	);
@@ -101,6 +132,20 @@ test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => 
 	assert.equal(report.snapshots.length, 1);
 	assert.equal(report.snapshots[0]?.primary?.usedPercent, 40);
 	assert.equal(report.snapshots[0]?.secondary?.windowMinutes, 10080);
+	assert.deepEqual(report.resetCredits, {
+		availableCount: 2,
+		credits: [
+			{
+				id: "reset-1",
+				resetType: "codexRateLimits",
+				status: "available",
+				grantedAt: 1_781_654_400,
+				expiresAt: 1_784_246_400,
+				title: "Full reset (Weekly + 5 hr)",
+				description: "Ready to redeem",
+			},
+		],
+	});
 });
 
 test("scheduled statusline refresh ignores stale extension contexts", async (t) => {
@@ -344,6 +389,7 @@ test("formatters render report text and model-specific statusline buckets", () =
 	const report: CodexUsageReport = {
 		source: "pi-auth",
 		capturedAt: 0,
+		resetCredits: { availableCount: 2 },
 		snapshots: [
 			{ limitId: "codex", primary: { usedPercent: 60 }, secondary: { usedPercent: 80 } },
 			{ limitId: "gpt-5.3-codex-spark", primary: { usedPercent: 10 } },
@@ -351,6 +397,7 @@ test("formatters render report text and model-specific statusline buckets", () =
 	};
 
 	assert.match(formatCodexUsageReport(report), /5h limit:/);
+	assert.match(formatCodexUsageReport(report), /Usage limit resets:\s+2 available/);
 	assert.equal(
 		formatCodexUsageStatusline(report, {
 			id: "gpt-5.3-codex-spark",

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -103,6 +103,23 @@ test("normalizeBackendPayload accepts a reset-credit-only usage response", () =>
 	assert.match(formatCodexUsageReport(report), /Usage limit resets:\s+2 available/);
 });
 
+test("normalizeBackendPayload skips malformed optional additional rate limits", () => {
+	const report = normalizeBackendPayload(
+		{
+			plan_type: "plus",
+			rate_limit: { primary_window: { used_percent: 25 } },
+			rate_limit_reset_credits: { available_count: 1 },
+			additional_rate_limits: [null, { metered_feature: "broken", rate_limit: "not-an-object" }],
+		},
+		1750,
+		"pi-auth",
+	);
+
+	assert.equal(report.snapshots.length, 1);
+	assert.equal(report.snapshots[0]?.limitId, "codex");
+	assert.deepEqual(report.resetCredits, { availableCount: 1 });
+});
+
 test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => {
 	const report = normalizeAppServerResponse(
 		{
@@ -146,6 +163,91 @@ test("normalizeAppServerResponse merges duplicate snapshots by limit id", () => 
 			},
 		],
 	});
+});
+
+test("normalizeAppServerResponse skips malformed optional buckets", () => {
+	const malformedEntry = normalizeAppServerResponse(
+		{
+			rateLimits: { limitId: "codex", primary: { usedPercent: 40 } },
+			rateLimitsByLimitId: {
+				broken: "not-an-object",
+			},
+			rateLimitResetCredits: { availableCount: 1 },
+		},
+		2250,
+	);
+	const arrayInsteadOfMap = normalizeAppServerResponse(
+		{
+			rateLimits: { limitId: "codex", primary: { usedPercent: 40 } },
+			rateLimitsByLimitId: [{ primary: { usedPercent: 10 } }],
+		},
+		2300,
+	);
+
+	assert.equal(malformedEntry.snapshots.length, 1);
+	assert.equal(malformedEntry.snapshots[0]?.limitId, "codex");
+	assert.deepEqual(malformedEntry.resetCredits, { availableCount: 1 });
+	assert.equal(arrayInsteadOfMap.snapshots.length, 1);
+});
+
+test("normalizeAppServerResponse distinguishes empty from malformed reset-credit details", () => {
+	const empty = normalizeAppServerResponse(
+		{
+			rateLimits: { limitId: "codex", primary: { usedPercent: 40 } },
+			rateLimitResetCredits: { availableCount: 0, credits: [] },
+		},
+		2500,
+	);
+	const malformed = normalizeAppServerResponse(
+		{
+			rateLimits: { limitId: "codex", primary: { usedPercent: 40 } },
+			rateLimitResetCredits: { availableCount: 2, credits: [null, { id: "" }] },
+		},
+		2750,
+	);
+	const capped = normalizeAppServerResponse(
+		{
+			rateLimits: { limitId: "codex", primary: { usedPercent: 40 } },
+			rateLimitResetCredits: {
+				availableCount: 1,
+				credits: [{ id: "reset-1" }, { id: "reset-2" }],
+			},
+		},
+		3000,
+	);
+
+	assert.deepEqual(empty.resetCredits, { availableCount: 0, credits: [] });
+	assert.deepEqual(malformed.resetCredits, { availableCount: 2 });
+	assert.deepEqual(capped.resetCredits, {
+		availableCount: 1,
+		credits: [{ id: "reset-1" }],
+	});
+});
+
+test("normalizers keep required primary snapshots strict", () => {
+	assert.throws(
+		() =>
+			normalizeBackendPayload(
+				{
+					rate_limit: "not-an-object",
+					rate_limit_reset_credits: { available_count: 1 },
+				},
+				3250,
+				"pi-auth",
+			),
+		/rate limit was not an object/,
+	);
+	assert.throws(
+		() =>
+			normalizeAppServerResponse(
+				{
+					rateLimits: "not-an-object",
+					rateLimitResetCredits: { availableCount: 1 },
+				},
+				3500,
+			),
+		/app-server rate-limit snapshot was not an object/,
+	);
 });
 
 test("scheduled statusline refresh ignores stale extension contexts", async (t) => {

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -487,6 +487,23 @@ test("isStaleExtensionContextError recognizes Pi stale-context failures", () => 
 	assert.equal(isStaleExtensionContextError(new Error("network failed")), false);
 });
 
+test("formatters label a primary weekly window from its reported duration", () => {
+	const report: CodexUsageReport = {
+		source: "pi-auth",
+		capturedAt: 0,
+		snapshots: [
+			{
+				limitId: "codex",
+				primary: { usedPercent: 16, windowMinutes: 10_080 },
+			},
+		],
+	};
+
+	assert.match(formatCodexUsageReport(report), /Weekly limit:/);
+	assert.doesNotMatch(formatCodexUsageReport(report), /5h limit:/);
+	assert.equal(formatCodexUsageStatusline(report), "codex 84% wk");
+});
+
 test("formatters render report text and model-specific statusline buckets", () => {
 	const report: CodexUsageReport = {
 		source: "pi-auth",


### PR DESCRIPTION
## Summary

- normalize the new `rate_limit_reset_credits` backend summary and app-server `rateLimitResetCredits` details
- show the authoritative available reset count in `/codex-status` while keeping the compact statusline unchanged
- accept reset-credit-only usage responses and document the current Codex contract
- skip malformed optional usage buckets without weakening required primary snapshot validation
- preserve empty, malformed-only, and capped reset-credit detail semantics

## Verification

- `npm run check --workspace @narumitw/pi-codex-usage`
- focused `pi-codex-usage` test compilation and execution: 17 passed
- `npm run check:boundaries`
- `just pack-codex-usage`
- `git diff --check`
- GitHub CI: Pi 0.79.10 and Pi latest passed

## Known baseline issues

- Repository-wide typecheck/tests currently fail locally in unchanged `pi-goal` and `pi-plan-mode` code because the checked-in Pi dependency types do not include their newer `agent_settled`/`max` usages; the clean GitHub CI matrix passes.