### PR TITLE
fix(goal): bind retry ownership to retry starts

### DIFF
--- a/docs/plans/archived/2026-07-16_pi-goal-pr208-postmerge-review-plan.md
+++ b/docs/plans/archived/2026-07-16_pi-goal-pr208-postmerge-review-plan.md
@@ -1,0 +1,25 @@
+## Goal
+
+Resolve the final post-merge review thread on PR #208, verify retry ownership is granted only to actual Pi retry starts, and open a focused follow-up PR.
+
+## Context
+
+A lingering `goalRecovery` currently survives unrelated extension-originated input, allowing that turn to inherit the displaced goal while priority is pending.
+
+## Plan
+
+- [x] Add a focused regression where unrelated extension input arrives before an automatic retry; the focused queue suite showed the extension turn incorrectly received the recovering goal system prompt against merged `main`.
+- [x] Clear stale recovery ownership at the extension-input boundary while preserving automatic retry behavior; all 43 focused queue tests and pi-goal typecheck pass.
+- [x] Run the repository gate, runtime smoke, package dry run, explicit ignored-source Biome check, and diff validation; `npm run check` passed 501 tests, runtime smoke passed, and `just pack-goal` produced the expected 12-file package.
+- [x] Commit and push the branch, open a follow-up PR referencing PR #208, reply to and resolve the late thread, and confirm final CI/thread state; commit `4e3944e` is pushed in PR #209, PR #208 has no unresolved threads, and both CI jobs pass.
+
+## Risks
+
+- Automatic Pi retries must continue to receive the displaced goal prompt and accounting.
+- Extension-owned goal prompts must not lose legitimate state that their command path already established.
+
+## Completion Checklist
+
+- [x] The post-merge PR #208 finding has focused regression coverage; all 43 queue tests and pi-goal typecheck pass.
+- [x] Repository, runtime, packaging, formatting, and diff checks pass with the evidence recorded above.
+- [x] PR #209 is open with both Pi 0.79/latest jobs passing, and PR #208 has no unresolved threads.

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -626,6 +626,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		if (runtime.queueFrozen) return;
 		if (event.source === "extension") {
 			if (consumeCancelledContinuationPrompt(event.text)) return { action: "handled" as const };
+			clearGoalRecovery();
 			return;
 		}
 		if (/^\/goal(?:\s|$)/u.test(event.text.trimStart())) return;

--- a/extensions/pi-goal/test/goal-queue.test.ts
+++ b/extensions/pi-goal/test/goal-queue.test.ts
@@ -436,6 +436,53 @@ test("pending prioritize preserves Pi-owned retry turns", async () => {
 	assert.equal(stateGoals(harness.mock)[0]?.text, "urgent goal");
 });
 
+test("extension input cannot claim a pending Pi retry under priority", async () => {
+	let idle = false;
+	const harness = await createHarness({ isIdle: () => idle });
+	await harness.command("recovering goal");
+	const recovering = stateGoals(harness.mock)[0];
+	const ownedPrompt = harness.mock.sentUserMessages.at(-1)?.text;
+	assert.ok(recovering);
+	assert.ok(ownedPrompt);
+	const beforeStart = harness.mock.events.get("before_agent_start")?.[0];
+	await beforeStart?.({ prompt: ownedPrompt, systemPrompt: "base" }, harness.ctx);
+	await harness.command("prioritize urgent goal");
+	await harness.mock.events.get("agent_end")?.[0]?.(
+		{
+			messages: [
+				{ role: "assistant", stopReason: "error", errorMessage: "rate limit; please retry" },
+			],
+		},
+		harness.ctx,
+	);
+	await harness.mock.events.get("input")?.[0]?.(
+		{ source: "extension", text: "unrelated extension work" },
+		harness.ctx,
+	);
+
+	const unrelatedStart = await beforeStart?.(
+		{ prompt: "unrelated extension work", systemPrompt: "base" },
+		harness.ctx,
+	);
+	assert.equal(unrelatedStart, undefined);
+	const staleCompletion = await completionTool(harness.mock).execute(
+		"extension-stale-completion",
+		{ goal_id: recovering.id, summary: "Recovering goal completed and verified." },
+		new AbortController().signal,
+		() => undefined,
+		harness.ctx,
+	);
+	assert.match(staleCompletion.content?.[0]?.text ?? "", /does not own the active goal/i);
+
+	await harness.mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", stopReason: "stop" }] },
+		harness.ctx,
+	);
+	idle = true;
+	await settled(harness);
+	assert.equal(stateGoals(harness.mock)[0]?.text, "urgent goal");
+});
+
 test("pending prioritize rejects terminal reports from unrelated turns", async () => {
 	const harness = await createHarness({ isIdle: () => false });
 	await harness.command("original goal");


### PR DESCRIPTION
## Summary

- clear stale goal-recovery ownership when unrelated extension-originated input arrives
- preserve the existing automatic Pi retry path when no superseding input is received
- prevent extension turns from inheriting displaced-goal prompts, accounting, or terminal-tool authority while priority is pending

Follow-up to the late post-merge review on #208: https://github.com/narumiruna/pi-extensions/pull/208#discussion_r3590357483

## Validation

- `npm run check` — 501 tests passed, plus Biome, boundary checks, and all workspace typechecks
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `just pack-goal` — expected 12-file package
- 43 focused queue tests
- explicit ignored-source Biome check and `git diff --check`
