### PR TITLE
feat(accounts)!: redesign accounts command as interactive menu

### DIFF
--- a/docs/plans/2026-07-21_pi-accounts-menu-redesign-plan.md
+++ b/docs/plans/2026-07-21_pi-accounts-menu-redesign-plan.md
@@ -1,0 +1,39 @@
+# Pi Accounts menu redesign plan
+
+## Goal
+
+Redesign `@narumitw/pi-accounts` from a multi-argument slash-command surface into a single interactive `/accounts` account manager, then open a PR with tests and documentation proving the new workflow.
+
+## Context
+
+The current extension exposes `/account list/login/switch/remove` plus temporary Codex aliases. The agreed design is a Pi-style interactive manager: `/accounts` is the only command, ignores arguments, requires interactive UI, shows all supported providers' active account summary, and routes login/switch/remove through selectors.
+
+## Non-Goals
+
+- Do not add API-key profile management or arbitrary custom provider support.
+- Do not introduce a custom TUI component; use `ctx.ui.select`, `ctx.ui.input`, `ctx.ui.confirm`, and notifications.
+- Do not change credential storage schema or OAuth provider adapters beyond what the new UI requires.
+
+## Plan
+
+- [x] Add failing tests for the new command surface, menu routing, empty state, non-interactive rejection, argument ignoring, and removed `/account`/Codex aliases; verified by the initial `npm test` red run timing out after reaching the new tests while `/accounts` was not implemented.
+- [x] Add failing tests for interactive login, duplicate-name replacement confirmation, reserved `default`, current-provider switch, other-provider switch, remove confirmation, active-account removal fallback, and unknown-model default selection; verified by the same red `npm test` run before implementation and by the final green test suite.
+- [x] Implement `/accounts` as the only registered account command and wire the interactive menu to existing OAuth/storage/runtime operations; verified by `npm test` passing 955 tests after implementation.
+- [x] Update README usage and feature text to document the single-command interactive workflow and removed aliases; verified by source inspection showing `pi.registerCommand("accounts", ...)` and no registered `/account` or Codex alias commands in `extensions/pi-accounts/src/accounts.ts`.
+- [x] Run formatting/type/test gates for the affected package and root checks that are practical for the change; verified by `npm --workspace @narumitw/pi-accounts run check`, `npm test`, `npm run check`, and `npm run pack:accounts`.
+- [ ] Commit the intended changes on a feature branch, push it, and create a GitHub PR; verify with `git status --short`, `git log -1`, and `gh pr view`.
+
+## Risks
+
+- The selector API only supports plain string choices, so provider/account grouping must be encoded in labels without relying on hidden values.
+- Removing aliases is a breaking command-surface change; README and tests must make the new single entry point explicit.
+- Login and switch affect runtime auth; tests should assert observable notifications, active storage, and model-selection side effects without real network calls.
+
+## Completion Checklist
+
+- [x] The saved implementation plan exists and reflects completed task evidence in `docs/plans/2026-07-21_pi-accounts-menu-redesign-plan.md`.
+- [x] `/accounts` is the only registered account-management command, verified by `accounts registers only the interactive /accounts command and lifecycle hooks` and source inspection of `extensions/pi-accounts/src/accounts.ts`.
+- [x] Interactive menu behavior matches the agreed design, verified by tests covering empty, current-provider, other-provider, login, remove, duplicate replacement cancellation/confirmation, active removal fallback, unknown-model onboarding, and non-interactive states.
+- [x] README documents the new `/accounts` workflow and no longer documents removed command entry points, verified by text search for removed command names.
+- [x] Verification commands pass for the changed package/repository scope, with command output recorded in this plan: `npm --workspace @narumitw/pi-accounts run check`, `npm test`, `npm run check`, and `npm run pack:accounts`.
+- [ ] A PR exists for the branch and contains the committed implementation, verified by `gh pr view`.

--- a/docs/plans/archived/2026-07-21_pi-accounts-menu-redesign-plan.md
+++ b/docs/plans/archived/2026-07-21_pi-accounts-menu-redesign-plan.md
@@ -21,7 +21,7 @@ The current extension exposes `/account list/login/switch/remove` plus temporary
 - [x] Implement `/accounts` as the only registered account command and wire the interactive menu to existing OAuth/storage/runtime operations; verified by `npm test` passing 955 tests after implementation.
 - [x] Update README usage and feature text to document the single-command interactive workflow and removed aliases; verified by source inspection showing `pi.registerCommand("accounts", ...)` and no registered `/account` or Codex alias commands in `extensions/pi-accounts/src/accounts.ts`.
 - [x] Run formatting/type/test gates for the affected package and root checks that are practical for the change; verified by `npm --workspace @narumitw/pi-accounts run check`, `npm test`, `npm run check`, and `npm run pack:accounts`.
-- [ ] Commit the intended changes on a feature branch, push it, and create a GitHub PR; verify with `git status --short`, `git log -1`, and `gh pr view`.
+- [x] Commit the intended changes on a feature branch, push it, and create a GitHub PR; verified by commit `04fbbfe`, branch `redesign-pi-accounts-menu`, push to `origin/redesign-pi-accounts-menu`, and PR #306.
 
 ## Risks
 
@@ -31,9 +31,9 @@ The current extension exposes `/account list/login/switch/remove` plus temporary
 
 ## Completion Checklist
 
-- [x] The saved implementation plan exists and reflects completed task evidence in `docs/plans/2026-07-21_pi-accounts-menu-redesign-plan.md`.
+- [x] The saved implementation plan exists and reflects completed task evidence in `docs/plans/archived/2026-07-21_pi-accounts-menu-redesign-plan.md`.
 - [x] `/accounts` is the only registered account-management command, verified by `accounts registers only the interactive /accounts command and lifecycle hooks` and source inspection of `extensions/pi-accounts/src/accounts.ts`.
 - [x] Interactive menu behavior matches the agreed design, verified by tests covering empty, current-provider, other-provider, login, remove, duplicate replacement cancellation/confirmation, active removal fallback, unknown-model onboarding, and non-interactive states.
 - [x] README documents the new `/accounts` workflow and no longer documents removed command entry points, verified by text search for removed command names.
 - [x] Verification commands pass for the changed package/repository scope, with command output recorded in this plan: `npm --workspace @narumitw/pi-accounts run check`, `npm test`, `npm run check`, and `npm run pack:accounts`.
-- [ ] A PR exists for the branch and contains the committed implementation, verified by `gh pr view`.
+- [x] A PR exists for the branch and contains the committed implementation, verified by PR #306 and `gh pr view`.

--- a/extensions/pi-accounts/README.md
+++ b/extensions/pi-accounts/README.md
@@ -8,7 +8,7 @@ It uses Pi's built-in providers and provider-owned OAuth implementations. A name
 
 ## ✨ Features
 
-- Manages OpenAI Codex, Anthropic Claude Pro/Max, and GitHub Copilot OAuth accounts through one `/account` command.
+- Manages OpenAI Codex, Anthropic Claude Pro/Max, and GitHub Copilot OAuth accounts through one interactive `/accounts` command.
 - Keeps an independent active named account—or Pi's built-in login—for every provider.
 - Stores complete provider-owned OAuth credentials, including GitHub Enterprise and available-model metadata.
 - Refreshes rotating OAuth credentials under a cross-process file lock.
@@ -19,7 +19,6 @@ It uses Pi's built-in providers and provider-owned OAuth implementations. A name
 - Restores the exact provider registration that existed before the account overlay.
 - Invalidates cached Codex WebSockets only when the applied Codex identity changes.
 - Migrates released `pi-codex-accounts.json` state without deleting the rollback source.
-- Retains `/codex-login`, `/codex-account`, and `/codex-logout` as temporary compatibility aliases.
 
 ## 🔌 Supported providers
 
@@ -34,7 +33,7 @@ It uses Pi's built-in providers and provider-owned OAuth implementations. A name
 
 ## 📦 Install
 
-`pi-codex-accounts` remains available during the `pi-accounts` soak period, but do not load both packages together; they register the same Codex compatibility commands and can refresh the same rotating credential independently. To move one Pi installation to the new package:
+`pi-codex-accounts` remains available during the `pi-accounts` soak period, but do not load both packages together; they can manage and refresh the same rotating Codex credential independently. To move one Pi installation to the new package:
 
 ```bash
 pi uninstall npm:@narumitw/pi-codex-accounts
@@ -55,59 +54,50 @@ pi -e ./extensions/pi-accounts
 
 ## 🚀 Usage
 
-List every provider or one provider:
+Open the interactive account manager:
 
 ```text
-/account list
-/account list anthropic
+/accounts
 ```
 
-Login and store a named subscription account (`default` is reserved):
+The command requires interactive UI. Any extra text after `/accounts` is ignored so the entry point stays singular.
+
+When no accounts are saved yet, the menu starts with login:
 
 ```text
-/account login openai-codex work
-/account login anthropic personal
-/account login github-copilot enterprise
+Accounts
+
+No saved accounts yet.
+
+What do you want to do?
+› Login new account
 ```
 
-Switch one provider without changing another provider's active account:
+After accounts exist, `/accounts` shows the current model and every supported provider's active account before offering actions:
 
 ```text
-/account switch openai-codex work
-/account switch anthropic personal
-/account switch github-copilot enterprise
+Accounts
+
+Current model:
+  Anthropic / claude-sonnet-4
+
+Active accounts:
+  Anthropic: work
+  GitHub Copilot: enterprise
+  OpenAI Codex: default
+
+What do you want to do?
+› Switch Anthropic account
+  Login new account
+  Remove account
+  Switch another provider’s account
 ```
 
-Omit the account name in interactive mode to open a selector:
+Login follows Pi's built-in `/login` style: choose a provider, enter a named account, then complete that provider's OAuth flow. `default` is reserved for Pi's built-in login. Reusing an existing provider/account name asks before replacing the stored credential.
 
-```text
-/account switch anthropic
-```
+Switching the current model provider is the primary flow. Switching a different provider is explicit: choose **Switch another provider’s account**, choose the provider, then choose the account. Choosing `default` restores Pi's built-in login for that provider. `/accounts` manages account identity only; it does not switch models except when login succeeds while the current model is still `unknown`, where it selects that provider's default model as onboarding help.
 
-Return only one provider to Pi's built-in login:
-
-```text
-/account switch anthropic default
-```
-
-Remove a named account:
-
-```text
-/account remove github-copilot enterprise
-```
-
-Provider and stored-account arguments offer completion. Press Tab repeatedly to step through the subcommand, provider, and stored account without adding spaces manually. Mutating commands always require an explicit provider ID.
-
-### Temporary Codex aliases
-
-These commands use exactly the same `openai-codex` state and runtime path as `/account`:
-
-```text
-/codex-login work
-/codex-account work
-/codex-account default
-/codex-logout work
-```
+Removing an account lists named accounts as `Provider · account`, asks for confirmation, then removes the credential. Removing an active account automatically restores that provider to Pi's built-in login.
 
 ## 🔐 Auth and fail-closed behavior
 

--- a/extensions/pi-accounts/src/accounts.ts
+++ b/extensions/pi-accounts/src/accounts.ts
@@ -44,12 +44,6 @@ export const ACCOUNTS_STATUS_KEY = "accounts";
 export const FAIL_CLOSED_API_KEY = RUNTIME_FAIL_CLOSED_API_KEY;
 export const DEFAULT_PI_LOGIN_LABEL = "(default pi login)";
 
-export type CommandArgumentCompletion = {
-	value: string;
-	label: string;
-	description?: string;
-};
-
 export type AccountsDependencies = {
 	store?: AccountStore;
 	providers?: readonly AccountProviderAdapter[];
@@ -140,8 +134,7 @@ export default function accountsExtension(
 	};
 
 	const accountCommand = createAccountCommand(pi, store, adapters, syncProvider);
-	pi.registerCommand("account", accountCommand);
-	registerCodexCompatibilityCommands(pi, store, adapters, syncProvider);
+	pi.registerCommand("accounts", accountCommand);
 
 	pi.on("session_start", async (_event, ctx) => {
 		if (migrationNotice) {
@@ -212,66 +205,311 @@ function createAccountCommand(
 	) => Promise<EnsureActiveProviderAuthResult>,
 ) {
 	return {
-		description: "Manage named subscription OAuth accounts",
-		getArgumentCompletions: (prefix: string) => completeAccountArguments(prefix, store),
-		handler: async (args: string, ctx: ExtensionCommandContext) => {
-			const [subcommand, providerArg, ...rest] = splitArguments(args);
-			if (subcommand === "list") {
-				const providerId = providerArg ? parseProviderId(providerArg) : undefined;
-				if (providerArg && !providerId) return notifyUnsupportedProvider(ctx, providerArg);
-				await listAccounts(ctx, store, adapters, providerId);
-				return;
-			}
-			if (!subcommand || !["login", "switch", "remove"].includes(subcommand)) {
-				ctx.ui.notify(
-					"Usage: /account list [provider] | login <provider> <name> | switch <provider> [name] | remove <provider> <name>",
-					"warning",
-				);
-				return;
-			}
-			const providerId = providerArg ? parseProviderId(providerArg) : undefined;
-			if (!providerId) return notifyUnsupportedProvider(ctx, providerArg ?? "");
-			const adapter = requireAdapter(adapters, providerId);
-			const nameArg = rest.join(" ").trim();
-			if (subcommand === "login") {
-				await loginAccount(pi, ctx, store, adapter, nameArg, syncProvider);
-				return;
-			}
-			if (subcommand === "switch") {
-				await switchAccount(ctx, store, adapter, nameArg, syncProvider);
-				return;
-			}
-			await removeAccount(ctx, store, adapter, nameArg, syncProvider);
+		description: "Open the interactive subscription account manager",
+		handler: async (_args: string, ctx: ExtensionCommandContext) => {
+			await showAccountsMenu(pi, ctx, store, adapters, syncProvider);
 		},
 	};
 }
 
-function registerCodexCompatibilityCommands(
+const LOGIN_ACTION = "Login new account";
+const REMOVE_ACTION = "Remove account";
+const SWITCH_PROVIDER_ACTION = "Switch provider account";
+const SWITCH_ANOTHER_PROVIDER_ACTION = "Switch another provider’s account";
+
+type ProviderMenuState = {
+	id: AccountProviderId;
+	adapter: AccountProviderAdapter;
+	active: string | undefined;
+	accounts: Record<string, StoredOAuthCredential>;
+};
+
+async function showAccountsMenu(
 	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
 	store: AccountStore,
 	adapters: Map<AccountProviderId, AccountProviderAdapter>,
 	syncProvider: (
 		providerId: AccountProviderId,
 		ctx: ExtensionContext,
 	) => Promise<EnsureActiveProviderAuthResult>,
-): void {
-	const adapter = requireAdapter(adapters, "openai-codex");
-	pi.registerCommand("codex-login", {
-		description: "Compatibility alias for /account login openai-codex",
-		handler: async (args, ctx) => loginAccount(pi, ctx, store, adapter, args, syncProvider),
-	});
-	pi.registerCommand("codex-account", {
-		description: "Compatibility alias for /account switch openai-codex",
-		getArgumentCompletions: (prefix) =>
-			completeProviderAccounts(prefix, store, "openai-codex", true),
-		handler: async (args, ctx) => switchAccount(ctx, store, adapter, args, syncProvider),
-	});
-	pi.registerCommand("codex-logout", {
-		description: "Compatibility alias for /account remove openai-codex",
-		getArgumentCompletions: (prefix) =>
-			completeProviderAccounts(prefix, store, "openai-codex", false),
-		handler: async (args, ctx) => removeAccount(ctx, store, adapter, args, syncProvider),
-	});
+): Promise<void> {
+	if (!ctx.hasUI) {
+		ctx.ui.notify("/accounts requires interactive UI.", "error");
+		return;
+	}
+	const states = await readProviderMenuStates(store, adapters);
+	const currentProviderId = toProviderId(ctx.model?.provider);
+	const currentState = currentProviderId ? states.get(currentProviderId) : undefined;
+	const hasAnyStoredAccount = [...states.values()].some((state) => accountNames(state).length > 0);
+	const action = await ctx.ui.select(
+		formatAccountsMenuTitle(ctx, states, hasAnyStoredAccount),
+		buildAccountsMenuActions(states, currentState, hasAnyStoredAccount),
+	);
+	if (!action) return;
+	if (action === LOGIN_ACTION) {
+		await showLoginAccount(pi, ctx, store, adapters, syncProvider);
+		return;
+	}
+	if (action === REMOVE_ACTION) {
+		await showRemoveAccount(ctx, store, adapters, syncProvider);
+		return;
+	}
+	if (currentState && action === switchCurrentProviderAction(currentState.adapter)) {
+		await showSwitchProviderAccount(ctx, store, currentState.adapter, syncProvider);
+		return;
+	}
+	if (action === SWITCH_ANOTHER_PROVIDER_ACTION || action === SWITCH_PROVIDER_ACTION) {
+		const excludeProviderId =
+			action === SWITCH_ANOTHER_PROVIDER_ACTION ? currentProviderId : undefined;
+		const provider = await selectProviderWithAccounts(ctx, states, excludeProviderId);
+		if (provider) await showSwitchProviderAccount(ctx, store, provider.adapter, syncProvider);
+	}
+}
+
+async function readProviderMenuStates(
+	store: AccountStore,
+	adapters: Map<AccountProviderId, AccountProviderAdapter>,
+): Promise<Map<AccountProviderId, ProviderMenuState>> {
+	const states = new Map<AccountProviderId, ProviderMenuState>();
+	for (const id of SUPPORTED_PROVIDER_IDS) {
+		const state = await store.readProviderAsync(id);
+		states.set(id, {
+			id,
+			adapter: requireAdapter(adapters, id),
+			active: state.active,
+			accounts: state.accounts,
+		});
+	}
+	return states;
+}
+
+function formatAccountsMenuTitle(
+	ctx: ExtensionCommandContext,
+	states: Map<AccountProviderId, ProviderMenuState>,
+	hasAnyStoredAccount: boolean,
+): string {
+	if (!hasAnyStoredAccount) return "Accounts\n\nNo saved accounts yet.\n\nWhat do you want to do?";
+	const activeLines = sortedProviderStates(states).map(
+		(state) => `  ${state.adapter.displayName}: ${state.active ?? "default"}`,
+	);
+	return [
+		"Accounts",
+		"",
+		"Current model:",
+		`  ${formatCurrentModel(ctx)}`,
+		"",
+		"Active accounts:",
+		...activeLines,
+		"",
+		"What do you want to do?",
+	].join("\n");
+}
+
+function formatCurrentModel(ctx: ExtensionCommandContext): string {
+	if (!ctx.model) return "(none)";
+	const providerId = toProviderId(ctx.model.provider);
+	const providerName = providerId ? providerDisplayName(providerId) : ctx.model.provider;
+	return `${providerName} / ${ctx.model.id}`;
+}
+
+function buildAccountsMenuActions(
+	states: Map<AccountProviderId, ProviderMenuState>,
+	currentState: ProviderMenuState | undefined,
+	hasAnyStoredAccount: boolean,
+): string[] {
+	if (!hasAnyStoredAccount) return [LOGIN_ACTION];
+	const currentHasAccounts = currentState ? accountNames(currentState).length > 0 : false;
+	if (currentState && currentHasAccounts) {
+		const actions = [
+			switchCurrentProviderAction(currentState.adapter),
+			LOGIN_ACTION,
+			REMOVE_ACTION,
+		];
+		if (providerStatesWithAccounts(states, currentState.id).length > 0) {
+			actions.push(SWITCH_ANOTHER_PROVIDER_ACTION);
+		}
+		return actions;
+	}
+	return [
+		LOGIN_ACTION,
+		currentState ? SWITCH_ANOTHER_PROVIDER_ACTION : SWITCH_PROVIDER_ACTION,
+		REMOVE_ACTION,
+	];
+}
+
+function switchCurrentProviderAction(adapter: AccountProviderAdapter): string {
+	return `Switch ${adapter.displayName} account`;
+}
+
+async function showLoginAccount(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	store: AccountStore,
+	adapters: Map<AccountProviderId, AccountProviderAdapter>,
+	syncProvider: (
+		providerId: AccountProviderId,
+		ctx: ExtensionContext,
+	) => Promise<EnsureActiveProviderAuthResult>,
+): Promise<void> {
+	const adapter = await selectProvider(
+		ctx,
+		sortedProviderStates(await readProviderMenuStates(store, adapters)),
+	);
+	if (!adapter) return;
+	const name = await ctx.ui.input(`Name this ${adapter.displayName} account:`, "work");
+	if (name === undefined) return;
+	await loginAccount(pi, ctx, store, adapter, name, syncProvider);
+}
+
+async function showSwitchProviderAccount(
+	ctx: ExtensionCommandContext,
+	store: AccountStore,
+	adapter: AccountProviderAdapter,
+	syncProvider: (
+		providerId: AccountProviderId,
+		ctx: ExtensionContext,
+	) => Promise<EnsureActiveProviderAuthResult>,
+): Promise<void> {
+	const state = await store.readProviderAsync(adapter.id);
+	const options = switchAccountOptions(state.active, Object.keys(state.accounts));
+	if (options.length <= 1) {
+		ctx.ui.notify(`${adapter.displayName} has no saved accounts to switch.`, "info");
+		return;
+	}
+	const selected = await ctx.ui.select(`Switch ${adapter.displayName} account:`, options);
+	if (!selected) return;
+	const accountName = stripActiveMarker(selected);
+	if (accountName === (state.active ?? "default")) {
+		ctx.ui.notify(`${adapter.displayName} account "${accountName}" is already active.`, "info");
+		return;
+	}
+	await switchAccount(ctx, store, adapter, accountName, syncProvider);
+}
+
+async function selectProviderWithAccounts(
+	ctx: ExtensionCommandContext,
+	states: Map<AccountProviderId, ProviderMenuState>,
+	excludeProviderId?: AccountProviderId,
+): Promise<ProviderMenuState | undefined> {
+	const candidates = providerStatesWithAccounts(states, excludeProviderId);
+	const adapter = await selectProvider(ctx, candidates);
+	return adapter ? candidates.find((state) => state.id === adapter.id) : undefined;
+}
+
+async function selectProvider(
+	ctx: ExtensionCommandContext,
+	states: readonly ProviderMenuState[],
+): Promise<AccountProviderAdapter | undefined> {
+	const labels = states.map((state) => state.adapter.displayName);
+	const selected = await ctx.ui.select("Select provider:", labels);
+	return states.find((state) => state.adapter.displayName === selected)?.adapter;
+}
+
+async function showRemoveAccount(
+	ctx: ExtensionCommandContext,
+	store: AccountStore,
+	adapters: Map<AccountProviderId, AccountProviderAdapter>,
+	syncProvider: (
+		providerId: AccountProviderId,
+		ctx: ExtensionContext,
+	) => Promise<EnsureActiveProviderAuthResult>,
+): Promise<void> {
+	const states = await readProviderMenuStates(store, adapters);
+	const options = removeAccountOptions(states, toProviderId(ctx.model?.provider));
+	if (options.length === 0) {
+		ctx.ui.notify("No saved accounts to remove.", "info");
+		return;
+	}
+	const selected = await ctx.ui.select(
+		"Remove account:",
+		options.map((option) => option.label),
+	);
+	const option = options.find((item) => item.label === selected);
+	if (!option) return;
+	const confirmed = await ctx.ui.confirm(
+		"Remove account",
+		`Remove ${option.adapter.displayName} account "${option.accountName}"?`,
+	);
+	if (!confirmed) return;
+	await removeAccount(ctx, store, option.adapter, option.accountName, syncProvider);
+}
+
+function sortedProviderStates(
+	states: Map<AccountProviderId, ProviderMenuState>,
+): ProviderMenuState[];
+function sortedProviderStates(states: readonly ProviderMenuState[]): ProviderMenuState[];
+function sortedProviderStates(
+	states: Map<AccountProviderId, ProviderMenuState> | readonly ProviderMenuState[],
+): ProviderMenuState[] {
+	const values = Array.isArray(states) ? [...states] : [...states.values()];
+	return values.sort((left, right) =>
+		left.adapter.displayName.localeCompare(right.adapter.displayName),
+	);
+}
+
+function providerStatesWithAccounts(
+	states: Map<AccountProviderId, ProviderMenuState>,
+	excludeProviderId?: AccountProviderId,
+): ProviderMenuState[] {
+	return sortedProviderStates(states).filter(
+		(state) => state.id !== excludeProviderId && accountNames(state).length > 0,
+	);
+}
+
+function accountNames(state: ProviderMenuState): string[] {
+	return Object.keys(state.accounts).sort();
+}
+
+function switchAccountOptions(activeName: string | undefined, names: string[]): string[] {
+	const active = activeName ?? "default";
+	const sortedNames = [...names].sort();
+	const options = [formatSwitchAccountOption(active, true)];
+	for (const name of sortedNames) {
+		if (name !== active) options.push(formatSwitchAccountOption(name, false));
+	}
+	if (active !== "default") options.push(formatSwitchAccountOption("default", false));
+	return options;
+}
+
+function formatSwitchAccountOption(name: string, active: boolean): string {
+	return active ? `✓ ${name}` : name;
+}
+
+function stripActiveMarker(value: string): string {
+	return value.replace(/^✓\s+/, "");
+}
+
+function removeAccountOptions(
+	states: Map<AccountProviderId, ProviderMenuState>,
+	currentProviderId?: AccountProviderId,
+): Array<{ label: string; adapter: AccountProviderAdapter; accountName: string }> {
+	const providerStates = providerStatesWithAccounts(states);
+	if (currentProviderId) {
+		const currentIndex = providerStates.findIndex((state) => state.id === currentProviderId);
+		if (currentIndex > 0) {
+			const [current] = providerStates.splice(currentIndex, 1);
+			if (current) providerStates.unshift(current);
+		}
+	}
+	return providerStates.flatMap((state) =>
+		accountNames(state).map((accountName) => ({
+			label: `${state.adapter.displayName} · ${accountName}`,
+			adapter: state.adapter,
+			accountName,
+		})),
+	);
+}
+
+function providerDisplayName(providerId: AccountProviderId): string {
+	switch (providerId) {
+		case "anthropic":
+			return "Anthropic";
+		case "github-copilot":
+			return "GitHub Copilot";
+		case "openai-codex":
+			return "OpenAI Codex";
+	}
 }
 
 async function loginAccount(
@@ -294,6 +532,14 @@ async function loginAccount(
 	if (!ctx.hasUI) {
 		ctx.ui.notify("Account login requires interactive UI.", "error");
 		return;
+	}
+	const state = await store.readProviderAsync(adapter.id);
+	if (getOwnCredential(state.accounts, parsed.name)) {
+		const confirmed = await ctx.ui.confirm(
+			"Replace account",
+			`${adapter.displayName} account "${parsed.name}" already exists. Replace it?`,
+		);
+		if (!confirmed) return;
 	}
 	ctx.ui.notify(`Starting ${adapter.displayName} login for "${parsed.name}".`, "info");
 	try {
@@ -335,7 +581,7 @@ async function switchAccount(
 		const names = Object.keys(state.accounts).sort();
 		if (!ctx.hasUI) {
 			ctx.ui.notify(
-				`${adapter.displayName} accounts: ${[DEFAULT_PI_LOGIN_LABEL, ...names].join(", ")}. Use /account switch ${adapter.id} <name>.`,
+				`${adapter.displayName} accounts: ${[DEFAULT_PI_LOGIN_LABEL, ...names].join(", ")}. Use /accounts in interactive mode to switch accounts.`,
 				"info",
 			);
 			return;
@@ -418,90 +664,6 @@ async function removeAccount(
 	ctx.ui.notify(`Removed ${adapter.displayName} account "${parsed.name}".`, "info");
 }
 
-async function listAccounts(
-	ctx: ExtensionCommandContext,
-	store: AccountStore,
-	adapters: Map<AccountProviderId, AccountProviderAdapter>,
-	providerId?: AccountProviderId,
-): Promise<void> {
-	const ids = providerId ? [providerId] : SUPPORTED_PROVIDER_IDS;
-	const lines: string[] = [];
-	for (const id of ids) {
-		const state = await store.readProviderAsync(id);
-		const names = Object.keys(state.accounts).sort();
-		const rendered = names.length
-			? names.map((name) => (name === state.active ? `${name} (active)` : name)).join(", ")
-			: "(none)";
-		lines.push(`${requireAdapter(adapters, id).displayName}: ${rendered}`);
-	}
-	ctx.ui.notify(lines.join("\n"), "info");
-}
-
-export async function completeAccountArguments(
-	argumentPrefix: string,
-	store: AccountStore,
-): Promise<CommandArgumentCompletion[]> {
-	const hasTrailingSpace = /\s$/.test(argumentPrefix);
-	const tokens = splitArguments(argumentPrefix);
-	if (hasTrailingSpace) tokens.push("");
-	if (tokens.length <= 1) {
-		return continueCompletionValues(
-			filterCompletions(
-				["list", "login", "switch", "remove"].map((value) => ({ value, label: value })),
-				tokens[0] ?? "",
-			),
-		);
-	}
-	const subcommand = tokens[0];
-	if (!["list", "login", "switch", "remove"].includes(subcommand)) return [];
-	if (tokens.length === 2) {
-		const providerCompletions = prefixCompletionValues(
-			subcommand,
-			filterCompletions(
-				SUPPORTED_PROVIDER_IDS.map((id) => ({ value: id, label: id })),
-				tokens[1] ?? "",
-			),
-		);
-		return subcommand === "list"
-			? providerCompletions
-			: continueCompletionValues(providerCompletions);
-	}
-	if ((subcommand === "switch" || subcommand === "remove") && tokens.length === 3) {
-		const providerId = parseProviderId(tokens[1] ?? "");
-		return providerId
-			? prefixCompletionValues(
-					`${subcommand} ${providerId}`,
-					await completeProviderAccounts(
-						tokens[2] ?? "",
-						store,
-						providerId,
-						subcommand === "switch",
-					),
-				)
-			: [];
-	}
-	return [];
-}
-
-async function completeProviderAccounts(
-	prefix: string,
-	store: AccountStore,
-	providerId: AccountProviderId,
-	includeDefault: boolean,
-): Promise<CommandArgumentCompletion[]> {
-	let names: string[] = [];
-	try {
-		names = Object.keys((await store.readAsync()).providers[providerId]?.accounts ?? {}).sort();
-	} catch {
-		return [];
-	}
-	const items: CommandArgumentCompletion[] = includeDefault
-		? [{ value: "default", label: DEFAULT_PI_LOGIN_LABEL, description: "Use Pi's built-in login" }]
-		: [];
-	for (const name of names) items.push({ value: name, label: name });
-	return filterCompletions(items, prefix.trim());
-}
-
 function validateProviderSet(providers: readonly AccountProviderAdapter[]): void {
 	const ids = new Set<AccountProviderId>();
 	for (const provider of providers) {
@@ -522,45 +684,12 @@ function requireAdapter(
 	return adapter;
 }
 
-function parseProviderId(value: string): AccountProviderId | undefined {
-	return isAccountProviderId(value) ? value : undefined;
-}
-
 function toProviderId(value: string | undefined): AccountProviderId | undefined {
 	return value && isAccountProviderId(value) ? value : undefined;
 }
 
 function isAccountProviderId(value: string): value is AccountProviderId {
 	return (SUPPORTED_PROVIDER_IDS as readonly string[]).includes(value);
-}
-
-function notifyUnsupportedProvider(ctx: ExtensionCommandContext, provider: string): void {
-	ctx.ui.notify(
-		`Unsupported account provider "${provider || "(missing)"}". Supported providers: ${SUPPORTED_PROVIDER_IDS.join(", ")}.`,
-		"warning",
-	);
-}
-
-function splitArguments(value: string): string[] {
-	return value.trim() ? value.trim().split(/\s+/) : [];
-}
-
-function filterCompletions(
-	items: CommandArgumentCompletion[],
-	prefix: string,
-): CommandArgumentCompletion[] {
-	return prefix ? items.filter((item) => item.value.startsWith(prefix)) : items;
-}
-
-function prefixCompletionValues(
-	prefix: string,
-	items: CommandArgumentCompletion[],
-): CommandArgumentCompletion[] {
-	return items.map((item) => ({ ...item, value: `${prefix} ${item.value}` }));
-}
-
-function continueCompletionValues(items: CommandArgumentCompletion[]): CommandArgumentCompletion[] {
-	return items.map((item) => ({ ...item, value: `${item.value} ` }));
 }
 
 function isDefaultPiLoginArg(value: string): boolean {

--- a/extensions/pi-accounts/test/accounts.test.ts
+++ b/extensions/pi-accounts/test/accounts.test.ts
@@ -4,7 +4,6 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import accountsExtension, {
 	ACCOUNTS_STATUS_KEY,
 	AccountStore,
-	completeAccountArguments,
 	FAIL_CLOSED_API_KEY,
 	parseAccountName,
 	type StoredOAuthCredential,
@@ -15,7 +14,7 @@ import {
 	createOAuthInteraction,
 } from "../src/oauth.js";
 import { RuntimeAuthCoordinator } from "../src/runtime-auth.js";
-import { type AccountStorageBackend, InMemoryAccountStorageBackend } from "../src/storage.js";
+import { InMemoryAccountStorageBackend } from "../src/storage.js";
 
 const credential = (
 	suffix: string,
@@ -108,6 +107,42 @@ function runtimeHarness(mock: ReturnType<typeof createMockPi>) {
 	return { keys, registry, runtime };
 }
 
+function createInteractiveAccountContext(
+	overrides: Record<string, unknown> = {},
+	options: {
+		selections?: string[];
+		inputs?: Array<string | undefined>;
+		confirms?: boolean[];
+	} = {},
+) {
+	const selections = [...(options.selections ?? [])];
+	const inputs = [...(options.inputs ?? [])];
+	const confirms = [...(options.confirms ?? [])];
+	const selectCalls: Array<{ title: string; options: string[] }> = [];
+	const inputCalls: Array<{ title: string; placeholder?: string }> = [];
+	const confirmCalls: Array<{ title: string; message: string }> = [];
+	const context = createMockContext({
+		hasUI: true,
+		...overrides,
+		select: async (title: string, values: string[]) => {
+			selectCalls.push({ title, options: values });
+			const selected = selections.shift();
+			if (selected !== undefined)
+				assert.ok(values.includes(selected), `Missing option: ${selected}`);
+			return selected;
+		},
+		input: async (title: string, placeholder?: string) => {
+			inputCalls.push({ title, placeholder });
+			return inputs.shift();
+		},
+		confirm: async (title: string, message: string) => {
+			confirmCalls.push({ title, message });
+			return confirms.shift() ?? true;
+		},
+	});
+	return { ...context, selectCalls, inputCalls, confirmCalls };
+}
+
 test("built-in provider adapters preserve each provider's complete OAuth auth shape", async () => {
 	const adapters = createBuiltinProviderAdapters();
 	const byId = new Map(adapters.map((adapter) => [adapter.id, adapter]));
@@ -161,7 +196,7 @@ test("OAuth interaction preserves provider prompts, cancellation, and notificati
 	assert.match(notifications.at(-1)?.message ?? "", /ABCD/);
 });
 
-test("accounts registers the generic command, compatibility aliases, and lifecycle hooks", () => {
+test("accounts registers only the interactive /accounts command and lifecycle hooks", () => {
 	const mock = createMockPi();
 	accountsExtension(mock.pi, {
 		store: new AccountStore(new InMemoryAccountStorageBackend()),
@@ -172,12 +207,7 @@ test("accounts registers the generic command, compatibility aliases, and lifecyc
 		],
 	});
 
-	assert.deepEqual([...mock.commands.keys()].sort(), [
-		"account",
-		"codex-account",
-		"codex-login",
-		"codex-logout",
-	]);
+	assert.deepEqual([...mock.commands.keys()].sort(), ["accounts"]);
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"before_agent_start",
 		"model_select",
@@ -187,71 +217,183 @@ test("accounts registers the generic command, compatibility aliases, and lifecyc
 	]);
 });
 
-test("account names and command completion are provider scoped", async () => {
+test("account names reserve default for Pi login", () => {
 	assert.equal(parseAccountName(" work-1 ").ok, true);
 	assert.equal(parseAccountName("../secret").ok, false);
+	assert.equal(parseAccountName("default").ok, true);
+});
+
+test("accounts command ignores arguments but requires interactive UI", async () => {
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store: new AccountStore(new InMemoryAccountStorageBackend()),
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { ctx, notifications } = createMockContext({ hasUI: false });
+
+	await mock.commands.get("accounts")?.handler("switch anthropic work", ctx);
+
+	assert.match(notifications.at(-1)?.message ?? "", /requires interactive UI/);
+	assert.equal(notifications.at(-1)?.level, "error");
+});
+
+test("accounts empty state offers only login and ignores command arguments", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx, selectCalls } = createInteractiveAccountContext(
+		{ model: { provider: "anthropic", id: "claude" }, modelRegistry: registry },
+		{ selections: [] },
+	);
+
+	await mock.commands.get("accounts")?.handler("anything ignored", ctx);
+
+	assert.match(selectCalls[0]?.title ?? "", /No saved accounts yet/);
+	assert.deepEqual(selectCalls[0]?.options, ["Login new account"]);
+});
+
+test("accounts menu summarizes all supported providers and prioritizes current provider switch", async () => {
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
 	await store.write({
 		version: 1,
 		providers: {
-			anthropic: { accounts: { work: credential("work"), home: credential("home") } },
+			anthropic: {
+				active: "work",
+				accounts: { personal: credential("personal"), work: credential("work") },
+			},
+			"openai-codex": { accounts: { codex: credential("codex") } },
 		},
 	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx, selectCalls } = createInteractiveAccountContext({
+		model: { provider: "anthropic", id: "claude" },
+		modelRegistry: registry,
+	});
 
-	assert.deepEqual(
-		(await completeAccountArguments("s", store)).map((item) => item.value),
-		["switch "],
-	);
-	assert.deepEqual(
-		(await completeAccountArguments("switch ", store)).map((item) => item.value),
-		["switch anthropic ", "switch github-copilot ", "switch openai-codex "],
-	);
-	assert.deepEqual(
-		(await completeAccountArguments("switch anthropic ", store)).map((item) => item.value),
-		["switch anthropic default", "switch anthropic home", "switch anthropic work"],
-	);
-	assert.deepEqual(
-		(await completeAccountArguments("remove anthropic h", store)).map((item) => item.value),
-		["remove anthropic home"],
-	);
-	assert.deepEqual(
-		(await completeAccountArguments("login ", store)).map((item) => item.value),
-		["login anthropic ", "login github-copilot ", "login openai-codex "],
-	);
-	assert.deepEqual(
-		(await completeAccountArguments("list open", store)).map((item) => item.value),
-		["list openai-codex"],
-	);
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	assert.match(selectCalls[0]?.title ?? "", /Current model:\n {2}Anthropic \/ claude/);
+	assert.match(selectCalls[0]?.title ?? "", /Anthropic: work/);
+	assert.match(selectCalls[0]?.title ?? "", /OpenAI Codex: default/);
+	assert.match(selectCalls[0]?.title ?? "", /GitHub Copilot: default/);
+	assert.deepEqual(selectCalls[0]?.options, [
+		"Switch Anthropic account",
+		"Login new account",
+		"Remove account",
+		"Switch another provider’s account",
+	]);
 });
 
-test("stored-account completion does not block on synchronous storage", async () => {
-	let synchronousReads = 0;
-	let asynchronousReads = 0;
-	const raw = JSON.stringify({
+test("accounts menu prioritizes login when the current provider has no saved accounts", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
 		version: 1,
-		providers: {
-			anthropic: { accounts: { work: credential("work") } },
-		},
+		providers: { "openai-codex": { accounts: { codex: credential("codex") } } },
 	});
-	const backend: AccountStorageBackend = {
-		withLock() {
-			synchronousReads += 1;
-			throw new Error("synchronous storage should not be used for completion");
-		},
-		async withLockAsync(mutator) {
-			asynchronousReads += 1;
-			return (await mutator(raw)).result;
-		},
-	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx, selectCalls } = createInteractiveAccountContext({
+		model: { provider: "anthropic", id: "claude" },
+		modelRegistry: registry,
+	});
 
-	assert.deepEqual(
-		(await completeAccountArguments("switch anthropic w", new AccountStore(backend))).map(
-			(item) => item.value,
-		),
-		["switch anthropic work"],
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	assert.deepEqual(selectCalls[0]?.options, [
+		"Login new account",
+		"Switch another provider’s account",
+		"Remove account",
+	]);
+});
+
+test("accounts menu uses generic provider switch for unsupported current models", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { anthropic: { accounts: { work: credential("work") } } },
+	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx, selectCalls } = createInteractiveAccountContext({
+		model: { provider: "google", id: "gemini" },
+		modelRegistry: registry,
+	});
+
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	assert.deepEqual(selectCalls[0]?.options, [
+		"Login new account",
+		"Switch provider account",
+		"Remove account",
+	]);
+});
+
+test("switch another provider account selects provider before account", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { "openai-codex": { accounts: { work: credential("codex") } } },
+	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { registry, keys } = runtimeHarness(mock);
+	const { ctx, selectCalls } = createInteractiveAccountContext(
+		{
+			model: { provider: "anthropic", id: "claude" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Switch another provider’s account", "OpenAI Codex", "work"] },
 	);
-	assert.equal(synchronousReads, 0);
-	assert.equal(asynchronousReads, 1);
+
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	assert.equal((await store.readProviderAsync("openai-codex")).active, "work");
+	assert.equal(keys.get("openai-codex"), "access-codex");
+	assert.deepEqual(selectCalls[1]?.options, ["OpenAI Codex"]);
 });
 
 test("provider accounts activate independently and default clears only one provider", async () => {
@@ -271,16 +413,19 @@ test("provider accounts activate independently and default clears only one provi
 	];
 	accountsExtension(mock.pi, { store, providers });
 	const { registry, keys } = runtimeHarness(mock);
-	const { ctx, notifications } = createMockContext({
-		model: { provider: "anthropic", id: "claude" },
-		modelRegistry: registry,
-	});
+	const { ctx, notifications } = createInteractiveAccountContext(
+		{
+			model: { provider: "anthropic", id: "claude" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Switch Anthropic account", "default"] },
+	);
 
 	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	assert.equal(keys.get("openai-codex"), "access-codex");
 	assert.equal(keys.get("anthropic"), "access-claude");
 
-	await mock.commands.get("account")?.handler("switch anthropic default", ctx);
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
 	const data = await store.readAsync();
 	assert.equal(data.providers.anthropic?.active, undefined);
 	assert.equal(data.providers["openai-codex"]?.active, "personal");
@@ -337,7 +482,14 @@ test("Codex connections invalidate only when the applied account identity change
 	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await mock.events.get("before_agent_start")?.[0]?.({}, ctx);
 	assert.deepEqual(invalidations, ["test-session"]);
-	await mock.commands.get("account")?.handler("switch openai-codex default", ctx);
+	const switchContext = createInteractiveAccountContext(
+		{
+			model: { provider: "openai-codex", id: "codex" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Switch OpenAI Codex account", "default"] },
+	).ctx;
+	await mock.commands.get("accounts")?.handler("ignored", switchContext);
 	assert.deepEqual(invalidations, ["test-session", "test-session"]);
 });
 
@@ -487,17 +639,102 @@ test("generic login stores the full provider-owned credential and activates it",
 		],
 	});
 	const { registry, keys } = runtimeHarness(mock);
-	const { ctx } = createMockContext({
-		hasUI: true,
-		model: { provider: "github-copilot", id: "allowed" },
-		modelRegistry: registry,
-	});
+	const { ctx } = createInteractiveAccountContext(
+		{
+			model: { provider: "github-copilot", id: "allowed" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Login new account", "GitHub Copilot"], inputs: ["personal"] },
+	);
 
-	await mock.commands.get("account")?.handler("login github-copilot personal", ctx);
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
 	const stored = (await store.readAsync()).providers["github-copilot"];
 	assert.equal(stored?.active, "personal");
 	assert.deepEqual(stored?.accounts.personal?.availableModelIds, ["allowed"]);
 	assert.equal(keys.get("github-copilot"), "access-login-github-copilot");
+});
+
+test("login rejects default as a reserved account name", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx, notifications } = createInteractiveAccountContext(
+		{ model: { provider: "anthropic", id: "claude" }, modelRegistry: registry },
+		{ selections: ["Login new account", "Anthropic"], inputs: ["default"] },
+	);
+
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	assert.equal((await store.readProviderAsync("anthropic")).accounts.default, undefined);
+	assert.match(notifications.at(-1)?.message ?? "", /reserved/);
+});
+
+test("login asks before replacing an existing account name", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { anthropic: { active: "work", accounts: { work: credential("old") } } },
+	});
+	let logins = 0;
+	const anthropic = fakeProvider("anthropic");
+	anthropic.oauth.login = async () => {
+		logins += 1;
+		return credential("new");
+	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [fakeProvider("openai-codex"), anthropic, fakeProvider("github-copilot")],
+	});
+	const { registry } = runtimeHarness(mock);
+	const cancelled = createInteractiveAccountContext(
+		{ model: { provider: "anthropic", id: "claude" }, modelRegistry: registry },
+		{ selections: ["Login new account", "Anthropic"], inputs: ["work"], confirms: [false] },
+	);
+
+	await mock.commands.get("accounts")?.handler("ignored", cancelled.ctx);
+	assert.equal(logins, 0);
+	assert.equal((await store.readProviderAsync("anthropic")).accounts.work?.access, "access-old");
+	assert.match(cancelled.confirmCalls[0]?.message ?? "", /already exists/);
+
+	const replaced = createInteractiveAccountContext(
+		{ model: { provider: "anthropic", id: "claude" }, modelRegistry: registry },
+		{ selections: ["Login new account", "Anthropic"], inputs: ["work"], confirms: [true] },
+	);
+	await mock.commands.get("accounts")?.handler("ignored", replaced.ctx);
+	assert.equal(logins, 1);
+	assert.equal((await store.readProviderAsync("anthropic")).accounts.work?.access, "access-new");
+});
+
+test("login selects a provider default model only when the current model is unknown", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	const codex = fakeProvider("openai-codex");
+	codex.defaultModelId = "codex";
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [codex, fakeProvider("anthropic"), fakeProvider("github-copilot")],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx } = createInteractiveAccountContext(
+		{
+			model: { provider: "unknown", id: "unknown", api: "unknown" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Login new account", "OpenAI Codex"], inputs: ["work"] },
+	);
+
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	assert.equal(mock.setModels.length, 1);
 });
 
 test("providers without account-specific overlays leave existing registrations untouched", async () => {
@@ -776,7 +1013,14 @@ test("account reset during OAuth conversion cannot restore a stale runtime overr
 
 	const startup = mock.events.get("session_start")?.[0]?.({}, ctx);
 	await conversionStarted;
-	const reset = mock.commands.get("account")?.handler("switch anthropic default", ctx);
+	const resetContext = createInteractiveAccountContext(
+		{
+			model: { provider: "anthropic", id: "claude" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Switch Anthropic account", "default"] },
+	).ctx;
+	const reset = mock.commands.get("accounts")?.handler("ignored", resetContext);
 	releaseConversion?.();
 	await Promise.all([startup, reset]);
 	assert.equal((await store.readProviderAsync("anthropic")).active, undefined);
@@ -815,23 +1059,43 @@ test("an overlapping account switch reports when its requested account was super
 		providers: [codex, fakeProvider("anthropic"), fakeProvider("github-copilot")],
 	});
 	const { registry } = runtimeHarness(mock);
-	const { ctx, notifications } = createMockContext({
-		model: { provider: "openai-codex", id: "codex" },
-		modelRegistry: registry,
-	});
+	const olderContext = createInteractiveAccountContext(
+		{
+			model: { provider: "openai-codex", id: "codex" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Switch OpenAI Codex account", "alpha"] },
+	);
+	const newerContext = createInteractiveAccountContext(
+		{
+			model: { provider: "openai-codex", id: "codex" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Switch OpenAI Codex account", "beta"] },
+	);
 
-	const older = mock.commands.get("account")?.handler("switch openai-codex alpha", ctx);
+	const older = mock.commands.get("accounts")?.handler("ignored", olderContext.ctx);
 	await alphaStarted;
-	await mock.commands.get("account")?.handler("switch openai-codex beta", ctx);
+	await mock.commands.get("accounts")?.handler("ignored", newerContext.ctx);
 	releaseAlpha?.();
 	await older;
 
 	assert.equal((await store.readProviderAsync("openai-codex")).active, "beta");
-	assert.match(notifications.at(-1)?.message ?? "", /alpha.*superseded/);
+	assert.match(olderContext.notifications.at(-1)?.message ?? "", /alpha.*superseded/);
 });
 
-test("Codex compatibility aliases write the generic provider state", async () => {
+test("remove account confirms and active removal restores default provider auth", async () => {
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			anthropic: {
+				active: "work",
+				accounts: { personal: credential("personal"), work: credential("work") },
+			},
+			"openai-codex": { accounts: { codex: credential("codex") } },
+		},
+	});
 	const mock = createMockPi();
 	accountsExtension(mock.pi, {
 		store,
@@ -841,13 +1105,23 @@ test("Codex compatibility aliases write the generic provider state", async () =>
 			fakeProvider("github-copilot"),
 		],
 	});
-	const { registry } = runtimeHarness(mock);
-	const { ctx } = createMockContext({ hasUI: true, modelRegistry: registry });
+	const { registry, keys } = runtimeHarness(mock);
+	const { ctx, confirmCalls } = createInteractiveAccountContext(
+		{
+			model: { provider: "anthropic", id: "claude" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Remove account", "Anthropic · work"], confirms: [true] },
+	);
 
-	await mock.commands.get("codex-login")?.handler("work", ctx);
-	assert.equal((await store.readAsync()).providers["openai-codex"]?.active, "work");
-	await mock.commands.get("codex-account")?.handler("default", ctx);
-	assert.equal((await store.readAsync()).providers["openai-codex"]?.active, undefined);
-	await mock.commands.get("codex-logout")?.handler("work", ctx);
-	assert.equal((await store.readAsync()).providers["openai-codex"]?.accounts.work, undefined);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	assert.equal(keys.get("anthropic"), "access-work");
+	await mock.commands.get("accounts")?.handler("ignored", ctx);
+
+	const state = await store.readProviderAsync("anthropic");
+	assert.equal(state.active, undefined);
+	assert.equal(state.accounts.work, undefined);
+	assert.equal(state.accounts.personal?.access, "access-personal");
+	assert.equal(keys.has("anthropic"), false);
+	assert.match(confirmCalls[0]?.message ?? "", /Remove Anthropic account "work"/);
 });


### PR DESCRIPTION
## Summary
- replace the old `/account` subcommand surface with one interactive `/accounts` account manager
- remove Codex compatibility slash commands from pi-accounts
- update tests, docs, and package plan for the new menu-driven login/switch/remove flows

## Verification
- npm --workspace @narumitw/pi-accounts run check
- npm test
- npm run check
- npm run pack:accounts
