### PR TITLE
feat: add multi-provider usage extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm scope](https://img.shields.io/badge/npm-@narumitw-blue)](https://www.npmjs.com/org/narumitw) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Independently installable [Pi](https://pi.dev) Coding Agent extension packages for AI coding workflows. This TypeScript monorepo publishes npm packages under `@narumitw` and gives Pi native tools, slash commands, and statusline integrations for LSP diagnostics and code actions across JavaScript, TypeScript, Python, Rust, Go, Ruby, C/C++, JVM, .NET, Swift, shell, infrastructure formats, and more; Chrome DevTools Protocol browser automation; Firecrawl web scraping, crawling, and web search; Google GenAI grounding for Google Search, Maps, and URL context; Langfuse LLM observability; multi-provider subscription account switching and ChatGPT Codex usage status; GitHub pull request checks; autonomous goal mode with opt-in ordered queues; Codex-like plan mode; local browser image staging and lightweight current-session web chat; subagents; rich terminal statuslines; Cloudflare R2/S3 settings sync; retry handling; side questions; and keep-awake automation.
+Independently installable [Pi](https://pi.dev) Coding Agent extension packages for AI coding workflows. This TypeScript monorepo publishes npm packages under `@narumitw` and gives Pi native tools, slash commands, and statusline integrations for LSP diagnostics and code actions across JavaScript, TypeScript, Python, Rust, Go, Ruby, C/C++, JVM, .NET, Swift, shell, infrastructure formats, and more; Chrome DevTools Protocol browser automation; Firecrawl web scraping, crawling, and web search; Google GenAI grounding for Google Search, Maps, and URL context; Langfuse LLM observability; multi-provider subscription account switching and current-account provider usage for Codex and OpenRouter; GitHub pull request checks; autonomous goal mode with opt-in ordered queues; Codex-like plan mode; local browser image staging and lightweight current-session web chat; subagents; rich terminal statuslines; Cloudflare R2/S3 settings sync; retry handling; side questions; and keep-awake automation.
 
 **Search keywords:** Pi Coding Agent extensions, AI coding agent tools, npm Pi packages, LSP diagnostics, Language Server Protocol, Chrome DevTools Protocol, browser automation, web scraping, Firecrawl, Google GenAI grounding, browser image staging, browser session chat, image attachments, Langfuse, LLM observability, ChatGPT Codex tools, subagents, terminal statusline, Cloudflare R2 sync, S3 sync.
 
@@ -17,7 +17,8 @@ Install only the Pi extensions you need. Each package is published under the `@n
 | [`@narumitw/pi-chrome-devtools`](./extensions/pi-chrome-devtools) | 🌐 Native Chrome DevTools Protocol tools for listing tabs, navigating pages, evaluating JavaScript, and taking screenshots. | `pi install npm:@narumitw/pi-chrome-devtools` |
 | [`@narumitw/pi-accounts`](./extensions/pi-accounts) | 🔐 `/account` for independently switching named OpenAI Codex, Anthropic, and GitHub Copilot subscription OAuth accounts, with temporary Codex command aliases. | `pi install npm:@narumitw/pi-accounts` |
 | [`@narumitw/pi-codex-accounts`](./extensions/pi-codex-accounts) | 🔐 Existing Codex-only account switcher retained during the `pi-accounts` soak period; do not load both account packages together. | `pi install npm:@narumitw/pi-codex-accounts` |
-| [`@narumitw/pi-codex-usage`](./extensions/pi-codex-usage) | 📊 `/codex-status` command and automatic statusline item for ChatGPT Codex subscription usage, using Pi auth first and Codex CLI only as fallback. | `pi install npm:@narumitw/pi-codex-usage` |
+| [`@narumitw/pi-codex-usage`](./extensions/pi-codex-usage) | 📊 Existing Codex-only usage package retained during the `pi-usage` soak period; do not load both usage packages together. | `pi install npm:@narumitw/pi-codex-usage` |
+| [`@narumitw/pi-usage`](./extensions/pi-usage) | 📊 Interactive `/usage` menu and current-account statusline for Codex subscription limits and OpenRouter API-key spend limits. | `pi install npm:@narumitw/pi-usage` |
 | [`@narumitw/pi-firecrawl`](./extensions/pi-firecrawl) | 🔥 Firecrawl-powered web scraping, crawling, URL discovery, and web search tools for documentation and research workflows. | `pi install npm:@narumitw/pi-firecrawl` |
 | [`@narumitw/pi-github-pr`](./extensions/pi-github-pr) | 🔎 Passive current-branch GitHub PR checks, review, and comment counts in the statusline. | `pi install npm:@narumitw/pi-github-pr` |
 | [`@narumitw/pi-goal`](./extensions/pi-goal) | 🎯 `/goal` mode that keeps the agent working until verified completion, with an opt-in experimental ordered queue. | `pi install npm:@narumitw/pi-goal` |
@@ -94,9 +95,9 @@ Use [`@narumitw/pi-accounts`](./extensions/pi-accounts) to keep independently se
 
 The existing Codex-only [`@narumitw/pi-codex-accounts`](./extensions/pi-codex-accounts) remains active while `pi-accounts` soaks. Choose one account package per Pi installation; loading both together is unsupported.
 
-### 📊 Codex usage status
+### 📊 Current-account provider usage
 
-Use [`@narumitw/pi-codex-usage`](./extensions/pi-codex-usage) to show ChatGPT Codex subscription usage and reset windows from Pi with `/codex-status`. When the current model uses `openai-codex`, it also shows compact quota status in the statusline. It uses Pi's OpenAI Codex auth first, so Codex CLI is optional.
+Use [`@narumitw/pi-usage`](./extensions/pi-usage) to open one interactive `/usage` menu that follows Pi's selected model and active runtime credential. It reports Codex ChatGPT subscription windows or OpenRouter API-key spend limits, keeps the statusline scoped to the current account, and makes cross-provider queries explicit. The existing [`@narumitw/pi-codex-usage`](./extensions/pi-codex-usage) package remains available while the successor soaks; choose one usage package per Pi installation.
 
 ### 🔎 GitHub pull request status
 
@@ -149,6 +150,7 @@ pi -e ./extensions/pi-chrome-devtools
 pi -e ./extensions/pi-accounts
 pi -e ./extensions/pi-codex-accounts
 pi -e ./extensions/pi-codex-usage
+pi -e ./extensions/pi-usage
 pi -e ./extensions/pi-firecrawl
 pi -e ./extensions/pi-github-pr
 pi -e ./extensions/pi-goal
@@ -174,6 +176,7 @@ npm run pack:chrome-devtools
 npm run pack:accounts
 npm run pack:codex-accounts
 npm run pack:codex-usage
+npm run pack:usage
 npm run pack:firecrawl
 npm run pack:github-pr
 npm run pack:goal
@@ -214,6 +217,7 @@ extensions/
 ├── pi-accounts/
 ├── pi-codex-accounts/
 ├── pi-codex-usage/
+├── pi-usage/
 ├── pi-firecrawl/
 ├── pi-github-pr/
 ├── pi-goal/

--- a/docs/plans/archived/2026-07-21_pi-usage-plan.md
+++ b/docs/plans/archived/2026-07-21_pi-usage-plan.md
@@ -1,0 +1,47 @@
+## Goal
+
+Resolve issue #268 by adding a production `@narumitw/pi-usage` successor package that reports usage for the active runtime account across OpenAI Codex and OpenRouter, provides one interactive `/usage` menu plus `/codex-status` compatibility alias, preserves current-account-only statusline behavior, and ships with verified package/repository integration in a pull request.
+
+## Context
+
+OpenRouter is the validated second provider. Its official `GET https://openrouter.ai/api/v1/key` API accepts the same inference API key Pi resolves for the `openrouter` provider and returns meaningful per-key spend, limit, reset, and usage metrics. The account-level `/credits` API is excluded because it requires a separate management key. The existing `pi-codex-usage` package remains available during successor soak.
+
+## Architecture
+
+- Add a provider-neutral adapter/report contract with Codex and OpenRouter adapters.
+- Resolve auth only through Pi's model registry and isolate in-memory cache entries with a process-salted credential fingerprint.
+- Keep automatic statusline queries scoped to the selected model provider; cross-provider queries are explicit menu actions with bounded concurrency and partial results.
+- Use `/usage` as the only primary command interface; retain `/codex-status` as an argument-free compatibility alias.
+
+## Non-Goals
+
+- Enumerating or switching accounts.
+- Reading Pi, account-extension, Codex CLI, or provider credential files.
+- Using OpenRouter management keys or claiming API-key limits are consumer subscription limits.
+- Removing or deprecating `pi-codex-usage` during this change.
+
+## Plan
+
+- [x] Add failing executable specifications for provider normalization, auth/cache isolation, menu/query-all behavior, lifecycle/statusline behavior, and Codex regressions; `npm test` reached the expected red state on missing `pi-usage` source modules.
+- [x] Implement the provider-neutral core plus Codex and OpenRouter adapters to satisfy normalization, formatting, timeout, cancellation, redaction, response-bound, and proxy-origin tests; 16 focused adapter/core tests pass.
+- [x] Implement `/usage`, `/codex-status`, interactive current/configured/all-provider flows, bounded concurrency, cache identity, and current-only lifecycle statusline; 14 focused command/lifecycle race and cancellation tests pass.
+- [x] Add package metadata, migration/provider-semantics documentation, root scripts/recipes/catalog entries, and the `usage` statusline icon; package/statusline typechecks and metadata tests pass.
+- [x] Run formatting, the full repository check, package dry run, and a local Pi runtime smoke; `npm run check` passed 992 tests, `just pack usage` contained 11 expected publish files, and `pi -p -e ./extensions/pi-usage '/usage'` exited 0 without network/model work.
+- [x] Audit issue #268 acceptance criteria, commit the focused diff, push `feat/pi-usage`, and create pull request #314 with issue linkage and verification evidence.
+
+## Risks
+
+- Runtime credentials can change without a dedicated auth-change event; re-resolve before commands, scheduled refreshes, and turns, then key cache/status publication by a process-salted fingerprint.
+- Cross-provider calls could become background traffic; allow them only after explicit menu selection and never publish their results to statusline.
+- Provider responses may include secrets or unstable fields; normalize allowlisted fields and redact exact resolved auth values plus token-shaped error text.
+
+## Completion Checklist
+
+- [x] Two provider adapters produce meaningful, semantically distinct usage reports, verified by deterministic Codex and OpenRouter tests.
+- [x] `/usage` automatically displays the active provider/account and exposes explicit refresh/other/all/close actions, verified by menu tests.
+- [x] Query-all is manual, concurrency-bounded, cancellation-aware, and retains partial success, verified by orchestration tests.
+- [x] Statusline follows only the active provider/account and invalidates on model/auth change, verified by lifecycle tests.
+- [x] No account switching or credential-file reads exist, verified by source audit and auth tests.
+- [x] Documentation distinguishes Codex subscription windows from OpenRouter API-key spend limits and explains migration, verified by README inspection.
+- [x] CI-equivalent checks and `just pack usage` pass, with expected package contents inspected.
+- [x] Branch is committed and pushed, and pull request #314 exists with issue linkage and verification evidence.

--- a/docs/plans/archived/2026-07-21_pi-usage-plan.md
+++ b/docs/plans/archived/2026-07-21_pi-usage-plan.md
@@ -24,9 +24,9 @@ OpenRouter is the validated second provider. Its official `GET https://openroute
 
 - [x] Add failing executable specifications for provider normalization, auth/cache isolation, menu/query-all behavior, lifecycle/statusline behavior, and Codex regressions; `npm test` reached the expected red state on missing `pi-usage` source modules.
 - [x] Implement the provider-neutral core plus Codex and OpenRouter adapters to satisfy normalization, formatting, timeout, cancellation, redaction, response-bound, and proxy-origin tests; 16 focused adapter/core tests pass.
-- [x] Implement `/usage`, `/codex-status`, interactive current/configured/all-provider flows, bounded concurrency, cache identity, and current-only lifecycle statusline; 14 focused command/lifecycle race and cancellation tests pass.
+- [x] Implement `/usage`, `/codex-status`, interactive current/configured/all-provider flows, bounded concurrency, cache identity, and current-only lifecycle statusline; 15 focused command/lifecycle race, account-transition, and cancellation tests pass.
 - [x] Add package metadata, migration/provider-semantics documentation, root scripts/recipes/catalog entries, and the `usage` statusline icon; package/statusline typechecks and metadata tests pass.
-- [x] Run formatting, the full repository check, package dry run, and a local Pi runtime smoke; `npm run check` passed 992 tests, `just pack usage` contained 11 expected publish files, and `pi -p -e ./extensions/pi-usage '/usage'` exited 0 without network/model work.
+- [x] Run formatting, the full repository check, package dry run, and a local Pi runtime smoke; `npm run check` passed 993 tests, `just pack usage` contained 11 expected publish files, and `pi -p -e ./extensions/pi-usage '/usage'` exited 0 without network/model work.
 - [x] Audit issue #268 acceptance criteria, commit the focused diff, push `feat/pi-usage`, and create pull request #314 with issue linkage and verification evidence.
 
 ## Risks

--- a/extensions/pi-codex-usage/README.md
+++ b/extensions/pi-codex-usage/README.md
@@ -6,6 +6,8 @@
 
 Use it when you want a quick Codex-style usage summary without leaving Pi or requiring Codex CLI to be installed.
 
+> **Successor:** [`@narumitw/pi-usage`](../pi-usage) adds a current-account-first `/usage` menu for Codex and OpenRouter. This predecessor remains available during the successor's soak period. Do not load both packages together because both register `/codex-status`; see the [migration guide](../pi-usage#-migrating-from-pi-codex-usage).
+
 ## ✨ Features
 
 - Adds a `/codex-status` command to Pi.

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -78,6 +78,7 @@ There are no project overrides or environment-variable overrides.
   "extensionStatusIcons": {
     "chrome-devtools": "🌐",
     "codex-usage": "📊",
+    "usage": "📊",
     "caffeinate": "💊",
     "firecrawl": "🔥",
     "github-pr": "🔎",

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -27,6 +27,7 @@ const LEGACY_SETTINGS_FILE_NAME = "pi-statusline-settings.json";
 export const DEFAULT_EXTENSION_STATUS_ICONS: Record<string, string> = {
 	"chrome-devtools": "🌐",
 	"codex-usage": "📊",
+	usage: "📊",
 	caffeinate: "💊",
 	firecrawl: "🔥",
 	"github-pr": "🔎",

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -32,6 +32,8 @@ test("statusline defaults describe the complete Tokyo Night JSON document", () =
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.provider.prefix, "🔌 ");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.turn.prefix, "🔁 #");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons.goal, "🎯");
+	assert.equal(DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons.usage, "📊");
+	assert.equal(DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons["codex-usage"], "📊");
 	assert.deepEqual(JSON.parse(DEFAULT_STATUSLINE_DOCUMENT), DEFAULT_STATUSLINE_CONFIG);
 	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.endsWith("\n"), true);
 });

--- a/extensions/pi-usage/LICENSE
+++ b/extensions/pi-usage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-usage/README.md
+++ b/extensions/pi-usage/README.md
@@ -1,0 +1,150 @@
+# 📊 pi-usage — Provider Usage for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds one interactive `/usage` command for reading usage from the account Pi is actually using. It supports OpenAI Codex ChatGPT subscription windows and OpenRouter API-key spend limits without pretending those limits have the same semantics.
+
+## ✨ Features
+
+- Opens one interactive `/usage` menu with current state and next actions.
+- Automatically queries the selected model provider and active runtime account.
+- Supports OpenAI Codex subscription windows, resets, credits, and model-specific buckets.
+- Supports OpenRouter per-key credit limits plus daily, weekly, monthly, and all-time spend.
+- Provides explicit refresh, another-provider, and all-configured-provider actions.
+- Runs manually requested all-provider queries with concurrency limited to two and preserves partial results.
+- Labels only the selected model provider as `Current`; other results are `Configured`.
+- Keeps the compact statusline scoped to the current provider and runtime account.
+- Isolates its five-minute in-memory cache by provider and a process-salted credential fingerprint.
+- Resolves credentials through Pi and never reads Pi, account-extension, Codex CLI, or provider auth files.
+- Retains `/codex-status` as a temporary argument-free compatibility alias.
+
+## 📦 Install
+
+Requires Pi 0.81.0 or newer so the extension can validate the effective base URL attached to resolved provider auth before sending credentials to an official usage endpoint.
+
+```bash
+pi install npm:@narumitw/pi-usage
+```
+
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-usage
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./extensions/pi-usage
+```
+
+## 🚀 Usage
+
+Run:
+
+```text
+/usage
+```
+
+The menu first queries the current model provider and presents its state with these actions:
+
+```text
+Refresh current usage
+View another configured provider…
+View all configured providers…
+Close
+```
+
+There are intentionally no `/usage --refresh`, `/usage <provider>`, or `/usage --all` argument paths. Cross-provider traffic requires an explicit interactive choice.
+
+`/codex-status` opens the same menu during the migration period. Its former flags are not supported by `pi-usage`.
+
+## 📋 Provider semantics
+
+### OpenAI Codex
+
+- Provider ID: `openai-codex`
+- Semantics: ChatGPT consumer subscription limits
+- Source: the Codex usage endpoint using Pi's resolved runtime authorization
+- Displayed data: returned duration-based windows, resets, credits, earned usage-limit resets, and additional model buckets
+- Statusline examples: `codex 59% 5h 61% wk` or `codex spark 100% 5h`
+
+The statusline selects a returned bucket that matches the current Codex model when one is available. Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
+
+### OpenRouter
+
+- Provider ID: `openrouter`
+- Semantics: API-key spend and per-key credit limits—not consumer subscription quota
+- Source: OpenRouter's documented [`GET /api/v1/key`](https://openrouter.ai/docs/api/api-reference/api-keys/get-current-api-key) endpoint using Pi's resolved inference API key
+- Displayed data: key label when safely returned, optional per-key limit and remaining amount, reset period, and daily/weekly/monthly/all-time spend
+- Statusline examples: `openrouter $74.50 left` or `openrouter $25.50 used`
+
+The extension does not call OpenRouter's account-level `/credits` endpoint because that operation requires a separate management key. OpenRouter documents the distinction between credit and rate limits in its [API limits guide](https://openrouter.ai/docs/api_reference/limits).
+
+## 🧭 Current and configured accounts
+
+`Current` means the provider and credential used by Pi's selected model. `Configured` means Pi reports runtime auth for another supported provider; it does not mean that provider is active.
+
+The extension does not enumerate multiple accounts inside one provider and does not switch accounts. Account selection remains owned by Pi or an account-management extension. After the active runtime credential changes, the next command, turn, or scheduled refresh resolves auth again and cannot reuse another account's cached report.
+
+## 📊 Statusline behavior
+
+The `usage` status item is active only for the selected model provider. It refreshes every five minutes while the session remains on a supported provider and is cleared when the model changes to an unsupported provider.
+
+Manual another-provider and all-provider queries never publish to the statusline. `@narumitw/pi-statusline` supplies the default `📊` icon; `pi-usage` publishes text-only values.
+
+## 🔄 Migrating from pi-codex-usage
+
+`pi-codex-usage` remains available while this successor soaks. To migrate one installation:
+
+```bash
+pi remove npm:@narumitw/pi-codex-usage
+pi install npm:@narumitw/pi-usage
+```
+
+Do not load both packages together: both register `/codex-status`, so Pi must suffix duplicate commands and the two packages can publish overlapping usage status.
+
+Behavior changes:
+
+- Use `/usage` as the primary entry point.
+- `/codex-status` is an argument-free compatibility alias.
+- Refresh and cross-provider operations are menu actions rather than flags.
+- Codex CLI fallback is removed to preserve active-runtime-account correctness.
+- The status key changes from `codex-usage` to `usage`.
+
+## 🚧 Limitations
+
+- Only providers with a stable, meaningful usage source and Pi-resolvable runtime auth are supported.
+- Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
+- Provider reports are snapshots and may themselves be delayed by the provider.
+- OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
+- A provider may not return a safe human-readable account identity. In that case the provider and runtime credential state remain visible without exposing secrets.
+- Immediate account-change events are not available from Pi; auth is re-resolved before commands, turns, and scheduled refreshes.
+
+## 🗂️ Package layout
+
+```txt
+extensions/pi-usage/
+├── src/
+│   ├── usage.ts       # Pi entrypoint, menu, cache, and lifecycle orchestration
+│   ├── query.ts       # Runtime auth resolution and provider queries
+│   ├── format.ts      # Provider-aware notifications and statusline text
+│   ├── core.ts        # Cache, concurrency, fingerprint, and redaction helpers
+│   ├── providers/     # Codex and OpenRouter normalization adapters
+│   └── types.ts       # Common presentation and adapter contracts
+├── test/
+├── README.md
+├── LICENSE
+├── tsconfig.json
+└── package.json
+```
+
+Only `usage.ts` is a Pi entrypoint; other source modules are internal.
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscription limits, OpenRouter credits, API-key spend limits, TypeScript Pi package, npm Pi extension.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@narumitw/pi-usage",
+	"version": "0.24.0",
+	"description": "Pi extension that shows current-account usage across supported model providers.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"usage",
+		"quota",
+		"codex",
+		"openrouter"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/usage.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check --vcs-use-ignore-file=false src test package.json tsconfig.json README.md && npm run typecheck",
+		"format": "biome check --write --vcs-use-ignore-file=false src test package.json tsconfig.json README.md",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": ">=0.81.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.3",
+		"@earendil-works/pi-coding-agent": "0.81.0",
+		"@types/node": "26.1.1",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "extensions/pi-usage"
+	}
+}

--- a/extensions/pi-usage/src/core.ts
+++ b/extensions/pi-usage/src/core.ts
@@ -1,0 +1,217 @@
+import { createHmac } from "node:crypto";
+import type { UsageReport } from "./types.js";
+
+export class UsageCache {
+	private readonly entries = new Map<string, { createdAt: number; report: UsageReport }>();
+	private readonly ttlMs: number;
+	private readonly maxEntries: number;
+
+	constructor(ttlMs: number, maxEntries = 32) {
+		if (!Number.isFinite(ttlMs) || ttlMs <= 0) throw new Error("Cache TTL must be positive.");
+		if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+			throw new Error("Cache entry limit must be a positive integer.");
+		}
+		this.ttlMs = ttlMs;
+		this.maxEntries = maxEntries;
+	}
+
+	get size(): number {
+		return this.entries.size;
+	}
+
+	get(providerId: string, fingerprint: string, now = Date.now()): UsageReport | undefined {
+		this.sweepExpired(now);
+		return this.entries.get(cacheKey(providerId, fingerprint))?.report;
+	}
+
+	set(providerId: string, fingerprint: string, report: UsageReport, now = Date.now()): void {
+		this.sweepExpired(now);
+		const key = cacheKey(providerId, fingerprint);
+		this.entries.delete(key);
+		while (this.entries.size >= this.maxEntries) {
+			const oldest = this.entries.keys().next().value;
+			if (oldest === undefined) break;
+			this.entries.delete(oldest);
+		}
+		this.entries.set(key, { createdAt: now, report });
+	}
+
+	clearProvider(providerId: string): void {
+		for (const key of this.entries.keys()) {
+			if (key.startsWith(`${providerId}:`)) this.entries.delete(key);
+		}
+	}
+
+	clear(): void {
+		this.entries.clear();
+	}
+
+	private sweepExpired(now: number): void {
+		for (const [key, entry] of this.entries) {
+			if (now - entry.createdAt >= this.ttlMs) this.entries.delete(key);
+		}
+	}
+}
+
+export function fingerprintResolvedAuth(
+	auth: { apiKey?: string; headers?: Record<string, string> },
+	salt: Uint8Array,
+): string {
+	const headers = Object.entries(auth.headers ?? {})
+		.map(([name, value]) => [name.toLowerCase(), value] as const)
+		.sort(([left], [right]) => left.localeCompare(right));
+	const canonical = JSON.stringify({ apiKey: auth.apiKey ?? "", headers });
+	return createHmac("sha256", salt).update(canonical).digest("hex");
+}
+
+export async function runWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	worker: (item: T, index: number, signal: AbortSignal) => Promise<R>,
+	signal: AbortSignal,
+): Promise<PromiseSettledResult<R>[]> {
+	if (signal.aborted) throw abortError();
+	if (!Number.isSafeInteger(limit) || limit < 1)
+		throw new Error("Concurrency limit must be positive.");
+
+	const results = new Array<PromiseSettledResult<R>>(items.length);
+	let nextIndex = 0;
+	const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (nextIndex < items.length) {
+			if (signal.aborted) throw abortError();
+			const index = nextIndex;
+			nextIndex += 1;
+			try {
+				results[index] = {
+					status: "fulfilled",
+					value: await worker(items[index] as T, index, signal),
+				};
+			} catch (reason) {
+				results[index] = { status: "rejected", reason };
+			}
+		}
+	});
+
+	await Promise.all(runners);
+	if (signal.aborted) throw abortError();
+	return results;
+}
+
+export async function awaitWithDeadline<T>(
+	operation: Promise<T>,
+	signal: AbortSignal,
+	timeoutMs: number,
+	description: string,
+): Promise<T> {
+	if (signal.aborted) throw abortError();
+	const controller = new AbortController();
+	const abortFromCaller = () => controller.abort();
+	signal.addEventListener("abort", abortFromCaller, { once: true });
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_resolve, reject) => {
+				controller.signal.addEventListener(
+					"abort",
+					() => {
+						reject(
+							signal.aborted
+								? abortError()
+								: Object.assign(
+										new Error(`Timed out after ${Math.round(timeoutMs / 1000)}s ${description}.`),
+										{ name: "TimeoutError" },
+									),
+						);
+					},
+					{ once: true },
+				);
+			}),
+		]);
+	} finally {
+		clearTimeout(timeout);
+		signal.removeEventListener("abort", abortFromCaller);
+	}
+}
+
+export function sanitizeDisplayText(value: string, maxChars = 160): string {
+	let result = "";
+	for (let index = 0; index < value.length; ) {
+		const codePoint = value.codePointAt(index) ?? 0;
+		const character = String.fromCodePoint(codePoint);
+		if (codePoint === 0x1b || codePoint === 0x9b || codePoint === 0x9d) {
+			index = skipTerminalEscape(value, index, codePoint);
+			continue;
+		}
+		if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+			if (codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d) result += " ";
+			index += character.length;
+			continue;
+		}
+		result += character;
+		index += character.length;
+	}
+	return truncate(result.replace(/\s+/gu, " ").trim(), maxChars);
+}
+
+export function redactUsageError(value: string, secrets: readonly string[] = []): string {
+	let redacted = value;
+	for (const secret of [...new Set(secrets)].filter(Boolean).sort((a, b) => b.length - a.length)) {
+		redacted = redacted.replace(new RegExp(escapeRegExp(secret), "g"), "<redacted>");
+	}
+	redacted = redacted
+		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer <redacted>")
+		.replace(/"(?:access_token|refresh_token|api_key)"\s*:\s*"[^"]+"/gi, (match) => {
+			const separator = match.indexOf(":");
+			return `${match.slice(0, separator + 1)}"<redacted>"`;
+		});
+	return sanitizeDisplayText(redacted, 600);
+}
+
+export function errorMessage(error: unknown): string {
+	return sanitizeDisplayText(error instanceof Error ? error.message : String(error), 600);
+}
+
+export function abortError(): Error {
+	return Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
+}
+
+function skipTerminalEscape(value: string, start: number, codePoint: number): number {
+	let index = start + 1;
+	const next = value.charCodeAt(index);
+	const isOsc = codePoint === 0x9d || (codePoint === 0x1b && next === 0x5d);
+	if (isOsc) {
+		if (codePoint === 0x1b) index += 1;
+		while (index < value.length) {
+			const current = value.charCodeAt(index);
+			if (current === 0x07) return index + 1;
+			if (current === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 2;
+			index += 1;
+		}
+		return index;
+	}
+	const isCsi = codePoint === 0x9b || (codePoint === 0x1b && next === 0x5b);
+	if (isCsi) {
+		if (codePoint === 0x1b) index += 1;
+		while (index < value.length) {
+			const current = value.charCodeAt(index);
+			index += 1;
+			if (current >= 0x40 && current <= 0x7e) break;
+		}
+		return index;
+	}
+	return Math.min(value.length, start + (codePoint === 0x1b ? 2 : 1));
+}
+
+function cacheKey(providerId: string, fingerprint: string): string {
+	return `${providerId}:${fingerprint}`;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function truncate(value: string, maxChars: number): string {
+	if (value.length <= maxChars) return value;
+	return `${value.slice(0, maxChars - 1)}…`;
+}

--- a/extensions/pi-usage/src/format.ts
+++ b/extensions/pi-usage/src/format.ts
@@ -1,0 +1,249 @@
+import type {
+	ProviderUsageState,
+	UsageBucket,
+	UsageDisplayState,
+	UsageModel,
+	UsageReport,
+} from "./types.js";
+
+const BAR_SEGMENTS = 20;
+const VALUE_COLUMN = 29;
+
+export function formatUsageReport(report: UsageReport, displayState: UsageDisplayState): string {
+	const stateLabel = displayState === "current" ? "Current" : "Configured";
+	const lines = [`${report.providerName} Usage · ${stateLabel}`];
+	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
+	lines.push(`Semantics: ${report.semantics.label}`, "");
+
+	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
+	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
+	else formatGenericReport(lines, report);
+
+	if (report.notes) {
+		for (const note of report.notes) lines.push(note);
+	}
+	return lines.join("\n").trimEnd();
+}
+
+export function formatUsageStatusline(report: UsageReport, model?: UsageModel): string | undefined {
+	if (report.providerId === "openai-codex") return formatCodexStatusline(report, model);
+	if (report.providerId === "openrouter") {
+		const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
+		if (limit?.remaining !== undefined) return `openrouter ${formatUsd(limit.remaining)} left`;
+		const total = report.metrics.find((metric) => metric.id === "usage-total");
+		if (typeof total?.value === "number") return `openrouter ${formatUsd(total.value)} used`;
+	}
+	return undefined;
+}
+
+export function formatProviderStates(states: readonly ProviderUsageState[]): string {
+	return states
+		.map((state) => {
+			if (state.status === "ready") return formatUsageReport(state.report, state.displayState);
+			const label = state.displayState === "current" ? "Current" : "Configured";
+			const status =
+				state.status === "auth-unavailable"
+					? "Authentication unavailable"
+					: state.status === "unsupported"
+						? "Unsupported"
+						: "Query failed";
+			return `${state.providerName} · ${label}\n${status}: ${state.message}`;
+		})
+		.join("\n\n");
+}
+
+function formatCodexReport(lines: string[], report: UsageReport): void {
+	let previousGroup: string | undefined;
+	for (const bucket of report.buckets) {
+		const group = bucket.groupId ?? bucket.id;
+		if (group !== previousGroup && group !== "codex") {
+			lines.push(`${bucket.groupLabel ?? group} limit:`);
+		}
+		previousGroup = group;
+		const fallback = bucket.id.endsWith(":secondary") ? "weekly" : "5h";
+		const label = `${formatWindowLabel(bucket.windowMinutes, fallback, false)} limit:`;
+		lines.push(`${label.padEnd(VALUE_COLUMN)}${formatPercentBucket(bucket)}`);
+	}
+	for (const metric of report.metrics) {
+		if (metric.id === "reset-credits") {
+			lines.push(`${"Usage limit resets:".padEnd(VALUE_COLUMN)}${metric.value} available`);
+		} else if (metric.id === "credits") {
+			lines.push(
+				`${"Credits:".padEnd(VALUE_COLUMN)}${formatMetricValue(metric.value, metric.unit)}`,
+			);
+		}
+	}
+}
+
+function formatOpenRouterReport(lines: string[], report: UsageReport): void {
+	const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
+	if (limit) {
+		const period = limit.period ? ` (${limit.period})` : "";
+		const value =
+			limit.remaining === undefined
+				? `${formatUsd(limit.limit ?? 0)} cap; remaining unavailable`
+				: `${formatUsd(limit.remaining)} of ${formatUsd(limit.limit ?? 0)} left`;
+		lines.push(`${`Key limit${period}:`.padEnd(VALUE_COLUMN)}${value}`);
+	}
+	for (const metric of report.metrics) {
+		lines.push(
+			`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${formatMetricValue(metric.value, metric.unit)}`,
+		);
+	}
+}
+
+function formatGenericReport(lines: string[], report: UsageReport): void {
+	for (const bucket of report.buckets) {
+		lines.push(
+			`${`${bucket.label}:`.padEnd(VALUE_COLUMN)}${formatMetricValue(bucket.remaining ?? bucket.used ?? "unavailable", bucket.unit)}`,
+		);
+	}
+	for (const metric of report.metrics) {
+		lines.push(
+			`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${formatMetricValue(metric.value, metric.unit)}`,
+		);
+	}
+}
+
+function formatCodexStatusline(report: UsageReport, model?: UsageModel): string | undefined {
+	const group = selectCodexGroup(report, model);
+	if (!group) return formatCodexCreditsStatus(report);
+	const buckets = report.buckets.filter((bucket) => (bucket.groupId ?? bucket.id) === group);
+	const labelBucket = buckets[0];
+	const parts = [
+		group === "codex" ? "codex" : `codex ${compactLimitLabel(labelBucket?.groupLabel ?? group)}`,
+	];
+	for (const bucket of buckets) {
+		if (bucket.remaining === undefined) continue;
+		const fallback = bucket.id.endsWith(":secondary") ? "weekly" : "5h";
+		parts.push(
+			`${clampPercent(bucket.remaining).toFixed(0)}% ${formatWindowLabel(bucket.windowMinutes, fallback, true)}`,
+		);
+	}
+	return parts.length > 1 ? parts.join(" ") : formatCodexCreditsStatus(report);
+}
+
+function formatCodexCreditsStatus(report: UsageReport): string {
+	const credits = report.metrics.find((metric) => metric.id === "credits");
+	if (!credits) return "codex usage unavailable";
+	if (credits.value === "none") return "codex no credits";
+	if (credits.value === "available") return "codex credits available";
+	if (credits.value === "unlimited") return "codex credits unlimited";
+	return `codex ${formatMetricValue(credits.value, "count")} credits`;
+}
+
+function selectCodexGroup(report: UsageReport, model?: UsageModel): string | undefined {
+	const groups = [...new Set(report.buckets.map((bucket) => bucket.groupId ?? bucket.id))];
+	if (model?.provider !== "openai-codex") {
+		return groups.includes("codex") ? "codex" : groups[0];
+	}
+	const modelKeys = normalizedModelKeys(model);
+	for (const group of groups) {
+		const bucket = report.buckets.find(
+			(candidate) => (candidate.groupId ?? candidate.id) === group,
+		);
+		const keys = [group, bucket?.groupLabel, ...(bucket?.modelKeys ?? [])]
+			.map(normalizeKey)
+			.filter((key): key is string => key !== undefined);
+		if (keys.some((key) => modelKeys.has(key))) return group;
+	}
+	const variants = [...modelKeys]
+		.map((key) => key.match(/(?:^|-)codex-(.+)$/)?.[1])
+		.filter((value): value is string => Boolean(value));
+	for (const variant of variants) {
+		const matches = groups.filter((group) => {
+			if (group === "codex") return false;
+			const key = normalizeKey(group);
+			return key ? normalizedKeyHasToken(key, variant) : false;
+		});
+		if (matches.length === 1) return matches[0];
+	}
+	return groups.includes("codex") ? "codex" : groups[0];
+}
+
+function normalizedModelKeys(model: UsageModel): Set<string> {
+	const keys = new Set<string>();
+	for (const value of [model.id, model.name]) {
+		const key = normalizeKey(value);
+		if (!key) continue;
+		keys.add(key);
+		const index = key.indexOf("codex");
+		if (index >= 0) keys.add(key.slice(index));
+	}
+	return keys;
+}
+
+function normalizeKey(value: string | undefined): string | undefined {
+	const normalized = value
+		?.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return normalized || undefined;
+}
+
+function normalizedKeyHasToken(key: string, token: string): boolean {
+	return (
+		key === token ||
+		key.startsWith(`${token}-`) ||
+		key.endsWith(`-${token}`) ||
+		key.includes(`-${token}-`)
+	);
+}
+
+function compactLimitLabel(label: string): string {
+	const normalized = label.replace(/[_-]+/g, " ").trim();
+	return (normalized.match(/\bcodex\s+(.+)$/i)?.[1]?.trim() || normalized)
+		.toLowerCase()
+		.replace(/\s+/g, " ");
+}
+
+function formatPercentBucket(bucket: UsageBucket): string {
+	const remaining = clampPercent(bucket.remaining ?? 0);
+	const filled = Math.round((remaining / 100) * BAR_SEGMENTS);
+	const reset = bucket.resetsAt ? ` (resets ${formatReset(bucket.resetsAt)})` : "";
+	return `[${"█".repeat(filled)}${"░".repeat(BAR_SEGMENTS - filled)}] ${remaining.toFixed(0)}% left${reset}`;
+}
+
+function formatWindowLabel(
+	minutes: number | undefined,
+	fallback: "5h" | "weekly",
+	compact: boolean,
+): string {
+	if (!minutes || !Number.isFinite(minutes) || minutes <= 0) {
+		return compact && fallback === "weekly" ? "wk" : capitalize(fallback);
+	}
+	if (minutes === 10_080) return compact ? "wk" : "Weekly";
+	if (minutes % 10_080 === 0) return `${minutes / 10_080}w`;
+	if (minutes % 1_440 === 0) return `${minutes / 1_440}d`;
+	if (minutes % 60 === 0) return `${minutes / 60}h`;
+	return `${minutes}m`;
+}
+
+function formatMetricValue(value: number | string, unit: UsageBucket["unit"] | undefined): string {
+	if (unit === "usd" && typeof value === "number") return formatUsd(value);
+	return String(value);
+}
+
+function formatUsd(value: number): string {
+	return `$${value.toFixed(2)}`;
+}
+
+function formatReset(epochSeconds: number): string {
+	const reset = new Date(epochSeconds * 1000);
+	if (Number.isNaN(reset.getTime())) return "at an unknown time";
+	const time = `${reset.getHours().toString().padStart(2, "0")}:${reset
+		.getMinutes()
+		.toString()
+		.padStart(2, "0")}`;
+	const now = new Date();
+	if (reset.toDateString() === now.toDateString()) return time;
+	return `${time} on ${reset.getDate()} ${reset.toLocaleDateString(undefined, { month: "short" })}`;
+}
+
+function capitalize(value: string): string {
+	return `${value[0]?.toUpperCase() ?? ""}${value.slice(1)}`;
+}
+
+function clampPercent(value: number): number {
+	return Math.min(100, Math.max(0, value));
+}

--- a/extensions/pi-usage/src/index.ts
+++ b/extensions/pi-usage/src/index.ts
@@ -1,0 +1,34 @@
+export {
+	abortError,
+	awaitWithDeadline,
+	errorMessage,
+	fingerprintResolvedAuth,
+	redactUsageError,
+	runWithConcurrency,
+	sanitizeDisplayText,
+	UsageCache,
+} from "./core.js";
+export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
+export { normalizeCodexBackendPayload } from "./providers/codex.js";
+export { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
+export {
+	adapterForProvider,
+	isStaleExtensionContextError,
+	providerIsConfigured,
+	queryProviderUsage,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+} from "./query.js";
+export type {
+	ProviderUsageState,
+	ResolvedUsageAuth,
+	UsageBucket,
+	UsageDisplayState,
+	UsageMetric,
+	UsageModel,
+	UsageProviderAdapter,
+	UsageReport,
+	UsageSemantics,
+	UsageSemanticsKind,
+	UsageUnit,
+} from "./types.js";

--- a/extensions/pi-usage/src/providers/codex.ts
+++ b/extensions/pi-usage/src/providers/codex.ts
@@ -1,0 +1,150 @@
+import { sanitizeDisplayText } from "../core.js";
+import type { CodexBackendPayload, UsageBucket, UsageMetric, UsageReport } from "../types.js";
+
+export function normalizeCodexBackendPayload(
+	payload: CodexBackendPayload,
+	capturedAt: number,
+): UsageReport {
+	const buckets: UsageBucket[] = [];
+	normalizeRateLimitGroup(buckets, "codex", "Codex", payload.rate_limit, false);
+
+	const additional = Array.isArray(payload.additional_rate_limits)
+		? payload.additional_rate_limits
+		: [];
+	for (const item of additional) {
+		const value = asObject(item);
+		const id = asString(value?.metered_feature) ?? asString(value?.limit_name);
+		if (!value || !id) continue;
+		try {
+			normalizeRateLimitGroup(
+				buckets,
+				id,
+				asString(value.limit_name) ?? id,
+				value.rate_limit,
+				true,
+			);
+		} catch {
+			// Optional provider-specific buckets must not hide otherwise useful primary data.
+		}
+	}
+
+	const metrics: UsageMetric[] = [];
+	const credits = asObject(payload.credits);
+	if (credits?.has_credits === true) {
+		if (credits.unlimited === true) {
+			metrics.push({ id: "credits", label: "Credits", value: "unlimited" });
+		} else {
+			const balance = asNumber(credits.balance);
+			if (balance !== undefined) {
+				metrics.push({ id: "credits", label: "Credits", value: balance, unit: "count" });
+			} else {
+				metrics.push({ id: "credits", label: "Credits", value: "available" });
+			}
+		}
+	} else if (credits?.has_credits === false) {
+		metrics.push({ id: "credits", label: "Credits", value: "none" });
+	}
+	const resetCredits = asObject(payload.rate_limit_reset_credits);
+	const resetCount = asNonnegativeInteger(resetCredits?.available_count);
+	if (resetCount !== undefined) {
+		metrics.push({
+			id: "reset-credits",
+			label: "Usage limit resets",
+			value: resetCount,
+			unit: "count",
+		});
+	}
+	if (buckets.length === 0 && metrics.length === 0) {
+		throw new Error("Codex usage endpoint returned no displayable usage data.");
+	}
+
+	const planType = asString(payload.plan_type);
+	return {
+		providerId: "openai-codex",
+		providerName: "OpenAI Codex",
+		capturedAt,
+		source: "codex-pi-auth",
+		semantics: {
+			kind: "consumer-subscription",
+			label: "ChatGPT subscription limits",
+		},
+		buckets,
+		metrics,
+		...(planType ? { notes: [`Plan: ${planType}`] } : {}),
+	};
+}
+
+function normalizeRateLimitGroup(
+	buckets: UsageBucket[],
+	groupId: string,
+	groupLabel: string,
+	raw: unknown,
+	optional: boolean,
+): void {
+	if (raw === undefined || raw === null) return;
+	const details = asObject(raw);
+	if (!details) {
+		if (optional) return;
+		throw new Error("Codex rate limit was not an object.");
+	}
+	addWindow(buckets, groupId, groupLabel, "primary", details.primary_window);
+	addWindow(buckets, groupId, groupLabel, "secondary", details.secondary_window);
+}
+
+function addWindow(
+	buckets: UsageBucket[],
+	groupId: string,
+	groupLabel: string,
+	position: "primary" | "secondary",
+	raw: unknown,
+): void {
+	if (raw === undefined || raw === null) return;
+	const value = asObject(raw);
+	if (!value) throw new Error("Codex rate-limit window was not an object.");
+	const used = asNumber(value.used_percent);
+	if (used === undefined) return;
+	const seconds = asNumber(value.limit_window_seconds);
+	const resetsAt = asNumber(value.reset_at);
+	buckets.push({
+		id: `${groupId}:${position}`,
+		label: position === "primary" ? "Primary limit" : "Secondary limit",
+		groupId,
+		groupLabel,
+		modelKeys: [groupId, groupLabel],
+		used,
+		remaining: 100 - clampPercent(used),
+		limit: 100,
+		unit: "percent",
+		...(seconds !== undefined && seconds > 0 ? { windowMinutes: Math.ceil(seconds / 60) } : {}),
+		...(resetsAt !== undefined ? { resetsAt } : {}),
+	});
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return sanitizeDisplayText(value, 160) || undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim()) {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	}
+	return undefined;
+}
+
+function asNonnegativeInteger(value: unknown): number | undefined {
+	const parsed = asNumber(value);
+	if (parsed === undefined || !Number.isSafeInteger(parsed)) return undefined;
+	return Math.max(0, parsed);
+}
+
+function clampPercent(value: number): number {
+	return Math.min(100, Math.max(0, value));
+}

--- a/extensions/pi-usage/src/providers/openrouter.ts
+++ b/extensions/pi-usage/src/providers/openrouter.ts
@@ -1,0 +1,73 @@
+import { sanitizeDisplayText } from "../core.js";
+import type { OpenRouterKeyPayload, UsageBucket, UsageMetric, UsageReport } from "../types.js";
+
+export function normalizeOpenRouterKeyPayload(
+	payload: OpenRouterKeyPayload,
+	capturedAt: number,
+): UsageReport {
+	const data = asObject(payload.data);
+	if (!data) throw new Error("OpenRouter key response data was not an object.");
+
+	const limit = asNonnegativeNumber(data.limit);
+	const remaining = asNonnegativeNumber(data.limit_remaining);
+	const period = asString(data.limit_reset);
+	const totalUsage = asNonnegativeNumber(data.usage);
+	const buckets: UsageBucket[] = [];
+	if (limit !== undefined) {
+		buckets.push({
+			id: "key-limit",
+			label: "Key limit",
+			...(remaining !== undefined ? { used: Math.max(0, limit - remaining), remaining } : {}),
+			limit,
+			unit: "usd",
+			...(period ? { period } : {}),
+		});
+	}
+
+	const metrics: UsageMetric[] = [];
+	addUsageMetric(metrics, "usage-daily", "Usage today", data.usage_daily);
+	addUsageMetric(metrics, "usage-weekly", "Usage this week", data.usage_weekly);
+	addUsageMetric(metrics, "usage-monthly", "Usage this month", data.usage_monthly);
+	addUsageMetric(metrics, "usage-total", "All-time usage", totalUsage);
+	if (buckets.length === 0 && metrics.length === 0) {
+		throw new Error("OpenRouter key response returned no displayable usage data.");
+	}
+
+	const notes: string[] = [];
+	if (data.limit === null) notes.push("No per-key spend cap");
+	else if (limit === undefined) notes.push("Per-key spend cap unavailable");
+	if (data.is_free_tier === true) notes.push("Free-tier API key");
+
+	return {
+		providerId: "openrouter",
+		providerName: "OpenRouter",
+		capturedAt,
+		source: "openrouter-key",
+		semantics: { kind: "api-key", label: "API-key spend limits" },
+		accountLabel: asString(data.label),
+		buckets,
+		metrics,
+		...(notes.length > 0 ? { notes } : {}),
+	};
+}
+
+function addUsageMetric(metrics: UsageMetric[], id: string, label: string, value: unknown): void {
+	const amount = typeof value === "number" ? asNonnegativeNumber(value) : undefined;
+	if (amount === undefined) return;
+	metrics.push({ id, label, value: amount, unit: "usd" });
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return sanitizeDisplayText(value, 80) || undefined;
+}
+
+function asNonnegativeNumber(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+	return value;
+}

--- a/extensions/pi-usage/src/query.ts
+++ b/extensions/pi-usage/src/query.ts
@@ -83,27 +83,35 @@ export async function resolveUsageAuth(
 		hasOfficialOrigin(candidate, adapter.id),
 	);
 	if (!model) return undefined;
-	const registry = ctx.modelRegistry as unknown as ProviderAuthRegistry;
+	const registry = ctx.modelRegistry as unknown as UsageAuthRegistry;
+	let modelAuth: RequestAuth | undefined;
+	if (ctx.model?.provider === adapter.id && typeof registry.getApiKeyAndHeaders === "function") {
+		const result = await registry.getApiKeyAndHeaders(ctx.model);
+		if (!result.ok) throw new Error(redactUsageError(result.error));
+		if (authorizationFrom(result)) modelAuth = result;
+	}
 	if (typeof registry.getProviderAuth !== "function") {
 		throw new Error("pi-usage requires Pi 0.81.0 or newer to validate resolved provider auth.");
 	}
-	const result = await registry.getProviderAuth(adapter.id);
-	if (!result) return undefined;
-	if (result.auth.baseUrl && !hasOfficialUrlOrigin(result.auth.baseUrl, adapter.id)) {
+	const providerResult = await registry.getProviderAuth(adapter.id);
+	if (
+		providerResult?.auth.baseUrl &&
+		!hasOfficialUrlOrigin(providerResult.auth.baseUrl, adapter.id)
+	) {
 		throw new Error(
 			`${adapter.displayName} usage cannot send a proxy-resolved credential to the official usage endpoint.`,
 		);
 	}
-	const resolvedAuthorization = headerValue(result.auth.headers, "Authorization");
-	const authorization =
-		resolvedAuthorization ?? (result.auth.apiKey ? `Bearer ${result.auth.apiKey}` : undefined);
+	const auth = modelAuth ?? providerResult?.auth;
+	if (!auth) return undefined;
+	const authorization = authorizationFrom(auth);
 	if (!authorization) return undefined;
 	const headers = { Authorization: authorization };
-	const secrets = [result.auth.apiKey, resolvedAuthorization, authorization].filter(
+	const secrets = [auth.apiKey, headerValue(auth.headers, "Authorization"), authorization].filter(
 		(value): value is string => Boolean(value),
 	);
 	return {
-		apiKey: result.auth.apiKey,
+		apiKey: auth.apiKey,
 		headers,
 		fingerprint: fingerprintResolvedAuth({ headers }, salt),
 		secrets,
@@ -249,18 +257,29 @@ async function readBoundedResponse(
 	return truncated ? `${text}…` : text;
 }
 
-type ProviderAuthRegistry = {
+type RequestAuth = {
+	apiKey?: string;
+	headers?: Record<string, string | null>;
+};
+
+type UsageAuthRegistry = {
+	getApiKeyAndHeaders?(
+		model: PiModel,
+	): Promise<({ ok: true } & RequestAuth) | { ok: false; error: string }>;
 	getProviderAuth?(providerId: string): Promise<
 		| {
-				auth: {
-					apiKey?: string;
-					headers?: Record<string, string | null>;
-					baseUrl?: string;
-				};
+				auth: RequestAuth & { baseUrl?: string };
 		  }
 		| undefined
 	>;
 };
+
+function authorizationFrom(auth: RequestAuth): string | undefined {
+	return (
+		headerValue(auth.headers, "Authorization") ??
+		(auth.apiKey ? `Bearer ${auth.apiKey}` : undefined)
+	);
+}
 
 function hasOfficialOrigin(model: PiModel, providerId: string): boolean {
 	return hasOfficialUrlOrigin(model.baseUrl, providerId);

--- a/extensions/pi-usage/src/query.ts
+++ b/extensions/pi-usage/src/query.ts
@@ -1,0 +1,294 @@
+import { randomBytes } from "node:crypto";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
+import { normalizeCodexBackendPayload } from "./providers/codex.js";
+import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
+import type {
+	CodexBackendPayload,
+	OpenRouterKeyPayload,
+	PiModel,
+	ResolvedUsageAuth,
+	UsageProviderAdapter,
+	UsageReport,
+} from "./types.js";
+
+const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
+const MAX_SUCCESS_BODY_BYTES = 64 * 1024;
+const MAX_ERROR_BODY_BYTES = 4 * 1024;
+
+export const AUTH_FINGERPRINT_SALT = randomBytes(32);
+
+export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
+	{
+		id: "openai-codex",
+		displayName: "OpenAI Codex",
+		semantics: {
+			kind: "consumer-subscription",
+			label: "ChatGPT subscription limits",
+		},
+		async query(auth, signal, timeoutMs) {
+			const payload = await fetchProviderJson(
+				CODEX_USAGE_URL,
+				auth,
+				signal,
+				timeoutMs,
+				"Codex usage endpoint",
+			);
+			return normalizeCodexBackendPayload(payload as CodexBackendPayload, Date.now());
+		},
+	},
+	{
+		id: "openrouter",
+		displayName: "OpenRouter",
+		semantics: { kind: "api-key", label: "API-key spend limits" },
+		async query(auth, signal, timeoutMs) {
+			const payload = await fetchProviderJson(
+				OPENROUTER_KEY_URL,
+				auth,
+				signal,
+				timeoutMs,
+				"OpenRouter key endpoint",
+			);
+			return normalizeOpenRouterKeyPayload(payload as OpenRouterKeyPayload, Date.now());
+		},
+	},
+];
+
+export function adapterForProvider(
+	providerId: string | undefined,
+): UsageProviderAdapter | undefined {
+	return SUPPORTED_ADAPTERS.find((adapter) => adapter.id === providerId);
+}
+
+export function isStaleExtensionContextError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		error.message.includes("This extension ctx is stale after session replacement or reload")
+	);
+}
+
+export async function resolveUsageAuth(
+	ctx: ExtensionContext,
+	adapter: UsageProviderAdapter,
+	salt: Uint8Array = AUTH_FINGERPRINT_SALT,
+): Promise<ResolvedUsageAuth | undefined> {
+	if (ctx.model?.provider === adapter.id && !hasOfficialOrigin(ctx.model, adapter.id)) {
+		throw new Error(
+			`${adapter.displayName} usage cannot send a custom provider base URL credential to the official usage endpoint.`,
+		);
+	}
+
+	const model = candidateModels(ctx, adapter.id).find((candidate) =>
+		hasOfficialOrigin(candidate, adapter.id),
+	);
+	if (!model) return undefined;
+	const registry = ctx.modelRegistry as unknown as ProviderAuthRegistry;
+	if (typeof registry.getProviderAuth !== "function") {
+		throw new Error("pi-usage requires Pi 0.81.0 or newer to validate resolved provider auth.");
+	}
+	const result = await registry.getProviderAuth(adapter.id);
+	if (!result) return undefined;
+	if (result.auth.baseUrl && !hasOfficialUrlOrigin(result.auth.baseUrl, adapter.id)) {
+		throw new Error(
+			`${adapter.displayName} usage cannot send a proxy-resolved credential to the official usage endpoint.`,
+		);
+	}
+	const resolvedAuthorization = headerValue(result.auth.headers, "Authorization");
+	const authorization =
+		resolvedAuthorization ?? (result.auth.apiKey ? `Bearer ${result.auth.apiKey}` : undefined);
+	if (!authorization) return undefined;
+	const headers = { Authorization: authorization };
+	const secrets = [result.auth.apiKey, resolvedAuthorization, authorization].filter(
+		(value): value is string => Boolean(value),
+	);
+	return {
+		apiKey: result.auth.apiKey,
+		headers,
+		fingerprint: fingerprintResolvedAuth({ headers }, salt),
+		secrets,
+		model,
+	};
+}
+
+export async function queryProviderUsage(
+	adapter: UsageProviderAdapter,
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<UsageReport> {
+	try {
+		return await adapter.query(auth, signal, timeoutMs);
+	} catch (error) {
+		if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
+		throw new Error(redactUsageError(errorMessage(error), auth.secrets));
+	}
+}
+
+export function providerIsConfigured(ctx: ExtensionContext, providerId: string): boolean {
+	try {
+		return ctx.modelRegistry.getProviderAuthStatus(providerId).configured;
+	} catch {
+		return candidateModels(ctx, providerId).length > 0;
+	}
+}
+
+function candidateModels(ctx: ExtensionContext, providerId: string): PiModel[] {
+	const candidates: PiModel[] = [];
+	const seen = new Set<string>();
+	const add = (model: PiModel | undefined) => {
+		if (!model || model.provider !== providerId) return;
+		const key = `${model.provider}/${model.id}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		candidates.push(model);
+	};
+	add(ctx.model);
+	for (const model of ctx.modelRegistry.getAvailable()) add(model);
+	for (const model of ctx.modelRegistry.getAll()) add(model);
+	return candidates;
+}
+
+async function fetchProviderJson(
+	url: string,
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	description: string,
+): Promise<Record<string, unknown>> {
+	const controller = new AbortController();
+	let timedOut = false;
+	const abortFromCaller = () => controller.abort();
+	if (signal.aborted) controller.abort();
+	else signal.addEventListener("abort", abortFromCaller, { once: true });
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, timeoutMs);
+	try {
+		const headers = { ...auth.headers };
+		if (!hasHeader(headers, "User-Agent")) headers["User-Agent"] = "pi-usage";
+		const response = await fetch(url, { headers, signal: controller.signal });
+		if (controller.signal.aborted)
+			throw Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
+		const text = await readBoundedResponse(
+			response,
+			response.ok ? MAX_SUCCESS_BODY_BYTES : MAX_ERROR_BODY_BYTES,
+			!response.ok,
+			description,
+		);
+		if (controller.signal.aborted)
+			throw Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
+		if (!response.ok) {
+			throw new Error(
+				`${description} returned ${response.status} ${response.statusText}: ${redactUsageError(text, auth.secrets)}`,
+			);
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(text) as unknown;
+		} catch (error) {
+			throw new Error(`${description} returned invalid JSON: ${errorMessage(error)}`);
+		}
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error(`${description} response was not an object.`);
+		}
+		return parsed as Record<string, unknown>;
+	} catch (error) {
+		if (timedOut) {
+			throw new Error(`Timed out after ${Math.round(timeoutMs / 1000)}s while fetching usage.`);
+		}
+		if (signal.aborted)
+			throw Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+		signal.removeEventListener("abort", abortFromCaller);
+	}
+}
+
+async function readBoundedResponse(
+	response: Response,
+	maxBytes: number,
+	truncateOverflow: boolean,
+	description: string,
+): Promise<string> {
+	if (!response.body) return "";
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	let truncated = false;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const remaining = maxBytes - total;
+			if (value.byteLength > remaining) {
+				if (remaining > 0) chunks.push(value.subarray(0, remaining));
+				total = maxBytes;
+				truncated = true;
+				await reader.cancel();
+				break;
+			}
+			chunks.push(value);
+			total += value.byteLength;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	if (truncated && !truncateOverflow) {
+		throw new Error(`${description} response exceeded ${maxBytes} bytes.`);
+	}
+	const body = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	const text = new TextDecoder().decode(body);
+	return truncated ? `${text}…` : text;
+}
+
+type ProviderAuthRegistry = {
+	getProviderAuth?(providerId: string): Promise<
+		| {
+				auth: {
+					apiKey?: string;
+					headers?: Record<string, string | null>;
+					baseUrl?: string;
+				};
+		  }
+		| undefined
+	>;
+};
+
+function hasOfficialOrigin(model: PiModel, providerId: string): boolean {
+	return hasOfficialUrlOrigin(model.baseUrl, providerId);
+}
+
+function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
+	const expected = providerId === "openai-codex" ? "https://chatgpt.com" : "https://openrouter.ai";
+	try {
+		return new URL(value).origin === expected;
+	} catch {
+		return false;
+	}
+}
+
+function headerValue(
+	headers: Record<string, string | null> | undefined,
+	name: string,
+): string | undefined {
+	const entry = Object.entries(headers ?? {}).find(
+		([candidate]) => candidate.toLowerCase() === name.toLowerCase(),
+	);
+	return entry?.[1] ?? undefined;
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+	return Object.keys(headers).some((key) => key.toLowerCase() === name.toLowerCase());
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}

--- a/extensions/pi-usage/src/types.ts
+++ b/extensions/pi-usage/src/types.ts
@@ -1,0 +1,90 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+export type PiModel = NonNullable<ExtensionContext["model"]>;
+export type UsageModel = Pick<PiModel, "id" | "name" | "provider">;
+
+export type UsageSemanticsKind = "consumer-subscription" | "api-key" | "project";
+export type UsageUnit = "percent" | "usd" | "count";
+export type UsageDisplayState = "current" | "configured";
+
+export interface UsageSemantics {
+	kind: UsageSemanticsKind;
+	label: string;
+}
+
+export interface UsageBucket {
+	id: string;
+	label: string;
+	groupId?: string;
+	groupLabel?: string;
+	modelKeys?: string[];
+	used?: number;
+	remaining?: number;
+	limit?: number;
+	unit: UsageUnit;
+	period?: string;
+	windowMinutes?: number;
+	resetsAt?: number;
+}
+
+export interface UsageMetric {
+	id: string;
+	label: string;
+	value: number | string;
+	unit?: UsageUnit;
+}
+
+export interface UsageReport {
+	providerId: string;
+	providerName: string;
+	capturedAt: number;
+	source: string;
+	semantics: UsageSemantics;
+	accountLabel?: string;
+	buckets: UsageBucket[];
+	metrics: UsageMetric[];
+	notes?: string[];
+}
+
+export interface ResolvedUsageAuth {
+	apiKey?: string;
+	headers: Record<string, string>;
+	fingerprint: string;
+	secrets: string[];
+	model: PiModel;
+}
+
+export interface UsageProviderAdapter {
+	id: string;
+	displayName: string;
+	semantics: UsageSemantics;
+	query(auth: ResolvedUsageAuth, signal: AbortSignal, timeoutMs: number): Promise<UsageReport>;
+}
+
+export type ProviderUsageState =
+	| {
+			providerId: string;
+			providerName: string;
+			displayState: UsageDisplayState;
+			status: "ready";
+			report: UsageReport;
+	  }
+	| {
+			providerId: string;
+			providerName: string;
+			displayState: UsageDisplayState;
+			status: "unsupported" | "auth-unavailable" | "query-failed";
+			message: string;
+	  };
+
+export type OpenRouterKeyPayload = {
+	data?: unknown;
+};
+
+export type CodexBackendPayload = {
+	plan_type?: unknown;
+	rate_limit?: unknown;
+	additional_rate_limits?: unknown;
+	credits?: unknown;
+	rate_limit_reset_credits?: unknown;
+};

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -1,0 +1,651 @@
+import {
+	BorderedLoader,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+	awaitWithDeadline,
+	errorMessage,
+	runWithConcurrency,
+	sanitizeDisplayText,
+	UsageCache,
+} from "./core.js";
+import { formatProviderStates, formatUsageStatusline } from "./format.js";
+import {
+	adapterForProvider,
+	isStaleExtensionContextError,
+	providerIsConfigured,
+	queryProviderUsage,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+} from "./query.js";
+import type {
+	PiModel,
+	ProviderUsageState,
+	ResolvedUsageAuth,
+	UsageDisplayState,
+	UsageProviderAdapter,
+} from "./types.js";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const ALL_PROVIDER_CONCURRENCY = 2;
+const FAILURE_BACKOFF_MS = 30_000;
+const MAX_ACCOUNT_STATES = 32;
+const STATUS_KEY = "usage";
+
+const REFRESH_CURRENT = "Refresh current usage";
+const VIEW_ANOTHER = "View another configured provider…";
+const VIEW_ALL = "View all configured providers…";
+const CLOSE = "Close";
+const MENU_ACTIONS = [REFRESH_CURRENT, VIEW_ANOTHER, VIEW_ALL, CLOSE];
+
+type QueryOutcome = {
+	state: ProviderUsageState;
+	fingerprint?: string;
+};
+
+type StableCurrent = {
+	outcome: QueryOutcome;
+	model: PiModel | undefined;
+};
+
+type LoaderResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+export default function usageExtension(pi: ExtensionAPI) {
+	const cache = new UsageCache(CACHE_TTL_MS);
+	const failureBackoff = new Map<string, { until: number; message: string }>();
+	const latestQueries = new Map<string, number>();
+	const activeControllers = new Set<AbortController>();
+	let querySequence = 0;
+	let activeCurrentIdentity: string | undefined;
+	let sessionActive = false;
+	let statusGeneration = 0;
+	let statusRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+	let statusController: AbortController | undefined;
+
+	const clearStatusTimer = () => {
+		if (statusRefreshTimer) clearTimeout(statusRefreshTimer);
+		statusRefreshTimer = undefined;
+	};
+
+	const safeSetStatus = (ctx: ExtensionContext, value: string | undefined): boolean => {
+		try {
+			ctx.ui.setStatus(STATUS_KEY, value);
+			return true;
+		} catch (error) {
+			if (isStaleExtensionContextError(error)) return false;
+			throw error;
+		}
+	};
+
+	const clearStatus = (ctx: ExtensionContext) => {
+		statusGeneration += 1;
+		statusController?.abort();
+		statusController = undefined;
+		clearStatusTimer();
+		safeSetStatus(ctx, undefined);
+	};
+
+	const scheduleStatusRefresh = (ctx: ExtensionContext, model: PiModel) => {
+		clearStatusTimer();
+		const generation = statusGeneration;
+		statusRefreshTimer = setTimeout(() => {
+			statusRefreshTimer = undefined;
+			if (!sessionActive || generation !== statusGeneration) return;
+			startStatusRefresh(ctx, model, true);
+		}, CACHE_TTL_MS);
+		statusRefreshTimer.unref?.();
+	};
+
+	const publishStatus = (
+		ctx: ExtensionContext,
+		outcome: QueryOutcome,
+		model: PiModel,
+		shouldSchedule: boolean,
+	) => {
+		if (outcome.state.status === "unsupported") {
+			clearStatusTimer();
+			safeSetStatus(ctx, undefined);
+			return;
+		}
+		if (outcome.state.status !== "ready") {
+			if (
+				safeSetStatus(
+					ctx,
+					outcome.state.status === "auth-unavailable" ? "auth unavailable" : "usage error",
+				)
+			) {
+				if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
+			}
+			return;
+		}
+		const value = formatUsageStatusline(outcome.state.report, model);
+		if (!safeSetStatus(ctx, value)) return;
+		if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
+	};
+
+	const transitionCurrentIdentity = (nextIdentity: string, providerId: string) => {
+		if (!activeCurrentIdentity || activeCurrentIdentity === nextIdentity) {
+			activeCurrentIdentity = nextIdentity;
+			return;
+		}
+		const previousProviderId = activeCurrentIdentity.split(":", 1)[0] ?? "";
+		for (const id of new Set([previousProviderId, providerId])) {
+			if (!id) continue;
+			cache.clearProvider(id);
+			for (const key of failureBackoff.keys()) {
+				if (key.startsWith(`${id}:`)) failureBackoff.delete(key);
+			}
+			for (const key of latestQueries.keys()) {
+				if (key.startsWith(`${id}:`)) latestQueries.delete(key);
+			}
+		}
+		activeCurrentIdentity = nextIdentity;
+	};
+
+	const queryAdapterState = async (
+		ctx: ExtensionContext,
+		adapter: UsageProviderAdapter,
+		displayState: UsageDisplayState,
+		force: boolean,
+		signal: AbortSignal,
+	): Promise<QueryOutcome> => {
+		const startedAt = Date.now();
+		let auth: ResolvedUsageAuth | undefined;
+		try {
+			auth = await awaitWithDeadline(
+				resolveUsageAuth(ctx, adapter),
+				signal,
+				DEFAULT_TIMEOUT_MS,
+				`resolving ${adapter.displayName} runtime auth`,
+			);
+		} catch (error) {
+			if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
+			return {
+				state: {
+					providerId: adapter.id,
+					providerName: adapter.displayName,
+					displayState,
+					status: isTimeoutError(error) ? "query-failed" : "auth-unavailable",
+					message: errorMessage(error),
+				},
+			};
+		}
+		if (!auth) {
+			if (displayState === "current") {
+				transitionCurrentIdentity(`${adapter.id}:unavailable`, adapter.id);
+			}
+			return {
+				state: {
+					providerId: adapter.id,
+					providerName: adapter.displayName,
+					displayState,
+					status: "auth-unavailable",
+					message: `No runtime credential is configured for ${adapter.displayName}.`,
+				},
+			};
+		}
+		if (displayState === "current") {
+			transitionCurrentIdentity(`${adapter.id}:${auth.fingerprint}`, adapter.id);
+		}
+
+		const cached = !force ? cache.get(adapter.id, auth.fingerprint) : undefined;
+		if (cached) {
+			return {
+				state: {
+					providerId: adapter.id,
+					providerName: adapter.displayName,
+					displayState,
+					status: "ready",
+					report: cached,
+				},
+				fingerprint: auth.fingerprint,
+			};
+		}
+
+		const failureKey = `${adapter.id}:${auth.fingerprint}`;
+		const previousFailure = failureBackoff.get(failureKey);
+		if (!force && previousFailure && previousFailure.until > Date.now()) {
+			return {
+				state: {
+					providerId: adapter.id,
+					providerName: adapter.displayName,
+					displayState,
+					status: "query-failed",
+					message: previousFailure.message,
+				},
+				fingerprint: auth.fingerprint,
+			};
+		}
+		failureBackoff.delete(failureKey);
+		querySequence += 1;
+		const queryId = querySequence;
+		setBoundedMap(latestQueries, failureKey, queryId, MAX_ACCOUNT_STATES);
+
+		try {
+			const remainingMs = Math.max(1, DEFAULT_TIMEOUT_MS - (Date.now() - startedAt));
+			const report = await queryProviderUsage(adapter, auth, signal, remainingMs);
+			if (latestQueries.get(failureKey) === queryId) {
+				cache.set(adapter.id, auth.fingerprint, report);
+				failureBackoff.delete(failureKey);
+			}
+			return {
+				state: {
+					providerId: adapter.id,
+					providerName: adapter.displayName,
+					displayState,
+					status: "ready",
+					report,
+				},
+				fingerprint: auth.fingerprint,
+			};
+		} catch (error) {
+			if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
+			const message = errorMessage(error);
+			const now = Date.now();
+			for (const [key, failure] of failureBackoff) {
+				if (failure.until <= now) failureBackoff.delete(key);
+			}
+			if (latestQueries.get(failureKey) === queryId) {
+				setBoundedMap(
+					failureBackoff,
+					failureKey,
+					{ until: now + FAILURE_BACKOFF_MS, message },
+					MAX_ACCOUNT_STATES,
+				);
+			}
+			return {
+				state: {
+					providerId: adapter.id,
+					providerName: adapter.displayName,
+					displayState,
+					status: "query-failed",
+					message,
+				},
+				fingerprint: auth.fingerprint,
+			};
+		}
+	};
+
+	const queryCurrentState = async (
+		ctx: ExtensionContext,
+		model: PiModel | undefined,
+		force: boolean,
+		signal: AbortSignal,
+	): Promise<QueryOutcome> => {
+		const adapter = adapterForProvider(model?.provider);
+		if (!adapter) {
+			const providerId = model?.provider ?? "none";
+			transitionCurrentIdentity(`unsupported:${providerId}`, providerId);
+			return {
+				state: {
+					providerId,
+					providerName: providerDisplayName(ctx, providerId),
+					displayState: "current",
+					status: "unsupported",
+					message: model
+						? `Usage reporting is not supported for ${providerDisplayName(ctx, providerId)}.`
+						: "No model is selected.",
+				},
+			};
+		}
+		return queryAdapterState(ctx, adapter, "current", force, signal);
+	};
+
+	const refreshCurrentStatus = async (
+		ctx: ExtensionContext,
+		model: PiModel | undefined,
+		force: boolean,
+	) => {
+		const adapter = adapterForProvider(model?.provider);
+		if (!adapter || !model) {
+			clearStatus(ctx);
+			return;
+		}
+		statusGeneration += 1;
+		const generation = statusGeneration;
+		statusController?.abort();
+		const controller = new AbortController();
+		statusController = controller;
+		activeControllers.add(controller);
+		try {
+			if (!safeSetStatus(ctx, "checking")) return;
+			const outcome = await queryCurrentState(ctx, model, force, controller.signal);
+			if (!sessionActive || generation !== statusGeneration || controller.signal.aborted) return;
+			if (!(await outcomeStillCurrent(ctx, model, generation, outcome, controller.signal))) {
+				if (sessionActive && generation === statusGeneration) {
+					queueMicrotask(() => startStatusRefresh(ctx, ctx.model, false));
+				}
+				return;
+			}
+			publishStatus(ctx, outcome, model, true);
+		} finally {
+			activeControllers.delete(controller);
+			if (statusController === controller) statusController = undefined;
+		}
+	};
+
+	const startStatusRefresh = (
+		ctx: ExtensionContext,
+		model: PiModel | undefined,
+		force: boolean,
+	) => {
+		void refreshCurrentStatus(ctx, model, force).catch((error) => {
+			if (isStaleExtensionContextError(error) || isAbortError(error)) return;
+			safeSetStatus(ctx, "usage error");
+		});
+	};
+
+	const runMenuOperation = async <T>(
+		ctx: ExtensionCommandContext,
+		label: string,
+		parentSignal: AbortSignal,
+		operation: (signal: AbortSignal) => Promise<T>,
+	): Promise<T | undefined> => {
+		if (ctx.mode !== "tui") return operation(parentSignal);
+		const result = await ctx.ui.custom<LoaderResult<T> | null>((tui, theme, _keybindings, done) => {
+			const loader = new BorderedLoader(tui, theme, label);
+			let finished = false;
+			const finish = (value: LoaderResult<T> | null) => {
+				if (finished) return;
+				finished = true;
+				done(value);
+			};
+			loader.onAbort = () => finish(null);
+			const signal = AbortSignal.any([parentSignal, loader.signal]);
+			void operation(signal)
+				.then((value) => finish({ ok: true, value }))
+				.catch((error) => {
+					if (isAbortError(error)) finish(null);
+					else finish({ ok: false, error });
+				});
+			return loader;
+		});
+		if (!result) return undefined;
+		if (!result.ok) throw result.error;
+		return result.value;
+	};
+
+	const outcomeStillCurrent = async (
+		ctx: ExtensionContext,
+		model: PiModel | undefined,
+		generation: number,
+		outcome: QueryOutcome,
+		signal: AbortSignal,
+	): Promise<boolean> => {
+		if (generation !== statusGeneration || modelIdentity(ctx.model) !== modelIdentity(model)) {
+			return false;
+		}
+		if (!outcome.fingerprint) return true;
+		const adapter = adapterForProvider(model?.provider);
+		if (!adapter) return false;
+		try {
+			const auth = await awaitWithDeadline(
+				resolveUsageAuth(ctx, adapter),
+				signal,
+				DEFAULT_TIMEOUT_MS,
+				`revalidating ${adapter.displayName} runtime auth`,
+			);
+			return (
+				generation === statusGeneration &&
+				modelIdentity(ctx.model) === modelIdentity(model) &&
+				auth?.fingerprint === outcome.fingerprint
+			);
+		} catch (error) {
+			if (isAbortError(error) || isStaleExtensionContextError(error)) throw error;
+			return false;
+		}
+	};
+
+	const queryStableCurrent = async (
+		ctx: ExtensionCommandContext,
+		force: boolean,
+		controller: AbortController,
+		label: string,
+	): Promise<StableCurrent | undefined> => {
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const model = ctx.model;
+			const generation = statusGeneration;
+			const result = await runMenuOperation(ctx, label, controller.signal, async (signal) => {
+				const outcome = await queryCurrentState(ctx, model, force, signal);
+				return {
+					outcome,
+					stable: await outcomeStillCurrent(ctx, model, generation, outcome, signal),
+				};
+			});
+			if (!result) return undefined;
+			if (result.stable) return { outcome: result.outcome, model };
+			force = false;
+		}
+		ctx.ui.notify("The active model or account kept changing; reopen /usage to retry.", "warning");
+		return undefined;
+	};
+
+	const publishStableCurrent = (ctx: ExtensionCommandContext, current: StableCurrent) => {
+		if (current.model) publishStatus(ctx, current.outcome, current.model, sessionActive);
+		else safeSetStatus(ctx, undefined);
+	};
+
+	const showMenu = async (ctx: ExtensionCommandContext): Promise<void> => {
+		if (!ctx.hasUI) {
+			ctx.ui.notify("/usage requires an interactive Pi mode.", "warning");
+			return;
+		}
+		statusGeneration += 1;
+		statusController?.abort();
+		statusController = undefined;
+		clearStatusTimer();
+		const controller = new AbortController();
+		activeControllers.add(controller);
+		try {
+			let stableCurrent = await queryStableCurrent(
+				ctx,
+				false,
+				controller,
+				"Checking current usage…",
+			);
+			if (!stableCurrent) return;
+			publishStableCurrent(ctx, stableCurrent);
+			let current = stableCurrent.outcome;
+			let visibleStates: ProviderUsageState[] = [current.state];
+
+			while (!controller.signal.aborted) {
+				const action = await ctx.ui.select(formatProviderStates(visibleStates), [...MENU_ACTIONS]);
+				if (!action || action === CLOSE) return;
+				if (action === REFRESH_CURRENT) {
+					stableCurrent = await queryStableCurrent(
+						ctx,
+						true,
+						controller,
+						"Refreshing current usage…",
+					);
+					if (!stableCurrent) continue;
+					publishStableCurrent(ctx, stableCurrent);
+					current = stableCurrent.outcome;
+					visibleStates = [current.state];
+					continue;
+				}
+				if (action === VIEW_ANOTHER) {
+					const others = configuredAdapters(ctx).filter(
+						(adapter) => adapter.id !== ctx.model?.provider,
+					);
+					if (others.length === 0) {
+						ctx.ui.notify("No other supported provider has configured runtime auth.", "info");
+						continue;
+					}
+					const choice = await ctx.ui.select(
+						"Select a configured provider",
+						others.map((adapter) => adapter.displayName),
+					);
+					const adapter = others.find((candidate) => candidate.displayName === choice);
+					if (!adapter) continue;
+					const outcome = await runMenuOperation(
+						ctx,
+						`Checking ${adapter.displayName} usage…`,
+						controller.signal,
+						(signal) => queryAdapterState(ctx, adapter, "configured", false, signal),
+					);
+					if (!outcome) continue;
+					const revalidated = await queryStableCurrent(
+						ctx,
+						false,
+						controller,
+						"Revalidating current usage…",
+					);
+					if (!revalidated) continue;
+					stableCurrent = revalidated;
+					current = revalidated.outcome;
+					visibleStates =
+						outcome.state.providerId === current.state.providerId
+							? [current.state]
+							: [current.state, { ...outcome.state, displayState: "configured" }];
+					continue;
+				}
+				if (action === VIEW_ALL) {
+					const adapters = configuredAdapters(ctx);
+					const currentProviderId = ctx.model?.provider;
+					const settled = await runMenuOperation(
+						ctx,
+						"Checking configured provider usage…",
+						controller.signal,
+						(signal) =>
+							runWithConcurrency(
+								adapters,
+								ALL_PROVIDER_CONCURRENCY,
+								(adapter, _index, workerSignal) =>
+									queryAdapterState(
+										ctx,
+										adapter,
+										adapter.id === currentProviderId ? "current" : "configured",
+										true,
+										workerSignal,
+									),
+								signal,
+							),
+					);
+					if (!settled) continue;
+					const queriedStates: ProviderUsageState[] = settled.map((result, index) => {
+						if (result.status === "fulfilled") {
+							return { ...result.value.state, displayState: "configured" };
+						}
+						const adapter = adapters[index] as UsageProviderAdapter;
+						return {
+							providerId: adapter.id,
+							providerName: adapter.displayName,
+							displayState: "configured",
+							status: "query-failed",
+							message: errorMessage(result.reason),
+						};
+					});
+					const revalidated = await queryStableCurrent(
+						ctx,
+						false,
+						controller,
+						"Revalidating current usage…",
+					);
+					if (!revalidated) continue;
+					stableCurrent = revalidated;
+					current = revalidated.outcome;
+					visibleStates = [
+						current.state,
+						...queriedStates.filter((state) => state.providerId !== current.state.providerId),
+					];
+				}
+			}
+		} finally {
+			controller.abort();
+			activeControllers.delete(controller);
+		}
+	};
+
+	const commandHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		if (args.trim()) {
+			ctx.ui.notify("/usage does not accept arguments; choose an action from its menu.", "warning");
+			return;
+		}
+		try {
+			await showMenu(ctx);
+		} catch (error) {
+			if (isStaleExtensionContextError(error) || isAbortError(error)) return;
+			throw error;
+		}
+	};
+
+	pi.registerCommand("usage", {
+		description: "Show usage for the current runtime account",
+		handler: commandHandler,
+	});
+	pi.registerCommand("codex-status", {
+		description: "Open /usage (temporary compatibility alias)",
+		handler: commandHandler,
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		sessionActive = true;
+		startStatusRefresh(ctx, ctx.model, false);
+	});
+	pi.on("session_tree", (_event, ctx) => {
+		startStatusRefresh(ctx, ctx.model, false);
+	});
+	pi.on("model_select", (event, ctx) => {
+		startStatusRefresh(ctx, event.model, false);
+	});
+	pi.on("turn_start", (_event, ctx) => {
+		if (!ctx.model || !adapterForProvider(ctx.model.provider)) {
+			clearStatus(ctx);
+			return;
+		}
+		startStatusRefresh(ctx, ctx.model, false);
+	});
+	pi.on("session_shutdown", (_event, ctx) => {
+		sessionActive = false;
+		statusGeneration += 1;
+		clearStatusTimer();
+		for (const controller of activeControllers) controller.abort();
+		activeControllers.clear();
+		statusController = undefined;
+		cache.clear();
+		failureBackoff.clear();
+		latestQueries.clear();
+		activeCurrentIdentity = undefined;
+		safeSetStatus(ctx, undefined);
+	});
+}
+
+function configuredAdapters(ctx: ExtensionContext): UsageProviderAdapter[] {
+	return SUPPORTED_ADAPTERS.filter(
+		(adapter) => adapter.id === ctx.model?.provider || providerIsConfigured(ctx, adapter.id),
+	);
+}
+
+function providerDisplayName(ctx: ExtensionContext, providerId: string): string {
+	try {
+		return sanitizeDisplayText(ctx.modelRegistry.getProviderDisplayName(providerId), 80);
+	} catch {
+		return sanitizeDisplayText(providerId, 80);
+	}
+}
+
+function setBoundedMap<T>(map: Map<string, T>, key: string, value: T, limit: number): void {
+	map.delete(key);
+	while (map.size >= limit) {
+		const oldest = map.keys().next().value;
+		if (oldest === undefined) break;
+		map.delete(oldest);
+	}
+	map.set(key, value);
+}
+
+function modelIdentity(model: PiModel | undefined): string | undefined {
+	return model ? `${model.provider}/${model.id}` : undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}
+
+function isTimeoutError(error: unknown): boolean {
+	return error instanceof Error && error.name === "TimeoutError";
+}

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -44,6 +44,7 @@ const MENU_ACTIONS = [REFRESH_CURRENT, VIEW_ANOTHER, VIEW_ALL, CLOSE];
 type QueryOutcome = {
 	state: ProviderUsageState;
 	fingerprint?: string;
+	authState?: "unavailable";
 };
 
 type StableCurrent = {
@@ -163,6 +164,9 @@ export default function usageExtension(pi: ExtensionAPI) {
 			);
 		} catch (error) {
 			if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
+			if (displayState === "current") {
+				transitionCurrentIdentity(`${adapter.id}:auth-error`, adapter.id);
+			}
 			return {
 				state: {
 					providerId: adapter.id,
@@ -185,6 +189,7 @@ export default function usageExtension(pi: ExtensionAPI) {
 					status: "auth-unavailable",
 					message: `No runtime credential is configured for ${adapter.displayName}.`,
 				},
+				authState: "unavailable",
 			};
 		}
 		if (displayState === "current") {
@@ -301,6 +306,8 @@ export default function usageExtension(pi: ExtensionAPI) {
 	) => {
 		const adapter = adapterForProvider(model?.provider);
 		if (!adapter || !model) {
+			const providerId = model?.provider ?? "none";
+			transitionCurrentIdentity(`unsupported:${providerId}`, providerId);
 			clearStatus(ctx);
 			return;
 		}
@@ -378,8 +385,27 @@ export default function usageExtension(pi: ExtensionAPI) {
 		if (generation !== statusGeneration || modelIdentity(ctx.model) !== modelIdentity(model)) {
 			return false;
 		}
-		if (!outcome.fingerprint) return true;
 		const adapter = adapterForProvider(model?.provider);
+		if (outcome.authState === "unavailable") {
+			if (!adapter) return false;
+			try {
+				const auth = await awaitWithDeadline(
+					resolveUsageAuth(ctx, adapter),
+					signal,
+					DEFAULT_TIMEOUT_MS,
+					`revalidating ${adapter.displayName} runtime auth`,
+				);
+				return (
+					generation === statusGeneration &&
+					modelIdentity(ctx.model) === modelIdentity(model) &&
+					auth === undefined
+				);
+			} catch (error) {
+				if (isAbortError(error) || isStaleExtensionContextError(error)) throw error;
+				return false;
+			}
+		}
+		if (!outcome.fingerprint) return true;
 		if (!adapter) return false;
 		try {
 			const auth = await awaitWithDeadline(
@@ -593,10 +619,6 @@ export default function usageExtension(pi: ExtensionAPI) {
 		startStatusRefresh(ctx, event.model, false);
 	});
 	pi.on("turn_start", (_event, ctx) => {
-		if (!ctx.model || !adapterForProvider(ctx.model.provider)) {
-			clearStatus(ctx);
-			return;
-		}
 		startStatusRefresh(ctx, ctx.model, false);
 	});
 	pi.on("session_shutdown", (_event, ctx) => {

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -478,7 +478,9 @@ export default function usageExtension(pi: ExtensionAPI) {
 			let visibleStates: ProviderUsageState[] = [current.state];
 
 			while (!controller.signal.aborted) {
-				const action = await ctx.ui.select(formatProviderStates(visibleStates), [...MENU_ACTIONS]);
+				const action = await ctx.ui.select(formatProviderStates(visibleStates), [...MENU_ACTIONS], {
+					signal: controller.signal,
+				});
 				if (!action || action === CLOSE) return;
 				if (action === REFRESH_CURRENT) {
 					stableCurrent = await queryStableCurrent(
@@ -504,6 +506,7 @@ export default function usageExtension(pi: ExtensionAPI) {
 					const choice = await ctx.ui.select(
 						"Select a configured provider",
 						others.map((adapter) => adapter.displayName),
+						{ signal: controller.signal },
 					);
 					const adapter = others.find((candidate) => candidate.displayName === choice);
 					if (!adapter) continue;

--- a/extensions/pi-usage/test/adapters.test.ts
+++ b/extensions/pi-usage/test/adapters.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeCodexBackendPayload,
+	normalizeOpenRouterKeyPayload,
+} from "../src/index.js";
+
+test("OpenRouter adapter normalizes documented per-key spend limits without claiming subscription quota", () => {
+	const report = normalizeOpenRouterKeyPayload(
+		{
+			data: {
+				label: "Production key",
+				limit: 100,
+				limit_remaining: 74.5,
+				limit_reset: "monthly",
+				usage: 25.5,
+				usage_daily: 1.25,
+				usage_weekly: 8,
+				usage_monthly: 25.5,
+				is_free_tier: false,
+			},
+		},
+		1_000,
+	);
+
+	assert.equal(report.providerId, "openrouter");
+	assert.deepEqual(report.semantics, { kind: "api-key", label: "API-key spend limits" });
+	assert.equal(report.accountLabel, "Production key");
+	assert.deepEqual(report.buckets[0], {
+		id: "key-limit",
+		label: "Key limit",
+		used: 25.5,
+		remaining: 74.5,
+		limit: 100,
+		unit: "usd",
+		period: "monthly",
+	});
+	assert.deepEqual(
+		report.metrics.map((metric) => [metric.id, metric.value]),
+		[
+			["usage-daily", 1.25],
+			["usage-weekly", 8],
+			["usage-monthly", 25.5],
+			["usage-total", 25.5],
+		],
+	);
+	assert.match(formatUsageReport(report, "current"), /OpenRouter Usage · Current/);
+	assert.match(formatUsageReport(report, "current"), /API-key spend limits/);
+	assert.equal(formatUsageStatusline(report), "openrouter $74.50 left");
+});
+
+test("OpenRouter adapter keeps unlimited keys meaningful and sanitizes account labels", () => {
+	const report = normalizeOpenRouterKeyPayload(
+		{
+			data: {
+				label: "main\u001b[31m\nkey",
+				limit: null,
+				limit_remaining: null,
+				limit_reset: null,
+				usage: 12.75,
+				usage_daily: 0,
+				usage_weekly: 2,
+				usage_monthly: 4,
+				is_free_tier: true,
+			},
+		},
+		2_000,
+	);
+
+	assert.equal(report.accountLabel, "main key");
+	assert.deepEqual(report.buckets, []);
+	assert.equal(formatUsageStatusline(report), "openrouter $12.75 used");
+	assert.match(formatUsageReport(report, "configured"), /OpenRouter Usage · Configured/);
+	assert.match(formatUsageReport(report, "configured"), /No per-key spend cap/);
+});
+
+test("OpenRouter adapter distinguishes unlimited keys from incomplete capped responses", () => {
+	const unlimited = normalizeOpenRouterKeyPayload(
+		{
+			data: {
+				label: "unlimited",
+				limit: null,
+				limit_remaining: null,
+				usage: 5,
+			},
+		},
+		2_500,
+	);
+	const unlimitedText = formatUsageReport(unlimited, "current");
+	assert.equal(unlimitedText.match(/No per-key spend cap/g)?.length, 1);
+
+	const incomplete = normalizeOpenRouterKeyPayload(
+		{
+			data: {
+				label: "capped",
+				limit: 100,
+				limit_remaining: null,
+				limit_reset: "monthly",
+				usage: 5,
+			},
+		},
+		2_750,
+	);
+	assert.equal(incomplete.buckets[0]?.limit, 100);
+	assert.equal(incomplete.buckets[0]?.remaining, undefined);
+	assert.match(formatUsageReport(incomplete, "current"), /remaining unavailable/i);
+	assert.doesNotMatch(formatUsageReport(incomplete, "current"), /No per-key spend cap/);
+});
+
+test("OpenRouter adapter rejects malformed or empty documented responses", () => {
+	assert.throws(() => normalizeOpenRouterKeyPayload({}, 0), /data/);
+	assert.throws(
+		() => normalizeOpenRouterKeyPayload({ data: { label: "empty" } }, 0),
+		/no displayable usage data/,
+	);
+});
+
+test("Codex adapter preserves credit availability without a numeric balance", () => {
+	const report = normalizeCodexBackendPayload(
+		{
+			credits: { has_credits: true, unlimited: false },
+		},
+		2_900,
+	);
+	assert.deepEqual(report.metrics, [{ id: "credits", label: "Credits", value: "available" }]);
+	assert.match(formatUsageReport(report, "current"), /Credits:\s+available/);
+	assert.equal(formatUsageStatusline(report), "codex credits available");
+});
+
+test("Codex adapter preserves explicit credit unavailability without rate-limit windows", () => {
+	const report = normalizeCodexBackendPayload({ credits: { has_credits: false } }, 2_950);
+	assert.deepEqual(report.metrics, [{ id: "credits", label: "Credits", value: "none" }]);
+	assert.match(formatUsageReport(report, "current"), /Credits:\s+none/);
+	assert.equal(formatUsageStatusline(report), "codex no credits");
+});
+
+test("Codex adapter preserves windows, credits, and model-specific statusline buckets", () => {
+	const report = normalizeCodexBackendPayload(
+		{
+			plan_type: "pro",
+			rate_limit: {
+				primary_window: { used_percent: 60, limit_window_seconds: 18_000, reset_at: 100 },
+				secondary_window: { used_percent: 80, limit_window_seconds: 604_800 },
+			},
+			credits: { has_credits: true, unlimited: false, balance: "12" },
+			rate_limit_reset_credits: { available_count: 2 },
+			additional_rate_limits: [
+				{
+					limit_name: "GPT-5.3 Codex Spark",
+					metered_feature: "gpt-5.3-codex-spark",
+					rate_limit: {
+						primary_window: { used_percent: 10, limit_window_seconds: 18_000 },
+					},
+				},
+			],
+		},
+		3_000,
+	);
+
+	assert.equal(report.providerId, "openai-codex");
+	assert.deepEqual(report.semantics, {
+		kind: "consumer-subscription",
+		label: "ChatGPT subscription limits",
+	});
+	assert.equal(report.buckets.length, 3);
+	assert.equal(report.metrics.find((metric) => metric.id === "reset-credits")?.value, 2);
+	assert.match(formatUsageReport(report, "current"), /5h limit:/);
+	assert.match(formatUsageReport(report, "current"), /Weekly limit:/);
+	assert.equal(
+		formatUsageStatusline(report, {
+			id: "gpt-5.3-codex-spark",
+			name: "GPT-5.3 Codex Spark",
+			provider: "openai-codex",
+		}),
+		"codex spark 90% 5h",
+	);
+});

--- a/extensions/pi-usage/test/core.test.ts
+++ b/extensions/pi-usage/test/core.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import type { UsageReport } from "../src/index.js";
+import {
+	awaitWithDeadline,
+	fingerprintResolvedAuth,
+	queryProviderUsage,
+	redactUsageError,
+	resolveUsageAuth,
+	runWithConcurrency,
+	SUPPORTED_ADAPTERS,
+	sanitizeDisplayText,
+	UsageCache,
+} from "../src/index.js";
+
+const report: UsageReport = {
+	providerId: "openrouter",
+	providerName: "OpenRouter",
+	capturedAt: 1,
+	source: "openrouter-key",
+	semantics: { kind: "api-key", label: "API-key spend limits" },
+	buckets: [],
+	metrics: [{ id: "usage-total", label: "All-time usage", value: 1, unit: "usd" }],
+};
+
+test("credential fingerprints are process-salted, deterministic, and do not expose secrets", () => {
+	const auth = {
+		apiKey: "sk-secret",
+		headers: { Authorization: "Bearer header-secret", "X-Test": "value" },
+	};
+	const first = fingerprintResolvedAuth(auth, Buffer.alloc(32, 1));
+	const same = fingerprintResolvedAuth(auth, Buffer.alloc(32, 1));
+	const anotherProcess = fingerprintResolvedAuth(auth, Buffer.alloc(32, 2));
+	const anotherAccount = fingerprintResolvedAuth({ apiKey: "different" }, Buffer.alloc(32, 1));
+
+	assert.equal(first, same);
+	assert.notEqual(first, anotherProcess);
+	assert.notEqual(first, anotherAccount);
+	assert.doesNotMatch(first, /secret/);
+});
+
+test("usage cache isolates identities, expires entries, and remains bounded", () => {
+	const cache = new UsageCache(300_000, 4);
+	cache.set("openrouter", "account-a", report, 1_000);
+
+	assert.equal(cache.get("openrouter", "account-a", 1_001), report);
+	assert.equal(cache.get("openrouter", "account-b", 1_001), undefined);
+	assert.equal(cache.get("openai-codex", "account-a", 1_001), undefined);
+	assert.equal(cache.get("openrouter", "account-a", 301_001), undefined);
+	assert.equal(cache.size, 0);
+
+	for (let index = 0; index < 10; index += 1) {
+		cache.set("openrouter", `account-${index}`, report, 400_000 + index);
+	}
+	assert.equal(cache.size, 4);
+	assert.equal(cache.get("openrouter", "account-0", 400_020), undefined);
+	assert.equal(cache.get("openrouter", "account-9", 400_020), report);
+	cache.clearProvider("openrouter");
+	assert.equal(cache.size, 0);
+});
+
+test("bounded orchestration retains stable partial results and respects cancellation", async () => {
+	let active = 0;
+	let maximumActive = 0;
+	const controller = new AbortController();
+	const results = await runWithConcurrency(
+		[1, 2, 3, 4],
+		2,
+		async (value) => {
+			active += 1;
+			maximumActive = Math.max(maximumActive, active);
+			await new Promise<void>((resolve) => setTimeout(resolve, value === 1 ? 10 : 1));
+			active -= 1;
+			if (value === 3) throw new Error("provider failed");
+			return value * 2;
+		},
+		controller.signal,
+	);
+
+	assert.equal(maximumActive, 2);
+	assert.deepEqual(
+		results.map((result) =>
+			result.status === "fulfilled" ? ["ok", result.value] : ["error", result.reason.message],
+		),
+		[
+			["ok", 2],
+			["ok", 4],
+			["error", "provider failed"],
+			["ok", 8],
+		],
+	);
+
+	controller.abort();
+	await assert.rejects(
+		() => runWithConcurrency([1], 2, async (value) => value, controller.signal),
+		/aborted/i,
+	);
+});
+
+test("end-to-end deadline bounds slow work and preserves caller cancellation", async () => {
+	const never = new Promise<never>(() => undefined);
+	const controller = new AbortController();
+	await assert.rejects(
+		() => awaitWithDeadline(never, controller.signal, 5, "resolving auth"),
+		(error: unknown) => error instanceof Error && error.name === "TimeoutError",
+	);
+
+	const cancelled = new AbortController();
+	const pending = awaitWithDeadline(never, cancelled.signal, 1_000, "resolving auth");
+	cancelled.abort();
+	await assert.rejects(
+		() => pending,
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+});
+
+test("runtime auth rejects proxy origins and forwards only adapter-approved headers", async () => {
+	const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "openrouter");
+	assert.ok(adapter);
+	const proxyModel = {
+		id: "proxy-model",
+		name: "Proxy",
+		provider: "openrouter",
+		baseUrl: "https://proxy.example.test/v1",
+	};
+	const { ctx: proxyContext } = createMockContext({
+		model: proxyModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "proxy-key" } }),
+			getAvailable: () => [proxyModel],
+			getAll: () => [proxyModel],
+		},
+	});
+	await assert.rejects(
+		() => resolveUsageAuth(proxyContext, adapter),
+		/custom.*base URL|official/iu,
+	);
+
+	const officialModel = { ...proxyModel, baseUrl: "https://openrouter.ai/api/v1" };
+	const { ctx: effectiveProxyContext } = createMockContext({
+		model: officialModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({
+				auth: { apiKey: "proxy-key", baseUrl: "https://proxy.example.test/v1" },
+			}),
+			getAvailable: () => [officialModel],
+			getAll: () => [officialModel],
+		},
+	});
+	await assert.rejects(
+		() => resolveUsageAuth(effectiveProxyContext, adapter),
+		/proxy-resolved.*official/iu,
+	);
+
+	const { ctx: officialContext } = createMockContext({
+		model: officialModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({
+				auth: {
+					apiKey: "official-key",
+					headers: { "X-Proxy-Secret": "must-not-leak", "X-Title": "private-title" },
+				},
+			}),
+			getAvailable: () => [officialModel],
+			getAll: () => [officialModel],
+		},
+	});
+	const auth = await resolveUsageAuth(officialContext, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer official-key" });
+});
+
+test("provider cancellation preserves AbortError identity", async () => {
+	const abort = Object.assign(new Error("cancelled"), { name: "AbortError" });
+	const adapter = {
+		id: "test",
+		displayName: "Test",
+		semantics: { kind: "api-key" as const, label: "Test" },
+		query: async () => {
+			throw abort;
+		},
+	};
+	const controller = new AbortController();
+	await assert.rejects(
+		() =>
+			queryProviderUsage(
+				adapter,
+				{
+					headers: { Authorization: "Bearer secret" },
+					fingerprint: "fingerprint",
+					secrets: ["secret"],
+					model: {} as never,
+				},
+				controller.signal,
+				10,
+			),
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+});
+
+test("display sanitization strips terminal escapes, controls, and excessive text", () => {
+	const sanitized = sanitizeDisplayText(
+		"safe\u001b]8;;https://evil.test\u0007link\u001b]8;;\u0007\nnext",
+		20,
+	);
+	assert.equal(sanitized, "safelink next");
+	assert.equal(sanitizeDisplayText("x".repeat(100), 10), "xxxxxxxxx…");
+});
+
+test("provider response reads are byte-bounded", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "openrouter");
+	assert.ok(adapter);
+	const auth = {
+		headers: { Authorization: "Bearer secret" },
+		fingerprint: "fingerprint",
+		secrets: ["secret"],
+		model: { ...report, baseUrl: "https://openrouter.ai/api/v1" } as never,
+	};
+	globalThis.fetch = async () => new Response("x".repeat(70_000), { status: 200 });
+	await assert.rejects(
+		() => queryProviderUsage(adapter, auth, new AbortController().signal, 1_000),
+		/exceeded.*bytes|too large/iu,
+	);
+
+	globalThis.fetch = async () => new Response("x".repeat(70_000), { status: 500 });
+	await assert.rejects(
+		() => queryProviderUsage(adapter, auth, new AbortController().signal, 1_000),
+		(error: unknown) =>
+			error instanceof Error && error.message.length < 1_000 && /returned 500/.test(error.message),
+	);
+});
+
+test("usage error redaction removes exact runtime auth and common token fields", () => {
+	const redacted = redactUsageError(
+		'Bearer common-token {"access_token":"json-token"} sk-secret header-secret',
+		["sk-secret", "header-secret"],
+	);
+	assert.doesNotMatch(redacted, /common-token|json-token|sk-secret|header-secret/);
+	assert.match(redacted, /<redacted>/);
+});

--- a/extensions/pi-usage/test/core.test.ts
+++ b/extensions/pi-usage/test/core.test.ts
@@ -141,6 +141,7 @@ test("runtime auth rejects proxy origins and forwards only adapter-approved head
 	const { ctx: effectiveProxyContext } = createMockContext({
 		model: officialModel,
 		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "current-model-key" }),
 			getProviderAuth: async () => ({
 				auth: { apiKey: "proxy-key", baseUrl: "https://proxy.example.test/v1" },
 			}),
@@ -168,6 +169,39 @@ test("runtime auth rejects proxy origins and forwards only adapter-approved head
 	});
 	const auth = await resolveUsageAuth(officialContext, adapter);
 	assert.deepEqual(auth?.headers, { Authorization: "Bearer official-key" });
+
+	const { ctx: modelScopedContext } = createMockContext({
+		model: officialModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				apiKey: "provider-default-key",
+				headers: {
+					Authorization: "Bearer current-model-key",
+					"X-Model-Secret": "must-not-leak",
+				},
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-default-key" } }),
+			getAvailable: () => [officialModel],
+			getAll: () => [officialModel],
+		},
+	});
+	const modelScopedAuth = await resolveUsageAuth(modelScopedContext, adapter);
+	assert.deepEqual(modelScopedAuth?.headers, { Authorization: "Bearer current-model-key" });
+	assert.ok(modelScopedAuth?.secrets.includes("Bearer current-model-key"));
+	assert.ok(!modelScopedAuth?.secrets.includes("must-not-leak"));
+
+	const { ctx: modelKeyContext } = createMockContext({
+		model: officialModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "current-model-key" }),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-default-key" } }),
+			getAvailable: () => [officialModel],
+			getAll: () => [officialModel],
+		},
+	});
+	const modelKeyAuth = await resolveUsageAuth(modelKeyContext, adapter);
+	assert.deepEqual(modelKeyAuth?.headers, { Authorization: "Bearer current-model-key" });
 });
 
 test("provider cancellation preserves AbortError identity", async () => {

--- a/extensions/pi-usage/test/usage.test.ts
+++ b/extensions/pi-usage/test/usage.test.ts
@@ -348,6 +348,61 @@ test("TUI usage queries can be cancelled with Escape", async () => {
 	assert.equal(selected, false);
 });
 
+test("session shutdown aborts usage action and provider selectors", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = usageFetch;
+
+	const dialogSignals: AbortSignal[] = [];
+	let providerSelectorStarted: () => void = () => undefined;
+	const providerSelectorReady = new Promise<void>((resolve) => {
+		providerSelectorStarted = resolve;
+	});
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (
+			title: string,
+			_options: string[],
+			opts?: { signal?: AbortSignal },
+		): Promise<string | undefined> => {
+			assert.ok(opts?.signal);
+			dialogSignals.push(opts.signal);
+			if (!title.includes("Select a configured provider")) {
+				return "View another configured provider…";
+			}
+			providerSelectorStarted();
+			return new Promise((resolve) => {
+				if (opts.signal?.aborted) resolve(undefined);
+				else opts.signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+			});
+		},
+		modelRegistry: {
+			getProviderAuth: async (provider: string) => ({ auth: { apiKey: `${provider}-key` } }),
+			getAvailable: () => [openRouterModel, codexModel],
+			getAll: () => [openRouterModel, codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	const pending = command.handler("", ctx);
+	await providerSelectorReady;
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	await pending;
+
+	assert.equal(dialogSignals.length, 2);
+	assert.equal(dialogSignals[0], dialogSignals[1]);
+	assert.equal(dialogSignals[0]?.aborted, true);
+});
+
 test("automatic provider failures back off instead of retrying every turn", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.after(() => {

--- a/extensions/pi-usage/test/usage.test.ts
+++ b/extensions/pi-usage/test/usage.test.ts
@@ -248,6 +248,45 @@ test("unsupported providers remain visible without publishing an error status", 
 	assert.equal(statuses.get("usage"), undefined);
 });
 
+test("current auth appearance during a command is revalidated before display", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = usageFetch;
+	let authCalls = 0;
+	let title = "";
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (value: string) => {
+			title = value;
+			return "Close";
+		},
+		modelRegistry: {
+			getProviderAuth: async () => {
+				authCalls += 1;
+				return authCalls === 1 ? undefined : { auth: { apiKey: "openrouter-key" } };
+			},
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.match(title, /OpenRouter Usage · Current/);
+	assert.match(title, /test-key/);
+	assert.ok(authCalls >= 3);
+});
+
 test("automatic lifecycle refresh starts asynchronously", () => {
 	const mock = createMockPi();
 	usageExtension(mock.pi);
@@ -544,7 +583,16 @@ test("statusline follows runtime auth changes and clears for unsupported selecte
 	globalThis.fetch = async () => {
 		fetches += 1;
 		if (activeKey === "account-a") accountAQueries += 1;
-		const remaining = activeKey === "account-a" ? (accountAQueries === 1 ? 75 : 20) : 40;
+		const remaining =
+			activeKey === "account-a"
+				? accountAQueries === 1
+					? 75
+					: accountAQueries === 2
+						? 20
+						: accountAQueries === 3
+							? 10
+							: 5
+				: 40;
 		return new Response(
 			JSON.stringify({
 				data: {
@@ -602,4 +650,21 @@ test("statusline follows runtime auth changes and clears for unsupported selecte
 		ctx,
 	);
 	assert.equal(statuses.get("usage"), undefined);
+
+	mock.events.get("model_select")?.[0]?.({ model: openRouterModel }, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $10.00 left");
+	assert.equal(fetches, 4);
+
+	const proxyModel = { ...openRouterModel, baseUrl: "https://proxy.example.test/v1" };
+	Object.assign(ctx, { model: proxyModel });
+	mock.events.get("model_select")?.[0]?.({ model: proxyModel }, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "auth unavailable");
+
+	Object.assign(ctx, { model: openRouterModel });
+	mock.events.get("model_select")?.[0]?.({ model: openRouterModel }, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $5.00 left");
+	assert.equal(fetches, 5);
 });

--- a/extensions/pi-usage/test/usage.test.ts
+++ b/extensions/pi-usage/test/usage.test.ts
@@ -1,0 +1,605 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import usageExtension from "../src/usage.js";
+
+initTheme("dark", false);
+
+const openRouterModel = {
+	id: "openai/gpt-4o",
+	name: "GPT-4o",
+	provider: "openrouter",
+	baseUrl: "https://openrouter.ai/api/v1",
+};
+const codexModel = {
+	id: "gpt-5.3-codex",
+	name: "GPT-5.3 Codex",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+};
+
+async function settle(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function usageFetch(input: string | URL | Request): Promise<Response> {
+	const url = String(input);
+	if (url.endsWith("/api/v1/key")) {
+		return Promise.resolve(
+			new Response(
+				JSON.stringify({
+					data: {
+						label: "test-key",
+						limit: 100,
+						limit_remaining: 75,
+						limit_reset: "monthly",
+						usage: 25,
+						usage_daily: 1,
+						usage_weekly: 5,
+						usage_monthly: 25,
+					},
+				}),
+				{ status: 200 },
+			),
+		);
+	}
+	return Promise.resolve(
+		new Response(
+			JSON.stringify({
+				plan_type: "pro",
+				rate_limit: { primary_window: { used_percent: 20, limit_window_seconds: 18_000 } },
+			}),
+			{ status: 200 },
+		),
+	);
+}
+
+test("pi-usage registers one primary command, compatibility alias, and lifecycle hooks", () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+
+	assert.ok(mock.commands.has("usage"));
+	assert.ok(mock.commands.has("codex-status"));
+	assert.equal(mock.commands.get("usage")?.getArgumentCompletions, undefined);
+	assert.equal(mock.commands.get("codex-status")?.getArgumentCompletions, undefined);
+	assert.deepEqual([...mock.events.keys()].sort(), [
+		"model_select",
+		"session_shutdown",
+		"session_start",
+		"session_tree",
+		"turn_start",
+	]);
+});
+
+test("/usage automatically queries the current runtime account and shows state plus next actions", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = usageFetch;
+
+	const selections: Array<{ title: string; options: string[] }> = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (title: string, options: string[]) => {
+			selections.push({ title, options });
+			return "Close";
+		},
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "openrouter-key" } }),
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel, codexModel],
+			getProviderAuthStatus: (provider: string) => ({ configured: provider === "openrouter" }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(selections.length, 1);
+	assert.match(selections[0]?.title ?? "", /OpenRouter Usage · Current/);
+	assert.match(selections[0]?.title ?? "", /test-key/);
+	assert.deepEqual(selections[0]?.options, [
+		"Refresh current usage",
+		"View another configured provider…",
+		"View all configured providers…",
+		"Close",
+	]);
+	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+});
+
+test("command arguments are rejected instead of becoming a hidden interface", async () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	let selected = false;
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async () => {
+			selected = true;
+			return "Close";
+		},
+	});
+
+	await command.handler("--all", ctx);
+
+	assert.equal(selected, false);
+	assert.match(notifications[0]?.message ?? "", /does not accept arguments/);
+});
+
+test("explicit all-provider query labels current/configured and retains provider failures", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = async (input) => {
+		if (String(input).endsWith("/api/v1/key")) return usageFetch(input);
+		return new Response("backend unavailable", { status: 503, statusText: "Unavailable" });
+	};
+
+	const titles: string[] = [];
+	const choices = ["View all configured providers…", "Close"];
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return choices.shift();
+		},
+		modelRegistry: {
+			getProviderAuth: async (provider: string) => ({ auth: { apiKey: `${provider}-key` } }),
+			getAvailable: () => [openRouterModel, codexModel],
+			getAll: () => [openRouterModel, codexModel],
+			getProviderAuthStatus: () => ({ configured: true, source: "stored" }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(titles.length, 2);
+	assert.match(titles[1] ?? "", /OpenRouter Usage · Current/);
+	assert.match(titles[1] ?? "", /OpenAI Codex · Configured/);
+	assert.match(titles[1] ?? "", /query failed/i);
+	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+});
+
+test("another-provider queries remain configured and never replace current status", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = usageFetch;
+	const choices = ["View another configured provider…", "OpenAI Codex", "Close"];
+	const titles: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return choices.shift();
+		},
+		modelRegistry: {
+			getProviderAuth: async (provider: string) => ({ auth: { apiKey: `${provider}-key` } }),
+			getAvailable: () => [openRouterModel, codexModel],
+			getAll: () => [openRouterModel, codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.match(titles.at(-1) ?? "", /OpenAI Codex Usage · Configured/);
+	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+});
+
+test("unsupported providers remain visible without publishing an error status", async () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const unsupportedModel = {
+		id: "claude",
+		name: "Claude",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+	};
+	let title = "";
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: unsupportedModel,
+		select: async (value: string) => {
+			title = value;
+			return "Close";
+		},
+		modelRegistry: {
+			getProviderDisplayName: () => "Anthropic",
+			getAvailable: () => [],
+			getAll: () => [],
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.match(title, /Unsupported/);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("automatic lifecycle refresh starts asynchronously", () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const never = new Promise<never>(() => undefined);
+	const { ctx } = createMockContext({
+		model: openRouterModel,
+		modelRegistry: {
+			getProviderAuth: () => never,
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+		},
+	});
+
+	const result = mock.events.get("session_start")?.[0]?.({}, ctx);
+	assert.equal(result, undefined);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+});
+
+test("TUI usage queries can be cancelled with Escape", async () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	let selected = false;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		model: openRouterModel,
+		select: async () => {
+			selected = true;
+			return "Close";
+		},
+		custom: async (factory: unknown) =>
+			new Promise<unknown>((resolve) => {
+				if (typeof factory !== "function") return resolve(undefined);
+				let component: { dispose?(): void; handleInput(data: string): void };
+				const done = (value: unknown) => {
+					component.dispose?.();
+					resolve(value);
+				};
+				component = (
+					factory as (
+						tui: { requestRender(): void },
+						theme: { fg(_color: string, text: string): string },
+						keybindings: object,
+						done: (value: unknown) => void,
+					) => { dispose?(): void; handleInput(data: string): void }
+				)({ requestRender() {} }, { fg: (_color, text) => text }, {}, done);
+				setImmediate(() => component.handleInput("\u001b"));
+			}),
+		modelRegistry: {
+			getProviderAuth: () => new Promise<never>(() => undefined),
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+		},
+	});
+
+	await command.handler("", ctx);
+	assert.equal(selected, false);
+});
+
+test("automatic provider failures back off instead of retrying every turn", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let fetches = 0;
+	globalThis.fetch = async () => {
+		fetches += 1;
+		return new Response("unavailable", { status: 503, statusText: "Unavailable" });
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx } = createMockContext({
+		model: openRouterModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "openrouter-key" } }),
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	mock.events.get("turn_start")?.[0]?.({}, ctx);
+	await settle();
+	mock.events.get("turn_start")?.[0]?.({}, ctx);
+	await settle();
+	assert.equal(fetches, 1);
+});
+
+test("a current command supersedes an older automatic query for the same provider", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeKey = "account-a";
+	let fetches = 0;
+	let resolveOldFetch: (response: Response) => void = () => undefined;
+	const oldFetch = new Promise<Response>((resolve) => {
+		resolveOldFetch = resolve;
+	});
+	const response = (label: string, remaining: number) =>
+		new Response(
+			JSON.stringify({
+				data: {
+					label,
+					limit: 100,
+					limit_remaining: remaining,
+					usage: 100 - remaining,
+				},
+			}),
+			{ status: 200 },
+		);
+	globalThis.fetch = async () => {
+		fetches += 1;
+		return fetches === 1 ? oldFetch : response("account-b", 40);
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async () => "Close",
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: activeKey } }),
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	while (fetches < 1) await settle();
+	activeKey = "account-b";
+	await command.handler("", ctx);
+	assert.equal(statuses.get("usage"), "openrouter $40.00 left");
+
+	resolveOldFetch(response("account-a", 75));
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $40.00 left");
+});
+
+test("cross-provider results revalidate which account is Current before display", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let codexFetches = 0;
+	let resolveCodex: (response: Response) => void = () => undefined;
+	const codexResponse = new Promise<Response>((resolve) => {
+		resolveCodex = resolve;
+	});
+	globalThis.fetch = async (input) => {
+		if (String(input).endsWith("/api/v1/key")) return usageFetch(input);
+		codexFetches += 1;
+		return codexFetches === 1 ? codexResponse : usageFetch(input);
+	};
+	const choices = ["View another configured provider…", "OpenAI Codex", "Close"];
+	const titles: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return choices.shift();
+		},
+		modelRegistry: {
+			getProviderAuth: async (provider: string) => ({ auth: { apiKey: `${provider}-key` } }),
+			getAvailable: () => [openRouterModel, codexModel],
+			getAll: () => [openRouterModel, codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	const pending = command.handler("", ctx);
+	while (codexFetches < 1) await settle();
+	Object.assign(ctx, { model: codexModel });
+	resolveCodex(await usageFetch("https://chatgpt.com/backend-api/wham/usage"));
+	await pending;
+
+	assert.match(titles.at(-1) ?? "", /OpenAI Codex Usage · Current/);
+	assert.doesNotMatch(titles.at(-1) ?? "", /OpenRouter Usage · Current/);
+});
+
+test("session shutdown clears status through the shutdown context", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = usageFetch;
+	const statuses = new Map<string, string | undefined>();
+	const ui = {
+		notify() {},
+		setStatus(key: string, value: string | undefined) {
+			statuses.set(key, value);
+		},
+	};
+	const registry = {
+		getProviderAuth: async () => ({ auth: { apiKey: "openrouter-key" } }),
+		getAvailable: () => [openRouterModel],
+		getAll: () => [openRouterModel],
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx: startContext } = createMockContext({
+		model: openRouterModel,
+		ui,
+		modelRegistry: registry,
+	});
+	const { ctx: shutdownContext } = createMockContext({
+		model: openRouterModel,
+		ui,
+		modelRegistry: registry,
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, startContext);
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+	mock.events.get("session_shutdown")?.[0]?.({}, shutdownContext);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("a slow command cannot overwrite status after the selected model changes", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let openRouterFetches = 0;
+	let resolveSlowFetch: (response: Response) => void = () => undefined;
+	const slowFetch = new Promise<Response>((resolve) => {
+		resolveSlowFetch = resolve;
+	});
+	globalThis.fetch = async (input) => {
+		if (String(input).endsWith("/api/v1/key")) {
+			openRouterFetches += 1;
+			if (openRouterFetches === 1) return usageFetch(input);
+			return slowFetch;
+		}
+		return usageFetch(input);
+	};
+
+	const choices = ["Refresh current usage", "Close"];
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async () => choices.shift(),
+		modelRegistry: {
+			getProviderAuth: async (provider: string) => ({ auth: { apiKey: `${provider}-key` } }),
+			getAvailable: () => [openRouterModel, codexModel],
+			getAll: () => [openRouterModel, codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	const commandPromise = command.handler("", ctx);
+	while (openRouterFetches < 2) await settle();
+	Object.assign(ctx, { model: codexModel });
+	mock.events.get("model_select")?.[0]?.({ model: codexModel }, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "codex 80% 5h");
+
+	resolveSlowFetch(await usageFetch("https://openrouter.ai/api/v1/key"));
+	await commandPromise;
+	assert.equal(statuses.get("usage"), "codex 80% 5h");
+});
+
+test("statusline follows runtime auth changes and clears for unsupported selected providers", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeKey = "account-a";
+	let accountAQueries = 0;
+	let fetches = 0;
+	globalThis.fetch = async () => {
+		fetches += 1;
+		if (activeKey === "account-a") accountAQueries += 1;
+		const remaining = activeKey === "account-a" ? (accountAQueries === 1 ? 75 : 20) : 40;
+		return new Response(
+			JSON.stringify({
+				data: {
+					label: activeKey,
+					limit: 100,
+					limit_remaining: remaining,
+					limit_reset: "monthly",
+					usage: 100 - remaining,
+					usage_daily: 1,
+					usage_weekly: 5,
+					usage_monthly: 25,
+				},
+			}),
+			{ status: 200 },
+		);
+	};
+
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx, statuses } = createMockContext({
+		model: openRouterModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: activeKey } }),
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+
+	activeKey = "account-b";
+	mock.events.get("turn_start")?.[0]?.({}, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $40.00 left");
+
+	activeKey = "account-a";
+	mock.events.get("turn_start")?.[0]?.({}, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "openrouter $20.00 left");
+	assert.equal(fetches, 3);
+
+	mock.events.get("model_select")?.[0]?.(
+		{
+			model: {
+				id: "x",
+				name: "X",
+				provider: "unsupported",
+				baseUrl: "https://example.test",
+			},
+		},
+		ctx,
+	);
+	assert.equal(statuses.get("usage"), undefined);
+});

--- a/extensions/pi-usage/tsconfig.json
+++ b/extensions/pi-usage/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -92,6 +92,9 @@ pack-codex-accounts:
 pack-codex-usage:
     just pack codex-usage
 
+pack-usage:
+    just pack usage
+
 pack-firecrawl:
     just pack firecrawl
 
@@ -152,6 +155,9 @@ try-codex-accounts:
 
 try-codex-usage:
     just try codex-usage
+
+try-usage:
+    just try usage
 
 try-firecrawl:
     just try firecrawl
@@ -214,6 +220,9 @@ install-codex-accounts:
 install-codex-usage:
     just install codex-usage
 
+install-usage:
+    just install usage
+
 install-firecrawl:
     just install firecrawl
 
@@ -271,6 +280,9 @@ publish-codex-accounts:
 
 publish-codex-usage:
     just publish codex-usage
+
+publish-usage:
+    just publish usage
 
 publish-firecrawl:
     just publish firecrawl

--- a/package-lock.json
+++ b/package-lock.json
@@ -901,6 +901,2005 @@
 				"@biomejs/cli-win32-x64": "2.5.3"
 			}
 		},
+		"extensions/pi-usage": {
+			"name": "@narumitw/pi-usage",
+			"version": "0.24.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.3",
+				"@earendil-works/pi-coding-agent": "0.81.0",
+				"@types/node": "26.1.1",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": ">=0.81.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@biomejs/biome": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
+			"integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.5.3",
+				"@biomejs/cli-darwin-x64": "2.5.3",
+				"@biomejs/cli-linux-arm64": "2.5.3",
+				"@biomejs/cli-linux-arm64-musl": "2.5.3",
+				"@biomejs/cli-linux-x64": "2.5.3",
+				"@biomejs/cli-linux-x64-musl": "2.5.3",
+				"@biomejs/cli-win32-arm64": "2.5.3",
+				"@biomejs/cli-win32-x64": "2.5.3"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.0.tgz",
+			"integrity": "sha512-2p0Dnx+3fkPLga8M82eg14ZYNLcFLhqxxKyVVfqUSIio9Xx4p7UjvJtopx/6PTeJKmdJl1/xOm/c02AFcJ+l/g==",
+			"dev": true,
+			"hasShrinkwrap": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.81.0",
+				"@earendil-works/pi-ai": "^0.81.0",
+				"@earendil-works/pi-tui": "^0.81.0",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"semver": "7.8.0",
+				"typebox": "1.1.38",
+				"undici": "8.5.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "0.3.9"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+			"version": "3.974.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-login": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-ini": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.81.0",
+				"ignore": "7.0.5",
+				"typebox": "1.1.38",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"extensions/pi-usage/node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
 		"extensions/pi-webui": {
 			"name": "@narumitw/pi-webui",
 			"version": "0.24.0",
@@ -4448,6 +6447,10 @@
 		},
 		"node_modules/@narumitw/pi-sync": {
 			"resolved": "extensions/pi-sync",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-usage": {
+			"resolved": "extensions/pi-usage",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-webui": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"pack:accounts": "npm --workspace @narumitw/pi-accounts pack --dry-run",
 		"pack:codex-accounts": "npm --workspace @narumitw/pi-codex-accounts pack --dry-run",
 		"pack:codex-usage": "npm --workspace @narumitw/pi-codex-usage pack --dry-run",
+		"pack:usage": "npm --workspace @narumitw/pi-usage pack --dry-run",
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:github-pr": "npm --workspace @narumitw/pi-github-pr pack --dry-run",
 		"pack:google-genai": "npm --workspace @narumitw/pi-google-genai pack --dry-run",


### PR DESCRIPTION
## Summary

- add the production `@narumitw/pi-usage` extension with normalized Codex and OpenRouter usage adapters
- make `/usage` an interactive current-account-first menu with explicit configured-provider and all-provider actions
- keep statusline reporting scoped to the active provider/account, with account-isolated caching, cancellation, race protection, and safe auth-origin validation
- retain `/codex-status` as a temporary compatibility alias and document migration from `pi-codex-usage`
- integrate package scripts, recipes, catalog documentation, and the `usage` statusline icon

## Verification

- `npm run check` — 992 tests passed
- `just pack usage` — 11 expected publish files
- `pi -p -e ./extensions/pi-usage '/usage'` — exited successfully without model/network work

## Notes

- Requires Pi 0.81.0 or newer so effective resolved-auth base URLs can be validated before credentials are sent to official usage endpoints.
- OpenRouter reports API-key spend limits; Codex reports ChatGPT subscription windows. The UI keeps those semantics distinct.

Closes #268
