### PR TITLE
fix(langfuse): bound trace sanitizer work

### DIFF
--- a/extensions/pi-langfuse/src/tracing.ts
+++ b/extensions/pi-langfuse/src/tracing.ts
@@ -358,9 +358,9 @@ function sanitize(
 		return consume(value, budget);
 	}
 	if (typeof value === "string") {
-		const redacted = value.replace(BASE64_DATA_URI, BASE64_DATA_URI_OMITTED);
-		const bounded = truncateString(redacted, Math.min(MAX_STRING_LENGTH, budget.remaining));
-		return consume(bounded, budget);
+		const bounded = truncateString(value, Math.min(MAX_STRING_LENGTH, budget.remaining));
+		const redacted = bounded.replace(BASE64_DATA_URI, BASE64_DATA_URI_OMITTED);
+		return consume(redacted, budget);
 	}
 	if (typeof value === "bigint") return consume(value.toString(), budget);
 	if (typeof value === "undefined" || typeof value === "function" || typeof value === "symbol") {
@@ -387,30 +387,44 @@ function sanitize(
 		result = items;
 	} else {
 		const record = value as Record<string, unknown>;
-		let keys: string[];
-		try {
-			keys = Object.keys(record);
-		} catch {
-			active.delete(value);
-			return consume("[unreadable object]", budget);
-		}
 		const output: Record<string, unknown> = {};
 		const objectType = readProperty(record, "type").value;
 		const redactData = objectType === "image" || objectType === "base64";
 		let processed = 0;
-		for (const key of keys.slice(0, MAX_COLLECTION_LENGTH)) {
-			if (budget.remaining <= byteLength(TRUNCATED)) break;
-			budget.remaining -= byteLength(key) + 4;
-			const property = readProperty(record, key);
-			if (redactData && key === "data") {
-				output[key] = consume("[base64 omitted]", budget);
-			} else if (!property.ok) output[key] = consume("[unreadable property]", budget);
-			else output[key] = sanitize(property.value, active, depth + 1, budget);
-			processed += 1;
+		let omitted = false;
+		try {
+			for (const key in record) {
+				if (!Object.hasOwn(record, key)) continue;
+				if (processed >= MAX_COLLECTION_LENGTH || budget.remaining <= byteLength(TRUNCATED)) {
+					omitted = true;
+					break;
+				}
+				const keyBudget = Math.min(MAX_STRING_LENGTH, Math.max(0, budget.remaining - 4));
+				if (key.length > keyBudget) {
+					omitted = true;
+					break;
+				}
+				const keyBytes = byteLength(key);
+				if (keyBytes > keyBudget) {
+					omitted = true;
+					break;
+				}
+				budget.remaining -= keyBytes + 4;
+				const property = readProperty(record, key);
+				if (redactData && key === "data") {
+					output[key] = consume("[base64 omitted]", budget);
+				} else if (!property.ok) output[key] = consume("[unreadable property]", budget);
+				else output[key] = sanitize(property.value, active, depth + 1, budget);
+				processed += 1;
+			}
+		} catch {
+			if (processed === 0) {
+				active.delete(value);
+				return consume("[unreadable object]", budget);
+			}
+			omitted = true;
 		}
-		if (processed < keys.length) {
-			output["$truncated"] = `${keys.length - processed} object entries omitted`;
-		}
+		if (omitted) output["$truncated"] = "additional object entries omitted";
 		result = output;
 	}
 	active.delete(value);
@@ -439,12 +453,15 @@ function consume<T>(value: T, budget: { remaining: number }): T | string {
 }
 
 function truncateString(value: string, maxBytes: number): string {
-	if (byteLength(value) <= maxBytes) return value;
+	const boundedPrefix = value.slice(0, maxBytes);
+	if (boundedPrefix.length === value.length && byteLength(boundedPrefix) <= maxBytes) {
+		return boundedPrefix;
+	}
 	const suffix = "… [truncated]";
 	const target = Math.max(0, maxBytes - byteLength(suffix) - 2);
 	let bytes = 0;
 	let output = "";
-	for (const character of value) {
+	for (const character of boundedPrefix) {
 		const size = byteLength(character);
 		if (bytes + size > target) break;
 		output += character;

--- a/extensions/pi-langfuse/src/tracing.ts
+++ b/extensions/pi-langfuse/src/tracing.ts
@@ -390,15 +390,16 @@ function sanitize(
 		const output: Record<string, unknown> = {};
 		const objectType = readProperty(record, "type").value;
 		const redactData = objectType === "image" || objectType === "base64";
+		let visited = 0;
 		let processed = 0;
 		let omitted = false;
 		try {
 			for (const key in record) {
-				if (!Object.hasOwn(record, key)) continue;
-				if (processed >= MAX_COLLECTION_LENGTH || budget.remaining <= byteLength(TRUNCATED)) {
+				if (visited >= MAX_COLLECTION_LENGTH || budget.remaining <= byteLength(TRUNCATED)) {
 					omitted = true;
 					break;
 				}
+				visited += 1;
 				const keyBudget = Math.min(MAX_STRING_LENGTH, Math.max(0, budget.remaining - 4));
 				if (key.length > keyBudget) {
 					omitted = true;
@@ -410,6 +411,7 @@ function sanitize(
 					break;
 				}
 				budget.remaining -= keyBytes + 4;
+				if (!Object.hasOwn(record, key)) continue;
 				const property = readProperty(record, key);
 				if (redactData && key === "data") {
 					output[key] = consume("[base64 omitted]", budget);

--- a/extensions/pi-langfuse/test/langfuse.test.ts
+++ b/extensions/pi-langfuse/test/langfuse.test.ts
@@ -714,6 +714,30 @@ test("sanitizeTraceValue stops enumerating object properties at the collection c
 	}
 });
 
+test("sanitizeTraceValue bounds inherited enumerable property scans", () => {
+	const prototype = Object.fromEntries(
+		Array.from({ length: 1_000 }, (_, index) => [`inherited-${index}`, `value-${index}`]),
+	);
+	const value = Object.create(prototype) as Record<string, unknown>;
+	const originalHasOwn = Object.hasOwn;
+	let propertyChecks = 0;
+	Object.hasOwn = ((target: object, key: PropertyKey) => {
+		if (target === value) {
+			propertyChecks += 1;
+			assert.ok(propertyChecks <= 200, "sanitizer scanned beyond inherited property limits");
+		}
+		return originalHasOwn(target, key);
+	}) as typeof Object.hasOwn;
+
+	try {
+		assert.deepEqual(sanitizeTraceValue(value), {
+			$truncated: "additional object entries omitted",
+		});
+	} finally {
+		Object.hasOwn = originalHasOwn;
+	}
+});
+
 test("sanitizeTraceValue omits object keys larger than the remaining budget", () => {
 	const oversizedKey = "k".repeat(MAX_CAPTURE_BYTES * 4);
 	const sanitized = sanitizeTraceValue({ [oversizedKey]: "secret" });

--- a/extensions/pi-langfuse/test/langfuse.test.ts
+++ b/extensions/pi-langfuse/test/langfuse.test.ts
@@ -665,6 +665,63 @@ test("sanitizeTraceValue globally bounds adversarial values in UTF-8 bytes", () 
 	);
 });
 
+test("sanitizeTraceValue bounds string work before redaction and UTF-8 sizing", () => {
+	const originalByteLength = Buffer.byteLength;
+	const originalReplace = RegExp.prototype[Symbol.replace];
+	Buffer.byteLength = ((value: unknown, encoding?: BufferEncoding) => {
+		if (typeof value === "string") {
+			assert.ok(
+				value.length <= MAX_CAPTURE_BYTES,
+				"sanitizer scanned the complete oversized string",
+			);
+		}
+		return Reflect.apply(originalByteLength, Buffer, [value, encoding]) as number;
+	}) as typeof Buffer.byteLength;
+	RegExp.prototype[Symbol.replace] = function (this: RegExp, value: string, replacement: unknown) {
+		assert.ok(
+			value.length <= MAX_CAPTURE_BYTES,
+			"sanitizer redacted the complete oversized string",
+		);
+		return Reflect.apply(originalReplace, this, [value, replacement]) as string;
+	} as (typeof RegExp.prototype)[typeof Symbol.replace];
+
+	try {
+		const sanitized = sanitizeTraceValue(
+			`data:text/plain;base64,${"a".repeat(MAX_CAPTURE_BYTES * 4)}`,
+		);
+		assert.match(String(sanitized), /base64 data URI omitted|truncated/i);
+	} finally {
+		Buffer.byteLength = originalByteLength;
+		RegExp.prototype[Symbol.replace] = originalReplace;
+	}
+});
+
+test("sanitizeTraceValue stops enumerating object properties at the collection cap", () => {
+	const value = Object.fromEntries(
+		Array.from({ length: 1_000 }, (_, index) => [`key-${index}`, `value-${index}`]),
+	);
+	const originalKeys = Object.keys;
+	Object.keys = ((target: object) => {
+		assert.notEqual(target, value, "sanitizer materialized every source key");
+		return originalKeys(target);
+	}) as typeof Object.keys;
+
+	try {
+		const sanitized = sanitizeTraceValue(value);
+		assert.match(JSON.stringify(sanitized), /object entries omitted/i);
+	} finally {
+		Object.keys = originalKeys;
+	}
+});
+
+test("sanitizeTraceValue omits object keys larger than the remaining budget", () => {
+	const oversizedKey = "k".repeat(MAX_CAPTURE_BYTES * 4);
+	const sanitized = sanitizeTraceValue({ [oversizedKey]: "secret" });
+
+	assert.deepEqual(sanitized, { $truncated: "additional object entries omitted" });
+	assert.ok(serializedBytes(sanitized) <= MAX_CAPTURE_BYTES);
+});
+
 test("sanitizeTraceValue contains malformed object values", () => {
 	const invalidDate = new Date(Number.NaN);
 	const value = {


### PR DESCRIPTION
## Summary

- truncate oversized strings before data-URI redaction and UTF-8 sizing
- stop object traversal at the collection or byte budget without materializing all keys
- omit property names that exceed the remaining capture budget
- add regressions for all three outstanding review comments from #201

## Verification

- `npx --yes npm@11.16.0 run check` (400 tests passed)