### PR TITLE
feat(langfuse): add interactive command manager

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-langfuse-command-ux-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-langfuse-command-ux-plan.md
@@ -1,0 +1,39 @@
+# Pi Langfuse command UX plan
+
+## Goal
+
+Replace the argument-heavy `/langfuse` workflow with one interactive manager that shows the current session's tracing state and offers context-aware next actions. Agent-directory configuration changes and per-process restart requirements must be labeled clearly, while current-session actions such as flushing stay prioritized.
+
+## Context
+
+`/langfuse` currently defaults to a status notification and expects users to remember `status`, `flush`, `help`, and `init` arguments. `MEMORY.md` prefers manager commands to use one interactive slash command, show current state plus next actions, prioritize the current session, make cross-context changes explicit, and avoid hidden argument fallbacks unless non-interactive support is a real product requirement.
+
+## Non-Goals
+
+- Do not change trace capture, export, credential storage, or runtime initialization semantics.
+- Do not add project-scoped configuration or environment-variable credential fallbacks.
+- Do not apply changed credentials to a running process; the isolated Langfuse runtime still requires each Pi process to restart.
+- Do not add a custom TUI component for this small action menu.
+
+## Plan
+
+- [x] Add command tests for enabled and disabled summaries, context-aware action ordering, ignored legacy arguments, non-interactive guidance, action routing, pending restart state, session replacement, and UI error secret redaction; verified by 33 focused pi-langfuse tests.
+- [x] Implement `/langfuse` as the only interactive entrypoint using `ctx.ui.select`, with the current session state in the menu title and no argument autocomplete or hidden subcommand dispatch; verified by command registration and menu tests.
+- [x] Label flush as a current-session action and configuration as an agent-directory change that requires each Pi process to restart; redact configured keys from all surfaced runtime/write errors; verified by menu, update, initialization, flush, and write-failure tests.
+- [x] Route configuration through the existing private atomic config writer and preserve the existing prompt/cancellation behavior; verified by the private-file create/update test.
+- [x] Update the README to document the single-command menu, dynamic actions, agent-directory configuration scope, per-process restart behavior, non-interactive manual setup, and all supported install paths; verified by source inspection and package dry-run contents.
+- [x] Run focused formatting, package typecheck, root tests/checks, package dry-run inspection, and `git diff --check`; verified by `npm --workspace @narumitw/pi-langfuse run check`, 33 focused tests, `npm run check` with 1,021 passing tests, `npm run pack:langfuse`, explicit ignored-source Biome checks, and `git diff --check`.
+
+## Risks
+
+- Removing documented subcommands is a command-surface change; tests and README must make argument ignoring explicit.
+- Selector labels are plain strings, so scope and restart semantics must be concise but visible before the user chooses an action.
+- A config may be saved while the old runtime remains active; the menu and success notification must not imply immediate application.
+
+## Completion Checklist
+
+- [x] Bare `/langfuse` shows current-session tracing state and relevant next actions in one selector.
+- [x] Enabled sessions prioritize flushing; disabled sessions prioritize setup.
+- [x] Configuration actions clearly state their Pi agent-directory scope and per-process restart requirement.
+- [x] Legacy arguments do not silently execute actions, and non-interactive invocation gives manual guidance without exposing credentials.
+- [x] Tests, typechecks, formatting, package contents, and repository checks pass.

--- a/extensions/pi-langfuse/README.md
+++ b/extensions/pi-langfuse/README.md
@@ -25,7 +25,13 @@
 pi install npm:@narumitw/pi-langfuse
 ```
 
-Try the local workspace package:
+Try the published package without installing it:
+
+```bash
+pi -e npm:@narumitw/pi-langfuse
+```
+
+Try a local checkout:
 
 ```bash
 pi -e ./extensions/pi-langfuse
@@ -35,13 +41,15 @@ The Langfuse v4 SDK requires Node.js 20 or newer.
 
 ## ⚙️ Configuration
 
-Create or update the private config interactively from Pi:
+Run the interactive manager, then choose **Set up Langfuse for this Pi agent directory** or **Update Langfuse for this Pi agent directory**:
 
 ```text
-/langfuse init
+/langfuse
 ```
 
-The command prompts for the secret key, public key, and base URL in the same order Langfuse presents them. Leave either key blank to preserve its existing value when updating a valid config. Leave the base URL blank to use `https://us.cloud.langfuse.com`. The file is saved atomically with mode `0600`; restart Pi after saving. In print or JSON mode, edit the file manually because interactive input is unavailable.
+The setup flow prompts for the secret key, public key, and base URL in the same order Langfuse presents them. Leave either key blank to preserve its existing value when updating a valid config. Leave the base URL blank to use `https://us.cloud.langfuse.com`. The file is saved atomically with mode `0600`.
+
+Configuration belongs to the displayed Pi agent directory, not just the current conversation. Restart each running Pi process after saving; the new connection applies to subsequent sessions in that process. `/reload` is not sufficient because the isolated Langfuse runtime is initialized once per process. In print or JSON mode, edit the file manually because the interactive manager is unavailable.
 
 You can also create the file manually:
 
@@ -66,7 +74,7 @@ The extension automatically restricts an existing config file to mode `0600` and
 chmod 600 ~/.pi/agent/pi-langfuse.json
 ```
 
-Restart Pi after changing credentials, endpoint, environment, or release. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
+Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
 
 ## 🔭 What is traced
 
@@ -84,23 +92,26 @@ Pi does not expose a post-transform provider payload event, so generation reques
 
 Images and embedded base64 data URIs are represented without their payloads, including provider data URLs. Every captured input or output has one cumulative 64 KiB serialized UTF-8 budget, bounded object/array traversal, and deterministic truncation markers. Langfuse credentials are masked again in the span processor before network export.
 
-Completed observations are exported in batches while Pi remains live. Normal `agent_end` handling never waits for Langfuse network I/O. Use `/langfuse flush` when you need to wait for completed exports; quit shutdown also drains the provider.
+Completed observations are exported in batches while Pi remains live. Normal `agent_end` handling never waits for Langfuse network I/O. When you need to wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
 
 Automatic retries or continuations that begin without a new user prompt are recorded as a new trace labeled `[automatic continuation]`, so provider activity is not lost on Pi versions without a final `agent_settled` extension event.
 
 ## 💬 Command
 
 ```text
-/langfuse status
-/langfuse flush
-/langfuse help
-/langfuse init
+/langfuse
 ```
 
-- `status` reports whether tracing is enabled, the endpoint, configuration source, and content-capture mode. It never displays credentials.
-- `flush` waits for all completed observations to export.
-- `help` displays command guidance.
-- `init` interactively creates or updates the private config without displaying existing credentials. Blank keys preserve valid existing values; a blank base URL uses the US cloud endpoint.
+The command opens one context-aware menu. Its title shows the current session's tracing state, endpoint, content-capture mode, initialization failure when applicable, and private configuration path. It never displays credentials.
+
+Available actions depend on that state:
+
+- **Flush completed traces for this session** appears first when tracing is active and waits for completed observations to export.
+- **Set up Langfuse for this Pi agent directory** appears when no valid config was loaded.
+- **Update Langfuse for this Pi agent directory** appears when a valid config exists.
+- **Show setup and privacy help** explains the agent-directory scope, manual configuration path, and content-capture risk.
+
+Connection actions state their agent-directory scope and per-process restart requirement before selection. Command arguments are intentionally ignored so remembered subcommands cannot silently bypass the menu. In non-interactive modes, the command reports that the menu is unavailable and points to the manual config path.
 
 ## 🔐 Privacy
 

--- a/extensions/pi-langfuse/src/langfuse.ts
+++ b/extensions/pi-langfuse/src/langfuse.ts
@@ -1,7 +1,4 @@
-import type {
-	ExtensionAPI,
-	ExtensionCommandContext,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
 	DEFAULT_BASE_URL,
 	type LangfuseConfig,
@@ -18,12 +15,10 @@ interface ExtensionDependencies {
 	createBackend(config: LangfuseConfig): Promise<TraceBackend>;
 }
 
-const COMMAND_COMPLETIONS = [
-	{ value: "status", label: "status", description: "Show Langfuse tracing status" },
-	{ value: "flush", label: "flush", description: "Export all completed traces now" },
-	{ value: "help", label: "help", description: "Show Langfuse command help" },
-	{ value: "init", label: "init", description: "Interactively create or update config" },
-];
+const FLUSH_ACTION = "Flush completed traces for this session";
+const SET_UP_ACTION = "Set up Langfuse for this Pi agent directory (restart required)";
+const UPDATE_ACTION = "Update Langfuse for this Pi agent directory (restart required)";
+const HELP_ACTION = "Show setup and privacy help";
 
 export function createLangfuseExtension(
 	dependencies: Partial<ExtensionDependencies> = {},
@@ -42,93 +37,87 @@ export function createLangfuseExtension(
 		let activeConfig: LangfuseConfig | undefined;
 		let configPath: string | undefined;
 		let initializationError: string | undefined;
+		let hasStoredConfig = false;
+		let configurationNotice: string | undefined;
+		let sessionGeneration = 0;
 
 		pi.registerCommand("langfuse", {
-			description: "Manage Langfuse tracing and configuration",
-			getArgumentCompletions: (prefix) => {
-				const normalized = prefix.trimStart().toLowerCase();
-				if (/\s/.test(normalized)) return null;
-				const matches = COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(normalized));
-				return matches.length > 0 ? matches : null;
-			},
-			handler: async (args, ctx) => {
-				const action = args.trim().toLowerCase() || "status";
-				if (action === "status") {
-					if (activeConfig) {
-						ctx.ui.notify(
-							[
-								"Langfuse tracing is enabled.",
-								`Endpoint: ${activeConfig.baseUrl}`,
-								`Content capture: ${activeConfig.captureContent ? "enabled" : "disabled"}`,
-								`Configuration: ${configPath ?? "unknown"}`,
-							].join("\n"),
-							"info",
-						);
-						return;
-					}
+			description: "Open interactive Langfuse tracing controls",
+			handler: async (_args, ctx) => {
+				if (!ctx.hasUI) {
 					ctx.ui.notify(
-						initializationError ??
-							"Langfuse tracing is disabled because its credentials are not configured.",
+						formatNonInteractiveStatus(activeConfig, configPath, initializationError),
 						"warning",
 					);
 					return;
 				}
-				if (action === "flush") {
-					if (!recorder) {
-						ctx.ui.notify("Langfuse tracing is not enabled.", "warning");
+
+				const menuGeneration = sessionGeneration;
+				const menuRecorder = recorder;
+				const menuConfig = activeConfig;
+				const choice = await ctx.ui.select(
+					formatMenuTitle(activeConfig, configPath, initializationError, configurationNotice),
+					[
+						...(menuRecorder ? [FLUSH_ACTION] : []),
+						hasStoredConfig ? UPDATE_ACTION : SET_UP_ACTION,
+						HELP_ACTION,
+					],
+				);
+				if (!choice || menuGeneration !== sessionGeneration) return;
+
+				if (choice === FLUSH_ACTION) {
+					if (!menuRecorder) {
+						ctx.ui.notify("Langfuse tracing is not enabled for this session.", "warning");
 						return;
 					}
 					try {
-						await recorder.flush();
-						ctx.ui.notify("Langfuse traces flushed.", "info");
+						await menuRecorder.flush();
+						if (menuGeneration !== sessionGeneration) return;
+						ctx.ui.notify("Langfuse traces flushed for this session.", "info");
 					} catch (error) {
-						ctx.ui.notify(`Langfuse flush failed: ${formatError(error)}`, "error");
+						if (menuGeneration !== sessionGeneration) return;
+						ctx.ui.notify(`Langfuse flush failed: ${formatError(error, menuConfig)}`, "error");
 					}
 					return;
 				}
-				if (action === "init") {
-					if (!ctx.hasUI) {
-						ctx.ui.notify(
-							"/langfuse init requires interactive UI. Edit pi-langfuse.json manually.",
-							"warning",
-						);
-						return;
-					}
+
+				if (choice === SET_UP_ACTION || choice === UPDATE_ACTION) {
 					const loaded = await loadConfig(configPath);
+					if (menuGeneration !== sessionGeneration) return;
 					configPath = loaded.path;
 					const next = await promptForConfig(ctx, loaded.ok ? loaded.config : undefined);
-					if (!next) return;
+					if (!next || menuGeneration !== sessionGeneration) return;
 					try {
 						await writeConfig(next, loaded.path);
-						initializationError =
-							"Langfuse config was saved. Restart Pi to apply the new configuration.";
-						ctx.ui.notify(`Saved Langfuse config to ${loaded.path}. Restart Pi to apply it.`, "info");
+						if (menuGeneration !== sessionGeneration) return;
+						hasStoredConfig = true;
+						configurationNotice =
+							"Saved; restart each Pi process to use it in subsequent sessions.";
+						ctx.ui.notify(
+							`Saved Langfuse config to ${loaded.path} for this Pi agent directory. Restart each Pi process to apply it to subsequent sessions.`,
+							"info",
+						);
 					} catch (error) {
-						ctx.ui.notify(`Failed to save Langfuse config: ${formatError(error)}`, "error");
+						if (menuGeneration !== sessionGeneration) return;
+						ctx.ui.notify(`Failed to save Langfuse config: ${formatError(error, next)}`, "error");
 					}
 					return;
 				}
-				if (action === "help") {
-					ctx.ui.notify(
-						[
-							"Usage: /langfuse [status|flush|help|init]",
-							"status: show tracing state without credentials",
-							"flush: wait for completed traces to export",
-							"init: interactively create or update the private config",
-						].join("\n"),
-						"info",
-					);
-					return;
+
+				if (choice === HELP_ACTION) {
+					ctx.ui.notify(formatHelp(configPath), "info");
 				}
-				ctx.ui.notify("Usage: /langfuse [status|flush|help|init]", "warning");
 			},
 		});
 
 		pi.on("session_start", async (_event, ctx) => {
+			sessionGeneration += 1;
 			recorder = undefined;
 			activeConfig = undefined;
 			configPath = undefined;
 			initializationError = undefined;
+			hasStoredConfig = false;
+			configurationNotice = undefined;
 
 			const result = await loadConfig();
 			configPath = result.path;
@@ -139,6 +128,7 @@ export function createLangfuseExtension(
 				return;
 			}
 
+			hasStoredConfig = true;
 			try {
 				const backend = await createBackend(result.config);
 				activeConfig = result.config;
@@ -149,7 +139,7 @@ export function createLangfuseExtension(
 					captureContent: result.config.captureContent,
 				});
 			} catch (error) {
-				initializationError = `Langfuse tracing could not start: ${formatError(error)}`;
+				initializationError = `Langfuse tracing could not start: ${formatError(error, result.config)}`;
 				ctx.ui.notify(initializationError, "warning");
 			}
 		});
@@ -227,7 +217,9 @@ export function createLangfuseExtension(
 		});
 
 		pi.on("session_shutdown", async (event, ctx) => {
+			sessionGeneration += 1;
 			const activeRecorder = recorder;
+			const shutdownConfig = activeConfig;
 			recorder = undefined;
 			activeConfig = undefined;
 			if (!activeRecorder) return;
@@ -238,7 +230,10 @@ export function createLangfuseExtension(
 					await activeRecorder.flush();
 				}
 			} catch (error) {
-				ctx.ui.notify(`Langfuse shutdown export failed: ${formatError(error)}`, "error");
+				ctx.ui.notify(
+					`Langfuse shutdown export failed: ${formatError(error, shutdownConfig)}`,
+					"error",
+				);
 			}
 		});
 	};
@@ -281,15 +276,87 @@ async function promptForConfig(
 	return normalized.config;
 }
 
+function formatMenuTitle(
+	activeConfig: LangfuseConfig | undefined,
+	configPath: string | undefined,
+	initializationError: string | undefined,
+	configurationNotice: string | undefined,
+): string {
+	const lines = [
+		"Langfuse",
+		"",
+		"Current session:",
+		`  Tracing: ${activeConfig ? "enabled" : "disabled"}`,
+	];
+	if (activeConfig) {
+		lines.push(
+			`  Endpoint: ${activeConfig.baseUrl}`,
+			`  Content capture: ${activeConfig.captureContent ? "enabled" : "disabled"}`,
+		);
+	} else if (configurationNotice) {
+		lines.push("  State: tracing remains disabled until Pi restarts.");
+	} else if (initializationError) {
+		lines.push(`  Reason: ${initializationError}`);
+	}
+	lines.push(
+		"",
+		"Agent-directory configuration:",
+		`  Configuration: ${configPath ?? "unknown"}`,
+		"  Scope: this Pi agent directory; restart each Pi process to apply changes.",
+	);
+	if (configurationNotice) lines.push(`  Pending: ${configurationNotice}`);
+	lines.push("", "What do you want to do?");
+	return lines.join("\n");
+}
+
+function formatNonInteractiveStatus(
+	activeConfig: LangfuseConfig | undefined,
+	configPath: string | undefined,
+	initializationError: string | undefined,
+): string {
+	return [
+		"/langfuse requires interactive UI.",
+		`Current session tracing: ${activeConfig ? "enabled" : "disabled"}`,
+		...(activeConfig
+			? [
+					`Endpoint: ${activeConfig.baseUrl}`,
+					`Content capture: ${activeConfig.captureContent ? "enabled" : "disabled"}`,
+				]
+			: initializationError
+				? [`Reason: ${initializationError}`]
+				: []),
+		`Configuration: ${configPath ?? "unknown"}`,
+		"Edit the private config manually, then restart each Pi process to apply it to subsequent sessions.",
+	].join("\n");
+}
+
+function formatHelp(configPath: string | undefined): string {
+	return [
+		"Langfuse setup and privacy:",
+		"Run /langfuse in interactive Pi to manage tracing for the current session.",
+		`Configuration: ${configPath ?? "pi-langfuse.json"}`,
+		"The file belongs to this Pi agent directory; restart each Pi process after changing it.",
+		"Trace content may contain prompts, responses, tool arguments, tool results, and source code.",
+		'Use "captureContent": false in the private config to export metadata only.',
+	].join("\n");
+}
+
 function formatConfigError(result: Extract<LangfuseConfigResult, { ok: false }>): string {
 	const setupHint = result.reason.startsWith("Configuration file not found:")
-		? " Run /langfuse init to create it."
+		? " Run /langfuse and choose Set up Langfuse."
 		: "";
 	return `Langfuse tracing is disabled: ${result.reason}${setupHint}`;
 }
 
-function formatError(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+function formatError(error: unknown, config?: LangfuseConfig): string {
+	let message = error instanceof Error ? error.message : String(error);
+	const secrets = [config?.publicKey, config?.secretKey]
+		.filter((secret): secret is string => Boolean(secret))
+		.sort((left, right) => right.length - left.length);
+	for (const secret of secrets) {
+		message = message.split(secret).join("[LANGFUSE_KEY_REDACTED]");
+	}
+	return message;
 }
 
 export default createLangfuseExtension();

--- a/extensions/pi-langfuse/test/langfuse.test.ts
+++ b/extensions/pi-langfuse/test/langfuse.test.ts
@@ -127,7 +127,7 @@ test("loadLangfuseConfig reports missing and unsafe settings without environment
 	if (!invalid.ok) assert.match(invalid.reason, /publicKey must be literal/i);
 });
 
-test("session start suggests /langfuse init when the config file is missing", async () => {
+test("session start suggests the /langfuse setup action when the config file is missing", async () => {
 	const mock = createMockPi();
 	createLangfuseExtension({
 		loadConfig: async () => ({
@@ -141,7 +141,7 @@ test("session start suggests /langfuse init when the config file is missing", as
 
 	await mock.events.get("session_start")?.[0]?.({}, ctx);
 
-	assert.match(notifications.at(-1)?.message ?? "", /run \/langfuse init/i);
+	assert.match(notifications.at(-1)?.message ?? "", /run \/langfuse and choose set up langfuse/i);
 });
 
 test("TraceRecorder builds one agent trace with child generations and tool spans", async () => {
@@ -849,13 +849,8 @@ test("configuration covers malformed JSON, normalization, and captureContent fal
 	assert.deepEqual(repaired.warnings, [`Restricted ${path} permissions to 0600.`]);
 });
 
-test("commands expose status, flush, help, and init without a config alias", async () => {
+test("/langfuse shows enabled current-session state and context-aware next actions", async () => {
 	const backend = new FakeBackend();
-	let releaseFlush: (() => void) | undefined;
-	backend.forceFlush = () =>
-		new Promise<void>((resolve) => {
-			releaseFlush = resolve;
-		});
 	const mock = createMockPi();
 	createLangfuseExtension({
 		loadConfig: async () => ({
@@ -871,22 +866,62 @@ test("commands expose status, flush, help, and init without a config alias", asy
 		}),
 		createBackend: async () => backend,
 	})(mock.pi);
-	const { ctx, notifications } = createMockContext({ hasUI: false });
+	const selectCalls: Array<{ title: string; options: string[] }> = [];
+	const { ctx } = createMockContext({
+		hasUI: true,
+		select: async (title: string, options: string[]) => {
+			selectCalls.push({ title, options });
+			return undefined;
+		},
+	});
 	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	const command = mock.commands.get("langfuse");
-	const completions = command?.getArgumentCompletions?.("") as Array<{ value: string }>;
-	assert.deepEqual(
-		completions.map(({ value }) => value),
-		["status", "flush", "help", "init"],
-	);
-	await command?.handler("status", ctx);
-	await command?.handler("help", ctx);
-	await command?.handler("config", ctx);
-	assert.deepEqual(notifications.at(-1), {
-		message: "Usage: /langfuse [status|flush|help|init]",
-		level: "warning",
+
+	await command?.handler("legacy arguments are ignored", ctx);
+
+	assert.equal(command?.getArgumentCompletions, undefined);
+	assert.match(selectCalls[0]?.title ?? "", /Current session:\n {2}Tracing: enabled/);
+	assert.match(selectCalls[0]?.title ?? "", /Endpoint: https:\/\/example\.test/);
+	assert.match(selectCalls[0]?.title ?? "", /Content capture: enabled/);
+	assert.match(selectCalls[0]?.title ?? "", /Configuration: \/private\/pi-langfuse\.json/);
+	assert.match(selectCalls[0]?.title ?? "", /this Pi agent directory.*restart each Pi process/i);
+	assert.deepEqual(selectCalls[0]?.options, [
+		"Flush completed traces for this session",
+		"Update Langfuse for this Pi agent directory (restart required)",
+		"Show setup and privacy help",
+	]);
+	assert.doesNotMatch(selectCalls[0]?.title ?? "", /private-value/);
+});
+
+test("/langfuse routes the current-session flush action and waits for export", async () => {
+	const backend = new FakeBackend();
+	let releaseFlush: (() => void) | undefined;
+	backend.forceFlush = () =>
+		new Promise<void>((resolve) => {
+			releaseFlush = resolve;
+		});
+	const mock = createMockPi();
+	createLangfuseExtension({
+		loadConfig: async () => ({
+			ok: true,
+			config: {
+				publicKey: "pk",
+				secretKey: "sk",
+				baseUrl: "https://example.test",
+				captureContent: true,
+			},
+			path: "/private/pi-langfuse.json",
+			warnings: [],
+		}),
+		createBackend: async () => backend,
+	})(mock.pi);
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		select: async () => "Flush completed traces for this session",
 	});
-	const flush = command?.handler("flush", ctx) as Promise<void>;
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+	const flush = mock.commands.get("langfuse")?.handler("flush", ctx) as Promise<void>;
 	await new Promise((resolve) => setImmediate(resolve));
 	assert.equal(
 		notifications.some(({ message }) => /flushed/.test(message)),
@@ -894,12 +929,118 @@ test("commands expose status, flush, help, and init without a config alias", asy
 	);
 	releaseFlush?.();
 	await flush;
-
-	const output = notifications.map(({ message }) => message).join("\n");
-	assert.doesNotMatch(output, /private-value/);
+	assert.match(notifications.at(-1)?.message ?? "", /flushed/i);
 });
 
-test("/langfuse init interactively creates and updates a private config", async (t) => {
+test("/langfuse does not apply a pending menu choice after the session changes", async () => {
+	const firstBackend = new FakeBackend();
+	const secondBackend = new FakeBackend();
+	const backends = [firstBackend, secondBackend];
+	let choose: ((choice: string) => void) | undefined;
+	const mock = createMockPi();
+	createLangfuseExtension({
+		loadConfig: async () => ({
+			ok: true,
+			config: {
+				publicKey: "pk",
+				secretKey: "sk",
+				baseUrl: "https://example.test",
+				captureContent: true,
+			},
+			path: "/private/pi-langfuse.json",
+			warnings: [],
+		}),
+		createBackend: async () => backends.shift() ?? secondBackend,
+	})(mock.pi);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		select: async () =>
+			new Promise<string>((resolve) => {
+				choose = resolve;
+			}),
+	});
+	const sessionStart = mock.events.get("session_start")?.[0];
+	await sessionStart?.({}, ctx);
+	const pending = mock.commands.get("langfuse")?.handler("", ctx) as Promise<void>;
+	await new Promise((resolve) => setImmediate(resolve));
+
+	await sessionStart?.({}, ctx);
+	assert.ok(choose);
+	choose("Flush completed traces for this session");
+	await pending;
+
+	assert.equal(firstBackend.flushes, 0);
+	assert.equal(secondBackend.flushes, 0);
+});
+
+test("/langfuse redacts configured keys from flush failures", async () => {
+	const backend = new FakeBackend();
+	backend.forceFlush = async () => {
+		throw new Error("flush exposed pk-private-ui and sk-private-ui");
+	};
+	const mock = createMockPi();
+	createLangfuseExtension({
+		loadConfig: async () => ({
+			ok: true,
+			config: {
+				publicKey: "pk-private-ui",
+				secretKey: "sk-private-ui",
+				baseUrl: "https://example.test",
+				captureContent: true,
+			},
+			path: "/private/pi-langfuse.json",
+			warnings: [],
+		}),
+		createBackend: async () => backend,
+	})(mock.pi);
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		select: async () => "Flush completed traces for this session",
+	});
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+	await mock.commands.get("langfuse")?.handler("", ctx);
+
+	const message = notifications.at(-1)?.message ?? "";
+	assert.match(message, /flush exposed/);
+	assert.match(message, /LANGFUSE_KEY_REDACTED/);
+	assert.doesNotMatch(message, /pk-private-ui|sk-private-ui/);
+});
+
+test("/langfuse disabled state prioritizes agent-directory setup and routes privacy help", async () => {
+	const mock = createMockPi();
+	createLangfuseExtension({
+		loadConfig: async () => ({
+			ok: false,
+			path: "/config/pi-langfuse.json",
+			warnings: [],
+			reason: "Configuration file not found: /config/pi-langfuse.json",
+		}),
+		createBackend: async () => new FakeBackend(),
+	})(mock.pi);
+	const selectCalls: Array<{ title: string; options: string[] }> = [];
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		select: async (title: string, options: string[]) => {
+			selectCalls.push({ title, options });
+			return "Show setup and privacy help";
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+	await mock.commands.get("langfuse")?.handler("status", ctx);
+
+	assert.match(selectCalls[0]?.title ?? "", /Current session:\n {2}Tracing: disabled/);
+	assert.match(selectCalls[0]?.title ?? "", /Configuration file not found/);
+	assert.deepEqual(selectCalls[0]?.options, [
+		"Set up Langfuse for this Pi agent directory (restart required)",
+		"Show setup and privacy help",
+	]);
+	assert.match(notifications.at(-1)?.message ?? "", /trace content may contain/i);
+	assert.match(notifications.at(-1)?.message ?? "", /\/config\/pi-langfuse\.json/);
+});
+
+test("/langfuse interactively creates and updates a private agent-directory config", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-langfuse-init-"));
 	t.after(() => rm(dir, { recursive: true, force: true }));
 	const path = join(dir, "nested", "pi-langfuse.json");
@@ -913,10 +1054,19 @@ test("/langfuse init interactively creates and updates a private config", async 
 	const command = mock.commands.get("langfuse");
 	const notifications: Array<{ message: string; level?: string }> = [];
 	const prompts: Array<{ title: string; placeholder?: string }> = [];
+	const menuTitles: string[] = [];
 	const answers = ["sk-new", "pk-new", ""];
+	const selections = [
+		"Set up Langfuse for this Pi agent directory (restart required)",
+		"Update Langfuse for this Pi agent directory (restart required)",
+	];
 	const ctx = {
 		hasUI: true,
 		ui: {
+			select: async (title: string) => {
+				menuTitles.push(title);
+				return selections.shift();
+			},
 			input: async (title: string, placeholder?: string) => {
 				prompts.push({ title, placeholder });
 				return answers.shift();
@@ -945,11 +1095,20 @@ test("/langfuse init interactively creates and updates a private config", async 
 		captureContent: true,
 	});
 	assert.equal((await stat(path)).mode & 0o777, 0o600);
-	assert.match(notifications.at(-1)?.message ?? "", /saved.*restart pi/i);
+	assert.match(
+		notifications.at(-1)?.message ?? "",
+		/this Pi agent directory.*restart each Pi process/i,
+	);
 	assert.equal(notifications.at(-1)?.level, "info");
 
 	answers.push("", "", "https://self-hosted.example/");
-	await command?.handler("init", ctx);
+	await command?.handler("anything", ctx);
+	assert.match(menuTitles[1] ?? "", /State: tracing remains disabled until Pi restarts/i);
+	assert.match(
+		menuTitles[1] ?? "",
+		/Pending: Saved; restart each Pi process to use it in subsequent sessions/i,
+	);
+	assert.doesNotMatch(menuTitles[1] ?? "", /Reason:|Configuration file not found/);
 	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
 		publicKey: "pk-new",
 		secretKey: "sk-new",
@@ -958,7 +1117,98 @@ test("/langfuse init interactively creates and updates a private config", async 
 	});
 });
 
-test("/langfuse init requires interactive UI", async () => {
+test("/langfuse keeps an active session on its original connection after an update", async () => {
+	const backend = new FakeBackend();
+	const originalConfig = {
+		publicKey: "pk-original",
+		secretKey: "sk-original",
+		baseUrl: "https://original.example",
+		captureContent: true,
+	};
+	let backendCreations = 0;
+	let savedConfig: unknown;
+	const menuCalls: Array<{ title: string; options: string[] }> = [];
+	const selections = ["Update Langfuse for this Pi agent directory (restart required)", undefined];
+	const answers = ["sk-updated", "pk-updated", "https://updated.example"];
+	const mock = createMockPi();
+	createLangfuseExtension({
+		loadConfig: async () => ({
+			ok: true,
+			config: originalConfig,
+			path: "/private/pi-langfuse.json",
+			warnings: [],
+		}),
+		writeConfig: async (config) => {
+			savedConfig = config;
+			return config;
+		},
+		createBackend: async () => {
+			backendCreations += 1;
+			return backend;
+		},
+	})(mock.pi);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		select: async (title: string, options: string[]) => {
+			menuCalls.push({ title, options });
+			return selections.shift();
+		},
+		input: async () => answers.shift(),
+	});
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	const command = mock.commands.get("langfuse");
+
+	await command?.handler("", ctx);
+	await command?.handler("", ctx);
+
+	assert.deepEqual(savedConfig, {
+		publicKey: "pk-updated",
+		secretKey: "sk-updated",
+		baseUrl: "https://updated.example",
+		captureContent: true,
+	});
+	assert.equal(backendCreations, 1);
+	assert.match(menuCalls[1]?.title ?? "", /Endpoint: https:\/\/original\.example/);
+	assert.match(menuCalls[1]?.title ?? "", /Content capture: enabled/);
+	assert.match(menuCalls[1]?.title ?? "", /Pending: Saved; restart each Pi process/i);
+	assert.deepEqual(menuCalls[1]?.options, [
+		"Flush completed traces for this session",
+		"Update Langfuse for this Pi agent directory (restart required)",
+		"Show setup and privacy help",
+	]);
+});
+
+test("/langfuse redacts entered keys from configuration save failures", async () => {
+	const mock = createMockPi();
+	createLangfuseExtension({
+		loadConfig: async () => ({
+			ok: false,
+			path: "/private/pi-langfuse.json",
+			warnings: [],
+			reason: "missing",
+		}),
+		writeConfig: async (config) => {
+			throw new Error(`write exposed ${config.publicKey} and ${config.secretKey}`);
+		},
+		createBackend: async () => new FakeBackend(),
+	})(mock.pi);
+	const answers = ["sk-private-ui", "pk-private-ui", "https://example.test"];
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		select: async () => "Set up Langfuse for this Pi agent directory (restart required)",
+		input: async () => answers.shift(),
+	});
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+	await mock.commands.get("langfuse")?.handler("", ctx);
+
+	const message = notifications.at(-1)?.message ?? "";
+	assert.match(message, /write exposed/);
+	assert.match(message, /LANGFUSE_KEY_REDACTED/);
+	assert.doesNotMatch(message, /pk-private-ui|sk-private-ui/);
+});
+
+test("/langfuse ignores arguments but requires interactive UI", async () => {
 	const mock = createMockPi();
 	createLangfuseExtension({
 		loadConfig: async () => ({
@@ -971,8 +1221,10 @@ test("/langfuse init requires interactive UI", async () => {
 	})(mock.pi);
 	const { ctx, notifications } = createMockContext({ hasUI: false });
 	await mock.events.get("session_start")?.[0]?.({}, ctx);
-	await mock.commands.get("langfuse")?.handler("init", ctx);
-	assert.match(notifications.at(-1)?.message ?? "", /requires interactive ui/i);
+	await mock.commands.get("langfuse")?.handler("flush", ctx);
+	assert.match(notifications.at(-1)?.message ?? "", /requires interactive UI/i);
+	assert.match(notifications.at(-1)?.message ?? "", /Current session tracing: disabled/i);
+	assert.match(notifications.at(-1)?.message ?? "", /\/config\/pi-langfuse\.json/);
 	assert.equal(notifications.at(-1)?.level, "warning");
 });
 
@@ -1035,8 +1287,8 @@ test("session shutdown is idempotent and reports initialization failures", async
 		loadConfig: async () => ({
 			ok: true,
 			config: {
-				publicKey: "pk",
-				secretKey: "sk",
+				publicKey: "pk-private-ui",
+				secretKey: "sk-private-ui",
 				baseUrl: "https://example.test",
 				captureContent: true,
 			},
@@ -1044,12 +1296,15 @@ test("session shutdown is idempotent and reports initialization failures", async
 			warnings: [],
 		}),
 		createBackend: async () => {
-			throw new Error("backend unavailable");
+			throw new Error("backend unavailable for pk-private-ui and sk-private-ui");
 		},
 	})(failedMock.pi);
 	const failed = createMockContext();
 	await failedMock.events.get("session_start")?.[0]?.({}, failed.ctx);
-	assert.match(failed.notifications.at(-1)?.message ?? "", /backend unavailable/);
+	const failureMessage = failed.notifications.at(-1)?.message ?? "";
+	assert.match(failureMessage, /backend unavailable/);
+	assert.match(failureMessage, /LANGFUSE_KEY_REDACTED/);
+	assert.doesNotMatch(failureMessage, /pk-private-ui|sk-private-ui/);
 });
 
 test("isolated runtime preserves the global provider and exports native observation hierarchy", async () => {


### PR DESCRIPTION
## Summary

- replace argument-driven `/langfuse` subcommands with one state-aware interactive menu
- distinguish current-session actions from agent-directory configuration and restart requirements
- guard stale menu actions across session changes and redact Langfuse keys from surfaced errors
- update documentation and regression coverage

## Testing

- `npm --workspace @narumitw/pi-langfuse run check`
- 33 focused pi-langfuse tests
- `npm run check` (1,021 tests passed)
- `npm run pack:langfuse`
- `git diff --check`
