### PR TITLE
feat(goal): expose session-local lifecycle RPC

### DIFF
--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -166,6 +166,38 @@ Do not use `goal_blocked` merely because work is difficult, incomplete, uncertai
 
 A user pause or aborted turn produces `paused`; a terminal provider/account quota error produces `usage_limited`; another non-retryable agent error produces `blocked`. Each stopped transition cancels pending continuation intent or delivery, aborts stale work when applicable, and blocks stale tool calls until the next non-goal user prompt, successful reactivation/replacement, or `/goal clear`. On `/goal clear`, the extension clears goal state, continuation markers, and any stale tool-call block without aborting an unrelated in-flight turn. Retryable provider interruptions and overflow compaction retries stay `active` while Pi retries; no extra continuation is queued. User and extension work that starts before settlement supersedes the older continuation intent, and pending messages always take priority.
 
+## 🤝 Cross-extension RPC and events
+
+pi-goal exposes a session-local, dependency-free integration contract over Pi's shared `pi.events` bus so sibling extensions (such as `@tintinweb/pi-subagents`) can start, pause, and observe goals programmatically without driving the `/goal` slash command. The contract is bound only while a Pi session is active: it is established on `session_start` and the captured session context is unbound on `session_shutdown`. All channels are plain JSON-shaped payloads; this extension never adds a runtime dependency for them.
+
+### Starting a goal: `pi-goal:rpc:start`
+
+Emit `pi-goal:rpc:start` with `{ requestId: string, objective: string, tokenBudget?: number }`. `tokenBudget` is an absolute positive integer token count (for example `100000`), not a `k`/`m` string. The request reuses the same `startGoal()` transition as the slash command, so it never implements goal transitions twice.
+
+pi-goal replies on `pi-goal:rpc:start:reply:${requestId}` with one of:
+
+```jsonc
+// success
+{ "success": true, "data": { "goalId": "<uuid>", "status": "active" } }
+// failure (validation, no session, pre-existing goal, or failed activation)
+{ "success": false, "error": "<human-readable reason>" }
+```
+
+Behavior notes:
+
+- Malformed payloads (missing/empty/non-string `objective`, or a non-positive-integer `tokenBudget`) fail fast with a descriptive `error`.
+- If no session context is bound (before `session_start` or after `session_shutdown`), the reply is a failure rather than starting a goal.
+- RPC starts run in a fresh child context, so a **pre-existing goal fails** instead of prompting, replacing, or reusing stale state. Clear the existing goal first.
+- The reply `status` is read from the authoritative goal state, so an immediate terminal outcome during start is represented rather than assumed to be `active`.
+
+### Pausing a goal: `pi-goal:rpc:pause`
+
+Emit `pi-goal:rpc:pause` with `{ goalId?: string, reason?: string }` to stop an active RPC-owned goal safely. When `goalId` is present and does not match the active goal, the request is ignored; omitting it supports cancellation while the start reply is still pending. A successful pause uses the normal Goal pause transition and emits the authoritative `pi-goal:state` event described below.
+
+### Observing goal state: `pi-goal:state`
+
+Whenever pi-goal persists canonical goal state, it emits `pi-goal:state` with `{ goalId, status, summary?, reason? }`. `goalId` and `status` are always authoritative. Terminal statuses are `complete`, `blocked`, `paused`, `usage_limited`, and `budget_limited`. `summary` is populated from the `goal_complete` summary when available, and `reason` is populated from the blocked/usage/budget failure state where available; an `active` or `queued` event carries only `goalId` and `status`. Listeners must treat any non-terminal status as in-progress and should key follow-up behavior on `goalId` plus a terminal `status`.
+
 ## 🧠 Use cases
 
 - Finish implementation tasks without stopping at a plan.

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -1,10 +1,10 @@
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { currentTokenTotal } from "./accounting.js";
-import { completeGoalArguments, parseCommand } from "./command.js";
+import { completeGoalArguments, parseCommand, validateObjective } from "./command.js";
 import { GoalCommandController } from "./commands.js";
 import { type ActiveGoal, loadGoalStateFromSession } from "./persistence.js";
-import { buildGoalPrompt, buildGoalSystemPrompt } from "./prompts.js";
+import { buildGoalPrompt, buildGoalSystemPrompt, type GoalStatus } from "./prompts.js";
 import { activateQueuedGoal } from "./queue.js";
 import {
 	type AssistantMessageLike,
@@ -51,6 +51,101 @@ interface GoalOptions {
 	settingsPath?: string;
 }
 
+// Cross-extension RPC contract over Pi's session-local events bus. pi-subagents
+// (or any sibling extension) starts or pauses a goal through RPC; pi-goal replies
+// to starts and broadcasts `pi-goal:state` on every persist.
+const RPC_START_CHANNEL = "pi-goal:rpc:start";
+const RPC_PAUSE_CHANNEL = "pi-goal:rpc:pause";
+
+interface GoalRpcStartPayload {
+	requestId: string;
+	objective: string;
+	tokenBudget?: number;
+}
+
+type GoalRpcReply =
+	| { success: true; data: { goalId: string; status: GoalStatus } }
+	| { success: false; error: string };
+
+function rpcReplyChannel(requestId: string) {
+	return `pi-goal:rpc:start:reply:${requestId}`;
+}
+
+function parseRpcStartPayload(
+	payload: Partial<GoalRpcStartPayload> | null,
+): string | { objective: string; tokenBudget?: number } {
+	if (!payload || typeof payload !== "object") return "rpc:start payload is missing";
+	if (typeof payload.objective !== "string") return "objective must be a string";
+	const objective = payload.objective.trim();
+	const objectiveError = validateObjective(objective);
+	if (objectiveError) return objectiveError;
+	let tokenBudget: number | undefined;
+	if (payload.tokenBudget !== undefined) {
+		if (
+			typeof payload.tokenBudget !== "number" ||
+			!Number.isFinite(payload.tokenBudget) ||
+			!Number.isSafeInteger(payload.tokenBudget) ||
+			payload.tokenBudget <= 0
+		) {
+			return "tokenBudget must be a positive integer";
+		}
+		tokenBudget = payload.tokenBudget;
+	}
+	return { objective, tokenBudget };
+}
+
+async function handleGoalRpcStart(
+	runtime: GoalRuntime,
+	commands: GoalCommandController,
+	data: unknown,
+	sessionContext: StatusContext | undefined,
+) {
+	const payload = data as Partial<GoalRpcStartPayload> | null;
+	const requestId = typeof payload?.requestId === "string" ? payload.requestId.trim() : "";
+	// Without a usable requestId there is no reply channel to address safely.
+	if (!requestId) return;
+	const reply = (envelope: GoalRpcReply) =>
+		runtime.pi.events.emit(rpcReplyChannel(requestId), envelope);
+
+	if (!sessionContext) {
+		reply({ success: false, error: "no active pi-goal session context" });
+		return;
+	}
+	const parsed = parseRpcStartPayload(payload);
+	if (typeof parsed === "string") {
+		reply({ success: false, error: parsed });
+		return;
+	}
+	// RPC starts run in a fresh child: any pre-existing goal must fail rather
+	// than trigger interactive replacement confirmation or reuse stale state.
+	const existingGoal = runtime.activeGoal;
+	if (existingGoal) {
+		reply({
+			success: false,
+			error: "a goal already exists; clear it before starting another via RPC",
+		});
+		return;
+	}
+	try {
+		await commands.startGoal(parsed.objective, parsed.tokenBudget, sessionContext);
+	} catch (error) {
+		reply({ success: false, error: `goal start failed: ${formatError(error)}` });
+		return;
+	}
+	// Read the authoritative status so an immediate terminal outcome during start
+	// is reflected in the reply instead of assuming "active".
+	const goal = runtime.activeGoal;
+	if (!goal) {
+		reply({
+			success: false,
+			error:
+				"goal start failed; the objective could not be activated (goal tools unavailable or kickoff delivery failed)",
+		});
+		return;
+	}
+	reply({ success: true, data: { goalId: goal.id, status: goal.status } });
+}
+
 const EXPERIMENTAL_GOALS_WARNING =
 	"Experimental ordered goals are enabled for pi-goal. Queue behavior and persisted state may change.";
 const MAX_BLOCKER_REASON_LENGTH = 1_000;
@@ -69,6 +164,21 @@ function onAgentSettled(pi: ExtensionAPI, handler: AgentSettledHandler) {
 function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 	const runtime = new GoalRuntime(pi);
 	const commands = new GoalCommandController(runtime);
+
+	// Session-local cross-extension RPC context. session_start binds it and
+	// session_shutdown unbinds it; the RPC channel replies failure while unbound.
+	let sessionContext: StatusContext | undefined;
+	pi.events.on(RPC_START_CHANNEL, (data) => {
+		void handleGoalRpcStart(runtime, commands, data, sessionContext);
+	});
+	pi.events.on(RPC_PAUSE_CHANNEL, (data) => {
+		if (!sessionContext || runtime.activeGoal?.status !== "active") return;
+		const payload = data as { goalId?: unknown; reason?: unknown } | null;
+		if (typeof payload?.goalId === "string" && payload.goalId !== runtime.activeGoal.id) return;
+		const reason = typeof payload?.reason === "string" ? payload.reason.trim() : "";
+		runtime.terminalReason = reason || "goal paused by RPC";
+		commands.pauseGoal(sessionContext);
+	});
 
 	// Bind per-factory runtime operations once so event orchestration stays concise
 	// without reintroducing module-global mutable state.
@@ -225,6 +335,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			}
 
 			runtime.activeGoal = transitionGoal(completedGoal, "complete");
+			runtime.completionSummary = summary;
 			updateGoalUsage(runtime.activeGoal, ctx);
 			if (runtime.pendingQueueAction?.kind === "prioritize") {
 				persistGoal(runtime.activeGoal);
@@ -368,6 +479,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			clearGoalRecoveryForGoal(blockedGoal.id);
 			blockStaleGoalToolCalls();
 			runtime.activeGoal = transitionGoal(blockedGoal, "blocked");
+			runtime.terminalReason = reason;
 			persistGoal(runtime.activeGoal);
 			updateStatus(ctx, runtime.activeGoal);
 			ctx.ui.notify(`Goal blocked: ${truncateNotification(reason)}`, "warning");
@@ -466,6 +578,9 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.queuedGoals = [];
 		runtime.pendingQueueAction = undefined;
 		runtime.queueFrozen = false;
+		runtime.completionSummary = undefined;
+		runtime.terminalReason = undefined;
+		sessionContext = ctx;
 		const previousToolVisibility = runtime.settings.toolVisibility;
 		const settingsResult = readGoalSettings(options.settingsPath);
 		runtime.settings =
@@ -580,6 +695,9 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.queueFrozen = false;
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		clearCompletionStatusTimer();
+		runtime.completionSummary = undefined;
+		runtime.terminalReason = undefined;
+		sessionContext = undefined;
 	});
 
 	pi.on("session_before_compact", (event, ctx) => {
@@ -897,6 +1015,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		blockStaleGoalToolCalls();
 		abortCurrentTurn(ctx);
 		runtime.activeGoal = transitionGoal(goal, status);
+		runtime.terminalReason = assistant.errorMessage ?? `goal ${status} after agent interruption`;
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
 

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -80,6 +80,39 @@ export const GOAL_COMPLETE_TOOL = "goal_complete";
 export const GOAL_BLOCKED_TOOL = "goal_blocked";
 export const GOAL_TOOL_NAMES = [GOAL_COMPLETE_TOOL, GOAL_BLOCKED_TOOL] as const;
 
+/** Cross-extension event channel carrying the canonical persisted goal state. */
+export const GOAL_STATE_EVENT_CHANNEL = "pi-goal:state";
+
+/** Payload emitted on {@link GOAL_STATE_EVENT_CHANNEL} whenever goal state persists. */
+export interface GoalStateEventPayload {
+	goalId: string;
+	status: GoalStatus;
+	summary?: string;
+	reason?: string;
+}
+
+/** Terminal statuses broadcast to cross-extension listeners. */
+export function isTerminalGoalStatus(status: GoalStatus): boolean {
+	return status !== "active" && status !== "queued";
+}
+
+/**
+ * Build the cross-extension state payload from the canonical goal plus the most
+ * recent completion summary or blocked/failure reason, without re-deriving state.
+ */
+export function buildGoalStateEvent(
+	goal: ActiveGoal,
+	summary: string | undefined,
+	reason: string | undefined,
+): GoalStateEventPayload {
+	const payload: GoalStateEventPayload = { goalId: goal.id, status: goal.status };
+	if (goal.status === "complete" && summary) payload.summary = summary;
+	else if (goal.status !== "complete" && isTerminalGoalStatus(goal.status) && reason) {
+		payload.reason = reason;
+	}
+	return payload;
+}
+
 const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
 const MAX_PENDING_GOAL_PROMPTS = 20;
 const GOAL_PROMPT_MARKER_PREFIX = "pi-goal-prompt:";
@@ -115,6 +148,10 @@ const RETRYABLE_GOAL_ERROR_PATTERNS = [
 export class GoalRuntime {
 	settings: GoalSettings = DEFAULT_GOAL_SETTINGS;
 	activeGoal?: ActiveGoal;
+	/** Completion summary captured for cross-extension `pi-goal:state` events. */
+	completionSummary?: string;
+	/** Blocked/failure reason captured for cross-extension `pi-goal:state` events. */
+	terminalReason?: string;
 	queuedGoals: ActiveGoal[] = [];
 	pendingQueueAction?: PendingQueueAction;
 	queueFrozen = false;
@@ -299,6 +336,7 @@ export class GoalRuntime {
 		this.clearGoalRecoveryForGoal(goal.id);
 		this.clearBudgetWrapUp();
 		this.activeGoal = transitionGoal(goal, "budget_limited");
+		this.terminalReason = `token budget reached (${formatBudget(this.activeGoal)})`;
 		this.persistGoal(this.activeGoal);
 		this.updateStatus(ctx, this.activeGoal);
 		ctx.ui.notify(`Goal token budget reached: ${formatBudget(this.activeGoal)}`, "warning");
@@ -381,9 +419,17 @@ export class GoalRuntime {
 	}
 
 	persistGoal(goal: ActiveGoal) {
+		if (!isTerminalGoalStatus(goal.status)) {
+			this.completionSummary = undefined;
+			this.terminalReason = undefined;
+		}
 		this.pi.appendEntry(
 			GOAL_STATE_ENTRY_TYPE,
 			serializeGoalState(goal, this.queuedGoals, this.pendingQueueAction),
+		);
+		this.pi.events.emit(
+			GOAL_STATE_EVENT_CHANNEL,
+			buildGoalStateEvent(goal, this.completionSummary, this.terminalReason),
 		);
 	}
 

--- a/extensions/pi-goal/test/goal-rpc.test.ts
+++ b/extensions/pi-goal/test/goal-rpc.test.ts
@@ -1,0 +1,452 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import goal from "../src/goal.js";
+
+// Cross-extension RPC over Pi's session-local events bus. These tests cover the
+// pi-goal half: the pi-goal:rpc:start request/reply handshake, pi-goal:state
+// lifecycle broadcasts (including terminal summary/reason), and session-local
+// bind/unbind behavior. They never touch pi-subagents.
+
+type GoalTool = {
+	name?: string;
+	execute: (...args: unknown[]) => Promise<{
+		content?: Array<{ type: string; text: string }>;
+		terminate?: boolean;
+	}>;
+};
+
+type RpcSuccess = { success: true; data: { goalId: string; status: string } };
+type RpcFailure = { success: false; error: string };
+type RpcReply = RpcSuccess | RpcFailure;
+
+type StateEvent = {
+	goalId: string;
+	status: string;
+	summary?: string;
+	reason?: string;
+};
+
+const GOAL_SETTINGS_DIRECTORY = mkdtempSync(join(tmpdir(), "pi-goal-rpc-settings-"));
+const ALWAYS_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "always.json");
+writeFileSync(ALWAYS_SETTINGS_PATH, '{"toolVisibility":"always"}\n');
+after(() => rmSync(GOAL_SETTINGS_DIRECTORY, { recursive: true, force: true }));
+
+function registerGoal(pi: Parameters<typeof goal>[0]) {
+	pi.setActiveTools([...new Set([...pi.getActiveTools(), "goal_complete", "goal_blocked"])]);
+	goal(pi, { settingsPath: ALWAYS_SETTINGS_PATH });
+}
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function lastPersistedGoal(mock: ReturnType<typeof createMockPi>) {
+	const entry = mock.entries.filter((entry) => entry.customType === "goal-state").at(-1);
+	return (
+		entry?.data as { goal?: { id?: string; status?: string; text?: string } | null } | undefined
+	)?.goal;
+}
+
+function requireGoalTool(mock: ReturnType<typeof createMockPi>, name: string) {
+	const tool = mock.tools.find((tool) => tool.name === name);
+	assert.ok(tool, `expected ${name} to be registered`);
+	return tool as unknown as GoalTool;
+}
+
+function rpcStart(
+	mock: ReturnType<typeof createMockPi>,
+	payload: Record<string, unknown>,
+	requestId = payload.requestId,
+) {
+	const replies: RpcReply[] = [];
+	const id = typeof requestId === "string" ? requestId : "";
+	assert.ok(id, "test rpc:start must carry a requestId");
+	mock.eventBus.on(`pi-goal:rpc:start:reply:${id}`, (data) => replies.push(data as RpcReply));
+	mock.eventBus.emit("pi-goal:rpc:start", payload);
+	return { replies };
+}
+
+test("rpc start replies with the active goal id and status, and broadcasts active state", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, {
+		requestId: "req-1",
+		objective: "  ship the feature  ",
+	});
+	await flush();
+
+	assert.equal(replies.length, 1);
+	assert.equal(replies[0]?.success, true);
+	const reply = replies[0] as RpcSuccess;
+	assert.equal(reply.data.status, "active");
+	assert.equal(typeof reply.data.goalId, "string");
+	assert.ok(reply.data.goalId);
+	assert.equal(lastPersistedGoal(mock)?.text, "ship the feature");
+	// The kickoff prompt was delivered.
+	assert.ok(
+		mock.sentUserMessages.some((message) => /ship the feature/.test(message.text)),
+		"expected a goal kickoff message",
+	);
+	// An authoritative active state event was broadcast on persist.
+	assert.ok(
+		stateEvents.some((event) => event.status === "active" && event.goalId === reply.data.goalId),
+		"expected an active pi-goal:state event",
+	);
+});
+
+test("rpc pause transitions the active goal and broadcasts its reason", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	let aborts = 0;
+	const context = createMockContext({ abort: () => aborts++ });
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const { replies } = rpcStart(mock, { requestId: "req-pause", objective: "pause task" });
+	await flush();
+	const goalId = (replies[0] as RpcSuccess).data.goalId;
+
+	mock.eventBus.emit("pi-goal:rpc:pause", { goalId, reason: "parent agent stopped" });
+
+	assert.equal(lastPersistedGoal(mock)?.status, "paused");
+	assert.equal(aborts, 1);
+	const pausedEvent = stateEvents.filter((event) => event.status === "paused").at(-1);
+	assert.equal(pausedEvent?.goalId, goalId);
+	assert.equal(pausedEvent?.reason, "parent agent stopped");
+});
+
+test("rpc start honors a token budget", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, {
+		requestId: "req-budget",
+		objective: "scoped task",
+		tokenBudget: 50_000,
+	});
+	await flush();
+
+	assert.equal(replies[0]?.success, true);
+	const goal = lastPersistedGoal(mock);
+	assert.equal(goal?.status, "active");
+	assert.equal(
+		(mock.entries.at(-1)?.data as { goal?: { tokenBudget?: number } } | undefined)?.goal
+			?.tokenBudget,
+		50_000,
+	);
+});
+
+test("rpc start fails fast for a malformed payload (missing objective)", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-missing", objective: "" });
+	await flush();
+
+	assert.equal(replies.length, 1);
+	assert.equal(replies[0]?.success, false);
+	assert.match((replies[0] as RpcFailure).error, /goal_to_complete|objective/i);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("rpc start rejects an oversized objective even when padded", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, {
+		requestId: "req-oversized",
+		objective: `  ${"x".repeat(4_001)}  `,
+	});
+	await flush();
+
+	assert.equal(replies[0]?.success, false);
+	assert.match((replies[0] as RpcFailure).error, /too long/i);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("rpc start fails fast for a malformed payload (non-string objective)", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-type", objective: 42 });
+	await flush();
+
+	assert.equal(replies[0]?.success, false);
+	assert.match((replies[0] as RpcFailure).error, /objective must be a string/i);
+});
+
+test("rpc start fails fast for an invalid token budget", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	for (const tokenBudget of [-1, 0, 1.5, "100", true]) {
+		const { replies } = rpcStart(mock, {
+			requestId: `req-budget-${String(tokenBudget)}`,
+			objective: "task",
+			tokenBudget,
+		});
+		await flush();
+		assert.equal(
+			replies[0]?.success,
+			false,
+			`expected failure for tokenBudget ${String(tokenBudget)}`,
+		);
+		assert.match((replies[0] as RpcFailure).error, /tokenBudget must be a positive integer/i);
+	}
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("rpc start rejects a pre-existing goal without interactive replacement", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	let confirmCalls = 0;
+	const context = createMockContext({
+		confirm: async () => {
+			confirmCalls += 1;
+			return true;
+		},
+	});
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	// Establish an active goal through the normal slash-command path first.
+	await mock.commands.get("goal")?.handler("first goal", context.ctx);
+	const firstGoal = lastPersistedGoal(mock);
+	assert.equal(firstGoal?.status, "active");
+
+	const { replies } = rpcStart(mock, { requestId: "req-existing", objective: "second goal" });
+	await flush();
+
+	assert.equal(replies.length, 1);
+	assert.equal(replies[0]?.success, false);
+	assert.match((replies[0] as RpcFailure).error, /already exists/i);
+	// No interactive confirmation and the original goal is untouched.
+	assert.equal(confirmCalls, 0);
+	assert.equal(lastPersistedGoal(mock)?.id, firstGoal?.id);
+});
+
+test("pi-goal:state carries the completion summary on a terminal complete event", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-complete", objective: "finish it" });
+	await flush();
+	const goalId = (replies[0] as RpcSuccess).data.goalId;
+
+	const complete = requireGoalTool(mock, "goal_complete");
+	await complete.execute(
+		"complete-1",
+		{ goal_id: goalId, summary: "All requirements verified against current evidence." },
+		new AbortController().signal,
+		() => undefined,
+		context.ctx,
+	);
+
+	const completeEvent = stateEvents.filter((event) => event.status === "complete").at(-1);
+	assert.ok(completeEvent, "expected a complete pi-goal:state event");
+	assert.equal(completeEvent?.goalId, goalId);
+	assert.equal(completeEvent?.summary, "All requirements verified against current evidence.");
+});
+
+test("pi-goal:state carries the blocked reason on a terminal blocked event", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-blocked", objective: "blocked task" });
+	await flush();
+	const goalId = (replies[0] as RpcSuccess).data.goalId;
+
+	const blocked = requireGoalTool(mock, "goal_blocked");
+	await blocked.execute(
+		"blocked-1",
+		{
+			goal_id: goalId,
+			reason: "Needs a production API key that only the user can provision.",
+			evidence: "Attempted three auth flows; each failed with missing credentials.",
+			repeated_turns: 3,
+		},
+		new AbortController().signal,
+		() => undefined,
+		context.ctx,
+	);
+
+	const blockedEvent = stateEvents.filter((event) => event.status === "blocked").at(-1);
+	assert.ok(blockedEvent, "expected a blocked pi-goal:state event");
+	assert.equal(blockedEvent?.goalId, goalId);
+	assert.match(blockedEvent?.reason ?? "", /production API key/);
+});
+
+test("pi-goal:state carries the usage-limited reason from the agent error", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-usage", objective: "usage task" });
+	await flush();
+	const goalId = (replies[0] as RpcSuccess).data.goalId;
+
+	mock.events.get("agent_end")?.[0]?.(
+		{
+			messages: [
+				{
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "You have exceeded your usage limit for this period.",
+				},
+			],
+		},
+		context.ctx,
+	);
+
+	const usageEvent = stateEvents.filter((event) => event.status === "usage_limited").at(-1);
+	assert.ok(usageEvent, "expected a usage_limited pi-goal:state event");
+	assert.equal(usageEvent?.goalId, goalId);
+	assert.match(usageEvent?.reason ?? "", /exceeded your usage limit/);
+});
+
+test("terminal details do not leak across session bindings", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const firstContext = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, firstContext.ctx);
+	const { replies } = rpcStart(mock, { requestId: "req-old", objective: "old task" });
+	await flush();
+	const blocked = requireGoalTool(mock, "goal_blocked");
+	await blocked.execute(
+		"blocked-old",
+		{
+			goal_id: (replies[0] as RpcSuccess).data.goalId,
+			reason: "Old session reason",
+			evidence: "The same dependency failed on three separate turns.",
+			repeated_turns: 3,
+		},
+		new AbortController().signal,
+		() => undefined,
+		firstContext.ctx,
+	);
+	mock.events.get("session_shutdown")?.[0]?.({}, firstContext.ctx);
+
+	const restoredGoal = {
+		id: "restored-other-goal",
+		text: "restored task",
+		status: "blocked",
+		startedAt: 1,
+		updatedAt: 2,
+		iteration: 1,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		baselineTokens: 0,
+	};
+	const branch = [{ type: "custom", customType: "goal-state", data: { goal: restoredGoal } }];
+	const secondContext = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, secondContext.ctx);
+	mock.events.get("session_shutdown")?.[0]?.({}, secondContext.ctx);
+
+	const restoredEvent = stateEvents
+		.filter((event) => event.goalId === restoredGoal.id && event.status === "blocked")
+		.at(-1);
+	assert.ok(restoredEvent, "expected restored blocked state to persist on shutdown");
+	assert.equal(restoredEvent?.reason, undefined);
+});
+
+test("rpc start replies failure before a session context is bound", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	// Deliberately do not fire session_start: no session context is bound.
+
+	const { replies } = rpcStart(mock, { requestId: "req-unbound-start", objective: "task" });
+	await flush();
+
+	assert.equal(replies.length, 1);
+	assert.equal(replies[0]?.success, false);
+	assert.match((replies[0] as RpcFailure).error, /no active pi-goal session context/i);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("rpc start replies failure after session shutdown unbinds the context", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-unbound-shutdown", objective: "task" });
+	await flush();
+
+	assert.equal(replies.length, 1);
+	assert.equal(replies[0]?.success, false);
+	assert.match((replies[0] as RpcFailure).error, /no active pi-goal session context/i);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("pi-goal:state never carries a summary or reason for an active goal", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, {
+		requestId: "req-active-only",
+		objective: "active task",
+	});
+	await flush();
+
+	const activeEvents = stateEvents.filter((event) => event.status === "active");
+	assert.ok(activeEvents.length > 0, "expected active state events");
+	for (const event of activeEvents) {
+		assert.equal(event.summary, undefined, "active state must not carry a summary");
+		assert.equal(event.reason, undefined, "active state must not carry a reason");
+	}
+
+	const blocked = requireGoalTool(mock, "goal_blocked");
+	await blocked.execute(
+		"blocked-before-resume",
+		{
+			goal_id: (replies[0] as RpcSuccess).data.goalId,
+			reason: "Old terminal reason",
+			evidence: "The same external dependency failed on three separate turns.",
+			repeated_turns: 3,
+		},
+		new AbortController().signal,
+		() => undefined,
+		context.ctx,
+	);
+	await mock.commands.get("goal")?.handler("resume", context.ctx);
+	await mock.commands.get("goal")?.handler("pause", context.ctx);
+
+	const pausedEvent = stateEvents.filter((event) => event.status === "paused").at(-1);
+	assert.ok(pausedEvent, "expected a paused state event");
+	assert.equal(pausedEvent?.reason, undefined, "old terminal reasons must not leak");
+});

--- a/test/support.ts
+++ b/test/support.ts
@@ -26,6 +26,11 @@ type MockPiApi = {
 	registerProvider(name: string, config: unknown): void;
 	unregisterProvider(name: string): void;
 	on(name: string, handler: MockHandler): void;
+	events: {
+		emit: (channel: string, data: unknown) => void;
+		on: (channel: string, handler: (data: unknown) => void) => () => void;
+		clear: () => void;
+	};
 	getFlag(name: string): unknown;
 	getActiveTools(): string[];
 	setActiveTools(names: string[]): void;
@@ -58,6 +63,26 @@ export function createMockPi(
 	const sentMessages: Array<{ message: unknown; options?: unknown }> = [];
 	const setModels: unknown[] = [];
 	const thinkingLevels: string[] = [];
+	const eventBusSubscriptions = new Map<string, Array<(data: unknown) => void>>();
+	const eventBus = {
+		emit(channel: string, data: unknown) {
+			for (const handler of eventBusSubscriptions.get(channel) ?? []) handler(data);
+		},
+		on(channel: string, handler: (data: unknown) => void) {
+			const list = eventBusSubscriptions.get(channel) ?? [];
+			list.push(handler);
+			eventBusSubscriptions.set(channel, list);
+			return () => {
+				const current = eventBusSubscriptions.get(channel);
+				if (!current) return;
+				const index = current.indexOf(handler);
+				if (index >= 0) current.splice(index, 1);
+			};
+		},
+		clear() {
+			eventBusSubscriptions.clear();
+		},
+	};
 	let thinkingLevel = options.thinkingLevel ?? "off";
 	let activeTools = [...(options.activeTools ?? [])];
 	const allTools = options.allTools ?? activeTools.map((name) => builtinTool(name));
@@ -125,6 +150,7 @@ export function createMockPi(
 			setModels.push(model);
 			return true;
 		},
+		events: eventBus,
 	};
 
 	return {
@@ -133,6 +159,7 @@ export function createMockPi(
 		commands,
 		flags,
 		events,
+		eventBus,
 		tools,
 		providers,
 		providerRegistrations,


### PR DESCRIPTION
## Summary

- add session-local `pi-goal:rpc:start` and `pi-goal:rpc:pause` channels over `pi.events`
- emit authoritative `pi-goal:state` payloads from canonical persistence, including terminal summary/reason
- reuse `GoalCommandController` transitions, reject stale/pre-existing RPC state, and reset terminal metadata across sessions
- document and test the cross-extension contract

This is the provider half of tintinweb/pi-subagents#161. Companion consumer PR: tintinweb/pi-subagents#162. It lets a child agent start Goal after extensions bind, wait for a terminal state, and pause safely even when cancellation arrives before the start reply.

## Verification

- `npm run biome:check`
- `npm run check:boundaries`
- `npm run typecheck`
- all pi-goal tests: **176 passed**
- real cross-repository smoke with pi-subagents, the real Pi loader/session, this source extension, and `goal_complete`: passed

`npm run check` reached **849/854** root tests; the 5 failures are unrelated existing timing/environment failures in pi-image-drop/pi-webui SSE tests and pi-subagents worktree setup. The changed pi-goal suite is fully green.
