### PR TITLE
feat(pi-lsp): capability-based routing + settled push diagnostics

### DIFF
--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -151,6 +151,8 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		command: ["intelephense", "--stdio"],
 		extensions: [".php"],
 		initialization: { intelephense: { telemetry: { enabled: false } } },
+		// Publishes empty on didOpen, then real diagnostics ~0.2-3s later.
+		diagnosticsSettleMs: 4000,
 	},
 	{
 		name: "prisma",
@@ -419,6 +421,7 @@ function normalizeServer(name: string, value: unknown, label: string): InternalL
 		env: optionalStringRecordField(value, "env", label),
 		initialization: optionalRecordField(value, "initialization", label),
 		skipDirectories: optionalDirectoryNamesField(value, "skipDirectories", label),
+		diagnosticsSettleMs: optionalPositiveNumberField(value, "diagnosticsSettleMs", label),
 	};
 }
 
@@ -444,6 +447,7 @@ function configToAdapter(config: InternalLspServer): LspServerAdapter {
 		env: config.env,
 		initialization: config.initialization,
 		skipDirectories: new Set([...COMMON_SKIP_DIRECTORIES, ...(config.skipDirectories ?? [])]),
+		diagnosticsSettleMs: config.diagnosticsSettleMs,
 		isSupportedFile: (filePath) => extensionSet.has(path.extname(filePath)),
 		languageIdFor: (filePath) => languageIdFor(config, filePath),
 	};
@@ -543,6 +547,15 @@ function stringArrayField(value: Record<string, unknown>, field: string, label: 
 	const fieldValue = value[field];
 	if (!Array.isArray(fieldValue) || !fieldValue.every((item) => typeof item === "string")) {
 		throw new Error(`${label}.${field} must be an array of strings.`);
+	}
+	return fieldValue;
+}
+
+function optionalPositiveNumberField(value: Record<string, unknown>, field: string, label: string) {
+	const fieldValue = value[field];
+	if (fieldValue === undefined) return undefined;
+	if (typeof fieldValue !== "number" || !Number.isFinite(fieldValue) || fieldValue <= 0) {
+		throw new Error(`${label}.${field} must be a positive number.`);
 	}
 	return fieldValue;
 }

--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -24,6 +24,10 @@ export function resolveSpawnCommand(
 	};
 }
 
+// Quiet period (ms) to wait after an empty publish for a later non-empty one
+// before settling. Non-empty publishes settle immediately.
+const PUBLISHED_DIAGNOSTICS_SETTLE_MS = 800;
+
 export class LspClient {
 	#child?: ChildProcessWithoutNullStreams;
 	#buffer = Buffer.alloc(0);
@@ -39,13 +43,14 @@ export class LspClient {
 	#publishedDiagnostics = new Map<string, LspDiagnostic[]>();
 	#diagnosticWaiters = new Map<
 		string,
-		Array<{
-			resolve: (diagnostics: LspDiagnostic[]) => void;
+		Set<{
+			onPublish: (diagnostics: LspDiagnostic[]) => void;
 			reject: (reason: unknown) => void;
-			timeout: NodeJS.Timeout;
+			dispose: () => void;
 		}>
 	>();
 	#stderr = "";
+	#serverCapabilities: Record<string, unknown> = {};
 	#adapter: LspServerAdapter;
 	#command: ServerCommand;
 	#cwd: string;
@@ -118,18 +123,20 @@ export class LspClient {
 	async initialize(root: string) {
 		const rootUri = directoryUri(root);
 		const workspaceFolders = [{ uri: rootUri, name: path.basename(root) || "workspace" }];
-		await this.request("initialize", {
+		const response = await this.request("initialize", {
 			processId: process.pid,
 			rootUri,
 			workspaceFolders,
 			initializationOptions: this.#adapter.initialization ?? {},
 			capabilities: {
 				textDocument: {
+					// This spawn-per-call client can't track dynamic registrations, so
+					// capabilities must be advertised statically.
 					codeAction: {
-						dynamicRegistration: true,
+						dynamicRegistration: false,
 						resolveSupport: { properties: ["edit"] },
 					},
-					diagnostic: { dynamicRegistration: true, relatedDocumentSupport: true },
+					diagnostic: { dynamicRegistration: false, relatedDocumentSupport: true },
 					publishDiagnostics: {},
 					synchronization: { didSave: true },
 				},
@@ -140,6 +147,9 @@ export class LspClient {
 				},
 			},
 		});
+		this.#serverCapabilities =
+			(response.result as { capabilities?: Record<string, unknown> } | undefined)?.capabilities ??
+			{};
 		this.notify("initialized", {});
 		if (this.#adapter.initialization) {
 			this.notify("workspace/didChangeConfiguration", { settings: this.#adapter.initialization });
@@ -161,6 +171,10 @@ export class LspClient {
 	}
 
 	async diagnostics(uri: string) {
+		// Only pull if the server advertised it; otherwise use push diagnostics.
+		if (!this.#serverCapabilities.diagnosticProvider) {
+			return this.#waitForPublishedDiagnostics(uri);
+		}
 		try {
 			const response = await this.request("textDocument/diagnostic", {
 				textDocument: { uri },
@@ -169,8 +183,8 @@ export class LspClient {
 			});
 			const result = response.result as { items?: LspDiagnostic[] } | undefined;
 			return result?.items ?? [];
-		} catch (error) {
-			if (!isUnsupportedMethodError(error)) throw error;
+		} catch {
+			// Advertised pull but the request failed; fall back to pushed diagnostics.
 			return this.#waitForPublishedDiagnostics(uri);
 		}
 	}
@@ -185,20 +199,23 @@ export class LspClient {
 	}
 
 	async resolveActions(actions: CodeAction[]) {
+		// Only resolve when the server advertised resolveProvider; otherwise use the
+		// action as-is. Any error from an advertised resolve is real and propagates.
+		const codeActionProvider = this.#serverCapabilities.codeActionProvider;
+		const canResolve =
+			typeof codeActionProvider === "object" &&
+			codeActionProvider !== null &&
+			(codeActionProvider as { resolveProvider?: boolean }).resolveProvider === true;
+
 		const resolvedActions: CodeAction[] = [];
 		for (const action of actions) {
-			if (action.edit) {
+			if (action.edit || !canResolve) {
 				resolvedActions.push(action);
 				continue;
 			}
 
-			try {
-				const response = await this.request("codeAction/resolve", action);
-				resolvedActions.push((response.result as CodeAction | undefined) ?? action);
-			} catch (error) {
-				if (!isUnsupportedMethodError(error)) throw error;
-				resolvedActions.push(action);
-			}
+			const response = await this.request("codeAction/resolve", action);
+			resolvedActions.push((response.result as CodeAction | undefined) ?? action);
 		}
 
 		return resolvedActions;
@@ -231,8 +248,7 @@ export class LspClient {
 		}
 		this.#pending.clear();
 		for (const waiters of this.#diagnosticWaiters.values()) {
-			for (const waiter of waiters) {
-				clearTimeout(waiter.timeout);
+			for (const waiter of [...waiters]) {
 				waiter.reject(new Error(typeof message === "string" ? message : message("diagnostics")));
 			}
 		}
@@ -331,11 +347,9 @@ export class LspClient {
 			if (params?.uri) {
 				const diagnostics = params.diagnostics ?? [];
 				this.#publishedDiagnostics.set(params.uri, diagnostics);
-				const waiters = this.#diagnosticWaiters.get(params.uri) ?? [];
-				this.#diagnosticWaiters.delete(params.uri);
-				for (const waiter of waiters) {
-					clearTimeout(waiter.timeout);
-					waiter.resolve(diagnostics);
+				const waiters = this.#diagnosticWaiters.get(params.uri);
+				if (waiters) {
+					for (const waiter of [...waiters]) waiter.onPublish(diagnostics);
 				}
 			}
 			return;
@@ -347,26 +361,58 @@ export class LspClient {
 	}
 
 	#waitForPublishedDiagnostics(uri: string) {
-		const diagnostics = this.#publishedDiagnostics.get(uri);
-		if (diagnostics) return Promise.resolve(diagnostics);
-
+		// See PUBLISHED_DIAGNOSTICS_SETTLE_MS. Bounded by #timeoutMs.
 		return new Promise<LspDiagnostic[]>((resolve, reject) => {
-			const waiter = {
-				resolve,
-				reject,
-				timeout: setTimeout(() => {
-					const waiters =
-						this.#diagnosticWaiters.get(uri)?.filter((entry) => entry !== waiter) ?? [];
-					if (waiters.length) this.#diagnosticWaiters.set(uri, waiters);
-					else this.#diagnosticWaiters.delete(uri);
-					reject(
+			let settleTimer: NodeJS.Timeout | undefined;
+			let overallTimer: NodeJS.Timeout | undefined;
+
+			const dispose = () => {
+				if (settleTimer) clearTimeout(settleTimer);
+				if (overallTimer) clearTimeout(overallTimer);
+				const set = this.#diagnosticWaiters.get(uri);
+				set?.delete(waiter);
+				if (set && set.size === 0) this.#diagnosticWaiters.delete(uri);
+			};
+			const settleWith = (diagnostics: LspDiagnostic[]) => {
+				dispose();
+				resolve(diagnostics);
+			};
+			const fail = (reason: unknown) => {
+				dispose();
+				reject(reason);
+			};
+			const onPublish = (diagnostics: LspDiagnostic[]) => {
+				if (diagnostics.length > 0) {
+					settleWith(diagnostics);
+					return;
+				}
+				if (settleTimer) clearTimeout(settleTimer);
+				settleTimer = setTimeout(
+					() => settleWith(this.#publishedDiagnostics.get(uri) ?? []),
+					this.#adapter.diagnosticsSettleMs ?? PUBLISHED_DIAGNOSTICS_SETTLE_MS,
+				);
+			};
+
+			const waiter = { onPublish, reject: fail, dispose };
+			const set = this.#diagnosticWaiters.get(uri) ?? new Set<typeof waiter>();
+			set.add(waiter);
+			this.#diagnosticWaiters.set(uri, set);
+
+			overallTimer = setTimeout(() => {
+				const latest = this.#publishedDiagnostics.get(uri);
+				if (latest !== undefined) {
+					settleWith(latest);
+				} else {
+					fail(
 						new Error(
 							`${this.#adapter.name} LSP did not return diagnostics for ${uri} before timeout.`,
 						),
 					);
-				}, this.#timeoutMs),
-			};
-			this.#diagnosticWaiters.set(uri, [...(this.#diagnosticWaiters.get(uri) ?? []), waiter]);
+				}
+			}, this.#timeoutMs);
+
+			const existing = this.#publishedDiagnostics.get(uri);
+			if (existing !== undefined) onPublish(existing);
 		});
 	}
 
@@ -415,13 +461,6 @@ export class LspClient {
 		const stderr = this.#stderr.trim();
 		return stderr ? `\nServer stderr:\n${stderr}` : "";
 	}
-}
-
-function isUnsupportedMethodError(error: unknown) {
-	return (
-		error instanceof Error &&
-		/method not found|unhandled method|not supported|unsupported/i.test(error.message)
-	);
 }
 
 function formatErrorMessage(error: unknown) {

--- a/extensions/pi-lsp/src/types.ts
+++ b/extensions/pi-lsp/src/types.ts
@@ -67,6 +67,8 @@ export interface ConfiguredLspServer {
 	env?: Record<string, string>;
 	initialization?: Record<string, unknown>;
 	skipDirectories?: string[];
+	// ms to wait after an empty publish for a later non-empty one before settling.
+	diagnosticsSettleMs?: number;
 }
 
 export interface LspConfig {
@@ -89,6 +91,7 @@ export interface LspServerAdapter {
 	env?: Record<string, string>;
 	initialization?: Record<string, unknown>;
 	skipDirectories: Set<string>;
+	diagnosticsSettleMs?: number;
 	isSupportedFile: (filePath: string) => boolean;
 	languageIdFor: (filePath: string) => string;
 }


### PR DESCRIPTION
Routes diagnostics and code-action resolution by **advertised server capabilities** instead of sniffing error-message strings, and captures a push-diagnostics server's **real (post-analysis) publish** instead of its initial empty one.

### Changes
- **`initialize`**: capture `serverCapabilities` from the response; disable `dynamicRegistration` for `diagnostic`/`codeAction` so servers advertise statically (this spawn-per-call client can't track dynamic registrations).
- **`diagnostics()`**: send `textDocument/diagnostic` only when `diagnosticProvider` is advertised; otherwise use push diagnostics. Removed the `isUnsupportedMethodError` regex.
- **`resolveActions()`**: call `codeAction/resolve` only when `codeActionProvider.resolveProvider` is advertised; use the action as-is otherwise, and let real errors propagate.
- **Push diagnostics**: settle on the first **non-empty** publish immediately; for empty publishes, debounce (`PUBLISHED_DIAGNOSTICS_SETTLE_MS`, bounded by `#timeoutMs`) so a later real publish can supersede.
- **Per-server `diagnosticsSettleMs`** (config + type): default `4000` for intelephense, which publishes empty on `didOpen` then real diagnostics ~0.2–3s later.

### Behavior

| Server | Before | After |
| --- | --- | --- |
| gopls, `.go` with error | `JSON RPC parse error` | reports the diagnostic |
| gopls / tsserver, clean | `[]` / error | `[]` (unchanged, non-empty settles immediately) |
| intelephense, undefined function | `[]` | `Undefined function '...'` |

### Testing
- `npm run typecheck` ✔, `npm run biome:check` ✔, `npm test` → **737 pass / 0 fail** ✔
- Manually verified against real gopls v0.15.3, typescript-language-server, intelephense 1.18.5, and a mock server for the pull branch and the empty→non-empty publish sequence.

### Trade-offs
- **Clean files on push servers wait out the debounce** (~800ms default; ~4s for intelephense, which only ever publishes empty for a clean file). Files *with* diagnostics settle as soon as the real publish arrives.
- `diagnosticsSettleMs` is configurable per server for workspaces where indexing is slower.

### Not included
- Progress-aware settling (holding on `$/progress`/`indexingEnded`) was investigated but intelephense sends no progress events during the publish gap in the warm case, so a configurable debounce is the reliable approach.

---

Fixes #279.
