### PR TITLE
fix(webui): improve image drag ordering

### DIFF
--- a/extensions/pi-webui/src/server.ts
+++ b/extensions/pi-webui/src/server.ts
@@ -233,7 +233,9 @@ export class WebUIServer {
 			}
 			if (
 				request.method === "GET" &&
-				["/app.js", "/state.js", "/markdown.js", "/transcript.js"].includes(url.pathname)
+				["/app.js", "/state.js", "/markdown.js", "/transcript.js", "/image-drag.js"].includes(
+					url.pathname,
+				)
 			) {
 				await this.asset(response, url.pathname.slice(1), "text/javascript; charset=utf-8");
 				return;

--- a/extensions/pi-webui/src/web/app.js
+++ b/extensions/pi-webui/src/web/app.js
@@ -1,3 +1,4 @@
+import { createImageDragController } from "./image-drag.js";
 import {
 	acknowledgeDraftText,
 	applyAttachments,
@@ -17,6 +18,7 @@ import {
 	initialState,
 	invalidateSendAttempt,
 	moveImage,
+	moveImageAfter,
 	moveImageBefore,
 	noteUnseenUpdate,
 	prepareSend,
@@ -87,6 +89,16 @@ const ui = {
 	previewClose: document.querySelector("#image-preview-close"),
 	previewDismiss: document.querySelector("#image-preview-dismiss"),
 };
+
+const imageDrag = createImageDragController(ui.previews, {
+	isLocked: composerLocked,
+	onDrop: ({ sourceId, targetId, after }) => {
+		const images = after
+			? moveImageAfter(model.images, sourceId, targetId)
+			: moveImageBefore(model.images, sourceId, targetId);
+		void reorderImages(images, sourceId);
+	},
+});
 
 const transcriptRenderer = createTranscriptRenderer({
 	documentRef: document,
@@ -311,7 +323,7 @@ function connectionFailure(error) {
 }
 
 async function send(steer) {
-	if (!canSend(model)) return;
+	if (composerLocked() || !canSend(model)) return;
 	try {
 		await flushDraftText();
 	} catch (error) {
@@ -319,7 +331,7 @@ async function send(steer) {
 		render();
 		return;
 	}
-	if (!canSend(model) || model.textDirty) return;
+	if (composerLocked() || !canSend(model) || model.textDirty) return;
 	const prepared = prepareSend(model, crypto.randomUUID(), steer ? "steer" : "next");
 	const attempt = prepared.attempt;
 	model = prepared.state;
@@ -613,22 +625,38 @@ async function clearAttachments() {
 
 async function reorderImages(images, focusId) {
 	if (composerLocked()) return;
-	const state = await mutateAttachmentState("/api/attachments/reorder", {
-		method: "POST",
-		body: JSON.stringify({
-			revision: model.attachmentRevision,
-			ids: images.map((image) => image.id),
-		}),
-	});
-	if (state) focusImageItem(focusId);
-}
-
-function focusImageItem(id) {
-	requestAnimationFrame(() => {
-		const escapedId = CSS.escape(id);
-		const item = ui.previews.querySelector(`[data-image-id="${escapedId}"]`);
-		(item?.tabIndex === 0 ? item : item?.querySelector(".remove-image"))?.focus();
-	});
+	if (images.every((image, index) => image.id === model.images[index]?.id)) {
+		imageDrag.focus(focusId);
+		return;
+	}
+	const previousImages = model.images;
+	const previousRevision = model.attachmentRevision;
+	model = { ...model, images };
+	mutatingAttachments = true;
+	renderComposer();
+	imageDrag.focus(focusId);
+	ui.previews.setAttribute("aria-busy", "true");
+	try {
+		const state = await attachmentMutation("/api/attachments/reorder", {
+			method: "POST",
+			body: JSON.stringify({
+				revision: previousRevision,
+				ids: images.map((image) => image.id),
+			}),
+		});
+		model = applyAttachments(model, state);
+		model = { ...model, error: "" };
+	} catch (error) {
+		if (model.attachmentRevision === previousRevision) {
+			model = { ...model, images: previousImages };
+		}
+		model = { ...model, error: errorMessage(error) };
+	} finally {
+		mutatingAttachments = false;
+		ui.previews.removeAttribute("aria-busy");
+		render();
+		imageDrag.focus(focusId);
+	}
 }
 
 async function removeImage(id) {
@@ -727,9 +755,9 @@ function renderComposer() {
 	const locked = composerLocked();
 	ui.composer.classList.toggle("locked", locked);
 	ui.send.textContent = busyLabel(model);
-	ui.send.disabled = !canSend(model);
+	ui.send.disabled = locked || !canSend(model);
 	ui.steer.hidden = model.activity !== "running";
-	ui.steer.disabled = !canSend(model);
+	ui.steer.disabled = locked || !canSend(model);
 	ui.input.disabled = model.closed || model.stale;
 	const admissionLocked = locked || model.readingImages > 0;
 	ui.imageInput.disabled = admissionLocked;
@@ -759,8 +787,9 @@ function renderComposer() {
 		item.dataset.imageId = image.id;
 		const retryable = image.status === "error" && (image.retryable || retryFiles.has(image.id));
 		const orderingLocked = locked || model.attachmentPhase !== "ready";
+		const reorderable = model.images.length > 1 && image.status === "ready";
 		item.draggable = model.images.length > 1 && image.status === "ready" && !orderingLocked;
-		if (item.draggable) {
+		if (reorderable) {
 			item.tabIndex = 0;
 			item.setAttribute(
 				"aria-label",
@@ -771,6 +800,7 @@ function renderComposer() {
 		item.addEventListener("keydown", (event) => {
 			if (
 				event.target !== item ||
+				composerLocked() ||
 				orderingLocked ||
 				!event.altKey ||
 				event.ctrlKey ||
@@ -783,31 +813,7 @@ function renderComposer() {
 			event.preventDefault();
 			void reorderImages(moveImage(model.images, image.id, direction), image.id);
 		});
-		item.addEventListener("dragstart", (event) => {
-			if (orderingLocked || !event.dataTransfer) return;
-			event.dataTransfer.effectAllowed = "move";
-			event.dataTransfer.setData("application/x-pi-webui-image", image.id);
-			item.classList.add("dragging");
-		});
-		item.addEventListener("dragend", () => {
-			item.classList.remove("dragging");
-			for (const candidate of ui.previews.children) candidate.classList.remove("drag-target");
-		});
-		item.addEventListener("dragover", (event) => {
-			const draggedId = event.dataTransfer?.getData("application/x-pi-webui-image");
-			if (orderingLocked || !draggedId || draggedId === image.id) return;
-			event.preventDefault();
-			item.classList.add("drag-target");
-		});
-		item.addEventListener("dragleave", () => item.classList.remove("drag-target"));
-		item.addEventListener("drop", (event) => {
-			const draggedId = event.dataTransfer?.getData("application/x-pi-webui-image");
-			item.classList.remove("drag-target");
-			if (orderingLocked || !draggedId || draggedId === image.id) return;
-			event.preventDefault();
-			event.stopPropagation();
-			void reorderImages(moveImageBefore(model.images, draggedId, image.id), draggedId);
-		});
+		imageDrag.bind(item, { id: image.id, orderingLocked });
 		const previewButton = document.createElement("button");
 		previewButton.type = "button";
 		previewButton.className = "attachment-preview";
@@ -819,6 +825,7 @@ function renderComposer() {
 			preview.src = `/api/attachments/${encodeURIComponent(image.id)}/preview?v=${model.attachmentRevision}`;
 		}
 		preview.alt = "";
+		preview.draggable = false;
 		previewButton.append(preview);
 		const details = document.createElement("span");
 		details.className = "attachment-details";

--- a/extensions/pi-webui/src/web/image-drag.js
+++ b/extensions/pi-webui/src/web/image-drag.js
@@ -1,0 +1,86 @@
+const IMAGE_DRAG_TYPE = "application/x-pi-webui-image";
+
+export function createImageDragController(previews, { isLocked, onDrop }) {
+	let draggedId = "";
+
+	function clearDropTargets() {
+		previews.classList.remove("vertical-drop");
+		for (const candidate of previews.children) {
+			candidate.classList.remove("drag-before", "drag-after");
+		}
+	}
+
+	function setDropTarget(item, after, vertical) {
+		previews.classList.toggle("vertical-drop", vertical);
+		for (const candidate of previews.children) {
+			candidate.classList.toggle("drag-before", candidate === item && !after);
+			candidate.classList.toggle("drag-after", candidate === item && after);
+		}
+	}
+
+	function focus(id) {
+		requestAnimationFrame(() => {
+			const escapedId = CSS.escape(id);
+			const item = previews.querySelector(`[data-image-id="${escapedId}"]`);
+			(item?.tabIndex === 0 ? item : item?.querySelector(".remove-image"))?.focus();
+		});
+	}
+
+	function bind(item, { id, orderingLocked }) {
+		item.addEventListener("dragstart", (event) => {
+			if (isLocked() || orderingLocked || !event.dataTransfer) return;
+			draggedId = id;
+			event.dataTransfer.effectAllowed = "move";
+			event.dataTransfer.setData(IMAGE_DRAG_TYPE, id);
+			item.classList.add("dragging");
+		});
+		item.addEventListener("dragend", () => {
+			draggedId = "";
+			item.classList.remove("dragging");
+			clearDropTargets();
+		});
+		item.addEventListener("dragover", (event) => {
+			const sourceId = draggedId || event.dataTransfer?.getData(IMAGE_DRAG_TYPE);
+			if (isLocked() || orderingLocked || !sourceId) return;
+			if (sourceId === id) {
+				clearDropTargets();
+				return;
+			}
+			event.preventDefault();
+			if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+			const vertical = imagesStackVertically(previews.children);
+			setDropTarget(item, dropAfterTarget(event, item, vertical), vertical);
+		});
+		item.addEventListener("dragleave", (event) => {
+			if (event.relatedTarget && item.contains(event.relatedTarget)) return;
+			item.classList.remove("drag-before", "drag-after");
+		});
+		item.addEventListener("drop", (event) => {
+			const sourceId = draggedId || event.dataTransfer?.getData(IMAGE_DRAG_TYPE);
+			if (isLocked() || orderingLocked || !sourceId || sourceId === id) return;
+			event.preventDefault();
+			event.stopPropagation();
+			const vertical = imagesStackVertically(previews.children);
+			const after = dropAfterTarget(event, item, vertical);
+			draggedId = "";
+			clearDropTargets();
+			onDrop({ sourceId, targetId: id, after });
+		});
+	}
+
+	return { bind, clearDropTargets, focus };
+}
+
+export function imagesStackVertically(items) {
+	const list = [...items];
+	return !list.some((item, index) =>
+		list.slice(index + 1).some((candidate) => Math.abs(item.offsetTop - candidate.offsetTop) < 2),
+	);
+}
+
+export function dropAfterTarget(event, item, vertical) {
+	const bounds = item.getBoundingClientRect();
+	return vertical
+		? event.clientY >= bounds.top + bounds.height / 2
+		: event.clientX >= bounds.left + bounds.width / 2;
+}

--- a/extensions/pi-webui/src/web/state.js
+++ b/extensions/pi-webui/src/web/state.js
@@ -289,6 +289,18 @@ export function moveImageBefore(images, id, targetId) {
 	return next;
 }
 
+export function moveImageAfter(images, id, targetId) {
+	if (id === targetId) return [...images];
+	const from = images.findIndex((image) => image.id === id);
+	const target = images.findIndex((image) => image.id === targetId);
+	if (from === -1 || target === -1) return [...images];
+	const next = images.filter((image) => image.id !== id);
+	const targetIndex = next.findIndex((image) => image.id === targetId);
+	if (targetIndex === -1) return [...images];
+	next.splice(targetIndex + 1, 0, images[from]);
+	return next;
+}
+
 export function upsertById(items, value) {
 	const index = items.findIndex((item) => item.id === value.id);
 	if (index < 0) return [...items, value];

--- a/extensions/pi-webui/src/web/styles.css
+++ b/extensions/pi-webui/src/web/styles.css
@@ -551,6 +551,10 @@ textarea:disabled {
 	border: 1px solid var(--border);
 	border-radius: 10px;
 	background: var(--surface-secondary);
+	transition:
+		border-color 0.12s ease,
+		box-shadow 0.12s ease,
+		transform 0.12s ease;
 }
 
 .image-preview-item[draggable="true"] {
@@ -562,12 +566,26 @@ textarea:disabled {
 }
 
 .image-preview-item.dragging {
-	opacity: 0.55;
+	opacity: 0.5;
+	transform: scale(0.985);
 }
 
-.image-preview-item.drag-target {
+.image-preview-item.drag-before {
 	border-color: var(--accent);
-	box-shadow: 0 0 0 2px var(--accent-soft);
+	box-shadow: inset 3px 0 var(--accent);
+}
+
+.image-preview-item.drag-after {
+	border-color: var(--accent);
+	box-shadow: inset -3px 0 var(--accent);
+}
+
+.image-previews.vertical-drop .image-preview-item.drag-before {
+	box-shadow: inset 0 3px var(--accent);
+}
+
+.image-previews.vertical-drop .image-preview-item.drag-after {
+	box-shadow: inset 0 -3px var(--accent);
 }
 
 .attachment-details {

--- a/extensions/pi-webui/test/image-drag.test.ts
+++ b/extensions/pi-webui/test/image-drag.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+const drag = (await import(
+	`${pathToFileURL(path.join(process.cwd(), "extensions/pi-webui/src/web/image-drag.js")).href}?t=${Date.now()}`
+)) as {
+	dropAfterTarget(
+		event: { clientX: number; clientY: number },
+		item: { getBoundingClientRect(): { left: number; top: number; width: number; height: number } },
+		vertical: boolean,
+	): boolean;
+	imagesStackVertically(items: Array<{ offsetTop: number }>): boolean;
+};
+
+const item = {
+	getBoundingClientRect: () => ({ left: 20, top: 40, width: 200, height: 80 }),
+};
+
+test("drop placement follows the pointer half on the active layout axis", () => {
+	assert.equal(drag.dropAfterTarget({ clientX: 119, clientY: 79 }, item, false), false);
+	assert.equal(drag.dropAfterTarget({ clientX: 120, clientY: 79 }, item, false), true);
+	assert.equal(drag.dropAfterTarget({ clientX: 119, clientY: 79 }, item, true), false);
+	assert.equal(drag.dropAfterTarget({ clientX: 119, clientY: 80 }, item, true), true);
+});
+
+test("drop feedback uses vertical placement only when every card occupies its own row", () => {
+	assert.equal(drag.imagesStackVertically([{ offsetTop: 0 }, { offsetTop: 0 }]), false);
+	assert.equal(drag.imagesStackVertically([{ offsetTop: 0 }, { offsetTop: 90 }]), true);
+	assert.equal(
+		drag.imagesStackVertically([{ offsetTop: 0 }, { offsetTop: 90 }, { offsetTop: 91 }]),
+		false,
+	);
+});

--- a/extensions/pi-webui/test/server.test.ts
+++ b/extensions/pi-webui/test/server.test.ts
@@ -103,7 +103,7 @@ test("assets and APIs require auth and carry restrictive headers", async () => {
 		assert.match(page.headers.get("content-security-policy") ?? "", /default-src 'self'/);
 		assert.equal(page.headers.get("access-control-allow-origin"), null);
 		assert.match(await page.text(), /id="composer"/);
-		for (const module of ["app.js", "state.js", "markdown.js", "transcript.js"]) {
+		for (const module of ["app.js", "state.js", "markdown.js", "transcript.js", "image-drag.js"]) {
 			const asset = await api(server, `/${module}`, { cookie });
 			assert.equal(asset.status, 200, module);
 			assert.match(asset.headers.get("content-type") ?? "", /javascript/, module);

--- a/extensions/pi-webui/test/web-state.test.ts
+++ b/extensions/pi-webui/test/web-state.test.ts
@@ -42,6 +42,7 @@ const state = (await import(
 	followLatest(current: WebState): WebState;
 	moveImage(images: WebImage[], id: string, direction: number): WebImage[];
 	moveImageBefore(images: WebImage[], id: string, targetId: string): WebImage[];
+	moveImageAfter(images: WebImage[], id: string, targetId: string): WebImage[];
 	clearDraftImages(current: WebState): WebState;
 	canSend(current: WebState): boolean;
 	busyLabel(current: WebState): string;
@@ -446,8 +447,18 @@ test("image ordering helpers are immutable and bounded", () => {
 		state.moveImageBefore(images, "three", "one").map((image) => image.id),
 		["three", "one", "two"],
 	);
+	assert.deepEqual(
+		state.moveImageAfter(images, "one", "three").map((image) => image.id),
+		["two", "three", "one"],
+	);
+	assert.deepEqual(
+		state.moveImageAfter(images, "one", "two").map((image) => image.id),
+		["two", "one", "three"],
+	);
 	assert.deepEqual(state.moveImageBefore(images, "one", "one"), images);
 	assert.deepEqual(state.moveImageBefore(images, "missing", "one"), images);
+	assert.deepEqual(state.moveImageAfter(images, "one", "one"), images);
+	assert.deepEqual(state.moveImageAfter(images, "missing", "one"), images);
 	assert.deepEqual(
 		images.map((image) => image.id),
 		["one", "two", "three"],

--- a/extensions/pi-webui/test/web-ui-contract.test.ts
+++ b/extensions/pi-webui/test/web-ui-contract.test.ts
@@ -4,12 +4,13 @@ import path from "node:path";
 import test from "node:test";
 
 const root = path.join(process.cwd(), "extensions/pi-webui/src/web");
-const [html, app, styles, transcript, markdown] = await Promise.all([
+const [html, app, styles, transcript, markdown, imageDrag] = await Promise.all([
 	readFile(path.join(root, "index.html"), "utf8"),
 	readFile(path.join(root, "app.js"), "utf8"),
 	readFile(path.join(root, "styles.css"), "utf8"),
 	readFile(path.join(root, "transcript.js"), "utf8"),
 	readFile(path.join(root, "markdown.js"), "utf8"),
+	readFile(path.join(root, "image-drag.js"), "utf8"),
 ]);
 
 test("page hierarchy keeps session context, transcript, and composer in reading order", () => {
@@ -105,18 +106,20 @@ test("image input stages authenticated per-item uploads with visible status and 
 	assert.match(app, /previewReturnFocus.*focus/s);
 	assert.match(app, /drag-active/);
 	assert.match(app, /moveImageBefore/);
+	assert.match(app, /moveImageAfter/);
 	assert.match(app, /moveImage/);
 	assert.match(
 		app,
 		/item\.draggable =\s*model\.images\.length > 1 && image\.status === "ready" && !orderingLocked/,
 	);
-	assert.match(app, /addEventListener\("dragstart"/);
+	assert.match(imageDrag, /addEventListener\("dragstart"/);
 	assert.match(app, /addEventListener\("keydown"/);
 	assert.match(app, /aria-keyshortcuts/);
 	assert.match(app, /attachment-order-context/);
 	assert.match(app, /Order \$\{index \+ 1\} of \$\{model\.images\.length\}/);
 	assert.doesNotMatch(app, /Move image earlier|Move image later|data-order-action/);
-	assert.match(app, /focusImageItem/);
+	assert.match(app, /imageDrag\.focus/);
+	assert.match(imageDrag, /function focus\(id\)/);
 	assert.match(html, /id="clear-attachments"[^>]*hidden/);
 	assert.match(html, /id="clear-attachments-dialog"/);
 	assert.match(html, /id="confirm-clear-attachments"/);
@@ -125,6 +128,20 @@ test("image input stages authenticated per-item uploads with visible status and 
 	assert.match(app, /retryFiles\.delete/);
 	assert.match(app, /clearDialog\.showModal/);
 	assert.match(app, /returnValue !== "confirm"/);
+});
+
+test("drag ordering gives directional feedback and updates before the request settles", () => {
+	assert.match(app, /createImageDragController/);
+	assert.match(imageDrag, /dropAfterTarget/);
+	assert.match(imageDrag, /setDropTarget/);
+	assert.match(imageDrag, /clearDropTargets/);
+	assert.match(imageDrag, /imagesStackVertically/);
+	assert.match(app, /model = \{ \.\.\.model, images \}/);
+	assert.match(app, /preview\.draggable = false/);
+	assert.match(styles, /\.image-preview-item\.drag-before/);
+	assert.match(styles, /\.image-preview-item\.drag-after/);
+	assert.match(styles, /\.image-previews\.vertical-drop/);
+	assert.doesNotMatch(styles, /\.image-preview-item\.drag-target/);
 });
 
 test("sent-image actions stay contextual, authenticated, and distinguish expiration", () => {


### PR DESCRIPTION
## Summary

- show a directional insertion line and choose before/after placement from the pointer position
- adapt insertion feedback to horizontal card rows and vertically stacked narrow layouts
- update the card order immediately on drop, then reconcile with the server and roll back safely on failure
- prevent native thumbnail dragging, preserve keyboard focus, and block overlapping composer mutations
- isolate drag behavior in a tested browser module served and packed with WebUI

## Verification

- `npm run check` (802 tests passed)
- `git diff --check`
- `just pack-webui`
- headless Chrome drag smoke verified the after-target marker and drop payload