### PR TITLE
docs: align extension README structure

### DIFF
--- a/extensions/pi-image-drop/README.md
+++ b/extensions/pi-image-drop/README.md
@@ -1,12 +1,22 @@
 # 🖼️ pi-image-drop — Browser Image Staging for Pi
 
-[![npm](https://img.shields.io/npm/v/@narumitw/pi-image-drop)](https://www.npmjs.com/package/@narumitw/pi-image-drop) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-image-drop)](https://www.npmjs.com/package/@narumitw/pi-image-drop) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 `@narumitw/pi-image-drop` adds one `/image-drop` command to the latest [Pi Coding Agent](https://pi.dev). It serves a private loopback page where you can paste, drop, choose, preview, reorder, retry, and remove local images. The ordered batch is attached to your next non-empty interactive Pi message.
 
 The page never contains a prompt or Attach button: Pi remains the only place where messages are written and sent.
 
-## Install
+## ✨ Features
+
+- Stages pasted, dropped, or selected images on a private loopback page.
+- Preserves an ordered batch for the next non-empty interactive Pi message.
+- Previews, reorders, retries, and removes images before submission.
+- Supports PNG, JPEG, WebP, GIF, BMP, TIFF, HEIC/HEIF, and AVIF input.
+- Applies orientation, strips private metadata, and enforces Pi-compatible image limits.
+- Keeps bounded sent-image history for explicit re-attachment during the live session.
+- Reports batch state above Pi's editor and can start automatically with each session.
+
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-image-drop
@@ -22,7 +32,7 @@ just try image-drop
 
 This package targets the latest Pi release and uses its `agent_settled` lifecycle event. Older Pi releases are not supported.
 
-## Workflow
+## 🚀 Workflow
 
 1. Run `/image-drop` in an interactive Pi session. You can instead set `startOnSessionStart: true` to start the service with every Pi session.
 2. Pi prints and displays a clickable one-time `http://127.0.0.1:<port>/...` link. The extension does **not** open a browser, including when session startup is enabled.
@@ -35,7 +45,7 @@ The `🖼️` widget above Pi's editor reports ready, uploading, error, and queu
 
 By default, the loopback service starts lazily when you run `/image-drop`. With `startOnSessionStart: true`, it starts after each Pi session initializes and displays the link in Pi automatically. Each later `/image-drop` invocation reuses the service and rotates the unused one-time link. A browser refresh keeps the current in-memory batch and sent-image history. Opening the authenticated page in another tab gives the new tab the editing lease and makes the old tab stale. Reloading, replacing, forking, or shutting down the Pi session releases both the draft and all retained history.
 
-## Supported images
+## 🖼️ Supported images
 
 | Input | Provider-ready output |
 | --- | --- |
@@ -52,7 +62,7 @@ Detection uses file signatures, not filenames or browser MIME types. SVG, HTML, 
 
 The processor applies orientation and removes EXIF (including GPS), XMP, IPTC, comments, and other sensitive metadata. It retains an ICC color profile and animated GIF timing where the output format supports them. With Pi's `images.autoResize` enabled (the default), output is reduced to fit Pi's 2,000-pixel and approximately 4.5 MiB Base64 inline limits. With it disabled, output that exceeds either limit fails visibly instead of being resized.
 
-## Configuration
+## ⚙️ Configuration
 
 Image Drop has one optional **global-only** JSON file:
 
@@ -93,7 +103,7 @@ Limit values are positive integer counts/bytes/pixels, and `startOnSessionStart`
 
 At upload and submission time, the extension also re-reads Pi's documented global and trusted-project `images.autoResize` and `images.blockImages` settings. `blockImages: true` or a text-only current model blocks processing/submission without discarding the draft.
 
-## Security and privacy
+## 🔐 Security and privacy
 
 - The HTTP listener binds only to a random `127.0.0.1` port.
 - A rotating bootstrap token is exchanged once for an HttpOnly, `SameSite=Strict` session cookie, then removed from the URL.
@@ -105,7 +115,7 @@ At upload and submission time, the extension also re-reads Pi's documented globa
 
 A loopback page is local to your operating-system network namespace. Do not expose the port to a LAN or public interface.
 
-## Platforms, browsers, and remote environments
+## 🖥️ Platforms, browsers, and remote environments
 
 The supported local targets are current macOS, Windows, desktop Linux, and WSL with current stable Chrome, Edge, Firefox, or Safari where those browsers are available. Native `sharp` packages are installed for the current platform; HEVC-backed HEIC and BMP use bounded portable decoders because the patent-safe prebuilt `sharp`/libvips bundle omits them.
 
@@ -117,7 +127,7 @@ ssh -L 45678:127.0.0.1:45678 user@remote-host
 
 Then open the unchanged `http://127.0.0.1:45678/...` link locally. Image Drop does not provide a cloud relay or remote upload endpoint.
 
-## Limitations
+## 🚧 Limitations
 
 - Only `/image-drop` is registered; there is no `/image-drop clear` command.
 - A non-empty interactive Pi message is required. RPC, extension-generated, slash-command, and image-only inputs do not consume the batch.
@@ -126,7 +136,7 @@ Then open the unchanged `http://127.0.0.1:45678/...` link locally. Image Drop do
 - Sent history exists only for the current live Pi session. It is not reconstructed from the transcript, persisted across sessions, or shared with another Pi process.
 - FIFO retention can remove the oldest sent images automatically at the configured count or memory limit; the browser displays the current usage and limit.
 
-## Package layout
+## 🗂️ Package layout
 
 ```text
 src/image-drop.ts       Pi extension entrypoint
@@ -139,7 +149,7 @@ src/pi-settings.ts      effective Pi image settings adapter
 src/web/                framework-free browser page
 ```
 
-## Development
+## 🧪 Development
 
 From the repository root:
 
@@ -152,7 +162,7 @@ just pack image-drop
 
 The dry-run package must contain the manifest, license, README, TypeScript sources, and static web assets, but no tests, fixtures, image bytes, or `node_modules`.
 
-## Publishing
+## 🚀 Publishing
 
 The first publication is intentionally a maintainer action:
 
@@ -161,3 +171,11 @@ npm publish --workspace @narumitw/pi-image-drop --access public
 ```
 
 `just npm-public` only changes visibility after a scoped package already exists. Do not publish from an implementation or verification run.
+
+## 🔎 Keywords
+
+Pi extension, Pi Coding Agent, browser image staging, image prompt, local image upload, metadata removal, local-first AI coding agent.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -234,6 +234,10 @@ extensions/pi-lsp/
 └── package.json
 ```
 
+## 🔎 Keywords
+
+Pi extension, Pi Coding Agent, Language Server Protocol, LSP diagnostics, code actions, source fixes, configurable language servers, TypeScript Pi package.
+
 ## 📄 License
 
 MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -4,7 +4,7 @@
 
 `@narumitw/pi-statusline` is a native [Pi coding agent](https://pi.dev) extension that replaces Pi's footer with a configurable Tokyo Night powerline statusline.
 
-## Features
+## ✨ Features
 
 - Shows provider, model, thinking, directory, Git/PR state, tools, context, tokens, cost, time, and extension statuses.
 - Uses one Starship-inspired `░▒▓` / `` Tokyo Night layout.
@@ -14,7 +14,7 @@
 - Caches Git state outside footer rendering and guards stale session results.
 - Wraps extension statuses safely at narrow terminal widths.
 
-## Install
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-statusline
@@ -29,7 +29,7 @@ pi -e ./extensions/pi-statusline
 
 Do not enable this together with `@narumitw/pi-starship`: both extensions own Pi's footer. Use `pi-starship` instead when you need full Starship-style format/style grammar.
 
-## Configuration
+## ⚙️ Configuration
 
 The only configuration source is:
 
@@ -160,7 +160,7 @@ This structured model intentionally does not provide variables or a format langu
 
 Statuses from other extensions appear below the main powerline. The linked GitHub PR status is hidden from that line when the branch segment already renders it.
 
-## Commands
+## 💬 Commands
 
 | Command | Purpose |
 | --- | --- |
@@ -170,13 +170,13 @@ Statuses from other extensions appear below the main powerline. The linked GitHu
 
 Invalid or cancelled edits leave both the previous file and effective runtime configuration unchanged. The editor is TUI-only; status and help are safe in TUI, print, JSON, and RPC modes.
 
-## Git and activity details
+## 🌿 Git and activity details
 
 Git status tokens are hidden for clean repositories. When present, they mean `⇡` ahead, `⇣` behind, `+` staged, `~` modified/deleted, `?` untracked, and `!` conflicts.
 
 The tools segment distinguishes active tools, streaming/thinking, the last completed tool, and idle state. Parallel calls are summarized without running subprocesses during footer rendering.
 
-## Package layout
+## 🗂️ Package layout
 
 ```text
 extensions/pi-statusline/
@@ -199,10 +199,10 @@ extensions/pi-statusline/
 
 Only `src/statusline.ts` is a Pi entrypoint. Other modules are package-internal.
 
-## Keywords
+## 🔎 Keywords
 
 Pi extension, Pi coding agent, configurable statusline, Tokyo Night, terminal footer, token usage, context window, model status, TypeScript Pi package.
 
-## License
+## 📄 License
 
 MIT. See [`LICENSE`](./LICENSE).

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -1,12 +1,12 @@
 # 🌐 pi-webui — Current-session Web Companion for Pi
 
-[![npm](https://img.shields.io/npm/v/@narumitw/pi-webui)](https://www.npmjs.com/package/@narumitw/pi-webui) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-webui)](https://www.npmjs.com/package/@narumitw/pi-webui) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 `@narumitw/pi-webui` adds a private, lightweight browser companion to the current terminal-owned [Pi Coding Agent](https://pi.dev) session. It displays Pi's semantic conversation and tool activity as they happen and can send text or sanitized images back into that same session.
 
 This package is intentionally different from the broader, separately maintained `@narumitw/pi-web` application. WebUI has one current-session chat page and no session manager, shell, file browser, git UI, control room, or task board.
 
-## Features
+## ✨ Features
 
 - Streams current-branch user and assistant messages, assistant text updates, tool activity/results, errors, and busy/idle state over Server-Sent Events.
 - Renders a safe Markdown subset for headings, lists, emphasis, code, blockquotes, and HTTP(S) links without executing model-provided HTML.
@@ -18,7 +18,7 @@ This package is intentionally different from the broader, separately maintained 
 - Keeps a failed browser draft and prevents rapid duplicate submission with request IDs.
 - Uses no frontend framework, build step, browser storage, remote service, or automatically launched browser.
 
-## Install
+## 📦 Install
 
 ```bash
 pi install npm:@narumitw/pi-webui
@@ -34,7 +34,7 @@ just try webui
 
 The package targets the latest Pi release.
 
-## Usage
+## 🚀 Usage
 
 1. Start Pi in a terminal and run `/webui`.
 2. Open the one-time `http://127.0.0.1:<port>/bootstrap?...` link shown by Pi. The extension does not open a browser itself.
@@ -44,7 +44,7 @@ The package targets the latest Pi release.
 
 If another installed extension also registers `/webui`, Pi assigns numeric command suffixes according to extension load order. Check Pi's command provenance and invoke the WebUI entry.
 
-## Commands
+## 💬 Commands
 
 | Command | Behavior |
 | --- | --- |
@@ -56,7 +56,7 @@ If another installed extension also registers `/webui`, Pi assigns numeric comma
 
 Argument completion is available for all subcommands. Bare `/webui` remains the direct browser-link action.
 
-## Settings
+## ⚙️ Settings
 
 WebUI has one optional, **global-only** JSON settings file:
 
@@ -100,13 +100,13 @@ Settings are reloaded on every `session_start`. Changes made in `/webui settings
 
 In print, JSON, and RPC modes, `/webui settings` does not open custom TUI or write protocol-breaking output. Use `/webui status`, `/webui help`, or edit the reported path manually.
 
-## What synchronization means
+## 🔄 What synchronization means
 
 WebUI mirrors Pi's semantic session events, not terminal pixels. It displays conversation content, streaming assistant state, tool calls/results, errors, and activity using browser-native presentation. It does not reproduce ANSI colors, terminal wrapping, footer/widgets, built-in dialogs, arbitrary custom TUI components, or unsent terminal editor text.
 
 The initial transcript comes from the active session branch. Unsent browser message text and ordered attachment references are authoritative in the live Pi process, so refresh, reconnect, and active-tab takeover restore the same draft without creating a second transcript or altering Pi's session tree. Text edits are revisioned and saved with bounded, deduplicated mutations; stale or delayed responses cannot overwrite newer typing.
 
-## Images
+## 🖼️ Images
 
 | Input | Provider-ready output |
 | --- | --- |
@@ -129,7 +129,7 @@ Pi's effective global and trusted-project `images.autoResize` and `images.blockI
 
 When `retainSentImages` is enabled, only provider-ready sanitized bytes transfer into a separate session-memory store after Pi accepts the matching browser message. Content-identical sanitized images share one opaque session reference. Oldest entries are evicted first when either retention ceiling is exceeded. WebUI also reconciles retained, current-draft, and conservative in-flight processing bytes against one aggregate resident-image budget (the larger of the configured retention byte ceiling and the staging store's maximum working set), evicting sent entries before that aggregate can grow. Eligible transcript image chips offer **Attach again** and **Forget**; evicted or forgotten references read **Expired**, and terminal-origin images never gain those actions. Attach again clones the retained bytes into the current authoritative draft, reuses normal count/byte admission, and never mutates the earlier message. Refresh and active-tab takeover recover eligibility from Pi-process state; session replacement, reload, shutdown, or process exit releases all retained bytes.
 
-## Security and privacy
+## 🔐 Security and privacy
 
 - The server binds only to a random `127.0.0.1` port and is owned by one live Pi session.
 - A rotating bootstrap token is exchanged once for a per-server HttpOnly, `SameSite=Strict` cookie and removed from the URL.
@@ -141,11 +141,11 @@ When `retainSentImages` is enabled, only provider-ready sanitized bytes transfer
 
 A loopback page is local to the operating-system network namespace. WebUI does not support LAN/public binding or a cloud relay. For SSH, containers, or devcontainers, forward the exact printed port and preserve the `127.0.0.1:<port>` Host value.
 
-## Accessibility and browsers
+## ♿ Accessibility and browsers
 
 The page uses semantic headings, native disclosure/dialog controls, concise status/alert live regions, accessible labels, visible keyboard focus, at least 44 px controls, keyboard image preview/removal/reordering, `Ctrl/Command+Enter` submission, reduced-motion handling, dark mode, and responsive reflow. It targets current stable desktop Chrome, Edge, Firefox, and Safari.
 
-## Limitations
+## 🚧 Limitations
 
 - One active Pi session and one active browser editing tab only.
 - No persistent browser transcript, permanent sent-image gallery, cross-session image history, remote access, PTY/terminal control, model/settings controls, or session switching.
@@ -153,7 +153,7 @@ The page uses semantic headings, native disclosure/dialog controls, concise stat
 - Browser acknowledgment means Pi accepted or queued the message. Provider failures follow Pi's normal session/retry behavior.
 - Built-in TUI commands and dialogs are not reimplemented in the browser.
 
-## Package layout
+## 🗂️ Package layout
 
 ```text
 src/webui.ts         Pi extension entrypoint
@@ -170,7 +170,7 @@ src/pi-settings.ts   effective Pi image settings reader
 src/web/             framework-free browser page
 ```
 
-## Development
+## 🧪 Development
 
 From the repository root:
 
@@ -183,10 +183,10 @@ just pack webui
 
 The package preview must contain its manifest, license, README, TypeScript source, and static web assets, but no tests, fixtures, cache, or `node_modules`.
 
-## Keywords
+## 🔎 Keywords
 
 Pi extension, Pi Coding Agent, browser companion, local web chat, terminal session sync, Server-Sent Events, image prompt, tool activity, local-first AI coding agent.
 
-## License
+## 📄 License
 
 MIT


### PR DESCRIPTION
## Summary

- add the shared Features, Keywords, and License sections missing from `pi-image-drop`
- add the missing Keywords section to `pi-lsp`
- add Pi extension badges to `pi-image-drop` and `pi-webui`
- align `pi-image-drop`, `pi-statusline`, and `pi-webui` H2 headings with the repository emoji style

## Verification

- `git diff --check`
- README alignment checks
- `npm run check` (1075 tests passed)