### PR TITLE
feat(statusline): show provider next to model

### DIFF
--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -4,12 +4,12 @@
 
 `@narumitw/pi-statusline` is a native [Pi coding agent](https://pi.dev) extension that replaces Pi's footer with a beautiful, information-rich terminal statusline.
 
-Use it to monitor model selection, thinking level, git branch, working directory, active tools, context usage, token totals, estimated cost, time, and statuses from other Pi extensions.
+Use it to monitor provider, model selection, thinking level, git branch, working directory, active tools, context usage, token totals, estimated cost, time, and statuses from other Pi extensions.
 
 ## ✨ Features
 
 - Replaces the default Pi footer with a compact preset-based statusline.
-- Shows model, thinking level, git branch/status, project directory, active tool, context usage, tokens, cost, and clock.
+- Shows provider, model, thinking level, git branch/status, project directory, active tool, context usage, tokens, cost, and clock.
 - Displays compact statuses published through Pi's generic extension status API.
 - Owns extension status icons through optional JSON config, including per-extension icon suppression with `""`.
 - Warns when the same extension package is installed from multiple sources.
@@ -88,6 +88,7 @@ During the `PI_CAFFEINATE_ICON` deprecation window, a leading emoji from `pi-caf
 The default `tokyo-night` statusline uses a Starship-inspired `░▒▓` / `` powerline layout and includes:
 
 - `π` brand marker.
+- 🔌 current provider.
 - 🤖 current model.
 - 🧠 thinking level.
 - 📁 current project directory.
@@ -117,7 +118,7 @@ Examples:
 ## 🧠 Use cases
 
 - Track agent context usage during long coding sessions.
-- See which model and thinking level are active.
+- See which provider, model, and thinking level are active.
 - Monitor token totals and estimated cost.
 - Keep git branch and project directory visible.
 - Make Pi terminal sessions easier to scan at a glance.

--- a/extensions/pi-statusline/presets/types.ts
+++ b/extensions/pi-statusline/presets/types.ts
@@ -2,6 +2,7 @@ import type { ThemeColor } from "@earendil-works/pi-coding-agent";
 
 export type SegmentName =
 	| "brand"
+	| "provider"
 	| "model"
 	| "thinking"
 	| "cwd"

--- a/extensions/pi-statusline/src/render.ts
+++ b/extensions/pi-statusline/src/render.ts
@@ -100,6 +100,8 @@ function buildSegment(
 	switch (name) {
 		case "brand":
 			return segment(name, "π", "accent", "header", true);
+		case "provider":
+			return segment(name, `🔌 ${ctx.model?.provider ?? "no-provider"}`, color, "header");
 		case "model":
 			return segment(name, `🤖 ${shortenModel(ctx.model?.id ?? "no-model")}`, color, "header");
 		case "thinking":

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -10,6 +10,7 @@ const LEGACY_SETTINGS_FILE = "pi-statusline-settings.json";
 const DEFAULT_PRESET: StatuslinePresetName = "tokyo-night";
 const DEFAULT_SEGMENTS: SegmentName[] = [
 	"brand",
+	"provider",
 	"model",
 	"thinking",
 	"cwd",

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -121,6 +121,52 @@ test("statusline renders max thinking with the latest theme color", async () => 
 	}
 });
 
+test("statusline renders provider next to the model", async () => {
+	const previousPreset = process.env.PI_STATUSLINE_PRESET;
+	process.env.PI_STATUSLINE_PRESET = "classic";
+	try {
+		const mock = createMockPi();
+		statusline(mock.pi);
+		const context = createMockContext({
+			mode: "tui",
+			model: { id: "claude-sonnet-4", provider: "anthropic" },
+		});
+
+		await emit(mock.events, "session_start", {}, context.ctx);
+		const footerFactory = context.footer as (
+			tui: { requestRender(): void },
+			theme: { fg(color: string, text: string): string; bold(text: string): string },
+			footerData: {
+				getGitBranch(): string | null;
+				getExtensionStatuses(): ReadonlyMap<string, string>;
+				onBranchChange(callback: () => void): () => void;
+			},
+		) => { render(width: number): string[]; dispose(): void };
+		const footer = footerFactory(
+			{ requestRender() {} },
+			{
+				fg(_color, text) {
+					return text;
+				},
+				bold: (text) => text,
+			},
+			{
+				getGitBranch: () => null,
+				getExtensionStatuses: () => new Map(),
+				onBranchChange: () => () => undefined,
+			},
+		);
+
+		const line = footer.render(200)[0] ?? "";
+		assert.match(line, /🔌 anthropic/);
+		assert.match(line, /🤖 sonnet-4/);
+		footer.dispose();
+	} finally {
+		if (previousPreset === undefined) delete process.env.PI_STATUSLINE_PRESET;
+		else process.env.PI_STATUSLINE_PRESET = previousPreset;
+	}
+});
+
 test("statusline skips git status refreshes outside TUI mode", async () => {
 	const mock = createMockPi();
 	let execCalls = 0;


### PR DESCRIPTION
## Summary
- Add a default `provider` statusline segment that renders `🔌 <provider>` from `ctx.model.provider`
- Place the segment next to model in the default segment order and update the statusline docs
- Cover the new segment with a classic-preset render regression test

## Test plan
- [x] `npx biome check extensions/pi-statusline`
- [x] `npm --workspace @narumitw/pi-statusline run typecheck`
- [x] `node --test .../pi-statusline/test/statusline.test.js` (23/23 pass, including `statusline renders provider next to the model`)
- [x] Manually verify in TUI that the statusline shows provider + model for the active selection