### PR TITLE
fix: match Intelephense and phpactor error messages in unsupported method fallback

### DIFF
--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -396,7 +396,7 @@ export class LspClient {
 }
 
 function isUnsupportedMethodError(error: unknown) {
-	return error instanceof Error && /method not found|not supported|unsupported/i.test(error.message);
+	return error instanceof Error && /method not found|unhandled method|not supported|unsupported/i.test(error.message);
 }
 
 function formatErrorMessage(error: unknown) {


### PR DESCRIPTION
 ## Problem

   The `isUnsupportedMethodError` check in `lsp-client.ts` only matches:
   - `method not found`
   - `not supported`
   - `unsupported`

   But LSP servers use different wording:
   - **Intelephense:** `Unhandled method textDocument/diagnostic`

   This causes `lsp_diagnostics` to throw instead of falling back to push diagnostics.

   ## Fix

   Added one pattern to the regex:
   - `unhandled method` — matches Intelephense's error format

   ## Testing

   Verified with Intelephense 1.18.5 :

   ```bash
   # Before: throws error
   $ lsp_diagnostics paths=["app/Models/User.php"]
   intelephense LSP error: Unhandled method textDocument/diagnostic

   # After: falls back to push diagnostics
   $ lsp_diagnostics paths=["app/Models/User.php"]
   intelephense LSP diagnostics: 0 diagnostic(s) across 1 file(s).
 ```

 Closes #211 