### PR TITLE
fix(lsp): handle unavailable default servers gracefully

### DIFF
--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -36,7 +36,7 @@ pi -e ./extensions/pi-lsp
 
 ## ⚙️ Configuration
 
-If no config is provided, pi-lsp ships a broad catalog of direct-command defaults. Servers are started only when matching files are requested. pi-lsp does not download language servers, so install the commands you need and make them available on `PATH`. During no-config diagnostics, unavailable default commands are filtered before workspace discovery; explicitly selected or custom-configured missing commands still report an error.
+If no config is provided, pi-lsp ships a broad catalog of direct-command defaults. Servers are started only when matching files are requested. pi-lsp does not download language servers, so install the commands you need and make them available on `PATH`. During no-config diagnostics, unavailable default commands are filtered before workspace discovery. If none can run, diagnostics completes successfully and reports the skipped servers. Explicitly selected or custom-configured missing commands still report an error.
 
 | Language or format | Default server | Startup command | Extensions |
 | --- | --- | --- | --- |

--- a/extensions/pi-lsp/src/routes.ts
+++ b/extensions/pi-lsp/src/routes.ts
@@ -50,14 +50,6 @@ export function selectDiagnosticRoutes(
 				return false;
 			});
 
-	if (runnableCandidates.length === 0 && skipped.length > 0) {
-		const names = skipped.map((route) => route.adapter.name).join(", ");
-		throw new Error(
-			`No available default LSP commands: ${names}. ` +
-				"Install a matching server command or explicitly select a configured server.",
-		);
-	}
-
 	const filesByPolicy = new Map<string, string[]>();
 	const routes = runnableCandidates
 		.map((adapter) => {
@@ -71,16 +63,8 @@ export function selectDiagnosticRoutes(
 		})
 		.filter((route) => route.files.length > 0);
 
-	if (routes.length === 0) {
+	if (routes.length === 0 && skipped.length === 0) {
 		const scope = params.paths?.length ? ` in requested paths: ${params.paths.join(", ")}` : "";
-		if (skipped.length > 0) {
-			const names = skipped.map((route) => route.adapter.name).join(", ");
-			throw new Error(
-				`No supported files found for available LSP commands${scope}. ` +
-					`Skipped unavailable default LSP commands: ${names}. ` +
-					"Install a matching server command or explicitly select a configured server.",
-			);
-		}
 		throw new Error(`No supported files found${scope}. ${SUPPORTED_SERVER_DESCRIPTION}`);
 	}
 
@@ -125,7 +109,13 @@ function filterAdapters(adapters: LspServerAdapter[], selected: string | string[
 	if (names.length === 0) throw new Error("LSP server parameter must not be blank.");
 	const matched = adapters.filter((adapter) => names.includes(adapter.name));
 	const missing = names.filter((name) => !adapters.some((adapter) => adapter.name === name));
-	if (missing.length) throw new Error(`Unknown LSP server(s): ${missing.join(", ")}.`);
+	if (missing.length) {
+		const configured = adapters.map((adapter) => adapter.name).join(", ") || "none";
+		throw new Error(
+			`Unknown LSP server(s): ${missing.join(", ")}. Configured LSP servers: ${configured}. ` +
+				"Omit the server parameter to select matching servers automatically.",
+		);
+	}
 	return matched;
 }
 

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -570,8 +570,12 @@ test("route selection handles server filters and ambiguous fix routes", () => {
 		"also-ts",
 	);
 	assert.throws(
-		() => selectDiagnosticRoutes([ts], { root, server: "missing" }, 50),
-		/Unknown LSP server/,
+		() => selectDiagnosticRoutes([ts, alsoTs], { root, server: "missing" }, 50),
+		(error: unknown) =>
+			error instanceof Error &&
+			error.message ===
+				"Unknown LSP server(s): missing. Configured LSP servers: ts, also-ts. " +
+					"Omit the server parameter to select matching servers automatically.",
 	);
 });
 
@@ -642,14 +646,19 @@ test("diagnostic routes skip missing defaults but preserve explicit selection", 
 		unrelated.defaultCommand = { command: "available-lsp", args: [] };
 		unrelated.env = { PATH: root };
 		unrelated.isDefault = true;
-		assert.throws(
-			() => selectDiagnosticRoutes([unrelated, missing], { root }, 50),
-			/No supported files found for available LSP commands.*Skipped unavailable.*missing/,
+		const partiallyUnavailable = selectDiagnosticRoutes([unrelated, missing], { root }, 50);
+		assert.deepEqual(partiallyUnavailable.routes, []);
+		assert.deepEqual(
+			partiallyUnavailable.skipped.map((route) => route.adapter.name),
+			["missing"],
 		);
 		assert.equal(missingFileChecks, 0);
-		assert.throws(
-			() => selectDiagnosticRoutes([missing], { root }, 50),
-			/No available default LSP commands.*missing/,
+
+		const unavailable = selectDiagnosticRoutes([missing], { root }, 50);
+		assert.deepEqual(unavailable.routes, []);
+		assert.deepEqual(
+			unavailable.skipped.map((route) => route.adapter.name),
+			["missing"],
 		);
 	} finally {
 		rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- let automatic diagnostics complete successfully when no default LSP command is available
- report unavailable defaults as skipped while keeping explicit/custom selections fail-closed
- make unknown-server errors list configured server names and recommend automatic selection
- document and test the updated behavior

## Testing

- `npm run check --workspace @narumitw/pi-lsp`
- `npm run check` (802 tests passed)
