### PR TITLE
feat: publish only changed extension packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout tag
+      - name: Checkout ref
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -42,34 +44,36 @@ jobs:
       - name: Verify packages
         run: npm run check
 
+      - name: Select workspace packages
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            node scripts/list-publish-workspaces.mjs --release "$RELEASE_TAG" > /tmp/pi-workspaces.tsv
+          else
+            node scripts/list-publish-workspaces.mjs --all > /tmp/pi-workspaces.tsv
+          fi
+
+          if [[ -s /tmp/pi-workspaces.tsv ]]; then
+            echo "Selected workspace packages:"
+            while IFS=$'\t' read -r package version; do
+              echo "- ${package}@${version}"
+            done < /tmp/pi-workspaces.tsv
+          else
+            echo "No workspace packages selected for publishing."
+          fi
+
       - name: Publish unpublished workspace packages
         env:
           NPM_CONFIG_PROVENANCE: "true"
         run: |
           set -euo pipefail
 
-          node - <<'NODE' > /tmp/pi-workspaces.tsv
-          const fs = require("node:fs");
-          const path = require("node:path");
-
-          const extensionsDir = "extensions";
-          for (const dirent of fs.readdirSync(extensionsDir, { withFileTypes: true })) {
-            if (!dirent.isDirectory()) continue;
-            // Experimental packages may be published only through an explicit local just recipe.
-            if (dirent.name === "experimental" || dirent.name === "deprecated") continue;
-
-            const packageJsonPath = path.join(extensionsDir, dirent.name, "package.json");
-            if (!fs.existsSync(packageJsonPath)) continue;
-
-            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-            if (packageJson.private) continue;
-
-            console.log(`${packageJson.name}\t${packageJson.version}`);
-          }
-          NODE
-
           while IFS=$'\t' read -r package version; do
-            if [ -z "$package" ] || [ -z "$version" ]; then
+            if [[ -z "$package" || -z "$version" ]]; then
               continue
             fi
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -29,6 +29,7 @@
 - Symptom: concurrent tools sharing one extension status key can clear or mislabel a still-running sibling. Cause: each call unconditionally owns set/clear. Fix: track active statuses per UI/session, restore the latest remaining status, and invalidate the tracker on session teardown.
 - Reopening `ctx.ui.select()` after every toggle resets its cursor to row one; use one `ctx.ui.custom()` selector with a persistent selected index, retaining the dialog loop only as a fallback. Serialize selector saves, recover the queue after each failure, and preserve prior save/apply ordering; roll back optimistic UI state when persistence fails.
 - Run Biome `--write` only on intended files during bounded work; formatting whole extension trees can rewrite unrelated source that is currently outside the root's normal ignore-aware formatting path.
+- Root Biome checks reject nested Git worktrees that contain another root `biome.json`; create worktrees outside the repository or locally ignore their parent directory during verification.
 - Headless Pi runners can share a no-op UI object; key session-owned resources such as temporary output files by `sessionManager`, not `ctx.ui`.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.

--- a/docs/plans/archived/2026-07-18_changed-extension-publish-plan.md
+++ b/docs/plans/archived/2026-07-18_changed-extension-publish-plan.md
@@ -1,0 +1,50 @@
+## Goal
+
+Change tag-driven npm publishing so a release publishes only production extensions changed since the previous release, while retaining the shared repository version bump and accepting skipped npm version numbers for unchanged extensions.
+
+## Context
+
+`bump-version.yml` currently creates a final `chore(release): vX.Y.Z` commit that updates every production extension's version. `publish.yml` then sees every new `package@version` as unpublished and publishes all production extensions. GitHub Actions does not evaluate `paths` filters for tag pushes, so candidate selection must happen inside the workflow.
+
+## Architecture
+
+Add a small, testable repository script that emits publish candidates as package/version TSV. In release mode it will compare the previous reachable `v*.*.*` tag with the tagged release commit's parent, deliberately excluding the generated all-package version-bump commit. In all-packages mode it will preserve manual recovery behavior. The existing npm registry check remains the final idempotency guard before each publish.
+
+## Non-Goals
+
+- Do not change the shared version-bump model or assign independent package versions.
+- Do not publish experimental, deprecated, private, deleted, or unchanged packages.
+- Do not infer that root-only changes affect every extension; an extension is changed only when a path under its direct `extensions/<package>/` directory changed.
+
+## Assumptions
+
+- Normal release tags are created by `.github/workflows/bump-version.yml` on its generated `chore(release): <tag>` commit.
+- A missing previous release tag or a nonstandard tag/commit shape should safely fall back to considering all production packages, preventing accidental under-publishing.
+- `workflow_dispatch` remains a recovery path that considers all production packages; npm's existing-version check still prevents duplicate publication.
+
+## Plan
+
+- [x] Add `scripts/list-publish-workspaces.mjs` with release and all-packages modes, deterministic deduplicated TSV output, direct production-workspace discovery, previous-tag lookup, and the release-parent diff rule; its CLI passed temporary Git repository tests in `test/publish-workspaces.test.ts` (7/7).
+- [x] Cover release selection cases in `test/publish-workspaces.test.ts`: one/multiple changed extensions, root-only changes, version-bump-only release commits, newly added and deleted packages, experimental/deprecated/private exclusions, first release, nonstandard release tags, deterministic ordering, and all-packages recovery mode; the focused compiled selector test passed (7/7), including a package introduced inside a noncanonical release commit.
+- [x] Update `.github/workflows/publish.yml` to checkout full Git history, invoke release-mode selection for `v*.*.*` tag pushes, invoke all-packages mode for `workflow_dispatch`, log the selected candidates, and feed only those candidates into the existing npm existence-check/publish loop; the focused workflow/selector tests passed (11/11), including an empty candidate list, and the registry/provenance settings remain unchanged.
+- [x] Validate the selector against repository history: `node scripts/list-publish-workspaces.mjs --release v0.18.0` selected exactly `pi-chrome-devtools`, `pi-firecrawl`, `pi-google-genai`, `pi-plan-mode`, `pi-subagents`, and `pi-telegraph`, demonstrating that the generated v0.18.0 bump commit does not select every package.
+- [x] Run `npm run check` to verify formatting, boundary checks, workspace typechecks, and the complete test suite; the gate passed with 608 tests passed and 1 compatibility test skipped, and `git diff --check` passed.
+
+## Risks
+
+- Excluding the tagged commit would miss real extension changes placed directly in a manually created tag commit. Mitigation: only use diff-based selection for the canonical generated release shape and fall back to all production packages otherwise.
+- A selector bug could omit a package from automated publishing. Mitigation: keep `workflow_dispatch` as an all-packages recovery path and retain the per-version npm existence guard.
+- Root tooling or lockfile-only changes will not trigger any extension publication. This is intentional under the path-based definition and should be explicit in tests.
+
+## Rollback / Recovery
+
+- Re-run `Publish` through `workflow_dispatch` to publish any still-unpublished production `package@version`; already published versions will be skipped.
+- Reverting the workflow and selector-script change restores the current publish-all-unpublished behavior without changing package metadata or npm state.
+
+## Completion Checklist
+
+- [x] A canonical tag release publishes only changed direct production extensions, verified by 7 temporary Git-history tests and the historical v0.18.0 check selecting exactly its 6 changed extensions.
+- [x] Unchanged, experimental, deprecated, private, and deleted packages cannot enter the automated tag candidate list, verified by `test/publish-workspaces.test.ts`.
+- [x] First-release, nonstandard-tag, and manual-dispatch recovery paths consider all production packages, verified by selector tests and `.github/workflows/publish.yml` event branching.
+- [x] Publishing remains idempotent and provenance-enabled, verified by the retained `npm view "${package}@${version}"` guard and `NPM_CONFIG_PROVENANCE: "true"` in `.github/workflows/publish.yml`.
+- [x] Repository quality gates pass, verified by `npm run check` (608 passed, 1 skipped) and `git diff --check`.

--- a/scripts/list-publish-workspaces.mjs
+++ b/scripts/list-publish-workspaces.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { isDeepStrictEqual } from "node:util";
+
+const releaseTagPattern = /^v(\d+)\.(\d+)\.(\d+)$/;
+const excludedDirectories = new Set(["deprecated", "experimental"]);
+const [mode, ...args] = process.argv.slice(2);
+
+let releaseCommit;
+let selectedDirectories;
+
+if (mode === "--all" && args.length === 0) {
+	releaseCommit = resolveCommit("HEAD");
+} else if (mode === "--release" && args.length === 1) {
+	const [tag] = args;
+	releaseCommit = resolveTagCommit(tag);
+	selectedDirectories = selectChangedDirectories(tag, releaseCommit);
+} else {
+	throw new Error(
+		"Usage: scripts/list-publish-workspaces.mjs --all | --release <vMAJOR.MINOR.PATCH>",
+	);
+}
+
+const packages = listProductionPackages(releaseCommit);
+const selectedPackages = selectedDirectories
+	? packages.filter(({ directory }) => selectedDirectories.has(directory))
+	: packages;
+
+process.stdout.write(
+	selectedPackages.length > 0
+		? `${selectedPackages.map(({ name, version }) => `${name}\t${version}`).join("\n")}\n`
+		: "",
+);
+
+function selectChangedDirectories(tag, commit) {
+	const match = releaseTagPattern.exec(tag);
+	if (!match) return fallbackToAll(`tag ${JSON.stringify(tag)} is not a stable release tag`);
+
+	const parent = tryResolveCommit(`${commit}^`);
+	if (!parent) return fallbackToAll(`release ${tag} has no parent commit`);
+
+	const previousRelease = findPreviousRelease(parent);
+	if (!previousRelease) return fallbackToAll(`release ${tag} has no previous release tag`);
+
+	const packages = listProductionPackages(commit);
+	const releaseVersion = match.slice(1).join(".");
+	if (!isCanonicalReleaseCommit(tag, releaseVersion, commit, parent, packages)) {
+		return fallbackToAll(`release ${tag} was not created by the shared version-bump workflow`);
+	}
+
+	const changedDirectories = new Set();
+	for (const changedPath of gitNullList([
+		"diff",
+		"--name-only",
+		"-z",
+		previousRelease.commit,
+		parent,
+		"--",
+		"extensions",
+	])) {
+		const [topLevel, directory, child] = changedPath.split("/");
+		if (topLevel === "extensions" && directory && child) changedDirectories.add(directory);
+	}
+	return changedDirectories;
+}
+
+function fallbackToAll(reason) {
+	console.error(`Publish selection fallback: ${reason}; considering all production packages.`);
+	return undefined;
+}
+
+function findPreviousRelease(commit) {
+	const tagsByCommit = new Map();
+	for (const tag of gitLines(["tag", "--merged", commit, "--list"])) {
+		if (!releaseTagPattern.test(tag)) continue;
+		const tagCommit = tryResolveCommit(`refs/tags/${tag}^{commit}`);
+		if (!tagCommit) continue;
+		const tags = tagsByCommit.get(tagCommit) ?? [];
+		tags.push(tag);
+		tagsByCommit.set(tagCommit, tags);
+	}
+
+	for (const candidate of gitLines(["rev-list", "--first-parent", commit])) {
+		const tags = tagsByCommit.get(candidate);
+		if (!tags) continue;
+		tags.sort(compareStrings);
+		return { tag: tags.at(-1), commit: candidate };
+	}
+	return undefined;
+}
+
+function isCanonicalReleaseCommit(tag, version, commit, parent, packages) {
+	const subject = git(["show", "--no-patch", "--format=%s", commit]).trimEnd();
+	if (subject !== `chore(release): ${tag}`) return false;
+
+	const parents = gitLines(["rev-list", "--parents", "--max-count=1", commit]);
+	if (parents.length !== 1 || parents[0].split(" ").length !== 2) return false;
+
+	const manifestPaths = ["package.json", ...packages.map(({ manifestPath }) => manifestPath)];
+	const expectedPaths = [...manifestPaths, "package-lock.json"].sort(compareStrings);
+	const actualPaths = gitNullList(["diff", "--name-only", "-z", parent, commit]).sort(
+		compareStrings,
+	);
+	if (!isDeepStrictEqual(actualPaths, expectedPaths)) return false;
+
+	for (const manifestPath of manifestPaths) {
+		const before = tryReadJsonAt(parent, manifestPath);
+		const after = tryReadJsonAt(commit, manifestPath);
+		if (!before || !after) return false;
+		if (after.version !== version || typeof before.version !== "string") return false;
+		delete before.version;
+		delete after.version;
+		if (!isDeepStrictEqual(before, after)) return false;
+	}
+
+	const beforeLock = tryReadJsonAt(parent, "package-lock.json");
+	const afterLock = tryReadJsonAt(commit, "package-lock.json");
+	if (!beforeLock || !afterLock) return false;
+	const workspacePaths = packages.map(({ directory }) => `extensions/${directory}`);
+	if (!normalizeLockfileVersions(beforeLock, workspacePaths)) return false;
+	if (!normalizeLockfileVersions(afterLock, workspacePaths, version)) return false;
+	return isDeepStrictEqual(beforeLock, afterLock);
+}
+
+function normalizeLockfileVersions(lockfile, workspacePaths, expectedVersion) {
+	if (!isObject(lockfile) || !isObject(lockfile.packages)) return false;
+	if (!normalizeVersion(lockfile, expectedVersion)) return false;
+
+	for (const packagePath of ["", ...workspacePaths]) {
+		const packageEntry = lockfile.packages[packagePath];
+		if (!isObject(packageEntry) || !normalizeVersion(packageEntry, expectedVersion)) return false;
+	}
+	return true;
+}
+
+function normalizeVersion(value, expectedVersion) {
+	if (typeof value.version !== "string") return false;
+	if (expectedVersion !== undefined && value.version !== expectedVersion) return false;
+	value.version = "<workspace-version>";
+	return true;
+}
+
+function listProductionPackages(commit) {
+	const packages = [];
+	for (const directory of gitNullList(["ls-tree", "-z", "--name-only", `${commit}:extensions`])) {
+		if (excludedDirectories.has(directory) || directory.includes("/")) continue;
+		const manifestPath = `extensions/${directory}/package.json`;
+		const packageJson = tryReadJsonAt(commit, manifestPath);
+		if (!packageJson || packageJson.private) continue;
+
+		const { name, version } = packageJson;
+		if (!isTsvValue(name) || !isTsvValue(version)) {
+			throw new Error(`${manifestPath} must contain string name and version fields without tabs`);
+		}
+		packages.push({ directory, manifestPath, name, version });
+	}
+
+	packages.sort(
+		(a, b) => compareStrings(a.name, b.name) || compareStrings(a.directory, b.directory),
+	);
+	for (let index = 1; index < packages.length; index += 1) {
+		if (packages[index - 1].name === packages[index].name) {
+			throw new Error(`Duplicate production package name: ${packages[index].name}`);
+		}
+	}
+	return packages;
+}
+
+function isTsvValue(value) {
+	return typeof value === "string" && value.length > 0 && !/[\t\r\n]/.test(value);
+}
+
+function resolveTagCommit(tag) {
+	git(["check-ref-format", `refs/tags/${tag}`]);
+	return resolveCommit(`refs/tags/${tag}^{commit}`);
+}
+
+function resolveCommit(revision) {
+	const commit = tryResolveCommit(revision);
+	if (!commit) throw new Error(`Cannot resolve Git commit: ${revision}`);
+	return commit;
+}
+
+function tryResolveCommit(revision) {
+	const result = runGit(["rev-parse", "--verify", revision], true);
+	return result.status === 0 ? result.stdout.trimEnd() : undefined;
+}
+
+function tryReadJsonAt(commit, filePath) {
+	const result = runGit(["show", `${commit}:${filePath}`], true);
+	if (result.status !== 0) return undefined;
+	return parseJson(result.stdout, `${commit}:${filePath}`);
+}
+
+function parseJson(contents, source) {
+	const value = JSON.parse(contents);
+	if (!isObject(value)) throw new Error(`${source} must contain a JSON object`);
+	return value;
+}
+
+function isObject(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function git(args) {
+	const result = runGit(args);
+	return result.stdout;
+}
+
+function gitLines(args) {
+	return git(args).split("\n").filter(Boolean);
+}
+
+function gitNullList(args) {
+	const output = git(args);
+	return output.split("\0").filter(Boolean);
+}
+
+function runGit(args, allowFailure = false) {
+	const result = spawnSync("git", args, {
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+	});
+	if (result.error) throw result.error;
+	if (!allowFailure && result.status !== 0) {
+		throw new Error(
+			[`git ${args.join(" ")} failed with status ${result.status}`, result.stderr.trimEnd()]
+				.filter(Boolean)
+				.join(": "),
+		);
+	}
+	return {
+		status: result.status,
+		stdout: result.stdout ?? "",
+	};
+}
+
+function compareStrings(a, b) {
+	return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/test/publish-workspaces.test.ts
+++ b/test/publish-workspaces.test.ts
@@ -1,0 +1,324 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = process.cwd();
+const publishSelector = path.join(repositoryRoot, "scripts", "list-publish-workspaces.mjs");
+const gitEnvironment = {
+	...process.env,
+	GIT_AUTHOR_EMAIL: "fixture@example.com",
+	GIT_AUTHOR_NAME: "Fixture Author",
+	GIT_COMMITTER_EMAIL: "fixture@example.com",
+	GIT_COMMITTER_NAME: "Fixture Author",
+};
+
+test("canonical releases select only changed production extensions in deterministic order", () => {
+	withRepository(
+		[
+			{ directory: "pi-zulu", name: "@fixture/zulu" },
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+			{ directory: "pi-private", name: "@fixture/private", private: true },
+			{ directory: "experimental/pi-experiment", name: "@fixture/experiment" },
+			{ directory: "deprecated/pi-legacy", name: "@fixture/legacy" },
+		],
+		(repository) => {
+			tag(repository, "v1.0.0");
+			write(repository, "README.md", "root-only change\n");
+			write(repository, "extensions/pi-zulu/src/index.ts", "export const zulu = 1;\n");
+			write(repository, "extensions/pi-zulu/test/index.test.ts", "// second zulu path\n");
+			write(repository, "extensions/pi-private/src/index.ts", "private change\n");
+			write(
+				repository,
+				"extensions/experimental/pi-experiment/src/index.ts",
+				"experimental change\n",
+			);
+			write(repository, "extensions/deprecated/pi-legacy/src/index.ts", "legacy change\n");
+			addPackage(repository, { directory: "pi-middle", name: "@fixture/middle" });
+			refreshLockfile(repository);
+			commit(repository, "feat: change selected extensions");
+
+			createRelease(repository, "v1.1.0");
+
+			assert.deepEqual(select(repository, "--release", "v1.1.0"), [
+				["@fixture/middle", "1.1.0"],
+				["@fixture/zulu", "1.1.0"],
+			]);
+		},
+	);
+});
+
+test("release selection ignores root-only changes and the generated version bump", () => {
+	withRepository(
+		[
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+			{ directory: "pi-beta", name: "@fixture/beta" },
+		],
+		(repository) => {
+			tag(repository, "v1.0.0");
+			write(repository, "README.md", "root-only change\n");
+			commit(repository, "docs: update root readme");
+			createRelease(repository, "v1.1.0");
+
+			assert.deepEqual(select(repository, "--release", "v1.1.0"), []);
+		},
+	);
+});
+
+test("release selection omits deleted and unchanged packages", () => {
+	withRepository(
+		[
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+			{ directory: "pi-deleted", name: "@fixture/deleted" },
+		],
+		(repository) => {
+			tag(repository, "v1.0.0");
+			rmSync(path.join(repository, "extensions/pi-deleted"), { recursive: true });
+			refreshLockfile(repository);
+			commit(repository, "chore: remove deleted extension");
+			createRelease(repository, "v1.1.0");
+
+			assert.deepEqual(select(repository, "--release", "v1.1.0"), []);
+		},
+	);
+});
+
+test("first and nonstandard releases safely select every production package", () => {
+	withRepository(
+		[
+			{ directory: "pi-beta", name: "@fixture/beta" },
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+			{ directory: "pi-private", name: "@fixture/private", private: true },
+			{ directory: "experimental/pi-experiment", name: "@fixture/experiment" },
+		],
+		(repository) => {
+			createRelease(repository, "v1.0.0");
+			assert.deepEqual(select(repository, "--release", "v1.0.0"), [
+				["@fixture/alpha", "1.0.0"],
+				["@fixture/beta", "1.0.0"],
+			]);
+		},
+	);
+
+	withRepository(
+		[
+			{ directory: "pi-beta", name: "@fixture/beta" },
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+		],
+		(repository) => {
+			tag(repository, "v1.0.0");
+			write(repository, "extensions/pi-alpha/src/index.ts", "export const alpha = 1;\n");
+			commit(repository, "feat: manually tagged change");
+			tag(repository, "v1.1.0");
+
+			assert.deepEqual(select(repository, "--release", "v1.1.0"), [
+				["@fixture/alpha", "0.0.0"],
+				["@fixture/beta", "0.0.0"],
+			]);
+		},
+	);
+});
+
+test("a release-shaped commit with extra source changes falls back to all packages", () => {
+	withRepository(
+		[
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+			{ directory: "pi-beta", name: "@fixture/beta" },
+		],
+		(repository) => {
+			tag(repository, "v1.0.0");
+			write(repository, "extensions/pi-alpha/src/index.ts", "export const alpha = 1;\n");
+			createRelease(repository, "v1.1.0");
+
+			assert.deepEqual(select(repository, "--release", "v1.1.0"), [
+				["@fixture/alpha", "1.1.0"],
+				["@fixture/beta", "1.1.0"],
+			]);
+		},
+	);
+});
+
+test("a package introduced inside the release commit falls back to all packages", () => {
+	withRepository([{ directory: "pi-alpha", name: "@fixture/alpha" }], (repository) => {
+		tag(repository, "v1.0.0");
+		writeJson(repository, "extensions/pi-new/package.json", {
+			name: "@fixture/new",
+			version: "0.0.0",
+		});
+		createRelease(repository, "v1.1.0");
+
+		assert.deepEqual(select(repository, "--release", "v1.1.0"), [
+			["@fixture/alpha", "1.1.0"],
+			["@fixture/new", "1.1.0"],
+		]);
+	});
+});
+
+test("all-packages mode is deterministic and excludes non-production workspaces", () => {
+	withRepository(
+		[
+			{ directory: "pi-zulu", name: "@fixture/zulu" },
+			{ directory: "pi-alpha", name: "@fixture/alpha" },
+			{ directory: "pi-private", name: "@fixture/private", private: true },
+			{ directory: "experimental/pi-experiment", name: "@fixture/experiment" },
+			{ directory: "deprecated/pi-legacy", name: "@fixture/legacy" },
+		],
+		(repository) => {
+			assert.deepEqual(select(repository, "--all"), [
+				["@fixture/alpha", "0.0.0"],
+				["@fixture/zulu", "0.0.0"],
+			]);
+		},
+	);
+});
+
+type PackageFixture = {
+	directory: string;
+	name: string;
+	private?: boolean;
+};
+
+function withRepository(packages: PackageFixture[], run: (repository: string) => void) {
+	const repository = mkdtempSync(path.join(tmpdir(), "pi-publish-workspaces-"));
+	try {
+		git(repository, "init", "--quiet");
+		writeJson(repository, "package.json", {
+			name: "fixture-root",
+			version: "0.0.0",
+			private: true,
+			workspaces: ["extensions/*", "extensions/experimental/*"],
+		});
+		for (const packageFixture of packages) addPackage(repository, packageFixture);
+		refreshLockfile(repository);
+		commit(repository, "chore: initial fixture");
+		run(repository);
+	} finally {
+		rmSync(repository, { recursive: true, force: true });
+	}
+}
+
+function addPackage(repository: string, packageFixture: PackageFixture) {
+	writeJson(repository, `extensions/${packageFixture.directory}/package.json`, {
+		name: packageFixture.name,
+		version: "0.0.0",
+		...(packageFixture.private ? { private: true } : {}),
+	});
+	write(repository, `extensions/${packageFixture.directory}/src/index.ts`, "export {};\n");
+}
+
+function createRelease(repository: string, tagName: string) {
+	const version = tagName.slice(1);
+	const rootPackage = readJson(path.join(repository, "package.json"));
+	rootPackage.version = version;
+	writeJson(repository, "package.json", rootPackage);
+
+	for (const directory of productionPackageDirectories(repository)) {
+		const packagePath = path.join(repository, "extensions", directory, "package.json");
+		const packageJson = readJson(packagePath);
+		packageJson.version = version;
+		writeJson(repository, path.relative(repository, packagePath), packageJson);
+	}
+	refreshLockfile(repository);
+	commit(repository, `chore(release): ${tagName}`);
+	tag(repository, tagName);
+}
+
+function refreshLockfile(repository: string) {
+	const rootPackage = readJson(path.join(repository, "package.json"));
+	const packages: Record<string, unknown> = {
+		"": {
+			name: rootPackage.name,
+			version: rootPackage.version,
+			workspaces: rootPackage.workspaces,
+		},
+	};
+	const extensions = path.join(repository, "extensions");
+	if (existsSync(extensions)) {
+		for (const directory of listPackageDirectories(repository)) {
+			const packagePath = path.join(extensions, directory, "package.json");
+			const packageJson = readJson(packagePath);
+			packages[`extensions/${directory}`] = {
+				name: packageJson.name,
+				version: packageJson.version,
+				...(packageJson.private ? { private: true } : {}),
+			};
+		}
+	}
+	writeJson(repository, "package-lock.json", {
+		name: rootPackage.name,
+		version: rootPackage.version,
+		lockfileVersion: 3,
+		requires: true,
+		packages,
+	});
+}
+
+function productionPackageDirectories(repository: string) {
+	return listPackageDirectories(repository).filter((directory) => {
+		if (directory.includes("/")) return false;
+		if (directory === "experimental" || directory === "deprecated") return false;
+		const packageJson = readJson(path.join(repository, "extensions", directory, "package.json"));
+		return packageJson.private !== true;
+	});
+}
+
+function listPackageDirectories(repository: string) {
+	const output = git(repository, "ls-files", "extensions/**/package.json");
+	const tracked = output
+		.split("\n")
+		.filter(Boolean)
+		.map((file) => path.posix.dirname(file).slice("extensions/".length));
+	const untracked = git(repository, "ls-files", "--others", "--exclude-standard", "extensions")
+		.split("\n")
+		.filter((file) => file.endsWith("/package.json"))
+		.map((file) => path.posix.dirname(file).slice("extensions/".length));
+	return [...new Set([...tracked, ...untracked])]
+		.filter((directory) =>
+			existsSync(path.join(repository, "extensions", directory, "package.json")),
+		)
+		.sort();
+}
+
+function select(repository: string, ...args: string[]): string[][] {
+	const output = execFileSync(process.execPath, [publishSelector, ...args], {
+		cwd: repository,
+		encoding: "utf8",
+	});
+	return output
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => line.split("\t"));
+}
+
+function commit(repository: string, message: string) {
+	git(repository, "add", "--all");
+	git(repository, "commit", "--quiet", "--message", message);
+}
+
+function tag(repository: string, tagName: string) {
+	git(repository, "tag", tagName);
+}
+
+function git(repository: string, ...args: string[]) {
+	return execFileSync("git", args, {
+		cwd: repository,
+		encoding: "utf8",
+		env: gitEnvironment,
+	}).trimEnd();
+}
+
+function write(repository: string, relativePath: string, contents: string) {
+	const filePath = path.join(repository, relativePath);
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(filePath, contents);
+}
+
+function writeJson(repository: string, relativePath: string, value: unknown) {
+	write(repository, relativePath, `${JSON.stringify(value, null, "\t")}\n`);
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+	return JSON.parse(readFileSync(filePath, "utf8"));
+}

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -60,10 +60,24 @@ test("shared-version discovery skips workspace roots that are not present", () =
 	}
 });
 
-test("experimental publishing is manual-only", () => {
+test("publish workflow selects changed tag packages and all manual recovery packages", () => {
 	const workflow = readFileSync(path.join(repositoryRoot, ".github/workflows/publish.yml"), "utf8");
+	assert.match(workflow, /fetch-depth: 0/);
+	assert.match(workflow, /EVENT_NAME: \$\{\{ github\.event_name \}\}/);
+	assert.match(workflow, /RELEASE_TAG: \$\{\{ github\.ref_name \}\}/);
+	assert.match(workflow, /list-publish-workspaces\.mjs --release "\$RELEASE_TAG"/);
+	assert.match(workflow, /list-publish-workspaces\.mjs --all/);
+	assert.match(workflow, /npm view "\$\{package\}@\$\{version\}" version/);
+	assert.match(workflow, /NPM_CONFIG_PROVENANCE: "true"/);
+});
+
+test("experimental publishing is manual-only", () => {
+	const selector = readFileSync(
+		path.join(repositoryRoot, "scripts/list-publish-workspaces.mjs"),
+		"utf8",
+	);
 	const justfile = readFileSync(path.join(repositoryRoot, "justfile"), "utf8");
-	assert.match(workflow, /dirent\.name === "experimental"/);
+	assert.match(selector, /new Set\(\["deprecated", "experimental"\]\)/);
 	assert.match(justfile, /package_json="\.\/extensions\/experimental\/pi-\$name\/package\.json"/);
 	assert.match(justfile, /WARNING: manually publishing experimental Pi extension/);
 	assert.match(justfile, /publish name otp=""/);


### PR DESCRIPTION
## Summary

- select production extension workspaces changed since the previous release while ignoring the shared version-bump commit
- preserve all-package fallback behavior for first/nonstandard releases and manual workflow recovery
- add Git-history fixtures covering changed, new, deleted, unchanged, private, experimental, and deprecated packages

## Verification

- `npm run check` (608 passed, 1 skipped)
- `node scripts/list-publish-workspaces.mjs --release v0.18.0` (selected the expected 6 changed packages)
- `git diff --check`
- parsed `.github/workflows/publish.yml` as valid YAML