### PR TITLE
fix(pi-subagents): preserve failed live progress

### DIFF
--- a/docs/plans/archived/2026-07-16_pi-subagents-pr215-postmerge-review-plan.md
+++ b/docs/plans/archived/2026-07-16_pi-subagents-pr215-postmerge-review-plan.md
@@ -1,0 +1,26 @@
+## Goal
+
+Resolve the three post-merge review findings on PR #215 in a focused follow-up PR without regressing live running-state classification or partial-output visibility.
+
+## Context
+
+PR #215 merged before its final Codex review completed. The remaining findings cover the transition from failed fan-out to fan-in, failed parallel partial output, and timeout reasons in chain partials.
+
+## Plan
+
+- [x] Add focused regression coverage that fails on `origin/main` for a failed fan-out awaiting fan-in, failed parallel output plus its error, and chain timeout errors; `npm test` failed in the new rendering and pending-fan-in regressions (504 passed, 2 failed).
+- [x] Represent the pending fan-in transition in execution updates and render errors additively with retained activity/final output across affected collapsed and expanded sibling flows; `npm test` passes 506 tests and the pi-subagents package check passes.
+- [x] Scan single, chain, parallel-task, and fan-in rendering for the same error/output exclusivity pattern, run `npm run check`, inspect the final diff, then commit and push PR #217 at `7b08297`.
+- [x] Reply to and resolve all three remaining PR #215 review threads with PR #217 and `7b08297` evidence; both Pi 0.79.10 and latest CI jobs pass.
+
+## Risks
+
+- A generic partial-state fallback could make terminal timeout failures look running again. Pending fan-in must therefore be represented explicitly rather than inferred from `isPartial` alone.
+- Rendering the error and partial output together must avoid duplicating the same output through both recent activity and `finalOutput`.
+
+## Completion Checklist
+
+- [x] The failed-fanout transition remains visibly running until fan-in emits or settles, while no-aggregator timeout partials remain terminal; verified by execution and rendering regressions.
+- [x] Failed single, chain, parallel-task, and fan-in rows retain useful output while surfacing their error reason; verified in collapsed rendering and expanded chain rendering.
+- [x] `npm run check` passes 506 tests and both PR #217 CI jobs pass.
+- [x] PR #215 has zero unresolved review threads, PR #217 is open and mergeable, and only this completed plan remains to archive.

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -286,6 +286,34 @@ export async function executeSubagent(
 					const emitParallelUpdate = () => {
 						status.update(parallelStatus(doneCount, allResults.length, runningCount));
 						if (onUpdate) {
+							const aggregator = params.aggregator;
+							const pendingAggregator: SingleResult | undefined =
+								aggregator && !signal?.aborted && doneCount === allResults.length
+									? {
+											agent: aggregator.agent,
+											agentSource:
+												agents.find((agent) => agent.name === aggregator.agent)?.source ?? "unknown",
+											task: aggregator.task,
+											exitCode: -1,
+											messages: [],
+											stderr: "",
+											usage: {
+												input: 0,
+												output: 0,
+												cacheRead: 0,
+												cacheWrite: 0,
+												cost: 0,
+												contextTokens: 0,
+												turns: 0,
+											},
+											thinkingLevel: resolveThinkingLevel(
+												aggregator.agent,
+												aggregator.thinkingLevel,
+											),
+											timeoutMs: resolveTimeoutMs(aggregator.agent, aggregator.timeoutMs),
+											finalOutput: "",
+										}
+									: undefined;
 							onUpdate({
 								content: [
 									{
@@ -293,7 +321,7 @@ export async function executeSubagent(
 										text: `Parallel: ${doneCount}/${allResults.length} done, ${runningCount} running...`,
 									},
 								],
-								details: makeDetails("parallel")([...allResults]),
+								details: makeDetails("parallel")([...allResults], pendingAggregator),
 							});
 						}
 					};

--- a/extensions/pi-subagents/src/render.ts
+++ b/extensions/pi-subagents/src/render.ts
@@ -315,14 +315,14 @@ export function renderSubagentResult(
 		let text = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
 		if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
 		if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
-		else if (collapsed.items.length > 0) {
+		if (collapsed.items.length > 0) {
 			text += `\n${renderDisplayItems(collapsed.items, COLLAPSED_ITEM_COUNT, collapsed.total)}`;
 			if (collapsed.total > COLLAPSED_ITEM_COUNT)
 				text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
 		} else if (finalOutput.trim()) {
 			text += `\n${theme.fg("toolOutput", finalOutput.trim().split("\n").slice(0, 3).join("\n"))}`;
-		} else {
-			text += `\n${theme.fg("muted", isPartial ? "(running...)" : "(no output)")}`;
+		} else if (!isError || !r.errorMessage) {
+			text += `\n${theme.fg("muted", isPartial && !isError ? "(running...)" : "(no output)")}`;
 		}
 		const usageStr = formatResultUsageStats(r);
 		if (usageStr) text += `\n${theme.fg("dim", usageStr)}`;
@@ -369,7 +369,8 @@ export function renderSubagentResult(
 			);
 
 			for (const r of details.results) {
-				const rIcon = isResultError(r)
+				const rFailed = isResultError(r);
+				const rIcon = rFailed
 					? theme.fg("error", "✗")
 					: currentIsRunning && r === currentResult
 						? theme.fg("warning", "⏳")
@@ -386,6 +387,8 @@ export function renderSubagentResult(
 					),
 				);
 				container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
+				if (rFailed && r.errorMessage)
+					container.addChild(new Text(theme.fg("error", `Error: ${r.errorMessage}`), 0, 0));
 
 				// Show tool calls
 				for (const item of displayItems) {
@@ -426,7 +429,8 @@ export function renderSubagentResult(
 			theme.fg("toolTitle", theme.bold("chain ")) +
 			theme.fg("accent", `${successCount}/${details.results.length} steps`);
 		for (const r of details.results) {
-			const rIcon = isResultError(r)
+			const rFailed = isResultError(r);
+			const rIcon = rFailed
 				? theme.fg("error", "✗")
 				: currentIsRunning && r === currentResult
 					? theme.fg("warning", "⏳")
@@ -434,13 +438,15 @@ export function renderSubagentResult(
 			const collapsed = getCollapsedDisplayItems(r);
 			const finalOutput = getResultFinalOutput(r).trim();
 			text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}`;
+			if (rFailed && r.errorMessage)
+				text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
 			if (collapsed.items.length > 0)
 				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
 			else if (currentIsRunning && r === currentResult)
 				text += `\n${theme.fg("muted", "(running...)")}`;
 			else if (finalOutput)
 				text += `\n${theme.fg("toolOutput", finalOutput.split("\n").slice(0, 3).join("\n"))}`;
-			else text += `\n${theme.fg("muted", "(no output)")}`;
+			else if (!rFailed || !r.errorMessage) text += `\n${theme.fg("muted", "(no output)")}`;
 		}
 		const usageStr = formatUsageStats(aggregateUsage(details.results));
 		if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
@@ -599,12 +605,12 @@ export function renderSubagentResult(
 			text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", r.agent)} ${rIcon}`;
 			if (rFailed && r.errorMessage)
 				text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
-			else if (collapsed.items.length > 0)
+			if (collapsed.items.length > 0)
 				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
 			else if (rRunning) text += `\n${theme.fg("muted", "(running...)")}`;
 			else if (finalOutput)
 				text += `\n${theme.fg("toolOutput", finalOutput.split("\n").slice(0, 3).join("\n"))}`;
-			else text += `\n${theme.fg("muted", "(no output)")}`;
+			else if (!rFailed || !r.errorMessage) text += `\n${theme.fg("muted", "(no output)")}`;
 		}
 		if (aggregator) {
 			const rIcon = aggregatorFailed
@@ -617,12 +623,13 @@ export function renderSubagentResult(
 			text += `\n\n${theme.fg("muted", "─── fan-in → ")}${theme.fg("accent", aggregator.agent)} ${rIcon}`;
 			if (aggregatorFailed && aggregator.errorMessage)
 				text += `\n${theme.fg("error", `Error: ${aggregator.errorMessage}`)}`;
-			else if (collapsed.items.length > 0)
+			if (collapsed.items.length > 0)
 				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
 			else if (aggregatorRunning) text += `\n${theme.fg("muted", "(running...)")}`;
 			else if (finalOutput)
 				text += `\n${theme.fg("toolOutput", finalOutput.split("\n").slice(0, 3).join("\n"))}`;
-			else text += `\n${theme.fg("muted", "(no output)")}`;
+			else if (!aggregatorFailed || !aggregator.errorMessage)
+				text += `\n${theme.fg("muted", "(no output)")}`;
 		}
 		if (!isRunning) {
 			const usageResults = aggregator ? [...details.results, aggregator] : details.results;

--- a/extensions/pi-subagents/test/runner-render.test.ts
+++ b/extensions/pi-subagents/test/runner-render.test.ts
@@ -564,10 +564,10 @@ test("renderSubagentResult keeps partial views running and renders final-only pr
 		},
 		finalOutput,
 	});
-	const render = (details: unknown, isPartial: boolean) =>
+	const render = (details: unknown, isPartial: boolean, expanded = false) =>
 		renderSubagentResult(
 			{ content: [], details } as never,
-			{ expanded: false, isPartial } as never,
+			{ expanded, isPartial } as never,
 			identityTheme as never,
 		)
 			.render(120)
@@ -655,6 +655,82 @@ test("renderSubagentResult keeps partial views running and renders final-only pr
 	assert.match(fanInTimeout, /fan-in → fan-in ✗/);
 	assert.match(fanInTimeout, /Error: fan-in timed out/);
 	assert.doesNotMatch(fanInTimeout, /running/);
+
+	const failedWithOutput = (agent: string) => ({
+		...result(agent, `${agent.toUpperCase()}_PARTIAL`),
+		stopReason: "error",
+		errorMessage: `${agent} provider failed`,
+	});
+	const singleFailure = render(
+		{
+			mode: "single",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [failedWithOutput("single-failed")],
+		},
+		true,
+	);
+	assert.match(singleFailure, /Error: single-failed provider failed/);
+	assert.match(singleFailure, /SINGLE-FAILED_PARTIAL/);
+
+	const chainTimeoutDetails = {
+		mode: "chain",
+		agentScope: "user",
+		projectAgentsDir: null,
+		results: [
+			{
+				...timedOutResult("chain-timeout", -1),
+				step: 1,
+				finalOutput: "CHAIN_TIMEOUT_PARTIAL",
+			},
+		],
+	};
+	for (const chainTimeout of [
+		render(chainTimeoutDetails, true),
+		render(chainTimeoutDetails, true, true),
+	]) {
+		assert.match(chainTimeout, /Error: chain-timeout timed out/);
+		assert.match(chainTimeout, /CHAIN_TIMEOUT_PARTIAL/);
+		assert.doesNotMatch(chainTimeout, /running/);
+	}
+
+	const parallelFailure = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [failedWithOutput("parallel-failed")],
+		},
+		true,
+	);
+	assert.match(parallelFailure, /Error: parallel-failed provider failed/);
+	assert.match(parallelFailure, /PARALLEL-FAILED_PARTIAL/);
+
+	const failedFanOutPendingFanIn = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [failedWithOutput("fan-out-failed")],
+			aggregator: result("fan-in-pending", "", -1),
+		},
+		true,
+	);
+	assert.match(failedFanOutPendingFanIn, /^⏳ parallel 1\/1 done, fan-in running/);
+	assert.doesNotMatch(failedFanOutPendingFanIn, /Total:/);
+
+	const fanInFailure = render(
+		{
+			mode: "parallel",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [result("done")],
+			aggregator: failedWithOutput("fan-in-failed"),
+		},
+		true,
+	);
+	assert.match(fanInFailure, /Error: fan-in-failed provider failed/);
+	assert.match(fanInFailure, /FAN-IN-FAILED_PARTIAL/);
 
 	const chainPartial = render(
 		{

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -417,6 +417,59 @@ test("subagent execute resolves thinking level in single, chain, parallel, and a
 	assert.equal(parallel.details?.aggregator?.thinkingLevel, "xhigh");
 });
 
+test("parallel updates keep failed fan-out pending while fan-in starts", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools[0] as SubagentTool;
+	const { ctx } = createMockContext();
+	const signal = new AbortController().signal;
+	const dir = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-pending-fan-in-"));
+	const fakePi = path.join(dir, "fake-pi.mjs");
+	writeFileSync(
+		fakePi,
+		[
+			"const task=process.argv.at(-1) ?? '';",
+			"const failed=task.includes('RUN_FANOUT_FAILURE')&&!task.includes('RUN_AGGREGATOR');",
+			"const message=failed",
+			"? {role:'assistant',content:[{type:'text',text:'FANOUT_PARTIAL'}],stopReason:'error',errorMessage:'FANOUT_FAILED',timestamp:Date.now()}",
+			": {role:'assistant',content:[{type:'text',text:'FAN_IN_COMPLETE'}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const updates: Array<{
+		details?: {
+			results: Array<{ stopReason?: string }>;
+			aggregator?: { exitCode: number };
+		};
+	}> = [];
+	const originalScript = process.argv[1];
+	process.argv[1] = fakePi;
+	try {
+		const result = await tool.execute(
+			"pending-fan-in",
+			{
+				tasks: [{ agent: "scout", task: "RUN_FANOUT_FAILURE" }],
+				aggregator: { agent: "scout", task: "RUN_AGGREGATOR" },
+			},
+			signal,
+			(update: unknown) => updates.push(update as (typeof updates)[number]),
+			ctx,
+		);
+		assert.match(result.content?.[0]?.text ?? "", /FAN_IN_COMPLETE/);
+		assert.ok(
+			updates.some(
+				(update) =>
+					update.details?.results[0]?.stopReason === "error" &&
+					update.details.aggregator?.exitCode === -1,
+			),
+			"expected a failed fan-out update with a pending fan-in result",
+		);
+	} finally {
+		process.argv[1] = originalScript;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test("parallel summaries classify provider errors and retain partial output", async () => {
 	const mock = createMockPi();
 	subagents(mock.pi);


### PR DESCRIPTION
## Summary

Follow-up to #215's final review:

- emit an explicit pending fan-in result once fan-out settles, so failed fan-out does not briefly render as terminal before aggregation starts
- render failure reasons additively with retained activity/final output instead of hiding useful partial output
- surface chain timeout reasons in both collapsed and expanded live views
- apply the same error-plus-output behavior to single, parallel-task, and fan-in rows

## Review findings addressed

- https://github.com/narumiruna/pi-extensions/pull/215#discussion_r3595206809
- https://github.com/narumiruna/pi-extensions/pull/215#discussion_r3595206813
- https://github.com/narumiruna/pi-extensions/pull/215#discussion_r3595206816

## Verification

- TDD red: the new renderer and pending-fan-in regressions failed on `origin/main` (504 passed, 2 failed)
- `npm run check --workspace @narumitw/pi-subagents`
- `npm run check` — 506 tests passed, including Biome, extension-boundary checks, and all workspace typechecks
