### PR TITLE
feat(pi-codex-accounts): warn about deprecation

### DIFF
--- a/docs/plans/archived/2026-07-21_pi-codex-accounts-deprecation-warning-plan.md
+++ b/docs/plans/archived/2026-07-21_pi-codex-accounts-deprecation-warning-plan.md
@@ -1,0 +1,51 @@
+## Goal
+
+Add a clear, low-noise deprecation path for `@narumitw/pi-codex-accounts` so users who still load it are warned to migrate to `@narumitw/pi-accounts`, with verified code, docs, and release guidance.
+
+## Context
+
+`pi-accounts` now manages Codex plus additional subscription OAuth providers and already documents that users should not load both packages together. `pi-codex-accounts` still registers commands and runs on `session_start`, making that extension the reliable place to warn users who have only the legacy package loaded.
+
+## Non-Goals
+
+- Do not remove or break existing `pi-codex-accounts` commands in this change.
+- Do not publish an npm deprecation notice without explicit maintainer approval for the exact npm action.
+- Do not make `pi-codex-accounts` hard-fail on startup during this warning phase.
+
+## Plan
+
+- [x] Add a module-level deprecation warning message in `extensions/pi-codex-accounts/src/codex-accounts.ts` that names `@narumitw/pi-codex-accounts`, points to `@narumitw/pi-accounts`, includes uninstall/install commands, and says not to load both packages; verified by source inspection of exported `DEPRECATION_WARNING_MESSAGE` in `extensions/pi-codex-accounts/src/codex-accounts.ts`.
+- [x] Emit the deprecation warning once per Pi session from the existing `session_start` handler before or near the migration notice without blocking `sync(ctx)`; verified by `session_start warns once that pi-codex-accounts is deprecated` and source inspection of the `deprecationWarningShown` guard before `await sync(ctx)`.
+- [x] Add or update `extensions/pi-codex-accounts/test/*.test.ts` coverage to assert the warning is shown once on `session_start` and existing migration notice behavior remains intact; verified by `npm run check` with 962 passing tests, including the new session-start warning test and updated migration test.
+- [x] Add a deprecated banner near the top of `extensions/pi-codex-accounts/README.md` with migration commands and the “do not load both” warning; verified by reading `extensions/pi-codex-accounts/README.md`.
+- [x] Not applicable: `extensions/pi-codex-accounts/package.json` metadata was reviewed and left unchanged because no package metadata change was needed for runtime or README discoverability in this implementation pass.
+- [x] Run formatting, typechecking, and relevant tests for the touched package; verified by `npm run check` from the worktree root, which completed Biome check, boundary check, workspace typechecks, and 962 passing tests.
+- [x] Prepare release notes and, only after explicit maintainer approval, run the npm deprecation command for the published legacy package; verified by the release-notes draft below. The npm deprecation action is not applicable for this implementation pass because no explicit maintainer approval for the public npm action was given.
+
+## Risks
+
+- A warning every startup may annoy users, but showing it once per session keeps the reminder visible without repeating every turn. Mitigated by the `deprecationWarningShown` per-extension-instance guard.
+- Loading both packages can still cause credential-refresh conflicts; mitigated by stating this clearly in both the runtime warning and README banner.
+- npm deprecation is a public package action and must be explicitly approved before execution. Accepted for this implementation pass; the command was not run.
+
+## Rollback / Recovery
+
+- If the runtime warning is too noisy, revert the `session_start` notification change or gate it behind a persisted acknowledgement in a follow-up.
+- If package users report confusion, update the README and warning copy without changing credential storage or auth behavior.
+
+## Release Notes Draft
+
+`@narumitw/pi-codex-accounts` now warns once per Pi session that the package is deprecated and directs users to migrate to `@narumitw/pi-accounts`. The README includes matching migration commands and warns not to load both extensions at the same time. Existing account-switching behavior is unchanged.
+
+Optional npm deprecation command, pending explicit maintainer approval for the exact public action:
+
+```bash
+npm deprecate @narumitw/pi-codex-accounts "@narumitw/pi-codex-accounts is deprecated; please migrate to @narumitw/pi-accounts. Do not load both extensions at the same time."
+```
+
+## Completion Checklist
+
+- [x] Users loading `pi-codex-accounts` receive a once-per-session deprecation warning verified by `session_start warns once that pi-codex-accounts is deprecated` and `npm run check`.
+- [x] The warning and README both tell users to migrate to `@narumitw/pi-accounts` and not to load both packages, verified by `extensions/pi-codex-accounts/src/codex-accounts.ts` and `extensions/pi-codex-accounts/README.md` source inspection.
+- [x] Existing account-switching behavior remains working, verified by `npm run check` completing workspace typechecks and 962 passing tests.
+- [x] Any public npm deprecation action is either explicitly approved and verified with `npm view`, or marked not applicable for this implementation pass; no approval was given, so the npm deprecation action was not run and is documented as not applicable above.

--- a/extensions/pi-codex-accounts/README.md
+++ b/extensions/pi-codex-accounts/README.md
@@ -2,6 +2,15 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-accounts)](https://www.npmjs.com/package/@narumitw/pi-codex-accounts) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
+> [!WARNING]
+> `@narumitw/pi-codex-accounts` is deprecated and will be replaced by `@narumitw/pi-accounts`.
+> Do not load both extensions at the same time. To migrate one Pi installation, run:
+>
+> ```bash
+> pi uninstall npm:@narumitw/pi-codex-accounts
+> pi install npm:@narumitw/pi-accounts
+> ```
+
 `@narumitw/pi-codex-accounts` is a native [Pi coding agent](https://pi.dev) extension that lets you log in to, switch between, and remove multiple ChatGPT Plus/Pro Codex subscription accounts.
 
 It keeps using Pi's built-in `openai-codex` provider and does **not** add provider aliases or register another OAuth provider. While a named account is active, it temporarily adds API-key resolution to that native provider so Pi can consume the account's runtime access token; returning to the default Pi login removes the overlay.

--- a/extensions/pi-codex-accounts/src/codex-accounts.ts
+++ b/extensions/pi-codex-accounts/src/codex-accounts.ts
@@ -37,6 +37,13 @@ const LEGACY_CODEX_ACCOUNTS_FILE = "codex-accounts.json";
 export const CODEX_ACCOUNTS_STATUS_KEY = "codex-accounts";
 export const DEFAULT_PI_LOGIN_LABEL = "(default pi login)";
 export const FAIL_CLOSED_API_KEY = "pi-codex-accounts-refresh-failed";
+export const DEPRECATION_WARNING_MESSAGE = [
+	"@narumitw/pi-codex-accounts is deprecated and will be replaced by @narumitw/pi-accounts.",
+	"Please migrate by running:",
+	"  pi uninstall npm:@narumitw/pi-codex-accounts",
+	"  pi install npm:@narumitw/pi-accounts",
+	"Do not load both extensions at the same time.",
+].join("\n");
 
 const runtimeCodexAuth = new RuntimeApiKeyController(CODEX_PROVIDER_ID);
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
@@ -137,6 +144,7 @@ export default function codexAccounts(
 ) {
 	const store = dependencies.store ?? new CodexAccountStore();
 	let migrationNotice = dependencies.store ? undefined : consumeAccountsMigrationNotice();
+	let deprecationWarningShown = false;
 	const oauthProvider =
 		dependencies.oauthProvider ?? getDefaultCodexOAuthProvider(CODEX_PROVIDER_ID);
 	// Keep cleanup injectable until WebSocket controls are available through a loader-safe export.
@@ -256,6 +264,10 @@ export default function codexAccounts(
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
+		if (!deprecationWarningShown) {
+			ctx.ui.notify(DEPRECATION_WARNING_MESSAGE, "warning");
+			deprecationWarningShown = true;
+		}
 		if (migrationNotice) {
 			ctx.ui.notify(migrationNotice, "warning");
 			migrationNotice = undefined;

--- a/extensions/pi-codex-accounts/test/codex-accounts-storage.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts-storage.test.ts
@@ -22,6 +22,7 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexAccounts, {
 	CODEX_ACCOUNTS_FILE,
 	CodexAccountStore,
+	DEPRECATION_WARNING_MESSAGE,
 	ensureActiveCodexAuth,
 } from "../src/codex-accounts.js";
 import {
@@ -195,7 +196,12 @@ test("default store migrates credentials to the canonical package filename", asy
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		assert.match(context.notifications[0]?.message ?? "", /migrated/i);
+		assert.ok(
+			context.notifications.some(
+				(notification) => notification.message === DEPRECATION_WARNING_MESSAGE,
+			),
+		);
+		assert.ok(context.notifications.some((notification) => /migrated/i.test(notification.message)));
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/extensions/pi-codex-accounts/test/codex-accounts.test.ts
+++ b/extensions/pi-codex-accounts/test/codex-accounts.test.ts
@@ -11,6 +11,7 @@ import codexAccounts, {
 	completeStoredAccountArguments,
 	DEFAULT_CODEX_MODEL_ID,
 	DEFAULT_PI_LOGIN_LABEL,
+	DEPRECATION_WARNING_MESSAGE,
 	ensureActiveCodexAuth,
 	FAIL_CLOSED_API_KEY,
 	isOpenAICodexModel,
@@ -41,6 +42,31 @@ test("codex-accounts registers commands and lifecycle hooks", () => {
 		"session_start",
 		"turn_start",
 	]);
+});
+
+test("session_start warns once that pi-codex-accounts is deprecated", async () => {
+	const mock = createMockPi();
+	codexAccounts(mock.pi, { store: new CodexAccountStore(new InMemoryAuthStorageBackend()) });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	assert.ok(sessionStart);
+	const { ctx, notifications } = createMockContext();
+
+	await sessionStart({}, ctx);
+	await sessionStart({}, ctx);
+
+	const deprecationWarnings = notifications.filter(
+		(notification) => notification.message === DEPRECATION_WARNING_MESSAGE,
+	);
+	assert.equal(deprecationWarnings.length, 1);
+	assert.equal(deprecationWarnings[0]?.level, "warning");
+	assert.match(deprecationWarnings[0]?.message ?? "", /@narumitw\/pi-codex-accounts/);
+	assert.match(deprecationWarnings[0]?.message ?? "", /@narumitw\/pi-accounts/);
+	assert.match(
+		deprecationWarnings[0]?.message ?? "",
+		/pi uninstall npm:@narumitw\/pi-codex-accounts/,
+	);
+	assert.match(deprecationWarnings[0]?.message ?? "", /pi install npm:@narumitw\/pi-accounts/);
+	assert.match(deprecationWarnings[0]?.message ?? "", /Do not load both extensions/);
 });
 
 test("parseAccountName accepts small account labels and rejects unsafe names", () => {


### PR DESCRIPTION
## Summary
- warn once per session when `pi-codex-accounts` is loaded
- add README migration guidance to `pi-accounts`
- archive the completed implementation plan

## Tests
- npm run check