### PR TITLE
feat(image-drop): refine browser UI hierarchy

### DIFF
--- a/docs/plans/archived/2026-07-18_image-drop-ui-refinement-plan.md
+++ b/docs/plans/archived/2026-07-18_image-drop-ui-refinement-plan.md
@@ -1,0 +1,45 @@
+## Goal
+
+Refine the Image Drop browser page so desktop space is used coherently, empty-state copy is easier to scan, history controls stay near their context, and repeated per-image metadata notices do not dominate the cards. Success means the page remains clear across empty, staged, processing, error, queued, and retained-history states without changing image staging, Pi handoff, retention, or deletion semantics.
+
+## Context
+
+- The framework-free UI lives in `extensions/pi-image-drop/src/web/index.html`, `app.js`, `state.js`, and `styles.css`.
+- The current page already has a 1120 px outer width, responsive layouts, 44 px controls, keyboard operation, previews, confirmation dialogs, dark mode, and reduced-motion support.
+- The screenshot shows three remaining hierarchy issues: the full-width history toolbar separates **Clear history** from its heading, `auto-fill` leaves an empty grid track when only a few history cards exist, and the empty draft uses three adjacent lines to communicate one state.
+- `Sensitive image metadata removed` is generated for every successfully processed image, while conversion and resize notes are item-specific and must remain attached to their cards.
+
+## Non-Goals
+
+- Do not add history folding, timestamps, overflow menus, undo behavior, localization, dependencies, or new server/API data.
+- Do not change upload, paste, drag-and-drop, reordering, preview, re-staging, deletion confirmation, retention, security, or Pi lifecycle behavior.
+- Do not hide conversion, resize, processing, or error details that vary by image.
+
+## Assumptions
+
+- The shared metadata-removal guarantee can be stated once near the image collections while item-specific notes remain on each card.
+- Three history cards should expand into three balanced columns on a wide viewport rather than reserve a blank fourth track; very wide individual cards should remain bounded through the page width and responsive breakpoints.
+
+## Plan
+
+- [x] Add focused presentation tests before changing the UI: `node --test extensions/pi-image-drop/test/web-state.test.ts extensions/pi-image-drop/test/web-ui-contract.test.ts` failed five new assertions before implementation and passes afterward.
+- [x] Consolidate the empty draft presentation in `src/web/state.js` and `src/web/app.js` so status and next-step text answer distinct questions without repeating that no images are staged; all six lifecycle branches pass in `test/web-state.test.ts` and browser rendering.
+- [x] Update `src/web/index.html` and `src/web/app.js` to present the metadata-removal guarantee once at collection level and suppress only that exact shared note from individual cards, while retaining conversion, resize, processing, and error information per image; helper/DOM tests and mixed-note browser rendering pass for draft and history.
+- [x] Adjust `src/web/styles.css` so the history toolbar action stays visually associated with the history heading and low-count grids use available width without an empty `auto-fill` track; browser metrics for 0/1/3/8 cards at 320, 620, 1120, and 2000 px show balanced tracks, a 360 px lone-card cap, and zero horizontal overflow.
+- [x] Recheck action hierarchy without changing behavior: browser smoke verification confirms **Choose images** remains the sole primary action, **Add again** stays visible, destructive actions remain secondary, clear confirmations open/cancel, focus order is unchanged, and visible controls are at least 45 px high.
+- [x] README update is not applicable because visible labels and instructions did not change. `npm --workspace @narumitw/pi-image-drop run check`, `npm test` (693 passing), `npm run check` (693 passing), and `git diff --check` pass; final scope is Image Drop web UI/tests and this plan.
+
+## Risks
+
+- Suppressing a repeated note too broadly could hide resize or conversion evidence; match only the exact shared metadata-removal note and test mixed-note cards.
+- `auto-fit` can make a single card excessively wide; verify low-count states and add a bounded grid/card rule if the rendered result weakens preview readability.
+- Shortening the empty state can remove useful next-step guidance; preserve explicit direction to choose images and keep ready/blocked/queued guidance unchanged.
+
+## Completion Checklist
+
+- [x] Empty, processing, blocked, ready, queued, and closed draft states remain unambiguous, verified by exhaustive `web-state.test.ts` assertions and rendered browser-state inspection at 320 px.
+- [x] Metadata removal is communicated once without losing item-specific conversion, resize, processing, or error details, verified by mixed-note rendering tests and browser inspection.
+- [x] History heading, count, retention detail, and **Clear history** scan as one group, and 0/1/3/8-card grids have no accidental empty track or horizontal overflow, verified at 320, 620, 1120, and 2000 px.
+- [x] File selection, paste/drop, preview, reorder, re-stage, delete, clear, stale-tab, and session-ended event wiring is unchanged; browser smoke and the full 693-test integration suite verify visible actions, dialogs, lifecycle paths, and at least 44 px targets.
+- [x] Dark mode, reduced motion, and 200%-equivalent narrow reflow preserve content and controls; Chrome media emulation produced dark tokens (`#10131a`/`#edf1f8`), zero-second drop transitions, and zero overflow at 320 px.
+- [x] The bounded change passes `npm --workspace @narumitw/pi-image-drop run check`, `npm test`, `npm run check`, and `git diff --check`, with final diff inspection showing only Image Drop web UI/tests and this plan.

--- a/extensions/pi-image-drop/src/web/app.js
+++ b/extensions/pi-image-drop/src/web/app.js
@@ -1,13 +1,14 @@
 import {
 	attemptMutation,
 	canMutate,
-	draftGuidance,
+	draftPresentation,
 	formatBytes,
 	moveItem,
 	moveItemBefore,
 	preferNewestState,
 	summarizeBatch,
 	summarizeHistory,
+	visibleItemNotes,
 } from "/state.js";
 
 const $ = (selector) => document.querySelector(selector);
@@ -291,8 +292,10 @@ function render() {
 		: state.projectName;
 	ui.cwd.textContent = state.cwd;
 	const summary = summarizeBatch(state.batch);
-	ui.status.textContent = `${summary.label} · ${formatBytes(summary.bytes)}`;
-	ui.nextStep.textContent = draftGuidance(state.batch);
+	const presentation = draftPresentation(state.batch);
+	ui.status.textContent = presentation.status;
+	ui.status.hidden = presentation.status === "";
+	ui.nextStep.textContent = presentation.guidance;
 	const mutable = canMutate(state.batch);
 	ui.clear.hidden = summary.total === 0;
 	ui.clear.disabled = !mutable || summary.total === 0;
@@ -363,7 +366,7 @@ function card(item, index, mutable) {
 				`${item.sourceFormat.toUpperCase()} → ${item.outputFormat.toUpperCase()}`,
 			),
 		);
-	for (const note of item.notes ?? []) body.append(element("p", "note", note));
+	for (const note of visibleItemNotes(item.notes)) body.append(element("p", "note", note));
 	if (item.error) body.append(element("p", "item-error", item.error));
 	article.append(body);
 
@@ -407,7 +410,7 @@ function historyCard(item, index, mutable) {
 	body.append(
 		element("p", "meta", `${index + 1} · ${formatBytes(item.size)} · ${item.width}×${item.height}`),
 	);
-	for (const note of item.notes ?? []) body.append(element("p", "note", note));
+	for (const note of visibleItemNotes(item.notes)) body.append(element("p", "note", note));
 	article.append(body);
 
 	const actions = element("div", "card-actions");

--- a/extensions/pi-image-drop/src/web/index.html
+++ b/extensions/pi-image-drop/src/web/index.html
@@ -36,11 +36,13 @@
 				</div>
 			</section>
 
+			<p class="collection-note">Sensitive image metadata removed from processed images.</p>
+
 			<section class="batch draft" aria-labelledby="batch-title">
 				<div class="batch-toolbar">
 					<div>
 						<h2 id="batch-title">Ready for next message</h2>
-						<p id="status">No images staged</p>
+						<p id="status" hidden></p>
 						<p id="next-step" class="next-step" role="status" aria-live="polite">Choose images to add them to your next Pi message.</p>
 					</div>
 					<button id="clear-all" class="danger-secondary" type="button" hidden disabled>Clear all</button>
@@ -50,14 +52,14 @@
 			</section>
 
 			<section class="history" aria-labelledby="history-title">
-				<div class="batch-toolbar">
-					<div>
+				<header class="history-toolbar">
+					<div class="history-summary">
 						<h2 id="history-title">Previously sent</h2>
 						<p id="history-status" role="status" aria-live="polite">No images sent yet</p>
+						<p class="history-note"><span id="history-retention">0 images retained</span>. Images here are not attached again unless you choose <strong>Add again</strong>. The oldest are removed at the configured memory limit, and all are cleared when this Pi session ends.</p>
 					</div>
 					<button id="clear-history" class="danger-secondary" type="button" hidden disabled>Clear history</button>
-				</div>
-				<p class="history-note"><span id="history-retention">0 images retained</span>. Images here are not attached again unless you choose <strong>Add again</strong>. The oldest are removed at the configured memory limit, and all are cleared when this Pi session ends.</p>
+				</header>
 				<div id="history-grid" class="image-grid" aria-live="polite"></div>
 			</section>
 

--- a/extensions/pi-image-drop/src/web/state.js
+++ b/extensions/pi-image-drop/src/web/state.js
@@ -28,6 +28,16 @@ export function summarizeHistory(history) {
 	};
 }
 
+const SHARED_METADATA_NOTE = "Sensitive image metadata removed";
+
+export function draftPresentation(batch) {
+	const summary = summarizeBatch(batch);
+	return {
+		status: summary.total === 0 ? "" : `${summary.label} · ${formatBytes(summary.bytes)}`,
+		guidance: draftGuidance(batch),
+	};
+}
+
 export function draftGuidance(batch) {
 	const summary = summarizeBatch(batch);
 	if (batch.phase === "closed") return "This Pi session is no longer accepting images.";
@@ -51,6 +61,10 @@ export function statusLabel(phase, counts, total) {
 	if (counts.uploading > 0) parts.push(`${counts.uploading} uploading`);
 	if (counts.error > 0) parts.push(`${counts.error} need attention`);
 	return parts.join(" · ");
+}
+
+export function visibleItemNotes(notes) {
+	return Array.isArray(notes) ? notes.filter((note) => note !== SHARED_METADATA_NOTE) : [];
 }
 
 export function moveItem(ids, id, direction) {

--- a/extensions/pi-image-drop/src/web/styles.css
+++ b/extensions/pi-image-drop/src/web/styles.css
@@ -173,8 +173,13 @@ main {
 	font-size: 2.2rem;
 }
 
+.collection-note {
+	margin: 1rem 0 0;
+	color: var(--muted);
+	font-size: 0.9rem;
+}
 .batch {
-	margin-top: 1.25rem;
+	margin-top: 0.75rem;
 }
 .history {
 	margin-top: 2rem;
@@ -204,10 +209,26 @@ main {
 	color: var(--text);
 	font-weight: 600;
 }
-.history-note {
+.history-toolbar {
+	display: flex;
+	align-items: start;
+	justify-content: flex-start;
+	gap: 1rem;
+	margin-bottom: 0.8rem;
+}
+.history-summary {
+	min-width: 0;
 	max-width: 58rem;
-	margin: 0 0 0.8rem;
+}
+.history-summary h2,
+.history-summary p {
+	margin: 0;
+}
+.history-summary > p {
 	color: var(--muted);
+}
+.history-note {
+	margin-top: 0.35rem;
 	font-size: 0.9rem;
 }
 .history .image-card {
@@ -225,7 +246,7 @@ main {
 }
 .image-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(min(100%, 245px), 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 245px), 1fr));
 	gap: 1rem;
 }
 .image-card {
@@ -237,6 +258,9 @@ main {
 	border-radius: 14px;
 	background: var(--surface);
 	box-shadow: 0 4px 16px rgb(19 33 68 / 7%);
+}
+.image-card:only-child {
+	max-width: 360px;
 }
 .image-card.status-error {
 	border-color: color-mix(in srgb, var(--danger) 55%, var(--line));
@@ -479,6 +503,12 @@ dialog::backdrop {
 	}
 	.batch-toolbar {
 		align-items: start;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.history-toolbar {
+		flex-direction: column;
+		gap: 0.5rem;
 	}
 	.image-grid {
 		grid-template-columns: 1fr;

--- a/extensions/pi-image-drop/test/server.test.ts
+++ b/extensions/pi-image-drop/test/server.test.ts
@@ -145,7 +145,7 @@ test("bootstrap tokens rotate, replay fails, and clean pages require the session
 		assert.match(app, /event\.target === ui\.previewDialog\) closePreview\(\)/);
 		assert.match(app, /showModal\(\)/);
 		assert.match(app, /Enlarge preview of/);
-		assert.match(app, /draftGuidance/);
+		assert.match(app, /draftPresentation/);
 		assert.match(
 			app,
 			/button\("Delete", "Delete", !mutable, \(\) => remove\(item\.id\), "danger-secondary"\)/,

--- a/extensions/pi-image-drop/test/web-state.test.ts
+++ b/extensions/pi-image-drop/test/web-state.test.ts
@@ -19,6 +19,8 @@ type StateHelpers = {
 		maxBytes: number;
 	};
 	draftGuidance(batch: unknown): string;
+	draftPresentation(batch: unknown): { status: string; guidance: string };
+	visibleItemNotes(notes: unknown): string[];
 	moveItem(ids: string[], id: string, direction: number): string[];
 	moveItemBefore(ids: string[], id: string, target: string): string[];
 	canMutate(batch: { phase: string }): boolean;
@@ -95,40 +97,76 @@ test("web history helpers separate concise status from secondary retention limit
 	);
 });
 
-test("draft guidance names the next valid action for every lifecycle state", () => {
-	assert.equal(
-		helpers.draftGuidance({ phase: "empty", items: [] }),
-		"Choose images to add them to your next Pi message.",
+test("draft presentation keeps empty copy concise and separates progress from guidance", () => {
+	const cases = [
+		{
+			batch: { phase: "empty", items: [], totalSourceBytes: 0 },
+			status: "",
+			guidance: "Choose images to add them to your next Pi message.",
+		},
+		{
+			batch: {
+				phase: "editing",
+				items: [{ status: "processing" }, { status: "processing" }],
+				totalSourceBytes: 2048,
+			},
+			status: "0/2 ready · 2 uploading · 2.0 KB",
+			guidance: "Wait for 2 images to finish processing before sending from Pi.",
+		},
+		{
+			batch: {
+				phase: "blocked",
+				items: [{ status: "ready" }, { status: "error" }],
+				totalSourceBytes: 1024,
+			},
+			status: "1/2 ready · 1 need attention · 1.0 KB",
+			guidance: "Fix or delete 1 image that needs attention before sending from Pi.",
+		},
+		{
+			batch: { phase: "ready", items: [{ status: "ready" }], totalSourceBytes: 512 },
+			status: "1/1 ready · 512 B",
+			guidance:
+				"Return to Pi and send a non-empty message. 1 ready image will be attached automatically.",
+		},
+		{
+			batch: {
+				phase: "reserved",
+				items: [{ status: "ready" }, { status: "ready" }],
+				totalSourceBytes: 4096,
+			},
+			status: "2 images queued with Pi · 4.0 KB",
+			guidance: "Queued with Pi. These images will be attached when Pi sends this message.",
+		},
+		{
+			batch: { phase: "closed", items: [{ status: "ready" }], totalSourceBytes: 512 },
+			status: "1/1 ready · 512 B",
+			guidance: "This Pi session is no longer accepting images.",
+		},
+	];
+
+	for (const { batch, status, guidance } of cases) {
+		assert.deepEqual(helpers.draftPresentation(batch), { status, guidance });
+		assert.equal(helpers.draftGuidance(batch), guidance);
+	}
+});
+
+test("only the shared metadata notice is removed from per-image notes", () => {
+	assert.deepEqual(
+		helpers.visibleItemNotes([
+			"Sensitive image metadata removed",
+			"Converted from TIFF to PNG",
+			"Resized from 4000×3000 to 2000×1500",
+		]),
+		["Converted from TIFF to PNG", "Resized from 4000×3000 to 2000×1500"],
 	);
-	assert.equal(
-		helpers.draftGuidance({
-			phase: "editing",
-			items: [{ status: "processing" }, { status: "processing" }],
-		}),
-		"Wait for 2 images to finish processing before sending from Pi.",
+	assert.deepEqual(
+		helpers.visibleItemNotes([
+			"sensitive image metadata removed",
+			"Sensitive image metadata removed after conversion",
+		]),
+		["sensitive image metadata removed", "Sensitive image metadata removed after conversion"],
 	);
-	assert.equal(
-		helpers.draftGuidance({
-			phase: "blocked",
-			items: [{ status: "ready" }, { status: "error" }],
-		}),
-		"Fix or delete 1 image that needs attention before sending from Pi.",
-	);
-	assert.equal(
-		helpers.draftGuidance({ phase: "ready", items: [{ status: "ready" }] }),
-		"Return to Pi and send a non-empty message. 1 ready image will be attached automatically.",
-	);
-	assert.equal(
-		helpers.draftGuidance({
-			phase: "reserved",
-			items: [{ status: "ready" }, { status: "ready" }],
-		}),
-		"Queued with Pi. These images will be attached when Pi sends this message.",
-	);
-	assert.equal(
-		helpers.draftGuidance({ phase: "closed", items: [{ status: "ready" }] }),
-		"This Pi session is no longer accepting images.",
-	);
+	assert.deepEqual(helpers.visibleItemNotes(undefined), []);
 });
 
 test("web ordering helpers are immutable and bounded", () => {

--- a/extensions/pi-image-drop/test/web-ui-contract.test.ts
+++ b/extensions/pi-image-drop/test/web-ui-contract.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const webRoot = path.join(process.cwd(), "extensions/pi-image-drop/src/web");
+const [html, app, styles] = await Promise.all(
+	["index.html", "app.js", "styles.css"].map((file) => readFile(path.join(webRoot, file), "utf8")),
+);
+
+test("web page presents one shared metadata-removal guarantee", () => {
+	assert.equal(
+		[html, app].join("\n").match(/Sensitive image metadata removed/g)?.length,
+		1,
+		"the exact shared notice should appear once in page source",
+	);
+	assert.match(html, /class="collection-note"/);
+	assert.equal(
+		app.match(/visibleItemNotes\(item\.notes\)/g)?.length,
+		2,
+		"draft and history cards should use the exact-note filter",
+	);
+});
+
+test("history controls and retention details share one contextual header", () => {
+	assert.match(
+		html,
+		/<header class="history-toolbar">[\s\S]*id="history-title"[\s\S]*id="history-status"[\s\S]*id="history-retention"[\s\S]*id="clear-history"[\s\S]*<\/header>/,
+	);
+	assert.match(styles, /\.history-toolbar\s*\{[\s\S]*justify-content:\s*flex-start/);
+});
+
+test("image grids collapse unused tracks and bound a lone wide card", () => {
+	assert.match(
+		styles,
+		/grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(min\(100%,\s*245px\),\s*1fr\)\)/,
+	);
+	assert.doesNotMatch(styles, /grid-template-columns:\s*repeat\(auto-fill/);
+	assert.match(styles, /\.image-card:only-child\s*\{[\s\S]*max-width:/);
+});
+
+test("visible action labels preserve selection, re-staging, and confirmed destructive paths", () => {
+	for (const label of ["Choose images", "Add again", "Clear all", "Clear history", "Delete"]) {
+		assert.match(`${html}\n${app}`, new RegExp(`>${label}<|["']${label}["']`));
+	}
+	assert.equal((html.match(/<dialog/g) ?? []).length, 3);
+	assert.match(styles, /button\s*\{[\s\S]*min-height:\s*44px/);
+	assert.match(styles, /button:focus-visible/);
+});


### PR DESCRIPTION
## Summary
- simplify empty draft copy and centralize lifecycle presentation
- show the metadata-removal guarantee once while retaining item-specific notes
- keep history controls contextual and use balanced `auto-fit` card grids
- add focused state and static UI contract coverage

## Verification
- `npm --workspace @narumitw/pi-image-drop run check`
- `npm test` (693 passing)
- `npm run check` (693 passing)
- `git diff --check`
- Chrome smoke checks at 320, 620, 1120, and 2000 px, including dark mode and reduced motion
