### PR TITLE
feat(webui): add session startup settings

### DIFF
--- a/docs/plans/archived/2026-07-19_pi-webui-settings-plan.md
+++ b/docs/plans/archived/2026-07-19_pi-webui-settings-plan.md
@@ -1,0 +1,25 @@
+## Goal
+
+Add convention-compliant global WebUI settings and automatic per-session startup while preserving bare `/webui` behavior.
+
+## Assumptions
+
+- `startOnSessionStart` is the only user-facing setting.
+- Settings are global-only at `<getAgentDir()>/pi-webui.json`.
+- Automatic startup applies to every `session_start`, displays a link, and never opens a browser.
+
+## Plan
+
+- [x] Add and test settings loading, validation, unknown-field preservation, no-overwrite initialization, and atomic persistence; focused settings tests pass.
+- [x] Add and test `/webui settings`, `status`, `help`, and `init`, argument completion, non-TUI behavior, ordered UI saves, and rollback; `npm test` passes all 773 tests.
+- [x] Add and test settings-aware session startup without weakening existing lifecycle guards; lifecycle and full repository tests pass.
+- [x] Add the Pi TUI peer/development dependency and update the root lockfile; package typecheck passes.
+- [x] Document settings, commands, paths, validation, and startup behavior in `extensions/pi-webui/README.md`.
+- [x] Run package, repository, and package-content verification; package check, full check, and pack dry run pass.
+
+## Completion Checklist
+
+- [x] New pi-webui tests prove command, persistence, UI rollback, and lifecycle behavior; `npm run check` passes all 774 tests.
+- [x] Documentation and package metadata match behavior; `npm --workspace @narumitw/pi-webui run check` passes.
+- [x] `npm run check` passes.
+- [x] `npm run pack:webui` reports 16 publishable files including `src/settings.ts` and browser assets, with no tests, caches, tarball, or dependency output.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -44,6 +44,44 @@ The package targets the latest Pi release.
 
 If another installed extension also registers `/webui`, Pi assigns numeric command suffixes according to extension load order. Check Pi's command provenance and invoke the WebUI entry.
 
+## Commands
+
+| Command | Behavior |
+| --- | --- |
+| `/webui` | Start or reuse the current session server and display a fresh one-time link. |
+| `/webui settings` | Open the interactive settings screen in TUI mode. Other modes report the manual settings path when notifications are available. |
+| `/webui status` | Show the effective startup preference and source, settings path, and whether the current session server is running. It never issues a bootstrap link. |
+| `/webui help` | Show command and manual-settings help. |
+| `/webui init` | Create the defaults file without overwriting existing content, then open settings in TUI mode. |
+
+Argument completion is available for all subcommands. Bare `/webui` remains the direct browser-link action.
+
+## Settings
+
+WebUI has one optional, **global-only** JSON settings file:
+
+```text
+<getAgentDir()>/pi-webui.json
+```
+
+The normal default path is `~/.pi/agent/pi-webui.json`. Pi installations that use another agent directory are resolved through Pi's `getAgentDir()` API; WebUI adds no environment variable or project override.
+
+```json
+{
+  "startOnSessionStart": false
+}
+```
+
+| Setting | Default | Behavior |
+| --- | --- | --- |
+| `startOnSessionStart` | `false` | Start WebUI and display a fresh one-time link after every Pi session initialization, including startup, reload, new, resume, and fork. It never opens a browser. |
+
+A missing file uses defaults. The file must contain a top-level JSON object, and `startOnSessionStart` must be a boolean when present. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility.
+
+Settings are reloaded on every `session_start`. Changes made in `/webui settings` are saved atomically and update the in-memory preference immediately, but they intentionally do not start or stop the server in the current session; they take effect at the next session initialization or `/reload`. `/webui init` creates formatted defaults once and refuses to overwrite valid or invalid existing content.
+
+In print, JSON, and RPC modes, `/webui settings` does not open custom TUI or write protocol-breaking output. Use `/webui status`, `/webui help`, or edit the reported path manually.
+
 ## What synchronization means
 
 WebUI mirrors Pi's semantic session events, not terminal pixels. It displays conversation content, streaming assistant state, tool calls/results, errors, and activity using browser-native presentation. It does not reproduce ANSI colors, terminal wrapping, footer/widgets, built-in dialogs, arbitrary custom TUI components, or unsent terminal editor text.
@@ -90,13 +128,14 @@ The page uses semantic headings, native disclosure/dialog controls, concise stat
 ## Package layout
 
 ```text
-src/webui.ts       Pi extension entrypoint
-src/runtime.ts        Pi lifecycle, event projection, and browser message routing
-src/conversation.ts   bounded transcript snapshot and ordered event replay
-src/server.ts         authenticated loopback HTTP/SSE server
-src/images.ts         bounded provider-ready image processing
-src/pi-settings.ts    effective Pi image settings reader
-src/web/              framework-free browser page
+src/webui.ts         Pi extension entrypoint
+src/runtime.ts       Pi lifecycle, commands, event projection, and browser message routing
+src/settings.ts      global WebUI settings validation and atomic persistence
+src/conversation.ts  bounded transcript snapshot and ordered event replay
+src/server.ts        authenticated loopback HTTP/SSE server
+src/images.ts        bounded provider-ready image processing
+src/pi-settings.ts   effective Pi image settings reader
+src/web/             framework-free browser page
 ```
 
 ## Development

--- a/extensions/pi-webui/package.json
+++ b/extensions/pi-webui/package.json
@@ -33,12 +33,14 @@
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
-		"@earendil-works/pi-coding-agent": "*"
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",
 		"@earendil-works/pi-ai": "0.80.10",
 		"@earendil-works/pi-coding-agent": "0.80.10",
+		"@earendil-works/pi-tui": "0.80.10",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/extensions/pi-webui/src/runtime.ts
+++ b/extensions/pi-webui/src/runtime.ts
@@ -1,6 +1,12 @@
 import { basename } from "node:path";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+	getSettingsListTheme,
+} from "@earendil-works/pi-coding-agent";
+import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
 import { ConversationProjection, projectBranchMessages } from "./conversation.js";
 import {
 	type BrowserImageInput,
@@ -14,8 +20,23 @@ import {
 	WebUIServer,
 	type WebUIServerOptions,
 } from "./server.js";
+import {
+	DEFAULT_SETTINGS,
+	initializeSettings,
+	loadSettings,
+	type SettingsLoadResult,
+	saveSettings,
+	type WebUISettings,
+} from "./settings.js";
 
 const WIDGET_KEY = "webui";
+const COMMAND_USAGE = "Usage: /webui [settings|status|help|init]";
+const COMMAND_COMPLETIONS = [
+	{ value: "settings", label: "settings", description: "Open WebUI settings" },
+	{ value: "status", label: "status", description: "Show effective WebUI settings and state" },
+	{ value: "help", label: "help", description: "Show WebUI command help" },
+	{ value: "init", label: "init", description: "Create the default WebUI settings file" },
+];
 
 type ServerControl = Pick<WebUIServer, "issueLink" | "close">;
 type LatestEventHandler = (event: unknown, ctx: ExtensionContext) => void | Promise<void>;
@@ -24,6 +45,9 @@ type LatestExtensionAPI = ExtensionAPI & {
 };
 
 export interface RuntimeDependencies {
+	loadSettings: typeof loadSettings;
+	saveSettings: typeof saveSettings;
+	initializeSettings: typeof initializeSettings;
 	startServer(options: WebUIServerOptions): Promise<ServerControl>;
 	readPiSettings(cwd: string, projectTrusted: boolean): Promise<EffectivePiImageSettings>;
 	processImages(
@@ -33,6 +57,9 @@ export interface RuntimeDependencies {
 }
 
 const DEFAULT_DEPENDENCIES: RuntimeDependencies = {
+	loadSettings,
+	saveSettings,
+	initializeSettings,
 	startServer: (options) => WebUIServer.start(options),
 	readPiSettings: readEffectivePiImageSettings,
 	processImages: processBrowserImages,
@@ -51,6 +78,11 @@ export class WebUIRuntime {
 	private nextLiveMessageId = 0;
 	private readonly activeMessageIds = new Map<string, string>();
 	private readonly finalMessageTimers = new Set<ReturnType<typeof setTimeout>>();
+	private settings: WebUISettings = { ...DEFAULT_SETTINGS };
+	private settingsDocument?: Record<string, unknown> = {};
+	private settingsPath = "pi-webui.json";
+	private settingsSource: SettingsLoadResult["source"] = "defaults";
+	private settingsSaveQueue: Promise<void> = Promise.resolve();
 
 	constructor(
 		private readonly pi: ExtensionAPI,
@@ -61,16 +93,44 @@ export class WebUIRuntime {
 
 	register(): void {
 		this.pi.registerCommand("webui", {
-			description: "Open a lightweight local web companion for this Pi session",
-			handler: async (_args, ctx) => {
+			description: "Open or configure the local web companion for this Pi session",
+			getArgumentCompletions: (prefix) => {
+				const normalized = prefix.trimStart().toLowerCase();
+				if (/\s/.test(normalized)) return null;
+				const matches = COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(normalized));
+				return matches.length > 0 ? matches : null;
+			},
+			handler: async (args, ctx) => {
 				this.context = ctx;
+				const action = args.trim().toLowerCase();
 				try {
-					const server = await this.ensureServer();
-					const link = server.issueLink();
-					ctx.ui.setWidget(WIDGET_KEY, [`🌐 Pi WebUI: ${link}`]);
-					ctx.ui.notify(`Pi WebUI: ${link}`, "info");
+					if (!action) {
+						await this.presentLink(ctx);
+						return;
+					}
+					if (action === "settings") {
+						await this.showSettings(ctx);
+						return;
+					}
+					if (action === "status") {
+						this.showStatus(ctx);
+						return;
+					}
+					if (action === "help") {
+						this.showHelp(ctx);
+						return;
+					}
+					if (action === "init") {
+						await this.initializeSettings(ctx);
+						return;
+					}
+					if (ctx.hasUI) ctx.ui.notify(COMMAND_USAGE, "warning");
 				} catch (error) {
-					ctx.ui.notify(`Pi WebUI could not start: ${formatError(error)}`, "error");
+					if (!action) {
+						ctx.ui.notify(`Pi WebUI could not start: ${formatError(error)}`, "error");
+					} else if (ctx.hasUI) {
+						ctx.ui.notify(`Pi WebUI command failed: ${formatError(error)}`, "error");
+					}
 				}
 			},
 		});
@@ -129,6 +189,9 @@ export class WebUIRuntime {
 		previousConversation?.close();
 		await this.releaseServer();
 		if (generation !== this.generation) return;
+		const settingsResult = await this.dependencies.loadSettings();
+		if (generation !== this.generation) return;
+		this.applySettingsResult(settingsResult);
 		this.sessionAbort = new AbortController();
 		this.context = ctx;
 		this.conversation = new ConversationProjection(
@@ -145,6 +208,14 @@ export class WebUIRuntime {
 		this.closed = false;
 		this.lastSettingsWarning = "";
 		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		if (settingsResult.warning) ctx.ui.notify(settingsResult.warning, "warning");
+		if (!this.settings.startOnSessionStart) return;
+		try {
+			await this.presentLink(ctx);
+		} catch (error) {
+			if (generation !== this.generation || this.closed) return;
+			ctx.ui.notify(`Pi WebUI could not start: ${formatError(error)}`, "error");
+		}
 	}
 
 	async shutdown(ctx: ExtensionContext): Promise<void> {
@@ -219,6 +290,134 @@ export class WebUIRuntime {
 			result,
 			typeof event.isError === "boolean" ? event.isError : undefined,
 		);
+	}
+
+	private async presentLink(ctx: ExtensionContext): Promise<void> {
+		const server = await this.ensureServer();
+		const link = server.issueLink();
+		ctx.ui.setWidget(WIDGET_KEY, [`🌐 Pi WebUI: ${link}`]);
+		ctx.ui.notify(`Pi WebUI: ${link}`, "info");
+	}
+
+	private async showSettings(ctx: ExtensionCommandContext): Promise<void> {
+		if (ctx.mode !== "tui") {
+			if (ctx.hasUI) {
+				ctx.ui.notify(`Edit WebUI settings manually: ${this.settingsPath}`, "info");
+			}
+			return;
+		}
+
+		const items: SettingItem[] = [
+			{
+				id: "startOnSessionStart",
+				label: "Start on session start",
+				description: "Start WebUI and display a link for each newly initialized Pi session",
+				currentValue: String(this.settings.startOnSessionStart),
+				values: ["true", "false"],
+			},
+		];
+
+		await ctx.ui.custom((tui, theme, _keybindings, done) => {
+			const container = new Container();
+			container.addChild(new Text(theme.fg("accent", theme.bold("Pi WebUI Settings")), 1, 1));
+			const list = new SettingsList(
+				items,
+				Math.min(items.length + 2, 15),
+				getSettingsListTheme(),
+				(id, value) => {
+					if (id !== "startOnSessionStart") return;
+					const requested = value === "true";
+					const operation = this.settingsSaveQueue.then(async () => {
+						const previous = this.settings.startOnSessionStart;
+						try {
+							if (!this.settingsDocument) {
+								throw new Error("the invalid settings file must be repaired manually first");
+							}
+							const next = { startOnSessionStart: requested };
+							const document = await this.dependencies.saveSettings(
+								next,
+								this.settingsDocument,
+								this.settingsPath,
+							);
+							this.settings = next;
+							this.settingsDocument = document;
+							this.settingsSource = "settings file";
+						} catch (error) {
+							list.updateValue(id, String(previous));
+							ctx.ui.notify(`WebUI settings save failed: ${formatError(error)}`, "error");
+							tui.requestRender();
+						}
+					});
+					this.settingsSaveQueue = operation.catch(() => undefined);
+				},
+				() => done(undefined),
+				{ enableSearch: true },
+			);
+			container.addChild(list);
+			return {
+				render: (width: number) => container.render(width),
+				invalidate: () => container.invalidate(),
+				handleInput(data: string) {
+					list.handleInput?.(data);
+					tui.requestRender();
+				},
+			};
+		});
+	}
+
+	private showStatus(ctx: ExtensionCommandContext): void {
+		if (!ctx.hasUI) return;
+		const source =
+			this.settingsDocument === undefined ? "defaults (invalid file ignored)" : this.settingsSource;
+		ctx.ui.notify(
+			[
+				"Pi WebUI status",
+				`startOnSessionStart: ${this.settings.startOnSessionStart} (${source})`,
+				`Settings: ${this.settingsPath}`,
+				`Server: ${this.server ? "running" : "stopped"}`,
+			].join("\n"),
+			"info",
+		);
+	}
+
+	private showHelp(ctx: ExtensionCommandContext): void {
+		if (!ctx.hasUI) return;
+		ctx.ui.notify(
+			[
+				COMMAND_USAGE,
+				"/webui: start or reuse the current session server and display a fresh one-time link",
+				"settings: edit WebUI settings in TUI mode",
+				"status: show effective settings, source, path, and current server state",
+				"init: create the defaults file without overwriting existing content",
+				'Accepted JSON: { "startOnSessionStart": false }',
+				`Settings path: ${this.settingsPath}`,
+				"The default is false. Changes apply on the next session initialization or reload.",
+			].join("\n"),
+			"info",
+		);
+	}
+
+	private async initializeSettings(ctx: ExtensionCommandContext): Promise<void> {
+		const result = await this.dependencies.initializeSettings(this.settingsPath);
+		if (ctx.hasUI) {
+			ctx.ui.notify(
+				result === "created"
+					? `Created WebUI settings: ${this.settingsPath}`
+					: `WebUI settings already exists and was not overwritten: ${this.settingsPath}`,
+				"info",
+			);
+		}
+		const loaded = await this.dependencies.loadSettings(this.settingsPath);
+		this.applySettingsResult(loaded);
+		if (loaded.warning && ctx.hasUI) ctx.ui.notify(loaded.warning, "warning");
+		if (ctx.mode === "tui") await this.showSettings(ctx);
+	}
+
+	private applySettingsResult(result: SettingsLoadResult): void {
+		this.settings = { ...result.settings };
+		this.settingsDocument = result.kind === "invalid" ? undefined : { ...(result.document ?? {}) };
+		this.settingsPath = result.path;
+		this.settingsSource = result.source;
 	}
 
 	private async ensureServer(): Promise<ServerControl> {

--- a/extensions/pi-webui/src/settings.ts
+++ b/extensions/pi-webui/src/settings.ts
@@ -1,0 +1,174 @@
+import {
+	link as linkFile,
+	lstat,
+	mkdir,
+	readFile,
+	rename,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const SETTINGS_FILE = "pi-webui.json";
+
+export interface WebUISettings {
+	startOnSessionStart: boolean;
+}
+
+export const DEFAULT_SETTINGS: Readonly<WebUISettings> = Object.freeze({
+	startOnSessionStart: false,
+});
+
+export interface SettingsLoadResult {
+	kind: "missing" | "loaded" | "invalid";
+	path: string;
+	settings: WebUISettings;
+	source: "defaults" | "settings file";
+	document?: Record<string, unknown>;
+	warning?: string;
+}
+
+export interface SettingsFileOperations {
+	write(path: string, data: string): Promise<void>;
+	rename(source: string, destination: string): Promise<void>;
+	link(source: string, destination: string): Promise<void>;
+}
+
+const DEFAULT_FILE_OPERATIONS: SettingsFileOperations = {
+	write: (path, data) =>
+		writeFile(path, data, { encoding: "utf8", flag: "wx", mode: 0o600 }).then(() => undefined),
+	rename,
+	link: linkFile,
+};
+
+export function settingsFilePath(): string {
+	return join(getAgentDir(), SETTINGS_FILE);
+}
+
+export function normalizeSettings(value: unknown): WebUISettings | undefined {
+	if (!isRecord(value)) return undefined;
+	if (
+		Object.hasOwn(value, "startOnSessionStart") &&
+		typeof value.startOnSessionStart !== "boolean"
+	) {
+		return undefined;
+	}
+	return {
+		startOnSessionStart:
+			typeof value.startOnSessionStart === "boolean"
+				? value.startOnSessionStart
+				: DEFAULT_SETTINGS.startOnSessionStart,
+	};
+}
+
+export async function loadSettings(path = settingsFilePath()): Promise<SettingsLoadResult> {
+	let text: string;
+	try {
+		const stats = await lstat(path);
+		if (stats.isSymbolicLink()) return invalid(path, "symbolic links are not accepted");
+		if (!stats.isFile()) return invalid(path, "settings path is not a regular file");
+		text = await readFile(path, "utf8");
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return {
+				kind: "missing",
+				path,
+				settings: { ...DEFAULT_SETTINGS },
+				source: "defaults",
+				document: {},
+			};
+		}
+		return invalid(path, formatError(error));
+	}
+
+	try {
+		const document = JSON.parse(text) as unknown;
+		if (!isRecord(document)) return invalid(path, "the top level must be a JSON object");
+		const settings = normalizeSettings(document);
+		if (!settings) return invalid(path, "startOnSessionStart must be a boolean");
+		return { kind: "loaded", path, settings, source: "settings file", document };
+	} catch (error) {
+		return invalid(path, formatError(error));
+	}
+}
+
+export async function saveSettings(
+	settings: WebUISettings,
+	document: Record<string, unknown>,
+	path = settingsFilePath(),
+	operations: Partial<SettingsFileOperations> = {},
+): Promise<Record<string, unknown>> {
+	const nextDocument = { ...document, startOnSessionStart: settings.startOnSessionStart };
+	const directory = dirname(path);
+	await mkdir(directory, { recursive: true });
+	const temporaryPath = temporaryFilePath(path);
+	try {
+		await (operations.write ?? DEFAULT_FILE_OPERATIONS.write)(
+			temporaryPath,
+			`${JSON.stringify(nextDocument, null, 2)}\n`,
+		);
+		await (operations.rename ?? DEFAULT_FILE_OPERATIONS.rename)(temporaryPath, path);
+		return nextDocument;
+	} catch (error) {
+		await unlink(temporaryPath).catch(() => undefined);
+		throw error;
+	}
+}
+
+export async function initializeSettings(
+	path = settingsFilePath(),
+	operations: Partial<SettingsFileOperations> = {},
+): Promise<"created" | "exists"> {
+	try {
+		await lstat(path);
+		return "exists";
+	} catch (error) {
+		if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+	}
+
+	const directory = dirname(path);
+	await mkdir(directory, { recursive: true });
+	const temporaryPath = temporaryFilePath(path);
+	try {
+		await (operations.write ?? DEFAULT_FILE_OPERATIONS.write)(
+			temporaryPath,
+			`${JSON.stringify(DEFAULT_SETTINGS, null, 2)}\n`,
+		);
+		try {
+			await (operations.link ?? DEFAULT_FILE_OPERATIONS.link)(temporaryPath, path);
+		} catch (error) {
+			if (isNodeError(error) && error.code === "EEXIST") return "exists";
+			throw error;
+		}
+		return "created";
+	} finally {
+		await unlink(temporaryPath).catch(() => undefined);
+	}
+}
+
+function invalid(path: string, reason: string): SettingsLoadResult {
+	return {
+		kind: "invalid",
+		path,
+		settings: { ...DEFAULT_SETTINGS },
+		source: "defaults",
+		warning: `${SETTINGS_FILE} ignored (${path}: ${reason}); using defaults without overwriting it.`,
+	};
+}
+
+function temporaryFilePath(path: string): string {
+	return `${path}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-webui/test/commands.test.ts
+++ b/extensions/pi-webui/test/commands.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import { type RuntimeDependencies, WebUIRuntime } from "../src/runtime.js";
+import { DEFAULT_SETTINGS, type SettingsLoadResult } from "../src/settings.js";
+
+initTheme("dark", false);
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (await predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 1));
+	}
+	throw new Error("condition was not met");
+}
+
+function createRuntime(
+	overrides: Partial<RuntimeDependencies> = {},
+	loaded: SettingsLoadResult = {
+		kind: "missing",
+		path: "/agent/pi-webui.json",
+		settings: { ...DEFAULT_SETTINGS },
+		source: "defaults",
+		document: {},
+	},
+) {
+	const mock = createMockPi();
+	let links = 0;
+	const runtime = new WebUIRuntime(mock.pi, {
+		loadSettings: async () => loaded,
+		saveSettings: async (settings, document) => ({ ...document, ...settings }),
+		initializeSettings: async () => "created",
+		startServer: async () => ({
+			issueLink: () => `http://127.0.0.1:1234/bootstrap?token=${++links}`,
+			close: async () => undefined,
+		}),
+		readPiSettings: async () => ({ autoResize: true, blockImages: false, warnings: [] }),
+		processImages: async () => [],
+		...overrides,
+	});
+	runtime.register();
+	return { mock, runtime };
+}
+
+test("webui command completes and routes settings, status, help, and invalid arguments", async () => {
+	const { mock, runtime } = createRuntime();
+	const context = createMockContext({ hasUI: true, mode: "rpc" });
+	await runtime.start(context.ctx);
+	const command = mock.commands.get("webui");
+	assert.ok(command);
+	const completions = command.getArgumentCompletions?.("") as Array<{ value: string }> | undefined;
+	assert.ok(completions);
+	assert.deepEqual(
+		completions.map((item) => item.value),
+		["settings", "status", "help", "init"],
+	);
+
+	await command.handler("settings", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /manual.*pi-webui\.json/i);
+	await command.handler("status", context.ctx);
+	const status = context.notifications.at(-1)?.message ?? "";
+	assert.match(status, /startOnSessionStart: false.*defaults/is);
+	assert.match(status, /server: stopped/i);
+	assert.doesNotMatch(status, /token=/i);
+	await command.handler("help", context.ctx);
+	const help = context.notifications.at(-1)?.message ?? "";
+	assert.match(help, /\/webui \[settings\|status\|help\|init\]/i);
+	assert.match(help, /"startOnSessionStart": false/);
+	assert.doesNotMatch(help, /token=/i);
+	await command.handler("unknown", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /usage:/i);
+
+	await command.handler("", context.ctx);
+	await command.handler("status", context.ctx);
+	const runningStatus = context.notifications.at(-1)?.message ?? "";
+	assert.match(runningStatus, /server: running/i);
+	assert.doesNotMatch(runningStatus, /token=/i);
+});
+
+test("settings never opens custom TUI in RPC, JSON, or print modes", async () => {
+	const { mock, runtime } = createRuntime();
+	let customCalls = 0;
+	for (const mode of ["rpc", "json", "print"]) {
+		const context = createMockContext({
+			hasUI: mode === "rpc",
+			mode,
+			custom: async () => {
+				customCalls += 1;
+			},
+		});
+		await runtime.start(context.ctx);
+		await mock.commands.get("webui")?.handler("settings", context.ctx);
+	}
+	assert.equal(customCalls, 0);
+});
+
+test("init creates defaults without TUI in non-TUI modes and opens settings in TUI", async () => {
+	let initialized = 0;
+	let customCalls = 0;
+	const { mock, runtime } = createRuntime({
+		initializeSettings: async () => {
+			initialized += 1;
+			return initialized === 1 ? "created" : "exists";
+		},
+	});
+	const rpc = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		custom: async () => {
+			customCalls += 1;
+		},
+	});
+	await runtime.start(rpc.ctx);
+	await mock.commands.get("webui")?.handler("init", rpc.ctx);
+	assert.equal(initialized, 1);
+	assert.equal(customCalls, 0);
+	assert.match(rpc.notifications.at(-1)?.message ?? "", /created.*pi-webui\.json/i);
+
+	const tui = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const selector = createCustomSelectorHarness(factory);
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+	await mock.commands.get("webui")?.handler("init", tui.ctx);
+	assert.equal(initialized, 2);
+	assert.equal(customCalls, 1);
+	assert.match(tui.notifications[0]?.message ?? "", /already exists/i);
+});
+
+test("settings changes save in action order and update effective status", async () => {
+	const first = deferred<void>();
+	const requested: boolean[] = [];
+	const { mock, runtime } = createRuntime({
+		saveSettings: async (settings, document) => {
+			requested.push(settings.startOnSessionStart);
+			if (requested.length === 1) await first.promise;
+			return { ...document, ...settings };
+		},
+	});
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory);
+			selector.handleInput("\r");
+			selector.handleInput("\r");
+			await waitFor(() => requested.length === 1);
+			assert.deepEqual(requested, [true]);
+			first.resolve(undefined);
+			await waitFor(() => requested.length === 2);
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+	await runtime.start(context.ctx);
+	await mock.commands.get("webui")?.handler("settings", context.ctx);
+	assert.deepEqual(
+		requested,
+		[true, false],
+		context.notifications.map((item) => item.message).join("\n"),
+	);
+	await mock.commands.get("webui")?.handler("status", context.ctx);
+	assert.match(
+		context.notifications.at(-1)?.message ?? "",
+		/startOnSessionStart: false.*settings file/is,
+	);
+});
+
+test("failed settings save rolls back the displayed and effective value", async () => {
+	const { mock, runtime } = createRuntime({
+		saveSettings: async () => {
+			throw new Error("disk full");
+		},
+	});
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory);
+			selector.handleInput("\r");
+			await waitFor(() => context.notifications.some((item) => /disk full/i.test(item.message)));
+			assert.ok(selector.render().some((line) => /false/.test(line)));
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+	await runtime.start(context.ctx);
+	await mock.commands.get("webui")?.handler("settings", context.ctx);
+	await mock.commands.get("webui")?.handler("status", context.ctx);
+	assert.match(
+		context.notifications.at(-1)?.message ?? "",
+		/startOnSessionStart: false.*defaults/is,
+	);
+});

--- a/extensions/pi-webui/test/lifecycle.test.ts
+++ b/extensions/pi-webui/test/lifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { type RuntimeDependencies, WebUIRuntime } from "../src/runtime.js";
 import type { WebSendRequest, WebUIServerOptions } from "../src/server.js";
+import { DEFAULT_SETTINGS } from "../src/settings.js";
 
 function nextTask(): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, 0));
@@ -92,6 +93,15 @@ function harness(overrides: Partial<RuntimeDependencies> = {}) {
 		},
 	};
 	const dependencies: RuntimeDependencies = {
+		loadSettings: async () => ({
+			kind: "missing",
+			path: "/agent/pi-webui.json",
+			settings: { ...DEFAULT_SETTINGS },
+			source: "defaults",
+			document: {},
+		}),
+		saveSettings: async (settings, document) => ({ ...document, ...settings }),
+		initializeSettings: async () => "created",
 		startServer: async (options) => {
 			starts += 1;
 			serverOptions = options;
@@ -157,6 +167,57 @@ test("/webui lazily starts one server, rotates links, and projects the existing 
 	assert.equal(h.links, 2);
 	assert.match(String(h.widgets.get("webui")), /127\.0\.0\.1/);
 	assert.equal(h.serverOptions?.conversation.snapshot().messages[0]?.id, "existing");
+});
+
+test("startOnSessionStart starts automatically for every initialized session and reuses the link server", async () => {
+	const h = harness({
+		loadSettings: async () => ({
+			kind: "loaded",
+			path: "/agent/pi-webui.json",
+			settings: { startOnSessionStart: true },
+			source: "settings file",
+			document: { startOnSessionStart: true },
+		}),
+	});
+	for (const reason of ["startup", "reload", "new", "resume", "fork"]) {
+		await h.emit("session_start", { reason });
+		assert.equal(h.starts, h.links);
+	}
+	assert.equal(h.starts, 5);
+	assert.equal(h.closes, 4);
+	await h.commands.get("webui")?.handler("", h.ctx as never);
+	assert.equal(h.starts, 5);
+	assert.equal(h.links, 6);
+});
+
+test("invalid settings warn and automatic startup failures remain non-fatal", async () => {
+	const invalid = harness({
+		loadSettings: async () => ({
+			kind: "invalid",
+			path: "/agent/pi-webui.json",
+			settings: { ...DEFAULT_SETTINGS },
+			source: "defaults",
+			warning: "pi-webui.json ignored; using defaults",
+		}),
+	});
+	await invalid.emit("session_start");
+	assert.equal(invalid.starts, 0);
+	assert.match(invalid.notifications.join("\n"), /ignored/i);
+
+	const failing = harness({
+		loadSettings: async () => ({
+			kind: "loaded",
+			path: "/agent/pi-webui.json",
+			settings: { startOnSessionStart: true },
+			source: "settings file",
+			document: { startOnSessionStart: true },
+		}),
+		startServer: async () => {
+			throw new Error("listener unavailable");
+		},
+	});
+	await failing.emit("session_start");
+	assert.match(failing.notifications.join("\n"), /could not start.*listener unavailable/i);
 });
 
 test("Pi message, tool, and activity events update the browser projection", async () => {

--- a/extensions/pi-webui/test/settings.test.ts
+++ b/extensions/pi-webui/test/settings.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	DEFAULT_SETTINGS,
+	initializeSettings,
+	loadSettings,
+	saveSettings,
+} from "../src/settings.js";
+
+test("settings loading distinguishes missing, valid, malformed, and invalid files", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	try {
+		const missing = await loadSettings(settingsPath);
+		assert.equal(missing.kind, "missing");
+		assert.deepEqual(missing.settings, DEFAULT_SETTINGS);
+		assert.equal(missing.source, "defaults");
+
+		await writeFile(settingsPath, '{"startOnSessionStart":true,"future":"kept"}\n');
+		const loaded = await loadSettings(settingsPath);
+		assert.equal(loaded.kind, "loaded");
+		assert.deepEqual(loaded.settings, { startOnSessionStart: true });
+		assert.deepEqual(loaded.document, { startOnSessionStart: true, future: "kept" });
+		assert.equal(loaded.source, "settings file");
+
+		await writeFile(settingsPath, "{broken\n");
+		const malformed = await loadSettings(settingsPath);
+		assert.equal(malformed.kind, "invalid");
+		assert.deepEqual(malformed.settings, DEFAULT_SETTINGS);
+		assert.match(malformed.warning ?? "", /ignored.*using defaults/i);
+
+		await writeFile(settingsPath, '{"startOnSessionStart":"yes"}\n');
+		const invalid = await loadSettings(settingsPath);
+		assert.equal(invalid.kind, "invalid");
+		assert.deepEqual(invalid.settings, DEFAULT_SETTINGS);
+		assert.match(invalid.warning ?? "", /boolean/i);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("saving is atomic and preserves unknown fields", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	try {
+		await writeFile(settingsPath, '{"future":{"enabled":true},"startOnSessionStart":false}\n');
+		const loaded = await loadSettings(settingsPath);
+		assert.equal(loaded.kind, "loaded");
+		await saveSettings({ startOnSessionStart: true }, loaded.document ?? {}, settingsPath);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			future: { enabled: true },
+			startOnSessionStart: true,
+		});
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("failed atomic publish keeps the previous settings file", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	const original = '{"startOnSessionStart":false,"future":1}\n';
+	try {
+		await writeFile(settingsPath, original);
+		await assert.rejects(
+			() =>
+				saveSettings({ startOnSessionStart: true }, { future: 1 }, settingsPath, {
+					rename: async () => {
+						throw new Error("publish failed");
+					},
+				}),
+			/publish failed/,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), original);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("failed temporary write leaves the previous settings file untouched", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	const original = '{"startOnSessionStart":false}\n';
+	try {
+		await writeFile(settingsPath, original);
+		await assert.rejects(
+			() =>
+				saveSettings({ startOnSessionStart: true }, {}, settingsPath, {
+					write: async () => {
+						throw new Error("write failed");
+					},
+				}),
+			/write failed/,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), original);
+		assert.deepEqual(await import("node:fs/promises").then(({ readdir }) => readdir(directory)), [
+			"pi-webui.json",
+		]);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("init creates formatted defaults once and never overwrites existing content", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	try {
+		assert.equal(await initializeSettings(settingsPath), "created");
+		assert.equal(await readFile(settingsPath, "utf8"), '{\n  "startOnSessionStart": false\n}\n');
+		await writeFile(settingsPath, "{invalid but owned}\n");
+		assert.equal(await initializeSettings(settingsPath), "exists");
+		assert.equal(await readFile(settingsPath, "utf8"), "{invalid but owned}\n");
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("failed init publish leaves no canonical or temporary file", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	try {
+		await assert.rejects(
+			() =>
+				initializeSettings(settingsPath, {
+					link: async () => {
+						throw new Error("publish failed");
+					},
+				}),
+			/publish failed/,
+		);
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+		assert.deepEqual(
+			await import("node:fs/promises").then(({ readdir }) => readdir(directory)),
+			[],
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2783,11 +2783,13 @@
 				"@biomejs/biome": "2.5.3",
 				"@earendil-works/pi-ai": "0.80.10",
 				"@earendil-works/pi-coding-agent": "0.80.10",
+				"@earendil-works/pi-tui": "0.80.10",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-ai": "*",
-				"@earendil-works/pi-coding-agent": "*"
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"extensions/pi-webui/node_modules/@biomejs/biome": {


### PR DESCRIPTION
## Summary
- add global `pi-webui.json` settings with `/webui settings`, `status`, `help`, and `init` commands
- support `startOnSessionStart` while preserving bare `/webui` link behavior and session lifecycle guards
- add atomic persistence, rollback tests, documentation, and Pi TUI package metadata

## Testing
- `npm --workspace @narumitw/pi-webui run check`
- `npm run check` (774 tests)
- `npm run pack:webui`