### PR TITLE
feat(pi-lsp): handle push diagnostics by capability

### DIFF
--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -156,6 +156,7 @@ Each server entry supports:
 - `env`: extra environment variables for the LSP server process.
 - `initialization`: LSP initialization options and workspace configuration values.
 - `skipDirectories`: additional directory names to exclude from recursive discovery. Explicitly requested paths remain available.
+- `diagnosticsSettleMs`: positive number of milliseconds without another push-diagnostics publication before using the latest result. Defaults to `800`; the built-in intelephense route uses `4000`. The global timeout remains the upper bound.
 
 Global options:
 

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -151,6 +151,8 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		command: ["intelephense", "--stdio"],
 		extensions: [".php"],
 		initialization: { intelephense: { telemetry: { enabled: false } } },
+		// Publishes empty on didOpen, then real diagnostics ~0.2-3s later.
+		diagnosticsSettleMs: 4000,
 	},
 	{
 		name: "prisma",
@@ -419,6 +421,7 @@ function normalizeServer(name: string, value: unknown, label: string): InternalL
 		env: optionalStringRecordField(value, "env", label),
 		initialization: optionalRecordField(value, "initialization", label),
 		skipDirectories: optionalDirectoryNamesField(value, "skipDirectories", label),
+		diagnosticsSettleMs: optionalPositiveNumberField(value, "diagnosticsSettleMs", label),
 	};
 }
 
@@ -444,6 +447,7 @@ function configToAdapter(config: InternalLspServer): LspServerAdapter {
 		env: config.env,
 		initialization: config.initialization,
 		skipDirectories: new Set([...COMMON_SKIP_DIRECTORIES, ...(config.skipDirectories ?? [])]),
+		diagnosticsSettleMs: config.diagnosticsSettleMs,
 		isSupportedFile: (filePath) => extensionSet.has(path.extname(filePath)),
 		languageIdFor: (filePath) => languageIdFor(config, filePath),
 	};
@@ -543,6 +547,15 @@ function stringArrayField(value: Record<string, unknown>, field: string, label: 
 	const fieldValue = value[field];
 	if (!Array.isArray(fieldValue) || !fieldValue.every((item) => typeof item === "string")) {
 		throw new Error(`${label}.${field} must be an array of strings.`);
+	}
+	return fieldValue;
+}
+
+function optionalPositiveNumberField(value: Record<string, unknown>, field: string, label: string) {
+	const fieldValue = value[field];
+	if (fieldValue === undefined) return undefined;
+	if (typeof fieldValue !== "number" || !Number.isFinite(fieldValue) || fieldValue <= 0) {
+		throw new Error(`${label}.${field} must be a positive number.`);
 	}
 	return fieldValue;
 }

--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -24,8 +24,7 @@ export function resolveSpawnCommand(
 	};
 }
 
-// Quiet period (ms) to wait after an empty publish for a later non-empty one
-// before settling. Non-empty publishes settle immediately.
+// Quiet period (ms) after each publish before treating push diagnostics as settled.
 const PUBLISHED_DIAGNOSTICS_SETTLE_MS = 800;
 
 export class LspClient {
@@ -44,7 +43,7 @@ export class LspClient {
 	#diagnosticWaiters = new Map<
 		string,
 		Set<{
-			onPublish: (diagnostics: LspDiagnostic[]) => void;
+			onPublish: () => void;
 			reject: (reason: unknown) => void;
 			dispose: () => void;
 		}>
@@ -175,18 +174,13 @@ export class LspClient {
 		if (!this.#serverCapabilities.diagnosticProvider) {
 			return this.#waitForPublishedDiagnostics(uri);
 		}
-		try {
-			const response = await this.request("textDocument/diagnostic", {
-				textDocument: { uri },
-				identifier: null,
-				previousResultId: null,
-			});
-			const result = response.result as { items?: LspDiagnostic[] } | undefined;
-			return result?.items ?? [];
-		} catch {
-			// Advertised pull but the request failed; fall back to pushed diagnostics.
-			return this.#waitForPublishedDiagnostics(uri);
-		}
+		const response = await this.request("textDocument/diagnostic", {
+			textDocument: { uri },
+			identifier: null,
+			previousResultId: null,
+		});
+		const result = response.result as { items?: LspDiagnostic[] } | undefined;
+		return result?.items ?? [];
 	}
 
 	async codeActions(uri: string, text: string, diagnostics: LspDiagnostic[], kind: string) {
@@ -349,7 +343,7 @@ export class LspClient {
 				this.#publishedDiagnostics.set(params.uri, diagnostics);
 				const waiters = this.#diagnosticWaiters.get(params.uri);
 				if (waiters) {
-					for (const waiter of [...waiters]) waiter.onPublish(diagnostics);
+					for (const waiter of [...waiters]) waiter.onPublish();
 				}
 			}
 			return;
@@ -381,11 +375,7 @@ export class LspClient {
 				dispose();
 				reject(reason);
 			};
-			const onPublish = (diagnostics: LspDiagnostic[]) => {
-				if (diagnostics.length > 0) {
-					settleWith(diagnostics);
-					return;
-				}
+			const onPublish = () => {
 				if (settleTimer) clearTimeout(settleTimer);
 				settleTimer = setTimeout(
 					() => settleWith(this.#publishedDiagnostics.get(uri) ?? []),
@@ -411,8 +401,7 @@ export class LspClient {
 				}
 			}, this.#timeoutMs);
 
-			const existing = this.#publishedDiagnostics.get(uri);
-			if (existing !== undefined) onPublish(existing);
+			if (this.#publishedDiagnostics.has(uri)) onPublish();
 		});
 	}
 

--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -24,6 +24,10 @@ export function resolveSpawnCommand(
 	};
 }
 
+// Quiet period (ms) to wait after an empty publish for a later non-empty one
+// before settling. Non-empty publishes settle immediately.
+const PUBLISHED_DIAGNOSTICS_SETTLE_MS = 800;
+
 export class LspClient {
 	#child?: ChildProcessWithoutNullStreams;
 	#buffer = Buffer.alloc(0);
@@ -39,13 +43,14 @@ export class LspClient {
 	#publishedDiagnostics = new Map<string, LspDiagnostic[]>();
 	#diagnosticWaiters = new Map<
 		string,
-		Array<{
-			resolve: (diagnostics: LspDiagnostic[]) => void;
+		Set<{
+			onPublish: (diagnostics: LspDiagnostic[]) => void;
 			reject: (reason: unknown) => void;
-			timeout: NodeJS.Timeout;
+			dispose: () => void;
 		}>
 	>();
 	#stderr = "";
+	#serverCapabilities: Record<string, unknown> = {};
 	#adapter: LspServerAdapter;
 	#command: ServerCommand;
 	#cwd: string;
@@ -118,18 +123,20 @@ export class LspClient {
 	async initialize(root: string) {
 		const rootUri = directoryUri(root);
 		const workspaceFolders = [{ uri: rootUri, name: path.basename(root) || "workspace" }];
-		await this.request("initialize", {
+		const response = await this.request("initialize", {
 			processId: process.pid,
 			rootUri,
 			workspaceFolders,
 			initializationOptions: this.#adapter.initialization ?? {},
 			capabilities: {
 				textDocument: {
+					// This spawn-per-call client can't track dynamic registrations, so
+					// capabilities must be advertised statically.
 					codeAction: {
-						dynamicRegistration: true,
+						dynamicRegistration: false,
 						resolveSupport: { properties: ["edit"] },
 					},
-					diagnostic: { dynamicRegistration: true, relatedDocumentSupport: true },
+					diagnostic: { dynamicRegistration: false, relatedDocumentSupport: true },
 					publishDiagnostics: {},
 					synchronization: { didSave: true },
 				},
@@ -140,6 +147,9 @@ export class LspClient {
 				},
 			},
 		});
+		this.#serverCapabilities =
+			(response.result as { capabilities?: Record<string, unknown> } | undefined)?.capabilities ??
+			{};
 		this.notify("initialized", {});
 		if (this.#adapter.initialization) {
 			this.notify("workspace/didChangeConfiguration", { settings: this.#adapter.initialization });
@@ -161,6 +171,10 @@ export class LspClient {
 	}
 
 	async diagnostics(uri: string) {
+		// Only pull if the server advertised it; otherwise use push diagnostics.
+		if (!this.#serverCapabilities.diagnosticProvider) {
+			return this.#waitForPublishedDiagnostics(uri);
+		}
 		try {
 			const response = await this.request("textDocument/diagnostic", {
 				textDocument: { uri },
@@ -169,8 +183,8 @@ export class LspClient {
 			});
 			const result = response.result as { items?: LspDiagnostic[] } | undefined;
 			return result?.items ?? [];
-		} catch (error) {
-			if (!isUnsupportedMethodError(error)) throw error;
+		} catch {
+			// Advertised pull but the request failed; fall back to pushed diagnostics.
 			return this.#waitForPublishedDiagnostics(uri);
 		}
 	}
@@ -185,20 +199,23 @@ export class LspClient {
 	}
 
 	async resolveActions(actions: CodeAction[]) {
+		// Only resolve when the server advertised resolveProvider; otherwise use the
+		// action as-is. Any error from an advertised resolve is real and propagates.
+		const codeActionProvider = this.#serverCapabilities.codeActionProvider;
+		const canResolve =
+			typeof codeActionProvider === "object" &&
+			codeActionProvider !== null &&
+			(codeActionProvider as { resolveProvider?: boolean }).resolveProvider === true;
+
 		const resolvedActions: CodeAction[] = [];
 		for (const action of actions) {
-			if (action.edit) {
+			if (action.edit || !canResolve) {
 				resolvedActions.push(action);
 				continue;
 			}
 
-			try {
-				const response = await this.request("codeAction/resolve", action);
-				resolvedActions.push((response.result as CodeAction | undefined) ?? action);
-			} catch (error) {
-				if (!isUnsupportedMethodError(error)) throw error;
-				resolvedActions.push(action);
-			}
+			const response = await this.request("codeAction/resolve", action);
+			resolvedActions.push((response.result as CodeAction | undefined) ?? action);
 		}
 
 		return resolvedActions;
@@ -231,8 +248,7 @@ export class LspClient {
 		}
 		this.#pending.clear();
 		for (const waiters of this.#diagnosticWaiters.values()) {
-			for (const waiter of waiters) {
-				clearTimeout(waiter.timeout);
+			for (const waiter of [...waiters]) {
 				waiter.reject(new Error(typeof message === "string" ? message : message("diagnostics")));
 			}
 		}
@@ -331,11 +347,9 @@ export class LspClient {
 			if (params?.uri) {
 				const diagnostics = params.diagnostics ?? [];
 				this.#publishedDiagnostics.set(params.uri, diagnostics);
-				const waiters = this.#diagnosticWaiters.get(params.uri) ?? [];
-				this.#diagnosticWaiters.delete(params.uri);
-				for (const waiter of waiters) {
-					clearTimeout(waiter.timeout);
-					waiter.resolve(diagnostics);
+				const waiters = this.#diagnosticWaiters.get(params.uri);
+				if (waiters) {
+					for (const waiter of [...waiters]) waiter.onPublish(diagnostics);
 				}
 			}
 			return;
@@ -347,26 +361,58 @@ export class LspClient {
 	}
 
 	#waitForPublishedDiagnostics(uri: string) {
-		const diagnostics = this.#publishedDiagnostics.get(uri);
-		if (diagnostics) return Promise.resolve(diagnostics);
-
+		// See PUBLISHED_DIAGNOSTICS_SETTLE_MS. Bounded by #timeoutMs.
 		return new Promise<LspDiagnostic[]>((resolve, reject) => {
-			const waiter = {
-				resolve,
-				reject,
-				timeout: setTimeout(() => {
-					const waiters =
-						this.#diagnosticWaiters.get(uri)?.filter((entry) => entry !== waiter) ?? [];
-					if (waiters.length) this.#diagnosticWaiters.set(uri, waiters);
-					else this.#diagnosticWaiters.delete(uri);
-					reject(
+			let settleTimer: NodeJS.Timeout | undefined;
+			let overallTimer: NodeJS.Timeout | undefined;
+
+			const dispose = () => {
+				if (settleTimer) clearTimeout(settleTimer);
+				if (overallTimer) clearTimeout(overallTimer);
+				const set = this.#diagnosticWaiters.get(uri);
+				set?.delete(waiter);
+				if (set && set.size === 0) this.#diagnosticWaiters.delete(uri);
+			};
+			const settleWith = (diagnostics: LspDiagnostic[]) => {
+				dispose();
+				resolve(diagnostics);
+			};
+			const fail = (reason: unknown) => {
+				dispose();
+				reject(reason);
+			};
+			const onPublish = (diagnostics: LspDiagnostic[]) => {
+				if (diagnostics.length > 0) {
+					settleWith(diagnostics);
+					return;
+				}
+				if (settleTimer) clearTimeout(settleTimer);
+				settleTimer = setTimeout(
+					() => settleWith(this.#publishedDiagnostics.get(uri) ?? []),
+					this.#adapter.diagnosticsSettleMs ?? PUBLISHED_DIAGNOSTICS_SETTLE_MS,
+				);
+			};
+
+			const waiter = { onPublish, reject: fail, dispose };
+			const set = this.#diagnosticWaiters.get(uri) ?? new Set<typeof waiter>();
+			set.add(waiter);
+			this.#diagnosticWaiters.set(uri, set);
+
+			overallTimer = setTimeout(() => {
+				const latest = this.#publishedDiagnostics.get(uri);
+				if (latest !== undefined) {
+					settleWith(latest);
+				} else {
+					fail(
 						new Error(
 							`${this.#adapter.name} LSP did not return diagnostics for ${uri} before timeout.`,
 						),
 					);
-				}, this.#timeoutMs),
-			};
-			this.#diagnosticWaiters.set(uri, [...(this.#diagnosticWaiters.get(uri) ?? []), waiter]);
+				}
+			}, this.#timeoutMs);
+
+			const existing = this.#publishedDiagnostics.get(uri);
+			if (existing !== undefined) onPublish(existing);
 		});
 	}
 
@@ -415,13 +461,6 @@ export class LspClient {
 		const stderr = this.#stderr.trim();
 		return stderr ? `\nServer stderr:\n${stderr}` : "";
 	}
-}
-
-function isUnsupportedMethodError(error: unknown) {
-	return (
-		error instanceof Error &&
-		/method not found|unhandled method|not supported|unsupported/i.test(error.message)
-	);
 }
 
 function formatErrorMessage(error: unknown) {

--- a/extensions/pi-lsp/src/runner.ts
+++ b/extensions/pi-lsp/src/runner.ts
@@ -47,26 +47,32 @@ export async function runDiagnostics(
 		await client.start();
 		await client.initialize(root);
 
-		const entries: DiagnosticEntry[] = [];
-		for (const file of files) {
-			throwIfAborted(signal, adapter);
-			const uri = pathToFileURL(file).href;
-			const text = readFileSync(file, "utf8");
-			client.didOpen(uri, text, adapter.languageIdFor(file));
-			try {
-				const diagnostics = await client.diagnostics(uri);
-				entries.push({ path: path.relative(root, file) || file, uri, diagnostics });
-			} finally {
-				client.didClose(uri);
+		const openedFiles: Array<{ file: string; uri: string }> = [];
+		try {
+			for (const file of files) {
+				throwIfAborted(signal, adapter);
+				const uri = pathToFileURL(file).href;
+				const text = readFileSync(file, "utf8");
+				client.didOpen(uri, text, adapter.languageIdFor(file));
+				openedFiles.push({ file, uri });
 			}
-		}
 
-		return textResult(formatDiagnostics(adapter, entries), {
-			root,
-			command,
-			files: entries,
-			summary: summarize(entries),
-		});
+			const entries: DiagnosticEntry[] = await Promise.all(
+				openedFiles.map(async ({ file, uri }) => ({
+					path: path.relative(root, file) || file,
+					uri,
+					diagnostics: await client.diagnostics(uri),
+				})),
+			);
+			return textResult(formatDiagnostics(adapter, entries), {
+				root,
+				command,
+				files: entries,
+				summary: summarize(entries),
+			});
+		} finally {
+			for (const { uri } of openedFiles) client.didClose(uri);
+		}
 	} finally {
 		ctx.ui.setStatus(statusKey, undefined);
 		signal?.removeEventListener("abort", abort);

--- a/extensions/pi-lsp/src/types.ts
+++ b/extensions/pi-lsp/src/types.ts
@@ -67,6 +67,8 @@ export interface ConfiguredLspServer {
 	env?: Record<string, string>;
 	initialization?: Record<string, unknown>;
 	skipDirectories?: string[];
+	// ms to wait after an empty publish for a later non-empty one before settling.
+	diagnosticsSettleMs?: number;
 }
 
 export interface LspConfig {
@@ -89,6 +91,7 @@ export interface LspServerAdapter {
 	env?: Record<string, string>;
 	initialization?: Record<string, unknown>;
 	skipDirectories: Set<string>;
+	diagnosticsSettleMs?: number;
 	isSupportedFile: (filePath: string) => boolean;
 	languageIdFor: (filePath: string) => string;
 }

--- a/extensions/pi-lsp/src/types.ts
+++ b/extensions/pi-lsp/src/types.ts
@@ -67,7 +67,7 @@ export interface ConfiguredLspServer {
 	env?: Record<string, string>;
 	initialization?: Record<string, unknown>;
 	skipDirectories?: string[];
-	// ms to wait after an empty publish for a later non-empty one before settling.
+	// Quiet period in ms after the latest push-diagnostics publication.
 	diagnosticsSettleMs?: number;
 }
 

--- a/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -1,0 +1,119 @@
+const scenario = process.argv[2];
+const expectedFiles = Number(process.argv[3] ?? "0");
+let buffer = Buffer.alloc(0);
+const openedUris = [];
+
+function send(message) {
+	const body = JSON.stringify(message);
+	process.stdout.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+}
+
+function diagnostic(message, line = 0) {
+	return {
+		range: {
+			start: { line, character: 0 },
+			end: { line, character: 1 },
+		},
+		severity: 1,
+		source: "fixture",
+		message,
+	};
+}
+
+function publish(uri, diagnostics) {
+	send({
+		jsonrpc: "2.0",
+		method: "textDocument/publishDiagnostics",
+		params: { uri, diagnostics },
+	});
+}
+
+function handle(message) {
+	if (message.method === "initialize") {
+		send({
+			jsonrpc: "2.0",
+			id: message.id,
+			result: {
+				capabilities:
+					scenario === "pull-error"
+						? {
+								diagnosticProvider: {
+									interFileDependencies: false,
+									workspaceDiagnostics: false,
+								},
+							}
+						: scenario === "resolve-enabled"
+							? { codeActionProvider: { resolveProvider: true } }
+							: scenario === "resolve-disabled"
+								? { codeActionProvider: true }
+								: {},
+			},
+		});
+		return;
+	}
+
+	if (message.method === "textDocument/didOpen") {
+		const uri = message.params.textDocument.uri;
+		openedUris.push(uri);
+		publish(uri, []);
+		if (scenario === "push-sequence") {
+			setTimeout(() => publish(uri, [diagnostic("first")]), 20);
+			setTimeout(() => publish(uri, [diagnostic("first"), diagnostic("second", 1)]), 40);
+		} else if (scenario === "batch-push" && openedUris.length === expectedFiles) {
+			setTimeout(() => {
+				for (const openedUri of openedUris) {
+					publish(openedUri, [diagnostic(`ready:${openedUri}`)]);
+				}
+			}, 5);
+		}
+		return;
+	}
+
+	if (message.method === "textDocument/diagnostic") {
+		send({
+			jsonrpc: "2.0",
+			id: message.id,
+			error: { code: -32603, message: "intentional pull failure" },
+		});
+		return;
+	}
+
+	if (message.method === "codeAction/resolve") {
+		if (scenario === "resolve-enabled") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result: { ...message.params, title: `${message.params.title}:resolved` },
+			});
+		} else {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				error: { code: -32603, message: "unexpected code-action resolve" },
+			});
+		}
+		return;
+	}
+
+	if (message.method === "shutdown") {
+		send({ jsonrpc: "2.0", id: message.id, result: null });
+		return;
+	}
+
+	if (message.method === "exit") process.exit(0);
+}
+
+process.stdin.on("data", (chunk) => {
+	buffer = Buffer.concat([buffer, chunk]);
+	while (true) {
+		const separator = buffer.indexOf("\r\n\r\n");
+		if (separator < 0) return;
+		const header = buffer.subarray(0, separator).toString("utf8");
+		const length = Number(/Content-Length:\s*(\d+)/i.exec(header)?.[1]);
+		const bodyStart = separator + 4;
+		if (!Number.isFinite(length) || buffer.length < bodyStart + length) return;
+		const body = buffer.subarray(bodyStart, bodyStart + length).toString("utf8");
+		buffer = buffer.subarray(bodyStart + length);
+		handle(JSON.parse(body));
+	}
+});

--- a/extensions/pi-lsp/test/lsp-client.test.ts
+++ b/extensions/pi-lsp/test/lsp-client.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+import { LspClient } from "../src/lsp-client.js";
+import { runDiagnostics } from "../src/runner.js";
+import type { LspServerAdapter } from "../src/types.js";
+
+const fixture = path.resolve("extensions/pi-lsp/test/fixtures/diagnostics-server.mjs");
+
+test("advertised pull diagnostic errors propagate", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-pull-error-"));
+	const file = path.join(root, "main.go");
+	writeFileSync(file, "package main\n");
+	const adapter = fixtureAdapter("pull-error", 30);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		const uri = pathToFileURL(file).href;
+		client.didOpen(uri, "package main\n", "go");
+		await assert.rejects(client.diagnostics(uri), /intentional pull failure/);
+		client.didClose(uri);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("push diagnostics settle on the latest publication", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-push-sequence-"));
+	const file = path.join(root, "main.go");
+	writeFileSync(file, "package main\n");
+	const adapter = fixtureAdapter("push-sequence", 80);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		const uri = pathToFileURL(file).href;
+		client.didOpen(uri, "package main\n", "go");
+		const diagnostics = await client.diagnostics(uri);
+		assert.deepEqual(
+			diagnostics.map(({ message }) => message),
+			["first", "second"],
+		);
+		client.didClose(uri);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("code-action resolution follows the advertised server capability", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-resolve-capability-"));
+	const action = { title: "fixture action", data: { id: 1 } };
+
+	try {
+		for (const [scenario, expectedTitle] of [
+			["resolve-disabled", "fixture action"],
+			["resolve-enabled", "fixture action:resolved"],
+		] as const) {
+			const adapter = fixtureAdapter(scenario, 30);
+			const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+			try {
+				await client.start();
+				await client.initialize(root);
+				const [resolved] = await client.resolveActions([action]);
+				assert.equal(resolved?.title, expectedTitle);
+			} finally {
+				await client.shutdown();
+			}
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("diagnostics open all files before awaiting push publications", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-batch-push-"));
+	mkdirSync(path.join(root, "pkg"));
+	const files = ["a.go", "b.go", "c.go"].map((name) => path.join(root, "pkg", name));
+	for (const file of files) writeFileSync(file, "package pkg\n");
+	const adapter = fixtureAdapter("batch-push", 30, files.length);
+
+	try {
+		const result = await runDiagnostics(
+			adapter,
+			{ root, files },
+			1_000,
+			undefined,
+			{ ui: { setStatus() {} } },
+			"test",
+		);
+		const details = result.details as {
+			files: Array<{ path: string; diagnostics: Array<{ message: string }> }>;
+		};
+		assert.deepEqual(
+			details.files.map(({ diagnostics }) => diagnostics.length),
+			[1, 1, 1],
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+function fixtureAdapter(
+	scenario: string,
+	diagnosticsSettleMs: number,
+	expectedFiles?: number,
+): LspServerAdapter {
+	return {
+		name: `fixture-${scenario}`,
+		isDefault: false,
+		defaultCommand: {
+			command: process.execPath,
+			args: [fixture, scenario, ...(expectedFiles === undefined ? [] : [String(expectedFiles)])],
+		},
+		commandEnvVar: `PI_LSP_FIXTURE_${scenario.toUpperCase().replaceAll("-", "_")}_COMMAND`,
+		missingCommandHint: "Node is required for the test fixture.",
+		extensions: [".go"],
+		skipDirectories: new Set(),
+		diagnosticsSettleMs,
+		isSupportedFile: (filePath) => filePath.endsWith(".go"),
+		languageIdFor: () => "go",
+	};
+}

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -97,6 +97,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 			languageId: string;
 			skipDirectories?: string[];
 			initialization?: Record<string, unknown>;
+			diagnosticsSettleMs?: number;
 		}> = [
 			{
 				name: "rubocop",
@@ -191,6 +192,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				sample: "index.php",
 				languageId: "php",
 				initialization: { intelephense: { telemetry: { enabled: false } } },
+				diagnosticsSettleMs: 4000,
 			},
 			{
 				name: "prisma",
@@ -295,6 +297,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 			assert.deepEqual(adapter.extensions, expected.extensions);
 			assert.equal(adapter.languageIdFor(expected.sample), expected.languageId);
 			assert.deepEqual(adapter.initialization, expected.initialization);
+			assert.equal(adapter.diagnosticsSettleMs, expected.diagnosticsSettleMs);
 			for (const directory of expected.skipDirectories ?? []) {
 				assert.equal(
 					adapter.skipDirectories.has(directory),
@@ -449,12 +452,14 @@ test("LSP config applies safe server-specific skip directories", () => {
 					command: ["custom-lsp"],
 					extensions: [".foo"],
 					skipDirectories: ["generated"],
+					diagnosticsSettleMs: 250,
 				},
 			},
 		});
 		const adapter = loadRuntime(project).adapters[0];
 		assert.ok(adapter);
 		assert.equal(adapter.isDefault, false);
+		assert.equal(adapter.diagnosticsSettleMs, 250);
 		assert.deepEqual(collectSupportedFiles(adapter, project, undefined, 50), [
 			path.join(project, "src", "main.foo"),
 		]);
@@ -472,6 +477,17 @@ test("LSP config applies safe server-specific skip directories", () => {
 			},
 		});
 		assert.throws(() => loadConfig(project), /skipDirectories.*directory names/);
+
+		process.env.PI_LSP_CONFIG = JSON.stringify({
+			servers: {
+				custom: {
+					command: ["custom-lsp"],
+					extensions: [".foo"],
+					diagnosticsSettleMs: 0,
+				},
+			},
+		});
+		assert.throws(() => loadConfig(project), /diagnosticsSettleMs.*positive number/);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;


### PR DESCRIPTION
## Summary

- preserve dabeeduu's capability-based diagnostics and code-action routing commit from #281
- propagate real errors from servers that advertise pull diagnostics
- debounce every push-diagnostics publication so the latest settled result wins
- open matching files before awaiting diagnostics, avoiding per-file settle-delay multiplication
- document and test `diagnosticsSettleMs`, capability routing, settling, and multi-file collection

## Verification

- `npm run check` — 741 tests passed
- gopls v0.15.3 reproducer: base reports the JSON-RPC parse error; this branch reports `undefined: doesNotExist`
- regression tests fail on #281's head for swallowed pull errors, first-non-empty settling, and sequential push collection, then pass with the follow-up commit

This keeps dabeeduu's `cb51ee5` commit unchanged as the direct parent of the follow-up fix and is intended to supersede #281.

Closes #279.
