### PR TITLE
feat(goal): create default settings on startup

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-goal-auto-settings-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-goal-auto-settings-plan.md
@@ -1,0 +1,20 @@
+# pi-goal 自動建立設定檔
+
+## Goal
+
+讓 pi-goal 在 session start 發現設定檔不存在時，自動建立含完整預設值的 `pi-goal.json`，且不覆寫任何既有檔案。
+
+## Plan
+
+- [x] 先在 `extensions/pi-goal/test/settings.test.ts` 加入 load-or-create 的紅燈測試，涵蓋建立預設檔、保留有效/無效檔、發佈失敗清理與競爭建立。紅燈：缺少新匯出與 lifecycle 建檔時發生 `ENOENT`；綠燈：`npm test` 的 1,124 項測試通過。
+- [x] 在 `extensions/pi-goal/src/settings.ts` 實作同目錄暫存檔、exclusive hard-link 發佈、競爭重讀及明確建立失敗結果。
+- [x] 在 `extensions/pi-goal/src/goal.ts` 將 session start 接到 load-or-create，並在 `extensions/pi-goal/test/goal.test.ts` 驗證 lifecycle 建檔、失敗 warning 與既有預設行為。
+- [x] 更新 `extensions/pi-goal/README.md` 的自動建立、預設內容、reload 與不覆寫保證。
+- [x] 執行相關測試、`npm run typecheck --workspace @narumitw/pi-goal` 與 `npm run check`。證據：workspace typecheck 通過；完整 check 的 1,124 項測試全數通過。
+
+## Completion Checklist
+
+- [x] 缺失設定在首次 session start 後成為可解析、格式化、含結尾換行的完整預設 JSON。
+- [x] 既有有效或無效設定不被覆寫；競爭建立採用先完成的檔案。
+- [x] 建立失敗使用內建預設、顯示 warning 且不留下暫存檔。
+- [x] 文件與實際 lifecycle 行為一致，所有驗證通過。

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -54,7 +54,8 @@ pi -e ./extensions/pi-goal
 
 ## ⚙️ Configuration
 
-Configuration is optional. Create `~/.pi/agent/pi-goal.json` only when overriding the defaults:
+On the first session start, pi-goal automatically creates `~/.pi/agent/pi-goal.json`
+with the complete current defaults:
 
 ```json
 {
@@ -69,6 +70,8 @@ Configuration is optional. Create `~/.pi/agent/pi-goal.json` only when overridin
 }
 ```
 
+Edit this generated file only when overriding the defaults.
+
 `toolVisibility` accepts:
 
 - `"always"` (default) — pi-goal does not proactively hide `goal_complete` or `goal_blocked`, keeping the tool schema stable from session startup.
@@ -82,8 +85,16 @@ Configuration is optional. Create `~/.pi/agent/pi-goal.json` only when overridin
 - `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
 
 Settings are reread at Pi startup, session replacement, and `/reload`; the file is not watched live.
+A missing file is created during any of those session starts, while an existing file is read without
+being rewritten. Initialization publishes the generated file atomically and never overwrites a file
+created concurrently by another process.
 
-Missing settings and omitted fields use the defaults above. Invalid settings produce a warning and fall back to all defaults; pi-goal never creates the file automatically. Reload Pi after changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"` restores only the exact tools that pi-goal previously hid, while switching to `"after-first-goal"` locks a runtime that has no unfinished goal.
+Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten;
+they produce a warning and fall back to all defaults. If the default file cannot be created, pi-goal
+warns, continues with the built-in defaults, and retries on the next session start. Reload Pi after
+changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"`
+restores only the exact tools that pi-goal previously hid, while switching to
+`"after-first-goal"` locks a runtime that has no unfinished goal.
 
 Tool visibility is a baseline, not ownership of Pi's global active-tool list. Plan mode or another restrictive policy may temporarily hide the tools. pi-goal does not fight that policy on restore or on every turn: activation is rejected if both tools cannot be made available, and an already-active goal is paused without automatic continuation if they disappear. The pause aborts a Goal-owned kickoff, resume, active-edit, or automatic-continuation prompt, but it does not cancel or stale-block an unrelated user or extension turn, including startup follow-ups after a restrictive restore.
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -30,7 +30,7 @@ import {
 	truncateNotification,
 } from "./runtime.js";
 import { hasAssistantToolCall } from "./safety.js";
-import { DEFAULT_GOAL_SETTINGS, readGoalSettings } from "./settings.js";
+import { DEFAULT_GOAL_SETTINGS, loadOrCreateGoalSettings } from "./settings.js";
 
 // goal.ts is the Pi-facing composition root: it keeps tool contracts and event
 // ordering together. Per-session mechanisms live in runtime.ts, while user command
@@ -52,6 +52,7 @@ interface GoalBlockedDetails {
 
 interface GoalOptions {
 	settingsPath?: string;
+	settingsFileSystem?: Parameters<typeof loadOrCreateGoalSettings>[1];
 }
 
 const EXPERIMENTAL_GOALS_WARNING =
@@ -472,12 +473,20 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.clearTerminalDetails();
 		rpc.bindSession(ctx);
 		const previousToolVisibility = runtime.settings.toolVisibility;
-		const settingsResult = readGoalSettings(options.settingsPath);
+		const settingsResult = loadOrCreateGoalSettings(
+			options.settingsPath,
+			options.settingsFileSystem,
+		);
 		runtime.settings =
 			settingsResult.kind === "loaded" ? settingsResult.settings : DEFAULT_GOAL_SETTINGS;
 		if (settingsResult.kind === "invalid") {
 			ctx.ui.notify(
 				`pi-goal settings ignored: ${settingsResult.reason}. Using default settings.`,
+				"warning",
+			);
+		} else if (settingsResult.kind === "create-failed") {
+			ctx.ui.notify(
+				`Could not create pi-goal settings: ${settingsResult.reason}. Using default settings.`,
 				"warning",
 			);
 		}

--- a/extensions/pi-goal/src/settings.ts
+++ b/extensions/pi-goal/src/settings.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { linkSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export const GOAL_SETTINGS_FILE = "pi-goal.json";
@@ -25,10 +26,23 @@ export const DEFAULT_GOAL_SETTINGS: GoalSettings = {
 	continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
 };
 
+export const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`;
+
 export type GoalSettingsLoadResult =
 	| { kind: "missing" }
 	| { kind: "invalid"; reason: string }
 	| { kind: "loaded"; settings: GoalSettings };
+
+export type GoalSettingsInitializationResult =
+	| Exclude<GoalSettingsLoadResult, { kind: "missing" }>
+	| { kind: "create-failed"; reason: string };
+
+interface GoalSettingsInitializationFileSystem {
+	mkdirSync: typeof mkdirSync;
+	writeFileSync: typeof writeFileSync;
+	linkSync: typeof linkSync;
+	rmSync: typeof rmSync;
+}
 
 export function normalizeGoalSettings(value: unknown): GoalSettings | undefined {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
@@ -95,6 +109,51 @@ function normalizeContinuationLimit(
 	return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
 }
 
+export function loadOrCreateGoalSettings(
+	settingsPath = join(getAgentDir(), GOAL_SETTINGS_FILE),
+	overrides: Partial<GoalSettingsInitializationFileSystem> = {},
+): GoalSettingsInitializationResult {
+	const loaded = readGoalSettings(settingsPath);
+	if (loaded.kind !== "missing") return loaded;
+
+	const fs = { mkdirSync, writeFileSync, linkSync, rmSync, ...overrides };
+	const temporaryPath = join(
+		dirname(settingsPath),
+		`.${basename(settingsPath)}.${randomUUID()}.tmp`,
+	);
+	try {
+		fs.mkdirSync(dirname(settingsPath), { recursive: true });
+		fs.writeFileSync(temporaryPath, DEFAULT_GOAL_SETTINGS_DOCUMENT, {
+			encoding: "utf8",
+			flag: "wx",
+		});
+		try {
+			fs.linkSync(temporaryPath, settingsPath);
+		} catch (error) {
+			if (!isAlreadyExistsError(error)) throw error;
+		}
+
+		const published = readGoalSettings(settingsPath);
+		return published.kind === "missing"
+			? {
+					kind: "create-failed",
+					reason: `${settingsPath}: settings file disappeared during initialization`,
+				}
+			: published;
+	} catch (error) {
+		return {
+			kind: "create-failed",
+			reason: `${settingsPath}: ${formatError(error)}`,
+		};
+	} finally {
+		try {
+			fs.rmSync(temporaryPath, { force: true });
+		} catch {
+			// Best-effort cleanup must not replace the initialization result.
+		}
+	}
+}
+
 export function readGoalSettings(
 	settingsPath = join(getAgentDir(), GOAL_SETTINGS_FILE),
 ): GoalSettingsLoadResult {
@@ -118,6 +177,10 @@ export function readGoalSettings(
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
 	return error instanceof Error && "code" in error;
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+	return isNodeError(error) && error.code === "EEXIST";
 }
 
 function formatError(error: unknown) {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
@@ -26,6 +26,7 @@ import {
 	nextToolFreeRepeatState,
 	normalizeVisibleAssistantOutput,
 } from "../src/safety.js";
+import { DEFAULT_GOAL_SETTINGS_DOCUMENT } from "../src/settings.js";
 
 // This suite stays in one file because it exercises one module-scoped extension
 // state machine across commands, lifecycle hooks, tools, persistence, prompts,
@@ -132,6 +133,50 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 		"tool_execution_end",
 		"turn_end",
 	]);
+});
+
+test("session start creates complete default settings when the file is missing", () => {
+	const settingsPath = join(GOAL_SETTINGS_DIRECTORY, "session-created.json");
+	const mock = createMockPi({
+		activeTools: ["read", "bash", "goal_complete", "goal_blocked"],
+	});
+	registerGoalWithSettingsPath(mock.pi, settingsPath);
+	const context = createMockContext();
+
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	assert.equal(readFileSync(settingsPath, "utf8"), DEFAULT_GOAL_SETTINGS_DOCUMENT);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "goal_complete", "goal_blocked"]);
+	assert.equal(context.notifications.length, 0);
+});
+
+test("session start warns and keeps defaults when settings creation fails", () => {
+	const settingsPath = join(GOAL_SETTINGS_DIRECTORY, "create-failed.json");
+	const mock = createMockPi({
+		activeTools: ["read", "bash", "goal_complete", "goal_blocked"],
+	});
+	mock.rawPi.setActiveTools([
+		...new Set([...mock.rawPi.getActiveTools(), "goal_complete", "goal_blocked"]),
+	]);
+	goal(mock.pi, {
+		settingsPath,
+		settingsFileSystem: {
+			linkSync() {
+				throw new Error("publish failed");
+			},
+		},
+	});
+	const context = createMockContext();
+
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	assert.equal(existsSync(settingsPath), false);
+	assert.equal(
+		readdirSync(GOAL_SETTINGS_DIRECTORY).some((name) => name.includes("create-failed.json")),
+		false,
+	);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "goal_complete", "goal_blocked"]);
+	assert.match(context.notifications[0]?.message ?? "", /could not create.*publish failed/i);
 });
 
 test("missing and invalid settings fall back to always-visible tools", () => {

--- a/extensions/pi-goal/test/settings.test.ts
+++ b/extensions/pi-goal/test/settings.test.ts
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { DEFAULT_GOAL_SETTINGS, normalizeGoalSettings, readGoalSettings } from "../src/settings.js";
+import {
+	DEFAULT_GOAL_SETTINGS,
+	DEFAULT_GOAL_SETTINGS_DOCUMENT,
+	loadOrCreateGoalSettings,
+	normalizeGoalSettings,
+	readGoalSettings,
+} from "../src/settings.js";
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
 	assert.deepEqual(normalizeGoalSettings({}), DEFAULT_GOAL_SETTINGS);
@@ -59,6 +66,108 @@ test("normalizeGoalSettings applies defaults and accepts bounded continuation li
 	]) {
 		assert.equal(normalizeGoalSettings(value), undefined);
 	}
+});
+
+test("loadOrCreateGoalSettings creates a readable complete default document", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-create-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const settingsPath = join(directory, "nested", "pi-goal.json");
+
+	assert.deepEqual(loadOrCreateGoalSettings(settingsPath), {
+		kind: "loaded",
+		settings: DEFAULT_GOAL_SETTINGS,
+	});
+	assert.equal(readFileSync(settingsPath, "utf8"), DEFAULT_GOAL_SETTINGS_DOCUMENT);
+	assert.equal(
+		DEFAULT_GOAL_SETTINGS_DOCUMENT,
+		`${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`,
+	);
+});
+
+test("loadOrCreateGoalSettings never overwrites existing valid or invalid settings", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-existing-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const settingsPath = join(directory, "pi-goal.json");
+	const validDocument = '{"toolVisibility":"after-first-goal"}\n';
+	writeFileSync(settingsPath, validDocument);
+
+	assert.deepEqual(loadOrCreateGoalSettings(settingsPath), {
+		kind: "loaded",
+		settings: {
+			...DEFAULT_GOAL_SETTINGS,
+			toolVisibility: "after-first-goal",
+		},
+	});
+	assert.equal(readFileSync(settingsPath, "utf8"), validDocument);
+
+	const invalidDocument = "{invalid";
+	writeFileSync(settingsPath, invalidDocument);
+	assert.equal(loadOrCreateGoalSettings(settingsPath).kind, "invalid");
+	assert.equal(readFileSync(settingsPath, "utf8"), invalidDocument);
+});
+
+test("loadOrCreateGoalSettings reports creation failures and removes temporary files", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-failure-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+
+	for (const [name, overrides] of [
+		[
+			"directory",
+			{
+				mkdirSync() {
+					throw new Error("mkdir failed");
+				},
+			},
+		],
+		[
+			"temporary file",
+			{
+				writeFileSync() {
+					throw new Error("write failed");
+				},
+			},
+		],
+		[
+			"publish",
+			{
+				linkSync() {
+					throw new Error("publish failed");
+				},
+			},
+		],
+	] as const) {
+		const parent = join(directory, name);
+		const settingsPath = join(parent, "pi-goal.json");
+		const result = loadOrCreateGoalSettings(settingsPath, overrides);
+		assert.equal(result.kind, "create-failed");
+		assert.match(result.kind === "create-failed" ? result.reason : "", /failed/);
+		assert.equal(existsSync(settingsPath), false);
+		assert.deepEqual(existsSync(parent) ? readdirSync(parent) : [], []);
+	}
+});
+
+test("loadOrCreateGoalSettings adopts a concurrent winner without overwriting it", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-race-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const settingsPath = join(directory, "pi-goal.json");
+	const winnerDocument = '{"experimental":{"goals":true}}\n';
+
+	const result = loadOrCreateGoalSettings(settingsPath, {
+		linkSync(_temporaryPath, targetPath) {
+			writeFileSync(targetPath, winnerDocument);
+			throw Object.assign(new Error("already exists"), { code: "EEXIST" });
+		},
+	});
+
+	assert.deepEqual(result, {
+		kind: "loaded",
+		settings: {
+			...DEFAULT_GOAL_SETTINGS,
+			experimental: { goals: true },
+		},
+	});
+	assert.equal(readFileSync(settingsPath, "utf8"), winnerDocument);
+	assert.deepEqual(readdirSync(directory), ["pi-goal.json"]);
 });
 
 test("readGoalSettings distinguishes missing, loaded, malformed, and unreadable files", async (t) => {


### PR DESCRIPTION
## Summary

- create `pi-goal.json` with the complete defaults when a session starts without one
- publish the generated file atomically without overwriting existing or concurrently created settings
- keep built-in defaults active with a warning when initialization fails, and document the lifecycle

## Testing

- `npm run typecheck --workspace @narumitw/pi-goal`
- `npm run check` (1,124 tests passed)
