### PR TITLE
feat(plan-mode): allowlist subagent roles

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-plan-mode-subagent-allowlist-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-plan-mode-subagent-allowlist-plan.md
@@ -1,0 +1,62 @@
+## Goal
+
+Resolve [issue #335](https://github.com/narumiruna/pi-extensions/issues/335) with an opt-in, Plan-mode-only allowlist for subagent role names. A configured Plan session must reject disallowed blocking and detached subagent launches before execution, while `pi-plan-mode` and `pi-subagents` remain independently installable and normal non-Plan sessions remain unchanged.
+
+## Context
+
+`defaultPlanTools` can expose the extension-owned `subagent` tool during Plan mode, but `extensions/pi-plan-mode/src/plan-mode.ts` currently guards only `update_plan`, blocked built-ins, and the canonical `bash` name. It does not inspect which role an enabled delegation tool will launch.
+
+The current `pi-subagents` request surface selects roles at `agent`, `tasks[].agent`, `chain[].agent`, and `aggregator.agent` for blocking calls (`extensions/pi-subagents/src/params.ts`), plus `agent` for `subagent_spawn` (`extensions/pi-subagents/src/stateful.ts`). `pi-subagents` owns role discovery and execution, while Plan mode owns whether a launch is acceptable in a Plan session. Pi has no shared capability-policy API yet, so this change is a bounded name-based integration rather than capability inheritance.
+
+## Architecture
+
+Extend the optional user settings file `$PI_CODING_AGENT_DIR/pi-plan-mode.json` with:
+
+```json
+{
+  "defaultPlanTools": ["read", "bash", "grep", "find", "ls", "subagent"],
+  "allowedPlanSubagents": ["plan-scout", "plan-researcher", "plan-reviewer"]
+}
+```
+
+- Omitted `allowedPlanSubagents` preserves current behavior and does not restrict subagent roles.
+- An explicit empty array denies every covered subagent launch while Plan mode is active.
+- Entries are exact, case-sensitive, non-empty role-name strings, deduplicated in first-seen order. Malformed values use the existing invalid-settings warning and fallback behavior.
+- The policy is enforced from `pi-plan-mode`'s existing `tool_call` hook only while `state.enabled` is true, independently of whether the launch tool came from `defaultPlanTools` or a session-level `/plan tools` selection.
+- A package-local policy helper will recognize `subagent` and `subagent_spawn` by tool name without importing `pi-subagents`. It will collect every role-bearing field in the current public call shapes, reject the whole call if any role is disallowed, and fail closed when a covered launch payload does not provide a complete non-empty role set. Full mode/schema validation remains owned by `pi-subagents`.
+- The block reason will identify disallowed roles and the configured allowed roles so the model can retry with a permitted role. Returning `{ block: true, reason }` prevents the launch tool's executor from starting a child; it does not terminate the Plan turn.
+- When `pi-subagents` is absent, no covered tool call exists and the setting is inert. No dependency, package import, event-bus requirement, or settings ownership is added between the extensions.
+
+## Non-Goals
+
+- Do not inspect or prove the effective tools, permissions, source, or mutability of an allowed role; the allowlist is name-based defense in depth, not a sandbox.
+- Do not add RPC, a core capability protocol, a bridge package, or a dependency from `pi-plan-mode` to `pi-subagents`.
+- Do not change `pi-subagents` role discovery, tool schemas, execution, or project-agent confirmation behavior.
+- Do not authorize or classify `subagent_send` by retained agent ID; it does not launch a named role and Plan mode cannot resolve its effective role without a shared runtime contract.
+- Do not change extension/custom-tool defaults, `/plan tools` persistence, or tool restoration outside Plan mode.
+
+## Risks
+
+- Role names can resolve to changed or same-name user/project definitions, so an allowed name can later become write-capable. Document that users must keep allowed role definitions read-only and that this setting does not validate capabilities.
+- Tool names and argument paths are an implicit cross-extension protocol. Keep parsing isolated and tested; malformed covered launch shapes fail closed, but renamed/new delegation tools require a follow-up integration update.
+- Omitted or invalid allowlist configuration does not establish the restriction. Preserve backward compatibility, surface the existing settings warning, and document exact empty-versus-omitted semantics.
+- Existing retained agents can be addressed through lifecycle tools such as `subagent_send`; this bounded issue does not claim to make every custom delegation workflow read-only.
+
+## Plan
+
+- [x] Add focused failing cases to `extensions/pi-plan-mode/test/settings.test.ts` for omitted, populated, duplicate, empty, whitespace-only, non-array, and mixed-type `allowedPlanSubagents`; `npm test` produced the intended missing-property assertion failure before implementation (with two unrelated environment/timing failures elsewhere in the suite).
+- [x] Add a new focused policy test module under `extensions/pi-plan-mode/test/` covering allowed and disallowed single, parallel, chain, aggregator, and `subagent_spawn` roles; `npm test` produced the intended seven policy failures from the no-op scaffold, including disallowed, mixed, malformed, and empty-allowlist cases.
+- [x] Extend `PlanModeSettings` and `normalizePlanModeSettings()` in `extensions/pi-plan-mode/src/settings.ts` with strict ordered-deduplicated `allowedPlanSubagents` normalization while preserving omitted-versus-empty semantics and existing settings loading/migration behavior; all 5 focused settings tests pass.
+- [x] Add a cohesive package-local subagent policy helper under `extensions/pi-plan-mode/src/` that recognizes only `subagent` and `subagent_spawn`, extracts all current role positions without importing another extension, rejects malformed covered role payloads, and returns deterministic disallowed-role details; all 7 focused policy tests pass and the source/package search reports no `pi-subagents` reference.
+- [x] Wire the helper into the active `tool_call` path in `extensions/pi-plan-mode/src/plan-mode.ts` before launch execution; 78 focused Plan-mode tests and all 1,067 repository tests pass for inactive, omitted, configured, empty, manual-selection, missing-extension, malformed-call, and reload behavior.
+- [x] Update `extensions/pi-plan-mode/README.md` with the complete setting example, precedence and reload behavior, omitted/empty semantics, covered blocking/detached call shapes, independent-install behavior, and the name/source/capability limitation; source/test/documentation search confirms every documented field and boundary matches the implementation.
+- [x] Run the release-equivalent checks `npm run check` and `just pack-plan-mode`, inspect the dry-run package for the new source helper and unchanged `src/plan-mode.ts` entrypoint, and review the final diff to confirm no `pi-subagents` package or dependency changed; `NODE_OPTIONS=--test-isolation=none npm run check` passes all 1,067 tests after the default parallel runner repeatedly exposed one unrelated timer-sensitive `pi-subagents` test, and the 13-file package preview includes `src/subagent-policy.ts`.
+
+## Completion Checklist
+
+- [x] Active Plan mode blocks every disallowed role in current `subagent` single/parallel/chain/fan-in calls and `subagent_spawn` calls before execution, proven by focused hook and policy tests.
+- [x] Allowed roles pass unchanged, any mixed call is rejected as a whole, and malformed covered launch payloads fail closed, proven by exact test assertions.
+- [x] Omitted settings preserve compatibility, an empty allowlist denies all covered launches, inactive Plan mode is unaffected, and absence of `pi-subagents` causes no error or behavior change, proven by lifecycle tests.
+- [x] `pi-plan-mode` remains independently installable with no source import, package dependency, or required runtime service from `pi-subagents`, proven by boundary checks and package inspection.
+- [x] README documentation clearly describes the name-based safety boundary and does not claim capability or sandbox enforcement, verified against source and tests.
+- [x] `npm run check` and `just pack-plan-mode` pass with the intended publish contents and no unrelated changes.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -12,6 +12,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Adds `--plan` to start a session in Plan mode.
 - Enables built-in read-only tools by default while Plan mode is active.
 - Disables extension and custom tools by default, with a `/plan tools` selector for explicit user-risk opt-in.
+- Optionally limits `subagent` and `subagent_spawn` launches to named planning roles while Plan mode is active.
 - Blocks `update_plan`, mutating built-in tools, and unsafe `bash` forms such as writes, substitutions, background jobs, dependency installs, and mutating Git commands.
 - Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finalize only when decision-complete.
 - Adds required `plan_mode_question` and `plan_mode_complete` tools for structured questions and completion.
@@ -90,7 +91,8 @@ Create `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-m
 ```json
 {
   "thinkingLevel": "inherit",
-  "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
+  "defaultPlanTools": ["read", "bash", "grep", "find", "ls", "subagent"],
+  "allowedPlanSubagents": ["plan-scout", "plan-researcher", "plan-reviewer"],
   "safeSubcommands": {
     "git": ["status", "log", "rev-parse", "blame"],
     "gh": ["pr view", "pr list", "issue view", "issue list"]
@@ -105,6 +107,16 @@ Create `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-m
 Tool names must be non-empty strings; duplicates are removed in first-seen order. Unknown, unavailable, and Plan-mode-blocked names are ignored when tools are activated. A tool registered after Plan mode is already active is not added automatically; re-enter Plan mode or reopen `/plan tools` to reapply the selection. Non-built-in tools named in this global setting are an explicit user-risk opt-in, just like selecting them with `/plan tools`. Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead. An effective tool named `bash` remains subject to the limited-shell policy regardless of its source metadata.
 
 A selection made with `/plan tools` is stored in that Pi session and takes precedence over `defaultPlanTools` when the session resumes. The global setting remains the baseline for fresh sessions and sessions without an explicit selection.
+
+### Allowed Plan subagents
+
+`allowedPlanSubagents` is an optional, exact, case-sensitive allowlist of role names for subagent launches while Plan mode is active. It does not activate delegation tools by itself: add `subagent` or `subagent_spawn` to `defaultPlanTools`, or select the tool through `/plan tools`. The same role policy applies whichever activation path is used.
+
+When configured, Plan mode checks every role in blocking `subagent` single, parallel, chain, and fan-in calls (`agent`, `tasks[].agent`, `chain[].agent`, and `aggregator.agent`) and the top-level `agent` in `subagent_spawn`. A call containing any disallowed role is rejected as a whole before the launch tool executes. Covered calls whose role fields cannot be verified are also rejected so a malformed launch cannot bypass the policy.
+
+Omit `allowedPlanSubagents` to preserve the unrestricted role behavior for explicitly enabled delegation tools. Set it to `[]` to reject every covered launch in Plan mode. Names must be non-empty strings; duplicates are removed in first-seen order. A wrong type or an empty, whitespace-only, or non-string entry invalidates the settings file and triggers the normal warning/default fallback. Settings reload on `session_start`; removing the property removes the role restriction. Non-Plan sessions are never restricted. If no extension has registered the covered tool names, the setting is inert, so `pi-plan-mode` and `pi-subagents` remain independently installable.
+
+This is a name check, not capability enforcement or a sandbox. `pi-plan-mode` does not inspect an allowed role's effective tools, permissions, or source. User or project definitions can change or override the meaning of an allowed name, so keep every allowed role independently read-only and retain normal project-agent trust and confirmation controls. The policy does not resolve retained agent IDs used by `subagent_send`; enabling follow-up lifecycle tools remains a separate user-risk decision.
 
 ### Safe shell subcommands
 

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -32,6 +32,7 @@ import {
 	readPlanModeSettings,
 } from "./settings.js";
 import { type PlanCompletionSource, type PlanModeState, restorePlanModeState } from "./state.js";
+import { enforcePlanSubagentAllowlist } from "./subagent-policy.js";
 import {
 	canSelectToolInPlanMode,
 	classifyPlanModeTool,
@@ -263,6 +264,14 @@ export default function planMode(pi: ExtensionAPI) {
 				reason:
 					"Plan mode blocks update_plan because it tracks execution progress rather than conversational planning.",
 			};
+		}
+		if (settings.allowedPlanSubagents !== undefined) {
+			const blocked = enforcePlanSubagentAllowlist(
+				event.toolName,
+				event.input,
+				settings.allowedPlanSubagents,
+			);
+			if (blocked) return blocked;
 		}
 		const calledTool = toolByName(event.toolName);
 		if (calledTool && classifyPlanModeTool(calledTool) === "blocked") {

--- a/extensions/pi-plan-mode/src/settings.ts
+++ b/extensions/pi-plan-mode/src/settings.ts
@@ -28,6 +28,7 @@ export type PlanModeFixedThinkingLevel = Exclude<PlanModeThinkingLevel, "inherit
 export interface PlanModeSettings {
 	thinkingLevel: PlanModeThinkingLevel;
 	defaultPlanTools?: string[];
+	allowedPlanSubagents?: string[];
 	safeSubcommands?: SafeSubcommands;
 }
 export type PlanModeSettingsLoadResult =
@@ -50,6 +51,11 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		const defaultPlanTools = normalizeToolNames(Reflect.get(value, "defaultPlanTools"));
 		if (!defaultPlanTools) return undefined;
 		settings.defaultPlanTools = defaultPlanTools;
+	}
+	if (Object.hasOwn(value, "allowedPlanSubagents")) {
+		const allowedPlanSubagents = normalizeToolNames(Reflect.get(value, "allowedPlanSubagents"));
+		if (!allowedPlanSubagents) return undefined;
+		settings.allowedPlanSubagents = allowedPlanSubagents;
 	}
 	if (Object.hasOwn(value, "safeSubcommands")) {
 		const safeSubcommands = normalizeSafeSubcommands(Reflect.get(value, "safeSubcommands"));

--- a/extensions/pi-plan-mode/src/subagent-policy.ts
+++ b/extensions/pi-plan-mode/src/subagent-policy.ts
@@ -1,0 +1,98 @@
+export interface PlanSubagentPolicyBlock {
+	block: true;
+	reason: string;
+}
+
+const COVERED_SUBAGENT_TOOLS = new Set(["subagent", "subagent_spawn"]);
+
+export function enforcePlanSubagentAllowlist(
+	toolName: string,
+	input: unknown,
+	allowedRoleNames: readonly string[],
+): PlanSubagentPolicyBlock | undefined {
+	if (!COVERED_SUBAGENT_TOOLS.has(toolName)) return undefined;
+
+	const requestedRoleNames =
+		toolName === "subagent_spawn" ? readSpawnRoleNames(input) : readBlockingRoleNames(input);
+	const allowedNames = unique(allowedRoleNames);
+	if (!requestedRoleNames) {
+		return {
+			block: true,
+			reason: `Plan mode could not verify subagent roles for tool '${toolName}'. ${formatAllowedRoles(allowedNames)}`,
+		};
+	}
+
+	const allowed = new Set(allowedNames);
+	const disallowedNames = unique(requestedRoleNames).filter((name) => !allowed.has(name));
+	if (disallowedNames.length === 0) return undefined;
+
+	return {
+		block: true,
+		reason: `Plan mode blocks subagent role(s): ${disallowedNames.join(", ")}. ${formatAllowedRoles(allowedNames)}`,
+	};
+}
+
+function readSpawnRoleNames(input: unknown) {
+	if (!isRecord(input)) return undefined;
+	const agent = readRoleName(input.agent);
+	return agent ? [agent] : undefined;
+}
+
+function readBlockingRoleNames(input: unknown) {
+	if (!isRecord(input)) return undefined;
+	const roleNames: string[] = [];
+	let hasRoleField = false;
+
+	if (Object.hasOwn(input, "agent")) {
+		hasRoleField = true;
+		const agent = readRoleName(input.agent);
+		if (!agent) return undefined;
+		roleNames.push(agent);
+	}
+	for (const field of ["tasks", "chain"] as const) {
+		if (!Object.hasOwn(input, field)) continue;
+		hasRoleField = true;
+		const agents = readRoleArray(input[field]);
+		if (!agents) return undefined;
+		roleNames.push(...agents);
+	}
+	if (Object.hasOwn(input, "aggregator")) {
+		hasRoleField = true;
+		if (!isRecord(input.aggregator)) return undefined;
+		const agent = readRoleName(input.aggregator.agent);
+		if (!agent) return undefined;
+		roleNames.push(agent);
+	}
+
+	return hasRoleField && roleNames.length > 0 ? roleNames : undefined;
+}
+
+function readRoleArray(value: unknown) {
+	if (!Array.isArray(value) || value.length === 0) return undefined;
+	const roleNames: string[] = [];
+	for (const item of value) {
+		if (!isRecord(item)) return undefined;
+		const agent = readRoleName(item.agent);
+		if (!agent) return undefined;
+		roleNames.push(agent);
+	}
+	return roleNames;
+}
+
+function readRoleName(value: unknown) {
+	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatAllowedRoles(allowedRoleNames: readonly string[]) {
+	return allowedRoleNames.length > 0
+		? `Allowed Plan subagents: ${allowedRoleNames.join(", ")}.`
+		: "No subagent roles are allowed in Plan mode.";
+}
+
+function unique(values: readonly string[]) {
+	return Array.from(new Set(values));
+}

--- a/extensions/pi-plan-mode/test/settings.test.ts
+++ b/extensions/pi-plan-mode/test/settings.test.ts
@@ -63,6 +63,26 @@ test("Plan-mode settings normalize default tool names strictly", async () => {
 	}
 });
 
+test("Plan-mode settings normalize allowed subagent names strictly", () => {
+	assert.deepEqual(normalizePlanModeSettings({}), { thinkingLevel: "inherit" });
+	assert.deepEqual(
+		normalizePlanModeSettings({
+			allowedPlanSubagents: ["plan-scout", "plan-reviewer", "plan-scout"],
+		}),
+		{
+			thinkingLevel: "inherit",
+			allowedPlanSubagents: ["plan-scout", "plan-reviewer"],
+		},
+	);
+	assert.deepEqual(normalizePlanModeSettings({ allowedPlanSubagents: [] }), {
+		thinkingLevel: "inherit",
+		allowedPlanSubagents: [],
+	});
+	for (const allowedPlanSubagents of ["plan-scout", [""], ["   "], ["plan-scout", 42]]) {
+		assert.equal(normalizePlanModeSettings({ allowedPlanSubagents }), undefined);
+	}
+});
+
 test("Plan-mode settings validate safe subcommands strictly", async () => {
 	assert.deepEqual(
 		normalizePlanModeSettings({

--- a/extensions/pi-plan-mode/test/subagent-allowlist.test.ts
+++ b/extensions/pi-plan-mode/test/subagent-allowlist.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	builtinTool,
+	createMockContext,
+	createMockPi,
+	extensionTool,
+} from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+
+const SETTINGS_FILE = "pi-plan-mode.json";
+
+test("configured roles guard blocking and detached launches only in active Plan mode", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, SETTINGS_FILE),
+			JSON.stringify({
+				defaultPlanTools: ["subagent", "subagent_spawn"],
+				allowedPlanSubagents: ["plan-scout", "plan-reviewer"],
+			}),
+		);
+		const mock = createMockPi({
+			activeTools: ["read"],
+			allTools: [builtinTool("read"), extensionTool("subagent"), extensionTool("subagent_spawn")],
+		});
+		planMode(mock.pi);
+		const context = createMockContext();
+		const hook = mock.events.get("tool_call")?.[0];
+		assert.ok(hook);
+
+		assert.equal(
+			await hook(
+				{ toolName: "subagent", input: { agent: "worker", task: "Implement" } },
+				context.ctx,
+			),
+			undefined,
+			"inactive Plan mode must not enforce its role policy",
+		);
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"subagent",
+			"subagent_spawn",
+			"plan_mode_question",
+			"plan_mode_complete",
+		]);
+		assert.equal(
+			await hook(
+				{ toolName: "subagent", input: { agent: "plan-scout", task: "Inspect" } },
+				context.ctx,
+			),
+			undefined,
+		);
+		assert.match(
+			(
+				(await hook(
+					{
+						toolName: "subagent",
+						input: {
+							tasks: [
+								{ agent: "plan-scout", task: "Inspect" },
+								{ agent: "worker", task: "Implement" },
+							],
+						},
+					},
+					context.ctx,
+				)) as { reason?: string } | undefined
+			)?.reason ?? "",
+			/role\(s\): worker/,
+		);
+		assert.match(
+			(
+				(await hook(
+					{
+						toolName: "subagent_spawn",
+						input: { agent: "worker", task: "Implement" },
+					},
+					context.ctx,
+				)) as { reason?: string } | undefined
+			)?.reason ?? "",
+			/role\(s\): worker/,
+		);
+		assert.match(
+			(
+				(await hook({ toolName: "subagent", input: { tasks: [] } }, context.ctx)) as
+					| { reason?: string }
+					| undefined
+			)?.reason ?? "",
+			/could not verify subagent roles/,
+		);
+	});
+});
+
+test("omitted and empty role allowlists preserve distinct compatibility behavior", async () => {
+	await withAgentDir(async (agentDir) => {
+		const settingsPath = join(agentDir, SETTINGS_FILE);
+		await writeFile(settingsPath, JSON.stringify({ defaultPlanTools: ["subagent"] }));
+		const allTools = [builtinTool("read"), extensionTool("subagent")];
+		const omitted = createMockPi({ activeTools: ["read"], allTools });
+		planMode(omitted.pi);
+		const omittedContext = createMockContext();
+		await omitted.events.get("session_start")?.[0]?.({}, omittedContext.ctx);
+		await omitted.commands.get("plan")?.handler("", omittedContext.ctx);
+		assert.equal(
+			await omitted.events.get("tool_call")?.[0]?.(
+				{ toolName: "subagent", input: { agent: "worker", task: "Implement" } },
+				omittedContext.ctx,
+			),
+			undefined,
+		);
+
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ defaultPlanTools: ["subagent"], allowedPlanSubagents: [] }),
+		);
+		const empty = createMockPi({ activeTools: ["read"], allTools });
+		planMode(empty.pi);
+		const emptyContext = createMockContext();
+		await empty.events.get("session_start")?.[0]?.({}, emptyContext.ctx);
+		await empty.commands.get("plan")?.handler("", emptyContext.ctx);
+		assert.match(
+			(
+				(await empty.events.get("tool_call")?.[0]?.(
+					{ toolName: "subagent", input: { agent: "plan-scout", task: "Inspect" } },
+					emptyContext.ctx,
+				)) as { reason?: string } | undefined
+			)?.reason ?? "",
+			/No subagent roles are allowed/,
+		);
+	});
+});
+
+test("a session-level Plan tools selection remains guarded", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, SETTINGS_FILE),
+			JSON.stringify({ defaultPlanTools: [], allowedPlanSubagents: ["plan-scout"] }),
+		);
+		const mock = createMockPi({
+			activeTools: ["read"],
+			allTools: [builtinTool("read"), extensionTool("subagent")],
+		});
+		planMode(mock.pi);
+		let selectedSubagent = false;
+		const context = createMockContext({
+			hasUI: true,
+			select: async (_title: unknown, choices: string[]) => {
+				if (selectedSubagent) return "Done";
+				selectedSubagent = true;
+				return choices.find((choice) => choice.includes(". subagent "));
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("tools", context.ctx);
+		assert.ok(mock.rawPi.getActiveTools().includes("subagent"));
+		assert.match(
+			(
+				(await mock.events.get("tool_call")?.[0]?.(
+					{ toolName: "subagent", input: { agent: "worker", task: "Implement" } },
+					context.ctx,
+				)) as { reason?: string } | undefined
+			)?.reason ?? "",
+			/role\(s\): worker/,
+		);
+	});
+});
+
+test("session reload replaces and removes the role policy", async () => {
+	await withAgentDir(async (agentDir) => {
+		const settingsPath = join(agentDir, SETTINGS_FILE);
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ defaultPlanTools: ["subagent"], allowedPlanSubagents: ["plan-scout"] }),
+		);
+		const mock = createMockPi({
+			activeTools: ["read"],
+			allTools: [builtinTool("read"), extensionTool("subagent")],
+		});
+		planMode(mock.pi);
+		const context = createMockContext();
+		const hook = mock.events.get("tool_call")?.[0];
+		assert.ok(hook);
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.ok(
+			await hook(
+				{ toolName: "subagent", input: { agent: "worker", task: "Implement" } },
+				context.ctx,
+			),
+		);
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ defaultPlanTools: ["subagent"], allowedPlanSubagents: ["worker"] }),
+		);
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.equal(
+			await hook(
+				{ toolName: "subagent", input: { agent: "worker", task: "Implement" } },
+				context.ctx,
+			),
+			undefined,
+		);
+		assert.ok(
+			await hook(
+				{ toolName: "subagent", input: { agent: "plan-scout", task: "Inspect" } },
+				context.ctx,
+			),
+		);
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+
+		await rm(settingsPath);
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.equal(
+			await hook(
+				{ toolName: "subagent", input: { agent: "worker", task: "Implement" } },
+				context.ctx,
+			),
+			undefined,
+		);
+	});
+});
+
+test("configured role policy is inert when no subagent tools are installed", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, SETTINGS_FILE),
+			JSON.stringify({ allowedPlanSubagents: ["plan-scout"] }),
+		);
+		const mock = createMockPi({ activeTools: ["read"], allTools: [builtinTool("read")] });
+		planMode(mock.pi);
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.equal(mock.rawPi.getActiveTools().includes("subagent"), false);
+		assert.equal(
+			await mock.events.get("tool_call")?.[0]?.(
+				{ toolName: "custom_delegate", input: { agent: "worker" } },
+				context.ctx,
+			),
+			undefined,
+		);
+	});
+});
+
+async function withAgentDir(run: (agentDir: string) => Promise<void>) {
+	const agentDir = await mkdtemp(join(tmpdir(), "pi-plan-mode-subagent-allowlist-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		await run(agentDir);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+}

--- a/extensions/pi-plan-mode/test/subagent-policy.test.ts
+++ b/extensions/pi-plan-mode/test/subagent-policy.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { enforcePlanSubagentAllowlist } from "../src/subagent-policy.js";
+
+const ALLOWED = ["plan-scout", "plan-researcher", "plan-reviewer"];
+
+test("subagent policy ignores unrelated tools and permits allowed single roles", () => {
+	assert.equal(
+		enforcePlanSubagentAllowlist("custom_delegate", { agent: "worker" }, ALLOWED),
+		undefined,
+	);
+	assert.equal(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{ agent: "plan-scout", task: "Inspect the repository" },
+			ALLOWED,
+		),
+		undefined,
+	);
+});
+
+test("subagent policy blocks disallowed and case-mismatched single roles", () => {
+	assert.deepEqual(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{ agent: "worker", task: "Implement the change" },
+			ALLOWED,
+		),
+		{
+			block: true,
+			reason:
+				"Plan mode blocks subagent role(s): worker. Allowed Plan subagents: plan-scout, plan-researcher, plan-reviewer.",
+		},
+	);
+	assert.match(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{ agent: "Plan-Scout", task: "Inspect the repository" },
+			ALLOWED,
+		)?.reason ?? "",
+		/Plan-Scout/,
+	);
+});
+
+test("subagent policy checks every parallel task", () => {
+	assert.equal(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{
+				tasks: [
+					{ agent: "plan-scout", task: "Inspect A" },
+					{ agent: "plan-reviewer", task: "Inspect B" },
+				],
+			},
+			ALLOWED,
+		),
+		undefined,
+	);
+	assert.match(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{
+				tasks: [
+					{ agent: "plan-scout", task: "Inspect A" },
+					{ agent: "worker", task: "Implement B" },
+				],
+			},
+			ALLOWED,
+		)?.reason ?? "",
+		/role\(s\): worker/,
+	);
+});
+
+test("subagent policy checks every chain step and the fan-in aggregator", () => {
+	assert.equal(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{
+				chain: [
+					{ agent: "plan-scout", task: "Inspect" },
+					{ agent: "plan-reviewer", task: "Review {previous}" },
+				],
+			},
+			ALLOWED,
+		),
+		undefined,
+	);
+	assert.equal(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{
+				tasks: [{ agent: "plan-scout", task: "Inspect" }],
+				aggregator: { agent: "plan-reviewer", task: "Combine {previous}" },
+			},
+			ALLOWED,
+		),
+		undefined,
+	);
+	assert.match(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{
+				chain: [
+					{ agent: "plan-scout", task: "Inspect" },
+					{ agent: "worker", task: "Use {previous}" },
+				],
+			},
+			ALLOWED,
+		)?.reason ?? "",
+		/role\(s\): worker/,
+	);
+	assert.match(
+		enforcePlanSubagentAllowlist(
+			"subagent",
+			{
+				tasks: [{ agent: "plan-scout", task: "Inspect" }],
+				aggregator: { agent: "worker", task: "Combine {previous}" },
+			},
+			ALLOWED,
+		)?.reason ?? "",
+		/role\(s\): worker/,
+	);
+});
+
+test("subagent policy checks detached spawn roles", () => {
+	assert.equal(
+		enforcePlanSubagentAllowlist(
+			"subagent_spawn",
+			{ agent: "plan-researcher", task: "Research" },
+			ALLOWED,
+		),
+		undefined,
+	);
+	assert.match(
+		enforcePlanSubagentAllowlist("subagent_spawn", { agent: "worker", task: "Implement" }, ALLOWED)
+			?.reason ?? "",
+		/role\(s\): worker/,
+	);
+});
+
+test("subagent policy rejects malformed covered launch payloads", () => {
+	for (const [toolName, input] of [
+		["subagent", undefined],
+		["subagent", {}],
+		["subagent", { agent: "" }],
+		["subagent", { tasks: [] }],
+		["subagent", { tasks: [{ task: "Missing role" }] }],
+		["subagent", { chain: "plan-scout" }],
+		["subagent", { aggregator: {} }],
+		["subagent_spawn", {}],
+	] as const) {
+		assert.match(
+			enforcePlanSubagentAllowlist(toolName, input, ALLOWED)?.reason ?? "",
+			/could not verify subagent roles/,
+			`${toolName}: ${JSON.stringify(input)}`,
+		);
+	}
+});
+
+test("an empty allowlist denies every valid covered launch", () => {
+	assert.deepEqual(
+		enforcePlanSubagentAllowlist("subagent", { agent: "plan-scout", task: "Inspect" }, []),
+		{
+			block: true,
+			reason:
+				"Plan mode blocks subagent role(s): plan-scout. No subagent roles are allowed in Plan mode.",
+		},
+	);
+});


### PR DESCRIPTION
## Summary

- add optional `allowedPlanSubagents` settings for Plan-mode delegation
- block disallowed or malformed `subagent` and `subagent_spawn` role selections before execution
- keep `pi-plan-mode` independently installable and document the name-based safety boundary

## Testing

- `NODE_OPTIONS=--test-isolation=none npm run check` (1,071 tests; avoids a pre-existing timer-sensitive `pi-subagents` assertion under file-level parallelism)
- `just pack-plan-mode`

Closes #335