### PR TITLE
feat(webui): recover drafts from session memory

### DIFF
--- a/docs/plans/archived/2026-07-19_pi-webui-memory-draft-recovery-plan.md
+++ b/docs/plans/archived/2026-07-19_pi-webui-memory-draft-recovery-plan.md
@@ -1,0 +1,44 @@
+## Goal
+
+Preserve an unsent WebUI text-and-image draft across browser refresh and active-tab takeover using only Pi-process memory. Success means the newest authorized tab resumes one authoritative draft without browser storage, cross-session leakage, or stale-tab overwrites.
+
+## Context
+
+Conversation snapshots intentionally preserve the current browser-local draft during reconnect, but a full page refresh loses it. Image Drop keeps its batch in the session-owned server and transfers editing authority through a lease. This plan depends on the server-side image staging plan so attachment bytes and status already have a canonical server owner.
+
+## Architecture
+
+The server owns a revisioned draft containing text plus ordered attachment references. The active tab sends bounded patch/replace mutations with expected revision and client lease. `/api/state` and SSE snapshots return draft state to authenticated clients; stale tabs can read but not mutate. Text updates must be debounced and serialized in browser order, while attachment operations remain explicit protocol mutations.
+
+## Non-Goals
+
+- localStorage, sessionStorage, IndexedDB, files, or transcript persistence.
+- Draft recovery after Pi reload/new/resume/fork/shutdown.
+- Synchronizing with Pi's terminal editor or attaching to a terminal-authored prompt.
+
+## Plan
+
+- [x] Add failing draft-store tests for text revisions, ordered attachment references, stale revisions, duplicate mutation IDs, clear-after-accepted-send, failed-send retention, newer edits during send, lease takeover, close, and memory cleanup; compilation first failed because `src/drafts.ts` was absent and all seven focused tests now pass.
+- [x] Add a focused `DraftStore` without coupling it to conversation projection; immutable snapshots, revisioned/deduplicated mutations, bounded UTF-8 text, send snapshots, and idempotent memory cleanup are verified by the focused tests.
+- [x] Add authenticated draft read/mutation protocol paths to `src/server.ts`, enforcing exact Origin/Host, cookie, active lease, expected revision, request IDs, UTF-8/body bounds, and stale-client errors; 20 server tests pass, including dedicated draft protocol coverage.
+- [x] Update browser state/app to hydrate from the authoritative draft, serialize debounced text writes, reconcile revision conflicts from a fresh snapshot, and never let stale responses overwrite newer local input; reducer tests cover delayed acknowledgements and browser smoke verified refresh recovery.
+- [x] Update send lifecycle so the accepted attempt clears only the exact sent text/attachment revision while preserving edits made during the request; server tests verify pending-send edits and failed retention, while lifecycle tests retain immediate/follow-up/steer coverage.
+- [x] Test refresh, network reconnect, second-tab takeover, old-tab mutation, browser close/reopen, processing attachment, pending send, session replacement, and shutdown; deterministic store/server/state/lifecycle tests pass and Chrome smoke verified refresh, takeover/read-only state, pending-send typing, and authoritative recovery.
+- [x] Update privacy documentation to state that unsent drafts live only in the Pi process until cleared or the session ends; `npm run check` passes 771 tests, `git diff --check` passes, and `just pack webui` contains 20 intended runtime files.
+
+## Risks
+
+- Debounced text and explicit image mutations can reorder; use one browser mutation queue and server revisions.
+- A snapshot can erase keystrokes typed after the request began; merge only by acknowledged revision and preserve unsent local operations.
+- Server ownership increases sensitive in-memory retention; clear on exact send acceptance, explicit clear, lease-independent session teardown, and configured bounds.
+
+## Rollback / Recovery
+
+Because no persistent migration exists, rollback restores browser-local drafts and drops only unsent in-memory server drafts on process/session end.
+
+## Completion Checklist
+
+- [x] Refresh and tab takeover restore the same authoritative text, order, status, and attachments, verified by server/state tests and Chrome browser smoke.
+- [x] Out-of-order acknowledgements, stale revisions, old tabs, pending sends, and newer edits cannot lose or duplicate draft content, verified by reducer, store, and server race tests.
+- [x] No browser or disk persistence is introduced, verified by source inspection, Chrome reporting zero local/session/IndexedDB entries, and shutdown cleanup tests.
+- [x] `npm run check` passes 771 tests, `git diff --check` passes, and `just pack webui` contains 20 intended runtime files.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -86,7 +86,7 @@ In print, JSON, and RPC modes, `/webui settings` does not open custom TUI or wri
 
 WebUI mirrors Pi's semantic session events, not terminal pixels. It displays conversation content, streaming assistant state, tool calls/results, errors, and activity using browser-native presentation. It does not reproduce ANSI colors, terminal wrapping, footer/widgets, built-in dialogs, arbitrary custom TUI components, or unsent terminal editor text.
 
-The initial transcript comes from the active session branch. Browser refresh does not create a second transcript or alter Pi's session tree.
+The initial transcript comes from the active session branch. Unsent browser message text and ordered attachment references are authoritative in the live Pi process, so refresh, reconnect, and active-tab takeover restore the same draft without creating a second transcript or altering Pi's session tree. Text edits are revisioned and saved with bounded, deduplicated mutations; stale or delayed responses cannot overwrite newer typing.
 
 ## Images
 
@@ -115,7 +115,7 @@ Pi's effective global and trusted-project `images.autoResize` and `images.blockI
 - A rotating bootstrap token is exchanged once for a per-server HttpOnly, `SameSite=Strict` cookie and removed from the URL.
 - Every endpoint requires the cookie. Mutations also require exact Host and Origin values plus the active browser-tab lease.
 - Responses use no-store, no-referrer, MIME-sniffing, frame-denial, same-origin resource, and restrictive Content Security Policy headers.
-- Transcript projection retains at most the newest 500 messages and 500 tool records, event replay keeps 256 updates, and request-id records keep 128 sends. Unsent staged images live only in bounded Pi-process memory; the page uses no localStorage, sessionStorage, IndexedDB, script-readable cookies, or image/transcript cache.
+- Transcript projection retains at most the newest 500 messages and 500 tool records, event replay keeps 256 updates, and request-id records keep 128 sends. Unsent message text, ordered attachment references, and staged image bytes live only in bounded Pi-process memory until cleared, accepted, or the session ends; the page uses no localStorage, sessionStorage, IndexedDB, script-readable cookies, or image/transcript cache.
 - Tool arguments/results, paths, images, and model thinking can be sensitive. Thinking is collapsed by default; only open a link issued by a Pi process you trust.
 - Reload, session replacement/fork, or Pi shutdown closes sockets, invalidates old callbacks, ends the page, and releases in-memory state.
 
@@ -140,6 +140,7 @@ src/webui.ts         Pi extension entrypoint
 src/runtime.ts       Pi lifecycle, commands, event projection, and browser message routing
 src/settings.ts      global WebUI settings validation and atomic persistence
 src/conversation.ts  bounded transcript snapshot and ordered event replay
+src/drafts.ts        authoritative in-memory text and attachment-reference revisions
 src/attachments.ts   revisioned staged-image state, processing queue, and byte ownership
 src/server.ts        authenticated loopback HTTP/SSE server and raw attachment protocol
 src/images.ts        bounded provider-ready image processing

--- a/extensions/pi-webui/src/drafts.ts
+++ b/extensions/pi-webui/src/drafts.ts
@@ -1,0 +1,226 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export interface DraftSettings {
+	maxTextBytes: number;
+	maxMutationRecords?: number;
+}
+
+export interface PublicDraftState {
+	revision: number;
+	text: string;
+	attachmentRevision: number;
+	attachmentIds: string[];
+}
+
+export interface DraftSendReservation {
+	token: string;
+	revision: number;
+	text: string;
+	attachmentRevision: number;
+	attachmentIds: string[];
+}
+
+interface MutationRecord {
+	digest: string;
+	result: PublicDraftState;
+}
+
+export class DraftError extends Error {
+	constructor(
+		message: string,
+		readonly status = 409,
+	) {
+		super(message);
+		this.name = "DraftError";
+	}
+}
+
+export class DraftStore {
+	private readonly mutations = new Map<string, MutationRecord>();
+	private readonly reservations = new Map<string, DraftSendReservation>();
+	private readonly maxMutationRecords: number;
+	private revision = 0;
+	private text = "";
+	private attachmentRevision = 0;
+	private attachmentIds: string[] = [];
+	private closed = false;
+
+	constructor(private readonly settings: DraftSettings) {
+		if (!Number.isSafeInteger(settings.maxTextBytes) || settings.maxTextBytes <= 0) {
+			throw new Error("Draft maxTextBytes must be a positive integer.");
+		}
+		this.maxMutationRecords = settings.maxMutationRecords ?? 128;
+		if (!Number.isSafeInteger(this.maxMutationRecords) || this.maxMutationRecords <= 0) {
+			throw new Error("Draft maxMutationRecords must be a positive integer.");
+		}
+	}
+
+	publicState(): PublicDraftState {
+		return {
+			revision: this.revision,
+			text: this.text,
+			attachmentRevision: this.attachmentRevision,
+			attachmentIds: [...this.attachmentIds],
+		};
+	}
+
+	residentBytes(): number {
+		return Buffer.byteLength(this.text);
+	}
+
+	setText(text: string, expectedRevision: number, mutationId: string): PublicDraftState {
+		this.assertOpen();
+		const normalized = normalizeText(text, this.settings.maxTextBytes);
+		const id = normalizeMutationId(mutationId);
+		const digest = mutationDigest(normalized);
+		const prior = this.mutations.get(id);
+		if (prior) {
+			if (prior.digest !== digest) throw new DraftError("Draft mutation id was reused.");
+			return cloneState(prior.result);
+		}
+		this.assertRevision(expectedRevision);
+		if (normalized !== this.text) {
+			this.text = normalized;
+			this.revision += 1;
+		}
+		const result = this.publicState();
+		this.mutations.set(id, { digest, result: cloneState(result) });
+		this.evictMutations();
+		return result;
+	}
+
+	syncAttachments(ids: readonly string[], attachmentRevision: number): PublicDraftState {
+		this.assertOpen();
+		const normalized = normalizeAttachmentIds(ids);
+		if (!Number.isSafeInteger(attachmentRevision) || attachmentRevision < 0) {
+			throw new DraftError("Attachment revision is invalid.", 400);
+		}
+		if (sameIds(normalized, this.attachmentIds)) return this.publicState();
+		this.attachmentIds = normalized;
+		this.attachmentRevision = attachmentRevision;
+		this.revision += 1;
+		return this.publicState();
+	}
+
+	beginSend(expectedRevision: number): DraftSendReservation {
+		this.assertOpen();
+		this.assertRevision(expectedRevision);
+		if (!this.text.trim() && this.attachmentIds.length === 0) {
+			throw new DraftError("Draft cannot be empty.", 400);
+		}
+		const reservation: DraftSendReservation = {
+			token: randomUUID(),
+			revision: this.revision,
+			text: this.text,
+			attachmentRevision: this.attachmentRevision,
+			attachmentIds: [...this.attachmentIds],
+		};
+		this.reservations.set(reservation.token, reservation);
+		return cloneReservation(reservation);
+	}
+
+	finishSend(
+		token: string,
+		committed: boolean,
+		attachments?: { revision: number; ids: readonly string[] },
+	): PublicDraftState {
+		this.assertOpen();
+		const reservation = this.reservations.get(token);
+		if (!reservation) throw new DraftError("Draft send reservation is stale.");
+		this.reservations.delete(token);
+		if (!committed) return this.publicState();
+		let changed = false;
+		if (this.text === reservation.text && this.text !== "") {
+			this.text = "";
+			changed = true;
+		}
+		if (attachments && sameIds(this.attachmentIds, reservation.attachmentIds)) {
+			const normalized = normalizeAttachmentIds(attachments.ids);
+			if (!Number.isSafeInteger(attachments.revision) || attachments.revision < 0) {
+				throw new DraftError("Attachment revision is invalid.", 400);
+			}
+			if (
+				!sameIds(this.attachmentIds, normalized) ||
+				this.attachmentRevision !== attachments.revision
+			) {
+				this.attachmentIds = normalized;
+				this.attachmentRevision = attachments.revision;
+				changed = true;
+			}
+		}
+		if (changed) this.revision += 1;
+		return this.publicState();
+	}
+
+	close(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.text = "";
+		this.attachmentIds = [];
+		this.attachmentRevision = 0;
+		this.mutations.clear();
+		this.reservations.clear();
+		this.revision += 1;
+	}
+
+	private assertRevision(expectedRevision: number): void {
+		if (!Number.isSafeInteger(expectedRevision) || expectedRevision !== this.revision) {
+			throw new DraftError(`Draft revision mismatch; current revision is ${this.revision}.`);
+		}
+	}
+
+	private assertOpen(): void {
+		if (this.closed) throw new DraftError("Draft store is closed.", 410);
+	}
+
+	private evictMutations(): void {
+		while (this.mutations.size > this.maxMutationRecords) {
+			const oldest = this.mutations.keys().next().value;
+			if (typeof oldest !== "string") return;
+			this.mutations.delete(oldest);
+		}
+	}
+}
+
+function normalizeText(value: string, maxBytes: number): string {
+	if (typeof value !== "string") throw new DraftError("Draft text is invalid.", 400);
+	if (Buffer.byteLength(value) > maxBytes) throw new DraftError("Draft text is too large.", 413);
+	return value;
+}
+
+function normalizeMutationId(value: string): string {
+	if (typeof value !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+		throw new DraftError("Draft mutation id is invalid.", 400);
+	}
+	return value;
+}
+
+function normalizeAttachmentIds(values: readonly string[]): string[] {
+	if (!Array.isArray(values)) throw new DraftError("Attachment ids are invalid.", 400);
+	const result = values.map((value) => {
+		if (typeof value !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+			throw new DraftError("Attachment id is invalid.", 400);
+		}
+		return value;
+	});
+	if (new Set(result).size !== result.length) {
+		throw new DraftError("Attachment ids contain a duplicate.", 400);
+	}
+	return result;
+}
+
+function mutationDigest(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
+}
+
+function sameIds(left: readonly string[], right: readonly string[]): boolean {
+	return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+function cloneState(state: PublicDraftState): PublicDraftState {
+	return { ...state, attachmentIds: [...state.attachmentIds] };
+}
+
+function cloneReservation(reservation: DraftSendReservation): DraftSendReservation {
+	return { ...reservation, attachmentIds: [...reservation.attachmentIds] };
+}

--- a/extensions/pi-webui/src/server.ts
+++ b/extensions/pi-webui/src/server.ts
@@ -12,12 +12,14 @@ import {
 	type PublicAttachmentState,
 } from "./attachments.js";
 import type { ConversationEvent, ConversationProjection } from "./conversation.js";
+import { DraftError, DraftStore, type PublicDraftState } from "./drafts.js";
 import { type BrowserImageInput, DEFAULT_IMAGE_LIMITS } from "./images.js";
 
 const JSON_LIMIT = 64 * 1024 * 1024;
 const CLIENT_ID = /^[A-Za-z0-9_-]{1,80}$/;
 const REQUEST_ID = /^[A-Za-z0-9_-]{1,120}$/;
 const MAX_REQUESTS = 128;
+const DEFAULT_MAX_DRAFT_TEXT_BYTES = 1024 * 1024;
 const SSE_FLUSH_TIMEOUT_MS = 250;
 
 export interface WebSendRequest {
@@ -32,9 +34,7 @@ export interface WebSendRequest {
 
 interface ParsedSendRequest {
 	requestId: string;
-	text: string;
-	attachmentRevision: number;
-	attachmentIds: string[];
+	draftRevision: number;
 	delivery: "next" | "steer";
 }
 
@@ -47,6 +47,7 @@ export interface WebUIServerOptions {
 	send: (request: WebSendRequest) => Promise<WebSendResult>;
 	processAttachment?: (source: Uint8Array, signal?: AbortSignal) => Promise<PreparedAttachment>;
 	attachmentLimits?: AttachmentLimits;
+	maxDraftTextBytes?: number;
 	maxRequestBytes?: number;
 }
 
@@ -82,6 +83,7 @@ export class WebUIServer {
 	private readonly activeAttachmentControllers = new Set<AbortController>();
 	private readonly attachments: AttachmentStore;
 	private readonly attachmentLimits: AttachmentLimits;
+	private readonly draft: DraftStore;
 	private activeClientId?: string;
 	private leaseGeneration = 0;
 	private closed = false;
@@ -99,6 +101,9 @@ export class WebUIServer {
 			maxImageBytes: DEFAULT_IMAGE_LIMITS.maxImageBytes,
 			maxPromptBytes: DEFAULT_IMAGE_LIMITS.maxPromptBytes,
 		};
+		this.draft = new DraftStore({
+			maxTextBytes: options.maxDraftTextBytes ?? DEFAULT_MAX_DRAFT_TEXT_BYTES,
+		});
 		this.attachments = new AttachmentStore({
 			limits: this.attachmentLimits,
 			process:
@@ -163,6 +168,7 @@ export class WebUIServer {
 		this.activeSendControllers.clear();
 		this.activeAttachmentControllers.clear();
 		this.attachments.close();
+		this.draft.close();
 		this.requests.clear();
 		const responses = [...this.sseClients].map((client) => client.response);
 		this.broadcastControl("session-ended", { message: "Pi session ended" });
@@ -205,6 +211,7 @@ export class WebUIServer {
 				this.json(response, 200, {
 					...this.options.conversation.snapshot(),
 					lease: this.leaseSnapshot(),
+					draft: this.draft.publicState(),
 					attachments: this.attachments.publicState(),
 				});
 				return;
@@ -247,6 +254,25 @@ export class WebUIServer {
 				return;
 			}
 			const lease = this.assertActiveClient(request);
+			if (request.method === "POST" && url.pathname === "/api/draft") {
+				const body = requireRecord(
+					await readJson(
+						request,
+						(this.options.maxDraftTextBytes ?? DEFAULT_MAX_DRAFT_TEXT_BYTES) + 8192,
+					),
+					"draft mutation",
+				);
+				this.assertLease(lease);
+				const state = this.draft.setText(
+					stringField(body, "text"),
+					numberField(body, "revision"),
+					stringField(body, "requestId"),
+				);
+				this.assertLease(lease);
+				this.broadcastDraft(state);
+				this.json(response, 200, state);
+				return;
+			}
 			if (request.method === "POST" && url.pathname === "/api/attachments/reserve") {
 				const body = requireRecord(await readJson(request, 64 * 1024), "attachment reservation");
 				this.assertLease(lease);
@@ -255,6 +281,7 @@ export class WebUIServer {
 					numberField(body, "revision"),
 				);
 				this.assertLease(lease);
+				this.syncDraftAttachments(state);
 				this.json(response, 201, state);
 				return;
 			}
@@ -296,6 +323,7 @@ export class WebUIServer {
 			if (request.method === "DELETE" && deleteId) {
 				const state = this.attachments.remove(deleteId, revisionParameter(url));
 				this.assertLease(lease);
+				this.syncDraftAttachments(state);
 				this.json(response, 200, state);
 				return;
 			}
@@ -307,6 +335,7 @@ export class WebUIServer {
 					numberField(body, "revision"),
 				);
 				this.assertLease(lease);
+				this.syncDraftAttachments(state);
 				this.json(response, 200, state);
 				return;
 			}
@@ -315,6 +344,7 @@ export class WebUIServer {
 				this.assertLease(lease);
 				const state = this.attachments.clear(numberField(body, "revision"));
 				this.assertLease(lease);
+				this.syncDraftAttachments(state);
 				this.json(response, 200, state);
 				return;
 			}
@@ -327,6 +357,7 @@ export class WebUIServer {
 					accepted: true,
 					requestId: message.requestId,
 					...result,
+					draft: this.draft.publicState(),
 					attachments: this.attachments.publicState(),
 				});
 				return;
@@ -334,7 +365,11 @@ export class WebUIServer {
 			throw new HttpError(404, "Not found");
 		} catch (error) {
 			const status =
-				error instanceof HttpError || error instanceof AttachmentError ? error.status : 500;
+				error instanceof HttpError ||
+				error instanceof AttachmentError ||
+				error instanceof DraftError
+					? error.status
+					: 500;
 			if (error instanceof HttpError && error.closeConnection)
 				response.setHeader("Connection", "close");
 			this.json(response, status, { error: formatError(error) });
@@ -413,21 +448,53 @@ export class WebUIServer {
 				throw new HttpError(409, "Request id was reused with different content");
 			return current.promise;
 		}
-		const reservation =
-			message.attachmentIds.length > 0
-				? this.attachments.beginSend(message.attachmentIds, message.attachmentRevision)
-				: undefined;
+		const draftReservation = this.draft.beginSend(message.draftRevision);
+		const attachmentState = this.attachments.publicState();
+		if (
+			!sameIds(
+				draftReservation.attachmentIds,
+				attachmentState.items.map((item) => item.id),
+			)
+		) {
+			this.draft.finishSend(draftReservation.token, false);
+			throw new HttpError(409, "Draft attachment references are stale");
+		}
+		let attachmentReservation: ReturnType<AttachmentStore["beginSend"]> | undefined;
+		try {
+			attachmentReservation =
+				draftReservation.attachmentIds.length > 0
+					? this.attachments.beginSend(draftReservation.attachmentIds, attachmentState.revision)
+					: undefined;
+		} catch (error) {
+			this.draft.finishSend(draftReservation.token, false);
+			throw error;
+		}
 		const controller = new AbortController();
 		this.activeSendControllers.add(controller);
 		const abort = () => controller.abort();
 		request.once("aborted", abort);
 		response.once("close", abort);
-		let attachmentReservationSettled = false;
+		let reservationsSettled = false;
 		const promise = this.options
-			.send({ ...message, images: reservation?.images ?? [], signal: controller.signal })
+			.send({
+				requestId: message.requestId,
+				text: draftReservation.text,
+				attachmentRevision: attachmentState.revision,
+				attachmentIds: draftReservation.attachmentIds,
+				images: attachmentReservation?.images ?? [],
+				delivery: message.delivery,
+				signal: controller.signal,
+			})
 			.then((result) => {
-				if (reservation) this.attachments.finishSend(reservation.token, true);
-				attachmentReservationSettled = true;
+				const nextAttachments = attachmentReservation
+					? this.attachments.finishSend(attachmentReservation.token, true)
+					: this.attachments.publicState();
+				const nextDraft = this.draft.finishSend(draftReservation.token, true, {
+					revision: nextAttachments.revision,
+					ids: nextAttachments.items.map((item) => item.id),
+				});
+				this.broadcastDraft(nextDraft);
+				reservationsSettled = true;
 				const record = this.requests.get(message.requestId);
 				if (record?.promise === promise) {
 					record.settled = true;
@@ -436,13 +503,16 @@ export class WebUIServer {
 				return result;
 			})
 			.catch((error) => {
-				if (reservation && !attachmentReservationSettled) {
+				if (!reservationsSettled) {
 					try {
-						this.attachments.finishSend(reservation.token, false);
+						if (attachmentReservation) {
+							this.attachments.finishSend(attachmentReservation.token, false);
+						}
+						this.draft.finishSend(draftReservation.token, false);
 					} catch {
-						// Session shutdown may already have released the reservation.
+						// Session shutdown may already have released the reservations.
 					}
-					attachmentReservationSettled = true;
+					reservationsSettled = true;
 				}
 				if (this.requests.get(message.requestId)?.promise === promise) {
 					this.requests.delete(message.requestId);
@@ -489,6 +559,7 @@ export class WebUIServer {
 			return;
 		}
 		this.writeSse(client, "lease", this.leaseSnapshot());
+		this.writeSse(client, "draft", this.draft.publicState());
 		this.writeSse(client, "attachments", this.attachments.publicState());
 		const replay = this.options.conversation.eventsAfter(since);
 		if (replay === undefined) {
@@ -504,6 +575,20 @@ export class WebUIServer {
 			...(this.activeClientId ? { activeClientId: this.activeClientId } : {}),
 			generation: this.leaseGeneration,
 		};
+	}
+
+	private syncDraftAttachments(attachments: PublicAttachmentState): PublicDraftState {
+		const before = this.draft.publicState().revision;
+		const next = this.draft.syncAttachments(
+			attachments.items.map((item) => item.id),
+			attachments.revision,
+		);
+		if (next.revision !== before) this.broadcastDraft(next);
+		return next;
+	}
+
+	private broadcastDraft(state: PublicDraftState): void {
+		this.broadcastControl("draft", state);
 	}
 
 	private broadcastEvent(event: ConversationEvent): void {
@@ -587,13 +672,7 @@ async function readAsset(name: string): Promise<Buffer> {
 
 function messageDigest(message: ParsedSendRequest): string {
 	const hash = createHash("sha256");
-	for (const value of [
-		message.requestId,
-		message.delivery,
-		message.text,
-		String(message.attachmentRevision),
-		...message.attachmentIds,
-	]) {
+	for (const value of [message.requestId, message.delivery, String(message.draftRevision)]) {
 		hash
 			.update(String(Buffer.byteLength(value)))
 			.update(":")
@@ -606,15 +685,11 @@ function parseSendRequest(value: unknown): ParsedSendRequest {
 	if (!isRecord(value)) throw new HttpError(400, "Invalid message request");
 	const requestId = stringField(value, "requestId");
 	if (!REQUEST_ID.test(requestId)) throw new HttpError(400, "Invalid request id");
-	const text = stringField(value, "text");
-	const attachmentRevision = numberField(value, "attachmentRevision");
-	const attachmentIds = stringArrayField(value, "attachmentIds");
-	if (!text.trim() && attachmentIds.length === 0)
-		throw new HttpError(400, "Message cannot be empty");
+	const draftRevision = numberField(value, "draftRevision");
 	const delivery = value.delivery;
 	if (delivery !== "next" && delivery !== "steer")
 		throw new HttpError(400, "Invalid delivery mode");
-	return { requestId, text, attachmentRevision, attachmentIds, delivery };
+	return { requestId, draftRevision, delivery };
 }
 
 async function readBytes(request: IncomingMessage, limit: number): Promise<Buffer> {
@@ -709,6 +784,10 @@ function attachmentPathId(
 	const suffix = action ? `/${action}` : "";
 	const match = new RegExp(`^/api/attachments/([A-Za-z0-9_-]{1,128})${suffix}$`).exec(pathname);
 	return match?.[1];
+}
+
+function sameIds(left: readonly string[], right: readonly string[]): boolean {
+	return left.length === right.length && left.every((id, index) => id === right[index]);
 }
 
 function token(): string {

--- a/extensions/pi-webui/src/web/app.js
+++ b/extensions/pi-webui/src/web/app.js
@@ -1,12 +1,15 @@
 import {
+	acknowledgeDraftText,
 	applyAttachments,
 	applyConversationEvent,
+	applyDraft,
 	applyLease,
 	applySnapshot,
 	busyLabel,
 	canSend,
 	completeSend,
 	deliveryNotice,
+	editDraftText,
 	failSend,
 	followLatest,
 	initialState,
@@ -31,6 +34,8 @@ let transcriptAnnouncement = "";
 let dragDepth = 0;
 let previewReturnFocus;
 let mutatingAttachments = false;
+let draftSaveTimer;
+let draftSaveQueue = Promise.resolve();
 const retryFiles = new Map();
 const uploadProgress = new Map();
 
@@ -82,7 +87,8 @@ const ui = {
 const transcriptRenderer = createTranscriptRenderer({ documentRef: document, list: ui.transcript });
 
 ui.input.addEventListener("input", () => {
-	model = invalidateSendAttempt({ ...model, text: ui.input.value, error: "" });
+	model = editDraftText(model, ui.input.value);
+	scheduleDraftSave();
 	resizeInput();
 	renderComposer();
 });
@@ -210,6 +216,7 @@ async function claimLease() {
 	});
 	if (!response.ok) throw new Error(await responseError(response));
 	model = applyLease(model, await response.json(), clientId, true);
+	if (model.textDirty) scheduleDraftSave();
 	render();
 }
 
@@ -220,6 +227,7 @@ function connectEvents() {
 	events.addEventListener("open", () => {
 		reconnectDelay = 500;
 		model = { ...model, connected: true, error: "" };
+		if (model.textDirty) scheduleDraftSave();
 		render();
 	});
 	events.addEventListener("conversation", (event) => {
@@ -241,6 +249,10 @@ function connectEvents() {
 	events.addEventListener("lease", (event) => {
 		model = applyLease(model, JSON.parse(event.data), clientId);
 		render();
+	});
+	events.addEventListener("draft", (event) => {
+		model = applyDraft(model, JSON.parse(event.data));
+		renderComposer();
 	});
 	events.addEventListener("attachments", (event) => {
 		model = applyAttachments(model, JSON.parse(event.data));
@@ -283,15 +295,21 @@ function connectionFailure(error) {
 
 async function send(steer) {
 	if (!canSend(model)) return;
+	try {
+		await flushDraftText();
+	} catch (error) {
+		model = { ...model, error: errorMessage(error) };
+		render();
+		return;
+	}
+	if (!canSend(model) || model.textDirty) return;
 	const prepared = prepareSend(model, crypto.randomUUID(), steer ? "steer" : "next");
 	const attempt = prepared.attempt;
 	model = prepared.state;
 	renderComposer();
 	const payload = {
 		requestId: attempt.requestId,
-		text: attempt.text,
-		attachmentRevision: attempt.attachmentRevision,
-		attachmentIds: attempt.attachmentIds,
+		draftRevision: attempt.draftRevision,
 		delivery: attempt.delivery,
 	};
 	try {
@@ -306,6 +324,7 @@ async function send(steer) {
 			throw new Error(message);
 		}
 		const accepted = await response.json();
+		if (accepted.draft) model = applyDraft(model, accepted.draft);
 		if (accepted.attachments) model = applyAttachments(model, accepted.attachments);
 		if (attempt.attachmentIds.includes(ui.previewImage.dataset.imageId)) {
 			ui.previewDialog.close();
@@ -440,6 +459,50 @@ async function retryImage(id) {
 		mutatingAttachments = false;
 		renderComposer();
 	}
+}
+
+function scheduleDraftSave() {
+	clearTimeout(draftSaveTimer);
+	if (!model.textDirty || model.closed || model.stale || !model.connected) return;
+	draftSaveTimer = setTimeout(() => {
+		draftSaveTimer = undefined;
+		void flushDraftText().catch((error) => {
+			model = { ...model, error: errorMessage(error) };
+			render();
+		});
+	}, 180);
+}
+
+function flushDraftText() {
+	clearTimeout(draftSaveTimer);
+	draftSaveTimer = undefined;
+	draftSaveQueue = draftSaveQueue
+		.catch(() => undefined)
+		.then(async () => {
+			while (model.textDirty) {
+				if (model.closed || model.stale || !model.connected) {
+					throw new Error("Reconnect the active tab to save this draft.");
+				}
+				const submittedText = model.text;
+				const response = await fetch("/api/draft", {
+					method: "POST",
+					headers: { "Content-Type": "application/json", "X-Pi-Web-Client": clientId },
+					body: JSON.stringify({
+						requestId: crypto.randomUUID(),
+						revision: model.draftRevision,
+						text: submittedText,
+					}),
+				});
+				if (response.status === 409) {
+					await refreshSnapshot();
+					continue;
+				}
+				if (!response.ok) throw new Error(await responseError(response));
+				model = acknowledgeDraftText(model, await response.json(), submittedText);
+				renderComposer();
+			}
+		});
+	return draftSaveQueue;
 }
 
 function isSupportedImageFile(file) {
@@ -586,7 +649,7 @@ function renderComposer() {
 	ui.send.disabled = !canSend(model);
 	ui.steer.hidden = model.activity !== "running";
 	ui.steer.disabled = !canSend(model);
-	ui.input.disabled = locked;
+	ui.input.disabled = model.closed || model.stale;
 	const admissionLocked = locked || model.readingImages > 0;
 	ui.imageInput.disabled = admissionLocked;
 	ui.addImages.classList.toggle("disabled", admissionLocked);

--- a/extensions/pi-webui/src/web/state.js
+++ b/extensions/pi-webui/src/web/state.js
@@ -13,6 +13,9 @@ export function initialState() {
 		readingImages: 0,
 		leaseClaimed: false,
 		leaseGeneration: 0,
+		draftRevision: 0,
+		authoritativeText: "",
+		textDirty: false,
 		attachmentRevision: 0,
 		attachmentPhase: "empty",
 		following: true,
@@ -37,7 +40,41 @@ export function applySnapshot(current, snapshot) {
 			needsSnapshot: false,
 		};
 	}
-	return applyAttachments(next, snapshot?.attachments);
+	return applyAttachments(applyDraft(next, snapshot?.draft), snapshot?.attachments);
+}
+
+export function applyDraft(current, draft) {
+	if (
+		!Number.isSafeInteger(draft?.revision) ||
+		draft.revision < current.draftRevision ||
+		typeof draft.text !== "string"
+	) {
+		return current;
+	}
+	const preserveLocal = current.textDirty && current.text !== draft.text;
+	return {
+		...current,
+		draftRevision: draft.revision,
+		authoritativeText: draft.text,
+		text: preserveLocal ? current.text : draft.text,
+		textDirty: preserveLocal,
+	};
+}
+
+export function editDraftText(current, text) {
+	return invalidateSendAttempt({
+		...current,
+		text,
+		textDirty: text !== current.authoritativeText,
+		error: "",
+	});
+}
+
+export function acknowledgeDraftText(current, draft, submittedText) {
+	if (current.text === submittedText) {
+		return applyDraft({ ...current, textDirty: false }, draft);
+	}
+	return applyDraft(current, draft);
 }
 
 export function applyAttachments(current, attachments) {
@@ -114,6 +151,7 @@ export function prepareSend(current, requestId, delivery = "next") {
 	const attempt = current.outbox ?? {
 		requestId,
 		text: current.text,
+		draftRevision: current.draftRevision,
 		attachmentRevision: current.attachmentRevision,
 		attachmentIds: current.images.map((image) => image.id),
 		images: [...current.images],

--- a/extensions/pi-webui/test/drafts.test.ts
+++ b/extensions/pi-webui/test/drafts.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DraftError, DraftStore } from "../src/drafts.js";
+
+function store() {
+	return new DraftStore({ maxTextBytes: 32, maxMutationRecords: 4 });
+}
+
+test("draft text mutations require revisions, bound bytes, and deduplicate mutation ids", () => {
+	const draft = store();
+	assert.deepEqual(draft.publicState(), {
+		revision: 0,
+		text: "",
+		attachmentRevision: 0,
+		attachmentIds: [],
+	});
+	const first = draft.setText("hello", 0, "mutation-1");
+	assert.equal(first.revision, 1);
+	assert.equal(first.text, "hello");
+	assert.equal(draft.residentBytes(), 5);
+	assert.deepEqual(draft.setText("hello", 0, "mutation-1"), first);
+	assert.throws(() => draft.setText("changed", 1, "mutation-1"), /reused/i);
+	assert.throws(() => draft.setText("stale", 0, "mutation-2"), /revision/i);
+	assert.throws(() => draft.setText("x".repeat(33), 1, "mutation-3"), /large/i);
+	assert.equal(draft.publicState().text, "hello");
+});
+
+test("ordered attachment references synchronize independently from processing status", () => {
+	const draft = store();
+	draft.setText("describe", 0, "text");
+	let state = draft.syncAttachments(["one", "two"], 4);
+	assert.deepEqual(state.attachmentIds, ["one", "two"]);
+	assert.equal(state.attachmentRevision, 4);
+	const unchanged = draft.syncAttachments(["one", "two"], 5);
+	assert.equal(unchanged.revision, state.revision);
+	assert.equal(unchanged.attachmentRevision, 4);
+	state = draft.syncAttachments(["two", "one"], 6);
+	assert.deepEqual(state.attachmentIds, ["two", "one"]);
+	assert.throws(() => draft.syncAttachments(["two", "two"], 7), /duplicate/i);
+});
+
+test("accepted sends clear only matching text and attachment references", () => {
+	const draft = store();
+	draft.setText("old", 0, "old-text");
+	draft.syncAttachments(["one"], 2);
+	const attempt = draft.beginSend(draft.publicState().revision);
+	draft.setText("new", draft.publicState().revision, "new-text");
+	const completed = draft.finishSend(attempt.token, true, { revision: 3, ids: [] });
+	assert.equal(completed.text, "new");
+	assert.deepEqual(completed.attachmentIds, []);
+	assert.equal(completed.attachmentRevision, 3);
+});
+
+test("a newer attachment draft created during send is preserved", () => {
+	const draft = store();
+	draft.setText("send", 0, "text");
+	draft.syncAttachments(["one"], 2);
+	const attempt = draft.beginSend(draft.publicState().revision);
+	draft.syncAttachments(["one", "two"], 3);
+	const completed = draft.finishSend(attempt.token, true, { revision: 4, ids: [] });
+	assert.deepEqual(completed.attachmentIds, ["one", "two"]);
+	assert.equal(completed.attachmentRevision, 3);
+});
+
+test("failed sends retain the exact draft and reservations reject stale revisions", () => {
+	const draft = store();
+	draft.setText("retry", 0, "text");
+	const before = draft.publicState();
+	assert.throws(() => draft.beginSend(0), /revision/i);
+	const attempt = draft.beginSend(before.revision);
+	assert.deepEqual(draft.finishSend(attempt.token, false), before);
+	assert.throws(() => draft.finishSend(attempt.token, false), /stale/i);
+});
+
+test("lease takeover leaves authoritative content available to the new client", () => {
+	const draft = store();
+	draft.setText("recover me", 0, "text");
+	draft.syncAttachments(["one", "two"], 3);
+	const snapshot = draft.publicState();
+	assert.deepEqual(snapshot, draft.publicState());
+	assert.notEqual(snapshot.attachmentIds, draft.publicState().attachmentIds);
+});
+
+test("close clears memory and rejects later mutations idempotently", () => {
+	const draft = store();
+	draft.setText("secret", 0, "text");
+	draft.syncAttachments(["one"], 2);
+	draft.close();
+	draft.close();
+	assert.equal(draft.residentBytes(), 0);
+	assert.deepEqual(draft.publicState().attachmentIds, []);
+	assert.equal(draft.publicState().text, "");
+	assert.throws(() => draft.setText("late", draft.publicState().revision, "late"), DraftError);
+});

--- a/extensions/pi-webui/test/server.test.ts
+++ b/extensions/pi-webui/test/server.test.ts
@@ -143,9 +143,7 @@ test("mutations require exact Origin, Host, cookie, and current tab lease", asyn
 					client: "one",
 					body: JSON.stringify({
 						requestId: "r1",
-						text: "hello",
-						attachmentRevision: 0,
-						attachmentIds: [],
+						draftRevision: 0,
 						delivery: "next",
 					}),
 				})
@@ -181,15 +179,14 @@ test("a new tab lease aborts an in-flight asynchronous send before mutation", as
 	try {
 		const cookie = await authenticate(server);
 		const firstClient = await takeLease(server, cookie, "first");
+		const draft = await setDraftText(server, cookie, firstClient, "hello");
 		const sending = api(server, "/api/messages", {
 			method: "POST",
 			cookie,
 			client: firstClient,
 			body: JSON.stringify({
 				requestId: "in-flight",
-				text: "hello",
-				attachmentRevision: 0,
-				attachmentIds: [],
+				draftRevision: draft.revision,
 				delivery: "next",
 			}),
 		});
@@ -226,11 +223,10 @@ test("a completed upload aborts when its response connection closes", async () =
 	try {
 		const cookie = await authenticate(server);
 		const client = await takeLease(server, cookie);
+		const draft = await setDraftText(server, cookie, client, "hello");
 		const request = rawMessageRequest(server, cookie, client, {
 			requestId: "disconnect",
-			text: "hello",
-			attachmentRevision: 0,
-			attachmentIds: [],
+			draftRevision: draft.revision,
 			delivery: "next",
 		});
 		await started.promise;
@@ -259,6 +255,7 @@ test("in-flight request ids remain deduplicated when the completed-result cache 
 	try {
 		const cookie = await authenticate(server);
 		const client = await takeLease(server, cookie);
+		const draft = await setDraftText(server, cookie, client, "stress");
 		const send = (requestId: string) =>
 			api(server, "/api/messages", {
 				method: "POST",
@@ -266,9 +263,7 @@ test("in-flight request ids remain deduplicated when the completed-result cache 
 				client,
 				body: JSON.stringify({
 					requestId,
-					text: requestId,
-					attachmentRevision: 0,
-					attachmentIds: [],
+					draftRevision: draft.revision,
 					delivery: "next",
 				}),
 			});
@@ -303,11 +298,10 @@ test("failed sends release their request id for an unchanged browser retry", asy
 	try {
 		const cookie = await authenticate(server);
 		const client = await takeLease(server, cookie);
+		const draft = await setDraftText(server, cookie, client, "hello");
 		const body = JSON.stringify({
 			requestId: "retryable",
-			text: "hello",
-			attachmentRevision: 0,
-			attachmentIds: [],
+			draftRevision: draft.revision,
 			delivery: "next",
 		});
 		assert.equal(
@@ -324,16 +318,56 @@ test("failed sends release their request id for an unchanged browser retry", asy
 	}
 });
 
+test("accepted sends clear only their snapshot while preserving text edited during the request", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	const started = deferred<void>();
+	const gate = deferred<WebSendResult>();
+	const server = await WebUIServer.start({
+		conversation,
+		send: async () => {
+			started.resolve(undefined);
+			return gate.promise;
+		},
+	});
+	try {
+		const cookie = await authenticate(server);
+		const client = await takeLease(server, cookie);
+		const original = await setDraftText(server, cookie, client, "old", 0, "old");
+		const sending = api(server, "/api/messages", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				requestId: "pending",
+				draftRevision: original.revision,
+				delivery: "next",
+			}),
+		});
+		await started.promise;
+		const newer = await setDraftText(server, cookie, client, "new", original.revision, "new");
+		gate.resolve({ delivery: "immediate" });
+		const accepted = await sending;
+		assert.equal(accepted.status, 202);
+		assert.deepEqual(((await accepted.json()) as { draft: unknown }).draft, newer);
+		const recovered = (await (await api(server, "/api/state", { cookie })).json()) as {
+			draft: { text: string };
+		};
+		assert.equal(recovered.draft.text, "new");
+	} finally {
+		gate.resolve({ delivery: "immediate" });
+		await server.close();
+	}
+});
+
 test("message requests validate, deduplicate, and reject request-id payload conflicts", async () => {
 	const { sends, server } = await harness();
 	try {
 		const cookie = await authenticate(server);
 		const client = await takeLease(server, cookie);
+		const draft = await setDraftText(server, cookie, client, "hello");
 		const body = JSON.stringify({
 			requestId: "request-1",
-			text: "hello",
-			attachmentRevision: 0,
-			attachmentIds: [],
+			draftRevision: draft.revision,
 			delivery: "next",
 		});
 		const first = await api(server, "/api/messages", { method: "POST", cookie, client, body });
@@ -345,6 +379,12 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 			accepted: true,
 			requestId: "request-1",
 			delivery: "immediate",
+			draft: {
+				revision: 2,
+				text: "",
+				attachmentRevision: 0,
+				attachmentIds: [],
+			},
 			attachments: {
 				revision: 0,
 				phase: "empty",
@@ -359,10 +399,8 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 			client,
 			body: JSON.stringify({
 				requestId: "request-1",
-				text: "changed",
-				attachmentRevision: 0,
-				attachmentIds: [],
-				delivery: "next",
+				draftRevision: draft.revision,
+				delivery: "steer",
 			}),
 		});
 		assert.equal(conflict.status, 409);
@@ -374,9 +412,7 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 					client,
 					body: JSON.stringify({
 						requestId: "empty",
-						text: "  ",
-						attachmentRevision: 0,
-						attachmentIds: [],
+						draftRevision: 2,
 						delivery: "next",
 					}),
 				})
@@ -408,10 +444,9 @@ test("oversized and cancelled request bodies do not mutate or stop the server", 
 			client,
 			body: JSON.stringify({
 				requestId: "large",
-				text: "x".repeat(300),
-				attachmentRevision: 0,
-				attachmentIds: [],
+				draftRevision: 0,
 				delivery: "next",
+				padding: "x".repeat(300),
 			}),
 		});
 		assert.equal(oversized.status, 413);
@@ -419,6 +454,88 @@ test("oversized and cancelled request bodies do not mutate or stop the server", 
 		await new Promise((resolve) => setTimeout(resolve, 10));
 		assert.equal(sends, 0);
 		assert.equal((await api(server, "/api/state", { cookie })).status, 200);
+	} finally {
+		await server.close();
+	}
+});
+
+test("draft mutations enforce auth, lease, revisions, deduplication, and UTF-8 body bounds", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	const server = await WebUIServer.start({
+		conversation,
+		maxDraftTextBytes: 8,
+		send: async () => ({ delivery: "immediate" }),
+	});
+	try {
+		const cookie = await authenticate(server);
+		let client = await takeLease(server, cookie, "first");
+		assert.equal(
+			(
+				await api(server, "/api/draft", {
+					method: "POST",
+					client,
+					body: JSON.stringify({ requestId: "missing-cookie", revision: 0, text: "x" }),
+				})
+			).status,
+			401,
+		);
+		const first = await setDraftText(server, cookie, client, "hello", 0, "same");
+		assert.equal(first.revision, 1);
+		assert.deepEqual(await setDraftText(server, cookie, client, "hello", 0, "same"), first);
+		assert.equal(
+			(
+				await api(server, "/api/draft", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({ requestId: "same", revision: 1, text: "changed" }),
+				})
+			).status,
+			409,
+		);
+		assert.equal(
+			(
+				await api(server, "/api/draft", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({ requestId: "stale", revision: 0, text: "stale" }),
+				})
+			).status,
+			409,
+		);
+		assert.equal(
+			(
+				await api(server, "/api/draft", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({ requestId: "large", revision: 1, text: "界界界" }),
+				})
+			).status,
+			413,
+		);
+		client = await takeLease(server, cookie, "second");
+		const recovered = (await (await api(server, "/api/state", { cookie })).json()) as {
+			draft: { text: string; revision: number };
+		};
+		assert.deepEqual(recovered.draft, {
+			text: "hello",
+			revision: 1,
+			attachmentRevision: 0,
+			attachmentIds: [],
+		});
+		assert.equal(
+			(
+				await api(server, "/api/draft", {
+					method: "POST",
+					cookie,
+					client: "first",
+					body: JSON.stringify({ requestId: "old-tab", revision: 1, text: "lost" }),
+				})
+			).status,
+			409,
+		);
 	} finally {
 		await server.close();
 	}
@@ -853,6 +970,24 @@ function cancelRequest(server: WebUIServer, cookie: string, client: string): Pro
 		request.destroy();
 		setTimeout(resolve, 20);
 	});
+}
+
+async function setDraftText(
+	server: WebUIServer,
+	cookie: string,
+	client: string,
+	text: string,
+	revision = 0,
+	requestId = `draft-${revision}-${text.length}`,
+): Promise<{ revision: number; text: string; attachmentIds: string[] }> {
+	const response = await api(server, "/api/draft", {
+		method: "POST",
+		cookie,
+		client,
+		body: JSON.stringify({ requestId, revision, text }),
+	});
+	assert.equal(response.status, 200);
+	return response.json() as Promise<{ revision: number; text: string; attachmentIds: string[] }>;
 }
 
 function preparedAttachment(marker: string): PreparedAttachment {

--- a/extensions/pi-webui/test/web-state.test.ts
+++ b/extensions/pi-webui/test/web-state.test.ts
@@ -8,6 +8,13 @@ const state = (await import(
 )) as {
 	initialState(): WebState;
 	applySnapshot(current: WebState, snapshot: Snapshot): WebState;
+	applyDraft(current: WebState, draft: Record<string, unknown>): WebState;
+	editDraftText(current: WebState, text: string): WebState;
+	acknowledgeDraftText(
+		current: WebState,
+		draft: Record<string, unknown>,
+		submittedText: string,
+	): WebState;
 	applyAttachments(current: WebState, attachments: Record<string, unknown>): WebState;
 	applyConversationEvent(current: WebState, event: ConversationEvent): WebState;
 	applyLease(
@@ -61,6 +68,9 @@ interface WebState {
 	readingImages: number;
 	leaseClaimed: boolean;
 	leaseGeneration: number;
+	draftRevision: number;
+	authoritativeText: string;
+	textDirty: boolean;
 	attachmentRevision: number;
 	attachmentPhase: string;
 	following: boolean;
@@ -74,6 +84,7 @@ interface WebState {
 interface SendAttempt {
 	requestId: string;
 	text: string;
+	draftRevision: number;
 	attachmentRevision: number;
 	attachmentIds: string[];
 	images: Array<{ id: string }>;
@@ -113,6 +124,41 @@ test("snapshots replace authoritative server state without discarding the browse
 	assert.equal(next.text, "draft");
 	assert.deepEqual(next.images, [{ id: "image" }]);
 	assert.equal(next.needsSnapshot, false);
+});
+
+test("authoritative drafts hydrate refreshes without overwriting newer local input", () => {
+	let current = state.applyDraft(state.initialState(), { revision: 1, text: "restored" });
+	assert.equal(current.text, "restored");
+	assert.equal(current.authoritativeText, "restored");
+	current = state.editDraftText(current, "new local text");
+	assert.equal(current.textDirty, true);
+	const refreshed = state.applyDraft(current, { revision: 2, text: "remote text" });
+	assert.equal(refreshed.text, "new local text");
+	assert.equal(refreshed.authoritativeText, "remote text");
+	assert.equal(refreshed.draftRevision, 2);
+	assert.equal(state.applyDraft(refreshed, { revision: 1, text: "stale" }), refreshed);
+});
+
+test("delayed text acknowledgements never overwrite input typed after the request", () => {
+	let current = state.applyDraft(state.initialState(), { revision: 1, text: "one" });
+	current = state.editDraftText(current, "submitted");
+	const submitted = current.text;
+	current = state.editDraftText(current, "typed later");
+	const acknowledged = state.acknowledgeDraftText(
+		current,
+		{ revision: 2, text: "submitted" },
+		submitted,
+	);
+	assert.equal(acknowledged.text, "typed later");
+	assert.equal(acknowledged.authoritativeText, "submitted");
+	assert.equal(acknowledged.textDirty, true);
+	const final = state.acknowledgeDraftText(
+		acknowledged,
+		{ revision: 3, text: "typed later" },
+		"typed later",
+	);
+	assert.equal(final.text, "typed later");
+	assert.equal(final.textDirty, false);
 });
 
 test("older snapshots cannot roll browser state back", () => {

--- a/extensions/pi-webui/test/web-ui-contract.test.ts
+++ b/extensions/pi-webui/test/web-ui-contract.test.ts
@@ -34,6 +34,11 @@ test("browser logic authenticates a lease, reconnects from sequence, and keeps f
 	assert.match(app, /\/api\/lease/);
 	assert.match(app, /new EventSource\(`\/api\/events\?since=\$\{model\.sequence\}`\)/);
 	assert.match(app, /\/api\/messages/);
+	assert.match(app, /\/api\/draft/);
+	assert.match(app, /scheduleDraftSave\(\)/);
+	assert.match(app, /flushDraftText\(\)/);
+	assert.match(app, /acknowledgeDraftText/);
+	assert.match(app, /draftRevision: attempt\.draftRevision/);
 	assert.match(app, /prepareSend\(model, crypto\.randomUUID\(\), steer \? "steer" : "next"\)/);
 	assert.match(app, /delivery: attempt\.delivery/);
 	assert.match(app, /deliveryNotice\(model\)/);
@@ -43,6 +48,7 @@ test("browser logic authenticates a lease, reconnects from sequence, and keeps f
 	assert.match(app, /completeSend/);
 	assert.match(app, /failSend/);
 	assert.match(app, /if \(!model\.leaseClaimed\) await claimLease\(\)/);
+	assert.match(app, /events\.addEventListener\("draft"/);
 	assert.match(app, /applyLease\(model, snapshot\.lease, clientId\)/);
 	assert.match(app, /applyLease\(model, await response\.json\(\), clientId, true\)/);
 	assert.match(app, /snapshotRefresh/);


### PR DESCRIPTION
## Summary
- keep unsent text and ordered attachment references authoritative in bounded Pi-process memory
- add authenticated revisioned and deduplicated draft mutation APIs
- debounce browser saves, reconcile conflicts, and preserve newer typing across sends, refreshes, reconnects, and lease takeover

## Verification
- `npm run check` (771 tests)
- `git diff --check`
- `just pack webui`
- Chrome smoke for refresh recovery, active-tab takeover, pending-send edits, and empty browser storage

Built after #284.