### PR TITLE
feat(plan-mode): add configurable default tools

### DIFF
--- a/docs/plans/2026-07-16_pi-plan-mode-configurable-git-policy-plan.md
+++ b/docs/plans/2026-07-16_pi-plan-mode-configurable-git-policy-plan.md
@@ -1,0 +1,71 @@
+## Goal
+
+Add an opt-in, additive configuration for a small vetted set of read-only Git inspection subcommands so Plan mode can run the issue #212 examples without allowing arbitrary Git or weakening existing argument-level mutation and command-execution protections.
+
+## Context
+
+`isSafeCommand()` currently permits eight built-in Git subcommands and applies extra checks to risky `branch`, `remote`, diff/textconv, pager, and output forms. The policy is evaluated by `pi-plan-mode` before another permission extension can participate, so the opt-in must live in this extension.
+
+This is the recommended second sequential change for issue #212, after `docs/plans/2026-07-16_pi-plan-mode-default-tools-plan.md`. If implemented independently, rebase its settings-schema and test-file changes before starting rather than duplicating them.
+
+## Architecture
+
+Extend the user-global settings file with an optional additive property:
+
+```json
+{
+  "additionalSafeGitSubcommands": [
+    "rev-parse",
+    "blame",
+    "describe",
+    "merge-base",
+    "ls-tree",
+    "cat-file"
+  ]
+}
+```
+
+- The built-in Git policy remains active regardless of this setting; the property can add vetted policies but cannot replace or remove built-ins.
+- Omitted or empty configuration preserves current behavior.
+- Accepted values are a documented, versioned set of subcommands for which the extension implements argument validation. Unknown strings and malformed items invalidate the settings file through the existing warning/fallback path rather than becoming arbitrary allowlist entries.
+- Refactor Git handling into a registry of named subcommand validators. Configuration activates validators; it never turns a string directly into permission.
+- Shared Git guards continue rejecting output files, external diff/textconv execution, editor/pager execution paths, and unsupported shell syntax. Subcommand-specific guards must reject execution-capable forms such as `git cat-file --filters` and retain all existing mutating `branch`/`remote` rejections.
+- `isSafeCommand()` receives the resolved opt-in policy explicitly, while its default call remains backward-compatible and strict. The active Plan-mode `tool_call` hook passes the session’s loaded policy.
+
+## Non-Goals
+
+- Do not allow user-defined arbitrary Git subcommands, shell fragments, regular expressions, or command templates.
+- Do not make `bash` unrestricted or delegate blocked commands to a later permission extension.
+- Do not claim that read-only Git access hides repository history, tracked secrets, hooks, filters, or project-defined behavior; this remains extension-level risk reduction, not a sandbox.
+- Do not broaden unrelated shell commands or add write-capable Git operations such as checkout, switch, reset, clean, commit, tag mutation, config mutation, remote mutation, or branch mutation.
+
+## Plan
+
+- [ ] Extract the existing shell/tool-policy tests from `extensions/pi-plan-mode/test/plan-mode.test.ts` into `extensions/pi-plan-mode/test/tool-policy.test.ts` without changing behavior; verify the responsibility split with `npm test`.
+- [ ] Add failing policy tests showing all six requested examples are blocked by default, become allowed only when their named vetted policies are enabled, and remain composable only in pipelines/lists whose every segment is safe; verify the new assertions fail before implementation.
+- [ ] Add adversarial failing tests for unknown configured names, `cat-file` filter/textconv execution, output-writing flags, malformed Git option/subcommand layouts, and existing mutating `branch`/`remote` forms under the broadest opt-in; verify each case fails for one clear policy reason before implementation.
+- [ ] Extend `PlanModeSettings` normalization in `extensions/pi-plan-mode/src/settings.ts` with deduplicated, strictly validated `additionalSafeGitSubcommands`, preserving omitted/empty defaults, canonical migration behavior, and any previously implemented `defaultPlanTools` semantics; verify with settings tests and `npm run typecheck --workspace @narumitw/pi-plan-mode`.
+- [ ] Refactor `extensions/pi-plan-mode/src/tool-policy.ts` to resolve Git subcommands through built-in and opt-in validator registries, centralize shared no-write/no-external-execution guards, and pass the optional policy through `isSafeCommand()`; make the smallest implementation that passes the positive and adversarial matrices without loosening defaults.
+- [ ] Load and pass the resolved policy from `extensions/pi-plan-mode/src/plan-mode.ts` into the active Plan-mode `tool_call` gate, reset it on every `session_start`, and add lifecycle tests proving valid configuration applies, removed/invalid configuration falls back on the next session, and inactive Plan mode is unchanged.
+- [ ] Update `extensions/pi-plan-mode/README.md` with the additive setting, exact supported values, enabled examples, rejected dangerous counterparts, and the limitation that repository contents/history remain readable; verify documentation against the executable matrix and inspect `just pack-plan-mode` output.
+- [ ] Perform a focused sibling scan across every Git validator and shell-segment path for aliases, global options, redirects, substitutions, pagers, filters, external commands, and chained segments; fix only plausible bypasses demonstrated by regression tests, then run `npm run check`.
+
+## Risks
+
+- Git options that appear read-only can execute configured helpers, filters, textconv drivers, difftools, editors, or pagers. Validators must reject uncertain execution paths rather than infer safety from the subcommand name.
+- A generic configurable string allowlist would convert future or aliased Git behavior into an accidental escape hatch; configuration must select code-owned validators only.
+- Refactoring the current Git branch may regress its established `branch`, `remote`, output, and external-diff checks; preserve the old matrix and run it under both empty and maximal opt-in policies.
+- `cat-file` can expose deleted history or tracked secrets even when it does not mutate the repository. Document this capability plainly.
+
+## Rollback / Recovery
+
+Because the setting is additive and omitted by default, recovery is to ignore the optional list with a warning and retain the built-in validator registry. Do not remove or weaken the built-in Git policy if an optional validator proves unsafe.
+
+## Completion Checklist
+
+- [ ] Default Plan-mode Git behavior remains equivalent at the policy boundary, verified by the pre-existing command matrix with no opt-in configuration.
+- [ ] The six issue #212 inspection examples are accepted only when their vetted validators are configured, verified by positive and default-denial tests.
+- [ ] Unknown names, malformed settings, mutating Git forms, output writes, filters/textconv, helper execution, and unsafe chained segments fail closed, verified by adversarial tests.
+- [ ] Configuration is additive and resets on session reload/removal without affecting inactive Plan mode, verified by settings and lifecycle tests.
+- [ ] README examples and warnings match the supported validator registry and security limitations, verified by source/test comparison and inspected `just pack-plan-mode` contents.
+- [ ] Repository verification passes with `npm run check`, with no unresolved same-pattern bypass found in the final Git/shell policy scan.

--- a/docs/plans/archived/2026-07-16_pi-plan-mode-default-tools-plan.md
+++ b/docs/plans/archived/2026-07-16_pi-plan-mode-default-tools-plan.md
@@ -1,0 +1,60 @@
+## Goal
+
+Add a user-global `defaultPlanTools` setting to `pi-plan-mode` so fresh Plan-mode sessions start with a stable, user-selected tool baseline, while preserving the current built-in defaults, required Plan tools, session-level `/plan tools` overrides, and fail-closed tool classification.
+
+## Context
+
+`pi-plan-mode.json` currently configures only `thinkingLevel`. When a session has no stored `/plan tools` selection, `defaultPlanModeToolNames()` selects the available safe built-ins; an explicit selection is stored in `PlanModeState.selectedToolNames` and restored by tool name. Issue #212 asks for a global baseline that does not need to be reselected in every new session.
+
+This plan is the recommended first of two sequential changes for issue #212. The configurable Git-policy plan should follow it because both changes extend the same settings schema, tests, and README section.
+
+## Architecture
+
+Extend the user-global settings file with an optional property:
+
+```json
+{
+  "thinkingLevel": "inherit",
+  "defaultPlanTools": ["read", "bash", "grep", "find", "ls"]
+}
+```
+
+- An omitted `defaultPlanTools` keeps today’s available safe-built-in defaults; no settings file is created automatically.
+- An explicit empty array is valid and enables only the required `plan_mode_question` and `plan_mode_complete` tools.
+- Values must be non-empty tool-name strings and are deduplicated in first-seen order. A wrong type or malformed item invalidates the settings file and uses the existing warning/fallback path.
+- At activation, configured names are intersected with currently available tools accepted by `canSelectToolInPlanMode()`. Unknown, unavailable, and blocked names never reach `setActiveTools()`; required Plan tools are still added unconditionally.
+- A restored `selectedToolNames` value—including an explicit empty selection—wins over the global default. Legacy `selectedToolKeys` migration also remains higher precedence. Therefore `/plan tools` stays a session-level override.
+- Configured non-built-in names retain the selector’s existing user-risk semantics and name/source caveat; a trusted extension overriding the same name is the effective tool Pi exposes.
+
+## Non-Goals
+
+- Do not add a `Save as default` TUI action or write `pi-plan-mode.json` from the extension.
+- Do not add project-local defaults or bypass Pi project trust.
+- Do not change which tools are classified as read-only, limited, user-opt-in, or blocked.
+- Do not alter active tools outside Plan mode or change exact pre-Plan restoration behavior.
+
+## Plan
+
+- [x] Extracted the existing settings-focused tests from `extensions/pi-plan-mode/test/plan-mode.test.ts` into `extensions/pi-plan-mode/test/settings.test.ts` without changing assertions; `npm test` passes 506/506 tests before adding new behavior.
+- [x] Added settings tests for omitted, explicit, empty, duplicate, malformed-item, and wrong-type `defaultPlanTools` values in `extensions/pi-plan-mode/test/settings.test.ts`; the new normalization test failed before implementation and now passes.
+- [x] Extended `PlanModeSettings` and `normalizePlanModeSettings()` in `extensions/pi-plan-mode/src/settings.ts` with strict, ordered-deduplicated `defaultPlanTools` normalization while preserving existing settings behavior; `npm test` passes 507/507 and the pi-plan-mode workspace typecheck passes.
+- [x] Added lifecycle tests proving a fresh session uses the configured baseline, missing configuration keeps current defaults, an empty baseline keeps only required Plan tools, unavailable/blocked names fail closed, and explicit, empty, or legacy restored session selections win; two new default-selection tests failed before runtime integration and all now pass.
+- [x] Integrated the configured baseline into `defaultPlanModeToolNames()` without mutating persisted session state or widening blocked tools; exact active-tool tests cover entry, resume, `/plan tools` override, implementation, exit, and session shutdown, and `npm test` passes 512/512.
+- [x] Updated `extensions/pi-plan-mode/README.md` with the setting path, precedence, empty-array behavior, unavailable/blocked filtering, non-built-in risk, and a complete JSON example; source/test comparison matches and `just pack-plan-mode` contains the expected 11 package files.
+- [x] Reviewed settings reload, dynamic tool availability, overridden built-in names, duplicate names, missing tool metadata, and no-UI startup; added regression tests for reload fallback, effective-source selection, bounded dynamic activation, and fail-closed explicit defaults, with 515/515 tests passing.
+
+## Risks
+
+- Tool identity is name-based in Pi, so an extension can replace a built-in name. Keep the existing source warning explicit and never describe configured non-built-ins as inherently read-only.
+- Treating an empty array as “use defaults” would make it impossible to request only the required Plan tools; preserve the distinction between omitted and empty.
+- Persisting resolved defaults into `selectedToolNames` would accidentally turn a global baseline into a sticky session override and hide later settings changes; compute defaults without storing them.
+- Settings are loaded at `session_start`; tools registered later may not become active until Plan tools are reapplied. Document no dynamic auto-activation guarantee unless testing proves one already exists.
+
+## Completion Checklist
+
+- [x] Fresh Plan-mode sessions honor valid `defaultPlanTools`, while omitted settings preserve current defaults, verified by exact active-tool lifecycle tests in the 515-test suite.
+- [x] `/plan tools` and restored legacy selections override the global baseline for their session, verified by resume and selector persistence tests.
+- [x] Empty, duplicate, unknown, unavailable, blocked, and malformed values have deterministic fail-closed behavior, verified by settings, reload, and lifecycle tests.
+- [x] Required Plan tools remain active and pre-Plan tools are restored exactly on implementation, exit, and shutdown, verified by regression tests.
+- [x] User documentation matches the implemented precedence and safety boundaries, verified by README/source/test review and an inspected 11-file `just pack-plan-mode` dry run.
+- [x] Repository verification passes with `npm run check` (515/515 tests), targeted Biome checks pass for ignored extension source, and the isolated-agent-dir runtime smoke exposes `--plan`.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -83,19 +83,30 @@ You can also exit directly. Direct exit discards the latest proposed plan instea
 /plan exit
 ```
 
-## ⚙️ Thinking level
+## ⚙️ Settings
 
-Plan mode inherits Pi's current thinking level by default. To request a fixed level only while Plan mode is active, create `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`):
+Create `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) to configure Plan mode globally. The file is optional, is read at session start, and is never created automatically.
 
 ```json
 {
-  "thinkingLevel": "medium"
+  "thinkingLevel": "inherit",
+  "defaultPlanTools": ["read", "bash", "grep", "find", "ls"]
 }
 ```
 
-Supported values are `inherit`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. The extension snapshots the prior level and restores it on exit only if the level still matches the value it applied; a manual change made during Plan mode is preserved. The settings file is optional, is read at session start, and never changes Pi's default setting. Invalid settings produce a warning and fall back to `inherit`.
+### Default Plan tools
 
-Compatibility: a valid legacy `plan-mode.json` is migrated automatically to `pi-plan-mode.json`. If both files exist, the new filename takes precedence.
+`defaultPlanTools` defines the initial tool selection when a session has no stored `/plan tools` selection. Omit it to keep the available safe built-ins as the default. An explicit empty array is valid and enables only the required `plan_mode_question` and `plan_mode_complete` tools.
+
+Tool names must be non-empty strings; duplicates are removed in first-seen order. Unknown, unavailable, and Plan-mode-blocked names are ignored when tools are activated. A tool registered after Plan mode is already active is not added automatically; re-enter Plan mode or reopen `/plan tools` to reapply the selection. Non-built-in tools named in this global setting are an explicit user-risk opt-in, just like selecting them with `/plan tools`. Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead.
+
+A selection made with `/plan tools` is stored in that Pi session and takes precedence over `defaultPlanTools` when the session resumes. The global setting remains the baseline for fresh sessions and sessions without an explicit selection.
+
+### Thinking level
+
+Plan mode inherits Pi's current thinking level by default. Set `thinkingLevel` to request a fixed level only while Plan mode is active. Supported values are `inherit`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. The extension snapshots the prior level and restores it on exit only if the level still matches the value it applied; a manual change made during Plan mode is preserved. The setting never changes Pi's default thinking level.
+
+Invalid settings produce a warning and fall back to inherited thinking plus the available safe-built-in tool defaults. Compatibility: a valid legacy `plan-mode.json` is migrated automatically to `pi-plan-mode.json`. If both files exist, the new filename takes precedence.
 
 ## 🧠 Codex-like behavior
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -1,21 +1,16 @@
-import type {
-	ExtensionAPI,
-	ExtensionContext,
-	ToolInfo,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import {
+	normalizePlanModeCompletion,
 	PLAN_MODE_COMPLETE_PARAMS,
 	PLAN_MODE_COMPLETE_TOOL_NAME,
-	normalizePlanModeCompletion,
 	planModeCompleted,
 } from "./completion-tool.js";
 import {
-	extractProposedPlan,
 	isEmptyAssistantMessage,
 	latestAssistantText,
-	parseProposedPlan,
 	messageContainsInactivePlanModeArtifact,
 	messageContainsLegacyPlanModeContextArtifact,
+	parseProposedPlan,
 	stripPlanModeCompletionCallsFromMessage,
 	stripProposedPlanBlocksFromMessage,
 } from "./message-transform.js";
@@ -29,6 +24,12 @@ import {
 	planModeQuestionCancelled,
 } from "./question-tool.js";
 import {
+	configuredThinkingLevel,
+	type PlanModeSettings,
+	readPlanModeSettings,
+} from "./settings.js";
+import { type PlanCompletionSource, type PlanModeState, restorePlanModeState } from "./state.js";
+import {
 	canSelectToolInPlanMode,
 	classifyPlanModeTool,
 	isBuiltinTool,
@@ -36,16 +37,6 @@ import {
 	readCommand,
 	SAFE_BUILTIN_PLAN_TOOLS,
 } from "./tool-policy.js";
-import {
-	configuredThinkingLevel,
-	readPlanModeSettings,
-	type PlanModeSettings,
-} from "./settings.js";
-import {
-	restorePlanModeState,
-	type PlanCompletionSource,
-	type PlanModeState,
-} from "./state.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
 const STATUS_KEY = "plan-mode";
@@ -66,11 +57,6 @@ interface ReadyPresentationIntent {
 	plan: string;
 	source: PlanCompletionSource;
 }
-
-type TextBlock = {
-	type?: string;
-	text?: string;
-};
 
 const PLAN_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 	{ value: "show", label: "show", description: "Show the completed plan" },
@@ -405,11 +391,7 @@ export default function planMode(pi: ExtensionAPI) {
 		}
 	}
 
-	function acceptCompletedPlan(
-		plan: string,
-		source: PlanCompletionSource,
-		ctx: ExtensionContext,
-	) {
+	function acceptCompletedPlan(plan: string, source: PlanCompletionSource, ctx: ExtensionContext) {
 		if (
 			state.enabled &&
 			state.awaitingAction &&
@@ -449,7 +431,10 @@ export default function planMode(pi: ExtensionAPI) {
 	function showStoredPlan(ctx: ExtensionContext) {
 		const plan = state.latestPlan?.trim();
 		if (!state.enabled || !plan) {
-			ctx.ui.notify("No completed plan is available. Use /plan finalize when planning is complete.", "info");
+			ctx.ui.notify(
+				"No completed plan is available. Use /plan finalize when planning is complete.",
+				"info",
+			);
 			return;
 		}
 		try {
@@ -514,12 +499,7 @@ export default function planMode(pi: ExtensionAPI) {
 					"Stay in Plan mode",
 					"Exit Plan mode",
 				]
-			: [
-					"Request final plan",
-					"Configure Plan-mode tools",
-					"Stay in Plan mode",
-					"Exit Plan mode",
-				];
+			: ["Request final plan", "Configure Plan-mode tools", "Stay in Plan mode", "Exit Plan mode"];
 		const choice = await ctx.ui.select(planStatusText(), choices);
 		if (choice === "Show latest proposed plan") {
 			showStoredPlan(ctx);
@@ -637,7 +617,12 @@ export default function planMode(pi: ExtensionAPI) {
 
 	function planModeToolNames() {
 		const tools = selectableTools();
-		if (tools.length === 0) {
+		if (
+			tools.length === 0 &&
+			state.selectedToolNames === undefined &&
+			state.selectedToolKeys === undefined &&
+			settings.defaultPlanTools === undefined
+		) {
 			return ["read", "bash", PLAN_MODE_QUESTION_TOOL_NAME, PLAN_MODE_COMPLETE_TOOL_NAME];
 		}
 
@@ -662,6 +647,9 @@ export default function planMode(pi: ExtensionAPI) {
 	}
 
 	function defaultPlanModeToolNames(tools: ToolInfo[]) {
+		if (settings.defaultPlanTools !== undefined) {
+			return filterAvailableSelectedNames(settings.defaultPlanTools, tools);
+		}
 		return tools
 			.filter((tool) => isBuiltinTool(tool) && SAFE_BUILTIN_PLAN_TOOLS.has(tool.name))
 			.map((tool) => tool.name);
@@ -808,7 +796,8 @@ export default function planMode(pi: ExtensionAPI) {
 
 	function planStatusText() {
 		if (!state.enabled) return "Plan mode is off.";
-		if (state.latestPlan) return `Plan mode is active and a proposed plan is ready. ${formatToolSummary()}`;
+		if (state.latestPlan)
+			return `Plan mode is active and a proposed plan is ready. ${formatToolSummary()}`;
 		return `Plan mode is active. ${formatToolSummary()} Explore, ask, and finish with plan_mode_complete when decision-ready.`;
 	}
 

--- a/extensions/pi-plan-mode/src/settings.ts
+++ b/extensions/pi-plan-mode/src/settings.ts
@@ -20,6 +20,7 @@ export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
 export type PlanModeFixedThinkingLevel = Exclude<PlanModeThinkingLevel, "inherit">;
 export interface PlanModeSettings {
 	thinkingLevel: PlanModeThinkingLevel;
+	defaultPlanTools?: string[];
 }
 export type PlanModeSettingsLoadResult =
 	| { kind: "missing"; notice?: string }
@@ -31,9 +32,26 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 	const thinkingLevel = Object.hasOwn(value, "thinkingLevel")
 		? Reflect.get(value, "thinkingLevel")
 		: "inherit";
-	return PLAN_MODE_THINKING_LEVELS.includes(thinkingLevel as PlanModeThinkingLevel)
-		? { thinkingLevel: thinkingLevel as PlanModeThinkingLevel }
+	if (!PLAN_MODE_THINKING_LEVELS.includes(thinkingLevel as PlanModeThinkingLevel)) {
+		return undefined;
+	}
+	if (!Object.hasOwn(value, "defaultPlanTools")) {
+		return { thinkingLevel: thinkingLevel as PlanModeThinkingLevel };
+	}
+	const defaultPlanTools = normalizeToolNames(Reflect.get(value, "defaultPlanTools"));
+	return defaultPlanTools
+		? { thinkingLevel: thinkingLevel as PlanModeThinkingLevel, defaultPlanTools }
 		: undefined;
+}
+
+function normalizeToolNames(value: unknown) {
+	if (
+		!Array.isArray(value) ||
+		!value.every((item): item is string => typeof item === "string" && item.trim().length > 0)
+	) {
+		return undefined;
+	}
+	return Array.from(new Set(value));
 }
 
 export async function readPlanModeSettings(
@@ -59,10 +77,7 @@ export async function readPlanModeSettings(
 	if (legacy.kind !== "loaded") return legacy;
 	let installedIdentity: FileIdentity;
 	try {
-		installedIdentity = await installFileExclusively(
-			canonicalPath,
-			legacySnapshot.contents ?? "",
-		);
+		installedIdentity = await installFileExclusively(canonicalPath, legacySnapshot.contents ?? "");
 	} catch (error) {
 		const created = await readSettingsFile(canonicalPath);
 		if (created.kind !== "missing") {

--- a/extensions/pi-plan-mode/test/default-tools.test.ts
+++ b/extensions/pi-plan-mode/test/default-tools.test.ts
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	builtinTool,
+	createMockContext,
+	createMockPi,
+	extensionTool,
+} from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+
+const REQUIRED_PLAN_TOOLS = ["plan_mode_question", "plan_mode_complete"];
+
+test("fresh Plan mode uses configured default tools and restores previous tools", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({
+				defaultPlanTools: ["bash", "custom", "write", "missing", "bash"],
+			}),
+		);
+		const mock = createMockPi({
+			activeTools: ["read", "write"],
+			allTools: [
+				builtinTool("read"),
+				builtinTool("bash"),
+				builtinTool("write"),
+				extensionTool("custom"),
+			],
+		});
+		planMode(mock.pi);
+		const context = createMockContext();
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", "custom", ...REQUIRED_PLAN_TOOLS]);
+
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	});
+});
+
+test("missing and empty default tool settings remain distinct", async () => {
+	await withAgentDir(async (agentDir) => {
+		const allTools = [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("grep"),
+			builtinTool("write"),
+			extensionTool("custom"),
+		];
+		const missing = createMockPi({ activeTools: ["write"], allTools });
+		planMode(missing.pi);
+		const missingContext = createMockContext();
+		await missing.events.get("session_start")?.[0]?.({}, missingContext.ctx);
+		await missing.commands.get("plan")?.handler("", missingContext.ctx);
+		assert.deepEqual(missing.rawPi.getActiveTools(), [
+			"bash",
+			"grep",
+			"read",
+			...REQUIRED_PLAN_TOOLS,
+		]);
+
+		await writeFile(join(agentDir, "pi-plan-mode.json"), JSON.stringify({ defaultPlanTools: [] }));
+		const empty = createMockPi({ activeTools: ["write"], allTools });
+		planMode(empty.pi);
+		const emptyContext = createMockContext();
+		await empty.events.get("session_start")?.[0]?.({}, emptyContext.ctx);
+		await empty.commands.get("plan")?.handler("", emptyContext.ctx);
+		assert.deepEqual(empty.rawPi.getActiveTools(), REQUIRED_PLAN_TOOLS);
+	});
+});
+
+test("explicit defaults stay fail closed when tool metadata is unavailable", async () => {
+	await withAgentDir(async (agentDir) => {
+		const settingsPath = join(agentDir, "pi-plan-mode.json");
+		await writeFile(settingsPath, JSON.stringify({ defaultPlanTools: [] }));
+		const explicit = createMockPi({ activeTools: ["write"], allTools: [] });
+		planMode(explicit.pi);
+		const explicitContext = createMockContext();
+		await explicit.events.get("session_start")?.[0]?.({}, explicitContext.ctx);
+		await explicit.commands.get("plan")?.handler("", explicitContext.ctx);
+		assert.deepEqual(explicit.rawPi.getActiveTools(), REQUIRED_PLAN_TOOLS);
+
+		await rm(settingsPath);
+		const fallback = createMockPi({ activeTools: ["write"], allTools: [] });
+		planMode(fallback.pi);
+		const fallbackContext = createMockContext();
+		await fallback.events.get("session_start")?.[0]?.({}, fallbackContext.ctx);
+		await fallback.commands.get("plan")?.handler("", fallbackContext.ctx);
+		assert.deepEqual(fallback.rawPi.getActiveTools(), ["read", "bash", ...REQUIRED_PLAN_TOOLS]);
+	});
+});
+
+test("restored session tool selections override configured defaults", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({ defaultPlanTools: ["bash", "custom"] }),
+		);
+		const allTools = [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("grep"),
+			extensionTool("custom"),
+		];
+
+		for (const { data, expected } of [
+			{
+				data: { enabled: true, awaitingAction: false, selectedToolNames: ["read"] },
+				expected: ["read", ...REQUIRED_PLAN_TOOLS],
+			},
+			{
+				data: { enabled: true, awaitingAction: false, selectedToolNames: [] },
+				expected: REQUIRED_PLAN_TOOLS,
+			},
+			{
+				data: {
+					enabled: true,
+					awaitingAction: false,
+					selectedToolKeys: ["grep\u001fbuiltin"],
+				},
+				expected: ["grep", ...REQUIRED_PLAN_TOOLS],
+			},
+		]) {
+			const mock = createMockPi({ activeTools: ["write"], allTools });
+			planMode(mock.pi);
+			const stateEntry = { type: "custom", customType: "plan-mode-state", data };
+			const context = createMockContext({
+				sessionManager: {
+					getBranch: () => [stateEntry],
+					getEntries: () => [stateEntry],
+				},
+			});
+
+			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+			assert.deepEqual(mock.rawPi.getActiveTools(), expected);
+		}
+	});
+});
+
+test("settings reload resets removed or invalid configured defaults", async () => {
+	await withAgentDir(async (agentDir) => {
+		const settingsPath = join(agentDir, "pi-plan-mode.json");
+		await writeFile(settingsPath, JSON.stringify({ defaultPlanTools: ["bash"] }));
+		const allTools = [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("grep"),
+			builtinTool("write"),
+		];
+		const mock = createMockPi({ activeTools: ["write"], allTools });
+		planMode(mock.pi);
+		const context = createMockContext();
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", ...REQUIRED_PLAN_TOOLS]);
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+
+		await rm(settingsPath);
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", "grep", "read", ...REQUIRED_PLAN_TOOLS]);
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+
+		await writeFile(settingsPath, JSON.stringify({ defaultPlanTools: "read" }));
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", "grep", "read", ...REQUIRED_PLAN_TOOLS]);
+		assert.match(context.notifications.at(-2)?.message ?? "", /settings ignored/i);
+	});
+});
+
+test("configured names follow effective sources without dynamic auto-activation", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({ defaultPlanTools: ["read", "late"] }),
+		);
+		const allTools = [extensionTool("read"), builtinTool("bash"), builtinTool("write")];
+		const mock = createMockPi({ activeTools: ["write"], allTools });
+		planMode(mock.pi);
+		const context = createMockContext();
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+
+		allTools.push(extensionTool("late"));
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["late", "read", ...REQUIRED_PLAN_TOOLS]);
+	});
+});
+
+test("the tool selector persists a session override and shutdown restores prior tools", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({ defaultPlanTools: ["bash", "custom"] }),
+		);
+		const allTools = [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("write"),
+			extensionTool("custom"),
+		];
+		const mock = createMockPi({ activeTools: ["write"], allTools });
+		planMode(mock.pi);
+		let selectedRead = false;
+		const context = createMockContext({
+			hasUI: true,
+			select: async (_title: unknown, choices: string[]) => {
+				if (selectedRead) return "Done";
+				selectedRead = true;
+				return choices.find((choice) => choice.includes(". read "));
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("tools", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"bash",
+			"read",
+			"custom",
+			...REQUIRED_PLAN_TOOLS,
+		]);
+		const persisted = mock.entries.at(-1);
+		assert.ok(persisted);
+		assert.deepEqual((persisted.data as { selectedToolNames?: string[] }).selectedToolNames, [
+			"bash",
+			"custom",
+			"read",
+		]);
+
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["write"]);
+
+		const resumed = createMockPi({ activeTools: ["write"], allTools });
+		planMode(resumed.pi);
+		const stateEntry = { type: "custom", ...persisted };
+		const resumedContext = createMockContext({
+			sessionManager: {
+				getBranch: () => [stateEntry],
+				getEntries: () => [stateEntry],
+			},
+		});
+		await resumed.events.get("session_start")?.[0]?.({}, resumedContext.ctx);
+		assert.deepEqual(resumed.rawPi.getActiveTools(), [
+			"bash",
+			"read",
+			"custom",
+			...REQUIRED_PLAN_TOOLS,
+		]);
+	});
+});
+
+test("implementation handoff restores tools after using configured defaults", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({ defaultPlanTools: ["bash"] }),
+		);
+		const mock = createMockPi({
+			activeTools: ["read", "write", "custom"],
+			allTools: [
+				builtinTool("read"),
+				builtinTool("bash"),
+				builtinTool("write"),
+				extensionTool("custom"),
+			],
+		});
+		planMode(mock.pi);
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", ...REQUIRED_PLAN_TOOLS]);
+
+		const execute = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+			| ((...args: unknown[]) => Promise<unknown>)
+			| undefined;
+		assert.ok(execute);
+		await execute("complete", { plan: "# Configured handoff" }, undefined, undefined, context.ctx);
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write", "custom"]);
+		assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /# Configured handoff/);
+	});
+});
+
+async function withAgentDir(run: (agentDir: string) => Promise<void>) {
+	const agentDir = await mkdtemp(join(tmpdir(), "pi-plan-mode-default-tools-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		await run(agentDir);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+}

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -18,9 +18,7 @@ import planMode, {
 	isSafeCommand,
 	latestAssistantText,
 	normalizePlanModeQuestionParams,
-	normalizePlanModeSettings,
 	parseProposedPlan,
-	readPlanModeSettings,
 	stripProposedPlanBlocks,
 	stripProposedPlanBlocksFromMessage,
 	withoutPlanModeQuestionTool,
@@ -231,86 +229,6 @@ test("normalizePlanModeQuestionParams validates question shape", () => {
 		ok: false,
 		error: "questions must contain 1-3 items",
 	});
-});
-
-test("Plan-mode settings validate inherit and fixed thinking levels", async () => {
-	assert.deepEqual(normalizePlanModeSettings({}), { thinkingLevel: "inherit" });
-	assert.deepEqual(normalizePlanModeSettings({ thinkingLevel: "medium" }), {
-		thinkingLevel: "medium",
-	});
-	assert.deepEqual(normalizePlanModeSettings({ thinkingLevel: "max" }), {
-		thinkingLevel: "max",
-	});
-	assert.equal(normalizePlanModeSettings({ thinkingLevel: "extreme" }), undefined);
-
-	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-test-"));
-	try {
-		const path = join(directory, "pi-plan-mode.json");
-		await writeFile(path, '{"thinkingLevel":"high"}');
-		assert.deepEqual(await readPlanModeSettings(path), {
-			kind: "loaded",
-			settings: { thinkingLevel: "high" },
-		});
-	} finally {
-		await rm(directory, { recursive: true, force: true });
-	}
-});
-
-test("Plan-mode settings migrate to the canonical package filename", async () => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-migration-"));
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = directory;
-	try {
-		await writeFile(
-			join(directory, "plan-mode.json"),
-			'{"thinkingLevel":"high","futureOption":true}',
-		);
-		const loaded = await readPlanModeSettings();
-		assert.equal(loaded.kind, "loaded");
-		assert.match(loaded.notice ?? "", /migrated/i);
-		assert.deepEqual(JSON.parse(await readFile(join(directory, "pi-plan-mode.json"), "utf8")), {
-			thinkingLevel: "high",
-			futureOption: true,
-		});
-		await assert.rejects(access(join(directory, "plan-mode.json")));
-
-		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"low"}');
-		await writeFile(join(directory, "pi-plan-mode.json"), '{"thinkingLevel":"medium"}');
-		const preferred = await readPlanModeSettings();
-		assert.deepEqual(preferred.kind === "loaded" ? preferred.settings : undefined, {
-			thinkingLevel: "medium",
-		});
-		assert.match(preferred.notice ?? "", /ignored/i);
-
-		await writeFile(join(directory, "pi-plan-mode.json"), "invalid");
-		const invalid = await readPlanModeSettings();
-		assert.equal(invalid.kind, "invalid");
-		assert.equal(
-			await readFile(join(directory, "plan-mode.json"), "utf8"),
-			'{"thinkingLevel":"low"}',
-		);
-
-		await unlink(join(directory, "pi-plan-mode.json"));
-		await writeFile(join(directory, "plan-mode.json"), "invalid");
-		assert.equal((await readPlanModeSettings()).kind, "invalid");
-		await assert.rejects(access(join(directory, "pi-plan-mode.json")));
-
-		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"high"}');
-		await symlink("missing-target", join(directory, "pi-plan-mode.json"));
-		const fallback = await readPlanModeSettings();
-		assert.deepEqual(fallback.kind === "loaded" ? fallback.settings : undefined, {
-			thinkingLevel: "high",
-		});
-		assert.match(fallback.notice ?? "", /migration failed/i);
-		assert.equal(
-			await readFile(join(directory, "plan-mode.json"), "utf8"),
-			'{"thinkingLevel":"high"}',
-		);
-	} finally {
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		await rm(directory, { recursive: true, force: true });
-	}
 });
 
 test("missing settings reset a previously loaded fixed thinking level", async () => {

--- a/extensions/pi-plan-mode/test/settings.test.ts
+++ b/extensions/pi-plan-mode/test/settings.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { normalizePlanModeSettings, readPlanModeSettings } from "../src/settings.js";
+
+test("Plan-mode settings validate inherit and fixed thinking levels", async () => {
+	assert.deepEqual(normalizePlanModeSettings({}), { thinkingLevel: "inherit" });
+	assert.deepEqual(normalizePlanModeSettings({ thinkingLevel: "medium" }), {
+		thinkingLevel: "medium",
+	});
+	assert.deepEqual(normalizePlanModeSettings({ thinkingLevel: "max" }), {
+		thinkingLevel: "max",
+	});
+	assert.equal(normalizePlanModeSettings({ thinkingLevel: "extreme" }), undefined);
+
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-test-"));
+	try {
+		const path = join(directory, "pi-plan-mode.json");
+		await writeFile(path, '{"thinkingLevel":"high"}');
+		assert.deepEqual(await readPlanModeSettings(path), {
+			kind: "loaded",
+			settings: { thinkingLevel: "high" },
+		});
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("Plan-mode settings normalize default tool names strictly", async () => {
+	assert.deepEqual(
+		normalizePlanModeSettings({
+			thinkingLevel: "medium",
+			defaultPlanTools: ["bash", "read", "bash", "grep"],
+		}),
+		{
+			thinkingLevel: "medium",
+			defaultPlanTools: ["bash", "read", "grep"],
+		},
+	);
+	assert.deepEqual(normalizePlanModeSettings({ defaultPlanTools: [] }), {
+		thinkingLevel: "inherit",
+		defaultPlanTools: [],
+	});
+	for (const defaultPlanTools of ["read", [""], ["   "], ["read", 42]]) {
+		assert.equal(normalizePlanModeSettings({ defaultPlanTools }), undefined);
+	}
+
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-default-tools-test-"));
+	try {
+		const path = join(directory, "pi-plan-mode.json");
+		await writeFile(path, '{"defaultPlanTools":["read","bash","read"]}');
+		assert.deepEqual(await readPlanModeSettings(path), {
+			kind: "loaded",
+			settings: {
+				thinkingLevel: "inherit",
+				defaultPlanTools: ["read", "bash"],
+			},
+		});
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("Plan-mode settings migrate to the canonical package filename", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		await writeFile(
+			join(directory, "plan-mode.json"),
+			'{"thinkingLevel":"high","futureOption":true}',
+		);
+		const loaded = await readPlanModeSettings();
+		assert.equal(loaded.kind, "loaded");
+		assert.match(loaded.notice ?? "", /migrated/i);
+		assert.deepEqual(JSON.parse(await readFile(join(directory, "pi-plan-mode.json"), "utf8")), {
+			thinkingLevel: "high",
+			futureOption: true,
+		});
+		await assert.rejects(access(join(directory, "plan-mode.json")));
+
+		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"low"}');
+		await writeFile(join(directory, "pi-plan-mode.json"), '{"thinkingLevel":"medium"}');
+		const preferred = await readPlanModeSettings();
+		assert.deepEqual(preferred.kind === "loaded" ? preferred.settings : undefined, {
+			thinkingLevel: "medium",
+		});
+		assert.match(preferred.notice ?? "", /ignored/i);
+
+		await writeFile(join(directory, "pi-plan-mode.json"), "invalid");
+		const invalid = await readPlanModeSettings();
+		assert.equal(invalid.kind, "invalid");
+		assert.equal(
+			await readFile(join(directory, "plan-mode.json"), "utf8"),
+			'{"thinkingLevel":"low"}',
+		);
+
+		await unlink(join(directory, "pi-plan-mode.json"));
+		await writeFile(join(directory, "plan-mode.json"), "invalid");
+		assert.equal((await readPlanModeSettings()).kind, "invalid");
+		await assert.rejects(access(join(directory, "pi-plan-mode.json")));
+
+		await writeFile(join(directory, "plan-mode.json"), '{"thinkingLevel":"high"}');
+		await symlink("missing-target", join(directory, "pi-plan-mode.json"));
+		const fallback = await readPlanModeSettings();
+		assert.deepEqual(fallback.kind === "loaded" ? fallback.settings : undefined, {
+			thinkingLevel: "high",
+		});
+		assert.match(fallback.notice ?? "", /migration failed/i);
+		assert.equal(
+			await readFile(join(directory, "plan-mode.json"), "utf8"),
+			'{"thinkingLevel":"high"}',
+		);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(directory, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- add user-global `defaultPlanTools` configuration in `pi-plan-mode.json`
- preserve safe built-in defaults, required Plan tools, and session-level `/plan tools` precedence
- fail closed for blocked, unavailable, malformed, or metadata-less configured selections
- document the configuration and retain a follow-up plan for additive read-only Git policies

## Testing

- `npm run check` (515 tests)
- targeted Biome check for ignored `pi-plan-mode` source and tests
- `just pack-plan-mode` (11 expected package files)
- isolated-agent-dir `pi -ne -e ./extensions/pi-plan-mode --help` smoke

Refs #212
