### PR TITLE
fix(accounts): streamline argument autocomplete

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,6 +3,7 @@
 ## GOTCHA
 
 - `MEMORY.md` is not auto-loaded; check it before non-trivial debugging or design work when prior project context may matter.
+- Pi command argument completion replaces the full argument prefix; nested values must retain prior tokens, intermediate values need a trailing space for repeated-Tab chaining, and storage-backed suggestions should avoid synchronous locks.
 - npm can show a scoped package dist-tag (for example `latest`) while `npm view <package>` still returns 404; fix visibility with `npm access set status=public <package> --otp=<otp>` or publish a bumped version.
 - `npm access set status=public <package>` cannot create brand-new scoped packages; if it returns access 404, first run `npm publish --workspace <package> --access public`.
 - For sleep-inhibitor extensions on WSL, prefer Windows `powershell.exe` with `SetThreadExecutionState`; `systemd-inhibit` may exist but fail without a usable systemd/logind session. Ensure Windows inhibitors exit on stdin EOF, clear `ES_CONTINUOUS`, and pass execution-state flags as `[uint32]'0x...'`; ensure Unix inhibitors are parent-bound and trap cleanup, or Pi shutdown can leave a power request/process active.

--- a/extensions/pi-accounts/README.md
+++ b/extensions/pi-accounts/README.md
@@ -96,7 +96,7 @@ Remove a named account:
 /account remove github-copilot enterprise
 ```
 
-Provider and stored-account arguments offer completion. Mutating commands always require an explicit provider ID.
+Provider and stored-account arguments offer completion. Press Tab repeatedly to step through the subcommand, provider, and stored account without adding spaces manually. Mutating commands always require an explicit provider ID.
 
 ### Temporary Codex aliases
 

--- a/extensions/pi-accounts/src/accounts.ts
+++ b/extensions/pi-accounts/src/accounts.ts
@@ -437,51 +437,61 @@ async function listAccounts(
 	ctx.ui.notify(lines.join("\n"), "info");
 }
 
-export function completeAccountArguments(
+export async function completeAccountArguments(
 	argumentPrefix: string,
 	store: AccountStore,
-): CommandArgumentCompletion[] {
+): Promise<CommandArgumentCompletion[]> {
 	const hasTrailingSpace = /\s$/.test(argumentPrefix);
 	const tokens = splitArguments(argumentPrefix);
 	if (hasTrailingSpace) tokens.push("");
 	if (tokens.length <= 1) {
-		return filterCompletions(
-			["list", "login", "switch", "remove"].map((value) => ({ value, label: value })),
-			tokens[0] ?? "",
+		return continueCompletionValues(
+			filterCompletions(
+				["list", "login", "switch", "remove"].map((value) => ({ value, label: value })),
+				tokens[0] ?? "",
+			),
 		);
 	}
 	const subcommand = tokens[0];
 	if (!["list", "login", "switch", "remove"].includes(subcommand)) return [];
 	if (tokens.length === 2) {
-		return prefixCompletionValues(
+		const providerCompletions = prefixCompletionValues(
 			subcommand,
 			filterCompletions(
 				SUPPORTED_PROVIDER_IDS.map((id) => ({ value: id, label: id })),
 				tokens[1] ?? "",
 			),
 		);
+		return subcommand === "list"
+			? providerCompletions
+			: continueCompletionValues(providerCompletions);
 	}
 	if ((subcommand === "switch" || subcommand === "remove") && tokens.length === 3) {
 		const providerId = parseProviderId(tokens[1] ?? "");
 		return providerId
 			? prefixCompletionValues(
 					`${subcommand} ${providerId}`,
-					completeProviderAccounts(tokens[2] ?? "", store, providerId, subcommand === "switch"),
+					await completeProviderAccounts(
+						tokens[2] ?? "",
+						store,
+						providerId,
+						subcommand === "switch",
+					),
 				)
 			: [];
 	}
 	return [];
 }
 
-function completeProviderAccounts(
+async function completeProviderAccounts(
 	prefix: string,
 	store: AccountStore,
 	providerId: AccountProviderId,
 	includeDefault: boolean,
-): CommandArgumentCompletion[] {
+): Promise<CommandArgumentCompletion[]> {
 	let names: string[] = [];
 	try {
-		names = Object.keys(store.read().providers[providerId]?.accounts ?? {}).sort();
+		names = Object.keys((await store.readAsync()).providers[providerId]?.accounts ?? {}).sort();
 	} catch {
 		return [];
 	}
@@ -547,6 +557,10 @@ function prefixCompletionValues(
 	items: CommandArgumentCompletion[],
 ): CommandArgumentCompletion[] {
 	return items.map((item) => ({ ...item, value: `${prefix} ${item.value}` }));
+}
+
+function continueCompletionValues(items: CommandArgumentCompletion[]): CommandArgumentCompletion[] {
+	return items.map((item) => ({ ...item, value: `${item.value} ` }));
 }
 
 function isDefaultPiLoginArg(value: string): boolean {

--- a/extensions/pi-accounts/test/accounts.test.ts
+++ b/extensions/pi-accounts/test/accounts.test.ts
@@ -15,7 +15,7 @@ import {
 	createOAuthInteraction,
 } from "../src/oauth.js";
 import { RuntimeAuthCoordinator } from "../src/runtime-auth.js";
-import { InMemoryAccountStorageBackend } from "../src/storage.js";
+import { type AccountStorageBackend, InMemoryAccountStorageBackend } from "../src/storage.js";
 
 const credential = (
 	suffix: string,
@@ -199,21 +199,59 @@ test("account names and command completion are provider scoped", async () => {
 	});
 
 	assert.deepEqual(
-		completeAccountArguments("switch anthropic ", store).map((item) => item.value),
+		(await completeAccountArguments("s", store)).map((item) => item.value),
+		["switch "],
+	);
+	assert.deepEqual(
+		(await completeAccountArguments("switch ", store)).map((item) => item.value),
+		["switch anthropic ", "switch github-copilot ", "switch openai-codex "],
+	);
+	assert.deepEqual(
+		(await completeAccountArguments("switch anthropic ", store)).map((item) => item.value),
 		["switch anthropic default", "switch anthropic home", "switch anthropic work"],
 	);
 	assert.deepEqual(
-		completeAccountArguments("remove anthropic h", store).map((item) => item.value),
+		(await completeAccountArguments("remove anthropic h", store)).map((item) => item.value),
 		["remove anthropic home"],
 	);
 	assert.deepEqual(
-		completeAccountArguments("login ", store).map((item) => item.value),
-		["login anthropic", "login github-copilot", "login openai-codex"],
+		(await completeAccountArguments("login ", store)).map((item) => item.value),
+		["login anthropic ", "login github-copilot ", "login openai-codex "],
 	);
 	assert.deepEqual(
-		completeAccountArguments("list open", store).map((item) => item.value),
+		(await completeAccountArguments("list open", store)).map((item) => item.value),
 		["list openai-codex"],
 	);
+});
+
+test("stored-account completion does not block on synchronous storage", async () => {
+	let synchronousReads = 0;
+	let asynchronousReads = 0;
+	const raw = JSON.stringify({
+		version: 1,
+		providers: {
+			anthropic: { accounts: { work: credential("work") } },
+		},
+	});
+	const backend: AccountStorageBackend = {
+		withLock() {
+			synchronousReads += 1;
+			throw new Error("synchronous storage should not be used for completion");
+		},
+		async withLockAsync(mutator) {
+			asynchronousReads += 1;
+			return (await mutator(raw)).result;
+		},
+	};
+
+	assert.deepEqual(
+		(await completeAccountArguments("switch anthropic w", new AccountStore(backend))).map(
+			(item) => item.value,
+		),
+		["switch anthropic work"],
+	);
+	assert.equal(synchronousReads, 0);
+	assert.equal(asynchronousReads, 1);
 });
 
 test("provider accounts activate independently and default clears only one provider", async () => {


### PR DESCRIPTION
## Summary

- chain `/account` subcommand and provider completions with repeated Tab presses
- load stored-account suggestions asynchronously to avoid blocking synchronous file locks
- document the improved workflow and cover it with regression tests

## Verification

- `npm run check` (924 tests)
- `npm run pack:accounts --silent`