### PR TITLE
fix(caffeinate): hide status in quiet mode

### DIFF
--- a/docs/plans/archived/2026-07-17_caffeinate-quiet-status-plan.md
+++ b/docs/plans/archived/2026-07-17_caffeinate-quiet-status-plan.md
@@ -1,0 +1,26 @@
+## Goal
+
+Make `pi-caffeinate` quiet mode suppress ambient status-bar output while the sleep inhibitor remains active, then open a verified pull request that closes issue #214.
+
+## Context
+
+`quiet: true` already suppresses routine lifecycle notifications, but `updateStatus` still publishes active and unavailable status values. Explicit `/caffeinate` command feedback and actionable warnings should remain visible because they are not routine lifecycle output.
+
+## Plan
+
+- [x] Add regression coverage for active and failed inhibitors in quiet mode, proving the inhibitor still starts while the `caffeinate` status remains cleared; the focused test failed in three expected assertions before implementation and passed 20/20 afterward.
+- [x] Gate `pi-caffeinate` status publication on quiet mode and update its README contract; `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` and `npm run pack:caffeinate` passed.
+- [x] Review the complete branch diff, commit only the issue-related files, push the branch, and open a PR that closes #214; verified by commit `4cc6c76` and PR #230.
+
+## Risks
+
+- Quiet mode must not disable the sleep inhibitor or suppress explicit command feedback and failure warnings.
+- Switching into quiet mode during `/reload` must clear a status value published earlier in the session.
+
+## Completion Checklist
+
+- [x] `quiet: true` leaves the inhibitor active but no `caffeinate` status item is published, verified by `quiet mode keeps the inhibitor active without lifecycle UI output`.
+- [x] Quiet-mode failure warnings remain visible without an `unavailable` status item, verified by `quiet mode preserves inhibitor failure warnings`.
+- [x] Documentation describes quiet mode as suppressing routine lifecycle notifications and status output while preserving commands and warnings in `extensions/pi-caffeinate/README.md`.
+- [x] Repository checks and the caffeinate package dry-run pass, verified by `npm run check` with canonical `TMPDIR` and `npm run pack:caffeinate`.
+- [x] A focused commit is pushed and GitHub PR #230 closes #214: https://github.com/narumiruna/pi-extensions/pull/230.

--- a/extensions/pi-caffeinate/README.md
+++ b/extensions/pi-caffeinate/README.md
@@ -10,7 +10,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 
 - Starts an OS sleep inhibitor when Pi begins processing (`agent_start`).
 - Releases the inhibitor when processing ends (`agent_end`) or the session shuts down.
-- Publishes the active keep-awake mode as status while an inhibitor is active.
+- Publishes the active keep-awake mode as status while an inhibitor is active, unless quiet mode is enabled.
 - Supports macOS, Windows, WSL, and Linux.
 - Defaults to display-awake mode on every supported OS: prevent system sleep and keep the screen/display awake.
 - Provides a single `/caffeinate` command with menu-based controls and direct subcommands.
@@ -112,10 +112,11 @@ Example:
 ```
 
 Set `"quiet": true` to hide the routine `Keeping computer awake (...)` and
-`Released pi-caffeinate (agent finished)` lifecycle notifications. Quiet mode does not hide
-warnings, status updates, or feedback from `/caffeinate` commands such as `status`, mode changes,
-help, and manual stop. It defaults to `false` when omitted. The file is read at startup and on
-`/reload`; run `/reload` after editing it in a running Pi session before using mode commands.
+`Released pi-caffeinate (agent finished)` lifecycle notifications and keep the `caffeinate` status
+item clear while active or unavailable. Quiet mode does not hide warnings or explicit feedback from
+`/caffeinate` commands such as `status`, mode changes, help, and manual stop. It defaults to `false`
+when omitted. The file is read at startup and on `/reload`; run `/reload` after editing it in a
+running Pi session before using mode commands.
 
 Missing, invalid, or deleted settings default back to `display` mode with quiet mode disabled on
 every supported OS.

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -333,7 +333,7 @@ function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?
 }
 
 function updateStatus(ctx: ExtensionContext) {
-	if (state.disabled) {
+	if (state.disabled || state.quiet) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		return;
 	}

--- a/extensions/pi-caffeinate/test/caffeinate.test.ts
+++ b/extensions/pi-caffeinate/test/caffeinate.test.ts
@@ -127,23 +127,31 @@ test("caffeinate loads the new settings file without a migration warning", async
 	});
 });
 
-test("session reload applies manual quiet mode changes", async () => {
+test("session reload applies quiet mode and clears an active status", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		writeSettings(agentDir, NEW_SETTINGS_FILE, "display");
+		process.env.PI_CAFFEINATE_COMMAND = longRunningCustomCommand();
 		const caffeinateModule = await importFreshCaffeinate();
 		const mock = createMockPi();
-		const { ctx, notifications } = createMockContext();
+		const { ctx, notifications, statuses } = createMockContext();
 
 		caffeinateModule.default(mock.pi);
 		const sessionStart = mock.events.get("session_start")?.[0];
 		await sessionStart?.({ reason: "startup" }, ctx);
-		await mock.commands.get("caffeinate")?.handler("status", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /Quiet mode: disabled/);
+		await mock.events.get("agent_start")?.[0]?.({}, ctx);
+		assert.equal(statuses.get("caffeinate"), "custom");
 
 		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
 		await sessionStart?.({ reason: "reload" }, ctx);
+		const quietStatus = statuses.get("caffeinate");
+
 		await mock.commands.get("caffeinate")?.handler("status", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /Quiet mode: enabled/);
+		const statusMessage = notifications.at(-1)?.message ?? "";
+		await mock.events.get("agent_end")?.[0]?.({}, ctx);
+
+		assert.equal(quietStatus, undefined);
+		assert.match(statusMessage, /pi-caffeinate is active/);
+		assert.match(statusMessage, /Quiet mode: enabled/);
 	});
 });
 
@@ -297,7 +305,7 @@ test("caffeinate saves mode only to the new settings file and preserves quiet mo
 	});
 });
 
-test("quiet mode keeps lifecycle and status active without routine notifications", async () => {
+test("quiet mode keeps the inhibitor active without lifecycle UI output", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		writeSettings(agentDir, NEW_SETTINGS_FILE, "display", true);
 		process.env.PI_CAFFEINATE_COMMAND = longRunningCustomCommand();
@@ -309,10 +317,18 @@ test("quiet mode keeps lifecycle and status active without routine notifications
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 		await mock.events.get("agent_start")?.[0]?.({}, ctx);
 		const activeStatus = statuses.get("caffeinate");
+		const lifecycleNotificationCount = notifications.length;
+
+		await mock.commands.get("caffeinate")?.handler("status", ctx);
+		const statusMessage = notifications[0]?.message ?? "";
+		const statusAfterCommand = statuses.get("caffeinate");
 		await mock.events.get("agent_end")?.[0]?.({}, ctx);
 
-		assert.equal(notifications.length, 0);
-		assert.equal(activeStatus, "custom");
+		assert.equal(lifecycleNotificationCount, 0);
+		assert.equal(activeStatus, undefined);
+		assert.match(statusMessage, /pi-caffeinate is active/);
+		assert.equal(statusAfterCommand, undefined);
+		assert.equal(notifications.length, 1);
 		assert.equal(statuses.get("caffeinate"), undefined);
 	});
 });
@@ -347,12 +363,12 @@ test("quiet mode preserves inhibitor failure warnings", async () => {
 		caffeinateModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 		await mock.events.get("agent_start")?.[0]?.({}, ctx);
-		await waitFor(() => notifications.length > 0 && statuses.get("caffeinate") === "unavailable");
+		await waitFor(() => notifications.length > 0);
 
 		assert.equal(notifications.length, 1);
 		assert.equal(notifications[0]?.level, "warning");
 		assert.match(notifications[0]?.message ?? "", /exited unexpectedly \(code 7\)/);
-		assert.equal(statuses.get("caffeinate"), "unavailable");
+		assert.equal(statuses.get("caffeinate"), undefined);
 	});
 });
 


### PR DESCRIPTION
## Summary

- clear the `caffeinate` status item whenever quiet mode is enabled, including after reload and inhibitor failures
- keep the sleep inhibitor active while preserving explicit command feedback and actionable warnings
- document the expanded quiet-mode contract and add regression coverage

## Testing

- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check`
- `npm run pack:caffeinate`

Closes #214