### PR TITLE
feat(webui): reattach sanitized sent images

### DIFF
--- a/docs/plans/archived/2026-07-19_pi-webui-sent-image-reattach-plan.md
+++ b/docs/plans/archived/2026-07-19_pi-webui-sent-image-reattach-plan.md
@@ -1,0 +1,49 @@
+## Goal
+
+Allow users to reattach sanitized images from a recent browser-originated user message through a contextual `Attach again` action, with explicit bounded in-memory retention. Success means reuse is convenient without implying permanent transcript image storage or retaining original uploads.
+
+## Context
+
+WebUI currently projects sent images as MIME-type chips and discards source bytes after message acceptance. Image Drop retains sanitized provider-ready bytes per live session and supports Add again. This plan depends on server-side image staging and should follow memory draft recovery so ownership and revisions are stable.
+
+## Resolved Decisions
+
+- Under the maintainer directive to implement this plan, retention is opt-in and defaults to 32 images/128 MiB with hard ceilings of 128 images/512 MiB. The server additionally reconciles retained, current-draft, and conservative in-flight image bytes under one aggregate resident-image budget.
+
+## Architecture
+
+Maintain a FIFO `SentImageStore` keyed by a non-sensitive internal image ID associated with projected browser-originated user messages. Store only sanitized provider-ready bytes and display metadata. Transcript image chips expose `Attach again` only while bytes remain. Reattachment clones bytes into the current draft under its normal count/byte limits; eviction changes the action to an `Expired` status rather than failing unexpectedly.
+
+## Non-Goals
+
+- Reconstructing bytes from historical Pi session entries, retaining terminal-origin images, disk/browser persistence, remote downloads, or retracting provider data.
+- A global image gallery or Image Drop-style history section.
+
+## Plan
+
+- [x] Resolve and record conservative retention policy under the maintainer directive to implement this plan: retention is opt-in (`retainSentImages: false`), defaults are 32 images/128 MiB, and hard ceilings are 128 images/512 MiB; settings tests and README document the decision.
+- [x] Add failing store tests for sanitized-only admission, message association, FIFO count/byte eviction, duplicate sanitized hashes, cloning into drafts, deletion, clear, session shutdown, and no source-byte retention; compilation first failed because `src/sent-images.ts` was absent and all seven focused tests now pass.
+- [x] Implement a separate bounded sent-image store with session-keyed opaque IDs and independent sanitized-byte clones; references alone retain no bytes, commit occurs only after accepted send, and focused tests cover late failure, deduplication, eviction, and shutdown.
+- [x] Extend conversation projection with trusted opaque retained-image IDs only for accepted browser messages; conversation/lifecycle tests prove terminal-forged IDs are stripped and public snapshots contain metadata/IDs but no bytes.
+- [x] Add authenticated revisioned preview, reattach, delete, and clear endpoints; server tests cover failed-send non-admission, stale-tab rejection, pending-send rejection, draft revisions, duplicate rejection, ordered cloning, and expiration.
+- [x] Render contextual `Attach again` on eligible image chips and `Expired` when evicted/forgotten; reducer, transcript, lifecycle, and UI-contract tests cover eligibility and terminal-origin absence with labeled 44 px keyboard controls.
+- [x] Add contextual `Forget` beside eligible chips plus the revisioned clear API, while UI contract and desktop/narrow browser inspection confirm there is no permanent gallery.
+- [x] Document opt-in retention, aggregate/FIFO byte accounting, session-only lifetime, refresh/takeover behavior, and non-retraction of provider content; `npm run check` passed 787 tests, `git diff --check` and `just pack webui` passed, and 1280×900/320×900 Chrome smoke verified Attach again, refresh recovery, draft cloning, Forget/Expired, and responsive controls.
+
+## Risks
+
+- Retained image bytes can dominate process memory; enforce one global WebUI resident-byte budget across current draft, in-flight work, and sent retention.
+- Transcript IDs may outlive bytes after eviction; represent availability explicitly and never promise recovery from Pi session files.
+- Reattaching during a pending send can mutate the wrong attempt; target an exact draft revision and preserve newer work.
+
+## Rollback / Recovery
+
+Removing this feature only clears ephemeral retained bytes and contextual actions; no persisted migration is required.
+
+## Completion Checklist
+
+- [x] Accepted retention policy and limits are recorded in settings constants, tests, this plan, and README under the directive to implement the plan.
+- [x] Only sanitized provider-ready bytes are retained and bounded; eight focused store tests cover count/byte/aggregate accounting, deduplication, deletion, and shutdown cleanup.
+- [x] Eligible, expired, terminal-origin, stale-tab, pending-send, and eviction states are verified by projection, lifecycle, server, reducer, UI-contract, and browser tests.
+- [x] Reattachment preserves selected order and normal draft limits without mutating prior messages, verified by attachment/store/server lifecycle tests.
+- [x] `npm run check`, `git diff --check`, and `just pack webui` pass; package dry-run includes `src/sent-images.ts` and all expected WebUI assets.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -68,15 +68,21 @@ The normal default path is `~/.pi/agent/pi-webui.json`. Pi installations that us
 
 ```json
 {
-  "startOnSessionStart": false
+  "startOnSessionStart": false,
+  "retainSentImages": false,
+  "maxRetainedImages": 32,
+  "maxRetainedBytes": 134217728
 }
 ```
 
 | Setting | Default | Behavior |
 | --- | --- | --- |
 | `startOnSessionStart` | `false` | Start WebUI and display a fresh one-time link after every Pi session initialization, including startup, reload, new, resume, and fork. It never opens a browser. |
+| `retainSentImages` | `false` | Opt in to bounded, session-only retention of sanitized images after Pi accepts their browser message. |
+| `maxRetainedImages` | `32` | FIFO retained-image count ceiling. Positive integers up to the hard ceiling of 128 are accepted. |
+| `maxRetainedBytes` | `134217728` (128 MiB) | FIFO retained provider-ready byte ceiling. Positive integers up to the hard ceiling of 536870912 (512 MiB) are accepted. |
 
-A missing file uses defaults. The file must contain a top-level JSON object, and `startOnSessionStart` must be a boolean when present. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility.
+A missing file uses defaults. The file must contain a top-level JSON object; recognized booleans and positive integer limits must have the documented types and remain within their hard ceilings. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility. The settings screen currently exposes the startup toggle; retention fields can be edited in the reported JSON path.
 
 Settings are reloaded on every `session_start`. Changes made in `/webui settings` are saved atomically and update the in-memory preference immediately, but they intentionally do not start or stop the server in the current session; they take effect at the next session initialization or `/reload`. `/webui init` creates formatted defaults once and refuses to overwrite valid or invalid existing content.
 
@@ -109,13 +115,15 @@ Drag thumbnails or use their visible arrow controls to set provider order before
 
 Pi's effective global and trusted-project `images.autoResize` and `images.blockImages` settings plus the current model's image capability and authentication are checked again at send time. A failed send leaves the exact Ready batch available for an idempotent retry. BMP and HEIC use bounded portable decoders because the prebuilt `sharp`/libvips distribution does not decode those inputs consistently across supported platforms.
 
+When `retainSentImages` is enabled, only provider-ready sanitized bytes transfer into a separate session-memory store after Pi accepts the matching browser message. Content-identical sanitized images share one opaque session reference. Oldest entries are evicted first when either retention ceiling is exceeded. WebUI also reconciles retained, current-draft, and conservative in-flight processing bytes against one aggregate resident-image budget (the larger of the configured retention byte ceiling and the staging store's maximum working set), evicting sent entries before that aggregate can grow. Eligible transcript image chips offer **Attach again** and **Forget**; evicted or forgotten references read **Expired**, and terminal-origin images never gain those actions. Attach again clones the retained bytes into the current authoritative draft, reuses normal count/byte admission, and never mutates the earlier message. Refresh and active-tab takeover recover eligibility from Pi-process state; session replacement, reload, shutdown, or process exit releases all retained bytes.
+
 ## Security and privacy
 
 - The server binds only to a random `127.0.0.1` port and is owned by one live Pi session.
 - A rotating bootstrap token is exchanged once for a per-server HttpOnly, `SameSite=Strict` cookie and removed from the URL.
 - Every endpoint requires the cookie. Mutations also require exact Host and Origin values plus the active browser-tab lease.
 - Responses use no-store, no-referrer, MIME-sniffing, frame-denial, same-origin resource, and restrictive Content Security Policy headers.
-- Transcript projection retains at most the newest 500 messages and 500 tool records, event replay keeps 256 updates, and request-id records keep 128 sends. Unsent message text, ordered attachment references, and staged image bytes live only in bounded Pi-process memory until cleared, accepted, or the session ends; the page uses no localStorage, sessionStorage, IndexedDB, script-readable cookies, or image/transcript cache.
+- Transcript projection retains at most the newest 500 messages and 500 tool records, event replay keeps 256 updates, and request-id records keep 128 sends. Unsent message text, ordered attachment references, staged image bytes, and opt-in sanitized sent-image bytes live only in bounded Pi-process memory under their documented lifecycles; the page uses no localStorage, sessionStorage, IndexedDB, script-readable cookies, or image/transcript cache.
 - Tool arguments/results, paths, images, and model thinking can be sensitive. Thinking is collapsed by default; only open a link issued by a Pi process you trust.
 - Reload, session replacement/fork, or Pi shutdown closes sockets, invalidates old callbacks, ends the page, and releases in-memory state.
 
@@ -128,7 +136,7 @@ The page uses semantic headings, native disclosure/dialog controls, concise stat
 ## Limitations
 
 - One active Pi session and one active browser editing tab only.
-- No persistent browser transcript, sent-image history, remote access, PTY/terminal control, model/settings controls, or session switching.
+- No persistent browser transcript, permanent sent-image gallery, cross-session image history, remote access, PTY/terminal control, model/settings controls, or session switching.
 - No SVG, remote image URL, OCR, annotation, or directory upload support.
 - Browser acknowledgment means Pi accepted or queued the message. Provider failures follow Pi's normal session/retry behavior.
 - Built-in TUI commands and dialogs are not reimplemented in the browser.
@@ -142,6 +150,7 @@ src/settings.ts      global WebUI settings validation and atomic persistence
 src/conversation.ts  bounded transcript snapshot and ordered event replay
 src/drafts.ts        authoritative in-memory text and attachment-reference revisions
 src/attachments.ts   revisioned staged-image state, processing queue, and byte ownership
+src/sent-images.ts   opt-in bounded sanitized sent-image retention
 src/server.ts        authenticated loopback HTTP/SSE server and raw attachment protocol
 src/images.ts        bounded provider-ready image processing
 src/pi-settings.ts   effective Pi image settings reader

--- a/extensions/pi-webui/src/attachments.ts
+++ b/extensions/pi-webui/src/attachments.ts
@@ -73,6 +73,12 @@ export interface SendReservation {
 	images: StagedBrowserImage[];
 }
 
+export interface PreparedAttachmentInput {
+	id: string;
+	name: string;
+	prepared: PreparedAttachment;
+}
+
 interface AttachmentItem extends AttachmentReservationInput {
 	status: AttachmentStatus;
 	reservedRevision: number;
@@ -195,6 +201,64 @@ export class AttachmentStore {
 				...item,
 				status: "uploading" as const,
 				reservedRevision,
+			})),
+		);
+		this.changed();
+		return this.publicState();
+	}
+
+	attachPrepared(
+		inputs: readonly PreparedAttachmentInput[],
+		expectedRevision: number,
+	): PublicAttachmentState {
+		this.assertMutable(expectedRevision);
+		if (!Array.isArray(inputs) || inputs.length === 0) {
+			throw new AttachmentError("At least one prepared attachment is required.", 400);
+		}
+		if (this.items.some((item) => item.status !== "ready")) {
+			throw new AttachmentError(
+				"Current attachments must be ready before attaching retained images.",
+			);
+		}
+		if (this.items.length + inputs.length > this.options.limits.maxImages) {
+			throw new AttachmentError(
+				`Attachment count exceeds the maximum of ${this.options.limits.maxImages}.`,
+				413,
+			);
+		}
+		const ids = new Set(this.items.map((item) => item.id));
+		const existingBytes = this.items.flatMap((item) =>
+			item.prepared ? [item.prepared.bytes] : [],
+		);
+		const additions = inputs.map((input) => {
+			const prepared = validatePrepared(input.prepared, this.options.limits);
+			const reservation = normalizeReservation(
+				{ id: input.id, name: input.name, size: prepared.bytes.byteLength },
+				this.options.limits,
+			);
+			if (ids.has(reservation.id)) throw new AttachmentError("Attachment id is duplicate.", 400);
+			ids.add(reservation.id);
+			if (
+				existingBytes.some((bytes) => bytes.equals(prepared.bytes)) ||
+				additionsContainBytes(inputs, input, prepared.bytes)
+			) {
+				throw new AttachmentError("Prepared attachment is a duplicate of the draft.");
+			}
+			return { reservation, prepared };
+		});
+		const total =
+			this.reservedSourceBytes() +
+			additions.reduce((sum, item) => sum + item.prepared.bytes.byteLength, 0);
+		if (total > this.options.limits.maxPromptBytes) {
+			throw new AttachmentError("Combined prepared attachments are too large.", 413);
+		}
+		const reservedRevision = this.revision + 1;
+		this.items.push(
+			...additions.map(({ reservation, prepared }) => ({
+				...reservation,
+				status: "ready" as const,
+				reservedRevision,
+				prepared,
 			})),
 		);
 		this.changed();
@@ -558,6 +622,34 @@ function normalizeReservation(
 		throw new AttachmentError("Attachment MIME type is invalid.", 400);
 	}
 	return { id: input.id, name: input.name, size: input.size, mimeType: input.mimeType };
+}
+
+function validatePrepared(
+	prepared: PreparedAttachment,
+	limits: AttachmentLimits,
+): PreparedAttachment {
+	if (
+		!prepared ||
+		!Buffer.isBuffer(prepared.bytes) ||
+		prepared.bytes.length === 0 ||
+		prepared.bytes.length > limits.maxImageBytes ||
+		typeof prepared.mimeType !== "string" ||
+		!/^image\/[a-z0-9.+-]{1,64}$/i.test(prepared.mimeType)
+	) {
+		throw new AttachmentError("Prepared attachment is invalid.", 400);
+	}
+	return clonePrepared(prepared);
+}
+
+function additionsContainBytes(
+	inputs: readonly PreparedAttachmentInput[],
+	current: PreparedAttachmentInput,
+	bytes: Buffer,
+): boolean {
+	const currentIndex = inputs.indexOf(current);
+	return inputs
+		.slice(0, currentIndex)
+		.some((input) => Buffer.isBuffer(input.prepared?.bytes) && input.prepared.bytes.equals(bytes));
 }
 
 function validateLimits(limits: AttachmentLimits): void {

--- a/extensions/pi-webui/src/conversation.ts
+++ b/extensions/pi-webui/src/conversation.ts
@@ -12,7 +12,7 @@ export interface SessionDescriptor {
 export type PublicContent =
 	| { type: "text"; text: string }
 	| { type: "thinking"; text: string }
-	| { type: "image"; mimeType?: string }
+	| { type: "image"; mimeType?: string; retainedImageId?: string }
 	| { type: "toolCall"; id: string; name: string; arguments: unknown };
 
 export interface PublicMessage {
@@ -116,8 +116,13 @@ export class ConversationProjection {
 		this.publishSnapshot();
 	}
 
-	recordMessage(message: unknown, final = true, entryId?: string): void {
-		const projected = projectMessage(message, entryId, final);
+	recordMessage(
+		message: unknown,
+		final = true,
+		entryId?: string,
+		retainedImageIds: readonly string[] = [],
+	): void {
+		const projected = projectMessage(message, entryId, final, retainedImageIds);
 		const previous = this.messages.get(projected.id);
 		if (previous && JSON.stringify(previous) === JSON.stringify(projected)) return;
 		this.messages.set(projected.id, projected);
@@ -194,12 +199,17 @@ export function projectBranchMessages(branch: unknown): PublicMessage[] {
 	return messages;
 }
 
-export function projectMessage(message: unknown, entryId?: string, final = true): PublicMessage {
+export function projectMessage(
+	message: unknown,
+	entryId?: string,
+	final = true,
+	retainedImageIds: readonly string[] = [],
+): PublicMessage {
 	if (!isRecord(message) || typeof message.role !== "string") {
 		throw new Error("Invalid Pi message");
 	}
 	const timestamp = typeof message.timestamp === "number" ? message.timestamp : undefined;
-	const content = projectContent(message.content);
+	const content = projectContent(message.content, retainedImageIds);
 	const id = entryId ?? messageId(message, timestamp, content);
 	return {
 		id,
@@ -217,10 +227,14 @@ export function projectMessage(message: unknown, entryId?: string, final = true)
 	};
 }
 
-function projectContent(content: unknown): PublicContent[] {
+function projectContent(
+	content: unknown,
+	retainedImageIds: readonly string[] = [],
+): PublicContent[] {
 	if (typeof content === "string") return [{ type: "text", text: truncateText(content) }];
 	if (!Array.isArray(content)) return [];
 	const projected: PublicContent[] = [];
+	let imageIndex = 0;
 	for (const block of content) {
 		if (!isRecord(block) || typeof block.type !== "string") continue;
 		if (block.type === "text" && typeof block.text === "string") {
@@ -228,9 +242,12 @@ function projectContent(content: unknown): PublicContent[] {
 		} else if (block.type === "thinking" && typeof block.thinking === "string") {
 			projected.push({ type: "thinking", text: truncateText(block.thinking) });
 		} else if (block.type === "image") {
+			const retainedImageId = retainedImageIds[imageIndex];
+			imageIndex += 1;
 			projected.push({
 				type: "image",
 				...(typeof block.mimeType === "string" ? { mimeType: block.mimeType } : {}),
+				...(typeof retainedImageId === "string" ? { retainedImageId } : {}),
 			});
 		} else if (
 			block.type === "toolCall" &&

--- a/extensions/pi-webui/src/runtime.ts
+++ b/extensions/pi-webui/src/runtime.ts
@@ -54,6 +54,12 @@ interface PendingBrowserInput {
 	resolve(): void;
 	reject(error: Error): void;
 	text: string;
+	retainedImageIds: string[];
+}
+
+interface AcceptedBrowserInput {
+	text: string;
+	retainedImageIds: string[];
 }
 
 export interface RuntimeDependencies {
@@ -96,7 +102,7 @@ export class WebUIRuntime {
 	private readonly activeMessageIds = new Map<string, string>();
 	private readonly finalMessageTimers = new Set<ReturnType<typeof setTimeout>>();
 	private readonly pendingBrowserInputs = new Map<string, PendingBrowserInput>();
-	private readonly acceptedBrowserInputs = new Map<string, string>();
+	private readonly acceptedBrowserInputs = new Map<string, AcceptedBrowserInput>();
 	private settings: WebUISettings = { ...DEFAULT_SETTINGS };
 	private settingsDocument?: Record<string, unknown> = {};
 	private settingsPath = "pi-webui.json";
@@ -172,7 +178,10 @@ export class WebUIRuntime {
 			if (!wrapped) return;
 			const pending = this.pendingBrowserInputs.get(wrapped.nonce);
 			if (!pending) return;
-			this.acceptedBrowserInputs.set(wrapped.nonce, pending.text);
+			this.acceptedBrowserInputs.set(wrapped.nonce, {
+				text: pending.text,
+				retainedImageIds: [...pending.retainedImageIds],
+			});
 			this.settleBrowserInput(wrapped.nonce);
 		});
 		this.pi.on("message_start", async (event, ctx) => {
@@ -289,8 +298,11 @@ export class WebUIRuntime {
 			id = `web-live:${++this.nextLiveMessageId}`;
 			this.activeMessageIds.set(key, id);
 		}
+		const retainedImageIds = Array.isArray(event.retainedImageIds)
+			? event.retainedImageIds.filter((value): value is string => typeof value === "string")
+			: [];
 		if (phase !== "end") {
-			this.recordProjectedMessage(event.message, false, id);
+			this.recordProjectedMessage(event.message, false, id, retainedImageIds);
 			return;
 		}
 		this.activeMessageIds.delete(key);
@@ -298,14 +310,19 @@ export class WebUIRuntime {
 		const timer = setTimeout(() => {
 			this.finalMessageTimers.delete(timer);
 			if (generation !== this.generation || this.closed) return;
-			this.recordProjectedMessage(event.message, true, id);
+			this.recordProjectedMessage(event.message, true, id, retainedImageIds);
 		}, 0);
 		this.finalMessageTimers.add(timer);
 	}
 
-	private recordProjectedMessage(message: unknown, final: boolean, id: string): void {
+	private recordProjectedMessage(
+		message: unknown,
+		final: boolean,
+		id: string,
+		retainedImageIds: readonly string[] = [],
+	): void {
 		try {
-			this.conversation?.recordMessage(message, final, id);
+			this.conversation?.recordMessage(message, final, id, retainedImageIds);
 		} catch {
 			// Unknown custom message shapes do not block the supported transcript.
 		}
@@ -377,7 +394,7 @@ export class WebUIRuntime {
 							if (!this.settingsDocument) {
 								throw new Error("the invalid settings file must be repaired manually first");
 							}
-							const next = { startOnSessionStart: requested };
+							const next = { ...this.settings, startOnSessionStart: requested };
 							const document = await this.dependencies.saveSettings(
 								next,
 								this.settingsDocument,
@@ -473,6 +490,11 @@ export class WebUIRuntime {
 			const starting = this.dependencies.startServer({
 				conversation,
 				send: (request) => this.sendBrowserMessage(request, generation),
+				sentImageSettings: {
+					enabled: this.settings.retainSentImages,
+					maxImages: this.settings.maxRetainedImages,
+					maxBytes: this.settings.maxRetainedBytes,
+				},
 				processAttachment: (source, signal) =>
 					this.processStagedAttachment(source, generation, signal),
 			});
@@ -558,7 +580,7 @@ export class WebUIRuntime {
 			images.length === 0
 				? text
 				: [...(text.trim() ? ([{ type: "text", text }] satisfies TextContent[]) : []), ...images];
-		const wrapped = this.createBrowserInput(content);
+		const wrapped = this.createBrowserInput(content, request.retainedImageIds ?? []);
 		const delivery =
 			request.delivery === "steer"
 				? "steer"
@@ -613,7 +635,10 @@ export class WebUIRuntime {
 		if (ctx.model !== model) throw new Error("The Pi model changed; retry the browser message.");
 	}
 
-	private createBrowserInput(content: string | Array<TextContent | ImageContent>): {
+	private createBrowserInput(
+		content: string | Array<TextContent | ImageContent>,
+		retainedImageIds: readonly string[],
+	): {
 		nonce: string;
 		content: string | Array<TextContent | ImageContent>;
 		accepted: Promise<void>;
@@ -629,7 +654,12 @@ export class WebUIRuntime {
 						...content.filter((part): part is ImageContent => part.type === "image"),
 					];
 		const accepted = new Promise<void>((resolve, reject) => {
-			this.pendingBrowserInputs.set(nonce, { resolve, reject, text });
+			this.pendingBrowserInputs.set(nonce, {
+				resolve,
+				reject,
+				text,
+				retainedImageIds: [...retainedImageIds],
+			});
 		});
 		return { nonce, content: wrappedContent, accepted };
 	}
@@ -692,35 +722,41 @@ function contentText(content: Array<TextContent | ImageContent>): string {
 
 function sanitizeBrowserMessageEvent(
 	event: unknown,
-	acceptedNonces: Map<string, string>,
+	acceptedNonces: Map<string, AcceptedBrowserInput>,
 	consume: boolean,
 ): unknown {
 	if (!isRecord(event) || !isRecord(event.message) || event.message.role !== "user") return event;
 	const content = event.message.content;
 	if (typeof content === "string") {
 		const wrapped = parseBrowserInput(content);
-		if (!wrapped || !acceptedNonces.has(wrapped.nonce)) return event;
-		const text = acceptedNonces.get(wrapped.nonce) ?? "";
+		const accepted = wrapped ? acceptedNonces.get(wrapped.nonce) : undefined;
+		if (!wrapped || !accepted) return event;
 		if (consume) acceptedNonces.delete(wrapped.nonce);
-		return { ...event, message: { ...event.message, content: text } };
+		return {
+			...event,
+			retainedImageIds: [...accepted.retainedImageIds],
+			message: { ...event.message, content: accepted.text },
+		};
 	}
 	if (!Array.isArray(content)) return event;
-	let changed = false;
-	const consumed = new Set<string>();
-	const sanitized = content.flatMap((part) => {
+	let accepted: AcceptedBrowserInput | undefined;
+	let acceptedNonce: string | undefined;
+	const sanitizedText = content.flatMap((part) => {
 		if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") return [part];
 		const wrapped = parseBrowserInput(part.text);
-		if (!wrapped || !acceptedNonces.has(wrapped.nonce)) return [part];
-		const text = acceptedNonces.get(wrapped.nonce) ?? "";
-		changed = true;
-		consumed.add(wrapped.nonce);
-		return text ? [{ ...part, text }] : [];
+		const candidate = wrapped ? acceptedNonces.get(wrapped.nonce) : undefined;
+		if (!wrapped || !candidate) return [part];
+		accepted = candidate;
+		acceptedNonce = wrapped.nonce;
+		return candidate.text ? [{ ...part, text: candidate.text }] : [];
 	});
-	if (!changed) return event;
-	if (consume) {
-		for (const nonce of consumed) acceptedNonces.delete(nonce);
-	}
-	return { ...event, message: { ...event.message, content: sanitized } };
+	if (!accepted) return event;
+	if (consume && acceptedNonce) acceptedNonces.delete(acceptedNonce);
+	return {
+		...event,
+		retainedImageIds: [...accepted.retainedImageIds],
+		message: { ...event.message, content: sanitizedText },
+	};
 }
 
 function attachmentNotes(image: ProcessedBrowserImage): string[] {

--- a/extensions/pi-webui/src/sent-images.ts
+++ b/extensions/pi-webui/src/sent-images.ts
@@ -1,0 +1,279 @@
+import { createHmac, randomBytes } from "node:crypto";
+
+export interface SentImageSettings {
+	enabled: boolean;
+	maxImages: number;
+	maxBytes: number;
+}
+
+export interface RetainedImageInput {
+	name?: string;
+	mimeType?: string;
+	data: string;
+}
+
+export interface RetainedImageClone {
+	retainedId: string;
+	name: string;
+	bytes: Buffer;
+	mimeType: string;
+}
+
+export interface PublicSentImage {
+	id: string;
+	name: string;
+	mimeType: string;
+	size: number;
+}
+
+export interface PublicSentImageState {
+	revision: number;
+	enabled: boolean;
+	items: PublicSentImage[];
+	totalBytes: number;
+	maxImages: number;
+	maxBytes: number;
+}
+
+interface SentImageItem {
+	id: string;
+	name: string;
+	mimeType: string;
+	bytes: Buffer;
+	associations: Set<string>;
+}
+
+export class SentImageError extends Error {
+	constructor(
+		message: string,
+		readonly status = 409,
+	) {
+		super(message);
+		this.name = "SentImageError";
+	}
+}
+
+export class SentImageStore {
+	private readonly key = randomBytes(32);
+	private readonly items: SentImageItem[] = [];
+	private revision = 0;
+	private closed = false;
+
+	constructor(private readonly settings: SentImageSettings) {
+		for (const value of [settings.maxImages, settings.maxBytes]) {
+			if (!Number.isSafeInteger(value) || value <= 0) {
+				throw new Error("Sent-image limits must be positive integers.");
+			}
+		}
+	}
+
+	publicState(): PublicSentImageState {
+		return {
+			revision: this.revision,
+			enabled: this.settings.enabled,
+			items: this.items.map((item) => ({
+				id: item.id,
+				name: item.name,
+				mimeType: item.mimeType,
+				size: item.bytes.byteLength,
+			})),
+			totalBytes: this.residentBytes(),
+			maxImages: this.settings.maxImages,
+			maxBytes: this.settings.maxBytes,
+		};
+	}
+
+	residentBytes(): number {
+		return this.items.reduce((total, item) => total + item.bytes.byteLength, 0);
+	}
+
+	referencesFor(messageId: string, images: readonly RetainedImageInput[]): string[] {
+		this.assertOpen();
+		if (!this.settings.enabled) return [];
+		normalizeMessageId(messageId);
+		return images.map((image, index) => {
+			const normalized = normalizeImage(image, index);
+			return this.idFor(normalized.bytes);
+		});
+	}
+
+	commit(
+		messageId: string,
+		images: readonly RetainedImageInput[],
+		expectedReferences: readonly string[],
+	): PublicSentImageState {
+		this.assertOpen();
+		if (!this.settings.enabled) {
+			if (expectedReferences.length !== 0) {
+				throw new SentImageError("Sent-image retention is disabled.");
+			}
+			return this.publicState();
+		}
+		normalizeMessageId(messageId);
+		const normalized = images.map(normalizeImage);
+		const references = normalized.map((image) => this.idFor(image.bytes));
+		if (!sameIds(references, expectedReferences)) {
+			throw new SentImageError("Sent-image references are stale.");
+		}
+		let changed = false;
+		for (const [index, image] of normalized.entries()) {
+			const id = references[index];
+			if (!id) throw new SentImageError("Sent-image reference is missing.");
+			const existing = this.items.find((item) => item.id === id);
+			if (existing) {
+				existing.associations.add(messageId);
+				continue;
+			}
+			this.items.push({
+				id,
+				name: image.name,
+				mimeType: image.mimeType,
+				bytes: Buffer.from(image.bytes),
+				associations: new Set([messageId]),
+			});
+			changed = true;
+		}
+		if (this.evict()) changed = true;
+		if (changed) this.revision += 1;
+		return this.publicState();
+	}
+
+	preview(id: string): { bytes: Buffer; mimeType: string } {
+		const item = this.item(id);
+		return { bytes: Buffer.from(item.bytes), mimeType: item.mimeType };
+	}
+
+	clone(ids: readonly string[]): RetainedImageClone[] {
+		this.assertOpen();
+		if (!Array.isArray(ids) || ids.length === 0) {
+			throw new SentImageError("No retained images were selected.", 400);
+		}
+		if (new Set(ids).size !== ids.length) {
+			throw new SentImageError("Retained image selection contains a duplicate.", 400);
+		}
+		return ids.map((id) => {
+			const item = this.item(id);
+			return {
+				retainedId: item.id,
+				name: item.name,
+				bytes: Buffer.from(item.bytes),
+				mimeType: item.mimeType,
+			};
+		});
+	}
+
+	reconcile(externalBytes: number, totalBudget = this.settings.maxBytes): PublicSentImageState {
+		this.assertOpen();
+		if (
+			!Number.isSafeInteger(externalBytes) ||
+			externalBytes < 0 ||
+			!Number.isSafeInteger(totalBudget) ||
+			totalBudget <= 0
+		) {
+			throw new SentImageError("Image resident-byte accounting is invalid.", 500);
+		}
+		if (!this.evict(externalBytes, totalBudget)) return this.publicState();
+		this.revision += 1;
+		return this.publicState();
+	}
+
+	remove(id: string, expectedRevision: number): PublicSentImageState {
+		this.assertRevision(expectedRevision);
+		const index = this.items.findIndex((item) => item.id === id);
+		if (index === -1) throw new SentImageError("Retained image was not found.", 404);
+		this.items.splice(index, 1);
+		this.revision += 1;
+		return this.publicState();
+	}
+
+	clear(expectedRevision: number): PublicSentImageState {
+		this.assertRevision(expectedRevision);
+		if (this.items.length === 0) return this.publicState();
+		this.items.length = 0;
+		this.revision += 1;
+		return this.publicState();
+	}
+
+	close(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.items.length = 0;
+		this.revision += 1;
+	}
+
+	private item(id: string): SentImageItem {
+		this.assertOpen();
+		if (typeof id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(id)) {
+			throw new SentImageError("Retained image id is invalid.", 400);
+		}
+		const item = this.items.find((candidate) => candidate.id === id);
+		if (!item) throw new SentImageError("Retained image has expired.", 404);
+		return item;
+	}
+
+	private idFor(bytes: Buffer): string {
+		return `sent_${createHmac("sha256", this.key).update(bytes).digest("base64url").slice(0, 32)}`;
+	}
+
+	private evict(externalBytes = 0, totalBudget = this.settings.maxBytes): boolean {
+		let changed = false;
+		while (
+			this.items.length > 0 &&
+			(this.items.length > this.settings.maxImages ||
+				this.residentBytes() > this.settings.maxBytes ||
+				this.residentBytes() + externalBytes > totalBudget)
+		) {
+			this.items.shift();
+			changed = true;
+		}
+		return changed;
+	}
+
+	private assertRevision(expectedRevision: number): void {
+		this.assertOpen();
+		if (!Number.isSafeInteger(expectedRevision) || expectedRevision !== this.revision) {
+			throw new SentImageError(
+				`Sent-image revision mismatch; current revision is ${this.revision}.`,
+			);
+		}
+	}
+
+	private assertOpen(): void {
+		if (this.closed) throw new SentImageError("Sent-image store is closed.", 410);
+	}
+}
+
+function normalizeImage(
+	input: RetainedImageInput,
+	index = 0,
+): {
+	name: string;
+	mimeType: string;
+	bytes: Buffer;
+} {
+	if (!input || typeof input.data !== "string" || !validBase64(input.data)) {
+		throw new SentImageError(`Sent image ${index + 1} has invalid data.`, 400);
+	}
+	const bytes = Buffer.from(input.data, "base64");
+	if (bytes.length === 0) throw new SentImageError(`Sent image ${index + 1} is empty.`, 400);
+	const mimeType = input.mimeType;
+	if (typeof mimeType !== "string" || !/^image\/[a-z0-9.+-]{1,64}$/i.test(mimeType)) {
+		throw new SentImageError(`Sent image ${index + 1} has an invalid MIME type.`, 400);
+	}
+	const name = typeof input.name === "string" && input.name ? input.name.slice(0, 255) : "Image";
+	return { name, mimeType, bytes };
+}
+
+function normalizeMessageId(value: string): void {
+	if (typeof value !== "string" || !/^[A-Za-z0-9_-]{1,120}$/.test(value)) {
+		throw new SentImageError("Message association is invalid.", 400);
+	}
+}
+
+function validBase64(value: string): boolean {
+	return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value);
+}
+
+function sameIds(left: readonly string[], right: readonly string[]): boolean {
+	return left.length === right.length && left.every((id, index) => id === right[index]);
+}

--- a/extensions/pi-webui/src/server.ts
+++ b/extensions/pi-webui/src/server.ts
@@ -14,6 +14,7 @@ import {
 import type { ConversationEvent, ConversationProjection } from "./conversation.js";
 import { DraftError, DraftStore, type PublicDraftState } from "./drafts.js";
 import { type BrowserImageInput, DEFAULT_IMAGE_LIMITS } from "./images.js";
+import { SentImageError, type SentImageSettings, SentImageStore } from "./sent-images.js";
 
 const JSON_LIMIT = 64 * 1024 * 1024;
 const CLIENT_ID = /^[A-Za-z0-9_-]{1,80}$/;
@@ -28,6 +29,7 @@ export interface WebSendRequest {
 	attachmentRevision?: number;
 	attachmentIds?: string[];
 	images: BrowserImageInput[];
+	retainedImageIds?: string[];
 	delivery: "next" | "steer";
 	signal?: AbortSignal;
 }
@@ -47,6 +49,7 @@ export interface WebUIServerOptions {
 	send: (request: WebSendRequest) => Promise<WebSendResult>;
 	processAttachment?: (source: Uint8Array, signal?: AbortSignal) => Promise<PreparedAttachment>;
 	attachmentLimits?: AttachmentLimits;
+	sentImageSettings?: SentImageSettings;
 	maxDraftTextBytes?: number;
 	maxRequestBytes?: number;
 }
@@ -84,6 +87,8 @@ export class WebUIServer {
 	private readonly attachments: AttachmentStore;
 	private readonly attachmentLimits: AttachmentLimits;
 	private readonly draft: DraftStore;
+	private readonly sentImages: SentImageStore;
+	private readonly imageResidentBudget: number;
 	private activeClientId?: string;
 	private leaseGeneration = 0;
 	private closed = false;
@@ -104,6 +109,16 @@ export class WebUIServer {
 		this.draft = new DraftStore({
 			maxTextBytes: options.maxDraftTextBytes ?? DEFAULT_MAX_DRAFT_TEXT_BYTES,
 		});
+		const sentImageSettings = options.sentImageSettings ?? {
+			enabled: false,
+			maxImages: 32,
+			maxBytes: 128 * 1024 * 1024,
+		};
+		this.sentImages = new SentImageStore(sentImageSettings);
+		this.imageResidentBudget = Math.max(
+			sentImageSettings.maxBytes,
+			this.attachmentLimits.maxPromptBytes + this.attachmentLimits.maxImageBytes * 2,
+		);
 		this.attachments = new AttachmentStore({
 			limits: this.attachmentLimits,
 			process:
@@ -111,7 +126,10 @@ export class WebUIServer {
 				(async () => {
 					throw new Error("Image processing is unavailable.");
 				}),
-			onChange: (state) => this.broadcastControl("attachments", state),
+			onChange: (state) => {
+				this.reconcileSentImageBytes(state);
+				this.broadcastControl("attachments", state);
+			},
 		});
 		server.on("connection", (socket) => {
 			this.sockets.add(socket);
@@ -169,6 +187,7 @@ export class WebUIServer {
 		this.activeAttachmentControllers.clear();
 		this.attachments.close();
 		this.draft.close();
+		this.sentImages.close();
 		this.requests.clear();
 		const responses = [...this.sseClients].map((client) => client.response);
 		this.broadcastControl("session-ended", { message: "Pi session ended" });
@@ -213,7 +232,18 @@ export class WebUIServer {
 					lease: this.leaseSnapshot(),
 					draft: this.draft.publicState(),
 					attachments: this.attachments.publicState(),
+					sentImages: this.sentImages.publicState(),
 				});
+				return;
+			}
+			const sentPreviewId = sentImagePathId(url.pathname, "preview");
+			if (request.method === "GET" && sentPreviewId) {
+				const preview = this.sentImages.preview(sentPreviewId);
+				response.writeHead(200, {
+					"Content-Type": preview.mimeType,
+					"Content-Length": preview.bytes.byteLength,
+				});
+				response.end(preview.bytes);
 				return;
 			}
 			const previewId = attachmentPathId(url.pathname, "preview");
@@ -270,6 +300,44 @@ export class WebUIServer {
 				);
 				this.assertLease(lease);
 				this.broadcastDraft(state);
+				this.json(response, 200, state);
+				return;
+			}
+			if (request.method === "POST" && url.pathname === "/api/sent-images/reattach") {
+				const body = requireRecord(await readJson(request, 64 * 1024), "sent-image reattach");
+				this.assertLease(lease);
+				const items = parseSentImageReattachments(body.items);
+				const clones = this.sentImages.clone(items.map((item) => item.retainedId));
+				const attachments = this.attachments.attachPrepared(
+					clones.map((clone, index) => ({
+						id: items[index]?.id ?? "",
+						name: clone.name,
+						prepared: { bytes: clone.bytes, mimeType: clone.mimeType, notes: [] },
+					})),
+					numberField(body, "revision"),
+				);
+				this.assertLease(lease);
+				const draft = this.syncDraftAttachments(attachments);
+				this.json(response, 200, {
+					attachments,
+					draft,
+					sentImages: this.sentImages.publicState(),
+				});
+				return;
+			}
+			const sentDeleteId = sentImagePathId(url.pathname);
+			if (request.method === "DELETE" && sentDeleteId) {
+				const state = this.sentImages.remove(sentDeleteId, revisionParameter(url));
+				this.assertLease(lease);
+				this.broadcastSentImages(state);
+				this.json(response, 200, state);
+				return;
+			}
+			if (request.method === "POST" && url.pathname === "/api/sent-images/clear") {
+				const body = requireRecord(await readJson(request, 8 * 1024), "sent-image clear");
+				const state = this.sentImages.clear(numberField(body, "revision"));
+				this.assertLease(lease);
+				this.broadcastSentImages(state);
 				this.json(response, 200, state);
 				return;
 			}
@@ -359,6 +427,7 @@ export class WebUIServer {
 					...result,
 					draft: this.draft.publicState(),
 					attachments: this.attachments.publicState(),
+					sentImages: this.sentImages.publicState(),
 				});
 				return;
 			}
@@ -367,7 +436,8 @@ export class WebUIServer {
 			const status =
 				error instanceof HttpError ||
 				error instanceof AttachmentError ||
-				error instanceof DraftError
+				error instanceof DraftError ||
+				error instanceof SentImageError
 					? error.status
 					: 500;
 			if (error instanceof HttpError && error.closeConnection)
@@ -469,6 +539,10 @@ export class WebUIServer {
 			this.draft.finishSend(draftReservation.token, false);
 			throw error;
 		}
+		const retainedImageIds = this.sentImages.referencesFor(
+			message.requestId,
+			attachmentReservation?.images ?? [],
+		);
 		const controller = new AbortController();
 		this.activeSendControllers.add(controller);
 		const abort = () => controller.abort();
@@ -482,10 +556,28 @@ export class WebUIServer {
 				attachmentRevision: attachmentState.revision,
 				attachmentIds: draftReservation.attachmentIds,
 				images: attachmentReservation?.images ?? [],
+				retainedImageIds,
 				delivery: message.delivery,
 				signal: controller.signal,
 			})
 			.then((result) => {
+				if (retainedImageIds.length > 0) {
+					try {
+						const before = this.sentImages.publicState().revision;
+						this.sentImages.commit(
+							message.requestId,
+							attachmentReservation?.images ?? [],
+							retainedImageIds,
+						);
+						const retained = this.sentImages.reconcile(
+							attachmentState.totalResidentBytes,
+							this.imageResidentBudget,
+						);
+						if (retained.revision !== before) this.broadcastSentImages(retained);
+					} catch {
+						// Retention is optional and must not turn an accepted Pi message into a failure.
+					}
+				}
 				const nextAttachments = attachmentReservation
 					? this.attachments.finishSend(attachmentReservation.token, true)
 					: this.attachments.publicState();
@@ -561,6 +653,7 @@ export class WebUIServer {
 		this.writeSse(client, "lease", this.leaseSnapshot());
 		this.writeSse(client, "draft", this.draft.publicState());
 		this.writeSse(client, "attachments", this.attachments.publicState());
+		this.writeSse(client, "sent-images", this.sentImages.publicState());
 		const replay = this.options.conversation.eventsAfter(since);
 		if (replay === undefined) {
 			this.writeSse(client, "snapshot", this.options.conversation.snapshot());
@@ -589,6 +682,21 @@ export class WebUIServer {
 
 	private broadcastDraft(state: PublicDraftState): void {
 		this.broadcastControl("draft", state);
+	}
+
+	private broadcastSentImages(state: ReturnType<SentImageStore["publicState"]>): void {
+		this.broadcastControl("sent-images", state);
+	}
+
+	private reconcileSentImageBytes(attachments = this.attachments.publicState()): void {
+		const processingReserve =
+			attachments.phase === "processing" ? this.attachmentLimits.maxImageBytes * 2 : 0;
+		const before = this.sentImages.publicState().revision;
+		const retained = this.sentImages.reconcile(
+			attachments.totalResidentBytes + processingReserve,
+			this.imageResidentBudget,
+		);
+		if (retained.revision !== before) this.broadcastSentImages(retained);
 	}
 
 	private broadcastEvent(event: ConversationEvent): void {
@@ -769,6 +877,22 @@ function parseAttachmentReservations(value: unknown): Array<{
 	});
 }
 
+function parseSentImageReattachments(value: unknown): Array<{
+	retainedId: string;
+	id: string;
+}> {
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new HttpError(400, "Invalid sent-image reattach list");
+	}
+	return value.map((entry) => {
+		const item = requireRecord(entry, "sent-image reattach item");
+		return {
+			retainedId: stringField(item, "retainedId"),
+			id: stringField(item, "id"),
+		};
+	});
+}
+
 function revisionParameter(url: URL): number {
 	const value = url.searchParams.get("revision");
 	if (!value || !/^\d+$/.test(value)) throw new HttpError(400, "Invalid attachment revision");
@@ -783,6 +907,12 @@ function attachmentPathId(
 ): string | undefined {
 	const suffix = action ? `/${action}` : "";
 	const match = new RegExp(`^/api/attachments/([A-Za-z0-9_-]{1,128})${suffix}$`).exec(pathname);
+	return match?.[1];
+}
+
+function sentImagePathId(pathname: string, action?: "preview"): string | undefined {
+	const suffix = action ? `/${action}` : "";
+	const match = new RegExp(`^/api/sent-images/([A-Za-z0-9_-]{1,128})${suffix}$`).exec(pathname);
 	return match?.[1];
 }
 

--- a/extensions/pi-webui/src/settings.ts
+++ b/extensions/pi-webui/src/settings.ts
@@ -12,12 +12,25 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export const SETTINGS_FILE = "pi-webui.json";
 
+const MIB = 1024 * 1024;
+
 export interface WebUISettings {
 	startOnSessionStart: boolean;
+	retainSentImages: boolean;
+	maxRetainedImages: number;
+	maxRetainedBytes: number;
 }
 
 export const DEFAULT_SETTINGS: Readonly<WebUISettings> = Object.freeze({
 	startOnSessionStart: false,
+	retainSentImages: false,
+	maxRetainedImages: 32,
+	maxRetainedBytes: 128 * MIB,
+});
+
+export const RETENTION_HARD_LIMITS = Object.freeze({
+	maxRetainedImages: 128,
+	maxRetainedBytes: 512 * MIB,
 });
 
 export interface SettingsLoadResult {
@@ -49,16 +62,41 @@ export function settingsFilePath(): string {
 export function normalizeSettings(value: unknown): WebUISettings | undefined {
 	if (!isRecord(value)) return undefined;
 	if (
-		Object.hasOwn(value, "startOnSessionStart") &&
-		typeof value.startOnSessionStart !== "boolean"
+		(Object.hasOwn(value, "startOnSessionStart") &&
+			typeof value.startOnSessionStart !== "boolean") ||
+		(Object.hasOwn(value, "retainSentImages") && typeof value.retainSentImages !== "boolean")
 	) {
 		return undefined;
+	}
+	for (const key of ["maxRetainedImages", "maxRetainedBytes"] as const) {
+		if (!Object.hasOwn(value, key)) continue;
+		const candidate = value[key];
+		if (
+			typeof candidate !== "number" ||
+			!Number.isSafeInteger(candidate) ||
+			candidate <= 0 ||
+			candidate > RETENTION_HARD_LIMITS[key]
+		) {
+			return undefined;
+		}
 	}
 	return {
 		startOnSessionStart:
 			typeof value.startOnSessionStart === "boolean"
 				? value.startOnSessionStart
 				: DEFAULT_SETTINGS.startOnSessionStart,
+		retainSentImages:
+			typeof value.retainSentImages === "boolean"
+				? value.retainSentImages
+				: DEFAULT_SETTINGS.retainSentImages,
+		maxRetainedImages:
+			typeof value.maxRetainedImages === "number"
+				? value.maxRetainedImages
+				: DEFAULT_SETTINGS.maxRetainedImages,
+		maxRetainedBytes:
+			typeof value.maxRetainedBytes === "number"
+				? value.maxRetainedBytes
+				: DEFAULT_SETTINGS.maxRetainedBytes,
 	};
 }
 
@@ -86,7 +124,7 @@ export async function loadSettings(path = settingsFilePath()): Promise<SettingsL
 		const document = JSON.parse(text) as unknown;
 		if (!isRecord(document)) return invalid(path, "the top level must be a JSON object");
 		const settings = normalizeSettings(document);
-		if (!settings) return invalid(path, "startOnSessionStart must be a boolean");
+		if (!settings) return invalid(path, "recognized settings have an invalid type or limit");
 		return { kind: "loaded", path, settings, source: "settings file", document };
 	} catch (error) {
 		return invalid(path, formatError(error));
@@ -99,7 +137,13 @@ export async function saveSettings(
 	path = settingsFilePath(),
 	operations: Partial<SettingsFileOperations> = {},
 ): Promise<Record<string, unknown>> {
-	const nextDocument = { ...document, startOnSessionStart: settings.startOnSessionStart };
+	const nextDocument = {
+		...document,
+		startOnSessionStart: settings.startOnSessionStart,
+		retainSentImages: settings.retainSentImages,
+		maxRetainedImages: settings.maxRetainedImages,
+		maxRetainedBytes: settings.maxRetainedBytes,
+	};
 	const directory = dirname(path);
 	await mkdir(directory, { recursive: true });
 	const temporaryPath = temporaryFilePath(path);

--- a/extensions/pi-webui/src/web/app.js
+++ b/extensions/pi-webui/src/web/app.js
@@ -4,6 +4,7 @@ import {
 	applyConversationEvent,
 	applyDraft,
 	applyLease,
+	applySentImages,
 	applySnapshot,
 	busyLabel,
 	canSend,
@@ -84,7 +85,12 @@ const ui = {
 	previewDismiss: document.querySelector("#image-preview-dismiss"),
 };
 
-const transcriptRenderer = createTranscriptRenderer({ documentRef: document, list: ui.transcript });
+const transcriptRenderer = createTranscriptRenderer({
+	documentRef: document,
+	list: ui.transcript,
+	onReattach: (id) => void reattachSentImage(id),
+	onForget: (id) => void forgetSentImage(id),
+});
 
 ui.input.addEventListener("input", () => {
 	model = editDraftText(model, ui.input.value);
@@ -258,6 +264,10 @@ function connectEvents() {
 		model = applyAttachments(model, JSON.parse(event.data));
 		render();
 	});
+	events.addEventListener("sent-images", (event) => {
+		model = applySentImages(model, JSON.parse(event.data));
+		render({ updateKey: "sent-images" });
+	});
 	events.addEventListener("session-ended", () => {
 		model = { ...model, closed: true, activity: "ended", connected: false };
 		events?.close();
@@ -326,6 +336,7 @@ async function send(steer) {
 		const accepted = await response.json();
 		if (accepted.draft) model = applyDraft(model, accepted.draft);
 		if (accepted.attachments) model = applyAttachments(model, accepted.attachments);
+		if (accepted.sentImages) model = applySentImages(model, accepted.sentImages);
 		if (attempt.attachmentIds.includes(ui.previewImage.dataset.imageId)) {
 			ui.previewDialog.close();
 		}
@@ -512,6 +523,54 @@ function isSupportedImageFile(file) {
 	);
 }
 
+async function reattachSentImage(retainedImageId) {
+	if (composerLocked() || !retainedImageId) return;
+	if (model.attachmentPhase !== "empty" && model.attachmentPhase !== "ready") {
+		model = { ...model, error: "Wait for current images to finish before attaching again." };
+		render();
+		return;
+	}
+	mutatingAttachments = true;
+	renderComposer();
+	try {
+		const response = await attachmentMutation("/api/sent-images/reattach", {
+			method: "POST",
+			body: JSON.stringify({
+				revision: model.attachmentRevision,
+				items: [{ retainedId: retainedImageId, id: crypto.randomUUID() }],
+			}),
+		});
+		model = applyDraft(model, response.draft);
+		model = applyAttachments(model, response.attachments);
+		model = applySentImages(model, response.sentImages);
+		model = { ...model, error: "" };
+		render();
+	} catch (error) {
+		model = { ...model, error: errorMessage(error) };
+		render();
+	} finally {
+		mutatingAttachments = false;
+		renderComposer();
+	}
+}
+
+async function forgetSentImage(retainedImageId) {
+	if (composerLocked() || !retainedImageId) return;
+	if (!window.confirm("Forget this retained image? This does not retract provider content."))
+		return;
+	try {
+		const response = await attachmentMutation(
+			`/api/sent-images/${encodeURIComponent(retainedImageId)}?revision=${model.sentImages.revision}`,
+			{ method: "DELETE" },
+		);
+		model = applySentImages(model, response);
+		render({ updateKey: "sent-images" });
+	} catch (error) {
+		model = { ...model, error: errorMessage(error) };
+		render();
+	}
+}
+
 async function clearAttachments() {
 	if (composerLocked() || model.images.length < 2) return;
 	const clearedIds = model.images.map((image) => image.id);
@@ -629,7 +688,7 @@ function queueTranscriptRender(updateKey, announcement) {
 	if (transcriptFrame) return;
 	transcriptFrame = requestAnimationFrame(() => {
 		transcriptFrame = undefined;
-		transcriptRenderer.render(model.messages, model.tools);
+		transcriptRenderer.render(model.messages, model.tools, model.sentImages);
 		ui.empty.hidden = model.messages.length > 0;
 		if (transcriptAnnouncement) {
 			ui.transcriptStatus.textContent = transcriptAnnouncement;

--- a/extensions/pi-webui/src/web/state.js
+++ b/extensions/pi-webui/src/web/state.js
@@ -18,6 +18,14 @@ export function initialState() {
 		textDirty: false,
 		attachmentRevision: 0,
 		attachmentPhase: "empty",
+		sentImages: {
+			revision: 0,
+			enabled: false,
+			items: [],
+			totalBytes: 0,
+			maxImages: 0,
+			maxBytes: 0,
+		},
 		following: true,
 		unseenUpdateIds: [],
 		text: "",
@@ -40,7 +48,10 @@ export function applySnapshot(current, snapshot) {
 			needsSnapshot: false,
 		};
 	}
-	return applyAttachments(applyDraft(next, snapshot?.draft), snapshot?.attachments);
+	return applySentImages(
+		applyAttachments(applyDraft(next, snapshot?.draft), snapshot?.attachments),
+		snapshot?.sentImages,
+	);
 }
 
 export function applyDraft(current, draft) {
@@ -75,6 +86,29 @@ export function acknowledgeDraftText(current, draft, submittedText) {
 		return applyDraft({ ...current, textDirty: false }, draft);
 	}
 	return applyDraft(current, draft);
+}
+
+export function applySentImages(current, sentImages) {
+	if (
+		!Number.isSafeInteger(sentImages?.revision) ||
+		sentImages.revision < current.sentImages.revision ||
+		!Array.isArray(sentImages.items)
+	) {
+		return current;
+	}
+	return {
+		...current,
+		sentImages: {
+			revision: sentImages.revision,
+			enabled: Boolean(sentImages.enabled),
+			items: sentImages.items
+				.filter((item) => item && typeof item.id === "string")
+				.map((item) => ({ ...item })),
+			totalBytes: Number.isSafeInteger(sentImages.totalBytes) ? sentImages.totalBytes : 0,
+			maxImages: Number.isSafeInteger(sentImages.maxImages) ? sentImages.maxImages : 0,
+			maxBytes: Number.isSafeInteger(sentImages.maxBytes) ? sentImages.maxBytes : 0,
+		},
+	};
 }
 
 export function applyAttachments(current, attachments) {

--- a/extensions/pi-webui/src/web/styles.css
+++ b/extensions/pi-webui/src/web/styles.css
@@ -301,12 +301,31 @@ main {
 	display: inline-flex;
 	min-height: 32px;
 	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.35rem;
 	margin-top: 0.65rem;
 	padding: 0.25rem 0.55rem;
 	border: 1px solid var(--border);
-	border-radius: 999px;
+	border-radius: 0.75rem;
 	color: var(--muted);
 	font-size: 0.82rem;
+}
+
+.message-image-action {
+	min-height: 44px;
+	padding-inline: 0.7rem;
+	border-color: var(--border);
+	background: var(--surface);
+	color: var(--text);
+}
+
+.message-image-action.subtle,
+.message-image-expired {
+	color: var(--muted);
+}
+
+.message-image-action.subtle {
+	background: transparent;
 }
 
 details {
@@ -833,8 +852,21 @@ footer p {
 		flex: 0 1 auto;
 	}
 
+	.image-previews {
+		flex-wrap: wrap;
+		overflow-x: visible;
+	}
+
 	.image-preview-item {
-		min-width: min(100%, 340px);
+		width: 100%;
+		min-width: 0;
+		grid-template-columns: 68px minmax(0, 1fr);
+	}
+
+	.image-order-actions {
+		grid-column: 1 / -1;
+		justify-content: flex-end;
+		flex-wrap: wrap;
 	}
 }
 

--- a/extensions/pi-webui/src/web/transcript.js
+++ b/extensions/pi-webui/src/web/transcript.js
@@ -1,11 +1,17 @@
 import { renderMarkdown } from "./markdown.js";
 
-export function createTranscriptRenderer({ documentRef = document, list }) {
+export function createTranscriptRenderer({
+	documentRef = document,
+	list,
+	onReattach = () => undefined,
+	onForget = () => undefined,
+}) {
 	const messages = new Map();
 
 	return {
-		render(nextMessages, tools) {
+		render(nextMessages, tools, sentImages = { items: [] }) {
 			const toolById = new Map(tools.map((tool) => [tool.id, tool]));
+			const retainedImageIds = new Set((sentImages.items ?? []).map((item) => item.id));
 			const retained = new Set();
 			const changed = [];
 			let cursor = list.firstChild;
@@ -16,7 +22,18 @@ export function createTranscriptRenderer({ documentRef = document, list }) {
 					view = createMessageView(message.role, documentRef);
 					messages.set(message.id, view);
 				}
-				if (updateMessageView(view, message, toolById, documentRef)) changed.push(message.id);
+				if (
+					updateMessageView(
+						view,
+						message,
+						toolById,
+						retainedImageIds,
+						{ onReattach, onForget },
+						documentRef,
+					)
+				) {
+					changed.push(message.id);
+				}
 				if (view.node !== cursor) list.insertBefore(view.node, cursor);
 				cursor = view.node.nextSibling;
 			}
@@ -39,6 +56,11 @@ export function toolPhaseLabel(tool) {
 	if (tool?.phase === "end") return "Completed";
 	if (tool?.phase === "start" || tool?.phase === "update") return "Running";
 	return "Requested";
+}
+
+export function retainedImageStatus(block, retainedImageIds) {
+	if (!block?.retainedImageId) return "none";
+	return retainedImageIds?.has(block.retainedImageId) ? "eligible" : "expired";
 }
 
 export function toolCommandPreview(tool) {
@@ -67,7 +89,7 @@ function createMessageView(role, documentRef) {
 	return { node, heading, body, blocks: new Map(), role: "", final: undefined };
 }
 
-function updateMessageView(view, message, toolById, documentRef) {
+function updateMessageView(view, message, toolById, retainedImageIds, actions, documentRef) {
 	let changed = false;
 	const role = knownRole(message.role);
 	if (view.role !== role) {
@@ -93,7 +115,18 @@ function updateMessageView(view, message, toolById, documentRef) {
 			view.blocks.set(key, blockView);
 			changed = true;
 		}
-		if (updateBlockView(blockView, block, toolById.get(block.id), documentRef)) changed = true;
+		if (
+			updateBlockView(
+				blockView,
+				block,
+				toolById.get(block.id),
+				retainedImageIds,
+				actions,
+				documentRef,
+			)
+		) {
+			changed = true;
+		}
 		if (blockView.node !== cursor) view.body.insertBefore(blockView.node, cursor);
 		cursor = blockView.node.nextSibling;
 	}
@@ -141,7 +174,7 @@ function createBlockView(block, documentRef) {
 	return { type: block.type, node, value: undefined };
 }
 
-function updateBlockView(view, block, tool, documentRef) {
+function updateBlockView(view, block, tool, retainedImageIds, actions, documentRef) {
 	if (block.type === "text") {
 		if (view.value === block.text) return false;
 		view.value = block.text;
@@ -155,10 +188,34 @@ function updateBlockView(view, block, tool, documentRef) {
 		return true;
 	}
 	if (block.type === "image") {
+		const status = retainedImageStatus(block, retainedImageIds);
 		const label = `Image${block.mimeType ? ` · ${block.mimeType}` : ""}`;
-		if (view.value === label) return false;
-		view.value = label;
-		view.node.textContent = label;
+		const value = `${label}:${status}`;
+		if (view.value === value) return false;
+		view.value = value;
+		const text = documentRef.createElement("span");
+		text.textContent = label;
+		view.node.replaceChildren(text);
+		if (status === "eligible") {
+			const attach = documentRef.createElement("button");
+			attach.type = "button";
+			attach.className = "message-image-action";
+			attach.textContent = "Attach again";
+			attach.setAttribute("aria-label", `Attach image again: ${label}`);
+			attach.addEventListener("click", () => actions.onReattach(block.retainedImageId));
+			const forget = documentRef.createElement("button");
+			forget.type = "button";
+			forget.className = "message-image-action subtle";
+			forget.textContent = "Forget";
+			forget.setAttribute("aria-label", `Forget retained image: ${label}`);
+			forget.addEventListener("click", () => actions.onForget(block.retainedImageId));
+			view.node.append(attach, forget);
+		} else if (status === "expired") {
+			const expired = documentRef.createElement("span");
+			expired.className = "message-image-expired";
+			expired.textContent = "Expired";
+			view.node.append(expired);
+		}
 		return true;
 	}
 	if (block.type === "toolCall") return updateToolView(view, block, tool);

--- a/extensions/pi-webui/test/attachments.test.ts
+++ b/extensions/pi-webui/test/attachments.test.ts
@@ -203,6 +203,45 @@ test("reorder, delete, and clear require exact revisions and release every byte"
 	assert.equal(store.residentBytes(), 0);
 });
 
+test("reattaching prepared images is atomic, ordered, bounded, and rejects draft duplicates", async () => {
+	const store = createStore();
+	const state = store.attachPrepared(
+		[
+			{ id: "two", name: "two.png", prepared: prepared(Buffer.from("two")) },
+			{ id: "one", name: "one.png", prepared: prepared(Buffer.from("one")) },
+		],
+		0,
+	);
+	assert.deepEqual(
+		state.items.map((item) => item.id),
+		["two", "one"],
+	);
+	assert.equal(state.phase, "ready");
+	assert.throws(
+		() =>
+			store.attachPrepared(
+				[{ id: "duplicate", name: "duplicate.png", prepared: prepared(Buffer.from("two")) }],
+				state.revision,
+			),
+		/duplicate/i,
+	);
+	assert.throws(
+		() =>
+			store.attachPrepared(
+				[
+					{ id: "three", name: "three.png", prepared: prepared(Buffer.from("three")) },
+					{ id: "four", name: "four.png", prepared: prepared(Buffer.from("four")) },
+				],
+				state.revision,
+			),
+		/maximum/i,
+	);
+	assert.deepEqual(
+		store.publicState().items.map((item) => item.id),
+		["two", "one"],
+	);
+});
+
 test("send reservation transfers sanitized bytes and commits only a matching ready snapshot", async () => {
 	const store = createStore();
 	store.reserve([{ id: "one", name: "one.png", size: 3 }], 0);

--- a/extensions/pi-webui/test/conversation.test.ts
+++ b/extensions/pi-webui/test/conversation.test.ts
@@ -38,6 +38,23 @@ test("branch snapshots retain the active message path and omit non-message entri
 	]);
 });
 
+test("retained image ids require an explicit trusted projection association", () => {
+	const projection = new ConversationProjection(session);
+	const message = {
+		role: "user",
+		content: [{ type: "image", data: "secret", mimeType: "image/png", retainedImageId: "forged" }],
+		timestamp: 2,
+	};
+	projection.recordMessage(message, true, "terminal");
+	assert.deepEqual(projection.snapshot().messages[0]?.content, [
+		{ type: "image", mimeType: "image/png" },
+	]);
+	projection.recordMessage(message, true, "browser", ["sent_trusted"]);
+	assert.deepEqual(projection.snapshot().messages[1]?.content, [
+		{ type: "image", mimeType: "image/png", retainedImageId: "sent_trusted" },
+	]);
+});
+
 test("message projection keeps semantic blocks and truncates large tool content", () => {
 	const projected = projectMessage(
 		{

--- a/extensions/pi-webui/test/lifecycle.test.ts
+++ b/extensions/pi-webui/test/lifecycle.test.ts
@@ -231,7 +231,7 @@ test("startOnSessionStart starts automatically for every initialized session and
 		loadSettings: async () => ({
 			kind: "loaded",
 			path: "/agent/pi-webui.json",
-			settings: { startOnSessionStart: true },
+			settings: { ...DEFAULT_SETTINGS, startOnSessionStart: true },
 			source: "settings file",
 			document: { startOnSessionStart: true },
 		}),
@@ -265,7 +265,7 @@ test("invalid settings warn and automatic startup failures remain non-fatal", as
 		loadSettings: async () => ({
 			kind: "loaded",
 			path: "/agent/pi-webui.json",
-			settings: { startOnSessionStart: true },
+			settings: { ...DEFAULT_SETTINGS, startOnSessionStart: true },
 			source: "settings file",
 			document: { startOnSessionStart: true },
 		}),
@@ -540,6 +540,40 @@ test("idle browser sends fail before acknowledgement when model authentication i
 		/authentication/i,
 	);
 	assert.equal(h.sent.length, 0);
+});
+
+test("only accepted browser image messages receive retained-image projection ids", async () => {
+	const h = harness();
+	await h.emit("session_start");
+	await h.commands.get("webui")?.handler("", h.ctx as never);
+	await h.serverOptions?.send({
+		requestId: "retained-browser-image",
+		text: "again later",
+		images: [{ data: Buffer.from("safe").toString("base64"), mimeType: "image/png" }],
+		retainedImageIds: ["sent_trusted"],
+		delivery: "next",
+	});
+	const browserMessage = { role: "user", content: h.sent[0]?.content, timestamp: 9 };
+	await h.emit("message_start", { message: browserMessage });
+	await h.emit("message_end", { message: browserMessage });
+	await nextTask();
+	assert.deepEqual(h.serverOptions?.conversation.snapshot().messages.at(-1)?.content, [
+		{ type: "text", text: "again later" },
+		{ type: "image", mimeType: "image/png", retainedImageId: "sent_trusted" },
+	]);
+	const terminalMessage = {
+		role: "user",
+		content: [
+			{ type: "image", mimeType: "image/png", data: "safe", retainedImageId: "sent_forged" },
+		],
+		timestamp: 10,
+	};
+	await h.emit("message_start", { message: terminalMessage });
+	await h.emit("message_end", { message: terminalMessage });
+	await nextTask();
+	assert.deepEqual(h.serverOptions?.conversation.snapshot().messages.at(-1)?.content, [
+		{ type: "image", mimeType: "image/png" },
+	]);
 });
 
 test("browser images are staged under live Pi guards and sent without reprocessing source bytes", async () => {

--- a/extensions/pi-webui/test/sent-images.test.ts
+++ b/extensions/pi-webui/test/sent-images.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SentImageError, SentImageStore } from "../src/sent-images.js";
+
+function image(marker: string) {
+	return {
+		name: `${marker}.png`,
+		mimeType: "image/png",
+		data: Buffer.from(marker).toString("base64"),
+	};
+}
+
+function store(overrides: Partial<{ enabled: boolean; maxImages: number; maxBytes: number }> = {}) {
+	return new SentImageStore({ enabled: true, maxImages: 3, maxBytes: 12, ...overrides });
+}
+
+test("only accepted sanitized images enter retention and source bytes have no API", () => {
+	const sent = store();
+	const references = sent.referencesFor("message-one", [image("safe")]);
+	assert.equal(references.length, 1);
+	assert.equal(sent.residentBytes(), 0);
+	assert.deepEqual(sent.publicState().items, []);
+	sent.commit("message-one", [image("safe")], references);
+	assert.equal(sent.residentBytes(), 4);
+	assert.equal(sent.publicState().items[0]?.id, references[0]);
+	assert.equal(sent.publicState().items[0]?.mimeType, "image/png");
+});
+
+test("duplicate sanitized hashes collapse while preserving stable opaque references", () => {
+	const sent = store();
+	const first = sent.referencesFor("first", [image("same")]);
+	sent.commit("first", [image("same")], first);
+	const second = sent.referencesFor("second", [image("same")]);
+	assert.deepEqual(second, first);
+	sent.commit("second", [image("same")], second);
+	assert.equal(sent.publicState().items.length, 1);
+	assert.equal(sent.residentBytes(), 4);
+});
+
+test("FIFO eviction enforces count and resident byte ceilings", () => {
+	const sent = store({ maxImages: 2, maxBytes: 5 });
+	for (const marker of ["aa", "bb", "cccc"]) {
+		const input = image(marker);
+		sent.commit(marker, [input], sent.referencesFor(marker, [input]));
+	}
+	assert.deepEqual(
+		sent.publicState().items.map((item) => item.name),
+		["cccc.png"],
+	);
+	assert.equal(sent.residentBytes(), 4);
+});
+
+test("shared resident-byte reconciliation evicts history around active draft and in-flight bytes", () => {
+	const sent = store({ maxBytes: 12 });
+	for (const marker of ["four", "more"]) {
+		const input = image(marker);
+		sent.commit(marker, [input], sent.referencesFor(marker, [input]));
+	}
+	assert.equal(sent.residentBytes(), 8);
+	const reconciled = sent.reconcile(6, 12);
+	assert.deepEqual(
+		reconciled.items.map((item) => item.name),
+		["more.png"],
+	);
+	assert.equal(sent.residentBytes() + 6 <= 12, true);
+});
+
+test("cloning selected retained images preserves order and independent bytes", () => {
+	const sent = store();
+	for (const marker of ["one", "two"]) {
+		const input = image(marker);
+		sent.commit(marker, [input], sent.referencesFor(marker, [input]));
+	}
+	const [one, two] = sent.publicState().items;
+	assert.ok(one && two);
+	const clones = sent.clone([two.id, one.id]);
+	assert.deepEqual(
+		clones.map((clone) => clone.name),
+		["two.png", "one.png"],
+	);
+	clones[0]?.bytes.fill(0);
+	assert.equal(sent.preview(two.id).bytes.toString(), "two");
+	assert.throws(() => sent.clone([one.id, one.id]), /duplicate/i);
+});
+
+test("delete and clear require current revisions and release bytes", () => {
+	const sent = store();
+	for (const marker of ["one", "two"]) {
+		const input = image(marker);
+		sent.commit(marker, [input], sent.referencesFor(marker, [input]));
+	}
+	const before = sent.publicState();
+	const firstId = before.items[0]?.id;
+	assert.ok(firstId);
+	assert.throws(() => sent.remove(firstId, before.revision - 1), /revision/i);
+	const removed = sent.remove(firstId, before.revision);
+	assert.equal(removed.items.length, 1);
+	sent.clear(removed.revision);
+	assert.equal(sent.residentBytes(), 0);
+	assert.deepEqual(sent.publicState().items, []);
+});
+
+test("disabled retention remains empty and exposes no reattach references", () => {
+	const sent = store({ enabled: false });
+	assert.deepEqual(sent.referencesFor("message", [image("safe")]), []);
+	sent.commit("message", [image("safe")], []);
+	assert.equal(sent.residentBytes(), 0);
+	assert.equal(sent.publicState().enabled, false);
+});
+
+test("close clears session memory and rejects future access idempotently", () => {
+	const sent = store();
+	const input = image("safe");
+	const [id] = sent.referencesFor("message", [input]);
+	assert.ok(id);
+	sent.commit("message", [input], [id]);
+	sent.close();
+	sent.close();
+	assert.equal(sent.residentBytes(), 0);
+	assert.deepEqual(sent.publicState().items, []);
+	assert.throws(() => sent.preview(id), SentImageError);
+});

--- a/extensions/pi-webui/test/server.test.ts
+++ b/extensions/pi-webui/test/server.test.ts
@@ -392,6 +392,14 @@ test("message requests validate, deduplicate, and reject request-id payload conf
 				totalSourceBytes: 0,
 				totalResidentBytes: 0,
 			},
+			sentImages: {
+				revision: 0,
+				enabled: false,
+				items: [],
+				totalBytes: 0,
+				maxImages: 32,
+				maxBytes: 128 * 1024 * 1024,
+			},
 		});
 		const conflict = await api(server, "/api/messages", {
 			method: "POST",
@@ -767,6 +775,167 @@ test("lease takeover and deletion cancel processing without stale completion res
 		assert.equal(((await response.json()) as { phase: string }).phase, "empty");
 	} finally {
 		for (const release of releases) release();
+		await server.close();
+	}
+});
+
+test("accepted sanitized images can be previewed, reattached atomically, forgotten, and expired", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	let attempts = 0;
+	let holdNextSend = false;
+	const nextSend = deferred<WebSendResult>();
+	const seenRetainedIds: string[][] = [];
+	const server = await WebUIServer.start({
+		conversation,
+		sentImageSettings: { enabled: true, maxImages: 2, maxBytes: 16 },
+		attachmentLimits: { maxImages: 3, maxImageBytes: 8, maxPromptBytes: 16 },
+		processAttachment: async (source) => preparedAttachment(Buffer.from(source).toString()),
+		send: async (request) => {
+			attempts += 1;
+			seenRetainedIds.push(request.retainedImageIds ?? []);
+			if (attempts === 1) throw new Error("Pi rejected the send");
+			if (holdNextSend) return nextSend.promise;
+			return { delivery: "immediate" };
+		},
+	});
+	try {
+		const cookie = await authenticate(server);
+		const client = await takeLease(server, cookie);
+		let response = await api(server, "/api/attachments/reserve", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: 0,
+				items: [{ id: "one", name: "one.png", size: 3 }],
+			}),
+		});
+		const attachments = (await response.json()) as { revision: number };
+		await api(server, `/api/attachments/one/upload?revision=${attachments.revision}`, {
+			method: "POST",
+			cookie,
+			client,
+			contentType: "application/octet-stream",
+			body: Buffer.from("one"),
+		});
+		await waitForAttachmentPhase(server, cookie, "ready");
+		const state = (await (await api(server, "/api/state", { cookie })).json()) as {
+			draft: { revision: number };
+		};
+		const body = JSON.stringify({
+			requestId: "retained-send",
+			draftRevision: state.draft.revision,
+			delivery: "next",
+		});
+		assert.equal(
+			(await api(server, "/api/messages", { method: "POST", cookie, client, body })).status,
+			500,
+		);
+		const afterFailure = (await (await api(server, "/api/state", { cookie })).json()) as {
+			sentImages: { items: unknown[] };
+			attachments: { phase: string };
+		};
+		assert.deepEqual(afterFailure.sentImages.items, []);
+		assert.equal(afterFailure.attachments.phase, "ready");
+		response = await api(server, "/api/messages", { method: "POST", cookie, client, body });
+		assert.equal(response.status, 202);
+		const accepted = (await response.json()) as {
+			attachments: { revision: number };
+			sentImages: { revision: number; items: Array<{ id: string }> };
+		};
+		assert.equal(seenRetainedIds[0]?.length, 1);
+		assert.deepEqual(seenRetainedIds[1], seenRetainedIds[0]);
+		const retainedId = accepted.sentImages.items[0]?.id;
+		assert.ok(retainedId);
+		assert.equal((await api(server, `/api/sent-images/${retainedId}/preview`)).status, 401);
+		assert.equal(
+			await (await api(server, `/api/sent-images/${retainedId}/preview`, { cookie })).text(),
+			"one",
+		);
+		const activeClient = await takeLease(server, cookie, "client-two");
+		assert.equal(
+			(
+				await api(server, "/api/sent-images/reattach", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({
+						revision: accepted.attachments.revision,
+						items: [{ retainedId, id: "stale-tab" }],
+					}),
+				})
+			).status,
+			409,
+		);
+		response = await api(server, "/api/sent-images/reattach", {
+			method: "POST",
+			cookie,
+			client: activeClient,
+			body: JSON.stringify({
+				revision: accepted.attachments.revision,
+				items: [{ retainedId, id: "again" }],
+			}),
+		});
+		assert.equal(response.status, 200);
+		const reattached = (await response.json()) as {
+			attachments: { revision: number; items: Array<{ id: string }> };
+			draft: { revision: number };
+		};
+		assert.deepEqual(
+			reattached.attachments.items.map((item) => item.id),
+			["again"],
+		);
+		assert.equal(
+			(
+				await api(server, "/api/sent-images/reattach", {
+					method: "POST",
+					cookie,
+					client: activeClient,
+					body: JSON.stringify({
+						revision: reattached.attachments.revision,
+						items: [{ retainedId, id: "duplicate" }],
+					}),
+				})
+			).status,
+			409,
+		);
+		holdNextSend = true;
+		const pendingSend = api(server, "/api/messages", {
+			method: "POST",
+			cookie,
+			client: activeClient,
+			body: JSON.stringify({
+				requestId: "pending-retained-send",
+				draftRevision: reattached.draft.revision,
+				delivery: "next",
+			}),
+		});
+		await waitFor(() => attempts === 3);
+		response = await api(server, "/api/sent-images/reattach", {
+			method: "POST",
+			cookie,
+			client: activeClient,
+			body: JSON.stringify({
+				revision: reattached.attachments.revision,
+				items: [{ retainedId, id: "during-send" }],
+			}),
+		});
+		assert.equal(response.status, 409);
+		assert.match(await response.text(), /reserved for sending/i);
+		nextSend.resolve({ delivery: "immediate" });
+		assert.equal((await pendingSend).status, 202);
+		response = await api(
+			server,
+			`/api/sent-images/${retainedId}?revision=${accepted.sentImages.revision}`,
+			{ method: "DELETE", cookie, client: activeClient },
+		);
+		assert.equal(response.status, 200);
+		assert.deepEqual(((await response.json()) as { items: unknown[] }).items, []);
+		assert.equal(
+			(await api(server, `/api/sent-images/${retainedId}/preview`, { cookie })).status,
+			404,
+		);
+	} finally {
 		await server.close();
 	}
 });

--- a/extensions/pi-webui/test/settings.test.ts
+++ b/extensions/pi-webui/test/settings.test.ts
@@ -7,8 +7,24 @@ import {
 	DEFAULT_SETTINGS,
 	initializeSettings,
 	loadSettings,
+	RETENTION_HARD_LIMITS,
 	saveSettings,
 } from "../src/settings.js";
+
+test("sent-image retention uses conservative opt-in defaults and finite hard ceilings", () => {
+	assert.deepEqual(
+		{
+			retainSentImages: DEFAULT_SETTINGS.retainSentImages,
+			maxRetainedImages: DEFAULT_SETTINGS.maxRetainedImages,
+			maxRetainedBytes: DEFAULT_SETTINGS.maxRetainedBytes,
+		},
+		{ retainSentImages: false, maxRetainedImages: 32, maxRetainedBytes: 128 * 1024 * 1024 },
+	);
+	assert.deepEqual(RETENTION_HARD_LIMITS, {
+		maxRetainedImages: 128,
+		maxRetainedBytes: 512 * 1024 * 1024,
+	});
+});
 
 test("settings loading distinguishes missing, valid, malformed, and invalid files", async () => {
 	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
@@ -22,7 +38,7 @@ test("settings loading distinguishes missing, valid, malformed, and invalid file
 		await writeFile(settingsPath, '{"startOnSessionStart":true,"future":"kept"}\n');
 		const loaded = await loadSettings(settingsPath);
 		assert.equal(loaded.kind, "loaded");
-		assert.deepEqual(loaded.settings, { startOnSessionStart: true });
+		assert.deepEqual(loaded.settings, { ...DEFAULT_SETTINGS, startOnSessionStart: true });
 		assert.deepEqual(loaded.document, { startOnSessionStart: true, future: "kept" });
 		assert.equal(loaded.source, "settings file");
 
@@ -36,7 +52,7 @@ test("settings loading distinguishes missing, valid, malformed, and invalid file
 		const invalid = await loadSettings(settingsPath);
 		assert.equal(invalid.kind, "invalid");
 		assert.deepEqual(invalid.settings, DEFAULT_SETTINGS);
-		assert.match(invalid.warning ?? "", /boolean/i);
+		assert.match(invalid.warning ?? "", /invalid type or limit/i);
 	} finally {
 		await rm(directory, { recursive: true, force: true });
 	}
@@ -49,10 +65,17 @@ test("saving is atomic and preserves unknown fields", async () => {
 		await writeFile(settingsPath, '{"future":{"enabled":true},"startOnSessionStart":false}\n');
 		const loaded = await loadSettings(settingsPath);
 		assert.equal(loaded.kind, "loaded");
-		await saveSettings({ startOnSessionStart: true }, loaded.document ?? {}, settingsPath);
+		await saveSettings(
+			{ ...DEFAULT_SETTINGS, startOnSessionStart: true },
+			loaded.document ?? {},
+			settingsPath,
+		);
 		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
 			future: { enabled: true },
 			startOnSessionStart: true,
+			retainSentImages: false,
+			maxRetainedImages: 32,
+			maxRetainedBytes: 128 * 1024 * 1024,
 		});
 	} finally {
 		await rm(directory, { recursive: true, force: true });
@@ -67,11 +90,16 @@ test("failed atomic publish keeps the previous settings file", async () => {
 		await writeFile(settingsPath, original);
 		await assert.rejects(
 			() =>
-				saveSettings({ startOnSessionStart: true }, { future: 1 }, settingsPath, {
-					rename: async () => {
-						throw new Error("publish failed");
+				saveSettings(
+					{ ...DEFAULT_SETTINGS, startOnSessionStart: true },
+					{ future: 1 },
+					settingsPath,
+					{
+						rename: async () => {
+							throw new Error("publish failed");
+						},
 					},
-				}),
+				),
 			/publish failed/,
 		);
 		assert.equal(await readFile(settingsPath, "utf8"), original);
@@ -88,7 +116,7 @@ test("failed temporary write leaves the previous settings file untouched", async
 		await writeFile(settingsPath, original);
 		await assert.rejects(
 			() =>
-				saveSettings({ startOnSessionStart: true }, {}, settingsPath, {
+				saveSettings({ ...DEFAULT_SETTINGS, startOnSessionStart: true }, {}, settingsPath, {
 					write: async () => {
 						throw new Error("write failed");
 					},
@@ -109,7 +137,10 @@ test("init creates formatted defaults once and never overwrites existing content
 	const settingsPath = path.join(directory, "pi-webui.json");
 	try {
 		assert.equal(await initializeSettings(settingsPath), "created");
-		assert.equal(await readFile(settingsPath, "utf8"), '{\n  "startOnSessionStart": false\n}\n');
+		assert.equal(
+			await readFile(settingsPath, "utf8"),
+			`${JSON.stringify(DEFAULT_SETTINGS, null, 2)}\n`,
+		);
 		await writeFile(settingsPath, "{invalid but owned}\n");
 		assert.equal(await initializeSettings(settingsPath), "exists");
 		assert.equal(await readFile(settingsPath, "utf8"), "{invalid but owned}\n");

--- a/extensions/pi-webui/test/transcript.test.ts
+++ b/extensions/pi-webui/test/transcript.test.ts
@@ -9,6 +9,10 @@ const transcript = (await import(
 	toolPhaseLabel(tool?: { phase?: string; isError?: boolean }): string;
 	toolCommandPreview(tool?: { args?: unknown }): string;
 	isCollapsibleMessageRole(role: string): boolean;
+	retainedImageStatus(
+		block: { retainedImageId?: string },
+		ids: Set<string>,
+	): "none" | "eligible" | "expired";
 };
 
 test("standalone tool-result messages use collapsed disclosure", () => {
@@ -23,6 +27,13 @@ test("tool phase labels describe user-visible state", () => {
 	assert.equal(transcript.toolPhaseLabel({ phase: "update" }), "Running");
 	assert.equal(transcript.toolPhaseLabel({ phase: "end" }), "Completed");
 	assert.equal(transcript.toolPhaseLabel({ phase: "end", isError: true }), "Failed");
+});
+
+test("retained image chips distinguish eligible, expired, and terminal-origin images", () => {
+	const active = new Set(["sent-one"]);
+	assert.equal(transcript.retainedImageStatus({}, active), "none");
+	assert.equal(transcript.retainedImageStatus({ retainedImageId: "sent-one" }, active), "eligible");
+	assert.equal(transcript.retainedImageStatus({ retainedImageId: "sent-old" }, active), "expired");
 });
 
 test("tool command preview accepts only a compact string command", () => {

--- a/extensions/pi-webui/test/web-state.test.ts
+++ b/extensions/pi-webui/test/web-state.test.ts
@@ -16,6 +16,7 @@ const state = (await import(
 		submittedText: string,
 	): WebState;
 	applyAttachments(current: WebState, attachments: Record<string, unknown>): WebState;
+	applySentImages(current: WebState, sentImages: Record<string, unknown>): WebState;
 	applyConversationEvent(current: WebState, event: ConversationEvent): WebState;
 	applyLease(
 		current: WebState,
@@ -73,6 +74,14 @@ interface WebState {
 	textDirty: boolean;
 	attachmentRevision: number;
 	attachmentPhase: string;
+	sentImages: {
+		revision: number;
+		enabled: boolean;
+		items: Array<{ id: string; name?: string }>;
+		totalBytes: number;
+		maxImages: number;
+		maxBytes: number;
+	};
 	following: boolean;
 	unseenUpdateIds: string[];
 	text: string;
@@ -193,6 +202,24 @@ test("server attachment revisions replace browser images and ignore stale update
 	});
 	assert.equal(processing.readingImages, 1);
 	assert.equal(state.canSend({ ...processing, connected: true, text: "send" }), false);
+});
+
+test("sent-image snapshots are immutable and ignore stale eviction state", () => {
+	const source = {
+		revision: 2,
+		enabled: true,
+		items: [{ id: "sent-one", name: "one.png" }],
+		totalBytes: 4,
+		maxImages: 32,
+		maxBytes: 128,
+	};
+	const retained = state.applySentImages(state.initialState(), source);
+	const first = source.items[0];
+	assert.ok(first);
+	first.name = "mutated";
+	assert.deepEqual(retained.sentImages.items, [{ id: "sent-one", name: "one.png" }]);
+	assert.equal(retained.sentImages.enabled, true);
+	assert.equal(state.applySentImages(retained, { ...source, revision: 1, items: [] }), retained);
 });
 
 test("attachment snapshots clone item notes and gate every non-ready batch phase", () => {

--- a/extensions/pi-webui/test/web-ui-contract.test.ts
+++ b/extensions/pi-webui/test/web-ui-contract.test.ts
@@ -105,6 +105,19 @@ test("image input stages authenticated per-item uploads with visible status and 
 	assert.match(app, /returnValue !== "confirm"/);
 });
 
+test("sent-image actions stay contextual, authenticated, and distinguish expiration", () => {
+	assert.match(app, /events\.addEventListener\("sent-images"/);
+	assert.match(app, /\/api\/sent-images\/reattach/);
+	assert.match(app, /\/api\/sent-images\/\$\{encodeURIComponent\(retainedImageId\)\}/);
+	assert.match(transcript, /Attach again/);
+	assert.match(transcript, /Forget/);
+	assert.match(transcript, /Expired/);
+	assert.match(transcript, /retainedImageStatus/);
+	assert.match(transcript, /aria-label.*Attach image again/);
+	assert.match(styles, /\.message-image-action/);
+	assert.doesNotMatch(html, /sent-image-gallery|retained-image-gallery/);
+});
+
 test("attachment copy keeps routine status local and states metadata removal once", () => {
 	for (const label of ["Uploading", "Processing", "Ready", "Needs attention", "Retry", "Remove"]) {
 		assert.match(app, new RegExp(label));
@@ -134,4 +147,9 @@ test("responsive and accessibility CSS covers focus, targets, reflow, dark mode,
 	assert.match(styles, /@media \(prefers-reduced-motion: reduce\)/);
 	assert.match(styles, /overflow-wrap:\s*anywhere/);
 	assert.match(styles, /max-width:\s*100%/);
+	assert.match(styles, /\.image-previews\s*\{[\s\S]*flex-wrap:\s*wrap/);
+	assert.match(
+		styles,
+		/\.image-preview-item\s*\{[\s\S]*grid-template-columns:\s*68px minmax\(0, 1fr\)/,
+	);
 });


### PR DESCRIPTION
## Summary
- retain only sanitized browser-origin image bytes in bounded session memory after accepted sends
- add revisioned reattach/preview/delete APIs and contextual Attach again, Forget, and Expired transcript states
- document the opt-in policy and cover lifecycle, privacy, limits, stale-tab, pending-send, and responsive behavior

## Verification
- `npm run check` (787 tests)
- `git diff --check`
- `just pack webui`
- Chrome smoke at 1280×900 and 320×900, including refresh recovery, Attach again, Forget, and Expired