### PR TITLE
chore: remove publish OTP option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,6 @@ Run commands from the repository root unless noted otherwise.
 
 ## Publishing and release safety
 
-- Publish recipes accept an optional OTP, e.g. `just publish-goal 123456`; never commit OTPs, tokens, or npm credentials.
 - Experimental packages may be published only by an explicit maintainer using `just publish <name>`; never add them to `publish-all` or GitHub publish workflows.
 - If npm shows a scoped package dist-tag but `npm view <package>` returns 404, use `just npm-public <package> <otp>` to set public visibility before bumping or republishing.
 - Use `just bump <package> patch|minor|major` for a no-tag workspace bump. The GitHub `bump-version` workflow bumps all package versions together and tags `v*.*.*`.

--- a/justfile
+++ b/justfile
@@ -65,9 +65,9 @@ install name: (_validate-extension-name name)
     name={{quote(name)}}; package="$(node -p "require('./extensions/pi-' + process.argv[1] + '/package.json').name" "$name")"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else echo "$package is not published; installing local workspace package instead."; pi install "./extensions/pi-$name"; fi
 
 # Manually publish one production or experimental package, skipping an existing version
-# Usage: just publish subagents [otp]
-publish name otp="": (_validate-extension-name name)
-    name={{quote(name)}}; otp={{quote(otp)}}; package_json="./extensions/pi-$name/package.json"; if [[ ! -f "$package_json" ]]; then package_json="./extensions/experimental/pi-$name/package.json"; fi; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; if [[ "$package_json" == ./extensions/experimental/* ]]; then echo "WARNING: manually publishing experimental Pi extension pi-$name; automated workflows exclude it." >&2; fi; package="$(node -p "require(process.argv[1]).name" "$package_json")"; version="$(node -p "require(process.argv[1]).version" "$package_json")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else otp_flag=(); [[ -z "$otp" ]] || otp_flag=(--otp "$otp"); npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public "${otp_flag[@]}"; fi
+# Usage: just publish subagents
+publish name: (_validate-extension-name name)
+    name={{quote(name)}}; package_json="./extensions/pi-$name/package.json"; if [[ ! -f "$package_json" ]]; then package_json="./extensions/experimental/pi-$name/package.json"; fi; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; if [[ "$package_json" == ./extensions/experimental/* ]]; then echo "WARNING: manually publishing experimental Pi extension pi-$name; automated workflows exclude it." >&2; fi; package="$(node -p "require(process.argv[1]).name" "$package_json")"; version="$(node -p "require(process.argv[1]).version" "$package_json")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public; fi
 
 # Publish all production extension packages to npm; experimental packages are excluded
 publish-all:

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -84,8 +84,8 @@ test("experimental publishing is manual-only", () => {
 	assert.match(selector, /new Set\(\["experimental"\]\)/);
 	assert.match(justfile, /package_json="\.\/extensions\/experimental\/pi-\$name\/package\.json"/);
 	assert.match(justfile, /WARNING: manually publishing experimental Pi extension/);
-	assert.match(justfile, /publish name otp=""/);
-	assert.match(justfile, /otp_flag=\(\).*--otp "\$otp"/);
+	assert.match(justfile, /^publish name:/m);
+	assert.doesNotMatch(justfile, /\botp\b|--otp/);
 });
 
 function writeJson(filePath: string, value: unknown) {


### PR DESCRIPTION
## Summary
- remove the optional OTP argument from the `publish` recipe
- stop forwarding `--otp` to `npm publish`
- update the usage example, repository-script assertions, and publishing guidance

## Verification
- `npm run check`
- `just --list`
- `just --dry-run publish subagents`
- confirmed an extra OTP argument is rejected