### PR TITLE
feat(pi-sync): add unified command menu

### DIFF
--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -8,7 +8,7 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
 
 ## ✨ Features
 
-- Adds a `/sync` command with `status`, `diff`, `push`, `pull`, `sync`, `history`, `rollback`, `doctor`, and `unlock` subcommands.
+- Opens every pi-sync action from the bare `/sync` menu and keeps direct `help`, `init`, `config`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` subcommands for automation and advanced flags.
 - Syncs allowlisted Pi configuration from `~/.pi/agent`:
   - `settings.json`
   - `keybindings.json`
@@ -111,11 +111,21 @@ Session files can contain prompts, model output, tool results, file paths, image
 
 ## 🚀 Usage
 
+Run `/sync` without arguments to open the interactive menu containing every pi-sync action. Choosing rollback asks for the snapshot id before showing the existing confirmation. Cancelling either selection leaves sync state unchanged.
+
 ```text
+/sync
+```
+
+The same actions remain available as direct routes for automation, non-interactive use, and advanced flags:
+
+```text
+/sync help
+/sync init
 /sync config
-/sync doctor
 /sync status
 /sync diff
+/sync doctor
 /sync push
 /sync pull
 /sync sync
@@ -123,6 +133,8 @@ Session files can contain prompts, model output, tool results, file paths, image
 /sync rollback <snapshot-id>
 /sync unlock --stale
 ```
+
+Bare `/sync` reports command usage when an interactive UI is unavailable; use a direct route for the desired operation.
 
 Useful flags:
 

--- a/extensions/pi-sync/src/command.ts
+++ b/extensions/pi-sync/src/command.ts
@@ -1,23 +1,30 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { CommandArgumentCompletion, CommandOptions } from "./types.js";
 
 const YES_FLAG_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 	{ value: "--yes", label: "--yes", description: "Skip confirmation prompts" },
 	{ value: "-y", label: "-y", description: "Skip confirmation prompts" },
 ];
-const SYNC_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
-	{ value: "help", label: "help", description: "Show command usage" },
-	{ value: "init", label: "init", description: "Create local config template" },
-	{ value: "config", label: "config", description: "Show resolved configuration" },
-	{ value: "status", label: "status", description: "Show sync status" },
-	{ value: "diff", label: "diff", description: "Show local/remote diff" },
-	{ value: "doctor", label: "doctor", description: "Check config, secrets, and lock state" },
-	{ value: "push", label: "push", description: "Upload local settings" },
-	{ value: "pull", label: "pull", description: "Apply remote settings" },
-	{ value: "sync", label: "sync", description: "Push or pull as needed" },
-	{ value: "history", label: "history", description: "Show recent remote snapshots" },
-	{ value: "rollback", label: "rollback", description: "Apply a previous snapshot" },
-	{ value: "unlock", label: "unlock", description: "Remove a stale local lock" },
-];
+export const SYNC_COMMANDS = [
+	{ name: "help", description: "Show command usage" },
+	{ name: "init", description: "Create local config template" },
+	{ name: "config", description: "Show resolved configuration" },
+	{ name: "status", description: "Show sync status" },
+	{ name: "diff", description: "Show local/remote diff" },
+	{ name: "doctor", description: "Check config, secrets, and lock state" },
+	{ name: "push", description: "Upload local settings" },
+	{ name: "pull", description: "Apply remote settings" },
+	{ name: "sync", description: "Push or pull as needed" },
+	{ name: "history", description: "Show recent remote snapshots" },
+	{ name: "rollback", description: "Apply a previous snapshot", usageSuffix: " <snapshot>" },
+	{ name: "unlock", description: "Remove a stale local lock", usageSuffix: " --stale" },
+] as const;
+
+export type SyncCommandName = (typeof SYNC_COMMANDS)[number]["name"];
+
+const SYNC_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = SYNC_COMMANDS.map(
+	({ name, description }) => ({ value: name, label: name, description }),
+);
 const SYNC_FLAG_COMPLETIONS: Record<string, readonly CommandArgumentCompletion[]> = {
 	push: [
 		...YES_FLAG_COMPLETIONS,
@@ -88,10 +95,42 @@ export function completeSyncArguments(argumentPrefix: string): CommandArgumentCo
 		: null;
 }
 
+export function syncMenuOptions() {
+	return SYNC_COMMANDS.map(({ name, description }) => `${name} — ${description}`);
+}
+
+export function syncCommandFromMenuOption(option: string): SyncCommandName | undefined {
+	return SYNC_COMMANDS.find(({ name, description }) => option === `${name} — ${description}`)?.name;
+}
+
+export async function resolveSyncCommand(input: string, ctx: ExtensionCommandContext) {
+	const [subcommand, ...rest] = splitArgs(input);
+	if (subcommand) return { subcommand, rest };
+	if (!ctx.hasUI) {
+		ctx.ui.notify(usage(), "info");
+		return undefined;
+	}
+
+	const selectedOption = await ctx.ui.select("pi-sync", syncMenuOptions());
+	const selected = selectedOption ? syncCommandFromMenuOption(selectedOption) : undefined;
+	if (!selected) return undefined;
+	if (selected !== "rollback") return { subcommand: selected, rest: [] };
+
+	const target = (await ctx.ui.input("Rollback snapshot", "snapshot id"))?.trim();
+	if (!target) {
+		ctx.ui.notify("Rollback cancelled.", "info");
+		return undefined;
+	}
+	return { subcommand: selected, rest: [target] };
+}
+
 export function usage() {
+	const commands = SYNC_COMMANDS.map(
+		(command) => `${command.name}${"usageSuffix" in command ? command.usageSuffix : ""}`,
+	).join(", ");
 	return [
 		"Usage: /sync <command>",
-		"Commands: init, config, status, diff, doctor, push, pull, sync, history, rollback <snapshot>, unlock --stale",
+		`Commands: ${commands}`,
 		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json when PI_CODING_AGENT_DIR is set).",
 	].join("\n");
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { gunzip, gzip } from "node:zlib";
 import { promisify } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { completeSyncArguments, parseOptions, splitArgs, usage } from "./command.js";
+import { completeSyncArguments, parseOptions, resolveSyncCommand, usage } from "./command.js";
 import {
 	agentDir,
 	ensureStateDir,
@@ -118,10 +118,11 @@ export default function sync(pi: ExtensionAPI) {
 }
 
 async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
-	const [subcommand = "status", ...rest] = splitArgs(rawArgs);
-	const options = parseOptions(rest);
-
 	try {
+		const command = await resolveSyncCommand(rawArgs, ctx);
+		if (!command) return;
+		const { subcommand, rest } = command;
+		const options = parseOptions(rest);
 		await ensureStateDir();
 
 		switch (subcommand) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
@@ -15,6 +16,12 @@ import path from "node:path";
 import test from "node:test";
 import { gunzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	SYNC_COMMANDS,
+	syncCommandFromMenuOption,
+	syncMenuOptions,
+	usage,
+} from "../src/command.js";
 import {
 	configuredSessionDir,
 	ensureStateDir,
@@ -80,6 +87,132 @@ test("sync command help and errors use the public command name", async () => {
 		assert.match(notifications[0]?.message ?? "", /Usage: \/sync <command>/);
 		assert.match(notifications[1]?.message ?? "", /Unknown \/sync command: unknown/);
 		assert.doesNotMatch(notifications.map(({ message }) => message).join("\n"), /\/pisync/);
+	});
+});
+
+const expectedSyncMenuOptions = [
+	"help — Show command usage",
+	"init — Create local config template",
+	"config — Show resolved configuration",
+	"status — Show sync status",
+	"diff — Show local/remote diff",
+	"doctor — Check config, secrets, and lock state",
+	"push — Upload local settings",
+	"pull — Apply remote settings",
+	"sync — Push or pull as needed",
+	"history — Show recent remote snapshots",
+	"rollback — Apply a previous snapshot",
+	"unlock — Remove a stale local lock",
+];
+
+test("bare sync command opens an all-subcommand menu and cancellation is a no-op", async () => {
+	await withTempHome(async (agentDir) => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		let selectedTitle: string | undefined;
+		let selectedOptions: string[] | undefined;
+		const { ctx, notifications, statuses } = createMockContext({
+			hasUI: true,
+			select: async (title: string, options: string[]) => {
+				selectedTitle = title;
+				selectedOptions = options;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.equal(selectedTitle, "pi-sync");
+		assert.deepEqual(selectedOptions, expectedSyncMenuOptions);
+		assert.deepEqual(notifications, []);
+		assert.equal(statuses.size, 0);
+		assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
+	});
+});
+
+test("sync menu options map one-to-one to the canonical command catalog", () => {
+	const commandNames = SYNC_COMMANDS.map(({ name }) => name);
+	const options = syncMenuOptions();
+
+	assert.deepEqual(options, expectedSyncMenuOptions);
+	assert.deepEqual(options.map(syncCommandFromMenuOption), commandNames);
+	assert.equal(new Set(commandNames).size, commandNames.length);
+	for (const commandName of commandNames) {
+		assert.match(usage(), new RegExp(`\\b${commandName}\\b`));
+	}
+});
+
+test("sync menu dispatches its selected subcommand through the public command path", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			select: async () => expectedSyncMenuOptions[0],
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(notifications[0]?.message ?? "", /Usage: \/sync <command>/);
+	});
+});
+
+test("bare sync command reports usage without an interactive UI", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		let selected = false;
+		const { ctx, notifications } = createMockContext({
+			hasUI: false,
+			select: async () => {
+				selected = true;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.equal(selected, false);
+		assert.match(notifications[0]?.message ?? "", /Usage: \/sync <command>/);
+	});
+});
+
+test("sync rollback menu requests a snapshot id and cancels empty input", async () => {
+	await withTempHome(async (agentDir) => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		let inputCalls = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			select: async () => expectedSyncMenuOptions[10],
+			input: async () => {
+				inputCalls += 1;
+				return "  ";
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.equal(inputCalls, 1);
+		assert.match(notifications[0]?.message ?? "", /Rollback cancelled/);
+		assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
+	});
+});
+
+test("sync rollback menu passes a provided snapshot id to rollback", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			select: async () => expectedSyncMenuOptions[10],
+			input: async () => "snapshot-id",
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(notifications[0]?.message ?? "", /Missing pi-sync config/);
+		assert.doesNotMatch(notifications[0]?.message ?? "", /Usage: \/sync rollback/);
 	});
 });
 


### PR DESCRIPTION
## Summary

- open an interactive all-actions menu for bare `/sync`
- derive menu labels, completions, and usage from one canonical subcommand catalog
- prompt for rollback snapshot IDs while preserving direct routes, flags, and destructive-operation safeguards
- document the menu behavior and add focused interactive/non-interactive coverage

## Testing

- `npm run check` (Biome, boundaries, all workspace typechecks, 1,142 tests)