### PR TITLE
fix(pi-subagents): preserve live progress rendering

### DIFF
--- a/extensions/pi-subagents/src/render.ts
+++ b/extensions/pi-subagents/src/render.ts
@@ -38,6 +38,8 @@ export function formatUsageStats(
 	},
 	model?: string,
 	thinkingLevel?: SubagentThinkingLevel,
+	actualProvider?: string,
+	actualModel?: string,
 ): string {
 	const parts: string[] = [];
 	if (usage.turns) parts.push(`${usage.turns} turn${usage.turns > 1 ? "s" : ""}`);
@@ -46,12 +48,25 @@ export function formatUsageStats(
 	if (usage.cacheRead) parts.push(`R${formatTokens(usage.cacheRead)}`);
 	if (usage.cacheWrite) parts.push(`W${formatTokens(usage.cacheWrite)}`);
 	if (usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
-	if (usage.contextTokens && usage.contextTokens > 0) {
+	if (usage.contextTokens && usage.contextTokens > 0)
 		parts.push(`ctx:${formatTokens(usage.contextTokens)}`);
-	}
-	if (model) parts.push(model);
-	if (thinkingLevel) parts.push(`thinking:${thinkingLevel}`);
+	const actual =
+		actualProvider && actualModel
+			? `${actualProvider}/${actualModel}`
+			: (actualModel ?? actualProvider);
+	if (actual ?? model) parts.push(actual ?? model ?? "");
+	if (thinkingLevel) parts.push(`requested-thinking:${thinkingLevel}`);
 	return parts.join(" ");
+}
+
+function formatResultUsageStats(result: SingleResult): string {
+	return formatUsageStats(
+		result.usage,
+		result.model,
+		result.thinkingLevel,
+		result.actualProvider,
+		result.actualModel,
+	);
 }
 
 function formatToolCall(
@@ -103,7 +118,11 @@ function formatToolCall(
 		case "find": {
 			const pattern = (args.pattern || "*") as string;
 			const rawPath = (args.path || ".") as string;
-			return themeFg("muted", "find ") + themeFg("accent", pattern) + themeFg("dim", ` in ${shortenPath(rawPath)}`);
+			return (
+				themeFg("muted", "find ") +
+				themeFg("accent", pattern) +
+				themeFg("dim", ` in ${shortenPath(rawPath)}`)
+			);
 		}
 		case "grep": {
 			const pattern = (args.pattern || "") as string;
@@ -131,400 +150,472 @@ function getDisplayItems(messages: Message[]): DisplayItem[] {
 	for (const msg of messages) {
 		if (msg.role === "assistant") {
 			for (const part of msg.content) {
-				if (part.type === "text") items.push({ type: "text", text: part.text });
-				else if (part.type === "toolCall") items.push({ type: "toolCall", name: part.name, args: part.arguments });
+				if (part.type === "text" && part.text.trim()) items.push({ type: "text", text: part.text });
+				else if (part.type === "toolCall")
+					items.push({ type: "toolCall", name: part.name, args: part.arguments });
 			}
 		}
 	}
 	return items;
 }
+function getCollapsedDisplayItems(result: SingleResult): { items: DisplayItem[]; total: number } {
+	if (result.recentActivity && result.recentActivity.length > 0) {
+		return {
+			items: result.recentActivity,
+			total: Math.max(result.recentActivity.length, result.recentActivityTotal ?? 0),
+		};
+	}
+	const items = getDisplayItems(result.messages);
+	return { items, total: items.length };
+}
 
 export function renderSubagentCall(args: SubagentParams, theme: Theme) {
-			const scope: AgentScope = args.agentScope ?? "user";
-			if (args.chain && args.chain.length > 0) {
-				let text =
-					theme.fg("toolTitle", theme.bold("subagent ")) +
-					theme.fg("accent", `chain (${args.chain.length} steps)`) +
-					theme.fg("muted", ` [${scope}]`);
-				for (let i = 0; i < Math.min(args.chain.length, 3); i++) {
-					const step = args.chain[i];
-					// Clean up {previous} placeholder for display
-					const cleanTask = step.task.replace(/\{previous\}/g, "").trim();
-					const preview = cleanTask.length > 40 ? `${cleanTask.slice(0, 40)}...` : cleanTask;
-					text +=
-						"\n  " +
-						theme.fg("muted", `${i + 1}.`) +
-						" " +
-						theme.fg("accent", step.agent) +
-						theme.fg("dim", ` ${preview}`);
-				}
-				if (args.chain.length > 3) text += `\n  ${theme.fg("muted", `... +${args.chain.length - 3} more`)}`;
-				return new Text(text, 0, 0);
-			}
-			if (args.tasks && args.tasks.length > 0) {
-				let text =
-					theme.fg("toolTitle", theme.bold("subagent ")) +
-					theme.fg("accent", `parallel (${args.tasks.length} tasks)`) +
-					theme.fg("muted", ` [${scope}]`);
-				for (const t of args.tasks.slice(0, 3)) {
-					const preview = t.task.length > 40 ? `${t.task.slice(0, 40)}...` : t.task;
-					text += `\n  ${theme.fg("accent", t.agent)}${theme.fg("dim", ` ${preview}`)}`;
-				}
-				if (args.tasks.length > 3) text += `\n  ${theme.fg("muted", `... +${args.tasks.length - 3} more`)}`;
-				if (args.aggregator) {
-					const preview =
-						args.aggregator.task.length > 40 ? `${args.aggregator.task.slice(0, 40)}...` : args.aggregator.task;
-					text += `\n  ${theme.fg("muted", "fan-in → ")}${theme.fg("accent", args.aggregator.agent)}${theme.fg(
-						"dim",
-						` ${preview}`,
-					)}`;
-				}
-				return new Text(text, 0, 0);
-			}
-			const agentName = args.agent || "...";
-			const preview = args.task ? (args.task.length > 60 ? `${args.task.slice(0, 60)}...` : args.task) : "...";
-			let text =
-				theme.fg("toolTitle", theme.bold("subagent ")) +
-				theme.fg("accent", agentName) +
-				theme.fg("muted", ` [${scope}]`);
-			text += `\n  ${theme.fg("dim", preview)}`;
-			return new Text(text, 0, 0);
+	const scope: AgentScope = args.agentScope ?? "user";
+	if (args.chain && args.chain.length > 0) {
+		let text =
+			theme.fg("toolTitle", theme.bold("subagent ")) +
+			theme.fg("accent", `chain (${args.chain.length} steps)`) +
+			theme.fg("muted", ` [${scope}]`);
+		for (let i = 0; i < Math.min(args.chain.length, 3); i++) {
+			const step = args.chain[i];
+			// Clean up {previous} placeholder for display
+			const cleanTask = step.task.replace(/\{previous\}/g, "").trim();
+			const preview = cleanTask.length > 40 ? `${cleanTask.slice(0, 40)}...` : cleanTask;
+			text +=
+				"\n  " +
+				theme.fg("muted", `${i + 1}.`) +
+				" " +
+				theme.fg("accent", step.agent) +
+				theme.fg("dim", ` ${preview}`);
+		}
+		if (args.chain.length > 3)
+			text += `\n  ${theme.fg("muted", `... +${args.chain.length - 3} more`)}`;
+		return new Text(text, 0, 0);
+	}
+	if (args.tasks && args.tasks.length > 0) {
+		let text =
+			theme.fg("toolTitle", theme.bold("subagent ")) +
+			theme.fg("accent", `parallel (${args.tasks.length} tasks)`) +
+			theme.fg("muted", ` [${scope}]`);
+		for (const t of args.tasks.slice(0, 3)) {
+			const preview = t.task.length > 40 ? `${t.task.slice(0, 40)}...` : t.task;
+			text += `\n  ${theme.fg("accent", t.agent)}${theme.fg("dim", ` ${preview}`)}`;
+		}
+		if (args.tasks.length > 3)
+			text += `\n  ${theme.fg("muted", `... +${args.tasks.length - 3} more`)}`;
+		if (args.aggregator) {
+			const preview =
+				args.aggregator.task.length > 40
+					? `${args.aggregator.task.slice(0, 40)}...`
+					: args.aggregator.task;
+			text += `\n  ${theme.fg("muted", "fan-in → ")}${theme.fg("accent", args.aggregator.agent)}${theme.fg(
+				"dim",
+				` ${preview}`,
+			)}`;
+		}
+		return new Text(text, 0, 0);
+	}
+	const agentName = args.agent || "...";
+	const preview = args.task
+		? args.task.length > 60
+			? `${args.task.slice(0, 60)}...`
+			: args.task
+		: "...";
+	let text =
+		theme.fg("toolTitle", theme.bold("subagent ")) +
+		theme.fg("accent", agentName) +
+		theme.fg("muted", ` [${scope}]`);
+	text += `\n  ${theme.fg("dim", preview)}`;
+	return new Text(text, 0, 0);
 }
 
 export function renderSubagentResult(
 	result: AgentToolResult<SubagentDetails>,
-	{ expanded }: ToolRenderResultOptions,
+	{ expanded, isPartial }: ToolRenderResultOptions,
 	theme: Theme,
 ) {
-			const details = result.details as SubagentDetails | undefined;
-			if (!details || details.results.length === 0) {
-				const text = result.content[0];
-				return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
+	const details = result.details as SubagentDetails | undefined;
+	if (!details || details.results.length === 0) {
+		const text = result.content[0];
+		return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
+	}
+
+	const mdTheme = getMarkdownTheme();
+
+	const renderDisplayItems = (items: DisplayItem[], limit?: number, total = items.length) => {
+		const toShow = limit ? items.slice(-limit) : items;
+		const skipped = Math.max(0, total - toShow.length);
+		let text = "";
+		if (skipped > 0) text += theme.fg("muted", `... ${skipped} earlier items\n`);
+		for (const item of toShow) {
+			if (item.type === "text") {
+				const preview = expanded ? item.text : item.text.split("\n").slice(0, 3).join("\n");
+				text += `${theme.fg("toolOutput", preview)}\n`;
+			} else {
+				text += `${theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`;
 			}
+		}
+		return text.trimEnd();
+	};
 
-			const mdTheme = getMarkdownTheme();
+	if (details.mode === "single" && details.results.length === 1) {
+		const r = details.results[0];
+		const isError = isResultError(r);
+		const icon = isError
+			? theme.fg("error", "✗")
+			: isPartial
+				? theme.fg("warning", "⏳")
+				: theme.fg("success", "✓");
+		const displayItems = getDisplayItems(r.messages);
+		const finalOutput = getResultFinalOutput(r);
 
-			const renderDisplayItems = (items: DisplayItem[], limit?: number) => {
-				const toShow = limit ? items.slice(-limit) : items;
-				const skipped = limit && items.length > limit ? items.length - limit : 0;
-				let text = "";
-				if (skipped > 0) text += theme.fg("muted", `... ${skipped} earlier items\n`);
-				for (const item of toShow) {
-					if (item.type === "text") {
-						const preview = expanded ? item.text : item.text.split("\n").slice(0, 3).join("\n");
-						text += `${theme.fg("toolOutput", preview)}\n`;
-					} else {
-						text += `${theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`;
-					}
+		if (expanded) {
+			const container = new Container();
+			let header = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+			if (isError && r.stopReason) header += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
+			container.addChild(new Text(header, 0, 0));
+			if (isError && r.errorMessage)
+				container.addChild(new Text(theme.fg("error", `Error: ${r.errorMessage}`), 0, 0));
+			container.addChild(new Spacer(1));
+			container.addChild(new Text(theme.fg("muted", "─── Task ───"), 0, 0));
+			container.addChild(new Text(theme.fg("dim", r.task), 0, 0));
+			container.addChild(new Spacer(1));
+			container.addChild(new Text(theme.fg("muted", "─── Output ───"), 0, 0));
+			if (displayItems.length === 0 && !finalOutput) {
+				container.addChild(new Text(theme.fg("muted", "(no output)"), 0, 0));
+			} else {
+				for (const item of displayItems) {
+					if (item.type === "toolCall")
+						container.addChild(
+							new Text(
+								theme.fg("muted", "→ ") +
+									formatToolCall(item.name, item.args, theme.fg.bind(theme)),
+								0,
+								0,
+							),
+						);
 				}
-				return text.trimEnd();
-			};
+				if (finalOutput) {
+					container.addChild(new Spacer(1));
+					container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
+				}
+			}
+			const usageStr = formatResultUsageStats(r);
+			if (usageStr) {
+				container.addChild(new Spacer(1));
+				container.addChild(new Text(theme.fg("dim", usageStr), 0, 0));
+			}
+			return container;
+		}
 
-			if (details.mode === "single" && details.results.length === 1) {
-				const r = details.results[0];
-				const isError = isResultError(r);
-				const icon = isError ? theme.fg("error", "✗") : theme.fg("success", "✓");
+		const collapsed = getCollapsedDisplayItems(r);
+		let text = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+		if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
+		if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
+		else if (collapsed.items.length > 0) {
+			text += `\n${renderDisplayItems(collapsed.items, COLLAPSED_ITEM_COUNT, collapsed.total)}`;
+			if (collapsed.total > COLLAPSED_ITEM_COUNT)
+				text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+		} else if (finalOutput.trim()) {
+			text += `\n${theme.fg("toolOutput", finalOutput.trim().split("\n").slice(0, 3).join("\n"))}`;
+		} else {
+			text += `\n${theme.fg("muted", isPartial ? "(running...)" : "(no output)")}`;
+		}
+		const usageStr = formatResultUsageStats(r);
+		if (usageStr) text += `\n${theme.fg("dim", usageStr)}`;
+		return new Text(text, 0, 0);
+	}
+
+	const aggregateUsage = (results: SingleResult[]) => {
+		const total = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+		for (const r of results) {
+			total.input += r.usage.input;
+			total.output += r.usage.output;
+			total.cacheRead += r.usage.cacheRead;
+			total.cacheWrite += r.usage.cacheWrite;
+			total.cost += r.usage.cost;
+			total.turns += r.usage.turns;
+		}
+		return total;
+	};
+
+	if (details.mode === "chain") {
+		const currentResult = details.results.at(-1);
+		const currentIsRunning =
+			isPartial && currentResult !== undefined && !isResultError(currentResult);
+		const successCount = details.results.filter(
+			(result) => !isResultError(result) && (!currentIsRunning || result !== currentResult),
+		).length;
+		const icon = currentIsRunning
+			? theme.fg("warning", "⏳")
+			: successCount === details.results.length
+				? theme.fg("success", "✓")
+				: theme.fg("error", "✗");
+
+		if (expanded) {
+			const container = new Container();
+			container.addChild(
+				new Text(
+					icon +
+						" " +
+						theme.fg("toolTitle", theme.bold("chain ")) +
+						theme.fg("accent", `${successCount}/${details.results.length} steps`),
+					0,
+					0,
+				),
+			);
+
+			for (const r of details.results) {
+				const rIcon = isResultError(r)
+					? theme.fg("error", "✗")
+					: currentIsRunning && r === currentResult
+						? theme.fg("warning", "⏳")
+						: theme.fg("success", "✓");
 				const displayItems = getDisplayItems(r.messages);
 				const finalOutput = getResultFinalOutput(r);
 
-				if (expanded) {
-					const container = new Container();
-					let header = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
-					if (isError && r.stopReason) header += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
-					container.addChild(new Text(header, 0, 0));
-					if (isError && r.errorMessage)
-						container.addChild(new Text(theme.fg("error", `Error: ${r.errorMessage}`), 0, 0));
-					container.addChild(new Spacer(1));
-					container.addChild(new Text(theme.fg("muted", "─── Task ───"), 0, 0));
-					container.addChild(new Text(theme.fg("dim", r.task), 0, 0));
-					container.addChild(new Spacer(1));
-					container.addChild(new Text(theme.fg("muted", "─── Output ───"), 0, 0));
-					if (displayItems.length === 0 && !finalOutput) {
-						container.addChild(new Text(theme.fg("muted", "(no output)"), 0, 0));
-					} else {
-						for (const item of displayItems) {
-							if (item.type === "toolCall")
-								container.addChild(
-									new Text(
-										theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme)),
-										0,
-										0,
-									),
-								);
-						}
-						if (finalOutput) {
-							container.addChild(new Spacer(1));
-							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
-						}
-					}
-					const usageStr = formatUsageStats(r.usage, r.model, r.thinkingLevel);
-					if (usageStr) {
-						container.addChild(new Spacer(1));
-						container.addChild(new Text(theme.fg("dim", usageStr), 0, 0));
-					}
-					return container;
-				}
+				container.addChild(new Spacer(1));
+				container.addChild(
+					new Text(
+						`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon}`,
+						0,
+						0,
+					),
+				);
+				container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
 
-				let text = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
-				if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
-				if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
-				else if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
-				else {
-					text += `\n${renderDisplayItems(displayItems, COLLAPSED_ITEM_COUNT)}`;
-					if (displayItems.length > COLLAPSED_ITEM_COUNT) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
-				}
-				const usageStr = formatUsageStats(r.usage, r.model, r.thinkingLevel);
-				if (usageStr) text += `\n${theme.fg("dim", usageStr)}`;
-				return new Text(text, 0, 0);
-			}
-
-			const aggregateUsage = (results: SingleResult[]) => {
-				const total = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
-				for (const r of results) {
-					total.input += r.usage.input;
-					total.output += r.usage.output;
-					total.cacheRead += r.usage.cacheRead;
-					total.cacheWrite += r.usage.cacheWrite;
-					total.cost += r.usage.cost;
-					total.turns += r.usage.turns;
-				}
-				return total;
-			};
-
-			if (details.mode === "chain") {
-				const successCount = details.results.filter((result) => !isResultError(result)).length;
-				const icon = successCount === details.results.length ? theme.fg("success", "✓") : theme.fg("error", "✗");
-
-				if (expanded) {
-					const container = new Container();
-					container.addChild(
-						new Text(
-							icon +
-								" " +
-								theme.fg("toolTitle", theme.bold("chain ")) +
-								theme.fg("accent", `${successCount}/${details.results.length} steps`),
-							0,
-							0,
-						),
-					);
-
-					for (const r of details.results) {
-						const rIcon = !isResultError(r) ? theme.fg("success", "✓") : theme.fg("error", "✗");
-						const displayItems = getDisplayItems(r.messages);
-						const finalOutput = getResultFinalOutput(r);
-
-						container.addChild(new Spacer(1));
+				// Show tool calls
+				for (const item of displayItems) {
+					if (item.type === "toolCall") {
 						container.addChild(
 							new Text(
-								`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon}`,
+								theme.fg("muted", "→ ") +
+									formatToolCall(item.name, item.args, theme.fg.bind(theme)),
 								0,
 								0,
 							),
 						);
-						container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
-
-						// Show tool calls
-						for (const item of displayItems) {
-							if (item.type === "toolCall") {
-								container.addChild(
-									new Text(
-										theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme)),
-										0,
-										0,
-									),
-								);
-							}
-						}
-
-						// Show final output as markdown
-						if (finalOutput) {
-							container.addChild(new Spacer(1));
-							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
-						}
-
-						const stepUsage = formatUsageStats(r.usage, r.model, r.thinkingLevel);
-						if (stepUsage) container.addChild(new Text(theme.fg("dim", stepUsage), 0, 0));
 					}
-
-					const usageStr = formatUsageStats(aggregateUsage(details.results));
-					if (usageStr) {
-						container.addChild(new Spacer(1));
-						container.addChild(new Text(theme.fg("dim", `Total: ${usageStr}`), 0, 0));
-					}
-					return container;
 				}
 
-				// Collapsed view
-				let text =
-					icon +
-					" " +
-					theme.fg("toolTitle", theme.bold("chain ")) +
-					theme.fg("accent", `${successCount}/${details.results.length} steps`);
-				for (const r of details.results) {
-					const rIcon = !isResultError(r) ? theme.fg("success", "✓") : theme.fg("error", "✗");
-					const displayItems = getDisplayItems(r.messages);
-					text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}`;
-					if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
-					else text += `\n${renderDisplayItems(displayItems, 5)}`;
+				// Show final output as markdown
+				if (finalOutput) {
+					container.addChild(new Spacer(1));
+					container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
 				}
-				const usageStr = formatUsageStats(aggregateUsage(details.results));
-				if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
-				text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
-				return new Text(text, 0, 0);
+
+				const stepUsage = formatResultUsageStats(r);
+				if (stepUsage) container.addChild(new Text(theme.fg("dim", stepUsage), 0, 0));
 			}
 
-			if (details.mode === "parallel") {
-				const running = details.results.filter((result) => result.exitCode === -1).length;
-				const successCount = details.results.filter(
-					(result) => result.exitCode !== -1 && !isResultError(result),
-				).length;
-				const failCount = details.results.filter(
-					(result) => result.exitCode !== -1 && isResultError(result),
-				).length;
-				const aggregator = details.aggregator;
-				const aggregatorRunning = aggregator?.exitCode === -1;
-				const aggregatorFailed = aggregator
-					? aggregator.exitCode !== -1 && isResultError(aggregator)
-					: false;
-				const isRunning = running > 0 || aggregatorRunning;
-				const icon = isRunning
+			const usageStr = formatUsageStats(aggregateUsage(details.results));
+			if (usageStr) {
+				container.addChild(new Spacer(1));
+				container.addChild(new Text(theme.fg("dim", `Total: ${usageStr}`), 0, 0));
+			}
+			return container;
+		}
+
+		// Collapsed view
+		let text =
+			icon +
+			" " +
+			theme.fg("toolTitle", theme.bold("chain ")) +
+			theme.fg("accent", `${successCount}/${details.results.length} steps`);
+		for (const r of details.results) {
+			const rIcon = isResultError(r)
+				? theme.fg("error", "✗")
+				: currentIsRunning && r === currentResult
 					? theme.fg("warning", "⏳")
-					: failCount > 0 || aggregatorFailed
-						? theme.fg("warning", "◐")
+					: theme.fg("success", "✓");
+			const collapsed = getCollapsedDisplayItems(r);
+			const finalOutput = getResultFinalOutput(r).trim();
+			text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}`;
+			if (collapsed.items.length > 0)
+				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
+			else if (currentIsRunning && r === currentResult)
+				text += `\n${theme.fg("muted", "(running...)")}`;
+			else if (finalOutput)
+				text += `\n${theme.fg("toolOutput", finalOutput.split("\n").slice(0, 3).join("\n"))}`;
+			else text += `\n${theme.fg("muted", "(no output)")}`;
+		}
+		const usageStr = formatUsageStats(aggregateUsage(details.results));
+		if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
+		text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+		return new Text(text, 0, 0);
+	}
+
+	if (details.mode === "parallel") {
+		const running = details.results.filter((result) => result.exitCode === -1).length;
+		const successCount = details.results.filter(
+			(result) => result.exitCode !== -1 && !isResultError(result),
+		).length;
+		const failCount = details.results.filter(
+			(result) => result.exitCode !== -1 && isResultError(result),
+		).length;
+		const aggregator = details.aggregator;
+		const aggregatorRunning = aggregator?.exitCode === -1;
+		const aggregatorFailed = aggregator
+			? aggregator.exitCode !== -1 && isResultError(aggregator)
+			: false;
+		const isRunning = isPartial || running > 0 || aggregatorRunning;
+		const icon = isRunning
+			? theme.fg("warning", "⏳")
+			: failCount > 0 || aggregatorFailed
+				? theme.fg("warning", "◐")
+				: theme.fg("success", "✓");
+		const status = isRunning
+			? isPartial && aggregator
+				? `${successCount + failCount}/${details.results.length} done, fan-in running`
+				: running > 0
+					? `${successCount + failCount}/${details.results.length} done, ${running} running`
+					: `${successCount + failCount}/${details.results.length} done, running`
+			: aggregator
+				? `${successCount}/${details.results.length} tasks + fan-in`
+				: `${successCount}/${details.results.length} tasks`;
+
+		if (expanded && !isRunning) {
+			const container = new Container();
+			container.addChild(
+				new Text(
+					`${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`,
+					0,
+					0,
+				),
+			);
+
+			for (const r of details.results) {
+				const rIcon = isResultError(r)
+					? theme.fg("error", "✗")
+					: isPartial
+						? theme.fg("warning", "⏳")
 						: theme.fg("success", "✓");
-				const status = isRunning
-					? aggregatorRunning
-						? `${successCount + failCount}/${details.results.length} done, fan-in running`
-						: `${successCount + failCount}/${details.results.length} done, ${running} running`
-					: aggregator
-						? `${successCount}/${details.results.length} tasks + fan-in`
-						: `${successCount}/${details.results.length} tasks`;
+				const displayItems = getDisplayItems(r.messages);
+				const finalOutput = getResultFinalOutput(r);
 
-				if (expanded && !isRunning) {
-					const container = new Container();
-					container.addChild(
-						new Text(
-							`${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`,
-							0,
-							0,
-						),
-					);
+				container.addChild(new Spacer(1));
+				container.addChild(
+					new Text(`${theme.fg("muted", "─── ") + theme.fg("accent", r.agent)} ${rIcon}`, 0, 0),
+				);
+				container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
 
-					for (const r of details.results) {
-						const rIcon = !isResultError(r) ? theme.fg("success", "✓") : theme.fg("error", "✗");
-						const displayItems = getDisplayItems(r.messages);
-						const finalOutput = getResultFinalOutput(r);
-
-						container.addChild(new Spacer(1));
-						container.addChild(
-							new Text(`${theme.fg("muted", "─── ") + theme.fg("accent", r.agent)} ${rIcon}`, 0, 0),
-						);
-						container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
-
-						// Show tool calls
-						for (const item of displayItems) {
-							if (item.type === "toolCall") {
-								container.addChild(
-									new Text(
-										theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme)),
-										0,
-										0,
-									),
-								);
-							}
-						}
-
-						// Show final output as markdown
-						if (finalOutput) {
-							container.addChild(new Spacer(1));
-							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
-						}
-
-						const taskUsage = formatUsageStats(r.usage, r.model, r.thinkingLevel);
-						if (taskUsage) container.addChild(new Text(theme.fg("dim", taskUsage), 0, 0));
-					}
-
-					if (aggregator) {
-						const rIcon = !isResultError(aggregator)
-							? theme.fg("success", "✓")
-							: theme.fg("error", "✗");
-						const displayItems = getDisplayItems(aggregator.messages);
-						const finalOutput = getResultFinalOutput(aggregator);
-
-						container.addChild(new Spacer(1));
+				// Show tool calls
+				for (const item of displayItems) {
+					if (item.type === "toolCall") {
 						container.addChild(
 							new Text(
-								`${theme.fg("muted", "─── fan-in → ") + theme.fg("accent", aggregator.agent)} ${rIcon}`,
+								theme.fg("muted", "→ ") +
+									formatToolCall(item.name, item.args, theme.fg.bind(theme)),
 								0,
 								0,
 							),
 						);
-						container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", aggregator.task), 0, 0));
-						for (const item of displayItems) {
-							if (item.type === "toolCall") {
-								container.addChild(
-									new Text(
-										theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme)),
-										0,
-										0,
-									),
-								);
-							}
-						}
-						if (finalOutput) {
-							container.addChild(new Spacer(1));
-							container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
-						}
-						const fanInUsage = formatUsageStats(aggregator.usage, aggregator.model, aggregator.thinkingLevel);
-						if (fanInUsage) container.addChild(new Text(theme.fg("dim", fanInUsage), 0, 0));
 					}
-
-					const usageResults = aggregator ? [...details.results, aggregator] : details.results;
-					const usageStr = formatUsageStats(aggregateUsage(usageResults));
-					if (usageStr) {
-						container.addChild(new Spacer(1));
-						container.addChild(new Text(theme.fg("dim", `Total: ${usageStr}`), 0, 0));
-					}
-					return container;
 				}
 
-				// Collapsed view (or still running)
-				let text = `${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`;
-				for (const r of details.results) {
-					const rIcon =
-						r.exitCode === -1
-							? theme.fg("warning", "⏳")
-							: !isResultError(r)
-								? theme.fg("success", "✓")
-								: theme.fg("error", "✗");
-					const displayItems = getDisplayItems(r.messages);
-					text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", r.agent)} ${rIcon}`;
-					if (displayItems.length === 0)
-						text += `\n${theme.fg("muted", r.exitCode === -1 ? "(running...)" : "(no output)")}`;
-					else text += `\n${renderDisplayItems(displayItems, 5)}`;
+				// Show final output as markdown
+				if (finalOutput) {
+					container.addChild(new Spacer(1));
+					container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
 				}
-				if (aggregator) {
-					const rIcon =
-						aggregator.exitCode === -1
-							? theme.fg("warning", "⏳")
-							: !isResultError(aggregator)
-								? theme.fg("success", "✓")
-								: theme.fg("error", "✗");
-					const displayItems = getDisplayItems(aggregator.messages);
-					text += `\n\n${theme.fg("muted", "─── fan-in → ")}${theme.fg("accent", aggregator.agent)} ${rIcon}`;
-					if (displayItems.length === 0)
-						text += `\n${theme.fg("muted", aggregator.exitCode === -1 ? "(running...)" : "(no output)")}`;
-					else text += `\n${renderDisplayItems(displayItems, 5)}`;
-				}
-				if (!isRunning) {
-					const usageResults = aggregator ? [...details.results, aggregator] : details.results;
-					const usageStr = formatUsageStats(aggregateUsage(usageResults));
-					if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
-				}
-				if (!expanded) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
-				return new Text(text, 0, 0);
+
+				const taskUsage = formatResultUsageStats(r);
+				if (taskUsage) container.addChild(new Text(theme.fg("dim", taskUsage), 0, 0));
 			}
 
-			const text = result.content[0];
-			return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
+			if (aggregator) {
+				const rIcon = isResultError(aggregator)
+					? theme.fg("error", "✗")
+					: isPartial
+						? theme.fg("warning", "⏳")
+						: theme.fg("success", "✓");
+				const displayItems = getDisplayItems(aggregator.messages);
+				const finalOutput = getResultFinalOutput(aggregator);
+
+				container.addChild(new Spacer(1));
+				container.addChild(
+					new Text(
+						`${theme.fg("muted", "─── fan-in → ") + theme.fg("accent", aggregator.agent)} ${rIcon}`,
+						0,
+						0,
+					),
+				);
+				container.addChild(
+					new Text(theme.fg("muted", "Task: ") + theme.fg("dim", aggregator.task), 0, 0),
+				);
+				for (const item of displayItems) {
+					if (item.type === "toolCall") {
+						container.addChild(
+							new Text(
+								theme.fg("muted", "→ ") +
+									formatToolCall(item.name, item.args, theme.fg.bind(theme)),
+								0,
+								0,
+							),
+						);
+					}
+				}
+				if (finalOutput) {
+					container.addChild(new Spacer(1));
+					container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
+				}
+				const fanInUsage = formatResultUsageStats(aggregator);
+				if (fanInUsage) container.addChild(new Text(theme.fg("dim", fanInUsage), 0, 0));
+			}
+
+			const usageResults = aggregator ? [...details.results, aggregator] : details.results;
+			const usageStr = formatUsageStats(aggregateUsage(usageResults));
+			if (usageStr) {
+				container.addChild(new Spacer(1));
+				container.addChild(new Text(theme.fg("dim", `Total: ${usageStr}`), 0, 0));
+			}
+			return container;
+		}
+
+		// Collapsed view (or still running)
+		let text = `${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`;
+		for (const r of details.results) {
+			const rIcon = isResultError(r)
+				? theme.fg("error", "✗")
+				: r.exitCode === -1
+					? theme.fg("warning", "⏳")
+					: theme.fg("success", "✓");
+			const collapsed = getCollapsedDisplayItems(r);
+			const finalOutput = getResultFinalOutput(r).trim();
+			text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", r.agent)} ${rIcon}`;
+			if (collapsed.items.length > 0)
+				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
+			else if (r.exitCode === -1) text += `\n${theme.fg("muted", "(running...)")}`;
+			else if (finalOutput)
+				text += `\n${theme.fg("toolOutput", finalOutput.split("\n").slice(0, 3).join("\n"))}`;
+			else text += `\n${theme.fg("muted", "(no output)")}`;
+		}
+		if (aggregator) {
+			const rIcon = isResultError(aggregator)
+				? theme.fg("error", "✗")
+				: isPartial || aggregator.exitCode === -1
+					? theme.fg("warning", "⏳")
+					: theme.fg("success", "✓");
+			const collapsed = getCollapsedDisplayItems(aggregator);
+			const finalOutput = getResultFinalOutput(aggregator).trim();
+			text += `\n\n${theme.fg("muted", "─── fan-in → ")}${theme.fg("accent", aggregator.agent)} ${rIcon}`;
+			if (collapsed.items.length > 0)
+				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
+			else if (isPartial || aggregator.exitCode === -1)
+				text += `\n${theme.fg("muted", "(running...)")}`;
+			else if (finalOutput)
+				text += `\n${theme.fg("toolOutput", finalOutput.split("\n").slice(0, 3).join("\n"))}`;
+			else text += `\n${theme.fg("muted", "(no output)")}`;
+		}
+		if (!isRunning) {
+			const usageResults = aggregator ? [...details.results, aggregator] : details.results;
+			const usageStr = formatUsageStats(aggregateUsage(usageResults));
+			if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
+		}
+		if (!expanded) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+		return new Text(text, 0, 0);
+	}
+
+	const text = result.content[0];
+	return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
 }

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -5,12 +5,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Message } from "@earendil-works/pi-ai";
 import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
-import type {
-	AgentConfig,
-	AgentScope,
-	AgentSource,
-	SubagentThinkingLevel,
-} from "./agents.js";
+import type { AgentConfig, AgentScope, AgentSource, SubagentThinkingLevel } from "./agents.js";
 import {
 	appendBounded,
 	DEFAULT_MAX_CONTEXT_BYTES,
@@ -32,6 +27,13 @@ export interface UsageStats {
 	contextTokens: number;
 	turns: number;
 }
+export type RecentActivityItem =
+	| { type: "text"; text: string }
+	| { type: "toolCall"; name: string; args: Record<string, unknown> };
+
+const MAX_RECENT_ACTIVITY_ITEMS = 10;
+const MAX_RECENT_ACTIVITY_BYTES = 8 * 1024;
+const MAX_RECENT_ACTIVITY_ARGUMENT_BYTES = 1024;
 
 export interface SingleResult {
 	agent: string;
@@ -42,6 +44,10 @@ export interface SingleResult {
 	stderr: string;
 	usage: UsageStats;
 	model?: string;
+	actualProvider?: string;
+	actualModel?: string;
+	recentActivity?: RecentActivityItem[];
+	recentActivityTotal?: number;
 	thinkingLevel?: SubagentThinkingLevel;
 	stopReason?: string;
 	errorMessage?: string;
@@ -102,27 +108,123 @@ export function formatResultFailure(result: SingleResult): string {
 	return truncateUtf8(combined, DEFAULT_MAX_CONTEXT_BYTES).text;
 }
 
-function boundMessageText(message: Message, maxBytes: number): { message: Message; bytes: number; truncated: boolean } {
-	const serializedBytes = Buffer.byteLength(JSON.stringify(message), "utf8");
-	if (serializedBytes <= maxBytes) return { message, bytes: serializedBytes, truncated: false };
-	if (!Array.isArray(message.content)) return { message, bytes: Math.min(serializedBytes, maxBytes), truncated: true };
-	let remaining = maxBytes;
-	const content = message.content
-		.filter((part) => part.type === "text")
-		.map((part) => {
-			const bounded = truncateUtf8(part.text, remaining);
-			remaining = Math.max(0, remaining - Buffer.byteLength(bounded.text, "utf8"));
-			return { ...part, text: bounded.text };
-		});
-	const boundedMessage = { ...message, content } as Message;
-	return {
-		message: boundedMessage,
-		bytes: Math.min(Buffer.byteLength(JSON.stringify(boundedMessage), "utf8"), maxBytes),
-		truncated: true,
+function boundMessageText(
+	message: Message,
+	maxBytes: number,
+): { message?: Message; bytes: number; truncated: boolean } {
+	const originalBytes = Buffer.byteLength(JSON.stringify(message), "utf8");
+	if (Number.isSafeInteger(maxBytes) && maxBytes >= 0 && originalBytes <= maxBytes) {
+		return { message, bytes: originalBytes, truncated: false };
+	}
+	if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) return { bytes: 0, truncated: true };
+
+	const content: Array<
+		| { type: "text"; text: string }
+		| { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+	> = [];
+	const bounded = () => ({ ...message, content }) as Message;
+	const fits = () => Buffer.byteLength(JSON.stringify(bounded()), "utf8") <= maxBytes;
+	const addText = (text: string, prepend = false) => {
+		if (!text.trim()) return;
+		const part = { type: "text" as const, text: "" };
+		if (prepend) content.unshift(part);
+		else content.push(part);
+		if (!fits()) {
+			content.splice(content.indexOf(part), 1);
+			return;
+		}
+		let low = 0;
+		let high = Buffer.byteLength(text, "utf8");
+		while (low < high) {
+			const middle = Math.ceil((low + high) / 2);
+			part.text = truncateUtf8(text, middle).text;
+			if (fits()) low = middle;
+			else high = middle - 1;
+		}
+		part.text = truncateUtf8(text, low).text;
+		if (!part.text.trim()) content.splice(content.indexOf(part), 1);
 	};
+	const addToolCall = (part: Extract<Message["content"][number], { type: "toolCall" }>) => {
+		const toolCall = {
+			type: "toolCall" as const,
+			id: part.id,
+			name: part.name,
+			arguments: part.arguments,
+		};
+		content.unshift(toolCall);
+		if (fits()) return;
+		const arguments_: Record<string, unknown> = {};
+		for (const key of ["command", "path", "file_path", "pattern", "url"]) {
+			const value = part.arguments[key];
+			if (typeof value === "string") arguments_[key] = truncateUtf8(value, 256).text;
+		}
+		toolCall.arguments = arguments_;
+		if (fits()) return;
+		toolCall.arguments = {};
+		if (!fits()) content.shift();
+	};
+
+	if (message.role === "assistant") {
+		for (let index = message.content.length - 1; index >= 0; index--) {
+			const part = message.content[index];
+			if (part.type === "text") addText(part.text, true);
+			else if (part.type === "toolCall") addToolCall(part);
+		}
+	} else {
+		for (const part of message.content) {
+			if (typeof part === "object" && part && part.type === "text") addText(part.text);
+		}
+	}
+
+	if (content.length === 0) return { bytes: 0, truncated: true };
+	const result = bounded();
+	const bytes = Buffer.byteLength(JSON.stringify(result), "utf8");
+	return { message: result, bytes, truncated: true };
+}
+function compactRecentActivityArguments(args: Record<string, unknown>): Record<string, unknown> {
+	if (Buffer.byteLength(JSON.stringify(args), "utf8") <= MAX_RECENT_ACTIVITY_ARGUMENT_BYTES)
+		return args;
+	const compact: Record<string, unknown> = {};
+	for (const key of ["command", "path", "file_path", "pattern", "url", "selector"]) {
+		const value = args[key];
+		if (typeof value === "string") compact[key] = truncateUtf8(value, 256).text;
+		else if (typeof value === "number" || typeof value === "boolean") compact[key] = value;
+	}
+	return compact;
 }
 
-export function buildFanInContext(results: SingleResult[], maxBytes = DEFAULT_MAX_CONTEXT_BYTES): string {
+function appendRecentActivity(result: SingleResult, message: Message): void {
+	if (message.role !== "assistant") return;
+	const append = (item: RecentActivityItem) => {
+		result.recentActivity ??= [];
+		result.recentActivityTotal = (result.recentActivityTotal ?? 0) + 1;
+		result.recentActivity.push(item);
+		if (result.recentActivity.length > MAX_RECENT_ACTIVITY_ITEMS) {
+			result.recentActivity.splice(0, result.recentActivity.length - MAX_RECENT_ACTIVITY_ITEMS);
+		}
+		while (
+			Buffer.byteLength(JSON.stringify(result.recentActivity), "utf8") > MAX_RECENT_ACTIVITY_BYTES
+		) {
+			result.recentActivity.shift();
+		}
+	};
+	for (const part of message.content) {
+		if (part.type === "text" && part.text.trim()) {
+			append({ type: "text", text: truncateUtf8(part.text, 1024).text });
+		} else if (part.type === "toolCall") {
+			append({
+				type: "toolCall",
+				name: part.name,
+				args: compactRecentActivityArguments(part.arguments),
+			});
+		}
+	}
+}
+
+export function buildFanInContext(
+	results: SingleResult[],
+	maxBytes = DEFAULT_MAX_CONTEXT_BYTES,
+): string {
 	const text = results
 		.map((result, index) => {
 			const failed = isResultError(result);
@@ -170,7 +272,10 @@ export async function mapWithConcurrencyLimit<TIn, TOut>(
 	return results;
 }
 
-async function writePromptToTempFile(agentName: string, prompt: string): Promise<{ dir: string; filePath: string }> {
+async function writePromptToTempFile(
+	agentName: string,
+	prompt: string,
+): Promise<{ dir: string; filePath: string }> {
 	const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pi-subagent-"));
 	const safeName = agentName.replace(/[^\w.-]+/g, "_");
 	const filePath = path.join(tmpDir, `prompt-${safeName}.md`);
@@ -231,7 +336,10 @@ function signalProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): 
 	}
 }
 
-export function terminateProcess(proc: ReturnType<typeof spawn>, graceMs = KILL_GRACE_MS): () => void {
+export function terminateProcess(
+	proc: ReturnType<typeof spawn>,
+	graceMs = KILL_GRACE_MS,
+): () => void {
 	let closed = proc.exitCode !== null || proc.signalCode !== null;
 	const onClose = () => {
 		closed = true;
@@ -275,7 +383,15 @@ export async function runSingleAgent(
 			exitCode: 1,
 			messages: [],
 			stderr: `Unknown agent: "${agentName}". Available agents: ${available}.`,
-			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: 0,
+				contextTokens: 0,
+				turns: 0,
+			},
 			thinkingLevel,
 			step,
 			finalOutput: "",
@@ -295,7 +411,15 @@ export async function runSingleAgent(
 		exitCode: 0,
 		messages: [],
 		stderr: "",
-		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			contextTokens: 0,
+			turns: 0,
+		},
 		model: agent.model ?? undefined,
 		thinkingLevel,
 		step,
@@ -394,21 +518,37 @@ export async function runSingleAgent(
 					},
 				});
 			} catch (error) {
-				currentResult.stderr = setErrorMessage(error instanceof Error ? error.message : String(error));
+				currentResult.stderr = setErrorMessage(
+					error instanceof Error ? error.message : String(error),
+				);
 				finish(1);
 				return;
 			}
 
-			let capturedMessageBytes = 0;
 			const addMessage = (msg: Message) => {
-				if (currentResult.messages.length >= DEFAULT_MAX_MESSAGES) {
+				const boundedMessage = boundMessageText(msg, DEFAULT_MAX_OUTPUT_BYTES - 2);
+				currentResult.truncated ||= boundedMessage.truncated;
+				if (!boundedMessage.message) return;
+				while (
+					currentResult.messages.length >= DEFAULT_MAX_MESSAGES ||
+					Buffer.byteLength(
+						JSON.stringify([...currentResult.messages, boundedMessage.message]),
+						"utf8",
+					) > DEFAULT_MAX_OUTPUT_BYTES
+				) {
+					const removed = currentResult.messages.shift();
+					if (!removed) break;
+					currentResult.truncated = true;
+				}
+				if (
+					Buffer.byteLength(
+						JSON.stringify([...currentResult.messages, boundedMessage.message]),
+						"utf8",
+					) > DEFAULT_MAX_OUTPUT_BYTES
+				) {
 					currentResult.truncated = true;
 					return;
 				}
-				const remaining = Math.max(0, DEFAULT_MAX_OUTPUT_BYTES - capturedMessageBytes);
-				const boundedMessage = boundMessageText(msg, remaining);
-				capturedMessageBytes += boundedMessage.bytes;
-				currentResult.truncated ||= boundedMessage.truncated;
 				currentResult.messages.push(boundedMessage.message);
 			};
 			const processEvent = (raw: unknown) => {
@@ -424,6 +564,7 @@ export async function runSingleAgent(
 							terminalAssistantOutput = output.text;
 						}
 					}
+					appendRecentActivity(currentResult, msg);
 					addMessage(msg);
 					if (msg.role === "assistant") {
 						currentResult.usage.turns++;
@@ -436,7 +577,9 @@ export async function runSingleAgent(
 							currentResult.usage.cost += usage.cost?.total || 0;
 							currentResult.usage.contextTokens = usage.totalTokens || 0;
 						}
-						if (!currentResult.model && msg.model) currentResult.model = msg.model;
+						if (msg.provider) currentResult.actualProvider = msg.provider;
+						if (msg.responseModel ?? msg.model)
+							currentResult.actualModel = msg.responseModel ?? msg.model;
 						if (msg.stopReason) currentResult.stopReason = msg.stopReason;
 						if (msg.errorMessage) setErrorMessage(msg.errorMessage);
 					}
@@ -475,7 +618,11 @@ export async function runSingleAgent(
 
 			proc.stdout?.on("data", (data) => decoder.push(data));
 			proc.stderr?.on("data", (data) => {
-				const bounded = appendBounded(currentResult.stderr, data.toString(), DEFAULT_MAX_STDERR_BYTES);
+				const bounded = appendBounded(
+					currentResult.stderr,
+					data.toString(),
+					DEFAULT_MAX_STDERR_BYTES,
+				);
 				currentResult.stderr = bounded.text;
 				currentResult.truncated ||= bounded.truncated;
 			});

--- a/extensions/pi-subagents/test/evolution.test.ts
+++ b/extensions/pi-subagents/test/evolution.test.ts
@@ -25,12 +25,14 @@ import { RootOrchestrationState } from "../src/orchestration.js";
 import { AgentPersistence } from "../src/persistence.js";
 import { JsonLineDecoder } from "../src/protocol.js";
 import { AgentRegistry, type ManagedAgent } from "../src/registry.js";
+import { renderSubagentResult } from "../src/render.js";
 import {
 	buildFanInContext,
 	formatResultFailure,
 	isResultError,
 	mapWithConcurrencyLimit,
 	runSingleAgent,
+	type SubagentDetails,
 	terminateProcess,
 } from "../src/runner.js";
 import { normalizeSubagentSettings } from "../src/settings.js";
@@ -1377,6 +1379,7 @@ test("runSingleAgent preserves final text beyond its history budget and rejects 
 			description: "test",
 			systemPrompt: "",
 			source: "built-in" as const,
+			model: "requested-alias",
 			filePath: "built-in:test",
 		},
 	];
@@ -1498,6 +1501,449 @@ test("runSingleAgent preserves final text beyond its history budget and rejects 
 	assert.ok(Buffer.byteLength(boundedFailure, "utf8") <= DEFAULT_MAX_CONTEXT_BYTES);
 	assert.match(boundedFailure, /Partial output/);
 	assert.match(boundedFailure, /truncated by pi-subagents/);
+
+	const rollingWindow = await runScript(
+		[
+			"for(let i=0;i<201;i++){const arguments_=i===200?{command:'echo call-200 '+ 'x'.repeat(200000)}:{};const toolCall={type:'toolCall',id:'call-'+i,name:'bash',arguments:arguments_};const content=i===200?[{type:'thinking',thinking:'omit'},toolCall]:[toolCall];const message={role:'assistant',content,stopReason:'toolUse'};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');}",
+			"const final={role:'assistant',provider:'actual-provider',responseModel:'actual-model',model:'fallback-alias',content:[{type:'text',text:'FINAL_WINDOW_SURVIVES'}],stopReason:'stop'};process.stdout.write(JSON.stringify({type:'message_end',message:final})+'\\n');",
+		].join(""),
+	);
+	assert.equal(rollingWindow.finalOutput, "FINAL_WINDOW_SURVIVES");
+	assert.equal(rollingWindow.actualProvider, "actual-provider");
+	assert.equal(rollingWindow.actualModel, "actual-model");
+	assert.equal(rollingWindow.model, "requested-alias");
+	assert.equal(rollingWindow.recentActivityTotal, 202);
+	assert.equal(rollingWindow.recentActivity?.length, 10);
+	assert.ok(Buffer.byteLength(JSON.stringify(rollingWindow.recentActivity), "utf8") <= 8 * 1024);
+	assert.ok(
+		rollingWindow.recentActivity?.some(
+			(item) => item.type === "toolCall" && String(item.args.command).startsWith("echo call-200"),
+		),
+	);
+	assert.ok(rollingWindow.messages.length <= 200);
+	assert.ok(
+		Buffer.byteLength(JSON.stringify(rollingWindow.messages), "utf8") <= DEFAULT_MAX_OUTPUT_BYTES,
+	);
+	const calls = rollingWindow.messages.flatMap((message) =>
+		message.role === "assistant" ? message.content.filter((part) => part.type === "toolCall") : [],
+	);
+	assert.equal(
+		calls.some((call) => call.id === "call-0"),
+		false,
+	);
+	assert.ok(calls.some((call) => call.id === "call-200" && call.name === "bash"));
+	const lastCall = calls.find((call) => call.id === "call-200");
+	assert.match(String(lastCall?.arguments.command), /^echo call-200/);
+	assert.ok(
+		rollingWindow.messages.every(
+			(message) =>
+				message.role !== "assistant" || message.content.every((part) => part.type !== "thinking"),
+		),
+	);
+	assert.ok(
+		rollingWindow.messages.every((message) =>
+			message.role !== "assistant" && message.role !== "toolResult"
+				? true
+				: message.content.every((part) => part.type !== "text" || part.text.trim()),
+		),
+	);
+
+	const updateSnapshots: Array<{ details: { results: Array<{ messages: unknown[] }> } }> = [];
+	await runSingleAgent(
+		process.cwd(),
+		agents,
+		"test",
+		"task",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		1_000,
+		(update) => updateSnapshots.push(structuredClone(update) as never),
+		makeDetails,
+		{
+			command: process.execPath,
+			argsPrefix: [
+				"-e",
+				`const tool={role:'toolResult',toolCallId:'oversize-call',toolName:'read',content:[{type:'text',text:'x'.repeat(${DEFAULT_MAX_OUTPUT_BYTES * 2})}],isError:true,timestamp:123};process.stdout.write(JSON.stringify({type:'tool_result_end',message:tool})+'\\n');`,
+				"--",
+			],
+		},
+	);
+	assert.equal(updateSnapshots.length, 1);
+	const compressedToolResult = updateSnapshots[0].details.results[0].messages.find(
+		(
+			message,
+		): message is {
+			role: "toolResult";
+			content: Array<{ type: "text"; text: string }>;
+			toolCallId: string;
+			toolName: string;
+			isError: boolean;
+			timestamp: number;
+		} =>
+			typeof message === "object" &&
+			message !== null &&
+			"role" in message &&
+			message.role === "toolResult",
+	);
+	assert.ok(compressedToolResult);
+	assert.ok(
+		Buffer.byteLength(JSON.stringify(compressedToolResult), "utf8") <= DEFAULT_MAX_OUTPUT_BYTES,
+	);
+	assert.equal(compressedToolResult.toolCallId, "oversize-call");
+	assert.equal(compressedToolResult.toolName, "read");
+	assert.equal(compressedToolResult.isError, true);
+	assert.equal(compressedToolResult.timestamp, 123);
+	assert.ok(compressedToolResult.content[0].text.length > 0);
+
+	const smallMessages = await runScript(
+		[
+			"const tool={role:'toolResult',content:[{type:'text',text:'small tool result'}],toolCallId:'tool-1',toolName:'read',isError:true,timestamp:123};",
+			"process.stdout.write(JSON.stringify({type:'tool_result_end',message:tool})+'\\n');",
+			"const message={role:'assistant',content:[{type:'text',text:'small assistant'}],timestamp:456,provider:'small-provider',responseModel:'small-model',usage:{input:1,output:2,cacheRead:3,cacheWrite:4,totalTokens:5,cost:{total:0.1}},stopReason:'stop'};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	assert.notEqual(smallMessages.truncated, true);
+	const smallToolResult = smallMessages.messages.find((message) => message.role === "toolResult");
+	assert.deepEqual(smallToolResult, {
+		role: "toolResult",
+		content: [{ type: "text", text: "small tool result" }],
+		toolCallId: "tool-1",
+		toolName: "read",
+		isError: true,
+		timestamp: 123,
+	});
+	const smallAssistant = smallMessages.messages.find((message) => message.role === "assistant");
+	assert.equal(smallAssistant?.timestamp, 456);
+	assert.equal(smallAssistant?.provider, "small-provider");
+	assert.equal(smallAssistant?.responseModel, "small-model");
+	assert.deepEqual(smallAssistant?.usage, {
+		input: 1,
+		output: 2,
+		cacheRead: 3,
+		cacheWrite: 4,
+		totalTokens: 5,
+		cost: { total: 0.1 },
+	});
+});
+
+test("large tool results do not erase recent collapsed activity", async () => {
+	const agents = [
+		{
+			name: "test",
+			description: "test",
+			systemPrompt: "",
+			source: "built-in" as const,
+			filePath: "built-in:test",
+		},
+	];
+	const makeDetails = (results: Parameters<Parameters<typeof runSingleAgent>[10]>[0]) => ({
+		mode: "single" as const,
+		agentScope: "user" as const,
+		projectAgentsDir: null,
+		results,
+	});
+	const snapshots: Array<ReturnType<typeof structuredClone>> = [];
+	const script = [
+		"const assistant={role:'assistant',content:[{type:'toolCall',id:'latest',name:'bash',arguments:{command:'echo stays visible'}}],stopReason:'toolUse',timestamp:1};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message:assistant})+'\\n');",
+		`const tool={role:'toolResult',toolCallId:'latest',toolName:'bash',content:[{type:'text',text:'x'.repeat(${DEFAULT_MAX_OUTPUT_BYTES * 2})}],isError:false,timestamp:2};`,
+		"process.stdout.write(JSON.stringify({type:'tool_result_end',message:tool})+'\\n');",
+	].join("");
+	await runSingleAgent(
+		process.cwd(),
+		agents,
+		"test",
+		"task",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		1_000,
+		(update) => snapshots.push(structuredClone(update)),
+		makeDetails,
+		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },
+	);
+	assert.equal(snapshots.length, 2);
+	const afterToolResult = snapshots[1] as never;
+	const details = (snapshots[1] as { details: SubagentDetails }).details;
+	assert.equal(details.results[0].recentActivityTotal, 1);
+	assert.deepEqual(details.results[0].recentActivity, [
+		{ type: "toolCall", name: "bash", args: { command: "echo stays visible" } },
+	]);
+	assert.equal(
+		details.results[0].messages.some(
+			(message) =>
+				message.role === "assistant" && message.content.some((part) => part.type === "toolCall"),
+		),
+		false,
+	);
+	const identityTheme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+	const rendered = renderSubagentResult(
+		afterToolResult,
+		{ expanded: false, isPartial: true } as never,
+		identityTheme as never,
+	)
+		.render(120)
+		.join("\n");
+	assert.match(rendered, /echo stays visible/);
+	assert.doesNotMatch(rendered, /\(running\.\.\.\)/);
+});
+
+test("renderSubagentResult keeps collapsed partial output dense and current", () => {
+	const identityTheme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+	const partial = renderSubagentResult(
+		{
+			content: [],
+			details: {
+				mode: "single",
+				agentScope: "user",
+				projectAgentsDir: null,
+				results: [
+					{
+						agent: "worker",
+						agentSource: "built-in",
+						task: "task",
+						exitCode: 0,
+						messages: [
+							{
+								role: "assistant",
+								content: [
+									...Array.from({ length: 12 }, () => ({ type: "text" as const, text: "" })),
+									{
+										type: "toolCall" as const,
+										id: "latest",
+										name: "bash",
+										arguments: { command: "echo newest" },
+									},
+								],
+							},
+						],
+						stderr: "",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							cost: 0,
+							contextTokens: 0,
+							turns: 1,
+						},
+						actualProvider: "actual-provider",
+						actualModel: "actual-model",
+						thinkingLevel: "high",
+					},
+				],
+			},
+		} as never,
+		{ expanded: false, isPartial: true } as never,
+		identityTheme as never,
+	)
+		.render(120)
+		.join("\n");
+	assert.doesNotMatch(partial, /\n{2,}/);
+	assert.match(partial, /echo newest/);
+	assert.match(partial, /actual-provider\/actual-model/);
+	assert.match(partial, /requested-thinking:high/);
+
+	const empty = (isPartial: boolean) =>
+		renderSubagentResult(
+			{
+				content: [],
+				details: {
+					mode: "single",
+					agentScope: "user",
+					projectAgentsDir: null,
+					results: [
+						{
+							agent: "worker",
+							agentSource: "built-in",
+							task: "task",
+							exitCode: 0,
+							messages: [],
+							stderr: "",
+							usage: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0,
+								contextTokens: 0,
+								turns: 0,
+							},
+						},
+					],
+				},
+			} as never,
+			{ expanded: false, isPartial } as never,
+			identityTheme as never,
+		)
+			.render(120)
+			.join("\n");
+	assert.match(empty(true), /\(running\.\.\.\)/);
+	assert.match(empty(false), /\(no output\)/);
+});
+
+test("renderSubagentResult keeps partial views running and renders final-only previews", () => {
+	const identityTheme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+	const result = (agent: string, finalOutput = "", exitCode = 0) => ({
+		agent,
+		agentSource: "built-in",
+		task: `${agent} task`,
+		exitCode,
+		messages: [],
+		stderr: "",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			contextTokens: 0,
+			turns: 0,
+		},
+		finalOutput,
+	});
+	const render = (details: unknown, isPartial: boolean) =>
+		renderSubagentResult(
+			{ content: [], details } as never,
+			{ expanded: false, isPartial } as never,
+			identityTheme as never,
+		)
+			.render(120)
+			.join("\n");
+
+	const singlePartial = render(
+		{ mode: "single", agentScope: "user", projectAgentsDir: null, results: [result("single")] },
+		true,
+	);
+	assert.match(singlePartial, /^⏳ single/);
+	assert.doesNotMatch(singlePartial, /^✓/);
+
+	const chainPartial = render(
+		{
+			mode: "chain",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [
+				{ ...result("first"), step: 1 },
+				{ ...result("current"), step: 2 },
+			],
+		},
+		true,
+	);
+	assert.match(chainPartial, /^⏳ chain 1\/2 steps/);
+	assert.match(chainPartial, /Step 2: current ⏳/);
+
+	const parallelPartial = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [result("done"), result("running", "", -1)],
+		},
+		true,
+	);
+	assert.match(parallelPartial, /^⏳ parallel 1\/2 done, 1 running/);
+	assert.match(parallelPartial, /done ✓/);
+	assert.match(parallelPartial, /running ⏳/);
+
+	const fanInPartial = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [result("task")],
+			aggregator: result("fan-in"),
+		},
+		true,
+	);
+	assert.match(fanInPartial, /^⏳ parallel 1\/1 done, fan-in running/);
+	assert.match(fanInPartial, /fan-in → fan-in ⏳/);
+
+	const withActivity = (agent: string, command: string) => ({
+		...result(agent),
+		recentActivity: [{ type: "toolCall" as const, name: "bash", args: { command } }],
+		recentActivityTotal: 1,
+	});
+	const chainActivity = render(
+		{
+			mode: "chain",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [{ ...withActivity("chain", "echo chain activity"), step: 1 }],
+		},
+		false,
+	);
+	const parallelActivity = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [withActivity("parallel", "echo parallel activity")],
+		},
+		false,
+	);
+	const aggregatorActivity = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [result("task")],
+			aggregator: withActivity("fan-in", "echo fan-in activity"),
+		},
+		false,
+	);
+	assert.match(chainActivity, /echo chain activity/);
+	assert.match(parallelActivity, /echo parallel activity/);
+	assert.match(aggregatorActivity, /echo fan-in activity/);
+
+	const finalOnly = "FINAL_ONLY_1\nFINAL_ONLY_2\nFINAL_ONLY_3\nFINAL_ONLY_4";
+	const chainFinal = render(
+		{
+			mode: "chain",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [{ ...result("chain", finalOnly), step: 1 }],
+		},
+		false,
+	);
+	const parallelFinal = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [result("parallel", finalOnly)],
+		},
+		false,
+	);
+	const aggregatorFinal = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [result("task")],
+			aggregator: result("fan-in", finalOnly),
+		},
+		false,
+	);
+	for (const output of [chainFinal, parallelFinal, aggregatorFinal]) {
+		assert.match(output, /FINAL_ONLY_1/);
+		assert.match(output, /FINAL_ONLY_2/);
+		assert.match(output, /FINAL_ONLY_3/);
+		assert.doesNotMatch(output, /FINAL_ONLY_4/);
+	}
 });
 
 test("terminateProcess escalates when a child ignores SIGTERM", {

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -300,7 +300,17 @@ test("subagent formatting and set helpers are deterministic", () => {
 			"gpt",
 			"high",
 		),
-		"2 turns ↑1.5k ↓20 $0.0123 gpt thinking:high",
+		"2 turns ↑1.5k ↓20 $0.0123 gpt requested-thinking:high",
+	);
+	assert.equal(
+		formatUsageStats(
+			{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			"requested-alias",
+			"high",
+			"actual-provider",
+			"actual-model",
+		),
+		"actual-provider/actual-model requested-thinking:high",
 	);
 	assert.deepEqual(uniqueToolNames(["read", "read", "bash"]), ["read", "bash"]);
 	assert.equal(sameToolSet(["read", "bash"], ["bash", "read"]), true);


### PR DESCRIPTION
## Summary

- keep captured subagent messages in a strict latest-preserving 50 KiB / 200-message rolling window
- keep the latest compact assistant activity independently bounded, so a large tool result cannot erase the command currently shown in collapsed single, chain, parallel, or fan-in views
- remove empty progress rows and retain standalone final output after captured-message eviction
- report the child-provided provider/model separately from the requested model alias, label thinking as `requested-thinking`, and render partial work as running instead of completed

## Root cause

The previous capture path exhausted a head-only byte budget, then rebuilt later assistant messages with empty text while dropping their tool calls. The compact renderer kept those empty items as its newest rows, producing a large blank area even though the subprocess was still active.

A first rolling-window fix still let this event sequence regress: an assistant tool call appeared, then its large `tool_result_end` occupied the shared capture budget and evicted the assistant message. Because tool results are not rendered as progress, the command flashed once and the card returned to `(running...)`.

The final implementation keeps a separate, strictly bounded recent assistant activity ring for compact rendering. Full captured messages, final output, and fan-in context retain their existing responsibilities.

## Verification

- exact regression: assistant tool call followed by a 100 KiB tool result; the captured message is evicted while the compact command remains visible
- compiled and ran the complete `pi-subagents` evolution and subagents test files: 55/55 passed
- `TMPDIR=/private/tmp env -u PI_SUBAGENT_DEPTH npm run check`: 504/504 tests passed, with Biome, extension-boundary checks, and all workspace typechecks passing

## Review note

`render.ts` had pre-existing noncanonical indentation in ignored `src/` paths; the touched module was normalized with the package's Biome settings, so hiding whitespace changes makes the functional renderer diff easier to inspect.
