### PR TITLE
fix(goal): preserve owned prompt lifecycle markers

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-goal-pr345-review-follow-up-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-goal-pr345-review-follow-up-plan.md
@@ -1,0 +1,19 @@
+# Pi Goal PR 345 Review Follow-up
+
+## Goal
+
+Resolve every actionable review comment on PR #345 and open a clean superseding pull request.
+
+## Plan
+
+- [x] Audit PR #345 issue comments, reviews, inline comments, and thread state; one actionable lifecycle-ordering report remains unresolved.
+- [x] Extend the regression to prove transformed follow-up ownership survives both `message_start` → `before_agent_start` and `before_agent_start` → `message_start` orders for goal and continuation prompts; all four subtests failed before the fix and pass afterward.
+- [x] Retain bounded recognition of claimed goal and continuation markers across lifecycle boundaries without reapplying ownership effects; claimed markers clear at settlement and session cleanup.
+- [x] Run focused pi-goal coverage and `npm run check`; all 224 pi-goal tests and the 1,118-test CI-equivalent gate pass, and the diff remains limited to lifecycle state and regression coverage.
+- [x] Commit and push the intended files, open superseding PR #346, reply to and resolve PR #345's review thread, and close #345 as superseded.
+
+## Completion Checklist
+
+- [x] PR #345's actionable review thread is resolved with regression evidence.
+- [x] The repository CI-equivalent check passes.
+- [x] PR #346 is open with passing CI, and PR #345 is closed as superseded.

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -712,8 +712,8 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			: typeof message.content === "string"
 				? message.content
 				: "";
-		const queuedNonGoalInput = runtime.consumeQueuedNonGoalInput(prompt);
 		const ownedPrompt = consumePendingGoalPrompt(prompt);
+		const queuedNonGoalInput = runtime.consumeQueuedNonGoalInput(prompt, ownedPrompt === undefined);
 		if (!ownedPrompt) {
 			if (queuedNonGoalInput?.behavior === "followUp") {
 				beginNonGoalFollowUp(ctx, queuedNonGoalInput.resetSafetyEpoch);

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -713,7 +713,8 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 				? message.content
 				: "";
 		const ownedPrompt = consumePendingGoalPrompt(prompt);
-		const queuedNonGoalInput = runtime.consumeQueuedNonGoalInput(prompt, ownedPrompt === undefined);
+		const ownedPromptBoundary = runtime.hasOwnedPromptBoundary(prompt);
+		const queuedNonGoalInput = runtime.consumeQueuedNonGoalInput(prompt, !ownedPromptBoundary);
 		if (!ownedPrompt) {
 			if (queuedNonGoalInput?.behavior === "followUp") {
 				beginNonGoalFollowUp(ctx, queuedNonGoalInput.resetSafetyEpoch);
@@ -816,13 +817,14 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		const goalPromptGoalId = goalPrompt?.goalId;
 		const continuationGoalId = goalPromptGoalId ? undefined : markContinuationStarted(event.prompt);
 		const ownedPromptGoalId = goalPromptGoalId ?? continuationGoalId;
+		const ownedPromptBoundary = runtime.hasOwnedPromptBoundary(event.prompt);
 		const activeBudgetWrapUp = runtime.hasActiveBudgetWrapUp();
 		const activeGoalRecovery = runtime.hasActiveGoalRecovery();
 		const queuedNonGoalInput = activeBudgetWrapUp
 			? undefined
 			: runtime.consumeQueuedNonGoalInput(
 					event.prompt,
-					!activeGoalRecovery && ownedPromptGoalId === undefined,
+					!activeGoalRecovery && ownedPromptGoalId === undefined && !ownedPromptBoundary,
 				);
 		if (queuedNonGoalInput?.behavior === "followUp") {
 			beginNonGoalFollowUp(ctx, queuedNonGoalInput.resetSafetyEpoch);

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -170,7 +170,9 @@ export class GoalRuntime {
 	/** Exact lazy goal tools this runtime removed and may restore on a mode change. */
 	goalToolsHiddenByPolicy = new Set<string>();
 	pendingGoalPromptMarkers = new Map<string, PendingGoalPrompt>();
+	claimedGoalPromptMarkers = new Set<string>();
 	cancelledContinuationMarkers = new Set<string>();
+	claimedContinuationMarkers = new Set<string>();
 	pendingNonGoalInputs: PendingNonGoalInput[] = [];
 
 	readonly pi: ExtensionAPI;
@@ -531,6 +533,8 @@ export class GoalRuntime {
 	clearSettledSafetyTracking() {
 		this.guardAbortGoalId = undefined;
 		this.pendingNonGoalInputs = [];
+		this.claimedGoalPromptMarkers.clear();
+		this.claimedContinuationMarkers.clear();
 		this.clearAgentRun();
 	}
 
@@ -552,10 +556,12 @@ export class GoalRuntime {
 		this.continuationIntent = undefined;
 		this.continuationDelivery = undefined;
 		this.cancelledContinuationMarkers.clear();
+		this.claimedContinuationMarkers.clear();
 	}
 
 	clearPendingGoalPrompts() {
 		this.pendingGoalPromptMarkers.clear();
+		this.claimedGoalPromptMarkers.clear();
 		this.pendingNonGoalInputs = [];
 	}
 
@@ -587,6 +593,23 @@ export class GoalRuntime {
 	hasPendingOwnedGoalPrompt(prompt: string) {
 		const marker = extractGoalPromptMarker(prompt);
 		return marker ? this.pendingGoalPromptMarkers.has(marker) : false;
+	}
+
+	hasOwnedPromptBoundary(prompt: string) {
+		const goalMarker = extractGoalPromptMarker(prompt);
+		if (
+			goalMarker &&
+			(this.pendingGoalPromptMarkers.has(goalMarker) ||
+				this.claimedGoalPromptMarkers.has(goalMarker))
+		) {
+			return true;
+		}
+		const continuationMarker = extractContinuationMarker(prompt);
+		return Boolean(
+			continuationMarker &&
+				(this.continuationDelivery?.marker === continuationMarker ||
+					this.claimedContinuationMarkers.has(continuationMarker)),
+		);
 	}
 
 	consumeStaleOwnedGoalPrompt(prompt: string) {
@@ -667,7 +690,10 @@ export class GoalRuntime {
 			this.cancelContinuationWork();
 			return undefined;
 		}
-		if (this.continuationDelivery?.marker === marker) this.continuationDelivery = undefined;
+		if (this.continuationDelivery?.marker === marker) {
+			this.continuationDelivery = undefined;
+			this.rememberClaimedContinuationMarker(marker);
+		}
 		return marker.split(":", 1)[0];
 	}
 
@@ -872,7 +898,22 @@ export class GoalRuntime {
 		if (!marker) return undefined;
 		const pending = this.pendingGoalPromptMarkers.get(marker);
 		this.pendingGoalPromptMarkers.delete(marker);
+		if (pending) this.rememberClaimedGoalPromptMarker(marker);
 		return pending;
+	}
+
+	private rememberClaimedGoalPromptMarker(marker: string) {
+		this.claimedGoalPromptMarkers.add(marker);
+		if (this.claimedGoalPromptMarkers.size <= MAX_PENDING_GOAL_PROMPTS) return;
+		const oldest = this.claimedGoalPromptMarkers.values().next().value;
+		if (oldest) this.claimedGoalPromptMarkers.delete(oldest);
+	}
+
+	private rememberClaimedContinuationMarker(marker: string) {
+		this.claimedContinuationMarkers.add(marker);
+		if (this.claimedContinuationMarkers.size <= MAX_CANCELLED_CONTINUATION_PROMPTS) return;
+		const oldest = this.claimedContinuationMarkers.values().next().value;
+		if (oldest) this.claimedContinuationMarkers.delete(oldest);
 	}
 
 	consumeOwnedGoalPrompt(prompt: string) {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -2956,6 +2956,42 @@ test("expanded queued follow-up claims manual ownership at its delivery boundary
 	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
 });
 
+test("owned goal message start does not consume a pending transformed follow-up", async () => {
+	const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
+	const ownedPrompt = active.mock.sentUserMessages.at(-1)?.text ?? "";
+	const safety = requireLastGoal(active.mock);
+	safety.automaticModelTurns = 2;
+	safety.toolFreeRepeatCount = 2;
+	safety.lastToolFreeOutputFingerprint = "7".repeat(64);
+	active.mock.events.get("input")?.[0]?.(
+		{ source: "interactive", text: "/skill:review", streamingBehavior: "followUp" },
+		active.ctx,
+	);
+
+	active.mock.events.get("message_start")?.[0]?.(
+		{ message: { role: "user", content: [{ type: "text", text: ownedPrompt }] } },
+		active.ctx,
+	);
+	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+	const afterOwnedPrompt = requireLastGoal(active.mock);
+	afterOwnedPrompt.automaticModelTurns = 2;
+	afterOwnedPrompt.toolFreeRepeatCount = 2;
+	afterOwnedPrompt.lastToolFreeOutputFingerprint = "6".repeat(64);
+
+	active.mock.events.get("message_start")?.[0]?.(
+		{
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "Expanded review skill instructions" }],
+			},
+		},
+		active.ctx,
+	);
+	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+});
+
 test("owned continuation does not consume a pending transformed follow-up", async () => {
 	const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
 	await active.mock.events.get("agent_end")?.[0]?.(

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -2956,77 +2956,112 @@ test("expanded queued follow-up claims manual ownership at its delivery boundary
 	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
 });
 
-test("owned goal message start does not consume a pending transformed follow-up", async () => {
-	const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
-	const ownedPrompt = active.mock.sentUserMessages.at(-1)?.text ?? "";
-	const safety = requireLastGoal(active.mock);
-	safety.automaticModelTurns = 2;
-	safety.toolFreeRepeatCount = 2;
-	safety.lastToolFreeOutputFingerprint = "7".repeat(64);
-	active.mock.events.get("input")?.[0]?.(
-		{ source: "interactive", text: "/skill:review", streamingBehavior: "followUp" },
-		active.ctx,
-	);
+test("owned goal lifecycle boundaries do not consume a transformed follow-up", async (t) => {
+	for (const order of ["message-before-agent", "agent-before-message"] as const) {
+		await t.test(order, async () => {
+			const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
+			const ownedPrompt = active.mock.sentUserMessages.at(-1)?.text ?? "";
+			const safety = requireLastGoal(active.mock);
+			safety.automaticModelTurns = 2;
+			safety.toolFreeRepeatCount = 2;
+			safety.lastToolFreeOutputFingerprint = "7".repeat(64);
+			active.mock.events.get("input")?.[0]?.(
+				{ source: "interactive", text: "/skill:review", streamingBehavior: "followUp" },
+				active.ctx,
+			);
 
-	active.mock.events.get("message_start")?.[0]?.(
-		{ message: { role: "user", content: [{ type: "text", text: ownedPrompt }] } },
-		active.ctx,
-	);
-	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
-	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
-	const afterOwnedPrompt = requireLastGoal(active.mock);
-	afterOwnedPrompt.automaticModelTurns = 2;
-	afterOwnedPrompt.toolFreeRepeatCount = 2;
-	afterOwnedPrompt.lastToolFreeOutputFingerprint = "6".repeat(64);
+			const startMessage = () =>
+				active.mock.events.get("message_start")?.[0]?.(
+					{ message: { role: "user", content: [{ type: "text", text: ownedPrompt }] } },
+					active.ctx,
+				);
+			const startAgent = () =>
+				active.mock.events.get("before_agent_start")?.[0]?.(
+					{ prompt: ownedPrompt, systemPrompt: "base" },
+					active.ctx,
+				);
+			if (order === "message-before-agent") {
+				startMessage();
+				startAgent();
+			} else {
+				startAgent();
+				startMessage();
+			}
 
-	active.mock.events.get("message_start")?.[0]?.(
-		{
-			message: {
-				role: "user",
-				content: [{ type: "text", text: "Expanded review skill instructions" }],
-			},
-		},
-		active.ctx,
-	);
-	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
-	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+			assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+			assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+			const afterOwnedPrompt = requireLastGoal(active.mock);
+			afterOwnedPrompt.automaticModelTurns = 2;
+			afterOwnedPrompt.toolFreeRepeatCount = 2;
+			afterOwnedPrompt.lastToolFreeOutputFingerprint = "6".repeat(64);
+
+			active.mock.events.get("message_start")?.[0]?.(
+				{
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "Expanded review skill instructions" }],
+					},
+				},
+				active.ctx,
+			);
+			assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+			assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+		});
+	}
 });
 
-test("owned continuation does not consume a pending transformed follow-up", async () => {
-	const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
-	await active.mock.events.get("agent_end")?.[0]?.(
-		{ messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
-		active.ctx,
-	);
-	await active.mock.events.get("agent_settled")?.[0]?.({}, active.ctx);
-	const continuation = active.mock.sentUserMessages.at(-1)?.text ?? "";
-	const safety = requireLastGoal(active.mock);
-	safety.automaticModelTurns = 2;
-	safety.toolFreeRepeatCount = 2;
-	safety.lastToolFreeOutputFingerprint = "8".repeat(64);
-	active.mock.events.get("input")?.[0]?.(
-		{ source: "interactive", text: "/skill:review", streamingBehavior: "followUp" },
-		active.ctx,
-	);
+test("owned continuation lifecycle boundaries do not consume a transformed follow-up", async (t) => {
+	for (const order of ["message-before-agent", "agent-before-message"] as const) {
+		await t.test(order, async () => {
+			const active = await startGoalForTest({}, "finish", LOW_LIMITS_SETTINGS_PATH);
+			await active.mock.events.get("agent_end")?.[0]?.(
+				{ messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+				active.ctx,
+			);
+			await active.mock.events.get("agent_settled")?.[0]?.({}, active.ctx);
+			const continuation = active.mock.sentUserMessages.at(-1)?.text ?? "";
+			const safety = requireLastGoal(active.mock);
+			safety.automaticModelTurns = 2;
+			safety.toolFreeRepeatCount = 2;
+			safety.lastToolFreeOutputFingerprint = "8".repeat(64);
+			active.mock.events.get("input")?.[0]?.(
+				{ source: "interactive", text: "/skill:review", streamingBehavior: "followUp" },
+				active.ctx,
+			);
 
-	active.mock.events.get("before_agent_start")?.[0]?.(
-		{ prompt: continuation, systemPrompt: "base" },
-		active.ctx,
-	);
-	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 2);
-	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 2);
+			const startMessage = () =>
+				active.mock.events.get("message_start")?.[0]?.(
+					{ message: { role: "user", content: [{ type: "text", text: continuation }] } },
+					active.ctx,
+				);
+			const startAgent = () =>
+				active.mock.events.get("before_agent_start")?.[0]?.(
+					{ prompt: continuation, systemPrompt: "base" },
+					active.ctx,
+				);
+			if (order === "message-before-agent") {
+				startMessage();
+				startAgent();
+			} else {
+				startAgent();
+				startMessage();
+			}
 
-	active.mock.events.get("message_start")?.[0]?.(
-		{
-			message: {
-				role: "user",
-				content: [{ type: "text", text: "Expanded review skill instructions" }],
-			},
-		},
-		active.ctx,
-	);
-	assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
-	assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+			assert.equal(requireLastGoal(active.mock).automaticModelTurns, 2);
+			assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 2);
+			active.mock.events.get("message_start")?.[0]?.(
+				{
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "Expanded review skill instructions" }],
+					},
+				},
+				active.ctx,
+			);
+			assert.equal(requireLastGoal(active.mock).automaticModelTurns, 0);
+			assert.equal(requireLastGoal(active.mock).toolFreeRepeatCount, 0);
+		});
+	}
 });
 
 test("provider retry does not consume a pending transformed follow-up", async () => {


### PR DESCRIPTION
## Summary

- supersede #345 with lifecycle-safe owned prompt recognition
- retain bounded claimed goal and continuation markers through both `message_start` and `before_agent_start`
- prevent owned prompt boundaries from draining transformed follow-up ownership regardless of callback order
- clear claimed markers at settlement and session cleanup

## Review coverage

This resolves the actionable review feedback on #345 and also covers the adjacent continuation-marker path with the same lifecycle risk.

## Verification

- focused goal and continuation regressions failed in all four callback-order subtests before the fix and pass afterward
- all 224 compiled pi-goal tests pass
- `npm run check` passes with 1,118 tests
