### PR TITLE
feat(langfuse): group complete conversations in spans

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-langfuse-conversation-span-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-langfuse-conversation-span-plan.md
@@ -1,0 +1,46 @@
+# Pi Langfuse conversation span plan
+
+## Goal
+
+Group every complete Pi prompt-processing cycle in one Langfuse `pi.conversation` span. The span must start with the submitted prompt, remain open across all LLM/tool turns and automatic continuations, and end only when Pi reports `agent_settled`.
+
+## Context
+
+`pi-langfuse` currently creates a trace-level `pi.agent` observation and closes it at `agent_end`. Pi can emit another low-level agent run for automatic retry, overflow compaction recovery, or a queued continuation before the interaction is actually settled. Those runs therefore appear as separate trace groups, while Langfuse's observation list makes the turn, generation, and tool rows look scattered.
+
+## Architecture
+
+- `pi.conversation`: root Langfuse `span` and trace owner for one submitted prompt through the settled idle boundary.
+- `pi.agent`: native `agent` child retained for semantic compatibility and as the parent of Pi turns.
+- `pi.turn`: one child `span` for each LLM/tool loop turn.
+- `pi.llm` and `pi.tool.*`: existing generation/tool children under the active turn.
+- `agent_end`: reconcile the latest finalized assistant output only.
+- `agent_settled`: close the conversation and all remaining observations without forcing network export.
+
+## Non-Goals
+
+- Do not change Langfuse credentials, configuration scope, content-capture policy, batching, or trace naming.
+- Do not combine separate user prompts submitted after Pi has settled.
+- Do not remove native agent, generation, or tool observation types.
+
+## Plan
+
+- [x] Add recorder and lifecycle regression coverage for the conversation span hierarchy and settled boundary; verified by 33 focused pi-langfuse tests.
+- [x] Add `pi.conversation` as the root span while retaining `pi.agent` beneath it; verified by fake-backend and in-memory OpenTelemetry parentage assertions.
+- [x] Move routine trace settlement from `agent_end` to `agent_settled`, preserving finalized output reconciliation and automatic-continuation fallback; verified by the two-run lifecycle and nonblocking-settlement tests.
+- [x] Update runtime hierarchy assertions and the README's trace model/lifecycle documentation; verified by source inspection and package dry-run contents.
+- [x] Run focused formatting/typechecks/tests, the repository CI-equivalent check, package dry run, and diff hygiene checks; verified by `npm run check` with 1,021 passing tests, `npm run pack:langfuse`, and `git diff --check`.
+
+## Risks
+
+- Closing on `agent_settled` keeps spans open longer than `agent_end`, but that is required to include retries, compaction recovery, and queued continuations in one interaction.
+- The extra root observation duplicates some input/output metadata with `pi.agent`; retaining both preserves existing agent semantics while making the requested conversation boundary explicit.
+- Interrupted sessions must still close the root span during session shutdown or when an unexpected new prompt starts.
+
+## Completion Checklist
+
+- [x] Every new user prompt creates exactly one root `pi.conversation` span.
+- [x] `pi.agent`, all `pi.turn` spans, generations, and tools are descendants of that conversation span.
+- [x] `agent_end` leaves the conversation open, and `agent_settled` closes it with the final output.
+- [x] Automatic continuations before settlement remain in the same conversation span.
+- [x] Existing privacy, batching, failure, and shutdown behavior remains covered and passing.

--- a/docs/plans/archived/2026-07-23_pi-langfuse-git-metadata-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-langfuse-git-metadata-plan.md
@@ -1,0 +1,33 @@
+# Pi Langfuse Git metadata plan
+
+## Goal
+
+Attach the active Git branch to every Langfuse conversation as both trace metadata and a filterable tag, with commit/detached metadata for unambiguous source context.
+
+## Architecture
+
+- Resolve Git state once in `before_agent_start`, so the value represents the branch at conversation start.
+- Run bounded, non-shell `git symbolic-ref` and `git rev-parse` commands through `pi.exec`.
+- Add `pi.git.branch`, `pi.git.commit`, and `pi.git.detached` to the `pi.conversation`/`pi.agent` metadata.
+- Add `branch:<name>` to trace tags; use `git:detached` when only a detached commit is available.
+- Omit Git metadata without warning outside a repository or when Git lookup fails.
+
+## Non-Goals
+
+- Do not put branch names into trace or observation names.
+- Do not capture remotes, repository URLs, dirty state, diffs, or file names.
+- Do not add Git configuration or block tracing when Git is unavailable.
+
+## Plan
+
+- [x] Add deterministic resolver tests for branches, detached HEADs, and non-repositories; verified by focused resolver tests.
+- [x] Add Git metadata/tag inputs to the conversation recorder and lifecycle integration; verified by recorder and lifecycle hierarchy assertions.
+- [x] Document filtering behavior and the metadata privacy boundary; verified in the README and `/langfuse` privacy help test.
+- [x] Run focused and repository verification plus the Langfuse package dry run; verified by 35 focused tests, `npm run check` with 1,023 passing tests, and `npm run pack:langfuse`.
+
+## Completion Checklist
+
+- [x] Normal branches produce `pi.git.branch`, commit metadata, and `branch:<name>`.
+- [x] Detached HEADs produce commit/detached metadata and `git:detached`.
+- [x] Lookup failures do not interrupt Pi or create misleading Git fields.
+- [x] `captureContent: false` still behaves as documented: content is hidden while Git context remains metadata.

--- a/extensions/pi-langfuse/README.md
+++ b/extensions/pi-langfuse/README.md
@@ -12,6 +12,7 @@
 - Records provider, model, stop reason, token usage, and known non-zero reported cost.
 - Records normalized tool inputs, finalized outputs, duration, and failures as child spans.
 - Groups traces with Pi's session id.
+- Adds the conversation-start Git branch and commit as metadata plus a filterable branch tag.
 - Records provider HTTP status codes when Pi exposes them.
 - Reads Langfuse credentials and options only from a private `pi-langfuse.json` file.
 - Batches routine exports without delaying normal Pi agent completion.
@@ -97,6 +98,8 @@ The hierarchy records:
 - a `pi.llm` native `generation` under the active turn for every provider request;
 - a `pi.tool.<tool-name>` native `tool` observation under the active turn for every tool execution;
 - the Pi session id, working directory, mode, provider, and model;
+- `pi.git.branch`, `pi.git.commit`, and `pi.git.detached` at conversation start when the working directory is in a Git repository;
+- a `branch:<branch-name>` trace tag, or `git:detached` for a detached HEAD, for Langfuse filtering;
 - generation token usage and positive total cost when Pi reports a known price;
 - the concrete response model when Pi reports one, with a differing requested alias retained in metadata;
 - error levels and status messages for failed provider responses, model calls, and tools.
@@ -106,6 +109,8 @@ Pi does not expose a post-transform provider payload event, so generation reques
 Images and embedded base64 data URIs are represented without their payloads, including provider data URLs. Every captured input or output has one cumulative 64 KiB serialized UTF-8 budget, bounded object/array traversal, and deterministic truncation markers. Langfuse credentials are masked again in the span processor before network export.
 
 A conversation span starts from the submitted prompt and remains open across all of its model/tool turns, automatic retries, overflow-compaction recovery, and queued continuations. Pi's `agent_end` only reconciles the latest finalized assistant output; `agent_settled` closes the conversation after no automatic work remains. Activity that unexpectedly arrives without a submitted prompt still gets a fallback conversation labeled `[automatic continuation]` so it is not lost.
+
+At conversation start, the extension runs bounded, non-shell Git lookups in `ctx.cwd`. A branch switch therefore applies to the next conversation. Detached HEADs retain only commit/detached metadata and the `git:detached` tag. Missing Git, non-repositories, timeouts, and lookup failures silently omit Git context without affecting tracing.
 
 Completed observations are exported in batches while Pi remains live. Neither `agent_end` nor `agent_settled` waits for Langfuse network I/O. When you need to wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
 
@@ -130,7 +135,9 @@ Connection actions state their agent-directory scope and per-process restart req
 
 With content capture enabled, traces can contain user prompts, model responses, tool arguments, and tool results. These may include source code, file contents, shell output, or other sensitive project data. Review your Langfuse retention and access controls before enabling this extension.
 
-The built-in mask specifically protects Langfuse credentials; it is not a general secret scanner. Set `"captureContent": false` in `pi-langfuse.json` when content must remain local.
+Git branch names, commit ids, working directory, model, usage, and other operational fields are metadata. They remain exported when `captureContent` is `false`; branch names can themselves contain issue or project details.
+
+The built-in mask specifically protects Langfuse credentials; it is not a general secret scanner. Set `"captureContent": false` in `pi-langfuse.json` when prompts, responses, and tool content must remain local.
 
 ## 🗂️ Package layout
 

--- a/extensions/pi-langfuse/README.md
+++ b/extensions/pi-langfuse/README.md
@@ -6,8 +6,8 @@
 
 ## ✨ Features
 
-- Names each Langfuse trace `pi.trace` and creates a native `pi.agent` observation for the Pi agent run.
-- Adds a `pi.turn` span for every Pi turn, with generations and tools nested beneath it.
+- Names each Langfuse trace `pi.trace` and wraps one complete prompt-processing cycle in a root `pi.conversation` span.
+- Keeps the native `pi.agent` observation inside that span, with every `pi.turn`, generation, and tool nested beneath it.
 - Records finalized assistant outputs without retaining intermediate provider request payloads.
 - Records provider, model, stop reason, token usage, and known non-zero reported cost.
 - Records normalized tool inputs, finalized outputs, duration, and failures as child spans.
@@ -78,8 +78,21 @@ Restart Pi after changing credentials, endpoint, environment, release, or `captu
 
 ## 🔭 What is traced
 
-Each `pi.trace` contains one `pi.agent` native `agent` observation, which contains:
+Each trace has this observation hierarchy:
 
+```text
+pi.conversation (span: submitted prompt until Pi fully settles)
+└── pi.agent (agent)
+    ├── pi.turn (span)
+    │   ├── pi.llm (generation)
+    │   └── pi.tool.<tool-name> (tool)
+    └── pi.turn ...
+```
+
+The hierarchy records:
+
+- one root `pi.conversation` native `span` for the complete prompt-processing cycle;
+- one `pi.agent` native `agent` child that retains the submitted prompt and final assistant output;
 - a `pi.turn` native `span` for every Pi turn, including its index, stop reason, tool-result count, duration, and failure status;
 - a `pi.llm` native `generation` under the active turn for every provider request;
 - a `pi.tool.<tool-name>` native `tool` observation under the active turn for every tool execution;
@@ -92,9 +105,9 @@ Pi does not expose a post-transform provider payload event, so generation reques
 
 Images and embedded base64 data URIs are represented without their payloads, including provider data URLs. Every captured input or output has one cumulative 64 KiB serialized UTF-8 budget, bounded object/array traversal, and deterministic truncation markers. Langfuse credentials are masked again in the span processor before network export.
 
-Completed observations are exported in batches while Pi remains live. Normal `agent_end` handling never waits for Langfuse network I/O. When you need to wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
+A conversation span starts from the submitted prompt and remains open across all of its model/tool turns, automatic retries, overflow-compaction recovery, and queued continuations. Pi's `agent_end` only reconciles the latest finalized assistant output; `agent_settled` closes the conversation after no automatic work remains. Activity that unexpectedly arrives without a submitted prompt still gets a fallback conversation labeled `[automatic continuation]` so it is not lost.
 
-Automatic retries or continuations that begin without a new user prompt are recorded as a new trace labeled `[automatic continuation]`, so provider activity is not lost on Pi versions without a final `agent_settled` extension event.
+Completed observations are exported in batches while Pi remains live. Neither `agent_end` nor `agent_settled` waits for Langfuse network I/O. When you need to wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
 
 ## 💬 Command
 

--- a/extensions/pi-langfuse/src/langfuse.ts
+++ b/extensions/pi-langfuse/src/langfuse.ts
@@ -7,12 +7,13 @@ import {
 	normalizeLangfuseConfig,
 	writeLangfuseConfig,
 } from "./config.js";
-import { type TraceBackend, TraceRecorder } from "./tracing.js";
+import { type GitMetadata, type TraceBackend, TraceRecorder } from "./tracing.js";
 
 interface ExtensionDependencies {
 	loadConfig(path?: string): Promise<LangfuseConfigResult>;
 	writeConfig(config: LangfuseConfig, path?: string): Promise<LangfuseConfig>;
 	createBackend(config: LangfuseConfig): Promise<TraceBackend>;
+	resolveGitMetadata(cwd: string): Promise<GitMetadata | undefined>;
 }
 
 const FLUSH_ACTION = "Flush completed traces for this session";
@@ -33,6 +34,10 @@ export function createLangfuseExtension(
 		});
 
 	return function langfuse(pi: ExtensionAPI) {
+		const resolveGit =
+			dependencies.resolveGitMetadata ??
+			((cwd: string) =>
+				resolveGitMetadata((command, args, options) => pi.exec(command, args, options), cwd));
 		let recorder: TraceRecorder | undefined;
 		let activeConfig: LangfuseConfig | undefined;
 		let configPath: string | undefined;
@@ -144,11 +149,16 @@ export function createLangfuseExtension(
 			}
 		});
 
-		pi.on("before_agent_start", (event, ctx) => {
-			recorder?.beginAgent({
+		pi.on("before_agent_start", async (event, ctx) => {
+			const activeRecorder = recorder;
+			if (!activeRecorder) return;
+			const git = await resolveGit(ctx.cwd).catch(() => undefined);
+			if (recorder !== activeRecorder) return;
+			activeRecorder.beginAgent({
 				prompt: event.prompt,
 				images: event.images,
 				model: ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined,
+				git,
 			});
 		});
 
@@ -240,6 +250,73 @@ export function createLangfuseExtension(
 			}
 		});
 	};
+}
+
+const GIT_LOOKUP_TIMEOUT_MS = 1_000;
+const MAX_GIT_BRANCH_LENGTH = 256;
+
+type GitExecutor = ExtensionAPI["exec"];
+
+export async function resolveGitMetadata(
+	exec: GitExecutor,
+	cwd: string,
+): Promise<GitMetadata | undefined> {
+	const [branchResult, commit] = await Promise.all([
+		resolveGitBranch(exec, cwd),
+		resolveGitCommit(exec, cwd),
+	]);
+	if (!branchResult.resolved) return undefined;
+	if (branchResult.branch) {
+		return {
+			branch: branchResult.branch,
+			...(commit ? { commit } : {}),
+			detached: false,
+		};
+	}
+	return commit ? { commit, detached: true } : undefined;
+}
+
+async function resolveGitBranch(
+	exec: GitExecutor,
+	cwd: string,
+): Promise<{ resolved: boolean; branch?: string }> {
+	try {
+		const result = await exec("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], {
+			cwd,
+			timeout: GIT_LOOKUP_TIMEOUT_MS,
+		});
+		if (result.killed) return { resolved: false };
+		if (result.code === 1) return { resolved: true };
+		if (result.code !== 0) return { resolved: false };
+		const branch = normalizeGitBranch(result.stdout);
+		return branch ? { resolved: true, branch } : { resolved: false };
+	} catch {
+		return { resolved: false };
+	}
+}
+
+async function resolveGitCommit(exec: GitExecutor, cwd: string): Promise<string | undefined> {
+	try {
+		const result = await exec("git", ["rev-parse", "--verify", "--short=12", "HEAD"], {
+			cwd,
+			timeout: GIT_LOOKUP_TIMEOUT_MS,
+		});
+		if (result.code !== 0 || result.killed) return undefined;
+		const commit = result.stdout.trim();
+		return /^[0-9a-f]{4,64}$/iu.test(commit) ? commit.toLowerCase() : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizeGitBranch(value: string): string | undefined {
+	const branch = value.trim();
+	if (!branch || branch.length > MAX_GIT_BRANCH_LENGTH) return undefined;
+	for (const character of branch) {
+		const code = character.codePointAt(0) ?? 0;
+		if (code <= 31 || code === 127) return undefined;
+	}
+	return branch;
 }
 
 async function promptForConfig(
@@ -340,6 +417,7 @@ function formatHelp(configPath: string | undefined): string {
 		`Configuration: ${configPath ?? "pi-langfuse.json"}`,
 		"The file belongs to this Pi agent directory; restart each Pi process after changing it.",
 		"Trace content may contain prompts, responses, tool arguments, tool results, and source code.",
+		"Git branch, commit, cwd, model, and usage remain in metadata when content capture is disabled.",
 		'Use "captureContent": false in the private config to export metadata only.',
 	].join("\n");
 }

--- a/extensions/pi-langfuse/src/langfuse.ts
+++ b/extensions/pi-langfuse/src/langfuse.ts
@@ -213,6 +213,9 @@ export function createLangfuseExtension(
 				recorder?.finishAssistant(message);
 				break;
 			}
+		});
+
+		pi.on("agent_settled", () => {
 			recorder?.settle();
 		});
 

--- a/extensions/pi-langfuse/src/tracing.ts
+++ b/extensions/pi-langfuse/src/tracing.ts
@@ -51,10 +51,17 @@ interface ModelDescriptor {
 	id?: string;
 }
 
+export interface GitMetadata {
+	branch?: string;
+	commit?: string;
+	detached: boolean;
+}
+
 interface BeginAgentInput {
 	prompt: unknown;
 	images?: unknown;
 	model?: ModelDescriptor;
+	git?: GitMetadata;
 }
 
 interface AssistantMessage {
@@ -115,12 +122,20 @@ export class TraceRecorder {
 		});
 		const metadata: Record<string, unknown> = {
 			"pi.cwd": this.context.cwd,
+			...(input.git?.branch ? { "pi.git.branch": input.git.branch } : {}),
+			...(input.git?.commit ? { "pi.git.commit": input.git.commit } : {}),
+			...(input.git ? { "pi.git.detached": input.git.detached } : {}),
 			"pi.mode": this.context.mode,
 			...(input.model?.id ? { "pi.model": input.model.id } : {}),
 			...(input.model?.provider ? { "pi.provider": input.model.provider } : {}),
 			"pi.session.id": this.context.sessionId,
 		};
 		const attributes = { input: traceInput, metadata };
+		const gitTag = input.git?.branch
+			? `branch:${input.git.branch}`
+			: input.git?.detached
+				? "git:detached"
+				: undefined;
 
 		this.root = this.backend.start("pi.conversation", attributes, { asType: "span" });
 		this.root.updateTrace?.({
@@ -128,7 +143,7 @@ export class TraceRecorder {
 			sessionId: this.context.sessionId,
 			input: traceInput,
 			metadata,
-			tags: ["pi"],
+			tags: ["pi", ...(gitTag ? [gitTag] : [])],
 		});
 		this.agent = this.backend.start("pi.agent", attributes, {
 			asType: "agent",

--- a/extensions/pi-langfuse/src/tracing.ts
+++ b/extensions/pi-langfuse/src/tracing.ts
@@ -88,6 +88,7 @@ interface TurnResult {
 
 export class TraceRecorder {
 	private root: Observation | undefined;
+	private agent: Observation | undefined;
 	private turn: Observation | undefined;
 	private turnIndex: number | undefined;
 	private generation: Observation | undefined;
@@ -105,7 +106,7 @@ export class TraceRecorder {
 	}
 
 	beginAgent(input: BeginAgentInput): void {
-		if (this.root) this.closeActiveTrace("Interrupted by a new Pi agent run.");
+		if (this.root) this.closeActiveTrace("Interrupted by a new Pi conversation.");
 
 		this.lastOutput = undefined;
 		const traceInput = this.capture({
@@ -119,14 +120,19 @@ export class TraceRecorder {
 			...(input.model?.provider ? { "pi.provider": input.model.provider } : {}),
 			"pi.session.id": this.context.sessionId,
 		};
+		const attributes = { input: traceInput, metadata };
 
-		this.root = this.backend.start("pi.agent", { input: traceInput, metadata }, { asType: "agent" });
+		this.root = this.backend.start("pi.conversation", attributes, { asType: "span" });
 		this.root.updateTrace?.({
 			name: "pi.trace",
 			sessionId: this.context.sessionId,
 			input: traceInput,
 			metadata,
 			tags: ["pi"],
+		});
+		this.agent = this.backend.start("pi.agent", attributes, {
+			asType: "agent",
+			parent: this.root,
 		});
 	}
 
@@ -137,7 +143,7 @@ export class TraceRecorder {
 		this.turn = this.backend.start(
 			"pi.turn",
 			{ metadata: { "pi.turn.index": turnIndex } },
-			{ asType: "span", parent: this.root },
+			{ asType: "span", parent: this.agent ?? this.root },
 		);
 	}
 
@@ -154,9 +160,7 @@ export class TraceRecorder {
 			metadata: {
 				"pi.turn.index": this.turnIndex ?? turnIndex,
 				"pi.turn.tool_result_count": result.toolResultCount,
-				...(result.message.stopReason
-					? { "pi.turn.stop_reason": result.message.stopReason }
-					: {}),
+				...(result.message.stopReason ? { "pi.turn.stop_reason": result.message.stopReason } : {}),
 			},
 			...(failed
 				? {
@@ -182,7 +186,7 @@ export class TraceRecorder {
 		this.generation = this.backend.start(
 			"pi.llm",
 			{},
-			{ asType: "generation", parent: this.turn ?? this.root },
+			{ asType: "generation", parent: this.turn ?? this.agent ?? this.root },
 		);
 	}
 
@@ -258,7 +262,7 @@ export class TraceRecorder {
 					...(args !== undefined ? { input: this.capture(args) } : {}),
 					metadata: { "pi.tool.call_id": toolCallId, "pi.tool.name": toolName },
 				},
-				{ asType: "tool", parent: this.turn ?? this.root },
+				{ asType: "tool", parent: this.turn ?? this.agent ?? this.root },
 			),
 		);
 	}
@@ -294,13 +298,19 @@ export class TraceRecorder {
 	}
 
 	private closeActiveTrace(statusMessage?: string): void {
-		this.closeTurn(statusMessage ?? "Pi turn ended when the agent settled.");
+		this.closeTurn(statusMessage ?? "Pi turn ended when the conversation settled.");
 
-		if (!this.root) return;
-		this.root.update({
+		const finalAttributes: ObservationAttributes = {
 			...(this.lastOutput !== undefined ? { output: this.lastOutput } : {}),
 			...(statusMessage ? { level: "WARNING" as const, statusMessage } : {}),
-		});
+		};
+		if (this.agent) {
+			this.agent.update(finalAttributes);
+			this.agent.end();
+			this.agent = undefined;
+		}
+		if (!this.root) return;
+		this.root.update(finalAttributes);
 		this.root.updateTrace?.({
 			...(this.lastOutput !== undefined ? { output: this.lastOutput } : {}),
 			...(statusMessage ? { metadata: { "pi.status": statusMessage } } : {}),

--- a/extensions/pi-langfuse/test/langfuse.test.ts
+++ b/extensions/pi-langfuse/test/langfuse.test.ts
@@ -8,7 +8,7 @@ import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-tr
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { loadLangfuseConfig, normalizeLangfuseConfig } from "../src/config.js";
-import { createLangfuseExtension } from "../src/langfuse.js";
+import { createLangfuseExtension, resolveGitMetadata } from "../src/langfuse.js";
 import { createProductionBackend, maskSecrets } from "../src/runtime.js";
 import {
 	MAX_CAPTURE_BYTES,
@@ -127,6 +127,62 @@ test("loadLangfuseConfig reports missing and unsafe settings without environment
 	if (!invalid.ok) assert.match(invalid.reason, /publicKey must be literal/i);
 });
 
+test("resolveGitMetadata captures branch and commit with bounded non-shell commands", async () => {
+	const calls: Array<{ command: string; args: string[]; cwd?: string; timeout?: number }> = [];
+	const metadata = await resolveGitMetadata(async (command, args, options) => {
+		calls.push({ command, args, cwd: options?.cwd, timeout: options?.timeout });
+		if (args[0] === "symbolic-ref") {
+			return {
+				stdout: "feature/langfuse-context\n",
+				stderr: "",
+				code: 0,
+				killed: false,
+			};
+		}
+		return { stdout: "0123456789ab\n", stderr: "", code: 0, killed: false };
+	}, "/workspace");
+
+	assert.deepEqual(metadata, {
+		branch: "feature/langfuse-context",
+		commit: "0123456789ab",
+		detached: false,
+	});
+	assert.deepEqual(calls, [
+		{
+			command: "git",
+			args: ["symbolic-ref", "--quiet", "--short", "HEAD"],
+			cwd: "/workspace",
+			timeout: 1_000,
+		},
+		{
+			command: "git",
+			args: ["rev-parse", "--verify", "--short=12", "HEAD"],
+			cwd: "/workspace",
+			timeout: 1_000,
+		},
+	]);
+});
+
+test("resolveGitMetadata handles detached HEADs and omits unavailable repositories", async () => {
+	const detached = await resolveGitMetadata(async (_command, args) => {
+		if (args[0] === "symbolic-ref") {
+			return { stdout: "", stderr: "", code: 1, killed: false };
+		}
+		return { stdout: "abcdef012345\n", stderr: "", code: 0, killed: false };
+	}, "/detached");
+	assert.deepEqual(detached, { commit: "abcdef012345", detached: true });
+
+	const unavailable = await resolveGitMetadata(async () => {
+		return { stdout: "", stderr: "not a repository", code: 128, killed: false };
+	}, "/outside");
+	assert.equal(unavailable, undefined);
+
+	const failed = await resolveGitMetadata(async () => {
+		throw new Error("git is unavailable");
+	}, "/missing-git");
+	assert.equal(failed, undefined);
+});
+
 test("session start suggests the /langfuse setup action when the config file is missing", async () => {
 	const mock = createMockPi();
 	createLangfuseExtension({
@@ -156,6 +212,11 @@ test("TraceRecorder wraps one agent hierarchy in a conversation span", async () 
 	recorder.beginAgent({
 		prompt: "Fix the test",
 		model: { provider: "anthropic", id: "claude" },
+		git: {
+			branch: "feature/langfuse-context",
+			commit: "0123456789ab",
+			detached: false,
+		},
 	});
 	recorder.beginGeneration();
 	recorder.finishAssistant({
@@ -191,11 +252,14 @@ test("TraceRecorder wraps one agent hierarchy in a conversation span", async () 
 		sessionId: "session-1",
 		input: { prompt: "Fix the test" },
 		metadata: conversation?.attributes.metadata,
-		tags: ["pi"],
+		tags: ["pi", "branch:feature/langfuse-context"],
 	});
 	assert.deepEqual(conversation?.attributes.input, { prompt: "Fix the test" });
 	assert.deepEqual(conversation?.attributes.metadata, {
 		"pi.cwd": "/workspace",
+		"pi.git.branch": "feature/langfuse-context",
+		"pi.git.commit": "0123456789ab",
+		"pi.git.detached": false,
 		"pi.mode": "tui",
 		"pi.model": "claude",
 		"pi.provider": "anthropic",
@@ -288,7 +352,10 @@ test("TraceRecorder replaces all captured values when content capture is disable
 		mode: "tui",
 		captureContent: false,
 	});
-	recorder.beginAgent({ prompt: "private prompt" });
+	recorder.beginAgent({
+		prompt: "private prompt",
+		git: { commit: "abcdef012345", detached: true },
+	});
 	recorder.beginGeneration();
 	recorder.finishAssistant({ role: "assistant", content: "private response" });
 	recorder.beginTool("call", "read", { path: "private path" });
@@ -298,12 +365,17 @@ test("TraceRecorder replaces all captured values when content capture is disable
 	for (const observation of backend.observations) {
 		if (observation.name === "pi.llm") assert.equal(observation.attributes.input, undefined);
 		else assert.equal(observation.attributes.input, "[content capture disabled]");
+		if (observation.name === "pi.conversation" || observation.name === "pi.agent") {
+			assert.equal(observation.attributes.metadata?.["pi.git.commit"], "abcdef012345");
+			assert.equal(observation.attributes.metadata?.["pi.git.detached"], true);
+		}
 		for (const update of observation.updates) {
 			if (update.output !== undefined) {
 				assert.equal(update.output, "[content capture disabled]");
 			}
 		}
 	}
+	assert.deepEqual(backend.observations[0]?.traceUpdates[0]?.tags, ["pi", "git:detached"]);
 });
 
 test("TraceRecorder closes interrupted observations and redacts image payloads", () => {
@@ -375,6 +447,14 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 			warnings: [],
 		}),
 		createBackend: async () => backend,
+		resolveGitMetadata: async (cwd) => {
+			assert.equal(cwd, "/workspace");
+			return {
+				branch: "feature/lifecycle",
+				commit: "fedcba987654",
+				detached: false,
+			};
+		},
 	});
 	extension(mock.pi);
 
@@ -437,6 +517,10 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	assert.equal(conversation?.name, "pi.conversation");
 	assert.equal(conversation?.type, "span");
 	assert.equal(conversation?.ended, false);
+	assert.equal(conversation?.attributes.metadata?.["pi.git.branch"], "feature/lifecycle");
+	assert.equal(conversation?.attributes.metadata?.["pi.git.commit"], "fedcba987654");
+	assert.equal(conversation?.attributes.metadata?.["pi.git.detached"], false);
+	assert.deepEqual(conversation?.traceUpdates[0]?.tags, ["pi", "branch:feature/lifecycle"]);
 	assert.equal(agent?.name, "pi.agent");
 	assert.equal(agent?.parent, conversation);
 	assert.equal(agent?.ended, false);
@@ -1063,6 +1147,7 @@ test("/langfuse disabled state prioritizes agent-directory setup and routes priv
 		"Show setup and privacy help",
 	]);
 	assert.match(notifications.at(-1)?.message ?? "", /trace content may contain/i);
+	assert.match(notifications.at(-1)?.message ?? "", /git branch.*remain in metadata/i);
 	assert.match(notifications.at(-1)?.message ?? "", /\/config\/pi-langfuse\.json/);
 });
 

--- a/extensions/pi-langfuse/test/langfuse.test.ts
+++ b/extensions/pi-langfuse/test/langfuse.test.ts
@@ -144,7 +144,7 @@ test("session start suggests the /langfuse setup action when the config file is 
 	assert.match(notifications.at(-1)?.message ?? "", /run \/langfuse and choose set up langfuse/i);
 });
 
-test("TraceRecorder builds one agent trace with child generations and tool spans", async () => {
+test("TraceRecorder wraps one agent hierarchy in a conversation span", async () => {
 	const backend = new FakeBackend();
 	const recorder = new TraceRecorder(backend, {
 		sessionId: "session-1",
@@ -181,28 +181,33 @@ test("TraceRecorder builds one agent trace with child generations and tool spans
 	recorder.settle();
 	await recorder.flush();
 
-	assert.equal(backend.observations.length, 3);
-	const [root, generation, tool] = backend.observations;
-	assert.equal(root?.name, "pi.agent");
-	assert.equal(root?.type, "agent");
-	assert.deepEqual(root?.traceUpdates[0], {
+	assert.equal(backend.observations.length, 4);
+	const [conversation, agent, generation, tool] = backend.observations;
+	assert.equal(conversation?.name, "pi.conversation");
+	assert.equal(conversation?.type, "span");
+	assert.equal(conversation?.parent, undefined);
+	assert.deepEqual(conversation?.traceUpdates[0], {
 		name: "pi.trace",
 		sessionId: "session-1",
 		input: { prompt: "Fix the test" },
-		metadata: root?.attributes.metadata,
+		metadata: conversation?.attributes.metadata,
 		tags: ["pi"],
 	});
-	assert.deepEqual(root?.attributes.input, { prompt: "Fix the test" });
-	assert.deepEqual(root?.attributes.metadata, {
+	assert.deepEqual(conversation?.attributes.input, { prompt: "Fix the test" });
+	assert.deepEqual(conversation?.attributes.metadata, {
 		"pi.cwd": "/workspace",
 		"pi.mode": "tui",
 		"pi.model": "claude",
 		"pi.provider": "anthropic",
 		"pi.session.id": "session-1",
 	});
+	assert.equal(agent?.name, "pi.agent");
+	assert.equal(agent?.type, "agent");
+	assert.equal(agent?.parent, conversation);
+	assert.deepEqual(agent?.attributes, conversation?.attributes);
 	assert.equal(generation?.name, "pi.llm");
 	assert.equal(generation?.type, "generation");
-	assert.equal(generation?.parent, root);
+	assert.equal(generation?.parent, agent);
 	assert.equal(generation?.attributes.input, undefined);
 	assert.deepEqual(generation?.updates.at(-1)?.usageDetails, {
 		cache_creation_input_tokens: 1,
@@ -214,9 +219,10 @@ test("TraceRecorder builds one agent trace with child generations and tool spans
 	assert.equal(generation?.ended, true);
 	assert.equal(tool?.name, "pi.tool.read");
 	assert.equal(tool?.type, "tool");
-	assert.equal(tool?.parent, root);
+	assert.equal(tool?.parent, agent);
 	assert.equal(tool?.ended, true);
-	assert.equal(root?.ended, true);
+	assert.equal(agent?.ended, true);
+	assert.equal(conversation?.ended, true);
 	assert.equal(backend.flushes, 1);
 });
 
@@ -243,8 +249,8 @@ test("TraceRecorder only exports known non-zero costs with the Langfuse total bu
 		usage: { cost: { total: 0.01 } },
 	});
 
-	assert.equal(backend.observations[1]?.updates.at(-1)?.costDetails, undefined);
-	assert.deepEqual(backend.observations[2]?.updates.at(-1)?.costDetails, { total: 0.01 });
+	assert.equal(backend.observations[2]?.updates.at(-1)?.costDetails, undefined);
+	assert.deepEqual(backend.observations[3]?.updates.at(-1)?.costDetails, { total: 0.01 });
 });
 
 test("TraceRecorder prefers the concrete response model and retains the requested alias", () => {
@@ -266,8 +272,8 @@ test("TraceRecorder prefers the concrete response model and retains the requeste
 		stopReason: "stop",
 	});
 
-	assert.equal(backend.observations[1]?.updates.at(-1)?.model, "concrete-model");
-	assert.deepEqual(backend.observations[1]?.updates.at(-1)?.metadata, {
+	assert.equal(backend.observations[2]?.updates.at(-1)?.model, "concrete-model");
+	assert.deepEqual(backend.observations[2]?.updates.at(-1)?.metadata, {
 		"pi.provider": "openai",
 		"pi.requested_model": "requested-alias",
 		"pi.stop_reason": "stop",
@@ -320,11 +326,12 @@ test("TraceRecorder closes interrupted observations and redacts image payloads",
 	recorder.finishTool("call-1", { content: "failed", isError: true });
 	recorder.settle();
 
-	const [root, firstGeneration, secondGeneration, tool] = backend.observations;
-	assert.deepEqual(root?.attributes.input, {
+	const [conversation, agent, firstGeneration, secondGeneration, tool] = backend.observations;
+	assert.deepEqual(conversation?.attributes.input, {
 		images: [{ type: "image", mimeType: "image/png", data: "[base64 omitted]" }],
 		prompt: "Describe this",
 	});
+	assert.deepEqual(agent?.attributes.input, conversation?.attributes.input);
 	assert.equal(firstGeneration?.updates.at(-1)?.level, "ERROR");
 	assert.match(String(firstGeneration?.updates.at(-1)?.statusMessage), /interrupted/i);
 	assert.equal(firstGeneration?.ended, true);
@@ -375,6 +382,7 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"after_provider_response",
 		"agent_end",
+		"agent_settled",
 		"before_agent_start",
 		"before_provider_request",
 		"message_end",
@@ -423,16 +431,20 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	);
 	await mock.events.get("agent_end")?.[0]?.({ messages: [] }, ctx);
 
-	assert.equal(backend.observations.length, 3);
-	assert.equal(
-		backend.observations.every((observation) => observation.ended),
-		true,
-	);
+	assert.equal(backend.observations.length, 4);
 	assert.equal(backend.flushes, 0);
-	const [root, turn, generation] = backend.observations;
+	const [conversation, agent, turn, generation] = backend.observations;
+	assert.equal(conversation?.name, "pi.conversation");
+	assert.equal(conversation?.type, "span");
+	assert.equal(conversation?.ended, false);
+	assert.equal(agent?.name, "pi.agent");
+	assert.equal(agent?.parent, conversation);
+	assert.equal(agent?.ended, false);
 	assert.equal(turn?.name, "pi.turn");
-	assert.equal(turn?.parent, root);
+	assert.equal(turn?.parent, agent);
+	assert.equal(turn?.ended, true);
 	assert.equal(generation?.parent, turn);
+	assert.equal(generation?.ended, true);
 	assert.deepEqual(turn?.attributes.metadata, { "pi.turn.index": 0 });
 	assert.deepEqual(turn?.updates.at(-1)?.metadata, {
 		"pi.turn.index": 0,
@@ -467,15 +479,23 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	await mock.events.get("agent_end")?.[0]?.({ messages: [] }, ctx);
 
 	assert.equal(backend.observations.length, 6);
-	assert.deepEqual(backend.observations[3]?.attributes.input, {
-		prompt: "[automatic continuation]",
-	});
-	assert.equal(backend.observations[4]?.name, "pi.turn");
-	assert.equal(backend.observations[5]?.parent, backend.observations[4]);
+	const continuationTurn = backend.observations[4];
+	const continuationGeneration = backend.observations[5];
+	assert.equal(continuationTurn?.name, "pi.turn");
+	assert.equal(continuationTurn?.parent, agent);
+	assert.equal(continuationTurn?.ended, true);
+	assert.equal(continuationGeneration?.parent, continuationTurn);
+	assert.equal(continuationGeneration?.ended, true);
+	assert.equal(conversation?.ended, false);
+	assert.equal(agent?.ended, false);
+
+	await mock.events.get("agent_settled")?.[0]?.({}, ctx);
+
 	assert.equal(
-		backend.observations.slice(3).every((observation) => observation.ended),
+		backend.observations.every((observation) => observation.ended),
 		true,
 	);
+	assert.deepEqual(conversation?.updates.at(-1)?.output, [{ type: "text", text: "Recovered" }]);
 	assert.equal(backend.flushes, 0);
 });
 
@@ -514,10 +534,16 @@ test("pi-langfuse reconciles the finalized assistant message from agent_end", as
 	};
 	await mock.events.get("agent_end")?.[0]?.({ messages: [finalized] }, ctx);
 
-	const generation = backend.observations[1];
+	const [conversation, agent, generation] = backend.observations;
 	assert.deepEqual(generation?.updates.at(-1)?.output, finalized.content);
 	assert.equal(generation?.updates.at(-1)?.statusMessage, finalized.errorMessage);
 	assert.equal(generation?.ended, true);
+	assert.equal(conversation?.ended, false);
+	assert.equal(agent?.ended, false);
+
+	await mock.events.get("agent_settled")?.[0]?.({}, ctx);
+	assert.equal(conversation?.ended, true);
+	assert.equal(agent?.ended, true);
 });
 
 test("pi-langfuse traces normalized tool inputs and finalized tool outputs", async () => {
@@ -611,8 +637,8 @@ test("pi-langfuse traces normalized tool inputs and finalized tool outputs", asy
 	assert.equal(generation?.ended, true);
 	assert.equal(typeof generation?.endTime, "number");
 	const tool = backend.observations.at(-1);
-	assert.equal(backend.observations[1]?.name, "pi.turn");
-	assert.equal(tool?.parent, backend.observations[1]);
+	assert.equal(backend.observations[2]?.name, "pi.turn");
+	assert.equal(tool?.parent, backend.observations[2]);
 	assert.equal(tool?.attributes.input, undefined);
 	assert.deepEqual(tool?.updates.find((update) => update.input !== undefined)?.input, {
 		path: "file.ts",
@@ -792,7 +818,7 @@ test("TraceRecorder bounds oversized tool details as one captured output", () =>
 		),
 	});
 
-	const tool = backend.observations[1];
+	const tool = backend.observations[2];
 	assert.ok(serializedBytes(tool?.attributes.input) <= MAX_CAPTURE_BYTES);
 	assert.ok(serializedBytes(tool?.updates.at(-1)?.output) <= MAX_CAPTURE_BYTES);
 });
@@ -1228,7 +1254,7 @@ test("/langfuse ignores arguments but requires interactive UI", async () => {
 	assert.equal(notifications.at(-1)?.level, "warning");
 });
 
-test("agent_end never waits for or starts a routine flush", async () => {
+test("agent_end leaves the conversation open and settled never starts a routine flush", async () => {
 	const backend = new FakeBackend();
 	backend.forceFlush = () => new Promise<void>(() => undefined);
 	const mock = createMockPi();
@@ -1256,6 +1282,19 @@ test("agent_end never waits for or starts a routine flush", async () => {
 		mock.events.get("agent_end")?.[0]?.({ messages: [] }, ctx),
 		new Promise((_, reject) => setTimeout(() => reject(new Error("agent_end blocked")), 50)),
 	]);
+	assert.equal(
+		backend.observations.every((observation) => observation.ended),
+		false,
+	);
+
+	await Promise.race([
+		mock.events.get("agent_settled")?.[0]?.({}, ctx),
+		new Promise((_, reject) => setTimeout(() => reject(new Error("agent_settled blocked")), 50)),
+	]);
+	assert.equal(
+		backend.observations.every((observation) => observation.ended),
+		true,
+	);
 	assert.equal(backend.flushes, 0);
 });
 
@@ -1372,12 +1411,15 @@ test("isolated runtime preserves the global provider and exports native observat
 		"agent",
 		"generation",
 		"span",
+		"span",
 		"tool",
 	]);
-	const root = spans.find((span) => span.name === "pi.agent");
+	const conversation = spans.find((span) => span.name === "pi.conversation");
+	const agent = spans.find((span) => span.name === "pi.agent");
 	const turn = spans.find((span) => span.name === "pi.turn");
-	assert.equal(root?.parentSpanContext, undefined);
-	assert.equal(turn?.parentSpanContext?.spanId, root?.spanContext().spanId);
+	assert.equal(conversation?.parentSpanContext, undefined);
+	assert.equal(agent?.parentSpanContext?.spanId, conversation?.spanContext().spanId);
+	assert.equal(turn?.parentSpanContext?.spanId, agent?.spanContext().spanId);
 	for (const child of spans.filter((span) => ["pi.llm", "pi.tool.read"].includes(span.name))) {
 		assert.equal(child.parentSpanContext?.spanId, turn?.spanContext().spanId);
 	}


### PR DESCRIPTION
## Summary

- add a root `pi.conversation` span around each complete Pi prompt-processing cycle
- keep retries, overflow-compaction recovery, and queued continuations grouped until `agent_settled`
- preserve the native `pi.agent` hierarchy and update tracing docs and regression coverage

## Testing

- `npm run check` (1,021 tests passed)
- `npm run pack:langfuse`
- `git diff --check`