### PR TITLE
fix(lsp): address late language defaults review

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -20,6 +20,7 @@
 - Keep pi-lsp's built-in catalog to direct-command, non-overlapping routes unless project-marker selection is added; mark defaults so unavailable optional commands can be skipped, keep explicit/custom selections fail-closed, and cache discovery by both extensions and skip policy.
 - pi-lsp catalog entries must target actual standalone launchers, handle platform wrappers, and include initialization needed by a stateless client; do not infer server readiness from a toolchain executable or route ambiguous/partially supported dialects.
 - On Windows, extensionless LSP commands can resolve to `.cmd`/`.bat` PATH shims; resolve with the adapter's effective `PATH` and child cwd before wrapping batch launchers through `%ComSpec%`.
+- pi-lsp defaults must use dialect-specific language IDs, nest workspace settings under the server-requested section, and avoid save-only settings unless diagnostics emit `didSave`.
 - pi-statusline is display-only; avoid prompt interception or customization commands unless intentionally reintroduced.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
 - Symptom: extension actions from `agent_end` may not trigger a new turn. Cause: follow-ups can miss the late drain point. Fix: on Pi 0.80.6+, record intent in `agent_end` and dispatch from `agent_settled`; standalone manual compaction does not emit `agent_settled`, so use a narrowly idle-gated `session_compact` fallback when needed.

--- a/docs/plans/2026-07-18_pi-lsp-pr237-late-review-plan.md
+++ b/docs/plans/2026-07-18_pi-lsp-pr237-late-review-plan.md
@@ -1,0 +1,27 @@
+## Goal
+
+Address every actionable comment in PR #237 review 4727878361 and deliver the verified fixes in a new pull request.
+
+## Context
+
+PR #237 merged before a late automated review reported five issues: a save-only Terraform setting, incorrectly shaped Intelephense settings, Windows `Path` override handling, and language IDs for OCaml interfaces and literate Haskell.
+
+## Plan
+
+- [x] Add regression expectations for Intelephense/Terraform defaults, `.mli`/`.lhs` language IDs, and case-insensitive Windows `Path` handling; `tsc -p tsconfig.test.json` fails on the missing Windows helpers before implementation.
+- [x] Correct the catalog settings and language IDs, and normalize Windows environment lookup/child environment merging; focused pi-lsp tests pass 10/10.
+- [x] Run the repository and package gates; `npm run check` passes 600/601 with one intentional skip, `npm run pack:lsp` contains the expected 12 files, `git diff --check` passes, and the bounded attribution search is clean.
+- [ ] Commit and push the focused changes, create a new PR against `main`, then reply to and resolve all five late-review threads with the new PR evidence.
+- [ ] Confirm the new PR is open, all checks pass, all targeted threads are resolved, the branch is synchronized, and the worktree is clean.
+
+## Risks
+
+- Windows environment behavior is tested through platform-parameterized pure helpers because the repository CI matrix runs on Linux.
+- Sending save notifications to every language server could change diagnostics behavior globally, so the Terraform fix removes the unsupported save-only default instead of broadening the client protocol flow.
+
+## Completion Checklist
+
+- [x] All five review findings are covered by code and regression assertions in `extensions/pi-lsp`.
+- [x] Full verification and the pi-lsp package dry run pass.
+- [ ] A new PR exists with the fixes, passing CI, and no unresolved targeted review threads.
+- [ ] The final branch and remote are synchronized with a clean worktree.

--- a/docs/plans/archived/2026-07-18_pi-lsp-pr237-late-review-plan.md
+++ b/docs/plans/archived/2026-07-18_pi-lsp-pr237-late-review-plan.md
@@ -12,7 +12,7 @@ PR #237 merged before a late automated review reported five issues: a save-only 
 - [x] Correct the catalog settings and language IDs, and normalize Windows environment lookup/child environment merging; focused pi-lsp tests pass 10/10.
 - [x] Run the repository and package gates; `npm run check` passes 600/601 with one intentional skip, `npm run pack:lsp` contains the expected 12 files, `git diff --check` passes, and the bounded attribution search is clean.
 - [x] Commit and push the focused changes as `599b369`, create PR #244 against `main`, then reply to and resolve all five late-review threads with the new PR evidence.
-- [x] Confirm PR #244 is open, all three CI jobs pass, all five targeted threads are resolved, and commit `599b369` is synchronized with its upstream branch.
+- [x] Confirm PR #244 is open, all three CI jobs pass on the archived-plan head, all five targeted threads are resolved, and the branch is synchronized with its upstream.
 
 ## Risks
 
@@ -24,4 +24,4 @@ PR #237 merged before a late automated review reported five issues: a save-only 
 - [x] All five review findings are covered by code and regression assertions in `extensions/pi-lsp`.
 - [x] Full verification and the pi-lsp package dry run pass.
 - [x] PR #244 exists with the fixes, all three CI jobs passing, no PR #244 review threads, and all five targeted PR #237 threads resolved.
-- [x] The implementation commit and remote are synchronized; the plan archive commit will be verified after push.
+- [x] The final PR head and upstream are synchronized with a clean worktree, verified by equal local/upstream revisions and `git status -sb` after the archive push.

--- a/docs/plans/archived/2026-07-18_pi-lsp-pr237-late-review-plan.md
+++ b/docs/plans/archived/2026-07-18_pi-lsp-pr237-late-review-plan.md
@@ -11,8 +11,8 @@ PR #237 merged before a late automated review reported five issues: a save-only 
 - [x] Add regression expectations for Intelephense/Terraform defaults, `.mli`/`.lhs` language IDs, and case-insensitive Windows `Path` handling; `tsc -p tsconfig.test.json` fails on the missing Windows helpers before implementation.
 - [x] Correct the catalog settings and language IDs, and normalize Windows environment lookup/child environment merging; focused pi-lsp tests pass 10/10.
 - [x] Run the repository and package gates; `npm run check` passes 600/601 with one intentional skip, `npm run pack:lsp` contains the expected 12 files, `git diff --check` passes, and the bounded attribution search is clean.
-- [ ] Commit and push the focused changes, create a new PR against `main`, then reply to and resolve all five late-review threads with the new PR evidence.
-- [ ] Confirm the new PR is open, all checks pass, all targeted threads are resolved, the branch is synchronized, and the worktree is clean.
+- [x] Commit and push the focused changes as `599b369`, create PR #244 against `main`, then reply to and resolve all five late-review threads with the new PR evidence.
+- [x] Confirm PR #244 is open, all three CI jobs pass, all five targeted threads are resolved, and commit `599b369` is synchronized with its upstream branch.
 
 ## Risks
 
@@ -23,5 +23,5 @@ PR #237 merged before a late automated review reported five issues: a save-only 
 
 - [x] All five review findings are covered by code and regression assertions in `extensions/pi-lsp`.
 - [x] Full verification and the pi-lsp package dry run pass.
-- [ ] A new PR exists with the fixes, passing CI, and no unresolved targeted review threads.
-- [ ] The final branch and remote are synchronized with a clean worktree.
+- [x] PR #244 exists with the fixes, all three CI jobs passing, no PR #244 review threads, and all five targeted PR #237 threads resolved.
+- [x] The implementation commit and remote are synchronized; the plan archive commit will be verified after push.

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -150,7 +150,7 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		name: "intelephense",
 		command: ["intelephense", "--stdio"],
 		extensions: [".php"],
-		initialization: { telemetry: { enabled: false } },
+		initialization: { intelephense: { telemetry: { enabled: false } } },
 	},
 	{
 		name: "prisma",
@@ -180,7 +180,7 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		extensions: [".tf", ".tfvars"],
 		skipDirectories: [".terraform"],
 		initialization: {
-			experimentalFeatures: { prefillRequiredFields: true, validateOnSave: true },
+			experimentalFeatures: { prefillRequiredFields: true },
 		},
 	},
 	{
@@ -493,11 +493,11 @@ const LANGUAGE_IDS: Record<string, string> = {
 	".ksh": "shellscript",
 	".kt": "kotlin",
 	".kts": "kotlin",
-	".lhs": "haskell",
+	".lhs": "lhaskell",
 	".m": "objective-c",
 	".mjs": "javascript",
 	".ml": "ocaml",
-	".mli": "ocaml",
+	".mli": "ocaml.interface",
 	".mm": "objective-cpp",
 	".mts": "typescript",
 	".nix": "nix",

--- a/extensions/pi-lsp/src/command.ts
+++ b/extensions/pi-lsp/src/command.ts
@@ -21,8 +21,42 @@ export function commandExists(
 	return resolveCommandPath(command, cwd, process.platform, pathValue) !== undefined;
 }
 
-export function commandPathValue(env: Record<string, string> | undefined) {
-	return env?.PATH ?? process.env.PATH ?? "";
+export function commandPathValue(
+	env: Record<string, string> | undefined,
+	platform: NodeJS.Platform = process.platform,
+) {
+	return (
+		environmentValue(env, "PATH", platform) ?? environmentValue(process.env, "PATH", platform) ?? ""
+	);
+}
+
+export function mergeEnvironment(
+	overrides: Record<string, string> | undefined,
+	platform: NodeJS.Platform = process.platform,
+) {
+	const environment: NodeJS.ProcessEnv = { ...process.env };
+	for (const [key, value] of Object.entries(overrides ?? {})) {
+		if (platform === "win32") {
+			for (const existingKey of Object.keys(environment)) {
+				if (existingKey.toLowerCase() === key.toLowerCase()) delete environment[existingKey];
+			}
+		}
+		environment[key] = value;
+	}
+	return environment;
+}
+
+function environmentValue(
+	environment: NodeJS.ProcessEnv | Record<string, string> | undefined,
+	name: string,
+	platform: NodeJS.Platform,
+) {
+	if (platform !== "win32") return environment?.[name];
+	let value: string | undefined;
+	for (const [key, candidate] of Object.entries(environment ?? {})) {
+		if (key.toLowerCase() === name.toLowerCase()) value = candidate;
+	}
+	return value;
 }
 
 export function resolveCommandPath(

--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -1,7 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
-import { commandPathValue, resolveCommandPath } from "./command.js";
+import { commandPathValue, mergeEnvironment, resolveCommandPath } from "./command.js";
 import { directoryUri } from "./files.js";
 import { positionAt } from "./text-edits.js";
 import type {
@@ -74,7 +74,7 @@ export class LspClient {
 		const spawnCommand = resolveSpawnCommand({ ...this.#command, command: commandPath });
 		const child = spawn(spawnCommand.command, spawnCommand.args, {
 			cwd: this.#cwd,
-			env: { ...process.env, ...this.#adapter.env },
+			env: mergeEnvironment(this.#adapter.env),
 			stdio: "pipe",
 		});
 		this.#child = child;

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -15,7 +15,14 @@ import path from "node:path";
 import test from "node:test";
 import { createMockPi } from "../../../test/support.js";
 import { consumeLspConfigNotice, loadConfig, loadRuntime } from "../src/adapters.js";
-import { commandExists, commandFromEnv, resolveCommandPath, splitCommand } from "../src/command.js";
+import {
+	commandExists,
+	commandFromEnv,
+	commandPathValue,
+	mergeEnvironment,
+	resolveCommandPath,
+	splitCommand,
+} from "../src/command.js";
 import { collectSupportedFiles, directoryUri, resolveSupportedFile } from "../src/files.js";
 import { resolveSpawnCommand } from "../src/lsp-client.js";
 import lsp from "../src/pi-lsp.js";
@@ -183,7 +190,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				extensions: [".php"],
 				sample: "index.php",
 				languageId: "php",
-				initialization: { telemetry: { enabled: false } },
+				initialization: { intelephense: { telemetry: { enabled: false } } },
 			},
 			{
 				name: "prisma",
@@ -205,7 +212,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				command: ["ocamllsp"],
 				extensions: [".ml", ".mli"],
 				sample: "lib/app.mli",
-				languageId: "ocaml",
+				languageId: "ocaml.interface",
 				skipDirectories: ["_build", "_opam"],
 			},
 			{
@@ -223,7 +230,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				languageId: "terraform-vars",
 				skipDirectories: [".terraform"],
 				initialization: {
-					experimentalFeatures: { prefillRequiredFields: true, validateOnSave: true },
+					experimentalFeatures: { prefillRequiredFields: true },
 				},
 			},
 			{
@@ -268,7 +275,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				command: ["haskell-language-server-wrapper", "--lsp"],
 				extensions: [".hs", ".lhs"],
 				sample: "src/Main.lhs",
-				languageId: "haskell",
+				languageId: "lhaskell",
 				skipDirectories: [".stack-work", "dist-newstyle"],
 			},
 		];
@@ -309,6 +316,13 @@ test("command helpers split shell-like strings and honor environment overrides",
 	const windowsBin = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-windows-bin-"));
 	const commandShim = path.join(windowsBin, "language-server.cmd");
 	writeFileSync(commandShim, "@echo off\r\n");
+	assert.equal(commandPathValue({ Path: windowsBin }, "win32"), windowsBin);
+	assert.deepEqual(
+		Object.entries(mergeEnvironment({ Path: windowsBin }, "win32")).filter(
+			([key]) => key.toLowerCase() === "path",
+		),
+		[["Path", windowsBin]],
+	);
 	const resolvedShim = resolveCommandPath("language-server", windowsBin, "win32", windowsBin);
 	assert.ok(resolvedShim);
 	assert.equal(resolvedShim, commandShim);


### PR DESCRIPTION
## Summary

- correct Intelephense workspace settings and remove Terraform's unused save-only validation setting
- use dialect-specific language IDs for OCaml interfaces and literate Haskell
- honor case-insensitive Windows `Path` overrides consistently during preflight and child process launch

## Context

Follow-up to the late review on #237: https://github.com/narumiruna/pi-extensions/pull/237#pullrequestreview-4727878361

## Verification

- `npm run check` (600 passed, 1 skipped)
- focused pi-lsp tests (10 passed)
- `npm run pack:lsp` (12 expected files)
- `git diff --check`
- bounded attribution search
