### PR TITLE
fix(pi-sync): make corrupt lock recovery race-safe

### DIFF
--- a/docs/plans/archived/2026-07-21_pi-sync-pr312-review-fixes-plan.md
+++ b/docs/plans/archived/2026-07-21_pi-sync-pr312-review-fixes-plan.md
@@ -1,0 +1,18 @@
+## Goal
+
+Resolve confirmed PR #312 review findings without allowing legacy pi-sync writers to overlap a guarded sync.
+
+## Plan
+
+- [x] Add failing regressions for an aged legacy writer, unreadable doctor state, and orphan-guard diagnostics; all three failed against the prior PR head.
+- [x] Require explicit stale unlock for unreadable metadata and expose structured lock inspection to callers; verified with the focused 35-test pi-sync suite.
+- [x] Make doctor and unlock diagnostics distinguish unreadable metadata, active owners, and exited owners with an expiring guard; verified with focused command tests.
+- [x] Run explicit formatting/typechecks, `npm run check`, and `just pack-sync`; explicit Biome, typechecks, 977-test gate, package dry run, and independent review pass.
+- [x] Commit and push the review fixes to PR #312; commit `24f9199` is pushed and GitHub CI run `29847110843` passes.
+
+## Completion Checklist
+
+- [x] All confirmed findings have deterministic regression coverage in `extensions/pi-sync/test/sync.test.ts`.
+- [x] `npm run check` passes with 977 tests.
+- [x] `just pack-sync` includes the lock module and dependency metadata.
+- [x] PR #312 contains commit `24f9199` and has passing CI.

--- a/docs/plans/archived/2026-07-21_pi-sync-safe-lock-recovery-plan.md
+++ b/docs/plans/archived/2026-07-21_pi-sync-safe-lock-recovery-plan.md
@@ -1,0 +1,23 @@
+## Goal
+
+Resolve PR #310's two major review findings so corrupt lock recovery remains automatic without allowing concurrent syncs or silently accepting malformed configuration/state JSON.
+
+## Plan
+
+- [x] Add regression tests for an in-progress lock, concurrent corrupt-lock reclaim, and malformed non-lock JSON; verified the fresh-lock and malformed-JSON tests failed against PR #310, and the deterministic delayed-removal race reproduced two concurrent callbacks.
+- [x] Make lock publication and corrupt-lock reclamation race-safe while keeping valid/stale lock behavior; verified with a proper-lockfile guard and 33 focused pi-sync tests.
+- [x] Restrict tolerant malformed-JSON handling to lock files and preserve explicit errors for config, settings, and state; verified malformed config, state, and settings reject in the focused test suite.
+- [x] Format and inspect the bounded diff; verified explicit Biome for `src/lock.ts`, pi-sync TypeScript, `git diff --check`, and the focused 34-test suite.
+- [x] Run the repository CI-equivalent gate, package dry run, commit the focused changes, push the branch, and open replacement PR #312 against `main`.
+
+## Risks
+
+- Lock recovery must remain compatible with zero-byte files left by older pi-sync versions.
+- Reclamation must not unlink a lock path that changed after inspection.
+
+## Completion Checklist
+
+- [x] Both major findings are covered by deterministic regression tests in `extensions/pi-sync/test/sync.test.ts`.
+- [x] `npm run check` passes with 972 tests.
+- [x] `just pack-sync` contains the expected source files, including `src/lock.ts` and its runtime dependency metadata.
+- [x] Commit `9803e0d` is pushed on `fix/pi-sync-safe-lock-recovery` and represented by open PR #312 targeting `main`.

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -28,9 +28,13 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"dependencies": {
+		"proper-lockfile": "^4.1.2"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",
 		"@earendil-works/pi-coding-agent": "0.80.10",
+		"@types/proper-lockfile": "^4.1.4",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -1,17 +1,15 @@
-import { randomUUID } from "node:crypto";
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { isDeniedPath, safeName } from "./paths.js";
-import type { LockFile, PartialConfig, Snapshot, SyncConfig, SyncState } from "./types.js";
+import type { PartialConfig, Snapshot, SyncConfig, SyncState } from "./types.js";
 
 const VERSION = 1;
 const DEFAULT_PROFILE = "default";
 const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
-const LOCK_STALE_MS = 30 * 60 * 1000;
 const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
 const TOP_LEVEL_FILE_NAMES = new Set([...TOP_LEVEL_FILES].map((name) => name.toLowerCase()));
 const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
@@ -40,52 +38,6 @@ function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) 
 	return typeof getSessionDir === "function"
 		? (getSessionDir.call(manager) as string | undefined)
 		: undefined;
-}
-
-export async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
-	await ensureStateDir();
-	const lock: LockFile = {
-		id: randomUUID(),
-		pid: process.pid,
-		command,
-		startedAt: new Date().toISOString(),
-	};
-	let handle: fs.FileHandle | undefined;
-	try {
-		// Acquire the lock, reclaiming an unreadable (zero-byte/truncated/corrupt)
-		// lock file once. Such a file can never represent a real holder, so removing
-		// it lets sync/push/pull/rollback self-heal after a crashed or interrupted run.
-		for (let attempt = 0; ; attempt++) {
-			try {
-				handle = await fs.open(lockPath(), "wx");
-				break;
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-				const current = await readLock();
-				if (current && isStaleLock(current)) {
-					throw new Error(`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`);
-				}
-				if (current) {
-					throw new Error(
-						`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
-					);
-				}
-				if (attempt > 0) {
-					throw new Error("pi-sync is already running.");
-				}
-				// Lock file exists but is unreadable: reclaim and retry.
-				await fs.rm(lockPath(), { force: true });
-			}
-		}
-		await handle.writeFile(JSON.stringify(lock, null, "\t"));
-		await handle.close();
-		handle = undefined;
-		return await fn();
-	} finally {
-		await handle?.close();
-		const current = await readLock();
-		if (current?.id === lock.id) await fs.rm(lockPath(), { force: true });
-	}
 }
 
 export async function loadConfigInternal(): Promise<SyncConfig> {
@@ -219,42 +171,11 @@ export async function ensureStateDir() {
 	await fs.mkdir(stateDir(), { recursive: true });
 }
 
-export async function readLock() {
-	return readJsonIfExists<LockFile>(lockPath());
-}
-
-export async function lockFileExists(): Promise<boolean> {
-	try {
-		await fs.stat(lockPath());
-		return true;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
-		throw error;
-	}
-}
-
-export function isStaleLock(lock: LockFile) {
-	if (!Number.isInteger(lock.pid) || lock.pid <= 0) return true;
-	try {
-		process.kill(lock.pid, 0);
-		return false;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ESRCH") return true;
-		return Date.now() - Date.parse(lock.startedAt) > LOCK_STALE_MS;
-	}
-}
-
 async function readJsonIfExists<T>(filePath: string): Promise<T | undefined> {
 	try {
-		const text = await fs.readFile(filePath, "utf8");
-		// Treat empty/whitespace files (e.g. a truncated or zero-byte lock) as absent.
-		if (text.trim().length === 0) return undefined;
-		return JSON.parse(text) as T;
+		return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		// Treat corrupt/unparseable files as absent so callers can self-heal
-		// instead of crashing with a raw SyntaxError.
-		if (error instanceof SyntaxError) return undefined;
 		throw error;
 	}
 }

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -52,20 +52,35 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 	};
 	let handle: fs.FileHandle | undefined;
 	try {
-		handle = await fs.open(lockPath(), "wx");
+		// Acquire the lock, reclaiming an unreadable (zero-byte/truncated/corrupt)
+		// lock file once. Such a file can never represent a real holder, so removing
+		// it lets sync/push/pull/rollback self-heal after a crashed or interrupted run.
+		for (let attempt = 0; ; attempt++) {
+			try {
+				handle = await fs.open(lockPath(), "wx");
+				break;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+				const current = await readLock();
+				if (current && isStaleLock(current)) {
+					throw new Error(`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`);
+				}
+				if (current) {
+					throw new Error(
+						`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
+					);
+				}
+				if (attempt > 0) {
+					throw new Error("pi-sync is already running.");
+				}
+				// Lock file exists but is unreadable: reclaim and retry.
+				await fs.rm(lockPath(), { force: true });
+			}
+		}
 		await handle.writeFile(JSON.stringify(lock, null, "\t"));
 		await handle.close();
 		handle = undefined;
 		return await fn();
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-			const current = await readLock();
-			if (current && isStaleLock(current)) {
-				throw new Error(`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`);
-			}
-			throw new Error(`pi-sync is already running${current ? ` (${current.command}, pid ${current.pid}, started ${current.startedAt})` : ""}.`);
-		}
-		throw error;
 	} finally {
 		await handle?.close();
 		const current = await readLock();
@@ -208,6 +223,16 @@ export async function readLock() {
 	return readJsonIfExists<LockFile>(lockPath());
 }
 
+export async function lockFileExists(): Promise<boolean> {
+	try {
+		await fs.stat(lockPath());
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
 export function isStaleLock(lock: LockFile) {
 	if (!Number.isInteger(lock.pid) || lock.pid <= 0) return true;
 	try {
@@ -221,9 +246,15 @@ export function isStaleLock(lock: LockFile) {
 
 async function readJsonIfExists<T>(filePath: string): Promise<T | undefined> {
 	try {
-		return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+		const text = await fs.readFile(filePath, "utf8");
+		// Treat empty/whitespace files (e.g. a truncated or zero-byte lock) as absent.
+		if (text.trim().length === 0) return undefined;
+		return JSON.parse(text) as T;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		// Treat corrupt/unparseable files as absent so callers can self-heal
+		// instead of crashing with a raw SyntaxError.
+		if (error instanceof SyntaxError) return undefined;
 		throw error;
 	}
 }

--- a/extensions/pi-sync/src/lock.ts
+++ b/extensions/pi-sync/src/lock.ts
@@ -18,7 +18,6 @@ import { ensureStateDir, lockPath } from "./config.js";
 import type { CommandOptions, LockFile } from "./types.js";
 
 const LOCK_STALE_MS = 30 * 60 * 1000;
-const LOCK_WRITE_GRACE_MS = 5_000;
 const GUARD_STALE_MS = 30_000;
 const GUARD_UPDATE_MS = 10_000;
 const MAX_PROCESS_ID = 2_147_483_647;
@@ -55,6 +54,11 @@ interface Guard {
 	isCompromised: () => boolean;
 }
 
+export type LockInspection =
+	| { status: "missing" }
+	| { status: "unreadable" }
+	| { status: "valid"; lock: LockFile };
+
 export async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
 	await ensureStateDir();
 	const lock: LockFile = {
@@ -75,24 +79,21 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 			throw await describeHeldLock();
 		}
 
-		const current = await readLock();
-		if (current && isStaleLock(current)) {
+		const inspection = await inspectLock();
+		if (inspection.status === "valid" && isStaleLock(inspection.lock)) {
 			throw new Error(
-				`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`,
+				`pi-sync lock is stale (pid ${inspection.lock.pid}). Run /pisync unlock --stale, then retry.`,
 			);
 		}
-		if (current) {
+		if (inspection.status === "valid") {
 			throw new Error(
-				`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
+				`pi-sync is already running (${inspection.lock.command}, pid ${inspection.lock.pid}, started ${inspection.lock.startedAt}).`,
 			);
 		}
-
-		const recovery = await reclaimUnreadableLock();
-		if (recovery === "fresh") {
-			throw new Error("pi-sync is already running (lock metadata is still being written).");
-		}
-		if (recovery === "changed") {
-			throw new Error("pi-sync is already running (lock changed while being inspected).");
+		if (inspection.status === "unreadable") {
+			throw new Error(
+				"pi-sync lock metadata is unreadable. Run /pisync unlock --stale after verifying no sync is running.",
+			);
 		}
 
 		await fs.writeFile(lockPath(), JSON.stringify(lock, null, "\t"), { flag: "wx" });
@@ -124,17 +125,22 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 	return result as T;
 }
 
-export async function readLock(): Promise<LockFile | undefined> {
+export async function inspectLock(): Promise<LockInspection> {
 	try {
 		const text = await fs.readFile(lockPath(), "utf8");
-		if (text.trim().length === 0) return undefined;
+		if (text.trim().length === 0) return { status: "unreadable" };
 		const parsed = JSON.parse(text) as unknown;
-		return isLockFile(parsed) ? parsed : undefined;
+		return isLockFile(parsed) ? { status: "valid", lock: parsed } : { status: "unreadable" };
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		if (error instanceof SyntaxError) return undefined;
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return { status: "missing" };
+		if (error instanceof SyntaxError) return { status: "unreadable" };
 		throw error;
 	}
+}
+
+export async function readLock(): Promise<LockFile | undefined> {
+	const inspection = await inspectLock();
+	return inspection.status === "valid" ? inspection.lock : undefined;
 }
 
 export async function lockFileExists(): Promise<boolean> {
@@ -147,19 +153,13 @@ export async function lockFileExists(): Promise<boolean> {
 	}
 }
 
-export async function reclaimUnreadableLock(force = false) {
-	if (await readLock()) return "changed" as const;
-	try {
-		const unreadable = await fs.stat(lockPath());
-		if (!force && Date.now() - unreadable.mtimeMs < LOCK_WRITE_GRACE_MS) {
-			return "fresh" as const;
-		}
-		await fs.rm(lockPath());
-		return "removed" as const;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing" as const;
-		throw error;
-	}
+export function isLockGuardHeld() {
+	return lockfile.check(lockPath(), {
+		fs: LOCKFILE_FS_ADAPTER,
+		lockfilePath: `${lockPath()}.guard`,
+		realpath: false,
+		stale: GUARD_STALE_MS,
+	});
 }
 
 export function isStaleLock(lock: LockFile) {
@@ -179,7 +179,7 @@ export async function unlock(ctx: ExtensionCommandContext, options: CommandOptio
 		guard = await acquireGuard();
 	} catch (error) {
 		if (!isLockHeldError(error)) throw error;
-		ctx.ui.notify("Pi-sync is currently running; retry unlock after it finishes.", "warning");
+		ctx.ui.notify((await describeHeldLock()).message, "warning");
 		return;
 	}
 
@@ -200,32 +200,35 @@ export async function unlock(ctx: ExtensionCommandContext, options: CommandOptio
 }
 
 async function unlockGuarded(ctx: ExtensionCommandContext, options: CommandOptions) {
-	const lock = await readLock();
-	if (!lock) {
-		const recovery = await reclaimUnreadableLock(options.stale);
-		if (recovery === "removed") {
-			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
-			return;
-		}
-		if (recovery === "fresh") {
+	let inspection = await inspectLock();
+	if (inspection.status === "missing") {
+		ctx.ui.notify("No pi-sync lock is present.", "info");
+		return;
+	}
+	if (inspection.status === "unreadable") {
+		if (!options.stale) {
 			ctx.ui.notify(
-				"Lock metadata may still be initializing. Retry shortly, or use /pisync unlock --stale after verifying no sync is running.",
+				"Pi-sync lock metadata is unreadable. Use /pisync unlock --stale only after verifying no sync is running.",
 				"warning",
 			);
 			return;
 		}
-		if (recovery === "changed") {
-			ctx.ui.notify("Pi-sync lock changed while being inspected; retry the command.", "warning");
+		inspection = await inspectLock();
+		if (inspection.status === "unreadable") {
+			// Legacy writers expose an empty file before writing owner metadata, so no
+			// automatic test can prove this file is abandoned. The explicit --stale
+			// flag is the user's confirmation that no legacy sync is still running.
+			await fs.rm(lockPath(), { force: true });
+			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
 			return;
 		}
-		ctx.ui.notify("No pi-sync lock is present.", "info");
-		return;
+		if (inspection.status === "missing") {
+			ctx.ui.notify("No pi-sync lock is present.", "info");
+			return;
+		}
 	}
-	if (!options.stale && !isStaleLock(lock)) {
-		ctx.ui.notify(
-			"Lock is not stale. Use /pisync unlock --stale only after verifying no sync is running.",
-			"warning",
-		);
+	if (!isStaleLock(inspection.lock)) {
+		ctx.ui.notify("Lock owner is still live; refusing to remove it.", "warning");
 		return;
 	}
 	await fs.rm(lockPath(), { force: true });
@@ -269,10 +272,12 @@ async function describeHeldLock() {
 	}
 	if (current) {
 		return new Error(
-			`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
+			`Pi-sync is currently running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
 		);
 	}
-	return new Error("pi-sync is already running (lock metadata is still being written).");
+	return new Error(
+		"Pi-sync is currently running (lock metadata is unreadable or still being written).",
+	);
 }
 
 function isLockHeldError(error: unknown) {

--- a/extensions/pi-sync/src/lock.ts
+++ b/extensions/pi-sync/src/lock.ts
@@ -1,0 +1,296 @@
+import { randomUUID } from "node:crypto";
+import {
+	mkdir,
+	mkdirSync,
+	realpath,
+	realpathSync,
+	rmdir,
+	rmdirSync,
+	stat,
+	statSync,
+	utimes,
+	utimesSync,
+} from "node:fs";
+import fs from "node:fs/promises";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import lockfile from "proper-lockfile";
+import { ensureStateDir, lockPath } from "./config.js";
+import type { CommandOptions, LockFile } from "./types.js";
+
+const LOCK_STALE_MS = 30 * 60 * 1000;
+const LOCK_WRITE_GRACE_MS = 5_000;
+const GUARD_STALE_MS = 30_000;
+const GUARD_UPDATE_MS = 10_000;
+const MAX_PROCESS_ID = 2_147_483_647;
+
+type LockfileFsAdapter = {
+	mkdir: typeof mkdir;
+	mkdirSync: typeof mkdirSync;
+	realpath: typeof realpath;
+	realpathSync: typeof realpathSync;
+	rmdir: typeof rmdir;
+	rmdirSync: typeof rmdirSync;
+	stat: typeof stat;
+	statSync: typeof statSync;
+	utimes: typeof utimes;
+	utimesSync: typeof utimesSync;
+};
+
+const LOCKFILE_FS_ADAPTER: LockfileFsAdapter = {
+	mkdir,
+	mkdirSync,
+	realpath,
+	realpathSync,
+	rmdir,
+	rmdirSync,
+	stat,
+	statSync,
+	utimes,
+	utimesSync,
+};
+
+interface Guard {
+	release: () => Promise<void>;
+	throwIfCompromised: () => void;
+	isCompromised: () => boolean;
+}
+
+export async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
+	await ensureStateDir();
+	const lock: LockFile = {
+		id: randomUUID(),
+		pid: process.pid,
+		command,
+		startedAt: new Date().toISOString(),
+	};
+	let guard: Guard | undefined;
+	let result: T | undefined;
+	let failed = false;
+	let failure: unknown;
+	try {
+		try {
+			guard = await acquireGuard();
+		} catch (error) {
+			if (!isLockHeldError(error)) throw error;
+			throw await describeHeldLock();
+		}
+
+		const current = await readLock();
+		if (current && isStaleLock(current)) {
+			throw new Error(
+				`pi-sync lock is stale (pid ${current.pid}). Run /pisync unlock --stale, then retry.`,
+			);
+		}
+		if (current) {
+			throw new Error(
+				`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
+			);
+		}
+
+		const recovery = await reclaimUnreadableLock();
+		if (recovery === "fresh") {
+			throw new Error("pi-sync is already running (lock metadata is still being written).");
+		}
+		if (recovery === "changed") {
+			throw new Error("pi-sync is already running (lock changed while being inspected).");
+		}
+
+		await fs.writeFile(lockPath(), JSON.stringify(lock, null, "\t"), { flag: "wx" });
+		guard.throwIfCompromised();
+		result = await fn();
+		guard.throwIfCompromised();
+	} catch (error) {
+		failed = true;
+		failure = error;
+	}
+
+	try {
+		const current = await readLock();
+		if (current?.id === lock.id) await fs.rm(lockPath(), { force: true });
+	} catch (error) {
+		if (!failed) {
+			failed = true;
+			failure = error;
+		}
+	}
+	if (guard) {
+		const releaseError = await releaseGuard(guard);
+		if (releaseError && !failed) {
+			failed = true;
+			failure = releaseError;
+		}
+	}
+	if (failed) throw failure;
+	return result as T;
+}
+
+export async function readLock(): Promise<LockFile | undefined> {
+	try {
+		const text = await fs.readFile(lockPath(), "utf8");
+		if (text.trim().length === 0) return undefined;
+		const parsed = JSON.parse(text) as unknown;
+		return isLockFile(parsed) ? parsed : undefined;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		if (error instanceof SyntaxError) return undefined;
+		throw error;
+	}
+}
+
+export async function lockFileExists(): Promise<boolean> {
+	try {
+		await fs.stat(lockPath());
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+export async function reclaimUnreadableLock(force = false) {
+	if (await readLock()) return "changed" as const;
+	try {
+		const unreadable = await fs.stat(lockPath());
+		if (!force && Date.now() - unreadable.mtimeMs < LOCK_WRITE_GRACE_MS) {
+			return "fresh" as const;
+		}
+		await fs.rm(lockPath());
+		return "removed" as const;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing" as const;
+		throw error;
+	}
+}
+
+export function isStaleLock(lock: LockFile) {
+	try {
+		process.kill(lock.pid, 0);
+		return false;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ESRCH") return true;
+		return Date.now() - Date.parse(lock.startedAt) > LOCK_STALE_MS;
+	}
+}
+
+export async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
+	await ensureStateDir();
+	let guard: Guard;
+	try {
+		guard = await acquireGuard();
+	} catch (error) {
+		if (!isLockHeldError(error)) throw error;
+		ctx.ui.notify("Pi-sync is currently running; retry unlock after it finishes.", "warning");
+		return;
+	}
+
+	let failed = false;
+	let failure: unknown;
+	try {
+		await unlockGuarded(ctx, options);
+	} catch (error) {
+		failed = true;
+		failure = error;
+	}
+	const releaseError = await releaseGuard(guard);
+	if (releaseError && !failed) {
+		failed = true;
+		failure = releaseError;
+	}
+	if (failed) throw failure;
+}
+
+async function unlockGuarded(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const lock = await readLock();
+	if (!lock) {
+		const recovery = await reclaimUnreadableLock(options.stale);
+		if (recovery === "removed") {
+			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
+			return;
+		}
+		if (recovery === "fresh") {
+			ctx.ui.notify(
+				"Lock metadata may still be initializing. Retry shortly, or use /pisync unlock --stale after verifying no sync is running.",
+				"warning",
+			);
+			return;
+		}
+		if (recovery === "changed") {
+			ctx.ui.notify("Pi-sync lock changed while being inspected; retry the command.", "warning");
+			return;
+		}
+		ctx.ui.notify("No pi-sync lock is present.", "info");
+		return;
+	}
+	if (!options.stale && !isStaleLock(lock)) {
+		ctx.ui.notify(
+			"Lock is not stale. Use /pisync unlock --stale only after verifying no sync is running.",
+			"warning",
+		);
+		return;
+	}
+	await fs.rm(lockPath(), { force: true });
+	ctx.ui.notify("Removed stale pi-sync lock.", "info");
+}
+
+async function releaseGuard(guard: Guard) {
+	try {
+		await guard.release();
+		return undefined;
+	} catch (error) {
+		return guard.isCompromised() ? undefined : error;
+	}
+}
+
+async function acquireGuard(): Promise<Guard> {
+	let compromisedError: Error | undefined;
+	const release = await lockfile.lock(lockPath(), {
+		fs: LOCKFILE_FS_ADAPTER,
+		lockfilePath: `${lockPath()}.guard`,
+		realpath: false,
+		stale: GUARD_STALE_MS,
+		update: GUARD_UPDATE_MS,
+		onCompromised: (error) => {
+			compromisedError = error;
+		},
+	});
+	return {
+		release,
+		throwIfCompromised: () => {
+			if (compromisedError) throw compromisedError;
+		},
+		isCompromised: () => compromisedError !== undefined,
+	};
+}
+
+async function describeHeldLock() {
+	const current = await readLock();
+	if (current && isStaleLock(current)) {
+		return new Error("pi-sync lock owner exited; retry shortly while the lock guard expires.");
+	}
+	if (current) {
+		return new Error(
+			`pi-sync is already running (${current.command}, pid ${current.pid}, started ${current.startedAt}).`,
+		);
+	}
+	return new Error("pi-sync is already running (lock metadata is still being written).");
+}
+
+function isLockHeldError(error: unknown) {
+	return (error as NodeJS.ErrnoException).code === "ELOCKED";
+}
+
+function isLockFile(value: unknown): value is LockFile {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const lock = value as Partial<LockFile>;
+	return (
+		typeof lock.id === "string" &&
+		lock.id.length > 0 &&
+		Number.isInteger(lock.pid) &&
+		(lock.pid ?? 0) > 0 &&
+		(lock.pid ?? 0) <= MAX_PROCESS_ID &&
+		typeof lock.command === "string" &&
+		lock.command.length > 0 &&
+		typeof lock.startedAt === "string" &&
+		Number.isFinite(Date.parse(lock.startedAt))
+	);
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -15,6 +15,7 @@ import {
 	isStaleLock,
 	loadPartialConfig,
 	localConfigPath,
+	lockFileExists,
 	lockPath,
 	normalizeExtraFiles,
 	readLock,
@@ -622,6 +623,13 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const lock = await readLock();
 	if (!lock) {
+		// The lock file may be present but unreadable (zero-byte/truncated/corrupt);
+		// reclaim it so users are never stuck needing a manual `rm`.
+		if (await lockFileExists()) {
+			await fs.rm(lockPath(), { force: true });
+			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
+			return;
+		}
 		ctx.ui.notify("No pi-sync lock is present.", "info");
 		return;
 	}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -28,7 +28,7 @@ import {
 	syncSessionsWarnings,
 	writeState,
 } from "./config.js";
-import { readLock, unlock, withLock } from "./lock.js";
+import { inspectLock, isLockGuardHeld, isStaleLock, unlock, withLock } from "./lock.js";
 import { encodeKey, posixJoin, safeJoin, safeName, toPosix } from "./paths.js";
 import {
 	historyKey,
@@ -343,8 +343,25 @@ async function doctor(ctx: ExtensionCommandContext) {
 		messages.push(`secret scan: ok (${local.files.length} files checked)`);
 	}
 
-	const lock = await readLock();
-	messages.push(lock ? `lock: held by pid ${lock.pid} since ${lock.startedAt}` : "lock: free");
+	const lock = await inspectLock();
+	if (lock.status === "valid" && isStaleLock(lock.lock)) {
+		level = "warning";
+		messages.push(
+			`lock: stale (pid ${lock.lock.pid}); run /pisync unlock after verifying no sync is running`,
+		);
+	} else if (lock.status === "valid") {
+		messages.push(`lock: held by pid ${lock.lock.pid} since ${lock.lock.startedAt}`);
+	} else if (lock.status === "unreadable") {
+		level = "warning";
+		messages.push(
+			"lock: unreadable; use /pisync unlock --stale only after verifying no sync is running",
+		);
+	} else if (await isLockGuardHeld()) {
+		level = "warning";
+		messages.push("lock: guard active while metadata is missing or still being initialized");
+	} else {
+		messages.push("lock: free");
+	}
 	ctx.ui.notify(messages.join("\n"), level);
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -12,13 +12,9 @@ import {
 	ensureStateDir,
 	extraFilePathsByLower,
 	isMissingConfigError,
-	isStaleLock,
 	loadPartialConfig,
 	localConfigPath,
-	lockFileExists,
-	lockPath,
 	normalizeExtraFiles,
-	readLock,
 	stateDir,
 	writeJson,
 	configuredSessionDir,
@@ -30,9 +26,9 @@ import {
 	sessionDirForApply,
 	sessionTokenWarnings,
 	syncSessionsWarnings,
-	withLock,
 	writeState,
 } from "./config.js";
+import { readLock, unlock, withLock } from "./lock.js";
 import { encodeKey, posixJoin, safeJoin, safeName, toPosix } from "./paths.js";
 import {
 	historyKey,
@@ -618,27 +614,6 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	});
 	ctx.ui.notify(`Rolled back to ${target}; latest: ${pointer.snapshot}. Backup: ${backup}`, "info");
 	await maybeReload(ctx);
-}
-
-async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
-	const lock = await readLock();
-	if (!lock) {
-		// The lock file may be present but unreadable (zero-byte/truncated/corrupt);
-		// reclaim it so users are never stuck needing a manual `rm`.
-		if (await lockFileExists()) {
-			await fs.rm(lockPath(), { force: true });
-			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
-			return;
-		}
-		ctx.ui.notify("No pi-sync lock is present.", "info");
-		return;
-	}
-	if (!options.stale && !isStaleLock(lock)) {
-		ctx.ui.notify("Lock is not stale. Use /pisync unlock --stale only after verifying no sync is running.", "warning");
-		return;
-	}
-	await fs.rm(lockPath(), { force: true });
-	ctx.ui.notify("Removed stale pi-sync lock.", "info");
 }
 
 function protectedSessionPaths(ctx: ExtensionCommandContext | ExtensionContext) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -38,6 +38,7 @@ import sync, {
 	snapshotWithoutSessions,
 	splitArgs,
 } from "../src/sync.js";
+import { ensureStateDir, lockFileExists, lockPath, readLock, withLock } from "../src/config.js";
 
 test("sync registers pisync command and session lifecycle hooks", () => {
 	const mock = createMockPi();
@@ -933,6 +934,47 @@ test("getBuffer throws after retrying a persistently empty R2 response body", as
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
+});
+
+test("withLock self-heals a zero-byte lock file", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const result = await withLock("test", async () => "ok");
+		assert.equal(result, "ok");
+		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("withLock self-heals a corrupt lock file", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{not valid json");
+		const result = await withLock("test", async () => "ok");
+		assert.equal(result, "ok");
+		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("withLock rejects when a valid foreign lock is held", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({ id: "other", pid: process.pid, command: "push", startedAt: new Date().toISOString() }),
+		);
+		await assert.rejects(withLock("test", async () => "ok"), /already running/);
+	});
+});
+
+test("readLock treats empty, whitespace, and corrupt lock files as absent", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		for (const contents of ["", "  \n  ", "{broken"]) {
+			writeFileSync(lockPath(), contents);
+			assert.equal(await readLock(), undefined, `expected undefined for ${JSON.stringify(contents)}`);
+		}
+	});
 });
 
 function snapshot(files: Array<{ path: string; content: Buffer }>) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -1,11 +1,29 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { gunzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	configuredSessionDir,
+	ensureStateDir,
+	loadPartialConfig,
+	localConfigPath,
+	lockPath,
+	readState,
+} from "../src/config.js";
+import { lockFileExists, readLock, withLock } from "../src/lock.js";
 import { S3Client } from "../src/s3-client.js";
 import sync, {
 	addTopLevelCaseVariantDeletes,
@@ -38,7 +56,6 @@ import sync, {
 	snapshotWithoutSessions,
 	splitArgs,
 } from "../src/sync.js";
-import { ensureStateDir, lockFileExists, lockPath, readLock, withLock } from "../src/config.js";
 
 test("sync registers pisync command and session lifecycle hooks", () => {
 	const mock = createMockPi();
@@ -936,23 +953,153 @@ test("getBuffer throws after retrying a persistently empty R2 response body", as
 	}
 });
 
-test("withLock self-heals a zero-byte lock file", async () => {
+test("withLock self-heals an old zero-byte lock file", async () => {
 	await withTempHome(async () => {
 		await ensureStateDir();
-		writeFileSync(lockPath(), "");
+		writeOldLock("");
 		const result = await withLock("test", async () => "ok");
 		assert.equal(result, "ok");
 		assert.equal(await lockFileExists(), false);
 	});
 });
 
-test("withLock self-heals a corrupt lock file", async () => {
+test("withLock self-heals an old corrupt lock file", async () => {
 	await withTempHome(async () => {
 		await ensureStateDir();
-		writeFileSync(lockPath(), "{not valid json");
+		writeOldLock("{not valid json");
 		const result = await withLock("test", async () => "ok");
 		assert.equal(result, "ok");
 		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("concurrent corrupt-lock reclaimers never remove a replacement lock", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeOldLock("{broken");
+		const originalRm = fs.rm;
+		let releaseDelayedRemoval: (() => void) | undefined;
+		const delayedRemoval = new Promise<void>((resolve) => {
+			releaseDelayedRemoval = resolve;
+		});
+		let recoveryRemovals = 0;
+		let active = 0;
+		let maxActive = 0;
+		let firstRunStarted: (() => void) | undefined;
+		const runStarted = new Promise<void>((resolve) => {
+			firstRunStarted = resolve;
+		});
+
+		fs.rm = async (...args: Parameters<typeof fs.rm>) => {
+			if (args[0] === lockPath() && args[1] === undefined) {
+				recoveryRemovals += 1;
+				if (recoveryRemovals === 2) await delayedRemoval;
+			}
+			return originalRm(...args);
+		};
+
+		try {
+			const run = () =>
+				withLock("test", async () => {
+					active += 1;
+					maxActive = Math.max(maxActive, active);
+					firstRunStarted?.();
+					await new Promise((resolve) => setTimeout(resolve, 25));
+					active -= 1;
+				});
+			const resultsPromise = Promise.allSettled([run(), run()]);
+			await runStarted;
+			releaseDelayedRemoval?.();
+			const results = await resultsPromise;
+
+			assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+			assert.equal(maxActive, 1);
+		} finally {
+			fs.rm = originalRm;
+			releaseDelayedRemoval?.();
+		}
+	});
+});
+
+test("withLock does not reclaim a lock file that may still be initializing", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		let ran = false;
+		await assert.rejects(
+			withLock("test", async () => {
+				ran = true;
+			}),
+			/already running/,
+		);
+		assert.equal(ran, false);
+	});
+});
+
+test("unlock keeps a fresh unreadable lock unless stale removal is explicit", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("pisync")?.handler("unlock", ctx);
+		assert.equal(await lockFileExists(), true);
+		assert.match(notifications.at(-1)?.message ?? "", /may still be initializing/);
+
+		await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+		assert.equal(await lockFileExists(), false);
+		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable/);
+	});
+});
+
+test("unlock cannot remove the lock for an active guarded sync", async () => {
+	await withTempHome(async () => {
+		let releaseRun: (() => void) | undefined;
+		const keepRunning = new Promise<void>((resolve) => {
+			releaseRun = resolve;
+		});
+		let markStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const running = withLock("test", async () => {
+			markStarted?.();
+			await keepRunning;
+		});
+		await started;
+
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+		try {
+			await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+			assert.equal(await lockFileExists(), true);
+			assert.match(notifications.at(-1)?.message ?? "", /currently running/);
+		} finally {
+			releaseRun?.();
+			await running;
+		}
+		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("concurrent withLock calls never execute together", async () => {
+	await withTempHome(async () => {
+		let active = 0;
+		let maxActive = 0;
+		const run = () =>
+			withLock("test", async () => {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				active -= 1;
+			});
+
+		const results = await Promise.allSettled([run(), run()]);
+		assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+		assert.equal(maxActive, 1);
 	});
 });
 
@@ -961,21 +1108,68 @@ test("withLock rejects when a valid foreign lock is held", async () => {
 		await ensureStateDir();
 		writeFileSync(
 			lockPath(),
-			JSON.stringify({ id: "other", pid: process.pid, command: "push", startedAt: new Date().toISOString() }),
+			JSON.stringify({
+				id: "other",
+				pid: process.pid,
+				command: "push",
+				startedAt: new Date().toISOString(),
+			}),
 		);
-		await assert.rejects(withLock("test", async () => "ok"), /already running/);
+		await assert.rejects(
+			withLock("test", async () => "ok"),
+			/already running/,
+		);
 	});
 });
 
 test("readLock treats empty, whitespace, and corrupt lock files as absent", async () => {
 	await withTempHome(async () => {
 		await ensureStateDir();
-		for (const contents of ["", "  \n  ", "{broken"]) {
+		for (const contents of [
+			"",
+			"  \n  ",
+			"{broken",
+			"{}",
+			"[]",
+			"null",
+			"1",
+			JSON.stringify({
+				id: "invalid-pid",
+				pid: 2_147_483_648,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		]) {
 			writeFileSync(lockPath(), contents);
-			assert.equal(await readLock(), undefined, `expected undefined for ${JSON.stringify(contents)}`);
+			assert.equal(
+				await readLock(),
+				undefined,
+				`expected undefined for ${JSON.stringify(contents)}`,
+			);
 		}
 	});
 });
+
+test("malformed non-lock JSON remains an explicit error", async () => {
+	await withTempHome(async (agentDir) => {
+		await ensureStateDir();
+
+		writeFileSync(localConfigPath(), "{broken");
+		await assert.rejects(loadPartialConfig(), SyntaxError);
+
+		writeFileSync(path.join(agentDir, ".pisync", "default.state.json"), "{broken");
+		await assert.rejects(readState("default"), SyntaxError);
+
+		writeFileSync(path.join(agentDir, "settings.json"), "{broken");
+		await assert.rejects(configuredSessionDir(), SyntaxError);
+	});
+});
+
+function writeOldLock(contents: string) {
+	writeFileSync(lockPath(), contents);
+	const old = new Date(Date.now() - 60_000);
+	utimesSync(lockPath(), old, old);
+}
 
 function snapshot(files: Array<{ path: string; content: Buffer }>) {
 	return {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -953,70 +953,63 @@ test("getBuffer throws after retrying a persistently empty R2 response body", as
 	}
 });
 
-test("withLock self-heals an old zero-byte lock file", async () => {
+test("old unreadable locks require explicit stale unlock before recovery", async () => {
 	await withTempHome(async () => {
 		await ensureStateDir();
-		writeOldLock("");
-		const result = await withLock("test", async () => "ok");
-		assert.equal(result, "ok");
-		assert.equal(await lockFileExists(), false);
-	});
-});
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext();
 
-test("withLock self-heals an old corrupt lock file", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeOldLock("{not valid json");
-		const result = await withLock("test", async () => "ok");
-		assert.equal(result, "ok");
-		assert.equal(await lockFileExists(), false);
-	});
-});
-
-test("concurrent corrupt-lock reclaimers never remove a replacement lock", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeOldLock("{broken");
-		const originalRm = fs.rm;
-		let releaseDelayedRemoval: (() => void) | undefined;
-		const delayedRemoval = new Promise<void>((resolve) => {
-			releaseDelayedRemoval = resolve;
-		});
-		let recoveryRemovals = 0;
-		let active = 0;
-		let maxActive = 0;
-		let firstRunStarted: (() => void) | undefined;
-		const runStarted = new Promise<void>((resolve) => {
-			firstRunStarted = resolve;
-		});
-
-		fs.rm = async (...args: Parameters<typeof fs.rm>) => {
-			if (args[0] === lockPath() && args[1] === undefined) {
-				recoveryRemovals += 1;
-				if (recoveryRemovals === 2) await delayedRemoval;
-			}
-			return originalRm(...args);
-		};
-
-		try {
-			const run = () =>
+		for (const contents of ["", "{not valid json"]) {
+			writeOldLock(contents);
+			let ran = false;
+			await assert.rejects(
 				withLock("test", async () => {
-					active += 1;
-					maxActive = Math.max(maxActive, active);
-					firstRunStarted?.();
-					await new Promise((resolve) => setTimeout(resolve, 25));
-					active -= 1;
-				});
-			const resultsPromise = Promise.allSettled([run(), run()]);
-			await runStarted;
-			releaseDelayedRemoval?.();
-			const results = await resultsPromise;
+					ran = true;
+				}),
+				/unreadable/,
+			);
+			assert.equal(ran, false);
+			assert.equal(await lockFileExists(), true);
 
-			assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
-			assert.equal(maxActive, 1);
+			await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+			assert.equal(await lockFileExists(), false);
+			assert.equal(await withLock("test", async () => "ok"), "ok");
+		}
+	});
+});
+
+test("withLock never reclaims an aged lock that a legacy writer still owns", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		const legacyHandle = await fs.open(lockPath(), "wx");
+		const old = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath(), old, old);
+		let ran = false;
+		try {
+			await assert.rejects(
+				withLock("test", async () => {
+					ran = true;
+				}),
+				/unreadable/,
+			);
+			assert.equal(ran, false);
+
+			await legacyHandle.writeFile(
+				JSON.stringify({
+					id: "legacy",
+					pid: process.pid,
+					command: "sync",
+					startedAt: new Date().toISOString(),
+				}),
+			);
+			await assert.rejects(
+				withLock("test", async () => undefined),
+				/already running/,
+			);
 		} finally {
-			fs.rm = originalRm;
-			releaseDelayedRemoval?.();
+			await legacyHandle.close();
+			await fs.rm(lockPath(), { force: true });
 		}
 	});
 });
@@ -1030,7 +1023,7 @@ test("withLock does not reclaim a lock file that may still be initializing", asy
 			withLock("test", async () => {
 				ran = true;
 			}),
-			/already running/,
+			/unreadable/,
 		);
 		assert.equal(ran, false);
 	});
@@ -1046,11 +1039,48 @@ test("unlock keeps a fresh unreadable lock unless stale removal is explicit", as
 
 		await mock.commands.get("pisync")?.handler("unlock", ctx);
 		assert.equal(await lockFileExists(), true);
-		assert.match(notifications.at(-1)?.message ?? "", /may still be initializing/);
+		assert.match(notifications.at(-1)?.message ?? "", /unreadable/);
 
 		await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
 		assert.equal(await lockFileExists(), false);
 		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable/);
+	});
+});
+
+test("stale unlock rechecks unreadable metadata before removing it", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const originalReadFile = fs.readFile;
+		let lockReads = 0;
+		fs.readFile = (async (...args: Parameters<typeof fs.readFile>) => {
+			const result = await originalReadFile(...args);
+			if (args[0] === lockPath() && lockReads++ === 0) {
+				await fs.writeFile(
+					lockPath(),
+					JSON.stringify({
+						id: "legacy",
+						pid: process.pid,
+						command: "sync",
+						startedAt: new Date().toISOString(),
+					}),
+				);
+			}
+			return result;
+		}) as typeof fs.readFile;
+
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext();
+			await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+
+			assert.equal(await lockFileExists(), true);
+			assert.match(notifications.at(-1)?.message ?? "", /not stale|still live/);
+		} finally {
+			fs.readFile = originalReadFile;
+			await fs.rm(lockPath(), { force: true });
+		}
 	});
 });
 
@@ -1082,6 +1112,29 @@ test("unlock cannot remove the lock for an active guarded sync", async () => {
 			await running;
 		}
 		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("unlock reports when a dead owner's guard is still expiring", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "dead-owner",
+				pid: 2_147_483_647,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		mkdirSync(`${lockPath()}.guard`);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+		assert.equal(await lockFileExists(), true);
+		assert.match(notifications.at(-1)?.message ?? "", /owner exited.*guard expires/);
 	});
 });
 
@@ -1147,6 +1200,84 @@ test("readLock treats empty, whitespace, and corrupt lock files as absent", asyn
 				`expected undefined for ${JSON.stringify(contents)}`,
 			);
 		}
+	});
+});
+
+test("doctor warns when lock metadata is unreadable", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{broken");
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: unreadable/);
+		assert.equal(notifications.at(-1)?.level, "warning");
+	});
+});
+
+test("doctor warns when a lock guard is active without metadata", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		mkdirSync(`${lockPath()}.guard`);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: guard active.*metadata/);
+		assert.equal(notifications.at(-1)?.level, "warning");
+	});
+});
+
+test("doctor warns when a valid lock owner has exited", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "dead-owner",
+				pid: 2_147_483_647,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: stale.*unlock/);
+		assert.equal(notifications.at(-1)?.level, "warning");
+	});
+});
+
+test("doctor reports live and free lock states", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "live-owner",
+				pid: process.pid,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: held by pid/);
+		assert.equal(notifications.at(-1)?.level, "info");
+
+		await fs.rm(lockPath());
+		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: free/);
+		assert.equal(notifications.at(-1)?.level, "info");
 	});
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,9 +868,13 @@
 			"name": "@narumitw/pi-sync",
 			"version": "0.24.0",
 			"license": "MIT",
+			"dependencies": {
+				"proper-lockfile": "^4.1.2"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.3",
 				"@earendil-works/pi-coding-agent": "0.80.10",
+				"@types/proper-lockfile": "^4.1.4",
 				"typescript": "7.0.2"
 			}
 		},


### PR DESCRIPTION
## Summary

Builds on #310 and preserves its automatic recovery for zero-byte, truncated, and corrupt pi-sync lock files while resolving the two major review findings.

- serialize lock acquisition, corrupt-lock reclamation, and unlock through a cross-process `proper-lockfile` guard
- keep fresh unreadable metadata intact so an in-progress writer cannot be mistaken for a crashed process
- validate parsed lock metadata before treating it as a live owner
- keep malformed config, state, and Pi settings JSON as explicit errors instead of silently applying defaults
- isolate lock lifecycle logic in `src/lock.ts` so `src/sync.ts` remains below the repository's source-size threshold

## Tests

- added deterministic coverage for concurrent corrupt-lock reclaimers
- added coverage for fresh/in-progress lock metadata and concurrent acquisition
- added coverage preventing forced unlock from removing an active guarded lock
- added malformed lock-shape and malformed non-lock JSON coverage
- `npm run check` (972 tests)
- `just pack-sync`
- explicit Biome check for `extensions/pi-sync/src/lock.ts`
- pi-sync workspace typecheck and focused 34-test suite

Closes #310 