### PR TITLE
fix(image-drop): harden lease and lifecycle races

### DIFF
--- a/extensions/pi-image-drop/src/batch.ts
+++ b/extensions/pi-image-drop/src/batch.ts
@@ -142,6 +142,9 @@ export class BatchStore {
 		this.assertOpen();
 		if (this.reservation) throw new BatchError("Batch is frozen", "frozen");
 		const item = this.item(id);
+		if (item.status !== "uploading" && item.status !== "error") {
+			throw new BatchError("Image is already processing or ready", "not-ready");
+		}
 		if (source.byteLength !== item.size) {
 			throw new BatchError("Uploaded size does not match the reservation", "invalid");
 		}
@@ -205,6 +208,23 @@ export class BatchStore {
 		item.status = "error";
 		item.error = sanitizeError(error);
 		return this.bump();
+	}
+
+	cancelInFlight(error: string): boolean {
+		this.assertOpen();
+		if (this.reservation) return false;
+		const inFlight = this.items.filter(
+			(item) => item.status === "uploading" || item.status === "processing",
+		);
+		if (inFlight.length === 0) return false;
+		for (const item of inFlight) {
+			item.status = "error";
+			item.error = sanitizeError(error);
+			item.processed = undefined;
+			item.processedAutoResize = undefined;
+		}
+		this.bump();
+		return true;
 	}
 
 	beginAutoResizeReprocessing(autoResize: boolean): Array<{ id: string; source: Buffer }> {

--- a/extensions/pi-image-drop/src/runtime.ts
+++ b/extensions/pi-image-drop/src/runtime.ts
@@ -90,10 +90,12 @@ export class ImageDropRuntime {
 
 	async start(ctx: ExtensionContext): Promise<void> {
 		const generation = ++this.generation;
+		const previousBatch = this.batch;
 		this.closed = true;
 		this.sessionAbort.abort();
 		await this.releaseServer();
-		this.batch?.close();
+		previousBatch?.close();
+		if (generation !== this.generation) return;
 		const result = await this.dependencies.loadSettings();
 		if (generation !== this.generation) return;
 		this.settings = result.settings;
@@ -111,11 +113,13 @@ export class ImageDropRuntime {
 	}
 
 	async shutdown(ctx: ExtensionContext): Promise<void> {
-		this.generation += 1;
+		const generation = ++this.generation;
+		const previousBatch = this.batch;
 		this.closed = true;
 		this.sessionAbort.abort();
 		await this.releaseServer();
-		this.batch?.close();
+		previousBatch?.close();
+		if (generation !== this.generation) return;
 		this.batch = undefined;
 		this.settings = undefined;
 		this.processor = undefined;
@@ -306,10 +310,10 @@ export class ImageDropRuntime {
 
 	private async releaseServer(): Promise<void> {
 		const server = this.server;
-		this.server = undefined;
-		if (server) await server.close();
 		const starting = this.serverStarting;
+		this.server = undefined;
 		this.serverStarting = undefined;
+		if (server) await server.close();
 		if (starting) {
 			try {
 				await (await starting).close();

--- a/extensions/pi-image-drop/src/server.ts
+++ b/extensions/pi-image-drop/src/server.ts
@@ -189,6 +189,7 @@ export class ImageDropServer {
 					throw new HttpError(400, "Invalid client id");
 				}
 				this.takeLease(clientId);
+				this.broadcastState();
 				this.json(response, 200, this.statePayload());
 				return;
 			}
@@ -329,6 +330,9 @@ export class ImageDropServer {
 		if (previous !== clientId) this.activeClientGeneration += 1;
 		this.activeClientId = clientId;
 		if (previous && previous !== clientId) {
+			this.options.batch.cancelInFlight(
+				"Upload cancelled because the Image Drop page was replaced.",
+			);
 			for (const client of [...this.sseClients]) {
 				if (client.id !== previous) continue;
 				writeSse(client.response, "stale", { message: "Image Drop opened in another tab" });

--- a/extensions/pi-image-drop/test/batch.test.ts
+++ b/extensions/pi-image-drop/test/batch.test.ts
@@ -122,6 +122,27 @@ test("error items retain uploaded bytes for retry and sanitize displayed errors"
 	assert.equal(batch.publicState().items[0]?.status, "ready");
 });
 
+test("lease replacement cancels uploading and processing items without dropping retry sources", () => {
+	const batch = new BatchStore(DEFAULT_SETTINGS);
+	batch.reserveItems([
+		{ id: "uploading", name: "uploading.png", size: 3 },
+		{ id: "processing", name: "processing.png", size: 3 },
+	]);
+	batch.startProcessing("processing", Buffer.from("two"));
+	assert.equal(batch.cancelInFlight("Page was replaced"), true);
+	assert.deepEqual(
+		batch.publicState().items.map((item) => ({ status: item.status, error: item.error })),
+		[
+			{ status: "error", error: "Page was replaced" },
+			{ status: "error", error: "Page was replaced" },
+		],
+	);
+	assert.throws(() => batch.retrySource("uploading"), /without uploaded source/i);
+	assert.deepEqual(batch.retrySource("processing"), Buffer.from("two"));
+	assert.equal(batch.cancelInFlight("Again"), true);
+	assert.equal(batch.cancelInFlight("Again"), false);
+});
+
 test("reorder, delete, and clear require exact current revisions", () => {
 	const batch = new BatchStore(DEFAULT_SETTINGS);
 	ready(batch, "one");

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -451,6 +451,83 @@ test("a stale input settings read cannot consume the replacement session batch",
 	assert.equal(newContext.editorText, "");
 });
 
+test("a stale session start cannot close the newer batch after slow server shutdown", async () => {
+	const mock = createMockPi();
+	let markClosing!: () => void;
+	let releaseClose!: () => void;
+	const closing = new Promise<void>((resolve) => {
+		markClosing = resolve;
+	});
+	const runtime = new ImageDropRuntime(mock.pi, {
+		loadSettings: async () => ({ kind: "missing", settings: { ...DEFAULT_SETTINGS } }),
+		startServer: async () => ({
+			issueLink: () => "http://127.0.0.1/link",
+			broadcastState() {},
+			close: () => {
+				markClosing();
+				return new Promise<void>((resolve) => {
+					releaseClose = resolve;
+				});
+			},
+		}),
+	});
+	runtime.register();
+	const initialContext = createMockContext({ cwd: "/workspace/initial" });
+	const staleContext = createMockContext({ cwd: "/workspace/stale" });
+	const currentContext = createMockContext({ cwd: "/workspace/current" });
+	await runtime.start(initialContext.ctx);
+	await mock.commands.get("image-drop")?.handler("", initialContext.ctx);
+
+	const staleStart = runtime.start(staleContext.ctx);
+	await closing;
+	await runtime.start(currentContext.ctx);
+	const currentBatch = runtime.getBatchForTesting();
+	runtime.addReadyImageForTesting("current", "current.png", Buffer.from("current"), PROCESSED);
+	releaseClose();
+	await staleStart;
+
+	assert.equal(runtime.getBatchForTesting(), currentBatch);
+	assert.equal(currentBatch?.publicState().phase, "ready");
+});
+
+test("a stale shutdown cannot clear a newer batch after slow server shutdown", async () => {
+	const mock = createMockPi();
+	let markClosing!: () => void;
+	let releaseClose!: () => void;
+	const closing = new Promise<void>((resolve) => {
+		markClosing = resolve;
+	});
+	const runtime = new ImageDropRuntime(mock.pi, {
+		loadSettings: async () => ({ kind: "missing", settings: { ...DEFAULT_SETTINGS } }),
+		startServer: async () => ({
+			issueLink: () => "http://127.0.0.1/link",
+			broadcastState() {},
+			close: () => {
+				markClosing();
+				return new Promise<void>((resolve) => {
+					releaseClose = resolve;
+				});
+			},
+		}),
+	});
+	runtime.register();
+	const oldContext = createMockContext({ cwd: "/workspace/old" });
+	const currentContext = createMockContext({ cwd: "/workspace/current" });
+	await runtime.start(oldContext.ctx);
+	await mock.commands.get("image-drop")?.handler("", oldContext.ctx);
+
+	const staleShutdown = runtime.shutdown(oldContext.ctx);
+	await closing;
+	await runtime.start(currentContext.ctx);
+	const currentBatch = runtime.getBatchForTesting();
+	runtime.addReadyImageForTesting("current", "current.png", Buffer.from("current"), PROCESSED);
+	releaseClose();
+	await staleShutdown;
+
+	assert.equal(runtime.getBatchForTesting(), currentBatch);
+	assert.equal(currentBatch?.publicState().phase, "ready");
+});
+
 test("an overlapping stale session start cannot replace the newer session", async () => {
 	const mock = createMockPi();
 	let resolveFirst!: (value: { kind: "missing"; settings: typeof DEFAULT_SETTINGS }) => void;

--- a/extensions/pi-image-drop/test/server.test.ts
+++ b/extensions/pi-image-drop/test/server.test.ts
@@ -347,10 +347,11 @@ test("an interrupted browser upload becomes a visible deletable error after refr
 	}
 });
 
-test("a stale lease cannot complete processing after a new page takes control", async () => {
+test("a stale lease resets in-flight processing for the new page to retry", async () => {
 	const batch = new BatchStore(SETTINGS);
 	let release!: () => void;
 	let processing!: () => void;
+	let attempts = 0;
 	const started = new Promise<void>((resolve) => {
 		processing = resolve;
 	});
@@ -360,10 +361,13 @@ test("a stale lease cannot complete processing after a new page takes control", 
 		projectName: "demo",
 		cwd: "/workspace/demo",
 		process: async (source) => {
-			processing();
-			await new Promise<void>((resolve) => {
-				release = resolve;
-			});
+			attempts += 1;
+			if (attempts === 1) {
+				processing();
+				await new Promise<void>((resolve) => {
+					release = resolve;
+				});
+			}
 			return result(source);
 		},
 		getAutoResize: async () => true,
@@ -384,10 +388,80 @@ test("a stale lease cannot complete processing after a new page takes control", 
 			body: Buffer.from("one"),
 		});
 		await started;
-		await lease(server, cookie, "new-client");
+		const newClient = await lease(server, cookie, "new-client");
+		assert.equal(batch.publicState().items[0]?.status, "error");
+		assert.match(batch.publicState().items[0]?.error ?? "", /page was replaced/i);
 		release();
 		assert.equal((await upload).status, 409);
-		assert.notEqual(batch.publicState().items[0]?.status, "ready");
+		assert.equal(
+			(
+				await api(server, "/api/items/one/retry", {
+					method: "POST",
+					cookie,
+					client: newClient,
+				})
+			).status,
+			200,
+		);
+		assert.equal(batch.publicState().items[0]?.status, "ready");
+	} finally {
+		await server.close();
+	}
+});
+
+test("duplicate content uploads cannot overtake an in-flight retry", async () => {
+	const batch = new BatchStore(SETTINGS);
+	let release!: () => void;
+	let processing!: () => void;
+	let attempts = 0;
+	const started = new Promise<void>((resolve) => {
+		processing = resolve;
+	});
+	const server = await ImageDropServer.start({
+		batch,
+		settings: SETTINGS,
+		projectName: "demo",
+		cwd: "/workspace/demo",
+		process: async (source) => {
+			attempts += 1;
+			if (attempts === 1) {
+				processing();
+				await new Promise<void>((resolve) => {
+					release = resolve;
+				});
+			}
+			return result(source);
+		},
+		getAutoResize: async () => true,
+	});
+	try {
+		const cookie = await authenticate(server);
+		const client = await lease(server, cookie);
+		await api(server, "/api/items", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({ revision: 0, items: [{ id: "one", name: "one.png", size: 3 }] }),
+		});
+		batch.failUpload("one", "browser upload failed");
+		const first = api(server, "/api/items/one/content", {
+			method: "PUT",
+			cookie,
+			client,
+			body: Buffer.from("one"),
+		});
+		await started;
+		const duplicate = await api(server, "/api/items/one/content", {
+			method: "PUT",
+			cookie,
+			client,
+			body: Buffer.from("one"),
+		});
+		assert.equal(duplicate.status, 409);
+		assert.equal(attempts, 1);
+		release();
+		assert.equal((await first).status, 200);
+		assert.equal(batch.publicState().items[0]?.status, "ready");
 	} finally {
 		await server.close();
 	}


### PR DESCRIPTION
## Summary

- reset in-flight uploads to retryable errors when a new browser page takes the editing lease
- reject duplicate content uploads while the same item is already processing
- prevent stale session start/shutdown continuations from closing or clearing replacement-session resources

Follow-up to the unresolved review findings on #249.

## Verification

- `npm run check` (674 tests)
- focused image-drop batch, lifecycle, and server tests (42 tests)