### PR TITLE
fix(pi-subagents): preserve final output after history truncation

### DIFF
--- a/docs/plans/archived/2026-07-14_pi-subagents-final-output-hardening-plan.md
+++ b/docs/plans/archived/2026-07-14_pi-subagents-final-output-hardening-plan.md
@@ -1,0 +1,22 @@
+## Goal
+
+Resolve the PR #204 review findings so subprocess subagents preserve complete terminal text, retain provider errors, and classify failures consistently across single, chain, parallel, and fan-in flows.
+
+## Plan
+
+- [x] Add regression tests for empty provider errors, provider failures with partial output, and multi-block assistant text; the fan-in assertion failed before implementation by reporting the provider error as completed.
+- [x] Centralize subagent failure classification and formatting, preserve provider error details, join all assistant text blocks, and apply the shared behavior to parallel, fan-in, and render output; targeted regression tests passed.
+- [x] Run the repository verification gate and inspect the package contents; `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` passed 403 tests and `npm run pack:subagents -- --json` verified 23 package entries.
+- [x] Review the final diff, commit only intended paths, and push to the PR head branch; PR #204 reports commit `e8a316e`.
+
+## Risks
+
+- Changing failure classification could alter partial-success summaries; preserve the existing policy that parallel mode itself may return partial results while accurately labeling each failed result.
+- Combining text blocks and error context must remain within existing UTF-8 byte limits.
+
+## Completion Checklist
+
+- [x] Empty provider errors retain their original `errorMessage`, proven by the `RATE_LIMIT_DETAIL` regression assertion.
+- [x] Provider failures are labeled failed and expose both error and partial output in fan-in/parallel paths, proven by unit and tool integration tests.
+- [x] Multi-block assistant messages preserve all text within the output byte limit, proven by the `FIRST\nSECOND` regression assertion.
+- [x] Full checks and package dry-run pass, and PR #204 contains pushed fix commit `e8a316e`.

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -6,17 +6,19 @@ import {
 	type AgentScope,
 	type SubagentThinkingLevel,
 } from "./agents.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import type { SubagentParams } from "./params.js";
 import {
 	buildFanInContext,
+	formatResultFailure,
 	getResultFinalOutput,
+	isResultError,
 	mapWithConcurrencyLimit,
-	runSingleAgent,
 	type OnUpdateCallback,
+	runSingleAgent,
 	type SingleResult,
 	type SubagentDetails,
 } from "./runner.js";
-import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
-import type { SubagentParams } from "./params.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
 
 const MAX_PARALLEL_TASKS = 8;
@@ -41,13 +43,6 @@ export function assertSubagentDepthAllowed(): void {
 	if (depth >= maxDepth) {
 		throw new Error(`Subagent recursion depth limit reached (${maxDepth})`);
 	}
-}
-
-export function formatResultFailure(result: SingleResult): string {
-	const error = result.errorMessage || result.stderr.trim();
-	const output = getResultFinalOutput(result);
-	const combined = error && output ? `${error}\n\nPartial output:\n${output}` : error || output || "(no output)";
-	return truncateUtf8(combined, DEFAULT_MAX_CONTEXT_BYTES).text;
 }
 
 interface StatusContext {
@@ -232,8 +227,7 @@ export async function executeSubagent(
 						);
 						results.push(result);
 
-						const isError =
-							result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
+						const isError = isResultError(result);
 						if (isError) {
 							const errorMsg = formatResultFailure(result);
 							return {
@@ -379,14 +373,16 @@ export async function executeSubagent(
 						);
 					}
 
-					const successCount = results.filter((r) => r.exitCode === 0).length;
-					const summaries = results.map((r) => {
-						const output = getResultFinalOutput(r);
-						const error = r.errorMessage || r.stderr.trim();
-						const summaryText = output || error;
-						const preview = summaryText.slice(0, 160) + (summaryText.length > 160 ? "..." : "");
-						return `[${r.agent}] ${r.exitCode === 0 ? "completed" : "failed"}: ${preview || "(no output)"}`;
+					const successCount = results.filter((result) => !isResultError(result)).length;
+					const summaries = results.map((result) => {
+						const failed = isResultError(result);
+						const output = getResultFinalOutput(result);
+						const error = result.errorMessage || result.stderr.trim();
+						const summaryText = failed ? formatResultFailure(result) : output || error;
+						const preview = truncateUtf8(summaryText, 160).text;
+						return `[${result.agent}] ${failed ? "failed" : "completed"}: ${preview || "(no output)"}`;
 					});
+					const aggregatorFailed = aggregatorResult ? isResultError(aggregatorResult) : false;
 					const aggregatorOutput = aggregatorResult ? getResultFinalOutput(aggregatorResult) : "";
 					const aggregatorError = aggregatorResult?.errorMessage || aggregatorResult?.stderr.trim() || "";
 					return {
@@ -394,23 +390,19 @@ export async function executeSubagent(
 							{
 								type: "text",
 								text: aggregatorResult
-									? aggregatorOutput || aggregatorError || `(aggregator ${aggregatorResult.agent} produced no output)`
+									? aggregatorFailed
+										? formatResultFailure(aggregatorResult)
+										: aggregatorOutput ||
+											aggregatorError ||
+											`(aggregator ${aggregatorResult.agent} produced no output)`
 									: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join("\n\n")}`,
 							},
 						],
 						details: {
 							...makeDetails("parallel")(results, aggregatorResult),
-							isError: aggregatorResult
-								? aggregatorResult.exitCode !== 0 ||
-									aggregatorResult.stopReason === "error" ||
-									aggregatorResult.stopReason === "aborted"
-								: false,
+							isError: aggregatorFailed,
 						},
-						isError: aggregatorResult
-							? aggregatorResult.exitCode !== 0 ||
-								aggregatorResult.stopReason === "error" ||
-								aggregatorResult.stopReason === "aborted"
-							: undefined,
+						isError: aggregatorResult ? aggregatorFailed : undefined,
 					};
 				} finally {
 					status.clear();
@@ -434,7 +426,7 @@ export async function executeSubagent(
 						onUpdate,
 						makeDetails("single"),
 					);
-					const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
+					const isError = isResultError(result);
 					if (isError) {
 						const errorMsg = formatResultFailure(result);
 						return {

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -43,6 +43,13 @@ export function assertSubagentDepthAllowed(): void {
 	}
 }
 
+export function formatResultFailure(result: SingleResult): string {
+	const error = result.errorMessage || result.stderr.trim();
+	const output = getResultFinalOutput(result);
+	const combined = error && output ? `${error}\n\nPartial output:\n${output}` : error || output || "(no output)";
+	return truncateUtf8(combined, DEFAULT_MAX_CONTEXT_BYTES).text;
+}
+
 interface StatusContext {
 	ui: { setStatus: (key: string, value: string | undefined) => void };
 }
@@ -228,7 +235,7 @@ export async function executeSubagent(
 						const isError =
 							result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
 						if (isError) {
-							const errorMsg = result.errorMessage || result.stderr || getResultFinalOutput(result) || "(no output)";
+							const errorMsg = formatResultFailure(result);
 							return {
 								content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
 								details: { ...makeDetails("chain")(results), isError: true },
@@ -429,7 +436,7 @@ export async function executeSubagent(
 					);
 					const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
 					if (isError) {
-						const errorMsg = result.errorMessage || result.stderr || getResultFinalOutput(result) || "(no output)";
+						const errorMsg = formatResultFailure(result);
 						return {
 							content: [{ type: "text", text: `Agent ${result.stopReason || "failed"}: ${errorMsg}` }],
 							details: { ...makeDetails("single")([result]), isError: true },

--- a/extensions/pi-subagents/src/render.ts
+++ b/extensions/pi-subagents/src/render.ts
@@ -12,6 +12,7 @@ import type { AgentScope, SubagentThinkingLevel } from "./agents.js";
 import type { SubagentParams } from "./params.js";
 import {
 	getResultFinalOutput,
+	isResultError,
 	type SingleResult,
 	type SubagentDetails,
 } from "./runner.js";
@@ -221,7 +222,7 @@ export function renderSubagentResult(
 
 			if (details.mode === "single" && details.results.length === 1) {
 				const r = details.results[0];
-				const isError = r.exitCode !== 0 || r.stopReason === "error" || r.stopReason === "aborted";
+				const isError = isResultError(r);
 				const icon = isError ? theme.fg("error", "✗") : theme.fg("success", "✓");
 				const displayItems = getDisplayItems(r.messages);
 				const finalOutput = getResultFinalOutput(r);
@@ -291,7 +292,7 @@ export function renderSubagentResult(
 			};
 
 			if (details.mode === "chain") {
-				const successCount = details.results.filter((r) => r.exitCode === 0).length;
+				const successCount = details.results.filter((result) => !isResultError(result)).length;
 				const icon = successCount === details.results.length ? theme.fg("success", "✓") : theme.fg("error", "✗");
 
 				if (expanded) {
@@ -308,7 +309,7 @@ export function renderSubagentResult(
 					);
 
 					for (const r of details.results) {
-						const rIcon = r.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+						const rIcon = !isResultError(r) ? theme.fg("success", "✓") : theme.fg("error", "✗");
 						const displayItems = getDisplayItems(r.messages);
 						const finalOutput = getResultFinalOutput(r);
 
@@ -360,7 +361,7 @@ export function renderSubagentResult(
 					theme.fg("toolTitle", theme.bold("chain ")) +
 					theme.fg("accent", `${successCount}/${details.results.length} steps`);
 				for (const r of details.results) {
-					const rIcon = r.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+					const rIcon = !isResultError(r) ? theme.fg("success", "✓") : theme.fg("error", "✗");
 					const displayItems = getDisplayItems(r.messages);
 					text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}`;
 					if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
@@ -373,12 +374,18 @@ export function renderSubagentResult(
 			}
 
 			if (details.mode === "parallel") {
-				const running = details.results.filter((r) => r.exitCode === -1).length;
-				const successCount = details.results.filter((r) => r.exitCode === 0).length;
-				const failCount = details.results.filter((r) => r.exitCode > 0).length;
+				const running = details.results.filter((result) => result.exitCode === -1).length;
+				const successCount = details.results.filter(
+					(result) => result.exitCode !== -1 && !isResultError(result),
+				).length;
+				const failCount = details.results.filter(
+					(result) => result.exitCode !== -1 && isResultError(result),
+				).length;
 				const aggregator = details.aggregator;
 				const aggregatorRunning = aggregator?.exitCode === -1;
-				const aggregatorFailed = aggregator ? aggregator.exitCode > 0 || aggregator.stopReason === "error" : false;
+				const aggregatorFailed = aggregator
+					? aggregator.exitCode !== -1 && isResultError(aggregator)
+					: false;
 				const isRunning = running > 0 || aggregatorRunning;
 				const icon = isRunning
 					? theme.fg("warning", "⏳")
@@ -404,7 +411,7 @@ export function renderSubagentResult(
 					);
 
 					for (const r of details.results) {
-						const rIcon = r.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+						const rIcon = !isResultError(r) ? theme.fg("success", "✓") : theme.fg("error", "✗");
 						const displayItems = getDisplayItems(r.messages);
 						const finalOutput = getResultFinalOutput(r);
 
@@ -438,7 +445,9 @@ export function renderSubagentResult(
 					}
 
 					if (aggregator) {
-						const rIcon = aggregator.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+						const rIcon = !isResultError(aggregator)
+							? theme.fg("success", "✓")
+							: theme.fg("error", "✗");
 						const displayItems = getDisplayItems(aggregator.messages);
 						const finalOutput = getResultFinalOutput(aggregator);
 
@@ -485,7 +494,7 @@ export function renderSubagentResult(
 					const rIcon =
 						r.exitCode === -1
 							? theme.fg("warning", "⏳")
-							: r.exitCode === 0
+							: !isResultError(r)
 								? theme.fg("success", "✓")
 								: theme.fg("error", "✗");
 					const displayItems = getDisplayItems(r.messages);
@@ -498,7 +507,7 @@ export function renderSubagentResult(
 					const rIcon =
 						aggregator.exitCode === -1
 							? theme.fg("warning", "⏳")
-							: aggregator.exitCode === 0
+							: !isResultError(aggregator)
 								? theme.fg("success", "✓")
 								: theme.fg("error", "✗");
 					const displayItems = getDisplayItems(aggregator.messages);

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -72,9 +72,11 @@ function getFinalOutput(messages: Message[]): string {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i];
 		if (msg.role === "assistant") {
-			for (const part of msg.content) {
-				if (part.type === "text") return part.text;
-			}
+			const text = msg.content
+				.filter((part) => part.type === "text")
+				.map((part) => part.text)
+				.join("\n");
+			if (text) return text;
 		}
 	}
 	return "";
@@ -82,6 +84,22 @@ function getFinalOutput(messages: Message[]): string {
 
 export function getResultFinalOutput(result: SingleResult): string {
 	return result.finalOutput ?? getFinalOutput(result.messages);
+}
+
+export function isResultError(result: SingleResult): boolean {
+	return (
+		(result.exitCode !== 0 && result.exitCode !== -1) ||
+		result.stopReason === "error" ||
+		result.stopReason === "aborted"
+	);
+}
+
+export function formatResultFailure(result: SingleResult): string {
+	const error = result.errorMessage || result.stderr.trim();
+	const output = getResultFinalOutput(result);
+	const combined =
+		error && output ? `${error}\n\nPartial output:\n${output}` : error || output || "(no output)";
+	return truncateUtf8(combined, DEFAULT_MAX_CONTEXT_BYTES).text;
 }
 
 function boundMessageText(message: Message, maxBytes: number): { message: Message; bytes: number; truncated: boolean } {
@@ -107,13 +125,19 @@ function boundMessageText(message: Message, maxBytes: number): { message: Messag
 export function buildFanInContext(results: SingleResult[], maxBytes = DEFAULT_MAX_CONTEXT_BYTES): string {
 	const text = results
 		.map((result, index) => {
-			const status = result.exitCode === 0 ? "completed" : result.exitCode === -1 ? "running" : "failed";
+			const failed = isResultError(result);
+			const status = result.exitCode === -1 ? "running" : failed ? "failed" : "completed";
 			const output = getResultFinalOutput(result);
 			const error = result.errorMessage || result.stderr.trim();
+			const resultText = failed
+				? `${error ? "Error" : output ? "Partial output" : "Error"}:\n${formatResultFailure(result)}`
+				: output
+					? `Output:\n${output}`
+					: "Output: (no output)";
 			return [
 				`## Result ${index + 1}: ${result.agent} (${status})`,
 				`Task: ${result.task}`,
-				output ? `Output:\n${output}` : error ? `Error:\n${error}` : "Output: (no output)",
+				resultText,
 			].join("\n\n");
 		})
 		.join("\n\n---\n\n");
@@ -491,6 +515,7 @@ export async function runSingleAgent(
 		currentResult.truncated ||= final.truncated;
 		if (
 			currentResult.exitCode === 0 &&
+			currentResult.stopReason !== "error" &&
 			(currentResult.stopReason === "toolUse" || !currentResult.finalOutput.trim())
 		) {
 			currentResult.exitCode = 1;

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -261,6 +261,9 @@ export async function runSingleAgent(
 	let tmpPromptDir: string | null = null;
 	let tmpPromptPath: string | null = null;
 
+	let latestAssistantOutput = "";
+	let terminalAssistantOutput: string | undefined;
+
 	const currentResult: SingleResult = {
 		agent: agentName,
 		agentSource: agent.source,
@@ -274,9 +277,21 @@ export async function runSingleAgent(
 		step,
 		timeoutMs,
 	};
+	const selectedAssistantOutput = () =>
+		terminalAssistantOutput !== undefined
+			? terminalAssistantOutput
+			: latestAssistantOutput || getFinalOutput(currentResult.messages);
+	const setErrorMessage = (message: string) => {
+		const bounded = truncateUtf8(message, DEFAULT_MAX_STDERR_BYTES);
+		currentResult.errorMessage = bounded.text;
+		currentResult.truncated ||= bounded.truncated;
+		return bounded.text;
+	};
 
 	const emitUpdate = () => {
-		currentResult.finalOutput = getFinalOutput(currentResult.messages);
+		const latest = truncateUtf8(selectedAssistantOutput(), DEFAULT_MAX_OUTPUT_BYTES);
+		currentResult.finalOutput = latest.text;
+		currentResult.truncated ||= latest.truncated;
 		if (onUpdate) {
 			onUpdate({
 				content: [{ type: "text", text: currentResult.finalOutput || "(running...)" }],
@@ -293,8 +308,7 @@ export async function runSingleAgent(
 			currentResult.exitCode = 1;
 			currentResult.stopReason = "error";
 			const reason = error instanceof Error ? error.message : String(error);
-			currentResult.errorMessage = `Invalid subagent cwd: ${effectiveCwd} (${reason})`;
-			currentResult.stderr = currentResult.errorMessage;
+			currentResult.stderr = setErrorMessage(`Invalid subagent cwd: ${effectiveCwd} (${reason})`);
 			return currentResult;
 		}
 
@@ -302,7 +316,7 @@ export async function runSingleAgent(
 			currentResult.exitCode = 130;
 			currentResult.aborted = true;
 			currentResult.stopReason = "aborted";
-			currentResult.errorMessage = "Subagent was aborted before start";
+			setErrorMessage("Subagent was aborted before start");
 			return currentResult;
 		}
 
@@ -356,8 +370,7 @@ export async function runSingleAgent(
 					},
 				});
 			} catch (error) {
-				currentResult.errorMessage = error instanceof Error ? error.message : String(error);
-				currentResult.stderr = currentResult.errorMessage;
+				currentResult.stderr = setErrorMessage(error instanceof Error ? error.message : String(error));
 				finish(1);
 				return;
 			}
@@ -379,6 +392,14 @@ export async function runSingleAgent(
 				const event = raw as { type?: string; message?: Message };
 				if (event.type === "message_end" && event.message) {
 					const msg = event.message;
+					if (msg.role === "assistant") {
+						const output = truncateUtf8(getFinalOutput([msg]), DEFAULT_MAX_OUTPUT_BYTES);
+						currentResult.truncated ||= output.truncated;
+						if (output.text) latestAssistantOutput = output.text;
+						if (msg.stopReason === "stop" || msg.stopReason === "length") {
+							terminalAssistantOutput = output.text;
+						}
+					}
 					addMessage(msg);
 					if (msg.role === "assistant") {
 						currentResult.usage.turns++;
@@ -393,7 +414,7 @@ export async function runSingleAgent(
 						}
 						if (!currentResult.model && msg.model) currentResult.model = msg.model;
 						if (msg.stopReason) currentResult.stopReason = msg.stopReason;
-						if (msg.errorMessage) currentResult.errorMessage = msg.errorMessage;
+						if (msg.errorMessage) setErrorMessage(msg.errorMessage);
 					}
 					emitUpdate();
 				} else if (event.type === "tool_result_end" && event.message) {
@@ -415,7 +436,7 @@ export async function runSingleAgent(
 				timedOut = true;
 				currentResult.timedOut = true;
 				currentResult.stopReason = "timeout";
-				currentResult.errorMessage = `Subagent timed out after ${timeoutMs}ms`;
+				setErrorMessage(`Subagent timed out after ${timeoutMs}ms`);
 				const bounded = appendBounded(
 					currentResult.stderr,
 					`\nSubagent timed out after ${timeoutMs}ms.`,
@@ -439,10 +460,10 @@ export async function runSingleAgent(
 				finish(timedOut ? 124 : wasAborted ? 130 : (code ?? 0));
 			});
 			proc.on("error", (error) => {
-				currentResult.errorMessage = error.message;
+				const message = setErrorMessage(error.message);
 				const bounded = appendBounded(
 					currentResult.stderr,
-					`${currentResult.stderr ? "\n" : ""}${error.message}`,
+					`${currentResult.stderr ? "\n" : ""}${message}`,
 					DEFAULT_MAX_STDERR_BYTES,
 				);
 				currentResult.stderr = bounded.text;
@@ -456,7 +477,7 @@ export async function runSingleAgent(
 					wasAborted = true;
 					currentResult.aborted = true;
 					currentResult.stopReason = "aborted";
-					currentResult.errorMessage = "Subagent was aborted";
+					setErrorMessage("Subagent was aborted");
 					cleanupTermination = terminateProcess(proc);
 				};
 				if (signal.aborted) abortHandler();
@@ -465,9 +486,17 @@ export async function runSingleAgent(
 		});
 
 		currentResult.exitCode = exitCode;
-		const final = truncateUtf8(getFinalOutput(currentResult.messages), DEFAULT_MAX_OUTPUT_BYTES);
+		const final = truncateUtf8(selectedAssistantOutput(), DEFAULT_MAX_OUTPUT_BYTES);
 		currentResult.finalOutput = final.text;
 		currentResult.truncated ||= final.truncated;
+		if (
+			currentResult.exitCode === 0 &&
+			(currentResult.stopReason === "toolUse" || !currentResult.finalOutput.trim())
+		) {
+			currentResult.exitCode = 1;
+			currentResult.stopReason = "error";
+			setErrorMessage("Subagent completed without final text");
+		}
 		currentResult.policy = {
 			inherited: ["environment"],
 			overridden: [

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -14,7 +14,14 @@ import path from "node:path";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { buildContextSnapshot, redactPrivateText } from "../src/context.js";
-import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8, truncateUtf8Tail } from "../src/limits.js";
+import { formatResultFailure } from "../src/execution.js";
+import {
+	DEFAULT_MAX_CONTEXT_BYTES,
+	DEFAULT_MAX_OUTPUT_BYTES,
+	DEFAULT_MAX_STDERR_BYTES,
+	truncateUtf8,
+	truncateUtf8Tail,
+} from "../src/limits.js";
 import { RootOrchestrationState } from "../src/orchestration.js";
 import { AgentPersistence } from "../src/persistence.js";
 import { JsonLineDecoder } from "../src/protocol.js";
@@ -1360,6 +1367,112 @@ test("runSingleAgent preserves partial output on mid-stream abort and handles pr
 	);
 	assert.equal(beforeStart.aborted, true);
 	assert.equal(beforeStart.exitCode, 130);
+});
+
+test("runSingleAgent preserves final text beyond its history budget and rejects empty final output", async () => {
+	const agents = [
+		{
+			name: "test",
+			description: "test",
+			systemPrompt: "",
+			source: "built-in" as const,
+			filePath: "built-in:test",
+		},
+	];
+	const makeDetails = (results: Parameters<Parameters<typeof runSingleAgent>[10]>[0]) => ({
+		mode: "single" as const,
+		agentScope: "user" as const,
+		projectAgentsDir: null,
+		results,
+	});
+	const runScript = (script: string) =>
+		runSingleAgent(
+			process.cwd(),
+			agents,
+			"test",
+			"task",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			1_000,
+			undefined,
+			makeDetails,
+			{ command: process.execPath, argsPrefix: ["-e", script, "--"] },
+		);
+
+	const script = [
+		`const large='x'.repeat(${DEFAULT_MAX_OUTPUT_BYTES});`,
+		"const tool={role:'toolResult',toolCallId:'call-1',toolName:'read',content:[{type:'text',text:large}],isError:false,timestamp:Date.now()};",
+		"process.stdout.write(JSON.stringify({type:'tool_result_end',message:tool})+'\\n');",
+		"process.stdout.write(JSON.stringify({type:'tool_result_end',message:{...tool,toolCallId:'call-2'}})+'\\n');",
+		"const final={role:'assistant',content:[{type:'text',text:'FINAL_SURVIVES'}],stopReason:'stop',timestamp:Date.now()};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message:final})+'\\n');",
+	].join("");
+	const result = await runScript(script);
+	assert.equal(result.exitCode, 0);
+	assert.equal(result.truncated, true);
+	assert.equal(result.finalOutput, "FINAL_SURVIVES");
+	assert.match(buildFanInContext([result]), /FINAL_SURVIVES/);
+
+	const hugeFinal = await runScript(
+		[
+			`const text='界'.repeat(${DEFAULT_MAX_OUTPUT_BYTES});`,
+			"const message={role:'assistant',content:[{type:'text',text}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	assert.ok(Buffer.byteLength(hugeFinal.finalOutput ?? "", "utf8") <= DEFAULT_MAX_OUTPUT_BYTES);
+	assert.match(hugeFinal.finalOutput ?? "", /truncated by pi-subagents/);
+
+	const providerError = await runScript(
+		[
+			`const errorMessage='E'.repeat(${DEFAULT_MAX_OUTPUT_BYTES});`,
+			"const message={role:'assistant',content:[{type:'text',text:'PARTIAL'}],stopReason:'error',errorMessage,timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	assert.ok(
+		Buffer.byteLength(providerError.errorMessage ?? "", "utf8") <= DEFAULT_MAX_STDERR_BYTES,
+	);
+	assert.match(providerError.errorMessage ?? "", /truncated by pi-subagents/);
+	assert.equal(providerError.finalOutput, "PARTIAL");
+
+	const empty = await runScript(
+		[
+			"const commentary={role:'assistant',content:[{type:'text',text:'OLD_COMMENTARY'}],stopReason:'toolUse',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message:commentary})+'\\n');",
+			"const final={role:'assistant',content:[{type:'text',text:''}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message:final})+'\\n');",
+		].join(""),
+	);
+	assert.equal(empty.exitCode, 1);
+	assert.equal(empty.stopReason, "error");
+	assert.equal(empty.finalOutput, "");
+	assert.equal(empty.errorMessage, "Subagent completed without final text");
+
+	const boundedFailure = formatResultFailure({
+		agent: "test",
+		agentSource: "built-in",
+		task: "task",
+		exitCode: 124,
+		messages: [],
+		stderr: "",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			contextTokens: 0,
+			turns: 1,
+		},
+		errorMessage: "E".repeat(20_000),
+		finalOutput: "界".repeat(DEFAULT_MAX_CONTEXT_BYTES),
+	});
+	assert.ok(Buffer.byteLength(boundedFailure, "utf8") <= DEFAULT_MAX_CONTEXT_BYTES);
+	assert.match(boundedFailure, /Partial output/);
+	assert.match(boundedFailure, /truncated by pi-subagents/);
 });
 
 test("terminateProcess escalates when a child ignores SIGTERM", {

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -14,7 +14,6 @@ import path from "node:path";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { buildContextSnapshot, redactPrivateText } from "../src/context.js";
-import { formatResultFailure } from "../src/execution.js";
 import {
 	DEFAULT_MAX_CONTEXT_BYTES,
 	DEFAULT_MAX_OUTPUT_BYTES,
@@ -28,6 +27,8 @@ import { JsonLineDecoder } from "../src/protocol.js";
 import { AgentRegistry, type ManagedAgent } from "../src/registry.js";
 import {
 	buildFanInContext,
+	formatResultFailure,
+	isResultError,
 	mapWithConcurrencyLimit,
 	runSingleAgent,
 	terminateProcess,
@@ -1437,6 +1438,30 @@ test("runSingleAgent preserves final text beyond its history budget and rejects 
 	);
 	assert.match(providerError.errorMessage ?? "", /truncated by pi-subagents/);
 	assert.equal(providerError.finalOutput, "PARTIAL");
+	assert.equal(isResultError(providerError), true);
+	const providerFailureContext = buildFanInContext([providerError]);
+	assert.match(providerFailureContext, /test \(failed\)/);
+	assert.match(providerFailureContext, /Error:\nE/);
+	assert.match(providerFailureContext, /Partial output:\nPARTIAL/);
+
+	const emptyProviderError = await runScript(
+		[
+			"const message={role:'assistant',content:[],stopReason:'error',errorMessage:'RATE_LIMIT_DETAIL',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	assert.equal(emptyProviderError.stopReason, "error");
+	assert.equal(emptyProviderError.errorMessage, "RATE_LIMIT_DETAIL");
+	assert.equal(emptyProviderError.finalOutput, "");
+
+	const multiBlock = await runScript(
+		[
+			"const message={role:'assistant',content:[{type:'text',text:'FIRST'},{type:'text',text:'SECOND'}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	assert.equal(multiBlock.exitCode, 0);
+	assert.equal(multiBlock.finalOutput, "FIRST\nSECOND");
 
 	const empty = await runScript(
 		[

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -38,10 +38,12 @@ type SchemaObject = {
 
 type SubagentTool = {
 	execute: (...args: unknown[]) => Promise<{
+		content?: Array<{ type: string; text: string }>;
 		details?: {
 			results: Array<{ thinkingLevel?: string }>;
 			aggregator?: { thinkingLevel?: string };
 		};
+		isError?: boolean;
 	}>;
 };
 
@@ -403,4 +405,49 @@ test("subagent execute resolves thinking level in single, chain, parallel, and a
 	assert.equal(parallel.details?.results[0]?.thinkingLevel, "minimal");
 	assert.equal(parallel.details?.results[1]?.thinkingLevel, "off");
 	assert.equal(parallel.details?.aggregator?.thinkingLevel, "xhigh");
+});
+
+test("parallel summaries classify provider errors and retain partial output", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools[0] as SubagentTool;
+	const { ctx } = createMockContext();
+	const signal = new AbortController().signal;
+	const dir = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-parallel-error-"));
+	const fakePi = path.join(dir, "fake-pi.mjs");
+	writeFileSync(
+		fakePi,
+		[
+			"const task=process.argv.at(-1) ?? '';",
+			"const failed=task.includes('provider failure');",
+			"const message=failed",
+			"? {role:'assistant',content:[{type:'text',text:'PARTIAL'}],stopReason:'error',errorMessage:'PROVIDER_FAILED',timestamp:Date.now()}",
+			": {role:'assistant',content:[{type:'text',text:'DONE'}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const originalScript = process.argv[1];
+	process.argv[1] = fakePi;
+	try {
+		const result = await tool.execute(
+			"parallel-errors",
+			{
+				tasks: [
+					{ agent: "scout", task: "provider failure" },
+					{ agent: "scout", task: "success" },
+				],
+			},
+			signal,
+			() => undefined,
+			ctx,
+		);
+		const text = result.content?.[0]?.text ?? "";
+		assert.match(text, /Parallel: 1\/2 succeeded/);
+		assert.match(text, /\[scout\] failed: PROVIDER_FAILED/);
+		assert.match(text, /Partial output:\nPARTIAL/);
+		assert.match(text, /\[scout\] completed: DONE/);
+	} finally {
+		process.argv[1] = originalScript;
+		rmSync(dir, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
## Summary

- preserve terminal assistant output independently from the bounded diagnostic message history
- retain the latest non-empty assistant output for interrupted runs while rejecting successful exits without a final answer
- bound assistant output, provider errors, and combined failure context
- add regression coverage for exhausted history budgets, empty terminal output, UTF-8 boundaries, and interruption handling

## Problem

`runSingleAgent` stores tool results and assistant messages in a shared bounded history. Tool-heavy subagents can exhaust the history byte budget before their terminal assistant message is captured. The subprocess then exits successfully, but callers receive empty output or only intermediate runner/tool traces.

## Implementation

Assistant output is captured from the original `message_end` event before the message is copied into bounded history. Terminal `stop`/`length` output is tracked separately from the latest non-empty partial output, so an empty terminal answer cannot fall back to stale commentary. Successful subprocesses that finish without a final answer, or finish at `toolUse`, are reported as incomplete. Existing message-history bounds remain unchanged.

## Verification

- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` — 402/402 tests passed, including all workspace typechecks, Biome, and extension boundary checks
- `npm run pack:subagents -- --json` — package contents verified
- real single and parallel researcher runs returned non-empty terminal output after tool-heavy execution