### PR TITLE
fix(goal): harden published queue runtime

### DIFF
--- a/docs/plans/archived/2026-07-16_pi-goal-late-review-follow-up-plan.md
+++ b/docs/plans/archived/2026-07-16_pi-goal-late-review-follow-up-plan.md
@@ -1,0 +1,25 @@
+## Goal
+
+Resolve all three findings in the late review on merged PR #173, verify the published pi-goal package, and open a focused follow-up PR.
+
+## Context
+
+The review identifies unsupported TypeScript parameter properties, old-goal ownership leaking into turns while priority activation is pending, and restored queued goals being prompted after their token budget is already exhausted.
+
+## Plan
+
+- [x] Add focused regressions for pending-priority turn ownership, exhausted queued-goal restoration, and erasable published TypeScript; the focused queue suite failed both behavior regressions and pi-goal typecheck reported TS1294 for both parameter properties.
+- [x] Apply the smallest fixes in `extensions/pi-goal/src/` and scan adjacent queue/runtime paths for the same patterns; all 35 focused queue tests and pi-goal typecheck pass, including the adjacent stale owned-prompt priority case.
+- [x] Run the repository gate, pi-goal runtime smoke, package dry run, and diff checks; `npm run check` passed 493 tests, runtime smoke passed, `just pack-goal` produced the expected 12-file package, and `git diff --check` passed.
+- [x] Commit and push the focused branch, open a new PR referencing the late review, and update the old review threads with the follow-up evidence; commit `d312f13` is pushed in PR #207 and both late inline threads on PR #173 are replied to and resolved.
+
+## Risks
+
+- Pending-priority suppression must not abort unrelated user work; tests will distinguish prompt ownership from goal ownership.
+- Restored budget-limited goals must remain resumable only after a real budget increase and must not be rewritten by prompt-delivery recovery.
+
+## Completion Checklist
+
+- [x] All three review findings have regression coverage and focused passing checks: 35 queue tests pass and `erasableSyntaxOnly` rejects unsupported published syntax.
+- [x] The repository gate, runtime smoke, package dry run, and diff validation pass with the evidence recorded above.
+- [x] A focused commit is pushed at `d312f13`, PR #207 links the original review, and PR #173 records the follow-up verification evidence.

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -30,7 +30,11 @@ import {
 // User-command mutations are kept separate from Pi event wiring. Every controller
 // receives exactly one per-factory GoalRuntime, preserving session isolation.
 export class GoalCommandController {
-	constructor(private readonly runtime: GoalRuntime) {}
+	private readonly runtime: GoalRuntime;
+
+	constructor(runtime: GoalRuntime) {
+		this.runtime = runtime;
+	}
 
 	async startGoal(objective: string, tokenBudget: number | undefined, ctx: StatusContext) {
 		const validationError = validateObjective(objective);

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -498,7 +498,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		let startRestoredQueuedGoal = false;
 		if (runtime.activeGoal?.status === "queued" && !runtime.pendingQueueAction) {
 			runtime.activeGoal = activateQueuedGoal(runtime.activeGoal, currentTokenTotal(ctx));
-			startRestoredQueuedGoal = true;
+			startRestoredQueuedGoal = runtime.activeGoal.status === "active";
 		}
 		if (runtime.pendingQueueAction) await dispatchPendingQueueActionIfSettled(ctx);
 		if (runtime.activeGoal) {
@@ -690,6 +690,13 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		const goalPromptGoalId = consumePendingGoalPrompt(event.prompt);
 		const continuationGoalId = goalPromptGoalId ? undefined : markContinuationStarted(event.prompt);
 		const ownedPromptGoalId = goalPromptGoalId ?? continuationGoalId;
+		if (runtime.pendingQueueAction?.kind === "prioritize") {
+			// A turn that starts after priority intent is committed belongs to neither
+			// the displaced goal nor the not-yet-activated urgent goal.
+			runtime.agentRunGoalId = null;
+			if (ownedPromptGoalId) abortCurrentTurn(ctx);
+			return;
+		}
 		if (
 			runtime.pendingQueueAction?.kind === "advance" &&
 			runtime.pendingQueueAction.goalId === runtime.activeGoal?.id
@@ -725,6 +732,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		if (runtime.queueFrozen) return;
 		const agentRunGoalId = runtime.agentRunGoalId;
 		runtime.agentRunGoalId = undefined;
+		if (agentRunGoalId === null) return;
 		if (agentRunGoalId && agentRunGoalId !== runtime.activeGoal?.id) return;
 		if (!runtime.activeGoal) return;
 		if (

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -123,7 +123,8 @@ export class GoalRuntime {
 	continuationDelivery?: ContinuationTicket;
 	goalRecovery?: GoalRecovery;
 	budgetWrapUp?: BudgetWrapUp;
-	agentRunGoalId?: string;
+	/** `null` marks a run that must not be charged to the active goal. */
+	agentRunGoalId?: string | null;
 	staleGoalToolCallsBlocked = false;
 	/** Once true, goal tools stay in the active set for this runtime (prompt-cache stable). */
 	goalToolsUnlocked = false;
@@ -132,7 +133,11 @@ export class GoalRuntime {
 	pendingGoalPromptMarkers = new Map<string, string>();
 	cancelledContinuationMarkers = new Set<string>();
 
-	constructor(readonly pi: ExtensionAPI) {}
+	readonly pi: ExtensionAPI;
+
+	constructor(pi: ExtensionAPI) {
+		this.pi = pi;
+	}
 
 	requestContinuation(goal: ActiveGoal) {
 		if (this.hasContinuationWorkForGoal(goal.id)) return false;

--- a/extensions/pi-goal/test/goal-queue.test.ts
+++ b/extensions/pi-goal/test/goal-queue.test.ts
@@ -208,6 +208,59 @@ test("busy prioritize preserves intent and excludes old-run tokens from the urge
 	assert.equal(goals[1]?.tokensUsed, 70);
 });
 
+test("pending prioritize does not inject or account the old goal on unrelated turns", async () => {
+	const branch: Array<Record<string, unknown>> = [assistantUsageEntry(100)];
+	let aborts = 0;
+	const harness = await createHarness({
+		isIdle: () => false,
+		abort: () => {
+			aborts += 1;
+		},
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
+	await harness.command("original goal");
+	await harness.command("prioritize urgent goal");
+	branch.push(assistantUsageEntry(25));
+
+	const beforeStart = harness.mock.events.get("before_agent_start")?.[0];
+	const result = await beforeStart?.(
+		{ prompt: "unrelated user work", systemPrompt: "base" },
+		harness.ctx,
+	);
+	assert.equal(result, undefined);
+	assert.equal(aborts, 0);
+
+	await harness.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		harness.ctx,
+	);
+	assert.equal(stateGoals(harness.mock)[0]?.tokensUsed, 0);
+	assert.equal(lastState(harness.mock)?.pendingAction?.kind, "prioritize");
+});
+
+test("pending prioritize aborts an already-queued displaced-goal prompt", async () => {
+	let aborts = 0;
+	const harness = await createHarness({
+		isIdle: () => false,
+		abort: () => {
+			aborts += 1;
+		},
+	});
+	await harness.command("original goal");
+	const displacedPrompt = harness.mock.sentUserMessages.at(-1)?.text;
+	assert.ok(displacedPrompt);
+	await harness.command("prioritize urgent goal");
+
+	const beforeStart = harness.mock.events.get("before_agent_start")?.[0];
+	const result = await beforeStart?.(
+		{ prompt: displacedPrompt, systemPrompt: "base" },
+		harness.ctx,
+	);
+	assert.equal(result, undefined);
+	assert.equal(aborts, 1);
+	assert.equal(lastState(harness.mock)?.pendingAction?.kind, "prioritize");
+});
+
 test("a completed head is dropped when a busy prioritize intent wins", async () => {
 	let idle = false;
 	const harness = await createHarness({ isIdle: () => idle });
@@ -235,6 +288,23 @@ test("a completed head is dropped when a busy prioritize intent wins", async () 
 			{ text: "later goal", status: "queued" },
 		],
 	);
+});
+
+test("restored exhausted queued heads remain budget-limited without a kickoff prompt", async () => {
+	const exhausted = {
+		...storedGoal("exhausted queued head", "queued"),
+		tokenBudget: 10,
+		tokensUsed: 10,
+	};
+	const state: GoalStateEntryData = { goal: exhausted };
+	const branch = [{ type: "custom", customType: "goal-state", data: state }];
+	const restored = await createHarness({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
+
+	assert.equal(restored.mock.sentUserMessages.length, 0);
+	assert.equal(stateGoals(restored.mock)[0]?.status, "budget_limited");
+	assert.equal(restored.statuses.get("goal"), "budget 10/10");
 });
 
 test("pending priority survives reload after the displaced head completes", async () => {

--- a/extensions/pi-goal/tsconfig.json
+++ b/extensions/pi-goal/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
+		"erasableSyntaxOnly": true,
 		"rootDir": "."
 	},
 	"include": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary

- remove non-erasable TypeScript parameter properties from the published pi-goal sources and enforce `erasableSyntaxOnly`
- suppress displaced-goal prompt injection and token accounting while a busy priority change waits for settlement, while aborting stale owned prompts
- keep restored queued goals budget-limited when their saved usage already exhausts the budget instead of sending a new kickoff prompt

Follow-up to the late review on #173: https://github.com/narumiruna/pi-extensions/pull/173#pullrequestreview-4706609169

## Validation

- `npm run check` — 493 tests passed, plus Biome, boundary checks, and all workspace typechecks
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `just pack-goal` — expected 12-file package
- explicit ignored-source Biome check and `git diff --check`
