### PR TITLE
feat(codex-usage): add pi-usage migration warning

### DIFF
--- a/extensions/pi-codex-usage/README.md
+++ b/extensions/pi-codex-usage/README.md
@@ -2,11 +2,20 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-usage)](https://www.npmjs.com/package/@narumitw/pi-codex-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
+> [!WARNING]
+> `@narumitw/pi-codex-usage` is deprecated and will be replaced by [`@narumitw/pi-usage`](../pi-usage).
+> Do not load both extensions at the same time. To migrate one Pi installation, run:
+>
+> ```bash
+> pi uninstall npm:@narumitw/pi-codex-usage
+> pi install npm:@narumitw/pi-usage
+> ```
+>
+> See the [`pi-usage` migration guide](../pi-usage#-migrating-from-pi-codex-usage) for behavior changes.
+
 `@narumitw/pi-codex-usage` is a native [Pi coding agent](https://pi.dev) extension that adds `/codex-status`, a command for showing ChatGPT Codex subscription usage from inside Pi.
 
 Use it when you want a quick Codex-style usage summary without leaving Pi or requiring Codex CLI to be installed.
-
-> **Successor:** [`@narumitw/pi-usage`](../pi-usage) adds a current-account-first `/usage` menu for Codex and OpenRouter. This predecessor remains available during the successor's soak period. Do not load both packages together because both register `/codex-status`; see the [migration guide](../pi-usage#-migrating-from-pi-codex-usage).
 
 ## ✨ Features
 

--- a/extensions/pi-codex-usage/src/codex-usage.ts
+++ b/extensions/pi-codex-usage/src/codex-usage.ts
@@ -12,6 +12,13 @@ const COMMAND_NAME = "codex-status";
 const DEFAULT_TIMEOUT_MS = 15_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const STATUS_KEY = "codex-usage";
+export const DEPRECATION_WARNING_MESSAGE = [
+	"@narumitw/pi-codex-usage is deprecated and will be replaced by @narumitw/pi-usage.",
+	"Please migrate by running:",
+	"  pi uninstall npm:@narumitw/pi-codex-usage",
+	"  pi install npm:@narumitw/pi-usage",
+	"Do not load both extensions at the same time.",
+].join("\n");
 
 interface CommandArgumentCompletion {
 	value: string;
@@ -41,6 +48,7 @@ export default function codexUsage(pi: ExtensionAPI) {
 	let statuslineRequestId = 0;
 	let sessionActive = false;
 	let activeStatuslineContext: ExtensionContext | undefined;
+	let deprecationWarningShown = false;
 
 	const clearStatuslineTimers = () => {
 		if (statuslineClearTimer) clearTimeout(statuslineClearTimer);
@@ -211,6 +219,10 @@ export default function codexUsage(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		if (!deprecationWarningShown) {
+			ctx.ui.notify(DEPRECATION_WARNING_MESSAGE, "warning");
+			deprecationWarningShown = true;
+		}
 		sessionActive = true;
 		if (isOpenAICodexModel(ctx.model)) {
 			void refreshCurrentCodexUsageStatusline(ctx, false, ctx.model).catch(

--- a/extensions/pi-codex-usage/test/codex-usage.test.ts
+++ b/extensions/pi-codex-usage/test/codex-usage.test.ts
@@ -4,6 +4,7 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import codexUsage, {
 	type CodexUsageReport,
 	completeCodexStatusArguments,
+	DEPRECATION_WARNING_MESSAGE,
 	formatCodexUsageReport,
 	formatCodexUsageStatusline,
 	isStaleExtensionContextError,
@@ -24,6 +25,28 @@ test("codex-usage registers command and statusline lifecycle hooks", () => {
 		"session_start",
 		"session_tree",
 	]);
+});
+
+test("session_start warns once that pi-codex-usage is deprecated", async () => {
+	const mock = createMockPi();
+	codexUsage(mock.pi);
+	const sessionStart = mock.events.get("session_start")?.[0];
+	assert.ok(sessionStart);
+	const { ctx, notifications } = createMockContext();
+
+	await sessionStart({}, ctx);
+	await sessionStart({}, ctx);
+
+	const deprecationWarnings = notifications.filter(
+		(notification) => notification.message === DEPRECATION_WARNING_MESSAGE,
+	);
+	assert.equal(deprecationWarnings.length, 1);
+	assert.equal(deprecationWarnings[0]?.level, "warning");
+	assert.match(deprecationWarnings[0]?.message ?? "", /@narumitw\/pi-codex-usage/);
+	assert.match(deprecationWarnings[0]?.message ?? "", /@narumitw\/pi-usage/);
+	assert.match(deprecationWarnings[0]?.message ?? "", /pi uninstall npm:@narumitw\/pi-codex-usage/);
+	assert.match(deprecationWarnings[0]?.message ?? "", /pi install npm:@narumitw\/pi-usage/);
+	assert.match(deprecationWarnings[0]?.message ?? "", /Do not load both extensions/);
 });
 
 test("completeCodexStatusArguments suggests accepted options", () => {


### PR DESCRIPTION
## Summary

- warn once per session that `pi-codex-usage` is deprecated
- direct users to `pi-usage` with migration commands and a coexistence warning
- update the README and add regression coverage

## Testing

- `npm run check`
- `npm run pack:codex-usage`
