### PR TITLE
fix(codex-accounts): restore Pi 0.80.8 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         pi_version:
           - "0.79.10"
+          - "0.80.3"
           - "latest"
 
     steps:

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -53,7 +53,7 @@
 - Symptom: Pi compaction event docs may mention `reason`/`willRetry` while project target typings lack them. Cause: local/global `@earendil-works/pi-coding-agent` version skew. Fix: run `npm install`, verify target version, and treat compaction event fields as optional.
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
-- Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends; extension runtime imports fail even though the classes remain internal. Keep extension-owned credential storage independent of those exports and test both the compatibility floor and latest Pi.
+- Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned, obtain built-in OAuth through `providers/all`, and test both the compatibility floor and latest Pi.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -53,6 +53,7 @@
 - Symptom: Pi compaction event docs may mention `reason`/`willRetry` while project target typings lack them. Cause: local/global `@earendil-works/pi-coding-agent` version skew. Fix: run `npm install`, verify target version, and treat compaction event fields as optional.
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
+- Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends; extension runtime imports fail even though the classes remain internal. Keep extension-owned credential storage independent of those exports and test both the compatibility floor and latest Pi.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -54,6 +54,7 @@
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
 - Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned; for cross-version OAuth, use the legacy `/oauth` value when present and lazily fall back to `providers/all` only on loaders that support it.
+- Provider-owned OAuth can abort an individual prompt after an out-of-band callback wins; preserve each prompt's signal through compatibility adapters and pass it to Pi's UI dialog options.
 - Pi runtime API-key set/remove methods and OAuth key conversion may be asynchronous; serialize override mutations per target and revalidate the selected credential after conversion so account changes cannot restore stale auth.
 - Legacy credential migration must wait through transient cross-process lock contention; do not bind a store to the legacy path after `ELOCKED`, because the winning process may remove that file and install the canonical one.
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -53,7 +53,7 @@
 - Symptom: Pi compaction event docs may mention `reason`/`willRetry` while project target typings lack them. Cause: local/global `@earendil-works/pi-coding-agent` version skew. Fix: run `npm install`, verify target version, and treat compaction event fields as optional.
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
-- Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned, obtain built-in OAuth through `providers/all`, and test both the compatibility floor and latest Pi.
+- Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned; for cross-version OAuth, use the legacy `/oauth` value when present and lazily fall back to `providers/all` only on loaders that support it.
 - Pi runtime API-key set/remove methods may be asynchronous; serialize override mutations per runtime target so reset, logout, or shutdown cannot overtake a pending setter and leave stale auth active.
 
 ## TASTE

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -54,7 +54,8 @@
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
 - Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned; for cross-version OAuth, use the legacy `/oauth` value when present and lazily fall back to `providers/all` only on loaders that support it.
-- Pi runtime API-key set/remove methods may be asynchronous; serialize override mutations per runtime target so reset, logout, or shutdown cannot overtake a pending setter and leave stale auth active.
+- Pi runtime API-key set/remove methods and OAuth key conversion may be asynchronous; serialize override mutations per target and revalidate the selected credential after conversion so account changes cannot restore stale auth.
+- Legacy credential migration must wait through transient cross-process lock contention; do not bind a store to the legacy path after `ELOCKED`, because the winning process may remove that file and install the canonical one.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -55,8 +55,10 @@
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
 - Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned; for cross-version OAuth, use the legacy `/oauth` value when present and lazily fall back to `providers/all` only on loaders that support it.
 - Provider-owned OAuth can abort an individual prompt after an out-of-band callback wins; preserve each prompt's signal through compatibility adapters and pass it to Pi's UI dialog options.
-- Pi runtime API-key set/remove methods and OAuth key conversion may be asynchronous; serialize override mutations per target and revalidate the selected credential after conversion so account changes cannot restore stale auth.
+- Pi runtime API-key set/remove methods and OAuth key conversion may be asynchronous; serialize mutations per target, mark possible ownership before awaiting a setter, revalidate selected credentials, and invalidate captured generations on clear/shutdown.
 - Legacy credential migration must wait through transient cross-process lock contention; do not bind a store to the legacy path after `ELOCKED`, because the winning process may remove that file and install the canonical one.
+- Treat parsed credential maps as own-property dictionaries: names such as `__proto__` and `constructor` must not mutate or resolve through `Object.prototype`.
+- Active-account API-key conversion failures must fail closed, and user-facing errors must redact the exact current access and refresh secrets rather than relying only on token-shape regexes.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -54,6 +54,7 @@
 - `fs.watch` on a single file can miss branch HEAD writes on some platforms; watch the parent directory and filter the `HEAD` filename instead.
 - Symptom: Pi 0.79 CI rejects `ProviderHeaders` imports from `@earendil-works/pi-ai`. Cause: that root type export is newer than the supported compatibility floor. Fix: use the compatible local `Record<string, string>` auth-header shape when an extension must typecheck across the 0.79/0.80 matrix.
 - Pi 0.80.8 no longer root-exports `AuthStorage` or its file/in-memory backends, and `@earendil-works/pi-ai/oauth` retains only compatibility types. Keep extension credential storage package-owned, obtain built-in OAuth through `providers/all`, and test both the compatibility floor and latest Pi.
+- Pi runtime API-key set/remove methods may be asynchronous; serialize override mutations per runtime target so reset, logout, or shutdown cannot overtake a pending setter and leave stale auth active.
 
 ## TASTE
 

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -8,7 +8,7 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 ## Plan
 
-- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 526 tests, including private writes and concurrent migration.
+- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 527 tests, including private writes and concurrent migration.
 - [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses the legacy OAuth value when available and lazily falls back to provider-owned OAuth, regression tests pass, and isolated active-account print-mode smokes complete on both versions.
 - [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
 - [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
@@ -22,5 +22,5 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 - [x] Pi 0.80.8 loads and runs `extensions/pi-codex-accounts` without extension errors, verified with an isolated active-account `/codex-account default` print-mode smoke.
 - [x] Pi 0.80.3 compatibility is covered by the explicit GitHub Actions matrix entry and a passing local `npm run check` on Pi 0.80.3 dependencies.
-- [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (526 tests).
+- [x] Credential storage, refresh serialization, runtime override, and OAuth prompt tests pass with `npm run check` (527 tests).
 - [x] The npm dry-run contains `src/codex-accounts.ts`, `src/oauth.ts`, and `src/storage.ts` plus package metadata, README, and license.

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -4,12 +4,12 @@ Restore `pi-codex-accounts` on Pi 0.80.8 without dropping Pi 0.80.3 compatibilit
 
 ## Context
 
-Pi 0.80.8 stopped exporting `FileAuthStorageBackend` and moved runtime API-key overrides behind its model runtime. The extension currently imports the removed constructor and accesses the older `modelRegistry.authStorage` shape.
+Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entry point type-only, and moved runtime API-key overrides behind its model runtime. The extension currently imports removed runtime values and accesses the older `modelRegistry.authStorage` shape.
 
 ## Plan
 
 - [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 523 tests, including private writes and migrations.
-- [x] Adapt runtime API-key application to both Pi 0.80.3 and 0.80.8 and await async overrides; regression tests pass and isolated `PI_OFFLINE=1 pi --list-models` smoke succeeds on Pi 0.80.8 with an active override.
+- [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses provider-owned OAuth, regression tests pass, Pi 0.80.8 typechecking passes, and an isolated active-account print-mode smoke completes session start and reset.
 - [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
 - [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
 
@@ -20,7 +20,7 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend` and moved runtime API-key o
 
 ## Completion Checklist
 
-- [x] Pi 0.80.8 loads `extensions/pi-codex-accounts` without the removed-constructor error, verified with an isolated non-interactive active-account smoke.
+- [x] Pi 0.80.8 loads and runs `extensions/pi-codex-accounts` without extension errors, verified with an isolated active-account `/codex-account default` print-mode smoke.
 - [x] Pi 0.80.3 compatibility is covered by the explicit GitHub Actions matrix entry and a passing local `npm run check` on Pi 0.80.3 dependencies.
 - [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (523 tests).
 - [x] The npm dry-run contains `src/codex-accounts.ts` and `src/storage.ts` plus package metadata, README, and license.

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -9,7 +9,7 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 ## Plan
 
 - [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 524 tests, including private writes and migrations.
-- [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses provider-owned OAuth, regression tests pass, Pi 0.80.8 typechecking passes, and an isolated active-account print-mode smoke completes session start and reset.
+- [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses the legacy OAuth value when available and lazily falls back to provider-owned OAuth, regression tests pass, and isolated active-account print-mode smokes complete on both versions.
 - [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
 - [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
 

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -8,7 +8,7 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 ## Plan
 
-- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 523 tests, including private writes and migrations.
+- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 524 tests, including private writes and migrations.
 - [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses provider-owned OAuth, regression tests pass, Pi 0.80.8 typechecking passes, and an isolated active-account print-mode smoke completes session start and reset.
 - [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
 - [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
@@ -22,5 +22,5 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 - [x] Pi 0.80.8 loads and runs `extensions/pi-codex-accounts` without extension errors, verified with an isolated active-account `/codex-account default` print-mode smoke.
 - [x] Pi 0.80.3 compatibility is covered by the explicit GitHub Actions matrix entry and a passing local `npm run check` on Pi 0.80.3 dependencies.
-- [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (523 tests).
+- [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (524 tests).
 - [x] The npm dry-run contains `src/codex-accounts.ts` and `src/storage.ts` plus package metadata, README, and license.

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -8,10 +8,10 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 ## Plan
 
-- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 527 tests, including private writes and concurrent migration.
+- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 534 tests, including private writes, schema edge cases, and concurrent migration.
 - [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses the legacy OAuth value when available and lazily falls back to provider-owned OAuth, regression tests pass, and isolated active-account print-mode smokes complete on both versions.
 - [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
-- [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
+- [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes all three source modules, metadata, README, and license.
 
 ## Risks
 
@@ -22,5 +22,5 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 - [x] Pi 0.80.8 loads and runs `extensions/pi-codex-accounts` without extension errors, verified with an isolated active-account `/codex-account default` print-mode smoke.
 - [x] Pi 0.80.3 compatibility is covered by the explicit GitHub Actions matrix entry and a passing local `npm run check` on Pi 0.80.3 dependencies.
-- [x] Credential storage, refresh serialization, runtime override, and OAuth prompt tests pass with `npm run check` (527 tests).
+- [x] Biome, boundary checks, workspace typechecks, and all 534 tests pass, including credential storage, shutdown races, fail-closed auth, and OAuth prompts.
 - [x] The npm dry-run contains `src/codex-accounts.ts`, `src/oauth.ts`, and `src/storage.ts` plus package metadata, README, and license.

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -1,0 +1,26 @@
+## Goal
+
+Restore `pi-codex-accounts` on Pi 0.80.8 without dropping Pi 0.80.3 compatibility, and add Pi 0.80.3 to the GitHub Actions compatibility matrix.
+
+## Context
+
+Pi 0.80.8 stopped exporting `FileAuthStorageBackend` and moved runtime API-key overrides behind its model runtime. The extension currently imports the removed constructor and accesses the older `modelRegistry.authStorage` shape.
+
+## Plan
+
+- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 523 tests, including private writes and migrations.
+- [x] Adapt runtime API-key application to both Pi 0.80.3 and 0.80.8 and await async overrides; regression tests pass and isolated `PI_OFFLINE=1 pi --list-models` smoke succeeds on Pi 0.80.8 with an active override.
+- [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
+- [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
+
+## Risks
+
+- The Pi 0.80.8 extension-facing registry does not publicly expose runtime override mutation, so compatibility requires a guarded adapter over the old and new runtime shapes.
+- Cross-process credential refresh must retain locking and `0600` writes after removing Pi's storage backend.
+
+## Completion Checklist
+
+- [x] Pi 0.80.8 loads `extensions/pi-codex-accounts` without the removed-constructor error, verified with an isolated non-interactive active-account smoke.
+- [x] Pi 0.80.3 compatibility is covered by the explicit GitHub Actions matrix entry and a passing local `npm run check` on Pi 0.80.3 dependencies.
+- [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (523 tests).
+- [x] The npm dry-run contains `src/codex-accounts.ts` and `src/storage.ts` plus package metadata, README, and license.

--- a/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
+++ b/docs/plans/archived/2026-07-16_codex-accounts-pi-0808-compat-plan.md
@@ -8,7 +8,7 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 ## Plan
 
-- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 524 tests, including private writes and migrations.
+- [x] Replace the removed Pi auth-storage dependency with package-owned locked file and in-memory backends; `npm test` passes all 526 tests, including private writes and concurrent migration.
 - [x] Adapt OAuth and runtime API-key application to Pi 0.80.3 and 0.80.8; the extension uses the legacy OAuth value when available and lazily falls back to provider-owned OAuth, regression tests pass, and isolated active-account print-mode smokes complete on both versions.
 - [x] Add Pi 0.80.3 to `.github/workflows/ci.yml`; matrix inspection passes and `npm run check` passes against the local Pi 0.80.3 dependency floor.
 - [x] Update package metadata/docs and inspect the publish payload; `just pack-codex-accounts` includes both source modules, metadata, README, and license.
@@ -22,5 +22,5 @@ Pi 0.80.8 stopped exporting `FileAuthStorageBackend`, made the legacy OAuth entr
 
 - [x] Pi 0.80.8 loads and runs `extensions/pi-codex-accounts` without extension errors, verified with an isolated active-account `/codex-account default` print-mode smoke.
 - [x] Pi 0.80.3 compatibility is covered by the explicit GitHub Actions matrix entry and a passing local `npm run check` on Pi 0.80.3 dependencies.
-- [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (524 tests).
-- [x] The npm dry-run contains `src/codex-accounts.ts` and `src/storage.ts` plus package metadata, README, and license.
+- [x] Credential storage, refresh serialization, and runtime override tests pass with `npm run check` (526 tests).
+- [x] The npm dry-run contains `src/codex-accounts.ts`, `src/oauth.ts`, and `src/storage.ts` plus package metadata, README, and license.

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -69,8 +69,7 @@ Remove one self-managed account:
 
 The canonical credential file is `~/.pi/agent/pi-codex-accounts.json`. A legacy-only `codex-accounts.json` is migrated under the existing credential-file lock, copied with `0600` permissions, and removed only after the canonical file is installed. If both files exist, the canonical file takes precedence and the legacy file is retained.
 
-
-When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider.
+When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider. It supports both Pi 0.80.3's auth-storage runtime shape and Pi 0.80.8's model runtime shape.
 
 When no self-managed account is active, the extension removes its runtime override and Pi uses its normal `openai-codex` auth resolution. That means existing `/login openai-codex`, `auth.json`, or environment behavior still works.
 
@@ -83,14 +82,15 @@ Account switches and token refreshes also close any cached Codex WebSocket for t
 - This extension supports ChatGPT Plus/Pro Codex subscription auth only.
 - It does not rotate accounts automatically or try to bypass rate limits.
 - It does not switch Claude, Anthropic, or browser-cookie sessions.
-- Multiple Pi processes refreshing the same account at the same time are serialized through Pi's auth-file lock helper, but the newest refreshed token wins.
+- Multiple Pi processes refreshing the same account at the same time are serialized through the extension's credential-file lock, but the newest refreshed token wins.
 
 ## 🗂️ Package layout
 
 ```txt
 extensions/pi-codex-accounts/
 ├── src/
-│   └── codex-accounts.ts
+│   ├── codex-accounts.ts
+│   └── storage.ts
 ├── test/
 │   └── codex-accounts.test.ts
 ├── README.md

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -90,6 +90,7 @@ Account switches and token refreshes also close any cached Codex WebSocket for t
 extensions/pi-codex-accounts/
 ├── src/
 │   ├── codex-accounts.ts
+│   ├── oauth.ts
 │   └── storage.ts
 ├── test/
 │   └── codex-accounts.test.ts

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -16,7 +16,7 @@ It keeps using Pi's built-in `openai-codex` provider. It does **not** add provid
 - Sets only the runtime API key for Pi's native `openai-codex` provider.
 - Leaves your selected `/model` unchanged, matching Pi's built-in `/login` behavior, except it may select `openai-codex/gpt-5.5` when the current model is `unknown/unknown`.
 - Shows `codex:<name>` in the statusline only while the current model provider is `openai-codex`.
-- Fails closed if an active self-managed account cannot refresh, so Pi does not silently fall back to a different Codex account.
+- Fails closed if an active self-managed account cannot refresh or produce a runtime key, so Pi does not silently fall back to a different Codex account.
 - Closes the current session's cached Codex WebSocket when auth changes, preventing a reused connection from staying on the previous account.
 
 ## 📦 Install
@@ -39,7 +39,7 @@ pi -e ./extensions/pi-codex-accounts
 
 ## 🚀 Usage
 
-Login to named accounts:
+Login to named accounts (`default` is reserved for Pi's built-in login):
 
 ```text
 /codex-login work
@@ -73,7 +73,7 @@ When an active self-managed account is set, the extension applies that account's
 
 When no self-managed account is active, the extension removes its runtime override and Pi uses its normal `openai-codex` auth resolution. That means existing `/login openai-codex`, `auth.json`, or environment behavior still works.
 
-If the active self-managed account refresh fails, the extension keeps a non-empty failing runtime key in place. This prevents accidental fallback to a different Codex account.
+If the active self-managed account cannot refresh or produce an API key, the extension keeps a non-empty failing runtime key in place. This prevents accidental fallback to a different Codex account.
 
 Account switches and token refreshes also close any cached Codex WebSocket for the current Pi session. The next request reconnects with the newly selected credentials; repeated pre-turn checks, including turns started after compaction, keep the connection when auth is unchanged.
 
@@ -93,6 +93,7 @@ extensions/pi-codex-accounts/
 │   ├── oauth.ts
 │   └── storage.ts
 ├── test/
+│   ├── codex-accounts-storage.test.ts
 │   └── codex-accounts.test.ts
 ├── README.md
 ├── LICENSE

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -69,7 +69,7 @@ Remove one self-managed account:
 
 The canonical credential file is `~/.pi/agent/pi-codex-accounts.json`. A legacy-only `codex-accounts.json` is migrated under the existing credential-file lock, copied with `0600` permissions, and removed only after the canonical file is installed. If both files exist, the canonical file takes precedence and the legacy file is retained.
 
-When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider. Login and refresh use Pi's provider-owned Codex OAuth implementation. Runtime key application supports both Pi 0.80.3's auth-storage shape and Pi 0.80.8's model-runtime shape.
+When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider. Login and refresh use Pi's built-in Codex OAuth implementation through the loader entry point supported by the running Pi version. Runtime key application supports both Pi 0.80.3's auth-storage shape and Pi 0.80.8's model-runtime shape.
 
 When no self-managed account is active, the extension removes its runtime override and Pi uses its normal `openai-codex` auth resolution. That means existing `/login openai-codex`, `auth.json`, or environment behavior still works.
 

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -69,7 +69,7 @@ Remove one self-managed account:
 
 The canonical credential file is `~/.pi/agent/pi-codex-accounts.json`. A legacy-only `codex-accounts.json` is migrated under the existing credential-file lock, copied with `0600` permissions, and removed only after the canonical file is installed. If both files exist, the canonical file takes precedence and the legacy file is retained.
 
-When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider. It supports both Pi 0.80.3's auth-storage runtime shape and Pi 0.80.8's model runtime shape.
+When an active self-managed account is set, the extension applies that account's access token as Pi's runtime key for the native `openai-codex` provider. Login and refresh use Pi's provider-owned Codex OAuth implementation. Runtime key application supports both Pi 0.80.3's auth-storage shape and Pi 0.80.8's model-runtime shape.
 
 When no self-managed account is active, the extension removes its runtime override and Pi uses its normal `openai-codex` auth resolution. That means existing `/login openai-codex`, `auth.json`, or environment behavior still works.
 

--- a/extensions/pi-codex-accounts/package.json
+++ b/extensions/pi-codex-accounts/package.json
@@ -29,6 +29,9 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"dependencies": {
+		"proper-lockfile": "^4.1.2"
+	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*"
@@ -37,6 +40,7 @@
 		"@biomejs/biome": "2.5.3",
 		"@earendil-works/pi-ai": "0.80.3",
 		"@earendil-works/pi-coding-agent": "0.80.3",
+		"@types/proper-lockfile": "^4.1.4",
 		"typescript": "6.0.3"
 	},
 	"repository": {

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -49,7 +49,15 @@ type RuntimeAuthStorage = {
 
 type RuntimeOverrideState = {
 	appliedApiKey?: string;
+	generation: number;
+	mayHaveOverride: boolean;
 	operationTail: Promise<void>;
+};
+
+type RuntimeOverrideSnapshot = {
+	target: RuntimeAuthStorage & object;
+	state: RuntimeOverrideState;
+	generation: number;
 };
 
 const runtimeOverrideStates = new WeakMap<object, RuntimeOverrideState>();
@@ -168,6 +176,10 @@ export default function codexAccounts(
 				ctx.ui.notify(parsedName.error, "warning");
 				return;
 			}
+			if (isDefaultPiLoginArg(parsedName.name)) {
+				ctx.ui.notify(`"${parsedName.name}" is reserved for Pi's default Codex login.`, "warning");
+				return;
+			}
 			if (!ctx.hasUI) {
 				ctx.ui.notify("/codex-login requires interactive UI", "error");
 				return;
@@ -228,7 +240,7 @@ export default function codexAccounts(
 			let removed = false;
 			let removedActive = false;
 			await store.update((data) => {
-				if (!data.accounts[parsedName.name]) return data;
+				if (!getOwnStoredAccount(data.accounts, parsedName.name)) return data;
 				removed = true;
 				removedActive = data.active === parsedName.name;
 				const accounts = { ...data.accounts };
@@ -287,6 +299,7 @@ export async function ensureActiveCodexAuth(
 	store: CodexAccountStore,
 	options: { oauthProvider?: RefreshOnlyCodexOAuthProvider; now?: number } = {},
 ): Promise<EnsureActiveCodexAuthResult> {
+	const runtimeOverride = captureRuntimeOverride(ctx);
 	const data = await store.readAsync();
 	const active = data.active;
 	if (!active) {
@@ -294,9 +307,13 @@ export async function ensureActiveCodexAuth(
 		return { status: "inactive" };
 	}
 
-	let credential = data.accounts[active];
+	let credential = getOwnStoredAccount(data.accounts, active);
 	if (!credential) {
-		await store.update((current) => ({ ...current, active: undefined }));
+		const current = await store.update((latest) => {
+			if (latest.active !== active || getOwnStoredAccount(latest.accounts, active)) return latest;
+			return { ...latest, active: undefined };
+		});
+		if (current.active) return ensureActiveCodexAuth(ctx, store, options);
 		await clearRuntimeCodexAuth(ctx);
 		return { status: "inactive" };
 	}
@@ -305,8 +322,8 @@ export async function ensureActiveCodexAuth(
 	if (credential.expires <= (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
 		let refreshError: unknown;
 		const current = await store.updateAsync(async (latest) => {
-			if (latest.active !== active || !latest.accounts[active]) return latest;
-			const latestCredential = latest.accounts[active];
+			const latestCredential = getOwnStoredAccount(latest.accounts, active);
+			if (latest.active !== active || !latestCredential) return latest;
 			credential = latestCredential;
 			if (latestCredential.expires > (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
 				return latest;
@@ -323,27 +340,46 @@ export async function ensureActiveCodexAuth(
 				return latest;
 			}
 		});
-		if (current.active !== active) {
+		if (current.active !== active || !getOwnStoredAccount(current.accounts, active)) {
 			return ensureActiveCodexAuth(ctx, store, options);
 		}
 		if (refreshError !== undefined) {
 			if (!(await activeCredentialMatches(store, active, credential))) {
 				return ensureActiveCodexAuth(ctx, store, options);
 			}
-			await setRuntimeCodexApiKey(ctx, FAIL_CLOSED_API_KEY);
+			if (!(await setRuntimeCodexApiKey(runtimeOverride, FAIL_CLOSED_API_KEY))) {
+				return { status: "inactive" };
+			}
 			return {
 				status: "error",
 				accountName: active,
-				message: redactTokenText(errorMessage(refreshError)),
+				message: redactCredentialError(refreshError, credential),
 			};
 		}
 	}
 
-	const apiKey = await oauthProvider.getApiKey(credential);
+	let apiKey: string;
+	try {
+		apiKey = await oauthProvider.getApiKey(credential);
+	} catch (error) {
+		if (!(await activeCredentialMatches(store, active, credential))) {
+			return ensureActiveCodexAuth(ctx, store, options);
+		}
+		if (!(await setRuntimeCodexApiKey(runtimeOverride, FAIL_CLOSED_API_KEY))) {
+			return { status: "inactive" };
+		}
+		return {
+			status: "error",
+			accountName: active,
+			message: redactCredentialError(error, credential),
+		};
+	}
 	if (!(await activeCredentialMatches(store, active, credential))) {
 		return ensureActiveCodexAuth(ctx, store, options);
 	}
-	await setRuntimeCodexApiKey(ctx, apiKey);
+	if (!(await setRuntimeCodexApiKey(runtimeOverride, apiKey))) {
+		return { status: "inactive" };
+	}
 	return { status: "active", accountName: active };
 }
 
@@ -353,7 +389,7 @@ async function activeCredentialMatches(
 	expected: StoredCodexCredential,
 ): Promise<boolean> {
 	const latest = await store.readAsync();
-	const current = latest.accounts[accountName];
+	const current = getOwnStoredAccount(latest.accounts, accountName);
 	return (
 		latest.active === accountName &&
 		current !== undefined &&
@@ -574,6 +610,13 @@ function parseStoredData(raw: string | undefined): CodexAccountsData {
 	return active ? { active, accounts } : { accounts };
 }
 
+function getOwnStoredAccount(
+	accounts: Record<string, StoredCodexCredential>,
+	name: string,
+): StoredCodexCredential | undefined {
+	return Object.hasOwn(accounts, name) ? accounts[name] : undefined;
+}
+
 function parseAccounts(rawAccounts: unknown): Record<string, StoredCodexCredential> {
 	if (rawAccounts === undefined) return {};
 	if (!isRecord(rawAccounts))
@@ -583,7 +626,12 @@ function parseAccounts(rawAccounts: unknown): Record<string, StoredCodexCredenti
 	for (const [name, rawCredential] of Object.entries(rawAccounts)) {
 		const parsedName = parseAccountName(name);
 		if (!parsedName.ok) throw new Error(`Invalid Codex accounts data: bad account name "${name}".`);
-		accounts[name] = normalizeCredential(rawCredential, name);
+		Object.defineProperty(accounts, name, {
+			configurable: true,
+			enumerable: true,
+			value: normalizeCredential(rawCredential, name),
+			writable: true,
+		});
 	}
 	return accounts;
 }
@@ -723,7 +771,7 @@ async function activateStoredAccount(
 ): Promise<void> {
 	let activated = false;
 	await store.update((data) => {
-		if (!data.accounts[name]) return data;
+		if (!getOwnStoredAccount(data.accounts, name)) return data;
 		activated = true;
 		return { ...data, active: name };
 	});
@@ -782,7 +830,7 @@ function formatActivatedMessage(
 	result: EnsureActiveCodexAuthResult,
 ): string {
 	if (result.status === "error") {
-		return `${action} Codex account "${name}", but refresh failed; Codex requests will fail closed: ${result.message}`;
+		return `${action} Codex account "${name}", but authentication failed; Codex requests will fail closed: ${result.message}`;
 	}
 	return `${action} Codex account "${name}".`;
 }
@@ -794,7 +842,7 @@ async function getActiveAuthIdentity(
 	if (result.status === "inactive") return "default";
 	if (result.status === "error") return `error:${result.accountName}`;
 	const data = await store.readAsync();
-	return `${result.accountName}:${data.accounts[result.accountName]?.access ?? "missing"}`;
+	return `${result.accountName}:${getOwnStoredAccount(data.accounts, result.accountName)?.access ?? "missing"}`;
 }
 
 function updateStatus(
@@ -825,14 +873,21 @@ function setStatus(ctx: ExtensionContext, value: string | undefined): void {
 	}
 }
 
-async function setRuntimeCodexApiKey(ctx: ExtensionContext, apiKey: string): Promise<void> {
-	const target = getRuntimeAuthStorage(ctx);
-	if (!target) throw new Error("This Pi version does not expose runtime provider authentication.");
-	const state = getRuntimeOverrideState(target);
-	await enqueueRuntimeOverrideMutation(state, async () => {
-		if (state.appliedApiKey === apiKey) return;
+async function setRuntimeCodexApiKey(
+	snapshot: RuntimeOverrideSnapshot | undefined,
+	apiKey: string,
+): Promise<boolean> {
+	if (!snapshot)
+		throw new Error("This Pi version does not expose runtime provider authentication.");
+	const { generation, state, target } = snapshot;
+	return enqueueRuntimeOverrideMutation(state, async () => {
+		if (state.generation !== generation) return false;
+		if (state.appliedApiKey === apiKey) return true;
+		state.appliedApiKey = undefined;
+		state.mayHaveOverride = true;
 		await target.setRuntimeApiKey(CODEX_PROVIDER_ID, apiKey);
 		state.appliedApiKey = apiKey;
+		return state.generation === generation;
 	});
 }
 
@@ -841,28 +896,44 @@ async function clearRuntimeCodexAuth(ctx: ExtensionContext): Promise<void> {
 	if (!target) return;
 	const state = runtimeOverrideStates.get(target);
 	if (!state) return;
+	state.generation += 1;
 	await enqueueRuntimeOverrideMutation(state, async () => {
-		if (state.appliedApiKey === undefined) return;
+		if (!state.mayHaveOverride) return;
 		await target.removeRuntimeApiKey(CODEX_PROVIDER_ID);
 		state.appliedApiKey = undefined;
+		state.mayHaveOverride = false;
 	});
+}
+
+function captureRuntimeOverride(ctx: ExtensionContext): RuntimeOverrideSnapshot | undefined {
+	const target = getRuntimeAuthStorage(ctx);
+	if (!target) return undefined;
+	const state = getRuntimeOverrideState(target);
+	return { target, state, generation: state.generation };
 }
 
 function getRuntimeOverrideState(target: object): RuntimeOverrideState {
 	let state = runtimeOverrideStates.get(target);
 	if (!state) {
-		state = { operationTail: Promise.resolve() };
+		state = {
+			generation: 0,
+			mayHaveOverride: false,
+			operationTail: Promise.resolve(),
+		};
 		runtimeOverrideStates.set(target, state);
 	}
 	return state;
 }
 
-function enqueueRuntimeOverrideMutation(
+function enqueueRuntimeOverrideMutation<T>(
 	state: RuntimeOverrideState,
-	mutate: () => Promise<void>,
-): Promise<void> {
+	mutate: () => Promise<T>,
+): Promise<T> {
 	const operation = state.operationTail.then(mutate);
-	state.operationTail = operation.catch(() => undefined);
+	state.operationTail = operation.then(
+		() => undefined,
+		() => undefined,
+	);
 	return operation;
 }
 
@@ -907,10 +978,23 @@ function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-function redactTokenText(text: string): string {
-	return text
+function redactCredentialError(error: unknown, credential: StoredCodexCredential): string {
+	return redactTokenText(errorMessage(error), [credential.access, credential.refresh]);
+}
+
+function redactTokenText(text: string, exactSecrets: readonly string[] = []): string {
+	const secrets = [...new Set(exactSecrets.filter(Boolean))].sort(
+		(left, right) => right.length - left.length,
+	);
+	const exactSecretPattern =
+		secrets.length > 0
+			? new RegExp(secrets.map((secret) => escapeRegExp(secret)).join("|"), "g")
+			: undefined;
+	return (exactSecretPattern ? text.replace(exactSecretPattern, "<redacted>") : text)
 		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer <redacted>")
 		.replace(/"access"\s*:\s*"[^"]+"/gi, '"access":"<redacted>"')
 		.replace(/"refresh"\s*:\s*"[^"]+"/gi, '"refresh":"<redacted>"')
 		.replace(/\b(access|refresh)[_-][A-Za-z0-9._~+/=-]+/gi, "$1-<redacted>");
 }
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -19,7 +19,9 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import {
 	type CodexOAuthCallbacks,
+	type CodexOAuthPrompt,
 	type CodexOAuthProvider,
+	type CodexOAuthSelectPrompt,
 	type DeviceCodeInfo,
 	getDefaultCodexOAuthProvider,
 	type OAuthCredentials,
@@ -651,21 +653,21 @@ async function loginCodexAccount(
 		onDeviceCode: (info: DeviceCodeInfo) => {
 			ctx.ui.notify(formatDeviceCodeMessage(info), "info");
 		},
-		onPrompt: async (prompt: { message: string; placeholder?: string; allowEmpty?: boolean }) => {
-			const value = await ctx.ui.input(prompt.message, prompt.placeholder ?? "");
+		onPrompt: async (prompt: CodexOAuthPrompt) => {
+			const value = await ctx.ui.input(prompt.message, prompt.placeholder ?? "", {
+				signal: prompt.signal,
+			});
 			if ((value === undefined || value === "") && !prompt.allowEmpty) {
 				throw new Error("Login cancelled");
 			}
 			return value ?? "";
 		},
 		onProgress: (message: string) => ctx.ui.notify(message, "info"),
-		onSelect: async (prompt: {
-			message: string;
-			options: Array<{ id: string; label: string }>;
-		}) => {
+		onSelect: async (prompt: CodexOAuthSelectPrompt) => {
 			const selected = await ctx.ui.select(
 				prompt.message,
 				prompt.options.map((option) => option.label),
+				{ signal: prompt.signal },
 			);
 			return prompt.options.find((option) => option.label === selected)?.id;
 		},

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -12,9 +12,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import {
-	FileAuthStorageBackend,
 	getAgentDir,
-	type AuthStorageBackend,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ExtensionContext,
@@ -24,6 +22,10 @@ import {
 	type OAuthCredentials,
 	type OAuthLoginCallbacks,
 } from "@earendil-works/pi-ai/oauth";
+import {
+	type CodexAccountStorageBackend,
+	FileCodexAccountStorageBackend,
+} from "./storage.js";
 
 export const CODEX_PROVIDER_ID = "openai-codex";
 export const DEFAULT_CODEX_MODEL_ID = "gpt-5.5";
@@ -38,9 +40,11 @@ let pendingAccountsMigrationNotice: string | undefined;
 const ACCOUNT_NAME_RE = /^[A-Za-z0-9._-]{1,64}$/;
 
 type RuntimeAuthStorage = {
-	setRuntimeApiKey(provider: string, apiKey: string): void;
-	removeRuntimeApiKey(provider: string): void;
+	setRuntimeApiKey(provider: string, apiKey: string): void | Promise<void>;
+	removeRuntimeApiKey(provider: string): void | Promise<void>;
 };
+
+const appliedRuntimeOverrides = new WeakMap<object, Map<string, string>>();
 
 type DeviceCodeInfo = {
 	userCode: string;
@@ -91,10 +95,12 @@ export type CodexAccountsDependencies = {
 };
 
 export class CodexAccountStore {
-	private readonly backend: AuthStorageBackend;
+	private readonly backend: CodexAccountStorageBackend;
 	private operationTail: Promise<void> = Promise.resolve();
 
-	constructor(backend: AuthStorageBackend = new FileAuthStorageBackend(defaultAccountsPath())) {
+	constructor(
+		backend: CodexAccountStorageBackend = new FileCodexAccountStorageBackend(defaultAccountsPath()),
+	) {
 		this.backend = backend;
 	}
 
@@ -263,8 +269,8 @@ export default function codexAccounts(
 		await sync(ctx);
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
-		clearRuntimeCodexAuth(ctx);
+	pi.on("session_shutdown", async (_event, ctx) => {
+		await clearRuntimeCodexAuth(ctx);
 		setStatus(ctx, undefined);
 	});
 }
@@ -289,14 +295,14 @@ export async function ensureActiveCodexAuth(
 	const data = await store.readAsync();
 	const active = data.active;
 	if (!active) {
-		clearRuntimeCodexAuth(ctx);
+		await clearRuntimeCodexAuth(ctx);
 		return { status: "inactive" };
 	}
 
 	let credential = data.accounts[active];
 	if (!credential) {
 		await store.update((current) => ({ ...current, active: undefined }));
-		clearRuntimeCodexAuth(ctx);
+		await clearRuntimeCodexAuth(ctx);
 		return { status: "inactive" };
 	}
 
@@ -328,7 +334,7 @@ export async function ensureActiveCodexAuth(
 			return ensureActiveCodexAuth(ctx, store, options);
 		}
 		if (refreshError !== undefined) {
-			setRuntimeCodexApiKey(ctx, FAIL_CLOSED_API_KEY);
+			await setRuntimeCodexApiKey(ctx, FAIL_CLOSED_API_KEY);
 			return {
 				status: "error",
 				accountName: active,
@@ -337,7 +343,7 @@ export async function ensureActiveCodexAuth(
 		}
 	}
 
-	setRuntimeCodexApiKey(ctx, oauthProvider.getApiKey(credential));
+	await setRuntimeCodexApiKey(ctx, oauthProvider.getApiKey(credential));
 	return { status: "active", accountName: active };
 }
 
@@ -401,7 +407,7 @@ function defaultAccountsPath(): string {
 	if (!pathEntryExists(legacyPath)) return canonicalPath;
 
 	try {
-		return new FileAuthStorageBackend(legacyPath).withLock(() => {
+		return new FileCodexAccountStorageBackend(legacyPath).withLock(() => {
 			const contents = readFileSync(legacyPath, "utf8");
 			const permissionError = enforcePrivateFilePermissions(legacyPath);
 			if (permissionError) throw new Error(permissionError);
@@ -757,16 +763,48 @@ function setStatus(ctx: ExtensionContext, value: string | undefined): void {
 	}
 }
 
-function setRuntimeCodexApiKey(ctx: ExtensionContext, apiKey: string): void {
-	getRuntimeAuthStorage(ctx)?.setRuntimeApiKey(CODEX_PROVIDER_ID, apiKey);
+async function setRuntimeCodexApiKey(ctx: ExtensionContext, apiKey: string): Promise<void> {
+	const target = getRuntimeAuthStorage(ctx);
+	if (!target) throw new Error("This Pi version does not expose runtime provider authentication.");
+	let overrides = appliedRuntimeOverrides.get(target);
+	if (!overrides) {
+		overrides = new Map();
+		appliedRuntimeOverrides.set(target, overrides);
+	}
+	if (overrides.get(CODEX_PROVIDER_ID) === apiKey) return;
+	await target.setRuntimeApiKey(CODEX_PROVIDER_ID, apiKey);
+	overrides.set(CODEX_PROVIDER_ID, apiKey);
 }
 
-function clearRuntimeCodexAuth(ctx: ExtensionContext): void {
-	getRuntimeAuthStorage(ctx)?.removeRuntimeApiKey(CODEX_PROVIDER_ID);
+async function clearRuntimeCodexAuth(ctx: ExtensionContext): Promise<void> {
+	const target = getRuntimeAuthStorage(ctx);
+	if (!target) return;
+	const overrides = appliedRuntimeOverrides.get(target);
+	if (!overrides?.has(CODEX_PROVIDER_ID)) return;
+	await target.removeRuntimeApiKey(CODEX_PROVIDER_ID);
+	overrides.delete(CODEX_PROVIDER_ID);
 }
 
-function getRuntimeAuthStorage(ctx: ExtensionContext): RuntimeAuthStorage | undefined {
-	return (ctx.modelRegistry as unknown as { authStorage?: RuntimeAuthStorage }).authStorage;
+function getRuntimeAuthStorage(ctx: ExtensionContext): (RuntimeAuthStorage & object) | undefined {
+	const registry = ctx.modelRegistry as unknown as {
+		authStorage?: unknown;
+		runtime?: unknown;
+	};
+	for (const candidate of [registry, registry.runtime, registry.authStorage]) {
+		if (isRuntimeAuthStorage(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+function isRuntimeAuthStorage(value: unknown): value is RuntimeAuthStorage & object {
+	return (
+		!!value &&
+		typeof value === "object" &&
+		"setRuntimeApiKey" in value &&
+		typeof value.setRuntimeApiKey === "function" &&
+		"removeRuntimeApiKey" in value &&
+		typeof value.removeRuntimeApiKey === "function"
+	);
 }
 
 function isStaleExtensionContextError(error: unknown): boolean {

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -11,8 +11,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
-import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import * as piAiOAuth from "@earendil-works/pi-ai/oauth";
 import {
 	type ExtensionAPI,
 	type ExtensionCommandContext,
@@ -52,6 +51,13 @@ type DeviceCodeInfo = {
 	expiresInSeconds?: number;
 };
 
+type OAuthCredentials = piAiOAuth.OAuthCredentials;
+type OAuthLoginCallbacks = piAiOAuth.OAuthLoginCallbacks;
+type BuiltinProvider = ReturnType<
+	typeof import("@earendil-works/pi-ai/providers/all").builtinProviders
+>[number];
+type ProviderOwnedOAuth = NonNullable<BuiltinProvider["auth"]["oauth"]>;
+
 type CodexOAuthCallbacks = OAuthLoginCallbacks & {
 	onDeviceCode?: (info: DeviceCodeInfo) => void;
 };
@@ -62,7 +68,8 @@ type CodexOAuthProvider = {
 	getApiKey(credentials: OAuthCredentials): string | Promise<string>;
 };
 
-let builtinCodexOAuthProvider: CodexOAuthProvider | undefined;
+let defaultCodexOAuthProvider: CodexOAuthProvider | undefined;
+let providerOwnedOAuthPromise: Promise<ProviderOwnedOAuth> | undefined;
 
 type RefreshOnlyCodexOAuthProvider = Pick<CodexOAuthProvider, "refreshToken" | "getApiKey">;
 
@@ -153,7 +160,7 @@ export default function codexAccounts(
 ) {
 	const store = dependencies.store ?? new CodexAccountStore();
 	let migrationNotice = dependencies.store ? undefined : consumeAccountsMigrationNotice();
-	const oauthProvider = dependencies.oauthProvider ?? getBuiltinCodexOAuthProvider();
+	const oauthProvider = dependencies.oauthProvider ?? getDefaultCodexOAuthProvider();
 	// Keep cleanup injectable until WebSocket controls are available through a loader-safe export.
 	const closeWebSocketSessions = dependencies.closeWebSocketSessions ?? (() => undefined);
 	let appliedAuthIdentity: string | undefined;
@@ -312,7 +319,7 @@ export async function ensureActiveCodexAuth(
 		return { status: "inactive" };
 	}
 
-	const oauthProvider = options.oauthProvider ?? getBuiltinCodexOAuthProvider();
+	const oauthProvider = options.oauthProvider ?? getDefaultCodexOAuthProvider();
 	if (credential.expires <= (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
 		let refreshError: unknown;
 		const current = await store.updateAsync(async (latest) => {
@@ -624,15 +631,19 @@ function normalizeCredential(
 			};
 }
 
-function getBuiltinCodexOAuthProvider(): CodexOAuthProvider {
-	if (builtinCodexOAuthProvider) return builtinCodexOAuthProvider;
-	const oauth = builtinProviders().find((provider) => provider.id === CODEX_PROVIDER_ID)?.auth
-		.oauth;
-	if (!oauth) throw new Error("Pi's built-in OpenAI Codex OAuth provider is unavailable.");
+function getDefaultCodexOAuthProvider(): CodexOAuthProvider {
+	if (defaultCodexOAuthProvider) return defaultCodexOAuthProvider;
+	const legacyProvider = (piAiOAuth as unknown as { openaiCodexOAuthProvider?: CodexOAuthProvider })
+		.openaiCodexOAuthProvider;
+	defaultCodexOAuthProvider = legacyProvider ?? createProviderOwnedCodexOAuthAdapter();
+	return defaultCodexOAuthProvider;
+}
 
-	builtinCodexOAuthProvider = {
-		login: (callbacks) =>
-			oauth.login({
+function createProviderOwnedCodexOAuthAdapter(): CodexOAuthProvider {
+	return {
+		login: async (callbacks) => {
+			const oauth = await loadProviderOwnedCodexOAuth();
+			return oauth.login({
 				signal: callbacks.signal,
 				prompt: async (prompt) => {
 					if (prompt.type === "select") {
@@ -674,16 +685,32 @@ function getBuiltinCodexOAuthProvider(): CodexOAuthProvider {
 							break;
 					}
 				},
-			}),
-		refreshToken: (credentials) => oauth.refresh(asOAuthCredential(credentials)),
+			});
+		},
+		refreshToken: async (credentials) => {
+			const oauth = await loadProviderOwnedCodexOAuth();
+			return oauth.refresh(asOAuthCredential(credentials));
+		},
 		getApiKey: async (credentials) => {
+			const oauth = await loadProviderOwnedCodexOAuth();
 			const auth = await oauth.toAuth(asOAuthCredential(credentials));
 			if (!auth.apiKey)
 				throw new Error("Pi's built-in OpenAI Codex OAuth provider returned no access token.");
 			return auth.apiKey;
 		},
 	};
-	return builtinCodexOAuthProvider;
+}
+
+function loadProviderOwnedCodexOAuth(): Promise<ProviderOwnedOAuth> {
+	providerOwnedOAuthPromise ??= import("@earendil-works/pi-ai/providers/all").then(
+		({ builtinProviders }) => {
+			const oauth = builtinProviders().find((provider) => provider.id === CODEX_PROVIDER_ID)?.auth
+				.oauth;
+			if (!oauth) throw new Error("Pi's built-in OpenAI Codex OAuth provider is unavailable.");
+			return oauth;
+		},
+	);
+	return providerOwnedOAuthPromise;
 }
 
 function asOAuthCredential(credentials: OAuthCredentials) {

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -11,21 +11,15 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
+import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import {
-	getAgentDir,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ExtensionContext,
+	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import {
-	openaiCodexOAuthProvider,
-	type OAuthCredentials,
-	type OAuthLoginCallbacks,
-} from "@earendil-works/pi-ai/oauth";
-import {
-	type CodexAccountStorageBackend,
-	FileCodexAccountStorageBackend,
-} from "./storage.js";
+import { type CodexAccountStorageBackend, FileCodexAccountStorageBackend } from "./storage.js";
 
 export const CODEX_PROVIDER_ID = "openai-codex";
 export const DEFAULT_CODEX_MODEL_ID = "gpt-5.5";
@@ -60,8 +54,10 @@ type CodexOAuthCallbacks = OAuthLoginCallbacks & {
 type CodexOAuthProvider = {
 	login(callbacks: CodexOAuthCallbacks): Promise<OAuthCredentials>;
 	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
-	getApiKey(credentials: OAuthCredentials): string;
+	getApiKey(credentials: OAuthCredentials): string | Promise<string>;
 };
+
+let builtinCodexOAuthProvider: CodexOAuthProvider | undefined;
 
 type RefreshOnlyCodexOAuthProvider = Pick<CodexOAuthProvider, "refreshToken" | "getApiKey">;
 
@@ -116,7 +112,9 @@ export class CodexAccountStore {
 		await this.updateAsync(async () => data);
 	}
 
-	async update(mutator: (data: CodexAccountsData) => CodexAccountsData): Promise<CodexAccountsData> {
+	async update(
+		mutator: (data: CodexAccountsData) => CodexAccountsData,
+	): Promise<CodexAccountsData> {
 		return this.updateAsync(async (data) => mutator(data));
 	}
 
@@ -150,9 +148,8 @@ export default function codexAccounts(
 ) {
 	const store = dependencies.store ?? new CodexAccountStore();
 	let migrationNotice = dependencies.store ? undefined : consumeAccountsMigrationNotice();
-	const oauthProvider = dependencies.oauthProvider ?? openaiCodexOAuthProvider;
-	// Pi's extension loader only exposes pi-ai's root, compat, and OAuth entry points.
-	// Keep cleanup injectable until the WebSocket API is available through a loader-safe export.
+	const oauthProvider = dependencies.oauthProvider ?? getBuiltinCodexOAuthProvider();
+	// Keep cleanup injectable until WebSocket controls are available through a loader-safe export.
 	const closeWebSocketSessions = dependencies.closeWebSocketSessions ?? (() => undefined);
 	let appliedAuthIdentity: string | undefined;
 	let authIdentityInitialized = false;
@@ -223,9 +220,10 @@ export default function codexAccounts(
 
 	pi.registerCommand("codex-logout", {
 		description: "Remove a self-managed Codex account",
-		getArgumentCompletions: (prefix) => completeStoredAccountArguments(prefix, store, {
-			includeDefault: false,
-		}),
+		getArgumentCompletions: (prefix) =>
+			completeStoredAccountArguments(prefix, store, {
+				includeDefault: false,
+			}),
 		handler: async (args, ctx) => {
 			const parsedName = parseAccountName(args);
 			if (!parsedName.ok) {
@@ -275,13 +273,16 @@ export default function codexAccounts(
 	});
 }
 
-export function parseAccountName(input: string): { ok: true; name: string } | { ok: false; error: string } {
+export function parseAccountName(
+	input: string,
+): { ok: true; name: string } | { ok: false; error: string } {
 	const name = input.trim();
 	if (!name) return { ok: false, error: "Account name is required." };
 	if (!ACCOUNT_NAME_RE.test(name)) {
 		return {
 			ok: false,
-			error: "Account names must be 1-64 characters using letters, numbers, dot, underscore, or hyphen.",
+			error:
+				"Account names must be 1-64 characters using letters, numbers, dot, underscore, or hyphen.",
 		};
 	}
 	return { ok: true, name };
@@ -306,7 +307,7 @@ export async function ensureActiveCodexAuth(
 		return { status: "inactive" };
 	}
 
-	const oauthProvider = options.oauthProvider ?? openaiCodexOAuthProvider;
+	const oauthProvider = options.oauthProvider ?? getBuiltinCodexOAuthProvider();
 	if (credential.expires <= (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
 		let refreshError: unknown;
 		const current = await store.updateAsync(async (latest) => {
@@ -317,9 +318,7 @@ export async function ensureActiveCodexAuth(
 				return latest;
 			}
 			try {
-				const refreshed = normalizeCredential(
-					await oauthProvider.refreshToken(latestCredential),
-				);
+				const refreshed = normalizeCredential(await oauthProvider.refreshToken(latestCredential));
 				credential = refreshed;
 				return {
 					...latest,
@@ -343,7 +342,7 @@ export async function ensureActiveCodexAuth(
 		}
 	}
 
-	await setRuntimeCodexApiKey(ctx, oauthProvider.getApiKey(credential));
+	await setRuntimeCodexApiKey(ctx, await oauthProvider.getApiKey(credential));
 	return { status: "active", accountName: active };
 }
 
@@ -361,7 +360,13 @@ export function completeStoredAccountArguments(
 	}
 
 	const items: CommandArgumentCompletion[] = includeDefault
-		? [{ value: "default", label: DEFAULT_PI_LOGIN_LABEL, description: "Use Pi's built-in Codex login" }]
+		? [
+				{
+					value: "default",
+					label: DEFAULT_PI_LOGIN_LABEL,
+					description: "Use Pi's built-in Codex login",
+				},
+			]
 		: [];
 	for (const name of names) items.push({ value: name, label: name });
 
@@ -369,7 +374,9 @@ export function completeStoredAccountArguments(
 	return prefix ? items.filter((item) => item.value.startsWith(prefix)) : items;
 }
 
-export function isOpenAICodexModel(model: Pick<NonNullable<ExtensionContext["model"]>, "provider"> | undefined): boolean {
+export function isOpenAICodexModel(
+	model: Pick<NonNullable<ExtensionContext["model"]>, "provider"> | undefined,
+): boolean {
 	return model?.provider === CODEX_PROVIDER_ID;
 }
 
@@ -548,7 +555,8 @@ function parseStoredData(raw: string | undefined): CodexAccountsData {
 
 function parseAccounts(rawAccounts: unknown): Record<string, StoredCodexCredential> {
 	if (rawAccounts === undefined) return {};
-	if (!isRecord(rawAccounts)) throw new Error("Invalid Codex accounts data: accounts must be an object.");
+	if (!isRecord(rawAccounts))
+		throw new Error("Invalid Codex accounts data: accounts must be an object.");
 
 	const accounts: Record<string, StoredCodexCredential> = {};
 	for (const [name, rawCredential] of Object.entries(rawAccounts)) {
@@ -573,23 +581,108 @@ function stringifyStoredData(data: CodexAccountsData): string {
 	return `${JSON.stringify(parseStoredData(JSON.stringify(data)), null, 2)}\n`;
 }
 
-function normalizeCredential(rawCredential: unknown, accountName = "account"): StoredCodexCredential {
+function normalizeCredential(
+	rawCredential: unknown,
+	accountName = "account",
+): StoredCodexCredential {
 	if (!isRecord(rawCredential)) {
 		throw new Error(`Invalid Codex accounts data: ${accountName} credential must be an object.`);
 	}
 	if (typeof rawCredential.access !== "string" || !rawCredential.access) {
-		throw new Error(`Invalid Codex accounts data: ${accountName} credential is missing access token.`);
+		throw new Error(
+			`Invalid Codex accounts data: ${accountName} credential is missing access token.`,
+		);
 	}
 	if (typeof rawCredential.refresh !== "string" || !rawCredential.refresh) {
-		throw new Error(`Invalid Codex accounts data: ${accountName} credential is missing refresh token.`);
+		throw new Error(
+			`Invalid Codex accounts data: ${accountName} credential is missing refresh token.`,
+		);
 	}
 	if (typeof rawCredential.expires !== "number" || !Number.isFinite(rawCredential.expires)) {
-		throw new Error(`Invalid Codex accounts data: ${accountName} credential has invalid expiration.`);
+		throw new Error(
+			`Invalid Codex accounts data: ${accountName} credential has invalid expiration.`,
+		);
 	}
-	const accountId = typeof rawCredential.accountId === "string" ? rawCredential.accountId : undefined;
+	const accountId =
+		typeof rawCredential.accountId === "string" ? rawCredential.accountId : undefined;
 	return accountId
-		? { access: rawCredential.access, refresh: rawCredential.refresh, expires: rawCredential.expires, accountId }
-		: { access: rawCredential.access, refresh: rawCredential.refresh, expires: rawCredential.expires };
+		? {
+				access: rawCredential.access,
+				refresh: rawCredential.refresh,
+				expires: rawCredential.expires,
+				accountId,
+			}
+		: {
+				access: rawCredential.access,
+				refresh: rawCredential.refresh,
+				expires: rawCredential.expires,
+			};
+}
+
+function getBuiltinCodexOAuthProvider(): CodexOAuthProvider {
+	if (builtinCodexOAuthProvider) return builtinCodexOAuthProvider;
+	const oauth = builtinProviders().find((provider) => provider.id === CODEX_PROVIDER_ID)?.auth
+		.oauth;
+	if (!oauth) throw new Error("Pi's built-in OpenAI Codex OAuth provider is unavailable.");
+
+	builtinCodexOAuthProvider = {
+		login: (callbacks) =>
+			oauth.login({
+				signal: callbacks.signal,
+				prompt: async (prompt) => {
+					if (prompt.type === "select") {
+						const selected = await callbacks.onSelect({
+							message: prompt.message,
+							options: prompt.options.map(({ id, label }) => ({ id, label })),
+						});
+						if (selected === undefined) throw new Error("Login cancelled");
+						return selected;
+					}
+					if (prompt.type === "manual_code" && callbacks.onManualCodeInput) {
+						return callbacks.onManualCodeInput();
+					}
+					return callbacks.onPrompt({
+						message: prompt.message,
+						placeholder: prompt.placeholder,
+					});
+				},
+				notify: (event) => {
+					if ((event as { type: string }).type === "info") {
+						const info = event as unknown as {
+							message: string;
+							links?: ReadonlyArray<{ url: string }>;
+						};
+						callbacks.onProgress?.(
+							[info.message, ...(info.links ?? []).map((link) => link.url)].join("\n"),
+						);
+						return;
+					}
+					switch (event.type) {
+						case "auth_url":
+							callbacks.onAuth({ url: event.url, instructions: event.instructions });
+							break;
+						case "device_code":
+							callbacks.onDeviceCode?.(event);
+							break;
+						case "progress":
+							callbacks.onProgress?.(event.message);
+							break;
+					}
+				},
+			}),
+		refreshToken: (credentials) => oauth.refresh(asOAuthCredential(credentials)),
+		getApiKey: async (credentials) => {
+			const auth = await oauth.toAuth(asOAuthCredential(credentials));
+			if (!auth.apiKey)
+				throw new Error("Pi's built-in OpenAI Codex OAuth provider returned no access token.");
+			return auth.apiKey;
+		},
+	};
+	return builtinCodexOAuthProvider;
+}
+
+function asOAuthCredential(credentials: OAuthCredentials) {
+	return { ...credentials, type: "oauth" as const };
 }
 
 async function loginCodexAccount(
@@ -613,7 +706,10 @@ async function loginCodexAccount(
 			return value ?? "";
 		},
 		onProgress: (message: string) => ctx.ui.notify(message, "info"),
-		onSelect: async (prompt: { message: string; options: Array<{ id: string; label: string }> }) => {
+		onSelect: async (prompt: {
+			message: string;
+			options: Array<{ id: string; label: string }>;
+		}) => {
 			const selected = await ctx.ui.select(
 				prompt.message,
 				prompt.options.map((option) => option.label),
@@ -681,7 +777,10 @@ async function activateStoredAccount(
 		return;
 	}
 	const result = await sync(ctx);
-	ctx.ui.notify(formatActivatedMessage("Activated", name, result), result.status === "error" ? "error" : "info");
+	ctx.ui.notify(
+		formatActivatedMessage("Activated", name, result),
+		result.status === "error" ? "error" : "info",
+	);
 }
 
 async function clearActiveAccount(
@@ -696,14 +795,22 @@ async function clearActiveAccount(
 
 function isDefaultPiLoginArg(arg: string): boolean {
 	const normalized = arg.trim().toLowerCase();
-	return normalized === "default" || normalized === "--default" || normalized === DEFAULT_PI_LOGIN_LABEL;
+	return (
+		normalized === "default" || normalized === "--default" || normalized === DEFAULT_PI_LOGIN_LABEL
+	);
 }
 
-async function selectDefaultCodexModelIfUnknown(pi: ExtensionAPI, ctx: ExtensionCommandContext): Promise<void> {
+async function selectDefaultCodexModelIfUnknown(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+): Promise<void> {
 	if (!isUnknownModel(ctx.model)) return;
 	const model = ctx.modelRegistry.find(CODEX_PROVIDER_ID, DEFAULT_CODEX_MODEL_ID);
 	if (!model) {
-		ctx.ui.notify(`Logged in, but ${CODEX_PROVIDER_ID}/${DEFAULT_CODEX_MODEL_ID} was not found.`, "warning");
+		ctx.ui.notify(
+			`Logged in, but ${CODEX_PROVIDER_ID}/${DEFAULT_CODEX_MODEL_ID} was not found.`,
+			"warning",
+		);
 		return;
 	}
 	const ok = await pi.setModel(model);
@@ -808,7 +915,10 @@ function isRuntimeAuthStorage(value: unknown): value is RuntimeAuthStorage & obj
 }
 
 function isStaleExtensionContextError(error: unknown): boolean {
-	return error instanceof Error && error.message.includes("This extension ctx is stale after session replacement or reload");
+	return (
+		error instanceof Error &&
+		error.message.includes("This extension ctx is stale after session replacement or reload")
+	);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -11,13 +11,20 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import * as piAiOAuth from "@earendil-works/pi-ai/oauth";
 import {
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ExtensionContext,
 	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
+import {
+	type CodexOAuthCallbacks,
+	type CodexOAuthProvider,
+	type DeviceCodeInfo,
+	getDefaultCodexOAuthProvider,
+	type OAuthCredentials,
+	type RefreshOnlyCodexOAuthProvider,
+} from "./oauth.js";
 import { type CodexAccountStorageBackend, FileCodexAccountStorageBackend } from "./storage.js";
 
 export const CODEX_PROVIDER_ID = "openai-codex";
@@ -29,6 +36,7 @@ export const DEFAULT_PI_LOGIN_LABEL = "(default pi login)";
 export const FAIL_CLOSED_API_KEY = "pi-codex-accounts-refresh-failed";
 
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
+const MIGRATION_LOCK_TIMEOUT_MS = 30_000;
 let pendingAccountsMigrationNotice: string | undefined;
 const ACCOUNT_NAME_RE = /^[A-Za-z0-9._-]{1,64}$/;
 
@@ -43,35 +51,6 @@ type RuntimeOverrideState = {
 };
 
 const runtimeOverrideStates = new WeakMap<object, RuntimeOverrideState>();
-
-type DeviceCodeInfo = {
-	userCode: string;
-	verificationUri: string;
-	intervalSeconds?: number;
-	expiresInSeconds?: number;
-};
-
-type OAuthCredentials = piAiOAuth.OAuthCredentials;
-type OAuthLoginCallbacks = piAiOAuth.OAuthLoginCallbacks;
-type BuiltinProvider = ReturnType<
-	typeof import("@earendil-works/pi-ai/providers/all").builtinProviders
->[number];
-type ProviderOwnedOAuth = NonNullable<BuiltinProvider["auth"]["oauth"]>;
-
-type CodexOAuthCallbacks = OAuthLoginCallbacks & {
-	onDeviceCode?: (info: DeviceCodeInfo) => void;
-};
-
-type CodexOAuthProvider = {
-	login(callbacks: CodexOAuthCallbacks): Promise<OAuthCredentials>;
-	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
-	getApiKey(credentials: OAuthCredentials): string | Promise<string>;
-};
-
-let defaultCodexOAuthProvider: CodexOAuthProvider | undefined;
-let providerOwnedOAuthPromise: Promise<ProviderOwnedOAuth> | undefined;
-
-type RefreshOnlyCodexOAuthProvider = Pick<CodexOAuthProvider, "refreshToken" | "getApiKey">;
 
 export type StoredCodexCredential = {
 	access: string;
@@ -160,7 +139,8 @@ export default function codexAccounts(
 ) {
 	const store = dependencies.store ?? new CodexAccountStore();
 	let migrationNotice = dependencies.store ? undefined : consumeAccountsMigrationNotice();
-	const oauthProvider = dependencies.oauthProvider ?? getDefaultCodexOAuthProvider();
+	const oauthProvider =
+		dependencies.oauthProvider ?? getDefaultCodexOAuthProvider(CODEX_PROVIDER_ID);
 	// Keep cleanup injectable until WebSocket controls are available through a loader-safe export.
 	const closeWebSocketSessions = dependencies.closeWebSocketSessions ?? (() => undefined);
 	let appliedAuthIdentity: string | undefined;
@@ -319,14 +299,14 @@ export async function ensureActiveCodexAuth(
 		return { status: "inactive" };
 	}
 
-	const oauthProvider = options.oauthProvider ?? getDefaultCodexOAuthProvider();
+	const oauthProvider = options.oauthProvider ?? getDefaultCodexOAuthProvider(CODEX_PROVIDER_ID);
 	if (credential.expires <= (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
 		let refreshError: unknown;
 		const current = await store.updateAsync(async (latest) => {
 			if (latest.active !== active || !latest.accounts[active]) return latest;
 			const latestCredential = latest.accounts[active];
+			credential = latestCredential;
 			if (latestCredential.expires > (options.now ?? Date.now()) + REFRESH_SKEW_MS) {
-				credential = latestCredential;
 				return latest;
 			}
 			try {
@@ -345,6 +325,9 @@ export async function ensureActiveCodexAuth(
 			return ensureActiveCodexAuth(ctx, store, options);
 		}
 		if (refreshError !== undefined) {
+			if (!(await activeCredentialMatches(store, active, credential))) {
+				return ensureActiveCodexAuth(ctx, store, options);
+			}
 			await setRuntimeCodexApiKey(ctx, FAIL_CLOSED_API_KEY);
 			return {
 				status: "error",
@@ -354,8 +337,29 @@ export async function ensureActiveCodexAuth(
 		}
 	}
 
-	await setRuntimeCodexApiKey(ctx, await oauthProvider.getApiKey(credential));
+	const apiKey = await oauthProvider.getApiKey(credential);
+	if (!(await activeCredentialMatches(store, active, credential))) {
+		return ensureActiveCodexAuth(ctx, store, options);
+	}
+	await setRuntimeCodexApiKey(ctx, apiKey);
 	return { status: "active", accountName: active };
+}
+
+async function activeCredentialMatches(
+	store: CodexAccountStore,
+	accountName: string,
+	expected: StoredCodexCredential,
+): Promise<boolean> {
+	const latest = await store.readAsync();
+	const current = latest.accounts[accountName];
+	return (
+		latest.active === accountName &&
+		current !== undefined &&
+		current.access === expected.access &&
+		current.refresh === expected.refresh &&
+		current.expires === expected.expires &&
+		current.accountId === expected.accountId
+	);
 }
 
 export function completeStoredAccountArguments(
@@ -426,7 +430,9 @@ function defaultAccountsPath(): string {
 	if (!pathEntryExists(legacyPath)) return canonicalPath;
 
 	try {
-		return new FileCodexAccountStorageBackend(legacyPath).withLock(() => {
+		return new FileCodexAccountStorageBackend(legacyPath, {
+			syncLockTimeoutMs: MIGRATION_LOCK_TIMEOUT_MS,
+		}).withLock(() => {
 			const contents = readFileSync(legacyPath, "utf8");
 			const permissionError = enforcePrivateFilePermissions(legacyPath);
 			if (permissionError) throw new Error(permissionError);
@@ -461,6 +467,7 @@ function defaultAccountsPath(): string {
 			pendingAccountsMigrationNotice = `${LEGACY_CODEX_ACCOUNTS_FILE} ignored because ${CODEX_ACCOUNTS_FILE} was created concurrently.`;
 			return canonicalPath;
 		}
+		if (hasErrorCode(error, "ELOCKED")) throw error;
 		pendingAccountsMigrationNotice = `Codex accounts migration failed: ${errorMessage(error)}. The legacy file will be used for this session.`;
 		return legacyPath;
 	}
@@ -629,92 +636,6 @@ function normalizeCredential(
 				refresh: rawCredential.refresh,
 				expires: rawCredential.expires,
 			};
-}
-
-function getDefaultCodexOAuthProvider(): CodexOAuthProvider {
-	if (defaultCodexOAuthProvider) return defaultCodexOAuthProvider;
-	const legacyProvider = (piAiOAuth as unknown as { openaiCodexOAuthProvider?: CodexOAuthProvider })
-		.openaiCodexOAuthProvider;
-	defaultCodexOAuthProvider = legacyProvider ?? createProviderOwnedCodexOAuthAdapter();
-	return defaultCodexOAuthProvider;
-}
-
-function createProviderOwnedCodexOAuthAdapter(): CodexOAuthProvider {
-	return {
-		login: async (callbacks) => {
-			const oauth = await loadProviderOwnedCodexOAuth();
-			return oauth.login({
-				signal: callbacks.signal,
-				prompt: async (prompt) => {
-					if (prompt.type === "select") {
-						const selected = await callbacks.onSelect({
-							message: prompt.message,
-							options: prompt.options.map(({ id, label }) => ({ id, label })),
-						});
-						if (selected === undefined) throw new Error("Login cancelled");
-						return selected;
-					}
-					if (prompt.type === "manual_code" && callbacks.onManualCodeInput) {
-						return callbacks.onManualCodeInput();
-					}
-					return callbacks.onPrompt({
-						message: prompt.message,
-						placeholder: prompt.placeholder,
-					});
-				},
-				notify: (event) => {
-					if ((event as { type: string }).type === "info") {
-						const info = event as unknown as {
-							message: string;
-							links?: ReadonlyArray<{ url: string }>;
-						};
-						callbacks.onProgress?.(
-							[info.message, ...(info.links ?? []).map((link) => link.url)].join("\n"),
-						);
-						return;
-					}
-					switch (event.type) {
-						case "auth_url":
-							callbacks.onAuth({ url: event.url, instructions: event.instructions });
-							break;
-						case "device_code":
-							callbacks.onDeviceCode?.(event);
-							break;
-						case "progress":
-							callbacks.onProgress?.(event.message);
-							break;
-					}
-				},
-			});
-		},
-		refreshToken: async (credentials) => {
-			const oauth = await loadProviderOwnedCodexOAuth();
-			return oauth.refresh(asOAuthCredential(credentials));
-		},
-		getApiKey: async (credentials) => {
-			const oauth = await loadProviderOwnedCodexOAuth();
-			const auth = await oauth.toAuth(asOAuthCredential(credentials));
-			if (!auth.apiKey)
-				throw new Error("Pi's built-in OpenAI Codex OAuth provider returned no access token.");
-			return auth.apiKey;
-		},
-	};
-}
-
-function loadProviderOwnedCodexOAuth(): Promise<ProviderOwnedOAuth> {
-	providerOwnedOAuthPromise ??= import("@earendil-works/pi-ai/providers/all").then(
-		({ builtinProviders }) => {
-			const oauth = builtinProviders().find((provider) => provider.id === CODEX_PROVIDER_ID)?.auth
-				.oauth;
-			if (!oauth) throw new Error("Pi's built-in OpenAI Codex OAuth provider is unavailable.");
-			return oauth;
-		},
-	);
-	return providerOwnedOAuthPromise;
-}
-
-function asOAuthCredential(credentials: OAuthCredentials) {
-	return { ...credentials, type: "oauth" as const };
 }
 
 async function loginCodexAccount(
@@ -974,6 +895,10 @@ function isStaleExtensionContextError(error: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
 }
 
 function errorMessage(error: unknown): string {

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -38,7 +38,12 @@ type RuntimeAuthStorage = {
 	removeRuntimeApiKey(provider: string): void | Promise<void>;
 };
 
-const appliedRuntimeOverrides = new WeakMap<object, Map<string, string>>();
+type RuntimeOverrideState = {
+	appliedApiKey?: string;
+	operationTail: Promise<void>;
+};
+
+const runtimeOverrideStates = new WeakMap<object, RuntimeOverrideState>();
 
 type DeviceCodeInfo = {
 	userCode: string;
@@ -873,23 +878,42 @@ function setStatus(ctx: ExtensionContext, value: string | undefined): void {
 async function setRuntimeCodexApiKey(ctx: ExtensionContext, apiKey: string): Promise<void> {
 	const target = getRuntimeAuthStorage(ctx);
 	if (!target) throw new Error("This Pi version does not expose runtime provider authentication.");
-	let overrides = appliedRuntimeOverrides.get(target);
-	if (!overrides) {
-		overrides = new Map();
-		appliedRuntimeOverrides.set(target, overrides);
-	}
-	if (overrides.get(CODEX_PROVIDER_ID) === apiKey) return;
-	await target.setRuntimeApiKey(CODEX_PROVIDER_ID, apiKey);
-	overrides.set(CODEX_PROVIDER_ID, apiKey);
+	const state = getRuntimeOverrideState(target);
+	await enqueueRuntimeOverrideMutation(state, async () => {
+		if (state.appliedApiKey === apiKey) return;
+		await target.setRuntimeApiKey(CODEX_PROVIDER_ID, apiKey);
+		state.appliedApiKey = apiKey;
+	});
 }
 
 async function clearRuntimeCodexAuth(ctx: ExtensionContext): Promise<void> {
 	const target = getRuntimeAuthStorage(ctx);
 	if (!target) return;
-	const overrides = appliedRuntimeOverrides.get(target);
-	if (!overrides?.has(CODEX_PROVIDER_ID)) return;
-	await target.removeRuntimeApiKey(CODEX_PROVIDER_ID);
-	overrides.delete(CODEX_PROVIDER_ID);
+	const state = runtimeOverrideStates.get(target);
+	if (!state) return;
+	await enqueueRuntimeOverrideMutation(state, async () => {
+		if (state.appliedApiKey === undefined) return;
+		await target.removeRuntimeApiKey(CODEX_PROVIDER_ID);
+		state.appliedApiKey = undefined;
+	});
+}
+
+function getRuntimeOverrideState(target: object): RuntimeOverrideState {
+	let state = runtimeOverrideStates.get(target);
+	if (!state) {
+		state = { operationTail: Promise.resolve() };
+		runtimeOverrideStates.set(target, state);
+	}
+	return state;
+}
+
+function enqueueRuntimeOverrideMutation(
+	state: RuntimeOverrideState,
+	mutate: () => Promise<void>,
+): Promise<void> {
+	const operation = state.operationTail.then(mutate);
+	state.operationTail = operation.catch(() => undefined);
+	return operation;
 }
 
 function getRuntimeAuthStorage(ctx: ExtensionContext): (RuntimeAuthStorage & object) | undefined {

--- a/extensions/pi-codex-accounts/src/oauth.ts
+++ b/extensions/pi-codex-accounts/src/oauth.ts
@@ -1,0 +1,115 @@
+import * as piAiOAuth from "@earendil-works/pi-ai/oauth";
+
+export type DeviceCodeInfo = {
+	userCode: string;
+	verificationUri: string;
+	intervalSeconds?: number;
+	expiresInSeconds?: number;
+};
+
+export type OAuthCredentials = piAiOAuth.OAuthCredentials;
+type OAuthLoginCallbacks = piAiOAuth.OAuthLoginCallbacks;
+type BuiltinProvider = ReturnType<
+	typeof import("@earendil-works/pi-ai/providers/all").builtinProviders
+>[number];
+type ProviderOwnedOAuth = NonNullable<BuiltinProvider["auth"]["oauth"]>;
+
+export type CodexOAuthCallbacks = OAuthLoginCallbacks & {
+	onDeviceCode?: (info: DeviceCodeInfo) => void;
+};
+
+export type CodexOAuthProvider = {
+	login(callbacks: CodexOAuthCallbacks): Promise<OAuthCredentials>;
+	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
+	getApiKey(credentials: OAuthCredentials): string | Promise<string>;
+};
+
+export type RefreshOnlyCodexOAuthProvider = Pick<CodexOAuthProvider, "refreshToken" | "getApiKey">;
+
+let defaultCodexOAuthProvider: CodexOAuthProvider | undefined;
+let providerOwnedOAuthPromise: Promise<ProviderOwnedOAuth> | undefined;
+
+export function getDefaultCodexOAuthProvider(providerId: string): CodexOAuthProvider {
+	if (defaultCodexOAuthProvider) return defaultCodexOAuthProvider;
+	const legacyProvider = (piAiOAuth as unknown as { openaiCodexOAuthProvider?: CodexOAuthProvider })
+		.openaiCodexOAuthProvider;
+	defaultCodexOAuthProvider = legacyProvider ?? createProviderOwnedCodexOAuthAdapter(providerId);
+	return defaultCodexOAuthProvider;
+}
+
+function createProviderOwnedCodexOAuthAdapter(providerId: string): CodexOAuthProvider {
+	return {
+		login: async (callbacks) => {
+			const oauth = await loadProviderOwnedCodexOAuth(providerId);
+			return oauth.login({
+				signal: callbacks.signal,
+				prompt: async (prompt) => {
+					if (prompt.type === "select") {
+						const selected = await callbacks.onSelect({
+							message: prompt.message,
+							options: prompt.options.map(({ id, label }) => ({ id, label })),
+						});
+						if (selected === undefined) throw new Error("Login cancelled");
+						return selected;
+					}
+					if (prompt.type === "manual_code" && callbacks.onManualCodeInput) {
+						return callbacks.onManualCodeInput();
+					}
+					return callbacks.onPrompt({
+						message: prompt.message,
+						placeholder: prompt.placeholder,
+					});
+				},
+				notify: (event) => {
+					if ((event as { type: string }).type === "info") {
+						const info = event as unknown as {
+							message: string;
+							links?: ReadonlyArray<{ url: string }>;
+						};
+						callbacks.onProgress?.(
+							[info.message, ...(info.links ?? []).map((link) => link.url)].join("\n"),
+						);
+						return;
+					}
+					switch (event.type) {
+						case "auth_url":
+							callbacks.onAuth({ url: event.url, instructions: event.instructions });
+							break;
+						case "device_code":
+							callbacks.onDeviceCode?.(event);
+							break;
+						case "progress":
+							callbacks.onProgress?.(event.message);
+							break;
+					}
+				},
+			});
+		},
+		refreshToken: async (credentials) => {
+			const oauth = await loadProviderOwnedCodexOAuth(providerId);
+			return oauth.refresh(asOAuthCredential(credentials));
+		},
+		getApiKey: async (credentials) => {
+			const oauth = await loadProviderOwnedCodexOAuth(providerId);
+			const auth = await oauth.toAuth(asOAuthCredential(credentials));
+			if (!auth.apiKey)
+				throw new Error("Pi's built-in OpenAI Codex OAuth provider returned no access token.");
+			return auth.apiKey;
+		},
+	};
+}
+
+function loadProviderOwnedCodexOAuth(providerId: string): Promise<ProviderOwnedOAuth> {
+	providerOwnedOAuthPromise ??= import("@earendil-works/pi-ai/providers/all").then(
+		({ builtinProviders }) => {
+			const oauth = builtinProviders().find((provider) => provider.id === providerId)?.auth.oauth;
+			if (!oauth) throw new Error("Pi's built-in OpenAI Codex OAuth provider is unavailable.");
+			return oauth;
+		},
+	);
+	return providerOwnedOAuthPromise;
+}
+
+function asOAuthCredential(credentials: OAuthCredentials) {
+	return { ...credentials, type: "oauth" as const };
+}

--- a/extensions/pi-codex-accounts/src/oauth.ts
+++ b/extensions/pi-codex-accounts/src/oauth.ts
@@ -9,13 +9,25 @@ export type DeviceCodeInfo = {
 
 export type OAuthCredentials = piAiOAuth.OAuthCredentials;
 type OAuthLoginCallbacks = piAiOAuth.OAuthLoginCallbacks;
+export type CodexOAuthPrompt = Parameters<OAuthLoginCallbacks["onPrompt"]>[0] & {
+	signal?: AbortSignal;
+};
+export type CodexOAuthSelectPrompt = Parameters<OAuthLoginCallbacks["onSelect"]>[0] & {
+	signal?: AbortSignal;
+};
 type BuiltinProvider = ReturnType<
 	typeof import("@earendil-works/pi-ai/providers/all").builtinProviders
 >[number];
 type ProviderOwnedOAuth = NonNullable<BuiltinProvider["auth"]["oauth"]>;
 
-export type CodexOAuthCallbacks = OAuthLoginCallbacks & {
+export type CodexOAuthCallbacks = Omit<
+	OAuthLoginCallbacks,
+	"onManualCodeInput" | "onPrompt" | "onSelect"
+> & {
 	onDeviceCode?: (info: DeviceCodeInfo) => void;
+	onManualCodeInput?: (signal?: AbortSignal) => Promise<string>;
+	onPrompt: (prompt: CodexOAuthPrompt) => Promise<string>;
+	onSelect: (prompt: CodexOAuthSelectPrompt) => Promise<string | undefined>;
 };
 
 export type CodexOAuthProvider = {
@@ -48,16 +60,18 @@ function createProviderOwnedCodexOAuthAdapter(providerId: string): CodexOAuthPro
 						const selected = await callbacks.onSelect({
 							message: prompt.message,
 							options: prompt.options.map(({ id, label }) => ({ id, label })),
+							signal: prompt.signal,
 						});
 						if (selected === undefined) throw new Error("Login cancelled");
 						return selected;
 					}
 					if (prompt.type === "manual_code" && callbacks.onManualCodeInput) {
-						return callbacks.onManualCodeInput();
+						return callbacks.onManualCodeInput(prompt.signal);
 					}
 					return callbacks.onPrompt({
 						message: prompt.message,
 						placeholder: prompt.placeholder,
+						signal: prompt.signal,
 					});
 				},
 				notify: (event) => {

--- a/extensions/pi-codex-accounts/src/storage.ts
+++ b/extensions/pi-codex-accounts/src/storage.ts
@@ -1,0 +1,143 @@
+import {
+	chmodSync,
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import lockfile from "proper-lockfile";
+
+const PRIVATE_FILE_WRITE_OPTIONS = { encoding: "utf8", mode: 0o600 } as const;
+
+type StorageLockResult<T> = {
+	result: T;
+	next?: string;
+};
+
+export interface CodexAccountStorageBackend {
+	withLock<T>(mutator: (current: string | undefined) => StorageLockResult<T>): T;
+	withLockAsync<T>(
+		mutator: (current: string | undefined) => Promise<StorageLockResult<T>>,
+	): Promise<T>;
+}
+
+export class FileCodexAccountStorageBackend implements CodexAccountStorageBackend {
+	constructor(private readonly filePath: string) {}
+
+	withLock<T>(mutator: (current: string | undefined) => StorageLockResult<T>): T {
+		this.ensureFileExists();
+		let release: (() => void) | undefined;
+		try {
+			release = this.acquireLockSyncWithRetry();
+			const { result, next } = mutator(readFileSync(this.filePath, "utf8"));
+			if (next !== undefined) this.writePrivate(next);
+			return result;
+		} finally {
+			release?.();
+		}
+	}
+
+	async withLockAsync<T>(
+		mutator: (current: string | undefined) => Promise<StorageLockResult<T>>,
+	): Promise<T> {
+		this.ensureFileExists();
+		let release: (() => Promise<void>) | undefined;
+		let compromisedError: Error | undefined;
+		const throwIfCompromised = () => {
+			if (compromisedError) throw compromisedError;
+		};
+
+		try {
+			release = await lockfile.lock(this.filePath, {
+				realpath: false,
+				retries: {
+					retries: 10,
+					factor: 2,
+					minTimeout: 100,
+					maxTimeout: 10_000,
+					randomize: true,
+				},
+				stale: 30_000,
+				onCompromised: (error) => {
+					compromisedError = error;
+				},
+			});
+			throwIfCompromised();
+			const { result, next } = await mutator(readFileSync(this.filePath, "utf8"));
+			throwIfCompromised();
+			if (next !== undefined) this.writePrivate(next);
+			throwIfCompromised();
+			return result;
+		} finally {
+			if (release) {
+				try {
+					await release();
+				} catch {
+					// A compromised lock may already have been removed by another process.
+				}
+			}
+		}
+	}
+
+	private ensureFileExists(): void {
+		mkdirSync(dirname(this.filePath), { recursive: true, mode: 0o700 });
+		let descriptor: number | undefined;
+		try {
+			descriptor = openSync(this.filePath, "wx", 0o600);
+			writeFileSync(descriptor, "", PRIVATE_FILE_WRITE_OPTIONS);
+		} catch (error) {
+			if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+		} finally {
+			if (descriptor !== undefined) closeSync(descriptor);
+		}
+	}
+
+	private acquireLockSyncWithRetry(): () => void {
+		const maxAttempts = 10;
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+			try {
+				return lockfile.lockSync(this.filePath, { realpath: false });
+			} catch (error) {
+				if (!isNodeError(error) || error.code !== "ELOCKED" || attempt === maxAttempts) {
+					throw error;
+				}
+				lastError = error;
+				const start = Date.now();
+				while (Date.now() - start < 20) {
+					// The synchronous API cannot use timed retries.
+				}
+			}
+		}
+		throw lastError ?? new Error("Failed to acquire Codex account storage lock");
+	}
+
+	private writePrivate(contents: string): void {
+		writeFileSync(this.filePath, contents, PRIVATE_FILE_WRITE_OPTIONS);
+		chmodSync(this.filePath, 0o600);
+	}
+}
+
+export class InMemoryCodexAccountStorageBackend implements CodexAccountStorageBackend {
+	private value: string | undefined;
+
+	withLock<T>(mutator: (current: string | undefined) => StorageLockResult<T>): T {
+		const { result, next } = mutator(this.value);
+		if (next !== undefined) this.value = next;
+		return result;
+	}
+
+	async withLockAsync<T>(
+		mutator: (current: string | undefined) => Promise<StorageLockResult<T>>,
+	): Promise<T> {
+		const { result, next } = await mutator(this.value);
+		if (next !== undefined) this.value = next;
+		return result;
+	}
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error;
+}

--- a/extensions/pi-codex-accounts/src/storage.ts
+++ b/extensions/pi-codex-accounts/src/storage.ts
@@ -1,11 +1,4 @@
-import {
-	chmodSync,
-	closeSync,
-	mkdirSync,
-	openSync,
-	readFileSync,
-	writeFileSync,
-} from "node:fs";
+import { chmodSync, closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import lockfile from "proper-lockfile";
 

--- a/extensions/pi-codex-accounts/src/storage.ts
+++ b/extensions/pi-codex-accounts/src/storage.ts
@@ -3,6 +3,9 @@ import { dirname } from "node:path";
 import lockfile from "proper-lockfile";
 
 const PRIVATE_FILE_WRITE_OPTIONS = { encoding: "utf8", mode: 0o600 } as const;
+const DEFAULT_SYNC_LOCK_TIMEOUT_MS = 200;
+const SYNC_LOCK_RETRY_INTERVAL_MS = 20;
+const syncSleepState = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 type StorageLockResult<T> = {
 	result: T;
@@ -17,7 +20,10 @@ export interface CodexAccountStorageBackend {
 }
 
 export class FileCodexAccountStorageBackend implements CodexAccountStorageBackend {
-	constructor(private readonly filePath: string) {}
+	constructor(
+		private readonly filePath: string,
+		private readonly options: { syncLockTimeoutMs?: number } = {},
+	) {}
 
 	withLock<T>(mutator: (current: string | undefined) => StorageLockResult<T>): T {
 		this.ensureFileExists();
@@ -88,23 +94,18 @@ export class FileCodexAccountStorageBackend implements CodexAccountStorageBacken
 	}
 
 	private acquireLockSyncWithRetry(): () => void {
-		const maxAttempts = 10;
-		let lastError: unknown;
-		for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		const timeoutMs = this.options.syncLockTimeoutMs ?? DEFAULT_SYNC_LOCK_TIMEOUT_MS;
+		const deadline = Date.now() + timeoutMs;
+		while (true) {
 			try {
 				return lockfile.lockSync(this.filePath, { realpath: false });
 			} catch (error) {
-				if (!isNodeError(error) || error.code !== "ELOCKED" || attempt === maxAttempts) {
-					throw error;
-				}
-				lastError = error;
-				const start = Date.now();
-				while (Date.now() - start < 20) {
-					// The synchronous API cannot use timed retries.
-				}
+				if (!isNodeError(error) || error.code !== "ELOCKED") throw error;
+				const remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) throw error;
+				Atomics.wait(syncSleepState, 0, 0, Math.min(SYNC_LOCK_RETRY_INTERVAL_MS, remainingMs));
 			}
 		}
-		throw lastError ?? new Error("Failed to acquire Codex account storage lock");
 	}
 
 	private writePrivate(contents: string): void {

--- a/extensions/pi-codex-accounts/test/codex-accounts-storage.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts-storage.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { access, chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import codexAccounts, {
+	CODEX_ACCOUNTS_FILE,
+	CodexAccountStore,
+	ensureActiveCodexAuth,
+} from "../src/codex-accounts.js";
+import {
+	FileCodexAccountStorageBackend as FileAuthStorageBackend,
+	InMemoryCodexAccountStorageBackend as InMemoryAuthStorageBackend,
+} from "../src/storage.js";
+
+const validCred = (suffix = "") => ({
+	access: `access-${suffix}`,
+	refresh: `refresh-${suffix}`,
+	expires: Date.now() + 60 * 60 * 1000,
+	accountId: `account-${suffix}`,
+});
+
+test("store writes private account files and redacts invalid JSON", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-"));
+	const file = join(dir, "pi-codex-accounts.json");
+	const store = new CodexAccountStore(new FileAuthStorageBackend(file));
+
+	await store.write({ active: "work", accounts: { work: validCred("work") } });
+	const mode = (await stat(file)).mode & 0o777;
+	assert.equal(mode, 0o600);
+
+	await store.writeRawForTest('{"active":"work","accounts":{"work":{"access":"secret-token"}}');
+	await assert.rejects(store.readAsync(), (error) => {
+		assert.ok(error instanceof Error);
+		assert.match(error.message, /Invalid Codex accounts JSON/);
+		assert.doesNotMatch(error.message, /secret-token/);
+		return true;
+	});
+});
+
+test("stored account maps preserve prototype-like account names as own entries", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	const credential = validCred("prototype");
+	await store.writeRawForTest(
+		`{"active":"__proto__","accounts":{"__proto__":${JSON.stringify(credential)}}}`,
+	);
+
+	const data = await store.readAsync();
+
+	assert.deepEqual(Object.keys(data.accounts), ["__proto__"]);
+	assert.deepEqual(Object.getOwnPropertyDescriptor(data.accounts, "__proto__")?.value, credential);
+});
+
+test("an inherited account-map property is not treated as a stored account", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.writeRawForTest('{"active":"constructor","accounts":{}}');
+	const runtimeCalls: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: (provider: string, key: string) =>
+					runtimeCalls.push(`set:${provider}:${key}`),
+				removeRuntimeApiKey: (provider: string) => runtimeCalls.push(`remove:${provider}`),
+			},
+		},
+	});
+
+	const result = await ensureActiveCodexAuth(ctx, store, {
+		oauthProvider: {
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			getApiKey() {
+				throw new Error("unexpected API-key conversion");
+			},
+		},
+	});
+
+	assert.deepEqual(result, { status: "inactive" });
+	assert.equal((await store.readAsync()).active, undefined);
+	assert.deepEqual(runtimeCalls, []);
+});
+
+test("default store migrates credentials to the canonical package filename", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		const raw = JSON.stringify({
+			active: "work",
+			accounts: { work: validCred("work") },
+			futureOption: true,
+		});
+		await writeFile(legacyPath, raw, { mode: 0o644 });
+		await chmod(legacyPath, 0o644);
+
+		const mock = createMockPi();
+		codexAccounts(mock.pi);
+		assert.equal(CODEX_ACCOUNTS_FILE, "pi-codex-accounts.json");
+		assert.equal(await readFile(canonicalPath, "utf8"), raw);
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		await assert.rejects(access(legacyPath));
+
+		const context = createMockContext({
+			modelRegistry: {
+				authStorage: {
+					setRuntimeApiKey: () => undefined,
+					removeRuntimeApiKey: () => undefined,
+				},
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		assert.match(context.notifications[0]?.message ?? "", /migrated/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("concurrent startup waits for an in-progress legacy account migration", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-migration-lock-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	let lockHolder: ReturnType<typeof spawn> | undefined;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		const raw = JSON.stringify({ active: "work", accounts: { work: validCred("work") } });
+		await writeFile(legacyPath, raw, { mode: 0o600 });
+		lockHolder = spawn(
+			process.execPath,
+			[
+				"-e",
+				`const lockfile = require("proper-lockfile");
+(async () => {
+	const release = await lockfile.lock(process.argv[1], { realpath: false });
+	process.stdout.write("locked\\n");
+	await new Promise((resolve) => setTimeout(resolve, 500));
+	await release();
+})().catch((error) => { console.error(error); process.exitCode = 1; });`,
+				legacyPath,
+			],
+			{ stdio: ["ignore", "pipe", "inherit"] },
+		);
+		const lockHolderExit = once(lockHolder, "exit");
+		assert.ok(lockHolder.stdout);
+		await once(lockHolder.stdout, "data");
+
+		const store = new CodexAccountStore();
+		assert.equal(store.read().active, "work");
+		assert.equal(await readFile(canonicalPath, "utf8"), raw);
+		await assert.rejects(access(legacyPath));
+		const [exitCode] = await lockHolderExit;
+		assert.equal(exitCode, 0);
+	} finally {
+		lockHolder?.kill();
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("migration preserves malformed credential data without leaking tokens", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-invalid-migration-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		await writeFile(legacyPath, '{"accounts":{"work":{"access":"secret-token"}}', {
+			mode: 0o600,
+		});
+		const store = new CodexAccountStore();
+
+		await assert.rejects(store.readAsync(), (error) => {
+			assert.ok(error instanceof Error);
+			assert.match(error.message, /pi-codex-accounts\.json/);
+			assert.doesNotMatch(error.message, /secret-token/);
+			return true;
+		});
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		await assert.rejects(access(legacyPath));
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("canonical Codex accounts file wins without deleting the legacy file", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-precedence-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		await writeFile(
+			legacyPath,
+			JSON.stringify({ active: "old", accounts: { old: validCred("old") } }),
+			{ mode: 0o600 },
+		);
+		await writeFile(
+			canonicalPath,
+			JSON.stringify({ active: "new", accounts: { new: validCred("new") } }),
+			{ mode: 0o644 },
+		);
+		await chmod(canonicalPath, 0o644);
+
+		const store = new CodexAccountStore();
+		assert.equal(store.read().active, "new");
+		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
+		assert.equal((await stat(legacyPath)).isFile(), true);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("default store falls back to legacy credentials for a broken canonical symlink", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-broken-canonical-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		await writeFile(
+			legacyPath,
+			JSON.stringify({ active: "legacy", accounts: { legacy: validCred("legacy") } }),
+			{ mode: 0o600 },
+		);
+		await symlink("missing-target", canonicalPath);
+
+		const store = new CodexAccountStore();
+		assert.equal(store.read().active, "legacy");
+		assert.equal((await stat(legacyPath)).mode & 0o777, 0o600);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { access, chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -105,6 +107,49 @@ test("default store migrates credentials to the canonical package filename", asy
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		assert.match(context.notifications[0]?.message ?? "", /migrated/i);
 	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("concurrent startup waits for an in-progress legacy account migration", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-migration-lock-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	let lockHolder: ReturnType<typeof spawn> | undefined;
+	try {
+		const legacyPath = join(dir, "codex-accounts.json");
+		const canonicalPath = join(dir, "pi-codex-accounts.json");
+		const raw = JSON.stringify({ active: "work", accounts: { work: validCred("work") } });
+		await writeFile(legacyPath, raw, { mode: 0o600 });
+		lockHolder = spawn(
+			process.execPath,
+			[
+				"-e",
+				`const lockfile = require("proper-lockfile");
+(async () => {
+	const release = await lockfile.lock(process.argv[1], { realpath: false });
+	process.stdout.write("locked\\n");
+	await new Promise((resolve) => setTimeout(resolve, 500));
+	await release();
+})().catch((error) => { console.error(error); process.exitCode = 1; });`,
+				legacyPath,
+			],
+			{ stdio: ["ignore", "pipe", "inherit"] },
+		);
+		const lockHolderExit = once(lockHolder, "exit");
+		assert.ok(lockHolder.stdout);
+		await once(lockHolder.stdout, "data");
+
+		const store = new CodexAccountStore();
+		assert.equal(store.read().active, "work");
+		assert.equal(await readFile(canonicalPath, "utf8"), raw);
+		await assert.rejects(access(legacyPath));
+		const [exitCode] = await lockHolderExit;
+		assert.equal(exitCode, 0);
+	} finally {
+		lockHolder?.kill();
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		await rm(dir, { recursive: true, force: true });
@@ -314,6 +359,57 @@ test("account reset removes an async runtime override that is still being applie
 		`finish:${CODEX_PROVIDER_ID}:access-work`,
 		`remove:${CODEX_PROVIDER_ID}`,
 	]);
+});
+
+test("account reset during API-key conversion cannot restore a stale runtime override", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({ active: "work", accounts: { work: validCred("work") } });
+	let releaseConversion: (() => void) | undefined;
+	const conversionBlocked = new Promise<void>((resolve) => {
+		releaseConversion = resolve;
+	});
+	let signalConversionStarted: (() => void) | undefined;
+	const conversionStarted = new Promise<void>((resolve) => {
+		signalConversionStarted = resolve;
+	});
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		oauthProvider: {
+			async login() {
+				throw new Error("unexpected login");
+			},
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			async getApiKey(credential) {
+				signalConversionStarted?.();
+				await conversionBlocked;
+				return credential.access;
+			},
+		},
+	});
+	const command = mock.commands.get("codex-account");
+	assert.ok(command);
+	const runtimeCalls: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: (provider: string, key: string) =>
+					runtimeCalls.push(`set:${provider}:${key}`),
+				removeRuntimeApiKey: (provider: string) => runtimeCalls.push(`remove:${provider}`),
+			},
+		},
+	});
+
+	const startup = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await conversionStarted;
+	await command.handler("default", ctx);
+	releaseConversion?.();
+	await startup;
+
+	assert.equal((await store.readAsync()).active, undefined);
+	assert.deepEqual(runtimeCalls, []);
 });
 
 test("ensureActiveCodexAuth refreshes near-expired active accounts", async () => {

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -1,13 +1,7 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
-import { once } from "node:events";
-import { access, chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexAccounts, {
-	CODEX_ACCOUNTS_FILE,
 	CODEX_ACCOUNTS_STATUS_KEY,
 	CODEX_PROVIDER_ID,
 	CodexAccountStore,
@@ -19,10 +13,7 @@ import codexAccounts, {
 	isOpenAICodexModel,
 	parseAccountName,
 } from "../src/codex-accounts.js";
-import {
-	FileCodexAccountStorageBackend as FileAuthStorageBackend,
-	InMemoryCodexAccountStorageBackend as InMemoryAuthStorageBackend,
-} from "../src/storage.js";
+import { InMemoryCodexAccountStorageBackend as InMemoryAuthStorageBackend } from "../src/storage.js";
 
 const validCred = (suffix = "") => ({
 	access: `access-${suffix}`,
@@ -54,187 +45,6 @@ test("parseAccountName accepts small account labels and rejects unsafe names", (
 	assert.equal(parseAccountName("").ok, false);
 	assert.equal(parseAccountName("../secret").ok, false);
 	assert.equal(parseAccountName("a".repeat(65)).ok, false);
-});
-
-test("store writes private account files and redacts invalid JSON", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-"));
-	const file = join(dir, "pi-codex-accounts.json");
-	const store = new CodexAccountStore(new FileAuthStorageBackend(file));
-
-	await store.write({ active: "work", accounts: { work: validCred("work") } });
-	const mode = (await stat(file)).mode & 0o777;
-	assert.equal(mode, 0o600);
-
-	await store.writeRawForTest('{"active":"work","accounts":{"work":{"access":"secret-token"}}');
-	await assert.rejects(store.readAsync(), (error) => {
-		assert.ok(error instanceof Error);
-		assert.match(error.message, /Invalid Codex accounts JSON/);
-		assert.doesNotMatch(error.message, /secret-token/);
-		return true;
-	});
-});
-
-test("default store migrates credentials to the canonical package filename", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-migration-"));
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = dir;
-	try {
-		const legacyPath = join(dir, "codex-accounts.json");
-		const canonicalPath = join(dir, "pi-codex-accounts.json");
-		const raw = JSON.stringify({
-			active: "work",
-			accounts: { work: validCred("work") },
-			futureOption: true,
-		});
-		await writeFile(legacyPath, raw, { mode: 0o644 });
-		await chmod(legacyPath, 0o644);
-
-		const mock = createMockPi();
-		codexAccounts(mock.pi);
-		assert.equal(CODEX_ACCOUNTS_FILE, "pi-codex-accounts.json");
-		assert.equal(await readFile(canonicalPath, "utf8"), raw);
-		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
-		await assert.rejects(access(legacyPath));
-
-		const context = createMockContext({
-			modelRegistry: {
-				authStorage: {
-					setRuntimeApiKey: () => undefined,
-					removeRuntimeApiKey: () => undefined,
-				},
-			},
-		});
-		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		assert.match(context.notifications[0]?.message ?? "", /migrated/i);
-	} finally {
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("concurrent startup waits for an in-progress legacy account migration", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-migration-lock-"));
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = dir;
-	let lockHolder: ReturnType<typeof spawn> | undefined;
-	try {
-		const legacyPath = join(dir, "codex-accounts.json");
-		const canonicalPath = join(dir, "pi-codex-accounts.json");
-		const raw = JSON.stringify({ active: "work", accounts: { work: validCred("work") } });
-		await writeFile(legacyPath, raw, { mode: 0o600 });
-		lockHolder = spawn(
-			process.execPath,
-			[
-				"-e",
-				`const lockfile = require("proper-lockfile");
-(async () => {
-	const release = await lockfile.lock(process.argv[1], { realpath: false });
-	process.stdout.write("locked\\n");
-	await new Promise((resolve) => setTimeout(resolve, 500));
-	await release();
-})().catch((error) => { console.error(error); process.exitCode = 1; });`,
-				legacyPath,
-			],
-			{ stdio: ["ignore", "pipe", "inherit"] },
-		);
-		const lockHolderExit = once(lockHolder, "exit");
-		assert.ok(lockHolder.stdout);
-		await once(lockHolder.stdout, "data");
-
-		const store = new CodexAccountStore();
-		assert.equal(store.read().active, "work");
-		assert.equal(await readFile(canonicalPath, "utf8"), raw);
-		await assert.rejects(access(legacyPath));
-		const [exitCode] = await lockHolderExit;
-		assert.equal(exitCode, 0);
-	} finally {
-		lockHolder?.kill();
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("migration preserves malformed credential data without leaking tokens", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-invalid-migration-"));
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = dir;
-	try {
-		const legacyPath = join(dir, "codex-accounts.json");
-		const canonicalPath = join(dir, "pi-codex-accounts.json");
-		await writeFile(legacyPath, '{"accounts":{"work":{"access":"secret-token"}}', {
-			mode: 0o600,
-		});
-		const store = new CodexAccountStore();
-
-		await assert.rejects(store.readAsync(), (error) => {
-			assert.ok(error instanceof Error);
-			assert.match(error.message, /pi-codex-accounts\.json/);
-			assert.doesNotMatch(error.message, /secret-token/);
-			return true;
-		});
-		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
-		await assert.rejects(access(legacyPath));
-	} finally {
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("canonical Codex accounts file wins without deleting the legacy file", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-precedence-"));
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = dir;
-	try {
-		const legacyPath = join(dir, "codex-accounts.json");
-		const canonicalPath = join(dir, "pi-codex-accounts.json");
-		await writeFile(
-			legacyPath,
-			JSON.stringify({ active: "old", accounts: { old: validCred("old") } }),
-			{ mode: 0o600 },
-		);
-		await writeFile(
-			canonicalPath,
-			JSON.stringify({ active: "new", accounts: { new: validCred("new") } }),
-			{ mode: 0o644 },
-		);
-		await chmod(canonicalPath, 0o644);
-
-		const store = new CodexAccountStore();
-		assert.equal(store.read().active, "new");
-		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
-		assert.equal((await stat(legacyPath)).isFile(), true);
-	} finally {
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("default store falls back to legacy credentials for a broken canonical symlink", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "pi-codex-accounts-broken-canonical-"));
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = dir;
-	try {
-		const legacyPath = join(dir, "codex-accounts.json");
-		const canonicalPath = join(dir, "pi-codex-accounts.json");
-		await writeFile(
-			legacyPath,
-			JSON.stringify({ active: "legacy", accounts: { legacy: validCred("legacy") } }),
-			{ mode: 0o600 },
-		);
-		await symlink("missing-target", canonicalPath);
-
-		const store = new CodexAccountStore();
-		assert.equal(store.read().active, "legacy");
-		assert.equal((await stat(legacyPath)).mode & 0o777, 0o600);
-	} finally {
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		await rm(dir, { recursive: true, force: true });
-	}
 });
 
 test("ensureActiveCodexAuth leaves normal Pi auth unchanged when no account override was applied", async () => {
@@ -272,6 +82,55 @@ test("ensureActiveCodexAuth applies active account access tokens", async () => {
 
 	assert.deepEqual(result, { status: "active", accountName: "work" });
 	assert.deepEqual(calls, [`set:${CODEX_PROVIDER_ID}:access-work`]);
+});
+
+test("missing-account cleanup preserves a concurrently selected account", async () => {
+	const missingSnapshot = JSON.stringify({ active: "missing", accounts: {} });
+	const currentSnapshot = JSON.stringify({ active: "home", accounts: { home: validCred("home") } });
+	let raw = missingSnapshot;
+	let replaceAfterRead = true;
+	const backend = {
+		withLock<T>(mutator: (current: string | undefined) => { result: T; next?: string }): T {
+			const { result, next } = mutator(raw);
+			if (next !== undefined) raw = next;
+			return result;
+		},
+		async withLockAsync<T>(
+			mutator: (current: string | undefined) => Promise<{ result: T; next?: string }>,
+		): Promise<T> {
+			const { result, next } = await mutator(raw);
+			if (next !== undefined) raw = next;
+			else if (replaceAfterRead) {
+				replaceAfterRead = false;
+				raw = currentSnapshot;
+			}
+			return result;
+		},
+	};
+	const store = new CodexAccountStore(backend);
+	const runtimeCalls: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: (provider: string, key: string) =>
+					runtimeCalls.push(`set:${provider}:${key}`),
+				removeRuntimeApiKey: (provider: string) => runtimeCalls.push(`remove:${provider}`),
+			},
+		},
+	});
+
+	const result = await ensureActiveCodexAuth(ctx, store, {
+		oauthProvider: {
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			getApiKey: (credential) => credential.access,
+		},
+	});
+
+	assert.deepEqual(result, { status: "active", accountName: "home" });
+	assert.equal((await store.readAsync()).active, "home");
+	assert.deepEqual(runtimeCalls, [`set:${CODEX_PROVIDER_ID}:access-home`]);
 });
 
 test("ensureActiveCodexAuth supports and awaits Pi's model runtime auth overrides", async () => {
@@ -412,6 +271,84 @@ test("account reset during API-key conversion cannot restore a stale runtime ove
 	assert.deepEqual(runtimeCalls, []);
 });
 
+test("session shutdown during API-key conversion cannot restore a runtime override", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({ active: "work", accounts: { work: validCred("work") } });
+	let releaseConversion: (() => void) | undefined;
+	const conversionBlocked = new Promise<void>((resolve) => {
+		releaseConversion = resolve;
+	});
+	let signalConversionStarted: (() => void) | undefined;
+	const conversionStarted = new Promise<void>((resolve) => {
+		signalConversionStarted = resolve;
+	});
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		oauthProvider: {
+			async login() {
+				throw new Error("unexpected login");
+			},
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			async getApiKey(credential) {
+				signalConversionStarted?.();
+				await conversionBlocked;
+				return credential.access;
+			},
+		},
+	});
+	const runtimeCalls: string[] = [];
+	const { ctx, statuses } = createMockContext({
+		model: { provider: CODEX_PROVIDER_ID },
+		modelRegistry: {
+			runtime: {
+				setRuntimeApiKey: (provider: string, key: string) =>
+					runtimeCalls.push(`set:${provider}:${key}`),
+				removeRuntimeApiKey: (provider: string) => runtimeCalls.push(`remove:${provider}`),
+			},
+		},
+	});
+
+	const startup = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await conversionStarted;
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	releaseConversion?.();
+	await startup;
+
+	assert.deepEqual(runtimeCalls, []);
+	assert.equal(statuses.get(CODEX_ACCOUNTS_STATUS_KEY), undefined);
+});
+
+test("a partially failed runtime setter remains removable", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({ active: "work", accounts: { work: validCred("work") } });
+	const runtimeCalls: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			runtime: {
+				async setRuntimeApiKey(provider: string, key: string) {
+					runtimeCalls.push(`set:${provider}:${key}`);
+					throw new Error("model refresh failed after applying the key");
+				},
+				removeRuntimeApiKey(provider: string) {
+					runtimeCalls.push(`remove:${provider}`);
+				},
+			},
+		},
+	});
+
+	await assert.rejects(ensureActiveCodexAuth(ctx, store), /model refresh failed/);
+	await store.update((data) => ({ ...data, active: undefined }));
+	assert.deepEqual(await ensureActiveCodexAuth(ctx, store), { status: "inactive" });
+
+	assert.deepEqual(runtimeCalls, [
+		`set:${CODEX_PROVIDER_ID}:access-work`,
+		`remove:${CODEX_PROVIDER_ID}`,
+	]);
+});
+
 test("ensureActiveCodexAuth refreshes near-expired active accounts", async () => {
 	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
 	await store.write({
@@ -503,6 +440,70 @@ test("ensureActiveCodexAuth fails closed when active account refresh fails", asy
 
 	assert.equal(result.status, "error");
 	assert.deepEqual(calls, [`set:${CODEX_PROVIDER_ID}:${FAIL_CLOSED_API_KEY}`]);
+});
+
+test("ensureActiveCodexAuth fails closed and redacts API-key conversion errors", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	const credential = {
+		access: "opaque-access-secret",
+		refresh: "opaque-refresh-secret",
+		expires: Date.now() + 60 * 60 * 1000,
+	};
+	await store.write({ active: "work", accounts: { work: credential } });
+	const runtimeCalls: string[] = [];
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: (provider: string, key: string) =>
+					runtimeCalls.push(`set:${provider}:${key}`),
+				removeRuntimeApiKey: () => undefined,
+			},
+		},
+	});
+
+	const result = await ensureActiveCodexAuth(ctx, store, {
+		oauthProvider: {
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			getApiKey() {
+				throw new Error(`conversion failed for ${credential.access} / ${credential.refresh}`);
+			},
+		},
+	});
+
+	assert.equal(result.status, "error");
+	if (result.status !== "error") assert.fail("expected an auth error");
+	assert.doesNotMatch(result.message, /opaque-(access|refresh)-secret/);
+	assert.deepEqual(runtimeCalls, [`set:${CODEX_PROVIDER_ID}:${FAIL_CLOSED_API_KEY}`]);
+});
+
+test("codex-login rejects the reserved default account name", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	let loginCalls = 0;
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		oauthProvider: {
+			async login() {
+				loginCalls += 1;
+				return validCred("default");
+			},
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			getApiKey: (credential) => credential.access,
+		},
+	});
+	const command = mock.commands.get("codex-login");
+	assert.ok(command);
+	const { ctx, notifications } = createMockContext({ hasUI: true });
+
+	await command.handler("DEFAULT", ctx);
+
+	assert.equal(loginCalls, 0);
+	assert.deepEqual(await store.readAsync(), { accounts: {} });
+	assert.match(notifications.at(-1)?.message ?? "", /reserved/i);
 });
 
 test("codex-login stores credentials, activates the account, and does not change non-unknown models", async () => {

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -3,10 +3,6 @@ import { access, chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from "
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import {
-	FileAuthStorageBackend,
-	InMemoryAuthStorageBackend,
-} from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexAccounts, {
 	CODEX_ACCOUNTS_FILE,
@@ -21,6 +17,10 @@ import codexAccounts, {
 	isOpenAICodexModel,
 	parseAccountName,
 } from "../src/codex-accounts.js";
+import {
+	FileCodexAccountStorageBackend as FileAuthStorageBackend,
+	InMemoryCodexAccountStorageBackend as InMemoryAuthStorageBackend,
+} from "../src/storage.js";
 
 const validCred = (suffix = "") => ({
 	access: `access-${suffix}`,
@@ -94,7 +94,14 @@ test("default store migrates credentials to the canonical package filename", asy
 		assert.equal((await stat(canonicalPath)).mode & 0o777, 0o600);
 		await assert.rejects(access(legacyPath));
 
-		const context = createMockContext();
+		const context = createMockContext({
+			modelRegistry: {
+				authStorage: {
+					setRuntimeApiKey: () => undefined,
+					removeRuntimeApiKey: () => undefined,
+				},
+			},
+		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		assert.match(context.notifications[0]?.message ?? "", /migrated/i);
 	} finally {
@@ -185,7 +192,7 @@ test("default store falls back to legacy credentials for a broken canonical syml
 	}
 });
 
-test("ensureActiveCodexAuth clears runtime auth when no self-managed account is active", async () => {
+test("ensureActiveCodexAuth leaves normal Pi auth unchanged when no account override was applied", async () => {
 	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
 	const calls: string[] = [];
 	const { ctx } = createMockContext({
@@ -200,7 +207,7 @@ test("ensureActiveCodexAuth clears runtime auth when no self-managed account is 
 	const result = await ensureActiveCodexAuth(ctx, store);
 
 	assert.deepEqual(result, { status: "inactive" });
-	assert.deepEqual(calls, [`remove:${CODEX_PROVIDER_ID}`]);
+	assert.deepEqual(calls, []);
 });
 
 test("ensureActiveCodexAuth applies active account access tokens", async () => {
@@ -220,6 +227,45 @@ test("ensureActiveCodexAuth applies active account access tokens", async () => {
 
 	assert.deepEqual(result, { status: "active", accountName: "work" });
 	assert.deepEqual(calls, [`set:${CODEX_PROVIDER_ID}:access-work`]);
+});
+
+test("ensureActiveCodexAuth supports and awaits Pi's model runtime auth overrides", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({ active: "work", accounts: { work: validCred("work") } });
+	const calls: string[] = [];
+	let releaseSet: (() => void) | undefined;
+	const setBlocked = new Promise<void>((resolve) => {
+		releaseSet = resolve;
+	});
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			runtime: {
+				async setRuntimeApiKey(provider: string, key: string) {
+					calls.push(`start:${provider}:${key}`);
+					await setBlocked;
+					calls.push(`finish:${provider}:${key}`);
+				},
+				async removeRuntimeApiKey(provider: string) {
+					calls.push(`remove:${provider}`);
+				},
+			},
+		},
+	});
+
+	let settled = false;
+	const auth = ensureActiveCodexAuth(ctx, store).finally(() => {
+		settled = true;
+	});
+	await new Promise<void>((resolve) => setImmediate(resolve));
+
+	assert.equal(settled, false);
+	assert.deepEqual(calls, [`start:${CODEX_PROVIDER_ID}:access-work`]);
+	releaseSet?.();
+	assert.deepEqual(await auth, { status: "active", accountName: "work" });
+	assert.deepEqual(calls, [
+		`start:${CODEX_PROVIDER_ID}:access-work`,
+		`finish:${CODEX_PROVIDER_ID}:access-work`,
+	]);
 });
 
 test("ensureActiveCodexAuth refreshes near-expired active accounts", async () => {
@@ -283,7 +329,7 @@ test("concurrent auth checks refresh an expiring account only once", async () =>
 	]);
 
 	assert.equal(refreshCalls, 1);
-	assert.deepEqual(runtimeKeys, ["access-new", "access-new"]);
+	assert.deepEqual(runtimeKeys, ["access-new"]);
 });
 
 test("ensureActiveCodexAuth fails closed when active account refresh fails", async () => {
@@ -601,6 +647,8 @@ test("codex-logout deletes accounts and clears active runtime auth", async () =>
 		},
 	});
 
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	runtimeCalls.length = 0;
 	await command.handler("home", ctx);
 	let data = await store.readAsync();
 	assert.equal(data.active, "work");

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -543,6 +543,51 @@ test("codex-login stores credentials, activates the account, and does not change
 	assert.match(notifications.at(-1)?.message ?? "", /Logged in Codex account "work"/);
 });
 
+test("codex-login forwards per-prompt abort signals to UI dialogs", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	const promptController = new AbortController();
+	let inputSignal: AbortSignal | undefined;
+	const mock = createMockPi();
+	codexAccounts(mock.pi, {
+		store,
+		oauthProvider: {
+			async login(callbacks) {
+				const code = await callbacks.onPrompt({
+					message: "Paste the authorization code",
+					placeholder: "code#state",
+					signal: promptController.signal,
+				});
+				assert.equal(code, "manual-code");
+				return validCred("work");
+			},
+			async refreshToken() {
+				throw new Error("unexpected refresh");
+			},
+			getApiKey: (credential) => credential.access,
+		},
+	});
+	const command = mock.commands.get("codex-login");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		input: async (_title: string, _placeholder: string, options?: { signal?: AbortSignal }) => {
+			inputSignal = options?.signal;
+			return "manual-code";
+		},
+		model: { provider: "anthropic", id: "claude", api: "anthropic-messages" },
+		modelRegistry: {
+			authStorage: {
+				setRuntimeApiKey: () => undefined,
+				removeRuntimeApiKey: () => undefined,
+			},
+		},
+	});
+
+	await command.handler("work", ctx);
+
+	assert.equal(inputSignal, promptController.signal);
+});
+
 test("codex-login selects the default Codex model only from unknown/unknown", async () => {
 	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
 	const mock = createMockPi();

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -268,6 +268,54 @@ test("ensureActiveCodexAuth supports and awaits Pi's model runtime auth override
 	]);
 });
 
+test("account reset removes an async runtime override that is still being applied", async () => {
+	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
+	await store.write({ active: "work", accounts: { work: validCred("work") } });
+	const mock = createMockPi();
+	codexAccounts(mock.pi, { store });
+	const command = mock.commands.get("codex-account");
+	assert.ok(command);
+
+	const calls: string[] = [];
+	let releaseSet: (() => void) | undefined;
+	const setBlocked = new Promise<void>((resolve) => {
+		releaseSet = resolve;
+	});
+	let signalSetStarted: (() => void) | undefined;
+	const setStarted = new Promise<void>((resolve) => {
+		signalSetStarted = resolve;
+	});
+	const { ctx } = createMockContext({
+		modelRegistry: {
+			runtime: {
+				async setRuntimeApiKey(provider: string, key: string) {
+					calls.push(`start:${provider}:${key}`);
+					signalSetStarted?.();
+					await setBlocked;
+					calls.push(`finish:${provider}:${key}`);
+				},
+				async removeRuntimeApiKey(provider: string) {
+					calls.push(`remove:${provider}`);
+				},
+			},
+		},
+	});
+
+	const startup = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await setStarted;
+	const reset = command.handler("default", ctx);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	releaseSet?.();
+	await Promise.all([startup, reset]);
+
+	assert.equal((await store.readAsync()).active, undefined);
+	assert.deepEqual(calls, [
+		`start:${CODEX_PROVIDER_ID}:access-work`,
+		`finish:${CODEX_PROVIDER_ID}:access-work`,
+		`remove:${CODEX_PROVIDER_ID}`,
+	]);
+});
+
 test("ensureActiveCodexAuth refreshes near-expired active accounts", async () => {
 	const store = new CodexAccountStore(new InMemoryAuthStorageBackend());
 	await store.write({

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,10 +59,14 @@
 			"name": "@narumitw/pi-codex-accounts",
 			"version": "0.16.0",
 			"license": "MIT",
+			"dependencies": {
+				"proper-lockfile": "^4.1.2"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.3",
 				"@earendil-works/pi-ai": "0.80.3",
 				"@earendil-works/pi-coding-agent": "0.80.3",
+				"@types/proper-lockfile": "^4.1.4",
 				"typescript": "6.0.3"
 			},
 			"peerDependencies": {
@@ -7501,6 +7505,16 @@
 				"undici-types": "~8.3.0"
 			}
 		},
+		"node_modules/@types/proper-lockfile": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+			"integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "*"
+			}
+		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -7716,6 +7730,12 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -7898,6 +7918,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/protobufjs": {
 			"version": "7.6.5",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -7952,6 +7992,12 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
 		},
 		"node_modules/ts-algebra": {
 			"version": "2.0.0",

--- a/test/support.ts
+++ b/test/support.ts
@@ -146,6 +146,7 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 				footer = value;
 			},
 			confirm: overrides.confirm ?? (async () => true),
+			input: overrides.input ?? (async () => undefined),
 			select: overrides.select ?? (async () => undefined),
 			editor: overrides.editor ?? (async () => undefined),
 			custom: overrides.custom ?? (async () => undefined),


### PR DESCRIPTION
## Summary

- replace removed Pi auth-storage imports with extension-owned locked file and in-memory backends
- support and await runtime API-key overrides across Pi 0.80.3 and 0.80.8 without clearing unrelated normal auth
- add Pi 0.80.3 to the compatibility matrix and update tests, package metadata, and documentation

## Verification

- `npm run check` (523 tests)
- `just pack-codex-accounts`