### PR TITLE
fix(goal): queue goal-owned prompts safely

### DIFF
--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -203,7 +203,7 @@ export class GoalRuntime {
 		this.continuationIntent = undefined;
 		this.continuationDelivery = intent;
 		try {
-			this.pi.sendUserMessage(intent.prompt);
+			this.pi.sendUserMessage(intent.prompt, { deliverAs: "followUp" });
 			return true;
 		} catch (error) {
 			if (this.continuationDelivery?.marker === intent.marker) {
@@ -757,10 +757,7 @@ export function truncateNotification(value: string) {
 
 async function sendPrompt(pi: ExtensionAPI, ctx: StatusContext, prompt: string) {
 	try {
-		const sent = ctx.isIdle?.()
-			? (pi.sendUserMessage(prompt) as void | Promise<void>)
-			: (pi.sendUserMessage(prompt, { deliverAs: "followUp" }) as void | Promise<void>);
-		await sent;
+		await pi.sendUserMessage(prompt, { deliverAs: "followUp" });
 		return true;
 	} catch (error) {
 		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -1495,6 +1495,7 @@ test("all goal prompt paths share the goal_id guard and hardened audit", async (
 	const started = await startGoalForTest();
 	const initialGoal = requireLastGoal(started.mock);
 	const initialPrompt = started.mock.sentUserMessages[0]?.text ?? "";
+	assert.deepEqual(started.mock.sentUserMessages[0]?.options, { deliverAs: "followUp" });
 	assertPromptHasGoalId(initialPrompt, initialGoal.id);
 	assertHardenedGoalPrompt(initialPrompt);
 
@@ -1512,6 +1513,9 @@ test("all goal prompt paths share the goal_id guard and hardened audit", async (
 	assert.equal(started.mock.sentUserMessages.length, 1);
 	await started.mock.events.get("agent_settled")?.[0]?.({}, started.ctx);
 	const continuationPrompt = started.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.deepEqual(started.mock.sentUserMessages.at(-1)?.options, {
+		deliverAs: "followUp",
+	});
 	assertPromptHasGoalId(continuationPrompt, initialGoal.id);
 	assertHardenedGoalPrompt(continuationPrompt);
 	assert.match(continuationPrompt, /automatic continuation #1/i);
@@ -1521,6 +1525,9 @@ test("all goal prompt paths share the goal_id guard and hardened audit", async (
 	await started.mock.commands.get("goal")?.handler("resume", started.ctx);
 	const resumedGoal = requireLastGoal(started.mock);
 	const resumedPrompt = started.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.deepEqual(started.mock.sentUserMessages.at(-1)?.options, {
+		deliverAs: "followUp",
+	});
 	assertPromptHasGoalId(resumedPrompt, resumedGoal.id);
 	assertHardenedGoalPrompt(resumedPrompt);
 	assert.match(resumedPrompt, /explicitly resumed the paused \/goal/i);
@@ -1528,6 +1535,9 @@ test("all goal prompt paths share the goal_id guard and hardened audit", async (
 	await started.mock.commands.get("goal")?.handler("edit verify edited objective", started.ctx);
 	const editedGoal = requireLastGoal(started.mock);
 	const editedPrompt = started.mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.deepEqual(started.mock.sentUserMessages.at(-1)?.options, {
+		deliverAs: "followUp",
+	});
 	assertPromptHasGoalId(editedPrompt, editedGoal.id);
 	assertHardenedGoalPrompt(editedPrompt);
 	assert.match(editedPrompt, /updated objective supersedes every previous goal objective/i);
@@ -2160,7 +2170,9 @@ test("agent_settled dispatches one idle continuation after agent_end records int
 
 	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
 	assert.equal(settled.mock.sentUserMessages.length, 2);
-	assert.equal(settled.mock.sentUserMessages.at(-1)?.options, undefined);
+	assert.deepEqual(settled.mock.sentUserMessages.at(-1)?.options, {
+		deliverAs: "followUp",
+	});
 	assert.match(settled.mock.sentUserMessages.at(-1)?.text ?? "", /automatic continuation #1/i);
 
 	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);


### PR DESCRIPTION
## Summary

- deliver every goal-owned user prompt with `deliverAs: "followUp"`
- remove the stale `ctx.isIdle()` delivery decision
- cover kickoff, continuation, resume, and edit delivery contracts

## Why

A goal continuation can observe Pi as idle, then lose a race to another prompt before dispatch. Sending it as an unqueued prompt can trigger `Agent is already processing a prompt`. `followUp` starts normally while idle and queues safely if activity begins.

This is the extension-side fix. The companion core change is tracked in earendil-works/pi#6744; it serializes asynchronous prompt startup so competing preflights cannot both reach `Agent.prompt()`.

## Validation

- `npm test`
- `npm run check`
