### PR TITLE
feat(image-drop): retain sent image history per session

### DIFF
--- a/docs/plans/archived/2026-07-18_image-drop-session-image-history-plan.md
+++ b/docs/plans/archived/2026-07-18_image-drop-session-image-history-plan.md
@@ -1,0 +1,71 @@
+## Goal
+
+Keep successfully sent images available within the same Pi session so users can browse them and add them to a future batch again. Release all retained content when leaving, replacing, forking, reloading, or shutting down the session, while keeping every image exclusively in Pi process memory.
+
+## Context
+
+- A matching `message_start` currently calls `BatchStore.commitReservation()`, which immediately clears the active items and their source/processed buffers.
+- Merely keeping the active batch would attach those images to every later prompt and break the meaning of “Next Pi message.” Sent images therefore need to move into separate session history.
+- `maxImages` and `maxBatchBytes` currently limit only one active batch. Retaining images across multiple sends without a session-wide limit would allow memory use to grow without bound.
+
+## Architecture
+
+`BatchStore` maintains two explicit regions:
+
+1. `draft`: the sortable batch for the next Pi message, using the existing reservation and recovery flow.
+2. `history`: images confirmed as sent by a matching `message_start`; these are never attached to prompts automatically.
+
+A successful commit moves immutable, metadata-cleared, provider-ready images into history and then clears the draft. Browser state and APIs expose session-history projection, authenticated previews, restaging, single-item deletion, and clearing all history. Restaging creates a new draft item ID and retains the existing batch limits, deduplication, and pre-send `autoResize` reprocessing without modifying the history entry directly.
+
+History stores only the sanitized bytes and display metadata required for reuse, never the original unsanitized files. Draft and history use measurable session memory accounting. When a limit is reached, the oldest history entries are removed in send order until the new draft can be accepted. New images must not be rejected because history is full, and active or reserved draft items must never be removed automatically. `BatchStore.close()` and the runtime’s existing session replacement and shutdown paths are the only terminal cleanup boundaries.
+
+## Non-Goals
+
+- Do not write images to files, databases, Pi session JSON, or browser storage.
+- Do not reconstruct history from an existing Pi transcript or restore it across sessions.
+- Do not attach history images to later prompts automatically.
+- Do not change Pi or model-provider retention after an image has been sent to the provider.
+
+## Assumptions
+
+- “Retain” includes browser preview and an explicit **Add again** action; retaining invisible bytes alone has no user value.
+- Only a matching user `message_start` counts as sent. A reservation restored after failed preflight or queued delivery must not enter history.
+- Session history has bounded limits configured through `maxRetainedImages` and `maxRetainedBytes` in `pi-image-drop.json`.
+- The maintainer accepted defaults of 128 images / 512 MiB and hard ceilings of 256 images / 1 GiB. At either limit, the oldest history is removed automatically using FIFO order, and new images must not be rejected because retained history is full.
+
+## Plan
+
+- [x] Complete the session memory-budget decision: each provider-ready image is below approximately 3.375 MiB; the existing default draft can retain approximately 40 MiB of source bytes plus 27 MiB of processed bytes, with another approximately 36 MiB of Base64 during reservation. The maintainer accepted `maxRetainedImages: 128` / `maxRetainedBytes: 512 MiB` defaults, `256` / `1 GiB` hard ceilings, and FIFO eviction of the oldest history instead of rejecting a new draft.
+- [x] Add state-machine tests in `extensions/pi-image-drop/test/batch.test.ts` for matching commits, independent history, restage ordering and deduplication, delete/clear/stale revisions, FIFO count and resident-byte budgets, failed recovery, and `close()` cleanup; focused batch tests pass 14/14.
+- [x] Refactor `extensions/pi-image-drop/src/batch.ts` with typed public history state, one shared monotonic revision, defensive Buffer copies, and draft-plus-history FIFO budget accounting; focused batch tests pass 14/14.
+- [x] Add lifecycle tests in `extensions/pi-image-drop/test/lifecycle.test.ts` proving matching `message_start` commits, no automatic resend on the next prompt, restaged-image reprocessing under the current `autoResize` setting, and session replacement/shutdown cleanup; focused lifecycle tests pass 24/24.
+- [x] Verify that the existing commit broadcast, draft-only widget, and teardown orchestration in `extensions/pi-image-drop/src/runtime.ts` correctly support the new history state; focused lifecycle tests prove history is not reported as pending in the widget and terminal cleanup works, without expanding the runtime surface.
+- [x] Add authenticated history preview, restage, delete, and clear endpoints plus top-level history state in `test/server.test.ts` and `src/server.ts`; focused server tests pass 15/15 for cookie, Origin, lease, revision, duplicate-restage, and existing shutdown guards.
+- [x] Update `src/web/state.js`, `index.html`, `app.js`, and `styles.css` with a **Sent this session** section, previews, **Add again**, delete, confirmed clear, memory usage/limit details, and FIFO/session-lifetime copy; web helper tests pass 5/5 and the server asset contract passes.
+- [x] Update `src/settings.ts` and `test/settings.test.ts` with strict `maxRetainedImages` / `maxRetainedBytes` defaults, hard ceilings, warnings, and combined validation with `startOnSessionStart`; focused settings tests pass 3/3.
+- [x] Update the workflow, privacy, configuration, and limitations sections in `extensions/pi-image-drop/README.md` to document session-only history, restage/delete actions, the 512 MiB / 1 GiB policy, FIFO eviction, and the absence of disk or browser persistence.
+- [x] Incorporate the click-to-close preview behavior from PR #256 while resolving review comment `discussion_r3608498431`: the semantic dismiss button now has a definite stage-sized `width` and `height`, so tall images remain constrained to the fixed-height preview stage; focused server asset tests pass 15/15.
+- [x] Run focused tests (75/75), `npm --workspace @narumitw/pi-image-drop run check`, root `npm run check` (686/686 tests), and `just pack image-drop` (15 expected files, no tests/fixtures/cache); a Chrome DevTools smoke verified tall-preview containment and click-to-close, rendered sent history, restaging, refresh retention, and terminal session invalidation, while lifecycle tests verified no automatic resend and empty replacement-session history.
+
+## Risks
+
+- Session history extends the in-memory lifetime of sensitive image bytes. The UI and README must explain this, and every terminal lifecycle path needs cleanup regression tests.
+- Cloned Buffers, Base64 `ImageContent`, and preview responses may make actual heap/external memory exceed logical byte counts. The budget must account for resident representations rather than only original file sizes.
+- When draft and history reference the same image content, deletion, restaging, reprocessing, or late async completion could cause use-after-delete, double accounting, or accidental byte retention. Ownership and generation/revision guards must remain explicit.
+- FIFO eviction can remove old images without a manual action. The UI and README must show the limit and automatic-removal policy, and eviction may affect only history, never the active or reserved draft.
+- `server.ts` already exceeds 600 lines. History routes should remain compact or move into route/state helpers before the file approaches the 1,000-line boundary.
+
+## Rollback / Recovery
+
+- This feature has no migration or persisted data. Reverting it restores the previous behavior, where matching `message_start` immediately clears the batch.
+- If the history UI or API fails, history can be feature-disabled while preserving the draft/send flow, but shutdown cleanup must remain enabled.
+
+## Completion Checklist
+
+- [x] Sent images enter independent history only after a matching `message_start` and are not attached to the next prompt automatically, proven by batch and lifecycle tests.
+- [x] The browser can preview, restage, delete, and clear session history, with auth, Origin, lease, and revision failures proven by server tests.
+- [x] Draft and history follow the maintainer-approved bounded-memory policy, removing the oldest history with FIFO order at the limit without rejecting a new draft, proven by settings, batch, and server tests.
+- [x] Refresh preserves history, while reload, session replacement/fork, and shutdown release all history and server state, proven by lifecycle tests and Chrome browser smoke testing.
+- [x] The repository and package contain no new image cache, temporary image file, or browser persistence, proven by a clean persistence-API source search and the 15-file pack inspection.
+- [x] README and browser privacy copy accurately describe memory lifetime, reuse, and limit behavior, proven by documentation and UI review.
+- [x] Package checks, root tests, pack dry-run, and Chrome browser smoke testing all pass, with commands and results recorded in the final plan task.

--- a/extensions/pi-image-drop/README.md
+++ b/extensions/pi-image-drop/README.md
@@ -29,10 +29,11 @@ This package targets the latest Pi release and uses its `agent_settled` lifecycl
 3. Open the link. Paste images anywhere, drop files, or select **Choose images**.
 4. Review previews and processing details. Drag to reorder, use the keyboard-accessible arrow buttons, retry failures, delete individual items, or use confirmed **Clear all**.
 5. Write and submit a non-empty message in Pi. The ready images are appended after any attachments already on that message, in browser order.
+6. After Pi records that user message, the sent images move to **Sent this session**. They are not attached to later prompts unless you explicitly choose **Add again**. You can preview, re-add, delete, or clear retained images from the browser page.
 
 The `🖼️` widget above Pi's editor reports ready, uploading, error, and queued counts. Uploading or failed items block the whole batch and preserve the Pi editor text. Image-only messages are not supported.
 
-By default, the loopback service starts lazily when you run `/image-drop`. With `startOnSessionStart: true`, it starts after each Pi session initializes and displays the link in Pi automatically. Each later `/image-drop` invocation reuses the service and rotates the unused one-time link. A browser refresh keeps the current in-memory batch. Opening the authenticated page in another tab gives the new tab the editing lease and makes the old tab stale.
+By default, the loopback service starts lazily when you run `/image-drop`. With `startOnSessionStart: true`, it starts after each Pi session initializes and displays the link in Pi automatically. Each later `/image-drop` invocation reuses the service and rotates the unused one-time link. A browser refresh keeps the current in-memory batch and sent-image history. Opening the authenticated page in another tab gives the new tab the editing lease and makes the old tab stale. Reloading, replacing, forking, or shutting down the Pi session releases both the draft and all retained history.
 
 ## Supported images
 
@@ -67,7 +68,9 @@ Example:
   "maxImages": 8,
   "maxImageBytes": 10485760,
   "maxBatchBytes": 41943040,
-  "maxImagePixels": 50000000
+  "maxImagePixels": 50000000,
+  "maxRetainedImages": 128,
+  "maxRetainedBytes": 536870912
 }
 ```
 
@@ -81,6 +84,10 @@ Example:
 | `maxImageBytes` | 10 MiB | 50 MiB |
 | `maxBatchBytes` | 40 MiB | 200 MiB |
 | `maxImagePixels` | 50 megapixels | 100 megapixels |
+| `maxRetainedImages` | 128 | 256 |
+| `maxRetainedBytes` | 512 MiB | 1 GiB |
+
+`maxRetainedImages` and `maxRetainedBytes` govern how much sent history can coexist with the current draft, using combined image-count and resident-byte accounting. When either limit is reached, Image Drop removes the oldest sent-history entries first until the new draft fits. It never automatically removes the active or queued draft and does not reject a new image merely because retained history is full; the draft remains independently bounded by the batch limits above.
 
 Limit values are positive integer counts/bytes/pixels, and `startOnSessionStart` must be a boolean. `maxImageBytes` cannot exceed `maxBatchBytes`. Unknown fields, malformed JSON, invalid values, symlinks, or values above a hard ceiling cause the **whole file** to be ignored with one warning and safe defaults to be used. Limit values above a safe default but within a hard ceiling produce a memory/provider-limit warning.
 
@@ -92,8 +99,9 @@ At upload and submission time, the extension also re-reads Pi's documented globa
 - A rotating bootstrap token is exchanged once for an HttpOnly, `SameSite=Strict` session cookie, then removed from the URL.
 - Exact Host, mutation Origin, session-cookie, and active-client checks are enforced. No permissive CORS headers are sent.
 - Pages use a restrictive Content Security Policy plus no-store, no-referrer, MIME-sniffing, and frame-denial headers.
-- Raw request bodies, decoded pixels, source bytes, previews, and provider-ready bytes are bounded and stay in the Pi process memory. The extension creates no image cache or temporary image files.
-- Bytes are released after Pi records the matching user message, after Delete/Clear all, and on reload, session replacement/fork, or shutdown. Once Pi records a message, normal Pi/provider retention rules apply.
+- Raw request bodies, decoded pixels, source bytes, previews, and provider-ready bytes are bounded and stay in the Pi process memory. The extension creates no image cache, temporary image files, browser storage, or session-file entries.
+- After Pi records the matching user message, only sanitized provider-ready bytes and display metadata move to sent history; original uploaded source bytes are released. History remains available for preview and explicit re-adding until you delete it, FIFO retention limits remove it, or the Pi session reaches reload, replacement/fork, or shutdown.
+- Once Pi records a message, normal Pi/provider retention rules apply independently of deleting Image Drop's in-process history.
 
 A loopback page is local to your operating-system network namespace. Do not expose the port to a LAN or public interface.
 
@@ -115,14 +123,15 @@ Then open the unchanged `http://127.0.0.1:45678/...` link locally. Image Drop do
 - A non-empty interactive Pi message is required. RPC, extension-generated, slash-command, and image-only inputs do not consume the batch.
 - All items must be ready. One uploading or failed item blocks submission until it is retried or deleted.
 - Provider aggregate request limits vary. Raising the defaults to the hard ceilings does not guarantee that a provider accepts the final multi-image request.
-- Batches are intentionally not persisted or shown as recent history.
+- Sent history exists only for the current live Pi session. It is not reconstructed from the transcript, persisted across sessions, or shared with another Pi process.
+- FIFO retention can remove the oldest sent images automatically at the configured count or memory limit; the browser displays the current usage and limit.
 
 ## Package layout
 
 ```text
 src/image-drop.ts       Pi extension entrypoint
 src/runtime.ts          Pi lifecycle and message orchestration
-src/batch.ts            in-memory batch state machine
+src/batch.ts            in-memory draft and sent-history state machine
 src/images.ts           bounded image processing
 src/server.ts           authenticated loopback HTTP/SSE server
 src/settings.ts         extension settings

--- a/extensions/pi-image-drop/src/batch.ts
+++ b/extensions/pi-image-drop/src/batch.ts
@@ -34,6 +34,13 @@ interface BatchItem extends ItemReservation {
 	error?: string;
 }
 
+interface HistoryItem {
+	id: string;
+	name: string;
+	processed: ProcessedImage;
+	processedAutoResize?: boolean;
+}
+
 export interface PublicBatchItem extends ItemReservation {
 	status: ItemStatus;
 	error?: string;
@@ -53,6 +60,39 @@ export interface PublicBatchState {
 	phase: BatchPhase;
 	items: PublicBatchItem[];
 	totalSourceBytes: number;
+}
+
+export interface PublicHistoryItem {
+	id: string;
+	name: string;
+	size: number;
+	mimeType: string;
+	width: number;
+	height: number;
+	originalWidth: number;
+	originalHeight: number;
+	sourceFormat: string;
+	outputFormat: string;
+	resized: boolean;
+	notes: string[];
+}
+
+export interface PublicHistoryState {
+	revision: number;
+	items: PublicHistoryItem[];
+	totalBytes: number;
+	maxImages: number;
+	maxBytes: number;
+}
+
+export interface HistoryRestageInput {
+	historyId: string;
+	id: string;
+}
+
+export interface HistoryRestageResult {
+	addedIds: string[];
+	duplicates: Array<{ historyId: string; existingId: string }>;
 }
 
 export interface MessageReservation {
@@ -77,6 +117,7 @@ export class BatchError extends Error {
 
 export class BatchStore {
 	private items: BatchItem[] = [];
+	private history: HistoryItem[] = [];
 	private revision = 0;
 	private reservation?: MessageReservation;
 	private closed = false;
@@ -104,6 +145,29 @@ export class BatchStore {
 				notes: [...(item.processed?.notes ?? [])],
 			})),
 			totalSourceBytes: this.items.reduce((sum, item) => sum + item.size, 0),
+		};
+	}
+
+	publicHistoryState(): PublicHistoryState {
+		return {
+			revision: this.revision,
+			items: this.history.map((item) => ({
+				id: item.id,
+				name: item.name,
+				size: item.processed.bytes.byteLength,
+				mimeType: item.processed.mimeType,
+				width: item.processed.width,
+				height: item.processed.height,
+				originalWidth: item.processed.originalWidth,
+				originalHeight: item.processed.originalHeight,
+				sourceFormat: item.processed.sourceFormat,
+				outputFormat: item.processed.outputFormat,
+				resized: item.processed.resized,
+				notes: [...item.processed.notes],
+			})),
+			totalBytes: this.historyBytes(),
+			maxImages: this.settings.maxRetainedImages,
+			maxBytes: this.settings.maxRetainedBytes,
 		};
 	}
 
@@ -136,6 +200,7 @@ export class BatchStore {
 			throw new BatchError("Batch exceeds the byte limit", "limit");
 		}
 		this.items.push(...inputs.map((input) => ({ ...input, status: "uploading" as const })));
+		this.evictHistoryToBudget();
 		return this.bump();
 	}
 
@@ -172,6 +237,7 @@ export class BatchStore {
 		const earlier = duplicates.find(({ index }) => index < itemIndex);
 		if (earlier) {
 			this.items = this.items.filter((candidate) => candidate.id !== id);
+			this.evictHistoryToBudget();
 			this.bump();
 			return { kind: "duplicate", existingId: earlier.candidate.id };
 		}
@@ -183,9 +249,11 @@ export class BatchStore {
 		if (duplicates.length > 0) {
 			const laterIds = new Set(duplicates.map(({ candidate }) => candidate.id));
 			this.items = this.items.filter((candidate) => !laterIds.has(candidate.id));
+			this.evictHistoryToBudget();
 			this.bump();
 			return { kind: "duplicate", existingId: item.id };
 		}
+		this.evictHistoryToBudget();
 		this.bump();
 		return { kind: "ready" };
 	}
@@ -342,10 +410,101 @@ export class BatchStore {
 		return { bytes: Buffer.from(processed.bytes), mimeType: processed.mimeType };
 	}
 
+	historyPreview(id: string): { bytes: Buffer; mimeType: string } {
+		this.assertOpen();
+		const processed = this.historyItem(id).processed;
+		return { bytes: Buffer.from(processed.bytes), mimeType: processed.mimeType };
+	}
+
+	restageHistory(
+		inputs: readonly HistoryRestageInput[],
+		expectedRevision = this.revision,
+	): HistoryRestageResult {
+		this.assertMutable(expectedRevision);
+		if (inputs.length === 0) throw new BatchError("No history images supplied", "invalid");
+		if (new Set(inputs.map((input) => input.historyId)).size !== inputs.length) {
+			throw new BatchError("History selection contains duplicates", "invalid");
+		}
+		const draftIds = new Set(this.items.map((item) => item.id));
+		const draftHashes = new Map(
+			this.items.flatMap((item) =>
+				item.processed ? [[item.processed.hash, item.id] as const] : [],
+			),
+		);
+		const additions: BatchItem[] = [];
+		const duplicates: HistoryRestageResult["duplicates"] = [];
+		for (const input of inputs) {
+			if (!isSafeIdentifier(input.id) || draftIds.has(input.id)) {
+				throw new BatchError("Image id is invalid or duplicated", "invalid");
+			}
+			draftIds.add(input.id);
+			const history = this.historyItem(input.historyId);
+			const existingId = draftHashes.get(history.processed.hash);
+			if (existingId) {
+				duplicates.push({ historyId: input.historyId, existingId });
+				continue;
+			}
+			const processed = cloneProcessed(history.processed);
+			additions.push({
+				id: input.id,
+				name: history.name,
+				size: processed.bytes.byteLength,
+				status: "ready",
+				source: Buffer.from(processed.bytes),
+				processed,
+				processedAutoResize: history.processedAutoResize,
+			});
+			draftHashes.set(processed.hash, input.id);
+		}
+		if (this.items.length + additions.length > this.settings.maxImages) {
+			throw new BatchError("Batch exceeds the image-count limit", "limit");
+		}
+		const currentBytes = this.items.reduce((sum, item) => sum + item.size, 0);
+		const addedBytes = additions.reduce((sum, item) => sum + item.size, 0);
+		if (currentBytes + addedBytes > this.settings.maxBatchBytes) {
+			throw new BatchError("Batch exceeds the byte limit", "limit");
+		}
+		if (additions.length > 0) {
+			this.items.push(...additions);
+			this.evictHistoryToBudget();
+			this.bump();
+		}
+		return { addedIds: additions.map((item) => item.id), duplicates };
+	}
+
+	deleteHistory(id: string, expectedRevision = this.revision): number {
+		this.assertHistoryMutation(expectedRevision);
+		const before = this.history.length;
+		this.history = this.history.filter((item) => item.id !== id);
+		if (this.history.length === before)
+			throw new BatchError("History image not found", "not-found");
+		return this.bump();
+	}
+
+	clearHistory(expectedRevision = this.revision): number {
+		this.assertHistoryMutation(expectedRevision);
+		if (this.history.length === 0) return this.revision;
+		this.history = [];
+		return this.bump();
+	}
+
 	commitReservation(digest: string): boolean {
 		if (!this.reservation || this.reservation.digest !== digest) return false;
+		for (const [index, item] of this.items.entries()) {
+			if (!item.processed) continue;
+			this.history = this.history.filter(
+				(history) => history.processed.hash !== item.processed?.hash,
+			);
+			this.history.push({
+				id: historyId(this.revision, index, item.processed.hash),
+				name: item.name,
+				processed: cloneProcessed(item.processed),
+				processedAutoResize: item.processedAutoResize,
+			});
+		}
 		this.reservation = undefined;
 		this.items = [];
+		this.evictHistoryToBudget();
 		this.bump();
 		return true;
 	}
@@ -363,6 +522,7 @@ export class BatchStore {
 		this.closed = true;
 		this.reservation = undefined;
 		this.items = [];
+		this.history = [];
 		this.bump();
 	}
 
@@ -380,8 +540,12 @@ export class BatchStore {
 	}
 
 	private assertMutable(expectedRevision: number): void {
-		this.assertOpen();
+		this.assertHistoryMutation(expectedRevision);
 		if (this.reservation) throw new BatchError("Batch is frozen", "frozen");
+	}
+
+	private assertHistoryMutation(expectedRevision: number): void {
+		this.assertOpen();
 		if (expectedRevision !== this.revision)
 			throw new BatchError("Batch revision is stale", "stale");
 	}
@@ -390,6 +554,34 @@ export class BatchStore {
 		const item = this.items.find((candidate) => candidate.id === id);
 		if (!item) throw new BatchError("Image not found", "not-found");
 		return item;
+	}
+
+	private historyItem(id: string): HistoryItem {
+		const item = this.history.find((candidate) => candidate.id === id);
+		if (!item) throw new BatchError("History image not found", "not-found");
+		return item;
+	}
+
+	private historyBytes(): number {
+		return this.history.reduce((sum, item) => sum + item.processed.bytes.byteLength, 0);
+	}
+
+	private draftResidentBytes(): number {
+		return this.items.reduce(
+			(sum, item) =>
+				sum + (item.source?.byteLength ?? item.size) + (item.processed?.bytes.byteLength ?? 0),
+			0,
+		);
+	}
+
+	private evictHistoryToBudget(): void {
+		while (
+			this.history.length > 0 &&
+			(this.history.length + this.items.length > this.settings.maxRetainedImages ||
+				this.historyBytes() + this.draftResidentBytes() > this.settings.maxRetainedBytes)
+		) {
+			this.history.shift();
+		}
 	}
 
 	private bump(): number {
@@ -437,6 +629,13 @@ function isControlCharacter(character: string): boolean {
 
 function isSafeIdentifier(id: string): boolean {
 	return /^[A-Za-z0-9_-]{1,80}$/.test(id);
+}
+
+function historyId(revision: number, index: number, hash: string): string {
+	return createHash("sha256")
+		.update(`history\0${revision}\0${index}\0${hash}`)
+		.digest("hex")
+		.slice(0, 24);
 }
 
 function cryptoId(revision: number, images: readonly ImageContent[]): string {

--- a/extensions/pi-image-drop/src/batch.ts
+++ b/extensions/pi-image-drop/src/batch.ts
@@ -391,6 +391,7 @@ export class BatchStore {
 			preflightStarted: false,
 		};
 		this.reservation = reservation;
+		this.evictHistoryToBudget();
 		this.bump();
 		return cloneReservation(reservation);
 	}
@@ -567,11 +568,14 @@ export class BatchStore {
 	}
 
 	private draftResidentBytes(): number {
-		return this.items.reduce(
+		const itemBytes = this.items.reduce(
 			(sum, item) =>
 				sum + (item.source?.byteLength ?? item.size) + (item.processed?.bytes.byteLength ?? 0),
 			0,
 		);
+		const queuedBase64Bytes =
+			this.reservation?.images.reduce((sum, image) => sum + Buffer.byteLength(image.data), 0) ?? 0;
+		return itemBytes + queuedBase64Bytes;
 	}
 
 	private evictHistoryToBudget(): void {

--- a/extensions/pi-image-drop/src/server.ts
+++ b/extensions/pi-image-drop/src/server.ts
@@ -176,9 +176,15 @@ export class ImageDropServer {
 			const previewMatch = /^\/api\/items\/([A-Za-z0-9_-]{1,80})\/preview$/.exec(url.pathname);
 			if (request.method === "GET" && previewMatch) {
 				const preview = this.options.batch.preview(previewMatch[1] as string);
-				response.setHeader("Content-Type", preview.mimeType);
-				response.setHeader("Content-Length", preview.bytes.byteLength);
-				response.writeHead(200).end(preview.bytes);
+				this.image(response, preview);
+				return;
+			}
+			const historyPreviewMatch = /^\/api\/history\/([A-Za-z0-9_-]{1,80})\/preview$/.exec(
+				url.pathname,
+			);
+			if (request.method === "GET" && historyPreviewMatch) {
+				const preview = this.options.batch.historyPreview(historyPreviewMatch[1] as string);
+				this.image(response, preview);
 				return;
 			}
 			if (request.method === "POST" && url.pathname === "/api/lease") {
@@ -195,6 +201,31 @@ export class ImageDropServer {
 			}
 			this.assertMutation(request);
 			const lease = this.assertActiveClient(request);
+			if (request.method === "POST" && url.pathname === "/api/history/restage") {
+				const body = await readJson(request, JSON_LIMIT);
+				this.assertLease(lease);
+				const items = arrayField(body, "items").map((item) => {
+					if (!isRecord(item)) throw new HttpError(400, "Invalid history restage item");
+					return { historyId: stringField(item, "historyId"), id: stringField(item, "id") };
+				});
+				const restage = this.options.batch.restageHistory(items, integerField(body, "revision"));
+				this.broadcastState();
+				this.json(response, 200, { ...this.statePayload(), restage });
+				return;
+			}
+			const historyMatch = /^\/api\/history\/([A-Za-z0-9_-]{1,80})$/.exec(url.pathname);
+			if (request.method === "DELETE" && historyMatch) {
+				this.options.batch.deleteHistory(historyMatch[1] as string, queryInteger(url, "revision"));
+				this.respondWithState(response);
+				return;
+			}
+			if (request.method === "POST" && url.pathname === "/api/history/clear") {
+				const body = await readJson(request, JSON_LIMIT);
+				this.assertLease(lease);
+				this.options.batch.clearHistory(integerField(body, "revision"));
+				this.respondWithState(response);
+				return;
+			}
 			if (request.method === "POST" && url.pathname === "/api/items") {
 				const body = await readJson(request, JSON_LIMIT);
 				this.assertLease(lease);
@@ -406,7 +437,14 @@ export class ImageDropServer {
 			cwd: this.options.cwd,
 			activeClientId: this.activeClientId,
 			batch: this.options.batch.publicState(),
+			history: this.options.batch.publicHistoryState(),
 		};
+	}
+
+	private image(response: ServerResponse, image: { bytes: Buffer; mimeType: string }): void {
+		response.setHeader("Content-Type", image.mimeType);
+		response.setHeader("Content-Length", image.bytes.byteLength);
+		response.writeHead(200).end(image.bytes);
 	}
 
 	private respondWithState(response: ServerResponse): void {

--- a/extensions/pi-image-drop/src/settings.ts
+++ b/extensions/pi-image-drop/src/settings.ts
@@ -10,6 +10,8 @@ export interface ImageDropLimits {
 	maxImageBytes: number;
 	maxBatchBytes: number;
 	maxImagePixels: number;
+	maxRetainedImages: number;
+	maxRetainedBytes: number;
 }
 
 export interface ImageDropSettings extends ImageDropLimits {
@@ -21,6 +23,8 @@ export const DEFAULT_SETTINGS: Readonly<ImageDropSettings> = Object.freeze({
 	maxImageBytes: 10 * MIB,
 	maxBatchBytes: 40 * MIB,
 	maxImagePixels: 50_000_000,
+	maxRetainedImages: 128,
+	maxRetainedBytes: 512 * MIB,
 	startOnSessionStart: false,
 });
 
@@ -29,6 +33,8 @@ export const HARD_LIMITS: Readonly<ImageDropLimits> = Object.freeze({
 	maxImageBytes: 50 * MIB,
 	maxBatchBytes: 200 * MIB,
 	maxImagePixels: 100_000_000,
+	maxRetainedImages: 256,
+	maxRetainedBytes: 1024 * MIB,
 });
 
 const LIMIT_KEYS = new Set<keyof ImageDropLimits>([
@@ -36,6 +42,8 @@ const LIMIT_KEYS = new Set<keyof ImageDropLimits>([
 	"maxImageBytes",
 	"maxBatchBytes",
 	"maxImagePixels",
+	"maxRetainedImages",
+	"maxRetainedBytes",
 ]);
 const SETTING_KEYS = new Set<keyof ImageDropSettings>([...LIMIT_KEYS, "startOnSessionStart"]);
 
@@ -89,15 +97,13 @@ export async function loadSettings(
 	try {
 		const settings = normalizeSettings(JSON.parse(text) as unknown);
 		if (!settings) return invalid(path, "invalid settings shape or value");
-		const raised = [...LIMIT_KEYS].filter(
-			(key) => settings[key] > DEFAULT_SETTINGS[key],
-		);
+		const raised = [...LIMIT_KEYS].filter((key) => settings[key] > DEFAULT_SETTINGS[key]);
 		return {
 			kind: "loaded",
 			settings,
 			warning:
 				raised.length > 0
-					? `${SETTINGS_FILE} raises ${raised.join(", ")} above the safe defaults; large provider requests may fail.`
+					? `${SETTINGS_FILE} raises ${raised.join(", ")} above the safe defaults; memory use or provider request size may increase.`
 					: undefined,
 		};
 	} catch (error) {

--- a/extensions/pi-image-drop/src/web/app.js
+++ b/extensions/pi-image-drop/src/web/app.js
@@ -6,6 +6,7 @@ import {
 	moveItemBefore,
 	preferNewestState,
 	summarizeBatch,
+	summarizeHistory,
 } from "/state.js";
 
 const $ = (selector) => document.querySelector(selector);
@@ -19,10 +20,14 @@ const ui = {
 	clear: $("#clear-all"),
 	error: $("#error-banner"),
 	grid: $("#grid"),
+	historyStatus: $("#history-status"),
+	historyClear: $("#clear-history"),
+	historyGrid: $("#history-grid"),
 	overlay: $("#connection-overlay"),
 	connectionTitle: $("#connection-title"),
 	connectionMessage: $("#connection-message"),
 	dialog: $("#clear-dialog"),
+	historyDialog: $("#clear-history-dialog"),
 	previewDialog: $("#image-preview-dialog"),
 	previewTitle: $("#image-preview-title"),
 	previewDismiss: $("#image-preview-dismiss"),
@@ -82,6 +87,13 @@ function wire() {
 	});
 	ui.dialog.addEventListener("close", () => {
 		if (ui.dialog.returnValue === "confirm") void clearAll();
+	});
+	ui.historyClear.addEventListener("click", () => {
+		ui.historyDialog.returnValue = "cancel";
+		ui.historyDialog.showModal();
+	});
+	ui.historyDialog.addEventListener("close", () => {
+		if (ui.historyDialog.returnValue === "confirm") void clearHistory();
 	});
 	ui.previewDismiss.addEventListener("click", closePreview);
 	ui.previewDialog.addEventListener("click", (event) => {
@@ -226,6 +238,36 @@ async function clearAll() {
 	}
 }
 
+async function restageHistory(historyId) {
+	try {
+		const response = await request("/api/history/restage", {
+			method: "POST",
+			json: {
+				revision: state.batch.revision,
+				items: [{ historyId, id: crypto.randomUUID() }],
+			},
+		});
+		applyState(response);
+		clearError();
+		render();
+		const target = response.restage.addedIds[0] ?? response.restage.duplicates[0]?.existingId;
+		if (target) highlight(target);
+	} catch (error) {
+		showError(errorMessage(error));
+	}
+}
+
+async function deleteHistory(id) {
+	await mutate(`/api/history/${id}?revision=${state.batch.revision}`, { method: "DELETE" });
+}
+
+async function clearHistory() {
+	await mutate("/api/history/clear", {
+		method: "POST",
+		json: { revision: state.batch.revision },
+	});
+}
+
 async function mutate(path, options) {
 	const result = await attemptMutation(() => request(path, options));
 	if (!result.ok) {
@@ -254,6 +296,12 @@ function render() {
 	ui.drop.classList.toggle("disabled", !mutable);
 	ui.drop.setAttribute("aria-disabled", String(!mutable));
 	ui.grid.replaceChildren(...state.batch.items.map((item, index) => card(item, index, mutable)));
+	const history = summarizeHistory(state.history);
+	ui.historyStatus.textContent = history.label;
+	ui.historyClear.disabled = history.total === 0;
+	ui.historyGrid.replaceChildren(
+		...(state.history?.items ?? []).map((item, index) => historyCard(item, index, mutable)),
+	);
 }
 
 function card(item, index, mutable) {
@@ -280,7 +328,7 @@ function card(item, index, mutable) {
 		preview = element("button", "preview preview-button");
 		preview.type = "button";
 		preview.setAttribute("aria-label", `Enlarge preview of ${item.name}`);
-		preview.addEventListener("click", () => openPreview(item));
+		preview.addEventListener("click", () => openPreview(item, "items"));
 		const image = document.createElement("img");
 		image.src = `/api/items/${item.id}/preview?revision=${state.batch.revision}`;
 		image.alt = `Preview of ${item.name}`;
@@ -328,9 +376,51 @@ function card(item, index, mutable) {
 	return article;
 }
 
-function openPreview(item) {
+function historyCard(item, index, mutable) {
+	const article = document.createElement("article");
+	article.className = "image-card history-card";
+	article.tabIndex = 0;
+	article.setAttribute("aria-label", `${index + 1}. ${item.name}, sent this session`);
+
+	const preview = element("button", "preview preview-button");
+	preview.type = "button";
+	preview.setAttribute("aria-label", `Enlarge preview of ${item.name}`);
+	preview.addEventListener("click", () => openPreview(item, "history"));
+	const image = document.createElement("img");
+	image.src = `/api/history/${item.id}/preview?revision=${state.batch.revision}`;
+	image.alt = `Preview of sent image ${item.name}`;
+	image.loading = "lazy";
+	preview.append(image);
+	article.append(preview);
+
+	const body = element("div", "card-body");
+	body.append(element("h3", "", item.name));
+	body.append(
+		element("p", "meta", `${index + 1} · ${formatBytes(item.size)} · ${item.width}×${item.height}`),
+	);
+	for (const note of item.notes ?? []) body.append(element("p", "note", note));
+	article.append(body);
+
+	const actions = element("div", "card-actions");
+	actions.append(
+		button("Add sent image to the next Pi message", "Add again", !mutable, () =>
+			restageHistory(item.id),
+		),
+		button(
+			"Delete sent image from session history",
+			"Delete",
+			false,
+			() => deleteHistory(item.id),
+			"delete",
+		),
+	);
+	article.append(actions);
+	return article;
+}
+
+function openPreview(item, collection) {
 	ui.previewTitle.textContent = item.name;
-	ui.previewImage.src = `/api/items/${item.id}/preview?revision=${state.batch.revision}`;
+	ui.previewImage.src = `/api/${collection}/${item.id}/preview?revision=${state.batch.revision}`;
 	ui.previewImage.alt = `Enlarged preview of ${item.name}`;
 	ui.previewDialog.showModal();
 }

--- a/extensions/pi-image-drop/src/web/index.html
+++ b/extensions/pi-image-drop/src/web/index.html
@@ -46,8 +46,20 @@
 				<div id="grid" class="image-grid" aria-live="polite"></div>
 			</section>
 
+			<section class="history" aria-labelledby="history-title">
+				<div class="batch-toolbar">
+					<div>
+						<h2 id="history-title">Sent this session</h2>
+						<p id="history-status" role="status" aria-live="polite">No images sent this session</p>
+					</div>
+					<button id="clear-history" class="danger-secondary" type="button" disabled>Clear history</button>
+				</div>
+				<p class="history-note">Sent images are not attached again unless you choose <strong>Add again</strong>. The oldest history is removed automatically at the configured memory limit, and all history is cleared when this Pi session ends.</p>
+				<div id="history-grid" class="image-grid" aria-live="polite"></div>
+			</section>
+
 			<p class="privacy">
-				Images stay in this Pi process until you submit a Pi message. They are then sent to your configured model provider with that message.
+				Draft and sent-history images stay only in this Pi process. Sending a Pi message also sends its staged images to your configured model provider; local sent history remains until deleted, automatically evicted at the limit, or the Pi session ends.
 			</p>
 		</main>
 
@@ -65,6 +77,17 @@
 				<div class="dialog-actions">
 					<button type="submit" value="cancel">Cancel</button>
 					<button type="submit" class="danger" value="confirm">Clear all</button>
+				</div>
+			</form>
+		</dialog>
+
+		<dialog id="clear-history-dialog">
+			<form method="dialog">
+				<h2>Clear sent image history?</h2>
+				<p>This releases every retained image from this Pi session. Images already sent to Pi or a model provider are unaffected.</p>
+				<div class="dialog-actions">
+					<button type="submit" value="cancel">Cancel</button>
+					<button type="submit" class="danger" value="confirm">Clear history</button>
 				</div>
 			</form>
 		</dialog>

--- a/extensions/pi-image-drop/src/web/state.js
+++ b/extensions/pi-image-drop/src/web/state.js
@@ -13,6 +13,21 @@ export function summarizeBatch(batch) {
 	};
 }
 
+export function summarizeHistory(history) {
+	const total = (history?.items ?? []).length;
+	const bytes = Number(history?.totalBytes ?? 0);
+	const maxImages = Number(history?.maxImages ?? 0);
+	const maxBytes = Number(history?.maxBytes ?? 0);
+	const usage = `${total}/${maxImages} images · ${formatBytes(bytes)} of ${formatBytes(maxBytes)}`;
+	return {
+		total,
+		bytes,
+		maxImages,
+		maxBytes,
+		label: total === 0 ? `No images sent this session · ${usage}` : usage,
+	};
+}
+
 export function statusLabel(phase, counts, total) {
 	if (phase === "empty" || total === 0) return "No images staged";
 	if (phase === "reserved") return `${total} ${plural(total, "image")} queued with Pi`;

--- a/extensions/pi-image-drop/src/web/styles.css
+++ b/extensions/pi-image-drop/src/web/styles.css
@@ -164,7 +164,8 @@ main {
 	font-size: 2.6rem;
 }
 
-.batch {
+.batch,
+.history {
 	margin-top: 1.5rem;
 }
 .batch-toolbar {
@@ -180,6 +181,11 @@ main {
 }
 .batch-toolbar p {
 	color: var(--muted);
+}
+.history-note {
+	margin: 0 0 0.8rem;
+	color: var(--muted);
+	font-size: 0.9rem;
 }
 .banner {
 	margin: 0.75rem 0;
@@ -364,22 +370,26 @@ dialog::backdrop {
 }
 .image-preview-dismiss {
 	display: grid;
-	max-width: 100%;
-	max-height: 100%;
+	width: 100%;
+	height: 100%;
 	min-height: 0;
+	place-items: center;
 	border: 0;
 	border-radius: 0;
 	padding: 0;
 	background: transparent;
-	cursor: zoom-out;
+	pointer-events: none;
 }
 .image-preview-dismiss:hover:not(:disabled) {
 	border-color: transparent;
 }
 .image-preview-dismiss img {
-	max-width: 100%;
-	max-height: 100%;
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+	cursor: zoom-out;
 	object-fit: contain;
+	pointer-events: auto;
 }
 .dialog-actions {
 	display: flex;

--- a/extensions/pi-image-drop/test/batch.test.ts
+++ b/extensions/pi-image-drop/test/batch.test.ts
@@ -321,6 +321,26 @@ test("history FIFO eviction also enforces the combined resident-byte budget", ()
 	assert.equal(batch.publicHistoryState().totalBytes, 6);
 });
 
+test("queued Base64 images participate in FIFO resident-byte eviction", () => {
+	const batch = new BatchStore({
+		...DEFAULT_SETTINGS,
+		maxRetainedImages: 100,
+		maxRetainedBytes: 25,
+	});
+	ready(batch, "one", "123456");
+	const first = batch.reserveMessage("send one");
+	batch.commitReservation(first.digest);
+	ready(batch, "two", "abcdef");
+	assert.deepEqual(
+		batch.publicHistoryState().items.map((item) => item.name),
+		["one.png"],
+	);
+
+	batch.reserveMessage("queue two");
+	assert.equal(batch.publicState().phase, "reserved");
+	assert.deepEqual(batch.publicHistoryState().items, []);
+});
+
 test("failed reservation recovery never enters history and close releases draft and history", () => {
 	const batch = new BatchStore(DEFAULT_SETTINGS);
 	ready(batch, "one", "one");

--- a/extensions/pi-image-drop/test/batch.test.ts
+++ b/extensions/pi-image-drop/test/batch.test.ts
@@ -210,6 +210,131 @@ test("message reservation freezes mutations and supports digest-bounded commit o
 	assert.equal(batch.publicState().phase, "empty");
 });
 
+test("matching commits move sanitized images into independent session history", () => {
+	const batch = new BatchStore(DEFAULT_SETTINGS);
+	ready(batch, "one", "one");
+	ready(batch, "two", "two");
+	const sent = batch.reserveMessage("send both");
+	assert.equal(batch.commitReservation(sent.digest), true);
+	assert.equal(batch.publicState().phase, "empty");
+	assert.deepEqual(
+		batch.publicHistoryState().items.map((item) => ({ name: item.name, size: item.size })),
+		[
+			{ name: "one.png", size: 3 },
+			{ name: "two.png", size: 3 },
+		],
+	);
+
+	ready(batch, "three", "three");
+	const next = batch.reserveMessage("only new image");
+	assert.deepEqual(
+		next.images.map((image) => image.data),
+		[Buffer.from("three").toString("base64")],
+	);
+	assert.equal(batch.restoreReservation()?.text, "only new image");
+	assert.equal(batch.publicHistoryState().items.length, 2);
+});
+
+test("history restaging preserves selection order, collapses duplicates, and clones bytes", () => {
+	const batch = new BatchStore(DEFAULT_SETTINGS);
+	ready(batch, "one", "one");
+	ready(batch, "two", "two");
+	const sent = batch.reserveMessage("send");
+	batch.commitReservation(sent.digest);
+	const [one, two] = batch.publicHistoryState().items;
+	assert.ok(one && two);
+	const preview = batch.historyPreview(one.id);
+	preview.bytes[0] = 0;
+	assert.deepEqual(batch.historyPreview(one.id).bytes, Buffer.from("one"));
+
+	assert.deepEqual(
+		batch.restageHistory(
+			[
+				{ historyId: two.id, id: "restaged-two" },
+				{ historyId: one.id, id: "restaged-one" },
+			],
+			batch.publicState().revision,
+		),
+		{ addedIds: ["restaged-two", "restaged-one"], duplicates: [] },
+	);
+	assert.deepEqual(
+		batch
+			.reserveMessage("again")
+			.images.map((image) => Buffer.from(image.data, "base64").toString()),
+		["two", "one"],
+	);
+	batch.restoreReservation();
+	assert.deepEqual(batch.restageHistory([{ historyId: one.id, id: "duplicate-one" }]), {
+		addedIds: [],
+		duplicates: [{ historyId: one.id, existingId: "restaged-one" }],
+	});
+});
+
+test("history mutations require current revisions and FIFO-evict oldest entries for new images", () => {
+	const batch = new BatchStore({
+		...DEFAULT_SETTINGS,
+		maxRetainedImages: 2,
+		maxRetainedBytes: 100,
+	});
+	for (const id of ["one", "two"]) {
+		ready(batch, id, id);
+		const reservation = batch.reserveMessage(`send ${id}`);
+		batch.commitReservation(reservation.digest);
+	}
+	const staleRevision = batch.publicState().revision;
+	const firstHistoryId = batch.publicHistoryState().items[0]?.id;
+	ready(batch, "three", "three");
+	assert.deepEqual(
+		batch.publicHistoryState().items.map((item) => item.name),
+		["two.png"],
+	);
+	assert.throws(() => batch.deleteHistory(firstHistoryId ?? "missing", staleRevision), /stale/i);
+	const historyId = batch.publicHistoryState().items[0]?.id;
+	assert.ok(historyId);
+	batch.deleteHistory(historyId, batch.publicState().revision);
+	assert.deepEqual(batch.publicHistoryState().items, []);
+
+	const reservation = batch.reserveMessage("send three");
+	batch.commitReservation(reservation.digest);
+	batch.clearHistory(batch.publicState().revision);
+	assert.deepEqual(batch.publicHistoryState().items, []);
+});
+
+test("history FIFO eviction also enforces the combined resident-byte budget", () => {
+	const batch = new BatchStore({
+		...DEFAULT_SETTINGS,
+		maxRetainedImages: 100,
+		maxRetainedBytes: 10,
+	});
+	for (const [id, marker] of [
+		["one", "123456"],
+		["two", "abcdef"],
+	] as const) {
+		ready(batch, id, marker);
+		const reservation = batch.reserveMessage(`send ${id}`);
+		batch.commitReservation(reservation.digest);
+	}
+	assert.deepEqual(
+		batch.publicHistoryState().items.map((item) => item.name),
+		["two.png"],
+	);
+	assert.equal(batch.publicHistoryState().totalBytes, 6);
+});
+
+test("failed reservation recovery never enters history and close releases draft and history", () => {
+	const batch = new BatchStore(DEFAULT_SETTINGS);
+	ready(batch, "one", "one");
+	batch.reserveMessage("not delivered");
+	batch.restoreReservation();
+	assert.deepEqual(batch.publicHistoryState().items, []);
+	const sent = batch.reserveMessage("delivered");
+	batch.commitReservation(sent.digest);
+	assert.equal(batch.publicHistoryState().items.length, 1);
+	batch.close();
+	assert.deepEqual(batch.publicState().items, []);
+	assert.deepEqual(batch.publicHistoryState().items, []);
+});
+
 test("not-ready and closed batches reject reservation and stale async completion", () => {
 	const batch = new BatchStore(DEFAULT_SETTINGS);
 	batch.reserveItems([{ id: "one", name: "one.png", size: 1 }]);

--- a/extensions/pi-image-drop/test/image-drop.test.ts
+++ b/extensions/pi-image-drop/test/image-drop.test.ts
@@ -30,6 +30,8 @@ test("settings expose the agreed defaults", () => {
 		maxImageBytes: 10 * 1024 * 1024,
 		maxBatchBytes: 40 * 1024 * 1024,
 		maxImagePixels: 50_000_000,
+		maxRetainedImages: 128,
+		maxRetainedBytes: 512 * 1024 * 1024,
 		startOnSessionStart: false,
 	});
 	assert.deepEqual(normalizeSettings({}), DEFAULT_SETTINGS);

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -132,7 +132,18 @@ test("interactive input appends one ready ordered batch and commits on matching 
 		context.ctx,
 	);
 	assert.equal(runtime.getBatchForTesting()?.publicState().phase, "empty");
+	assert.equal(runtime.getBatchForTesting()?.publicHistoryState().items.length, 1);
 	assert.equal(context.widgets.get("image-drop"), undefined);
+
+	const ordinary = (await emit(
+		mock,
+		"input",
+		{ type: "input", text: "text only next", source: "interactive" },
+		context.ctx,
+	)) as { action: string; images?: unknown[] };
+	assert.equal(ordinary.action, "continue");
+	assert.equal(ordinary.images, undefined);
+	assert.equal(runtime.getBatchForTesting()?.publicHistoryState().items.length, 1);
 });
 
 test("agent_settled restores a queued reservation that never became a user message", async () => {
@@ -186,8 +197,15 @@ test("/image-drop lazily starts one server, rotates links, and shutdown releases
 	assert.match(harness.context.notifications[0]?.message ?? "", /token=1/);
 	assert.match(harness.context.notifications[1]?.message ?? "", /token=2/);
 	assert.match(String(harness.context.widgets.get("image-drop")), /127\.0\.0\.1/);
+	harness.runtime.addReadyImageForTesting("one", "one.png", Buffer.from("source"), PROCESSED);
+	const closingBatch = harness.runtime.getBatchForTesting();
+	const sent = closingBatch?.reserveMessage("sent");
+	assert.ok(sent);
+	closingBatch?.commitReservation(sent.digest);
+	assert.equal(closingBatch?.publicHistoryState().items.length, 1);
 	await emit(harness.mock, "session_shutdown", {}, harness.context.ctx);
 	assert.equal(harness.serverCloses, 1);
+	assert.deepEqual(closingBatch?.publicHistoryState().items, []);
 	assert.equal(harness.context.widgets.get("image-drop"), undefined);
 });
 
@@ -293,6 +311,55 @@ test("submission reprocesses retained sources after autoResize changes", async (
 	assert.equal(result.action, "transform");
 	assert.deepEqual(seen, [false]);
 	assert.equal(result.images[0]?.data, Buffer.from("reprocessed").toString("base64"));
+});
+
+test("a sent history image can be restaged and reprocessed for the current autoResize setting", async () => {
+	const mock = createMockPi();
+	const seen: Array<{ source: string; autoResize: boolean }> = [];
+	let autoResize = true;
+	const runtime = new ImageDropRuntime(mock.pi, {
+		loadSettings: async () => ({ kind: "missing", settings: { ...DEFAULT_SETTINGS } }),
+		readPiSettings: async () => ({ autoResize, blockImages: false, warnings: [] }),
+		createProcessor: () => ({
+			process: async (source, options) => {
+				seen.push({ source: Buffer.from(source).toString(), autoResize: options.autoResize });
+				return { ...PROCESSED, bytes: Buffer.from("restaged-output"), hash: "restaged-output" };
+			},
+		}),
+	});
+	runtime.register();
+	const context = createMockContext({
+		model: { id: "vision", provider: "test", input: ["text", "image"] },
+	});
+	await emit(mock, "session_start", {}, context.ctx);
+	runtime.addReadyImageForTesting("one", "one.png", Buffer.from("raw-source"), PROCESSED);
+	const first = (await emit(
+		mock,
+		"input",
+		{ type: "input", text: "first send", source: "interactive" },
+		context.ctx,
+	)) as { images: Array<{ type: string; data: string; mimeType: string }> };
+	await emit(
+		mock,
+		"message_start",
+		{ message: { role: "user", content: [{ type: "text", text: "first send" }, ...first.images] } },
+		context.ctx,
+	);
+	const batch = runtime.getBatchForTesting();
+	autoResize = false;
+	const historyId = batch?.publicHistoryState().items[0]?.id;
+	assert.ok(historyId);
+	batch?.restageHistory([{ historyId, id: "restaged" }]);
+
+	const second = (await emit(
+		mock,
+		"input",
+		{ type: "input", text: "send again", source: "interactive" },
+		context.ctx,
+	)) as { action: string; images: Array<{ data: string }> };
+	assert.equal(second.action, "transform");
+	assert.deepEqual(seen, [{ source: PNG.toString(), autoResize: false }]);
+	assert.equal(second.images[0]?.data, Buffer.from("restaged-output").toString("base64"));
 });
 
 test("failed setting-change reprocessing restores text and blocks the batch", async () => {
@@ -438,14 +505,21 @@ test("empty image-only interactive input does not consume the browser batch", as
 	assert.equal(runtime.getBatchForTesting()?.publicState().phase, "ready");
 });
 
-test("session replacement closes the old server and clears every staged byte", async () => {
+test("session replacement closes the old server and clears every staged and retained byte", async () => {
 	const harness = createHarness();
 	await emit(harness.mock, "session_start", {}, harness.context.ctx);
 	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
 	harness.runtime.addReadyImageForTesting("one", "one.png", Buffer.from("source"), PROCESSED);
+	const oldBatch = harness.runtime.getBatchForTesting();
+	const reservation = oldBatch?.reserveMessage("sent");
+	assert.ok(reservation);
+	oldBatch?.commitReservation(reservation.digest);
+	assert.equal(oldBatch?.publicHistoryState().items.length, 1);
 	await emit(harness.mock, "session_start", {}, harness.context.ctx);
 	assert.equal(harness.serverCloses, 1);
+	assert.deepEqual(oldBatch?.publicHistoryState().items, []);
 	assert.equal(harness.runtime.getBatchForTesting()?.publicState().phase, "empty");
+	assert.deepEqual(harness.runtime.getBatchForTesting()?.publicHistoryState().items, []);
 	assert.equal(harness.context.widgets.get("image-drop"), undefined);
 });
 

--- a/extensions/pi-image-drop/test/server.test.ts
+++ b/extensions/pi-image-drop/test/server.test.ts
@@ -44,6 +44,18 @@ async function harness() {
 	return { batch, server };
 }
 
+function commitHistory(batch: BatchStore, id: string, marker = id): string {
+	const source = Buffer.from(marker);
+	batch.reserveItems([{ id, name: `${id}.png`, size: source.byteLength }]);
+	batch.startProcessing(id, source);
+	batch.complete(id, result(source), true);
+	const reservation = batch.reserveMessage(`send ${id}`);
+	assert.equal(batch.commitReservation(reservation.digest), true);
+	const historyId = batch.publicHistoryState().items.at(-1)?.id;
+	assert.ok(historyId);
+	return historyId;
+}
+
 async function authenticate(server: ImageDropServer) {
 	const link = server.issueLink();
 	const response = await fetch(link, { redirect: "manual" });
@@ -114,15 +126,26 @@ test("bootstrap tokens rotate, replay fails, and clean pages require the session
 		const html = await page.text();
 		const app = await (await api(server, "/app.js", { cookie })).text();
 		const styles = await (await api(server, "/styles.css", { cookie })).text();
+		assert.match(html, /<section class="history" aria-labelledby="history-title">/);
+		assert.match(html, /id="history-grid"/);
+		assert.match(html, /id="clear-history"/);
+		assert.match(html, /<dialog id="clear-history-dialog"/);
 		assert.match(html, /<dialog id="image-preview-dialog"/);
 		assert.doesNotMatch(html, /id="image-preview-close"/);
 		assert.match(html, /<button id="image-preview-dismiss"[^>]*aria-label="Close enlarged image"/);
-		assert.match(app, /showModal\(\)/);
-		assert.match(app, /Enlarge preview of/);
+		assert.match(app, /summarizeHistory/);
+		assert.match(app, /\/api\/history\//);
 		assert.match(app, /previewDismiss\.addEventListener\("click", closePreview\)/);
 		assert.match(app, /event\.target === ui\.previewDialog\) closePreview\(\)/);
+		assert.match(app, /showModal\(\)/);
+		assert.match(app, /Enlarge preview of/);
+		assert.match(styles, /\.history/);
 		assert.match(styles, /\.image-preview-dialog/);
-		assert.match(styles, /\.image-preview-dismiss\s*{[^}]*cursor: zoom-out/s);
+		assert.match(styles, /\.image-preview-dismiss\s*{[^}]*width: 100%[^}]*height: 100%/s);
+		assert.match(
+			styles,
+			/\.image-preview-dismiss img\s*{[^}]*width: 100%[^}]*height: 100%[^}]*cursor: zoom-out/s,
+		);
 	} finally {
 		await server.close();
 	}
@@ -286,6 +309,106 @@ test("reserve, upload, state, reorder, delete, retry errors, and clear use revis
 			200,
 		);
 		assert.equal(batch.publicState().phase, "empty");
+	} finally {
+		await server.close();
+	}
+});
+
+test("history preview, restage, delete, and clear enforce auth, lease, and revisions", async () => {
+	const { batch, server } = await harness();
+	try {
+		const cookie = await authenticate(server);
+		const client = await lease(server, cookie, "history-client");
+		const historyId = commitHistory(batch, "sent", "sent-bytes");
+		assert.equal((await api(server, `/api/history/${historyId}/preview`)).status, 401);
+		const preview = await api(server, `/api/history/${historyId}/preview`, { cookie });
+		assert.equal(preview.status, 200);
+		assert.deepEqual(Buffer.from(await preview.arrayBuffer()), Buffer.from("sent-bytes"));
+
+		const staleRevision = batch.publicState().revision;
+		const restaged = await api(server, "/api/history/restage", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: staleRevision,
+				items: [{ historyId, id: "restaged" }],
+			}),
+		});
+		assert.equal(restaged.status, 200);
+		const restagedState = (await restaged.json()) as {
+			batch: { revision: number; items: Array<{ id: string }> };
+			history: { items: Array<{ id: string }> };
+			restage: { addedIds: string[]; duplicates: unknown[] };
+		};
+		assert.deepEqual(
+			restagedState.batch.items.map((item) => item.id),
+			["restaged"],
+		);
+		assert.deepEqual(restagedState.restage, { addedIds: ["restaged"], duplicates: [] });
+
+		const duplicate = await api(server, "/api/history/restage", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: restagedState.batch.revision,
+				items: [{ historyId, id: "duplicate" }],
+			}),
+		});
+		assert.equal(duplicate.status, 200);
+		assert.deepEqual(
+			((await duplicate.json()) as { restage: { addedIds: string[] } }).restage.addedIds,
+			[],
+		);
+
+		assert.equal(
+			(
+				await api(server, `/api/history/${historyId}?revision=${staleRevision}`, {
+					method: "DELETE",
+					cookie,
+					client,
+				})
+			).status,
+			409,
+		);
+		assert.equal(
+			(
+				await api(server, `/api/history/${historyId}?revision=${batch.publicState().revision}`, {
+					method: "DELETE",
+					cookie,
+					client,
+				})
+			).status,
+			200,
+		);
+
+		batch.clear(batch.publicState().revision);
+		commitHistory(batch, "new-history");
+		await lease(server, cookie, "new-history-client");
+		assert.equal(
+			(
+				await api(server, "/api/history/clear", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({ revision: batch.publicState().revision }),
+				})
+			).status,
+			409,
+		);
+		assert.equal(
+			(
+				await api(server, "/api/history/clear", {
+					method: "POST",
+					cookie,
+					client: "new-history-client",
+					body: JSON.stringify({ revision: batch.publicState().revision }),
+				})
+			).status,
+			200,
+		);
+		assert.deepEqual(batch.publicHistoryState().items, []);
 	} finally {
 		await server.close();
 	}

--- a/extensions/pi-image-drop/test/settings.test.ts
+++ b/extensions/pi-image-drop/test/settings.test.ts
@@ -7,6 +7,10 @@ import { DEFAULT_SETTINGS, HARD_LIMITS, loadSettings, normalizeSettings } from "
 
 test("settings normalize partial values and reject unknown, inconsistent, and unsafe values", () => {
 	assert.equal(DEFAULT_SETTINGS.startOnSessionStart, false);
+	assert.equal(DEFAULT_SETTINGS.maxRetainedImages, 128);
+	assert.equal(DEFAULT_SETTINGS.maxRetainedBytes, 512 * 1024 * 1024);
+	assert.equal(HARD_LIMITS.maxRetainedImages, 256);
+	assert.equal(HARD_LIMITS.maxRetainedBytes, 1024 * 1024 * 1024);
 	assert.deepEqual(normalizeSettings({ maxImages: 4 }), { ...DEFAULT_SETTINGS, maxImages: 4 });
 	assert.deepEqual(normalizeSettings({ startOnSessionStart: true }), {
 		...DEFAULT_SETTINGS,
@@ -18,6 +22,14 @@ test("settings normalize partial values and reject unknown, inconsistent, and un
 	assert.equal(normalizeSettings({ maxImages: 0 }), undefined);
 	assert.equal(normalizeSettings({ maxImages: HARD_LIMITS.maxImages + 1 }), undefined);
 	assert.equal(normalizeSettings({ maxImageBytes: DEFAULT_SETTINGS.maxBatchBytes + 1 }), undefined);
+	assert.equal(
+		normalizeSettings({ maxRetainedImages: HARD_LIMITS.maxRetainedImages + 1 }),
+		undefined,
+	);
+	assert.equal(
+		normalizeSettings({ maxRetainedBytes: HARD_LIMITS.maxRetainedBytes + 1 }),
+		undefined,
+	);
 	assert.equal(normalizeSettings([]), undefined);
 });
 
@@ -29,10 +41,19 @@ test("settings loading distinguishes missing, valid, warned, and invalid files",
 			kind: "missing",
 			settings: { ...DEFAULT_SETTINGS },
 		});
-		await writeFile(settingsPath, '{"maxImages":4,"startOnSessionStart":true}\n');
+		await writeFile(
+			settingsPath,
+			'{"maxImages":4,"maxRetainedImages":32,"maxRetainedBytes":268435456,"startOnSessionStart":true}\n',
+		);
 		assert.deepEqual(await loadSettings(settingsPath), {
 			kind: "loaded",
-			settings: { ...DEFAULT_SETTINGS, maxImages: 4, startOnSessionStart: true },
+			settings: {
+				...DEFAULT_SETTINGS,
+				maxImages: 4,
+				maxRetainedImages: 32,
+				maxRetainedBytes: 256 * 1024 * 1024,
+				startOnSessionStart: true,
+			},
 			warning: undefined,
 		});
 		await writeFile(settingsPath, '{"maxImages":16}\n');

--- a/extensions/pi-image-drop/test/web-state.test.ts
+++ b/extensions/pi-image-drop/test/web-state.test.ts
@@ -10,6 +10,13 @@ type StateHelpers = {
 		uploading: number;
 		error: number;
 	};
+	summarizeHistory(history: unknown): {
+		label: string;
+		total: number;
+		bytes: number;
+		maxImages: number;
+		maxBytes: number;
+	};
 	moveItem(ids: string[], id: string, direction: number): string[];
 	moveItemBefore(ids: string[], id: string, target: string): string[];
 	canMutate(batch: { phase: string }): boolean;
@@ -48,6 +55,33 @@ test("web state helpers summarize every visible batch state without color-only m
 		helpers.summarizeBatch({ phase: "reserved", items: [{ status: "ready" }], totalSourceBytes: 1 })
 			.label,
 		"1 image queued with Pi",
+	);
+});
+
+test("web history helpers report session retention and memory limits", () => {
+	assert.deepEqual(
+		helpers.summarizeHistory({
+			items: [],
+			totalBytes: 0,
+			maxImages: 128,
+			maxBytes: 512 * 1024 * 1024,
+		}),
+		{
+			total: 0,
+			bytes: 0,
+			maxImages: 128,
+			maxBytes: 512 * 1024 * 1024,
+			label: "No images sent this session · 0/128 images · 0 B of 512 MB",
+		},
+	);
+	assert.equal(
+		helpers.summarizeHistory({
+			items: [{}, {}],
+			totalBytes: 5 * 1024 * 1024,
+			maxImages: 128,
+			maxBytes: 512 * 1024 * 1024,
+		}).label,
+		"2/128 images · 5.0 MB of 512 MB",
 	);
 });
 


### PR DESCRIPTION
## Summary

- retain sanitized provider-ready images in an in-memory **Sent this session** history after matching user messages start
- let the browser preview, restage, delete, and clear history without automatically attaching old images to later prompts
- bound combined draft/history accounting with configurable 128-image / 512 MiB defaults and FIFO eviction of the oldest history
- clear all retained bytes on reload, session replacement/fork, and shutdown
- incorporate the click-to-close preview behavior from #256 with a stage-sized dismiss control that fixes `discussion_r3608498431` for tall images

## Verification

- `npm run check` — 686 tests passed
- focused pi-image-drop suite — 75 tests passed
- `npm --workspace @narumitw/pi-image-drop run check`
- `just pack image-drop` — 15 expected package files
- headless Chrome DevTools smoke — tall preview constrained and click-close works; history rendered, survived refresh, restaged, and showed terminal session invalidation
- persistence API source search — no image cache, temporary image file, or browser storage added