### PR TITLE
refactor(plan-mode): split oversized test suite

### DIFF
--- a/docs/plans/2026-07-16_pi-plan-mode-configurable-git-policy-plan.md
+++ b/docs/plans/2026-07-16_pi-plan-mode-configurable-git-policy-plan.md
@@ -41,7 +41,7 @@ Extend the user-global settings file with an optional additive property:
 
 ## Plan
 
-- [ ] Extract the existing shell/tool-policy tests from `extensions/pi-plan-mode/test/plan-mode.test.ts` into `extensions/pi-plan-mode/test/tool-policy.test.ts` without changing behavior; verify the responsibility split with `npm test`.
+- [x] Extracted the existing shell/tool-policy tests into `extensions/pi-plan-mode/test/tool-policy.test.ts` and question-tool tests into `extensions/pi-plan-mode/test/question-tool.test.ts` without changing behavior; `plan-mode.test.ts` is now 986 lines and `npm test` passes 515/515.
 - [ ] Add failing policy tests showing all six requested examples are blocked by default, become allowed only when their named vetted policies are enabled, and remain composable only in pipelines/lists whose every segment is safe; verify the new assertions fail before implementation.
 - [ ] Add adversarial failing tests for unknown configured names, `cat-file` filter/textconv execution, output-writing flags, malformed Git option/subcommand layouts, and existing mutating `branch`/`remote` forms under the broadest opt-in; verify each case fails for one clear policy reason before implementation.
 - [ ] Extend `PlanModeSettings` normalization in `extensions/pi-plan-mode/src/settings.ts` with deduplicated, strictly validated `additionalSafeGitSubcommands`, preserving omitted/empty defaults, canonical migration behavior, and any previously implemented `defaultPlanTools` semantics; verify with settings tests and `npm run typecheck --workspace @narumitw/pi-plan-mode`.

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -3,26 +3,15 @@ import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import {
-	builtinTool,
-	createMockContext,
-	createMockPi,
-	extensionTool,
-} from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import planMode, {
 	buildPlanModePrompt,
-	canSelectToolInPlanMode,
-	classifyPlanModeTool,
 	completePlanArguments,
 	extractProposedPlan,
-	isSafeCommand,
 	latestAssistantText,
-	normalizePlanModeQuestionParams,
 	parseProposedPlan,
 	stripProposedPlanBlocks,
 	stripProposedPlanBlocksFromMessage,
-	withoutPlanModeQuestionTool,
-	withRequiredPlanModeTools,
 } from "../src/plan-mode.js";
 
 test("plan-mode registers flag, question tool, command, and safety hooks", () => {
@@ -52,183 +41,6 @@ test("completePlanArguments suggests management tokens only", () => {
 	assert.equal(completePlanArguments("tools "), null);
 	assert.equal(completePlanArguments("write a plan"), null);
 	assert.equal(completePlanArguments("unknown"), null);
-});
-
-test("tool selection allows safe built-ins and non-built-ins only", () => {
-	type PlanTool = Parameters<typeof canSelectToolInPlanMode>[0];
-	assert.equal(canSelectToolInPlanMode(builtinTool("read") as PlanTool), true);
-	assert.equal(canSelectToolInPlanMode(builtinTool("edit") as PlanTool), false);
-	assert.equal(canSelectToolInPlanMode(extensionTool("custom") as PlanTool), true);
-	assert.equal(canSelectToolInPlanMode(extensionTool("edit") as PlanTool), true);
-	assert.deepEqual(withRequiredPlanModeTools(["read", "plan_mode_question", "read"]), [
-		"read",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
-	assert.deepEqual(withoutPlanModeQuestionTool(["read", "plan_mode_question"]), ["read"]);
-});
-
-test("isSafeCommand permits read-only command lists and rejects shell mutation", () => {
-	for (const command of [
-		"git status --short && git diff --check",
-		"git branch --show-current",
-		"git remote get-url origin",
-		"rg -n 'plan' src | head -20",
-		"npm test -- --help",
-		"npm run typecheck",
-		"cargo test --no-run",
-		"sed -n '1,20p' file.ts",
-	]) {
-		assert.equal(isSafeCommand(command), true, command);
-	}
-	for (const command of [
-		"rm -rf build",
-		"npm install",
-		"echo $(rm file)",
-		"cat file > copy",
-		"git status; touch file",
-		"cat file & touch file",
-		"find . -delete",
-		"find . -exec rm {} ;",
-		"sed -i 's/a/b/' file",
-		"sed -ni 's/a/b/' file",
-		"sed -n 'w output' input",
-		"sed -n 'e touch output' input",
-		"uniq input output",
-		"diff left right --output=diff.txt",
-		"sort --compress-program='touch output' input",
-		"sort -T /tmp input",
-		"git grep --open-files-in-pager='sh -c touch output' pattern",
-		"git grep -O'sh -c touch output' pattern",
-		"git grep -O 'sh -c touch output' pattern",
-		"git branch -D old",
-		"git branch --unset-upstream",
-		"git branch --set-upstream-to=origin/main",
-		"git remote add origin url",
-		"git remote set-head origin -a",
-		"git remote set-branches origin main",
-		"npm audit --fix",
-		"npm audit fix",
-		"env sh -c 'touch file'",
-		"date --set tomorrow",
-		"sort input -o output",
-		"sort -o/tmp/output input",
-		"tree -o output",
-		"find . -fprint output",
-		"find . -fprint0 output",
-		"fd pattern --exec touch file",
-		"fd pattern -x rm {}",
-		"rg pattern --pre 'touch file'",
-		"bat file --pager 'sh -c touch file'",
-		"git diff --ext-diff",
-		"git log --output=log.txt",
-		"git remote update",
-		"tsc --noEmit --incremental --tsBuildInfoFile info.tsbuildinfo",
-		"tsc --noEmit --generateTrace trace",
-		"go build ./cmd/app",
-		"cargo build",
-		"npm run build",
-		"awk 'BEGIN { system(\"touch file\") }'",
-		"rg x || (echo bad > file)",
-		"cat <<EOF",
-		"unknown-command --dry-run",
-		"",
-	]) {
-		assert.equal(isSafeCommand(command), false, command);
-	}
-});
-
-test("tool policy classifies built-ins and extension tools consistently", () => {
-	type PlanTool = Parameters<typeof classifyPlanModeTool>[0];
-	assert.equal(classifyPlanModeTool(builtinTool("read") as PlanTool), "read-only");
-	assert.equal(classifyPlanModeTool(builtinTool("bash") as PlanTool), "limited");
-	assert.equal(classifyPlanModeTool(builtinTool("write") as PlanTool), "blocked");
-	assert.equal(classifyPlanModeTool(extensionTool("custom") as PlanTool), "user-opt-in");
-});
-
-test("active Plan mode blocks update_plan and blocked built-ins at the tool hook", async () => {
-	const mock = createMockPi({
-		activeTools: ["read", "bash", "update_plan", "danger"],
-		allTools: [
-			builtinTool("read"),
-			builtinTool("bash"),
-			builtinTool("danger"),
-			extensionTool("edit"),
-		],
-	});
-	planMode(mock.pi);
-	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
-	const hook = mock.events.get("tool_call")?.[0];
-	const blocked = await hook?.({ toolName: "update_plan", input: {} }, context.ctx);
-	const blockedBuiltin = await hook?.({ toolName: "danger", input: {} }, context.ctx);
-	const allowed = await hook?.({ toolName: "read", input: {} }, context.ctx);
-	const optedInExtension = await hook?.({ toolName: "edit", input: {} }, context.ctx);
-	assert.deepEqual(blocked, {
-		block: true,
-		reason:
-			"Plan mode blocks update_plan because it tracks execution progress rather than conversational planning.",
-	});
-	assert.deepEqual(blockedBuiltin, {
-		block: true,
-		reason: "Plan mode blocks built-in tool 'danger' because its policy class is blocked.",
-	});
-	assert.equal(allowed, undefined);
-	assert.equal(optedInExtension, undefined);
-});
-
-test("plan_mode_question reports non-interactive cancellation", async () => {
-	const mock = createMockPi();
-	planMode(mock.pi);
-	const execute = mock.tools[0]?.execute as
-		| ((...args: unknown[]) => Promise<{ details?: { reason?: string } }>)
-		| undefined;
-	assert.ok(execute);
-	const context = createMockContext({ hasUI: false });
-	await mock.commands.get("plan")?.handler("", context.ctx);
-	const result = await execute(
-		"call-1",
-		{
-			questions: [
-				{
-					id: "scope",
-					header: "Scope",
-					question: "How broad?",
-					options: [
-						{ label: "Small", description: "Only the bug." },
-						{ label: "Broad", description: "Include cleanup." },
-					],
-				},
-			],
-		},
-		undefined,
-		undefined,
-		context.ctx,
-	);
-	assert.equal(result.details?.reason, "ui_unavailable");
-});
-
-test("normalizePlanModeQuestionParams validates question shape", () => {
-	const result = normalizePlanModeQuestionParams({
-		questions: [
-			{
-				id: "scope",
-				header: "Scope",
-				question: "How broad?",
-				options: [
-					{ label: "Small", description: "Only the bug." },
-					{ label: "Broad", description: "Include nearby cleanup." },
-				],
-			},
-		],
-	});
-
-	assert.equal(result.ok, true);
-	if (result.ok) assert.equal(result.questions[0]?.options[1]?.label, "Broad");
-	assert.deepEqual(normalizePlanModeQuestionParams({ questions: [] }), {
-		ok: false,
-		error: "questions must contain 1-3 items",
-	});
 });
 
 test("missing settings reset a previously loaded fixed thinking level", async () => {

--- a/extensions/pi-plan-mode/test/question-tool.test.ts
+++ b/extensions/pi-plan-mode/test/question-tool.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import planMode, { normalizePlanModeQuestionParams } from "../src/plan-mode.js";
+
+test("plan_mode_question reports non-interactive cancellation", async () => {
+	const mock = createMockPi();
+	planMode(mock.pi);
+	const execute = mock.tools[0]?.execute as
+		| ((...args: unknown[]) => Promise<{ details?: { reason?: string } }>)
+		| undefined;
+	assert.ok(execute);
+	const context = createMockContext({ hasUI: false });
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	const result = await execute(
+		"call-1",
+		{
+			questions: [
+				{
+					id: "scope",
+					header: "Scope",
+					question: "How broad?",
+					options: [
+						{ label: "Small", description: "Only the bug." },
+						{ label: "Broad", description: "Include cleanup." },
+					],
+				},
+			],
+		},
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	assert.equal(result.details?.reason, "ui_unavailable");
+});
+
+test("normalizePlanModeQuestionParams validates question shape", () => {
+	const result = normalizePlanModeQuestionParams({
+		questions: [
+			{
+				id: "scope",
+				header: "Scope",
+				question: "How broad?",
+				options: [
+					{ label: "Small", description: "Only the bug." },
+					{ label: "Broad", description: "Include nearby cleanup." },
+				],
+			},
+		],
+	});
+
+	assert.equal(result.ok, true);
+	if (result.ok) assert.equal(result.questions[0]?.options[1]?.label, "Broad");
+	assert.deepEqual(normalizePlanModeQuestionParams({ questions: [] }), {
+		ok: false,
+		error: "questions must contain 1-3 items",
+	});
+});

--- a/extensions/pi-plan-mode/test/tool-policy.test.ts
+++ b/extensions/pi-plan-mode/test/tool-policy.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	builtinTool,
+	createMockContext,
+	createMockPi,
+	extensionTool,
+} from "../../../test/support.js";
+import planMode, {
+	canSelectToolInPlanMode,
+	classifyPlanModeTool,
+	isSafeCommand,
+	withoutPlanModeQuestionTool,
+	withRequiredPlanModeTools,
+} from "../src/plan-mode.js";
+
+test("tool selection allows safe built-ins and non-built-ins only", () => {
+	type PlanTool = Parameters<typeof canSelectToolInPlanMode>[0];
+	assert.equal(canSelectToolInPlanMode(builtinTool("read") as PlanTool), true);
+	assert.equal(canSelectToolInPlanMode(builtinTool("edit") as PlanTool), false);
+	assert.equal(canSelectToolInPlanMode(extensionTool("custom") as PlanTool), true);
+	assert.equal(canSelectToolInPlanMode(extensionTool("edit") as PlanTool), true);
+	assert.deepEqual(withRequiredPlanModeTools(["read", "plan_mode_question", "read"]), [
+		"read",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.deepEqual(withoutPlanModeQuestionTool(["read", "plan_mode_question"]), ["read"]);
+});
+
+test("isSafeCommand permits read-only command lists and rejects shell mutation", () => {
+	for (const command of [
+		"git status --short && git diff --check",
+		"git branch --show-current",
+		"git remote get-url origin",
+		"rg -n 'plan' src | head -20",
+		"npm test -- --help",
+		"npm run typecheck",
+		"cargo test --no-run",
+		"sed -n '1,20p' file.ts",
+	]) {
+		assert.equal(isSafeCommand(command), true, command);
+	}
+	for (const command of [
+		"rm -rf build",
+		"npm install",
+		"echo $(rm file)",
+		"cat file > copy",
+		"git status; touch file",
+		"cat file & touch file",
+		"find . -delete",
+		"find . -exec rm {} ;",
+		"sed -i 's/a/b/' file",
+		"sed -ni 's/a/b/' file",
+		"sed -n 'w output' input",
+		"sed -n 'e touch output' input",
+		"uniq input output",
+		"diff left right --output=diff.txt",
+		"sort --compress-program='touch output' input",
+		"sort -T /tmp input",
+		"git grep --open-files-in-pager='sh -c touch output' pattern",
+		"git grep -O'sh -c touch output' pattern",
+		"git grep -O 'sh -c touch output' pattern",
+		"git branch -D old",
+		"git branch --unset-upstream",
+		"git branch --set-upstream-to=origin/main",
+		"git remote add origin url",
+		"git remote set-head origin -a",
+		"git remote set-branches origin main",
+		"npm audit --fix",
+		"npm audit fix",
+		"env sh -c 'touch file'",
+		"date --set tomorrow",
+		"sort input -o output",
+		"sort -o/tmp/output input",
+		"tree -o output",
+		"find . -fprint output",
+		"find . -fprint0 output",
+		"fd pattern --exec touch file",
+		"fd pattern -x rm {}",
+		"rg pattern --pre 'touch file'",
+		"bat file --pager 'sh -c touch file'",
+		"git diff --ext-diff",
+		"git log --output=log.txt",
+		"git remote update",
+		"tsc --noEmit --incremental --tsBuildInfoFile info.tsbuildinfo",
+		"tsc --noEmit --generateTrace trace",
+		"go build ./cmd/app",
+		"cargo build",
+		"npm run build",
+		"awk 'BEGIN { system(\"touch file\") }'",
+		"rg x || (echo bad > file)",
+		"cat <<EOF",
+		"unknown-command --dry-run",
+		"",
+	]) {
+		assert.equal(isSafeCommand(command), false, command);
+	}
+});
+
+test("tool policy classifies built-ins and extension tools consistently", () => {
+	type PlanTool = Parameters<typeof classifyPlanModeTool>[0];
+	assert.equal(classifyPlanModeTool(builtinTool("read") as PlanTool), "read-only");
+	assert.equal(classifyPlanModeTool(builtinTool("bash") as PlanTool), "limited");
+	assert.equal(classifyPlanModeTool(builtinTool("write") as PlanTool), "blocked");
+	assert.equal(classifyPlanModeTool(extensionTool("custom") as PlanTool), "user-opt-in");
+});
+
+test("active Plan mode blocks update_plan and blocked built-ins at the tool hook", async () => {
+	const mock = createMockPi({
+		activeTools: ["read", "bash", "update_plan", "danger"],
+		allTools: [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("danger"),
+			extensionTool("edit"),
+		],
+	});
+	planMode(mock.pi);
+	const context = createMockContext();
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	const hook = mock.events.get("tool_call")?.[0];
+	const blocked = await hook?.({ toolName: "update_plan", input: {} }, context.ctx);
+	const blockedBuiltin = await hook?.({ toolName: "danger", input: {} }, context.ctx);
+	const allowed = await hook?.({ toolName: "read", input: {} }, context.ctx);
+	const optedInExtension = await hook?.({ toolName: "edit", input: {} }, context.ctx);
+	assert.deepEqual(blocked, {
+		block: true,
+		reason:
+			"Plan mode blocks update_plan because it tracks execution progress rather than conversational planning.",
+	});
+	assert.deepEqual(blockedBuiltin, {
+		block: true,
+		reason: "Plan mode blocks built-in tool 'danger' because its policy class is blocked.",
+	});
+	assert.equal(allowed, undefined);
+	assert.equal(optedInExtension, undefined);
+});


### PR DESCRIPTION
## Summary

- move shell and tool-policy coverage into `tool-policy.test.ts`
- move Plan question-tool coverage into `question-tool.test.ts`
- reduce `plan-mode.test.ts` from 1,174 to 986 lines without changing assertions or behavior
- record the completed test-extraction step in the follow-up Git-policy plan

## Testing

- `npm run check` (515 tests)
- targeted Biome check for all three split test files
- verified every `pi-plan-mode` source and test file is below 1,000 lines

Refs #212
