### PR TITLE
feat(image-drop): improve browser interface hierarchy

### DIFF
--- a/docs/plans/archived/2026-07-18_image-drop-interface-hierarchy-plan.md
+++ b/docs/plans/archived/2026-07-18_image-drop-interface-hierarchy-plan.md
@@ -1,0 +1,49 @@
+## Goal
+
+Make the Image Drop browser page explain the Pi handoff clearly, prioritize the next-message draft over session history, and use space and destructive-action emphasis more effectively without changing upload, staging, history, security, or retention behavior. Success means a user can identify what to do now, what will happen next, and which images were already sent across empty, processing, ready, queued, error, and history states.
+
+## Context
+
+- The page is a framework-free local web UI implemented in `extensions/pi-image-drop/src/web/index.html`, `app.js`, `state.js`, and `styles.css`.
+- Pi remains the canonical place for composing and sending messages; Image Drop intentionally has no prompt field or send/attach action.
+- The current screenshot and source show an oversized 260 px drop zone, a visually detached generic **Details** disclosure, always-visible disabled clear actions in empty states, prominent red destructive controls, dense retention copy, and no direct next-step instruction beside the staged-image status.
+- Existing keyboard reordering, drag-and-drop, paste-anywhere, previews, upload/error states, history re-staging, confirmations, dark mode, reduced motion, and session-disconnection behavior must remain available.
+
+## Non-Goals
+
+- Do not add a prompt editor, send button, automatic browser-to-Pi navigation, persistent browser storage, localization system, new settings, or server/API behavior.
+- Do not change image processing, batch limits, history eviction, authentication, active-tab leases, or Pi lifecycle semantics.
+- Do not remove detailed conversion, metadata-removal, resize, error, or retention information when it is relevant.
+
+## Assumptions
+
+- The primary user is already running an interactive Pi session and opened this page from Pi's one-time link.
+- Current desktop browsers and the existing 280 px minimum viewport remain the supported browser baseline.
+- Because the page cannot reliably focus or navigate back to the originating terminal, the handoff should be instructional text rather than a speculative **Return to Pi** control.
+
+## Plan
+
+- [x] Add focused web contract/helper tests before changing the UI: assertions now cover concise empty/history summaries, every draft-guidance branch, **Session details**, hierarchy labels, hidden empty clear actions, and secondary destructive card actions. Red evidence: direct `web-state.test.ts` run failed on the old history label/missing `draftGuidance`; direct server execution cannot resolve NodeNext `.js` imports without the root compile harness and will be verified through `npm test`.
+- [x] Restructure `src/web/index.html` so the reading order is purpose and session context → compact image picker → **Ready for next message** draft status and guidance → **Previously sent** history → concise privacy note. **Session details**, headings, live regions, controls, and dialogs were verified by source review, browser accessibility inspection, and the passing server asset-contract test.
+- [x] Extend `src/web/state.js` with deterministic presentation helpers for draft guidance and concise history summaries. `draftGuidance` now covers empty, editing, blocked/error, ready, reserved, and closed phases; `summarizeHistory` separates concise status from retention usage. All branches pass in `test/web-state.test.ts`.
+- [x] Update `src/web/app.js` to render guidance/retention detail, hide empty clear controls, and use secondary destructive card actions. Browser smoke evidence covered empty, ready, processing-error/retry visibility, sent history, keyboard re-stage/reorder, preview, both clear confirmations, stale-tab, and session-ended states; all server/helper tests pass.
+- [x] Revise `src/web/styles.css` with a 160 px horizontal desktop picker, stacked mobile picker, stronger draft guidance, separated lower-emphasis history, and transparent secondary destructive actions. CDP viewport checks at 320, 620, 1120, and 2000 px found no horizontal overflow and minimum 44 px targets; screenshots verified responsive, dark, and reduced-motion presentations.
+- [x] Tighten user-facing copy in `index.html` and generated status text while preserving provider-transfer, local-history, retention, and session-end meaning. Capacity/eviction is secondary, the Pi handoff is explicit, and `README.md` now uses the visible **Previously sent** label.
+- [x] Run accessibility and interaction checks in Chrome using a local compiled server harness: simulated file-input selection, paste, drag/drop and active feedback; trusted keyboard focus/Space activation and reorder; preview click and Escape dismissal; processing-error/retry visibility; history re-stage/delete availability; cancel/confirm paths for both clear dialogs; stale-tab/session-ended overlays; 320 px reflow (also representing a 200% zoom CSS viewport); and held CDP dark/reduced-motion media emulation. Focus outlines and 44 px targets were measured in rendered styles.
+- [x] Run package and repository verification: the workspace check passed, `npm test` passed 688 tests, and the final `npm run check` passed Biome, boundary checks, all workspace typechecks, and 688 tests. `git diff --check` passed and diff inspection showed only Image Drop UI/tests/README plus this plan.
+
+## Risks
+
+- Shortening retention and privacy copy could conceal consequential lifecycle behavior; preserve the full meaning in nearby secondary text or **Session details**.
+- Hiding disabled destructive controls can cause layout movement when images appear; reserve a stable toolbar alignment where necessary and test the transition rather than optimizing only static screenshots.
+- Making history too quiet could make **Add again** hard to discover; keep the history heading, count, cards, and contextual action visible whenever history exists.
+- Global paste/drop listeners may surprise users if future editable fields are added; this plan adds no editable field, but browser tests should confirm current keyboard and file-input behavior remains unchanged.
+
+## Completion Checklist
+
+- [x] The empty page presents one dominant compact image-selection task with hidden empty clear controls, verified by `/tmp/image-drop-empty-desktop.png`, the 320/620 px browser layouts, and rendered focus/target inspection.
+- [x] Every draft lifecycle state communicates current status and the next valid action without relying on color, verified by exhaustive `web-state.test.ts` assertions plus `/tmp/image-drop-ready-desktop.png` and `/tmp/image-drop-error.png` browser evidence.
+- [x] Previously sent images remain previewable, keyboard re-stageable, individually deletable, and confirmed-clearable while visually secondary to the draft, verified by browser interaction, `/tmp/image-drop-history-desktop.png`, and passing server/history tests.
+- [x] Working-directory, privacy, provider-transfer, retention-limit, automatic-eviction, and session-end information remains discoverable and accurate, verified against `index.html`, rendered browser text, session overlays, and `README.md`.
+- [x] Keyboard operation, visible focus, dialogs, live status/error announcements, dark mode, reduced motion, 200%-equivalent reflow, and 320–2000 px layouts were browser-verified with no lost control or horizontal overflow; evidence includes `/tmp/image-drop-history-320.png`, `-620.png`, `-2000.png`, and `/tmp/image-drop-dark-reduced.png`.
+- [x] The complete change passes `npm --workspace @narumitw/pi-image-drop run check`, `npm test` (688/688), and final `npm run check` (Biome, boundaries, all typechecks, 688/688 tests); final output is recorded in `/tmp/image-drop-final-check.log`.

--- a/extensions/pi-image-drop/README.md
+++ b/extensions/pi-image-drop/README.md
@@ -29,7 +29,7 @@ This package targets the latest Pi release and uses its `agent_settled` lifecycl
 3. Open the link. Paste images anywhere, drop files, or select **Choose images**.
 4. Review previews and processing details. Drag to reorder, use the keyboard-accessible arrow buttons, retry failures, delete individual items, or use confirmed **Clear all**.
 5. Write and submit a non-empty message in Pi. The ready images are appended after any attachments already on that message, in browser order.
-6. After Pi records that user message, the sent images move to **Sent this session**. They are not attached to later prompts unless you explicitly choose **Add again**. You can preview, re-add, delete, or clear retained images from the browser page.
+6. After Pi records that user message, the sent images move to **Previously sent**. They are not attached to later prompts unless you explicitly choose **Add again**. You can preview, re-add, delete, or clear retained images from the browser page.
 
 The `🖼️` widget above Pi's editor reports ready, uploading, error, and queued counts. Uploading or failed items block the whole batch and preserve the Pi editor text. Image-only messages are not supported.
 

--- a/extensions/pi-image-drop/src/web/app.js
+++ b/extensions/pi-image-drop/src/web/app.js
@@ -1,6 +1,7 @@
 import {
 	attemptMutation,
 	canMutate,
+	draftGuidance,
 	formatBytes,
 	moveItem,
 	moveItemBefore,
@@ -17,10 +18,12 @@ const ui = {
 	choose: $("#choose-files"),
 	input: $("#file-input"),
 	status: $("#status"),
+	nextStep: $("#next-step"),
 	clear: $("#clear-all"),
 	error: $("#error-banner"),
 	grid: $("#grid"),
 	historyStatus: $("#history-status"),
+	historyRetention: $("#history-retention"),
 	historyClear: $("#clear-history"),
 	historyGrid: $("#history-grid"),
 	overlay: $("#connection-overlay"),
@@ -289,7 +292,9 @@ function render() {
 	ui.cwd.textContent = state.cwd;
 	const summary = summarizeBatch(state.batch);
 	ui.status.textContent = `${summary.label} · ${formatBytes(summary.bytes)}`;
+	ui.nextStep.textContent = draftGuidance(state.batch);
 	const mutable = canMutate(state.batch);
+	ui.clear.hidden = summary.total === 0;
 	ui.clear.disabled = !mutable || summary.total === 0;
 	ui.choose.disabled = !mutable;
 	ui.input.disabled = !mutable;
@@ -298,6 +303,8 @@ function render() {
 	ui.grid.replaceChildren(...state.batch.items.map((item, index) => card(item, index, mutable)));
 	const history = summarizeHistory(state.history);
 	ui.historyStatus.textContent = history.label;
+	ui.historyRetention.textContent = history.usage;
+	ui.historyClear.hidden = history.total === 0;
 	ui.historyClear.disabled = history.total === 0;
 	ui.historyGrid.replaceChildren(
 		...(state.history?.items ?? []).map((item, index) => historyCard(item, index, mutable)),
@@ -371,7 +378,9 @@ function card(item, index, mutable) {
 	);
 	if (item.status === "error")
 		actions.append(button("Retry", "Retry", !mutable, () => retry(item.id)));
-	actions.append(button("Delete", "Delete", !mutable, () => remove(item.id), "delete"));
+	actions.append(
+		button("Delete", "Delete", !mutable, () => remove(item.id), "danger-secondary"),
+	);
 	article.append(actions);
 	return article;
 }
@@ -411,7 +420,7 @@ function historyCard(item, index, mutable) {
 			"Delete",
 			false,
 			() => deleteHistory(item.id),
-			"delete",
+			"danger-secondary",
 		),
 	);
 	article.append(actions);

--- a/extensions/pi-image-drop/src/web/index.html
+++ b/extensions/pi-image-drop/src/web/index.html
@@ -14,8 +14,8 @@
 				<h1>Image Drop</h1>
 				<p id="session-label" class="session-label">Connecting to Pi…</p>
 			</div>
-			<details>
-				<summary>Details</summary>
+			<details class="session-details">
+				<summary>Session details</summary>
 				<dl>
 					<dt>Working directory</dt>
 					<dd id="cwd">—</dd>
@@ -27,20 +27,23 @@
 			<section id="drop-zone" class="drop-zone" aria-labelledby="drop-title">
 				<div class="drop-copy">
 					<span class="drop-icon" aria-hidden="true">🖼️</span>
-					<h2 id="drop-title">Paste or drop images anywhere</h2>
-					<p>Use Ctrl+V or Command+V, drag files here, or choose files.</p>
+					<div>
+						<h2 id="drop-title">Add images</h2>
+						<p>Paste anywhere, drop files here, or choose images.</p>
+					</div>
 					<button id="choose-files" class="primary" type="button">Choose images</button>
 					<input id="file-input" type="file" multiple accept="image/png,image/jpeg,image/webp,image/gif,image/bmp,image/tiff,image/heic,image/heif,image/avif,.bmp,.tif,.tiff,.heic,.heif,.avif" hidden />
 				</div>
 			</section>
 
-			<section class="batch" aria-labelledby="batch-title">
+			<section class="batch draft" aria-labelledby="batch-title">
 				<div class="batch-toolbar">
 					<div>
-						<h2 id="batch-title">Next Pi message</h2>
-						<p id="status" role="status" aria-live="polite">No images staged</p>
+						<h2 id="batch-title">Ready for next message</h2>
+						<p id="status">No images staged</p>
+						<p id="next-step" class="next-step" role="status" aria-live="polite">Choose images to add them to your next Pi message.</p>
 					</div>
-					<button id="clear-all" class="danger-secondary" type="button" disabled>Clear all</button>
+					<button id="clear-all" class="danger-secondary" type="button" hidden disabled>Clear all</button>
 				</div>
 				<div id="error-banner" class="banner error" role="alert" hidden></div>
 				<div id="grid" class="image-grid" aria-live="polite"></div>
@@ -49,17 +52,17 @@
 			<section class="history" aria-labelledby="history-title">
 				<div class="batch-toolbar">
 					<div>
-						<h2 id="history-title">Sent this session</h2>
-						<p id="history-status" role="status" aria-live="polite">No images sent this session</p>
+						<h2 id="history-title">Previously sent</h2>
+						<p id="history-status" role="status" aria-live="polite">No images sent yet</p>
 					</div>
-					<button id="clear-history" class="danger-secondary" type="button" disabled>Clear history</button>
+					<button id="clear-history" class="danger-secondary" type="button" hidden disabled>Clear history</button>
 				</div>
-				<p class="history-note">Sent images are not attached again unless you choose <strong>Add again</strong>. The oldest history is removed automatically at the configured memory limit, and all history is cleared when this Pi session ends.</p>
+				<p class="history-note"><span id="history-retention">0 images retained</span>. Images here are not attached again unless you choose <strong>Add again</strong>. The oldest are removed at the configured memory limit, and all are cleared when this Pi session ends.</p>
 				<div id="history-grid" class="image-grid" aria-live="polite"></div>
 			</section>
 
 			<p class="privacy">
-				Draft and sent-history images stay only in this Pi process. Sending a Pi message also sends its staged images to your configured model provider; local sent history remains until deleted, automatically evicted at the limit, or the Pi session ends.
+				Draft and previously sent images stay in this Pi process until removed, evicted at the retention limit, or the session ends. Sending a Pi message sends its staged images to your configured model provider; deleting local history does not retract images already sent.
 			</p>
 		</main>
 

--- a/extensions/pi-image-drop/src/web/state.js
+++ b/extensions/pi-image-drop/src/web/state.js
@@ -18,14 +18,30 @@ export function summarizeHistory(history) {
 	const bytes = Number(history?.totalBytes ?? 0);
 	const maxImages = Number(history?.maxImages ?? 0);
 	const maxBytes = Number(history?.maxBytes ?? 0);
-	const usage = `${total}/${maxImages} images · ${formatBytes(bytes)} of ${formatBytes(maxBytes)}`;
 	return {
 		total,
 		bytes,
 		maxImages,
 		maxBytes,
-		label: total === 0 ? `No images sent this session · ${usage}` : usage,
+		label: total === 0 ? "No images sent yet" : `${total} ${plural(total, "image")} · ${formatBytes(bytes)}`,
+		usage: `${total}/${maxImages} images · ${formatBytes(bytes)} of ${formatBytes(maxBytes)}`,
 	};
+}
+
+export function draftGuidance(batch) {
+	const summary = summarizeBatch(batch);
+	if (batch.phase === "closed") return "This Pi session is no longer accepting images.";
+	if (batch.phase === "reserved") {
+		return "Queued with Pi. These images will be attached when Pi sends this message.";
+	}
+	if (summary.total === 0) return "Choose images to add them to your next Pi message.";
+	if (summary.error > 0) {
+		return `Fix or delete ${summary.error} ${plural(summary.error, "image")} that ${summary.error === 1 ? "needs" : "need"} attention before sending from Pi.`;
+	}
+	if (summary.uploading > 0) {
+		return `Wait for ${summary.uploading} ${plural(summary.uploading, "image")} to finish processing before sending from Pi.`;
+	}
+	return `Return to Pi and send a non-empty message. ${summary.ready} ready ${plural(summary.ready, "image")} will be attached automatically.`;
 }
 
 export function statusLabel(phase, counts, total) {

--- a/extensions/pi-image-drop/src/web/styles.css
+++ b/extensions/pi-image-drop/src/web/styles.css
@@ -61,14 +61,17 @@ button.primary {
 button.primary:hover:not(:disabled) {
 	background: var(--accent-strong);
 }
-button.danger,
-button.delete {
+button.danger {
 	border-color: var(--danger);
 	color: white;
 	background: var(--danger);
 }
 button.danger-secondary {
+	border-color: transparent;
+	background: transparent;
 	color: var(--danger);
+}
+button.danger-secondary:hover:not(:disabled) {
 	border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
 }
 
@@ -104,6 +107,9 @@ h1 {
 details {
 	max-width: min(28rem, 100%);
 }
+.session-details {
+	align-self: center;
+}
 summary {
 	min-height: 44px;
 	padding: 0.6rem;
@@ -129,14 +135,13 @@ main {
 }
 .drop-zone {
 	display: grid;
-	min-height: 260px;
+	min-height: 160px;
 	place-items: center;
 	border: 2px dashed #9da7ba;
 	border-radius: 18px;
-	padding: 2rem;
+	padding: 1.5rem 2rem;
 	background: var(--surface);
 	box-shadow: var(--shadow);
-	text-align: center;
 	transition:
 		border-color 0.15s,
 		background 0.15s,
@@ -151,22 +156,33 @@ main {
 	opacity: 0.66;
 }
 .drop-copy {
-	max-width: 36rem;
+	display: grid;
+	width: min(48rem, 100%);
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 1rem;
 }
 .drop-copy h2 {
-	margin: 0.4rem 0;
+	margin: 0;
 }
 .drop-copy p {
-	margin: 0.25rem 0 1.25rem;
+	margin: 0.15rem 0 0;
 	color: var(--muted);
 }
 .drop-icon {
-	font-size: 2.6rem;
+	font-size: 2.2rem;
 }
 
-.batch,
+.batch {
+	margin-top: 1.25rem;
+}
 .history {
-	margin-top: 1.5rem;
+	margin-top: 2rem;
+	border-top: 1px solid var(--line);
+	padding-top: 1.5rem;
+}
+.history h2 {
+	font-size: 1.25rem;
 }
 .batch-toolbar {
 	display: flex;
@@ -182,10 +198,20 @@ main {
 .batch-toolbar p {
 	color: var(--muted);
 }
+.batch-toolbar .next-step {
+	max-width: 48rem;
+	margin-top: 0.2rem;
+	color: var(--text);
+	font-weight: 600;
+}
 .history-note {
+	max-width: 58rem;
 	margin: 0 0 0.8rem;
 	color: var(--muted);
 	font-size: 0.9rem;
+}
+.history .image-card {
+	box-shadow: none;
 }
 .banner {
 	margin: 0.75rem 0;
@@ -444,6 +470,12 @@ dialog::backdrop {
 	.drop-zone {
 		min-height: 210px;
 		padding: 1rem;
+		text-align: center;
+	}
+	.drop-copy {
+		grid-template-columns: 1fr;
+		justify-items: center;
+		gap: 0.65rem;
 	}
 	.batch-toolbar {
 		align-items: start;

--- a/extensions/pi-image-drop/test/server.test.ts
+++ b/extensions/pi-image-drop/test/server.test.ts
@@ -126,9 +126,15 @@ test("bootstrap tokens rotate, replay fails, and clean pages require the session
 		const html = await page.text();
 		const app = await (await api(server, "/app.js", { cookie })).text();
 		const styles = await (await api(server, "/styles.css", { cookie })).text();
+		assert.match(html, /<summary>Session details<\/summary>/);
+		assert.match(html, /<h2 id="batch-title">Ready for next message<\/h2>/);
+		assert.match(html, /id="next-step"[^>]*role="status"/);
+		assert.match(html, /id="clear-all"[^>]*hidden/);
 		assert.match(html, /<section class="history" aria-labelledby="history-title">/);
+		assert.match(html, /<h2 id="history-title">Previously sent<\/h2>/);
+		assert.match(html, /id="history-retention"/);
 		assert.match(html, /id="history-grid"/);
-		assert.match(html, /id="clear-history"/);
+		assert.match(html, /id="clear-history"[^>]*hidden/);
 		assert.match(html, /<dialog id="clear-history-dialog"/);
 		assert.match(html, /<dialog id="image-preview-dialog"/);
 		assert.doesNotMatch(html, /id="image-preview-close"/);
@@ -139,6 +145,11 @@ test("bootstrap tokens rotate, replay fails, and clean pages require the session
 		assert.match(app, /event\.target === ui\.previewDialog\) closePreview\(\)/);
 		assert.match(app, /showModal\(\)/);
 		assert.match(app, /Enlarge preview of/);
+		assert.match(app, /draftGuidance/);
+		assert.match(
+			app,
+			/button\("Delete", "Delete", !mutable, \(\) => remove\(item\.id\), "danger-secondary"\)/,
+		);
 		assert.match(styles, /\.history/);
 		assert.match(styles, /\.image-preview-dialog/);
 		assert.match(styles, /\.image-preview-dismiss\s*{[^}]*width: 100%[^}]*height: 100%/s);

--- a/extensions/pi-image-drop/test/web-state.test.ts
+++ b/extensions/pi-image-drop/test/web-state.test.ts
@@ -12,11 +12,13 @@ type StateHelpers = {
 	};
 	summarizeHistory(history: unknown): {
 		label: string;
+		usage: string;
 		total: number;
 		bytes: number;
 		maxImages: number;
 		maxBytes: number;
 	};
+	draftGuidance(batch: unknown): string;
 	moveItem(ids: string[], id: string, direction: number): string[];
 	moveItemBefore(ids: string[], id: string, target: string): string[];
 	canMutate(batch: { phase: string }): boolean;
@@ -58,7 +60,7 @@ test("web state helpers summarize every visible batch state without color-only m
 	);
 });
 
-test("web history helpers report session retention and memory limits", () => {
+test("web history helpers separate concise status from secondary retention limits", () => {
 	assert.deepEqual(
 		helpers.summarizeHistory({
 			items: [],
@@ -71,17 +73,61 @@ test("web history helpers report session retention and memory limits", () => {
 			bytes: 0,
 			maxImages: 128,
 			maxBytes: 512 * 1024 * 1024,
-			label: "No images sent this session · 0/128 images · 0 B of 512 MB",
+			label: "No images sent yet",
+			usage: "0/128 images · 0 B of 512 MB",
 		},
 	);
-	assert.equal(
+	assert.deepEqual(
 		helpers.summarizeHistory({
 			items: [{}, {}],
 			totalBytes: 5 * 1024 * 1024,
 			maxImages: 128,
 			maxBytes: 512 * 1024 * 1024,
-		}).label,
-		"2/128 images · 5.0 MB of 512 MB",
+		}),
+		{
+			total: 2,
+			bytes: 5 * 1024 * 1024,
+			maxImages: 128,
+			maxBytes: 512 * 1024 * 1024,
+			label: "2 images · 5.0 MB",
+			usage: "2/128 images · 5.0 MB of 512 MB",
+		},
+	);
+});
+
+test("draft guidance names the next valid action for every lifecycle state", () => {
+	assert.equal(
+		helpers.draftGuidance({ phase: "empty", items: [] }),
+		"Choose images to add them to your next Pi message.",
+	);
+	assert.equal(
+		helpers.draftGuidance({
+			phase: "editing",
+			items: [{ status: "processing" }, { status: "processing" }],
+		}),
+		"Wait for 2 images to finish processing before sending from Pi.",
+	);
+	assert.equal(
+		helpers.draftGuidance({
+			phase: "blocked",
+			items: [{ status: "ready" }, { status: "error" }],
+		}),
+		"Fix or delete 1 image that needs attention before sending from Pi.",
+	);
+	assert.equal(
+		helpers.draftGuidance({ phase: "ready", items: [{ status: "ready" }] }),
+		"Return to Pi and send a non-empty message. 1 ready image will be attached automatically.",
+	);
+	assert.equal(
+		helpers.draftGuidance({
+			phase: "reserved",
+			items: [{ status: "ready" }, { status: "ready" }],
+		}),
+		"Queued with Pi. These images will be attached when Pi sends this message.",
+	);
+	assert.equal(
+		helpers.draftGuidance({ phase: "closed", items: [{ status: "ready" }] }),
+		"This Pi session is no longer accepting images.",
 	);
 });
 


### PR DESCRIPTION
## Summary

- make the Pi handoff and next-message state explicit across empty, processing, ready, queued, and error states
- compact the image picker and subordinate retained history and destructive actions
- preserve responsive, keyboard, dark-mode, reduced-motion, privacy, and retention behavior
- add web helper and asset-contract coverage and archive the completed implementation plan

## Verification

- `npm --workspace @narumitw/pi-image-drop run check`
- `npm test` (688 tests)
- `npm run check`
- Chrome smoke checks at 320, 620, 1120, and 2000 px, including keyboard interactions, dialogs, ready/error/history states, dark mode, and reduced motion