### PR TITLE
feat(webui): reorder image attachments

### DIFF
--- a/docs/plans/archived/2026-07-19_pi-webui-image-ordering-plan.md
+++ b/docs/plans/archived/2026-07-19_pi-webui-image-ordering-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Let WebUI users deliberately order multiple image attachments before sending, using both pointer drag-and-drop and visible keyboard controls. Success means the provider receives images in exactly the displayed order without changing text, delivery mode, retry identity, or newer draft edits.
+
+## Context
+
+The browser already preserves insertion order, previews each image, and removes individual attachments. Image Drop demonstrates drag ordering plus arrow controls, but WebUI should retain its compact composer rather than adopt a card grid.
+
+## Architecture
+
+The browser draft remains the owner in this phase. Add immutable ordering helpers to `src/web/state.js`; render contextual move controls on each thumbnail; snapshot the current ordered array in `prepareSend()` so pending or failed attempts retain their original order.
+
+## Non-Goals
+
+- Server-owned drafts, upload progress, per-image processing state, or sent-image history.
+- Reordering transcript messages or attachments after Pi accepts a message.
+
+## Plan
+
+- [x] Add failing reducer tests in `extensions/pi-webui/test/web-state.test.ts` for moving before/after, arrow moves, first/last no-ops, unknown IDs, immutability, and send-attempt order snapshots; `npm test` failed before implementation because `moveImage` was absent.
+- [x] Implement bounded immutable ordering helpers in `src/web/state.js` and wire drag and arrow actions in `src/web/app.js`; reducer/contracts verify pending/stale locking and failed retries retain the frozen attempt until ordering changes the draft.
+- [x] Update `src/web/index.html`/`styles.css` so ordering controls are secondary/contextual, have text-equivalent accessible names, retain at least 44 px pointer targets where visible, and do not obscure thumbnails at 320 px or 200% text; Chrome CDP measured 44 px-wide controls and no document overflow.
+- [x] Add DOM/static contracts for drag data, keyboard button labels, focus preservation after a move, stale/read-only behavior, and object-URL cleanup; all 744 tests pass and Chrome preserved focus after arrow ordering.
+- [x] Document that image order is provider order in `extensions/pi-webui/README.md`; reducer/send tests verify the attempt snapshots the displayed array order.
+- [x] Run the WebUI workspace check, root tests/check, `git diff --check`, and `just pack webui`; all 744 tests pass and the 18-file package preview contains the intended WebUI runtime.
+
+## Risks
+
+- Hidden drag-only behavior would be inaccessible; arrow controls must remain discoverable through focus and labels.
+- Re-rendering the list can lose focus; restore focus to the moved attachment/action after each operation.
+- A send racing with reorder could mismatch UI and payload; freeze the ordered attempt before network mutation.
+
+## Completion Checklist
+
+- [x] Pointer and keyboard ordering produce the same deterministic array, verified by reducer tests and Chrome drag/arrow interaction smoke.
+- [x] Immediate, follow-up, steer, failed retry, stale-tab, and pending-send paths preserve the expected order, verified by the 744-test `npm run check` run.
+- [x] Narrow, 200% text, keyboard-focus, and reduced-motion contracts show no clipped controls or inaccessible ordering path; Chrome measured no 320 px document overflow.
+- [x] `npm run check`, `git diff --check`, and `just pack webui` pass with only intended WebUI files and this plan changed.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -13,7 +13,7 @@ This package is intentionally different from the broader, separately maintained 
 - Preserves open tool/thinking disclosures during keyed streaming updates and offers **Jump to latest** when new activity arrives while you read earlier messages.
 - Sends immediately while Pi is idle and automatically queues **Queue next** as a follow-up while Pi is busy.
 - Provides a separate **Steer** action while Pi is working; steering is never the default submit action.
-- Accepts pasted, dropped, or selected PNG, JPEG, WebP, GIF, BMP, TIFF, HEIC/HEIF, and AVIF images, strips metadata server-side, applies Pi-compatible size limits, and provides contained thumbnails plus an enlarged preview.
+- Accepts pasted, dropped, or selected PNG, JPEG, WebP, GIF, BMP, TIFF, HEIC/HEIF, and AVIF images, strips metadata server-side, applies Pi-compatible size limits, and provides ordered thumbnails plus an enlarged preview.
 - Reconnects from an ordered event cursor and replaces state from an authoritative snapshot after a gap.
 - Keeps a failed browser draft and prevents rapid duplicate submission with request IDs.
 - Uses no frontend framework, build step, browser storage, remote service, or automatically launched browser.
@@ -103,7 +103,7 @@ The initial transcript comes from the active session branch. Browser refresh doe
 
 The server checks file signatures instead of trusting browser MIME types or filename extensions. It rejects corrupt/unknown formats, more than 8 images, individual source images over 10 MiB, combined image input over 40 MiB, images over 50 megapixels, and provider-ready Base64 content over Pi's approximately 4.5 MB inline limit. Images over 2,000 pixels on either side are resized when Pi's `images.autoResize` setting is enabled and rejected when it is disabled.
 
-Processing applies image orientation, re-encodes provider-ready output, strips EXIF and other private metadata, preserves ICC color profiles and animated GIF timing where supported, and does not retain browser source bytes after the message request is accepted. Pi's effective global and trusted-project `images.autoResize` and `images.blockImages` settings plus the current model's image capability are checked at send time. BMP and HEIC use bounded portable decoders because the prebuilt `sharp`/libvips distribution does not decode those inputs consistently across supported platforms.
+Drag thumbnails or use their visible arrow controls to set provider order before sending. Processing applies image orientation, re-encodes provider-ready output, strips EXIF and other private metadata, preserves ICC color profiles and animated GIF timing where supported, and does not retain browser source bytes after the message request is accepted. Pi's effective global and trusted-project `images.autoResize` and `images.blockImages` settings plus the current model's image capability are checked at send time. BMP and HEIC use bounded portable decoders because the prebuilt `sharp`/libvips distribution does not decode those inputs consistently across supported platforms.
 
 ## Security and privacy
 

--- a/extensions/pi-webui/src/web/app.js
+++ b/extensions/pi-webui/src/web/app.js
@@ -10,6 +10,8 @@ import {
 	followLatest,
 	initialState,
 	invalidateSendAttempt,
+	moveImage,
+	moveImageBefore,
 	noteUnseenUpdate,
 	prepareSend,
 	setNearBottom,
@@ -349,8 +351,28 @@ function isSupportedImageFile(file) {
 	);
 }
 
+function reorderImages(images, focusId, focusDirection) {
+	if (composerLocked()) return;
+	model = invalidateSendAttempt({ ...model, images, error: "" });
+	render();
+	focusOrderingControl(focusId, focusDirection);
+}
+
+function focusOrderingControl(id, direction) {
+	requestAnimationFrame(() => {
+		const escapedId = CSS.escape(id);
+		const item = ui.previews.querySelector(`[data-image-id="${escapedId}"]`);
+		const preferred = item?.querySelector(`[data-order-action="${direction}"]`);
+		const target =
+			preferred && !preferred.disabled
+				? preferred
+				: item?.querySelector("[data-order-action]:not(:disabled), .remove-image");
+		target?.focus();
+	});
+}
+
 function removeImage(id) {
-	if (model.pending) return;
+	if (composerLocked()) return;
 	const removed = model.images.find((image) => image.id === id);
 	if (removed) {
 		if (ui.previewImage.src === removed.previewUrl) ui.previewDialog.close();
@@ -446,14 +468,41 @@ function renderComposer() {
 		ui.attachmentStatus.textContent = attachmentStatus;
 	}
 	ui.previews.replaceChildren();
-	for (const image of model.images) {
+	for (const [index, image] of model.images.entries()) {
 		const item = document.createElement("li");
 		item.className = "image-preview-item";
+		item.dataset.imageId = image.id;
+		item.draggable = !model.pending && !locked;
+		item.addEventListener("dragstart", (event) => {
+			if (locked || !event.dataTransfer) return;
+			event.dataTransfer.effectAllowed = "move";
+			event.dataTransfer.setData("application/x-pi-webui-image", image.id);
+			item.classList.add("dragging");
+		});
+		item.addEventListener("dragend", () => {
+			item.classList.remove("dragging");
+			for (const candidate of ui.previews.children) candidate.classList.remove("drag-target");
+		});
+		item.addEventListener("dragover", (event) => {
+			const draggedId = event.dataTransfer?.getData("application/x-pi-webui-image");
+			if (locked || !draggedId || draggedId === image.id) return;
+			event.preventDefault();
+			item.classList.add("drag-target");
+		});
+		item.addEventListener("dragleave", () => item.classList.remove("drag-target"));
+		item.addEventListener("drop", (event) => {
+			const draggedId = event.dataTransfer?.getData("application/x-pi-webui-image");
+			item.classList.remove("drag-target");
+			if (locked || !draggedId || draggedId === image.id) return;
+			event.preventDefault();
+			event.stopPropagation();
+			reorderImages(moveImageBefore(model.images, draggedId, image.id), draggedId, "forward");
+		});
 		const previewButton = document.createElement("button");
 		previewButton.type = "button";
 		previewButton.className = "attachment-preview";
 		previewButton.setAttribute("aria-label", `Preview image ${image.name}`);
-		previewButton.disabled = model.pending;
+		previewButton.disabled = locked;
 		previewButton.addEventListener("click", () => openImagePreview(image));
 		const preview = document.createElement("img");
 		preview.src = image.previewUrl;
@@ -461,14 +510,37 @@ function renderComposer() {
 		previewButton.append(preview);
 		const name = document.createElement("span");
 		name.textContent = image.name;
+		const actions = document.createElement("div");
+		actions.className = "image-order-actions";
+		const backward = document.createElement("button");
+		backward.type = "button";
+		backward.className = "move-image";
+		backward.textContent = "←";
+		backward.dataset.orderAction = "backward";
+		backward.disabled = locked || index === 0;
+		backward.setAttribute("aria-label", `Move image backward: ${image.name}`);
+		backward.addEventListener("click", () =>
+			reorderImages(moveImage(model.images, image.id, -1), image.id, "backward"),
+		);
+		const forward = document.createElement("button");
+		forward.type = "button";
+		forward.className = "move-image";
+		forward.textContent = "→";
+		forward.dataset.orderAction = "forward";
+		forward.disabled = locked || index === model.images.length - 1;
+		forward.setAttribute("aria-label", `Move image forward: ${image.name}`);
+		forward.addEventListener("click", () =>
+			reorderImages(moveImage(model.images, image.id, 1), image.id, "forward"),
+		);
 		const remove = document.createElement("button");
 		remove.type = "button";
 		remove.className = "remove-image";
 		remove.textContent = "Remove";
-		remove.disabled = model.pending;
+		remove.disabled = locked;
 		remove.setAttribute("aria-label", `Remove image ${image.name}`);
 		remove.addEventListener("click", () => removeImage(image.id));
-		item.append(previewButton, name, remove);
+		actions.append(backward, forward, remove);
+		item.append(previewButton, name, actions);
 		ui.previews.append(item);
 	}
 	document.documentElement.style.setProperty("--composer-height", `${ui.composer.offsetHeight}px`);

--- a/extensions/pi-webui/src/web/state.js
+++ b/extensions/pi-webui/src/web/state.js
@@ -132,6 +132,29 @@ export function followLatest(current) {
 	return { ...current, following: true, unseenUpdateIds: [] };
 }
 
+export function moveImage(images, id, direction) {
+	const from = images.findIndex((image) => image.id === id);
+	if (from === -1) return [...images];
+	const to = Math.max(0, Math.min(images.length - 1, from + direction));
+	if (to === from) return [...images];
+	const next = [...images];
+	const [image] = next.splice(from, 1);
+	if (image) next.splice(to, 0, image);
+	return next;
+}
+
+export function moveImageBefore(images, id, targetId) {
+	if (id === targetId) return [...images];
+	const from = images.findIndex((image) => image.id === id);
+	const target = images.findIndex((image) => image.id === targetId);
+	if (from === -1 || target === -1) return [...images];
+	const next = images.filter((image) => image.id !== id);
+	const targetIndex = next.findIndex((image) => image.id === targetId);
+	if (targetIndex === -1) return [...images];
+	next.splice(targetIndex, 0, images[from]);
+	return next;
+}
+
 export function upsertById(items, value) {
 	const index = items.findIndex((item) => item.id === value.id);
 	if (index < 0) return [...items, value];

--- a/extensions/pi-webui/src/web/styles.css
+++ b/extensions/pi-webui/src/web/styles.css
@@ -515,7 +515,7 @@ textarea:disabled {
 
 .image-preview-item {
 	display: grid;
-	min-width: 270px;
+	min-width: 340px;
 	grid-template-columns: 68px minmax(6rem, 1fr) auto;
 	align-items: center;
 	gap: 0.5rem;
@@ -523,6 +523,33 @@ textarea:disabled {
 	border: 1px solid var(--border);
 	border-radius: 10px;
 	background: var(--surface-secondary);
+}
+
+.image-preview-item[draggable="true"] {
+	cursor: grab;
+}
+
+.image-preview-item.dragging {
+	opacity: 0.55;
+}
+
+.image-preview-item.drag-target {
+	border-color: var(--accent);
+	box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.image-order-actions {
+	display: flex;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+.move-image {
+	width: 44px;
+	padding-inline: 0;
+	border-color: var(--border);
+	color: var(--text);
+	background: var(--surface);
 }
 
 .attachment-preview {
@@ -579,6 +606,7 @@ button {
 }
 
 .button.secondary,
+.move-image,
 .remove-image {
 	border-color: var(--border);
 	color: var(--text);
@@ -742,7 +770,7 @@ footer p {
 	}
 
 	.image-preview-item {
-		min-width: min(100%, 270px);
+		min-width: min(100%, 340px);
 	}
 }
 

--- a/extensions/pi-webui/test/web-state.test.ts
+++ b/extensions/pi-webui/test/web-state.test.ts
@@ -30,11 +30,18 @@ const state = (await import(
 	setNearBottom(current: WebState, nearBottom: boolean): WebState;
 	noteUnseenUpdate(current: WebState, key: string): WebState;
 	followLatest(current: WebState): WebState;
+	moveImage(images: WebImage[], id: string, direction: number): WebImage[];
+	moveImageBefore(images: WebImage[], id: string, targetId: string): WebImage[];
 	canSend(current: WebState): boolean;
 	busyLabel(current: WebState): string;
 	deliveryNotice(current: WebState): string;
 	upsertById<T extends { id: string }>(items: T[], value: T): T[];
 };
+
+interface WebImage {
+	id: string;
+	name?: string;
+}
 
 interface WebState {
 	sequence: number;
@@ -53,7 +60,7 @@ interface WebState {
 	following: boolean;
 	unseenUpdateIds: string[];
 	text: string;
-	images: Array<{ id: string }>;
+	images: WebImage[];
 	outbox?: SendAttempt;
 	lastDelivery?: "immediate" | "followUp" | "steer";
 }
@@ -240,6 +247,57 @@ test("send completion removes only the submitted draft", () => {
 	assert.deepEqual(completed.images, [newer]);
 	assert.equal(completed.pending, false);
 	assert.equal(completed.lastDelivery, "immediate");
+});
+
+test("image ordering helpers are immutable and bounded", () => {
+	const images: WebImage[] = [{ id: "one" }, { id: "two" }, { id: "three" }];
+	assert.deepEqual(
+		state.moveImage(images, "two", -1).map((image) => image.id),
+		["two", "one", "three"],
+	);
+	assert.deepEqual(
+		state.moveImage(images, "two", 1).map((image) => image.id),
+		["one", "three", "two"],
+	);
+	assert.deepEqual(state.moveImage(images, "one", -1), images);
+	assert.deepEqual(state.moveImage(images, "three", 1), images);
+	assert.deepEqual(state.moveImage(images, "missing", 1), images);
+	assert.deepEqual(
+		state.moveImageBefore(images, "three", "one").map((image) => image.id),
+		["three", "one", "two"],
+	);
+	assert.deepEqual(state.moveImageBefore(images, "one", "one"), images);
+	assert.deepEqual(state.moveImageBefore(images, "missing", "one"), images);
+	assert.deepEqual(
+		images.map((image) => image.id),
+		["one", "two", "three"],
+	);
+	assert.notEqual(state.moveImage(images, "one", -1), images);
+});
+
+test("send attempts freeze the displayed image order until the draft changes", () => {
+	const images: WebImage[] = [{ id: "two" }, { id: "one" }];
+	const prepared = state.prepareSend(
+		{ ...state.initialState(), connected: true, images },
+		"request-1",
+	);
+	assert.deepEqual(
+		prepared.attempt.images.map((image) => image.id),
+		["two", "one"],
+	);
+	images.reverse();
+	assert.deepEqual(
+		prepared.attempt.images.map((image) => image.id),
+		["two", "one"],
+	);
+	const retry = state.prepareSend(
+		state.failSend(prepared.state, prepared.attempt, "failed"),
+		"new",
+	);
+	assert.deepEqual(
+		retry.attempt.images.map((image) => image.id),
+		["two", "one"],
+	);
 });
 
 test("live transcript follows only near the bottom and deduplicates unseen updates", () => {

--- a/extensions/pi-webui/test/web-ui-contract.test.ts
+++ b/extensions/pi-webui/test/web-ui-contract.test.ts
@@ -74,6 +74,13 @@ test("image input supports picker and paste with visible removable previews", ()
 	assert.match(app, /showModal/);
 	assert.match(app, /previewReturnFocus.*focus/s);
 	assert.match(app, /drag-active/);
+	assert.match(app, /moveImageBefore/);
+	assert.match(app, /moveImage/);
+	assert.match(app, /draggable = !model\.pending/);
+	assert.match(app, /addEventListener\("dragstart"/);
+	assert.match(app, /Move image backward/);
+	assert.match(app, /Move image forward/);
+	assert.match(app, /focusOrderingControl/);
 });
 
 test("tool, thinking, and Markdown rendering use safe DOM construction", () => {


### PR DESCRIPTION
## Summary

- add immutable attachment ordering helpers that freeze provider order in send attempts
- support pointer drag ordering and visible keyboard-accessible backward/forward controls
- preserve focus after moves and disable attachment mutations while the composer is locked
- document provider order and archive the completed implementation plan

## Verification

- `npm --workspace @narumitw/pi-webui run check`
- `npm run check` (744 passing)
- `git diff --check`
- `just pack webui` (18 intended files)
- headless Chrome CDP drag/arrow smoke at 320 px and 200% text

## Stack

- Base: #278 (`feat/webui-extended-image-formats`)
