### PR TITLE
fix(pi-sync): self-heal on unreadable lock and config files

### DIFF
--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -52,20 +52,35 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 	};
 	let handle: fs.FileHandle | undefined;
 	try {
-		handle = await fs.open(lockPath(), "wx");
+		// Acquire the lock, reclaiming an unreadable (zero-byte/truncated/corrupt)
+		// lock file once. Such a file can never represent a real holder, so removing
+		// it lets sync/push/pull/rollback self-heal after a crashed or interrupted run.
+		for (let attempt = 0; ; attempt++) {
+			try {
+				handle = await fs.open(lockPath(), "wx");
+				break;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+				const current = await readLock();
+				if (current && isStaleLock(current)) {
+					throw new Error(`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`);
+				}
+				if (current) {
+					throw new Error(
+						`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
+					);
+				}
+				if (attempt > 0) {
+					throw new Error("pi-sync is already running.");
+				}
+				// Lock file exists but is unreadable: reclaim and retry.
+				await fs.rm(lockPath(), { force: true });
+			}
+		}
 		await handle.writeFile(JSON.stringify(lock, null, "\t"));
 		await handle.close();
 		handle = undefined;
 		return await fn();
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-			const current = await readLock();
-			if (current && isStaleLock(current)) {
-				throw new Error(`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`);
-			}
-			throw new Error(`pi-sync is already running${current ? ` (${current.command}, pid ${current.pid}, started ${current.startedAt})` : ""}.`);
-		}
-		throw error;
 	} finally {
 		await handle?.close();
 		const current = await readLock();
@@ -208,6 +223,16 @@ export async function readLock() {
 	return readJsonIfExists<LockFile>(lockPath());
 }
 
+export async function lockFileExists(): Promise<boolean> {
+	try {
+		await fs.stat(lockPath());
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
 export function isStaleLock(lock: LockFile) {
 	if (!Number.isInteger(lock.pid) || lock.pid <= 0) return true;
 	try {
@@ -221,9 +246,15 @@ export function isStaleLock(lock: LockFile) {
 
 async function readJsonIfExists<T>(filePath: string): Promise<T | undefined> {
 	try {
-		return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+		const text = await fs.readFile(filePath, "utf8");
+		// Treat empty/whitespace files (e.g. a truncated or zero-byte lock) as absent.
+		if (text.trim().length === 0) return undefined;
+		return JSON.parse(text) as T;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		// Treat corrupt/unparseable files as absent so callers can self-heal
+		// instead of crashing with a raw SyntaxError.
+		if (error instanceof SyntaxError) return undefined;
 		throw error;
 	}
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -15,6 +15,7 @@ import {
 	isStaleLock,
 	loadPartialConfig,
 	localConfigPath,
+	lockFileExists,
 	lockPath,
 	normalizeExtraFiles,
 	readLock,
@@ -622,6 +623,13 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const lock = await readLock();
 	if (!lock) {
+		// The lock file may be present but unreadable (zero-byte/truncated/corrupt);
+		// reclaim it so users are never stuck needing a manual `rm`.
+		if (await lockFileExists()) {
+			await fs.rm(lockPath(), { force: true });
+			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
+			return;
+		}
 		ctx.ui.notify("No pi-sync lock is present.", "info");
 		return;
 	}

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -38,6 +38,7 @@ import sync, {
 	snapshotWithoutSessions,
 	splitArgs,
 } from "../src/sync.js";
+import { ensureStateDir, lockFileExists, lockPath, readLock, withLock } from "../src/config.js";
 
 test("sync registers pisync command and session lifecycle hooks", () => {
 	const mock = createMockPi();
@@ -933,6 +934,47 @@ test("getBuffer throws after retrying a persistently empty R2 response body", as
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
+});
+
+test("withLock self-heals a zero-byte lock file", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const result = await withLock("test", async () => "ok");
+		assert.equal(result, "ok");
+		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("withLock self-heals a corrupt lock file", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{not valid json");
+		const result = await withLock("test", async () => "ok");
+		assert.equal(result, "ok");
+		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("withLock rejects when a valid foreign lock is held", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({ id: "other", pid: process.pid, command: "push", startedAt: new Date().toISOString() }),
+		);
+		await assert.rejects(withLock("test", async () => "ok"), /already running/);
+	});
+});
+
+test("readLock treats empty, whitespace, and corrupt lock files as absent", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		for (const contents of ["", "  \n  ", "{broken"]) {
+			writeFileSync(lockPath(), contents);
+			assert.equal(await readLock(), undefined, `expected undefined for ${JSON.stringify(contents)}`);
+		}
+	});
 });
 
 function snapshot(files: Array<{ path: string; content: Buffer }>) {


### PR DESCRIPTION
## Summary

`pi-sync` could get permanently stuck when a sync run was interrupted (crash, OOM kill, terminal close, power loss). The lock file at `~/.pi/agent/.pisync/lock` would be left **zero-byte, truncated, or partially written**, after which:

- `readLock()` threw an uncaught `SyntaxError: Unexpected end of JSON input` (or `Unexpected token` in JSON at position 0) on every subsequent command;
- `withLock()` hit `EEXIST` on `open(..., "wx")` but had no path to reclaim an unreadable lock, so `sync`, `push`, `pull`, and `rollback` all failed until the user manually `rm`'d the file.

This is a common cause of "pi-sync just stopped working" reports — a manual file removal should never be required for recovery.

## Changes

### `readJsonIfExists` — tolerate empty and corrupt files
Returns `undefined` (instead of throwing) for:
- empty / whitespace-only files (a truncated or zero-byte lock), and
- `SyntaxError` from `JSON.parse` (corrupt / partially-written contents).

Still re-throws genuine I/O errors other than `ENOENT`. Callers (`readLock`, config loaders) now treat any unreadable file as "absent" and can self-heal.

### `withLock` — reclaim an unreadable lock once
On `EEXIST`, if `readLock()` returns `undefined` (file present but unreadable), the lock is removed and acquisition is retried once. Such a file can never represent a real holder, so this is always safe. A valid foreign lock still fails with the existing "already running" message; a stale lock still points the user at `/pisync unlock --stale`.

### `unlock` — clear unreadable locks
Previously reported `No pi-sync lock is present.` when the lock file existed but couldn't be parsed, leaving the user stuck. Now removes the unreadable file with an explanatory message.

### New helper: `lockFileExists`
`stat`-based existence check, complementing `readLock` (which returns parsed contents). Exported from `config.ts`.

## Tests

Four new regression tests in `extensions/pi-sync/test/sync.test.ts`:
- `withLock self-heals a zero-byte lock file`
- `withLock self-heals a corrupt lock file`
- `withLock rejects when a valid foreign lock is held` (negative case — must not steal a live lock)
- `readLock treats empty, whitespace, and corrupt lock files as absent`

All `extensions/pi-sync` tests pass. The full repo test suite has 5 pre-existing failures in `pi-image-drop`, `pi-subagents`, and `pi-webui` (SSE / worktree-internal) that are unrelated to this change and reproduce identically on `main`.

## Checklist
- [x] Conventional Commit (`fix(pi-sync): ...`)
- [x] Single self-contained commit on top of `main`
- [x] Regression tests cover happy path and failure modes
- [x] `tsc` clean (test runner compiles via `tsc -p tsconfig.test.json`)