### PR TITLE
feat(goal): expose ownership-safe lifecycle RPC

### DIFF
--- a/docs/plans/archived/2026-07-21_goal-rpc-lifecycle-hardening-plan.md
+++ b/docs/plans/archived/2026-07-21_goal-rpc-lifecycle-hardening-plan.md
@@ -1,0 +1,32 @@
+## Goal
+
+Harden the new pi-goal cross-extension RPC contract so pause requests cannot affect unrelated goals, terminal details stay bound to their goal instance, and observers receive an explicit terminal event when a goal is cleared.
+
+## Context
+
+This branch carries the provider work from PR #298 on top of current `main`. The fixes will produce a replacement PR and preserve the companion pi-subagents start/reply/state flow while making pre-reply cancellation correlate by `requestId`.
+
+## Architecture
+
+Move the RPC protocol controller out of the Pi composition root, keep RPC ownership session-local, bind terminal details to a goal ID in `GoalRuntime`, and extend state events with a terminal `cleared` status.
+
+## Plan
+
+- [x] Added regression tests for terminal-detail leakage after stopped-goal edits, unowned/id-less pause requests, correlated pre-reply cancellation, clear/rollback state events, and listener error isolation; the focused suite failed in six expected cases before implementation.
+- [x] Implemented goal-ID-bound terminal details and explicit `cleared` state events in `extensions/pi-goal/src/runtime.ts`; the focused pi-goal RPC suite passes 22/22.
+- [x] Extracted and hardened RPC request ownership in `extensions/pi-goal/src/rpc.ts`, wired it from `goal.ts`, and documented the `requestId` cancellation and `cleared` status contract; the focused suite passes.
+- [x] Aligned the shared event-bus mock with Pi listener error isolation and scanned sibling goal transitions for stale ownership or metadata paths; the root test suite passes.
+- [x] Ran repository checks and the pi-goal package dry run, inspected the final diff, and prepared this plan for archival before commit, push, and PR creation.
+
+## Risks
+
+- Adding `cleared` expands the state-event status union; the companion pi-subagents PR must treat it as terminal.
+- Pre-reply cancellation without `goalId` now requires the originating `requestId`; callers using the reviewed but unmerged contract must update.
+
+## Completion Checklist
+
+- [x] Unrelated manual or newer RPC goals cannot be paused by stale/id-less requests, proven by focused RPC regression tests.
+- [x] Terminal summary/reason data cannot cross goal IDs, proven by the stopped-goal edit regression test.
+- [x] Active-goal clear and failed activation rollback emit terminal `cleared` events, proven by clear and event-order tests.
+- [x] `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` passes 947/947 tests and `just pack-goal` includes `src/rpc.ts` in the 13-file package.
+- [x] The replacement PR content, verification, and companion-contract notes are prepared; push and GitHub PR creation are the remaining publication operations immediately following archival.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -192,11 +192,11 @@ Behavior notes:
 
 ### Pausing a goal: `pi-goal:rpc:pause`
 
-Emit `pi-goal:rpc:pause` with `{ goalId?: string, reason?: string }` to stop an active RPC-owned goal safely. When `goalId` is present and does not match the active goal, the request is ignored; omitting it supports cancellation while the start reply is still pending. A successful pause uses the normal Goal pause transition and emits the authoritative `pi-goal:state` event described below.
+Emit `pi-goal:rpc:pause` with `{ goalId?: string, requestId?: string, reason?: string }` to stop an active RPC-owned goal safely. After a successful start reply, pass its `goalId`. To cancel while the start reply is still pending, omit `goalId` and pass the originating start `requestId`. Uncorrelated requests, stale request IDs, mismatched goal IDs, and goals not created through RPC are ignored. A successful pause uses the normal Goal pause transition and emits the authoritative `pi-goal:state` event described below.
 
 ### Observing goal state: `pi-goal:state`
 
-Whenever pi-goal persists canonical goal state, it emits `pi-goal:state` with `{ goalId, status, summary?, reason? }`. `goalId` and `status` are always authoritative. Terminal statuses are `complete`, `blocked`, `paused`, `usage_limited`, and `budget_limited`. `summary` is populated from the `goal_complete` summary when available, and `reason` is populated from the blocked/usage/budget failure state where available; an `active` or `queued` event carries only `goalId` and `status`. Listeners must treat any non-terminal status as in-progress and should key follow-up behavior on `goalId` plus a terminal `status`.
+Whenever pi-goal persists canonical goal state, it emits `pi-goal:state` with `{ goalId, status, summary?, reason? }`. `goalId` and `status` are always authoritative. Terminal statuses are `complete`, `blocked`, `paused`, `usage_limited`, `budget_limited`, and `cleared`. Explicit clears and failed activation rollbacks emit `cleared` for the removed goal so observers cannot retain stale active state. `summary` is populated from the matching `goal_complete` summary when available, and `reason` is populated from the same goal instance's blocked/usage/budget/clear state where available; an `active` or `queued` event carries only `goalId` and `status`. Listeners must treat any non-terminal status as in-progress and should key follow-up behavior on `goalId` plus a terminal `status`.
 
 ## 🧠 Use cases
 
@@ -214,6 +214,7 @@ extensions/pi-goal/
 │   ├── goal.ts       # Pi entrypoint, tool contracts, and lifecycle orchestration
 │   ├── commands.ts   # Per-factory user-command and queue mutation controller
 │   ├── runtime.ts    # Per-factory state, prompt ownership, budgets, and tool policy
+│   ├── rpc.ts        # Session-local cross-extension request ownership and replies
 │   ├── queue.ts      # Pure ordered-goal transitions
 │   └── *.ts          # Package-local parsing, settings, prompts, accounting, and persistence
 ├── README.md

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -1,5 +1,6 @@
 import { currentTokenTotal } from "./accounting.js";
 import { validateObjective } from "./command.js";
+import type { ActiveGoal } from "./persistence.js";
 import { buildGoalPrompt, buildObjectiveUpdatedPrompt, buildResumePrompt } from "./prompts.js";
 import {
 	activateQueuedGoal,
@@ -36,7 +37,12 @@ export class GoalCommandController {
 		this.runtime = runtime;
 	}
 
-	async startGoal(objective: string, tokenBudget: number | undefined, ctx: StatusContext) {
+	async startGoal(
+		objective: string,
+		tokenBudget: number | undefined,
+		ctx: StatusContext,
+		onActivated?: (goal: ActiveGoal) => void,
+	) {
 		const validationError = validateObjective(objective);
 		if (validationError) {
 			ctx.ui.notify(validationError, "warning");
@@ -75,9 +81,10 @@ export class GoalCommandController {
 		this.runtime.queuedGoals = [];
 		this.runtime.pendingQueueAction = undefined;
 		this.runtime.activeGoal = createGoal(objective, tokenBudget, currentTokenTotal(ctx));
-		this.runtime.persistGoal(this.runtime.activeGoal);
-		this.runtime.updateStatus(ctx, this.runtime.activeGoal);
 		const startedGoal = this.runtime.activeGoal;
+		onActivated?.(startedGoal);
+		this.runtime.persistGoal(startedGoal);
+		this.runtime.updateStatus(ctx, startedGoal);
 		const sent = await this.runtime.sendOwnedGoalPrompt(
 			ctx,
 			startedGoal.id,

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -1,11 +1,12 @@
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { currentTokenTotal } from "./accounting.js";
-import { completeGoalArguments, parseCommand, validateObjective } from "./command.js";
+import { completeGoalArguments, parseCommand } from "./command.js";
 import { GoalCommandController } from "./commands.js";
 import { type ActiveGoal, loadGoalStateFromSession } from "./persistence.js";
-import { buildGoalPrompt, buildGoalSystemPrompt, type GoalStatus } from "./prompts.js";
+import { buildGoalPrompt, buildGoalSystemPrompt } from "./prompts.js";
 import { activateQueuedGoal } from "./queue.js";
+import { GoalRpcController } from "./rpc.js";
 import {
 	type AssistantMessageLike,
 	abortCurrentTurn,
@@ -51,101 +52,6 @@ interface GoalOptions {
 	settingsPath?: string;
 }
 
-// Cross-extension RPC contract over Pi's session-local events bus. pi-subagents
-// (or any sibling extension) starts or pauses a goal through RPC; pi-goal replies
-// to starts and broadcasts `pi-goal:state` on every persist.
-const RPC_START_CHANNEL = "pi-goal:rpc:start";
-const RPC_PAUSE_CHANNEL = "pi-goal:rpc:pause";
-
-interface GoalRpcStartPayload {
-	requestId: string;
-	objective: string;
-	tokenBudget?: number;
-}
-
-type GoalRpcReply =
-	| { success: true; data: { goalId: string; status: GoalStatus } }
-	| { success: false; error: string };
-
-function rpcReplyChannel(requestId: string) {
-	return `pi-goal:rpc:start:reply:${requestId}`;
-}
-
-function parseRpcStartPayload(
-	payload: Partial<GoalRpcStartPayload> | null,
-): string | { objective: string; tokenBudget?: number } {
-	if (!payload || typeof payload !== "object") return "rpc:start payload is missing";
-	if (typeof payload.objective !== "string") return "objective must be a string";
-	const objective = payload.objective.trim();
-	const objectiveError = validateObjective(objective);
-	if (objectiveError) return objectiveError;
-	let tokenBudget: number | undefined;
-	if (payload.tokenBudget !== undefined) {
-		if (
-			typeof payload.tokenBudget !== "number" ||
-			!Number.isFinite(payload.tokenBudget) ||
-			!Number.isSafeInteger(payload.tokenBudget) ||
-			payload.tokenBudget <= 0
-		) {
-			return "tokenBudget must be a positive integer";
-		}
-		tokenBudget = payload.tokenBudget;
-	}
-	return { objective, tokenBudget };
-}
-
-async function handleGoalRpcStart(
-	runtime: GoalRuntime,
-	commands: GoalCommandController,
-	data: unknown,
-	sessionContext: StatusContext | undefined,
-) {
-	const payload = data as Partial<GoalRpcStartPayload> | null;
-	const requestId = typeof payload?.requestId === "string" ? payload.requestId.trim() : "";
-	// Without a usable requestId there is no reply channel to address safely.
-	if (!requestId) return;
-	const reply = (envelope: GoalRpcReply) =>
-		runtime.pi.events.emit(rpcReplyChannel(requestId), envelope);
-
-	if (!sessionContext) {
-		reply({ success: false, error: "no active pi-goal session context" });
-		return;
-	}
-	const parsed = parseRpcStartPayload(payload);
-	if (typeof parsed === "string") {
-		reply({ success: false, error: parsed });
-		return;
-	}
-	// RPC starts run in a fresh child: any pre-existing goal must fail rather
-	// than trigger interactive replacement confirmation or reuse stale state.
-	const existingGoal = runtime.activeGoal;
-	if (existingGoal) {
-		reply({
-			success: false,
-			error: "a goal already exists; clear it before starting another via RPC",
-		});
-		return;
-	}
-	try {
-		await commands.startGoal(parsed.objective, parsed.tokenBudget, sessionContext);
-	} catch (error) {
-		reply({ success: false, error: `goal start failed: ${formatError(error)}` });
-		return;
-	}
-	// Read the authoritative status so an immediate terminal outcome during start
-	// is reflected in the reply instead of assuming "active".
-	const goal = runtime.activeGoal;
-	if (!goal) {
-		reply({
-			success: false,
-			error:
-				"goal start failed; the objective could not be activated (goal tools unavailable or kickoff delivery failed)",
-		});
-		return;
-	}
-	reply({ success: true, data: { goalId: goal.id, status: goal.status } });
-}
-
 const EXPERIMENTAL_GOALS_WARNING =
 	"Experimental ordered goals are enabled for pi-goal. Queue behavior and persisted state may change.";
 const MAX_BLOCKER_REASON_LENGTH = 1_000;
@@ -164,21 +70,8 @@ function onAgentSettled(pi: ExtensionAPI, handler: AgentSettledHandler) {
 function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 	const runtime = new GoalRuntime(pi);
 	const commands = new GoalCommandController(runtime);
-
-	// Session-local cross-extension RPC context. session_start binds it and
-	// session_shutdown unbinds it; the RPC channel replies failure while unbound.
-	let sessionContext: StatusContext | undefined;
-	pi.events.on(RPC_START_CHANNEL, (data) => {
-		void handleGoalRpcStart(runtime, commands, data, sessionContext);
-	});
-	pi.events.on(RPC_PAUSE_CHANNEL, (data) => {
-		if (!sessionContext || runtime.activeGoal?.status !== "active") return;
-		const payload = data as { goalId?: unknown; reason?: unknown } | null;
-		if (typeof payload?.goalId === "string" && payload.goalId !== runtime.activeGoal.id) return;
-		const reason = typeof payload?.reason === "string" ? payload.reason.trim() : "";
-		runtime.terminalReason = reason || "goal paused by RPC";
-		commands.pauseGoal(sessionContext);
-	});
+	const rpc = new GoalRpcController(runtime, commands);
+	rpc.register(pi);
 
 	// Bind per-factory runtime operations once so event orchestration stays concise
 	// without reintroducing module-global mutable state.
@@ -335,7 +228,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			}
 
 			runtime.activeGoal = transitionGoal(completedGoal, "complete");
-			runtime.completionSummary = summary;
+			runtime.setCompletionSummary(runtime.activeGoal.id, summary);
 			updateGoalUsage(runtime.activeGoal, ctx);
 			if (runtime.pendingQueueAction?.kind === "prioritize") {
 				persistGoal(runtime.activeGoal);
@@ -479,7 +372,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			clearGoalRecoveryForGoal(blockedGoal.id);
 			blockStaleGoalToolCalls();
 			runtime.activeGoal = transitionGoal(blockedGoal, "blocked");
-			runtime.terminalReason = reason;
+			runtime.setTerminalReason(runtime.activeGoal.id, reason);
 			persistGoal(runtime.activeGoal);
 			updateStatus(ctx, runtime.activeGoal);
 			ctx.ui.notify(`Goal blocked: ${truncateNotification(reason)}`, "warning");
@@ -578,9 +471,8 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.queuedGoals = [];
 		runtime.pendingQueueAction = undefined;
 		runtime.queueFrozen = false;
-		runtime.completionSummary = undefined;
-		runtime.terminalReason = undefined;
-		sessionContext = ctx;
+		runtime.clearTerminalDetails();
+		rpc.bindSession(ctx);
 		const previousToolVisibility = runtime.settings.toolVisibility;
 		const settingsResult = readGoalSettings(options.settingsPath);
 		runtime.settings =
@@ -695,9 +587,8 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.queueFrozen = false;
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		clearCompletionStatusTimer();
-		runtime.completionSummary = undefined;
-		runtime.terminalReason = undefined;
-		sessionContext = undefined;
+		runtime.clearTerminalDetails();
+		rpc.unbindSession();
 	});
 
 	pi.on("session_before_compact", (event, ctx) => {
@@ -1015,7 +906,10 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		blockStaleGoalToolCalls();
 		abortCurrentTurn(ctx);
 		runtime.activeGoal = transitionGoal(goal, status);
-		runtime.terminalReason = assistant.errorMessage ?? `goal ${status} after agent interruption`;
+		runtime.setTerminalReason(
+			runtime.activeGoal.id,
+			assistant.errorMessage ?? `goal ${status} after agent interruption`,
+		);
 		persistGoal(runtime.activeGoal);
 		updateStatus(ctx, runtime.activeGoal);
 

--- a/extensions/pi-goal/src/rpc.ts
+++ b/extensions/pi-goal/src/rpc.ts
@@ -1,0 +1,188 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { validateObjective } from "./command.js";
+import type { GoalCommandController } from "./commands.js";
+import type { GoalStatus } from "./prompts.js";
+import { formatError, type GoalRuntime, type StatusContext } from "./runtime.js";
+
+// Cross-extension RPC contract over Pi's session-local events bus. pi-subagents
+// (or any sibling extension) starts or pauses a goal through RPC; pi-goal replies
+// to starts and broadcasts `pi-goal:state` from the runtime persistence boundary.
+const RPC_START_CHANNEL = "pi-goal:rpc:start";
+const RPC_PAUSE_CHANNEL = "pi-goal:rpc:pause";
+
+interface GoalRpcStartPayload {
+	requestId: string;
+	objective: string;
+	tokenBudget?: number;
+}
+
+interface GoalRpcPausePayload {
+	requestId?: string;
+	goalId?: string;
+	reason?: string;
+}
+
+type GoalRpcReply =
+	| { success: true; data: { goalId: string; status: GoalStatus } }
+	| { success: false; error: string };
+
+interface GoalRpcOwnership {
+	requestId: string;
+	goalId: string;
+}
+
+function rpcReplyChannel(requestId: string) {
+	return `pi-goal:rpc:start:reply:${requestId}`;
+}
+
+function parseRpcStartPayload(
+	payload: Partial<GoalRpcStartPayload> | null,
+): string | { objective: string; tokenBudget?: number } {
+	if (!payload || typeof payload !== "object") return "rpc:start payload is missing";
+	if (typeof payload.objective !== "string") return "objective must be a string";
+	const objective = payload.objective.trim();
+	const objectiveError = validateObjective(objective);
+	if (objectiveError) return objectiveError;
+	let tokenBudget: number | undefined;
+	if (payload.tokenBudget !== undefined) {
+		if (
+			typeof payload.tokenBudget !== "number" ||
+			!Number.isFinite(payload.tokenBudget) ||
+			!Number.isSafeInteger(payload.tokenBudget) ||
+			payload.tokenBudget <= 0
+		) {
+			return "tokenBudget must be a positive integer";
+		}
+		tokenBudget = payload.tokenBudget;
+	}
+	return { objective, tokenBudget };
+}
+
+export class GoalRpcController {
+	private readonly runtime: GoalRuntime;
+	private readonly commands: GoalCommandController;
+	private sessionContext?: StatusContext;
+	private ownership?: GoalRpcOwnership;
+
+	constructor(runtime: GoalRuntime, commands: GoalCommandController) {
+		this.runtime = runtime;
+		this.commands = commands;
+	}
+
+	register(pi: ExtensionAPI) {
+		pi.events.on(RPC_START_CHANNEL, (data) => {
+			void this.handleStart(data);
+		});
+		pi.events.on(RPC_PAUSE_CHANNEL, (data) => {
+			this.handlePause(data);
+		});
+	}
+
+	bindSession(ctx: StatusContext) {
+		this.sessionContext = ctx;
+		this.ownership = undefined;
+	}
+
+	unbindSession() {
+		this.sessionContext = undefined;
+		this.ownership = undefined;
+	}
+
+	private async handleStart(data: unknown) {
+		const payload = data as Partial<GoalRpcStartPayload> | null;
+		const requestId = typeof payload?.requestId === "string" ? payload.requestId.trim() : "";
+		// Without a usable requestId there is no reply channel to address safely.
+		if (!requestId) return;
+		const reply = (envelope: GoalRpcReply) =>
+			this.runtime.pi.events.emit(rpcReplyChannel(requestId), envelope);
+
+		const sessionContext = this.sessionContext;
+		if (!sessionContext) {
+			reply({ success: false, error: "no active pi-goal session context" });
+			return;
+		}
+		const parsed = parseRpcStartPayload(payload);
+		if (typeof parsed === "string") {
+			reply({ success: false, error: parsed });
+			return;
+		}
+		// RPC starts run in a fresh child: any pre-existing goal must fail rather
+		// than trigger interactive replacement confirmation or reuse stale state.
+		const existingGoal = this.runtime.activeGoal;
+		if (existingGoal) {
+			reply({
+				success: false,
+				error: "a goal already exists; clear it before starting another via RPC",
+			});
+			return;
+		}
+
+		let activatedGoalId: string | undefined;
+		try {
+			await this.commands.startGoal(
+				parsed.objective,
+				parsed.tokenBudget,
+				sessionContext,
+				(goal) => {
+					activatedGoalId = goal.id;
+					this.ownership = { requestId, goalId: goal.id };
+				},
+			);
+		} catch (error) {
+			this.clearOwnership(requestId, activatedGoalId);
+			reply({ success: false, error: `goal start failed: ${formatError(error)}` });
+			return;
+		}
+
+		// Read only the goal activated by this request. A replacement or clear that
+		// wins while kickoff delivery is pending must not be reported as this start.
+		const goal = this.runtime.activeGoal;
+		if (!goal || !activatedGoalId || goal.id !== activatedGoalId) {
+			this.clearOwnership(requestId, activatedGoalId);
+			reply({
+				success: false,
+				error:
+					"goal start failed; the objective could not be activated (goal tools unavailable, kickoff delivery failed, or the goal was superseded)",
+			});
+			return;
+		}
+		reply({ success: true, data: { goalId: goal.id, status: goal.status } });
+	}
+
+	private handlePause(data: unknown) {
+		const sessionContext = this.sessionContext;
+		const goal = this.runtime.activeGoal;
+		const ownership = this.ownership;
+		if (
+			!sessionContext ||
+			goal?.status !== "active" ||
+			!ownership ||
+			ownership.goalId !== goal.id
+		) {
+			return;
+		}
+
+		const payload = data as GoalRpcPausePayload | null;
+		const goalId = typeof payload?.goalId === "string" ? payload.goalId : undefined;
+		if (goalId !== undefined) {
+			if (goalId !== goal.id) return;
+		} else {
+			const requestId =
+				typeof payload?.requestId === "string" ? payload.requestId.trim() : undefined;
+			if (!requestId || requestId !== ownership.requestId) return;
+		}
+
+		const reason = typeof payload?.reason === "string" ? payload.reason.trim() : "";
+		this.runtime.setTerminalReason(goal.id, reason || "goal paused by RPC");
+		this.commands.pauseGoal(sessionContext);
+	}
+
+	private clearOwnership(requestId: string, goalId: string | undefined) {
+		if (
+			this.ownership?.requestId === requestId &&
+			(goalId === undefined || this.ownership.goalId === goalId)
+		) {
+			this.ownership = undefined;
+		}
+	}
+}

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -83,16 +83,19 @@ export const GOAL_TOOL_NAMES = [GOAL_COMPLETE_TOOL, GOAL_BLOCKED_TOOL] as const;
 /** Cross-extension event channel carrying the canonical persisted goal state. */
 export const GOAL_STATE_EVENT_CHANNEL = "pi-goal:state";
 
+/** State values broadcast to cross-extension listeners. */
+export type GoalStateEventStatus = GoalStatus | "cleared";
+
 /** Payload emitted on {@link GOAL_STATE_EVENT_CHANNEL} whenever goal state persists. */
 export interface GoalStateEventPayload {
 	goalId: string;
-	status: GoalStatus;
+	status: GoalStateEventStatus;
 	summary?: string;
 	reason?: string;
 }
 
 /** Terminal statuses broadcast to cross-extension listeners. */
-export function isTerminalGoalStatus(status: GoalStatus): boolean {
+export function isTerminalGoalStatus(status: GoalStateEventStatus): boolean {
 	return status !== "active" && status !== "queued";
 }
 
@@ -111,6 +114,12 @@ export function buildGoalStateEvent(
 		payload.reason = reason;
 	}
 	return payload;
+}
+
+interface GoalTerminalDetails {
+	goalId: string;
+	summary?: string;
+	reason?: string;
 }
 
 const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
@@ -148,10 +157,8 @@ const RETRYABLE_GOAL_ERROR_PATTERNS = [
 export class GoalRuntime {
 	settings: GoalSettings = DEFAULT_GOAL_SETTINGS;
 	activeGoal?: ActiveGoal;
-	/** Completion summary captured for cross-extension `pi-goal:state` events. */
-	completionSummary?: string;
-	/** Blocked/failure reason captured for cross-extension `pi-goal:state` events. */
-	terminalReason?: string;
+	/** Terminal details captured for the matching cross-extension state event. */
+	private terminalDetails?: GoalTerminalDetails;
 	queuedGoals: ActiveGoal[] = [];
 	pendingQueueAction?: PendingQueueAction;
 	queueFrozen = false;
@@ -281,6 +288,18 @@ export class GoalRuntime {
 		this.budgetWrapUp = undefined;
 	}
 
+	setCompletionSummary(goalId: string, summary: string) {
+		this.terminalDetails = { goalId, summary };
+	}
+
+	setTerminalReason(goalId: string, reason: string) {
+		this.terminalDetails = { goalId, reason };
+	}
+
+	clearTerminalDetails() {
+		this.terminalDetails = undefined;
+	}
+
 	keepBudgetWrapUpMessage(message: unknown) {
 		if (!message || typeof message !== "object") return true;
 		const candidate = message as {
@@ -336,7 +355,10 @@ export class GoalRuntime {
 		this.clearGoalRecoveryForGoal(goal.id);
 		this.clearBudgetWrapUp();
 		this.activeGoal = transitionGoal(goal, "budget_limited");
-		this.terminalReason = `token budget reached (${formatBudget(this.activeGoal)})`;
+		this.setTerminalReason(
+			this.activeGoal.id,
+			`token budget reached (${formatBudget(this.activeGoal)})`,
+		);
 		this.persistGoal(this.activeGoal);
 		this.updateStatus(ctx, this.activeGoal);
 		ctx.ui.notify(`Goal token budget reached: ${formatBudget(this.activeGoal)}`, "warning");
@@ -419,9 +441,8 @@ export class GoalRuntime {
 	}
 
 	persistGoal(goal: ActiveGoal) {
-		if (!isTerminalGoalStatus(goal.status)) {
-			this.completionSummary = undefined;
-			this.terminalReason = undefined;
+		if (!isTerminalGoalStatus(goal.status) || this.terminalDetails?.goalId !== goal.id) {
+			this.clearTerminalDetails();
 		}
 		this.pi.appendEntry(
 			GOAL_STATE_ENTRY_TYPE,
@@ -429,16 +450,25 @@ export class GoalRuntime {
 		);
 		this.pi.events.emit(
 			GOAL_STATE_EVENT_CHANNEL,
-			buildGoalStateEvent(goal, this.completionSummary, this.terminalReason),
+			buildGoalStateEvent(goal, this.terminalDetails?.summary, this.terminalDetails?.reason),
 		);
 	}
 
-	clearPersistedGoal(cwd: string) {
+	clearPersistedGoal(cwd: string, clearedGoal?: ActiveGoal, reason = "goal cleared") {
 		this.pi.appendEntry(GOAL_STATE_ENTRY_TYPE, serializeGoalState(undefined, [], undefined));
+		if (clearedGoal) {
+			this.pi.events.emit(GOAL_STATE_EVENT_CHANNEL, {
+				goalId: clearedGoal.id,
+				status: "cleared",
+				reason,
+			} satisfies GoalStateEventPayload);
+		}
+		this.clearTerminalDetails();
 		clearLegacyPersistedGoal(cwd);
 	}
 
-	clearActiveGoal(ctx: StatusContext) {
+	clearActiveGoal(ctx: StatusContext, reason = "goal cleared") {
+		const clearedGoal = this.activeGoal;
 		this.cancelContinuationWork();
 		this.clearGoalRecovery();
 		this.clearBudgetWrapUp();
@@ -447,7 +477,7 @@ export class GoalRuntime {
 		this.queuedGoals = [];
 		this.pendingQueueAction = undefined;
 		this.queueFrozen = false;
-		this.clearPersistedGoal(ctx.cwd);
+		this.clearPersistedGoal(ctx.cwd, clearedGoal, reason);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		// Do not clear goalToolsUnlocked: after first activation, keep tools visible
 		// for the rest of this extension runtime to avoid repeated goal-tool schema

--- a/extensions/pi-goal/test/goal-rpc.test.ts
+++ b/extensions/pi-goal/test/goal-rpc.test.ts
@@ -450,3 +450,195 @@ test("pi-goal:state never carries a summary or reason for an active goal", async
 	assert.ok(pausedEvent, "expected a paused state event");
 	assert.equal(pausedEvent?.reason, undefined, "old terminal reasons must not leak");
 });
+
+test("editing a stopped goal does not attach its old reason to the new goal id", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const { replies } = rpcStart(mock, { requestId: "req-edit", objective: "old task" });
+	await flush();
+	const oldGoalId = (replies[0] as RpcSuccess).data.goalId;
+
+	await requireGoalTool(mock, "goal_blocked").execute(
+		"blocked-before-edit",
+		{
+			goal_id: oldGoalId,
+			reason: "Old dependency is unavailable.",
+			evidence: "The same external dependency failed on three separate turns.",
+			repeated_turns: 3,
+		},
+		new AbortController().signal,
+		() => undefined,
+		context.ctx,
+	);
+	await mock.commands.get("goal")?.handler("edit revised task", context.ctx);
+
+	const editedEvent = stateEvents.at(-1);
+	assert.equal(editedEvent?.status, "blocked");
+	assert.notEqual(editedEvent?.goalId, oldGoalId);
+	assert.equal(editedEvent?.reason, undefined);
+});
+
+test("unowned pause requests cannot stop a manual goal", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	let aborts = 0;
+	const context = createMockContext({ abort: () => aborts++ });
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("goal")?.handler("manual task", context.ctx);
+	const manualGoalId = lastPersistedGoal(mock)?.id;
+
+	mock.eventBus.emit("pi-goal:rpc:pause", { reason: "uncorrelated cancellation" });
+	mock.eventBus.emit("pi-goal:rpc:pause", {
+		goalId: manualGoalId,
+		reason: "matching id but not RPC-owned",
+	});
+
+	assert.equal(lastPersistedGoal(mock)?.status, "active");
+	assert.equal(aborts, 0);
+});
+
+test("pre-reply cancellation requires and accepts the originating request id", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.eventBus.on("pi-goal:state", (data) => {
+		if ((data as StateEvent).status !== "active") return;
+		mock.eventBus.emit("pi-goal:rpc:pause", {
+			requestId: "req-other",
+			reason: "unrelated cancellation",
+		});
+		assert.equal(lastPersistedGoal(mock)?.status, "active");
+		mock.eventBus.emit("pi-goal:rpc:pause", {
+			requestId: "req-pre-reply",
+			reason: "parent cancelled before reply",
+		});
+	});
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const { replies } = rpcStart(mock, { requestId: "req-pre-reply", objective: "pending task" });
+	await flush();
+
+	assert.equal(replies[0]?.success, true);
+	assert.equal((replies[0] as RpcSuccess).data.status, "paused");
+	assert.equal(stateEvents.at(-1)?.status, "paused");
+	assert.equal(stateEvents.at(-1)?.reason, "parent cancelled before reply");
+});
+
+test("a stale start request cannot pause a newer RPC-owned goal", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const first = rpcStart(mock, { requestId: "req-old", objective: "old task" });
+	await flush();
+	assert.equal(first.replies[0]?.success, true);
+	await mock.commands.get("goal")?.handler("clear", context.ctx);
+
+	const second = rpcStart(mock, { requestId: "req-new", objective: "new task" });
+	mock.eventBus.emit("pi-goal:rpc:pause", {
+		requestId: "req-old",
+		reason: "stale parent cancellation",
+	});
+	await flush();
+
+	assert.equal(second.replies[0]?.success, true);
+	assert.equal(lastPersistedGoal(mock)?.status, "active");
+});
+
+test("a pending start cannot reply with a newer goal after being superseded", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	let releaseKickoff!: () => void;
+	mock.rawPi.sendUserMessage = () =>
+		new Promise<void>((resolve) => {
+			releaseKickoff = resolve;
+		});
+	const context = createMockContext();
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const first = rpcStart(mock, { requestId: "req-pending", objective: "pending task" });
+
+	await mock.commands.get("goal")?.handler("clear", context.ctx);
+	mock.rawPi.sendUserMessage = () => undefined;
+	const second = rpcStart(mock, { requestId: "req-replacement", objective: "replacement task" });
+	await flush();
+	assert.equal(second.replies[0]?.success, true);
+	releaseKickoff();
+	await flush();
+
+	assert.equal(first.replies[0]?.success, false);
+	assert.match((first.replies[0] as RpcFailure).error, /superseded|could not be activated/i);
+	assert.equal(lastPersistedGoal(mock)?.id, (second.replies[0] as RpcSuccess).data.goalId);
+});
+
+test("clearing an active goal broadcasts a terminal cleared state", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	const stateEvents: StateEvent[] = [];
+	mock.eventBus.on("pi-goal:state", (data) => stateEvents.push(data as StateEvent));
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const { replies } = rpcStart(mock, { requestId: "req-clear", objective: "clear task" });
+	await flush();
+	const goalId = (replies[0] as RpcSuccess).data.goalId;
+
+	await mock.commands.get("goal")?.handler("clear", context.ctx);
+
+	assert.deepEqual(stateEvents.at(-1), {
+		goalId,
+		status: "cleared",
+		reason: "goal cleared",
+	});
+});
+
+test("failed RPC activation broadcasts cleared state before its failure reply", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	mock.rawPi.sendUserMessage = () => {
+		throw new Error("kickoff delivery failed");
+	};
+	const context = createMockContext();
+	const timeline: Array<{ kind: "state" | "reply"; value: StateEvent | RpcReply }> = [];
+	mock.eventBus.on("pi-goal:state", (data) => {
+		timeline.push({ kind: "state", value: data as StateEvent });
+	});
+	mock.eventBus.on("pi-goal:rpc:start:reply:req-rollback", (data) => {
+		timeline.push({ kind: "reply", value: data as RpcReply });
+	});
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	mock.eventBus.emit("pi-goal:rpc:start", {
+		requestId: "req-rollback",
+		objective: "rollback task",
+	});
+	await flush();
+
+	assert.deepEqual(
+		timeline.map((entry) =>
+			entry.kind === "state"
+				? `${entry.kind}:${(entry.value as StateEvent).status}`
+				: `${entry.kind}:${String((entry.value as RpcReply).success)}`,
+		),
+		["state:active", "state:cleared", "reply:false"],
+	);
+});
+
+test("state listener failures do not interrupt persistence or RPC replies", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const context = createMockContext();
+	mock.eventBus.on("pi-goal:state", () => {
+		throw new Error("observer failed");
+	});
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	const { replies } = rpcStart(mock, { requestId: "req-listener", objective: "safe task" });
+	await flush();
+
+	assert.equal(replies[0]?.success, true);
+	assert.equal(lastPersistedGoal(mock)?.status, "active");
+});

--- a/test/support.ts
+++ b/test/support.ts
@@ -66,7 +66,14 @@ export function createMockPi(
 	const eventBusSubscriptions = new Map<string, Array<(data: unknown) => void>>();
 	const eventBus = {
 		emit(channel: string, data: unknown) {
-			for (const handler of eventBusSubscriptions.get(channel) ?? []) handler(data);
+			for (const handler of eventBusSubscriptions.get(channel) ?? []) {
+				try {
+					const result = handler(data);
+					void Promise.resolve(result).catch(() => undefined);
+				} catch {
+					// Match Pi's event bus: one observer cannot interrupt sibling handlers.
+				}
+			}
 		},
 		on(channel: string, handler: (data: unknown) => void) {
 			const list = eventBusSubscriptions.get(channel) ?? [];


### PR DESCRIPTION
## Summary

- carry the session-local pi-goal lifecycle RPC provider from #298 onto current `main`
- bind pause requests to the RPC-owned goal and require the originating `requestId` for cancellation before the start reply
- bind terminal summaries and reasons to their goal ID so stopped-goal edits cannot inherit stale details
- emit an authoritative terminal `cleared` state for explicit clears and failed activation rollbacks
- isolate the RPC controller in `src/rpc.ts` and align the shared test event bus with Pi's listener-error isolation

This supersedes #298 and addresses its review findings.

## Companion contract

The companion `tintinweb/pi-subagents#162` consumer should:

- send `{ requestId, reason }` when cancelling before the start reply
- treat `cleared` as a terminal state

After a successful reply, `{ goalId, reason }` remains the normal pause request.

## Verification

- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` — 947 passed
- focused pi-goal RPC suite — 23 passed
- `just pack-goal` — 13 expected files, including `src/rpc.ts`
