### PR TITLE
feat(worktree): add configurable worktree root

### DIFF
--- a/docs/plans/archived/2026-07-23_pi-worktree-configurable-root-plan.md
+++ b/docs/plans/archived/2026-07-23_pi-worktree-configurable-root-plan.md
@@ -1,0 +1,52 @@
+## Goal
+
+Make `@narumitw/pi-worktree` suggest new worktrees under a configurable machine-local root, defaulting to `~/.worktrees`, while preserving the existing single interactive `/worktree` command and all Add, Switch, Remove, and Prune safety behavior.
+
+## Context
+
+- The current suggestion is a sibling of the registered main worktree, such as `/workspace/project-feat-login`.
+- The new default is `~/.worktrees/<main-worktree-name>/<normalized-branch>`, resolved with Node's `homedir()` on Linux, macOS, and Windows.
+- Repository guidance prefers one interactive manager command. `/worktree` must continue rejecting arguments; no subcommands, hidden argument fallbacks, or argument autocomplete will be added.
+- Production removal already uses argv-only `git worktree remove`; test-only `rmSync` fixture cleanup is not shipped runtime behavior.
+
+## Architecture
+
+- Add `src/settings.ts` to own `<getAgentDir()>/pi-worktree.json`, runtime validation, home expansion, effective-source tracking, last-known-good reload behavior, and unknown-field-preserving atomic saves.
+- Recognize only an optional string `worktreeRoot`. Missing settings use `join(homedir(), ".worktrees")`. Accept `~`, home-prefixed `~/...` (and the native Windows separator), or an absolute native-platform path. Reject empty, relative, NUL-containing, shell-variable-like, non-string, or unnormalizable values without overwriting the file.
+- Keep settings machine-local: no project override, environment override, migration, or dependency.
+- Inject a settings provider into command registration. Load on `session_start`, preserve the last valid runtime root after later load failures, warn through the fresh context, and apply a successful interactive save immediately.
+- Keep `/worktree` argument-free. Add `Configure worktree root` to its existing interactive menu, show the effective root/source in the menu title, use one input prompt, treat blank input as reset to `~/.worktrees`, and refuse to overwrite a currently malformed/invalid settings file.
+- Derive suggestions as `<effective-root>/<basename(registered-main-worktree)>/<branch-with-slashes-replaced-by-hyphens>`. Existing single-operation custom target input, collision checks, symlink-ancestor checks, Git identity verification, and fail-closed behavior remain unchanged.
+- Existing worktrees are never moved. Remove and Prune retain their current guards and invoke only Git argv; production code must not invoke a shell, `rm`, or filesystem directory deletion for worktrees.
+
+## Plan
+
+- [x] Added red-first path/settings tests under `extensions/pi-worktree/test/` for the `~/.worktrees` default, project/branch composition, custom roots, POSIX and Windows absolute paths, home expansion, rejected values, source reporting, and normalization collisions; `npm test` failed as intended because `settings.ts` and the root-aware path signature did not yet exist.
+- [x] Implemented `extensions/pi-worktree/src/settings.ts` with lazy path resolution through `getAgentDir()`, validation, missing/loaded/invalid results, serialized last-known-good runtime state, unknown-field-preserving atomic save/reset, and injectable file operations; root `npm test` passes missing, valid, malformed, invalid, reload-failure, ordering, unknown-field, and publish-failure tests.
+- [x] Updated path derivation and Add flow in `src/git.ts` and `src/command.ts` to use the effective root and registered main basename while preserving per-operation target overrides and all pre/post Git checks; root `npm test` passes focused Git and Add command coverage.
+- [x] Extended only the no-argument interactive menu with `Configure worktree root`, effective root/source display, cancel/reset/save/rollback behavior, and invalid-file protection; focused command tests prove arguments remain rejected, autocomplete remains absent, and non-UI invocation stays mutation-free.
+- [x] Updated `src/worktree.ts` to reload settings on `session_start` and inject the runtime provider without reading session state during factory load; tests pass for reload, immediate application, replacement-context warning, and last-known-good behavior.
+- [x] Updated `extensions/pi-worktree/README.md` with the new default layout, cross-platform home semantics, JSON file and accepted values, interactive configuration/reset flow, reload/error behavior, no migration of existing worktrees, collision behavior, and Git-only Remove/Prune boundary; package check and source review confirm the documented command/defaults match.
+- [x] Formatted intended files and ran focused coverage through root `npm test`, package check/typecheck, full `npm run check`, and `just pack-worktree`; all 1,129 tests pass, the tarball contains the expected eight package files including `src/settings.ts`, and the source audit finds only argv-based Git process calls plus temporary-settings-file cleanup.
+- [x] Audited the final diff against this plan, marked every completion check with evidence, and confirmed the destination is available before archiving this completed plan under `docs/plans/archived/`.
+
+## Risks
+
+- A global custom root can collide for same-named main worktrees. The implementation intentionally adds no hash or suffix; an existing/registered target remains a hard stop and the user can change the root or one-operation target.
+- A settings file can become invalid after a valid load. The runtime must retain the last-known root but refuse interactive overwrite until the file is fixed, so malformed user content is never destroyed.
+- Git can create a branch before a target-path setup error. Existing ancestor checks and post-add verification remain mandatory; successful Git creation is never rolled back solely because later Pi switching fails.
+
+## Non-Goals
+
+- No subcommands, autocomplete, project-scoped settings, environment variables, path templates, hashes, suffix allocation, bulk cleanup, automatic expiry, cache cleaner, `/tmp` fallback, or new dependency.
+- No movement, re-registration, or deletion of existing worktrees.
+- No changes to branch semantics, Pi session switching, removal confirmation, administrative-history checks, or prune policy.
+
+## Completion Checklist
+
+- [x] Missing settings and reset suggest `~/.worktrees/<main-name>/<branch-slug>` on the active platform; command tests prove a valid user override changes the next Add suggestion immediately.
+- [x] Invalid settings fail closed without overwrite; load/save failure tests retain the last valid runtime root and original file, and unknown fields survive save/reset.
+- [x] `/worktree` remains a single argument-free interactive command whose original four operations are unchanged and whose fifth action configures or resets the root; autocomplete remains absent.
+- [x] All existing Add, Switch, Remove, ignored-data, administrative-history, Prune, and session-switch regressions pass in the 1,129-test repository suite.
+- [x] README, the eight-file package dry run, and the runtime source audit match the implemented settings and Git-only mutation boundaries.
+- [x] Focused tests, package checks, full `npm run check`, `just pack-worktree`, and final diff checks pass with no known required work remaining.

--- a/extensions/pi-worktree/README.md
+++ b/extensions/pi-worktree/README.md
@@ -11,7 +11,7 @@ Pi cannot change its parent process working directory with `cd`. This extension 
 - Shows compact main, linked, current, detached, locked, and prunable state in worktree selectors.
 - Creates a new branch worktree or attaches an existing unoccupied local branch.
 - Rejects occupied targets and unresolvable symbolic-link ancestors before Git can create a branch.
-- Suggests a sibling path such as `/workspace/project-feat-login` for `feat/login`.
+- Suggests `~/.worktrees/<main-worktree-name>/<branch>` by default and lets the user configure the root interactively.
 - Optionally switches Pi into a newly created worktree while continuing the current conversation.
 - Switches among existing registered worktrees through Pi's public session replacement API.
 - Removes unlocked, non-current linked worktrees and preserves their branches.
@@ -54,24 +54,50 @@ Choose one action:
 - **Switch worktree** — select another existing worktree and continue this Pi conversation there.
 - **Remove worktree** — remove a linked worktree without deleting its branch; ignored-only data is listed for explicit confirmation.
 - **Prune stale metadata** — inspect Git's dry-run output, then optionally run the matching prune.
+- **Configure worktree root** — set a machine-local default root or submit a blank value to restore `~/.worktrees`.
 
-`/worktree` intentionally does not accept text subcommands in this version. Every mutation is initiated and confirmed through the interactive UI.
+The menu title shows the effective worktree root and whether it comes from the built-in default or the user settings file. `/worktree` intentionally does not accept text subcommands or expose argument autocomplete. Every change is initiated and confirmed through the interactive UI.
 
 ## 🌿 Add defaults
 
 For a new branch, the current symbolic branch is the default start point. If Pi is running from detached HEAD, the command requires an explicit commit-ish. Git must resolve the start point to exactly one commit.
 
-The suggested path is a sibling of the main worktree:
+The default root is `~/.worktrees`, where `~` is Node's platform home directory. Suggestions use the registered main worktree's directory name, not the current linked-worktree cwd:
 
 ```text
 main worktree: /home/user/workspace/project
 branch:        feat/login
-suggested:     /home/user/workspace/project-feat-login
+root:          /home/user/.worktrees
+suggested:     /home/user/.worktrees/project/feat-login
 ```
 
-Leave the path input blank to accept the suggestion. A custom absolute path is used directly; a custom relative path is resolved from the current Pi cwd. The target itself must not exist, and its nearest existing ancestor must resolve without a broken or looping symbolic link.
+On Windows, the equivalent default is such as `C:\Users\Alice\.worktrees`. Branch `/` characters become `-`. The extension does not add hashes or collision suffixes: if two normalized paths collide or the target already exists, Add stops before Git mutation.
+
+Leave the path input blank to accept the suggestion. A custom absolute path is used directly; a custom relative path is resolved from the current Pi cwd. The target itself must not exist, and its nearest existing ancestor must resolve without a broken or looping symbolic link. Existing registered worktrees are never moved when this default changes.
 
 The MVP does not expose `--force`, `-B`, `--detach`, `--orphan`, or lock options.
+
+## ⚙️ Worktree root settings
+
+The machine-local user settings file is:
+
+```text
+<getAgentDir()>/pi-worktree.json
+```
+
+For a default Pi installation this is typically `~/.pi/agent/pi-worktree.json`. Configure it through **Configure worktree root** or edit it manually:
+
+```json
+{
+  "worktreeRoot": "~/worktrees"
+}
+```
+
+`worktreeRoot` accepts `~`, a home-prefixed path such as `~/worktrees`, or a native-platform absolute path. It does not expand `$VAR`, `%VAR%`, or other shell syntax. Empty, relative, NUL-containing, non-string, and invalid paths are rejected. There is no project override or extension-specific environment variable.
+
+A missing `worktreeRoot` uses `~/.worktrees`. Submitting a blank value in the interactive action removes the override. Unknown JSON fields survive interactive saves and resets. Settings reload on every `session_start`, including `/reload` and workspace replacement; a successful interactive save applies immediately to the next Add flow.
+
+Malformed or invalid settings are warned about but never overwritten. An initial failure uses `~/.worktrees`; a later failure retains the last valid effective root. Interactive configuration remains blocked until the invalid file is fixed manually.
 
 ## 🔀 Pi workspace switching
 
@@ -96,6 +122,7 @@ A successfully created Git worktree is never rolled back merely because Pi sessi
 - Removal and prune inspect reflogs, pseudorefs, per-worktree refs, and `FETCH_HEAD`. Historical commits reachable only through this administrative recovery state are listed by full OID in the destructive confirmation; approval removes those recovery pointers, so Git may later garbage-collect the commits. Create a branch or tag instead when any listed commit should survive.
 - Staged-only administrative index state, a missing attached branch ref, or an unreachable current detached HEAD still blocks prune without an override.
 - Removal never deletes a branch and never uses `--force`.
+- Remove invokes only argv-based `git worktree remove <path>`; production runtime never invokes a shell, `rm`, `rm -rf`, or a Node filesystem directory-deletion API for worktrees.
 - Prune always runs `git worktree prune --dry-run --verbose` before confirmation, inspects candidates omitted from porcelain, rechecks the exact preview and recovery-risk set after confirmation, and uses Git's default expiry. Remove likewise rechecks worktree identity, inventory, administrative path, and the approved recovery-risk set before mutation.
 - The extension does not commit, push, rebase, repair, move, lock, or unlock worktrees.
 
@@ -106,7 +133,7 @@ Use Git directly when you intentionally need force removal, branch deletion, cus
 - Git must be installed and the current Pi cwd must be inside a non-bare Git worktree.
 - The command requires a UI-capable Pi mode; print and JSON modes cannot drive its dialogs.
 - Project trust and cwd-bound extension/resource loading during a switch remain owned by Pi.
-- The extension registers no LLM tool, background watcher, settings file, or statusline item.
+- The extension registers no LLM tool, background watcher, project settings, or statusline item.
 
 ## 📁 Package layout
 
@@ -116,13 +143,15 @@ extensions/pi-worktree/
 │   ├── command.ts
 │   ├── git.ts
 │   ├── session.ts
+│   ├── settings.ts
 │   └── worktree.ts
 ├── test/
 │   ├── command.test.ts
 │   ├── git.integration.test.ts
 │   ├── git.test.ts
 │   ├── remove-ignored-command.test.ts
-│   └── session.test.ts
+│   ├── session.test.ts
+│   └── settings.test.ts
 ├── package.json
 ├── README.md
 ├── LICENSE

--- a/extensions/pi-worktree/src/command.ts
+++ b/extensions/pi-worktree/src/command.ts
@@ -30,21 +30,23 @@ import {
 	worktreeInventory,
 } from "./git.js";
 import { switchToWorktree } from "./session.js";
+import type { WorktreeSettingsRuntime } from "./settings.js";
 
 const ACTION_ADD = "Add worktree";
 const ACTION_SWITCH = "Switch worktree";
 const ACTION_REMOVE = "Remove worktree";
 const ACTION_PRUNE = "Prune stale metadata";
-const ACTIONS = [ACTION_ADD, ACTION_SWITCH, ACTION_REMOVE, ACTION_PRUNE];
+const ACTION_CONFIGURE_ROOT = "Configure worktree root";
+const ACTIONS = [ACTION_ADD, ACTION_SWITCH, ACTION_REMOVE, ACTION_PRUNE, ACTION_CONFIGURE_ROOT];
 
 interface AdministrativeHistoryRisk {
 	label: string;
 	oids: string[];
 }
 
-export function registerWorktreeCommand(pi: ExtensionAPI): void {
+export function registerWorktreeCommand(pi: ExtensionAPI, settings: WorktreeSettingsRuntime): void {
 	pi.registerCommand("worktree", {
-		description: "Interactively add, switch, remove, or prune Git worktrees",
+		description: "Interactively manage Git worktrees and their default root",
 		handler: async (args, ctx) => {
 			if (args.trim()) {
 				safeNotify(
@@ -63,13 +65,17 @@ export function registerWorktreeCommand(pi: ExtensionAPI): void {
 				await ctx.waitForIdle();
 				const records = await listWorktrees(pi, ctx.cwd, ctx.signal);
 				const currentPath = await currentWorktreePath(pi, ctx.cwd, ctx.signal);
+				const root = settings.get();
+				const warning = root.warning ? " — settings warning" : "";
 				const action = await ctx.ui.select(
-					stripTerminalControls(`Git worktrees (${records.length}) — current: ${currentPath}`),
+					stripTerminalControls(
+						`Git worktrees (${records.length}) — current: ${currentPath}\nWorktree root: ${root.effectiveRoot} (${root.source})${warning}`,
+					),
 					ACTIONS,
 				);
 				switch (action) {
 					case ACTION_ADD:
-						await addFlow(pi, ctx, records);
+						await addFlow(pi, ctx, records, root.effectiveRoot);
 						return;
 					case ACTION_SWITCH:
 						await switchFlow(pi, ctx, records, currentPath);
@@ -80,6 +86,9 @@ export function registerWorktreeCommand(pi: ExtensionAPI): void {
 					case ACTION_PRUNE:
 						await pruneFlow(pi, ctx, records);
 						return;
+					case ACTION_CONFIGURE_ROOT:
+						await configureRootFlow(ctx, settings);
+						return;
 				}
 			} catch (error) {
 				safeNotify(ctx, formatError(error), "error");
@@ -88,10 +97,37 @@ export function registerWorktreeCommand(pi: ExtensionAPI): void {
 	});
 }
 
+async function configureRootFlow(
+	ctx: ExtensionCommandContext,
+	settings: WorktreeSettingsRuntime,
+): Promise<void> {
+	const current = await settings.reload();
+	if (!current.canSave) {
+		throw new Error(
+			current.warning ?? `Fix ${settings.getPath()} before changing pi-worktree settings.`,
+		);
+	}
+	const requested = await ctx.ui.input(
+		"Worktree root (blank restores ~/.worktrees)",
+		stripTerminalControls(current.configuredRoot ?? current.effectiveRoot),
+	);
+	if (requested === undefined) return;
+	const configuredRoot = requested.trim() || undefined;
+	const updated = await settings.save(configuredRoot);
+	safeNotify(
+		ctx,
+		configuredRoot === undefined
+			? `Worktree root reset to ${updated.effectiveRoot}.`
+			: `Worktree root saved as ${updated.effectiveRoot}.`,
+		"info",
+	);
+}
+
 async function addFlow(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
 	records: readonly WorktreeRecord[],
+	worktreeRoot: string,
 ): Promise<void> {
 	const main = records[0];
 	if (!main) throw new Error("Git returned no registered worktrees.");
@@ -133,7 +169,7 @@ async function addFlow(
 		startOid = await resolveCommit(pi, ctx.cwd, startLabel, ctx.signal);
 	}
 
-	const suggestedPath = defaultWorktreePath(main.path, branch);
+	const suggestedPath = defaultWorktreePath(main.path, branch, worktreeRoot);
 	const requestedPath = await ctx.ui.input(
 		stripTerminalControls(`Worktree path (blank uses ${suggestedPath})`),
 		stripTerminalControls(suggestedPath),

--- a/extensions/pi-worktree/src/git.ts
+++ b/extensions/pi-worktree/src/git.ts
@@ -120,11 +120,12 @@ export function worktreeForBranch(
 	return records.find((record) => record.branchRef === branchRef);
 }
 
-export function defaultWorktreePath(mainWorktreePath: string, branch: string): string {
-	return resolve(
-		dirname(mainWorktreePath),
-		`${basename(mainWorktreePath)}-${branch.replaceAll("/", "-")}`,
-	);
+export function defaultWorktreePath(
+	mainWorktreePath: string,
+	branch: string,
+	worktreeRoot: string,
+): string {
+	return resolve(worktreeRoot, basename(mainWorktreePath), branch.replaceAll("/", "-"));
 }
 
 export function buildAddArguments(input: AddArguments): string[] {

--- a/extensions/pi-worktree/src/settings.ts
+++ b/extensions/pi-worktree/src/settings.ts
@@ -1,0 +1,291 @@
+import { lstat, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, posix, win32 } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const SETTINGS_FILE = "pi-worktree.json";
+
+export type WorktreeSettingsSource = "default" | "user";
+
+export interface LoadedWorktreeSettings {
+	kind: "missing" | "loaded" | "invalid";
+	path: string;
+	effectiveRoot: string;
+	source: WorktreeSettingsSource;
+	configuredRoot?: string;
+	document?: Record<string, unknown>;
+	warning?: string;
+}
+
+export interface WorktreeSettingsState {
+	effectiveRoot: string;
+	source: WorktreeSettingsSource;
+	configuredRoot?: string;
+	warning?: string;
+	canSave: boolean;
+}
+
+export interface SettingsFileOperations {
+	write(path: string, data: string): Promise<void>;
+	rename(source: string, destination: string): Promise<void>;
+}
+
+export interface WorktreeSettingsRuntime {
+	get(): Readonly<WorktreeSettingsState>;
+	getPath(): string;
+	reload(): Promise<Readonly<WorktreeSettingsState>>;
+	save(configuredRoot: string | undefined): Promise<Readonly<WorktreeSettingsState>>;
+}
+
+interface RuntimeOptions {
+	path?: string | (() => string);
+	home?: string;
+	platform?: NodeJS.Platform;
+	operations?: Partial<SettingsFileOperations>;
+}
+
+const DEFAULT_FILE_OPERATIONS: SettingsFileOperations = {
+	write: (path, data) =>
+		writeFile(path, data, { encoding: "utf8", flag: "wx", mode: 0o600 }).then(() => undefined),
+	rename,
+};
+
+export function settingsFilePath(): string {
+	return join(getAgentDir(), SETTINGS_FILE);
+}
+
+export function defaultWorktreeRoot(
+	home = homedir(),
+	platform: NodeJS.Platform = process.platform,
+): string {
+	return platformPath(platform).join(home, ".worktrees");
+}
+
+export function resolveWorktreeRoot(
+	value: string,
+	home = homedir(),
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (!value || value.includes("\0")) {
+		throw new Error("worktreeRoot must be a non-empty path without NUL characters.");
+	}
+	if (hasShellVariableSyntax(value)) {
+		throw new Error("worktreeRoot must not contain shell variable syntax.");
+	}
+
+	const path = platformPath(platform);
+	let candidate = value;
+	if (value === "~") {
+		candidate = home;
+	} else if (value.startsWith("~/") || (platform === "win32" && value.startsWith("~\\"))) {
+		candidate = path.resolve(home, value.slice(2));
+	} else if (value.startsWith("~")) {
+		throw new Error("worktreeRoot supports only ~ itself or a path beginning with ~/.");
+	}
+	if (!path.isAbsolute(candidate)) {
+		throw new Error("worktreeRoot must be an absolute path or begin with ~/.");
+	}
+
+	try {
+		const normalized = path.normalize(candidate);
+		if (!normalized || !path.isAbsolute(normalized)) {
+			throw new Error("normalization did not produce an absolute path");
+		}
+		return normalized;
+	} catch (error) {
+		throw new Error(`worktreeRoot could not be normalized: ${formatError(error)}`);
+	}
+}
+
+export async function loadWorktreeSettings(
+	path = settingsFilePath(),
+	home = homedir(),
+	platform: NodeJS.Platform = process.platform,
+): Promise<LoadedWorktreeSettings> {
+	const fallback = defaultWorktreeRoot(home, platform);
+	let text: string;
+	try {
+		const stats = await lstat(path);
+		if (stats.isSymbolicLink()) return invalid(path, fallback, "symbolic links are not accepted");
+		if (!stats.isFile()) return invalid(path, fallback, "settings path is not a regular file");
+		text = await readFile(path, "utf8");
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return {
+				kind: "missing",
+				path,
+				effectiveRoot: fallback,
+				source: "default",
+				document: {},
+			};
+		}
+		return invalid(path, fallback, formatError(error));
+	}
+
+	try {
+		const document = JSON.parse(text) as unknown;
+		if (!isRecord(document)) return invalid(path, fallback, "the top level must be a JSON object");
+		if (!Object.hasOwn(document, "worktreeRoot")) {
+			return {
+				kind: "loaded",
+				path,
+				effectiveRoot: fallback,
+				source: "default",
+				document,
+			};
+		}
+		if (typeof document.worktreeRoot !== "string") {
+			return invalid(path, fallback, "worktreeRoot must be a string");
+		}
+		const effectiveRoot = resolveWorktreeRoot(document.worktreeRoot, home, platform);
+		return {
+			kind: "loaded",
+			path,
+			effectiveRoot,
+			source: "user",
+			configuredRoot: document.worktreeRoot,
+			document,
+		};
+	} catch (error) {
+		return invalid(path, fallback, formatError(error));
+	}
+}
+
+export async function saveWorktreeSettings(
+	document: Record<string, unknown>,
+	configuredRoot: string | undefined,
+	path = settingsFilePath(),
+	operations: Partial<SettingsFileOperations> = {},
+): Promise<Record<string, unknown>> {
+	const nextDocument = { ...document };
+	if (configuredRoot === undefined) delete nextDocument.worktreeRoot;
+	else nextDocument.worktreeRoot = configuredRoot;
+
+	await mkdir(dirname(path), { recursive: true });
+	const temporaryPath = temporaryFilePath(path);
+	try {
+		await (operations.write ?? DEFAULT_FILE_OPERATIONS.write)(
+			temporaryPath,
+			`${JSON.stringify(nextDocument, null, 2)}\n`,
+		);
+		await (operations.rename ?? DEFAULT_FILE_OPERATIONS.rename)(temporaryPath, path);
+		return nextDocument;
+	} catch (error) {
+		await unlink(temporaryPath).catch(() => undefined);
+		throw error;
+	}
+}
+
+export function createWorktreeSettingsRuntime(
+	options: RuntimeOptions = {},
+): WorktreeSettingsRuntime {
+	const home = options.home ?? homedir();
+	const platform = options.platform ?? process.platform;
+	let resolvedPath: string | undefined;
+	const getPath = () => {
+		resolvedPath ??=
+			typeof options.path === "function" ? options.path() : (options.path ?? settingsFilePath());
+		return resolvedPath;
+	};
+	let document: Record<string, unknown> = {};
+	let operationQueue = Promise.resolve();
+	const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+		const result = operationQueue.then(operation, operation);
+		operationQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+	let state: WorktreeSettingsState = {
+		effectiveRoot: defaultWorktreeRoot(home, platform),
+		source: "default",
+		canSave: true,
+	};
+
+	return {
+		get: () => Object.freeze({ ...state }),
+		getPath,
+		reload() {
+			return enqueue(async () => {
+				const loaded = await loadWorktreeSettings(getPath(), home, platform);
+				if (loaded.kind === "invalid") {
+					state = { ...state, warning: loaded.warning, canSave: false };
+					return Object.freeze({ ...state });
+				}
+				document = loaded.document ?? {};
+				state = stateFromLoaded(loaded);
+				return Object.freeze({ ...state });
+			});
+		},
+		save(configuredRoot) {
+			return enqueue(async () => {
+				if (!state.canSave) {
+					throw new Error(`Fix the pi-worktree settings file at ${getPath()} before changing it.`);
+				}
+				const effectiveRoot =
+					configuredRoot === undefined
+						? defaultWorktreeRoot(home, platform)
+						: resolveWorktreeRoot(configuredRoot, home, platform);
+				const nextDocument = await saveWorktreeSettings(
+					document,
+					configuredRoot,
+					getPath(),
+					options.operations,
+				);
+				document = nextDocument;
+				state = {
+					effectiveRoot,
+					source: configuredRoot === undefined ? "default" : "user",
+					...(configuredRoot === undefined ? {} : { configuredRoot }),
+					canSave: true,
+				};
+				return Object.freeze({ ...state });
+			});
+		},
+	};
+}
+
+function stateFromLoaded(loaded: LoadedWorktreeSettings): WorktreeSettingsState {
+	return {
+		effectiveRoot: loaded.effectiveRoot,
+		source: loaded.source,
+		...(loaded.configuredRoot === undefined ? {} : { configuredRoot: loaded.configuredRoot }),
+		...(loaded.warning === undefined ? {} : { warning: loaded.warning }),
+		canSave: true,
+	};
+}
+
+function invalid(path: string, fallback: string, reason: string): LoadedWorktreeSettings {
+	return {
+		kind: "invalid",
+		path,
+		effectiveRoot: fallback,
+		source: "default",
+		warning: `${SETTINGS_FILE} ignored (${path}: ${reason}); using the safe default or last valid root without overwriting the file.`,
+	};
+}
+
+function platformPath(platform: NodeJS.Platform): typeof posix | typeof win32 {
+	return platform === "win32" ? win32 : posix;
+}
+
+function hasShellVariableSyntax(value: string): boolean {
+	return /\$|%[^%]+%/u.test(value);
+}
+
+function temporaryFilePath(path: string): string {
+	return `${path}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-worktree/src/worktree.ts
+++ b/extensions/pi-worktree/src/worktree.ts
@@ -1,6 +1,29 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerWorktreeCommand } from "./command.js";
+import {
+	createWorktreeSettingsRuntime,
+	settingsFilePath,
+	type WorktreeSettingsRuntime,
+} from "./settings.js";
 
-export default function worktreeExtension(pi: ExtensionAPI): void {
-	registerWorktreeCommand(pi);
+interface WorktreeExtensionOptions {
+	settings?: WorktreeSettingsRuntime;
+}
+
+export default function worktreeExtension(
+	pi: ExtensionAPI,
+	options: WorktreeExtensionOptions = {},
+): void {
+	const settings = options.settings ?? createWorktreeSettingsRuntime({ path: settingsFilePath });
+	registerWorktreeCommand(pi, settings);
+
+	pi.on("session_start", async (_event, ctx) => {
+		const loaded = await settings.reload();
+		if (!loaded.warning || !ctx.hasUI) return;
+		try {
+			ctx.ui.notify(loaded.warning, "warning");
+		} catch {
+			// A replacement session may invalidate its predecessor context during async startup.
+		}
+	});
 }

--- a/extensions/pi-worktree/test/command.test.ts
+++ b/extensions/pi-worktree/test/command.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { ExecResult } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createWorktreeSettingsRuntime } from "../src/settings.js";
 import worktreeExtension from "../src/worktree.js";
 
 const oid = "0123456789abcdef0123456789abcdef01234567";
@@ -35,11 +36,42 @@ function porcelain(
 		.join("\0");
 }
 
-test("/worktree registers one interactive command and no LLM tool", () => {
+test("/worktree registers one argument-free interactive command and no LLM tool", () => {
 	const mock = createMockPi();
 	worktreeExtension(mock.pi);
-	assert.ok(mock.commands.has("worktree"));
+	const command = mock.commands.get("worktree");
+	assert.ok(command);
+	assert.equal(command.getArgumentCompletions, undefined);
 	assert.deepEqual(mock.tools, []);
+});
+
+test("session_start reloads settings and warns through the replacement context", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-session-settings-"));
+	const settingsPath = join(root, "pi-worktree.json");
+	writeFileSync(settingsPath, '{"worktreeRoot":"/srv/worktrees"}\n');
+	const settings = createWorktreeSettingsRuntime({
+		path: settingsPath,
+		home: "/home/alice",
+		platform: "linux",
+	});
+	const mock = createMockPi();
+	worktreeExtension(mock.pi, { settings });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	assert.ok(sessionStart);
+	try {
+		const first = createMockContext({ hasUI: true, mode: "tui" });
+		await sessionStart({}, first.ctx);
+		assert.equal(settings.get().effectiveRoot, "/srv/worktrees");
+		assert.deepEqual(first.notifications, []);
+
+		writeFileSync(settingsPath, "{broken\n");
+		const replacement = createMockContext({ hasUI: true, mode: "tui" });
+		await sessionStart({}, replacement.ctx);
+		assert.equal(settings.get().effectiveRoot, "/srv/worktrees");
+		assert.match(replacement.notifications.at(-1)?.message ?? "", /ignored/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("/worktree rejects hidden text arguments and non-UI mode without Git calls", async () => {
@@ -107,7 +139,180 @@ test("/worktree menu exposes only actionable flows", async () => {
 		"Switch worktree",
 		"Remove worktree",
 		"Prune stale metadata",
+		"Configure worktree root",
 	]);
+});
+
+test("interactive root configuration saves, applies to the next Add, and resets without subcommands", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-configure-"));
+	const main = join(root, "repo");
+	const settingsPath = join(root, "agent", "pi-worktree.json");
+	mkdirSync(main);
+	const settings = createWorktreeSettingsRuntime({
+		path: settingsPath,
+		home: "/home/alice",
+		platform: "linux",
+	});
+	const mock = createMockPi();
+	let mutations = 0;
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree" && args[1] === "add") mutations += 1;
+		if (args[0] === "worktree" && args[1] === "list") {
+			return result(porcelain([{ path: main, branch: "main" }]));
+		}
+		if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return result(`${main}\n`);
+		if (args[0] === "check-ref-format") return result("feat/login\n");
+		if (args[0] === "show-ref") return result("", 1);
+		if (args[0] === "symbolic-ref") return result("main\n");
+		if (args[0] === "rev-parse" && args[1] === "--verify") return result(`${oid}\n`);
+		return result();
+	};
+	worktreeExtension(mock.pi, { settings });
+
+	try {
+		const configure = createMockContext({
+			cwd: main,
+			hasUI: true,
+			mode: "tui",
+			select: async () => "Configure worktree root",
+			input: async () => "/srv/worktrees",
+		});
+		await mock.commands.get("worktree")?.handler("", configure.ctx);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			worktreeRoot: "/srv/worktrees",
+		});
+		assert.equal(settings.get().effectiveRoot, "/srv/worktrees");
+
+		const inputs = ["feat/login", "", undefined];
+		const menuTitles: string[] = [];
+		const pathPlaceholders: string[] = [];
+		const add = createMockContext({
+			cwd: main,
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				menuTitles.push(title);
+				return "Add worktree";
+			},
+			input: async (title: string, placeholder: string) => {
+				if (title.startsWith("Worktree path")) pathPlaceholders.push(placeholder);
+				return inputs.shift();
+			},
+		});
+		await mock.commands.get("worktree")?.handler("", add.ctx);
+		assert.match(menuTitles[0] ?? "", /Worktree root: \/srv\/worktrees \(user\)/);
+		assert.deepEqual(pathPlaceholders, ["/srv/worktrees/repo/feat-login"]);
+		assert.equal(mutations, 0);
+
+		const reset = createMockContext({
+			cwd: main,
+			hasUI: true,
+			mode: "tui",
+			select: async () => "Configure worktree root",
+			input: async () => "   ",
+		});
+		await mock.commands.get("worktree")?.handler("", reset.ctx);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {});
+		assert.equal(settings.get().effectiveRoot, "/home/alice/.worktrees");
+		assert.equal(settings.get().source, "default");
+
+		const defaultInputs = ["feat/login", "", undefined];
+		let defaultPlaceholder = "";
+		const addWithDefault = createMockContext({
+			cwd: main,
+			hasUI: true,
+			mode: "tui",
+			select: async () => "Add worktree",
+			input: async (title: string, placeholder: string) => {
+				if (title.startsWith("Worktree path")) defaultPlaceholder = placeholder;
+				return defaultInputs.shift();
+			},
+		});
+		await mock.commands.get("worktree")?.handler("", addWithDefault.ctx);
+		assert.equal(defaultPlaceholder, "/home/alice/.worktrees/repo/feat-login");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("interactive root configuration cancels cleanly and never overwrites invalid settings", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-configure-invalid-"));
+	const main = join(root, "repo");
+	const settingsPath = join(root, "pi-worktree.json");
+	mkdirSync(main);
+	const settings = createWorktreeSettingsRuntime({
+		path: settingsPath,
+		home: "/home/alice",
+		platform: "linux",
+	});
+	const mock = createMockPi();
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree") return result(porcelain([{ path: main, branch: "main" }]));
+		return result(`${main}\n`);
+	};
+	worktreeExtension(mock.pi, { settings });
+	let inputs = 0;
+	const context = createMockContext({
+		cwd: main,
+		hasUI: true,
+		mode: "tui",
+		select: async () => "Configure worktree root",
+		input: async () => {
+			inputs += 1;
+			return undefined;
+		},
+	});
+	try {
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(inputs, 1);
+		assert.equal(settings.get().source, "default");
+
+		writeFileSync(settingsPath, "{broken\n");
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(inputs, 1);
+		assert.equal(readFileSync(settingsPath, "utf8"), "{broken\n");
+		assert.match(context.notifications.at(-1)?.message ?? "", /ignored.*without overwriting/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("interactive root configuration keeps runtime state when atomic publication fails", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-configure-failure-"));
+	const main = join(root, "repo");
+	const settingsPath = join(root, "agent", "pi-worktree.json");
+	mkdirSync(main);
+	const settings = createWorktreeSettingsRuntime({
+		path: settingsPath,
+		home: "/home/alice",
+		platform: "linux",
+		operations: {
+			rename: async () => {
+				throw new Error("publish failed");
+			},
+		},
+	});
+	const mock = createMockPi();
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree") return result(porcelain([{ path: main, branch: "main" }]));
+		return result(`${main}\n`);
+	};
+	worktreeExtension(mock.pi, { settings });
+	const context = createMockContext({
+		cwd: main,
+		hasUI: true,
+		mode: "tui",
+		select: async () => "Configure worktree root",
+		input: async () => "/srv/worktrees",
+	});
+	try {
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(settings.get().effectiveRoot, "/home/alice/.worktrees");
+		assert.equal(settings.get().source, "default");
+		assert.match(context.notifications.at(-1)?.message ?? "", /publish failed/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("add creates a new branch with safe argv, verifies it, and can leave the session unchanged", async () => {
@@ -144,7 +349,7 @@ test("add creates a new branch with safe argv, verifies it, and can leave the se
 		return result();
 	};
 	worktreeExtension(mock.pi);
-	const inputs = ["feature", "", ""];
+	const inputs = ["feature", "", linked];
 	const confirms = [true, false];
 	const context = createMockContext({
 		cwd: main,
@@ -238,7 +443,7 @@ test("add refuses a broken symlink target before creating the branch", async () 
 		return result();
 	};
 	worktreeExtension(mock.pi);
-	const inputs = ["feature", "", ""];
+	const inputs = ["feature", "", linked];
 	const context = createMockContext({
 		cwd: main,
 		hasUI: true,

--- a/extensions/pi-worktree/test/git.integration.test.ts
+++ b/extensions/pi-worktree/test/git.integration.test.ts
@@ -44,10 +44,10 @@ const pi = {
 	},
 };
 
-test("Git service creates, inventories, and removes a real linked worktree while preserving branch", async () => {
+test("Git service creates a nested-root worktree, inventories it, and removes it while preserving branch", async () => {
 	const temporary = realpathSync(mkdtempSync(join(tmpdir(), "pi-worktree-git-")));
 	const main = join(temporary, "repo");
-	const linked = join(temporary, "repo-feature");
+	const linked = join(temporary, ".worktrees", "repo", "feature-test");
 	try {
 		git(temporary, ["init", "--initial-branch=main", main]);
 		git(main, ["config", "user.name", "Pi Worktree Test"]);

--- a/extensions/pi-worktree/test/git.test.ts
+++ b/extensions/pi-worktree/test/git.test.ts
@@ -76,10 +76,14 @@ test("parseWorktreePorcelain rejects malformed fields before a worktree record",
 	assert.throws(() => parseWorktreePorcelain("worktree\0"), /missing path/i);
 });
 
-test("defaultWorktreePath derives a sibling path and normalizes branch slashes", () => {
+test("defaultWorktreePath derives a root/project/branch path and normalizes branch slashes", () => {
 	assert.equal(
-		defaultWorktreePath("/home/me/project", "feat/login"),
-		join("/home/me", "project-feat-login"),
+		defaultWorktreePath("/home/me/project", "feat/login", "/home/me/.worktrees"),
+		join("/home/me", ".worktrees", "project", "feat-login"),
+	);
+	assert.equal(
+		defaultWorktreePath("/home/me/project", "feat-login", "/home/me/.worktrees"),
+		join("/home/me", ".worktrees", "project", "feat-login"),
 	);
 });
 

--- a/extensions/pi-worktree/test/settings.test.ts
+++ b/extensions/pi-worktree/test/settings.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, posix, win32 } from "node:path";
+import test from "node:test";
+import {
+	createWorktreeSettingsRuntime,
+	defaultWorktreeRoot,
+	loadWorktreeSettings,
+	resolveWorktreeRoot,
+	saveWorktreeSettings,
+} from "../src/settings.js";
+
+test("worktree root defaults to a home-scoped .worktrees directory on each platform", () => {
+	assert.equal(defaultWorktreeRoot("/home/alice", "linux"), "/home/alice/.worktrees");
+	assert.equal(defaultWorktreeRoot("C:\\Users\\Alice", "win32"), "C:\\Users\\Alice\\.worktrees");
+});
+
+test("worktree root accepts native absolute and home paths without shell expansion", () => {
+	assert.equal(resolveWorktreeRoot("~", "/home/alice", "linux"), "/home/alice");
+	assert.equal(resolveWorktreeRoot("~/worktrees", "/home/alice", "linux"), "/home/alice/worktrees");
+	assert.equal(resolveWorktreeRoot("/srv/worktrees", "/home/alice", "linux"), "/srv/worktrees");
+	assert.equal(
+		resolveWorktreeRoot("~\\worktrees", "C:\\Users\\Alice", "win32"),
+		"C:\\Users\\Alice\\worktrees",
+	);
+	assert.equal(resolveWorktreeRoot("D:\\worktrees", "C:\\Users\\Alice", "win32"), "D:\\worktrees");
+	assert.equal(
+		resolveWorktreeRoot("\\\\server\\share\\worktrees", "C:\\Users\\Alice", "win32"),
+		"\\\\server\\share\\worktrees",
+	);
+
+	for (const value of [
+		"",
+		"relative/path",
+		"../worktrees",
+		"~/bad\0path",
+		"$ROOT/worktrees",
+		["$", "{ROOT}/worktrees"].join(""),
+		"$(pwd)/worktrees",
+		"/srv/$9/worktrees",
+	]) {
+		assert.throws(() => resolveWorktreeRoot(value, "/home/alice", "linux"), /worktreeRoot/i);
+	}
+	for (const value of ["relative\\path", "%ROOT%\\worktrees", "C:worktrees"]) {
+		assert.throws(() => resolveWorktreeRoot(value, "C:\\Users\\Alice", "win32"), /worktreeRoot/i);
+	}
+});
+
+test("settings loading distinguishes missing, user, malformed, and invalid documents", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-worktree-settings-"));
+	const settingsPath = join(directory, "pi-worktree.json");
+	try {
+		const missing = await loadWorktreeSettings(settingsPath, "/home/alice", "linux");
+		assert.equal(missing.kind, "missing");
+		assert.equal(missing.effectiveRoot, "/home/alice/.worktrees");
+		assert.equal(missing.source, "default");
+		assert.deepEqual(missing.document, {});
+
+		await writeFile(settingsPath, '{"worktreeRoot":"~/trees","future":true}\n');
+		const loaded = await loadWorktreeSettings(settingsPath, "/home/alice", "linux");
+		assert.equal(loaded.kind, "loaded");
+		assert.equal(loaded.effectiveRoot, "/home/alice/trees");
+		assert.equal(loaded.source, "user");
+		assert.equal(loaded.configuredRoot, "~/trees");
+		assert.deepEqual(loaded.document, { worktreeRoot: "~/trees", future: true });
+
+		await writeFile(settingsPath, "{broken\n");
+		const malformed = await loadWorktreeSettings(settingsPath, "/home/alice", "linux");
+		assert.equal(malformed.kind, "invalid");
+		assert.match(malformed.warning ?? "", /ignored.*without overwriting/i);
+
+		for (const document of [
+			{ worktreeRoot: "" },
+			{ worktreeRoot: "relative" },
+			{ worktreeRoot: 42 },
+			[],
+		]) {
+			await writeFile(settingsPath, `${JSON.stringify(document)}\n`);
+			const invalid = await loadWorktreeSettings(settingsPath, "/home/alice", "linux");
+			assert.equal(invalid.kind, "invalid");
+			assert.equal(invalid.effectiveRoot, "/home/alice/.worktrees");
+		}
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("runtime reload retains the last-known valid root and blocks saves while the file is invalid", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-worktree-settings-"));
+	const settingsPath = join(directory, "pi-worktree.json");
+	try {
+		await writeFile(settingsPath, '{"worktreeRoot":"/srv/trees","future":1}\n');
+		const runtime = createWorktreeSettingsRuntime({
+			path: settingsPath,
+			home: "/home/alice",
+			platform: "linux",
+		});
+		await runtime.reload();
+		assert.equal(runtime.get().effectiveRoot, "/srv/trees");
+		assert.equal(runtime.get().canSave, true);
+
+		await writeFile(settingsPath, "{broken\n");
+		await runtime.reload();
+		assert.equal(runtime.get().effectiveRoot, "/srv/trees");
+		assert.equal(runtime.get().source, "user");
+		assert.equal(runtime.get().canSave, false);
+		assert.match(runtime.get().warning ?? "", /ignored/i);
+		await assert.rejects(() => runtime.save("/other"), /fix.*settings file/i);
+		assert.equal(await readFile(settingsPath, "utf8"), "{broken\n");
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("atomic save and reset preserve unknown fields and publish failures preserve file and runtime", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-worktree-settings-"));
+	const settingsPath = join(directory, "pi-worktree.json");
+	try {
+		await writeFile(settingsPath, '{"worktreeRoot":"~/old","future":{"kept":true}}\n');
+		const loaded = await loadWorktreeSettings(settingsPath, "/home/alice", "linux");
+		assert.equal(loaded.kind, "loaded");
+		await saveWorktreeSettings(loaded.document ?? {}, "/srv/new", settingsPath);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			worktreeRoot: "/srv/new",
+			future: { kept: true },
+		});
+		const reloaded = await loadWorktreeSettings(settingsPath, "/home/alice", "linux");
+		assert.equal(reloaded.kind, "loaded");
+		await saveWorktreeSettings(reloaded.document ?? {}, undefined, settingsPath);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			future: { kept: true },
+		});
+
+		const original = await readFile(settingsPath, "utf8");
+		const runtime = createWorktreeSettingsRuntime({
+			path: settingsPath,
+			home: "/home/alice",
+			platform: "linux",
+			operations: {
+				rename: async () => {
+					throw new Error("publish failed");
+				},
+			},
+		});
+		await runtime.reload();
+		const before = runtime.get();
+		await assert.rejects(() => runtime.save("/srv/failed"), /publish failed/);
+		assert.deepEqual(runtime.get(), before);
+		assert.equal(await readFile(settingsPath, "utf8"), original);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("runtime serializes saves in invocation order and remains usable after queued work", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-worktree-settings-order-"));
+	const settingsPath = join(directory, "pi-worktree.json");
+	let releaseFirst!: () => void;
+	const firstMayFinish = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	const writes: string[] = [];
+	const runtime = createWorktreeSettingsRuntime({
+		path: settingsPath,
+		home: "/home/alice",
+		platform: "linux",
+		operations: {
+			write: async (path, data) => {
+				writes.push(data);
+				if (writes.length === 1) await firstMayFinish;
+				await writeFile(path, data, { flag: "wx" });
+			},
+		},
+	});
+	try {
+		const first = runtime.save("/srv/first");
+		const second = runtime.save("/srv/second");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		assert.equal(writes.length, 1);
+		releaseFirst();
+		await Promise.all([first, second]);
+		assert.equal(writes.length, 2);
+		assert.equal(runtime.get().effectiveRoot, "/srv/second");
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			worktreeRoot: "/srv/second",
+		});
+	} finally {
+		releaseFirst();
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+// Keep platform-specific expectations explicit rather than depending on the test host.
+test("path fixtures use the platform path modules expected by validation", () => {
+	assert.equal(posix.isAbsolute("/srv/worktrees"), true);
+	assert.equal(win32.isAbsolute("D:\\worktrees"), true);
+	assert.equal(win32.isAbsolute("\\\\server\\share\\worktrees"), true);
+});


### PR DESCRIPTION
## Summary

- default new worktrees to `~/.worktrees/<main-worktree>/<branch-slug>`
- add validated machine-local `pi-worktree.json` root overrides through the existing argument-free `/worktree` menu
- preserve last-known-good settings with serialized atomic saves while keeping Add, Switch, Remove, and Prune safety behavior unchanged
- document the settings lifecycle and Git-only removal boundary

## Verification

- `npm run check` (1,129 tests)
- `just pack-worktree` (8 intended package files)
- production shell/deletion source audit
- nested-root Git integration coverage