### PR TITLE
feat(pi-sync)!: rename slash command to sync

### DIFF
--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -8,7 +8,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
 
 ## ✨ Features
 
-- Adds a `/pisync` command with `status`, `diff`, `push`, `pull`, `sync`, `history`, `rollback`, `doctor`, and `unlock` subcommands.
+- Adds a `/sync` command with `status`, `diff`, `push`, `pull`, `sync`, `history`, `rollback`, `doctor`, and `unlock` subcommands.
 - Syncs allowlisted Pi configuration from `~/.pi/agent`:
   - `settings.json`
   - `keybindings.json`
@@ -20,7 +20,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
 - Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
 - Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
-- Runs `/pisync sync` automatically on Pi startup when R2/S3 config is present.
+- Runs `/sync sync` automatically on Pi startup when R2/S3 config is present.
 - Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations and only treats locks as stale after checking process liveness.
 - Refuses to push common secret patterns and denylisted paths such as `.env`, `.env.local`, token/secret files, `.pisync`, `.git`, and `node_modules`.
 - Preflights snapshot apply operations before mutating local files, refuses symlink path escapes, and rejects writes over symlinks or directories.
@@ -48,7 +48,7 @@ pi -e ./extensions/pi-sync
 Run:
 
 ```text
-/pisync init
+/sync init
 ```
 
 Then edit:
@@ -103,7 +103,7 @@ pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TO
 
 `syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include Pi's configured session JSONL files in snapshots. pi-sync uses `PI_CODING_AGENT_SESSION_DIR`, Pi's `sessionDir` setting, or the default `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/**/*.jsonl` storage. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
 
-Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/pisync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/pisync diff`, then choose `/pisync pull --force` or `/pisync push --force` if needed.
+Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/sync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/sync diff`, then choose `/sync pull --force` or `/sync push --force` if needed.
 
 When both `autoSync` and `syncSessions` are enabled, pi-sync syncs on startup and attempts a quiet session push on shutdown when local files changed. Startup session pulls happen after Pi has already selected the current session, so restart Pi or resume a pulled session to use newly synced conversations. If the remote changed first, the shutdown push is skipped with a warning instead of overwriting it.
 
@@ -112,31 +112,31 @@ Session files can contain prompts, model output, tool results, file paths, image
 ## 🚀 Usage
 
 ```text
-/pisync config
-/pisync doctor
-/pisync status
-/pisync diff
-/pisync push
-/pisync pull
-/pisync sync
-/pisync history
-/pisync rollback <snapshot-id>
-/pisync unlock --stale
+/sync config
+/sync doctor
+/sync status
+/sync diff
+/sync push
+/sync pull
+/sync sync
+/sync history
+/sync rollback <snapshot-id>
+/sync unlock --stale
 ```
 
 Useful flags:
 
 - `--yes` / `-y`: skip confirmation prompts.
 - `--force`: allow push or pull when both local and remote state changed.
-- `--stale`: remove a stale local lock with `/pisync unlock --stale`.
+- `--stale`: remove a stale local lock with `/sync unlock --stale`.
 
 ## 🔄 Automatic sync
 
-`autoSync` defaults to `true`. When Pi starts, pi-sync runs the same conservative decision logic as `/pisync sync`:
+`autoSync` defaults to `true`. When Pi starts, pi-sync runs the same conservative decision logic as `/sync sync`:
 
 - only local changed or remote is empty → push
 - first sync with existing local settings and an identical remote snapshot → initialize local sync state without rewriting files
-- first sync with existing local settings and a different remote snapshot → skip and show a warning so you manually choose `/pisync pull` or `/pisync push`
+- first sync with existing local settings and a different remote snapshot → skip and show a warning so you manually choose `/sync pull` or `/sync push`
 - only remote changed after an established sync → pull with a backup
 - both local and remote changed after a previous sync → skip and show a warning
 - no config present → do nothing
@@ -171,13 +171,13 @@ pi-sync/
 
 Each snapshot contains the selected file tree and SHA-256 hashes. `latest.json` points to the active snapshot. Rollback applies an older snapshot locally and moves `latest.json` back to that snapshot.
 
-Before updating `latest.json`, pi-sync re-reads the current pointer and rejects the push if it already differs from the version seen at the start of the command. This prevents overwriting changes that are visible before the final write. It is not a true atomic cross-machine compare-and-swap on R2, so two machines that push at the same instant can still race; run `/pisync status` before important manual pushes if you use multiple machines heavily.
+Before updating `latest.json`, pi-sync re-reads the current pointer and rejects the push if it already differs from the version seen at the start of the command. This prevents overwriting changes that are visible before the final write. It is not a true atomic cross-machine compare-and-swap on R2, so two machines that push at the same instant can still race; run `/sync status` before important manual pushes if you use multiple machines heavily.
 
 ## 🛡️ Safety notes
 
 - pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
 - With `syncSessions`/`PI_SYNC_SESSIONS` disabled, pi-sync does not collect or apply local Pi sessions, though settings-only pushes may preserve session files already present in remote snapshots. It never syncs OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
-- If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/pisync unlock --stale` is intended for locks whose process is gone or invalid.
+- If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/sync unlock --stale` is intended for locks whose process is gone or invalid.
 - If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
 - Pull and rollback create backups before writing local files, then preflight deletes and writes before mutating the local settings tree.
 - Pull and rollback refuse to follow symlinked parent paths during snapshot apply and refuse to overwrite a symlink or directory with file content.

--- a/extensions/pi-sync/src/command.ts
+++ b/extensions/pi-sync/src/command.ts
@@ -90,7 +90,7 @@ export function completeSyncArguments(argumentPrefix: string): CommandArgumentCo
 
 export function usage() {
 	return [
-		"Usage: /pisync <command>",
+		"Usage: /sync <command>",
 		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
 		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json when PI_CODING_AGENT_DIR is set).",
 	].join("\n");

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -55,7 +55,7 @@ export async function loadConfigInternal(): Promise<SyncConfig> {
 		.filter(([, value]) => !value)
 		.map(([name]) => name);
 	if (missing.length > 0) {
-		throw new Error(`Missing pi-sync config: ${missing.join(", ")}. Run /pisync init or set PI_SYNC_* environment variables.`);
+		throw new Error(`Missing pi-sync config: ${missing.join(", ")}. Run /sync init or set PI_SYNC_* environment variables.`);
 	}
 
 	return {

--- a/extensions/pi-sync/src/lock.ts
+++ b/extensions/pi-sync/src/lock.ts
@@ -82,7 +82,7 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 		const inspection = await inspectLock();
 		if (inspection.status === "valid" && isStaleLock(inspection.lock)) {
 			throw new Error(
-				`pi-sync lock is stale (pid ${inspection.lock.pid}). Run /pisync unlock --stale, then retry.`,
+				`pi-sync lock is stale (pid ${inspection.lock.pid}). Run /sync unlock --stale, then retry.`,
 			);
 		}
 		if (inspection.status === "valid") {
@@ -92,7 +92,7 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 		}
 		if (inspection.status === "unreadable") {
 			throw new Error(
-				"pi-sync lock metadata is unreadable. Run /pisync unlock --stale after verifying no sync is running.",
+				"pi-sync lock metadata is unreadable. Run /sync unlock --stale after verifying no sync is running.",
 			);
 		}
 
@@ -208,7 +208,7 @@ async function unlockGuarded(ctx: ExtensionCommandContext, options: CommandOptio
 	if (inspection.status === "unreadable") {
 		if (!options.stale) {
 			ctx.ui.notify(
-				"Pi-sync lock metadata is unreadable. Use /pisync unlock --stale only after verifying no sync is running.",
+				"Pi-sync lock metadata is unreadable. Use /sync unlock --stale only after verifying no sync is running.",
 				"warning",
 			);
 			return;

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -97,7 +97,7 @@ const AUTO_SYNC_OPTIONS: CommandOptions = {
 	args: [],
 };
 export default function sync(pi: ExtensionAPI) {
-	pi.registerCommand("pisync", {
+	pi.registerCommand("sync", {
 		description: "Sync Pi settings through Cloudflare R2 or S3-compatible storage",
 		getArgumentCompletions: completeSyncArguments,
 		handler: async (args, ctx) => {
@@ -162,7 +162,7 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
 				await unlock(ctx, options);
 				return;
 			default:
-				ctx.ui.notify(`Unknown /pisync command: ${subcommand}\n\n${usage()}`, "warning");
+				ctx.ui.notify(`Unknown /sync command: ${subcommand}\n\n${usage()}`, "warning");
 		}
 	} catch (error) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -228,7 +228,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 		extraFiles: [],
 	};
 	await writeJson(configPath, sample);
-	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /pisync doctor.`, "info");
+	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /sync doctor.`, "info");
 }
 
 async function showConfig(ctx: ExtensionCommandContext) {
@@ -347,14 +347,14 @@ async function doctor(ctx: ExtensionCommandContext) {
 	if (lock.status === "valid" && isStaleLock(lock.lock)) {
 		level = "warning";
 		messages.push(
-			`lock: stale (pid ${lock.lock.pid}); run /pisync unlock after verifying no sync is running`,
+			`lock: stale (pid ${lock.lock.pid}); run /sync unlock after verifying no sync is running`,
 		);
 	} else if (lock.status === "valid") {
 		messages.push(`lock: held by pid ${lock.lock.pid} since ${lock.lock.startedAt}`);
 	} else if (lock.status === "unreadable") {
 		level = "warning";
 		messages.push(
-			"lock: unreadable; use /pisync unlock --stale only after verifying no sync is running",
+			"lock: unreadable; use /sync unlock --stale only after verifying no sync is running",
 		);
 	} else if (await isLockGuardHeld()) {
 		level = "warning";
@@ -386,7 +386,7 @@ async function push(
 			: undefined;
 		if (!remoteForConflict || !snapshotHashesMatchState(remoteForConflict, state, config)) {
 			throw new Error(
-				"Remote or sync policy changed since last sync. Run /pisync pull first or /pisync push --force.",
+				"Remote or sync policy changed since last sync. Run /sync pull first or /sync push --force.",
 			);
 		}
 	}
@@ -436,12 +436,12 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const state = await readState(config.profile);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
-	if (!remote) throw new Error("Remote is empty. Run /pisync push from a configured machine first.");
+	if (!remote) throw new Error("Remote is empty. Run /sync push from a configured machine first.");
 
 	const localChanged = hasLocalChanges(local, state, config);
 	const remoteChanged = hasRemoteChanges(remote, state, config, protectedSessionPaths(ctx));
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
-		throw new Error("Both local and remote changed since last sync. Run /pisync diff, then choose /pisync pull --force or /pisync push --force.");
+		throw new Error("Both local and remote changed since last sync. Run /sync diff, then choose /sync pull --force or /sync push --force.");
 	}
 
 	if (
@@ -497,11 +497,11 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 
 	if (firstSync && remote && remote.files.length > 0 && local.files.length > 0) {
 		if (!canPullRemoteSettingsOnFirstSync(local, remote)) {
-			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /sync diff, then manually choose /sync pull or /sync push.");
 		}
 		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
 			if (!canPullRemoteSessionsOnFirstSync(local, remote)) {
-				throw new Error("Remote settings match, but local and remote Pi sessions differ. Run /pisync diff, then manually choose /pisync pull or /pisync push.");
+				throw new Error("Remote settings match, but local and remote Pi sessions differ. Run /sync diff, then manually choose /sync pull or /sync push.");
 			}
 			await pull(ctx, options);
 			return;
@@ -532,7 +532,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 		return;
 	}
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
-		throw new Error("Both local and remote changed. Run /pisync diff and resolve with push --force or pull --force.");
+		throw new Error("Both local and remote changed. Run /sync diff and resolve with push --force or pull --force.");
 	}
 	if (remoteChanged) {
 		await pull(ctx, options);
@@ -577,7 +577,7 @@ async function history(ctx: ExtensionCommandContext) {
 
 async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const target = options.args[0];
-	if (!target) throw new Error("Usage: /pisync rollback <snapshot-id> [--yes]");
+	if (!target) throw new Error("Usage: /sync rollback <snapshot-id> [--yes]");
 
 	const config = await loadConfig();
 	const client = new S3Client(config);
@@ -724,12 +724,12 @@ async function uploadSnapshot(
 	await client.putBuffer(snapshotKey(config, snapshot.id), encoded, "application/gzip");
 	const current = await client.getJson<LatestPointer>(latestKey(config));
 	if (!force && remoteIdentity(current) !== remoteIdentity(latest)) {
-		throw new Error("Remote changed while pushing. Run /pisync pull first, then retry.");
+		throw new Error("Remote changed while pushing. Run /sync pull first, then retry.");
 	}
 	await client.putJson(latestKey(config), pointer);
 	const verified = await client.getJson<LatestPointer>(latestKey(config));
 	if (verified.value?.snapshot !== pointer.snapshot) {
-		throw new Error("Remote latest changed immediately after push. Run /pisync status before continuing.");
+		throw new Error("Remote latest changed immediately after push. Run /sync status before continuing.");
 	}
 	return pointer;
 }

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -57,13 +57,30 @@ import sync, {
 	splitArgs,
 } from "../src/sync.js";
 
-test("sync registers pisync command and session lifecycle hooks", () => {
+test("sync registers the sync command and session lifecycle hooks", () => {
 	const mock = createMockPi();
 	sync(mock.pi);
 
-	assert.ok(mock.commands.has("pisync"));
-	assert.equal(typeof mock.commands.get("pisync")?.getArgumentCompletions, "function");
+	assert.ok(mock.commands.has("sync"));
+	assert.equal(mock.commands.has("pisync"), false);
+	assert.equal(typeof mock.commands.get("sync")?.getArgumentCompletions, "function");
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+});
+
+test("sync command help and errors use the public command name", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+		const command = mock.commands.get("sync");
+
+		await command?.handler("help", ctx);
+		await command?.handler("unknown", ctx);
+
+		assert.match(notifications[0]?.message ?? "", /Usage: \/sync <command>/);
+		assert.match(notifications[1]?.message ?? "", /Unknown \/sync command: unknown/);
+		assert.doesNotMatch(notifications.map(({ message }) => message).join("\n"), /\/pisync/);
+	});
 });
 
 test("completeSyncArguments suggests commands and useful flags", () => {
@@ -211,7 +228,7 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 	});
 });
 
-test("pisync config output reports session sync and privacy warning", async () => {
+test("sync config output reports session sync and privacy warning", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(
@@ -223,7 +240,7 @@ test("pisync config output reports session sync and privacy warning", async () =
 		const { ctx, notifications } = createMockContext();
 
 		await withEnv({}, async () => {
-			await mock.commands.get("pisync")?.handler("config", ctx);
+			await mock.commands.get("sync")?.handler("config", ctx);
 		});
 
 		assert.match(notifications[0]?.message ?? "", /syncSessions: enabled/);
@@ -972,7 +989,7 @@ test("old unreadable locks require explicit stale unlock before recovery", async
 			assert.equal(ran, false);
 			assert.equal(await lockFileExists(), true);
 
-			await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
 			assert.equal(await lockFileExists(), false);
 			assert.equal(await withLock("test", async () => "ok"), "ok");
 		}
@@ -1037,11 +1054,11 @@ test("unlock keeps a fresh unreadable lock unless stale removal is explicit", as
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("pisync")?.handler("unlock", ctx);
+		await mock.commands.get("sync")?.handler("unlock", ctx);
 		assert.equal(await lockFileExists(), true);
 		assert.match(notifications.at(-1)?.message ?? "", /unreadable/);
 
-		await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+		await mock.commands.get("sync")?.handler("unlock --stale", ctx);
 		assert.equal(await lockFileExists(), false);
 		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable/);
 	});
@@ -1073,7 +1090,7 @@ test("stale unlock rechecks unreadable metadata before removing it", async () =>
 			const mock = createMockPi();
 			sync(mock.pi);
 			const { ctx, notifications } = createMockContext();
-			await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
 
 			assert.equal(await lockFileExists(), true);
 			assert.match(notifications.at(-1)?.message ?? "", /not stale|still live/);
@@ -1104,7 +1121,7 @@ test("unlock cannot remove the lock for an active guarded sync", async () => {
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 		try {
-			await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
 			assert.equal(await lockFileExists(), true);
 			assert.match(notifications.at(-1)?.message ?? "", /currently running/);
 		} finally {
@@ -1132,7 +1149,7 @@ test("unlock reports when a dead owner's guard is still expiring", async () => {
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("pisync")?.handler("unlock --stale", ctx);
+		await mock.commands.get("sync")?.handler("unlock --stale", ctx);
 		assert.equal(await lockFileExists(), true);
 		assert.match(notifications.at(-1)?.message ?? "", /owner exited.*guard expires/);
 	});
@@ -1211,7 +1228,7 @@ test("doctor warns when lock metadata is unreadable", async () => {
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		await mock.commands.get("sync")?.handler("doctor", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /lock: unreadable/);
 		assert.equal(notifications.at(-1)?.level, "warning");
 	});
@@ -1225,7 +1242,7 @@ test("doctor warns when a lock guard is active without metadata", async () => {
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		await mock.commands.get("sync")?.handler("doctor", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /lock: guard active.*metadata/);
 		assert.equal(notifications.at(-1)?.level, "warning");
 	});
@@ -1247,7 +1264,7 @@ test("doctor warns when a valid lock owner has exited", async () => {
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		await mock.commands.get("sync")?.handler("doctor", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /lock: stale.*unlock/);
 		assert.equal(notifications.at(-1)?.level, "warning");
 	});
@@ -1270,12 +1287,12 @@ test("doctor reports live and free lock states", async () => {
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		await mock.commands.get("sync")?.handler("doctor", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /lock: held by pid/);
 		assert.equal(notifications.at(-1)?.level, "info");
 
 		await fs.rm(lockPath());
-		await mock.commands.get("pisync")?.handler("doctor", ctx);
+		await mock.commands.get("sync")?.handler("doctor", ctx);
 		assert.match(notifications.at(-1)?.message ?? "", /lock: free/);
 		assert.equal(notifications.at(-1)?.level, "info");
 	});


### PR DESCRIPTION
## Summary

- rename the pi-sync slash command from `/pisync` to `/sync`
- update command help, diagnostics, recovery guidance, tests, and package documentation
- preserve the `.pisync` state directory, `PI_SYNC_*` environment variables, package identity, settings paths, and `pisync` status key

## Breaking change

`/pisync` is removed without a compatibility alias. Use `/sync` instead; existing subcommands remain unchanged, including `/sync status`, `/sync push`, and `/sync sync`.

## Affected paths

- `extensions/pi-sync/src/{sync,command,config,lock}.ts`
- `extensions/pi-sync/test/sync.test.ts`
- `extensions/pi-sync/README.md`

## Verification

- TDD red — focused registration expectation failed because the implementation still registered `pisync`
- `npm test` — passed, 1,136 tests
- `npm run check` — passed, 1,136 tests
- `npm pack --workspace @narumitw/pi-sync --dry-run --json` — passed; 13 expected package files present
- active-reference audit — only legacy-rejection assertions and intentional `.pisync`/status identifiers remain
- `git diff --check` — passed
