### PR TITLE
feat(subagents): select spawn thinking by task difficulty

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-subagents-spawn-thinking-level-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-subagents-spawn-thinking-level-plan.md
@@ -1,0 +1,29 @@
+# pi-subagents spawn thinking-level plan
+
+## Goal
+
+Let the root agent choose the lowest sufficient Pi thinking level for each `subagent_spawn` task, while preserving all existing defaults when the optional override is omitted.
+
+## Plan
+
+- [x] Add red tests under `extensions/pi-subagents/test/` for the spawn schema/rubric, lifecycle propagation and observability, transport precedence, persistence compatibility, and omission fallback; `npm test` failed on the missing `ManagedAgent.thinkingLevel` contract and subprocess resolver as intended.
+- [x] Add optional `thinkingLevel` to the stateful spawn contract and `ManagedAgent`; tests prove registry copies, follow-ups, persistence/restore, and list/result summaries retain it.
+- [x] Apply spawn override precedence in `SubprocessTransport` and `InProcessTransport`; tests cover explicit override, agent default, model suffix, parent snapshot, and omission.
+- [x] Add model-facing `subagent_spawn` guidance that selects the lowest sufficient level from `off|minimal|low|medium|high|xhigh|max` without a heuristic or extra classifier call; schema/guidance tests pass.
+- [x] Document selection ownership, rubric, precedence, lifecycle retention, Pi capability clamping, and omission compatibility in `extensions/pi-subagents/README.md`.
+- [x] Run `npm run check` (1,054 tests plus Biome, boundaries, and workspace typechecks) and `pi -ne -e ./extensions/pi-subagents --help`; both passed.
+
+## Assumptions
+
+- The root agent selects `thinkingLevel` from the delegated task; the extension does not infer difficulty.
+- An explicit spawn level applies to the entire retained agent lifecycle. `subagent_send` does not gain a per-turn override.
+- The requested level may be clamped by Pi for the selected model and is not claimed as the provider's effective level.
+- The persisted state version and existing blocking `subagent` API remain unchanged.
+
+## Completion Checklist
+
+- [x] `subagent_spawn` accepts exactly the seven Pi levels and advertises the difficulty rubric.
+- [x] Explicit levels reach both transports, survive follow-up/restore, and are observable in stateful tool details.
+- [x] Omitted levels preserve existing transport fallbacks and legacy persisted records.
+- [x] Illegal persisted levels are rejected by the existing quarantine path.
+- [x] README, tests, full repository check, and headless extension smoke are complete.

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -16,7 +16,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides `/subagents settings|status|help` for completion delivery plus `/subagents:config` for per-agent tool allow-lists.
-- Supports per-task `cwd`, hard subprocess `timeoutMs`, `thinkingLevel`, abort propagation, and streaming progress.
+- Supports per-task `cwd`, hard subprocess `timeoutMs`, task-selected `thinkingLevel`, abort propagation, and streaming progress.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
 - Enforces a recursion-depth guard and deterministic process-group termination.
 - Provides addressable stateful agents with follow-up, mailbox, list, interrupt, close, context selection, and persistence.
@@ -69,7 +69,9 @@ Common controls:
 
 - `cwd` — run a job from a different working directory.
 - `timeoutMs` — set a hard subprocess timeout.
-- `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process.
+- `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process or in-process child.
+
+For `subagent_spawn`, the root agent selects the lowest thinking level sufficient for the delegated task. This is a tool-argument decision made from the task already in context; `pi-subagents` does not run a string heuristic or an extra classifier model call.
 
 ## 🧭 Proactive use
 
@@ -246,7 +248,7 @@ The settings UI patches the raw JSON atomically and preserves unknown fields; it
 
 | Tool | Purpose |
 | --- | --- |
-| `subagent_spawn` | Start detached work, return an opaque `agentId` immediately, and deliver completion asynchronously. |
+| `subagent_spawn` | Start detached work with an optional task-selected thinking level, return an opaque `agentId` immediately, and deliver completion asynchronously. |
 | `subagent_send` | Send follow-up work to a reusable agent; shared-workspace write conflicts are guarded unless explicitly overridden. |
 | `subagent_message` | Queue a bounded mailbox message without starting a turn; sender IDs must be `root` or an agent in the same tree. |
 | `subagent_messages` | Read and optionally acknowledge unread mailbox messages. |
@@ -255,6 +257,18 @@ The settings UI patches the raw JSON atomically and preserves unknown fields; it
 | `subagent_close` | Abort if necessary, close the agent, and remove it from retained persistence. |
 
 Use `/subagents:agents list` to inspect the indented agent tree, lifecycle state, unread count, and available actions. Use `/subagents:agents clear` to close and delete all retained agents for the session. Active turns are FIFO-limited by `maxActiveTurns`; excess retained work remains in `starting` state until a slot is available. `maxAgents` separately bounds running, queued, and idle records. `parentId` creates a bounded child relationship; subtree interrupt and close operate child-first.
+
+A spawn can request a thinking level explicitly:
+
+```json
+{
+  "agent": "reviewer",
+  "task": "Analyze the cross-package concurrency failure and identify the safest fix",
+  "thinkingLevel": "high"
+}
+```
+
+The requested level is stored with the stateful agent and remains in effect for all follow-ups and after persisted restore. `subagent_send` does not provide a per-turn thinking override; create a new agent when a later task needs a different level.
 
 `subagent_spawn.context` accepts:
 
@@ -294,7 +308,7 @@ Existing `subagent` requests remain unchanged:
 | Parallel | Input order, with at most four active children. | Collects all task results; partial worker failure is reported in summaries but does not discard successful results. |
 | Parallel + aggregator | Source input order, then aggregator. | The aggregator runs with both successful outputs and failure descriptions; aggregator failure marks the tool result as an error. |
 
-Timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Thinking precedence remains: task/step/aggregator → call → agent setting → child default. Project-agent resolution and confirmation behavior is unchanged.
+Timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Blocking thinking precedence remains: task/step/aggregator → call → agent setting → child default. Stateful spawn thinking precedence is: `subagent_spawn.thinkingLevel` → agent setting → transport fallback. Project-agent resolution and confirmation behavior is unchanged.
 
 ## 🤖 Built-in agents
 
@@ -395,9 +409,24 @@ Each subprocess has a hard timeout to avoid runaway workers.
 - Set `timeoutMs` on a task, chain step, or aggregator to override it locally.
 - If omitted, the default is `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset.
 
-Set `thinkingLevel` to pass Pi's `--thinking <level>` to a subprocess. Supported values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+Set `thinkingLevel` to request one of Pi's supported levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Blocking subprocess calls pass the resolved value through `--thinking <level>`.
 
-Thinking-level precedence is: task/chain step/aggregator `thinkingLevel` → top-level `thinkingLevel` → agent default from config or frontmatter → Pi subprocess default. Omit `thinkingLevel` to preserve existing behavior. Pi still owns model capability clamping, so unsupported thinking levels are handled by the spawned Pi process.
+For `subagent_spawn`, the root agent should choose the lowest sufficient level:
+
+| Level | Appropriate delegated work |
+| --- | --- |
+| `off` / `minimal` | Extraction, formatting, or mechanical work requiring almost no reasoning. |
+| `low` | Straightforward, bounded tasks with direct steps. |
+| `medium` | Ordinary multi-step research or implementation. |
+| `high` | Complex debugging, design, review, or cross-file analysis. |
+| `xhigh` | Highly ambiguous, cross-system, or high-risk analysis. |
+| `max` | Exceptional hardest tasks where quality clearly outweighs latency and cost. |
+
+Blocking thinking precedence is: task/chain step/aggregator `thinkingLevel` → top-level `thinkingLevel` → agent default from config or frontmatter → Pi subprocess default.
+
+Stateful spawn precedence is: `subagent_spawn.thinkingLevel` → agent default from config or frontmatter → transport fallback. The subprocess transport then uses spawned Pi model/default resolution. The in-process transport uses a configured model thinking suffix and then the parent thinking snapshot captured when the child is created. An explicit spawn value is retained for the agent lifecycle and wins over all of those fallbacks.
+
+Omit `thinkingLevel` to preserve existing behavior. Reported stateful details show the requested level, not a guarantee of the provider's effective value. Pi still owns model capability clamping; `pi-subagents` does not duplicate capability detection.
 
 On timeout, the extension sends process-group `SIGTERM`, escalates to `SIGKILL` after a five-second grace period if the process has not actually closed, and returns partial bounded messages or stderr collected so far. Parent abort uses the same cleanup path and preserves a structured result.
 

--- a/extensions/pi-subagents/src/in-process-transport.ts
+++ b/extensions/pi-subagents/src/in-process-transport.ts
@@ -139,6 +139,7 @@ export class InProcessTransport implements SubagentTransport {
 		const final = latestAssistant(record.session.messages.slice(startingMessageCount));
 		const output = truncateUtf8(final.output || record.lastOutput, DEFAULT_MAX_OUTPUT_BYTES);
 		const truncated = output.truncated || agent.contextTruncated;
+		const policy = inProcessPolicy(agentConfig, agent);
 
 		switch (settlement.kind) {
 			case "completed":
@@ -148,21 +149,21 @@ export class InProcessTransport implements SubagentTransport {
 						exitCode: 1,
 						truncated,
 						error: final.error || "In-process subagent returned an error",
-						policy: inProcessPolicy(agentConfig),
+						policy,
 					};
 				}
 				if (final.stopReason === "aborted") {
 					return {
 						...interruptedOutcome(output.text),
 						truncated,
-						policy: inProcessPolicy(agentConfig),
+						policy,
 					};
 				}
 				return {
 					output: output.text,
 					exitCode: 0,
 					truncated,
-					policy: inProcessPolicy(agentConfig),
+					policy,
 				};
 			case "failed":
 				return {
@@ -170,7 +171,7 @@ export class InProcessTransport implements SubagentTransport {
 					exitCode: 1,
 					truncated,
 					error: errorMessage(settlement.error),
-					policy: inProcessPolicy(agentConfig),
+					policy,
 				};
 			case "timeout":
 				return {
@@ -178,13 +179,13 @@ export class InProcessTransport implements SubagentTransport {
 					exitCode: 124,
 					truncated,
 					error: `In-process subagent timed out after ${timeoutMs}ms`,
-					policy: inProcessPolicy(agentConfig),
+					policy,
 				};
 			case "aborted":
 				return {
 					...interruptedOutcome(output.text),
 					truncated,
-					policy: inProcessPolicy(agentConfig),
+					policy,
 				};
 		}
 	}
@@ -448,6 +449,7 @@ export async function resolveChildModel(options: ChildSessionCreateOptions): Pro
 	return {
 		model,
 		thinkingLevel:
+			options.agent.thinkingLevel ??
 			options.agentConfig.thinkingLevel ??
 			modelThinkingLevel ??
 			options.parentRuntime.thinkingLevel,
@@ -622,13 +624,16 @@ function interruptedOutcome(output: string): TurnOutcome {
 	return { output, exitCode: 130, aborted: true, error: "In-process subagent was aborted" };
 }
 
-function inProcessPolicy(agent: AgentConfig): NonNullable<TurnOutcome["policy"]> {
+function inProcessPolicy(
+	agentConfig: AgentConfig,
+	managedAgent: ManagedAgent,
+): NonNullable<TurnOutcome["policy"]> {
 	return {
 		inherited: ["modelRegistry", "authentication", "cwdResources"],
 		overridden: [
-			...(agent.model ? ["model"] : []),
-			...(agent.thinkingLevel ? ["thinkingLevel"] : []),
-			...(agent.tools ? ["tools"] : []),
+			...(agentConfig.model ? ["model"] : []),
+			...(managedAgent.thinkingLevel || agentConfig.thinkingLevel ? ["thinkingLevel"] : []),
+			...(agentConfig.tools ? ["tools"] : []),
 		],
 		unsupported: ["approvalPolicy", "sandboxProfile", "providerHeaders", "extensionState"],
 	};

--- a/extensions/pi-subagents/src/persistence.ts
+++ b/extensions/pi-subagents/src/persistence.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { isThinkingLevel } from "./agents.js";
 import { redactPrivateText } from "./context.js";
 import type { ManagedAgent } from "./registry.js";
 
@@ -165,8 +166,10 @@ function isStoredState(value: unknown): value is StoredState {
 			typeof record.updatedAt === "number" &&
 			Number.isFinite(record.updatedAt) &&
 			(record.parentId === undefined || typeof record.parentId === "string") &&
+			(record.thinkingLevel === undefined || isThinkingLevel(record.thinkingLevel)) &&
 			(record.children === undefined ||
-				(Array.isArray(record.children) && record.children.every((id) => typeof id === "string"))) &&
+				(Array.isArray(record.children) &&
+					record.children.every((id) => typeof id === "string"))) &&
 			Array.isArray(record.history) &&
 			record.history.every(isAgentTurn) &&
 			(record.mailbox === undefined ||

--- a/extensions/pi-subagents/src/registry.ts
+++ b/extensions/pi-subagents/src/registry.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
+import type { SubagentThinkingLevel } from "./agents.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
-import {
-	type AgentTurnRunner,
-	normalizeTransport,
-	type SubagentTransport,
-} from "./transport.js";
+import { type AgentTurnRunner, normalizeTransport, type SubagentTransport } from "./transport.js";
 
 export type AgentLifecycleState =
 	| "starting"
@@ -46,6 +43,7 @@ export interface ManagedAgent {
 	updatedAt: number;
 	cwd: string;
 	agentScope?: "user" | "project" | "both";
+	thinkingLevel?: SubagentThinkingLevel;
 	currentTask?: string;
 	history: AgentTurn[];
 	error?: string;
@@ -113,7 +111,11 @@ export class AgentRegistry {
 	private readonly agents = new Map<string, ManagedAgent>();
 	private readonly controllers = new Map<string, AbortController>();
 	private readonly running = new Map<string, Promise<ManagedAgent>>();
-	private readonly queue: Array<{ agent: ManagedAgent; task: string; resolve: (agent: ManagedAgent) => void }> = [];
+	private readonly queue: Array<{
+		agent: ManagedAgent;
+		task: string;
+		resolve: (agent: ManagedAgent) => void;
+	}> = [];
 	private changeQueue: Promise<void> = Promise.resolve();
 	private readonly maxAgents: number;
 	private readonly maxActiveTurns: number;
@@ -128,7 +130,10 @@ export class AgentRegistry {
 	private readonly transport: SubagentTransport;
 	private readonly now: () => number;
 
-	constructor(transport: SubagentTransport | AgentTurnRunner, private readonly options: AgentRegistryOptions = {}) {
+	constructor(
+		transport: SubagentTransport | AgentTurnRunner,
+		private readonly options: AgentRegistryOptions = {},
+	) {
 		this.transport = normalizeTransport(transport);
 		this.maxAgents = positiveInteger(options.maxAgents ?? 16, "maxAgents");
 		this.maxActiveTurns = positiveInteger(options.maxActiveTurns ?? 4, "maxActiveTurns");
@@ -210,6 +215,7 @@ export class AgentRegistry {
 		task: string;
 		cwd: string;
 		agentScope?: "user" | "project" | "both";
+		thinkingLevel?: SubagentThinkingLevel;
 		parentId?: string;
 		context?: string;
 		contextSourceIds?: string[];
@@ -250,6 +256,7 @@ export class AgentRegistry {
 			updatedAt: now,
 			cwd: input.cwd,
 			agentScope: input.agentScope,
+			thinkingLevel: input.thinkingLevel,
 			currentTask: task,
 			history: [],
 			mailbox: [],
@@ -293,10 +300,12 @@ export class AgentRegistry {
 			throw new Error("Subagent mailbox deduplication keys cannot exceed 256 characters");
 		}
 		const recipient = this.require(recipientId);
-		if (recipient.state === "closed") throw new Error(`Cannot message closed agent ${recipient.id}`);
+		if (recipient.state === "closed")
+			throw new Error(`Cannot message closed agent ${recipient.id}`);
 		if (senderId !== "root") {
 			const sender = this.require(senderId);
-			if (sender.state === "closed") throw new Error(`Closed agent ${sender.id} cannot send messages`);
+			if (sender.state === "closed")
+				throw new Error(`Closed agent ${sender.id} cannot send messages`);
 			if (sender.rootId !== recipient.rootId) {
 				throw new Error("Subagent mailbox messages cannot cross agent trees");
 			}
@@ -367,7 +376,8 @@ export class AgentRegistry {
 
 	async interrupt(id: string): Promise<ManagedAgent> {
 		const agent = this.require(id);
-		if (agent.state !== "running" && agent.state !== "starting") throw new Error(`Agent ${id} is not running`);
+		if (agent.state !== "running" && agent.state !== "starting")
+			throw new Error(`Agent ${id} is not running`);
 		if (agent.state === "starting") {
 			const index = this.queue.findIndex((entry) => entry.agent.id === id);
 			if (index >= 0) {
@@ -539,7 +549,11 @@ export class AgentRegistry {
 		}
 	}
 
-	private runQueuedTurn(agent: ManagedAgent, task: string, resolveQueued: (agent: ManagedAgent) => void): void {
+	private runQueuedTurn(
+		agent: ManagedAgent,
+		task: string,
+		resolveQueued: (agent: ManagedAgent) => void,
+	): void {
 		const controller = new AbortController();
 		this.controllers.set(agent.id, controller);
 		agent.state = "running";
@@ -549,7 +563,8 @@ export class AgentRegistry {
 		let completionContent = "";
 		let completionOutput = "";
 		let completionError: string | undefined;
-		void this.transport.runTurn(this.copy(agent), task, controller.signal)
+		void this.transport
+			.runTurn(this.copy(agent), task, controller.signal)
 			.then(async (outcome) => {
 				const output = truncateUtf8(outcome.output, this.maxTurnOutputBytes).text;
 				const error = outcome.error
@@ -564,7 +579,11 @@ export class AgentRegistry {
 					truncated: outcome.truncated,
 				});
 				agent.history = agent.history.slice(-this.maxHistoryTurns);
-				agent.state = outcome.aborted ? "interrupted" : outcome.exitCode === 0 ? "completed" : "failed";
+				agent.state = outcome.aborted
+					? "interrupted"
+					: outcome.exitCode === 0
+						? "completed"
+						: "failed";
 				agent.error = error;
 				agent.policy = outcome.policy;
 				completionOutput = output;
@@ -623,8 +642,7 @@ export class AgentRegistry {
 	): AgentMailboxMessage {
 		if (deduplicationKey) {
 			const existing = recipient.mailbox.find(
-				(message) =>
-					message.deduplicationKey === deduplicationKey && message.senderId === senderId,
+				(message) => message.deduplicationKey === deduplicationKey && message.senderId === senderId,
 			);
 			if (existing) return existing;
 		}

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -8,10 +8,11 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
+	type AgentScope,
 	type CompletionDelivery,
 	discoverAgents,
-	type AgentScope,
 	isThinkingLevel,
+	THINKING_LEVELS,
 } from "./agents.js";
 import { buildContextSnapshot, type ContextMode, redactPrivateText } from "./context.js";
 import { assertSubagentDepthAllowed } from "./execution.js";
@@ -36,6 +37,10 @@ const ScopeSchema = StringEnum(["user", "project", "both"] as const, {
 		'Per-invocation custom agent scope for this spawn. Default: "user". Use "project" for project-local agents or "both" for user and project agents; the selected scope is retained for follow-ups.',
 	default: "user",
 });
+const StatefulThinkingLevelSchema = StringEnum(THINKING_LEVELS, {
+	description:
+		"Optional requested Pi thinking level selected for this task difficulty; retained for every turn of the spawned agent.",
+});
 const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
 const MAX_COMPLETION_ERROR_BYTES = 512;
 const MAX_COMPLETIONS_PER_MESSAGE = 16;
@@ -52,6 +57,7 @@ function createSpawnPromptGuidelines(completionDelivery: CompletionDelivery): st
 			: "After subagent_spawn returns, do useful non-overlapping local work immediately. If none remains, briefly tell the user what subagent_spawn launched and end the response only when the current response does not depend on its result; next-turn delivery will not wake an idle root.";
 	return [
 		"Do not use subagent_spawn for simple or critical-path work that the main agent can perform directly.",
+		"Set subagent_spawn thinkingLevel to the lowest sufficient thinking level for the delegated task: use off or minimal for extraction, formatting, or mechanical work; low for straightforward bounded work; medium for ordinary multi-step research or implementation; high for complex debugging, design, review, or cross-file analysis; xhigh for highly ambiguous, cross-system, or high-risk analysis; and max only for the hardest tasks when quality clearly outweighs latency and cost. Omit subagent_spawn thinkingLevel only to preserve the agent or child default.",
 		deliveryGuidance,
 		"Use a single subagent_spawn only for a concrete bounded subtask that can run independently and has an isolation or specialization benefit such as independent review, bounded context/output, a distinct model/tool profile, or workspace isolation.",
 		"Use the blocking subagent instead of subagent_spawn when synchronous output is required before the main agent can continue and waiting is intentional; queued steering cannot be processed until that blocking call returns.",
@@ -136,7 +142,7 @@ export function registerStatefulSubagents(
 						getParentRuntime: () => ({ ...parentRuntime }),
 						createSession: dependencies.createInProcessSession,
 					})
-				: new SubprocessTransport(ctx);
+				: new SubprocessTransport();
 		registry = new AgentRegistry(transport, {
 			maxAgents: settings.maxAgents,
 			maxActiveTurns: settings.maxActiveTurns,
@@ -232,12 +238,13 @@ export function registerStatefulSubagents(
 		name: "subagent_spawn",
 		label: "Spawn Subagent",
 		description:
-			"Start an addressable background subagent, return immediately with an agentId, and receive its completion asynchronously.",
+			"Start an addressable background subagent with an optional thinking level chosen for the task difficulty, return immediately with an agentId, and receive its completion asynchronously.",
 		promptSnippet: "Start a reusable detached subagent; completion is delivered asynchronously",
 		promptGuidelines: createSpawnPromptGuidelines(completionDelivery),
 		parameters: Type.Object({
 			agent: Type.String({ minLength: 1 }),
 			task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
+			thinkingLevel: Type.Optional(StatefulThinkingLevelSchema),
 			cwd: Type.Optional(Type.String()),
 			agentScope: Type.Optional(ScopeSchema),
 			confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
@@ -289,6 +296,7 @@ export function registerStatefulSubagents(
 					task: params.task,
 					cwd: workspace?.path ?? requestedCwd,
 					agentScope: scope,
+					thinkingLevel: params.thinkingLevel,
 					parentId: params.parentId,
 					context: snapshot.text || undefined,
 					contextSourceIds: snapshot.sourceIds,
@@ -613,7 +621,8 @@ function formatLine(agent: ManagedAgent): string {
 	const task = agent.currentTask ? ` — ${agent.currentTask.slice(0, 80)}` : "";
 	const unread = agent.mailbox.filter((message) => !message.readAt).length;
 	const indent = "  ".repeat(agent.depth);
-	return `${indent}${agent.id} ${agent.agent} ${agent.state} ${elapsedSeconds}s unread:${unread} [${actions}]${task}`;
+	const thinking = agent.thinkingLevel ? ` thinking:${agent.thinkingLevel}` : "";
+	return `${indent}${agent.id} ${agent.agent} ${agent.state} ${elapsedSeconds}s${thinking} unread:${unread} [${actions}]${task}`;
 }
 
 function summarizeAgent(agent: ManagedAgent) {
@@ -628,6 +637,7 @@ function summarizeAgent(agent: ManagedAgent) {
 		createdAt: agent.createdAt,
 		updatedAt: agent.updatedAt,
 		cwd: agent.cwd,
+		thinkingLevel: agent.thinkingLevel,
 		currentTask: agent.currentTask
 			? truncateUtf8(agent.currentTask, MAX_TOOL_MESSAGE_BYTES).text
 			: undefined,
@@ -845,10 +855,13 @@ export function buildDetachedCompletionMessage(completion: AgentTurnCompletion):
 }
 
 function sanitizeCompletionLine(value: string, maxBytes: number): string {
-	return truncateUtf8(redactPrivateText(value), maxBytes)
-		.text.replace(/[\u0000-\u001f\u007f]+/g, " ")
-		.replace(/\s+/g, " ")
-		.trim();
+	return (
+		truncateUtf8(redactPrivateText(value), maxBytes)
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Strip untrusted terminal controls.
+			.text.replace(/[\u0000-\u001f\u007f]+/g, " ")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
 }
 
 async function cleanupClosedWorkspaces(

--- a/extensions/pi-subagents/src/subprocess-transport.ts
+++ b/extensions/pi-subagents/src/subprocess-transport.ts
@@ -1,18 +1,19 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { discoverAgents } from "./agents.js";
+import { type AgentConfig, discoverAgents, type SubagentThinkingLevel } from "./agents.js";
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
 import { getResultFinalOutput, runSingleAgent, type SubagentDetails } from "./runner.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
-import {
-	buildStatefulTurnPrompt,
-	resolveStatefulTurnTimeout,
-} from "./stateful-prompt.js";
+import { buildStatefulTurnPrompt, resolveStatefulTurnTimeout } from "./stateful-prompt.js";
 import type { SubagentTransport } from "./transport.js";
+
+export function resolveStatefulSubprocessThinkingLevel(
+	agents: readonly Pick<AgentConfig, "name" | "thinkingLevel">[],
+	record: Pick<ManagedAgent, "agent" | "thinkingLevel">,
+): SubagentThinkingLevel | undefined {
+	return resolveSubagentThinkingLevel(agents, record.agent, record.thinkingLevel);
+}
 
 export class SubprocessTransport implements SubagentTransport {
 	readonly kind = "subprocess" as const;
-
-	constructor(private readonly ctx: ExtensionContext) {}
 
 	async runTurn(record: ManagedAgent, task: string, signal: AbortSignal): Promise<TurnOutcome> {
 		const settings = readSubagentSettings();
@@ -33,7 +34,7 @@ export class SubprocessTransport implements SubagentTransport {
 			undefined,
 			undefined,
 			signal,
-			resolveSubagentThinkingLevel(discovery.agents, record.agent),
+			resolveStatefulSubprocessThinkingLevel(discovery.agents, record),
 			resolveStatefulTurnTimeout(agent),
 			undefined,
 			makeDetails,

--- a/extensions/pi-subagents/test/in-process-transport.test.ts
+++ b/extensions/pi-subagents/test/in-process-transport.test.ts
@@ -204,6 +204,7 @@ test("InProcessTransport reuses one child session and sends only each current ta
 		return child;
 	});
 	const agent = managedAgent({
+		thinkingLevel: "high",
 		context: "parent context",
 		history: [
 			{ task: "old task", output: "old output", startedAt: 1, completedAt: 2, exitCode: 0 },
@@ -221,6 +222,7 @@ test("InProcessTransport reuses one child session and sends only each current ta
 	);
 	assert.deepEqual(child.prompts, ["first", "second"]);
 	assert.equal(first.output, "done:first");
+	assert.deepEqual(first.policy?.overridden, ["thinkingLevel", "tools"]);
 	assert.equal(second.output, "done:second");
 	await transport.shutdown();
 	assert.equal(child.disposals, 1);
@@ -544,7 +546,10 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 				context.ctx,
 			) as Promise<{
 				content: Array<{ text: string }>;
-				details: { agent: { id: string; state: string } };
+				details: {
+					agent: { id: string; state: string; thinkingLevel?: string };
+					agents?: Array<{ id: string; thinkingLevel?: string }>;
+				};
 			}>;
 		};
 		const waitForCompletionCount = async (expected: number) => {
@@ -555,13 +560,24 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 		};
 
 		child.waitForNextAbort();
-		const spawned = await execute("subagent_spawn", { agent: "scout", task: "first" });
+		const spawned = await execute("subagent_spawn", {
+			agent: "scout",
+			task: "first",
+			thinkingLevel: "high",
+		});
 		const agentId = spawned.details.agent.id;
 		assert.match(spawned.details.agent.state, /starting|running/);
+		assert.equal(spawned.details.agent.thinkingLevel, "high");
 		assert.match(spawned.content[0]?.text ?? "", /useful non-overlapping work immediately/i);
 		assert.match(spawned.content[0]?.text ?? "", /end the response/i);
 		assert.match(spawned.content[0]?.text ?? "", /do not poll/i);
 		assert.deepEqual(child.prompts, ["first"]);
+		assert.equal(created[0].agent.thinkingLevel, "high");
+		const listedAfterSpawn = await execute("subagent_list", {});
+		assert.equal(
+			listedAfterSpawn.details.agents?.find((agent) => agent.id === agentId)?.thinkingLevel,
+			"high",
+		);
 		await execute("subagent_interrupt", { agentId });
 		await new Promise((resolve) => setTimeout(resolve, 15));
 		assert.equal(mock.sentMessages.length, 0, "active root completion waits for settlement");
@@ -756,6 +772,28 @@ test("public SDK child-session adapter completes a deterministic in-memory turn 
 	assert.equal(explicit.model.provider, model.provider);
 	assert.equal(explicit.model.id, model.id);
 	assert.equal(explicit.thinkingLevel, "max");
+	const agentDefault = await resolveChildModel({
+		agent: managedAgent(),
+		agentConfig: agentConfig({
+			model: "child-smoke/child-model:max",
+			thinkingLevel: "high",
+		}),
+		history: [],
+		modelRegistry,
+		parentRuntime: { model: undefined, thinkingLevel: "medium" },
+	});
+	assert.equal(agentDefault.thinkingLevel, "high");
+	const spawnOverride = await resolveChildModel({
+		agent: managedAgent({ thinkingLevel: "low" }),
+		agentConfig: agentConfig({
+			model: "child-smoke/child-model:max",
+			thinkingLevel: "high",
+		}),
+		history: [],
+		modelRegistry,
+		parentRuntime: { model: undefined, thinkingLevel: "medium" },
+	});
+	assert.equal(spawnOverride.thinkingLevel, "low");
 	const childCwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-turn-"));
 	const child = await createSdkChildSession({
 		agent: managedAgent({ cwd: childCwd }),

--- a/extensions/pi-subagents/test/orchestration.test.ts
+++ b/extensions/pi-subagents/test/orchestration.test.ts
@@ -15,6 +15,7 @@ import {
 	resolveSpawnContextMode,
 	resolveStatefulTransportKind,
 } from "../src/stateful.js";
+import { resolveStatefulSubprocessThinkingLevel } from "../src/subprocess-transport.js";
 import { WorkspaceManager } from "../src/workspace.js";
 
 function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
@@ -140,9 +141,20 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		);
 		const untrusted = createMockContext({ cwd: project, isProjectTrusted: () => false });
 		const spawnTool = mock.tools.find((tool) => tool.name === "subagent_spawn") as {
+			description: string;
 			execute: (...args: unknown[]) => Promise<unknown>;
+			parameters: {
+				properties?: Record<string, { description?: string; enum?: string[] }>;
+			};
 			promptGuidelines: string[];
 		};
+		const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+		assert.deepEqual(spawnTool.parameters.properties?.thinkingLevel?.enum, thinkingLevels);
+		assert.match(
+			spawnTool.parameters.properties?.thinkingLevel?.description ?? "",
+			/task difficulty/i,
+		);
+		assert.match(spawnTool.description, /thinking level.*task difficulty/i);
 		const spawnGuidance = spawnTool.promptGuidelines.join("\n");
 		assert.match(spawnGuidance, /simple or critical-path work/);
 		assert.match(spawnGuidance, /prefer one subagent_spawn.*broad.*research/i);
@@ -160,6 +172,13 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		assert.match(spawnGuidance, /tell the user.*end the response/i);
 		assert.match(spawnGuidance, /do not poll.*subagent_list/i);
 		assert.match(spawnGuidance, /synthesize available.*completion/i);
+		assert.match(spawnGuidance, /subagent_spawn.*lowest sufficient.*thinking level/i);
+		assert.match(spawnGuidance, /off.*minimal.*extraction.*mechanical/i);
+		assert.match(spawnGuidance, /low.*straightforward.*bounded/i);
+		assert.match(spawnGuidance, /medium.*multi-step/i);
+		assert.match(spawnGuidance, /high.*debugging.*design.*review/i);
+		assert.match(spawnGuidance, /xhigh.*ambiguous.*cross-system.*high-risk/i);
+		assert.match(spawnGuidance, /max.*hardest.*quality.*latency.*cost/i);
 		for (const guideline of spawnTool.promptGuidelines) {
 			assert.match(
 				guideline,
@@ -245,6 +264,19 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = originalDir;
 	}
+});
+
+test("stateful subprocess thinking uses spawn override before the agent default", () => {
+	const agents = [{ name: "scout", thinkingLevel: "low" as const }, { name: "reviewer" }];
+	assert.equal(
+		resolveStatefulSubprocessThinkingLevel(agents, record({ thinkingLevel: "high" })),
+		"high",
+	);
+	assert.equal(resolveStatefulSubprocessThinkingLevel(agents, record()), "low");
+	assert.equal(
+		resolveStatefulSubprocessThinkingLevel(agents, record({ agent: "reviewer" })),
+		undefined,
+	);
 });
 
 test("stateful settings validate transport, completion delivery, and bounded runtime options", () => {

--- a/extensions/pi-subagents/test/registry.test.ts
+++ b/extensions/pi-subagents/test/registry.test.ts
@@ -114,6 +114,27 @@ test("AgentRegistry supports follow-up, wait timeout, interrupt/reuse, limits, a
 	await assert.rejects(() => registry.close(first.id), /already closed/);
 });
 
+test("AgentRegistry retains an explicit spawn thinking level across follow-ups and copies", async () => {
+	const observed: Array<string | undefined> = [];
+	const registry = new AgentRegistry(async (agent) => {
+		observed.push(agent.thinkingLevel);
+		return { output: "done", exitCode: 0 };
+	});
+	const spawned = await registry.spawn({
+		agent: "scout",
+		task: "first",
+		cwd: process.cwd(),
+		thinkingLevel: "high",
+	});
+	assert.equal(spawned.thinkingLevel, "high");
+	await registry.wait(spawned.id, 100);
+	const followUp = await registry.followUp(spawned.id, "second");
+	assert.equal(followUp.thinkingLevel, "high");
+	await registry.wait(spawned.id, 100);
+	assert.deepEqual(observed, ["high", "high"]);
+	assert.equal(registry.get(spawned.id)?.thinkingLevel, "high");
+});
+
 test("AgentRegistry runs lifecycle operations through a transport contract", async () => {
 	const calls: string[] = [];
 	const registry = new AgentRegistry({
@@ -603,6 +624,7 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	const persistence = new AgentPersistence("session", { stateDir: dir, maxStoredAgents: 2 });
 	await persistence.save([
 		record({
+			thinkingLevel: "high",
 			context: "<private>secret</private>",
 			mailbox: [
 				{
@@ -629,6 +651,7 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	assert.match(raw, /visible/);
 	const restoredState = persistence.load()[0];
 	assert.equal(restoredState?.state, "idle");
+	assert.equal(restoredState?.thinkingLevel, "high");
 	assert.equal(restoredState?.mailbox[0]?.content, "[private content omitted]visible");
 	const competing = new AgentPersistence("session", { stateDir: dir, maxStoredAgents: 2 });
 	await Promise.all([
@@ -681,6 +704,27 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 		}),
 	);
 	assert.equal(persistence.load()[0]?.rootId, "legacy");
+	assert.equal(persistence.load()[0]?.thinkingLevel, undefined);
+	writeFileSync(
+		persistence.filePath,
+		JSON.stringify({
+			version: 2,
+			updatedAt: Date.now(),
+			agents: [
+				{
+					id: "invalid-thinking",
+					agent: "scout",
+					thinkingLevel: "huge",
+					state: "idle",
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+					cwd: process.cwd(),
+					history: [],
+				},
+			],
+		}),
+	);
+	assert.deepEqual(persistence.load(), []);
 	writeFileSync(
 		persistence.filePath,
 		JSON.stringify({


### PR DESCRIPTION
## Summary

- add task-selected `thinkingLevel` support to `subagent_spawn`
- preserve the requested level across follow-ups, persistence, and both transports
- document difficulty guidance, precedence, fallbacks, and model clamping

## Testing

- `npm run check`
- `pi -ne -e ./extensions/pi-subagents --help`