### PR TITLE
feat(statusline): show actionable PR state

### DIFF
--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -179,8 +179,15 @@ export async function runGhPrView(
 	cwd: string,
 	signal?: AbortSignal,
 ): Promise<PullRequestStatus> {
-	const args = ["pr", "view", "--json", GH_PR_FIELDS.join(",")];
-	const result = await execGh(pi, args, cwd, signal, "gh pr view");
+	const invocation = ghPrViewInvocation();
+	const result = await execGh(
+		pi,
+		invocation.command,
+		invocation.args,
+		cwd,
+		signal,
+		"gh pr view",
+	);
 	if (result.killed) throw new Error("gh pr view timed out or was cancelled.");
 	if (result.code !== 0) throw new Error(formatGhFailure("gh pr view", result));
 
@@ -460,6 +467,7 @@ async function runGhPrCountQuery(
 	const { host, owner, name, number } = parsePrCoordinates(pr);
 	const result = await execGh(
 		pi,
+		"gh",
 		[
 			"api",
 			"graphql",
@@ -493,19 +501,32 @@ async function runGhPrCountQuery(
 	}
 }
 
+export function ghPrViewInvocation(
+	ghHost = process.env.GH_HOST,
+	platform: NodeJS.Platform = process.platform,
+	comSpec = process.env.ComSpec,
+): { command: string; args: string[] } {
+	const args = ["pr", "view", "--json", GH_PR_FIELDS.join(",")];
+	if (!ghHost) return { command: "gh", args };
+	if (platform === "win32") {
+		return {
+			command: comSpec ?? "cmd.exe",
+			args: ["/d", "/s", "/c", `set "GH_HOST=" && gh ${args.join(" ")}`],
+		};
+	}
+	return { command: "env", args: ["-u", "GH_HOST", "gh", ...args] };
+}
+
 async function execGh(
 	pi: Pick<ExtensionAPI, "exec">,
+	executable: string,
 	args: string[],
 	cwd: string,
 	signal: AbortSignal | undefined,
 	command: string,
 ): Promise<ExecResult> {
 	try {
-		return await pi.exec(
-			"gh",
-			args,
-			{ cwd, signal, timeout: GH_TIMEOUT_MS },
-		);
+		return await pi.exec(executable, args, { cwd, signal, timeout: GH_TIMEOUT_MS });
 	} catch (error) {
 		const message = formatError(error);
 		if (isGhExecutableMissingMessage(message.toLowerCase())) {
@@ -536,6 +557,12 @@ function isGhExecutableMissingMessage(lowerMessage: string): boolean {
 		/\b(?:gh|gh\.exe)\b.*\benoent\b|\benoent\b.*\b(?:gh|gh\.exe)\b/.test(lowerMessage) ||
 		/\b(?:gh|gh\.exe): (?:command )?not found\b/.test(lowerMessage) ||
 		/\bcommand not found: (?:gh|gh\.exe)\b/.test(lowerMessage) ||
+		/\benv:\s+['"‘’]?(?:gh|gh\.exe)['"‘’]?: no such file or directory\b/.test(
+			lowerMessage,
+		) ||
+		/['"‘’]?(?:gh|gh\.exe)['"‘’]? is not recognized as an internal or external command\b/.test(
+			lowerMessage,
+		) ||
 		/\b(?:gh|gh\.exe): no such file or directory\b/.test(lowerMessage)
 	);
 }

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -4,6 +4,7 @@ import type { ExecResult, ExtensionAPI, ExtensionContext } from "@earendil-works
 
 export type ReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "UNKNOWN";
 export type CheckState = "pass" | "fail" | "pending" | "none";
+export type PullRequestState = "OPEN" | "CLOSED" | "MERGED";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -31,6 +32,9 @@ export interface CommentSummary {
 export interface PullRequestStatus {
 	number: number;
 	url: string;
+	state: PullRequestState;
+	closedAt?: string;
+	mergedAt?: string;
 	isDraft: boolean;
 	review: ReviewSummary;
 	checks: CheckSummary;
@@ -41,10 +45,14 @@ const STATUS_KEY = "github-pr";
 const GH_TIMEOUT_MS = 10_000;
 const GIT_TIMEOUT_MS = 5_000;
 const BRANCH_REFRESH_DEBOUNCE_MS = 100;
+const TERMINAL_PR_LIFETIME_MS = 24 * 60 * 60 * 1000;
 const GH_PR_FIELDS = [
 	"number",
 	"isDraft",
 	"url",
+	"state",
+	"closedAt",
+	"mergedAt",
 	"reviewDecision",
 	"latestReviews",
 	"statusCheckRollup",
@@ -73,14 +81,18 @@ export default function githubPr(pi: ExtensionAPI) {
 	) => {
 		try {
 			const status = await runGhPrView(pi, ctx.cwd, signal);
-			if (generation === branchWatch.generation) renderStatus(ctx, status);
+			if (generation === branchWatch.generation) renderStatus(ctx, status, branchWatch, generation);
 		} catch (error) {
-			if (generation === branchWatch.generation) renderAmbientFailure(ctx, error);
+			if (generation === branchWatch.generation) {
+				clearExpiryTimer(branchWatch);
+				renderAmbientFailure(ctx, error);
+			}
 		}
 	};
 	const scheduleBranchRefresh = (ctx: ExtensionContext) => {
 		branchWatch.generation += 1;
 		const generation = branchWatch.generation;
+		clearExpiryTimer(branchWatch);
 		clearStatus(ctx);
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = setTimeout(() => {
@@ -92,6 +104,7 @@ export default function githubPr(pi: ExtensionAPI) {
 	const closeBranchWatcher = () => {
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = undefined;
+		clearExpiryTimer(branchWatch);
 		branchWatch.watcher?.close();
 		branchWatch.watcher = undefined;
 	};
@@ -129,6 +142,7 @@ interface BranchWatchState {
 	session: number;
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
+	expiryTimer?: ReturnType<typeof setTimeout>;
 }
 
 async function createBranchWatcher(
@@ -190,6 +204,9 @@ export function normalizeGhPrView(value: unknown): PullRequestStatus {
 	return {
 		number: requiredNumber(pr.number, "number"),
 		url: optionalString(pr.url) ?? "",
+		state: pullRequestState(pr.state),
+		closedAt: optionalString(pr.closedAt),
+		mergedAt: optionalString(pr.mergedAt),
 		isDraft: pr.isDraft === true,
 		review: summarizeReviews(pr.reviewDecision, latestReviews.length > 0 ? latestReviews : reviews),
 		checks: summarizeChecks(pr.statusCheckRollup),
@@ -287,6 +304,11 @@ function reviewDecision(value: unknown): ReviewDecision {
 	return "UNKNOWN";
 }
 
+function pullRequestState(value: unknown): PullRequestState {
+	if (value === "OPEN" || value === "CLOSED" || value === "MERGED") return value;
+	throw new Error("Missing valid PR state");
+}
+
 function authorLogin(review: JsonRecord): string | undefined {
 	const author = objectRecord(review.author);
 	return optionalString(author.login);
@@ -300,6 +322,8 @@ function checkOverall(checks: CheckSummary): CheckState {
 }
 
 export function formatCompactStatus(status: PullRequestStatus): string {
+	if (status.state === "MERGED") return `PR #${status.number}: merged`;
+	if (status.state === "CLOSED") return `PR #${status.number}: closed`;
 	return `PR #${status.number}: ${[
 		formatCheckCompact(status.checks),
 		formatReviewCompact(status),
@@ -335,14 +359,51 @@ function formatReviewCompact(status: PullRequestStatus): string {
 		case "CHANGES_REQUESTED":
 			return "changes requested";
 		case "REVIEW_REQUIRED":
-			return review.commentedBy.length > 0 ? "commented" : "review required";
+			return "review required";
 		case "UNKNOWN":
 			return review.commentedBy.length > 0 ? "commented" : "review ?";
 	}
 }
 
-function renderStatus(ctx: ExtensionContext, status: PullRequestStatus) {
+function renderStatus(
+	ctx: ExtensionContext,
+	status: PullRequestStatus,
+	branchWatch: BranchWatchState,
+	generation: number,
+) {
+	clearExpiryTimer(branchWatch);
+	const now = Date.now();
+	const expiresAt = pullRequestExpiresAt(status);
+	if (!isPullRequestVisible(status, now)) {
+		clearStatus(ctx);
+		return;
+	}
+
 	ctx.ui.setStatus(STATUS_KEY, formatLinkedStatus(status));
+	if (expiresAt === undefined) return;
+	branchWatch.expiryTimer = setTimeout(() => {
+		branchWatch.expiryTimer = undefined;
+		if (generation === branchWatch.generation) clearStatus(ctx);
+	}, expiresAt - now);
+}
+
+export function isPullRequestVisible(status: PullRequestStatus, now = Date.now()): boolean {
+	if (status.state === "OPEN") return true;
+	const expiresAt = pullRequestExpiresAt(status);
+	return expiresAt !== undefined && now < expiresAt;
+}
+
+function pullRequestExpiresAt(status: PullRequestStatus): number | undefined {
+	if (status.state === "OPEN") return undefined;
+	const timestamp = status.state === "MERGED" ? status.mergedAt : status.closedAt;
+	if (!timestamp) return undefined;
+	const terminalAt = Date.parse(timestamp);
+	return Number.isFinite(terminalAt) ? terminalAt + TERMINAL_PR_LIFETIME_MS : undefined;
+}
+
+function clearExpiryTimer(branchWatch: BranchWatchState) {
+	if (branchWatch.expiryTimer) clearTimeout(branchWatch.expiryTimer);
+	branchWatch.expiryTimer = undefined;
 }
 
 export function formatLinkedStatus(status: PullRequestStatus): string {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -2,12 +2,13 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import type { ExecResult } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import githubPr, {
 	formatCompactStatus,
 	formatLinkedStatus,
+	ghPrViewInvocation,
 	isPullRequestVisible,
 	normalizeGhPrView,
 	runGhPrView,
@@ -16,6 +17,12 @@ import githubPr, {
 type ExecOptions = { cwd?: string; signal?: AbortSignal; timeout?: number };
 type ExecCall = { command: string; args: string[]; options?: ExecOptions };
 type ExecFunction = (command: string, args: string[], options?: ExecOptions) => Promise<ExecResult>;
+
+const ambientGhHost = process.env.GH_HOST;
+delete process.env.GH_HOST;
+after(() => {
+	if (ambientGhHost !== undefined) process.env.GH_HOST = ambientGhHost;
+});
 
 const okResult = (stdout: unknown): ExecResult => ({
 	stdout: JSON.stringify(stdout),
@@ -199,29 +206,79 @@ test("normalizeGhPrView accepts count-only review and comment payloads", () => {
 	assert.deepEqual(status.comments, { issue: 2, reviews: 3, total: 5 });
 });
 
+test("gh pr view resolves the repository host on POSIX and Windows", () => {
+	const args = [
+		"pr",
+		"view",
+		"--json",
+		"number,isDraft,url,state,closedAt,mergedAt,reviewDecision,latestReviews,statusCheckRollup",
+	];
+
+	assert.deepEqual(ghPrViewInvocation(undefined, "linux"), { command: "gh", args });
+	assert.deepEqual(ghPrViewInvocation("git.example.com", "darwin"), {
+		command: "env",
+		args: ["-u", "GH_HOST", "gh", ...args],
+	});
+	assert.deepEqual(ghPrViewInvocation("git.example.com", "win32", "C:\\Windows\\cmd.exe"), {
+		command: "C:\\Windows\\cmd.exe",
+		args: ["/d", "/s", "/c", `set "GH_HOST=" && gh ${args.join(" ")}`],
+	});
+});
+
 test("runGhPrView calls gh pr view for the current branch and reports actionable failures", async () => {
 	const calls: ExecCall[] = [];
+	const ghHosts: Array<string | undefined> = [];
 	const pi = {
 		exec: async (command, args, options) => {
 			calls.push({ command, args, options });
-			return okResult(args[0] === "pr" ? samplePr : sampleCounts);
+			ghHosts.push(process.env.GH_HOST);
+			if (command === "gh" && args[0] === "pr" && process.env.GH_HOST) {
+				return textResult(
+					"",
+					1,
+					"none of the git remotes configured for this repository correspond to GH_HOST",
+				);
+			}
+			return okResult(calls.length === 1 ? samplePr : sampleCounts);
 		},
 	} satisfies { exec: ExecFunction };
+	const previousGhHost = process.env.GH_HOST;
+	process.env.GH_HOST = "github.netflix.net";
 
-	const status = await runGhPrView(pi, "/repo");
+	let status: Awaited<ReturnType<typeof runGhPrView>>;
+	let restoredGhHost: string | undefined;
+	try {
+		status = await runGhPrView(pi, "/repo");
+		restoredGhHost = process.env.GH_HOST;
+	} finally {
+		if (previousGhHost === undefined) delete process.env.GH_HOST;
+		else process.env.GH_HOST = previousGhHost;
+	}
 
 	assert.equal(status.number, 123);
+	assert.deepEqual(ghHosts, ["github.netflix.net", "github.netflix.net"]);
+	assert.equal(restoredGhHost, "github.netflix.net");
 	assert.equal(calls.length, 2);
-	assert.deepEqual(calls[0], {
-		command: "gh",
-		args: [
-			"pr",
-			"view",
-			"--json",
-			"number,isDraft,url,state,closedAt,mergedAt,reviewDecision,latestReviews,statusCheckRollup",
-		],
-		options: { cwd: "/repo", signal: undefined, timeout: 10_000 },
-	});
+	const prArgs = [
+		"pr",
+		"view",
+		"--json",
+		"number,isDraft,url,state,closedAt,mergedAt,reviewDecision,latestReviews,statusCheckRollup",
+	];
+	assert.deepEqual(
+		calls[0],
+		process.platform === "win32"
+			? {
+					command: process.env.ComSpec ?? "cmd.exe",
+					args: ["/d", "/s", "/c", `set "GH_HOST=" && gh ${prArgs.join(" ")}`],
+					options: { cwd: "/repo", signal: undefined, timeout: 10_000 },
+				}
+			: {
+					command: "env",
+					args: ["-u", "GH_HOST", "gh", ...prArgs],
+					options: { cwd: "/repo", signal: undefined, timeout: 10_000 },
+				},
+	);
 	assert.deepEqual(calls[1]?.options, { cwd: "/repo", signal: undefined, timeout: 10_000 });
 	assert.deepEqual(calls[1]?.args.slice(0, 6), [
 		"api",
@@ -582,6 +639,18 @@ test("ambient failures stay non-intrusive", async () => {
 	const missingGh = await lifecycleStatusFor(async () => {
 		throw new Error("spawn gh ENOENT");
 	});
+	const missingGhViaEnv = await lifecycleStatusFor(async () => ({
+		stdout: "",
+		stderr: "env: ‘gh’: No such file or directory",
+		code: 127,
+		killed: false,
+	}));
+	const missingGhViaCmd = await lifecycleStatusFor(async () => ({
+		stdout: "",
+		stderr: "'gh' is not recognized as an internal or external command",
+		code: 1,
+		killed: false,
+	}));
 	const unauthenticated = await lifecycleStatusFor(async () => ({
 		stdout: "",
 		stderr: "not logged in",
@@ -608,6 +677,8 @@ test("ambient failures stay non-intrusive", async () => {
 	}));
 
 	assert.equal(missingGh.statuses.get("github-pr"), "PR gh missing");
+	assert.equal(missingGhViaEnv.statuses.get("github-pr"), "PR gh missing");
+	assert.equal(missingGhViaCmd.statuses.get("github-pr"), "PR gh missing");
 	assert.equal(unauthenticated.statuses.get("github-pr"), "PR gh auth");
 	assert.equal(execFailure.statuses.get("github-pr"), undefined);
 	assert.equal(spawnPermissionFailure.statuses.get("github-pr"), undefined);
@@ -615,6 +686,8 @@ test("ambient failures stay non-intrusive", async () => {
 	assert.equal(notFound.statuses.get("github-pr"), undefined);
 	for (const context of [
 		missingGh,
+		missingGhViaEnv,
+		missingGhViaCmd,
 		unauthenticated,
 		execFailure,
 		spawnPermissionFailure,

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -399,7 +399,7 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 
 test("recent terminal pull request status clears when its 24-hour lifetime expires", async () => {
 	const mock = createMockPi();
-	const mergedAt = new Date(Date.now() - 24 * 60 * 60 * 1000 + 300).toISOString();
+	const mergedAt = new Date(Date.now() - 24 * 60 * 60 * 1000 + 1_000).toISOString();
 	const calls = installExec(mock, async (_command, args) =>
 		okResult(args[0] === "pr" ? { ...samplePr, state: "MERGED", mergedAt } : sampleCounts),
 	);
@@ -410,14 +410,18 @@ test("recent terminal pull request status clears when its 24-hour lifetime expir
 	assert.ok(sessionStart);
 	assert.ok(sessionShutdown);
 
-	await sessionStart({}, context.ctx);
-	assert.match(context.statuses.get("github-pr") ?? "", /: merged$/);
-	await waitFor(
-		() => context.statuses.get("github-pr") === undefined,
-		"terminal pull request status expires",
-	);
-	assert.equal(calls.length, 3);
-	await sessionShutdown({}, context.ctx);
+	try {
+		await sessionStart({}, context.ctx);
+		assert.match(context.statuses.get("github-pr") ?? "", /: merged$/);
+		await waitFor(
+			() => context.statuses.get("github-pr") === undefined,
+			"terminal pull request status expires",
+			2_000,
+		);
+		assert.equal(calls.length, 3);
+	} finally {
+		await sessionShutdown({}, context.ctx);
+	}
 });
 
 test("branch changes clear stale PR status and stale refreshes cannot restore it", async () => {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -8,6 +8,7 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import githubPr, {
 	formatCompactStatus,
 	formatLinkedStatus,
+	isPullRequestVisible,
 	normalizeGhPrView,
 	runGhPrView,
 } from "../src/github-pr.js";
@@ -43,6 +44,9 @@ const sampleCounts = {
 
 const samplePr = {
 	number: 123,
+	state: "OPEN",
+	closedAt: null,
+	mergedAt: null,
 	isDraft: false,
 	url: "https://github.com/narumiruna/pi-extensions/pull/123",
 	reviewDecision: "APPROVED",
@@ -153,7 +157,36 @@ test("normalizeGhPrView summarizes pending, changes-requested, draft, and commen
 	);
 	assert.deepEqual(draft.comments, { issue: 0, reviews: 0, total: 0 });
 	assert.equal(formatCompactStatus(draft), "PR #123: no checks, draft, no comments");
-	assert.equal(formatCompactStatus(commented), "PR #123: checks passing, commented, 3 comments");
+	assert.equal(
+		formatCompactStatus(commented),
+		"PR #123: checks passing, review required, 3 comments",
+	);
+});
+
+test("terminal pull requests use their terminal state and expire after 24 hours", () => {
+	const now = Date.parse("2026-06-26T12:00:00.000Z");
+	const merged = normalizeGhPrView({
+		...samplePr,
+		state: "MERGED",
+		mergedAt: "2026-06-25T12:00:00.001Z",
+	});
+	const closed = normalizeGhPrView({
+		...samplePr,
+		state: "CLOSED",
+		closedAt: "2026-06-25T12:00:00.000Z",
+	});
+
+	assert.equal(formatCompactStatus(merged), "PR #123: merged");
+	assert.equal(formatCompactStatus(closed), "PR #123: closed");
+	assert.equal(isPullRequestVisible(merged, now), true);
+	assert.equal(isPullRequestVisible(closed, now), false);
+	assert.equal(isPullRequestVisible({ ...merged, mergedAt: undefined }, now), false);
+	assert.equal(isPullRequestVisible({ ...closed, closedAt: "invalid" }, now), false);
+	assert.equal(isPullRequestVisible(normalizeGhPrView(samplePr), now), true);
+	assert.equal(
+		isPullRequestVisible(normalizeGhPrView({ ...samplePr, closedAt: "invalid" }), now),
+		true,
+	);
 });
 
 test("normalizeGhPrView accepts count-only review and comment payloads", () => {
@@ -185,7 +218,7 @@ test("runGhPrView calls gh pr view for the current branch and reports actionable
 			"pr",
 			"view",
 			"--json",
-			"number,isDraft,url,reviewDecision,latestReviews,statusCheckRollup",
+			"number,isDraft,url,state,closedAt,mergedAt,reviewDecision,latestReviews,statusCheckRollup",
 		],
 		options: { cwd: "/repo", signal: undefined, timeout: 10_000 },
 	});
@@ -362,6 +395,29 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	assert.equal(context.statuses.get("github-pr"), undefined);
 	assert.equal(context.widgets.size, 0);
 	assert.equal(context.notifications.length, 0);
+});
+
+test("recent terminal pull request status clears when its 24-hour lifetime expires", async () => {
+	const mock = createMockPi();
+	const mergedAt = new Date(Date.now() - 24 * 60 * 60 * 1000 + 300).toISOString();
+	const calls = installExec(mock, async (_command, args) =>
+		okResult(args[0] === "pr" ? { ...samplePr, state: "MERGED", mergedAt } : sampleCounts),
+	);
+	githubPr(mock.pi);
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	await sessionStart({}, context.ctx);
+	assert.match(context.statuses.get("github-pr") ?? "", /: merged$/);
+	await waitFor(
+		() => context.statuses.get("github-pr") === undefined,
+		"terminal pull request status expires",
+	);
+	assert.equal(calls.length, 3);
+	await sessionShutdown({}, context.ctx);
 });
 
 test("branch changes clear stale PR status and stale refreshes cannot restore it", async () => {

--- a/extensions/pi-statusline/src/extension-status.ts
+++ b/extensions/pi-statusline/src/extension-status.ts
@@ -14,7 +14,6 @@ export interface ExtensionStatusRuntime {
 }
 
 const STATUSLINE_KEY = "statusline";
-const GITHUB_PR_KEY = "github-pr";
 const EMPTY_EXTENSION_STATUS_ICON_ALIASES: ExtensionStatusIconAliasMap = new Map();
 const DEFAULT_EXTENSION_STATUS_ICONS: Record<string, string> = {
 	"chrome-devtools": "🌐",
@@ -41,15 +40,15 @@ export function formatExtensionStatuses(
 	theme: Theme,
 	config: StatuslineConfig,
 	runtime: ExtensionStatusRuntime,
+	hiddenKeys: ReadonlySet<string> = new Set(),
 ): string {
 	const separator = extensionStatusSeparator(config.preset, theme);
 	const visibleStatuses = [
 		...formatDuplicateExtensionStatus(runtime, theme),
 		...[...statuses.entries()]
-			// github-pr is rendered inline in the branch segment, so skip it here to avoid duplication.
 			.filter(
 				([key, value]) =>
-					key !== STATUSLINE_KEY && key !== GITHUB_PR_KEY && value.trim().length > 0,
+					key !== STATUSLINE_KEY && !hiddenKeys.has(key) && value.trim().length > 0,
 			)
 			.map(([key, value]) =>
 				formatExtensionStatus(key, value, theme, config, runtime.extensionStatusIconAliases),

--- a/extensions/pi-statusline/src/render.ts
+++ b/extensions/pi-statusline/src/render.ts
@@ -41,6 +41,7 @@ interface TokenTotals {
 	cost: number;
 }
 const GITHUB_PR_KEY = "github-pr";
+const GITHUB_PR_STATUS_KEYS = new Set([GITHUB_PR_KEY]);
 const PALETTES: Record<PaletteName, ThemeColor[]> = {
 	ocean: ["accent", "muted", "success", "warning"],
 	sunset: ["warning", "accent", "success", "muted"],
@@ -82,8 +83,18 @@ export function renderExtensionStatusline(
 	theme: Theme,
 	config: StatuslineConfig,
 	runtime: RuntimeState,
+	mainLine: string,
 ): string[] {
-	const status = formatExtensionStatuses(footerData.getExtensionStatuses(), theme, config, runtime);
+	const statuses = footerData.getExtensionStatuses();
+	const prContext = prContextFromStatuses(statuses);
+	const rendersPrInline = prContext !== undefined && mainLine.includes(prContext);
+	const status = formatExtensionStatuses(
+		statuses,
+		theme,
+		config,
+		runtime,
+		rendersPrInline ? GITHUB_PR_STATUS_KEYS : undefined,
+	);
 	return wrapExtensionStatusline(status, width);
 }
 
@@ -113,7 +124,7 @@ function buildSegment(
 			);
 		case "branch": {
 			const branch = footerData.getGitBranch();
-			const pr = branch ? prLinkFromStatuses(footerData.getExtensionStatuses()) : undefined;
+			const pr = branch ? prContextFromStatuses(footerData.getExtensionStatuses()) : undefined;
 			return segment(name, formatGitBranchText(branch, runtime.gitStatus, pr), color, "git");
 		}
 		case "cwd":
@@ -217,6 +228,33 @@ export function prLinkFromStatuses(statuses: ReadonlyMap<string, string>): strin
 	const closeMarker = "\x1b]8;;\x07";
 	const close = value.indexOf(closeMarker, open + 1);
 	return close === -1 ? undefined : value.slice(open, close + closeMarker.length);
+}
+
+export function prContextFromStatuses(statuses: ReadonlyMap<string, string>): string | undefined {
+	const value = statuses.get(GITHUB_PR_KEY);
+	const link = prLinkFromStatuses(statuses);
+	if (!value || !link) return undefined;
+
+	const state = compactPrState(value);
+	return state ? `${link} · ${state}` : undefined;
+}
+
+function compactPrState(value: string): string | undefined {
+	if (/:\s*merged\s*$/.test(value)) return "merged";
+	if (/:\s*closed\s*$/.test(value)) return "closed";
+	if (/\bdraft\b/.test(value)) return "draft";
+
+	const failing = /\bchecks failing \((\d+)\)/.exec(value);
+	if (failing) return `${failing[1]} failing`;
+	if (/\bchanges requested\b/.test(value)) return "changes requested";
+
+	const pending = /\bchecks pending \((\d+)\)/.exec(value);
+	if (pending) return `${pending[1]} pending`;
+	if (/\bapproved\b/.test(value)) return "approved";
+	if (/\breview required\b/.test(value)) return "review required";
+	if (/\bchecks passing\b/.test(value)) return "checks passing";
+	if (/\bno checks\b/.test(value)) return "no checks";
+	return undefined;
 }
 
 function getTokenTotals(ctx: ExtensionContext): TokenTotals {

--- a/extensions/pi-statusline/src/render.ts
+++ b/extensions/pi-statusline/src/render.ts
@@ -1,5 +1,4 @@
 import { basename } from "node:path";
-import process from "node:process";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -18,8 +17,8 @@ import type {
 	TokyoNightBlockName,
 } from "../presets/types.js";
 import {
-	formatExtensionStatuses,
 	type ExtensionStatusRuntime,
+	formatExtensionStatuses,
 	wrapExtensionStatusline,
 } from "./extension-status.js";
 import { formatGitBranchText, type GitStatusSummary } from "./git-status.js";
@@ -235,7 +234,7 @@ export function prContextFromStatuses(statuses: ReadonlyMap<string, string>): st
 	const link = prLinkFromStatuses(statuses);
 	if (!value || !link) return undefined;
 
-	const state = compactPrState(value);
+	const state = compactPrState(value.replace(link, ""));
 	return state ? `${link} · ${state}` : undefined;
 }
 

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -152,8 +152,11 @@ export default function statusline(pi: ExtensionAPI) {
 				},
 				invalidate() {},
 				render(width: number): string[] {
-					const lines = [renderStatusline(width, ctx, footerData, theme, config, runtime)];
-					lines.push(...renderExtensionStatusline(width, footerData, theme, config, runtime));
+					const mainLine = renderStatusline(width, ctx, footerData, theme, config, runtime);
+					const lines = [mainLine];
+					lines.push(
+						...renderExtensionStatusline(width, footerData, theme, config, runtime, mainLine),
+					);
 					return lines;
 				},
 			};
@@ -254,6 +257,7 @@ export {
 	contextColor,
 	formatCount,
 	formatToolActivity,
+	prContextFromStatuses,
 	prLinkFromStatuses,
 	shortenModel,
 } from "./render.js";

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -27,6 +27,7 @@ import statusline, {
 	formatToolActivity,
 	npmPackageName,
 	parseGitStatusPorcelain,
+	prContextFromStatuses,
 	prLinkFromStatuses,
 	readStatuslineSettings,
 	shortenModel,
@@ -75,6 +76,63 @@ test("statusline registers lifecycle handlers without reading thinking level at 
 	assert.doesNotThrow(() => statusline(mock.pi));
 	assert.ok(mock.events.has("session_start"));
 	assert.ok(mock.events.has("tool_execution_start"));
+});
+
+test("statusline renders PR context inline only when a branch is available", async () => {
+	const previousPreset = process.env.PI_STATUSLINE_PRESET;
+	try {
+		for (const preset of ["classic", "tokyo-night"]) {
+			process.env.PI_STATUSLINE_PRESET = preset;
+			const mock = createMockPi();
+			statusline(mock.pi);
+			const context = createMockContext({ mode: "tui" });
+			await emit(mock.events, "session_start", {}, context.ctx);
+			const footerFactory = context.footer as (
+				tui: { requestRender(): void },
+				theme: { fg(color: string, text: string): string; bold(text: string): string },
+				footerData: {
+					getGitBranch(): string | null;
+					getExtensionStatuses(): ReadonlyMap<string, string>;
+					onBranchChange(callback: () => void): () => void;
+				},
+			) => { render(width: number): string[]; dispose(): void };
+			const link = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
+			const statuses = new Map([
+				["github-pr", `PR ${link}: checks failing (2), approved, 5 comments`],
+			]);
+			let branch: string | null = "feature";
+			const footer = footerFactory(
+				{ requestRender() {} },
+				{ fg: (_color, text) => text, bold: (text) => text },
+				{
+					getGitBranch: () => branch,
+					getExtensionStatuses: () => statuses,
+					onBranchChange: () => () => undefined,
+				},
+			);
+
+			const inlineLines = footer.render(300);
+			assert.ok(inlineLines[0]?.includes(`🌿 feature (${link} · 2 failing)`), preset);
+			assert.equal(inlineLines.length, 1);
+
+			const narrowLines = footer.render(20);
+			assert.match(narrowLines.slice(1).join(" "), /PR/);
+
+			branch = null;
+			const fallbackLines = footer.render(300);
+			assert.equal(fallbackLines.length, 2);
+			assert.match(fallbackLines[1] ?? "", /PR/);
+			assert.match(fallbackLines[1] ?? "", /checks failing/);
+
+			branch = "feature";
+			statuses.set("github-pr", "PR #123: checks failing (2), approved, 5 comments");
+			assert.match(footer.render(300).slice(1).join(" "), /PR/);
+			footer.dispose();
+		}
+	} finally {
+		if (previousPreset === undefined) delete process.env.PI_STATUSLINE_PRESET;
+		else process.env.PI_STATUSLINE_PRESET = previousPreset;
+	}
 });
 
 test("statusline renders max thinking with the latest theme color", async () => {
@@ -449,6 +507,26 @@ test("prLinkFromStatuses keeps the linked PR token and drops the tail and non-PR
 	);
 	assert.equal(prLinkFromStatuses(new Map([["github-pr", "PR gh missing"]])), undefined);
 	assert.equal(prLinkFromStatuses(new Map()), undefined);
+});
+
+test("prContextFromStatuses chooses one actionable state by precedence", () => {
+	const link = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
+	const context = (details: string) =>
+		prContextFromStatuses(new Map([["github-pr", `PR ${link}: ${details}`]]));
+
+	assert.equal(context("merged"), `${link} · merged`);
+	assert.equal(context("closed"), `${link} · closed`);
+	assert.equal(context("checks failing (2), draft, approved"), `${link} · draft`);
+	assert.equal(context("checks failing (2), changes requested"), `${link} · 2 failing`);
+	assert.equal(context("checks pending (3), changes requested"), `${link} · changes requested`);
+	assert.equal(context("checks pending (3), approved"), `${link} · 3 pending`);
+	assert.equal(context("checks passing, approved"), `${link} · approved`);
+	assert.equal(context("checks passing, review required"), `${link} · review required`);
+	assert.equal(context("checks passing, commented"), `${link} · checks passing`);
+	assert.equal(context("checks passing, review ?"), `${link} · checks passing`);
+	assert.equal(context("checks passing"), `${link} · checks passing`);
+	assert.equal(context("no checks"), `${link} · no checks`);
+	assert.equal(context("unknown"), undefined);
 });
 
 test("git status parser and formatter produce compact dirty tokens", () => {

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -510,7 +510,7 @@ test("prLinkFromStatuses keeps the linked PR token and drops the tail and non-PR
 });
 
 test("prContextFromStatuses chooses one actionable state by precedence", () => {
-	const link = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
+	const link = "\x1b]8;;https://github.com/o/draft-approved/pull/123\x07#123\x1b]8;;\x07";
 	const context = (details: string) =>
 		prContextFromStatuses(new Map([["github-pr", `PR ${link}: ${details}`]]));
 


### PR DESCRIPTION
## What

Enhances the clickable PR context introduced in #118:

- Shows one actionable state beside the linked PR number, such as `(#123 · 2 failing)`.
- Preserves the full standalone PR status when the inline context is unavailable or truncated.
- Keeps open PRs visible, while hiding merged or closed PRs after 24 hours.
- Clears recent terminal PR context at the cutoff without waiting for another agent turn.

## State priority

`merged/closed` → `draft` → failing checks → changes requested → pending checks → approved → review required → checks passing → no checks

## Test

- `npm run biome:check`
- `npm run check:boundaries`
- `npm run typecheck`
- `node --test .../pi-github-pr/test/github-pr.test.js` — 17 pass
- `node --test .../pi-statusline/test/statusline.test.js` — 25 pass

The repository-wide `npm test` runner was also attempted, but did not exit under local Node 26 after its first test file; both changed package suites pass independently.
