### PR TITLE
fix(btw): preserve side thread layout during reflow

### DIFF
--- a/extensions/pi-btw/src/transcript-pager.ts
+++ b/extensions/pi-btw/src/transcript-pager.ts
@@ -112,8 +112,9 @@ export class BtwTranscriptPager implements Component {
 			return;
 		}
 		if (matchesKey(data, Key.pageUp)) {
-			this.followBottom = false;
+			const previousOffset = this.scrollOffset;
 			this.scrollBy(-this.lastViewportHeight);
+			if (this.scrollOffset < previousOffset) this.followBottom = false;
 			this.tui.requestRender();
 			return;
 		}
@@ -229,8 +230,9 @@ export class BtwAnsweringView implements Component {
 			return;
 		}
 		if (matchesKey(data, Key.pageUp)) {
-			this.followBottom = false;
+			const previousOffset = this.scrollOffset;
 			this.scrollBy(-this.lastViewportHeight);
+			if (this.scrollOffset < previousOffset) this.followBottom = false;
 			this.tui.requestRender();
 		} else if (matchesKey(data, Key.pageDown)) {
 			this.scrollBy(this.lastViewportHeight);

--- a/extensions/pi-btw/src/transcript-pager.ts
+++ b/extensions/pi-btw/src/transcript-pager.ts
@@ -7,6 +7,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
+	CURSOR_MARKER,
 	Editor,
 	type EditorTheme,
 	Key,
@@ -32,8 +33,7 @@ export class BtwTranscriptPager implements Component {
 	private scrollOffset = 0;
 	private lastContentLineCount = 0;
 	private lastViewportHeight = 1;
-	private scrollToBottomOnFirstRender: boolean;
-	private hasRendered = false;
+	private followBottom: boolean;
 	private warning: string | undefined;
 	private finished = false;
 	private isFocused = false;
@@ -46,7 +46,7 @@ export class BtwTranscriptPager implements Component {
 		options: { startAtBottom?: boolean } = {},
 	) {
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme);
-		this.scrollToBottomOnFirstRender = options.startAtBottom ?? false;
+		this.followBottom = options.startAtBottom ?? false;
 		const editorTheme: EditorTheme = {
 			borderColor: (text) => this.theme.fg("accent", text),
 			selectList: {
@@ -90,23 +90,18 @@ export class BtwTranscriptPager implements Component {
 			availableRows - editorLines.length - TRANSCRIPT_CHROME_LINES,
 		);
 		const contentLines = renderTranscriptLines(this.transcriptComponents, safeWidth);
-		const shouldFollowBottom =
-			this.scrollToBottomOnFirstRender ||
-			(this.hasRendered && this.scrollOffset >= this.getMaxScrollOffset());
 		this.lastContentLineCount = contentLines.length;
 		this.lastViewportHeight = viewportHeight;
-		if (shouldFollowBottom) this.scrollOffset = this.getMaxScrollOffset();
-		this.scrollToBottomOnFirstRender = false;
-		this.hasRendered = true;
+		if (this.followBottom) this.scrollOffset = this.getMaxScrollOffset();
 		this.clampScrollOffset();
 
-		const lines = [
+		return fitComposerLayout(
 			renderSideThreadHeader(safeWidth, this.theme),
-			...contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
+			contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
 			this.renderFooter(safeWidth),
-			...editorLines,
-		];
-		return fitWithFixedHeader(lines, availableRows);
+			editorLines,
+			availableRows,
+		);
 	}
 
 	handleInput(data: string): void {
@@ -117,12 +112,14 @@ export class BtwTranscriptPager implements Component {
 			return;
 		}
 		if (matchesKey(data, Key.pageUp)) {
+			this.followBottom = false;
 			this.scrollBy(-this.lastViewportHeight);
 			this.tui.requestRender();
 			return;
 		}
 		if (matchesKey(data, Key.pageDown)) {
 			this.scrollBy(this.lastViewportHeight);
+			this.followBottom = this.scrollOffset >= this.getMaxScrollOffset();
 			this.tui.requestRender();
 			return;
 		}
@@ -141,15 +138,19 @@ export class BtwTranscriptPager implements Component {
 			return truncateToWidth(this.theme.fg("warning", warning), width);
 		}
 		const scrollable = this.getMaxScrollOffset() > 0;
-		let hints: string;
-		if (width < 28) {
-			hints = "btw • Enter • Ctrl+C";
-		} else if (width < 52) {
-			hints = `btw • Enter • Ctrl+C${scrollable ? " • PgUp/PgDn" : ""}`;
-		} else {
-			hints = `btw • Enter send • Ctrl+C exit${
-				scrollable ? ` • ${this.scrollOffset > 0 ? "↑ older" : "↓ newer"} • PgUp/PgDn history` : ""
-			}`;
+		const fullBase = "btw • Enter send • Ctrl+C exit";
+		const compactBase = "btw • Enter • Ctrl+C";
+		let hints = visibleWidth(fullBase) <= width ? fullBase : compactBase;
+		if (scrollable) {
+			const history = ` • ${this.scrollOffset > 0 ? "↑ older" : "↓ newer"} • PgUp/PgDn history`;
+			const compactHistory = " • PgUp/PgDn";
+			if (visibleWidth(`${hints}${history}`) <= width) {
+				hints += history;
+			} else if (visibleWidth(`${hints}${compactHistory}`) <= width) {
+				hints += compactHistory;
+			} else if (visibleWidth(`${compactBase}${compactHistory}`) <= width) {
+				hints = `${compactBase}${compactHistory}`;
+			}
 		}
 		return truncateToWidth(this.theme.fg("muted", hints), width);
 	}
@@ -175,8 +176,7 @@ export class BtwAnsweringView implements Component {
 	private scrollOffset = 0;
 	private lastContentLineCount = 0;
 	private lastViewportHeight = 1;
-	private scrollToBottomOnFirstRender = true;
-	private hasRendered = false;
+	private followBottom = true;
 	private finished = false;
 
 	constructor(
@@ -204,14 +204,9 @@ export class BtwAnsweringView implements Component {
 		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_LINES);
 		const viewportHeight = Math.max(0, availableRows - TRANSCRIPT_CHROME_LINES);
 		const contentLines = renderTranscriptLines(this.transcriptComponents, safeWidth);
-		const shouldFollowBottom =
-			this.scrollToBottomOnFirstRender ||
-			(this.hasRendered && this.scrollOffset >= this.getMaxScrollOffset());
 		this.lastContentLineCount = contentLines.length;
 		this.lastViewportHeight = viewportHeight;
-		if (shouldFollowBottom) this.scrollOffset = this.getMaxScrollOffset();
-		this.scrollToBottomOnFirstRender = false;
-		this.hasRendered = true;
+		if (this.followBottom) this.scrollOffset = this.getMaxScrollOffset();
 		this.clampScrollOffset();
 		const cancelHint = safeWidth < 28 ? "Ctrl+C" : "Ctrl+C cancel";
 		const loaderWidth = Math.max(1, safeWidth - visibleWidth(cancelHint) - 3);
@@ -234,10 +229,12 @@ export class BtwAnsweringView implements Component {
 			return;
 		}
 		if (matchesKey(data, Key.pageUp)) {
+			this.followBottom = false;
 			this.scrollBy(-this.lastViewportHeight);
 			this.tui.requestRender();
 		} else if (matchesKey(data, Key.pageDown)) {
 			this.scrollBy(this.lastViewportHeight);
+			this.followBottom = this.scrollOffset >= this.getMaxScrollOffset();
 			this.tui.requestRender();
 		}
 	}
@@ -329,6 +326,29 @@ function renderSideThreadHeader(width: number, theme: Theme): string {
 	const title = truncateToWidth("─ btw · side thread ", width);
 	const ruleWidth = Math.max(0, width - visibleWidth(title));
 	return theme.fg("muted", `${title}${"─".repeat(ruleWidth)}`);
+}
+
+function fitComposerLayout(
+	header: string,
+	contentLines: string[],
+	footer: string,
+	editorLines: string[],
+	availableRows: number,
+): string[] {
+	const lines = [header, ...contentLines, footer, ...editorLines];
+	if (lines.length <= availableRows) return lines;
+	if (availableRows <= 1) return [header];
+	const editorBudget = Math.max(0, availableRows - 2);
+	return [header, footer, ...fitEditorLines(editorLines, editorBudget)];
+}
+
+function fitEditorLines(editorLines: string[], budget: number): string[] {
+	if (budget <= 0) return [];
+	if (editorLines.length <= budget) return editorLines;
+	const cursorIndex = editorLines.findIndex((line) => line.includes(CURSOR_MARKER));
+	if (cursorIndex < 0) return editorLines.slice(-budget);
+	const start = Math.min(cursorIndex, editorLines.length - budget);
+	return editorLines.slice(start, start + budget);
 }
 
 function fitWithFixedHeader(lines: string[], availableRows: number): string[] {

--- a/extensions/pi-btw/test/side-thread.test.ts
+++ b/extensions/pi-btw/test/side-thread.test.ts
@@ -294,12 +294,56 @@ test("empty transcript composer accepts the first side-thread question", () => {
 	const emptyView = emptyLines.join("\n");
 	assert.match(emptyLines[0] ?? "", /─ btw · side thread/);
 	assert.doesNotMatch(emptyView, /turns|Q1|You:|Assistant:|%|history/);
-	assert.match(emptyView, /btw.*Enter.*Ctrl\+C/);
+	assert.match(emptyView, /btw • Enter send • Ctrl\+C exit/);
 	assert.equal(emptyView.includes(CURSOR_MARKER), true);
 	for (const character of "first question") composer.handleInput(character);
 	composer.handleInput("\r");
 
 	assert.deepEqual(actions, [{ kind: "submit", question: "first question" }]);
+});
+
+test("side-thread header and footer remain visible when the editor grows", () => {
+	initTheme("dark");
+	const tui = { terminal: { rows: 10 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const composer = new BtwTranscriptPager(tui as never, theme as never, [], () => undefined);
+	composer.focused = true;
+	for (const character of "long input ".repeat(30)) composer.handleInput(character);
+	const rendered = composer.render(20);
+
+	assert.match(rendered[0] ?? "", /btw/);
+	assert.match(rendered.join("\n"), /Ctrl\+C/);
+	assert.equal(rendered.join("\n").includes(CURSOR_MARKER), true);
+	assert.ok(rendered.length <= tui.terminal.rows - 3);
+});
+
+test("constrained composer keeps an earlier editor cursor visible", () => {
+	initTheme("dark");
+	const tui = { terminal: { rows: 10 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const composer = new BtwTranscriptPager(tui as never, theme as never, [], () => undefined);
+	composer.focused = true;
+	const text = Array.from({ length: 10 }, (_, index) => `line ${index + 1}`).join("\n");
+	composer.handleInput(`\u001b[200~${text}\u001b[201~`);
+	for (let index = 0; index < 9; index += 1) composer.handleInput("\u001b[A");
+
+	const rendered = composer.render(20).join("\n");
+	assert.equal(rendered.includes(CURSOR_MARKER), true);
+	assert.match(rendered, /Ctrl\+C/);
 });
 
 test("side-thread header stays fixed across narrow renders and history scrolling", () => {
@@ -441,6 +485,35 @@ test("transcript honors an explicit top start on its first render", () => {
 	assert.doesNotMatch(rendered, /line 20/);
 });
 
+test("transcript preserves an intentional scroll position across fit and reflow", () => {
+	initTheme("dark");
+	const tui = { terminal: { rows: 10 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const answer = `EARLIEST ${"middle content ".repeat(20)}LATEST`;
+	const composer = new BtwTranscriptPager(
+		tui as never,
+		theme as never,
+		[{ question: "question", answer, kind: "answered", response: response(answer) }],
+		() => undefined,
+		{ startAtBottom: true },
+	);
+	composer.render(20);
+	for (let index = 0; index < 20; index += 1) composer.handleInput("\u001b[5~");
+	tui.terminal.rows = 100;
+	composer.render(80);
+	tui.terminal.rows = 10;
+	const reflowed = composer.render(20).join("\n");
+
+	assert.doesNotMatch(reflowed, /LATEST/);
+});
+
 test("transcript stays anchored to the latest answer when terminal width changes", () => {
 	initTheme("dark");
 	const tui = { terminal: { rows: 10 }, requestRender() {} };
@@ -463,6 +536,38 @@ test("transcript stays anchored to the latest answer when terminal width changes
 
 	assert.match(composer.render(80).join("\n"), /LATEST/);
 	assert.match(composer.render(20).join("\n"), /LATEST/);
+});
+
+test("answering view preserves an intentional scroll position across fit and reflow", () => {
+	initTheme("dark");
+	const tui = { terminal: { rows: 10 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const answer = `EARLIEST ${"middle content ".repeat(20)}LATEST`;
+	const view = new BtwAnsweringView(
+		tui as never,
+		theme as never,
+		[{ question: "Earlier question", answer, kind: "answered", response: response(answer) }],
+		"CURRENT QUESTION",
+		() => undefined,
+	);
+	try {
+		view.render(20);
+		for (let index = 0; index < 20; index += 1) view.handleInput("\u001b[5~");
+		tui.terminal.rows = 100;
+		view.render(80);
+		tui.terminal.rows = 10;
+		const reflowed = view.render(20).join("\n");
+		assert.doesNotMatch(reflowed, /CURRENT QUESTION/);
+	} finally {
+		view.dispose();
+	}
 });
 
 test("answering view preserves the transcript and offers compact cancellation", () => {

--- a/extensions/pi-btw/test/side-thread.test.ts
+++ b/extensions/pi-btw/test/side-thread.test.ts
@@ -485,6 +485,32 @@ test("transcript honors an explicit top start on its first render", () => {
 	assert.doesNotMatch(rendered, /line 20/);
 });
 
+test("transcript keeps following the bottom when PageUp has no scrollback", () => {
+	initTheme("dark");
+	const tui = { terminal: { rows: 100 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const answer = `EARLIEST ${"middle content ".repeat(20)}LATEST`;
+	const composer = new BtwTranscriptPager(
+		tui as never,
+		theme as never,
+		[{ question: "question", answer, kind: "answered", response: response(answer) }],
+		() => undefined,
+		{ startAtBottom: true },
+	);
+	composer.render(80);
+	composer.handleInput("\u001b[5~");
+	tui.terminal.rows = 10;
+
+	assert.match(composer.render(20).join("\n"), /LATEST/);
+});
+
 test("transcript preserves an intentional scroll position across fit and reflow", () => {
 	initTheme("dark");
 	const tui = { terminal: { rows: 10 }, requestRender() {} };
@@ -536,6 +562,35 @@ test("transcript stays anchored to the latest answer when terminal width changes
 
 	assert.match(composer.render(80).join("\n"), /LATEST/);
 	assert.match(composer.render(20).join("\n"), /LATEST/);
+});
+
+test("answering view keeps following the bottom when PageUp has no scrollback", () => {
+	initTheme("dark");
+	const tui = { terminal: { rows: 100 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const answer = `EARLIEST ${"middle content ".repeat(20)}LATEST`;
+	const view = new BtwAnsweringView(
+		tui as never,
+		theme as never,
+		[{ question: "Earlier question", answer, kind: "answered", response: response(answer) }],
+		"CURRENT QUESTION",
+		() => undefined,
+	);
+	try {
+		view.render(80);
+		view.handleInput("\u001b[5~");
+		tui.terminal.rows = 10;
+		assert.match(view.render(20).join("\n"), /CURRENT QUESTION/);
+	} finally {
+		view.dispose();
+	}
 });
 
 test("answering view preserves an intentional scroll position across fit and reflow", () => {


### PR DESCRIPTION
## Summary

- keep the side-thread header, footer, draft, and active cursor visible when the composer outgrows the viewport
- preserve explicit transcript scroll intent across terminal resize and text reflow
- adapt shortcut labels to the available width without dropping the normal footer unnecessarily
- add regressions for constrained editors, cursor placement, scrolling, and resize behavior

## Testing

- `npm run check` (986 tests passed)
- `just pack-btw`
- focused `pi-btw` side-thread tests (24 passed)