### PR TITLE
feat(image-drop): support session startup

### DIFF
--- a/docs/plans/archived/2026-07-18_image-drop-start-on-session-plan.md
+++ b/docs/plans/archived/2026-07-18_image-drop-start-on-session-plan.md
@@ -1,0 +1,42 @@
+## Goal
+
+Allow users to configure global `pi-image-drop.json` settings so Image Drop starts automatically and provides a link when a Pi session starts, while preserving the current behavior of requiring `/image-drop` when the option is disabled.
+
+## Context
+
+- Currently, `ImageDropRuntime.start()` only creates the session batch and processor. The HTTP server starts lazily when `/image-drop` first calls `ensureServer()`.
+- The settings file uses strict whole-file validation. A new field must be added to the type, defaults, allowed keys, and documentation, or the entire settings file will be ignored.
+- Here, “automatic startup” means starting the loopback server, issuing a one-time link, and displaying the link in a Pi widget and notification. It does not open a browser through the operating system.
+
+## Architecture
+
+Add a boolean `startOnSessionStart` setting with a safe default of `false` to preserve backward compatibility. After `session_start` finishes initializing the settings and batch, a `true` value calls `ensureServer()` and `issueLink()` through the same link-presentation helper used by `/image-drop`, then displays the link. Automatic startup failures only display an error notification and must not fail Pi session startup. The existing generation guard and `releaseServer()` continue to handle session replacement and shutdown races.
+
+## Non-Goals
+
+- Do not open a browser automatically or add an external launcher dependency.
+- Do not add a project-local override or environment variable.
+- Do not change the bootstrap token, cookie, Host/Origin, or client lease security model.
+
+## Plan
+
+- [x] Add failing `startOnSessionStart` tests to `extensions/pi-image-drop/test/settings.test.ts`, covering the default `false`, valid `true`/`false`, non-boolean values, and unknown-field whole-file fallback. `npm test` failed with TS2339 because the setting did not yet exist, proving the tests detected the missing implementation.
+- [x] Update the settings type, defaults, and key validation in `extensions/pi-image-drop/src/settings.ts`, separating numeric hard-limit types from the boolean setting so `HARD_LIMITS` does not need a boolean value. `npm --workspace @narumitw/pi-image-drop run typecheck` passed, the settings tests passed in the root test run, and the existing defaults expectation was updated.
+- [x] Add failing lifecycle tests to `extensions/pi-image-drop/test/lifecycle.test.ts`: `false` does not start the server; `true` starts it during `session_start` and displays a usable link; a later `/image-drop` reuses the server and rotates the token; startup failure only notifies; and session replacement/shutdown close stale servers. Before implementation, `npm test` produced the two expected failures (`serverStarts` was `0` instead of `1`); after implementation, the full root suite passed.
+- [x] Refactor `extensions/pi-image-drop/src/runtime.ts` so automatic startup and `/image-drop` share one path for ensuring the server, issuing a link, updating the widget, and notifying the user, while preserving concurrent startup and generation guards. Lifecycle tests verify server reuse, replacement cleanup, shutdown cleanup, and startup error isolation.
+- [x] Update the settings example, field table, and workflow in `extensions/pi-image-drop/README.md`, clearly stating that `startOnSessionStart: true` only starts the service and displays a link; it does not open a browser. Documentation review confirmed that both the lazy default and opt-in workflow are documented.
+- [x] Run `npm --workspace @narumitw/pi-image-drop run check`, root `npm test`, `npm run check`, and `just pack image-drop`: all 678 tests passed, and the package contained the expected 15 files. Non-interactive Pi smoke tests using isolated `PI_CODING_AGENT_DIR` directories and both `true` and `false` settings exited successfully.
+
+## Risks
+
+- `session_start` can overlap with a fast reload or session replacement. If the generation is not checked again after awaited operations, the old session's server or link could remain active.
+- The automatically issued bootstrap token is rotated when the user later runs `/image-drop`; the widget and notification must display only the latest link.
+- Mixing the boolean field directly into the existing numeric limits type could break settings comparisons and warning logic.
+
+## Completion Checklist
+
+- [x] `startOnSessionStart` defaults to `false`, and its `true`, `false`, and invalid-value behavior is verified by passing `extensions/pi-image-drop/test/settings.test.ts` tests.
+- [x] When enabled, each session starts only one loopback server and displays a link; when disabled, startup remains lazy, as verified by passing lifecycle tests.
+- [x] Automatic startup errors, reload/session replacement, and shutdown do not leak listeners or stale UI, as verified by lifecycle race and cleanup tests.
+- [x] The README documents the setting format, default, and “does not open a browser” behavior, as verified by documentation review.
+- [x] The package check, root `npm run check` with 678 passing tests, `just pack image-drop` with 15 files, and non-interactive Pi smoke tests with both `true` and `false` settings all passed.

--- a/extensions/pi-image-drop/README.md
+++ b/extensions/pi-image-drop/README.md
@@ -24,15 +24,15 @@ This package targets the latest Pi release and uses its `agent_settled` lifecycl
 
 ## Workflow
 
-1. Run `/image-drop` in an interactive Pi session.
-2. Pi prints and displays a clickable one-time `http://127.0.0.1:<port>/...` link. The extension does **not** open a browser.
+1. Run `/image-drop` in an interactive Pi session. You can instead set `startOnSessionStart: true` to start the service with every Pi session.
+2. Pi prints and displays a clickable one-time `http://127.0.0.1:<port>/...` link. The extension does **not** open a browser, including when session startup is enabled.
 3. Open the link. Paste images anywhere, drop files, or select **Choose images**.
 4. Review previews and processing details. Drag to reorder, use the keyboard-accessible arrow buttons, retry failures, delete individual items, or use confirmed **Clear all**.
 5. Write and submit a non-empty message in Pi. The ready images are appended after any attachments already on that message, in browser order.
 
 The `🖼️` widget above Pi's editor reports ready, uploading, error, and queued counts. Uploading or failed items block the whole batch and preserve the Pi editor text. Image-only messages are not supported.
 
-Each `/image-drop` invocation rotates the unused one-time link. A browser refresh keeps the current in-memory batch. Opening the authenticated page in another tab gives the new tab the editing lease and makes the old tab stale.
+By default, the loopback service starts lazily when you run `/image-drop`. With `startOnSessionStart: true`, it starts after each Pi session initializes and displays the link in Pi automatically. Each later `/image-drop` invocation reuses the service and rotates the unused one-time link. A browser refresh keeps the current in-memory batch. Opening the authenticated page in another tab gives the new tab the editing lease and makes the old tab stale.
 
 ## Supported images
 
@@ -63,6 +63,7 @@ Example:
 
 ```json
 {
+  "startOnSessionStart": true,
   "maxImages": 8,
   "maxImageBytes": 10485760,
   "maxBatchBytes": 41943040,
@@ -70,14 +71,18 @@ Example:
 }
 ```
 
-| Setting | Safe default | Hard ceiling |
+| Setting | Default | Behavior |
+| --- | --- | --- |
+| `startOnSessionStart` | `false` | Start the loopback service and display a link after each Pi session initializes. This never opens a browser. |
+
+| Limit setting | Safe default | Hard ceiling |
 | --- | ---: | ---: |
 | `maxImages` | 8 | 32 |
 | `maxImageBytes` | 10 MiB | 50 MiB |
 | `maxBatchBytes` | 40 MiB | 200 MiB |
 | `maxImagePixels` | 50 megapixels | 100 megapixels |
 
-Values are positive integer counts/bytes/pixels. `maxImageBytes` cannot exceed `maxBatchBytes`. Unknown fields, malformed JSON, invalid values, symlinks, or values above a hard ceiling cause the **whole file** to be ignored with one warning and safe defaults to be used. Values above a safe default but within a hard ceiling produce a memory/provider-limit warning.
+Limit values are positive integer counts/bytes/pixels, and `startOnSessionStart` must be a boolean. `maxImageBytes` cannot exceed `maxBatchBytes`. Unknown fields, malformed JSON, invalid values, symlinks, or values above a hard ceiling cause the **whole file** to be ignored with one warning and safe defaults to be used. Limit values above a safe default but within a hard ceiling produce a memory/provider-limit warning.
 
 At upload and submission time, the extension also re-reads Pi's documented global and trusted-project `images.autoResize` and `images.blockImages` settings. `blockImages: true` or a text-only current model blocks processing/submission without discarding the draft.
 

--- a/extensions/pi-image-drop/src/runtime.ts
+++ b/extensions/pi-image-drop/src/runtime.ts
@@ -63,14 +63,7 @@ export class ImageDropRuntime {
 				this.context = ctx;
 				await this.recoverOrphanedReservation(ctx);
 				try {
-					const server = await this.ensureServer(ctx);
-					const link = server.issueLink();
-					if (this.batch?.publicState().phase === "empty") {
-						ctx.ui.setWidget(WIDGET_KEY, [`🖼️ Image Drop: ${link}`]);
-					} else {
-						this.updateWidget(ctx);
-					}
-					ctx.ui.notify(`Image Drop: ${link}`, "info");
+					await this.presentLink(ctx);
 				} catch (error) {
 					ctx.ui.notify(`Image Drop could not start: ${formatError(error)}`, "error");
 				}
@@ -110,6 +103,13 @@ export class ImageDropRuntime {
 			ctx.ui.notify(warning ?? "Image Drop settings ignored.", "warning");
 		}
 		this.updateWidget(ctx);
+		if (!result.settings.startOnSessionStart) return;
+		try {
+			await this.presentLink(ctx);
+		} catch (error) {
+			if (generation !== this.generation || this.closed) return;
+			ctx.ui.notify(`Image Drop could not start: ${formatError(error)}`, "error");
+		}
 	}
 
 	async shutdown(ctx: ExtensionContext): Promise<void> {
@@ -257,6 +257,17 @@ export class ImageDropRuntime {
 		}
 		this.updateWidget(ctx);
 		return true;
+	}
+
+	private async presentLink(ctx: ExtensionContext): Promise<void> {
+		const server = await this.ensureServer(ctx);
+		const link = server.issueLink();
+		if (this.batch?.publicState().phase === "empty") {
+			ctx.ui.setWidget(WIDGET_KEY, [`🖼️ Image Drop: ${link}`]);
+		} else {
+			this.updateWidget(ctx);
+		}
+		ctx.ui.notify(`Image Drop: ${link}`, "info");
 	}
 
 	private async ensureServer(ctx: ExtensionContext): Promise<ServerControl> {

--- a/extensions/pi-image-drop/src/settings.ts
+++ b/extensions/pi-image-drop/src/settings.ts
@@ -5,11 +5,15 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 export const SETTINGS_FILE = "pi-image-drop.json";
 const MIB = 1024 * 1024;
 
-export interface ImageDropSettings {
+export interface ImageDropLimits {
 	maxImages: number;
 	maxImageBytes: number;
 	maxBatchBytes: number;
 	maxImagePixels: number;
+}
+
+export interface ImageDropSettings extends ImageDropLimits {
+	startOnSessionStart: boolean;
 }
 
 export const DEFAULT_SETTINGS: Readonly<ImageDropSettings> = Object.freeze({
@@ -17,21 +21,23 @@ export const DEFAULT_SETTINGS: Readonly<ImageDropSettings> = Object.freeze({
 	maxImageBytes: 10 * MIB,
 	maxBatchBytes: 40 * MIB,
 	maxImagePixels: 50_000_000,
+	startOnSessionStart: false,
 });
 
-export const HARD_LIMITS: Readonly<ImageDropSettings> = Object.freeze({
+export const HARD_LIMITS: Readonly<ImageDropLimits> = Object.freeze({
 	maxImages: 32,
 	maxImageBytes: 50 * MIB,
 	maxBatchBytes: 200 * MIB,
 	maxImagePixels: 100_000_000,
 });
 
-const SETTING_KEYS = new Set<keyof ImageDropSettings>([
+const LIMIT_KEYS = new Set<keyof ImageDropLimits>([
 	"maxImages",
 	"maxImageBytes",
 	"maxBatchBytes",
 	"maxImagePixels",
 ]);
+const SETTING_KEYS = new Set<keyof ImageDropSettings>([...LIMIT_KEYS, "startOnSessionStart"]);
 
 export type SettingsLoadResult =
 	| { kind: "missing"; settings: ImageDropSettings }
@@ -43,7 +49,7 @@ export function normalizeSettings(value: unknown): ImageDropSettings | undefined
 		return undefined;
 	}
 	const settings: ImageDropSettings = { ...DEFAULT_SETTINGS };
-	for (const key of SETTING_KEYS) {
+	for (const key of LIMIT_KEYS) {
 		if (!Object.hasOwn(value, key)) continue;
 		const candidate = Reflect.get(value, key);
 		if (
@@ -55,6 +61,10 @@ export function normalizeSettings(value: unknown): ImageDropSettings | undefined
 			return undefined;
 		}
 		settings[key] = candidate;
+	}
+	if (Object.hasOwn(value, "startOnSessionStart")) {
+		if (typeof value.startOnSessionStart !== "boolean") return undefined;
+		settings.startOnSessionStart = value.startOnSessionStart;
 	}
 	if (settings.maxImageBytes > settings.maxBatchBytes) return undefined;
 	return settings;
@@ -79,7 +89,7 @@ export async function loadSettings(
 	try {
 		const settings = normalizeSettings(JSON.parse(text) as unknown);
 		if (!settings) return invalid(path, "invalid settings shape or value");
-		const raised = (Object.keys(DEFAULT_SETTINGS) as Array<keyof ImageDropSettings>).filter(
+		const raised = [...LIMIT_KEYS].filter(
 			(key) => settings[key] > DEFAULT_SETTINGS[key],
 		);
 		return {

--- a/extensions/pi-image-drop/test/image-drop.test.ts
+++ b/extensions/pi-image-drop/test/image-drop.test.ts
@@ -30,6 +30,7 @@ test("settings expose the agreed defaults", () => {
 		maxImageBytes: 10 * 1024 * 1024,
 		maxBatchBytes: 40 * 1024 * 1024,
 		maxImagePixels: 50_000_000,
+		startOnSessionStart: false,
 	});
 	assert.deepEqual(normalizeSettings({}), DEFAULT_SETTINGS);
 });

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -4,7 +4,7 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import { digestImages, type ProcessedImage } from "../src/batch.js";
 import { ImageDropRuntime } from "../src/runtime.js";
 import type { ImageDropServerOptions } from "../src/server.js";
-import { DEFAULT_SETTINGS } from "../src/settings.js";
+import { DEFAULT_SETTINGS, type ImageDropSettings } from "../src/settings.js";
 
 const PNG = Buffer.from("processed-png");
 const PROCESSED: ProcessedImage = {
@@ -21,7 +21,14 @@ const PROCESSED: ProcessedImage = {
 	notes: [],
 };
 
-function createHarness(options: { idle?: () => boolean; pending?: () => boolean } = {}) {
+function createHarness(
+	options: {
+		idle?: () => boolean;
+		pending?: () => boolean;
+		settings?: Partial<ImageDropSettings>;
+		startError?: Error;
+	} = {},
+) {
 	const mock = createMockPi();
 	let serverOptions: ImageDropServerOptions | undefined;
 	let serverStarts = 0;
@@ -35,11 +42,15 @@ function createHarness(options: { idle?: () => boolean; pending?: () => boolean 
 		},
 	};
 	const runtime = new ImageDropRuntime(mock.pi, {
-		loadSettings: async () => ({ kind: "missing", settings: { ...DEFAULT_SETTINGS } }),
+		loadSettings: async () => ({
+			kind: "missing",
+			settings: { ...DEFAULT_SETTINGS, ...options.settings },
+		}),
 		readPiSettings: async () => ({ autoResize: true, blockImages: false, warnings: [] }),
 		startServer: async (received) => {
 			serverStarts += 1;
 			serverOptions = received;
+			if (options.startError) throw options.startError;
 			return server;
 		},
 	});
@@ -178,6 +189,46 @@ test("/image-drop lazily starts one server, rotates links, and shutdown releases
 	await emit(harness.mock, "session_shutdown", {}, harness.context.ctx);
 	assert.equal(harness.serverCloses, 1);
 	assert.equal(harness.context.widgets.get("image-drop"), undefined);
+});
+
+test("startOnSessionStart starts once, presents a link, and reuses the server", async () => {
+	const harness = createHarness({ settings: { startOnSessionStart: true } });
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	assert.equal(harness.serverStarts, 1);
+	assert.match(harness.context.notifications[0]?.message ?? "", /token=1/);
+	assert.match(String(harness.context.widgets.get("image-drop")), /token=1/);
+
+	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+	assert.equal(harness.serverStarts, 1);
+	assert.match(harness.context.notifications[1]?.message ?? "", /token=2/);
+	assert.match(String(harness.context.widgets.get("image-drop")), /token=2/);
+	await emit(harness.mock, "session_shutdown", {}, harness.context.ctx);
+	assert.equal(harness.serverCloses, 1);
+});
+
+test("startOnSessionStart replaces and closes the session-owned server", async () => {
+	const harness = createHarness({ settings: { startOnSessionStart: true } });
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	assert.equal(harness.serverStarts, 2);
+	assert.equal(harness.serverCloses, 1);
+	assert.match(harness.context.notifications[1]?.message ?? "", /token=2/);
+	await emit(harness.mock, "session_shutdown", {}, harness.context.ctx);
+	assert.equal(harness.serverCloses, 2);
+});
+
+test("startOnSessionStart failure warns without failing session startup", async () => {
+	const harness = createHarness({
+		settings: { startOnSessionStart: true },
+		startError: new Error("listener unavailable"),
+	});
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	assert.equal(harness.serverStarts, 1);
+	assert.match(
+		harness.context.notifications[0]?.message ?? "",
+		/could not start.*listener unavailable/i,
+	);
+	assert.equal(harness.runtime.getBatchForTesting()?.publicState().phase, "empty");
 });
 
 test("browser processing re-reads Pi settings and guards model and blockImages", async () => {

--- a/extensions/pi-image-drop/test/settings.test.ts
+++ b/extensions/pi-image-drop/test/settings.test.ts
@@ -6,7 +6,14 @@ import test from "node:test";
 import { DEFAULT_SETTINGS, HARD_LIMITS, loadSettings, normalizeSettings } from "../src/settings.js";
 
 test("settings normalize partial values and reject unknown, inconsistent, and unsafe values", () => {
+	assert.equal(DEFAULT_SETTINGS.startOnSessionStart, false);
 	assert.deepEqual(normalizeSettings({ maxImages: 4 }), { ...DEFAULT_SETTINGS, maxImages: 4 });
+	assert.deepEqual(normalizeSettings({ startOnSessionStart: true }), {
+		...DEFAULT_SETTINGS,
+		startOnSessionStart: true,
+	});
+	assert.deepEqual(normalizeSettings({ startOnSessionStart: false }), DEFAULT_SETTINGS);
+	assert.equal(normalizeSettings({ startOnSessionStart: "yes" }), undefined);
 	assert.equal(normalizeSettings({ unknown: 1 }), undefined);
 	assert.equal(normalizeSettings({ maxImages: 0 }), undefined);
 	assert.equal(normalizeSettings({ maxImages: HARD_LIMITS.maxImages + 1 }), undefined);
@@ -22,16 +29,20 @@ test("settings loading distinguishes missing, valid, warned, and invalid files",
 			kind: "missing",
 			settings: { ...DEFAULT_SETTINGS },
 		});
-		await writeFile(settingsPath, '{"maxImages":4}\n');
+		await writeFile(settingsPath, '{"maxImages":4,"startOnSessionStart":true}\n');
 		assert.deepEqual(await loadSettings(settingsPath), {
 			kind: "loaded",
-			settings: { ...DEFAULT_SETTINGS, maxImages: 4 },
+			settings: { ...DEFAULT_SETTINGS, maxImages: 4, startOnSessionStart: true },
 			warning: undefined,
 		});
 		await writeFile(settingsPath, '{"maxImages":16}\n');
 		const warned = await loadSettings(settingsPath);
 		assert.equal(warned.kind, "loaded");
 		assert.match("warning" in warned ? (warned.warning ?? "") : "", /raises maxImages/i);
+		await writeFile(settingsPath, '{"startOnSessionStart":"yes"}\n');
+		const invalidBoolean = await loadSettings(settingsPath);
+		assert.equal(invalidBoolean.kind, "invalid");
+		assert.deepEqual(invalidBoolean.settings, DEFAULT_SETTINGS);
 		await writeFile(settingsPath, '{"maxImages":"many"}\n');
 		const invalid = await loadSettings(settingsPath);
 		assert.equal(invalid.kind, "invalid");


### PR DESCRIPTION
## Summary

- add a strict `startOnSessionStart` boolean setting with a backward-compatible `false` default
- start the loopback service and present its one-time link during session initialization when enabled
- share link presentation with `/image-drop`, while preserving token rotation and session cleanup
- document that automatic startup never opens a browser

## Verification

- `npm --workspace @narumitw/pi-image-drop run check`
- `npm test` (678 passed)
- `npm run check` (678 passed)
- `just pack image-drop` (15 intended files)
- isolated non-interactive Pi smokes with `startOnSessionStart` set to both `true` and `false`
