### PR TITLE
feat(subagents): add opt-in completion auto-resume

### DIFF
--- a/docs/implementation-notes/pi-subagents-capability-matrix.md
+++ b/docs/implementation-notes/pi-subagents-capability-matrix.md
@@ -1,6 +1,7 @@
 # pi-subagents capability matrix
 
 Date: 2026-07-11
+Updated: 2026-07-23
 
 | Capability | Status | Evidence |
 | --- | --- | --- |
@@ -10,14 +11,14 @@ Date: 2026-07-11
 | Abort with partial structured result | Implemented | `runner.ts::runSingleAgent`; abort no longer throws after process settlement |
 | Cwd validation and spawn-error normalization | Implemented | `runner.ts::runSingleAgent` |
 | Recursion guard | Implemented | `PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_MAX_DEPTH` in `execution.ts` and `runner.ts` |
-| Detached addressable agents | Implemented, default-on | `subagent_spawn` returns immediately; every settled turn sends one bounded non-triggering completion message; disable with `stateful.enabled: false` |
+| Detached addressable agents | Implemented, default-on | `subagent_spawn` returns immediately; bounded completions use default non-triggering delivery or opt-in batched `auto-resume`; disable with `stateful.enabled: false` |
 | Transport abstraction and fallback | Implemented | `transport.ts`, default `subprocess-transport.ts`, opt-in public-SDK `in-process-transport.ts` |
 | Hierarchical ownership and subtree lifecycle | Implemented | parent/root/depth/children metadata and child-first interrupt/close in `registry.ts` |
 | Bounded asynchronous mailbox | Implemented | message/read/ack tools, deduplication, completion delivery, and persistence tests |
 | Shared-write guard and disposable worktrees | Implemented, opt-in | `stateful.ts`, `workspace.ts`; clean-repository and cleanup tests |
-| Follow-up, wait, list, interrupt, close | Implemented, default-on | eight lifecycle tools in `stateful.ts`; registry lifecycle tests |
+| Follow-up, mailbox, list, interrupt, close | Implemented, default-on | seven non-waiting lifecycle tools in `stateful.ts`; registry and completion-delivery tests |
 | Separate active and retained capacity | Implemented | FIFO queue and limits in `registry.ts`; capacity/fairness test |
-| Interactive inspection | Implemented | `/subagents:agents list|clear` |
+| Interactive settings and inspection | Implemented | `/subagents settings|status|help`, compatibility `/subagents:config`, and `/subagents:agents list|clear` |
 | Native transcript switching | Core-blocked | Extension APIs expose custom entries/UI but no supported child transcript/session switch handle |
 | Parent context selection | Implemented | `context.ts`: none/all/summary/recent N/entry IDs, text-only sanitation and byte bound |
 | Approval/sandbox/header inheritance | Unsupported guarantee | `SingleResult.policy`; only environment and explicit CLI overrides are reported |

--- a/docs/implementation-notes/pi-subagents-evolution-verification.md
+++ b/docs/implementation-notes/pi-subagents-evolution-verification.md
@@ -2,6 +2,8 @@
 
 Date: 2026-07-11
 
+> Historical verification record. On 2026-07-23, detached waiting was removed and completion delivery gained opt-in batched `auto-resume`; wait-based smoke details below describe the earlier tool surface.
+
 ## Release gates
 
 The implementation is organized as independently reversible modules:

--- a/docs/implementation-notes/pi-subagents-l1-proactivity-eval.md
+++ b/docs/implementation-notes/pi-subagents-l1-proactivity-eval.md
@@ -3,6 +3,8 @@
 Original date: 2026-05-17
 Updated: 2026-07-11
 
+> Historical evaluation. On 2026-07-23, the detached wait tool was removed and opt-in `stateful.completionDelivery: "auto-resume"` added the bounded autonomous scheduler that this note previously rejected by default.
+
 ## Method
 
 The policy remains static tool prompt metadata and documentation, not autonomous runtime orchestration. Tests inspect both blocking `subagent` guidance and default-on background `subagent_spawn` guidance. Live model tool choice is not a deterministic pass/fail oracle.

--- a/docs/implementation-notes/pi-subagents-native-runtime-verification.md
+++ b/docs/implementation-notes/pi-subagents-native-runtime-verification.md
@@ -2,6 +2,8 @@
 
 Date: 2026-07-11
 
+> Historical verification record. On 2026-07-23, the detached `subagent_wait` tool was removed and completion delivery gained opt-in batched `auto-resume`; the original wait/`triggerTurn: false` assertions below describe the earlier runtime.
+
 ## Automated evidence
 
 - `npm run check`: passed with Biome, extension boundaries, every workspace typecheck, and 293 tests.

--- a/docs/implementation-notes/pi-subagents-stateful-runtime.md
+++ b/docs/implementation-notes/pi-subagents-stateful-runtime.md
@@ -1,7 +1,7 @@
 # pi-subagents stateful runtime decision
 
 Date: 2026-07-11
-Updated: 2026-07-11
+Updated: 2026-07-23
 
 ## Decision
 
@@ -12,7 +12,7 @@ Keep the existing logical stateful registry and support two transports:
 
 Stateful lifecycle tools are registered by default and can be removed with `stateful.enabled: false`. The default transport remains subprocess for compatibility and rollback safety.
 
-Detached completion follows Codex's completion-watcher pattern: spawn returns after scheduling, a background lifecycle observer publishes final status/output to the parent session, and the notification does not trigger a turn by itself. Pi implements this with `AgentRegistry.onTurnComplete` plus `pi.sendMessage(..., { deliverAs: "steer", triggerTurn: false })`. Completion metadata/output/error fields are independently sanitized and bounded so a large error cannot hide partial output, and runtime-generation guards prevent stale reload callbacks from writing into a replacement session.
+Detached completion is configurable. `stateful.completionDelivery: "next-turn"` is the default Codex-style behavior: the lifecycle observer publishes final status/output with `deliverAs: "steer"` and `triggerTurn: false`. Opt-in `"auto-resume"` holds completion while the root is active, coalesces simultaneous completions, and requests at most one synthesis turn after the parent settles when no input is pending. Completion metadata/output/error fields are independently sanitized and bounded, and session-generation, shutdown, batching, and in-flight wake guards prevent stale or duplicate scheduling pressure. Delivery remains best-effort because Pi's custom-message API is fire-and-forget.
 
 ## In-process ownership
 
@@ -43,10 +43,11 @@ restored persisted state -> idle -> explicit follow-up -> starting
 
 - `starting` means queued for an active-turn slot.
 - `running` owns one `AbortController` and one transport turn.
-- `subagent_spawn` returns immediately; prompt guidance requires useful non-overlapping main-agent work instead of polling or waiting.
-- Every settled turn emits one bounded `pi-subagent-completion` custom message through `deliverAs: "steer"` and `triggerTurn: false`. Active root turns can consume it; idle roots are not awakened autonomously.
+- `subagent_spawn` returns immediately; prompt guidance requires useful non-overlapping main-agent work or ending the response instead of polling.
+- Settled turns emit bounded `pi-subagent-completion` custom messages. The default does not wake an idle root; opt-in auto-resume batches a dispatch window and requests one synthesis turn.
+- Active parent work is not interrupted; `agent_settled` schedules the held batch. User or extension input already pending at flush time suppresses auto-resume, and a parent `agent_start` acknowledgement clears the pre-set one-wake guard.
 - Registry state-change callbacks are serialized in invocation order, preventing a slow `starting` persistence write from overwriting a later terminal snapshot.
-- `subagent_wait` is an explicit blocking fallback and times out only the caller's wait.
+- No detached wait tool is exposed; genuinely blocking one-shot work uses the batch `subagent` API.
 - `subagent_interrupt` aborts a queued/running turn but preserves identity and settled history.
 - `subagent_close` aborts current work, releases transport ownership exactly once, and excludes the record from persistence.
 - Session shutdown aborts active work, drains queued work, persists non-closed records as inert `idle`, and shuts down every owned child session.
@@ -57,7 +58,9 @@ Subprocess cleanup retains process-group SIGTERM/SIGKILL escalation. In-process 
 
 ## Public surface
 
-Separate lifecycle tools preserve the existing batch `subagent` schema and give each operation a precise contract. `subagent` remains the blocking API for single, parallel, chain, and fan-in work. `subagent_spawn` is the detached sidecar API: scheduling and execution continue independently, settled turns notify the root session without triggering a new turn, and explicit wait remains optional. It must not be used to delegate one immediate critical-path blocker while the main agent idles.
+Separate lifecycle tools preserve the existing batch `subagent` schema and give each operation a precise contract. `subagent` remains the blocking API for single, parallel, chain, and fan-in work. `subagent_spawn` is the detached sidecar API: scheduling and execution continue independently, settled turns notify the root session according to `completionDelivery`, and no wait operation is exposed. It must not be used to delegate one immediate critical-path blocker while the main agent idles.
+
+`/subagents settings` edits `completionDelivery` through `SettingsList`, patches the canonical raw JSON atomically without dropping unknown fields, and applies the runtime policy immediately. `/subagents status` reports configured versus runtime values; manual file edits remain reload-based. `/subagents:config` remains the compatibility UI for per-agent tool allow-lists and now also patches only the selected agent field.
 
 ## Context and policy boundary
 

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -10,16 +10,16 @@ Use it to split independent research, planning, implementation, and review work 
 
 - Registers a `subagent` tool for single-agent, parallel, fan-in, and chained delegation.
 - Keeps batch workers isolated in `pi --mode json -p --no-session` subprocesses.
-- Registers detached stateful lifecycle tools by default; spawn returns immediately and completion is delivered asynchronously without starting a new root turn.
+- Registers detached stateful lifecycle tools by default; completion can stay queued for the next turn or opt into an idle root synthesis turn.
 - Supports an opt-in public-SDK `in-process` stateful transport with one reusable child `AgentSession` per `agentId`.
 - Supports built-in `scout`, `planner`, `reviewer`, and `worker` agents.
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
-- Provides `/subagents:config` to persist per-agent tool allow-lists.
+- Provides `/subagents settings|status|help` for completion delivery plus `/subagents:config` for per-agent tool allow-lists.
 - Supports per-task `cwd`, hard subprocess `timeoutMs`, `thinkingLevel`, abort propagation, and streaming progress.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
 - Enforces a recursion-depth guard and deterministic process-group termination.
-- Provides addressable stateful agents with follow-up, wait, list, interrupt, close, context selection, and persistence.
+- Provides addressable stateful agents with follow-up, mailbox, list, interrupt, close, context selection, and persistence.
 - Publishes transient runtime status through Pi's generic extension status API while subagents are running.
 - Returns complete bounded worker output in tool details and a concise result for the main agent.
 
@@ -84,8 +84,8 @@ Count-selection guidance:
   only for a concrete bounded subtask that can run independently alongside useful main-agent work
   and when parallel work, bounded context/output, independent review, a distinct model/tool profile,
   or workspace isolation provides concrete value. After spawning, do useful non-overlapping work
-  immediately. Call `subagent_wait` sparingly, only when the immediate next critical-path step needs
-  the result and is blocked until it arrives; do not wait repeatedly by reflex.
+  immediately. If none remains, briefly tell the user what was launched and end the response. Do not
+  poll lifecycle tools for progress or duplicate the delegated work.
 - Prefer **2–4 parallel read-only subagents** when a broad task naturally splits into independent
   branches that can each return a concise summary.
 - Exceed 4 tasks only when the branches are clearly distinct and worth the extra cost, while staying
@@ -202,22 +202,28 @@ Run a chain where each step receives the previous output:
 
 ## 🔁 Stateful agents
 
-Stateful lifecycle tools are available by default. `subagent_spawn` is detached: it schedules work, returns immediately with an opaque `agentId`, and later injects one bounded `pi-subagent-completion` message per settled turn. The message uses `deliverAs: "steer"` with `triggerTurn: false`, so an active root turn can consume it naturally.
+Stateful lifecycle tools are available by default. `subagent_spawn` is detached: it schedules work, returns immediately with an opaque `agentId`, and later injects a bounded `pi-subagent-completion` custom message. Completions that settle in the same dispatch window are batched, and the broker allows at most one in-flight root wake until that parent turn starts.
 
-Detached work follows a critical-path policy: spawn only a concrete bounded subtask that can run independently alongside useful main-agent work, then do that non-overlapping work immediately. Use `subagent_wait` sparingly and only when the immediate next critical-path step requires the result and is blocked until it arrives. The extension does not start an autonomous recovery turn merely because delegated work remains live or completes. If the root turn has already ended, completion stays queued for the next turn instead of waking the root.
+Detached work follows a non-polling policy: spawn only a concrete bounded subtask that can run independently alongside useful main-agent work, then do that non-overlapping work immediately. If no useful non-overlapping work remains, briefly tell the user what was launched and end the response. Do not poll `subagent_list` or `subagent_messages` for progress, and do not duplicate the delegated work. The blocking `subagent` batch tool remains available when results are genuinely needed before the root can continue; detached lifecycle work intentionally has no `subagent_wait` tool.
 
 A single detached agent additionally needs a concrete isolation or specialization benefit such as independent review, bounded context/output, a distinct model/tool profile, or workspace isolation. Simple work that the main agent can perform directly should not be delegated.
 
-When `subagent_wait` starts while a turn is running, that wait consumes the turn's completion: the terminal output is returned by the tool and is not also injected as a duplicate asynchronous completion. Multiple active waiters may all receive the terminal result. A timed-out or aborted wait does not consume it, so later settlement still delivers the normal asynchronous completion. If a turn has already settled and queued its completion before a wait starts, the queued message cannot be retracted safely.
+`stateful.completionDelivery` controls settled completion delivery:
+
+- `"next-turn"` (default) preserves the previous behavior: use `deliverAs: "steer"` with `triggerTurn: false`. An active root can consume completion naturally; an idle root is not awakened.
+- `"auto-resume"` holds completion while the root is active, then requests one synthesis turn after the parent settles when no user or extension messages are already pending. Simultaneous completions share that turn, active work is not interrupted, and pending input suppresses the autonomous wake.
+
+Auto-resume is best-effort because Pi's custom-message API is fire-and-forget. Session-generation checks, shutdown cleanup, batching, and the in-flight wake guard prevent stale or duplicate scheduling pressure, but they do not make completion delivery durable across process exit.
 
 The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history. Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
 
-Configure the runtime in `~/.pi/agent/pi-subagents.json`, then reload Pi:
+Use `/subagents settings` to change completion delivery interactively and apply it immediately. `/subagents status` shows configured versus runtime values, source, and path; `/subagents help` summarizes the commands. Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
 
 ```json
 {
   "stateful": {
     "transport": "in-process",
+    "completionDelivery": "auto-resume",
     "maxAgents": 16,
     "maxActiveTurns": 4,
     "maxDepth": 3,
@@ -231,7 +237,7 @@ Configure the runtime in `~/.pi/agent/pi-subagents.json`, then reload Pi:
 }
 ```
 
-Set `"enabled": false` to remove all stateful lifecycle tools. Otherwise, the extension registers:
+The settings UI patches the raw JSON atomically and preserves unknown fields; it refuses to overwrite malformed or invalid settings. Set `"enabled": false` to remove all stateful lifecycle tools. Otherwise, the extension registers:
 
 | Tool | Purpose |
 | --- | --- |
@@ -239,7 +245,6 @@ Set `"enabled": false` to remove all stateful lifecycle tools. Otherwise, the ex
 | `subagent_send` | Send follow-up work to a reusable agent; shared-workspace write conflicts are guarded unless explicitly overridden. |
 | `subagent_message` | Queue a bounded mailbox message without starting a turn; sender IDs must be `root` or an agent in the same tree. |
 | `subagent_messages` | Read and optionally acknowledge unread mailbox messages. |
-| `subagent_wait` | Wait sparingly when the immediate next critical-path step is blocked on a result; timeout does not terminate the agent, and parent abort/user steering cancels only the wait. Already-terminal agents return immediately. |
 | `subagent_list` | List retained agents and lifecycle states. |
 | `subagent_interrupt` | Abort the current turn while retaining its identity and history. |
 | `subagent_close` | Abort if necessary, close the agent, and remove it from retained persistence. |
@@ -269,7 +274,7 @@ Stateful execution uses a transport boundary:
 
 No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used. Approval policy, sandbox profile, provider-header hooks, extension state, global scheduling, and parent/child transcript switching are not inherited or provided by the in-process transport.
 
-Write-capable agents share the workspace by default. Concurrent write-capable starts in the same cwd are rejected unless `allowConcurrentWrites` is explicitly set. Classification is intentionally conservative: an agent with `bash`, `write`, or `edit` is write-capable even when its task prompt says “read only,” because prompt wording is not a filesystem sandbox. For independent one-shot work, use batch parallel mode. Otherwise wait for or close the active agent, explicitly accept safe overlap with `allowConcurrentWrites`, or use an isolated worktree when repository isolation is actually needed.
+Write-capable agents share the workspace by default. Concurrent write-capable starts in the same cwd are rejected unless `allowConcurrentWrites` is explicitly set. Classification is intentionally conservative: an agent with `bash`, `write`, or `edit` is write-capable even when its task prompt says “read only,” because prompt wording is not a filesystem sandbox. For independent one-shot work, use batch parallel mode. Otherwise let the active agent finish or close it, explicitly accept safe overlap with `allowConcurrentWrites`, or use an isolated worktree when repository isolation is actually needed.
 
 Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; this requires a clean repository and the worktree is removed on close or session shutdown. Isolated worktree agents are intentionally not restored after shutdown.
 

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -47,9 +47,12 @@ export interface SubagentAgentConfig {
 
 export type SubagentTransportKind = "subprocess" | "in-process";
 
+export type CompletionDelivery = "next-turn" | "auto-resume";
+
 export interface SubagentRuntimeSettings {
 	enabled?: boolean;
 	transport?: SubagentTransportKind;
+	completionDelivery?: CompletionDelivery;
 	maxAgents?: number;
 	maxActiveTurns?: number;
 	maxDepth?: number;

--- a/extensions/pi-subagents/src/config-ui.ts
+++ b/extensions/pi-subagents/src/config-ui.ts
@@ -1,24 +1,42 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { DynamicBorder } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import { DynamicBorder, getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import {
+	type AutocompleteItem,
 	Container,
 	Key,
 	matchesKey,
 	type SelectItem,
 	SelectList,
+	type SettingItem,
+	SettingsList,
 	Spacer,
 	Text,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
-import { discoverAgents, type SubagentSettings } from "./agents.js";
+import { type CompletionDelivery, discoverAgents } from "./agents.js";
 import {
-	hasAnyAgentOverride,
 	hasOwn,
+	inspectCompletionDeliverySettings,
 	readSubagentSettings,
 	sameToolSet,
-	saveSubagentConfig,
+	updateAgentToolsSetting,
+	updateCompletionDeliverySetting,
 	uniqueToolNames,
 } from "./settings.js";
+
+const SUBCOMMANDS: AutocompleteItem[] = [
+	{ value: "settings", label: "settings", description: "Configure completion delivery" },
+	{ value: "status", label: "status", description: "Show effective subagent settings" },
+	{ value: "help", label: "help", description: "Show subagent settings help" },
+];
+
+export interface SubagentSettingsRuntime {
+	getCompletionDelivery(): CompletionDelivery;
+	setCompletionDelivery(value: CompletionDelivery): void;
+}
 
 export class ToolToggleList {
 	private items: { name: string; selected: boolean }[];
@@ -76,11 +94,16 @@ export class ToolToggleList {
 	}
 }
 
-export function registerSubagentConfigCommand(pi: ExtensionAPI) {
+export function registerSubagentConfigCommand(
+	pi: ExtensionAPI,
+	runtime: SubagentSettingsRuntime,
+) {
+	registerSubagentPrimaryCommand(pi, runtime);
 	pi.registerCommand("subagents:config", {
 		description: "Configure which tools each subagent can use",
 		handler: async (_args, ctx) => {
-			if (!ctx.hasUI) {
+			if (ctx.mode !== "tui") {
+				if (ctx.hasUI) ctx.ui.notify("/subagents:config requires TUI mode", "info");
 				return;
 			}
 
@@ -248,39 +271,12 @@ export function registerSubagentConfigCommand(pi: ExtensionAPI) {
 				// null means user cancelled — loop back to agent selection
 				if (selectedTools === null) continue;
 
-				// Save to global settings
-				const updatedAgents = { ...currentAgents };
-				let restoredDefaults = false;
-
-				const isSameAsDefault =
+				// Patch only this agent's tool field so forward-compatible settings survive.
+				const restoredDefaults =
 					defaultTools === undefined
 						? sameToolSet(selectedTools, allTools)
 						: sameToolSet(selectedTools, defaultTools);
-
-				if (isSameAsDefault) {
-					// Tools match defaults — remove only the tools override.
-					// Keep other settings (model, timeoutMs) if present.
-					const existing = updatedAgents[agentName];
-					if (existing) {
-						const nextConfig = { ...existing };
-						delete nextConfig.tools;
-						if (hasAnyAgentOverride(nextConfig)) updatedAgents[agentName] = nextConfig;
-						else delete updatedAgents[agentName];
-					}
-					restoredDefaults = true;
-				} else {
-					updatedAgents[agentName] = {
-						...updatedAgents[agentName],
-						tools: selectedTools,
-					};
-				}
-
-				const newSettings: SubagentSettings = {
-					...currentSettings,
-					agents: Object.keys(updatedAgents).length > 0 ? updatedAgents : undefined,
-				};
-
-				saveSubagentConfig(newSettings);
+				updateAgentToolsSetting(agentName, restoredDefaults ? undefined : selectedTools);
 				const message = restoredDefaults
 					? `${agentName}: defaults restored`
 					: `${agentName}: ${selectedTools.length} tool${selectedTools.length !== 1 ? "s" : ""} configured`;
@@ -290,4 +286,132 @@ export function registerSubagentConfigCommand(pi: ExtensionAPI) {
 			}
 		},
 	});
+}
+
+function registerSubagentPrimaryCommand(pi: ExtensionAPI, runtime: SubagentSettingsRuntime) {
+	pi.registerCommand("subagents", {
+		description: "Configure or inspect subagent settings",
+		getArgumentCompletions(prefix: string): AutocompleteItem[] | null {
+			const normalized = prefix.trim().toLowerCase();
+			const matches = SUBCOMMANDS.filter((item) => item.value.startsWith(normalized));
+			return matches.length > 0 ? matches : null;
+		},
+		async handler(args, ctx) {
+			const subcommand = args.trim().split(/\s+/u)[0]?.toLowerCase() || "help";
+			switch (subcommand) {
+				case "settings":
+					await showSubagentSettings(ctx, runtime);
+					return;
+				case "status":
+					showSubagentStatus(ctx, runtime);
+					return;
+				case "help":
+					showSubagentHelp(ctx);
+					return;
+				default:
+					if (ctx.mode === "tui" || ctx.hasUI) {
+						ctx.ui.notify(`Unknown /subagents subcommand: ${subcommand}`, "warning");
+					}
+			}
+		},
+	});
+}
+
+async function showSubagentSettings(
+	ctx: ExtensionCommandContext,
+	runtime: SubagentSettingsRuntime,
+) {
+	const snapshot = inspectCompletionDeliverySettings();
+	if (ctx.mode !== "tui") {
+		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${snapshot.path}`, "info");
+		return;
+	}
+	if (snapshot.error) {
+		ctx.ui.notify(`Subagent settings cannot be edited: ${snapshot.error}`, "error");
+		return;
+	}
+	let currentValue = snapshot.value;
+	await ctx.ui.custom((tui, theme, _keybindings, done) => {
+		const items: SettingItem[] = [
+			{
+				id: "completionDelivery",
+				label: "Completion delivery",
+				description:
+					"next-turn queues completion without waking an idle root; auto-resume starts one synthesis turn after the root settles.",
+				currentValue,
+				values: ["next-turn", "auto-resume"],
+			},
+		];
+		const container = new Container();
+		container.addChild(
+			new Text(theme.fg("accent", theme.bold("Subagent Settings")), 1, 1),
+		);
+		let settingsList: SettingsList;
+		settingsList = new SettingsList(
+			items,
+			Math.min(items.length + 2, 15),
+			getSettingsListTheme(),
+			(id, newValue) => {
+				if (id !== "completionDelivery") return;
+				const previous = currentValue;
+				const next = newValue as CompletionDelivery;
+				try {
+					updateCompletionDeliverySetting(next);
+					runtime.setCompletionDelivery(next);
+					currentValue = next;
+					ctx.ui.notify(`Completion delivery set to ${next}.`, "info");
+				} catch (error) {
+					settingsList.updateValue(id, previous);
+					ctx.ui.notify(`Subagent settings were not saved: ${formatError(error)}`, "error");
+				}
+				tui.requestRender();
+			},
+			() => done(undefined),
+		);
+		container.addChild(settingsList);
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput(data: string) {
+				settingsList.handleInput?.(data);
+				tui.requestRender();
+			},
+		};
+	});
+}
+
+function showSubagentStatus(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
+	if (ctx.mode !== "tui" && !ctx.hasUI) return;
+	const snapshot = inspectCompletionDeliverySettings();
+	ctx.ui.notify(
+		[
+			`pi-subagents source: ${snapshot.source}`,
+			`path: ${snapshot.path}`,
+			`configured completionDelivery: ${snapshot.value}`,
+			`runtime completionDelivery: ${runtime.getCompletionDelivery()}`,
+			snapshot.error ? `warning: ${snapshot.error}` : "warning: none",
+			"Manual file changes require /reload; /subagents settings applies immediately.",
+		].join("\n"),
+		snapshot.error ? "warning" : "info",
+	);
+}
+
+function showSubagentHelp(ctx: ExtensionCommandContext) {
+	if (ctx.mode !== "tui" && !ctx.hasUI) return;
+	const snapshot = inspectCompletionDeliverySettings();
+	ctx.ui.notify(
+		[
+			"/subagents settings — configure completion delivery",
+			"/subagents status — show configured and runtime values",
+			"/subagents help — show this help",
+			"/subagents:config — configure per-agent tool allow-lists",
+			"/subagents:agents list|clear — inspect or clear retained agents",
+			`Settings: ${snapshot.path}`,
+		].join("\n"),
+		"info",
+	);
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
 	type AgentConfig,
+	type CompletionDelivery,
 	isThinkingLevel,
 	type SubagentAgentConfig,
 	type SubagentSettings,
@@ -88,6 +89,15 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 			}
 			runtime.transport = value.stateful.transport;
 		}
+		if (hasOwn(value.stateful, "completionDelivery")) {
+			if (
+				value.stateful.completionDelivery !== "next-turn" &&
+				value.stateful.completionDelivery !== "auto-resume"
+			) {
+				return undefined;
+			}
+			runtime.completionDelivery = value.stateful.completionDelivery;
+		}
 		for (const key of [
 			"maxAgents",
 			"maxActiveTurns",
@@ -121,6 +131,7 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 
 const SETTINGS_FILE = "pi-subagents.json";
 const LEGACY_SETTINGS_FILE = "pi-subagents-config.json";
+const DEFAULT_COMPLETION_DELIVERY: CompletionDelivery = "next-turn";
 let pendingSettingsNotice: string | undefined;
 
 export function readSubagentSettings(): SubagentSettings | undefined {
@@ -227,6 +238,108 @@ export function consumeSubagentSettingsNotice() {
 }
 
 export function saveSubagentConfig(settings: SubagentSettings): void {
+	writeSettingsObject(settings);
+}
+
+export interface CompletionDeliverySettingsSnapshot {
+	path: string;
+	value: CompletionDelivery;
+	source: "default" | "user settings";
+	error?: string;
+}
+
+export function subagentSettingsFilePath(): string {
+	return path.join(getAgentDir(), SETTINGS_FILE);
+}
+
+export function inspectCompletionDeliverySettings(): CompletionDeliverySettingsSnapshot {
+	const configPath = subagentSettingsFilePath();
+	if (!fs.existsSync(configPath)) {
+		return { path: configPath, value: DEFAULT_COMPLETION_DELIVERY, source: "default" };
+	}
+	try {
+		const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
+		const settings = normalizeSubagentSettings(raw);
+		if (!settings) throw new Error(`${SETTINGS_FILE} is not a valid settings object`);
+		const explicit =
+			isPlainObject(raw.stateful) && hasOwn(raw.stateful, "completionDelivery");
+		return {
+			path: configPath,
+			value: settings.stateful?.completionDelivery ?? DEFAULT_COMPLETION_DELIVERY,
+			source: explicit ? "user settings" : "default",
+		};
+	} catch (error) {
+		return {
+			path: configPath,
+			value: DEFAULT_COMPLETION_DELIVERY,
+			source: "default",
+			error: formatError(error),
+		};
+	}
+}
+
+export function updateCompletionDeliverySetting(value: CompletionDelivery): void {
+	const raw = readSettingsObjectForUpdate();
+	const stateful = raw.stateful;
+	if (stateful !== undefined && !isPlainObject(stateful)) {
+		throw new Error(`Cannot update invalid ${SETTINGS_FILE} stateful settings`);
+	}
+	writeSettingsObject({
+		...raw,
+		stateful: {
+			...(stateful ?? {}),
+			completionDelivery: value,
+		},
+	});
+}
+
+export function updateAgentToolsSetting(name: string, tools: string[] | undefined): void {
+	const raw = readSettingsObjectForUpdate();
+	const rawAgents = raw.agents;
+	if (rawAgents !== undefined && !isPlainObject(rawAgents)) {
+		throw new Error(`Cannot update invalid ${SETTINGS_FILE} agent settings`);
+	}
+	const agents = { ...(rawAgents ?? {}) };
+	const rawAgent = hasOwn(agents, name) ? agents[name] : undefined;
+	if (rawAgent !== undefined && !isPlainObject(rawAgent)) {
+		throw new Error(`Cannot update invalid ${SETTINGS_FILE} settings for ${name}`);
+	}
+	const agent = { ...(rawAgent ?? {}) };
+	if (tools === undefined) delete agent.tools;
+	else agent.tools = tools;
+	if (Object.keys(agent).length > 0) {
+		Object.defineProperty(agents, name, {
+			value: agent,
+			enumerable: true,
+			configurable: true,
+			writable: true,
+		});
+	} else {
+		delete agents[name];
+	}
+
+	const updated = { ...raw };
+	if (Object.keys(agents).length > 0) updated.agents = agents;
+	else delete updated.agents;
+	writeSettingsObject(updated);
+}
+
+function readSettingsObjectForUpdate(): Record<string, unknown> {
+	const configPath = subagentSettingsFilePath();
+	if (!fs.existsSync(configPath)) return {};
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+	} catch (error) {
+		throw new Error(`Cannot update malformed ${SETTINGS_FILE}: ${formatError(error)}`);
+	}
+	if (!isPlainObject(parsed) || !normalizeSubagentSettings(parsed)) {
+		throw new Error(`Cannot update invalid ${SETTINGS_FILE}`);
+	}
+	return parsed;
+}
+
+function writeSettingsObject(settings: object): void {
 	const agentDir = getAgentDir();
 	fs.mkdirSync(agentDir, { recursive: true });
 	const configPath = path.join(agentDir, SETTINGS_FILE);

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -3,7 +3,12 @@ import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
-import { discoverAgents, type AgentScope, isThinkingLevel } from "./agents.js";
+import {
+	type CompletionDelivery,
+	discoverAgents,
+	type AgentScope,
+	isThinkingLevel,
+} from "./agents.js";
 import { buildContextSnapshot, type ContextMode, redactPrivateText } from "./context.js";
 import { assertSubagentDepthAllowed } from "./execution.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
@@ -29,27 +34,45 @@ const ScopeSchema = StringEnum(["user", "project", "both"] as const, {
 });
 const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
 const MAX_COMPLETION_ERROR_BYTES = 512;
+const MAX_COMPLETIONS_PER_MESSAGE = 16;
+const COMPLETION_BATCH_DELAY_MS = 10;
 
 export interface StatefulSubagentDependencies {
 	createInProcessSession?: ChildSessionFactory;
+	workspaceManager?: WorkspaceManager;
+}
+
+export interface StatefulSubagentController {
+	getCompletionDelivery(): CompletionDelivery;
+	setCompletionDelivery(value: CompletionDelivery): void;
 }
 
 export function registerStatefulSubagents(
 	pi: ExtensionAPI,
 	dependencies: StatefulSubagentDependencies = {},
-): void {
+): StatefulSubagentController {
 	const settings = readSubagentSettings()?.stateful ?? {};
-	if (settings.enabled === false) return;
+	let completionDelivery = resolveCompletionDelivery(settings.completionDelivery);
+	let completionBroker: CompletionDeliveryBroker | undefined;
+	const controller: StatefulSubagentController = {
+		getCompletionDelivery() {
+			return completionDelivery;
+		},
+		setCompletionDelivery(value) {
+			completionDelivery = value;
+			completionBroker?.setDelivery(value);
+		},
+	};
+	if (settings.enabled === false) return controller;
 
 	let registry: AgentRegistry | undefined;
 	let persistence: AgentPersistence | undefined;
 	let sweepTimer: NodeJS.Timeout | undefined;
 	let runtimeGeneration = 0;
-	const workspaceManager = new WorkspaceManager();
+	const workspaceManager = dependencies.workspaceManager ?? new WorkspaceManager();
 	const isolatedAgents = new Map<string, string>();
 	const seenMessageIds = new Set<string>();
 	const parentRuntime: ParentRuntimeSnapshot = { model: undefined, thinkingLevel: "off" };
-	const completionWaiters = new Map<string, number>();
 
 	const requireRegistry = () => {
 		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
@@ -58,6 +81,8 @@ export function registerStatefulSubagents(
 
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++runtimeGeneration;
+		completionBroker?.close();
+		completionBroker = undefined;
 		parentRuntime.model = ctx.model;
 		parentRuntime.thinkingLevel = normalizeRuntimeThinkingLevel(pi.getThinkingLevel());
 		const owner =
@@ -69,6 +94,18 @@ export function registerStatefulSubagents(
 			maxStoredAgents: settings.maxStoredAgents,
 		});
 		persistence = sessionPersistence;
+		completionBroker = new CompletionDeliveryBroker(
+			pi,
+			ctx,
+			completionDelivery,
+			{
+				onDeliveryError: (error) => {
+					if (!ctx.hasUI) return;
+					const reason = error instanceof Error ? error.message : String(error);
+					ctx.ui.notify(`Subagent completion delivery failed: ${reason}`, "warning");
+				},
+			},
+		);
 		const transport =
 			resolveStatefulTransportKind(settings.transport) === "in-process"
 				? new InProcessTransport({
@@ -102,9 +139,7 @@ export function registerStatefulSubagents(
 			},
 			onTurnComplete: (completion) => {
 				if (generation !== runtimeGeneration) return;
-				if (!completionWaiters.has(completion.agent.id)) {
-					sendDetachedCompletion(pi, completion);
-				}
+				completionBroker?.enqueue(completion);
 			},
 		});
 		const restored = sessionPersistence
@@ -128,6 +163,14 @@ export function registerStatefulSubagents(
 		sweepTimer.unref();
 	});
 
+	pi.on("agent_start", () => {
+		completionBroker?.onParentTurnStart();
+	});
+
+	pi.on("agent_settled", () => {
+		completionBroker?.onParentSettled();
+	});
+
 	pi.on("model_select", (event) => {
 		parentRuntime.model = event.model;
 	});
@@ -138,6 +181,8 @@ export function registerStatefulSubagents(
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		runtimeGeneration++;
+		completionBroker?.close();
+		completionBroker = undefined;
 		if (sweepTimer) clearInterval(sweepTimer);
 		sweepTimer = undefined;
 		for (const agentId of isolatedAgents.keys()) {
@@ -145,7 +190,6 @@ export function registerStatefulSubagents(
 		}
 		isolatedAgents.clear();
 		seenMessageIds.clear();
-		completionWaiters.clear();
 		let cleanupError: unknown;
 		try {
 			await workspaceManager.cleanupAll();
@@ -171,9 +215,9 @@ export function registerStatefulSubagents(
 			"Do not use subagent_spawn for simple or critical-path work that the main agent can perform directly.",
 			"Use a single subagent_spawn only for a concrete bounded subtask that can run independently alongside useful main-agent work and has an isolation or specialization benefit such as independent review, bounded context/output, a distinct model/tool profile, or workspace isolation.",
 			"Use one blocking subagent parallel call for multiple independent one-shot tasks; do not use repeated subagent_spawn calls when no reuse or overlap is needed.",
-			"After subagent_spawn returns, do useful non-overlapping local work immediately. Call subagent_wait sparingly, only when the immediate next critical-path step requires the result and is blocked until it arrives; do not wait repeatedly by reflex.",
+			"After subagent_spawn returns, do useful non-overlapping local work immediately. If no such work remains, briefly tell the user what subagent_spawn launched and end the response; completion delivery follows the configured policy.",
 			"Consume and synthesize available subagent_spawn completion messages; interrupt or close agents that are no longer needed.",
-			"subagent_spawn completion is delivered automatically. Do not poll, wait forever, or spawn additional agents without a distinct need.",
+			"subagent_spawn completion is delivered automatically. Do not poll with subagent_list or subagent_messages, repeatedly check progress, or duplicate the delegated work.",
 		],
 		parameters: Type.Object({
 			agent: Type.String({ minLength: 1 }),
@@ -241,7 +285,7 @@ export function registerStatefulSubagents(
 			if (workspace) isolatedAgents.set(agent.id, workspaceOwner);
 			return result(
 				agent,
-				`Spawned ${agent.agent} as ${agent.id}. Do useful non-overlapping work immediately. Completion will arrive asynchronously; call subagent_wait only if the immediate next critical-path step is blocked on this result.`,
+				`Spawned ${agent.agent} as ${agent.id}. Do useful non-overlapping work immediately, or briefly tell the user what was launched and end the response. Completion will arrive asynchronously according to the configured delivery policy; do not poll for progress.`,
 			);
 		},
 	});
@@ -330,35 +374,6 @@ export function registerStatefulSubagents(
 				content: [{ type: "text", text: truncateUtf8(text, DEFAULT_MAX_CONTEXT_BYTES).text }],
 				details: { messages: summaries },
 			};
-		},
-	});
-
-	pi.registerTool({
-		name: "subagent_wait",
-		label: "Wait for Subagent",
-		description:
-			"Wait for a stateful subagent turn without terminating it when the wait times out. Use sparingly, only when the immediate next critical-path step is blocked on this result.",
-		parameters: Type.Object({
-			agentId: Type.String(),
-			timeoutMs: Type.Optional(Type.Number({ minimum: 1, maximum: 3_600_000, default: 30_000 })),
-		}),
-		async execute(_id, params, signal) {
-			const existing = requireRegistry().get(params.agentId);
-			const registered = existing?.state === "starting" || existing?.state === "running";
-			if (registered) {
-				completionWaiters.set(params.agentId, (completionWaiters.get(params.agentId) ?? 0) + 1);
-			}
-			try {
-				const waited = await requireRegistry().wait(params.agentId, params.timeoutMs, signal);
-				return result(
-					waited.agent,
-					waited.timedOut
-						? `Wait timed out; ${waited.agent.id} is ${waited.agent.state}.`
-						: formatFinal(waited.agent),
-				);
-			} finally {
-				if (registered) decrementWaiter(completionWaiters, params.agentId);
-			}
 		},
 	});
 
@@ -473,6 +488,8 @@ export function registerStatefulSubagents(
 			);
 		},
 	});
+
+	return controller;
 }
 
 export function assertNoSharedWriteConflict(
@@ -495,7 +512,7 @@ export function assertNoSharedWriteConflict(
 		if (isWriteCapable(activeConfig?.tools)) {
 			throw new Error(
 				`Write-capable subagent ${active.id} is already active in shared workspace ${cwd}. ` +
-					"For independent one-shot work, use subagent parallel mode. Otherwise wait or close the active agent; set allowConcurrentWrites only when overlapping writes are knowingly safe, or use workspaceMode worktree when repository isolation is needed.",
+					"For independent one-shot work, use subagent parallel mode. Otherwise let the active agent finish or close it; set allowConcurrentWrites only when overlapping writes are knowingly safe, or use workspaceMode worktree when repository isolation is needed.",
 			);
 		}
 	}
@@ -514,12 +531,6 @@ export function assertFollowUpWriteAllowed(
 export function isWriteCapable(tools: string[] | undefined): boolean {
 	if (!tools) return true;
 	return tools.some((tool) => ["bash", "write", "edit"].includes(tool));
-}
-
-function decrementWaiter(waiters: Map<string, number>, agentId: string): void {
-	const count = waiters.get(agentId);
-	if (count === undefined || count <= 1) waiters.delete(agentId);
-	else waiters.set(agentId, count - 1);
 }
 
 async function confirmProjectAgent(
@@ -570,7 +581,7 @@ function formatLine(agent: ManagedAgent): string {
 	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - agent.updatedAt) / 1000));
 	const actions =
 		agent.state === "running" || agent.state === "starting"
-			? "wait, interrupt, close"
+			? "interrupt, close"
 			: agent.state === "closed"
 				? "inspect"
 				: "send, close";
@@ -578,11 +589,6 @@ function formatLine(agent: ManagedAgent): string {
 	const unread = agent.mailbox.filter((message) => !message.readAt).length;
 	const indent = "  ".repeat(agent.depth);
 	return `${indent}${agent.id} ${agent.agent} ${agent.state} ${elapsedSeconds}s unread:${unread} [${actions}]${task}`;
-}
-
-function formatFinal(agent: ManagedAgent): string {
-	const last = agent.history.at(-1);
-	return last?.output || agent.error || `${agent.id} is ${agent.state}.`;
 }
 
 function summarizeAgent(agent: ManagedAgent) {
@@ -607,21 +613,188 @@ function summarizeAgent(agent: ManagedAgent) {
 	};
 }
 
-function sendDetachedCompletion(pi: ExtensionAPI, completion: AgentTurnCompletion): void {
-	const content = buildDetachedCompletionMessage(completion);
-	pi.sendMessage(
-		{
+interface CompletionMetadata {
+	agentId: string;
+	agent: string;
+	state: string;
+}
+
+interface CompletionMessage {
+	customType: "pi-subagent-completion";
+	content: string;
+	display: true;
+	details:
+		| CompletionMetadata
+		| {
+				completionCount: number;
+				completions: CompletionMetadata[];
+		  };
+}
+
+type CompletionContext = Pick<ExtensionContext, "hasPendingMessages" | "isIdle">;
+type CompletionPi = Pick<ExtensionAPI, "sendMessage">;
+
+export interface CompletionDeliveryBrokerOptions {
+	onDeliveryError?: (error: unknown) => void;
+}
+
+/**
+ * Coalesces detached completions so one bounded notification batch starts at
+ * most one root synthesis turn. The broker belongs to one parent session and
+ * must be closed when that session is replaced or shut down.
+ */
+export class CompletionDeliveryBroker {
+	private pending: AgentTurnCompletion[] = [];
+	private flushTimer?: NodeJS.Timeout;
+	private wakeInFlight = false;
+	private closed = false;
+
+	constructor(
+		private readonly pi: CompletionPi,
+		private readonly ctx: CompletionContext,
+		private delivery: CompletionDelivery,
+		private readonly options: CompletionDeliveryBrokerOptions = {},
+	) {}
+
+	enqueue(completion: AgentTurnCompletion): void {
+		if (this.closed) return;
+		this.pending.push(completion);
+		this.scheduleFlush();
+	}
+
+	setDelivery(value: CompletionDelivery): void {
+		this.delivery = value;
+		this.scheduleFlush();
+	}
+
+	onParentTurnStart(): void {
+		this.wakeInFlight = false;
+		this.scheduleFlush();
+	}
+
+	onParentSettled(): void {
+		this.wakeInFlight = false;
+		this.scheduleFlush();
+	}
+
+	flush(): void {
+		if (this.closed || this.pending.length === 0) return;
+		if (this.flushTimer) clearTimeout(this.flushTimer);
+		this.flushTimer = undefined;
+		if (this.delivery === "auto-resume" && !this.isRootIdle()) return;
+
+		const completions = this.pending.splice(0);
+		const batches = chunkCompletions(completions);
+		let canWake = this.shouldWakeRoot();
+		for (let index = 0; index < batches.length; index++) {
+			const triggerTurn = canWake && index === batches.length - 1;
+			const message = buildCompletionMessage(batches[index]);
+			if (triggerTurn) this.wakeInFlight = true;
+			try {
+				this.pi.sendMessage(message, { deliverAs: "steer", triggerTurn });
+			} catch (primaryError) {
+				if (triggerTurn) this.wakeInFlight = false;
+				canWake = false;
+				try {
+					this.pi.sendMessage(message, { deliverAs: "nextTurn", triggerTurn: false });
+				} catch (fallbackError) {
+					this.pending = [...batches.slice(index).flat(), ...this.pending];
+					try {
+						this.options.onDeliveryError?.(
+							new AggregateError(
+								[primaryError, fallbackError],
+								"Detached subagent completion delivery failed",
+							),
+						);
+					} catch {
+						// Delivery retention must survive a failing observer.
+					}
+					return;
+				}
+			}
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		if (this.flushTimer) clearTimeout(this.flushTimer);
+		this.flushTimer = undefined;
+		this.pending = [];
+	}
+
+	private scheduleFlush(): void {
+		if (this.closed || this.pending.length === 0 || this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = undefined;
+			this.flush();
+		}, COMPLETION_BATCH_DELAY_MS);
+	}
+
+	private isRootIdle(): boolean {
+		try {
+			return this.ctx.isIdle();
+		} catch {
+			return false;
+		}
+	}
+
+	private shouldWakeRoot(): boolean {
+		if (this.delivery !== "auto-resume" || this.wakeInFlight) return false;
+		try {
+			return !this.ctx.hasPendingMessages();
+		} catch {
+			return false;
+		}
+	}
+}
+
+function chunkCompletions(completions: AgentTurnCompletion[]): AgentTurnCompletion[][] {
+	const batches: AgentTurnCompletion[][] = [];
+	for (let index = 0; index < completions.length; index += MAX_COMPLETIONS_PER_MESSAGE) {
+		batches.push(completions.slice(index, index + MAX_COMPLETIONS_PER_MESSAGE));
+	}
+	return batches;
+}
+
+function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionMessage {
+	if (completions.length === 1) {
+		const completion = completions[0];
+		return {
 			customType: "pi-subagent-completion",
-			content,
+			content: buildDetachedCompletionMessage(completion),
 			display: true,
-			details: {
-				agentId: completion.agent.id,
-				agent: completion.agent.agent,
-				state: completion.agent.state,
-			},
+			details: completionMetadata(completion),
+		};
+	}
+	const content = truncateUtf8(
+		[
+			"Message Type: SUBAGENT_COMPLETION_BATCH",
+			`Completion Count: ${completions.length}`,
+			...completions.flatMap((completion, index) => [
+				"",
+				`--- Completion ${index + 1} of ${completions.length} ---`,
+				buildDetachedCompletionMessage(completion),
+			]),
+		].join("\n"),
+		DEFAULT_MAX_CONTEXT_BYTES,
+	).text;
+	return {
+		customType: "pi-subagent-completion",
+		content,
+		display: true,
+		details: {
+			completionCount: completions.length,
+			completions: completions.map(completionMetadata),
 		},
-		{ deliverAs: "steer", triggerTurn: false },
-	);
+	};
+}
+
+function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata {
+	return {
+		agentId: completion.agent.id,
+		agent: completion.agent.agent,
+		state: completion.agent.state,
+	};
 }
 
 export function buildDetachedCompletionMessage(completion: AgentTurnCompletion): string {
@@ -676,6 +849,12 @@ export function resolveStatefulTransportKind(
 	value: "subprocess" | "in-process" | undefined,
 ): "subprocess" | "in-process" {
 	return value ?? "subprocess";
+}
+
+export function resolveCompletionDelivery(
+	value: CompletionDelivery | undefined,
+): CompletionDelivery {
+	return value ?? "next-turn";
 }
 
 function normalizeRuntimeThinkingLevel(value: string): ParentRuntimeSnapshot["thinkingLevel"] {

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -40,7 +40,8 @@ export default function (pi: ExtensionAPI) {
 			"A single blocking subagent call should be used only when independent context, high-volume output isolation, or an external review is worth waiting for; otherwise do the task in the main agent.",
 			"For one-shot parallel work, use a single subagent call with tasks instead of repeated subagent_spawn calls, even when the user explicitly requests multiple agents.",
 			"When subagent_spawn is available, use it only for a concrete bounded subtask that can run independently alongside useful main-agent work and has a parallel, isolation, or specialization benefit; otherwise keep the work in the main agent.",
-			"After subagent_spawn returns, do useful non-overlapping work immediately. Call subagent_wait sparingly, only when the immediate next critical-path step requires the result and is blocked until it arrives; do not wait repeatedly by reflex.",
+			"After subagent_spawn returns, do useful non-overlapping work immediately. If none remains, briefly tell the user what was launched and end the response; completion delivery follows the configured policy.",
+			"Do not poll subagent_spawn work with subagent_list or subagent_messages, repeatedly check progress, or duplicate the delegated work.",
 			"Consume and synthesize available subagent_spawn completion messages; interrupt or close agents that are no longer needed.",
 			"Use subagent parallel mode with 2-4 parallel read-only subagents when work has broad independent branches; prefer scout or reviewer for fan-out and add an aggregator when synthesis helps.",
 			"Use more than 4 subagent tasks only when clearly justified by distinct independent branches, and stay within the existing hard max 8 parallel tasks.",
@@ -78,18 +79,22 @@ export default function (pi: ExtensionAPI) {
 		if (notice) ctx.ui.notify(notice, "warning");
 	});
 
-	registerSubagentConfigCommand(pi);
-	registerStatefulSubagents(pi);
+	const statefulRuntime = registerStatefulSubagents(pi);
+	registerSubagentConfigCommand(pi, statefulRuntime);
 }
 export { formatTokens, formatUsageStats } from "./render.js";
 export { buildPiArgs } from "./runner.js";
 export {
+	inspectCompletionDeliverySettings,
 	normalizeAgentSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
 	resolveSubagentThinkingLevel,
 	saveSubagentConfig,
 	sameToolSet,
+	subagentSettingsFilePath,
+	updateAgentToolsSetting,
+	updateCompletionDeliverySetting,
 	uniqueToolNames,
 } from "./settings.js";
 export { parsePositiveInteger } from "./execution.js";

--- a/extensions/pi-subagents/test/completion-delivery.test.ts
+++ b/extensions/pi-subagents/test/completion-delivery.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentTurnCompletion, ManagedAgent } from "../src/registry.js";
+import { CompletionDeliveryBroker } from "../src/stateful.js";
+
+function completion(id: string, output = `output:${id}`): AgentTurnCompletion {
+	const agent: ManagedAgent = {
+		id,
+		agent: "scout",
+		rootId: id,
+		depth: 0,
+		children: [],
+		state: "completed",
+		createdAt: 1,
+		updatedAt: 2,
+		cwd: process.cwd(),
+		history: [],
+		mailbox: [],
+	};
+	return { agent, task: `task:${id}`, output };
+}
+
+function deliveryHarness(options: { idle?: boolean; pending?: boolean } = {}) {
+	const sent: Array<{ message: Record<string, unknown>; options: Record<string, unknown> }> = [];
+	const pi = {
+		sendMessage(message: Record<string, unknown>, messageOptions: Record<string, unknown>) {
+			sent.push({ message, options: messageOptions });
+		},
+	};
+	const ctx = {
+		isIdle: () => options.idle ?? true,
+		hasPendingMessages: () => options.pending ?? false,
+	};
+	return { pi, ctx, sent };
+}
+
+test("next-turn completion delivery never wakes an idle root", () => {
+	const harness = deliveryHarness();
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "next-turn");
+	broker.enqueue(completion("sa_one"));
+	broker.flush();
+
+	assert.equal(harness.sent.length, 1);
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: false });
+	assert.equal(harness.sent[0]?.message.customType, "pi-subagent-completion");
+	assert.match(String(harness.sent[0]?.message.content), /Agent ID: sa_one/);
+	assert.deepEqual(harness.sent[0]?.message.details, {
+		agentId: "sa_one",
+		agent: "scout",
+		state: "completed",
+	});
+	broker.close();
+});
+
+test("auto-resume batches simultaneous completions into one root synthesis turn", () => {
+	const harness = deliveryHarness();
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_one"));
+	broker.enqueue(completion("sa_two"));
+	broker.flush();
+
+	assert.equal(harness.sent.length, 1);
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: true });
+	assert.match(String(harness.sent[0]?.message.content), /SUBAGENT_COMPLETION_BATCH/);
+	assert.match(String(harness.sent[0]?.message.content), /Agent ID: sa_one/);
+	assert.match(String(harness.sent[0]?.message.content), /Agent ID: sa_two/);
+	assert.deepEqual(harness.sent[0]?.message.details, {
+		completionCount: 2,
+		completions: [
+			{ agentId: "sa_one", agent: "scout", state: "completed" },
+			{ agentId: "sa_two", agent: "scout", state: "completed" },
+		],
+	});
+	broker.close();
+});
+
+test("completion timer coalesces a burst into one batched wake", async () => {
+	const harness = deliveryHarness();
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_timer_one"));
+	broker.enqueue(completion("sa_timer_two"));
+	await new Promise((resolve) => setTimeout(resolve, 20));
+	assert.equal(harness.sent.length, 1);
+	assert.match(String(harness.sent[0]?.message.content), /SUBAGENT_COMPLETION_BATCH/);
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: true });
+	broker.close();
+});
+
+test("large completion bursts stay bounded and request only one synthesis turn", () => {
+	const harness = deliveryHarness();
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	for (let index = 0; index < 17; index++) broker.enqueue(completion(`sa_${index}`));
+	broker.flush();
+
+	assert.equal(harness.sent.length, 2);
+	assert.deepEqual(
+		harness.sent.map((entry) => entry.options),
+		[
+			{ deliverAs: "steer", triggerTurn: false },
+			{ deliverAs: "steer", triggerTurn: true },
+		],
+	);
+	assert.ok(Buffer.byteLength(String(harness.sent[0]?.message.content), "utf8") <= 50 * 1024);
+	broker.close();
+});
+
+test("auto-resume allows only one in-flight wake until the parent starts", () => {
+	const harness = deliveryHarness();
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_first"));
+	broker.flush();
+	broker.enqueue(completion("sa_second"));
+	broker.flush();
+	broker.onParentTurnStart();
+	broker.enqueue(completion("sa_third"));
+	broker.flush();
+
+	assert.deepEqual(
+		harness.sent.map((entry) => entry.options),
+		[
+			{ deliverAs: "steer", triggerTurn: true },
+			{ deliverAs: "steer", triggerTurn: false },
+			{ deliverAs: "steer", triggerTurn: true },
+		],
+	);
+	broker.close();
+});
+
+test("auto-resume holds active-turn completions until settlement", () => {
+	const options = { idle: false, pending: false };
+	const harness = deliveryHarness(options);
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_active"));
+	broker.flush();
+	assert.equal(harness.sent.length, 0);
+
+	options.idle = true;
+	broker.onParentSettled();
+	broker.flush();
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: true });
+	broker.onParentSettled();
+	broker.flush();
+	assert.equal(harness.sent.length, 1);
+	broker.close();
+});
+
+test("changing delivery policy flushes an active-root batch without waiting for settlement", () => {
+	const harness = deliveryHarness({ idle: false });
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_policy"));
+	broker.flush();
+	assert.equal(harness.sent.length, 0);
+	broker.setDelivery("next-turn");
+	broker.flush();
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: false });
+	broker.close();
+});
+
+test("auto-resume lets pending user input suppress its wake", () => {
+	const harness = deliveryHarness({ idle: true, pending: true });
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_pending"));
+	broker.flush();
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: false });
+	broker.close();
+});
+
+test("a synchronous parent-start acknowledgement clears the pre-set wake latch", () => {
+	const sent: Array<Record<string, unknown>> = [];
+	let broker: CompletionDeliveryBroker;
+	broker = new CompletionDeliveryBroker(
+		{
+			sendMessage(_message: unknown, options: Record<string, unknown>) {
+				sent.push(options);
+				broker.onParentTurnStart();
+			},
+		} as never,
+		{ isIdle: () => true, hasPendingMessages: () => false },
+		"auto-resume",
+	);
+	broker.enqueue(completion("sa_first"));
+	broker.flush();
+	broker.enqueue(completion("sa_second"));
+	broker.flush();
+	assert.deepEqual(sent, [
+		{ deliverAs: "steer", triggerTurn: true },
+		{ deliverAs: "steer", triggerTurn: true },
+	]);
+	broker.close();
+});
+
+test("a synchronous auto-resume delivery error falls back to the next user turn", () => {
+	const sent: Array<Record<string, unknown>> = [];
+	let attempts = 0;
+	const broker = new CompletionDeliveryBroker(
+		{
+			sendMessage(_message: unknown, options: Record<string, unknown>) {
+				attempts++;
+				if (attempts === 1) throw new Error("wake rejected");
+				sent.push(options);
+			},
+		} as never,
+		{ isIdle: () => true, hasPendingMessages: () => false },
+		"auto-resume",
+	);
+	broker.enqueue(completion("sa_fallback"));
+	broker.flush();
+	assert.deepEqual(sent, [{ deliverAs: "nextTurn", triggerTurn: false }]);
+	broker.close();
+});
+
+test("double delivery failure retains the complete unsent suffix in order", () => {
+	let failing = true;
+	let attempts = 0;
+	let errors = 0;
+	const sent: Array<{ message: Record<string, unknown>; options: Record<string, unknown> }> = [];
+	const broker = new CompletionDeliveryBroker(
+		{
+			sendMessage(message: Record<string, unknown>, options: Record<string, unknown>) {
+				attempts++;
+				if (failing) throw new Error("delivery rejected");
+				sent.push({ message, options });
+			},
+		} as never,
+		{ isIdle: () => true, hasPendingMessages: () => false },
+		"auto-resume",
+		{
+			onDeliveryError: () => {
+				errors++;
+				throw new Error("observer failed");
+			},
+		},
+	);
+	for (let index = 0; index < 17; index++) broker.enqueue(completion(`sa_${index}`));
+	broker.flush();
+	assert.equal(attempts, 2);
+	assert.equal(errors, 1);
+	assert.equal(sent.length, 0);
+
+	failing = false;
+	broker.enqueue(completion("sa_17"));
+	broker.flush();
+	assert.equal(sent.length, 2);
+	assert.match(String(sent[0]?.message.content), /Agent ID: sa_0/);
+	assert.match(String(sent[1]?.message.content), /Agent ID: sa_16/);
+	assert.match(String(sent[1]?.message.content), /Agent ID: sa_17/);
+	assert.deepEqual(sent[1]?.options, { deliverAs: "steer", triggerTurn: true });
+	broker.close();
+});
+
+test("closing a completion broker drops session-stale queued notifications", async () => {
+	const harness = deliveryHarness();
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
+	broker.enqueue(completion("sa_stale"));
+	broker.close();
+	await new Promise((resolve) => setTimeout(resolve, 5));
+	assert.deepEqual(harness.sent, []);
+});

--- a/extensions/pi-subagents/test/in-process-transport.test.ts
+++ b/extensions/pi-subagents/test/in-process-transport.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/in-process-transport.js";
 import type { ManagedAgent } from "../src/registry.js";
 import { registerStatefulSubagents } from "../src/stateful.js";
+import { type IsolatedWorkspace, WorkspaceManager } from "../src/workspace.js";
 
 function managedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	return {
@@ -99,6 +100,21 @@ async function createTestModelRegistry(): Promise<{
 	}
 }
 
+class FakeWorkspaceManager extends WorkspaceManager {
+	override async create(_ownerId: string, cwd: string): Promise<IsolatedWorkspace> {
+		return {
+			mode: "worktree",
+			path: cwd,
+			rootPath: cwd,
+			repositoryRoot: cwd,
+		};
+	}
+
+	override async cleanup(_ownerId: string): Promise<void> {}
+
+	override async cleanupAll(): Promise<void> {}
+}
+
 class FakeChildSession implements ChildSession {
 	readonly sessionId = "child-session";
 	readonly prompts: string[] = [];
@@ -156,6 +172,13 @@ class FakeChildSession implements ChildSession {
 
 	getActiveToolNames(): string[] {
 		return ["read"];
+	}
+}
+
+class DelayedAbortChildSession extends FakeChildSession {
+	override async abort(): Promise<void> {
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		await super.abort();
 	}
 }
 
@@ -474,13 +497,19 @@ test("child resource loader excludes extensions while retaining the agent prompt
 	assert.equal(loader.getAgentsFiles().agentsFiles.at(-1)?.content, "Trusted child context.");
 });
 
-test("registered detached spawn returns while running and publishes each in-process completion", async () => {
+test("registered detached spawn auto-resumes without exposing a wait tool", async () => {
 	const originalDir = process.env.PI_CODING_AGENT_DIR;
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-tools-"));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	writeFileSync(
 		path.join(agentDir, "pi-subagents.json"),
-		JSON.stringify({ stateful: { transport: "in-process", persistence: false } }),
+		JSON.stringify({
+			stateful: {
+				transport: "in-process",
+				completionDelivery: "auto-resume",
+				persistence: false,
+			},
+		}),
 	);
 	try {
 		const child = new FakeChildSession();
@@ -492,9 +521,14 @@ test("registered detached spawn returns while running and publishes each in-proc
 				return child;
 			},
 		});
+		assert.equal(
+			mock.tools.some((tool) => tool.name === "subagent_wait"),
+			false,
+		);
 		const initialModel = { id: "initial" };
 		const selectedModel = { id: "selected" };
-		const context = createMockContext({ model: initialModel });
+		let rootIdle = false;
+		const context = createMockContext({ model: initialModel, isIdle: () => rootIdle });
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		mock.events.get("model_select")?.[0]?.({ model: selectedModel }, context.ctx);
 		mock.events.get("thinking_level_select")?.[0]?.({ level: "max" }, context.ctx);
@@ -513,64 +547,146 @@ test("registered detached spawn returns while running and publishes each in-proc
 				details: { agent: { id: string; state: string } };
 			}>;
 		};
+		const waitForCompletionCount = async (expected: number) => {
+			for (let attempt = 0; attempt < 50 && mock.sentMessages.length < expected; attempt++) {
+				await new Promise((resolve) => setTimeout(resolve, 2));
+			}
+			assert.equal(mock.sentMessages.length, expected);
+		};
+
 		child.waitForNextAbort();
 		const spawned = await execute("subagent_spawn", { agent: "scout", task: "first" });
 		const agentId = spawned.details.agent.id;
 		assert.match(spawned.details.agent.state, /starting|running/);
 		assert.match(spawned.content[0]?.text ?? "", /useful non-overlapping work immediately/i);
-		assert.match(spawned.content[0]?.text ?? "", /critical-path step is blocked/i);
+		assert.match(spawned.content[0]?.text ?? "", /end the response/i);
+		assert.match(spawned.content[0]?.text ?? "", /do not poll/i);
 		assert.deepEqual(child.prompts, ["first"]);
-		assert.equal(mock.sentMessages.length, 0);
-		mock.events.get("agent_end")?.[0]?.({}, context.ctx);
-		mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
-		assert.equal(
-			mock.sentUserMessages.length,
-			0,
-			"detached work must not autonomously start a root recovery turn",
-		);
 		await execute("subagent_interrupt", { agentId });
-		assert.equal(
-			mock.sentUserMessages.length,
-			0,
-			"terminal completion remains asynchronous instead of waking the root",
-		);
+		await new Promise((resolve) => setTimeout(resolve, 15));
+		assert.equal(mock.sentMessages.length, 0, "active root completion waits for settlement");
+		rootIdle = true;
+		mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		await waitForCompletionCount(1);
+		mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+
 		await execute("subagent_send", { agentId, task: "second" });
-		await Promise.all([
-			execute("subagent_wait", { agentId, timeoutMs: 100 }),
-			execute("subagent_wait", { agentId, timeoutMs: 100 }),
-		]);
+		await waitForCompletionCount(2);
+		mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+
 		child.waitForNextAbort();
 		await execute("subagent_send", { agentId, task: "interrupt me" });
 		await execute("subagent_interrupt", { agentId });
+		await waitForCompletionCount(3);
+		mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+
 		await execute("subagent_send", { agentId, task: "recovered" });
-		await execute("subagent_wait", { agentId, timeoutMs: 100 });
+		await waitForCompletionCount(4);
 		await execute("subagent_close", { agentId });
+
 		assert.deepEqual(child.prompts, ["first", "second", "interrupt me", "recovered"]);
 		assert.equal(created.length, 1);
 		assert.equal(created[0].parentRuntime.model, selectedModel);
 		assert.equal(created[0].parentRuntime.thinkingLevel, "max");
 		assert.equal(child.disposals, 1);
-		await new Promise((resolve) => setImmediate(resolve));
-		assert.equal(
-			mock.sentMessages.length,
-			2,
-			"active waits consume completion without suppressing unwaited turns",
+		for (const entry of mock.sentMessages) {
+			const delivered = entry as {
+				message: { customType: string; content: string };
+				options: { deliverAs: string; triggerTurn: boolean };
+			};
+			assert.equal(delivered.message.customType, "pi-subagent-completion");
+			assert.match(delivered.message.content, /Message Type: SUBAGENT_COMPLETION/);
+			assert.deepEqual(delivered.options, { deliverAs: "steer", triggerTurn: true });
+		}
+		assert.match(
+			String((mock.sentMessages[0] as { message: { content: string } }).message.content),
+			/Payload:\ndone:first/,
 		);
-		const firstCompletion = mock.sentMessages[0] as {
-			message: { customType: string; content: string; details: { agentId: string; state: string } };
-			options: { deliverAs: string; triggerTurn: boolean };
-		};
-		assert.equal(firstCompletion.message.customType, "pi-subagent-completion");
-		assert.equal(firstCompletion.message.details.agentId, agentId);
-		assert.equal(firstCompletion.message.details.state, "interrupted");
-		assert.match(firstCompletion.message.content, /Message Type: SUBAGENT_COMPLETION/);
-		assert.match(firstCompletion.message.content, /Payload:\ndone:first/);
-		assert.deepEqual(firstCompletion.options, { deliverAs: "steer", triggerTurn: false });
-		assert.equal(mock.sentUserMessages.length, 0);
-		mock.events.get("agent_end")?.[0]?.({}, context.ctx);
-		mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
-		assert.equal(mock.sentUserMessages.length, 0, "closed work does not wake the root");
+		assert.equal(mock.sentUserMessages.length, 0, "completion uses a custom message wake");
 		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	} finally {
+		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalDir;
+	}
+});
+
+test("session shutdown closes completion delivery before delayed isolated-agent cleanup", async () => {
+	const originalDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-shutdown-delivery-"));
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	writeFileSync(
+		path.join(agentDir, "pi-subagents.json"),
+		JSON.stringify({
+			stateful: {
+				transport: "in-process",
+				completionDelivery: "auto-resume",
+			},
+		}),
+	);
+	try {
+		const completedChild = new FakeChildSession();
+		const activeChild = new DelayedAbortChildSession();
+		activeChild.waitForNextAbort();
+		let childIndex = 0;
+		const mock = createMockPi();
+		registerStatefulSubagents(mock.pi, {
+			createInProcessSession: async () => (childIndex++ === 0 ? completedChild : activeChild),
+			workspaceManager: new FakeWorkspaceManager(),
+		});
+		const context = createMockContext({ isIdle: () => true });
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const execute = async (name: string, params: Record<string, unknown>) => {
+			const tool = mock.tools.find((candidate) => candidate.name === name) as {
+				execute: (...args: unknown[]) => Promise<unknown>;
+			};
+			return tool.execute(
+				"call",
+				params,
+				new AbortController().signal,
+				undefined,
+				context.ctx,
+			) as Promise<{
+				details: {
+					agent?: { id: string };
+					agents?: Array<{ id: string; state: string }>;
+				};
+			}>;
+		};
+		const first = await execute("subagent_spawn", {
+			agent: "scout",
+			task: "complete before shutdown",
+			workspaceMode: "worktree",
+		});
+		const second = await execute("subagent_spawn", {
+			agent: "scout",
+			task: "delay shutdown cleanup",
+			workspaceMode: "worktree",
+		});
+		for (let attempt = 0; attempt < 50; attempt++) {
+			await Promise.resolve();
+			const listed = await execute("subagent_list", {});
+			const firstState = listed.details.agents?.find(
+				(agent) => agent.id === first.details.agent?.id,
+			)?.state;
+			const secondState = listed.details.agents?.find(
+				(agent) => agent.id === second.details.agent?.id,
+			)?.state;
+			if (firstState === "completed" && secondState === "running") break;
+		}
+		const listed = await execute("subagent_list", {});
+		assert.equal(
+			listed.details.agents?.find((agent) => agent.id === first.details.agent?.id)?.state,
+			"completed",
+		);
+		assert.equal(
+			listed.details.agents?.find((agent) => agent.id === second.details.agent?.id)?.state,
+			"running",
+		);
+		assert.equal(mock.sentMessages.length, 0, "completion timer has not fired yet");
+
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(mock.sentMessages.length, 0, "shutdown must suppress the queued root wake");
 	} finally {
 		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = originalDir;

--- a/extensions/pi-subagents/test/orchestration.test.ts
+++ b/extensions/pi-subagents/test/orchestration.test.ts
@@ -11,6 +11,7 @@ import {
 	assertFollowUpWriteAllowed,
 	isWriteCapable,
 	registerStatefulSubagents,
+	resolveCompletionDelivery,
 	resolveSpawnContextMode,
 	resolveStatefulTransportKind,
 } from "../src/stateful.js";
@@ -78,7 +79,7 @@ test("shared-workspace write classification and follow-up guards are conservativ
 		(error: unknown) => {
 			assert.match(String(error), /already active in shared workspace/);
 			assert.match(String(error), /subagent parallel mode/);
-			assert.match(String(error), /wait or close/);
+			assert.match(String(error), /let the active agent finish or close/);
 			assert.match(String(error), /allowConcurrentWrites/);
 			assert.match(String(error), /worktree/);
 			return true;
@@ -111,7 +112,6 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 				"subagent_send",
 				"subagent_message",
 				"subagent_messages",
-				"subagent_wait",
 				"subagent_list",
 				"subagent_interrupt",
 				"subagent_close",
@@ -144,9 +144,8 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			/single subagent_spawn.*isolation or specialization/i,
 		);
 		assert.match(spawnTool.promptGuidelines.join("\n"), /useful non-overlapping.*immediately/i);
-		assert.match(spawnTool.promptGuidelines.join("\n"), /subagent_wait.*sparingly/i);
-		assert.match(spawnTool.promptGuidelines.join("\n"), /immediate.*critical-path.*blocked/i);
-		assert.doesNotMatch(spawnTool.promptGuidelines.join("\n"), /rather than yielding/i);
+		assert.match(spawnTool.promptGuidelines.join("\n"), /tell the user.*end the response/i);
+		assert.match(spawnTool.promptGuidelines.join("\n"), /do not poll.*subagent_list/i);
 		assert.match(spawnTool.promptGuidelines.join("\n"), /synthesize available.*completion/i);
 		for (const guideline of spawnTool.promptGuidelines) {
 			assert.match(
@@ -155,11 +154,6 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 				`flattened spawn guideline must identify subagent_spawn: ${guideline}`,
 			);
 		}
-		const waitTool = mock.tools.find((tool) => tool.name === "subagent_wait") as {
-			description: string;
-		};
-		assert.match(waitTool.description, /use sparingly/i);
-		assert.match(waitTool.description, /immediate next critical-path step is blocked/i);
 		const originalDepth = process.env.PI_SUBAGENT_DEPTH;
 		process.env.PI_SUBAGENT_DEPTH = "1";
 		try {
@@ -227,14 +221,17 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 	}
 });
 
-test("stateful settings validate transport and bounded runtime options", () => {
+test("stateful settings validate transport, completion delivery, and bounded runtime options", () => {
 	assert.equal(resolveStatefulTransportKind(undefined), "subprocess");
 	assert.equal(resolveStatefulTransportKind("in-process"), "in-process");
+	assert.equal(resolveCompletionDelivery(undefined), "next-turn");
+	assert.equal(resolveCompletionDelivery("auto-resume"), "auto-resume");
 	assert.deepEqual(
 		normalizeSubagentSettings({
 			stateful: {
 				enabled: true,
 				transport: "in-process",
+				completionDelivery: "auto-resume",
 				maxAgents: 8,
 				maxDepth: 2,
 				maxChildrenPerAgent: 3,
@@ -247,6 +244,7 @@ test("stateful settings validate transport and bounded runtime options", () => {
 			stateful: {
 				enabled: true,
 				transport: "in-process",
+				completionDelivery: "auto-resume",
 				maxAgents: 8,
 				maxDepth: 2,
 				maxChildrenPerAgent: 3,
@@ -259,6 +257,10 @@ test("stateful settings validate transport and bounded runtime options", () => {
 		stateful: { transport: "subprocess" },
 	});
 	assert.equal(normalizeSubagentSettings({ stateful: { transport: "native" } }), undefined);
+	assert.equal(
+		normalizeSubagentSettings({ stateful: { completionDelivery: "always" } }),
+		undefined,
+	);
 	assert.equal(normalizeSubagentSettings({ stateful: { maxAgents: 0 } }), undefined);
 	assert.equal(normalizeSubagentSettings({ stateful: { maxAgents: 1.5 } }), undefined);
 	assert.deepEqual(normalizeSubagentSettings({ stateful: { maxDepth: 0 } }), {

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -13,7 +13,8 @@ import {
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
 import { discoverAgents, formatAgentList } from "../src/agents.js";
 import { ToolToggleList } from "../src/config-ui.js";
 import { consumeSubagentSettingsNotice } from "../src/settings.js";
@@ -21,6 +22,7 @@ import subagents, {
 	buildPiArgs,
 	formatTokens,
 	formatUsageStats,
+	inspectCompletionDeliverySettings,
 	normalizeSubagentSettings,
 	parsePositiveInteger,
 	readSubagentSettings,
@@ -28,7 +30,11 @@ import subagents, {
 	sameToolSet,
 	saveSubagentConfig,
 	uniqueToolNames,
+	updateAgentToolsSetting,
+	updateCompletionDeliverySetting,
 } from "../src/subagents.js";
+
+initTheme("dark", false);
 
 type SchemaObject = {
 	properties?: Record<string, SchemaObject>;
@@ -66,9 +72,8 @@ test("subagents registers self-directed fan-out guidance and configuration comma
 	assert.match(guidanceText, /critical-path/i);
 	assert.match(guidanceText, /subagent_spawn.*parallel, isolation, or specialization benefit/i);
 	assert.match(guidanceText, /useful non-overlapping.*immediately/i);
-	assert.match(guidanceText, /subagent_wait.*sparingly/i);
-	assert.match(guidanceText, /immediate.*critical-path.*blocked/i);
-	assert.doesNotMatch(guidanceText, /do not yield permanently/i);
+	assert.match(guidanceText, /tell the user.*end the response/i);
+	assert.match(guidanceText, /do not poll.*subagent_list/i);
 	assert.match(guidanceText, /synthesize available.*completion/i);
 	assert.match(guidanceText, /after subagent_spawn.*non-overlapping work immediately/i);
 	assert.match(guidanceText, /subagent_spawn completion messages/i);
@@ -95,7 +100,12 @@ test("subagents registers self-directed fan-out guidance and configuration comma
 		parameters?.properties?.aggregator?.properties?.thinkingLevel?.enum,
 		thinkingLevels,
 	);
+	assert.ok(mock.commands.has("subagents"));
 	assert.ok(mock.commands.has("subagents:config"));
+	assert.deepEqual(mock.commands.get("subagents")?.getArgumentCompletions?.("s"), [
+		{ value: "settings", label: "settings", description: "Configure completion delivery" },
+		{ value: "status", label: "status", description: "Show effective subagent settings" },
+	]);
 	const toolResultHandler = mock.events.get("tool_result")?.[0];
 	assert.deepEqual(
 		toolResultHandler?.(
@@ -104,6 +114,109 @@ test("subagents registers self-directed fan-out guidance and configuration comma
 		),
 		{ isError: true },
 	);
+});
+
+test("subagent settings UI preserves unknown JSON and applies completion delivery immediately", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-settings-ui-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ futureOption: true, stateful: { futureStatefulOption: "keep" } }),
+		);
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let customCalls = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				customCalls++;
+				return driveCustomSelector(factory, ["\r", "\u001b"]).result;
+			},
+		});
+		await command.handler("settings", context.ctx);
+		assert.equal(customCalls, 1);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			futureOption: true,
+			stateful: {
+				futureStatefulOption: "keep",
+				completionDelivery: "auto-resume",
+			},
+		});
+		updateAgentToolsSetting("scout", ["read"]);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			futureOption: true,
+			stateful: {
+				futureStatefulOption: "keep",
+				completionDelivery: "auto-resume",
+			},
+			agents: { scout: { tools: ["read"] } },
+		});
+		await command.handler("status", context.ctx);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			/runtime completionDelivery: auto-resume/,
+		);
+
+		const nonTui = createMockContext({
+			mode: "json",
+			hasUI: true,
+			custom: async () => {
+				throw new Error("custom UI must not open");
+			},
+		});
+		await command.handler("settings", nonTui.ctx);
+		assert.match(nonTui.notifications[0]?.message ?? "", /Edit settings manually/);
+		await mock.commands.get("subagents:config")?.handler("", nonTui.ctx);
+		assert.match(nonTui.notifications.at(-1)?.message ?? "", /requires TUI mode/);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("subagent settings UI rolls back after an atomic save failure", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-settings-rollback-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(settingsPath, "{}\n");
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let renders: string[][] = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				rmSync(settingsPath);
+				mkdirSync(settingsPath);
+				const driven = driveCustomSelector(factory, ["\r", "\u001b"]);
+				renders = driven.renders;
+				return driven.result;
+			},
+		});
+		await command.handler("settings", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /were not saved/i);
+		assert.ok(renders[0]?.some((line) => line.includes("next-turn")));
+		await command.handler("status", context.ctx);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			/runtime completionDelivery: next-turn/,
+		);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
 });
 
 test("subagent tool selection keeps the cursor on the toggled row", () => {
@@ -308,6 +421,46 @@ test("subagent settings migrate and save to the canonical package filename", () 
 		const ignoredContext = createMockContext();
 		ignoredMock.events.get("session_start")?.[0]?.({}, ignoredContext.ctx);
 		assert.match(ignoredContext.notifications[0]?.message ?? "", /ignored/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("completion delivery inspection rejects malformed settings without overwriting them", () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-completion-settings-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		assert.deepEqual(inspectCompletionDeliverySettings(), {
+			path: path.join(directory, "pi-subagents.json"),
+			value: "next-turn",
+			source: "default",
+		});
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(settingsPath, "{ malformed");
+		assert.match(inspectCompletionDeliverySettings().error ?? "", /JSON|position|property/i);
+		assert.throws(() => updateCompletionDeliverySetting("auto-resume"), /Cannot update malformed/);
+		assert.equal(readFileSync(settingsPath, "utf8"), "{ malformed");
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("agent tool patches preserve prototype-like names as data", () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-tools-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		updateAgentToolsSetting("__proto__", ["read"]);
+		const raw = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
+		assert.equal(Object.hasOwn(raw.agents, "__proto__"), true);
+		assert.deepEqual(Object.getOwnPropertyDescriptor(raw.agents, "__proto__")?.value, {
+			tools: ["read"],
+		});
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;


### PR DESCRIPTION
## Summary

- remove the detached `subagent_wait` tool and update orchestration guidance to avoid polling or idle waiting
- add opt-in `stateful.completionDelivery: \"auto-resume\"` with settled, batched completion synthesis while preserving `next-turn` as the default
- add `/subagents settings|status|help`, atomic forward-compatible settings patches, documentation, and regression coverage

## Reliability

- hold auto-resume completions while the root is active and flush after `agent_settled`
- batch bursts, allow only one in-flight wake, and prioritize pending user or extension input
- suppress stale shutdown/session delivery and retain the complete unsent suffix across delivery and observer failures

## Testing

- `npm run check` (1038 tests, 0 failures)
- `npm run pack:subagents` (22 expected package files)
- `git diff --check`