### PR TITLE
feat(webui): stage image attachments on the server

### DIFF
--- a/docs/plans/archived/2026-07-19_pi-webui-server-image-staging-plan.md
+++ b/docs/plans/archived/2026-07-19_pi-webui-server-image-staging-plan.md
@@ -1,0 +1,46 @@
+## Goal
+
+Move WebUI attachment upload and image preparation ahead of message submission so each image has visible upload/processing/ready/error state, individual retry/removal, bounded progress, and cancellation. Success means Send never starts with an ambiguous batch and one failed image does not force users to reselect successful siblings.
+
+## Context
+
+WebUI currently holds browser `File` objects locally, encodes all images into one JSON message request, and processes the whole batch in `WebUIRuntime.sendBrowserMessage()`. Image Drop proves per-item reservation, raw bounded upload, processing queues, revisioned mutations, retry, and stale-lease cancellation.
+
+## Architecture
+
+Add a session-owned `AttachmentDraft` module separate from `runtime.ts` and `server.ts`. The server reserves IDs atomically, accepts one bounded raw upload per item, processes with limited concurrency, and publishes revisioned public state over the existing control/SSE channel. Browser state stores IDs and display metadata, not source Base64. Message send references an exact ready draft revision; runtime snapshots sanitized provider-ready bytes before calling Pi.
+
+## Non-Goals
+
+- Attaching staged images to terminal-authored prompts.
+- Persisting drafts to disk/browser storage, sent-image history, or restoring drafts across Pi session replacement.
+- Chunked resumable uploads across process restarts.
+
+## Plan
+
+- [x] Specify the item/batch state machine in failing unit tests: atomic reservation, count/source-byte limits, ordered IDs, upload, processing, ready, error, retry, delete, clear, revision mismatch, late completion, send reservation, and close; `npm test` failed before implementation because `src/attachments.ts` was absent, and the nine focused compiled attachment tests now pass. Protocol duplicate/lease/abort behavior remains specified in the server test task.
+- [x] Implement `src/attachments.ts` with bounded resident bytes, source/provider-ready ownership, processing concurrency, immutable public snapshots, and idempotent cleanup; eight focused attachment tests pass and assert source release after processing plus remove, clear, accepted-send, failure-retry, and close transitions.
+- [x] Replace message-embedded Base64 uploads with authenticated per-item reservation/raw upload/retry/delete endpoints in `src/server.ts`; 18 focused server tests pass for cookie, exact Host/Origin, lease, revision, actual body limits without trusted `Content-Length`, duplicate requests, cancellation, and protocol errors.
+- [x] Integrate runtime processing and send preflight so only an exact all-ready snapshot can be submitted, Pi settings/model capability are revalidated at send time, accepted bytes transfer once, failed sends retain a retryable draft, and session teardown aborts every job; 20 lifecycle tests plus attachment send-reservation tests pass.
+- [x] Extend `src/web/state.js` and `app.js` with per-image Uploading/Processing/Ready/Needs attention status, byte progress, Retry/Remove actions, and whole-batch send gating; reducer/contracts pass and Chrome smoke exercised processing, ready, error, retry, removal, and disabled/enabled Send states without modal alerts.
+- [x] Show concise conversion/resize summaries only when they vary by item, while stating metadata removal once near the attachment collection; browser contracts and Chrome smoke verify per-item summaries and one collection notice.
+- [x] Test page refresh, new-tab lease takeover, stale upload completion, duplicate upload, delete-during-processing, cancellation, reconnect gaps, session shutdown, and a newer draft created during a pending send; deterministic attachment/server/lifecycle/state tests pass, and Chrome refresh restored the authoritative ordered batch.
+- [x] Update README protocol-visible behavior, privacy/memory ownership, retry workflow, and limitations; `npm run check` passes 760 tests, `git diff --check` passes, and `just pack webui` contains 19 intended runtime files.
+
+## Risks
+
+- This is the highest-risk image change because it changes protocol, memory ownership, and send lifecycle; split `attachments.ts` rather than growing `runtime.ts` or `server.ts` beyond clear responsibility boundaries.
+- Source and processed bytes can coexist; enforce one combined resident-byte budget and release originals immediately after successful sanitation unless needed for an explicit retry/reprocess contract.
+- Lease changes can leave asynchronous native work alive; generation/revision checks must discard late output after abort.
+
+## Rollback / Recovery
+
+Keep the old one-request send protocol behind no compatibility promise during development, then remove it before release. If staging cannot pass lifecycle/security review, revert the feature as one bounded change and retain the existing browser-local path.
+
+## Completion Checklist
+
+- [x] Every attachment state and cleanup transition is verified by nine attachment tests with explicit resident-byte assertions.
+- [x] Auth, lease, revision, request-size, cancellation, stale completion, duplicate, and shutdown boundaries are verified by 18 server tests and 20 lifecycle tests.
+- [x] Immediate, follow-up, steer, failed-send retry, and newer-draft preservation are verified by lifecycle, server, attachment, and reducer tests.
+- [x] Desktop and 320 px Chrome smoke plus browser contracts verify status, retry, removal, progress, ordering, send gating, refresh recovery, focus restoration, 44 px controls, and no horizontal overflow.
+- [x] `npm run check` passes 760 tests, `git diff --check` and `just pack webui` pass, the package has 19 intended files, and all final source files remain below 1,000 lines.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -103,7 +103,11 @@ The initial transcript comes from the active session branch. Browser refresh doe
 
 The server checks file signatures instead of trusting browser MIME types or filename extensions. It rejects corrupt/unknown formats, more than 8 images, individual source images over 10 MiB, combined image input over 40 MiB, images over 50 megapixels, and provider-ready Base64 content over Pi's approximately 4.5 MB inline limit. Images over 2,000 pixels on either side are resized when Pi's `images.autoResize` setting is enabled and rejected when it is disabled.
 
-Drag thumbnails or use their visible arrow controls to set provider order before sending. Remove images individually, or use the confirmed **Clear attachments** action when a draft contains several images. Processing applies image orientation, re-encodes provider-ready output, strips EXIF and other private metadata, preserves ICC color profiles and animated GIF timing where supported, and does not retain browser source bytes after the message request is accepted. Pi's effective global and trusted-project `images.autoResize` and `images.blockImages` settings plus the current model's image capability are checked at send time. BMP and HEIC use bounded portable decoders because the prebuilt `sharp`/libvips distribution does not decode those inputs consistently across supported platforms.
+Choosing, pasting, or dropping images first reserves an ordered server-side batch, uploads each source as a bounded raw request, and processes it before Send becomes available. Each thumbnail reports Uploading, Processing, Ready, or Needs attention; upload progress is shown when the browser reports a byte total. A failed item can be retried without reselecting successful siblings, and every item can be removed independently. Refreshing the active tab restores the authoritative staged batch, while another tab taking the editing lease cancels in-flight work safely.
+
+Drag thumbnails or use their visible arrow controls to set provider order before sending. Remove images individually, or use the confirmed **Clear attachments** action when a draft contains several images. Conversion and resize summaries appear only on affected items, while the metadata-removal guarantee is stated once for the collection. Processing applies image orientation, re-encodes provider-ready output, strips EXIF and other private metadata, preserves ICC color profiles and animated GIF timing where supported, and releases each source after successful sanitation. Failed processing retains only that bounded source for Retry; Ready provider bytes remain in the Pi process until accepted send, removal, clear, lease/session teardown, or failed-send retry. Image bytes are never embedded in the message JSON protocol.
+
+Pi's effective global and trusted-project `images.autoResize` and `images.blockImages` settings plus the current model's image capability and authentication are checked again at send time. A failed send leaves the exact Ready batch available for an idempotent retry. BMP and HEIC use bounded portable decoders because the prebuilt `sharp`/libvips distribution does not decode those inputs consistently across supported platforms.
 
 ## Security and privacy
 
@@ -111,7 +115,7 @@ Drag thumbnails or use their visible arrow controls to set provider order before
 - A rotating bootstrap token is exchanged once for a per-server HttpOnly, `SameSite=Strict` cookie and removed from the URL.
 - Every endpoint requires the cookie. Mutations also require exact Host and Origin values plus the active browser-tab lease.
 - Responses use no-store, no-referrer, MIME-sniffing, frame-denial, same-origin resource, and restrictive Content Security Policy headers.
-- Transcript projection retains at most the newest 500 messages and 500 tool records, event replay keeps 256 updates, and request-id records keep 128 sends. The page uses no localStorage, sessionStorage, IndexedDB, cookies of its own, or image/transcript cache.
+- Transcript projection retains at most the newest 500 messages and 500 tool records, event replay keeps 256 updates, and request-id records keep 128 sends. Unsent staged images live only in bounded Pi-process memory; the page uses no localStorage, sessionStorage, IndexedDB, script-readable cookies, or image/transcript cache.
 - Tool arguments/results, paths, images, and model thinking can be sensitive. Thinking is collapsed by default; only open a link issued by a Pi process you trust.
 - Reload, session replacement/fork, or Pi shutdown closes sockets, invalidates old callbacks, ends the page, and releases in-memory state.
 
@@ -136,7 +140,8 @@ src/webui.ts         Pi extension entrypoint
 src/runtime.ts       Pi lifecycle, commands, event projection, and browser message routing
 src/settings.ts      global WebUI settings validation and atomic persistence
 src/conversation.ts  bounded transcript snapshot and ordered event replay
-src/server.ts        authenticated loopback HTTP/SSE server
+src/attachments.ts   revisioned staged-image state, processing queue, and byte ownership
+src/server.ts        authenticated loopback HTTP/SSE server and raw attachment protocol
 src/images.ts        bounded provider-ready image processing
 src/pi-settings.ts   effective Pi image settings reader
 src/web/             framework-free browser page

--- a/extensions/pi-webui/src/attachments.ts
+++ b/extensions/pi-webui/src/attachments.ts
@@ -1,0 +1,606 @@
+import { randomUUID } from "node:crypto";
+
+export type AttachmentStatus = "uploading" | "processing" | "ready" | "error";
+export type AttachmentPhase =
+	| "empty"
+	| "uploading"
+	| "processing"
+	| "blocked"
+	| "ready"
+	| "reserved"
+	| "closed";
+
+export interface AttachmentLimits {
+	maxImages: number;
+	maxImageBytes: number;
+	maxPromptBytes: number;
+}
+
+export interface AttachmentReservationInput {
+	id: string;
+	name: string;
+	size: number;
+	mimeType?: string;
+}
+
+export interface PreparedAttachment {
+	bytes: Buffer;
+	mimeType: string;
+	width?: number;
+	height?: number;
+	originalWidth?: number;
+	originalHeight?: number;
+	sourceFormat?: string;
+	outputFormat?: string;
+	resized?: boolean;
+	notes?: string[];
+}
+
+export interface PublicAttachment {
+	id: string;
+	name: string;
+	size: number;
+	status: AttachmentStatus;
+	mimeType?: string;
+	width?: number;
+	height?: number;
+	originalWidth?: number;
+	originalHeight?: number;
+	sourceFormat?: string;
+	outputFormat?: string;
+	resized?: boolean;
+	notes: string[];
+	retryable: boolean;
+	error?: string;
+}
+
+export interface PublicAttachmentState {
+	revision: number;
+	phase: AttachmentPhase;
+	items: PublicAttachment[];
+	totalSourceBytes: number;
+	totalResidentBytes: number;
+}
+
+export interface StagedBrowserImage {
+	name: string;
+	mimeType: string;
+	data: string;
+}
+
+export interface SendReservation {
+	token: string;
+	images: StagedBrowserImage[];
+}
+
+interface AttachmentItem extends AttachmentReservationInput {
+	status: AttachmentStatus;
+	reservedRevision: number;
+	source?: Buffer;
+	prepared?: PreparedAttachment;
+	error?: string;
+	operation?: symbol;
+	controller?: AbortController;
+}
+
+interface ProcessingJob {
+	item: AttachmentItem;
+	operation: symbol;
+	controller: AbortController;
+	removeExternalAbort?: () => void;
+}
+
+export interface AttachmentStoreOptions {
+	limits: AttachmentLimits;
+	process: (source: Uint8Array, signal?: AbortSignal) => Promise<PreparedAttachment>;
+	concurrency?: number;
+	onChange?: (state: PublicAttachmentState) => void;
+}
+
+export class AttachmentError extends Error {
+	constructor(
+		message: string,
+		readonly status = 409,
+	) {
+		super(message);
+		this.name = "AttachmentError";
+	}
+}
+
+export class AttachmentStore {
+	private readonly items: AttachmentItem[] = [];
+	private readonly queue: ProcessingJob[] = [];
+	private readonly idleWaiters = new Set<() => void>();
+	private readonly concurrency: number;
+	private revision = 0;
+	private active = 0;
+	private closed = false;
+	private sendToken?: string;
+
+	constructor(private readonly options: AttachmentStoreOptions) {
+		validateLimits(options.limits);
+		this.concurrency = options.concurrency ?? 2;
+		if (!Number.isSafeInteger(this.concurrency) || this.concurrency <= 0) {
+			throw new Error("Attachment processing concurrency must be a positive integer.");
+		}
+	}
+
+	publicState(): PublicAttachmentState {
+		return {
+			revision: this.revision,
+			phase: this.phase(),
+			items: this.items.map((item) => ({
+				id: item.id,
+				name: item.name,
+				size: item.size,
+				status: item.status,
+				mimeType: item.prepared?.mimeType,
+				width: item.prepared?.width,
+				height: item.prepared?.height,
+				originalWidth: item.prepared?.originalWidth,
+				originalHeight: item.prepared?.originalHeight,
+				sourceFormat: item.prepared?.sourceFormat,
+				outputFormat: item.prepared?.outputFormat,
+				resized: item.prepared?.resized,
+				notes: [...(item.prepared?.notes ?? [])],
+				retryable: item.status === "error" && Boolean(item.source),
+				error: item.error,
+			})),
+			totalSourceBytes: this.reservedSourceBytes(),
+			totalResidentBytes: this.residentBytes(),
+		};
+	}
+
+	residentBytes(): number {
+		return this.items.reduce(
+			(total, item) =>
+				total + (item.source?.byteLength ?? 0) + (item.prepared?.bytes.byteLength ?? 0),
+			0,
+		);
+	}
+
+	reservedSourceBytes(): number {
+		return this.items.reduce((total, item) => total + item.size, 0);
+	}
+
+	waitForIdle(): Promise<void> {
+		if (this.active === 0 && this.queue.length === 0) return Promise.resolve();
+		return new Promise((resolve) => this.idleWaiters.add(resolve));
+	}
+
+	reserve(inputs: AttachmentReservationInput[], expectedRevision: number): PublicAttachmentState {
+		this.assertMutable(expectedRevision);
+		if (!Array.isArray(inputs) || inputs.length === 0) {
+			throw new AttachmentError("At least one attachment is required.", 400);
+		}
+		const normalized = inputs.map((input) => normalizeReservation(input, this.options.limits));
+		const ids = new Set(this.items.map((item) => item.id));
+		for (const item of normalized) {
+			if (ids.has(item.id)) throw new AttachmentError("Attachment id is duplicate.", 400);
+			ids.add(item.id);
+		}
+		if (this.items.length + normalized.length > this.options.limits.maxImages) {
+			throw new AttachmentError(
+				`Attachment count exceeds the maximum of ${this.options.limits.maxImages}.`,
+				413,
+			);
+		}
+		const total = this.reservedSourceBytes() + normalized.reduce((sum, item) => sum + item.size, 0);
+		if (total > this.options.limits.maxPromptBytes) {
+			throw new AttachmentError("Combined attachment input is too large.", 413);
+		}
+		const reservedRevision = this.revision + 1;
+		this.items.push(
+			...normalized.map((item) => ({
+				...item,
+				status: "uploading" as const,
+				reservedRevision,
+			})),
+		);
+		this.changed();
+		return this.publicState();
+	}
+
+	upload(
+		id: string,
+		source: Uint8Array,
+		expectedRevision: number,
+		signal?: AbortSignal,
+	): PublicAttachmentState {
+		this.assertOpen();
+		if (this.sendToken) throw new AttachmentError("Attachments are reserved for sending.");
+		const item = this.requireItem(id);
+		this.assertUploadRevision(item, expectedRevision);
+		if (item.status !== "uploading" && !(item.status === "error" && !item.source)) {
+			throw new AttachmentError("Attachment is not waiting for an upload.");
+		}
+		if (source.byteLength !== item.size) {
+			throw new AttachmentError("Attachment upload size does not match its reservation.", 400);
+		}
+		if (source.byteLength === 0 || source.byteLength > this.options.limits.maxImageBytes) {
+			throw new AttachmentError("Attachment upload is outside the allowed size.", 413);
+		}
+		item.source = Buffer.from(source);
+		this.schedule(item, signal);
+		return this.publicState();
+	}
+
+	failUpload(id: string, error: unknown): PublicAttachmentState {
+		this.assertOpen();
+		if (this.sendToken) throw new AttachmentError("Attachments are reserved for sending.");
+		const item = this.requireItem(id);
+		if (item.status !== "uploading") {
+			throw new AttachmentError("Attachment upload is no longer pending.");
+		}
+		item.status = "error";
+		item.error = publicError(error);
+		this.changed();
+		return this.publicState();
+	}
+
+	retry(id: string, expectedRevision: number, signal?: AbortSignal): PublicAttachmentState {
+		this.assertMutable(expectedRevision);
+		const item = this.requireItem(id);
+		if (item.status !== "error" || !item.source) {
+			throw new AttachmentError("Attachment is not available for retry.");
+		}
+		this.schedule(item, signal);
+		return this.publicState();
+	}
+
+	cancelInFlight(message: string): boolean {
+		this.assertOpen();
+		if (this.sendToken) return false;
+		let changed = false;
+		for (const item of this.items) {
+			if (item.status === "uploading") {
+				item.status = "error";
+				item.error = publicError(message);
+				changed = true;
+				continue;
+			}
+			if (item.status === "processing") {
+				item.controller?.abort();
+				item.operation = undefined;
+				item.controller = undefined;
+				item.status = "error";
+				item.error = publicError(message);
+				item.prepared = undefined;
+				changed = true;
+			}
+		}
+		if (changed) this.changed();
+		return changed;
+	}
+
+	reorder(ids: string[], expectedRevision: number): PublicAttachmentState {
+		this.assertMutable(expectedRevision);
+		if (
+			!Array.isArray(ids) ||
+			ids.length !== this.items.length ||
+			new Set(ids).size !== ids.length ||
+			ids.some((id) => typeof id !== "string")
+		) {
+			throw new AttachmentError("Attachment order must contain every id exactly once.", 400);
+		}
+		const byId = new Map(this.items.map((item) => [item.id, item]));
+		const ordered = ids.map((id) => byId.get(id));
+		if (ordered.some((item) => !item)) {
+			throw new AttachmentError("Attachment order contains an unknown id.", 400);
+		}
+		this.items.splice(0, this.items.length, ...(ordered as AttachmentItem[]));
+		this.changed();
+		return this.publicState();
+	}
+
+	remove(id: string, expectedRevision: number): PublicAttachmentState {
+		this.assertMutable(expectedRevision);
+		const index = this.items.findIndex((item) => item.id === id);
+		if (index === -1) throw new AttachmentError("Attachment was not found.", 404);
+		const [removed] = this.items.splice(index, 1);
+		this.releaseItem(removed);
+		this.changed();
+		return this.publicState();
+	}
+
+	clear(expectedRevision: number): PublicAttachmentState {
+		this.assertMutable(expectedRevision);
+		this.releaseItems();
+		this.changed();
+		return this.publicState();
+	}
+
+	preview(id: string): PreparedAttachment {
+		this.assertOpen();
+		const item = this.requireItem(id);
+		if (item.status !== "ready" || !item.prepared) {
+			throw new AttachmentError("Attachment preview is not ready.", 404);
+		}
+		return clonePrepared(item.prepared);
+	}
+
+	beginSend(ids: string[], expectedRevision: number): SendReservation {
+		this.assertMutable(expectedRevision);
+		if (
+			ids.length !== this.items.length ||
+			ids.some((id, index) => id !== this.items[index]?.id) ||
+			this.items.some((item) => item.status !== "ready" || !item.prepared)
+		) {
+			throw new AttachmentError("Every ordered attachment must be ready before sending.");
+		}
+		const token = randomUUID();
+		this.sendToken = token;
+		this.notify();
+		return {
+			token,
+			images: this.items.map((item) => ({
+				name: item.name,
+				mimeType: item.prepared?.mimeType ?? "",
+				data: item.prepared?.bytes.toString("base64") ?? "",
+			})),
+		};
+	}
+
+	finishSend(token: string, committed: boolean): PublicAttachmentState {
+		this.assertOpen();
+		if (!this.sendToken || token !== this.sendToken) {
+			throw new AttachmentError("Attachment send reservation is stale.");
+		}
+		this.sendToken = undefined;
+		if (committed) {
+			this.releaseItems();
+			this.changed();
+		} else {
+			this.notify();
+		}
+		return this.publicState();
+	}
+
+	close(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.sendToken = undefined;
+		this.releaseItems();
+		this.revision += 1;
+		this.notify();
+	}
+
+	private schedule(item: AttachmentItem, externalSignal?: AbortSignal): void {
+		const operation = Symbol(item.id);
+		const controller = new AbortController();
+		let removeExternalAbort: (() => void) | undefined;
+		if (externalSignal) {
+			const abort = () => controller.abort();
+			if (externalSignal.aborted) controller.abort();
+			else {
+				externalSignal.addEventListener("abort", abort, { once: true });
+				removeExternalAbort = () => externalSignal.removeEventListener("abort", abort);
+			}
+		}
+		item.operation = operation;
+		item.controller = controller;
+		item.status = "processing";
+		item.error = undefined;
+		item.prepared = undefined;
+		this.queue.push({ item, operation, controller, removeExternalAbort });
+		this.changed();
+		this.pump();
+	}
+
+	private pump(): void {
+		while (this.active < this.concurrency && this.queue.length > 0) {
+			const job = this.queue.shift();
+			if (!job) break;
+			if (job.controller.signal.aborted) {
+				this.finishProcessing(job, undefined, abortError());
+				continue;
+			}
+			this.active += 1;
+			void this.options
+				.process(Buffer.from(job.item.source ?? []), job.controller.signal)
+				.then(
+					(prepared) => this.finishProcessing(job, prepared),
+					(error) => this.finishProcessing(job, undefined, error),
+				)
+				.finally(() => {
+					this.active -= 1;
+					this.pump();
+					this.resolveIdle();
+				});
+		}
+		this.resolveIdle();
+	}
+
+	private finishProcessing(
+		job: ProcessingJob,
+		prepared?: PreparedAttachment,
+		error?: unknown,
+	): void {
+		job.removeExternalAbort?.();
+		if (!this.isCurrent(job.item, job.operation)) return;
+		job.item.operation = undefined;
+		job.item.controller = undefined;
+		if (error || job.controller.signal.aborted) {
+			job.item.status = "error";
+			job.item.error = publicError(job.controller.signal.aborted ? abortError() : error);
+			job.item.prepared = undefined;
+			this.changed();
+			return;
+		}
+		try {
+			if (!prepared?.bytes.length || !prepared.mimeType.startsWith("image/")) {
+				throw new Error("Image processing returned an invalid result.");
+			}
+			const otherPreparedBytes = this.items.reduce(
+				(total, item) => total + (item === job.item ? 0 : (item.prepared?.bytes.byteLength ?? 0)),
+				0,
+			);
+			if (otherPreparedBytes + prepared.bytes.byteLength > this.options.limits.maxPromptBytes) {
+				throw new Error("Combined processed attachments are too large.");
+			}
+			const maximumResident =
+				this.options.limits.maxPromptBytes + this.options.limits.maxImageBytes * this.concurrency;
+			if (this.residentBytes() + prepared.bytes.byteLength > maximumResident) {
+				throw new Error("Attachment memory limit exceeded.");
+			}
+			job.item.prepared = clonePrepared(prepared);
+			job.item.source = undefined;
+			job.item.status = "ready";
+			job.item.error = undefined;
+		} catch (processingError) {
+			job.item.status = "error";
+			job.item.error = publicError(processingError);
+			job.item.prepared = undefined;
+		}
+		this.changed();
+	}
+
+	private isCurrent(item: AttachmentItem, operation: symbol): boolean {
+		return !this.closed && item.operation === operation && this.items.includes(item);
+	}
+
+	private requireItem(id: string): AttachmentItem {
+		const item = this.items.find((candidate) => candidate.id === id);
+		if (!item) throw new AttachmentError("Attachment was not found.", 404);
+		return item;
+	}
+
+	private assertUploadRevision(item: AttachmentItem, expectedRevision: number): void {
+		if (
+			!Number.isSafeInteger(expectedRevision) ||
+			expectedRevision < item.reservedRevision ||
+			expectedRevision > this.revision
+		) {
+			throw new AttachmentError(
+				`Attachment revision mismatch; current revision is ${this.revision}.`,
+			);
+		}
+	}
+
+	private assertMutable(expectedRevision: number): void {
+		this.assertOpen();
+		if (this.sendToken) throw new AttachmentError("Attachments are reserved for sending.");
+		if (!Number.isSafeInteger(expectedRevision) || expectedRevision !== this.revision) {
+			throw new AttachmentError(
+				`Attachment revision mismatch; current revision is ${this.revision}.`,
+			);
+		}
+	}
+
+	private assertOpen(): void {
+		if (this.closed) throw new AttachmentError("Attachment store is closed.", 410);
+	}
+
+	private changed(): void {
+		this.revision += 1;
+		this.notify();
+	}
+
+	private notify(): void {
+		this.options.onChange?.(this.publicState());
+	}
+
+	private releaseItem(item: AttachmentItem): void {
+		item.controller?.abort();
+		item.operation = undefined;
+		item.controller = undefined;
+		item.source = undefined;
+		item.prepared = undefined;
+	}
+
+	private releaseItems(): void {
+		for (const item of this.items) this.releaseItem(item);
+		this.items.length = 0;
+	}
+
+	private resolveIdle(): void {
+		if (this.active !== 0 || this.queue.length !== 0) return;
+		for (const resolve of this.idleWaiters) resolve();
+		this.idleWaiters.clear();
+	}
+
+	private phase(): AttachmentPhase {
+		if (this.closed) return "closed";
+		if (this.sendToken) return "reserved";
+		if (this.items.length === 0) return "empty";
+		if (this.items.some((item) => item.status === "error")) return "blocked";
+		if (this.items.some((item) => item.status === "processing")) return "processing";
+		if (this.items.some((item) => item.status === "uploading")) return "uploading";
+		return "ready";
+	}
+}
+
+function normalizeReservation(
+	input: AttachmentReservationInput,
+	limits: AttachmentLimits,
+): AttachmentReservationInput {
+	if (!input || typeof input.id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(input.id)) {
+		throw new AttachmentError("Attachment id is invalid.", 400);
+	}
+	if (
+		typeof input.name !== "string" ||
+		input.name.length === 0 ||
+		input.name.length > 255 ||
+		hasControlCharacter(input.name)
+	) {
+		throw new AttachmentError("Attachment name is invalid.", 400);
+	}
+	if (!Number.isSafeInteger(input.size) || input.size <= 0) {
+		throw new AttachmentError("Attachment size is invalid.", 400);
+	}
+	if (input.size > limits.maxImageBytes) {
+		throw new AttachmentError("Attachment exceeds the per-image maximum.", 413);
+	}
+	if (
+		input.mimeType !== undefined &&
+		(typeof input.mimeType !== "string" || input.mimeType.length > 128)
+	) {
+		throw new AttachmentError("Attachment MIME type is invalid.", 400);
+	}
+	return { id: input.id, name: input.name, size: input.size, mimeType: input.mimeType };
+}
+
+function validateLimits(limits: AttachmentLimits): void {
+	for (const value of [limits.maxImages, limits.maxImageBytes, limits.maxPromptBytes]) {
+		if (!Number.isSafeInteger(value) || value <= 0) {
+			throw new Error("Attachment limits must be positive integers.");
+		}
+	}
+	if (limits.maxImageBytes > limits.maxPromptBytes) {
+		throw new Error("Attachment per-image limit cannot exceed the combined limit.");
+	}
+}
+
+function hasControlCharacter(value: string): boolean {
+	return [...value].some((character) => {
+		const code = character.charCodeAt(0);
+		return code < 32 || code === 127;
+	});
+}
+
+function clonePrepared(prepared: PreparedAttachment): PreparedAttachment {
+	return {
+		...prepared,
+		bytes: Buffer.from(prepared.bytes),
+		notes: [...(prepared.notes ?? [])],
+	};
+}
+
+function publicError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	const cleaned = [...message]
+		.map((character) => {
+			const code = character.charCodeAt(0);
+			return code < 32 || code === 127 ? " " : character;
+		})
+		.join("")
+		.replace(/\s+/g, " ")
+		.trim();
+	return (cleaned || "Image processing failed.").slice(0, 240);
+}
+
+function abortError(): Error {
+	const error = new Error("Image processing was cancelled.");
+	error.name = "AbortError";
+	return error;
+}

--- a/extensions/pi-webui/src/images.ts
+++ b/extensions/pi-webui/src/images.ts
@@ -1,5 +1,12 @@
 import type { ImageContent } from "@earendil-works/pi-ai";
-import { detectImageFormat, type ProcessImageOptions, processImage } from "./image-pipeline.js";
+import {
+	detectImageFormat,
+	type ProcessedBrowserImage,
+	type ProcessImageOptions,
+	processImage,
+} from "./image-pipeline.js";
+
+export type { ProcessedBrowserImage } from "./image-pipeline.js";
 
 export { detectImageFormat } from "./image-pipeline.js";
 
@@ -108,6 +115,26 @@ export class ImageProcessor {
 				});
 		}
 	}
+}
+
+export async function processStagedImage(
+	source: Uint8Array,
+	options: ProcessBrowserImageOptions = {},
+): Promise<ProcessedBrowserImage> {
+	const limits = { ...DEFAULT_IMAGE_LIMITS, ...definedLimits(options) };
+	if (options.blockImages) throw new Error("Pi image sending is disabled.");
+	if (options.supportsImages === false)
+		throw new Error("The current model does not support images.");
+	assertNotAborted(options.signal);
+	if (source.byteLength === 0) throw new Error("Image is empty.");
+	if (source.byteLength > limits.maxImageBytes) throw new Error("Image is too large.");
+	return processImage(source, {
+		autoResize: options.autoResize !== false,
+		maxPixels: limits.maxPixels,
+		maxDimension: limits.maxDimension,
+		maxBase64Bytes: limits.maxBase64Bytes,
+		signal: options.signal,
+	});
 }
 
 export async function processBrowserImages(

--- a/extensions/pi-webui/src/runtime.ts
+++ b/extensions/pi-webui/src/runtime.ts
@@ -8,11 +8,14 @@ import {
 	getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import type { PreparedAttachment } from "./attachments.js";
 import { ConversationProjection, projectBranchMessages } from "./conversation.js";
 import {
 	type BrowserImageInput,
 	type ProcessBrowserImageOptions,
+	type ProcessedBrowserImage,
 	processBrowserImages,
+	processStagedImage,
 } from "./images.js";
 import { type EffectivePiImageSettings, readEffectivePiImageSettings } from "./pi-settings.js";
 import {
@@ -63,6 +66,10 @@ export interface RuntimeDependencies {
 		inputs: BrowserImageInput[],
 		options?: ProcessBrowserImageOptions,
 	): Promise<ImageContent[]>;
+	processAttachment(
+		source: Uint8Array,
+		options?: ProcessBrowserImageOptions,
+	): Promise<ProcessedBrowserImage>;
 }
 
 const DEFAULT_DEPENDENCIES: RuntimeDependencies = {
@@ -72,6 +79,7 @@ const DEFAULT_DEPENDENCIES: RuntimeDependencies = {
 	startServer: (options) => WebUIServer.start(options),
 	readPiSettings: readEffectivePiImageSettings,
 	processImages: processBrowserImages,
+	processAttachment: processStagedImage,
 };
 
 export class WebUIRuntime {
@@ -465,6 +473,8 @@ export class WebUIRuntime {
 			const starting = this.dependencies.startServer({
 				conversation,
 				send: (request) => this.sendBrowserMessage(request, generation),
+				processAttachment: (source, signal) =>
+					this.processStagedAttachment(source, generation, signal),
 			});
 			this.serverStarting = starting.then(async (server) => {
 				if (generation !== this.generation || this.closed || conversation !== this.conversation) {
@@ -481,6 +491,35 @@ export class WebUIRuntime {
 		} finally {
 			if (this.serverStarting === starting) this.serverStarting = undefined;
 		}
+	}
+
+	private async processStagedAttachment(
+		source: Uint8Array,
+		generation: number,
+		signal?: AbortSignal,
+	): Promise<PreparedAttachment> {
+		const ctx = this.context;
+		if (!ctx || this.closed || generation !== this.generation) {
+			throw new Error("The Pi session has ended.");
+		}
+		const combinedSignal = signal
+			? AbortSignal.any([this.sessionAbort.signal, signal])
+			: this.sessionAbort.signal;
+		const settings = await this.dependencies.readPiSettings(ctx.cwd, ctx.isProjectTrusted());
+		this.notifySettingsWarnings(ctx, settings.warnings);
+		const image = await this.dependencies.processAttachment(source, {
+			autoResize: settings.autoResize,
+			blockImages: settings.blockImages,
+			supportsImages: ctx.model?.input.includes("image") ?? false,
+			signal: combinedSignal,
+		});
+		if (combinedSignal.aborted || generation !== this.generation || this.closed) {
+			throw new Error("Image processing was cancelled.");
+		}
+		return {
+			...image,
+			notes: attachmentNotes(image),
+		};
 	}
 
 	private async sendBrowserMessage(
@@ -501,13 +540,13 @@ export class WebUIRuntime {
 		if (request.images.length > 0) {
 			const settings = await this.dependencies.readPiSettings(ctx.cwd, ctx.isProjectTrusted());
 			this.notifySettingsWarnings(ctx, settings.warnings);
-			images = await this.dependencies.processImages(request.images, {
-				autoResize: settings.autoResize,
-				blockImages: settings.blockImages,
-				supportsImages: ctx.model?.input.includes("image") ?? false,
-				signal,
-			});
+			if (settings.blockImages) throw new Error("Pi image sending is disabled.");
 			await this.validateCurrentModel(ctx, generation, signal, true);
+			images = request.images.map((image) => ({
+				type: "image" as const,
+				data: image.data,
+				mimeType: image.mimeType ?? "image/png",
+			}));
 		}
 		if (signal.aborted) throw new Error("The browser message was cancelled.");
 		if (!this.context || this.closed || generation !== this.generation) {
@@ -682,6 +721,21 @@ function sanitizeBrowserMessageEvent(
 		for (const nonce of consumed) acceptedNonces.delete(nonce);
 	}
 	return { ...event, message: { ...event.message, content: sanitized } };
+}
+
+function attachmentNotes(image: ProcessedBrowserImage): string[] {
+	const notes: string[] = [];
+	if (image.sourceFormat !== image.outputFormat) {
+		notes.push(
+			`Converted ${image.sourceFormat.toUpperCase()} to ${image.outputFormat.toUpperCase()}`,
+		);
+	}
+	if (image.resized) {
+		notes.push(
+			`Resized ${image.originalWidth}×${image.originalHeight} to ${image.width}×${image.height}`,
+		);
+	}
+	return notes;
 }
 
 function messageLifecycleKey(message: Record<string, unknown>): string {

--- a/extensions/pi-webui/src/server.ts
+++ b/extensions/pi-webui/src/server.ts
@@ -4,8 +4,15 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { Socket } from "node:net";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	AttachmentError,
+	type AttachmentLimits,
+	AttachmentStore,
+	type PreparedAttachment,
+	type PublicAttachmentState,
+} from "./attachments.js";
 import type { ConversationEvent, ConversationProjection } from "./conversation.js";
-import type { BrowserImageInput } from "./images.js";
+import { type BrowserImageInput, DEFAULT_IMAGE_LIMITS } from "./images.js";
 
 const JSON_LIMIT = 64 * 1024 * 1024;
 const CLIENT_ID = /^[A-Za-z0-9_-]{1,80}$/;
@@ -16,9 +23,19 @@ const SSE_FLUSH_TIMEOUT_MS = 250;
 export interface WebSendRequest {
 	requestId: string;
 	text: string;
+	attachmentRevision?: number;
+	attachmentIds?: string[];
 	images: BrowserImageInput[];
 	delivery: "next" | "steer";
 	signal?: AbortSignal;
+}
+
+interface ParsedSendRequest {
+	requestId: string;
+	text: string;
+	attachmentRevision: number;
+	attachmentIds: string[];
+	delivery: "next" | "steer";
 }
 
 export interface WebSendResult {
@@ -28,6 +45,8 @@ export interface WebSendResult {
 export interface WebUIServerOptions {
 	conversation: ConversationProjection;
 	send: (request: WebSendRequest) => Promise<WebSendResult>;
+	processAttachment?: (source: Uint8Array, signal?: AbortSignal) => Promise<PreparedAttachment>;
+	attachmentLimits?: AttachmentLimits;
 	maxRequestBytes?: number;
 }
 
@@ -60,6 +79,9 @@ export class WebUIServer {
 	private readonly sseClients = new Set<SseClient>();
 	private readonly requests = new Map<string, RequestRecord>();
 	private readonly activeSendControllers = new Set<AbortController>();
+	private readonly activeAttachmentControllers = new Set<AbortController>();
+	private readonly attachments: AttachmentStore;
+	private readonly attachmentLimits: AttachmentLimits;
 	private activeClientId?: string;
 	private leaseGeneration = 0;
 	private closed = false;
@@ -72,6 +94,20 @@ export class WebUIServer {
 		port: number,
 	) {
 		this.origin = `http://127.0.0.1:${port}`;
+		this.attachmentLimits = options.attachmentLimits ?? {
+			maxImages: DEFAULT_IMAGE_LIMITS.maxImages,
+			maxImageBytes: DEFAULT_IMAGE_LIMITS.maxImageBytes,
+			maxPromptBytes: DEFAULT_IMAGE_LIMITS.maxPromptBytes,
+		};
+		this.attachments = new AttachmentStore({
+			limits: this.attachmentLimits,
+			process:
+				options.processAttachment ??
+				(async () => {
+					throw new Error("Image processing is unavailable.");
+				}),
+			onChange: (state) => this.broadcastControl("attachments", state),
+		});
 		server.on("connection", (socket) => {
 			this.sockets.add(socket);
 			socket.once("close", () => this.sockets.delete(socket));
@@ -123,7 +159,10 @@ export class WebUIServer {
 		this.bootstrapToken = undefined;
 		this.unsubscribe();
 		for (const controller of this.activeSendControllers) controller.abort();
+		for (const controller of this.activeAttachmentControllers) controller.abort();
 		this.activeSendControllers.clear();
+		this.activeAttachmentControllers.clear();
+		this.attachments.close();
 		this.requests.clear();
 		const responses = [...this.sseClients].map((client) => client.response);
 		this.broadcastControl("session-ended", { message: "Pi session ended" });
@@ -166,7 +205,18 @@ export class WebUIServer {
 				this.json(response, 200, {
 					...this.options.conversation.snapshot(),
 					lease: this.leaseSnapshot(),
+					attachments: this.attachments.publicState(),
 				});
+				return;
+			}
+			const previewId = attachmentPathId(url.pathname, "preview");
+			if (request.method === "GET" && previewId) {
+				const preview = this.attachments.preview(previewId);
+				response.writeHead(200, {
+					"Content-Type": preview.mimeType,
+					"Content-Length": preview.bytes.byteLength,
+				});
+				response.end(preview.bytes);
 				return;
 			}
 			if (request.method === "GET" && url.pathname === "/api/events") {
@@ -184,6 +234,8 @@ export class WebUIServer {
 				this.activeClientId = clientId;
 				this.leaseGeneration += 1;
 				for (const controller of this.activeSendControllers) controller.abort();
+				for (const controller of this.activeAttachmentControllers) controller.abort();
+				this.attachments.cancelInFlight("Editing moved to another browser tab.");
 				this.broadcastControl("lease", {
 					activeClientId: clientId,
 					generation: this.leaseGeneration,
@@ -195,17 +247,94 @@ export class WebUIServer {
 				return;
 			}
 			const lease = this.assertActiveClient(request);
+			if (request.method === "POST" && url.pathname === "/api/attachments/reserve") {
+				const body = requireRecord(await readJson(request, 64 * 1024), "attachment reservation");
+				this.assertLease(lease);
+				const state = this.attachments.reserve(
+					parseAttachmentReservations(body.items),
+					numberField(body, "revision"),
+				);
+				this.assertLease(lease);
+				this.json(response, 201, state);
+				return;
+			}
+			const uploadId = attachmentPathId(url.pathname, "upload");
+			if (request.method === "POST" && uploadId) {
+				const revision = revisionParameter(url);
+				let source: Buffer;
+				try {
+					source = await readBytes(request, this.attachmentLimits.maxImageBytes);
+				} catch (error) {
+					this.assertLease(lease);
+					try {
+						this.attachments.failUpload(uploadId, `Upload failed: ${formatError(error)}`);
+					} catch (failure) {
+						if (!(failure instanceof AttachmentError) || failure.status !== 409) throw failure;
+					}
+					throw error;
+				}
+				this.assertLease(lease);
+				const state = await this.runAttachmentOperation(request, response, (signal) =>
+					this.attachments.upload(uploadId, source, revision, signal),
+				);
+				this.assertLease(lease);
+				this.json(response, 200, state);
+				return;
+			}
+			const retryId = attachmentPathId(url.pathname, "retry");
+			if (request.method === "POST" && retryId) {
+				const body = requireRecord(await readJson(request, 8 * 1024), "attachment retry");
+				this.assertLease(lease);
+				const state = await this.runAttachmentOperation(request, response, (signal) =>
+					this.attachments.retry(retryId, numberField(body, "revision"), signal),
+				);
+				this.assertLease(lease);
+				this.json(response, 200, state);
+				return;
+			}
+			const deleteId = attachmentPathId(url.pathname);
+			if (request.method === "DELETE" && deleteId) {
+				const state = this.attachments.remove(deleteId, revisionParameter(url));
+				this.assertLease(lease);
+				this.json(response, 200, state);
+				return;
+			}
+			if (request.method === "POST" && url.pathname === "/api/attachments/reorder") {
+				const body = requireRecord(await readJson(request, 64 * 1024), "attachment reorder");
+				this.assertLease(lease);
+				const state = this.attachments.reorder(
+					stringArrayField(body, "ids"),
+					numberField(body, "revision"),
+				);
+				this.assertLease(lease);
+				this.json(response, 200, state);
+				return;
+			}
+			if (request.method === "POST" && url.pathname === "/api/attachments/clear") {
+				const body = requireRecord(await readJson(request, 8 * 1024), "attachment clear");
+				this.assertLease(lease);
+				const state = this.attachments.clear(numberField(body, "revision"));
+				this.assertLease(lease);
+				this.json(response, 200, state);
+				return;
+			}
 			if (request.method === "POST" && url.pathname === "/api/messages") {
 				const body = await readJson(request, this.options.maxRequestBytes ?? JSON_LIMIT);
 				this.assertLease(lease);
 				const message = parseSendRequest(body);
 				const result = await this.sendDeduplicated(message, request, response);
-				this.json(response, 202, { accepted: true, requestId: message.requestId, ...result });
+				this.json(response, 202, {
+					accepted: true,
+					requestId: message.requestId,
+					...result,
+					attachments: this.attachments.publicState(),
+				});
 				return;
 			}
 			throw new HttpError(404, "Not found");
 		} catch (error) {
-			const status = error instanceof HttpError ? error.status : 500;
+			const status =
+				error instanceof HttpError || error instanceof AttachmentError ? error.status : 500;
 			if (error instanceof HttpError && error.closeConnection)
 				response.setHeader("Connection", "close");
 			this.json(response, status, { error: formatError(error) });
@@ -253,8 +382,27 @@ export class WebUIServer {
 		}
 	}
 
+	private async runAttachmentOperation(
+		request: IncomingMessage,
+		response: ServerResponse,
+		operation: (signal: AbortSignal) => PublicAttachmentState | Promise<PublicAttachmentState>,
+	): Promise<PublicAttachmentState> {
+		const controller = new AbortController();
+		this.activeAttachmentControllers.add(controller);
+		const abort = () => controller.abort();
+		request.once("aborted", abort);
+		response.once("close", abort);
+		try {
+			return await operation(controller.signal);
+		} finally {
+			request.off("aborted", abort);
+			response.off("close", abort);
+			this.activeAttachmentControllers.delete(controller);
+		}
+	}
+
 	private async sendDeduplicated(
-		message: WebSendRequest,
+		message: ParsedSendRequest,
 		request: IncomingMessage,
 		response: ServerResponse,
 	): Promise<WebSendResult> {
@@ -265,14 +413,21 @@ export class WebUIServer {
 				throw new HttpError(409, "Request id was reused with different content");
 			return current.promise;
 		}
+		const reservation =
+			message.attachmentIds.length > 0
+				? this.attachments.beginSend(message.attachmentIds, message.attachmentRevision)
+				: undefined;
 		const controller = new AbortController();
 		this.activeSendControllers.add(controller);
 		const abort = () => controller.abort();
 		request.once("aborted", abort);
 		response.once("close", abort);
+		let attachmentReservationSettled = false;
 		const promise = this.options
-			.send({ ...message, signal: controller.signal })
+			.send({ ...message, images: reservation?.images ?? [], signal: controller.signal })
 			.then((result) => {
+				if (reservation) this.attachments.finishSend(reservation.token, true);
+				attachmentReservationSettled = true;
 				const record = this.requests.get(message.requestId);
 				if (record?.promise === promise) {
 					record.settled = true;
@@ -281,6 +436,14 @@ export class WebUIServer {
 				return result;
 			})
 			.catch((error) => {
+				if (reservation && !attachmentReservationSettled) {
+					try {
+						this.attachments.finishSend(reservation.token, false);
+					} catch {
+						// Session shutdown may already have released the reservation.
+					}
+					attachmentReservationSettled = true;
+				}
 				if (this.requests.get(message.requestId)?.promise === promise) {
 					this.requests.delete(message.requestId);
 				}
@@ -326,6 +489,7 @@ export class WebUIServer {
 			return;
 		}
 		this.writeSse(client, "lease", this.leaseSnapshot());
+		this.writeSse(client, "attachments", this.attachments.publicState());
 		const replay = this.options.conversation.eventsAfter(since);
 		if (replay === undefined) {
 			this.writeSse(client, "snapshot", this.options.conversation.snapshot());
@@ -421,46 +585,52 @@ async function readAsset(name: string): Promise<Buffer> {
 	}
 }
 
-function messageDigest(message: WebSendRequest): string {
+function messageDigest(message: ParsedSendRequest): string {
 	const hash = createHash("sha256");
-	for (const value of [message.requestId, message.delivery, message.text]) {
+	for (const value of [
+		message.requestId,
+		message.delivery,
+		message.text,
+		String(message.attachmentRevision),
+		...message.attachmentIds,
+	]) {
 		hash
 			.update(String(Buffer.byteLength(value)))
 			.update(":")
 			.update(value);
 	}
-	for (const image of message.images) {
-		for (const value of [image.name ?? "", image.mimeType ?? "", image.data]) {
-			hash
-				.update(String(Buffer.byteLength(value)))
-				.update(":")
-				.update(value);
-		}
-	}
 	return hash.digest("hex");
 }
 
-function parseSendRequest(value: unknown): WebSendRequest {
+function parseSendRequest(value: unknown): ParsedSendRequest {
 	if (!isRecord(value)) throw new HttpError(400, "Invalid message request");
 	const requestId = stringField(value, "requestId");
 	if (!REQUEST_ID.test(requestId)) throw new HttpError(400, "Invalid request id");
 	const text = stringField(value, "text");
-	const imagesValue = value.images;
-	if (!Array.isArray(imagesValue)) throw new HttpError(400, "Invalid image list");
-	if (!text.trim() && imagesValue.length === 0) throw new HttpError(400, "Message cannot be empty");
+	const attachmentRevision = numberField(value, "attachmentRevision");
+	const attachmentIds = stringArrayField(value, "attachmentIds");
+	if (!text.trim() && attachmentIds.length === 0)
+		throw new HttpError(400, "Message cannot be empty");
 	const delivery = value.delivery;
 	if (delivery !== "next" && delivery !== "steer")
 		throw new HttpError(400, "Invalid delivery mode");
-	const images = imagesValue.map((image) => {
-		if (!isRecord(image) || typeof image.data !== "string")
-			throw new HttpError(400, "Invalid image");
-		return {
-			data: image.data,
-			...(typeof image.name === "string" ? { name: image.name } : {}),
-			...(typeof image.mimeType === "string" ? { mimeType: image.mimeType } : {}),
-		};
-	});
-	return { requestId, text, images, delivery };
+	return { requestId, text, attachmentRevision, attachmentIds, delivery };
+}
+
+async function readBytes(request: IncomingMessage, limit: number): Promise<Buffer> {
+	const length = Number(request.headers["content-length"] ?? "0");
+	if (Number.isFinite(length) && length > limit) {
+		throw new HttpError(413, "Request body is too large", true);
+	}
+	const chunks: Buffer[] = [];
+	let total = 0;
+	for await (const chunk of request) {
+		const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+		total += bytes.byteLength;
+		if (total > limit) throw new HttpError(413, "Request body is too large", true);
+		chunks.push(bytes);
+	}
+	return Buffer.concat(chunks);
 }
 
 async function readJson(request: IncomingMessage, limit: number): Promise<unknown> {
@@ -479,10 +649,66 @@ async function readJson(request: IncomingMessage, limit: number): Promise<unknow
 	}
 }
 
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+	if (!isRecord(value)) throw new HttpError(400, `Invalid ${label}`);
+	return value;
+}
+
 function stringField(value: Record<string, unknown>, key: string): string {
 	const field = value[key];
 	if (typeof field !== "string") throw new HttpError(400, `Invalid ${key}`);
 	return field;
+}
+
+function numberField(value: Record<string, unknown>, key: string): number {
+	const field = value[key];
+	if (!Number.isSafeInteger(field) || (field as number) < 0) {
+		throw new HttpError(400, `Invalid ${key}`);
+	}
+	return field as number;
+}
+
+function stringArrayField(value: Record<string, unknown>, key: string): string[] {
+	const field = value[key];
+	if (!Array.isArray(field) || field.some((item) => typeof item !== "string")) {
+		throw new HttpError(400, `Invalid ${key}`);
+	}
+	return field;
+}
+
+function parseAttachmentReservations(value: unknown): Array<{
+	id: string;
+	name: string;
+	size: number;
+	mimeType?: string;
+}> {
+	if (!Array.isArray(value)) throw new HttpError(400, "Invalid attachment list");
+	return value.map((entry) => {
+		const item = requireRecord(entry, "attachment");
+		return {
+			id: stringField(item, "id"),
+			name: stringField(item, "name"),
+			size: numberField(item, "size"),
+			...(typeof item.mimeType === "string" ? { mimeType: item.mimeType } : {}),
+		};
+	});
+}
+
+function revisionParameter(url: URL): number {
+	const value = url.searchParams.get("revision");
+	if (!value || !/^\d+$/.test(value)) throw new HttpError(400, "Invalid attachment revision");
+	const revision = Number(value);
+	if (!Number.isSafeInteger(revision)) throw new HttpError(400, "Invalid attachment revision");
+	return revision;
+}
+
+function attachmentPathId(
+	pathname: string,
+	action?: "upload" | "retry" | "preview",
+): string | undefined {
+	const suffix = action ? `/${action}` : "";
+	const match = new RegExp(`^/api/attachments/([A-Za-z0-9_-]{1,128})${suffix}$`).exec(pathname);
+	return match?.[1];
 }
 
 function token(): string {

--- a/extensions/pi-webui/src/web/app.js
+++ b/extensions/pi-webui/src/web/app.js
@@ -1,10 +1,10 @@
 import {
+	applyAttachments,
 	applyConversationEvent,
 	applyLease,
 	applySnapshot,
 	busyLabel,
 	canSend,
-	clearDraftImages,
 	completeSend,
 	deliveryNotice,
 	failSend,
@@ -30,6 +30,9 @@ let transcriptFrame;
 let transcriptAnnouncement = "";
 let dragDepth = 0;
 let previewReturnFocus;
+let mutatingAttachments = false;
+const retryFiles = new Map();
+const uploadProgress = new Map();
 
 const SUPPORTED_IMAGE_TYPES = new Set([
 	"image/png",
@@ -103,7 +106,7 @@ ui.clearDialog.addEventListener("close", () => {
 		requestAnimationFrame(() => ui.clearAttachments.focus());
 		return;
 	}
-	clearAttachments();
+	void clearAttachments();
 });
 ui.input.addEventListener("keydown", (event) => {
 	if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
@@ -158,6 +161,7 @@ ui.previewClose.addEventListener("click", () => ui.previewDialog.close());
 ui.previewDismiss.addEventListener("click", () => ui.previewDialog.close());
 ui.previewDialog.addEventListener("close", () => {
 	ui.previewImage.removeAttribute("src");
+	delete ui.previewImage.dataset.imageId;
 	ui.previewImage.alt = "";
 	if (previewReturnFocus?.isConnected) previewReturnFocus.focus();
 	previewReturnFocus = undefined;
@@ -238,6 +242,10 @@ function connectEvents() {
 		model = applyLease(model, JSON.parse(event.data), clientId);
 		render();
 	});
+	events.addEventListener("attachments", (event) => {
+		model = applyAttachments(model, JSON.parse(event.data));
+		render();
+	});
 	events.addEventListener("session-ended", () => {
 		model = { ...model, closed: true, activity: "ended", connected: false };
 		events?.close();
@@ -282,7 +290,8 @@ async function send(steer) {
 	const payload = {
 		requestId: attempt.requestId,
 		text: attempt.text,
-		images: attempt.images.map(({ name, mimeType, data }) => ({ name, mimeType, data })),
+		attachmentRevision: attempt.attachmentRevision,
+		attachmentIds: attempt.attachmentIds,
 		delivery: attempt.delivery,
 	};
 	try {
@@ -297,10 +306,11 @@ async function send(steer) {
 			throw new Error(message);
 		}
 		const accepted = await response.json();
-		for (const image of attempt.images) URL.revokeObjectURL(image.previewUrl);
-		if (attempt.images.some((image) => image.previewUrl === ui.previewImage.src)) {
+		if (accepted.attachments) model = applyAttachments(model, accepted.attachments);
+		if (attempt.attachmentIds.includes(ui.previewImage.dataset.imageId)) {
 			ui.previewDialog.close();
 		}
+		for (const id of attempt.attachmentIds) retryFiles.delete(id);
 		model = completeSend(model, attempt, accepted.delivery);
 		render();
 		ui.input.focus();
@@ -311,52 +321,123 @@ async function send(steer) {
 }
 
 async function addFiles(fileList) {
-	if (composerLocked()) return;
+	if (composerLocked() || model.readingImages > 0) return;
 	const files = [...(fileList ?? [])];
+	if (files.length === 0) return;
 	if (model.images.length + files.length > 8) {
 		model = { ...model, error: "You can attach at most 8 images." };
 		render();
 		return;
 	}
-	model = { ...model, readingImages: model.readingImages + 1 };
+	for (const file of files) {
+		if (!isSupportedImageFile(file)) {
+			model = { ...model, error: `${file.name || "Image"} is not a supported image.` };
+			render();
+			return;
+		}
+		if (file.size > 10 * 1024 * 1024) {
+			model = { ...model, error: `${file.name || "Image"} is larger than 10 MB.` };
+			render();
+			return;
+		}
+	}
+	const pending = files.map((file) => ({ id: crypto.randomUUID(), file }));
+	try {
+		mutatingAttachments = true;
+		renderComposer();
+		const response = await attachmentMutation("/api/attachments/reserve", {
+			method: "POST",
+			body: JSON.stringify({
+				revision: model.attachmentRevision,
+				items: pending.map(({ id, file }) => ({
+					id,
+					name: file.name || "Pasted image",
+					size: file.size,
+					mimeType: file.type,
+				})),
+			}),
+		});
+		model = applyAttachments(model, response);
+		for (const { id, file } of pending) retryFiles.set(id, file);
+		render();
+		for (const { id, file } of pending) await uploadFile(id, file);
+	} catch (error) {
+		model = { ...model, error: errorMessage(error) };
+		render();
+	} finally {
+		mutatingAttachments = false;
+		renderComposer();
+	}
+}
+
+async function uploadFile(id, file) {
+	uploadProgress.set(id, { loaded: 0, total: file.size });
 	renderComposer();
 	try {
-		for (const file of files) {
-			if (model.images.length >= 8) {
-				model = { ...model, error: "You can attach at most 8 images." };
-				break;
+		const state = await uploadAttachment(
+			`/api/attachments/${encodeURIComponent(id)}/upload?revision=${model.attachmentRevision}`,
+			file,
+			(progress) => {
+				uploadProgress.set(id, progress);
+				renderComposer();
+			},
+		);
+		retryFiles.delete(id);
+		model = applyAttachments(model, state);
+		render();
+	} finally {
+		uploadProgress.delete(id);
+		renderComposer();
+	}
+}
+
+function uploadAttachment(path, file, onProgress) {
+	return new Promise((resolve, reject) => {
+		const request = new XMLHttpRequest();
+		request.open("POST", path);
+		request.responseType = "json";
+		request.setRequestHeader("Content-Type", "application/octet-stream");
+		request.setRequestHeader("X-Pi-Web-Client", clientId);
+		request.upload.addEventListener("progress", (event) => {
+			if (event.lengthComputable) onProgress({ loaded: event.loaded, total: event.total });
+		});
+		request.addEventListener("load", () => {
+			if (request.status >= 200 && request.status < 300) {
+				resolve(request.response);
+				return;
 			}
-			if (!isSupportedImageFile(file)) {
-				model = { ...model, error: `${file.name || "Image"} is not a supported image.` };
-				continue;
-			}
-			if (file.size > 10 * 1024 * 1024) {
-				model = { ...model, error: `${file.name || "Image"} is larger than 10 MB.` };
-				continue;
-			}
-			try {
-				const data = await readBase64(file);
-				model = invalidateSendAttempt({
-					...model,
-					images: [
-						...model.images,
-						{
-							id: crypto.randomUUID(),
-							name: file.name || "Pasted image",
-							mimeType: file.type,
-							data,
-							previewUrl: URL.createObjectURL(file),
-						},
-					],
-					error: "",
-				});
-			} catch (error) {
-				model = { ...model, error: errorMessage(error) };
-			}
+			reject(new Error(request.response?.error || `Request failed (${request.status}).`));
+		});
+		request.addEventListener("error", () => reject(new Error("Image upload failed.")));
+		request.addEventListener("abort", () => reject(new Error("Image upload was cancelled.")));
+		request.send(file);
+	});
+}
+
+async function retryImage(id) {
+	if (composerLocked()) return;
+	mutatingAttachments = true;
+	renderComposer();
+	try {
+		const file = retryFiles.get(id);
+		if (file) {
+			await uploadFile(id, file);
+		} else {
+			const response = await attachmentMutation(
+				`/api/attachments/${encodeURIComponent(id)}/retry`,
+				{
+					method: "POST",
+					body: JSON.stringify({ revision: model.attachmentRevision }),
+				},
+			);
+			model = applyAttachments(model, response);
 			render();
 		}
+	} catch (error) {
+		model = { ...model, error: errorMessage(error) };
+		render();
 	} finally {
-		model = { ...model, readingImages: Math.max(0, model.readingImages - 1) };
+		mutatingAttachments = false;
 		renderComposer();
 	}
 }
@@ -368,22 +449,29 @@ function isSupportedImageFile(file) {
 	);
 }
 
-function clearAttachments() {
+async function clearAttachments() {
 	if (composerLocked() || model.images.length < 2) return;
-	if (model.images.some((image) => image.previewUrl === ui.previewImage.src)) {
-		ui.previewDialog.close();
-	}
-	for (const image of model.images) URL.revokeObjectURL(image.previewUrl);
-	model = clearDraftImages(model);
-	render();
+	const clearedIds = model.images.map((image) => image.id);
+	if (clearedIds.includes(ui.previewImage.dataset.imageId)) ui.previewDialog.close();
+	const state = await mutateAttachmentState("/api/attachments/clear", {
+		method: "POST",
+		body: JSON.stringify({ revision: model.attachmentRevision }),
+	});
+	if (!state) return;
+	for (const id of clearedIds) retryFiles.delete(id);
 	ui.input.focus();
 }
 
-function reorderImages(images, focusId, focusDirection) {
+async function reorderImages(images, focusId, focusDirection) {
 	if (composerLocked()) return;
-	model = invalidateSendAttempt({ ...model, images, error: "" });
-	render();
-	focusOrderingControl(focusId, focusDirection);
+	const state = await mutateAttachmentState("/api/attachments/reorder", {
+		method: "POST",
+		body: JSON.stringify({
+			revision: model.attachmentRevision,
+			ids: images.map((image) => image.id),
+		}),
+	});
+	if (state) focusOrderingControl(focusId, focusDirection);
 }
 
 function focusOrderingControl(id, direction) {
@@ -399,41 +487,59 @@ function focusOrderingControl(id, direction) {
 	});
 }
 
-function removeImage(id) {
+async function removeImage(id) {
 	if (composerLocked()) return;
-	const removed = model.images.find((image) => image.id === id);
-	if (removed) {
-		if (ui.previewImage.src === removed.previewUrl) ui.previewDialog.close();
-		URL.revokeObjectURL(removed.previewUrl);
+	if (ui.previewImage.dataset.imageId === id) ui.previewDialog.close();
+	const state = await mutateAttachmentState(
+		`/api/attachments/${encodeURIComponent(id)}?revision=${model.attachmentRevision}`,
+		{ method: "DELETE", headers: { "Content-Type": "application/json" } },
+	);
+	if (state) {
+		retryFiles.delete(id);
+		uploadProgress.delete(id);
 	}
-	model = invalidateSendAttempt({
-		...model,
-		images: model.images.filter((image) => image.id !== id),
+}
+
+async function mutateAttachmentState(path, options) {
+	if (composerLocked()) return;
+	mutatingAttachments = true;
+	renderComposer();
+	try {
+		const state = await attachmentMutation(path, options);
+		model = applyAttachments(model, state);
+		model = { ...model, error: "" };
+		render();
+		return state;
+	} catch (error) {
+		model = { ...model, error: errorMessage(error) };
+		render();
+	} finally {
+		mutatingAttachments = false;
+		renderComposer();
+	}
+}
+
+async function attachmentMutation(path, options) {
+	const response = await fetch(path, {
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			"X-Pi-Web-Client": clientId,
+			...options.headers,
+		},
 	});
-	render();
+	if (!response.ok) throw new Error(await responseError(response));
+	return response.json();
 }
 
 function openImagePreview(image) {
+	if (image.status !== "ready") return;
 	previewReturnFocus = document.activeElement;
 	ui.previewTitle.textContent = image.name;
-	ui.previewImage.src = image.previewUrl;
+	ui.previewImage.src = `/api/attachments/${encodeURIComponent(image.id)}/preview?v=${model.attachmentRevision}`;
+	ui.previewImage.dataset.imageId = image.id;
 	ui.previewImage.alt = image.name;
 	ui.previewDialog.showModal();
-}
-
-function readBase64(file) {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.addEventListener("error", () => reject(new Error(`Could not read ${file.name}.`)));
-		reader.addEventListener("load", () => {
-			if (typeof reader.result !== "string") {
-				reject(new Error(`Could not read ${file.name}.`));
-				return;
-			}
-			resolve(reader.result.slice(reader.result.indexOf(",") + 1));
-		});
-		reader.readAsDataURL(file);
-	});
 }
 
 function render(options = {}) {
@@ -481,9 +587,10 @@ function renderComposer() {
 	ui.steer.hidden = model.activity !== "running";
 	ui.steer.disabled = !canSend(model);
 	ui.input.disabled = locked;
-	ui.imageInput.disabled = locked;
-	ui.addImages.classList.toggle("disabled", locked);
-	ui.addImages.setAttribute("aria-disabled", String(locked));
+	const admissionLocked = locked || model.readingImages > 0;
+	ui.imageInput.disabled = admissionLocked;
+	ui.addImages.classList.toggle("disabled", admissionLocked);
+	ui.addImages.setAttribute("aria-disabled", String(admissionLocked));
 	ui.clearAttachments.hidden = model.images.length < 2;
 	ui.clearAttachments.disabled = locked;
 	ui.status.textContent = composerStatus();
@@ -493,7 +600,7 @@ function renderComposer() {
 	const attachmentStatus =
 		model.images.length === 0
 			? ""
-			: `${model.images.length} of 8 images attached · Sensitive metadata is removed before sending.`;
+			: `${model.images.length} of 8 images staged · ${attachmentPhaseLabel(model.attachmentPhase)} · Sensitive metadata is removed before sending.`;
 	if (ui.attachmentStatus.textContent !== attachmentStatus) {
 		ui.attachmentStatus.textContent = attachmentStatus;
 	}
@@ -502,9 +609,10 @@ function renderComposer() {
 		const item = document.createElement("li");
 		item.className = "image-preview-item";
 		item.dataset.imageId = image.id;
-		item.draggable = !model.pending && !locked;
+		const orderingLocked = locked || model.attachmentPhase !== "ready";
+		item.draggable = image.status === "ready" && !orderingLocked;
 		item.addEventListener("dragstart", (event) => {
-			if (locked || !event.dataTransfer) return;
+			if (orderingLocked || !event.dataTransfer) return;
 			event.dataTransfer.effectAllowed = "move";
 			event.dataTransfer.setData("application/x-pi-webui-image", image.id);
 			item.classList.add("dragging");
@@ -515,7 +623,7 @@ function renderComposer() {
 		});
 		item.addEventListener("dragover", (event) => {
 			const draggedId = event.dataTransfer?.getData("application/x-pi-webui-image");
-			if (locked || !draggedId || draggedId === image.id) return;
+			if (orderingLocked || !draggedId || draggedId === image.id) return;
 			event.preventDefault();
 			item.classList.add("drag-target");
 		});
@@ -523,23 +631,37 @@ function renderComposer() {
 		item.addEventListener("drop", (event) => {
 			const draggedId = event.dataTransfer?.getData("application/x-pi-webui-image");
 			item.classList.remove("drag-target");
-			if (locked || !draggedId || draggedId === image.id) return;
+			if (orderingLocked || !draggedId || draggedId === image.id) return;
 			event.preventDefault();
 			event.stopPropagation();
-			reorderImages(moveImageBefore(model.images, draggedId, image.id), draggedId, "forward");
+			void reorderImages(moveImageBefore(model.images, draggedId, image.id), draggedId, "forward");
 		});
 		const previewButton = document.createElement("button");
 		previewButton.type = "button";
 		previewButton.className = "attachment-preview";
 		previewButton.setAttribute("aria-label", `Preview image ${image.name}`);
-		previewButton.disabled = locked;
+		previewButton.disabled = locked || image.status !== "ready";
 		previewButton.addEventListener("click", () => openImagePreview(image));
 		const preview = document.createElement("img");
-		preview.src = image.previewUrl;
+		if (image.status === "ready") {
+			preview.src = `/api/attachments/${encodeURIComponent(image.id)}/preview?v=${model.attachmentRevision}`;
+		}
 		preview.alt = "";
 		previewButton.append(preview);
+		const details = document.createElement("span");
+		details.className = "attachment-details";
 		const name = document.createElement("span");
 		name.textContent = image.name;
+		const itemStatus = document.createElement("span");
+		itemStatus.className = `attachment-item-status ${image.status}`;
+		itemStatus.textContent = attachmentItemLabel(image, uploadProgress.get(image.id));
+		details.append(name, itemStatus);
+		if (Array.isArray(image.notes) && image.notes.length > 0) {
+			const summary = document.createElement("span");
+			summary.className = "attachment-conversion-summary";
+			summary.textContent = image.notes.join(" · ");
+			details.append(summary);
+		}
 		const actions = document.createElement("div");
 		actions.className = "image-order-actions";
 		const backward = document.createElement("button");
@@ -547,20 +669,22 @@ function renderComposer() {
 		backward.className = "move-image";
 		backward.textContent = "←";
 		backward.dataset.orderAction = "backward";
-		backward.disabled = locked || index === 0;
+		backward.disabled = orderingLocked || index === 0;
 		backward.setAttribute("aria-label", `Move image backward: ${image.name}`);
-		backward.addEventListener("click", () =>
-			reorderImages(moveImage(model.images, image.id, -1), image.id, "backward"),
+		backward.addEventListener(
+			"click",
+			() => void reorderImages(moveImage(model.images, image.id, -1), image.id, "backward"),
 		);
 		const forward = document.createElement("button");
 		forward.type = "button";
 		forward.className = "move-image";
 		forward.textContent = "→";
 		forward.dataset.orderAction = "forward";
-		forward.disabled = locked || index === model.images.length - 1;
+		forward.disabled = orderingLocked || index === model.images.length - 1;
 		forward.setAttribute("aria-label", `Move image forward: ${image.name}`);
-		forward.addEventListener("click", () =>
-			reorderImages(moveImage(model.images, image.id, 1), image.id, "forward"),
+		forward.addEventListener(
+			"click",
+			() => void reorderImages(moveImage(model.images, image.id, 1), image.id, "forward"),
 		);
 		const remove = document.createElement("button");
 		remove.type = "button";
@@ -568,9 +692,19 @@ function renderComposer() {
 		remove.textContent = "Remove";
 		remove.disabled = locked;
 		remove.setAttribute("aria-label", `Remove image ${image.name}`);
-		remove.addEventListener("click", () => removeImage(image.id));
+		remove.addEventListener("click", () => void removeImage(image.id));
+		if (image.status === "error" && (image.retryable || retryFiles.has(image.id))) {
+			const retry = document.createElement("button");
+			retry.type = "button";
+			retry.className = "retry-image";
+			retry.textContent = "Retry";
+			retry.disabled = locked;
+			retry.setAttribute("aria-label", `Retry image ${image.name}`);
+			retry.addEventListener("click", () => void retryImage(image.id));
+			actions.append(retry);
+		}
 		actions.append(backward, forward, remove);
-		item.append(previewButton, name, actions);
+		item.append(previewButton, details, actions);
 		ui.previews.append(item);
 	}
 	document.documentElement.style.setProperty("--composer-height", `${ui.composer.offsetHeight}px`);
@@ -599,8 +733,31 @@ function resizeInput() {
 	ui.input.style.height = `${Math.min(ui.input.scrollHeight, window.innerHeight * 0.32)}px`;
 }
 
+function attachmentPhaseLabel(phase) {
+	if (phase === "uploading") return "Uploading";
+	if (phase === "processing") return "Processing";
+	if (phase === "blocked") return "Needs attention";
+	if (phase === "reserved") return "Submitting";
+	return "Ready";
+}
+
+function attachmentItemLabel(image, progress) {
+	if (image.status === "uploading" && progress?.total > 0) {
+		const percent = Math.min(100, Math.round((progress.loaded / progress.total) * 100));
+		return `Uploading · ${percent}%`;
+	}
+	if (image.status === "uploading") return "Uploading…";
+	if (image.status === "processing") return "Processing…";
+	if (image.status === "error") return image.error || "Needs attention";
+	const dimensions =
+		Number.isSafeInteger(image.width) && Number.isSafeInteger(image.height)
+			? ` · ${image.width}×${image.height}`
+			: "";
+	return `Ready${dimensions}`;
+}
+
 function composerStatus() {
-	if (model.readingImages > 0) return "Preparing images…";
+	if (model.readingImages > 0) return "Staging images on this Pi session…";
 	if (model.pending) return "Submitting message…";
 	const notice = deliveryNotice(model);
 	if (notice) return notice;
@@ -629,7 +786,13 @@ function conversationAnnouncement(event) {
 }
 
 function composerLocked() {
-	return model.closed || model.stale || model.pending;
+	return (
+		model.closed ||
+		model.stale ||
+		model.pending ||
+		mutatingAttachments ||
+		model.attachmentPhase === "reserved"
+	);
 }
 
 function hasDraggedFile(event) {

--- a/extensions/pi-webui/src/web/state.js
+++ b/extensions/pi-webui/src/web/state.js
@@ -13,6 +13,8 @@ export function initialState() {
 		readingImages: 0,
 		leaseClaimed: false,
 		leaseGeneration: 0,
+		attachmentRevision: 0,
+		attachmentPhase: "empty",
 		following: true,
 		unseenUpdateIds: [],
 		text: "",
@@ -22,17 +24,47 @@ export function initialState() {
 }
 
 export function applySnapshot(current, snapshot) {
-	if (!Number.isSafeInteger(snapshot?.sequence) || snapshot.sequence < current.sequence)
+	let next = current;
+	if (Number.isSafeInteger(snapshot?.sequence) && snapshot.sequence >= current.sequence) {
+		next = {
+			...current,
+			sequence: snapshot.sequence,
+			session: snapshot.session,
+			messages: Array.isArray(snapshot.messages) ? snapshot.messages : [],
+			tools: Array.isArray(snapshot.tools) ? snapshot.tools : [],
+			activity: snapshot.activity ?? "idle",
+			closed: Boolean(snapshot.closed),
+			needsSnapshot: false,
+		};
+	}
+	return applyAttachments(next, snapshot?.attachments);
+}
+
+export function applyAttachments(current, attachments) {
+	if (
+		!Number.isSafeInteger(attachments?.revision) ||
+		attachments.revision < current.attachmentRevision ||
+		!Array.isArray(attachments.items)
+	) {
 		return current;
+	}
+	const revisionChanged = attachments.revision !== current.attachmentRevision;
+	const images = attachments.items
+		.filter((item) => item && typeof item.id === "string" && typeof item.status === "string")
+		.map((item) => ({
+			...item,
+			notes: Array.isArray(item.notes) ? [...item.notes] : [],
+		}));
 	return {
 		...current,
-		sequence: snapshot.sequence,
-		session: snapshot.session,
-		messages: Array.isArray(snapshot.messages) ? snapshot.messages : [],
-		tools: Array.isArray(snapshot.tools) ? snapshot.tools : [],
-		activity: snapshot.activity ?? "idle",
-		closed: Boolean(snapshot.closed),
-		needsSnapshot: false,
+		attachmentRevision: attachments.revision,
+		attachmentPhase: typeof attachments.phase === "string" ? attachments.phase : "blocked",
+		images,
+		readingImages: images.filter(
+			(image) => image.status === "uploading" || image.status === "processing",
+		).length,
+		outbox: revisionChanged ? undefined : current.outbox,
+		lastDelivery: revisionChanged ? undefined : current.lastDelivery,
 	};
 }
 
@@ -82,6 +114,8 @@ export function prepareSend(current, requestId, delivery = "next") {
 	const attempt = current.outbox ?? {
 		requestId,
 		text: current.text,
+		attachmentRevision: current.attachmentRevision,
+		attachmentIds: current.images.map((image) => image.id),
 		images: [...current.images],
 		delivery,
 	};
@@ -174,6 +208,7 @@ export function canSend(current) {
 			!current.stale &&
 			!current.pending &&
 			current.readingImages === 0 &&
+			(current.images.length === 0 || current.attachmentPhase === "ready") &&
 			(current.text.trim() || current.images.length > 0),
 	);
 }

--- a/extensions/pi-webui/src/web/styles.css
+++ b/extensions/pi-webui/src/web/styles.css
@@ -538,6 +538,27 @@ textarea:disabled {
 	box-shadow: 0 0 0 2px var(--accent-soft);
 }
 
+.attachment-details {
+	display: grid;
+	gap: 0.2rem;
+	min-width: 0;
+}
+
+.attachment-item-status {
+	color: var(--muted);
+	font-size: 0.78rem;
+}
+
+.attachment-item-status.error {
+	color: var(--danger);
+}
+
+.attachment-conversion-summary {
+	color: var(--muted);
+	font-size: 0.74rem;
+	line-height: 1.35;
+}
+
 .image-order-actions {
 	display: flex;
 	align-items: center;
@@ -563,6 +584,12 @@ textarea:disabled {
 	padding: 0;
 	background: var(--surface);
 	cursor: zoom-in;
+}
+
+.attachment-preview:empty::after {
+	content: "…";
+	color: var(--muted);
+	font-size: 1.4rem;
 }
 
 .image-previews img {
@@ -607,7 +634,8 @@ button {
 
 .button.secondary,
 .move-image,
-.remove-image {
+.remove-image,
+.retry-image {
 	border-color: var(--border);
 	color: var(--text);
 	background: var(--surface);

--- a/extensions/pi-webui/test/attachments.test.ts
+++ b/extensions/pi-webui/test/attachments.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AttachmentError, AttachmentStore, type PreparedAttachment } from "../src/attachments.js";
+
+const limits = {
+	maxImages: 3,
+	maxImageBytes: 8,
+	maxPromptBytes: 16,
+};
+
+function prepared(source: Uint8Array, marker = Buffer.from(source).toString()): PreparedAttachment {
+	return {
+		bytes: Buffer.from(`safe-${marker}`),
+		mimeType: "image/png",
+		width: 2,
+		height: 1,
+		originalWidth: 4,
+		originalHeight: 2,
+		sourceFormat: "bmp",
+		outputFormat: "png",
+		resized: true,
+		notes: ["Converted from BMP to PNG", "Resized from 4×2"],
+	};
+}
+
+function createStore(
+	process: (source: Uint8Array, signal?: AbortSignal) => Promise<PreparedAttachment> = async (
+		source,
+	) => prepared(source),
+	concurrency = 2,
+) {
+	return new AttachmentStore({ limits, process, concurrency });
+}
+
+async function settle(store: AttachmentStore): Promise<void> {
+	await store.waitForIdle();
+}
+
+test("attachment admission is atomic across revisions, ids, counts, and source bytes", () => {
+	const store = createStore();
+	assert.equal(store.publicState().revision, 0);
+	store.reserve(
+		[
+			{ id: "one", name: "one.png", size: 4 },
+			{ id: "two", name: "two.png", size: 4 },
+		],
+		0,
+	);
+	assert.equal(store.publicState().revision, 1);
+	assert.equal(store.residentBytes(), 0);
+	assert.equal(store.reservedSourceBytes(), 8);
+	assert.throws(() => store.reserve([{ id: "three", name: "three.png", size: 1 }], 0), /revision/i);
+	assert.throws(
+		() => store.reserve([{ id: "one", name: "duplicate.png", size: 1 }], 1),
+		/id|duplicate/i,
+	);
+	assert.throws(
+		() => store.reserve([{ id: "three", name: "three.png", size: 9 }], 1),
+		/per-image|maximum/i,
+	);
+	assert.throws(
+		() =>
+			store.reserve(
+				[
+					{ id: "three", name: "three.png", size: 1 },
+					{ id: "four", name: "four.png", size: 1 },
+				],
+				1,
+			),
+		/count|maximum/i,
+	);
+	assert.equal(store.publicState().items.length, 2);
+});
+
+test("uploads expose processing then sanitized ready state while preserving order", async () => {
+	let release: (() => void) | undefined;
+	const store = createStore(async (source) => {
+		await new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		return prepared(source, "output");
+	});
+	store.reserve(
+		[
+			{ id: "one", name: "one.png", size: 3 },
+			{ id: "two", name: "two.png", size: 3 },
+		],
+		0,
+	);
+	const processing = store.upload("one", Buffer.from("one"), 1);
+	assert.equal(processing.items[0]?.status, "processing");
+	assert.equal(store.residentBytes(), 3);
+	release?.();
+	await settle(store);
+	const state = store.publicState();
+	assert.equal(state.items[0]?.status, "ready");
+	assert.equal(state.items[0]?.sourceFormat, "bmp");
+	assert.equal(state.items[0]?.outputFormat, "png");
+	assert.equal(state.items[0]?.resized, true);
+	assert.deepEqual(state.items[0]?.notes, ["Converted from BMP to PNG", "Resized from 4×2"]);
+	assert.deepEqual(
+		state.items.map((item) => item.id),
+		["one", "two"],
+	);
+	assert.equal(store.residentBytes(), Buffer.byteLength("safe-output"));
+});
+
+test("each reserved upload accepts its batch revision after an earlier sibling completes", async () => {
+	const store = createStore();
+	const reserved = store.reserve(
+		[
+			{ id: "one", name: "one.png", size: 3 },
+			{ id: "two", name: "two.png", size: 3 },
+		],
+		0,
+	);
+	store.upload("one", Buffer.from("one"), reserved.revision);
+	await settle(store);
+	assert.doesNotThrow(() => store.upload("two", Buffer.from("two"), reserved.revision));
+	await settle(store);
+	assert.equal(store.publicState().phase, "ready");
+});
+
+test("processing is concurrency bounded and queued aborts remain retryable", async () => {
+	let active = 0;
+	let peak = 0;
+	const releases: Array<() => void> = [];
+	const store = createStore(async (source) => {
+		active += 1;
+		peak = Math.max(peak, active);
+		await new Promise<void>((resolve) => releases.push(resolve));
+		active -= 1;
+		return prepared(source);
+	}, 1);
+	store.reserve(
+		[
+			{ id: "one", name: "one.png", size: 3 },
+			{ id: "two", name: "two.png", size: 3 },
+		],
+		0,
+	);
+	store.upload("one", Buffer.from("one"), 1);
+	const controller = new AbortController();
+	store.upload("two", Buffer.from("two"), store.publicState().revision, controller.signal);
+	controller.abort();
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(peak, 1);
+	releases.shift()?.();
+	await settle(store);
+	assert.equal(store.publicState().items[0]?.status, "ready");
+	assert.equal(store.publicState().items[1]?.status, "error");
+	assert.match(store.publicState().items[1]?.error ?? "", /cancel/i);
+	assert.equal(store.residentBytes(), Buffer.byteLength("safe-one") + 3);
+});
+
+test("processing errors retain only bounded source bytes for retry", async () => {
+	let attempts = 0;
+	const store = createStore(async (source) => {
+		attempts += 1;
+		if (attempts === 1) throw new Error("private\ndecoder detail\u0000");
+		return prepared(source);
+	});
+	store.reserve([{ id: "one", name: "one.png", size: 3 }], 0);
+	store.upload("one", Buffer.from("one"), 1);
+	await settle(store);
+	let state = store.publicState();
+	assert.equal(state.items[0]?.status, "error");
+	assert.equal(state.items[0]?.error, "private decoder detail");
+	assert.equal(store.residentBytes(), 3);
+	store.retry("one", state.revision);
+	await settle(store);
+	state = store.publicState();
+	assert.equal(state.items[0]?.status, "ready");
+	assert.equal(attempts, 2);
+	assert.equal(store.residentBytes(), Buffer.byteLength("safe-one"));
+});
+
+test("reorder, delete, and clear require exact revisions and release every byte", async () => {
+	const store = createStore();
+	store.reserve(
+		[
+			{ id: "one", name: "one.png", size: 3 },
+			{ id: "two", name: "two.png", size: 3 },
+		],
+		0,
+	);
+	store.upload("one", Buffer.from("one"), 1);
+	await settle(store);
+	store.upload("two", Buffer.from("two"), store.publicState().revision);
+	await settle(store);
+	let revision = store.publicState().revision;
+	store.reorder(["two", "one"], revision);
+	assert.deepEqual(
+		store.publicState().items.map((item) => item.id),
+		["two", "one"],
+	);
+	assert.throws(() => store.remove("one", revision), /revision/i);
+	revision = store.publicState().revision;
+	store.remove("one", revision);
+	assert.equal(store.publicState().items.length, 1);
+	store.clear(store.publicState().revision);
+	assert.equal(store.publicState().phase, "empty");
+	assert.equal(store.residentBytes(), 0);
+});
+
+test("send reservation transfers sanitized bytes and commits only a matching ready snapshot", async () => {
+	const store = createStore();
+	store.reserve([{ id: "one", name: "one.png", size: 3 }], 0);
+	store.upload("one", Buffer.from("one"), 1);
+	await settle(store);
+	const before = store.publicState();
+	const reservation = store.beginSend(["one"], before.revision);
+	assert.equal(store.publicState().phase, "reserved");
+	assert.deepEqual(
+		reservation.images.map((image) => Buffer.from(image.data, "base64").toString()),
+		["safe-one"],
+	);
+	assert.throws(() => store.clear(before.revision), /reserved/i);
+	store.finishSend(reservation.token, false);
+	assert.equal(store.publicState().phase, "ready");
+	const retry = store.beginSend(["one"], store.publicState().revision);
+	store.finishSend(retry.token, true);
+	assert.equal(store.publicState().phase, "empty");
+	assert.equal(store.residentBytes(), 0);
+});
+
+test("delete during processing aborts work and discards late native output", async () => {
+	let sawAbort = false;
+	let release: (() => void) | undefined;
+	const store = createStore(async (source, signal) => {
+		await new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		sawAbort = Boolean(signal?.aborted);
+		return prepared(source);
+	});
+	store.reserve([{ id: "one", name: "one.png", size: 3 }], 0);
+	store.upload("one", Buffer.from("one"), 1);
+	store.remove("one", store.publicState().revision);
+	release?.();
+	await settle(store);
+	assert.equal(sawAbort, true);
+	assert.equal(store.publicState().phase, "empty");
+	assert.equal(store.residentBytes(), 0);
+});
+
+test("close aborts retained state, waits idempotently, and rejects later mutations", async () => {
+	let release: (() => void) | undefined;
+	const store = createStore(async (source) => {
+		await new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		return prepared(source);
+	});
+	store.reserve([{ id: "one", name: "one.png", size: 3 }], 0);
+	store.upload("one", Buffer.from("one"), 1);
+	store.close();
+	store.close();
+	release?.();
+	await settle(store);
+	assert.equal(store.residentBytes(), 0);
+	assert.equal(store.publicState().phase, "closed");
+	assert.throws(() => store.reserve([], store.publicState().revision), AttachmentError);
+});

--- a/extensions/pi-webui/test/lifecycle.test.ts
+++ b/extensions/pi-webui/test/lifecycle.test.ts
@@ -145,6 +145,17 @@ function harness(overrides: Partial<RuntimeDependencies> = {}) {
 		},
 		readPiSettings: async () => ({ autoResize: true, blockImages: false, warnings: [] }),
 		processImages: async () => [{ type: "image", data: "processed", mimeType: "image/png" }],
+		processAttachment: async () => ({
+			bytes: Buffer.from("processed"),
+			mimeType: "image/png",
+			width: 1,
+			height: 1,
+			originalWidth: 1,
+			originalHeight: 1,
+			sourceFormat: "png",
+			outputFormat: "png",
+			resized: false,
+		}),
 		...overrides,
 	};
 	const runtime = new WebUIRuntime(pi as never, dependencies);
@@ -531,20 +542,37 @@ test("idle browser sends fail before acknowledgement when model authentication i
 	assert.equal(h.sent.length, 0);
 });
 
-test("browser images are processed under live Pi guards and sent with text", async () => {
+test("browser images are staged under live Pi guards and sent without reprocessing source bytes", async () => {
 	let processOptions: unknown;
+	let legacyBatchCalls = 0;
 	const h = harness({
-		processImages: async (_images, options) => {
+		processImages: async () => {
+			legacyBatchCalls += 1;
+			return [];
+		},
+		processAttachment: async (_source, options) => {
 			processOptions = options;
-			return [{ type: "image", data: "safe", mimeType: "image/png" }];
+			return {
+				bytes: Buffer.from("safe"),
+				mimeType: "image/png",
+				width: 1,
+				height: 1,
+				originalWidth: 2,
+				originalHeight: 2,
+				sourceFormat: "bmp",
+				outputFormat: "png",
+				resized: true,
+			};
 		},
 	});
 	await h.emit("session_start");
 	await h.commands.get("webui")?.handler("", h.ctx as never);
+	const staged = await h.serverOptions?.processAttachment?.(Buffer.from("raw"));
+	assert.ok(staged);
 	await h.serverOptions?.send({
 		requestId: "image",
 		text: "look",
-		images: [{ data: "raw", mimeType: "image/png" }],
+		images: [{ data: staged.bytes.toString("base64"), mimeType: staged.mimeType }],
 		delivery: "next",
 	});
 	assert.ok(processOptions && typeof processOptions === "object");
@@ -560,40 +588,36 @@ test("browser images are processed under live Pi guards and sent with text", asy
 		blockImages: false,
 		supportsImages: true,
 	});
+	assert.equal(legacyBatchCalls, 0);
 	assertBrowserEnvelope(h.sent[0]?.content);
 	assert.doesNotMatch(JSON.stringify(h.sent[0]?.content), /look/);
 	assert.ok(Array.isArray(h.sent[0]?.content));
 	assert.deepEqual(h.sent[0].content.slice(1), [
-		{ type: "image", data: "safe", mimeType: "image/png" },
+		{ type: "image", data: Buffer.from("safe").toString("base64"), mimeType: "image/png" },
 	]);
 });
 
-test("image sends revalidate model capabilities and authentication after processing", async () => {
+test("image sends revalidate model capabilities, authentication, and blockImages after staging", async () => {
 	const runRace = async (
 		mutate: (h: ReturnType<typeof harness>) => void,
 		pattern: RegExp,
 	): Promise<void> => {
-		const started = deferred<void>();
-		const processing = deferred<Array<{ type: "image"; data: string; mimeType: string }>>();
-		const h = harness({
-			processImages: async () => {
-				started.resolve(undefined);
-				return processing.promise;
-			},
-		});
+		const h = harness();
 		await h.emit("session_start");
 		await h.commands.get("webui")?.handler("", h.ctx as never);
-		const sending = h.serverOptions?.send({
-			requestId: "image-race",
-			text: "look",
-			images: [{ data: "raw", mimeType: "image/png" }],
-			delivery: "next",
-		});
-		assert.ok(sending);
-		await started.promise;
+		const staged = await h.serverOptions?.processAttachment?.(Buffer.from("raw"));
+		assert.ok(staged);
 		mutate(h);
-		processing.resolve([{ type: "image", data: "safe", mimeType: "image/png" }]);
-		await assert.rejects(() => sending, pattern);
+		await assert.rejects(
+			() =>
+				h.serverOptions?.send({
+					requestId: "image-race",
+					text: "look",
+					images: [{ data: staged.bytes.toString("base64"), mimeType: staged.mimeType }],
+					delivery: "next",
+				}) ?? Promise.reject(new Error("missing send")),
+			pattern,
+		);
 		assert.equal(h.sent.length, 0);
 	};
 
@@ -602,6 +626,21 @@ test("image sends revalidate model capabilities and authentication after process
 		/image/i,
 	);
 	await runRace((h) => h.setAuth({ ok: false }), /authentication/i);
+	const blocked = harness({
+		readPiSettings: async () => ({ autoResize: true, blockImages: true, warnings: [] }),
+	});
+	await blocked.emit("session_start");
+	await blocked.commands.get("webui")?.handler("", blocked.ctx as never);
+	await assert.rejects(
+		() =>
+			blocked.serverOptions?.send({
+				requestId: "blocked",
+				text: "look",
+				images: [{ data: "safe", mimeType: "image/png" }],
+				delivery: "next",
+			}) ?? Promise.reject(new Error("missing send")),
+		/disabled/i,
+	);
 });
 
 test("send callbacks fail closed after session replacement and Pi send errors propagate", async () => {
@@ -634,21 +673,36 @@ test("send callbacks fail closed after session replacement and Pi send errors pr
 	);
 });
 
-test("image preparation cannot deliver into a replacement session", async () => {
-	const processing = deferred<Array<{ type: "image"; data: string; mimeType: string }>>();
-	const h = harness({ processImages: async () => processing.promise });
+test("image preparation cannot complete into a replacement session", async () => {
+	const processing = deferred<{
+		bytes: Buffer;
+		mimeType: string;
+		width: number;
+		height: number;
+		originalWidth: number;
+		originalHeight: number;
+		sourceFormat: "png";
+		outputFormat: "png";
+		resized: false;
+	}>();
+	const h = harness({ processAttachment: async () => processing.promise });
 	await h.emit("session_start");
 	await h.commands.get("webui")?.handler("", h.ctx as never);
-	const sending = h.serverOptions?.send({
-		requestId: "race",
-		text: "look",
-		images: [{ data: "raw" }],
-		delivery: "next",
-	});
-	assert.ok(sending);
+	const preparing = h.serverOptions?.processAttachment?.(Buffer.from("raw"));
+	assert.ok(preparing);
 	await h.emit("session_start", { reason: "reload" });
-	processing.resolve([{ type: "image", data: "safe", mimeType: "image/png" }]);
-	await assert.rejects(() => sending, /cancelled|changed/i);
+	processing.resolve({
+		bytes: Buffer.from("safe"),
+		mimeType: "image/png",
+		width: 1,
+		height: 1,
+		originalWidth: 1,
+		originalHeight: 1,
+		sourceFormat: "png",
+		outputFormat: "png",
+		resized: false,
+	});
+	await assert.rejects(() => preparing, /cancelled|changed/i);
 	assert.equal(h.sent.length, 0);
 });
 

--- a/extensions/pi-webui/test/server.test.ts
+++ b/extensions/pi-webui/test/server.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import http from "node:http";
 import test from "node:test";
+import type { PreparedAttachment } from "../src/attachments.js";
 import { ConversationProjection } from "../src/conversation.js";
 import { type WebSendRequest, type WebSendResult, WebUIServer } from "../src/server.js";
 
@@ -36,15 +37,16 @@ async function api(
 		method?: string;
 		cookie?: string;
 		client?: string;
-		body?: string;
+		body?: BodyInit;
 		origin?: string;
+		contentType?: string;
 	} = {},
 ) {
 	const headers = new Headers();
 	if (options.cookie) headers.set("cookie", options.cookie);
 	if (options.client) headers.set("x-pi-web-client", options.client);
 	if (options.method && options.method !== "GET") {
-		headers.set("content-type", "application/json");
+		headers.set("content-type", options.contentType ?? "application/json");
 		headers.set("origin", options.origin ?? server.origin);
 	}
 	return fetch(`${server.origin}${path}`, {
@@ -139,7 +141,13 @@ test("mutations require exact Origin, Host, cookie, and current tab lease", asyn
 					method: "POST",
 					cookie,
 					client: "one",
-					body: JSON.stringify({ requestId: "r1", text: "hello", images: [], delivery: "next" }),
+					body: JSON.stringify({
+						requestId: "r1",
+						text: "hello",
+						attachmentRevision: 0,
+						attachmentIds: [],
+						delivery: "next",
+					}),
 				})
 			).status,
 			409,
@@ -180,7 +188,8 @@ test("a new tab lease aborts an in-flight asynchronous send before mutation", as
 			body: JSON.stringify({
 				requestId: "in-flight",
 				text: "hello",
-				images: [{ data: "raw" }],
+				attachmentRevision: 0,
+				attachmentIds: [],
 				delivery: "next",
 			}),
 		});
@@ -220,7 +229,8 @@ test("a completed upload aborts when its response connection closes", async () =
 		const request = rawMessageRequest(server, cookie, client, {
 			requestId: "disconnect",
 			text: "hello",
-			images: [],
+			attachmentRevision: 0,
+			attachmentIds: [],
 			delivery: "next",
 		});
 		await started.promise;
@@ -254,7 +264,13 @@ test("in-flight request ids remain deduplicated when the completed-result cache 
 				method: "POST",
 				cookie,
 				client,
-				body: JSON.stringify({ requestId, text: requestId, images: [], delivery: "next" }),
+				body: JSON.stringify({
+					requestId,
+					text: requestId,
+					attachmentRevision: 0,
+					attachmentIds: [],
+					delivery: "next",
+				}),
 			});
 		const originals = Array.from({ length: 129 }, (_, index) => send(`pending-${index}`));
 		await waitFor(() => attempts === 129);
@@ -290,7 +306,8 @@ test("failed sends release their request id for an unchanged browser retry", asy
 		const body = JSON.stringify({
 			requestId: "retryable",
 			text: "hello",
-			images: [],
+			attachmentRevision: 0,
+			attachmentIds: [],
 			delivery: "next",
 		});
 		assert.equal(
@@ -315,7 +332,8 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 		const body = JSON.stringify({
 			requestId: "request-1",
 			text: "hello",
-			images: [],
+			attachmentRevision: 0,
+			attachmentIds: [],
 			delivery: "next",
 		});
 		const first = await api(server, "/api/messages", { method: "POST", cookie, client, body });
@@ -327,6 +345,13 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 			accepted: true,
 			requestId: "request-1",
 			delivery: "immediate",
+			attachments: {
+				revision: 0,
+				phase: "empty",
+				items: [],
+				totalSourceBytes: 0,
+				totalResidentBytes: 0,
+			},
 		});
 		const conflict = await api(server, "/api/messages", {
 			method: "POST",
@@ -335,7 +360,8 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 			body: JSON.stringify({
 				requestId: "request-1",
 				text: "changed",
-				images: [],
+				attachmentRevision: 0,
+				attachmentIds: [],
 				delivery: "next",
 			}),
 		});
@@ -346,7 +372,13 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 					method: "POST",
 					cookie,
 					client,
-					body: JSON.stringify({ requestId: "empty", text: "  ", images: [], delivery: "next" }),
+					body: JSON.stringify({
+						requestId: "empty",
+						text: "  ",
+						attachmentRevision: 0,
+						attachmentIds: [],
+						delivery: "next",
+					}),
 				})
 			).status,
 			400,
@@ -377,7 +409,8 @@ test("oversized and cancelled request bodies do not mutate or stop the server", 
 			body: JSON.stringify({
 				requestId: "large",
 				text: "x".repeat(300),
-				images: [],
+				attachmentRevision: 0,
+				attachmentIds: [],
 				delivery: "next",
 			}),
 		});
@@ -387,6 +420,236 @@ test("oversized and cancelled request bodies do not mutate or stop the server", 
 		assert.equal(sends, 0);
 		assert.equal((await api(server, "/api/state", { cookie })).status, 200);
 	} finally {
+		await server.close();
+	}
+});
+
+test("attachment endpoints reserve, upload, preview, retry, reorder, delete, and clear by revision", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	let failOnce = true;
+	const server = await WebUIServer.start({
+		conversation,
+		attachmentLimits: { maxImages: 3, maxImageBytes: 8, maxPromptBytes: 16 },
+		processAttachment: async (source) => {
+			if (Buffer.from(source).toString() === "bad" && failOnce) {
+				failOnce = false;
+				throw new Error("decoder failed");
+			}
+			return preparedAttachment(`safe-${Buffer.from(source).toString()}`);
+		},
+		send: async () => ({ delivery: "immediate" }),
+	});
+	try {
+		const cookie = await authenticate(server);
+		const client = await takeLease(server, cookie);
+		assert.equal(
+			(
+				await api(server, "/api/attachments/reserve", {
+					method: "POST",
+					cookie,
+					client: "stale-client",
+					body: JSON.stringify({
+						revision: 0,
+						items: [{ id: "one", name: "one.png", size: 3 }],
+					}),
+				})
+			).status,
+			409,
+		);
+		let response = await api(server, "/api/attachments/reserve", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: 0,
+				items: [
+					{ id: "one", name: "one.png", size: 3 },
+					{ id: "two", name: "two.png", size: 3 },
+				],
+			}),
+		});
+		assert.equal(response.status, 201);
+		let attachments = (await response.json()) as { revision: number };
+		response = await api(server, `/api/attachments/one/upload?revision=${attachments.revision}`, {
+			method: "POST",
+			cookie,
+			client,
+			contentType: "application/octet-stream",
+			body: Buffer.from("one"),
+		});
+		assert.equal(response.status, 200);
+		await waitForAttachmentPhase(server, cookie, "uploading");
+		attachments = await attachmentState(server, cookie);
+		response = await api(server, `/api/attachments/two/upload?revision=${attachments.revision}`, {
+			method: "POST",
+			cookie,
+			client,
+			contentType: "application/octet-stream",
+			body: Buffer.from("bad"),
+		});
+		assert.equal(response.status, 200);
+		await waitForAttachmentPhase(server, cookie, "blocked");
+		attachments = await attachmentState(server, cookie);
+		response = await api(server, "/api/attachments/two/retry", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({ revision: attachments.revision }),
+		});
+		assert.equal(response.status, 200);
+		await waitForAttachmentPhase(server, cookie, "ready");
+		const preview = await api(server, "/api/attachments/one/preview", { cookie });
+		assert.equal(preview.status, 200);
+		assert.equal(await preview.text(), "safe-one");
+		attachments = await attachmentState(server, cookie);
+		response = await api(server, "/api/attachments/reorder", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({ revision: attachments.revision, ids: ["two", "one"] }),
+		});
+		assert.equal(response.status, 200);
+		attachments = (await response.json()) as { revision: number };
+		response = await api(server, `/api/attachments/one?revision=${attachments.revision}`, {
+			method: "DELETE",
+			cookie,
+			client,
+		});
+		assert.equal(response.status, 200);
+		attachments = (await response.json()) as { revision: number };
+		response = await api(server, "/api/attachments/clear", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({ revision: attachments.revision }),
+		});
+		assert.equal(response.status, 200);
+		assert.equal(((await response.json()) as { phase: string }).phase, "empty");
+	} finally {
+		await server.close();
+	}
+});
+
+test("raw attachment uploads enforce actual bytes, duplicate state, and declared limits", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	const gate = deferred<void>();
+	const server = await WebUIServer.start({
+		conversation,
+		attachmentLimits: { maxImages: 2, maxImageBytes: 4, maxPromptBytes: 8 },
+		processAttachment: async (source) => {
+			await gate.promise;
+			return preparedAttachment(Buffer.from(source).toString());
+		},
+		send: async () => ({ delivery: "immediate" }),
+	});
+	try {
+		const cookie = await authenticate(server);
+		const client = await takeLease(server, cookie);
+		const response = await api(server, "/api/attachments/reserve", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: 0,
+				items: [
+					{ id: "one", name: "one.png", size: 4 },
+					{ id: "two", name: "two.png", size: 4 },
+				],
+			}),
+		});
+		const revision = ((await response.json()) as { revision: number }).revision;
+		let rawResponse = await rawUpload(
+			server,
+			cookie,
+			client,
+			"one",
+			revision,
+			Buffer.from("12345"),
+			false,
+		);
+		assert.equal(rawResponse.statusCode, 413);
+		const failedUpload = await attachmentState(server, cookie);
+		assert.equal(failedUpload.phase, "blocked");
+		assert.equal(failedUpload.items?.[0]?.status, "error");
+		rawResponse = await rawUpload(
+			server,
+			cookie,
+			client,
+			"one",
+			revision,
+			Buffer.from("1234"),
+			false,
+		);
+		assert.equal(rawResponse.statusCode, 200);
+		const processingRevision = (await attachmentState(server, cookie)).revision;
+		rawResponse = await rawUpload(
+			server,
+			cookie,
+			client,
+			"one",
+			processingRevision,
+			Buffer.from("1234"),
+			true,
+		);
+		assert.equal(rawResponse.statusCode, 409);
+		gate.resolve(undefined);
+		await waitForAttachmentPhase(server, cookie, "uploading");
+	} finally {
+		gate.resolve(undefined);
+		await server.close();
+	}
+});
+
+test("lease takeover and deletion cancel processing without stale completion resurrection", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	const releases: Array<() => void> = [];
+	const signals: AbortSignal[] = [];
+	const server = await WebUIServer.start({
+		conversation,
+		attachmentLimits: { maxImages: 2, maxImageBytes: 8, maxPromptBytes: 16 },
+		processAttachment: async (source, signal) => {
+			signals.push(signal ?? new AbortController().signal);
+			await new Promise<void>((resolve) => releases.push(resolve));
+			return preparedAttachment(Buffer.from(source).toString());
+		},
+		send: async () => ({ delivery: "immediate" }),
+	});
+	try {
+		const cookie = await authenticate(server);
+		let client = await takeLease(server, cookie, "first");
+		let response = await api(server, "/api/attachments/reserve", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: 0,
+				items: [{ id: "one", name: "one.png", size: 3 }],
+			}),
+		});
+		let revision = ((await response.json()) as { revision: number }).revision;
+		await api(server, `/api/attachments/one/upload?revision=${revision}`, {
+			method: "POST",
+			cookie,
+			client,
+			contentType: "application/octet-stream",
+			body: Buffer.from("one"),
+		});
+		await waitFor(() => signals.length === 1);
+		client = await takeLease(server, cookie, "second");
+		await waitFor(() => signals[0]?.aborted === true);
+		assert.equal((await attachmentState(server, cookie)).phase, "blocked");
+		releases.shift()?.();
+		await waitForAttachmentPhase(server, cookie, "blocked");
+		revision = (await attachmentState(server, cookie)).revision;
+		response = await api(server, `/api/attachments/one?revision=${revision}`, {
+			method: "DELETE",
+			cookie,
+			client,
+		});
+		assert.equal(response.status, 200);
+		assert.equal(((await response.json()) as { phase: string }).phase, "empty");
+	} finally {
+		for (const release of releases) release();
 		await server.close();
 	}
 });
@@ -540,8 +803,8 @@ function deferred<T>() {
 	return { promise, resolve };
 }
 
-async function waitFor(predicate: () => boolean): Promise<void> {
-	while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 5));
+async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
+	while (!(await predicate())) await new Promise((resolve) => setTimeout(resolve, 5));
 }
 
 function rawMessageRequest(
@@ -589,6 +852,78 @@ function cancelRequest(server: WebUIServer, cookie: string, client: string): Pro
 		request.write('{"requestId":"cancelled"');
 		request.destroy();
 		setTimeout(resolve, 20);
+	});
+}
+
+function preparedAttachment(marker: string): PreparedAttachment {
+	return {
+		bytes: Buffer.from(marker),
+		mimeType: "image/png",
+		width: 1,
+		height: 1,
+		originalWidth: 1,
+		originalHeight: 1,
+		sourceFormat: "png",
+		outputFormat: "png",
+		resized: false,
+		notes: [],
+	};
+}
+
+async function attachmentState(
+	server: WebUIServer,
+	cookie: string,
+): Promise<{ revision: number; phase?: string; items?: Array<{ id: string; status: string }> }> {
+	const state = (await (await api(server, "/api/state", { cookie })).json()) as {
+		attachments: {
+			revision: number;
+			phase: string;
+			items: Array<{ id: string; status: string }>;
+		};
+	};
+	return state.attachments;
+}
+
+async function waitForAttachmentPhase(
+	server: WebUIServer,
+	cookie: string,
+	phase: string,
+): Promise<void> {
+	await waitFor(async () => (await attachmentState(server, cookie)).phase === phase);
+}
+
+function rawUpload(
+	server: WebUIServer,
+	cookie: string,
+	client: string,
+	id: string,
+	revision: number,
+	body: Buffer,
+	declareLength: boolean,
+): Promise<http.IncomingMessage> {
+	const url = new URL(server.origin);
+	return new Promise((resolve, reject) => {
+		const request = http.request(
+			{
+				hostname: url.hostname,
+				port: Number(url.port),
+				path: `/api/attachments/${id}/upload?revision=${revision}`,
+				method: "POST",
+				headers: {
+					Cookie: cookie,
+					Origin: server.origin,
+					"Content-Type": "application/octet-stream",
+					"X-Pi-Web-Client": client,
+					...(declareLength ? { "Content-Length": String(body.byteLength) } : {}),
+				},
+			},
+			(response) => {
+				response.resume();
+				response.once("end", () => resolve(response));
+			},
+		);
+		request.once("error", reject);
+		request.end(body);
 	});
 }
 

--- a/extensions/pi-webui/test/web-state.test.ts
+++ b/extensions/pi-webui/test/web-state.test.ts
@@ -8,6 +8,7 @@ const state = (await import(
 )) as {
 	initialState(): WebState;
 	applySnapshot(current: WebState, snapshot: Snapshot): WebState;
+	applyAttachments(current: WebState, attachments: Record<string, unknown>): WebState;
 	applyConversationEvent(current: WebState, event: ConversationEvent): WebState;
 	applyLease(
 		current: WebState,
@@ -42,6 +43,8 @@ const state = (await import(
 interface WebImage {
 	id: string;
 	name?: string;
+	status?: string;
+	notes?: string[];
 }
 
 interface WebState {
@@ -58,6 +61,8 @@ interface WebState {
 	readingImages: number;
 	leaseClaimed: boolean;
 	leaseGeneration: number;
+	attachmentRevision: number;
+	attachmentPhase: string;
 	following: boolean;
 	unseenUpdateIds: string[];
 	text: string;
@@ -69,6 +74,8 @@ interface WebState {
 interface SendAttempt {
 	requestId: string;
 	text: string;
+	attachmentRevision: number;
+	attachmentIds: string[];
 	images: Array<{ id: string }>;
 	delivery: "next" | "steer";
 }
@@ -118,6 +125,59 @@ test("older snapshots cannot roll browser state back", () => {
 	assert.equal(older, current);
 	assert.equal(older.sequence, 3);
 	assert.deepEqual(older.messages, [{ id: "one" }]);
+});
+
+test("server attachment revisions replace browser images and ignore stale updates", () => {
+	const initial = state.initialState();
+	const ready = state.applyAttachments(initial, {
+		revision: 2,
+		phase: "ready",
+		items: [{ id: "one", status: "ready" }],
+	});
+	assert.equal(ready.attachmentRevision, 2);
+	assert.equal(ready.attachmentPhase, "ready");
+	assert.deepEqual(ready.images, [{ id: "one", status: "ready", notes: [] }]);
+	assert.equal(ready.readingImages, 0);
+	const stale = state.applyAttachments(ready, { revision: 1, phase: "empty", items: [] });
+	assert.equal(stale, ready);
+	const processing = state.applyAttachments(ready, {
+		revision: 3,
+		phase: "processing",
+		items: [{ id: "one", status: "processing" }],
+	});
+	assert.equal(processing.readingImages, 1);
+	assert.equal(state.canSend({ ...processing, connected: true, text: "send" }), false);
+});
+
+test("attachment snapshots clone item notes and gate every non-ready batch phase", () => {
+	const source = {
+		revision: 1,
+		phase: "processing",
+		items: [
+			{
+				id: "one",
+				name: "one.bmp",
+				status: "processing",
+				notes: ["Converted BMP to PNG"],
+			},
+		],
+	};
+	const processing = state.applyAttachments(state.initialState(), source);
+	source.items[0]?.notes.push("mutated");
+	assert.deepEqual(processing.images[0]?.notes, ["Converted BMP to PNG"]);
+	assert.equal(processing.readingImages, 1);
+	assert.equal(state.canSend({ ...processing, connected: true, text: "send" }), false);
+	for (const phase of ["uploading", "processing", "blocked", "reserved"]) {
+		assert.equal(
+			state.canSend({
+				...processing,
+				connected: true,
+				readingImages: 0,
+				attachmentPhase: phase,
+			}),
+			false,
+		);
+	}
 });
 
 test("ordered conversation events replace messages/tools and sequence gaps request snapshots", () => {
@@ -201,7 +261,15 @@ test("send availability and labels distinguish immediate, follow-up, and disconn
 	assert.equal(state.busyLabel({ ...base, connected: false }), "Reconnect to send");
 	assert.equal(state.canSend({ ...base, pending: true }), false);
 	assert.equal(state.canSend({ ...base, readingImages: 1 }), false);
-	assert.equal(state.canSend({ ...base, text: "", images: [{ id: "image" }] }), true);
+	assert.equal(
+		state.canSend({
+			...base,
+			text: "",
+			images: [{ id: "image", status: "ready" }],
+			attachmentPhase: "ready",
+		}),
+		true,
+	);
 });
 
 test("failed sends retain one idempotent attempt until the draft changes", () => {
@@ -302,6 +370,8 @@ test("send attempts freeze the displayed image order until the draft changes", (
 		prepared.attempt.images.map((image) => image.id),
 		["two", "one"],
 	);
+	assert.equal(prepared.attempt.attachmentRevision, 0);
+	assert.deepEqual(prepared.attempt.attachmentIds, ["two", "one"]);
 	images.reverse();
 	assert.deepEqual(
 		prepared.attempt.images.map((image) => image.id),

--- a/extensions/pi-webui/test/web-ui-contract.test.ts
+++ b/extensions/pi-webui/test/web-ui-contract.test.ts
@@ -55,7 +55,7 @@ test("browser logic authenticates a lease, reconnects from sequence, and keeps f
 	assert.doesNotMatch(app, /localStorage|sessionStorage|indexedDB/i);
 });
 
-test("image input supports picker and paste with visible removable previews", () => {
+test("image input stages authenticated per-item uploads with visible status and recovery", () => {
 	assert.match(
 		html,
 		/id="image-input"[^>]*type="file"[^>]*accept="image\/png,image\/jpeg,image\/webp,image\/gif,image\/bmp,image\/tiff,image\/heic,image\/heif,image\/avif,\.bmp,\.tif,\.tiff,\.heic,\.heif,\.avif"[^>]*multiple/,
@@ -65,9 +65,17 @@ test("image input supports picker and paste with visible removable previews", ()
 	assert.match(app, /filter\(isSupportedImageFile\)/);
 	assert.match(html, /id="image-previews"[^>]*aria-label="Attached images"/);
 	assert.match(app, /addEventListener\("paste"/);
-	assert.match(app, /URL\.createObjectURL/);
-	assert.match(app, /URL\.revokeObjectURL/);
+	assert.match(app, /\/api\/attachments\/reserve/);
+	assert.match(app, /new XMLHttpRequest\(\)/);
+	assert.match(app, /request\.upload\.addEventListener\("progress"/);
+	assert.match(app, /X-Pi-Web-Client/);
+	assert.match(app, /\/api\/attachments\/\$\{encodeURIComponent\(id\)\}\/upload/);
+	assert.match(app, /\/api\/attachments\/\$\{encodeURIComponent\(id\)\}\/retry/);
+	assert.match(app, /attachment-item-status/);
+	assert.match(app, /attachment-conversion-summary/);
+	assert.match(app, /Retry image/);
 	assert.match(app, /Remove image/);
+	assert.doesNotMatch(app, /URL\.createObjectURL|URL\.revokeObjectURL/);
 	assert.match(html, /Paste, drop, or choose/);
 	assert.match(html, /id="image-preview-dialog"/);
 	assert.match(html, /id="attachment-status"[^>]*aria-live="polite"/);
@@ -76,7 +84,7 @@ test("image input supports picker and paste with visible removable previews", ()
 	assert.match(app, /drag-active/);
 	assert.match(app, /moveImageBefore/);
 	assert.match(app, /moveImage/);
-	assert.match(app, /draggable = !model\.pending/);
+	assert.match(app, /item\.draggable = image\.status === "ready"/);
 	assert.match(app, /addEventListener\("dragstart"/);
 	assert.match(app, /Move image backward/);
 	assert.match(app, /Move image forward/);
@@ -85,10 +93,19 @@ test("image input supports picker and paste with visible removable previews", ()
 	assert.match(html, /id="clear-attachments-dialog"/);
 	assert.match(html, /id="confirm-clear-attachments"/);
 	assert.match(app, /model\.images\.length < 2/);
-	assert.match(app, /clearDraftImages/);
-	assert.match(app, /for \(const image of model\.images\) URL\.revokeObjectURL/);
+	assert.match(app, /\/api\/attachments\/clear/);
+	assert.match(app, /retryFiles\.delete/);
 	assert.match(app, /clearDialog\.showModal/);
 	assert.match(app, /returnValue !== "confirm"/);
+});
+
+test("attachment copy keeps routine status local and states metadata removal once", () => {
+	for (const label of ["Uploading", "Processing", "Ready", "Needs attention", "Retry", "Remove"]) {
+		assert.match(app, new RegExp(label));
+	}
+	assert.equal((app.match(/Sensitive metadata is removed before sending\./g) ?? []).length, 1);
+	assert.match(app, /image\.notes\.join\(" · "\)/);
+	assert.doesNotMatch(app, /alert\(/);
 });
 
 test("tool, thinking, and Markdown rendering use safe DOM construction", () => {


### PR DESCRIPTION
## Summary
- stage image uploads in bounded session memory before message submission
- expose authenticated revisioned upload, retry, reorder, remove, clear, and preview endpoints
- show per-image processing state, upload progress, retry actions, and conversion summaries

## Verification
- `npm run check` (760 tests)
- `git diff --check`
- `just pack webui`
- Chrome desktop and 320 px smoke for processing, retry/removal, ordering, refresh recovery, focus, targets, and send gating