### PR TITLE
docs(subagents): clarify project agent scope

### DIFF
--- a/docs/plans/archived/2026-07-17_pi-subagents-agent-scope-docs-plan.md
+++ b/docs/plans/archived/2026-07-17_pi-subagents-agent-scope-docs-plan.md
@@ -1,0 +1,35 @@
+## Goal
+
+Resolve GitHub issue #227 by making it unambiguous where and when `agentScope` is supplied, with copyable examples for one-shot and stateful subagents, while preserving the existing project-agent trust boundary.
+
+## Context
+
+`agentScope` is currently a top-level tool-call parameter, not a persisted field in `~/.pi/agent/pi-subagents.json`. A blocking `subagent` call must opt in per invocation; `subagent_spawn` supplies the scope when creating the retained agent. The README says to “Set `agentScope`” without explicitly making that distinction, so users can reasonably interpret it as a configuration-file setting.
+
+## Non-Goals
+
+- Do not add a persistent `defaultAgentScope` setting.
+- Do not change the default scope from `"user"`.
+- Do not weaken project trust checks or interactive confirmation.
+- Do not change agent discovery, precedence, or execution behavior.
+
+## Plan
+
+- [x] Update the custom-agent documentation in `extensions/pi-subagents/README.md` to state that `agentScope` is a per-tool-call parameter rather than a `pi-subagents.json` setting; verified the section names both user and project directories and explicitly distinguishes invocation settings from persisted configuration.
+- [x] Add copyable JSON examples for `subagent` and `subagent_spawn` showing `agentScope: "project"`, explain when to use `"both"`, and state that a spawned stateful agent retains its selected scope for follow-ups; verified all README JSON fences parse and each example places `agentScope` at the top level of the tool arguments.
+- [x] Clarify the security behavior beside the examples: project agents require a trusted project, interactive confirmation remains enabled by default, and `confirmProjectAgents: false` suppresses only the prompt rather than the trust requirement; verified the wording against `extensions/pi-subagents/src/execution.ts` and `extensions/pi-subagents/src/stateful.ts`.
+- [x] Align the tool-facing parameter descriptions in `extensions/pi-subagents/src/params.ts` and `extensions/pi-subagents/src/stateful.ts` with the README by identifying `agentScope` as a per-invocation selection with a `"user"` default; verified with `rg -n "agentScope|per-invocation|per-call" extensions/pi-subagents/src extensions/pi-subagents/README.md`.
+- [x] Review the final diff against issue #227 to confirm it answers “where do I configure this?” without implying a new global setting, then run the repository gate; verified with `git diff --check` and `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check`.
+
+## Risks
+
+- Documentation could conflate Pi’s project trust requirement with the extension’s confirmation dialog. Keep them described as separate safeguards.
+- An example using only `"project"` could hide user agents from discovery. Explicitly explain that `"both"` includes user and project definitions.
+
+## Completion Checklist
+
+- [x] The README explicitly says `agentScope` is passed in tool arguments and is not configured in `pi-subagents.json`, verified in `extensions/pi-subagents/README.md`.
+- [x] One-shot and stateful examples are present and show correctly placed `agentScope` arguments, verified by manual review and parsing all 10 README JSON examples with `JSON.parse`.
+- [x] Trust, confirmation, and `"project"` versus `"both"` semantics match the implementation, verified against `extensions/pi-subagents/src/execution.ts`, `extensions/pi-subagents/src/stateful.ts`, and `extensions/pi-subagents/src/agents.ts`.
+- [x] Tool schema descriptions and user documentation use consistent terminology, verified with the repository search in the plan.
+- [x] Formatting, type checks, boundary checks, and tests pass, verified by `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` (541 passed, 1 skipped).

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -335,7 +335,43 @@ You are an API review subagent. Do not edit files. Check compatibility,
 test coverage, and migration risks. Report PASS/FAIL/PARTIAL with evidence.
 ```
 
-By default, `subagent` loads user agents only. Set `agentScope` to `"project"` or `"both"` to load project-local agents. Interactive sessions ask for confirmation before using project agents unless `confirmProjectAgents` is disabled.
+`agentScope` is a top-level tool argument supplied per invocation. It is not a setting in
+`~/.pi/agent/pi-subagents.json` and does not belong in agent frontmatter. The scope selects which
+custom agent directories are loaded; built-in agents remain available in every scope:
+
+| `agentScope` | Custom agents loaded |
+| --- | --- |
+| `"user"` (default) | User agents only. |
+| `"project"` | Project-local agents only. |
+| `"both"` | User and project-local agents. Project definitions override same-named user definitions. |
+
+For example, invoke a project-local agent with the blocking `subagent` tool:
+
+```json
+{
+  "agent": "api-reviewer",
+  "task": "Review this project's API changes",
+  "agentScope": "project"
+}
+```
+
+Or select the scope when creating a stateful agent with `subagent_spawn`:
+
+```json
+{
+  "agent": "api-reviewer",
+  "task": "Review this project's API changes",
+  "agentScope": "project"
+}
+```
+
+A stateful agent retains the scope selected by `subagent_spawn` for its follow-ups. Every new
+blocking `subagent` invocation or `subagent_spawn` call that needs project agents must supply
+`agentScope: "project"` or `"both"` again.
+
+Project-local agents require a trusted Pi project. Interactive sessions also ask for confirmation
+before using them by default. Passing `confirmProjectAgents: false` as another top-level tool
+argument skips that confirmation dialog, but it does not bypass the project trust requirement.
 
 ## ⏱️ Runtime limits and thinking levels
 

--- a/extensions/pi-subagents/src/params.ts
+++ b/extensions/pi-subagents/src/params.ts
@@ -37,7 +37,8 @@ const AggregatorItem = Type.Object({
 });
 
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
-	description: 'Which agent directories to use. Default: "user". Use "both" to include project-local agents.',
+	description:
+		'Per-invocation custom agent scope. Default: "user". Use "project" for project-local agents or "both" for user and project agents; this is a tool argument, not a pi-subagents.json setting.',
 	default: "user",
 });
 

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -31,7 +31,11 @@ const ContextModeSchema = Type.Union([
 	StringEnum(["none", "all", "summary"] as const),
 	Type.Number({ minimum: 1, description: "Include the most recent N user turns." }),
 ]);
-const ScopeSchema = StringEnum(["user", "project", "both"] as const);
+const ScopeSchema = StringEnum(["user", "project", "both"] as const, {
+	description:
+		'Per-invocation custom agent scope for this spawn. Default: "user". Use "project" for project-local agents or "both" for user and project agents; the selected scope is retained for follow-ups.',
+	default: "user",
+});
 const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
 const MAX_COMPLETION_ERROR_BYTES = 512;
 

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -30,7 +30,7 @@ export default function (pi: ExtensionAPI) {
 			"Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder).",
 			"Parallel mode may include an aggregator fan-in step that receives all task outputs.",
 			'Default agent scope is "user" (from ~/.pi/agent/agents).',
-			'To enable project-local agents in .pi/agents, set agentScope: "both" (or "project").',
+			'To enable project-local agents in .pi/agents, pass agentScope: "both" (or "project") as a top-level argument for that call.',
 		].join(" "),
 		promptSnippet:
 			"Decide whether to spawn 0, 1, or multiple subagents for independent research, review, verification, or multi-step work in isolated Pi processes.",


### PR DESCRIPTION
## Summary

- explain that `agentScope` is a per-invocation tool argument rather than a `pi-subagents.json` setting
- add copyable `subagent` and `subagent_spawn` examples plus scope-retention guidance
- distinguish project trust from optional interactive confirmation and align tool schema descriptions

## Verification

- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` (541 passed, 1 skipped)
- parsed all 10 JSON examples in `extensions/pi-subagents/README.md` with `JSON.parse`

Closes #227
