### PR TITLE
fix(worktree): tighten destructive revalidation ordering

### DIFF
--- a/extensions/pi-worktree/src/command.ts
+++ b/extensions/pi-worktree/src/command.ts
@@ -280,23 +280,13 @@ async function removeFlow(
 		return;
 	}
 
-	const latestAdministrativePath = await worktreeAdministrativeDirectory(
+	await assertAdministrativeHistoryUnchanged(
 		pi,
+		ctx,
 		selected.path,
-		ctx.signal,
+		administrativePath,
+		approvedHistoryRisks,
 	);
-	const latestHistoryRisks = historyRisks(
-		selected.path,
-		await unreachableAdministrativeHistoryOids(pi, ctx, latestAdministrativePath),
-	);
-	if (
-		!pathsEqual(administrativePath, latestAdministrativePath) ||
-		!sameAdministrativeHistoryRisks(approvedHistoryRisks, latestHistoryRisks)
-	) {
-		throw new Error(
-			`Worktree ${selected.path} administrative recovery history changed after confirmation; select it again.`,
-		);
-	}
 
 	const beforeRemoval = await listWorktrees(pi, ctx.cwd, ctx.signal);
 	const latest = beforeRemoval.find((record) => pathsEqual(record.path, selected.path));
@@ -309,7 +299,6 @@ async function removeFlow(
 			`Worktree ${selected.path} changed state after confirmation; removal was refused.`,
 		);
 	}
-	await assertDetachedHeadIsDurable(pi, ctx, latest);
 	const latestInventory = classifyRemovalInventory(
 		await worktreeInventory(pi, latest.path, ctx.signal),
 	);
@@ -323,6 +312,14 @@ async function removeFlow(
 			`Removal refused because ignored data changed after confirmation:\n${latestInventory.ignored.join("\n") || "(none)"}`,
 		);
 	}
+	await assertDetachedHeadIsDurable(pi, ctx, latest);
+	await assertAdministrativeHistoryUnchanged(
+		pi,
+		ctx,
+		latest.path,
+		administrativePath,
+		approvedHistoryRisks,
+	);
 	await removeWorktree(pi, ctx.cwd, latest.path, ctx.signal);
 	const updated = await listWorktrees(pi, ctx.cwd, ctx.signal);
 	if (updated.some((record) => pathsEqual(record.path, selected.path))) {
@@ -366,11 +363,15 @@ async function pruneFlow(
 	)) {
 		await assertDetachedHeadIsDurable(pi, ctx, record);
 	}
-	const latestHistoryRisks = await inspectAdministrativePruneCandidates(pi, ctx);
+	const beforePreviewHistoryRisks = await inspectAdministrativePruneCandidates(pi, ctx);
+	if (!sameAdministrativeHistoryRisks(approvedHistoryRisks, beforePreviewHistoryRisks)) {
+		throw new Error("Stale worktree metadata changed after confirmation; run prune again.");
+	}
 	const latestPreview = await prunePreview(pi, ctx.cwd, ctx.signal);
+	const finalHistoryRisks = await inspectAdministrativePruneCandidates(pi, ctx);
 	if (
 		latestPreview !== preview ||
-		!sameAdministrativeHistoryRisks(approvedHistoryRisks, latestHistoryRisks)
+		!sameAdministrativeHistoryRisks(approvedHistoryRisks, finalHistoryRisks)
 	) {
 		throw new Error("Stale worktree metadata changed after confirmation; run prune again.");
 	}
@@ -380,6 +381,32 @@ async function pruneFlow(
 		output ? `Pruned stale worktree metadata:\n${output}` : "Pruned stale worktree metadata.",
 		"info",
 	);
+}
+
+async function assertAdministrativeHistoryUnchanged(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	selectedPath: string,
+	approvedAdministrativePath: string,
+	approvedHistoryRisks: readonly AdministrativeHistoryRisk[],
+): Promise<void> {
+	const latestAdministrativePath = await worktreeAdministrativeDirectory(
+		pi,
+		selectedPath,
+		ctx.signal,
+	);
+	const latestHistoryRisks = historyRisks(
+		selectedPath,
+		await unreachableAdministrativeHistoryOids(pi, ctx, latestAdministrativePath),
+	);
+	if (
+		!pathsEqual(approvedAdministrativePath, latestAdministrativePath) ||
+		!sameAdministrativeHistoryRisks(approvedHistoryRisks, latestHistoryRisks)
+	) {
+		throw new Error(
+			`Worktree ${selectedPath} administrative recovery history changed after confirmation; select it again.`,
+		);
+	}
 }
 
 async function inspectAdministrativePruneCandidates(

--- a/extensions/pi-worktree/src/command.ts
+++ b/extensions/pi-worktree/src/command.ts
@@ -280,6 +280,24 @@ async function removeFlow(
 		return;
 	}
 
+	const latestAdministrativePath = await worktreeAdministrativeDirectory(
+		pi,
+		selected.path,
+		ctx.signal,
+	);
+	const latestHistoryRisks = historyRisks(
+		selected.path,
+		await unreachableAdministrativeHistoryOids(pi, ctx, latestAdministrativePath),
+	);
+	if (
+		!pathsEqual(administrativePath, latestAdministrativePath) ||
+		!sameAdministrativeHistoryRisks(approvedHistoryRisks, latestHistoryRisks)
+	) {
+		throw new Error(
+			`Worktree ${selected.path} administrative recovery history changed after confirmation; select it again.`,
+		);
+	}
+
 	const beforeRemoval = await listWorktrees(pi, ctx.cwd, ctx.signal);
 	const latest = beforeRemoval.find((record) => pathsEqual(record.path, selected.path));
 	if (!latest) throw new Error(`Worktree ${selected.path} is no longer registered.`);
@@ -291,6 +309,7 @@ async function removeFlow(
 			`Worktree ${selected.path} changed state after confirmation; removal was refused.`,
 		);
 	}
+	await assertDetachedHeadIsDurable(pi, ctx, latest);
 	const latestInventory = classifyRemovalInventory(
 		await worktreeInventory(pi, latest.path, ctx.signal),
 	);
@@ -302,24 +321,6 @@ async function removeFlow(
 	if (!sameInventory(inventory.ignored, latestInventory.ignored)) {
 		throw new Error(
 			`Removal refused because ignored data changed after confirmation:\n${latestInventory.ignored.join("\n") || "(none)"}`,
-		);
-	}
-	await assertDetachedHeadIsDurable(pi, ctx, latest);
-	const latestAdministrativePath = await worktreeAdministrativeDirectory(
-		pi,
-		latest.path,
-		ctx.signal,
-	);
-	const latestHistoryRisks = historyRisks(
-		latest.path,
-		await unreachableAdministrativeHistoryOids(pi, ctx, latestAdministrativePath),
-	);
-	if (
-		!pathsEqual(administrativePath, latestAdministrativePath) ||
-		!sameAdministrativeHistoryRisks(approvedHistoryRisks, latestHistoryRisks)
-	) {
-		throw new Error(
-			`Worktree ${selected.path} administrative recovery history changed after confirmation; select it again.`,
 		);
 	}
 	await removeWorktree(pi, ctx.cwd, latest.path, ctx.signal);
@@ -365,8 +366,8 @@ async function pruneFlow(
 	)) {
 		await assertDetachedHeadIsDurable(pi, ctx, record);
 	}
-	const latestPreview = await prunePreview(pi, ctx.cwd, ctx.signal);
 	const latestHistoryRisks = await inspectAdministrativePruneCandidates(pi, ctx);
+	const latestPreview = await prunePreview(pi, ctx.cwd, ctx.signal);
 	if (
 		latestPreview !== preview ||
 		!sameAdministrativeHistoryRisks(approvedHistoryRisks, latestHistoryRisks)

--- a/extensions/pi-worktree/test/command.test.ts
+++ b/extensions/pi-worktree/test/command.test.ts
@@ -502,7 +502,7 @@ test("remove explicitly confirms and discards reflog-only recovery history", asy
 	}
 });
 
-test("remove refuses administrative recovery history that changes after confirmation", async () => {
+test("remove refuses administrative recovery history added during final validation", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-worktree-remove-history-race-"));
 	const main = join(root, "repo");
 	const linked = join(root, "repo-feature");
@@ -517,6 +517,7 @@ test("remove refuses administrative recovery history that changes after confirma
 		`${"0".repeat(40)} ${firstOrphan} Test <test@example.invalid> 0 +0000\tcommit\n`,
 	);
 	const mock = createMockPi();
+	let statusCalls = 0;
 	let removeCalls = 0;
 	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
 		if (args[0] === "worktree" && args[1] === "list") {
@@ -527,14 +528,19 @@ test("remove refuses administrative recovery history that changes after confirma
 				]),
 			);
 		}
-		if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
-			return result(`${main}\n`);
+		if (args[0] === "rev-parse" && args.includes("--show-toplevel")) return result(`${main}\n`);
+		if (args[0] === "rev-parse" && args.includes("--git-dir")) return result(`${administrative}\n`);
+		if (args[0] === "status") {
+			statusCalls += 1;
+			if (statusCalls === 2) {
+				writeFileSync(
+					logPath,
+					`${"0".repeat(40)} ${firstOrphan} Test <test@example.invalid> 0 +0000\tcommit\n${firstOrphan} ${laterOrphan} Test <test@example.invalid> 1 +0000\tcommit\n`,
+				);
+			}
+			return result();
 		}
-		if (args[0] === "rev-parse" && args.includes("--git-dir")) {
-			return result(`${administrative}\n`);
-		}
-		if (args[0] === "status" || args[0] === "submodule") return result();
-		if (args.includes("for-each-ref")) return result();
+		if (args[0] === "submodule" || args.includes("for-each-ref")) return result();
 		if (args[0] === "worktree" && args[1] === "remove") removeCalls += 1;
 		return result();
 	};
@@ -546,13 +552,7 @@ test("remove refuses administrative recovery history that changes after confirma
 		mode: "tui",
 		select: async (_title: string, items: string[]) =>
 			selects++ === 0 ? "Remove worktree" : items[0],
-		confirm: async () => {
-			writeFileSync(
-				logPath,
-				`${"0".repeat(40)} ${firstOrphan} Test <test@example.invalid> 0 +0000\tcommit\n${firstOrphan} ${laterOrphan} Test <test@example.invalid> 1 +0000\tcommit\n`,
-			);
-			return true;
-		},
+		confirm: async () => true,
 	});
 	try {
 		await mock.commands.get("worktree")?.handler("", context.ctx);

--- a/extensions/pi-worktree/test/command.test.ts
+++ b/extensions/pi-worktree/test/command.test.ts
@@ -914,19 +914,24 @@ test("prune explicitly confirms and discards reflog-only recovery history", asyn
 	}
 });
 
-test("prune refuses metadata whose dry-run preview changes after confirmation", async () => {
+test("prune refuses metadata that changes during recovery-history revalidation", async () => {
 	const mock = createMockPi();
 	let dryRuns = 0;
+	let historyScans = 0;
 	let actualPruneCalls = 0;
 	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
 		if (args[0] === "worktree" && args[1] === "list") {
 			return result(porcelain([{ path: "/repo", branch: "main" }]));
 		}
+		if (args[0] === "rev-parse" && args.includes("--git-common-dir")) {
+			historyScans += 1;
+			return result("/repo/.git\n");
+		}
 		if (args[0] === "rev-parse") return result("/repo\n");
 		if (args.includes("--dry-run")) {
 			dryRuns += 1;
 			return result(
-				dryRuns === 1
+				historyScans < 2
 					? "Removing worktrees/first: missing gitdir\n"
 					: "Removing worktrees/second: missing gitdir\n",
 			);

--- a/extensions/pi-worktree/test/remove-ignored-command.test.ts
+++ b/extensions/pi-worktree/test/remove-ignored-command.test.ts
@@ -24,7 +24,7 @@ function porcelain(
 		.flatMap((record) => [
 			`worktree ${record.path}`,
 			`HEAD ${record.head ?? oid}`,
-			`branch refs/heads/${record.branch}`,
+			record.branch ? `branch refs/heads/${record.branch}` : "detached",
 			"",
 		])
 		.join("\0");
@@ -237,6 +237,117 @@ test("remove catches ignored data added during recovery-history revalidation", a
 		assert.equal(historyScans, 2);
 		assert.equal(removeCalls, 0);
 		assert.match(context.notifications.at(-1)?.message ?? "", /ignored data changed/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("remove rechecks detached HEAD durability after inventory", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-remove-detached-race-"));
+	const main = join(root, "repo");
+	const linked = join(root, "repo-detached");
+	mkdirSync(main);
+	mkdirSync(linked);
+	const mock = createMockPi();
+	let statusCalls = 0;
+	let durable = true;
+	let removeCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree" && args[1] === "list") {
+			return result(
+				porcelain([
+					{ path: main, branch: "main" },
+					{ path: linked, head: oid },
+				]),
+			);
+		}
+		if (args[0] === "rev-parse") return result(`${main}\n`);
+		if (args[0] === "status") {
+			statusCalls += 1;
+			if (statusCalls === 2) durable = false;
+			return result();
+		}
+		if (args[0] === "submodule") return result();
+		if (args.includes("for-each-ref")) {
+			return args.some((arg) => arg.startsWith("--contains=")) && durable
+				? result("refs/heads/safety\n")
+				: result();
+		}
+		if (args[0] === "worktree" && args[1] === "remove") removeCalls += 1;
+		return result();
+	};
+	worktreeExtension(mock.pi);
+	let selectCount = 0;
+	const context = createMockContext({
+		cwd: main,
+		hasUI: true,
+		mode: "tui",
+		select: async (_title: string, items: string[]) =>
+			selectCount++ === 0 ? "Remove worktree" : items[0],
+		confirm: async () => true,
+	});
+	try {
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(removeCalls, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /not reachable/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("prune rechecks recovery history after its final preview", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-prune-history-preview-race-"));
+	const main = join(root, "repo");
+	const administrative = join(main, ".git", "worktrees", "hidden");
+	const logPath = join(administrative, "logs", "HEAD");
+	mkdirSync(join(administrative, "logs"), { recursive: true });
+	writeFileSync(join(administrative, "HEAD"), "ref: refs/heads/feature\n");
+	const firstOrphan = oid.replace(/^0/, "1");
+	const laterOrphan = oid.replace(/^0/, "2");
+	writeFileSync(
+		logPath,
+		`${"0".repeat(40)} ${firstOrphan} Test <test@example.invalid> 0 +0000\tcommit\n`,
+	);
+	const mock = createMockPi();
+	let dryRuns = 0;
+	let actualPruneCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree" && args[1] === "list") {
+			return result(porcelain([{ path: main, branch: "main" }]));
+		}
+		if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+			return result(`${main}\n`);
+		}
+		if (args[0] === "rev-parse" && args.includes("--git-common-dir")) {
+			return result(".git\n");
+		}
+		if (args[0]?.startsWith("--git-dir=") && args[1] === "diff") return result();
+		if (args.includes("for-each-ref")) return result();
+		if (args.includes("--dry-run")) {
+			dryRuns += 1;
+			if (dryRuns === 2) {
+				writeFileSync(
+					logPath,
+					`${"0".repeat(40)} ${firstOrphan} Test <test@example.invalid> 0 +0000\tcommit\n${firstOrphan} ${laterOrphan} Test <test@example.invalid> 1 +0000\tcommit\n`,
+				);
+			}
+			return result("Removing worktrees/hidden: missing gitdir\n");
+		}
+		if (args[0] === "worktree" && args[1] === "prune") actualPruneCalls += 1;
+		return result();
+	};
+	worktreeExtension(mock.pi);
+	const context = createMockContext({
+		cwd: main,
+		hasUI: true,
+		mode: "tui",
+		select: async () => "Prune stale metadata",
+		confirm: async () => true,
+	});
+	try {
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(actualPruneCalls, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /metadata changed/i);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/extensions/pi-worktree/test/remove-ignored-command.test.ts
+++ b/extensions/pi-worktree/test/remove-ignored-command.test.ts
@@ -192,6 +192,56 @@ test("remove refuses ignored data that changes after confirmation", async () => 
 	}
 });
 
+test("remove catches ignored data added during recovery-history revalidation", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-remove-late-ignored-race-"));
+	const main = join(root, "repo");
+	const linked = join(root, "repo-feature");
+	mkdirSync(main);
+	mkdirSync(linked);
+	const mock = createMockPi();
+	let historyScans = 0;
+	let removeCalls = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree" && args[1] === "list") {
+			return result(
+				porcelain([
+					{ path: main, branch: "main" },
+					{ path: linked, branch: "feature" },
+				]),
+			);
+		}
+		if (args[0] === "rev-parse") return result(`${main}\n`);
+		if (args[0] === "status") {
+			return result(historyScans < 2 ? "!! node_modules/\n" : "!! node_modules/\n!! cache/\n");
+		}
+		if (args[0] === "submodule") return result();
+		if (args.includes("for-each-ref")) {
+			historyScans += 1;
+			return result();
+		}
+		if (args[0] === "worktree" && args[1] === "remove") removeCalls += 1;
+		return result();
+	};
+	worktreeExtension(mock.pi);
+	let selectCount = 0;
+	const context = createMockContext({
+		cwd: main,
+		hasUI: true,
+		mode: "tui",
+		select: async (_title: string, items: string[]) =>
+			selectCount++ === 0 ? "Remove worktree" : items[0],
+		confirm: async () => true,
+	});
+	try {
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(historyScans, 2);
+		assert.equal(removeCalls, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /ignored data changed/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 type ExecFunction = (
 	command: string,
 	args: string[],


### PR DESCRIPTION
## Summary

- move worktree removal identity and ignored-inventory checks after recovery-history scanning
- rerun the prune dry-run preview after recovery-history revalidation
- add regressions for state changes that occur during slower sibling checks

## Testing

- `npm run check` (1,102 tests passed)