### PR TITLE
fix(pi-sync): retry empty R2 response bodies

### DIFF
--- a/extensions/pi-sync/src/s3-client.ts
+++ b/extensions/pi-sync/src/s3-client.ts
@@ -48,14 +48,9 @@ export class S3Client {
 			// Retry so the transient blip is absorbed instead of surfacing as a
 			// "pi-sync auto sync skipped" warning on every session start.
 			if (body.length > 0) {
-				try {
-					return { value: JSON.parse(body) as T, etag: normalizeEtag(object.headers.get("etag")), missing: false };
-				} catch (error) {
-					lastError = error;
-				}
-			} else {
-				lastError = new Error(`S3 GET returned an empty body for ${key}`);
+				return { value: JSON.parse(body) as T, etag: normalizeEtag(object.headers.get("etag")), missing: false };
 			}
+			lastError = new Error(`S3 GET returned an empty body for ${key}`);
 			if (attempt < maxAttempts) {
 				await sleep(250 * attempt);
 			}

--- a/extensions/pi-sync/src/s3-client.ts
+++ b/extensions/pi-sync/src/s3-client.ts
@@ -1,4 +1,5 @@
 import { createHash, createHmac } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
 import { encodeKey, posixJoin } from "./paths.js";
 import type { LatestPointer, RemoteObject, Snapshot, SyncConfig } from "./types.js";
 
@@ -34,10 +35,32 @@ export class S3Client {
 	}
 
 	async getJson<T>(key: string): Promise<RemoteObject<T>> {
-		const object = await this.request("GET", key);
-		if (object.status === 404) return { missing: true };
-		if (!object.ok) throw new Error(`S3 GET failed (${object.status}): ${await object.text()}`);
-		return { value: (await object.json()) as T, etag: normalizeEtag(object.headers.get("etag")), missing: false };
+		const maxAttempts = 3;
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			const object = await this.request("GET", key);
+			if (object.status === 404) return { missing: true };
+			if (!object.ok) throw new Error(`S3 GET failed (${object.status}): ${await object.text()}`);
+			const body = await object.text();
+			// R2 can intermittently return an empty 200 body (read-after-write
+			// inconsistency on a long-lived keep-alive connection), which makes
+			// response.json() throw "JSON Parse error: Unexpected EOF" under Bun.
+			// Retry so the transient blip is absorbed instead of surfacing as a
+			// "pi-sync auto sync skipped" warning on every session start.
+			if (body.length > 0) {
+				try {
+					return { value: JSON.parse(body) as T, etag: normalizeEtag(object.headers.get("etag")), missing: false };
+				} catch (error) {
+					lastError = error;
+				}
+			} else {
+				lastError = new Error(`S3 GET returned an empty body for ${key}`);
+			}
+			if (attempt < maxAttempts) {
+				await sleep(250 * attempt);
+			}
+		}
+		throw lastError;
 	}
 
 	async getBuffer(key: string): Promise<RemoteObject<Buffer>> {

--- a/extensions/pi-sync/src/s3-client.ts
+++ b/extensions/pi-sync/src/s3-client.ts
@@ -64,10 +64,29 @@ export class S3Client {
 	}
 
 	async getBuffer(key: string): Promise<RemoteObject<Buffer>> {
-		const object = await this.request("GET", key);
-		if (object.status === 404) return { missing: true };
-		if (!object.ok) throw new Error(`S3 GET failed (${object.status}): ${await object.text()}`);
-		return { value: Buffer.from(await object.arrayBuffer()), etag: normalizeEtag(object.headers.get("etag")), missing: false };
+		const maxAttempts = 3;
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			const object = await this.request("GET", key);
+			if (object.status === 404) return { missing: true };
+			if (!object.ok) throw new Error(`S3 GET failed (${object.status}): ${await object.text()}`);
+			const buffer = Buffer.from(await object.arrayBuffer());
+			// R2 can intermittently return an empty 200 body on a long-lived
+			// keep-alive connection (same root cause as the getJson retry
+			// above). getBuffer is only used for snapshot .json.gz payloads,
+			// which are always non-empty, so an empty body is a transient
+			// blip, not a legitimate response. Retry so the checksum guard
+			// downstream doesn't surface it as "Remote snapshot checksum
+			// mismatch".
+			if (buffer.length > 0) {
+				return { value: buffer, etag: normalizeEtag(object.headers.get("etag")), missing: false };
+			}
+			lastError = new Error(`S3 GET returned an empty body for ${key}`);
+			if (attempt < maxAttempts) {
+				await sleep(250 * attempt);
+			}
+		}
+		throw lastError;
 	}
 
 	async putJson(key: string, value: unknown) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -859,6 +859,28 @@ test("getJson throws after retrying a persistently empty R2 response body", asyn
 	}
 });
 
+test("getJson does not retry a non-empty malformed response body", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls += 1;
+		return new Response("{", { status: 200, headers: { etag: "w/malformed" } });
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		await assert.rejects(client.getJson("latest.json"), SyntaxError);
+		assert.equal(calls, 1);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test("getBuffer retries on empty R2 response body and eventually succeeds", async () => {
 	const originalFetch = globalThis.fetch;
 	const payload = Buffer.from("snapshot-payload");

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { gunzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { S3Client } from "../src/s3-client.js";
 import sync, {
 	addTopLevelCaseVariantDeletes,
 	appliedFileHashMap,
@@ -800,6 +801,62 @@ test("security and configuration helpers detect secrets and R2 session-token war
 	assert.equal(isExplicitlyEnabled("true"), true);
 	assert.equal(isExplicitlyEnabled("tru"), false);
 	assert.equal(isExplicitlyEnabled(""), false);
+});
+
+test("getJson retries on empty R2 response body and eventually succeeds", async () => {
+	const originalFetch = globalThis.fetch;
+	const responses = [
+		new Response("", { status: 200, headers: { etag: "w/empty1" } }),
+		new Response("", { status: 200, headers: { etag: "w/empty2" } }),
+		new Response(JSON.stringify({ snapshot: "snap-1", sha256: "abc" }), {
+			status: 200,
+			headers: { etag: "w/ok" },
+		}),
+	];
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		const response = responses[Math.min(calls, responses.length - 1)];
+		calls += 1;
+		return response;
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		const result = await client.getJson<{ snapshot: string; sha256: string }>("latest.json");
+		assert.equal(result.missing, false);
+		assert.equal(result.value?.snapshot, "snap-1");
+		assert.equal(result.etag, "w/ok");
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("getJson throws after retrying a persistently empty R2 response body", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls += 1;
+		return new Response("", { status: 200, headers: { etag: "w/empty" } });
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		await assert.rejects(client.getJson("latest.json"), /empty body/);
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
 });
 
 function snapshot(files: Array<{ path: string; content: Buffer }>) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -859,6 +859,60 @@ test("getJson throws after retrying a persistently empty R2 response body", asyn
 	}
 });
 
+test("getBuffer retries on empty R2 response body and eventually succeeds", async () => {
+	const originalFetch = globalThis.fetch;
+	const payload = Buffer.from("snapshot-payload");
+	const responses = [
+		new Response("", { status: 200, headers: { etag: "w/empty1" } }),
+		new Response("", { status: 200, headers: { etag: "w/empty2" } }),
+		new Response(new Uint8Array(payload), { status: 200, headers: { etag: "w/ok" } }),
+	];
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		const response = responses[Math.min(calls, responses.length - 1)];
+		calls += 1;
+		return response;
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		const result = await client.getBuffer("snapshots/snap-1.json.gz");
+		assert.equal(result.missing, false);
+		assert.deepEqual(result.value, payload);
+		assert.equal(result.etag, "w/ok");
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("getBuffer throws after retrying a persistently empty R2 response body", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls += 1;
+		return new Response("", { status: 200, headers: { etag: "w/empty" } });
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		await assert.rejects(client.getBuffer("snapshots/snap-1.json.gz"), /empty body/);
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 function snapshot(files: Array<{ path: string; content: Buffer }>) {
 	return {
 		version: 1,


### PR DESCRIPTION
## Summary
- retry pi-sync JSON downloads when R2 returns an empty response body
- retry pi-sync binary downloads on the same empty-body R2 failure
- add regression coverage for persistent and eventually successful empty-body retries

Supersedes #301 with the branch hosted in this repository so CI can run normally.

## Verification
- npm run check


Closes #301