### PR TITLE
feat(webui): configure safe image limits

### DIFF
--- a/docs/plans/archived/2026-07-19_pi-webui-image-limit-settings-plan.md
+++ b/docs/plans/archived/2026-07-19_pi-webui-image-limit-settings-plan.md
@@ -1,0 +1,45 @@
+## Goal
+
+Let advanced users tune WebUI attachment count, source-byte, batch-byte, and pixel limits within documented hard ceilings while preserving current defaults and Pi's provider-ready dimension/Base64 constraints. Success means omitted settings are fully backward compatible and invalid settings fail safely without exposing an unsafe runtime state.
+
+## Context
+
+WebUI currently exposes only `startOnSessionStart` and hardcodes image limits in `src/images.ts`. Image Drop has proven safe defaults, hard ceilings, cross-field validation, warnings above defaults, and whole-file fallback. WebUI settings intentionally preserve unknown fields for forward compatibility.
+
+## Architecture
+
+Add optional image-limit fields to `pi-webui.json` and normalize them into one immutable runtime limits object loaded at `session_start`. Keep Pi's approximately 2,000-pixel and 4.5 MB inline constraints non-configurable. Apply limits consistently at browser admission, server body reads, resident-memory accounting, processing, send preflight, and reattachment.
+
+## Non-Goals
+
+- Raising provider-specific limits beyond Pi-compatible output constraints.
+- Project-scoped WebUI settings or environment-variable configuration.
+- Exposing every advanced limit as a prominent settings-screen row.
+
+## Plan
+
+- [x] Define central defaults (8 images, 10 MiB/image, 40 MiB/batch, 50 MP) and hard ceilings (32, 50 MiB, 200 MiB, 100 MP), with `maxImageBytes <= maxBatchBytes`; settings tests cover omission, exact ceilings, non-integers, non-positive/above-ceiling values, cross-field rejection, unknown preservation, invalid files, and elevated warnings.
+- [x] Extend `src/settings.ts` with whole-file recognized-field validation and atomic save of normalized fields while preserving unknown JSON; malformed/unsafe files remain untouched and use safe defaults under existing load tests.
+- [x] Add immutable `src/image-limits.ts` and thread one effective object through runtime, server state/SSE, raw admission, processing, resident accounting, send preflight, browser admission, and reattachment; focused attachment/image/lifecycle/server/reducer tests verify each layer and keep source-byte limits distinct from fixed provider-ready limits.
+- [x] Keep all image limits in Advanced JSON because no user-testing evidence currently justifies another routine row; command tests prove the interactive list stays uncluttered and existing cursor/save rollback behavior still passes.
+- [x] Emit one concise warning only when configured image limits exceed safe defaults and report effective limits plus source in `/webui status`; settings and command tests verify both paths without routine startup noise.
+- [x] Update README schema, Advanced JSON guidance, defaults, ceilings, cross-field/memory/provider warnings, and fixed constraints; command-help tests pass and package dry-run includes `src/image-limits.ts` plus expected assets.
+- [x] Run workspace/root checks (793 passing tests), focused settings/browser/server tests, `git diff --check`, `just pack webui`, and Chrome smoke with effective limits 2/1 MiB/1 MiB/123456 verifying dynamic count, per-file, and batch rejection before staging.
+
+## Risks
+
+- Limits enforced only at send time allow browser/server memory spikes; admission and streamed body reads must enforce them before allocation completes.
+- Settings changes during a live session could desynchronize browser and server; retain the existing next-session/reload application model.
+- Too many visible settings increase cognitive load; keep infrequent byte/pixel controls in documented JSON unless evidence supports UI exposure.
+
+## Rollback / Recovery
+
+Because fields are optional and defaults remain unchanged, rollback ignores the extra JSON fields while preserving them as unknown settings data.
+
+## Completion Checklist
+
+- [x] Omitted settings reproduce the original limits exactly, verified by settings and image tests.
+- [x] Invalid, exact-boundary, cross-field, and hard-ceiling cases are tested with safe whole-file fallback; source files remain untouched and source/provider-ready bytes retain distinct bounds.
+- [x] Browser admission, streamed server upload, processing/pixel checks, draft resident accounting, send preflight, and reattach consume the same session-loaded effective limits, verified by integration tests and browser smoke.
+- [x] `/webui settings`, status/help, README, and package contents accurately describe public settings; advanced fields remain out of the routine TUI and command/pack tests pass.
+- [x] `npm run check` (793 tests) and `git diff --check` pass.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -71,7 +71,11 @@ The normal default path is `~/.pi/agent/pi-webui.json`. Pi installations that us
   "startOnSessionStart": false,
   "retainSentImages": false,
   "maxRetainedImages": 32,
-  "maxRetainedBytes": 134217728
+  "maxRetainedBytes": 134217728,
+  "maxImages": 8,
+  "maxImageBytes": 10485760,
+  "maxBatchBytes": 41943040,
+  "maxImagePixels": 50000000
 }
 ```
 
@@ -81,8 +85,16 @@ The normal default path is `~/.pi/agent/pi-webui.json`. Pi installations that us
 | `retainSentImages` | `false` | Opt in to bounded, session-only retention of sanitized images after Pi accepts their browser message. |
 | `maxRetainedImages` | `32` | FIFO retained-image count ceiling. Positive integers up to the hard ceiling of 128 are accepted. |
 | `maxRetainedBytes` | `134217728` (128 MiB) | FIFO retained provider-ready byte ceiling. Positive integers up to the hard ceiling of 536870912 (512 MiB) are accepted. |
+| `maxImages` | `8` | Images in one active draft; hard ceiling 32. |
+| `maxImageBytes` | `10485760` (10 MiB) | Source bytes per image; hard ceiling 52428800 (50 MiB). Must not exceed `maxBatchBytes`. |
+| `maxBatchBytes` | `41943040` (40 MiB) | Combined source/processed draft bytes; hard ceiling 209715200 (200 MiB). |
+| `maxImagePixels` | `50000000` | Decoded pixels per image; hard ceiling 100000000. Animated-image frame area participates in this limit. |
 
-A missing file uses defaults. The file must contain a top-level JSON object; recognized booleans and positive integer limits must have the documented types and remain within their hard ceilings. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility. The settings screen currently exposes the startup toggle; retention fields can be edited in the reported JSON path.
+A missing file uses defaults. The file must contain a top-level JSON object; recognized booleans and positive integer limits must have the documented types and remain within their hard ceilings. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility. The settings screen exposes only the frequent startup toggle; there is not yet user-testing evidence that `maxImages` is adjusted often enough to justify another routine row. Retention and image-limit fields remain in Advanced JSON at the reported path.
+
+### Advanced image limits
+
+Omitting all four image-limit fields exactly reproduces the original 8 image / 10 MiB per image / 40 MiB batch / 50 megapixel behavior. Values are byte counts, not Base64 character counts. Raising any image limit above its safe default emits one concise session-start warning and can materially increase Pi-process memory, decoder work, and denial-of-service exposure; use the smallest value that solves the current workflow. Any non-integer, non-positive, above-ceiling, or cross-field-invalid recognized value rejects the whole file and safely restores all defaults without rewriting it. `/webui status` reports the effective limits and whether they came from defaults or the settings file.
 
 Settings are reloaded on every `session_start`. Changes made in `/webui settings` are saved atomically and update the in-memory preference immediately, but they intentionally do not start or stop the server in the current session; they take effect at the next session initialization or `/reload`. `/webui init` creates formatted defaults once and refuses to overwrite valid or invalid existing content.
 
@@ -107,7 +119,7 @@ The initial transcript comes from the active session branch. Unsent browser mess
 | HEIC/HEIF | PNG |
 | AVIF | PNG |
 
-The server checks file signatures instead of trusting browser MIME types or filename extensions. It rejects corrupt/unknown formats, more than 8 images, individual source images over 10 MiB, combined image input over 40 MiB, images over 50 megapixels, and provider-ready Base64 content over Pi's approximately 4.5 MB inline limit. Images over 2,000 pixels on either side are resized when Pi's `images.autoResize` setting is enabled and rejected when it is disabled.
+The server checks file signatures instead of trusting browser MIME types or filename extensions. It rejects corrupt/unknown formats and applies the effective `maxImages`, `maxImageBytes`, `maxBatchBytes`, and `maxImagePixels` settings at browser admission, streamed upload, processing, draft accounting, send preflight, and Attach again. Pi's approximately 4.5 MB inline Base64 constraint and 2,000-pixel provider-ready dimension constraint remain fixed and cannot be raised in WebUI settings. Images over 2,000 pixels on either side are resized when Pi's `images.autoResize` setting is enabled and rejected when it is disabled.
 
 Choosing, pasting, or dropping images first reserves an ordered server-side batch, uploads each source as a bounded raw request, and processes it before Send becomes available. Each thumbnail reports Uploading, Processing, Ready, or Needs attention; upload progress is shown when the browser reports a byte total. A failed item can be retried without reselecting successful siblings, and every item can be removed independently. Refreshing the active tab restores the authoritative staged batch, while another tab taking the editing lease cancels in-flight work safely.
 
@@ -152,6 +164,7 @@ src/drafts.ts        authoritative in-memory text and attachment-reference revis
 src/attachments.ts   revisioned staged-image state, processing queue, and byte ownership
 src/sent-images.ts   opt-in bounded sanitized sent-image retention
 src/server.ts        authenticated loopback HTTP/SSE server and raw attachment protocol
+src/image-limits.ts  shared configurable defaults, ceilings, and provider constraints
 src/images.ts        bounded provider-ready image processing
 src/pi-settings.ts   effective Pi image settings reader
 src/web/             framework-free browser page

--- a/extensions/pi-webui/src/attachments.ts
+++ b/extensions/pi-webui/src/attachments.ts
@@ -14,6 +14,7 @@ export interface AttachmentLimits {
 	maxImages: number;
 	maxImageBytes: number;
 	maxPromptBytes: number;
+	maxPreparedImageBytes?: number;
 }
 
 export interface AttachmentReservationInput {
@@ -235,6 +236,7 @@ export class AttachmentStore {
 			const reservation = normalizeReservation(
 				{ id: input.id, name: input.name, size: prepared.bytes.byteLength },
 				this.options.limits,
+				preparedImageLimit(this.options.limits),
 			);
 			if (ids.has(reservation.id)) throw new AttachmentError("Attachment id is duplicate.", 400);
 			ids.add(reservation.id);
@@ -502,8 +504,13 @@ export class AttachmentStore {
 			if (otherPreparedBytes + prepared.bytes.byteLength > this.options.limits.maxPromptBytes) {
 				throw new Error("Combined processed attachments are too large.");
 			}
+			if (prepared.bytes.byteLength > preparedImageLimit(this.options.limits)) {
+				throw new Error("Processed attachment exceeds Pi's provider-ready byte limit.");
+			}
 			const maximumResident =
-				this.options.limits.maxPromptBytes + this.options.limits.maxImageBytes * this.concurrency;
+				this.options.limits.maxPromptBytes +
+				Math.max(this.options.limits.maxImageBytes, preparedImageLimit(this.options.limits)) *
+					this.concurrency;
 			if (this.residentBytes() + prepared.bytes.byteLength > maximumResident) {
 				throw new Error("Attachment memory limit exceeded.");
 			}
@@ -597,6 +604,7 @@ export class AttachmentStore {
 function normalizeReservation(
 	input: AttachmentReservationInput,
 	limits: AttachmentLimits,
+	maxImageBytes = limits.maxImageBytes,
 ): AttachmentReservationInput {
 	if (!input || typeof input.id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(input.id)) {
 		throw new AttachmentError("Attachment id is invalid.", 400);
@@ -612,7 +620,7 @@ function normalizeReservation(
 	if (!Number.isSafeInteger(input.size) || input.size <= 0) {
 		throw new AttachmentError("Attachment size is invalid.", 400);
 	}
-	if (input.size > limits.maxImageBytes) {
+	if (input.size > maxImageBytes) {
 		throw new AttachmentError("Attachment exceeds the per-image maximum.", 413);
 	}
 	if (
@@ -632,7 +640,7 @@ function validatePrepared(
 		!prepared ||
 		!Buffer.isBuffer(prepared.bytes) ||
 		prepared.bytes.length === 0 ||
-		prepared.bytes.length > limits.maxImageBytes ||
+		prepared.bytes.length > preparedImageLimit(limits) ||
 		typeof prepared.mimeType !== "string" ||
 		!/^image\/[a-z0-9.+-]{1,64}$/i.test(prepared.mimeType)
 	) {
@@ -652,8 +660,17 @@ function additionsContainBytes(
 		.some((input) => Buffer.isBuffer(input.prepared?.bytes) && input.prepared.bytes.equals(bytes));
 }
 
+function preparedImageLimit(limits: AttachmentLimits): number {
+	return limits.maxPreparedImageBytes ?? limits.maxImageBytes;
+}
+
 function validateLimits(limits: AttachmentLimits): void {
-	for (const value of [limits.maxImages, limits.maxImageBytes, limits.maxPromptBytes]) {
+	for (const value of [
+		limits.maxImages,
+		limits.maxImageBytes,
+		limits.maxPromptBytes,
+		preparedImageLimit(limits),
+	]) {
 		if (!Number.isSafeInteger(value) || value <= 0) {
 			throw new Error("Attachment limits must be positive integers.");
 		}

--- a/extensions/pi-webui/src/image-limits.ts
+++ b/extensions/pi-webui/src/image-limits.ts
@@ -1,0 +1,36 @@
+const MIB = 1024 * 1024;
+
+export interface ImageLimits {
+	maxImages: number;
+	maxImageBytes: number;
+	maxBatchBytes: number;
+	maxImagePixels: number;
+}
+
+export const DEFAULT_IMAGE_LIMITS: Readonly<ImageLimits> = Object.freeze({
+	maxImages: 8,
+	maxImageBytes: 10 * MIB,
+	maxBatchBytes: 40 * MIB,
+	maxImagePixels: 50_000_000,
+});
+
+export const IMAGE_HARD_LIMITS: Readonly<ImageLimits> = Object.freeze({
+	maxImages: 32,
+	maxImageBytes: 50 * MIB,
+	maxBatchBytes: 200 * MIB,
+	maxImagePixels: 100_000_000,
+});
+
+export const PROVIDER_IMAGE_LIMITS = Object.freeze({
+	maxDimension: 2_000,
+	maxBase64Bytes: 4_500_000,
+});
+
+export function imageLimits(value: Partial<ImageLimits> = {}): Readonly<ImageLimits> {
+	return Object.freeze({
+		maxImages: value.maxImages ?? DEFAULT_IMAGE_LIMITS.maxImages,
+		maxImageBytes: value.maxImageBytes ?? DEFAULT_IMAGE_LIMITS.maxImageBytes,
+		maxBatchBytes: value.maxBatchBytes ?? DEFAULT_IMAGE_LIMITS.maxBatchBytes,
+		maxImagePixels: value.maxImagePixels ?? DEFAULT_IMAGE_LIMITS.maxImagePixels,
+	});
+}

--- a/extensions/pi-webui/src/images.ts
+++ b/extensions/pi-webui/src/images.ts
@@ -1,4 +1,5 @@
 import type { ImageContent } from "@earendil-works/pi-ai";
+import { DEFAULT_IMAGE_LIMITS, type ImageLimits, PROVIDER_IMAGE_LIMITS } from "./image-limits.js";
 import {
 	detectImageFormat,
 	type ProcessedBrowserImage,
@@ -6,18 +7,10 @@ import {
 	processImage,
 } from "./image-pipeline.js";
 
+export { DEFAULT_IMAGE_LIMITS, PROVIDER_IMAGE_LIMITS } from "./image-limits.js";
 export type { ProcessedBrowserImage } from "./image-pipeline.js";
 
 export { detectImageFormat } from "./image-pipeline.js";
-
-export const DEFAULT_IMAGE_LIMITS = {
-	maxImages: 8,
-	maxImageBytes: 10 * 1024 * 1024,
-	maxPromptBytes: 40 * 1024 * 1024,
-	maxPixels: 50_000_000,
-	maxDimension: 2_000,
-	maxBase64Bytes: 4_500_000,
-} as const;
 
 export interface BrowserImageInput {
 	name?: string;
@@ -75,8 +68,8 @@ export class ImageProcessor {
 	process(source: Uint8Array, options: ImageProcessorOptions): Promise<ImageContent> {
 		const resolved: ProcessImageOptions = {
 			...options,
-			maxDimension: options.maxDimension ?? DEFAULT_IMAGE_LIMITS.maxDimension,
-			maxBase64Bytes: options.maxBase64Bytes ?? DEFAULT_IMAGE_LIMITS.maxBase64Bytes,
+			maxDimension: options.maxDimension ?? PROVIDER_IMAGE_LIMITS.maxDimension,
+			maxBase64Bytes: options.maxBase64Bytes ?? PROVIDER_IMAGE_LIMITS.maxBase64Bytes,
 		};
 		assertNotAborted(resolved.signal);
 		return new Promise((resolve, reject) => {
@@ -117,11 +110,25 @@ export class ImageProcessor {
 	}
 }
 
+export function validateStagedBrowserImages(
+	inputs: readonly BrowserImageInput[],
+	limits: Readonly<ImageLimits> = DEFAULT_IMAGE_LIMITS,
+): void {
+	if (inputs.length > limits.maxImages) {
+		throw new Error(`Too many images; maximum is ${limits.maxImages}.`);
+	}
+	let total = 0;
+	for (const [index, input] of inputs.entries()) {
+		total += decodeInput(input, index, PROVIDER_IMAGE_LIMITS.maxBase64Bytes, false).byteLength;
+		if (total > limits.maxBatchBytes) throw new Error("Combined image input is too large.");
+	}
+}
+
 export async function processStagedImage(
 	source: Uint8Array,
 	options: ProcessBrowserImageOptions = {},
 ): Promise<ProcessedBrowserImage> {
-	const limits = { ...DEFAULT_IMAGE_LIMITS, ...definedLimits(options) };
+	const limits = resolvedLimits(options);
 	if (options.blockImages) throw new Error("Pi image sending is disabled.");
 	if (options.supportsImages === false)
 		throw new Error("The current model does not support images.");
@@ -141,7 +148,7 @@ export async function processBrowserImages(
 	inputs: BrowserImageInput[],
 	options: ProcessBrowserImageOptions = {},
 ): Promise<ImageContent[]> {
-	const limits = { ...DEFAULT_IMAGE_LIMITS, ...definedLimits(options) };
+	const limits = resolvedLimits(options);
 	if (options.blockImages) throw new Error("Pi image sending is disabled.");
 	if (options.supportsImages === false)
 		throw new Error("The current model does not support images.");
@@ -177,8 +184,23 @@ export async function processBrowserImages(
 	return output;
 }
 
-function definedLimits(options: ProcessBrowserImageOptions): Partial<typeof DEFAULT_IMAGE_LIMITS> {
-	const result: Record<string, number> = {};
+function resolvedLimits(options: ProcessBrowserImageOptions): {
+	maxImages: number;
+	maxImageBytes: number;
+	maxPromptBytes: number;
+	maxPixels: number;
+	maxDimension: number;
+	maxBase64Bytes: number;
+} {
+	const result = {
+		maxImages: DEFAULT_IMAGE_LIMITS.maxImages,
+		maxImageBytes: DEFAULT_IMAGE_LIMITS.maxImageBytes,
+		maxPromptBytes: DEFAULT_IMAGE_LIMITS.maxBatchBytes,
+		maxPixels: DEFAULT_IMAGE_LIMITS.maxImagePixels,
+		maxDimension: PROVIDER_IMAGE_LIMITS.maxDimension,
+		maxBase64Bytes: PROVIDER_IMAGE_LIMITS.maxBase64Bytes,
+	};
+	const mutable = result as Record<keyof typeof result, number>;
 	for (const key of [
 		"maxImages",
 		"maxImageBytes",
@@ -190,12 +212,17 @@ function definedLimits(options: ProcessBrowserImageOptions): Partial<typeof DEFA
 		const value = options[key];
 		if (value === undefined) continue;
 		if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`Invalid image limit: ${key}`);
-		result[key] = value;
+		mutable[key] = value;
 	}
 	return result;
 }
 
-function decodeInput(input: BrowserImageInput, index: number, maxImageBytes: number): Buffer {
+function decodeInput(
+	input: BrowserImageInput,
+	index: number,
+	maxImageBytes: number,
+	requireFormat = true,
+): Buffer {
 	if (!input || typeof input.data !== "string")
 		throw new Error(`Image ${index + 1} has invalid data.`);
 	if (!input.data) throw new Error(`Image ${index + 1} is empty.`);
@@ -207,7 +234,9 @@ function decodeInput(input: BrowserImageInput, index: number, maxImageBytes: num
 	const bytes = Buffer.from(input.data, "base64");
 	if (bytes.byteLength === 0) throw new Error(`Image ${index + 1} is empty.`);
 	if (bytes.byteLength > maxImageBytes) throw new Error(`Image ${index + 1} is too large.`);
-	if (!detectImageFormat(bytes)) throw new Error(`Image ${index + 1} uses an unsupported format.`);
+	if (requireFormat && !detectImageFormat(bytes)) {
+		throw new Error(`Image ${index + 1} uses an unsupported format.`);
+	}
 	return bytes;
 }
 

--- a/extensions/pi-webui/src/runtime.ts
+++ b/extensions/pi-webui/src/runtime.ts
@@ -10,12 +10,14 @@ import {
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
 import type { PreparedAttachment } from "./attachments.js";
 import { ConversationProjection, projectBranchMessages } from "./conversation.js";
+import { DEFAULT_IMAGE_LIMITS, type ImageLimits, imageLimits } from "./image-limits.js";
 import {
 	type BrowserImageInput,
 	type ProcessBrowserImageOptions,
 	type ProcessedBrowserImage,
 	processBrowserImages,
 	processStagedImage,
+	validateStagedBrowserImages,
 } from "./images.js";
 import { type EffectivePiImageSettings, readEffectivePiImageSettings } from "./pi-settings.js";
 import {
@@ -104,6 +106,7 @@ export class WebUIRuntime {
 	private readonly pendingBrowserInputs = new Map<string, PendingBrowserInput>();
 	private readonly acceptedBrowserInputs = new Map<string, AcceptedBrowserInput>();
 	private settings: WebUISettings = { ...DEFAULT_SETTINGS };
+	private effectiveImageLimits: Readonly<ImageLimits> = DEFAULT_IMAGE_LIMITS;
 	private settingsDocument?: Record<string, unknown> = {};
 	private settingsPath = "pi-webui.json";
 	private settingsSource: SettingsLoadResult["source"] = "defaults";
@@ -434,6 +437,7 @@ export class WebUIRuntime {
 			[
 				"Pi WebUI status",
 				`startOnSessionStart: ${this.settings.startOnSessionStart} (${source})`,
+				`Image limits (${source}): ${this.effectiveImageLimits.maxImages} images, ${formatMib(this.effectiveImageLimits.maxImageBytes)}/image, ${formatMib(this.effectiveImageLimits.maxBatchBytes)}/batch, ${this.effectiveImageLimits.maxImagePixels.toLocaleString("en-US")} pixels/image`,
 				`Settings: ${this.settingsPath}`,
 				`Server: ${this.server ? "running" : "stopped"}`,
 			].join("\n"),
@@ -450,9 +454,10 @@ export class WebUIRuntime {
 				"settings: edit WebUI settings in TUI mode",
 				"status: show effective settings, source, path, and current server state",
 				"init: create the defaults file without overwriting existing content",
-				'Accepted JSON: { "startOnSessionStart": false }',
+				'Accepted JSON starts with { "startOnSessionStart": false } and may include advanced maxImages, maxImageBytes, maxBatchBytes, and maxImagePixels fields.',
 				`Settings path: ${this.settingsPath}`,
-				"The default is false. Changes apply on the next session initialization or reload.",
+				"Image byte/pixel limits stay in Advanced JSON; Pi provider-ready dimension/Base64 limits are fixed.",
+				"Changes apply on the next session initialization or reload.",
 			].join("\n"),
 			"info",
 		);
@@ -476,6 +481,7 @@ export class WebUIRuntime {
 
 	private applySettingsResult(result: SettingsLoadResult): void {
 		this.settings = { ...result.settings };
+		this.effectiveImageLimits = imageLimits(result.settings);
 		this.settingsDocument = result.kind === "invalid" ? undefined : { ...(result.document ?? {}) };
 		this.settingsPath = result.path;
 		this.settingsSource = result.source;
@@ -490,6 +496,7 @@ export class WebUIRuntime {
 			const starting = this.dependencies.startServer({
 				conversation,
 				send: (request) => this.sendBrowserMessage(request, generation),
+				imageLimits: this.effectiveImageLimits,
 				sentImageSettings: {
 					enabled: this.settings.retainSentImages,
 					maxImages: this.settings.maxRetainedImages,
@@ -530,6 +537,8 @@ export class WebUIRuntime {
 		const settings = await this.dependencies.readPiSettings(ctx.cwd, ctx.isProjectTrusted());
 		this.notifySettingsWarnings(ctx, settings.warnings);
 		const image = await this.dependencies.processAttachment(source, {
+			maxImageBytes: this.effectiveImageLimits.maxImageBytes,
+			maxPixels: this.effectiveImageLimits.maxImagePixels,
 			autoResize: settings.autoResize,
 			blockImages: settings.blockImages,
 			supportsImages: ctx.model?.input.includes("image") ?? false,
@@ -560,6 +569,7 @@ export class WebUIRuntime {
 		await this.preflightIdlePrompt(ctx, request, generation, signal);
 		let images: ImageContent[] = [];
 		if (request.images.length > 0) {
+			validateStagedBrowserImages(request.images, this.effectiveImageLimits);
 			const settings = await this.dependencies.readPiSettings(ctx.cwd, ctx.isProjectTrusted());
 			this.notifySettingsWarnings(ctx, settings.warnings);
 			if (settings.blockImages) throw new Error("Pi image sending is disabled.");
@@ -780,6 +790,10 @@ function messageLifecycleKey(message: Record<string, unknown>): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatMib(bytes: number): string {
+	return `${bytes / (1024 * 1024)} MiB`;
 }
 
 function formatError(error: unknown): string {

--- a/extensions/pi-webui/src/server.ts
+++ b/extensions/pi-webui/src/server.ts
@@ -13,7 +13,8 @@ import {
 } from "./attachments.js";
 import type { ConversationEvent, ConversationProjection } from "./conversation.js";
 import { DraftError, DraftStore, type PublicDraftState } from "./drafts.js";
-import { type BrowserImageInput, DEFAULT_IMAGE_LIMITS } from "./images.js";
+import { type ImageLimits, imageLimits, PROVIDER_IMAGE_LIMITS } from "./image-limits.js";
+import type { BrowserImageInput } from "./images.js";
 import { SentImageError, type SentImageSettings, SentImageStore } from "./sent-images.js";
 
 const JSON_LIMIT = 64 * 1024 * 1024;
@@ -49,6 +50,7 @@ export interface WebUIServerOptions {
 	send: (request: WebSendRequest) => Promise<WebSendResult>;
 	processAttachment?: (source: Uint8Array, signal?: AbortSignal) => Promise<PreparedAttachment>;
 	attachmentLimits?: AttachmentLimits;
+	imageLimits?: Readonly<ImageLimits>;
 	sentImageSettings?: SentImageSettings;
 	maxDraftTextBytes?: number;
 	maxRequestBytes?: number;
@@ -86,6 +88,7 @@ export class WebUIServer {
 	private readonly activeAttachmentControllers = new Set<AbortController>();
 	private readonly attachments: AttachmentStore;
 	private readonly attachmentLimits: AttachmentLimits;
+	private readonly imageLimits: Readonly<ImageLimits>;
 	private readonly draft: DraftStore;
 	private readonly sentImages: SentImageStore;
 	private readonly imageResidentBudget: number;
@@ -101,10 +104,18 @@ export class WebUIServer {
 		port: number,
 	) {
 		this.origin = `http://127.0.0.1:${port}`;
-		this.attachmentLimits = options.attachmentLimits ?? {
-			maxImages: DEFAULT_IMAGE_LIMITS.maxImages,
-			maxImageBytes: DEFAULT_IMAGE_LIMITS.maxImageBytes,
-			maxPromptBytes: DEFAULT_IMAGE_LIMITS.maxPromptBytes,
+		this.imageLimits = options.imageLimits
+			? imageLimits(options.imageLimits)
+			: imageLimits({
+					maxImages: options.attachmentLimits?.maxImages,
+					maxImageBytes: options.attachmentLimits?.maxImageBytes,
+					maxBatchBytes: options.attachmentLimits?.maxPromptBytes,
+				});
+		this.attachmentLimits = {
+			maxImages: this.imageLimits.maxImages,
+			maxImageBytes: this.imageLimits.maxImageBytes,
+			maxPromptBytes: this.imageLimits.maxBatchBytes,
+			maxPreparedImageBytes: PROVIDER_IMAGE_LIMITS.maxBase64Bytes,
 		};
 		this.draft = new DraftStore({
 			maxTextBytes: options.maxDraftTextBytes ?? DEFAULT_MAX_DRAFT_TEXT_BYTES,
@@ -117,7 +128,12 @@ export class WebUIServer {
 		this.sentImages = new SentImageStore(sentImageSettings);
 		this.imageResidentBudget = Math.max(
 			sentImageSettings.maxBytes,
-			this.attachmentLimits.maxPromptBytes + this.attachmentLimits.maxImageBytes * 2,
+			this.attachmentLimits.maxPromptBytes +
+				Math.max(
+					this.attachmentLimits.maxImageBytes,
+					this.attachmentLimits.maxPreparedImageBytes ?? 0,
+				) *
+					2,
 		);
 		this.attachments = new AttachmentStore({
 			limits: this.attachmentLimits,
@@ -232,6 +248,7 @@ export class WebUIServer {
 					lease: this.leaseSnapshot(),
 					draft: this.draft.publicState(),
 					attachments: this.attachments.publicState(),
+					imageLimits: this.imageLimits,
 					sentImages: this.sentImages.publicState(),
 				});
 				return;
@@ -653,6 +670,7 @@ export class WebUIServer {
 		this.writeSse(client, "lease", this.leaseSnapshot());
 		this.writeSse(client, "draft", this.draft.publicState());
 		this.writeSse(client, "attachments", this.attachments.publicState());
+		this.writeSse(client, "image-limits", this.imageLimits);
 		this.writeSse(client, "sent-images", this.sentImages.publicState());
 		const replay = this.options.conversation.eventsAfter(since);
 		if (replay === undefined) {
@@ -690,7 +708,12 @@ export class WebUIServer {
 
 	private reconcileSentImageBytes(attachments = this.attachments.publicState()): void {
 		const processingReserve =
-			attachments.phase === "processing" ? this.attachmentLimits.maxImageBytes * 2 : 0;
+			attachments.phase === "processing"
+				? Math.max(
+						this.attachmentLimits.maxImageBytes,
+						this.attachmentLimits.maxPreparedImageBytes ?? 0,
+					) * 2
+				: 0;
 		const before = this.sentImages.publicState().revision;
 		const retained = this.sentImages.reconcile(
 			attachments.totalResidentBytes + processingReserve,

--- a/extensions/pi-webui/src/settings.ts
+++ b/extensions/pi-webui/src/settings.ts
@@ -9,12 +9,18 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	DEFAULT_IMAGE_LIMITS,
+	IMAGE_HARD_LIMITS,
+	type ImageLimits,
+	imageLimits,
+} from "./image-limits.js";
 
 export const SETTINGS_FILE = "pi-webui.json";
 
 const MIB = 1024 * 1024;
 
-export interface WebUISettings {
+export interface WebUISettings extends ImageLimits {
 	startOnSessionStart: boolean;
 	retainSentImages: boolean;
 	maxRetainedImages: number;
@@ -26,6 +32,7 @@ export const DEFAULT_SETTINGS: Readonly<WebUISettings> = Object.freeze({
 	retainSentImages: false,
 	maxRetainedImages: 32,
 	maxRetainedBytes: 128 * MIB,
+	...DEFAULT_IMAGE_LIMITS,
 });
 
 export const RETENTION_HARD_LIMITS = Object.freeze({
@@ -68,19 +75,26 @@ export function normalizeSettings(value: unknown): WebUISettings | undefined {
 	) {
 		return undefined;
 	}
-	for (const key of ["maxRetainedImages", "maxRetainedBytes"] as const) {
+	for (const [key, maximum] of [
+		["maxRetainedImages", RETENTION_HARD_LIMITS.maxRetainedImages],
+		["maxRetainedBytes", RETENTION_HARD_LIMITS.maxRetainedBytes],
+		["maxImages", IMAGE_HARD_LIMITS.maxImages],
+		["maxImageBytes", IMAGE_HARD_LIMITS.maxImageBytes],
+		["maxBatchBytes", IMAGE_HARD_LIMITS.maxBatchBytes],
+		["maxImagePixels", IMAGE_HARD_LIMITS.maxImagePixels],
+	] as const) {
 		if (!Object.hasOwn(value, key)) continue;
 		const candidate = value[key];
 		if (
 			typeof candidate !== "number" ||
 			!Number.isSafeInteger(candidate) ||
 			candidate <= 0 ||
-			candidate > RETENTION_HARD_LIMITS[key]
+			candidate > maximum
 		) {
 			return undefined;
 		}
 	}
-	return {
+	const normalized = {
 		startOnSessionStart:
 			typeof value.startOnSessionStart === "boolean"
 				? value.startOnSessionStart
@@ -97,7 +111,24 @@ export function normalizeSettings(value: unknown): WebUISettings | undefined {
 			typeof value.maxRetainedBytes === "number"
 				? value.maxRetainedBytes
 				: DEFAULT_SETTINGS.maxRetainedBytes,
+		...imageLimits({
+			maxImages: typeof value.maxImages === "number" ? value.maxImages : DEFAULT_SETTINGS.maxImages,
+			maxImageBytes:
+				typeof value.maxImageBytes === "number"
+					? value.maxImageBytes
+					: DEFAULT_SETTINGS.maxImageBytes,
+			maxBatchBytes:
+				typeof value.maxBatchBytes === "number"
+					? value.maxBatchBytes
+					: DEFAULT_SETTINGS.maxBatchBytes,
+			maxImagePixels:
+				typeof value.maxImagePixels === "number"
+					? value.maxImagePixels
+					: DEFAULT_SETTINGS.maxImagePixels,
+		}),
 	};
+	if (normalized.maxImageBytes > normalized.maxBatchBytes) return undefined;
+	return normalized;
 }
 
 export async function loadSettings(path = settingsFilePath()): Promise<SettingsLoadResult> {
@@ -125,7 +156,15 @@ export async function loadSettings(path = settingsFilePath()): Promise<SettingsL
 		if (!isRecord(document)) return invalid(path, "the top level must be a JSON object");
 		const settings = normalizeSettings(document);
 		if (!settings) return invalid(path, "recognized settings have an invalid type or limit");
-		return { kind: "loaded", path, settings, source: "settings file", document };
+		const warning = elevatedLimitWarning(settings);
+		return {
+			kind: "loaded",
+			path,
+			settings,
+			source: "settings file",
+			document,
+			...(warning ? { warning } : {}),
+		};
 	} catch (error) {
 		return invalid(path, formatError(error));
 	}
@@ -143,6 +182,10 @@ export async function saveSettings(
 		retainSentImages: settings.retainSentImages,
 		maxRetainedImages: settings.maxRetainedImages,
 		maxRetainedBytes: settings.maxRetainedBytes,
+		maxImages: settings.maxImages,
+		maxImageBytes: settings.maxImageBytes,
+		maxBatchBytes: settings.maxBatchBytes,
+		maxImagePixels: settings.maxImagePixels,
 	};
 	const directory = dirname(path);
 	await mkdir(directory, { recursive: true });
@@ -189,6 +232,14 @@ export async function initializeSettings(
 	} finally {
 		await unlink(temporaryPath).catch(() => undefined);
 	}
+}
+
+function elevatedLimitWarning(settings: WebUISettings): string | undefined {
+	const elevated = (Object.keys(DEFAULT_IMAGE_LIMITS) as Array<keyof ImageLimits>).filter(
+		(key) => settings[key] > DEFAULT_IMAGE_LIMITS[key],
+	);
+	if (elevated.length === 0) return undefined;
+	return `${SETTINGS_FILE} uses image limits above safe defaults: ${elevated.join(", ")}. Higher limits increase Pi-process memory and processing cost.`;
 }
 
 function invalid(path: string, reason: string): SettingsLoadResult {

--- a/extensions/pi-webui/src/web/app.js
+++ b/extensions/pi-webui/src/web/app.js
@@ -3,6 +3,7 @@ import {
 	applyAttachments,
 	applyConversationEvent,
 	applyDraft,
+	applyImageLimits,
 	applyLease,
 	applySentImages,
 	applySnapshot,
@@ -264,6 +265,10 @@ function connectEvents() {
 		model = applyAttachments(model, JSON.parse(event.data));
 		render();
 	});
+	events.addEventListener("image-limits", (event) => {
+		model = applyImageLimits(model, JSON.parse(event.data));
+		renderComposer();
+	});
 	events.addEventListener("sent-images", (event) => {
 		model = applySentImages(model, JSON.parse(event.data));
 		render({ updateKey: "sent-images" });
@@ -354,8 +359,14 @@ async function addFiles(fileList) {
 	if (composerLocked() || model.readingImages > 0) return;
 	const files = [...(fileList ?? [])];
 	if (files.length === 0) return;
-	if (model.images.length + files.length > 8) {
-		model = { ...model, error: "You can attach at most 8 images." };
+	const limits = model.imageLimits;
+	if (!limits) {
+		model = { ...model, error: "Effective image limits are still loading." };
+		render();
+		return;
+	}
+	if (model.images.length + files.length > limits.maxImages) {
+		model = { ...model, error: `You can attach at most ${limits.maxImages} images.` };
 		render();
 		return;
 	}
@@ -365,11 +376,25 @@ async function addFiles(fileList) {
 			render();
 			return;
 		}
-		if (file.size > 10 * 1024 * 1024) {
-			model = { ...model, error: `${file.name || "Image"} is larger than 10 MB.` };
+		if (file.size > limits.maxImageBytes) {
+			model = {
+				...model,
+				error: `${file.name || "Image"} is larger than ${formatMib(limits.maxImageBytes)}.`,
+			};
 			render();
 			return;
 		}
+	}
+	const batchBytes =
+		model.images.reduce((total, image) => total + (image.size ?? 0), 0) +
+		files.reduce((total, file) => total + file.size, 0);
+	if (batchBytes > limits.maxBatchBytes) {
+		model = {
+			...model,
+			error: `Combined image input is larger than ${formatMib(limits.maxBatchBytes)}.`,
+		};
+		render();
+		return;
 	}
 	const pending = files.map((file) => ({ id: crypto.randomUUID(), file }));
 	try {
@@ -932,6 +957,10 @@ async function responseError(response) {
 	} catch {
 		return `${response.status} ${response.statusText}`;
 	}
+}
+
+function formatMib(bytes) {
+	return `${bytes / (1024 * 1024)} MiB`;
 }
 
 function errorMessage(error) {

--- a/extensions/pi-webui/src/web/state.js
+++ b/extensions/pi-webui/src/web/state.js
@@ -18,6 +18,7 @@ export function initialState() {
 		textDirty: false,
 		attachmentRevision: 0,
 		attachmentPhase: "empty",
+		imageLimits: undefined,
 		sentImages: {
 			revision: 0,
 			enabled: false,
@@ -49,7 +50,10 @@ export function applySnapshot(current, snapshot) {
 		};
 	}
 	return applySentImages(
-		applyAttachments(applyDraft(next, snapshot?.draft), snapshot?.attachments),
+		applyImageLimits(
+			applyAttachments(applyDraft(next, snapshot?.draft), snapshot?.attachments),
+			snapshot?.imageLimits,
+		),
 		snapshot?.sentImages,
 	);
 }
@@ -86,6 +90,26 @@ export function acknowledgeDraftText(current, draft, submittedText) {
 		return applyDraft({ ...current, textDirty: false }, draft);
 	}
 	return applyDraft(current, draft);
+}
+
+export function applyImageLimits(current, limits) {
+	if (
+		!limits ||
+		!["maxImages", "maxImageBytes", "maxBatchBytes", "maxImagePixels"].every(
+			(key) => Number.isSafeInteger(limits[key]) && limits[key] > 0,
+		)
+	) {
+		return current;
+	}
+	return {
+		...current,
+		imageLimits: {
+			maxImages: limits.maxImages,
+			maxImageBytes: limits.maxImageBytes,
+			maxBatchBytes: limits.maxBatchBytes,
+			maxImagePixels: limits.maxImagePixels,
+		},
+	};
 }
 
 export function applySentImages(current, sentImages) {

--- a/extensions/pi-webui/test/attachments.test.ts
+++ b/extensions/pi-webui/test/attachments.test.ts
@@ -6,6 +6,7 @@ const limits = {
 	maxImages: 3,
 	maxImageBytes: 8,
 	maxPromptBytes: 16,
+	maxPreparedImageBytes: 16,
 };
 
 function prepared(source: Uint8Array, marker = Buffer.from(source).toString()): PreparedAttachment {
@@ -201,6 +202,27 @@ test("reorder, delete, and clear require exact revisions and release every byte"
 	store.clear(store.publicState().revision);
 	assert.equal(store.publicState().phase, "empty");
 	assert.equal(store.residentBytes(), 0);
+});
+
+test("source-byte and fixed provider-ready per-image limits stay distinct", () => {
+	const store = new AttachmentStore({
+		limits: {
+			maxImages: 2,
+			maxImageBytes: 3,
+			maxPromptBytes: 10,
+			maxPreparedImageBytes: 6,
+		},
+		process: async (source) => prepared(source),
+	});
+	assert.throws(
+		() => store.reserve([{ id: "source", name: "source.png", size: 4 }], 0),
+		/per-image maximum/i,
+	);
+	const state = store.attachPrepared(
+		[{ id: "ready", name: "ready.png", prepared: prepared(Buffer.from("x"), "") }],
+		0,
+	);
+	assert.equal(state.items[0]?.status, "ready");
 });
 
 test("reattaching prepared images is atomic, ordered, bounded, and rejects draft duplicates", async () => {

--- a/extensions/pi-webui/test/commands.test.ts
+++ b/extensions/pi-webui/test/commands.test.ts
@@ -73,12 +73,18 @@ test("webui command completes and routes settings, status, help, and invalid arg
 	await command.handler("status", context.ctx);
 	const status = context.notifications.at(-1)?.message ?? "";
 	assert.match(status, /startOnSessionStart: false.*defaults/is);
+	assert.match(
+		status,
+		/Image limits \(defaults\): 8 images, 10 MiB\/image, 40 MiB\/batch, 50,000,000 pixels\/image/,
+	);
 	assert.match(status, /server: stopped/i);
 	assert.doesNotMatch(status, /token=/i);
 	await command.handler("help", context.ctx);
 	const help = context.notifications.at(-1)?.message ?? "";
 	assert.match(help, /\/webui \[settings\|status\|help\|init\]/i);
 	assert.match(help, /"startOnSessionStart": false/);
+	assert.match(help, /maxImages.*maxImageBytes.*maxBatchBytes.*maxImagePixels/i);
+	assert.match(help, /provider-ready dimension\/Base64 limits are fixed/i);
 	assert.doesNotMatch(help, /token=/i);
 	await command.handler("unknown", context.ctx);
 	assert.match(context.notifications.at(-1)?.message ?? "", /usage:/i);
@@ -160,6 +166,10 @@ test("settings changes save in action order and update effective status", async 
 		mode: "tui",
 		custom: async (factory: unknown) => {
 			const selector = createCustomSelectorHarness(factory);
+			assert.doesNotMatch(
+				selector.render().join("\n"),
+				/maxImages|maxImageBytes|maxBatchBytes|maxImagePixels/,
+			);
 			selector.handleInput("\r");
 			selector.handleInput("\r");
 			await waitFor(() => requested.length === 1);

--- a/extensions/pi-webui/test/images.test.ts
+++ b/extensions/pi-webui/test/images.test.ts
@@ -7,6 +7,7 @@ import {
 	DEFAULT_IMAGE_LIMITS,
 	detectImageFormat,
 	ImageProcessor,
+	PROVIDER_IMAGE_LIMITS,
 	processBrowserImages,
 } from "../src/images.js";
 
@@ -73,8 +74,10 @@ test("image defaults stay bounded", () => {
 	assert.deepEqual(DEFAULT_IMAGE_LIMITS, {
 		maxImages: 8,
 		maxImageBytes: 10 * 1024 * 1024,
-		maxPromptBytes: 40 * 1024 * 1024,
-		maxPixels: 50_000_000,
+		maxBatchBytes: 40 * 1024 * 1024,
+		maxImagePixels: 50_000_000,
+	});
+	assert.deepEqual(PROVIDER_IMAGE_LIMITS, {
 		maxDimension: 2_000,
 		maxBase64Bytes: 4_500_000,
 	});

--- a/extensions/pi-webui/test/lifecycle.test.ts
+++ b/extensions/pi-webui/test/lifecycle.test.ts
@@ -277,6 +277,65 @@ test("invalid settings warn and automatic startup failures remain non-fatal", as
 	assert.match(failing.notifications.join("\n"), /could not start.*listener unavailable/i);
 });
 
+test("one immutable effective image-limit object reaches server, processing, and send preflight", async () => {
+	let processOptions: Record<string, unknown> | undefined;
+	const effective = {
+		...DEFAULT_SETTINGS,
+		maxImages: 1,
+		maxImageBytes: 12,
+		maxBatchBytes: 20,
+		maxImagePixels: 34,
+	};
+	const h = harness({
+		loadSettings: async () => ({
+			kind: "loaded",
+			path: "/agent/pi-webui.json",
+			settings: effective,
+			source: "settings file",
+			document: effective,
+		}),
+		processAttachment: async (_source, options) => {
+			processOptions = options as Record<string, unknown>;
+			return {
+				bytes: Buffer.from("processed"),
+				mimeType: "image/png",
+				width: 1,
+				height: 1,
+				originalWidth: 1,
+				originalHeight: 1,
+				sourceFormat: "png",
+				outputFormat: "png",
+				resized: false,
+			};
+		},
+	});
+	await h.emit("session_start");
+	await h.commands.get("webui")?.handler("", h.ctx as never);
+	assert.deepEqual(h.serverOptions?.imageLimits, {
+		maxImages: 1,
+		maxImageBytes: 12,
+		maxBatchBytes: 20,
+		maxImagePixels: 34,
+	});
+	assert.equal(Object.isFrozen(h.serverOptions?.imageLimits), true);
+	await h.serverOptions?.processAttachment?.(Buffer.from("x"));
+	assert.equal(processOptions?.maxImageBytes, 12);
+	assert.equal(processOptions?.maxPixels, 34);
+	await assert.rejects(
+		() =>
+			h.serverOptions?.send({
+				requestId: "too-many",
+				text: "",
+				images: [
+					{ data: Buffer.from("a").toString("base64"), mimeType: "image/png" },
+					{ data: Buffer.from("b").toString("base64"), mimeType: "image/png" },
+				],
+				delivery: "next",
+			}) ?? Promise.reject(new Error("server missing")),
+		/maximum is 1/i,
+	);
+});
+
 test("Pi message, tool, and activity events update the browser projection", async () => {
 	const h = harness();
 	await h.emit("session_start");
@@ -618,6 +677,8 @@ test("browser images are staged under live Pi guards and sent without reprocessi
 	};
 	assert.equal(signal.aborted, false);
 	assert.deepEqual(guards, {
+		maxImageBytes: DEFAULT_SETTINGS.maxImageBytes,
+		maxPixels: DEFAULT_SETTINGS.maxImagePixels,
 		autoResize: true,
 		blockImages: false,
 		supportsImages: true,

--- a/extensions/pi-webui/test/server.test.ts
+++ b/extensions/pi-webui/test/server.test.ts
@@ -940,6 +940,81 @@ test("accepted sanitized images can be previewed, reattached atomically, forgott
 	}
 });
 
+test("effective image limits drive public state, admission, upload, and batch memory", async () => {
+	const conversation = new ConversationProjection({ id: "s", cwd: "/w", projectName: "w" });
+	const limits = {
+		maxImages: 1,
+		maxImageBytes: 3,
+		maxBatchBytes: 3,
+		maxImagePixels: 10,
+	};
+	const server = await WebUIServer.start({
+		conversation,
+		imageLimits: limits,
+		processAttachment: async (source) => preparedAttachment(Buffer.from(source).toString()),
+		send: async () => ({ delivery: "immediate" }),
+	});
+	try {
+		const cookie = await authenticate(server);
+		const client = await takeLease(server, cookie);
+		const state = (await (await api(server, "/api/state", { cookie })).json()) as {
+			imageLimits: typeof limits;
+		};
+		assert.deepEqual(state.imageLimits, limits);
+		assert.equal(
+			(
+				await api(server, "/api/attachments/reserve", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({
+						revision: 0,
+						items: [
+							{ id: "one", name: "one.png", size: 1 },
+							{ id: "two", name: "two.png", size: 1 },
+						],
+					}),
+				})
+			).status,
+			413,
+		);
+		assert.equal(
+			(
+				await api(server, "/api/attachments/reserve", {
+					method: "POST",
+					cookie,
+					client,
+					body: JSON.stringify({
+						revision: 0,
+						items: [{ id: "large", name: "large.png", size: 4 }],
+					}),
+				})
+			).status,
+			413,
+		);
+		let response = await api(server, "/api/attachments/reserve", {
+			method: "POST",
+			cookie,
+			client,
+			body: JSON.stringify({
+				revision: 0,
+				items: [{ id: "exact", name: "exact.png", size: 3 }],
+			}),
+		});
+		const reserved = (await response.json()) as { revision: number };
+		response = await api(server, `/api/attachments/exact/upload?revision=${reserved.revision}`, {
+			method: "POST",
+			cookie,
+			client,
+			contentType: "application/octet-stream",
+			body: Buffer.from("four"),
+		});
+		assert.equal(response.status, 413);
+	} finally {
+		await server.close();
+	}
+});
+
 test("empty SSE streams flush immediately and remain available for later events", async () => {
 	const { conversation, server } = await harness();
 	try {

--- a/extensions/pi-webui/test/settings.test.ts
+++ b/extensions/pi-webui/test/settings.test.ts
@@ -3,10 +3,12 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { DEFAULT_IMAGE_LIMITS, IMAGE_HARD_LIMITS } from "../src/image-limits.js";
 import {
 	DEFAULT_SETTINGS,
 	initializeSettings,
 	loadSettings,
+	normalizeSettings,
 	RETENTION_HARD_LIMITS,
 	saveSettings,
 } from "../src/settings.js";
@@ -24,6 +26,42 @@ test("sent-image retention uses conservative opt-in defaults and finite hard cei
 		maxRetainedImages: 128,
 		maxRetainedBytes: 512 * 1024 * 1024,
 	});
+});
+
+test("image limit normalization preserves defaults and accepts exact hard boundaries", () => {
+	assert.deepEqual(normalizeSettings({}), DEFAULT_SETTINGS);
+	assert.deepEqual(normalizeSettings(IMAGE_HARD_LIMITS), {
+		...DEFAULT_SETTINGS,
+		...IMAGE_HARD_LIMITS,
+	});
+	for (const key of Object.keys(DEFAULT_IMAGE_LIMITS)) {
+		assert.equal(normalizeSettings({ [key]: 1.5 }), undefined);
+		assert.equal(normalizeSettings({ [key]: 0 }), undefined);
+		assert.equal(
+			normalizeSettings({ [key]: IMAGE_HARD_LIMITS[key as keyof typeof IMAGE_HARD_LIMITS] + 1 }),
+			undefined,
+		);
+	}
+	assert.equal(normalizeSettings({ maxImageBytes: 20, maxBatchBytes: 10 }), undefined);
+});
+
+test("loaded limits above defaults warn while omitted values and unknown fields remain safe", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-webui-settings-"));
+	const settingsPath = path.join(directory, "pi-webui.json");
+	try {
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ maxImages: DEFAULT_IMAGE_LIMITS.maxImages + 1, future: "kept" }),
+		);
+		const loaded = await loadSettings(settingsPath);
+		assert.equal(loaded.kind, "loaded");
+		assert.equal(loaded.settings.maxImages, 9);
+		assert.equal(loaded.settings.maxImageBytes, DEFAULT_IMAGE_LIMITS.maxImageBytes);
+		assert.match(loaded.warning ?? "", /above safe defaults.*maxImages/i);
+		assert.deepEqual(loaded.document, { maxImages: 9, future: "kept" });
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
 });
 
 test("settings loading distinguishes missing, valid, malformed, and invalid files", async () => {
@@ -76,6 +114,10 @@ test("saving is atomic and preserves unknown fields", async () => {
 			retainSentImages: false,
 			maxRetainedImages: 32,
 			maxRetainedBytes: 128 * 1024 * 1024,
+			maxImages: 8,
+			maxImageBytes: 10 * 1024 * 1024,
+			maxBatchBytes: 40 * 1024 * 1024,
+			maxImagePixels: 50_000_000,
 		});
 	} finally {
 		await rm(directory, { recursive: true, force: true });

--- a/extensions/pi-webui/test/web-state.test.ts
+++ b/extensions/pi-webui/test/web-state.test.ts
@@ -16,6 +16,7 @@ const state = (await import(
 		submittedText: string,
 	): WebState;
 	applyAttachments(current: WebState, attachments: Record<string, unknown>): WebState;
+	applyImageLimits(current: WebState, limits: Record<string, unknown>): WebState;
 	applySentImages(current: WebState, sentImages: Record<string, unknown>): WebState;
 	applyConversationEvent(current: WebState, event: ConversationEvent): WebState;
 	applyLease(
@@ -74,6 +75,12 @@ interface WebState {
 	textDirty: boolean;
 	attachmentRevision: number;
 	attachmentPhase: string;
+	imageLimits?: {
+		maxImages: number;
+		maxImageBytes: number;
+		maxBatchBytes: number;
+		maxImagePixels: number;
+	};
 	sentImages: {
 		revision: number;
 		enabled: boolean;
@@ -202,6 +209,21 @@ test("server attachment revisions replace browser images and ignore stale update
 	});
 	assert.equal(processing.readingImages, 1);
 	assert.equal(state.canSend({ ...processing, connected: true, text: "send" }), false);
+});
+
+test("effective image limits hydrate atomically from server state", () => {
+	const initial = state.initialState();
+	const limits = {
+		maxImages: 12,
+		maxImageBytes: 20,
+		maxBatchBytes: 40,
+		maxImagePixels: 60,
+	};
+	const applied = state.applyImageLimits(initial, limits);
+	assert.deepEqual(applied.imageLimits, limits);
+	limits.maxImages = 99;
+	assert.equal(applied.imageLimits?.maxImages, 12);
+	assert.equal(state.applyImageLimits(applied, { ...limits, maxImageBytes: 0 }), applied);
 });
 
 test("sent-image snapshots are immutable and ignore stale eviction state", () => {

--- a/extensions/pi-webui/test/web-ui-contract.test.ts
+++ b/extensions/pi-webui/test/web-ui-contract.test.ts
@@ -72,6 +72,13 @@ test("image input stages authenticated per-item uploads with visible status and 
 	assert.match(html, /id="image-previews"[^>]*aria-label="Attached images"/);
 	assert.match(app, /addEventListener\("paste"/);
 	assert.match(app, /\/api\/attachments\/reserve/);
+	assert.match(app, /model\.imageLimits/);
+	assert.match(app, /limits\.maxImages/);
+	assert.match(app, /limits\.maxImageBytes/);
+	assert.match(app, /limits\.maxBatchBytes/);
+	assert.match(app, /events\.addEventListener\("image-limits"/);
+	assert.doesNotMatch(app, /images\.length \+ files\.length > 8/);
+	assert.doesNotMatch(app, /file\.size > 10 \* 1024 \* 1024/);
 	assert.match(app, /new XMLHttpRequest\(\)/);
 	assert.match(app, /request\.upload\.addEventListener\("progress"/);
 	assert.match(app, /X-Pi-Web-Client/);


### PR DESCRIPTION
## Summary
- add optional count, source-byte, batch-byte, and pixel settings with safe defaults and hard ceilings
- thread one immutable effective limits object through browser admission, server upload, processing, memory accounting, send preflight, and reattach
- keep advanced controls in JSON, add elevated-limit warnings/status output, and document fixed provider constraints

## Verification
- `npm run check` (793 tests)
- `git diff --check`
- `just pack webui`
- Chrome smoke with custom 2 image / 1 MiB per-image / 1 MiB batch limits