### PR TITLE
feat(image-drop): enlarge image previews

### DIFF
--- a/extensions/pi-image-drop/src/web/app.js
+++ b/extensions/pi-image-drop/src/web/app.js
@@ -23,6 +23,10 @@ const ui = {
 	connectionTitle: $("#connection-title"),
 	connectionMessage: $("#connection-message"),
 	dialog: $("#clear-dialog"),
+	previewDialog: $("#image-preview-dialog"),
+	previewTitle: $("#image-preview-title"),
+	previewImage: $("#image-preview"),
+	previewClose: $("#image-preview-close"),
 };
 const clientId = crypto.randomUUID();
 const pendingFiles = new Map();
@@ -78,6 +82,13 @@ function wire() {
 	});
 	ui.dialog.addEventListener("close", () => {
 		if (ui.dialog.returnValue === "confirm") void clearAll();
+	});
+	ui.previewClose.addEventListener("click", () => ui.previewDialog.close());
+	ui.previewDialog.addEventListener("click", (event) => {
+		if (event.target === ui.previewDialog) ui.previewDialog.close();
+	});
+	ui.previewDialog.addEventListener("close", () => {
+		ui.previewImage.removeAttribute("src");
 	});
 }
 
@@ -264,14 +275,19 @@ function card(item, index, mutable) {
 		draggedId = undefined;
 	});
 
-	const preview = element("div", "preview");
+	let preview;
 	if (item.status === "ready") {
+		preview = element("button", "preview preview-button");
+		preview.type = "button";
+		preview.setAttribute("aria-label", `Enlarge preview of ${item.name}`);
+		preview.addEventListener("click", () => openPreview(item));
 		const image = document.createElement("img");
 		image.src = `/api/items/${item.id}/preview?revision=${state.batch.revision}`;
 		image.alt = `Preview of ${item.name}`;
 		image.loading = "lazy";
 		preview.append(image);
 	} else {
+		preview = element("div", "preview");
 		const placeholder = element("span", "placeholder", item.status === "error" ? "!" : "…");
 		placeholder.setAttribute("aria-hidden", "true");
 		preview.append(placeholder);
@@ -310,6 +326,13 @@ function card(item, index, mutable) {
 	actions.append(button("Delete", "Delete", !mutable, () => remove(item.id), "delete"));
 	article.append(actions);
 	return article;
+}
+
+function openPreview(item) {
+	ui.previewTitle.textContent = item.name;
+	ui.previewImage.src = `/api/items/${item.id}/preview?revision=${state.batch.revision}`;
+	ui.previewImage.alt = `Enlarged preview of ${item.name}`;
+	ui.previewDialog.showModal();
 }
 
 function button(label, text, disabled, action, className = "") {

--- a/extensions/pi-image-drop/src/web/index.html
+++ b/extensions/pi-image-drop/src/web/index.html
@@ -69,6 +69,18 @@
 			</form>
 		</dialog>
 
+		<dialog id="image-preview-dialog" class="image-preview-dialog" aria-labelledby="image-preview-title">
+			<div class="image-preview-content">
+				<header>
+					<h2 id="image-preview-title">Image preview</h2>
+					<button id="image-preview-close" type="button" aria-label="Close enlarged image">Close</button>
+				</header>
+				<div class="image-preview-stage">
+					<img id="image-preview" alt="" />
+				</div>
+			</div>
+		</dialog>
+
 		<script type="module" src="/app.js"></script>
 	</body>
 </html>

--- a/extensions/pi-image-drop/src/web/styles.css
+++ b/extensions/pi-image-drop/src/web/styles.css
@@ -223,6 +223,18 @@ main {
 	height: 100%;
 	object-fit: contain;
 }
+.preview-button {
+	width: 100%;
+	min-height: 0;
+	border: 0;
+	border-radius: 0;
+	padding: 0;
+	background: var(--surface-alt);
+	cursor: zoom-in;
+}
+.preview-button:hover:not(:disabled) {
+	border-color: transparent;
+}
 .placeholder {
 	display: grid;
 	width: 3rem;
@@ -311,6 +323,49 @@ dialog {
 }
 dialog::backdrop {
 	background: rgb(11 17 30 / 60%);
+}
+.image-preview-dialog {
+	width: min(96vw, 1400px);
+	max-width: none;
+	height: 94dvh;
+	max-height: none;
+	overflow: hidden;
+	padding: 0;
+}
+.image-preview-dialog::backdrop {
+	background: rgb(11 17 30 / 88%);
+}
+.image-preview-content {
+	display: grid;
+	height: 100%;
+	grid-template-rows: auto minmax(0, 1fr);
+}
+.image-preview-content header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	border-bottom: 1px solid var(--line);
+	padding: 0.75rem 1rem;
+}
+.image-preview-content h2 {
+	margin: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 1rem;
+}
+.image-preview-stage {
+	display: grid;
+	min-height: 0;
+	place-items: center;
+	padding: 1rem;
+	background: var(--surface-alt);
+}
+.image-preview-stage img {
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
 }
 .dialog-actions {
 	display: flex;

--- a/extensions/pi-image-drop/test/server.test.ts
+++ b/extensions/pi-image-drop/test/server.test.ts
@@ -110,6 +110,15 @@ test("bootstrap tokens rotate, replay fails, and clean pages require the session
 		assert.equal(page.headers.get("cache-control"), "no-store");
 		assert.equal(page.headers.get("x-content-type-options"), "nosniff");
 		assert.equal(page.headers.get("access-control-allow-origin"), null);
+
+		const html = await page.text();
+		const app = await (await api(server, "/app.js", { cookie })).text();
+		const styles = await (await api(server, "/styles.css", { cookie })).text();
+		assert.match(html, /<dialog id="image-preview-dialog"/);
+		assert.match(html, /id="image-preview-close"/);
+		assert.match(app, /showModal\(\)/);
+		assert.match(app, /Enlarge preview of/);
+		assert.match(styles, /\.image-preview-dialog/);
 	} finally {
 		await server.close();
 	}


### PR DESCRIPTION
## Summary
- make ready image thumbnails clickable and keyboard accessible
- show the selected image in a responsive modal preview
- support closing with the button, backdrop, or Escape

## Testing
- npm run check (675 tests passed)