### PR TITLE
fix(image-drop): preserve runtime resize processing

### DIFF
--- a/extensions/pi-image-drop/src/batch.ts
+++ b/extensions/pi-image-drop/src/batch.ts
@@ -30,6 +30,7 @@ interface BatchItem extends ItemReservation {
 	source?: Buffer;
 	processed?: ProcessedImage;
 	processedAutoResize?: boolean;
+	processingOwner?: "browser" | "runtime";
 	error?: string;
 }
 
@@ -153,6 +154,7 @@ export class BatchStore {
 		item.processedAutoResize = undefined;
 		item.error = undefined;
 		item.status = "processing";
+		item.processingOwner = "browser";
 		return this.bump();
 	}
 
@@ -176,6 +178,7 @@ export class BatchStore {
 		item.processed = cloneProcessed(processed);
 		item.processedAutoResize = autoResize;
 		item.status = "ready";
+		item.processingOwner = undefined;
 		item.error = undefined;
 		if (duplicates.length > 0) {
 			const laterIds = new Set(duplicates.map(({ candidate }) => candidate.id));
@@ -195,6 +198,7 @@ export class BatchStore {
 		item.error = sanitizeError(error);
 		item.processed = undefined;
 		item.processedAutoResize = undefined;
+		item.processingOwner = undefined;
 		return this.bump();
 	}
 
@@ -214,7 +218,9 @@ export class BatchStore {
 		this.assertOpen();
 		if (this.reservation) return false;
 		const inFlight = this.items.filter(
-			(item) => item.status === "uploading" || item.status === "processing",
+			(item) =>
+				item.status === "uploading" ||
+				(item.status === "processing" && item.processingOwner === "browser"),
 		);
 		if (inFlight.length === 0) return false;
 		for (const item of inFlight) {
@@ -222,6 +228,7 @@ export class BatchStore {
 			item.error = sanitizeError(error);
 			item.processed = undefined;
 			item.processedAutoResize = undefined;
+			item.processingOwner = undefined;
 		}
 		this.bump();
 		return true;
@@ -245,6 +252,7 @@ export class BatchStore {
 			item.status = "processing";
 			item.processed = undefined;
 			item.processedAutoResize = undefined;
+			item.processingOwner = "runtime";
 			item.error = undefined;
 		}
 		this.bump();
@@ -259,6 +267,7 @@ export class BatchStore {
 			throw new BatchError("Image cannot be retried without uploaded source bytes", "not-ready");
 		}
 		item.status = "processing";
+		item.processingOwner = "browser";
 		item.error = undefined;
 		item.processedAutoResize = undefined;
 		this.bump();

--- a/extensions/pi-image-drop/test/batch.test.ts
+++ b/extensions/pi-image-drop/test/batch.test.ts
@@ -143,6 +143,19 @@ test("lease replacement cancels uploading and processing items without dropping 
 	assert.equal(batch.cancelInFlight("Again"), false);
 });
 
+test("lease replacement preserves Pi-side auto-resize reprocessing", () => {
+	const batch = new BatchStore(DEFAULT_SETTINGS);
+	const source = Buffer.from("source");
+	batch.reserveItems([{ id: "one", name: "one.png", size: source.byteLength }]);
+	batch.startProcessing("one", source);
+	batch.complete("one", processed("one"), true);
+
+	assert.deepEqual(batch.beginAutoResizeReprocessing(false), [{ id: "one", source }]);
+	assert.equal(batch.cancelInFlight("Page was replaced"), false);
+	assert.deepEqual(batch.complete("one", processed("one-again"), false), { kind: "ready" });
+	assert.equal(batch.publicState().phase, "ready");
+});
+
 test("reorder, delete, and clear require exact current revisions", () => {
 	const batch = new BatchStore(DEFAULT_SETTINGS);
 	ready(batch, "one");


### PR DESCRIPTION
## Summary

- distinguish browser-owned processing from Pi-side auto-resize reprocessing
- cancel only browser upload and retry work when the editing lease changes
- cover lease replacement during auto-resize reprocessing

Follow-up to the late review on #251: https://github.com/narumiruna/pi-extensions/pull/251#discussion_r3608389073

## Verification

- `npm run check` (675 tests passed)