### PR TITLE
docs: add extension conventions guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ Run commands from the repository root unless noted otherwise.
 - TypeScript uses `module`/`moduleResolution: NodeNext`, `target: ES2022`, `strict: true`, and `noEmit: true`.
 - Biome is authoritative: tabs, 100-column line width, double quotes, semicolons, and recommended lint rules.
 - Keep extension packages small and self-contained. Add dependencies only when they solve a current extension need.
-- Before adding or changing extension-owned settings files, precedence, validation, persistence, migration, commands, or interactive settings UI, read and follow `docs/extension-settings.md`.
+- Before creating an extension or changing an existing extension's package, lifecycle, command, menu, UI, status, documentation, or verification behavior, read and follow the relevant sections of `docs/extension-conventions.md`.
+- Before adding or changing extension-owned settings files, precedence, validation, persistence, migration, commands, or interactive settings UI, also read and follow `docs/extension-settings.md`.
 - Every active extension package exposes Pi through a thin `src/index.ts` default-export forwarding entrypoint, and its `package.json` declares exactly `"pi": { "extensions": ["./src/index.ts"] }`; keep implementation in descriptive modules and run `npm run check:boundaries` to enforce this for production and experimental packages.
 - Production extensions include source in `pi.extensions`, publish `files`, and root workspace-aware scripts/recipes when users need them.
 - Standalone experimental extension packages must live under `extensions/experimental/`, show a user-facing warning, remain covered by root checks, and stay excluded from automated publish/version workflows. An opt-in experimental feature may remain inside a production package only when its default behavior stays compatible, configuration explicitly gates it, and enabling it shows a warning.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -26,7 +26,6 @@
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.
 - Symptom: extension actions from `agent_end` may not trigger a new turn. Cause: follow-ups can miss the late drain point. Fix: on Pi 0.80.6+, record intent in `agent_end` and dispatch from `agent_settled`; standalone manual compaction does not emit `agent_settled`, so use a narrowly idle-gated `session_compact` fallback when needed.
 - Detached orchestration recovery is more reliable when `agent_end` queues a `deliverAs: "followUp"` prompt and `agent_settled` retries retained intent if no pending message remains; settled-only `sendUserMessage` can be accepted yet lose the print-mode start race.
-- Extension statusline entries should be activity-based: only show an extension in status when it is actively running, retrying, or needs attention; avoid permanent “configured/ready/on” statuses.
 - Symptom: concurrent tools sharing one extension status key can clear or mislabel a still-running sibling. Cause: each call unconditionally owns set/clear. Fix: track active statuses per UI/session, restore the latest remaining status, and invalidate the tracker on session teardown.
 - Run Biome `--write` only on intended files during bounded work; formatting whole extension trees can rewrite unrelated source that is currently outside the root's normal ignore-aware formatting path.
 - Root Biome checks reject nested Git worktrees that contain another root `biome.json`; create worktrees outside the repository or locally ignore their parent directory during verification.
@@ -103,25 +102,14 @@
 
 ### README
 
-- New extension README files should mirror the existing style: emoji title, npm/Pi/license badges, Features, Install, Usage/What it does, Package layout, Keywords, and License.
-
-1. Write extension READMEs in English.
-2. Prefer practical documentation over marketing copy: explain capabilities, then installation, then commands, tools, configuration, or workflow.
-3. Document the applicable install paths: `pi install npm:@narumitw/...`, temporary `pi -e npm:@narumitw/...`, and local checkout `pi -e ./extensions/...`.
-4. Keep content easy to scan with short paragraphs, feature bullets, tables when useful, inline code, and language-tagged fenced blocks.
-5. State operational behavior clearly, including relevant defaults, precedence, persistence, lifecycle, failures, security, privacy, and limitations.
-6. End with a package layout that identifies `src/*.ts` modules and briefly explains their responsibilities.
+- Write extension READMEs in English and mirror the existing visual style, including the emoji title and npm/Pi/license badges.
 
 ### General
 
 - Prefer reading GitHub issue and pull request links with `gh --json` first; use web tools only when `gh` cannot access the needed content.
-- Prefer validating extensions against the latest Pi release only; do not maintain compatibility matrices for older Pi versions.
 - Live provider smokes are acceptable when relevant, but stop after one clear external or entitlement failure; use deterministic tests instead of repeatedly retrying unless the user explicitly asks.
 - Keep a predecessor extension active while its successor soaks; move it to `deprecated/` only after an explicit follow-up decision.
 - Prefer writing a repository plan before starting non-trivial implementation work; keep it executable, verify it, and archive it when complete.
 - Keep entries short and reusable.
-- Prefer status-producing extensions to publish text-only status values; keep extension icons in pi-statusline defaults/settings so styling and suppression stay centralized.
 - Keep `just` install recipes resilient by verifying registry visibility and falling back only when it solves the current install path.
-- New slash-command extensions should include argument autocomplete when the command has known subcommands, modes, or flags.
-- Prefer Pi extension manager commands to use one interactive slash command that shows current state plus next actions; prioritize the current session context, make cross-context changes explicit, and avoid hidden argument-based fallbacks unless non-interactive support is a real product requirement.
 - Earendil Works acquired the Pi tooling from mariozechner; prefer `@earendil-works/*` Pi packages because `@mariozechner/pi-*` packages are deprecated and should not be used for new extension work.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -12,7 +12,9 @@ The Pi guidance was last reviewed against the latest published
 - [TUI components](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/tui.md)
 
 Review this section when the repository updates its Pi dependencies or latest-release CI target.
-The official Pi documentation wins if this summary becomes stale.
+The official documentation is authoritative for the latest Pi behavior, while the repository's
+installed typings and tested runtime determine which APIs implementation code may rely on until its
+Pi dependencies are updated.
 
 ## Authority and adoption
 
@@ -135,15 +137,19 @@ lines for responsibility-based decomposition rather than mechanical splitting.
 
 A command's default shape depends on its product role:
 
-- A multi-action extension **SHOULD** expose one primary slash command. Invoking it without arguments
-  should open a current-state menu, while direct subcommands remain available for predictable and
-  non-interactive use.
-- A text-first command such as `/btw <question>`, a single-purpose action, or a passive extension MAY
-  use a different shape or expose no command.
+- A multi-action manager extension **SHOULD** expose one primary slash command whose no-argument form
+  opens a current-state menu. Do not mirror menu actions into textual subcommands by default.
+- Add command arguments or subcommands only for a concrete need: the text is the primary payload,
+  such as `/btw <question>` or `/goal <goal>`; a supported non-TUI, RPC, or automation workflow needs
+  a deterministic route; an existing public interface requires compatibility; or the command is a
+  frequent, single, unambiguous primary action.
+- A passive extension MAY expose no command. A menu-only manager MAY reject all arguments explicitly.
 - The primary command **SHOULD** usually derive from the unscoped package name by removing `pi-`.
   Preserve an established or clearer product name when compatibility or meaning outweighs symmetry.
-- Known subcommands, modes, and flags **SHOULD** provide `getArgumentCompletions`. Unknown arguments
-  should produce a clear warning and usage guidance rather than silently selecting another action.
+- **MUST:** Treat every accepted argument or subcommand as a public interface: document it, provide
+  `getArgumentCompletions` for known values, reject unknown input clearly, preserve applicable safety
+  checks, and test its supported TUI and non-TUI behavior. **Verification:** `Test` of direct command
+  routes plus `Review` of documentation, completion, compatibility, and safety behavior.
 - A main menu **SHOULD** show current state and the most relevant next actions. Prioritize current
   session context and label cross-provider, cross-workspace, destructive, or externally visible
   effects explicitly.
@@ -169,9 +175,10 @@ trust, validation, persistence, migration, secrets, interactive UI, and settings
 - **MUST:** Do not register a generic `/settings` command that competes with Pi's built-in command.
   **Verification:** `Review` of registered command names.
 
-A configurable extension **SHOULD** provide `/<command> settings`, `/<command> status`, and
-`/<command> help`. A small no-argument main menu may link to those direct entrypoints. Keep `config`
-only as a compatibility alias or when it describes a distinct setup workflow.
+A configurable manager extension **SHOULD** expose Settings, Status, and Help as actions in its
+no-argument menu. It MAY add documented direct routes for those actions only when one of the concrete
+needs in the command section applies. Keep `config` only as a compatibility alias or when it describes
+a distinct setup workflow.
 
 ### Status and persistent UI
 
@@ -211,7 +218,8 @@ fragile regular expressions. Until then, label the real verification method hone
 - [ ] Add the thin `src/index.ts` forwarder and canonical `pi.extensions` manifest entry.
 - [ ] Separate factory registration from session-owned startup and idempotent shutdown cleanup.
 - [ ] Choose the primary command and no-argument behavior from the extension's product role; add
-      completions for known arguments and a safe non-TUI path.
+      direct routes only for a concrete need, then document, complete, reject, and test them as public
+      interfaces.
 - [ ] Follow `docs/extension-settings.md` for every user or project setting.
 - [ ] Bound tool output, cancellation, state persistence, and file mutation where applicable.
 - [ ] Document installation, behavior, settings, security, limitations, and source responsibilities.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -45,10 +45,12 @@ it is not an API reference.
   `ExtensionAPI` and registers the extension's hooks, commands, tools, or providers.
   **Verification:** `Smoke` by loading the declared entrypoint with Pi; `Test` when the package has a
   loader smoke test.
-- **MUST:** Put runtime libraries in `dependencies`; list Pi packages imported at runtime in
-  `peerDependencies` with version `"*"`; do not rely on `devDependencies` being installed with a
-  production package. **Verification:** `Review` of imports and package metadata, plus an npm pack
-  dry run for dependency or publishing changes.
+- **MUST:** Put third-party runtime libraries in `dependencies`. List Pi-bundled core packages
+  imported at runtime—`@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`,
+  `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox`—in `peerDependencies`
+  with version `"*"`; do not rely on `devDependencies` being installed with a production package.
+  **Verification:** `Review` of imports and package metadata, plus an npm pack dry run for dependency
+  or publishing changes.
 - **MUST:** Treat installed extension code as fully privileged and load only trusted sources.
   **Verification:** `Review` of installation documentation and any code-loading path.
 
@@ -116,7 +118,7 @@ and long-running interactive work should expose cancellation.
 
 - **MUST:** Keep active production packages under `extensions/<package>/`, experiments under
   `extensions/experimental/<package>/`, and deprecated references under `deprecated/<package>/`.
-  **Verification:** `Validator` via `npm run check:boundaries` and `Review` for lifecycle moves.
+  **Verification:** `Review` of package locations and lifecycle moves.
 - **MUST:** Give every active package a thin `src/index.ts` default-export forwarder and declare
   exactly `"pi": { "extensions": ["./src/index.ts"] }`; keep implementation in descriptive modules.
   **Verification:** `Validator` via `npm run check:boundaries`.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -1,0 +1,229 @@
+# Pi extension conventions
+
+This guide defines the stable conventions for active extensions in this monorepo. It separates Pi
+platform constraints from repository requirements and preferred product patterns so that review does
+not confuse runtime correctness with local taste.
+
+The Pi guidance was last reviewed against the latest published
+`@earendil-works/pi-coding-agent` release, **0.81.1**, on **2026-07-23**:
+
+- [Extension API](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md)
+- [Package format](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md)
+- [TUI components](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/tui.md)
+
+Review this section when the repository updates its Pi dependencies or latest-release CI target.
+The official Pi documentation wins if this summary becomes stale.
+
+## Authority and adoption
+
+The key words **MUST**, **SHOULD**, and **MAY** describe requirement strength:
+
+- **MUST** identifies a Pi constraint or repository requirement. Each such rule names its current
+  verification method: `Validator`, `Test`, `Review`, or `Smoke`.
+- **SHOULD** identifies the default design. A better product or compatibility reason may override it.
+- **MAY** identifies an optional pattern.
+
+New extensions follow the full guide. Existing extensions adopt the relevant section when that area
+is changed: command work adopts command conventions, settings work follows the settings guide, and
+package work adopts package conventions. A small unrelated change does not require a whole-package
+migration.
+
+Keep exceptions close to their owner. Explain a non-obvious deviation in the package README or an
+adjacent code comment rather than in a central exception table. Pull-request discussion may provide
+additional context, but it is not durable documentation.
+
+## Official Pi conventions
+
+This section summarizes constraints and broadly applicable recommendations from Pi's documentation;
+it is not an API reference.
+
+### Entrypoints and packages
+
+- **MUST:** Export an extension factory as the entry module's default export. The factory receives an
+  `ExtensionAPI` and registers the extension's hooks, commands, tools, or providers.
+  **Verification:** `Smoke` by loading the declared entrypoint with Pi; `Test` when the package has a
+  loader smoke test.
+- **MUST:** Put runtime libraries in `dependencies`; list Pi packages imported at runtime in
+  `peerDependencies` with version `"*"`; do not rely on `devDependencies` being installed with a
+  production package. **Verification:** `Review` of imports and package metadata, plus an npm pack
+  dry run for dependency or publishing changes.
+- **MUST:** Treat installed extension code as fully privileged and load only trusted sources.
+  **Verification:** `Review` of installation documentation and any code-loading path.
+
+A package may declare multiple entrypoints, but this repository deliberately uses one forwarding
+entrypoint per active package as described below.
+
+### Factory and lifecycle
+
+- **MUST:** Keep factory evaluation free of session-owned background work. Start processes, servers,
+  watchers, timers, and other long-lived resources from `session_start` or on first use, not while the
+  module or factory is loading. **Verification:** `Review`; `Test` when the extension owns a resource
+  lifecycle.
+- **MUST:** Release session-owned resources during `session_shutdown`, and make cleanup safe after
+  partial initialization or repeated calls. **Verification:** `Test` plus `Review` for every owned
+  process, server, watcher, timer, widget, status, or temporary resource.
+- **MUST:** Do not continue using an `ExtensionContext` captured from a replaced session or reloaded
+  runtime. After awaiting `ctx.reload()`, return immediately from the old continuation.
+  **Verification:** `Test` for delayed or reload-capable flows and `Review` of asynchronous callbacks.
+
+Prefer plain data over a captured context in delayed callbacks. Scope generation guards, cancellation,
+and cleanup to the session or request that owns the work.
+
+### Commands, tools, and state
+
+- **MUST:** Invoke command-only session replacement APIs from command handlers, where Pi exposes the
+  required context. **Verification:** `Validator` through workspace typechecking and `Review` of
+  session-changing flows.
+
+Register slash commands with `pi.registerCommand()` and give them concise descriptions. Provide
+argument completions when the command has known values, as described in the repository command
+conventions below.
+- **MUST:** Make tool failures observable by throwing rather than returning only an error-looking
+  result, honor cancellation where the operation can be interrupted, and bound potentially large
+  text output to Pi's documented 50 KB or 2,000-line limit. **Verification:** `Test` plus `Review` for
+  each applicable failure, cancellation, and output path.
+- **MUST:** Serialize file mutations that can target the same path, using Pi's
+  `withFileMutationQueue()` where applicable. **Verification:** `Test` for concurrent mutation and
+  `Review` of the write path.
+- **MUST:** Persist fork-sensitive tool state in tool-result `details` or another session entry and
+  rebuild it from the active branch on `session_start`. **Verification:** `Test` of restart and fork
+  reconstruction for extensions that own session state.
+
+Use `StringEnum` from `@earendil-works/pi-ai` for string-valued tool schema enums so tools remain
+compatible with Google providers. Give tools explicit names in descriptions and prompt metadata.
+
+### TUI and non-interactive modes
+
+- **MUST:** Call `ctx.ui.custom()` only in TUI mode. Guard it with `ctx.mode === "tui"`, and use
+  `ctx.hasUI` before UI methods that are unavailable in the current mode. Do not write ad hoc output
+  that can corrupt JSON or RPC protocols. **Verification:** `Test` of supported non-TUI modes and
+  `Review` of every custom UI entrypoint.
+- **MUST:** Custom components must keep every rendered line within the supplied width, invalidate
+  cached themed content, and request a render after interactive state changes. Components containing
+  an `Input` or `Editor` must forward `Focusable.focused` to that child for IME support.
+  **Verification:** `Test` for custom component rendering and input behavior plus `Review` against
+  Pi's TUI contract.
+
+Use the callback-provided theme and keybindings. Prefer Pi's `SelectList`, `SettingsList`, and
+`BorderedLoader` over rebuilding equivalent controls. Escape should cancel or close transient UI,
+and long-running interactive work should expose cancellation.
+
+## Monorepo conventions
+
+### Package layout and boundaries
+
+- **MUST:** Keep active production packages under `extensions/<package>/`, experiments under
+  `extensions/experimental/<package>/`, and deprecated references under `deprecated/<package>/`.
+  **Verification:** `Validator` via `npm run check:boundaries` and `Review` for lifecycle moves.
+- **MUST:** Give every active package a thin `src/index.ts` default-export forwarder and declare
+  exactly `"pi": { "extensions": ["./src/index.ts"] }`; keep implementation in descriptive modules.
+  **Verification:** `Validator` via `npm run check:boundaries`.
+- **MUST:** Keep extension packages free of extension-to-extension dependencies.
+  **Verification:** `Validator` via `npm run check:boundaries`.
+- **MUST:** Keep each extension independently installable, with its own runtime dependencies and
+  package metadata. **Verification:** `Review` of package metadata and a `Smoke` npm pack dry run for
+  dependency or publishing changes.
+- **MUST:** Keep package contents aligned with the manifest's `files` list and include required
+  notices and licenses. **Verification:** `Smoke` with `npm pack --workspace <name> --dry-run --json`
+  for package or publishing changes.
+
+Use lowercase `pi-*` package directories and `@narumitw/pi-*` npm names. Keep packages small and
+self-contained, add dependencies only for current runtime needs, and review source files over 1,000
+lines for responsibility-based decomposition rather than mechanical splitting.
+
+### Slash commands and menus
+
+A command's default shape depends on its product role:
+
+- A multi-action extension **SHOULD** expose one primary slash command. Invoking it without arguments
+  should open a current-state menu, while direct subcommands remain available for predictable and
+  non-interactive use.
+- A text-first command such as `/btw <question>`, a single-purpose action, or a passive extension MAY
+  use a different shape or expose no command.
+- The primary command **SHOULD** usually derive from the unscoped package name by removing `pi-`.
+  Preserve an established or clearer product name when compatibility or meaning outweighs symmetry.
+- Known subcommands, modes, and flags **SHOULD** provide `getArgumentCompletions`. Unknown arguments
+  should produce a clear warning and usage guidance rather than silently selecting another action.
+- A main menu **SHOULD** show current state and the most relevant next actions. Prioritize current
+  session context and label cross-provider, cross-workspace, destructive, or externally visible
+  effects explicitly.
+- Destructive actions **SHOULD** show an exact summary and ask for confirmation. Cancellation should
+  leave state unchanged.
+
+- **MUST:** Provide a safe non-TUI result for every command that can run outside the TUI: execute a
+  direct operation, return status/help through a supported UI channel, or clearly reject the mode.
+  **Verification:** `Test` for supported command modes plus `Review` of the fallback.
+
+Use `ctx.ui.select()` for a small action menu. Use `SelectList` for richer selection and
+`SettingsList` for editable settings; do not repeatedly reopen `ctx.ui.select()` after each toggle,
+because that resets navigation state.
+
+### Settings
+
+[`docs/extension-settings.md`](extension-settings.md) owns settings names, paths, precedence, project
+trust, validation, persistence, migration, secrets, interactive UI, and settings-specific tests.
+
+- **MUST:** Read and follow that guide when adding or changing extension-owned settings, including
+  their commands or UI. **Verification:** `Review` against its applicable sections and verification
+  checklist.
+- **MUST:** Do not register a generic `/settings` command that competes with Pi's built-in command.
+  **Verification:** `Review` of registered command names.
+
+A configurable extension **SHOULD** provide `/<command> settings`, `/<command> status`, and
+`/<command> help`. A small no-argument main menu may link to those direct entrypoints. Keep `config`
+only as a compatibility alias or when it describes a distinct setup workflow.
+
+### Status and persistent UI
+
+- **MUST:** Use a stable package-specific key for statuses or widgets and clear session-owned UI on
+  shutdown, replacement, and failed initialization. **Verification:** `Test` of lifecycle cleanup and
+  `Review` of key ownership.
+
+Status values **SHOULD** be text-only and activity-based: show active work, retry, or a condition that
+needs attention, not a permanent `ready`, `configured`, or `on`. Keep icon mapping and suppression in
+`pi-statusline` so visual policy remains centralized. Concurrent work sharing one status key should
+restore the latest remaining activity rather than letting one completion clear its siblings.
+
+### Documentation and verification
+
+Package READMEs **SHOULD** remain practical and scannable: capabilities, installation, usage,
+commands/tools/settings, operational behavior, package layout, keywords, and license. Document the
+applicable persistent npm install, temporary npm execution, and local checkout commands. Include
+security, privacy, precedence, persistence, failure, or lifecycle details when users need them to use
+the extension safely.
+
+- **MUST:** Add or update deterministic tests for changed behavior when practical; when a behavior
+  requires a real Pi runtime or external service, record and run the smallest representative smoke
+  instead. **Verification:** `Test` through root `npm test`, `Smoke` for the stated runtime path, and
+  `Review` of any intentionally untested behavior.
+- **MUST:** Run the repository CI-equivalent gate before completing a change, and add an npm pack dry
+  run or local Pi load when package metadata or runtime loading changed. **Verification:** `Validator`
+  via `npm run check`; applicable `Smoke` evidence in the change handoff.
+
+Do not create a validator merely because a convention is written down. Add one when a new or touched
+area has a stable, low-false-positive rule that can be checked without encoding product semantics in
+fragile regular expressions. Until then, label the real verification method honestly.
+
+## New extension checklist
+
+- [ ] Place the package in the correct active or experimental directory and keep it independently
+      installable.
+- [ ] Add the thin `src/index.ts` forwarder and canonical `pi.extensions` manifest entry.
+- [ ] Separate factory registration from session-owned startup and idempotent shutdown cleanup.
+- [ ] Choose the primary command and no-argument behavior from the extension's product role; add
+      completions for known arguments and a safe non-TUI path.
+- [ ] Follow `docs/extension-settings.md` for every user or project setting.
+- [ ] Bound tool output, cancellation, state persistence, and file mutation where applicable.
+- [ ] Document installation, behavior, settings, security, limitations, and source responsibilities.
+- [ ] Add deterministic tests and run `npm run check`.
+- [ ] Inspect `npm pack --workspace <name> --dry-run --json` and load the declared entrypoint with Pi.
+
+## Touched-area checklist
+
+- [ ] Identify which sections the change touches; do not expand an unrelated change into a full
+      package migration.
+- [ ] Apply every relevant MUST and review SHOULD deviations near their owning package.
+- [ ] Update focused tests and run the verification method named by each relevant MUST.
+- [ ] Run `npm run check`; add pack or Pi runtime smokes when metadata or loading changed.
+- [ ] Report any skipped check, accepted exception, or follow-up validator opportunity in the change
+      handoff.

--- a/docs/extension-settings.md
+++ b/docs/extension-settings.md
@@ -36,13 +36,10 @@ Call user-editable preferences **settings** in new code and UI. Use names such a
 renaming would break compatibility or when configuration describes a distinct connection or setup
 workflow.
 
-An extension with user-facing settings should expose these subcommands from its primary command:
-
-```text
-/<command> settings    Open the interactive settings screen
-/<command> status      Show effective values, sources, and settings paths
-/<command> help        Show commands and manual configuration instructions
-```
+An extension with user-facing settings should expose Settings, Status, and Help as actions in its
+primary command's no-argument menu. Add documented direct subcommands only for a concrete payload,
+supported non-TUI workflow, compatibility requirement, or frequent unambiguous primary action, as
+defined in [`docs/extension-conventions.md`](extension-conventions.md).
 
 `config` may remain as a documented compatibility alias. Do not register a generic `/settings`
 command that competes with Pi's built-in command.
@@ -52,7 +49,7 @@ command that competes with Pi's built-in command.
 Extensions with multiple directly editable settings should provide a screen matching Pi's built-in
 `/settings` interaction pattern. In TUI mode:
 
-- Open `/<command> settings` with `ctx.ui.custom()`.
+- Open the Settings menu action with `ctx.ui.custom()`.
 - Use `SettingsList` from `@earendil-works/pi-tui` with `getSettingsListTheme()` from
   `@earendil-works/pi-coding-agent`; do not rebuild an equivalent selector or reopen
   `ctx.ui.select()` after every toggle, because doing so resets the cursor.
@@ -70,8 +67,9 @@ Extensions with multiple directly editable settings should provide a screen matc
   forcing them into a value cycle.
 - Use the callback-provided theme and keybindings, and request a render after state changes.
 
-A primary extension command invoked without arguments may open a small main menu containing
-Settings, Status, and Help. `/<command> settings` must remain the direct, predictable entrypoint.
+A primary extension command invoked without arguments should open a small main menu containing
+Settings, Status, and Help. If the extension has a justified direct settings route, it should open the
+same settings screen rather than a second implementation.
 
 Minimal structure:
 
@@ -185,10 +183,11 @@ created canonical file, and remove the legacy file only after confirming it did 
 
 ## Non-TUI behavior
 
-`ctx.ui.custom()` is TUI-only. In print, JSON, and RPC modes, `/<command> settings` must not attempt
-to open the interactive screen. RPC mode may use `ctx.ui.notify()` to provide the active settings
-path. Do not write ad hoc output that would corrupt JSON protocol output. Keep settings paths and
-manual instructions available through `status`, `help`, and the package README.
+`ctx.ui.custom()` is TUI-only. In print, JSON, and RPC modes, the Settings action and any justified
+direct settings route must not attempt to open the interactive screen. RPC mode may use
+`ctx.ui.notify()` to provide the active settings path. Do not write ad hoc output that would corrupt
+JSON protocol output. Keep settings paths and manual instructions available through the package
+README and any supported Status or Help route.
 
 ## Verification
 

--- a/docs/plans/2026-07-20_pi-accounts-multi-provider-plan.md
+++ b/docs/plans/2026-07-20_pi-accounts-multi-provider-plan.md
@@ -1,3 +1,0 @@
-# Pi Accounts multi-provider plan
-
-The completed implementation plan is archived at [`docs/plans/archived/2026-07-20_pi-accounts-multi-provider-plan.md`](./archived/2026-07-20_pi-accounts-multi-provider-plan.md).

--- a/docs/plans/archived/2026-07-23_extension-conventions-plan.md
+++ b/docs/plans/archived/2026-07-23_extension-conventions-plan.md
@@ -1,0 +1,41 @@
+# Extension Conventions Plan
+
+## Goal
+
+Create an English `docs/extension-conventions.md` that distinguishes official Pi requirements, monorepo requirements, and preferred patterns; gives maintainers actionable command, menu, lifecycle, package, UI, documentation, and verification guidance; and is discoverable from `AGENTS.md`.
+
+## Context
+
+- New extensions must follow the full convention set; existing extensions adopt the relevant section when that area is changed.
+- The document will use MUST/SHOULD/MAY and identify each MUST's actual verification method as Validator, Test, Review, or Smoke.
+- `docs/extension-settings.md` remains the detailed settings authority; the new document summarizes and links to it.
+- Pi guidance targets the latest release and records the version reviewed.
+
+## Non-Goals
+
+- Do not change extension runtime behavior, package metadata, or README content.
+- Do not add validators solely for this documentation change; future extension work may add reliable checks when touching the relevant area.
+- Do not duplicate the full Pi API reference or the detailed settings guide.
+
+## Plan
+
+- [x] Verify the current Pi release and canonical official documentation links; `npm view` reported 0.81.1 and all three `earendil-works/pi` documentation URLs returned HTTP 200.
+- [x] Add `docs/extension-conventions.md` with scoped authority, official Pi guidance, monorepo conventions, verification labels, and separate new-extension and touched-area checklists; a focused script confirmed every MUST names an actual verification method and the settings section links to `docs/extension-settings.md`.
+- [x] Update `AGENTS.md` with a concise pointer requiring maintainers to read the conventions document for new extensions and touched areas without duplicating the guide.
+- [x] Run formatting/document checks and the repository CI-equivalent gate; `npm run check` passed all 1,135 tests and `git diff --check` passed. Biome reported that the Markdown files are outside its handled file set.
+- [x] Review the final diff for scope, source accuracy, internal consistency, and whitespace errors; only `AGENTS.md`, the conventions guide, and this plan are changed.
+
+## Risks
+
+- Official guidance can drift; mitigate with canonical source links and a reviewed Pi version rather than copied API tutorials.
+- Overstating observed patterns as requirements could force unrelated migrations; mitigate by separating MUST/SHOULD/MAY and applying touched-area adoption to existing packages.
+- Verification labels can claim enforcement that does not exist; label only current checks as Validator and use Test, Review, or Smoke otherwise.
+
+## Completion Checklist
+
+- [x] `docs/extension-conventions.md` exists, is English, and clearly separates official, repository, and preferred guidance.
+- [x] A focused verification script confirmed all 23 MUST rules name a real Validator, Test, Review, or Smoke method.
+- [x] Settings ownership remains in `docs/extension-settings.md` without material duplication.
+- [x] `AGENTS.md` points agents to the new guide.
+- [x] No extension implementation, manifest, or README is changed.
+- [x] Required checks pass; archive this completed plan under `docs/plans/archived/` as the final file operation.


### PR DESCRIPTION
## Summary

- add a central extension conventions guide that separates official Pi constraints, monorepo requirements, and preferred product patterns
- document package, lifecycle, command/menu, TUI, settings, status, README, and verification conventions with new-extension and touched-area checklists
- point `AGENTS.md` at the guide while keeping detailed settings ownership in `docs/extension-settings.md`

## Affected paths

- `docs/extension-conventions.md`
- `AGENTS.md`
- `docs/plans/archived/2026-07-23_extension-conventions-plan.md`

## Verification

- `npm run check` — passed, 1,135 tests
- focused conventions check — all 23 MUST rules name a Validator, Test, Review, or Smoke method
- official Pi 0.81.1 documentation links — returned HTTP 200
- `git diff --check` — passed

## Notes

- this change adds no new validators and does not modify extension runtime behavior, manifests, or package READMEs
- reliable validators can be added when future extension work touches a machine-checkable convention
