### PR TITLE
fix(langfuse): flatten trace hierarchy

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-langfuse-flatten-trace-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-langfuse-flatten-trace-plan.md
@@ -1,0 +1,37 @@
+# Pi Langfuse Trace Flattening Plan
+
+## Goal
+
+Remove the redundant `pi.conversation` observation so each Langfuse trace starts directly at the native `pi.agent` observation while preserving attempt, turn, generation, tool, compaction, lifecycle, and trace metadata behavior.
+
+## Context
+
+`pi.conversation` and `pi.agent` cover the same submitted-prompt-to-settlement lifetime. The package is new, so there is no established saved-filter compatibility requirement that justifies keeping both observations.
+
+## Architecture
+
+```text
+pi.trace
+└─ pi.agent
+   ├─ pi.attempt
+   │  └─ pi.turn
+   │     ├─ pi.llm
+   │     └─ pi.tool.<tool-name>
+   └─ pi.compaction
+```
+
+`pi.agent` owns the trace update calls and remains open through retries, compaction recovery, and queued continuations until `agent_settled`.
+
+## Plan
+
+- [x] Change recorder tests to require `pi.agent` as the root observation with no `pi.conversation`; verified the focused test failed with four observations instead of three, then passed after the recorder change.
+- [x] Simplify `TraceRecorder` to make `pi.agent` the sole root observation and preserve child parentage, final metadata, outcomes, and exactly-once closure; verified all 46 pi-langfuse recorder, extension, and native-runtime tests pass.
+- [x] Update the README hierarchy and lifecycle descriptions to remove the unsupported compatibility claim; verified `pi.conversation` no longer appears under `extensions/pi-langfuse`.
+- [x] Run `npm run check`, `npm run pack:langfuse`, `git diff --check`, and inspect the final diff; verified 1,052 tests pass, the dry-run package contains the five source modules plus README/license/metadata, and the diff is clean and limited to this plan and pi-langfuse.
+
+## Completion Checklist
+
+- [x] A completed run exports `pi.agent` directly beneath `pi.trace`, without a `pi.conversation` observation.
+- [x] Attempts, turns, generations, tools, and compactions retain their intended parentage and lifecycle behavior.
+- [x] Trace-level input, output, session, tags, metadata, schema version, and outcome remain exported from `pi.agent`.
+- [x] Tests, README, and package contents agree with the flattened hierarchy.

--- a/extensions/pi-langfuse/README.md
+++ b/extensions/pi-langfuse/README.md
@@ -6,14 +6,14 @@
 
 ## ✨ Features
 
-- Names each Langfuse trace `pi.trace` and wraps one complete prompt-processing cycle in a root `pi.conversation` span.
-- Keeps one native `pi.agent` observation open until settlement, with indexed `pi.attempt` spans for retries and queued continuations.
+- Names each Langfuse trace `pi.trace` and uses a native `pi.agent` as its root observation.
+- Keeps the root agent open until settlement, with indexed `pi.attempt` spans for retries and queued continuations.
 - Records bounded provider-request snapshots, finalized assistant outputs, requested/response identity, TTFT, usage, and known cost buckets.
 - Retains ordered HTTP response history and safe diagnostic headers without marking recovered requests as errors.
 - Records final tool inputs and outputs, progress timing, duration, and failures without exporting partial-result content.
 - Records active compactions structurally without exporting generated summary text.
 - Groups traces with Pi's session id and adds bounded session/context snapshots and aggregate counters.
-- Adds the conversation-start Git branch and commit as metadata plus a filterable branch tag.
+- Adds the run-start Git branch and commit as metadata plus a filterable branch tag.
 - Reads Langfuse credentials and options only from a private `pi-langfuse.json` file.
 - Batches routine exports without delaying normal Pi agent completion.
 - Keeps its OpenTelemetry provider isolated so it coexists with other tracing extensions.
@@ -79,25 +79,24 @@ Restart Pi after changing credentials, endpoint, environment, release, or `captu
 
 ## 🔭 What is traced
 
-Each trace has this observation hierarchy. The `pi.conversation` wrapper is retained for compatibility with existing saved filters:
+Each trace has this observation hierarchy:
 
 ```text
 pi.trace
-└── pi.conversation (span: submitted prompt until Pi fully settles)
-    └── pi.agent (agent)
-        ├── pi.attempt (span: one agent_start/agent_end pair)
-        │   └── pi.turn (span)
-        │       ├── pi.llm (generation)
-        │       └── pi.tool.<tool-name> (tool)
-        ├── pi.compaction (span, only while the trace is active)
-        └── pi.attempt ...
+└── pi.agent (agent: submitted prompt until Pi fully settles)
+    ├── pi.attempt (span: one agent_start/agent_end pair)
+    │   └── pi.turn (span)
+    │       ├── pi.llm (generation)
+    │       └── pi.tool.<tool-name> (tool)
+    ├── pi.compaction (span, only while the trace is active)
+    └── pi.attempt ...
 ```
 
-All observations and the trace use schema version `2`. Existing observation names remain unchanged; schema version 2 adds `pi.attempt` and `pi.compaction` depth beneath the compatibility wrapper.
+All observations and the trace use schema version `2`. Schema version 2 adds indexed `pi.attempt` observations and active `pi.compaction` spans beneath the root agent.
 
 ### Trace and attempt fields
 
-The trace, `pi.conversation`, and `pi.agent` retain the submitted prompt, final assistant output, Pi session id, working directory, mode, initial provider/model, and optional Git context. Root metadata includes:
+The trace and root `pi.agent` retain the submitted prompt, final assistant output, Pi session id, working directory, mode, initial provider/model, and optional Git context. Root metadata includes:
 
 - `pi.trace.schema_version`, `pi.trace.outcome`, and `pi.trace.stop_reason`;
 - `pi.trace.attempt_count`, `pi.trace.turn_count`, `pi.trace.generation_count`, `pi.trace.tool_count`, `pi.trace.tool_error_count`, `pi.trace.compaction_count`, and `pi.trace.recovered_error_count`;
@@ -133,9 +132,9 @@ An active `pi.compaction` records `pi.compaction.reason`, `pi.compaction.will_re
 
 Images and embedded base64 data URIs are represented without their payloads, including provider data URLs. Opaque `thinkingSignature`, `textSignature`, and `thoughtSignature` continuity values are always removed. Every captured input or output has one cumulative 64 KiB serialized UTF-8 budget, bounded object/array traversal, and deterministic truncation markers. Langfuse credentials are masked again in the span processor before network export.
 
-A conversation begins before the first agent loop and remains open across retries, overflow-compaction recovery, and queued continuations. `agent_end` closes only the current attempt; `agent_settled` closes the root after no automatic work remains. Activity that unexpectedly arrives without a submitted prompt gets a fallback conversation labeled `[automatic continuation]`. Session replacement, reload, quit, and a new unexpected prompt close all descendants defensively and idempotently.
+The root agent begins before the first agent loop and remains open across retries, overflow-compaction recovery, and queued continuations. `agent_end` closes only the current attempt; `agent_settled` closes the root after no automatic work remains. Activity that unexpectedly arrives without a submitted prompt gets a fallback root input labeled `[automatic continuation]`. Session replacement, reload, quit, and a new unexpected prompt close all descendants defensively and idempotently.
 
-At conversation start, the extension runs bounded, non-shell Git lookups in `ctx.cwd`. A branch switch therefore applies to the next conversation. Detached HEADs retain only commit/detached metadata and the `git:detached` tag. Missing Git, non-repositories, timeouts, and lookup failures silently omit Git context without affecting tracing.
+At run start, the extension performs bounded, non-shell Git lookups in `ctx.cwd`. A branch switch therefore applies to the next run. Detached HEADs retain only commit/detached metadata and the `git:detached` tag. Missing Git, non-repositories, timeouts, and lookup failures silently omit Git context without affecting tracing.
 
 Completed observations are exported in batches while Pi remains live. Neither `agent_end` nor `agent_settled` waits for Langfuse network I/O. To wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
 

--- a/extensions/pi-langfuse/src/tracing.ts
+++ b/extensions/pi-langfuse/src/tracing.ts
@@ -214,7 +214,6 @@ interface Counters {
 
 export class TraceRecorder {
 	private root: Observation | undefined;
-	private agent: Observation | undefined;
 	private attempt: Observation | undefined;
 	private attemptIndex: number | undefined;
 	private turn: Observation | undefined;
@@ -245,7 +244,7 @@ export class TraceRecorder {
 
 	beginAgent(input: BeginAgentInput): void {
 		if (this.root)
-			this.closeActiveTrace("Interrupted by a new Pi conversation.", undefined, "interrupted");
+			this.closeActiveTrace("Interrupted by a new Pi run.", undefined, "interrupted");
 
 		this.lastOutput = undefined;
 		this.lastAssistant = undefined;
@@ -277,7 +276,7 @@ export class TraceRecorder {
 				? "git:detached"
 				: undefined;
 
-		this.root = this.backend.start("pi.conversation", attributes, { asType: "span" });
+		this.root = this.backend.start("pi.agent", attributes, { asType: "agent" });
 		this.root.updateTrace?.({
 			name: "pi.trace",
 			sessionId: this.context.sessionId,
@@ -285,10 +284,6 @@ export class TraceRecorder {
 			input: traceInput,
 			metadata,
 			tags: ["pi", ...(gitTag ? [gitTag] : [])],
-		});
-		this.agent = this.backend.start("pi.agent", attributes, {
-			asType: "agent",
-			parent: this.root,
 		});
 	}
 
@@ -311,7 +306,7 @@ export class TraceRecorder {
 				},
 				version: TRACE_SCHEMA_VERSION,
 			},
-			{ asType: "span", parent: this.agent ?? this.root },
+			{ asType: "span", parent: this.root },
 		);
 	}
 
@@ -334,7 +329,7 @@ export class TraceRecorder {
 		this.turn = this.backend.start(
 			"pi.turn",
 			{ metadata: { "pi.turn.index": turnIndex }, version: TRACE_SCHEMA_VERSION },
-			{ asType: "span", parent: this.attempt ?? this.agent ?? this.root },
+			{ asType: "span", parent: this.attempt ?? this.root },
 		);
 	}
 
@@ -389,7 +384,7 @@ export class TraceRecorder {
 				...(Object.keys(requestMetadata).length > 0 ? { metadata: requestMetadata } : {}),
 				version: TRACE_SCHEMA_VERSION,
 			},
-			{ asType: "generation", parent: this.turn ?? this.attempt ?? this.agent ?? this.root },
+			{ asType: "generation", parent: this.turn ?? this.attempt ?? this.root },
 		);
 		this.generation = {
 			observation,
@@ -576,7 +571,7 @@ export class TraceRecorder {
 					},
 					version: TRACE_SCHEMA_VERSION,
 				},
-				{ asType: "span", parent: this.agent ?? this.root },
+				{ asType: "span", parent: this.root },
 			),
 		};
 	}
@@ -637,9 +632,9 @@ export class TraceRecorder {
 		snapshot?: ContextSnapshot,
 		forcedOutcome?: Outcome,
 	): void {
-		this.closeTurn(statusMessage ?? "Pi turn ended when the conversation settled.");
+		this.closeTurn(statusMessage ?? "Pi turn ended when the agent run settled.");
 		this.closeAttempt(undefined, statusMessage, forcedOutcome ?? "interrupted");
-		this.closeCompaction(statusMessage ?? "Pi compaction ended when the conversation settled.");
+		this.closeCompaction(statusMessage ?? "Pi compaction ended when the agent run settled.");
 
 		if (!this.root) return;
 		const baseOutcome =
@@ -670,11 +665,6 @@ export class TraceRecorder {
 			metadata: finalMetadata,
 			...severityForOutcome(baseOutcome, statusMessage ?? this.lastAssistant?.errorMessage),
 		};
-		if (this.agent) {
-			this.agent.update(finalAttributes);
-			this.agent.end();
-			this.agent = undefined;
-		}
 		this.root.update(finalAttributes);
 		this.root.updateTrace?.({
 			...(this.lastOutput !== undefined ? { output: this.lastOutput } : {}),
@@ -724,7 +714,7 @@ export class TraceRecorder {
 				metadata: { "pi.tool.call_id": toolCallId, "pi.tool.name": toolName },
 				version: TRACE_SCHEMA_VERSION,
 			},
-			{ asType: "tool", parent: this.turn ?? this.attempt ?? this.agent ?? this.root },
+			{ asType: "tool", parent: this.turn ?? this.attempt ?? this.root },
 		);
 	}
 

--- a/extensions/pi-langfuse/test/extension.test.ts
+++ b/extensions/pi-langfuse/test/extension.test.ts
@@ -174,19 +174,17 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	);
 	await mock.events.get("agent_end")?.[0]?.({ messages: [] }, ctx);
 
-	assert.equal(backend.observations.length, 5);
+	assert.equal(backend.observations.length, 4);
 	assert.equal(backend.flushes, 0);
-	const [conversation, agent, attempt, turn, generation] = backend.observations;
-	assert.equal(conversation?.name, "pi.conversation");
-	assert.equal(conversation?.type, "span");
-	assert.equal(conversation?.ended, false);
-	assert.equal(conversation?.attributes.metadata?.["pi.git.branch"], "feature/lifecycle");
-	assert.equal(conversation?.attributes.metadata?.["pi.git.commit"], "fedcba987654");
-	assert.equal(conversation?.attributes.metadata?.["pi.git.detached"], false);
-	assert.deepEqual(conversation?.traceUpdates[0]?.tags, ["pi", "branch:feature/lifecycle"]);
+	const [agent, attempt, turn, generation] = backend.observations;
 	assert.equal(agent?.name, "pi.agent");
-	assert.equal(agent?.parent, conversation);
+	assert.equal(agent?.type, "agent");
+	assert.equal(agent?.parent, undefined);
 	assert.equal(agent?.ended, false);
+	assert.equal(agent?.attributes.metadata?.["pi.git.branch"], "feature/lifecycle");
+	assert.equal(agent?.attributes.metadata?.["pi.git.commit"], "fedcba987654");
+	assert.equal(agent?.attributes.metadata?.["pi.git.detached"], false);
+	assert.deepEqual(agent?.traceUpdates[0]?.tags, ["pi", "branch:feature/lifecycle"]);
 	assert.equal(attempt?.name, "pi.attempt");
 	assert.equal(attempt?.parent, agent);
 	assert.equal(attempt?.ended, true);
@@ -242,10 +240,10 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	);
 	await mock.events.get("agent_end")?.[0]?.({ messages: [] }, ctx);
 
-	assert.equal(backend.observations.length, 8);
-	const continuationAttempt = backend.observations[5];
-	const continuationTurn = backend.observations[6];
-	const continuationGeneration = backend.observations[7];
+	assert.equal(backend.observations.length, 7);
+	const continuationAttempt = backend.observations[4];
+	const continuationTurn = backend.observations[5];
+	const continuationGeneration = backend.observations[6];
 	assert.equal(continuationAttempt?.name, "pi.attempt");
 	assert.equal(continuationAttempt?.parent, agent);
 	assert.equal(continuationAttempt?.ended, true);
@@ -254,7 +252,6 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 	assert.equal(continuationTurn?.ended, true);
 	assert.equal(continuationGeneration?.parent, continuationTurn);
 	assert.equal(continuationGeneration?.ended, true);
-	assert.equal(conversation?.ended, false);
 	assert.equal(agent?.ended, false);
 
 	await mock.events.get("agent_settled")?.[0]?.({}, ctx);
@@ -263,7 +260,7 @@ test("pi-langfuse registers lifecycle hooks and exports completed traces", async
 		backend.observations.every((observation) => observation.ended),
 		true,
 	);
-	assert.deepEqual(conversation?.updates.at(-1)?.output, [{ type: "text", text: "Recovered" }]);
+	assert.deepEqual(agent?.updates.at(-1)?.output, [{ type: "text", text: "Recovered" }]);
 	assert.equal(backend.flushes, 0);
 });
 
@@ -302,15 +299,13 @@ test("pi-langfuse reconciles the finalized assistant message from agent_end", as
 	};
 	await mock.events.get("agent_end")?.[0]?.({ messages: [finalized] }, ctx);
 
-	const [conversation, agent, generation] = backend.observations;
+	const [agent, generation] = backend.observations;
 	assert.deepEqual(generation?.updates.at(-1)?.output, finalized.content);
 	assert.equal(generation?.updates.at(-1)?.statusMessage, finalized.errorMessage);
 	assert.equal(generation?.ended, true);
-	assert.equal(conversation?.ended, false);
 	assert.equal(agent?.ended, false);
 
 	await mock.events.get("agent_settled")?.[0]?.({}, ctx);
-	assert.equal(conversation?.ended, true);
 	assert.equal(agent?.ended, true);
 });
 
@@ -404,8 +399,8 @@ test("pi-langfuse traces normalized tool inputs and finalized tool outputs", asy
 	assert.equal(generation?.ended, true);
 	assert.equal(typeof generation?.endTime, "number");
 	const tool = backend.observations.at(-1);
-	assert.equal(backend.observations[3]?.name, "pi.turn");
-	assert.equal(tool?.parent, backend.observations[3]);
+	assert.equal(backend.observations[2]?.name, "pi.turn");
+	assert.equal(tool?.parent, backend.observations[2]);
 	assert.deepEqual(tool?.attributes.input, {
 		path: "file.ts",
 		oldText: "old",
@@ -419,7 +414,7 @@ test("pi-langfuse traces normalized tool inputs and finalized tool outputs", asy
 	});
 });
 
-test("agent_end leaves the conversation open and settled never starts a routine flush", async () => {
+test("agent_end leaves the root agent open and settled never starts a routine flush", async () => {
 	const backend = new FakeBackend();
 	backend.forceFlush = () => new Promise<void>(() => undefined);
 	const mock = createMockPi();

--- a/extensions/pi-langfuse/test/recorder.test.ts
+++ b/extensions/pi-langfuse/test/recorder.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { MAX_CAPTURE_BYTES, TraceRecorder } from "../src/tracing.js";
 import { FakeBackend, serializedBytes } from "./support.js";
 
-test("TraceRecorder wraps one agent hierarchy in a conversation span", async () => {
+test("TraceRecorder uses the agent as the root trace observation", async () => {
 	const backend = new FakeBackend();
 	const recorder = new TraceRecorder(backend, {
 		sessionId: "session-1",
@@ -45,21 +45,21 @@ test("TraceRecorder wraps one agent hierarchy in a conversation span", async () 
 	recorder.settle();
 	await recorder.flush();
 
-	assert.equal(backend.observations.length, 4);
-	const [conversation, agent, generation, tool] = backend.observations;
-	assert.equal(conversation?.name, "pi.conversation");
-	assert.equal(conversation?.type, "span");
-	assert.equal(conversation?.parent, undefined);
-	assert.deepEqual(conversation?.traceUpdates[0], {
+	assert.equal(backend.observations.length, 3);
+	const [agent, generation, tool] = backend.observations;
+	assert.equal(agent?.name, "pi.agent");
+	assert.equal(agent?.type, "agent");
+	assert.equal(agent?.parent, undefined);
+	assert.deepEqual(agent?.traceUpdates[0], {
 		name: "pi.trace",
 		sessionId: "session-1",
 		version: "2",
 		input: { prompt: "Fix the test" },
-		metadata: conversation?.attributes.metadata,
+		metadata: agent?.attributes.metadata,
 		tags: ["pi", "branch:feature/langfuse-context"],
 	});
-	assert.deepEqual(conversation?.attributes.input, { prompt: "Fix the test" });
-	assert.deepEqual(conversation?.attributes.metadata, {
+	assert.deepEqual(agent?.attributes.input, { prompt: "Fix the test" });
+	assert.deepEqual(agent?.attributes.metadata, {
 		"pi.cwd": "/workspace",
 		"pi.git.branch": "feature/langfuse-context",
 		"pi.git.commit": "0123456789ab",
@@ -70,10 +70,6 @@ test("TraceRecorder wraps one agent hierarchy in a conversation span", async () 
 		"pi.session.id": "session-1",
 		"pi.trace.schema_version": 2,
 	});
-	assert.equal(agent?.name, "pi.agent");
-	assert.equal(agent?.type, "agent");
-	assert.equal(agent?.parent, conversation);
-	assert.deepEqual(agent?.attributes, conversation?.attributes);
 	assert.equal(generation?.name, "pi.llm");
 	assert.equal(generation?.type, "generation");
 	assert.equal(generation?.parent, agent);
@@ -91,7 +87,6 @@ test("TraceRecorder wraps one agent hierarchy in a conversation span", async () 
 	assert.equal(tool?.parent, agent);
 	assert.equal(tool?.ended, true);
 	assert.equal(agent?.ended, true);
-	assert.equal(conversation?.ended, true);
 	assert.equal(backend.flushes, 1);
 });
 
@@ -118,8 +113,8 @@ test("TraceRecorder only exports known non-zero costs with the Langfuse total bu
 		usage: { cost: { total: 0.01 } },
 	});
 
-	assert.equal(backend.observations[2]?.updates.at(-1)?.costDetails, undefined);
-	assert.deepEqual(backend.observations[3]?.updates.at(-1)?.costDetails, { total: 0.01 });
+	assert.equal(backend.observations[1]?.updates.at(-1)?.costDetails, undefined);
+	assert.deepEqual(backend.observations[2]?.updates.at(-1)?.costDetails, { total: 0.01 });
 });
 
 test("TraceRecorder prefers the concrete response model and retains the requested alias", () => {
@@ -141,8 +136,8 @@ test("TraceRecorder prefers the concrete response model and retains the requeste
 		stopReason: "stop",
 	});
 
-	assert.equal(backend.observations[2]?.updates.at(-1)?.model, "concrete-model");
-	assert.deepEqual(backend.observations[2]?.updates.at(-1)?.metadata, {
+	assert.equal(backend.observations[1]?.updates.at(-1)?.model, "concrete-model");
+	assert.deepEqual(backend.observations[1]?.updates.at(-1)?.metadata, {
 		"pi.provider": "openai",
 		"pi.requested_model": "requested-alias",
 		"pi.response.model": "concrete-model",
@@ -172,7 +167,7 @@ test("TraceRecorder replaces all captured values when content capture is disable
 	for (const observation of backend.observations) {
 		if (observation.name === "pi.llm") assert.equal(observation.attributes.input, undefined);
 		else assert.equal(observation.attributes.input, "[content capture disabled]");
-		if (observation.name === "pi.conversation" || observation.name === "pi.agent") {
+		if (observation.name === "pi.agent") {
 			assert.equal(observation.attributes.metadata?.["pi.git.commit"], "abcdef012345");
 			assert.equal(observation.attributes.metadata?.["pi.git.detached"], true);
 		}
@@ -205,12 +200,11 @@ test("TraceRecorder closes interrupted observations and redacts image payloads",
 	recorder.finishTool("call-1", { content: "failed", isError: true });
 	recorder.settle();
 
-	const [conversation, agent, firstGeneration, secondGeneration, tool] = backend.observations;
-	assert.deepEqual(conversation?.attributes.input, {
+	const [agent, firstGeneration, secondGeneration, tool] = backend.observations;
+	assert.deepEqual(agent?.attributes.input, {
 		images: [{ type: "image", mimeType: "image/png", data: "[base64 omitted]" }],
 		prompt: "Describe this",
 	});
-	assert.deepEqual(agent?.attributes.input, conversation?.attributes.input);
 	assert.equal(firstGeneration?.updates.at(-1)?.level, "ERROR");
 	assert.match(String(firstGeneration?.updates.at(-1)?.statusMessage), /interrupted/i);
 	assert.equal(firstGeneration?.ended, true);
@@ -237,7 +231,7 @@ test("TraceRecorder bounds oversized tool details as one captured output", () =>
 		),
 	});
 
-	const tool = backend.observations[2];
+	const tool = backend.observations[1];
 	assert.ok(serializedBytes(tool?.attributes.input) <= MAX_CAPTURE_BYTES);
 	assert.ok(serializedBytes(tool?.updates.at(-1)?.output) <= MAX_CAPTURE_BYTES);
 });
@@ -291,7 +285,6 @@ test("TraceRecorder keeps retries in one trace with indexed attempt spans and ro
 		contextUsage: { tokens: 250, contextWindow: 1_000, percent: 25 },
 	});
 
-	const conversation = backend.observations.find(({ name }) => name === "pi.conversation");
 	const agent = backend.observations.find(({ name }) => name === "pi.agent");
 	const attempts = backend.observations.filter(({ name }) => name === "pi.attempt");
 	assert.equal(attempts.length, 2);
@@ -306,8 +299,8 @@ test("TraceRecorder keeps retries in one trace with indexed attempt spans and ro
 	assert.equal(attempts[1]?.updates.at(-1)?.level, undefined);
 	assert.equal(attempts[1]?.updates.at(-1)?.metadata?.["pi.attempt.outcome"], "success");
 	assert.equal(attempts[1]?.updates.at(-1)?.metadata?.["pi.attempt.stop_reason"], "stop");
-	assert.equal(conversation?.attributes.version, "2");
-	const finalMetadata = conversation?.updates.at(-1)?.metadata;
+	assert.equal(agent?.attributes.version, "2");
+	const finalMetadata = agent?.updates.at(-1)?.metadata;
 	assert.equal(finalMetadata?.["pi.trace.outcome"], "recovered_success");
 	assert.equal(finalMetadata?.["pi.trace.attempt_count"], 2);
 	assert.equal(finalMetadata?.["pi.trace.turn_count"], 2);
@@ -325,9 +318,7 @@ test("TraceRecorder keeps retries in one trace with indexed attempt spans and ro
 	assert.equal(finalMetadata?.["pi.trace.end_context_window"], 1_000);
 	assert.equal(finalMetadata?.["pi.trace.start_context_percent"], 10);
 	assert.equal(finalMetadata?.["pi.trace.end_context_percent"], 25);
-	assert.deepEqual(agent?.updates.at(-1)?.metadata, finalMetadata);
-	assert.deepEqual(conversation?.traceUpdates.at(-1)?.metadata, finalMetadata);
-	assert.equal(conversation?.endCalls, 1);
+	assert.deepEqual(agent?.traceUpdates.at(-1)?.metadata, finalMetadata);
 	assert.equal(agent?.endCalls, 1);
 	assert.equal(
 		backend.observations.every(({ endCalls }) => endCalls === 1),

--- a/extensions/pi-langfuse/test/runtime.test.ts
+++ b/extensions/pi-langfuse/test/runtime.test.ts
@@ -130,19 +130,16 @@ test("isolated runtime preserves the global provider and exports native observat
 		"span",
 		"span",
 		"span",
-		"span",
 		"tool",
 	]);
 	for (const span of spans) assert.equal(span.attributes["langfuse.version"], "2");
-	const conversation = spans.find((span) => span.name === "pi.conversation");
 	const agent = spans.find((span) => span.name === "pi.agent");
 	const attempt = spans.find((span) => span.name === "pi.attempt");
 	const turn = spans.find((span) => span.name === "pi.turn");
 	const generation = spans.find((span) => span.name === "pi.llm");
 	const tool = spans.find((span) => span.name === "pi.tool.read");
 	const compaction = spans.find((span) => span.name === "pi.compaction");
-	assert.equal(conversation?.parentSpanContext, undefined);
-	assert.equal(agent?.parentSpanContext?.spanId, conversation?.spanContext().spanId);
+	assert.equal(agent?.parentSpanContext, undefined);
 	assert.equal(attempt?.parentSpanContext?.spanId, agent?.spanContext().spanId);
 	assert.equal(turn?.parentSpanContext?.spanId, attempt?.spanContext().spanId);
 	assert.equal(compaction?.parentSpanContext?.spanId, agent?.spanContext().spanId);
@@ -163,13 +160,10 @@ test("isolated runtime preserves the global provider and exports native observat
 		generation?.attributes["langfuse.observation.cost_details"],
 		JSON.stringify({ input: 0.01, output: 0.02, total: 0.03 }),
 	);
-	assert.equal(conversation?.attributes["langfuse.observation.metadata.pi.cwd"], "/workspace");
-	assert.equal(conversation?.attributes["langfuse.trace.metadata.pi.cwd"], "/workspace");
-	assert.equal(
-		conversation?.attributes["langfuse.observation.metadata.pi.trace.outcome"],
-		"success",
-	);
-	assert.equal(conversation?.attributes["langfuse.trace.metadata.pi.trace.outcome"], "success");
+	assert.equal(agent?.attributes["langfuse.observation.metadata.pi.cwd"], "/workspace");
+	assert.equal(agent?.attributes["langfuse.trace.metadata.pi.cwd"], "/workspace");
+	assert.equal(agent?.attributes["langfuse.observation.metadata.pi.trace.outcome"], "success");
+	assert.equal(agent?.attributes["langfuse.trace.metadata.pi.trace.outcome"], "success");
 	assert.equal(
 		attempt?.attributes["langfuse.observation.metadata.pi.attempt.reason"],
 		"post_compaction",


### PR DESCRIPTION
## Summary
- remove the redundant `pi.conversation` observation
- use the native `pi.agent` observation as the trace root
- preserve attempt, turn, generation, tool, compaction, and trace metadata behavior
- update documentation and tests for the flattened hierarchy

## Testing
- `npm run check` — 1,052 tests passed
- `npm run pack:langfuse`
- `git diff --check`
