### PR TITLE
feat(image-drop): close previews on image click

### DIFF
--- a/docs/plans/archived/2026-07-18_image-preview-click-to-close-plan.md
+++ b/docs/plans/archived/2026-07-18_image-preview-click-to-close-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Remove the visible **Close** button from Image Drop’s enlarged image preview and close the preview when the enlarged image is clicked again, while preserving accessible dismissal paths.
+
+## Context
+
+The preview dialog is defined in `extensions/pi-image-drop/src/web/index.html`, wired in `extensions/pi-image-drop/src/web/app.js`, styled in `extensions/pi-image-drop/src/web/styles.css`, and covered by the static asset contract in `extensions/pi-image-drop/test/server.test.ts`.
+
+## Non-Goals
+
+- Do not redesign the image cards or change how previews open.
+- Do not change image staging, upload, ordering, or deletion behavior.
+- Do not change the separate **Clear all** confirmation dialog.
+
+## Assumptions
+
+- Clicking the enlarged image itself should dismiss the preview.
+- Existing dismissal by clicking the backdrop and pressing Escape should remain available.
+- The enlarged image should remain keyboard-operable after removing the visible button.
+
+## Plan
+
+- [x] Update `extensions/pi-image-drop/test/server.test.ts` to specify that the preview has no visible Close button and exposes click-to-close behavior; focused `server.test.js` failed on the existing Close button before implementation.
+- [x] Update `extensions/pi-image-drop/src/web/index.html` and `extensions/pi-image-drop/src/web/app.js` to remove the Close button, dismiss the dialog from the enlarged image, preserve backdrop/Escape dismissal, and provide keyboard semantics for the enlarged image; focused `server.test.js` passes all 14 tests.
+- [x] Update `extensions/pi-image-drop/src/web/styles.css` so the enlarged image communicates click-to-close with an appropriate pointer cursor and retains visible keyboard focus; focused Biome check passes, with native button focus semantics preserved.
+- [x] Run the Image Drop test coverage and package checks to confirm the behavior change does not regress server assets or TypeScript/style validation; `npm test` passed 678 tests, the workspace check passed, and the full `npm run check` gate passed.
+
+## Risks
+
+- Removing a labeled control makes dismissal less discoverable; retain Escape, backdrop dismissal, keyboard operation, and a zoom-out cursor to reduce that risk.
+- A click handler attached too broadly could close the preview when users click the title area; scope it to the enlarged image only.
+
+## Completion Checklist
+
+- [x] The enlarged preview contains no visible Close button, verified by `extensions/pi-image-drop/test/server.test.ts` and inspection of `src/web/index.html`.
+- [x] Clicking the enlarged image closes the dialog, verified by the focused 14-test server asset contract; browser smoke testing was unavailable in this environment.
+- [x] Backdrop click, native Escape dismissal, and native button keyboard dismissal remain functional, verified by the source-level asset contract and semantic `<dialog>`/`<button>` markup; browser smoke testing was unavailable.
+- [x] Image Drop tests and package checks pass with no unrelated files changed, verified by `npm run check`, the workspace check, and `git diff -- extensions/pi-image-drop`.

--- a/extensions/pi-image-drop/src/web/app.js
+++ b/extensions/pi-image-drop/src/web/app.js
@@ -25,8 +25,8 @@ const ui = {
 	dialog: $("#clear-dialog"),
 	previewDialog: $("#image-preview-dialog"),
 	previewTitle: $("#image-preview-title"),
+	previewDismiss: $("#image-preview-dismiss"),
 	previewImage: $("#image-preview"),
-	previewClose: $("#image-preview-close"),
 };
 const clientId = crypto.randomUUID();
 const pendingFiles = new Map();
@@ -83,9 +83,9 @@ function wire() {
 	ui.dialog.addEventListener("close", () => {
 		if (ui.dialog.returnValue === "confirm") void clearAll();
 	});
-	ui.previewClose.addEventListener("click", () => ui.previewDialog.close());
+	ui.previewDismiss.addEventListener("click", closePreview);
 	ui.previewDialog.addEventListener("click", (event) => {
-		if (event.target === ui.previewDialog) ui.previewDialog.close();
+		if (event.target === ui.previewDialog) closePreview();
 	});
 	ui.previewDialog.addEventListener("close", () => {
 		ui.previewImage.removeAttribute("src");
@@ -333,6 +333,10 @@ function openPreview(item) {
 	ui.previewImage.src = `/api/items/${item.id}/preview?revision=${state.batch.revision}`;
 	ui.previewImage.alt = `Enlarged preview of ${item.name}`;
 	ui.previewDialog.showModal();
+}
+
+function closePreview() {
+	ui.previewDialog.close();
 }
 
 function button(label, text, disabled, action, className = "") {

--- a/extensions/pi-image-drop/src/web/index.html
+++ b/extensions/pi-image-drop/src/web/index.html
@@ -73,10 +73,11 @@
 			<div class="image-preview-content">
 				<header>
 					<h2 id="image-preview-title">Image preview</h2>
-					<button id="image-preview-close" type="button" aria-label="Close enlarged image">Close</button>
 				</header>
 				<div class="image-preview-stage">
-					<img id="image-preview" alt="" />
+					<button id="image-preview-dismiss" class="image-preview-dismiss" type="button" aria-label="Close enlarged image">
+						<img id="image-preview" alt="" />
+					</button>
 				</div>
 			</div>
 		</dialog>

--- a/extensions/pi-image-drop/src/web/styles.css
+++ b/extensions/pi-image-drop/src/web/styles.css
@@ -362,7 +362,21 @@ dialog::backdrop {
 	padding: 1rem;
 	background: var(--surface-alt);
 }
-.image-preview-stage img {
+.image-preview-dismiss {
+	display: grid;
+	max-width: 100%;
+	max-height: 100%;
+	min-height: 0;
+	border: 0;
+	border-radius: 0;
+	padding: 0;
+	background: transparent;
+	cursor: zoom-out;
+}
+.image-preview-dismiss:hover:not(:disabled) {
+	border-color: transparent;
+}
+.image-preview-dismiss img {
 	max-width: 100%;
 	max-height: 100%;
 	object-fit: contain;

--- a/extensions/pi-image-drop/test/server.test.ts
+++ b/extensions/pi-image-drop/test/server.test.ts
@@ -115,10 +115,14 @@ test("bootstrap tokens rotate, replay fails, and clean pages require the session
 		const app = await (await api(server, "/app.js", { cookie })).text();
 		const styles = await (await api(server, "/styles.css", { cookie })).text();
 		assert.match(html, /<dialog id="image-preview-dialog"/);
-		assert.match(html, /id="image-preview-close"/);
+		assert.doesNotMatch(html, /id="image-preview-close"/);
+		assert.match(html, /<button id="image-preview-dismiss"[^>]*aria-label="Close enlarged image"/);
 		assert.match(app, /showModal\(\)/);
 		assert.match(app, /Enlarge preview of/);
+		assert.match(app, /previewDismiss\.addEventListener\("click", closePreview\)/);
+		assert.match(app, /event\.target === ui\.previewDialog\) closePreview\(\)/);
 		assert.match(styles, /\.image-preview-dialog/);
+		assert.match(styles, /\.image-preview-dismiss\s*{[^}]*cursor: zoom-out/s);
 	} finally {
 		await server.close();
 	}


### PR DESCRIPTION
## Summary

- remove the visible Close button from enlarged image previews
- close the dialog by clicking the enlarged image while preserving backdrop and Escape dismissal
- keep keyboard dismissal through a semantic image-wrapping button and add a zoom-out cursor

## Verification

- `npm run check`
- `npm run check --workspace @narumitw/pi-image-drop`
- focused Image Drop server test (14 passing)