### PR TITLE
fix(goal): retain follow-ups at owned message starts

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-goal-pr343-review-follow-up-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-goal-pr343-review-follow-up-plan.md
@@ -1,0 +1,19 @@
+# Pi Goal PR 343 Review Follow-up
+
+## Goal
+
+Resolve every actionable review comment left on merged PR #343 and open a focused follow-up pull request.
+
+## Plan
+
+- [x] Audit all PR #343 issue comments, reviews, inline comments, and thread state; four inline reports found, with the first three already covered on `main` and the final `message_start` ordering report still reproducible.
+- [x] Add a focused regression test proving that an owned goal prompt's `message_start` boundary does not consume a pending transformed follow-up marker; the test failed before the fix with `2 !== 0` at the actual follow-up boundary.
+- [x] Make the smallest lifecycle-ordering fix in `extensions/pi-goal/src/goal.ts`; the focused regression and all 220 compiled pi-goal tests pass.
+- [x] Run `npm run check` and inspect the final diff for bounded scope and complete review-comment coverage; all 1,111 tests and the full CI-equivalent gate pass.
+- [x] Commit the intended files as `dc717db`, push `fix/pi-goal-pr343-review-follow-up`, and open PR #345 against `main` describing the resolved PR #343 feedback.
+
+## Completion Checklist
+
+- [x] All actionable PR #343 comments are either already covered on `main` or fixed with regression evidence.
+- [x] The repository CI-equivalent check passes.
+- [x] PR #345 is open and reports the verification performed.

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -712,8 +712,8 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			: typeof message.content === "string"
 				? message.content
 				: "";
-		const queuedNonGoalInput = runtime.consumeQueuedNonGoalInput(prompt);
 		const ownedPrompt = consumePendingGoalPrompt(prompt);
+		const queuedNonGoalInput = runtime.consumeQueuedNonGoalInput(prompt, ownedPrompt === undefined);
 		if (!ownedPrompt) {
 			if (queuedNonGoalInput?.behavior === "followUp") {
 				beginNonGoalFollowUp(ctx, queuedNonGoalInput.resetSafetyEpoch);

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -2956,6 +2956,42 @@ test("expanded queued follow-up claims manual ownership at its delivery boundary
 	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
 });
 
+test("owned goal message start does not consume a pending transformed follow-up", async () => {
+	const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
+	const ownedPrompt = active.mock.sentUserMessages.at(-1)?.text ?? "";
+	const safety = requireLastGoal(active.mock);
+	safety.automaticModelTurns = 2;
+	safety.toolFreeRepeatCount = 2;
+	safety.lastToolFreeOutputFingerprint = "7".repeat(64);
+	active.mock.events.get("input")?.[0]?.(
+		{ source: "interactive", text: "/skill:review", streamingBehavior: "followUp" },
+		active.ctx,
+	);
+
+	active.mock.events.get("message_start")?.[0]?.(
+		{ message: { role: "user", content: [{ type: "text", text: ownedPrompt }] } },
+		active.ctx,
+	);
+	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+	const afterOwnedPrompt = requireLastGoal(active.mock);
+	afterOwnedPrompt.automaticModelTurns = 2;
+	afterOwnedPrompt.toolFreeRepeatCount = 2;
+	afterOwnedPrompt.lastToolFreeOutputFingerprint = "6".repeat(64);
+
+	active.mock.events.get("message_start")?.[0]?.(
+		{
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "Expanded review skill instructions" }],
+			},
+		},
+		active.ctx,
+	);
+	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+});
+
 test("owned continuation does not consume a pending transformed follow-up", async () => {
 	const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
 	await active.mock.events.get("agent_end")?.[0]?.(


### PR DESCRIPTION
## Summary

- preserve pending transformed follow-up ownership when an owned `/goal` prompt reaches `message_start`
- consume owned prompt markers before allowing non-goal delivery fallback
- add a regression covering the remaining actionable review feedback from merged PR #343

## PR #343 review coverage

The earlier PR already landed regression coverage for budget wrap-up ownership, queued safety-reset activation, and owned `before_agent_start` boundaries. This follow-up fixes the remaining `message_start` ordering gap.

## Verification

- `npm run check` (1,111 tests passed)
- focused regression was confirmed failing before the fix and passing afterward
