### PR TITLE
fix(accounts): preserve nested autocomplete prefixes

### DIFF
--- a/extensions/pi-accounts/src/accounts.ts
+++ b/extensions/pi-accounts/src/accounts.ts
@@ -453,15 +453,21 @@ export function completeAccountArguments(
 	const subcommand = tokens[0];
 	if (!["list", "login", "switch", "remove"].includes(subcommand)) return [];
 	if (tokens.length === 2) {
-		return filterCompletions(
-			SUPPORTED_PROVIDER_IDS.map((id) => ({ value: id, label: id })),
-			tokens[1] ?? "",
+		return prefixCompletionValues(
+			subcommand,
+			filterCompletions(
+				SUPPORTED_PROVIDER_IDS.map((id) => ({ value: id, label: id })),
+				tokens[1] ?? "",
+			),
 		);
 	}
 	if ((subcommand === "switch" || subcommand === "remove") && tokens.length === 3) {
 		const providerId = parseProviderId(tokens[1] ?? "");
 		return providerId
-			? completeProviderAccounts(tokens[2] ?? "", store, providerId, subcommand === "switch")
+			? prefixCompletionValues(
+					`${subcommand} ${providerId}`,
+					completeProviderAccounts(tokens[2] ?? "", store, providerId, subcommand === "switch"),
+				)
 			: [];
 	}
 	return [];
@@ -534,6 +540,13 @@ function filterCompletions(
 	prefix: string,
 ): CommandArgumentCompletion[] {
 	return prefix ? items.filter((item) => item.value.startsWith(prefix)) : items;
+}
+
+function prefixCompletionValues(
+	prefix: string,
+	items: CommandArgumentCompletion[],
+): CommandArgumentCompletion[] {
+	return items.map((item) => ({ ...item, value: `${prefix} ${item.value}` }));
 }
 
 function isDefaultPiLoginArg(value: string): boolean {

--- a/extensions/pi-accounts/test/accounts.test.ts
+++ b/extensions/pi-accounts/test/accounts.test.ts
@@ -200,11 +200,19 @@ test("account names and command completion are provider scoped", async () => {
 
 	assert.deepEqual(
 		completeAccountArguments("switch anthropic ", store).map((item) => item.value),
-		["default", "home", "work"],
+		["switch anthropic default", "switch anthropic home", "switch anthropic work"],
+	);
+	assert.deepEqual(
+		completeAccountArguments("remove anthropic h", store).map((item) => item.value),
+		["remove anthropic home"],
 	);
 	assert.deepEqual(
 		completeAccountArguments("login ", store).map((item) => item.value),
-		["anthropic", "github-copilot", "openai-codex"],
+		["login anthropic", "login github-copilot", "login openai-codex"],
+	);
+	assert.deepEqual(
+		completeAccountArguments("list open", store).map((item) => item.value),
+		["list openai-codex"],
 	);
 });
 


### PR DESCRIPTION
## Summary

- preserve existing `/account` subcommands when completing provider names
- preserve both subcommand and provider when completing stored account names
- add regression coverage for `list`, `login`, `switch`, and `remove` completion values

## Testing

- `npm run check` (923 tests passed)