### PR TITLE
fix(pi-subagents): keep reviewer verification lightweight

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -294,9 +294,11 @@ Built-in agents are available without setup and can be overridden by user or pro
 | --- | --- | --- |
 | `scout` | Read-only codebase reconnaissance. | `read`, `grep`, `find`, `ls`, `bash` |
 | `planner` | Grounded implementation plans. | `read`, `grep`, `find`, `ls` |
-| `reviewer` | Independent review and verification. | `read`, `grep`, `find`, `ls`, `bash` |
+| `reviewer` | Independent review of code and existing verification evidence. | `read`, `grep`, `find`, `ls`, `bash` |
 | `worker` | General-purpose implementation. | Pi default tools |
 | `general`, `general-purpose` | Aliases for `worker`. | Pi default tools |
+
+The built-in `reviewer` does not run tests, builds, benchmarks, or formatters. It recommends additional verification commands for the main agent to run instead. Custom agents can override this behavior.
 
 Built-in agents inherit the active/default Pi model instead of forcing a provider-specific model alias, which keeps subprocesses usable across different Pi setups.
 

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -93,14 +93,15 @@ const BUILT_IN_AGENTS: AgentConfig[] = [
 	},
 	{
 		name: "reviewer",
-		description: "Independent code review and verification agent for completed changes.",
+		description: "Independent code review agent that inspects existing verification evidence.",
 		tools: ["read", "grep", "find", "ls", "bash"],
 		source: "built-in",
 		filePath: "built-in:reviewer",
 		systemPrompt: [
-			"You are a reviewer subagent. Review changes adversarially and verify claims.",
-			"Do not edit files. Run safe inspection or test commands when useful.",
-			"Report PASS, FAIL, or PARTIAL with evidence, commands run, and specific follow-ups.",
+			"You are a reviewer subagent. Review changes adversarially and assess claims against the code and existing evidence.",
+			"Do not edit files or run tests, builds, benchmarks, formatters, or other long-running verification commands.",
+			"Inspect code, diffs, test definitions, and existing verification evidence. Recommend any additional commands for the main agent to run.",
+			"Report PASS, FAIL, or PARTIAL with evidence, commands inspected, and specific follow-ups.",
 		].join("\n"),
 	},
 	{

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -205,6 +205,26 @@ test("discoverAgents includes built-ins and lets project agents override by name
 	assert.ok(result.agents.some((agent) => agent.name === "worker" && agent.source === "built-in"));
 });
 
+test("built-in reviewer inspects evidence without running verification commands", () => {
+	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-reviewer-test-"));
+	try {
+		const reviewer = discoverAgents(cwd, "project").agents.find(
+			(agent) => agent.name === "reviewer",
+		);
+
+		assert.ok(reviewer);
+		assert.match(
+			reviewer.systemPrompt,
+			/do not edit files or run tests, builds, benchmarks, formatters/i,
+		);
+		assert.match(reviewer.systemPrompt, /recommend.*commands for the main agent to run/i);
+		assert.doesNotMatch(reviewer.systemPrompt, /run safe inspection or test commands/i);
+		assert.ok(reviewer.tools?.includes("bash"));
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
 test("formatAgentList returns concise text and remaining count", () => {
 	const agents = discoverAgents(process.cwd(), "project").agents;
 	const formatted = formatAgentList(agents, 2);


### PR DESCRIPTION
## Summary

- prevent the built-in reviewer from running tests, builds, benchmarks, or formatters
- keep read-only shell inspection available and delegate verification commands to the main agent
- document and test the reviewer execution policy

## Verification

- `npm run check` (958 tests passed)
- `just pack-subagents`
- `git diff --check`