### PR TITLE
Fix stale Plan Mode implementation context

### DIFF
--- a/extensions/pi-plan-mode/src/message-transform.ts
+++ b/extensions/pi-plan-mode/src/message-transform.ts
@@ -2,8 +2,12 @@ import { PLAN_MODE_COMPLETE_TOOL_NAME } from "./completion-tool.js";
 
 const PLAN_CONTEXT_MESSAGE_TYPE = "plan-mode-context";
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
-const PROPOSED_PLAN_PATTERN = /^<proposed_plan>[\t ]*\r?\n([\s\S]*?)\r?\n<\/proposed_plan>[\t ]*$/gm;
-const PROPOSED_PLAN_BLOCK_PATTERN = /^<proposed_plan>[\t ]*\r?\n[\s\S]*?\r?\n<\/proposed_plan>[\t ]*$/gm;
+const PLAN_IMPLEMENTATION_HANDOFF_PREFIX =
+	"Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:";
+const PROPOSED_PLAN_PATTERN =
+	/^<proposed_plan>[\t ]*\r?\n([\s\S]*?)\r?\n<\/proposed_plan>[\t ]*$/gm;
+const PROPOSED_PLAN_BLOCK_PATTERN =
+	/^<proposed_plan>[\t ]*\r?\n[\s\S]*?\r?\n<\/proposed_plan>[\t ]*$/gm;
 
 export type ProposedPlanParseResult =
 	| { kind: "absent" }
@@ -65,6 +69,14 @@ export function messageContainsInactivePlanModeArtifact(message: unknown) {
 	);
 }
 
+export function messageContainsPlanModeImplementationHandoff(message: unknown) {
+	const candidate = unwrapSessionMessage(message);
+	return (
+		candidate.role === "user" &&
+		contentText(candidate.content).trimStart().startsWith(PLAN_IMPLEMENTATION_HANDOFF_PREFIX)
+	);
+}
+
 export function stripProposedPlanBlocksFromMessage<T>(message: T): T {
 	return replaceAssistantContent(message, stripProposedPlanBlocksFromContent);
 }
@@ -74,9 +86,7 @@ export function stripPlanModeCompletionCallsFromMessage<T>(message: T): T {
 		if (!Array.isArray(content)) return content;
 		const nextContent = content.filter((block) => {
 			const candidate = block as { type?: string; name?: string };
-			return !(
-				candidate.type === "toolCall" && candidate.name === PLAN_MODE_COMPLETE_TOOL_NAME
-			);
+			return !(candidate.type === "toolCall" && candidate.name === PLAN_MODE_COMPLETE_TOOL_NAME);
 		});
 		return nextContent.length === content.length ? content : nextContent;
 	});
@@ -91,10 +101,7 @@ export function isEmptyAssistantMessage(message: unknown) {
 	);
 }
 
-function replaceAssistantContent<T>(
-	message: T,
-	transform: (content: unknown) => unknown,
-): T {
+function replaceAssistantContent<T>(message: T, transform: (content: unknown) => unknown): T {
 	const candidate = unwrapSessionMessage(message);
 	if (candidate.role !== "assistant") return message;
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -10,6 +10,7 @@ import {
 	latestAssistantText,
 	messageContainsInactivePlanModeArtifact,
 	messageContainsLegacyPlanModeContextArtifact,
+	messageContainsPlanModeImplementationHandoff,
 	parseProposedPlan,
 	stripPlanModeCompletionCallsFromMessage,
 	stripProposedPlanBlocksFromMessage,
@@ -292,7 +293,13 @@ export default function planMode(pi: ExtensionAPI) {
 		const messagesWithoutLegacyPlanContext = event.messages.filter(
 			(message: unknown) => !messageContainsLegacyPlanModeContextArtifact(message),
 		);
-		if (state.enabled) return { messages: messagesWithoutLegacyPlanContext };
+		if (state.enabled) {
+			return {
+				messages: messagesWithoutLegacyPlanContext.filter(
+					(message: unknown) => !messageContainsPlanModeImplementationHandoff(message),
+				),
+			};
+		}
 		return {
 			messages: messagesWithoutLegacyPlanContext
 				.filter((message: unknown) => !messageContainsInactivePlanModeArtifact(message))

--- a/extensions/pi-plan-mode/test/issue-302-repro.test.ts
+++ b/extensions/pi-plan-mode/test/issue-302-repro.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+
+test("issue 302: re-entered Plan Mode hides the previous implementation handoff", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash", "custom"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	const executeComplete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+	assert.ok(executeComplete);
+	await executeComplete(
+		"complete",
+		{ plan: "# Plan Mode repro" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	const implementationHandoff = mock.sentUserMessages.at(-1)?.text ?? "";
+	assert.match(implementationHandoff, /Plan mode is now disabled/);
+	assert.match(implementationHandoff, /Implement this proposed plan now/);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const implementationMessages = [
+		{ role: "user", content: "Plan a one-line README change." },
+		{ role: "user", content: implementationHandoff },
+		{ role: "assistant", content: "Implemented the requested plan." },
+	];
+	const inactiveContext = (await contextHook(
+		{ messages: implementationMessages },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.deepEqual(inactiveContext.messages, implementationMessages);
+
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"bash",
+		"read",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+
+	const beforeStart = mock.events.get("before_agent_start")?.[0];
+	assert.ok(beforeStart);
+	const promptResult = beforeStart({ systemPrompt: "base" }, context.ctx) as {
+		systemPrompt?: string;
+	};
+	assert.match(promptResult.systemPrompt ?? "", /You are in Plan Mode/);
+	assert.match(promptResult.systemPrompt ?? "", /plan_mode_complete/);
+
+	const activeMessages = [...implementationMessages, { role: "user", content: "continue" }];
+	const activeContext = (await contextHook({ messages: activeMessages }, context.ctx)) as {
+		messages: unknown[];
+	};
+
+	assert.deepEqual(activeContext.messages, [
+		implementationMessages[0],
+		implementationMessages[2],
+		activeMessages[3],
+	]);
+	assert.doesNotMatch(
+		JSON.stringify(activeContext.messages),
+		/Plan mode is now disabled\. Full tool access is restored/,
+	);
+});


### PR DESCRIPTION
## Summary
- filter the previous Plan-mode implementation handoff out of context after Plan Mode is re-enabled
- keep inactive implementation turns unchanged so the actual implementation still receives the plan
- add a regression test for the Plan Mode -> implement -> re-enter Plan Mode flow

Closes #302.

## Verification
- npm run check --workspace @narumitw/pi-plan-mode
- npx tsc -p tsconfig.test.json && node --test "$(realpath node_modules/.cache/pi-extensions-test/extensions/pi-plan-mode/test/issue-302-repro.test.js)"
- git diff --check

Note: full monorepo `npm run check`/`npm test` was attempted but is too slow for this session and was stopped before completion.