### PR TITLE
feat(pi-sync): add persistent file selection

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-sync-file-selection-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-sync-file-selection-plan.md
@@ -1,0 +1,22 @@
+# pi-sync file selection
+
+## Goal
+
+Add a persistent `/sync files` TUI for choosing top-level Pi files and directory groups, while treating unselected paths as unmanaged and preserving them locally and remotely.
+
+## Plan
+
+- [x] Added red-first tests for `syncFiles` validation/defaults, selected collection/apply policy, and unmanaged remote preservation.
+- [x] Centralized the built-in sync catalog and path policy, then threaded `syncFiles` through snapshots, state, comparison, apply, and upload merge behavior.
+- [x] Added `/sync files` with a searchable `SettingsList`, safe extra-file discovery, a read-only environment-overridden sessions row, and a non-TUI summary.
+- [x] Persisted UI changes serially and atomically while preserving unknown fields, rejecting malformed/symlink config, retaining POSIX `0600`, and rolling back failed UI changes.
+- [x] Updated package metadata, npm 11.16.0 lockfile, and README for the new public command and setting.
+- [x] Verified with focused red/green cycles, `npm test` (1,154 passing), workspace typechecks, `npm run check`, `just pack-sync` (16 expected files), and an isolated print-mode Pi load/command smoke.
+
+## Completion Checklist
+
+- [x] Existing configs without `syncFiles` retain the full legacy allowlist; empty selection is valid; invalid entries fail safely.
+- [x] Unselected built-ins, directories, sessions, and extra files are not collected/applied/deleted and remain preserved in remote uploads.
+- [x] TUI and non-TUI command behavior, persistence failures, permissions, and environment override behavior are covered by deterministic tests.
+- [x] Documentation and the inspected 16-file package tarball match the implementation.
+- [x] All required verification passes; interactive behavior is deterministic-test covered and the runtime smoke used isolated print mode to avoid launching an interactive TUI.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -8,14 +8,12 @@ It syncs automatically by default when Pi starts, then uses immutable snapshot b
 
 ## ✨ Features
 
-- Opens every pi-sync action from the bare `/sync` menu and keeps direct `help`, `init`, `config`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` subcommands for automation and advanced flags.
-- Syncs allowlisted Pi configuration from `~/.pi/agent`:
-  - `settings.json`
-  - `keybindings.json`
-  - `models.json`
-  - `AGENTS.md`
-  - `APPEND_SYSTEM.md`
-  - `skills/`, `prompts/`, `themes/`, and `extensions/`
+- Opens every pi-sync action from the bare `/sync` menu and keeps direct `help`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` subcommands for automation and advanced flags.
+- Uses `/sync files` to choose which top-level Pi files and recursive directory groups are managed by this machine.
+- Syncs selected, allowlisted Pi configuration from `~/.pi/agent`:
+  - `settings.json`, `keybindings.json`, `models.json`, `AGENTS.md`, and `APPEND_SYSTEM.md`
+  - recursive `skills/`, `prompts/`, `themes/`, and `extensions/` groups
+  - safe top-level files selected through `extraFiles`
   - optionally denylist-filtered `sessions/**/*.jsonl` when `syncSessions` is enabled
 - Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
 - Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
@@ -71,6 +69,17 @@ Example:
   "profile": "default",
   "prefix": "pi-sync",
   "autoSync": true,
+  "syncFiles": [
+    "settings.json",
+    "keybindings.json",
+    "models.json",
+    "AGENTS.md",
+    "APPEND_SYSTEM.md",
+    "skills",
+    "prompts",
+    "themes",
+    "extensions"
+  ],
   "syncSessions": false,
   "extraFiles": []
 }
@@ -91,7 +100,13 @@ export PI_SYNC_AUTO_SYNC="true"
 export PI_SYNC_SESSIONS="false" # opt in with true to sync Pi conversation JSONL files
 ```
 
-Set `extraFiles` to additional top-level file names to include beyond the default allowlist. Machines without a matching `extraFiles` entry preserve those remote files but do not apply or delete them locally.
+Run `/sync files` in TUI mode to edit `syncFiles`, `syncSessions`, and `extraFiles` with a searchable selector. Enter or Space toggles an item and Escape closes the screen. Each successful change is saved immediately to `pi-sync.local.json`, preserving unknown fields through an atomic replacement with `0600` permissions on POSIX. No network sync starts until the next manual `push`, `pull`, or `sync`, or the existing automatic sync lifecycle.
+
+`syncFiles` accepts the built-in names shown above and has no environment-variable override. Directory names select the complete recursive group. Omitting `syncFiles` preserves the legacy default of selecting every built-in item; an empty array is valid and means this machine manages none of them. Unknown values make configuration validation fail instead of silently narrowing the selection.
+
+The selector always shows built-in items, even when they are absent locally, so another machine can provide them on pull. It also shows safe top-level regular files found locally and configured `extraFiles` that may only exist remotely. It excludes directories, symlinks, reserved names, and denylisted names. You can still edit `extraFiles` manually to select additional safe top-level file names.
+
+An unselected item is unmanaged by this machine: pi-sync does not collect, compare, pull, overwrite, or delete its local content, and pushes preserve its existing remote snapshot content for other machines. This applies to built-ins, directory groups, sessions, and extra files. Selecting nothing therefore does not delete unmanaged local or remote files.
 
 `PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, assumed roles, or S3-compatible providers that issue short-lived credentials.
 
@@ -111,7 +126,7 @@ Session files can contain prompts, model output, tool results, file paths, image
 
 ## 🚀 Usage
 
-Run `/sync` without arguments to open the interactive menu containing every pi-sync action. Choosing rollback asks for the snapshot id before showing the existing confirmation. Cancelling either selection leaves sync state unchanged.
+Run `/sync` without arguments to open the interactive menu containing every pi-sync action. The **files — Choose synced files** action opens the persistent selector. Choosing rollback asks for the snapshot id before showing the existing confirmation. Cancelling either action leaves unmodified state unchanged; file-selection changes that were already saved are not rolled back when the screen closes.
 
 ```text
 /sync
@@ -123,6 +138,7 @@ The same actions remain available as direct routes for automation, non-interacti
 /sync help
 /sync init
 /sync config
+/sync files
 /sync status
 /sync diff
 /sync doctor
@@ -134,7 +150,7 @@ The same actions remain available as direct routes for automation, non-interacti
 /sync unlock --stale
 ```
 
-Bare `/sync` reports command usage when an interactive UI is unavailable; use a direct route for the desired operation.
+Bare `/sync` reports command usage when an interactive UI is unavailable; use a direct route for the desired operation. Outside TUI mode, `/sync files` does not open a custom component and instead reports the effective selection, config path, and manual editing fields. When `PI_SYNC_SESSIONS` is set, the sessions row is read-only and identifies the environment override.
 
 Useful flags:
 
@@ -188,6 +204,7 @@ Before updating `latest.json`, pi-sync re-reads the current pointer and rejects 
 ## 🛡️ Safety notes
 
 - pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
+- Unselected built-in files, directory groups, sessions, and extra files are unmanaged locally and preserved remotely; selecting nothing does not delete them.
 - With `syncSessions`/`PI_SYNC_SESSIONS` disabled, pi-sync does not collect or apply local Pi sessions, though settings-only pushes may preserve session files already present in remote snapshots. It never syncs OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
 - If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/sync unlock --stale` is intended for locks whose process is gone or invalid.
 - If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
@@ -201,6 +218,8 @@ extensions/pi-sync/
 ├── src/
 │   ├── index.ts       # Pi package entrypoint
 │   ├── sync.ts        # Extension registration and command orchestration
+│   ├── file-selection.ts # Persistent SettingsList selector
+│   ├── sync-policy.ts # Shared built-in catalog and path policy
 │   └── *.ts           # Package-local config, snapshot, path, and S3 modules
 ├── README.md
 ├── LICENSE

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -34,8 +34,13 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",
 		"@earendil-works/pi-coding-agent": "0.80.10",
+		"@earendil-works/pi-tui": "0.80.10",
 		"@types/proper-lockfile": "^4.1.4",
 		"typescript": "7.0.2"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-sync/src/command.ts
+++ b/extensions/pi-sync/src/command.ts
@@ -9,6 +9,7 @@ export const SYNC_COMMANDS = [
 	{ name: "help", description: "Show command usage" },
 	{ name: "init", description: "Create local config template" },
 	{ name: "config", description: "Show resolved configuration" },
+	{ name: "files", description: "Choose synced files" },
 	{ name: "status", description: "Show sync status" },
 	{ name: "diff", description: "Show local/remote diff" },
 	{ name: "doctor", description: "Check config, secrets, and lock state" },
@@ -43,7 +44,10 @@ const SYNC_FLAG_COMPLETIONS: Record<string, readonly CommandArgumentCompletion[]
 };
 
 export function splitArgs(input: string) {
-	return input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((arg) => arg.replace(/^['"]|['"]$/g, "")) ?? [];
+	return (
+		input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((arg) => arg.replace(/^['"]|['"]$/g, "")) ??
+		[]
+	);
 }
 
 export function parseOptions(args: string[]): CommandOptions {
@@ -131,6 +135,6 @@ export function usage() {
 	return [
 		"Usage: /sync <command>",
 		`Commands: ${commands}`,
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json when PI_CODING_AGENT_DIR is set).",
+		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit syncFiles/extraFiles in ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json when PI_CODING_AGENT_DIR is set).",
 	].join("\n");
 }

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -1,19 +1,18 @@
-import type { Dirent } from "node:fs";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { isDeniedPath, safeName } from "./paths.js";
+import { safeName } from "./paths.js";
+import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
 import type { PartialConfig, Snapshot, SyncConfig, SyncState } from "./types.js";
+
+export { extraFilePathsByLower, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
 
 const VERSION = 1;
 const DEFAULT_PROFILE = "default";
 const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
-const TOP_LEVEL_FILE_NAMES = new Set([...TOP_LEVEL_FILES].map((name) => name.toLowerCase()));
-const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
-const RESERVED_TOP_LEVEL_NAMES = new Set([...TOP_LEVEL_DIRS, "sessions"]);
 
 function trimSlashes(value: string) {
 	return value.replace(/^\/+|\/+$/g, "");
@@ -55,18 +54,24 @@ export async function loadConfigInternal(): Promise<SyncConfig> {
 		.filter(([, value]) => !value)
 		.map(([name]) => name);
 	if (missing.length > 0) {
-		throw new Error(`Missing pi-sync config: ${missing.join(", ")}. Run /sync init or set PI_SYNC_* environment variables.`);
+		throw new Error(
+			`Missing pi-sync config: ${missing.join(", ")}. Run /sync init or set PI_SYNC_* environment variables.`,
+		);
+	}
+	if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+		throw new Error("Missing pi-sync config after validation.");
 	}
 
 	return {
-		endpoint: endpoint!,
-		bucket: bucket!,
+		endpoint,
+		bucket,
 		region: partial.region ?? DEFAULT_REGION,
-		accessKeyId: accessKeyId!,
-		secretAccessKey: secretAccessKey!,
+		accessKeyId,
+		secretAccessKey,
 		sessionToken: partial.sessionToken,
 		profile: partial.profile ?? DEFAULT_PROFILE,
 		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
+		syncFiles: normalizeSyncFiles(partial.syncFiles),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
 		extraFiles: normalizeExtraFiles(partial.extraFiles),
 	};
@@ -77,18 +82,23 @@ export async function loadConfig(): Promise<SyncConfig> {
 }
 
 export async function loadPartialConfig(): Promise<PartialConfig> {
-	const fileConfig = (await readJsonIfExists<PartialConfig>(localConfigPath())) ?? {};
+	const fileConfig = ((await readLocalConfigObject()) ?? {}) as PartialConfig;
 	return {
 		...fileConfig,
 		endpoint: process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig.endpoint,
 		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? fileConfig.bucket,
 		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig.region,
-		accessKeyId: process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig.accessKeyId,
-		secretAccessKey: process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY ?? fileConfig.secretAccessKey,
+		accessKeyId:
+			process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID ?? fileConfig.accessKeyId,
+		secretAccessKey:
+			process.env.PI_SYNC_SECRET_ACCESS_KEY ??
+			process.env.AWS_SECRET_ACCESS_KEY ??
+			fileConfig.secretAccessKey,
 		sessionToken: selectSessionToken(fileConfig.sessionToken),
 		profile: process.env.PI_SYNC_PROFILE ?? fileConfig.profile,
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
+		syncFiles: fileConfig.syncFiles,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
 		extraFiles: fileConfig.extraFiles,
 	};
@@ -97,17 +107,25 @@ export async function loadPartialConfig(): Promise<PartialConfig> {
 export async function configuredSessionDir() {
 	const envSessionDir = normalizeOptionalString(process.env.PI_CODING_AGENT_SESSION_DIR);
 	if (envSessionDir) return expandHome(envSessionDir);
-	const settings = await readJsonIfExists<{ sessionDir?: string }>(path.join(agentDir(), "settings.json"));
+	const settings = await readJsonIfExists<{ sessionDir?: string }>(
+		path.join(agentDir(), "settings.json"),
+	);
 	return settings?.sessionDir ? expandHome(settings.sessionDir) : undefined;
 }
 
-export async function sessionDirForApply(ctx: ExtensionCommandContext | ExtensionContext, snapshot: Snapshot) {
+export async function sessionDirForApply(
+	ctx: ExtensionCommandContext | ExtensionContext,
+	snapshot: Snapshot,
+) {
 	const contextSessionDir = sessionDirFromContext(ctx);
 	const envSessionDir = normalizeOptionalString(process.env.PI_CODING_AGENT_SESSION_DIR);
 	if (envSessionDir) return contextSessionDir ?? expandHome(envSessionDir);
 
 	const localSessionDir = await configuredSessionDir();
-	if (contextSessionDir && path.resolve(contextSessionDir) !== path.resolve(localSessionDir ?? "")) {
+	if (
+		contextSessionDir &&
+		path.resolve(contextSessionDir) !== path.resolve(localSessionDir ?? "")
+	) {
 		return contextSessionDir;
 	}
 	return sessionDirFromSnapshot(snapshot) ?? contextSessionDir;
@@ -146,9 +164,7 @@ export function agentDir() {
 }
 
 function expandHome(value: string) {
-	return value === "~" || value.startsWith("~/")
-		? path.join(os.homedir(), value.slice(2))
-		: value;
+	return value === "~" || value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
 }
 
 export function stateDir() {
@@ -157,6 +173,81 @@ export function stateDir() {
 
 export function localConfigPath() {
 	return path.join(agentDir(), "pi-sync.local.json");
+}
+
+export function localConfigTemplate(): Record<string, unknown> {
+	return {
+		endpoint: "https://<account-id>.r2.cloudflarestorage.com",
+		bucket: "pi-sync",
+		region: DEFAULT_REGION,
+		accessKeyId: "<access-key-id>",
+		secretAccessKey: "<secret-access-key>",
+		profile: DEFAULT_PROFILE,
+		prefix: DEFAULT_PREFIX,
+		autoSync: true,
+		syncFiles: [...DEFAULT_SYNC_FILES],
+		syncSessions: false,
+		extraFiles: [],
+	};
+}
+
+export async function readLocalConfigObject(): Promise<Record<string, unknown> | undefined> {
+	const configPath = localConfigPath();
+	try {
+		const stat = await fs.lstat(configPath);
+		if (stat.isSymbolicLink())
+			throw new Error(`Refusing to read symlinked pi-sync config: ${configPath}`);
+		if (!stat.isFile()) throw new Error(`pi-sync config is not a regular file: ${configPath}`);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+	const parsed = JSON.parse(await fs.readFile(configPath, "utf8")) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`pi-sync config must contain a JSON object: ${configPath}`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+export async function updateLocalConfig(
+	update: (current: Record<string, unknown>) => Record<string, unknown>,
+) {
+	const current = (await readLocalConfigObject()) ?? localConfigTemplate();
+	const next = update({ ...current });
+	await writeLocalConfigObject(next);
+	return next;
+}
+
+export async function writeLocalConfigObject(value: Record<string, unknown>) {
+	const configPath = localConfigPath();
+	await fs.mkdir(path.dirname(configPath), { recursive: true });
+	try {
+		const stat = await fs.lstat(configPath);
+		if (stat.isSymbolicLink())
+			throw new Error(`Refusing to overwrite symlinked pi-sync config: ${configPath}`);
+		if (!stat.isFile()) throw new Error(`pi-sync config is not a regular file: ${configPath}`);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+
+	const temporaryPath = path.join(
+		path.dirname(configPath),
+		`.${path.basename(configPath)}.${process.pid}.${randomUUID()}.tmp`,
+	);
+	let handle: fs.FileHandle | undefined;
+	try {
+		handle = await fs.open(temporaryPath, "wx", 0o600);
+		await handle.writeFile(`${JSON.stringify(value, null, "\t")}\n`, "utf8");
+		if (process.platform !== "win32") await handle.chmod(0o600);
+		await handle.sync();
+		await handle.close();
+		handle = undefined;
+		await fs.rename(temporaryPath, configPath);
+	} catch (error) {
+		await handle?.close().catch(() => undefined);
+		await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+		throw error;
+	}
 }
 
 function statePath(profile: string) {
@@ -186,8 +277,12 @@ export async function writeJson(filePath: string, value: unknown) {
 }
 
 function selectSessionToken(fileSessionToken: string | undefined) {
-	if (hasEnv("PI_SYNC_SESSION_TOKEN")) return normalizeOptionalString(process.env.PI_SYNC_SESSION_TOKEN);
-	return normalizeOptionalString(process.env.AWS_SESSION_TOKEN) ?? normalizeOptionalString(fileSessionToken);
+	if (hasEnv("PI_SYNC_SESSION_TOKEN"))
+		return normalizeOptionalString(process.env.PI_SYNC_SESSION_TOKEN);
+	return (
+		normalizeOptionalString(process.env.AWS_SESSION_TOKEN) ??
+		normalizeOptionalString(fileSessionToken)
+	);
 }
 
 export function sessionTokenWarnings(config: { endpoint?: string; sessionToken?: string }) {
@@ -204,19 +299,14 @@ export function syncSessionsWarnings(config: { syncSessions?: boolean }) {
 	];
 }
 
-function isSecurityTokenInvalidArgument(text: string) {
-	return (
-		text.includes("<Code>InvalidArgument</Code>") &&
-		text.includes("<Message>X-Amz-Security-Token</Message>")
-	);
-}
-
 export function isCloudflareR2Endpoint(endpoint: string | undefined) {
 	const value = endpoint?.trim();
 	if (!value) return false;
 	try {
 		const hostname = new URL(value).hostname.toLowerCase();
-		return hostname === "r2.cloudflarestorage.com" || hostname.endsWith(".r2.cloudflarestorage.com");
+		return (
+			hostname === "r2.cloudflarestorage.com" || hostname.endsWith(".r2.cloudflarestorage.com")
+		);
 	} catch {
 		return false;
 	}
@@ -227,47 +317,8 @@ function normalizeOptionalString(value: string | undefined) {
 	return normalized ? normalized : undefined;
 }
 
-export function normalizeExtraFiles(value: unknown) {
-	if (!Array.isArray(value)) return [];
-	const seen = new Set<string>();
-	return value
-		.filter((item): item is string => typeof item === "string")
-		.map((item) => item.trim())
-		.filter((item) => {
-			const lower = item.toLowerCase();
-			if (
-				item === "" ||
-				item === "." ||
-				item === ".." ||
-				item.includes("/") ||
-				item.includes("\\") ||
-				TOP_LEVEL_FILE_NAMES.has(lower) ||
-				isDeniedPath(item) ||
-				RESERVED_TOP_LEVEL_NAMES.has(lower) ||
-				seen.has(lower)
-			) {
-				return false;
-			}
-			seen.add(lower);
-			return true;
-		});
-}
-
-export function extraFilePathsByLower(value: unknown) {
-	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
-}
-
-function selectTopLevelFileEntry(entries: Dirent[], fileName: string) {
-	const exact = entries.find((entry) => entry.isFile() && entry.name === fileName);
-	if (exact) return exact;
-	const lower = fileName.toLowerCase();
-	return entries
-		.filter((entry) => entry.isFile() && entry.name.toLowerCase() === lower)
-		.sort((left, right) => left.name.localeCompare(right.name))[0];
-}
-
 function hasEnv(name: string) {
-	return Object.prototype.hasOwnProperty.call(process.env, name);
+	return Object.hasOwn(process.env, name);
 }
 
 export function isEnabled(value: boolean | string | undefined, defaultValue: boolean) {
@@ -283,8 +334,4 @@ export function isExplicitlyEnabled(value: boolean | string | undefined) {
 
 export function isMissingConfigError(error: unknown) {
 	return error instanceof Error && error.message.startsWith("Missing pi-sync config:");
-}
-
-function errorMessage(error: unknown) {
-	return error instanceof Error ? error.message : String(error);
 }

--- a/extensions/pi-sync/src/file-selection.ts
+++ b/extensions/pi-sync/src/file-selection.ts
@@ -1,0 +1,192 @@
+import fs from "node:fs/promises";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
+import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import {
+	agentDir,
+	isExplicitlyEnabled,
+	loadPartialConfig,
+	localConfigPath,
+	updateLocalConfig,
+} from "./config.js";
+import {
+	DEFAULT_SYNC_FILES,
+	isSafeExtraFileName,
+	normalizeExtraFiles,
+	normalizeSyncFiles,
+} from "./sync-policy.js";
+
+const INCLUDED = "included";
+const EXCLUDED = "excluded";
+const BUILT_IN_PREFIX = "builtin:";
+const EXTRA_PREFIX = "extra:";
+const SESSIONS_ID = "sessions";
+
+export async function showFileSelection(ctx: ExtensionCommandContext) {
+	const partial = await loadPartialConfig();
+	const selectedBuiltIns = new Set(normalizeSyncFiles(partial.syncFiles));
+	const selectedExtras = new Set(normalizeExtraFiles(partial.extraFiles));
+	const sessionEnvironmentOverride = Object.hasOwn(process.env, "PI_SYNC_SESSIONS");
+	const sessionsIncluded = isExplicitlyEnabled(partial.syncSessions);
+	const extraCandidates = await listExtraFileCandidates(selectedExtras);
+
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify(
+			[
+				"pi-sync selected files:",
+				`built-ins: ${[...selectedBuiltIns].join(", ") || "none"}`,
+				`sessions: ${sessionsIncluded ? "included" : "excluded"}${sessionEnvironmentOverride ? " (PI_SYNC_SESSIONS)" : ""}`,
+				`extra files: ${[...selectedExtras].map(safeTerminalText).join(", ") || "none"}`,
+				`Edit syncFiles, syncSessions, and extraFiles in ${safeTerminalText(localConfigPath())}.`,
+			].join("\n"),
+			"info",
+		);
+		return;
+	}
+
+	const items: SettingItem[] = [
+		...DEFAULT_SYNC_FILES.map((fileName) => ({
+			id: `${BUILT_IN_PREFIX}${fileName}`,
+			label: fileName,
+			description: fileName.includes(".")
+				? `Sync the top-level ${fileName} file when present.`
+				: `Recursively sync every safe file under ${fileName}/.`,
+			currentValue: selectedBuiltIns.has(fileName) ? INCLUDED : EXCLUDED,
+			values: [INCLUDED, EXCLUDED],
+		})),
+		{
+			id: SESSIONS_ID,
+			label: "sessions",
+			description: sessionEnvironmentOverride
+				? "Read-only here because PI_SYNC_SESSIONS overrides the local setting. Session JSONL may contain prompts, tool output, paths, images, and secrets."
+				: "Session JSONL may contain prompts, tool output, paths, images, and secrets. Sync only to storage you trust.",
+			currentValue: sessionEnvironmentOverride
+				? `${sessionsIncluded ? INCLUDED : EXCLUDED} (environment)`
+				: sessionsIncluded
+					? INCLUDED
+					: EXCLUDED,
+			...(sessionEnvironmentOverride ? {} : { values: [INCLUDED, EXCLUDED] }),
+		},
+		...extraCandidates.map((fileName) => ({
+			id: `${EXTRA_PREFIX}${fileName}`,
+			label: safeTerminalText(fileName),
+			description:
+				"Additional safe top-level file. It may be absent locally and pulled from another machine.",
+			currentValue: selectedExtras.has(fileName) ? INCLUDED : EXCLUDED,
+			values: [INCLUDED, EXCLUDED],
+		})),
+	];
+
+	let saveQueue = Promise.resolve();
+	let nextOwner = 0;
+	const owners = new Map<string, number>();
+	let closed = false;
+
+	await ctx.ui.custom((tui, theme, _keybindings, done) => {
+		const container = new Container();
+		const title = new Text("", 1, 0);
+		const hint = new Text("", 1, 0);
+		const updateChrome = () => {
+			title.setText(theme.fg("accent", theme.bold("pi-sync Files")));
+			hint.setText(
+				theme.fg("dim", "Changes save immediately and apply to the next manual or automatic sync."),
+			);
+		};
+		updateChrome();
+		container.addChild(title);
+
+		let settingsList: SettingsList;
+		const queueChange = (id: string, newValue: string) => {
+			const previousValue = newValue === INCLUDED ? EXCLUDED : INCLUDED;
+			const owner = ++nextOwner;
+			owners.set(id, owner);
+			const save = async () => {
+				try {
+					await persistSelectionChange(id, newValue === INCLUDED);
+				} catch (error) {
+					if (owners.get(id) === owner && !closed) {
+						settingsList.updateValue(id, previousValue);
+						tui.requestRender();
+					}
+					ctx.ui.notify(`Could not save pi-sync file selection: ${errorMessage(error)}`, "error");
+				}
+			};
+			saveQueue = saveQueue.then(save, save);
+		};
+
+		settingsList = new SettingsList(
+			items,
+			Math.min(items.length + 2, 15),
+			getSettingsListTheme(),
+			queueChange,
+			() => done(undefined),
+			{ enableSearch: true },
+		);
+		container.addChild(settingsList);
+		container.addChild(hint);
+
+		return {
+			render(width: number) {
+				return container.render(width);
+			},
+			invalidate() {
+				updateChrome();
+				container.invalidate();
+			},
+			handleInput(data: string) {
+				settingsList.handleInput(data);
+				tui.requestRender();
+			},
+		};
+	});
+	closed = true;
+	await saveQueue;
+}
+
+async function listExtraFileCandidates(configured: Set<string>) {
+	const candidates = new Map([...configured].map((fileName) => [fileName.toLowerCase(), fileName]));
+	try {
+		for (const entry of await fs.readdir(agentDir(), { withFileTypes: true })) {
+			if (!entry.isFile() || !isSafeExtraFileName(entry.name)) continue;
+			if (!candidates.has(entry.name.toLowerCase())) {
+				candidates.set(entry.name.toLowerCase(), entry.name);
+			}
+		}
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	return [...candidates.values()].sort((left, right) => left.localeCompare(right));
+}
+
+async function persistSelectionChange(id: string, included: boolean) {
+	await updateLocalConfig((current) => {
+		if (id.startsWith(BUILT_IN_PREFIX)) {
+			const fileName = id.slice(BUILT_IN_PREFIX.length);
+			const selected = new Set(normalizeSyncFiles(current.syncFiles));
+			if (included) selected.add(fileName as (typeof DEFAULT_SYNC_FILES)[number]);
+			else selected.delete(fileName as (typeof DEFAULT_SYNC_FILES)[number]);
+			return {
+				...current,
+				syncFiles: DEFAULT_SYNC_FILES.filter((candidate) => selected.has(candidate)),
+			};
+		}
+		if (id.startsWith(EXTRA_PREFIX)) {
+			const fileName = id.slice(EXTRA_PREFIX.length);
+			const selected = new Set(normalizeExtraFiles(current.extraFiles));
+			if (included) selected.add(fileName);
+			else selected.delete(fileName);
+			return { ...current, extraFiles: [...selected] };
+		}
+		if (id === SESSIONS_ID) return { ...current, syncSessions: included };
+		throw new Error(`Unknown file selection: ${id}`);
+	});
+}
+
+function safeTerminalText(value: string) {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "?");
+}
+
+function errorMessage(error: unknown) {
+	return safeTerminalText(error instanceof Error ? error.message : String(error));
+}

--- a/extensions/pi-sync/src/snapshot-apply.ts
+++ b/extensions/pi-sync/src/snapshot-apply.ts
@@ -3,7 +3,14 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { agentDir } from "./config.js";
-import { assertWithinRoot, isDeniedPath, isPathInside, parentPaths, safeJoin, toPosix } from "./paths.js";
+import {
+	assertWithinRoot,
+	isDeniedPath,
+	isPathInside,
+	parentPaths,
+	safeJoin,
+	toPosix,
+} from "./paths.js";
 import {
 	createSnapshot,
 	isSessionFilePath,
@@ -25,11 +32,12 @@ function fileHashMap(snapshot: Snapshot) {
 export async function applySnapshot(
 	snapshot: Snapshot,
 	protectedRelativePaths = new Set<string>(),
-	options: Pick<SnapshotOptions, "sessionDir" | "extraFiles"> = {},
+	options: Pick<SnapshotOptions, "syncFiles" | "sessionDir" | "extraFiles"> = {},
 ) {
 	const root = agentDir();
 	const { sessionDir } = options;
 	const current = await createSnapshot(snapshot.profile, {
+		syncFiles: options.syncFiles,
 		syncSessions: snapshotIncludesSessions(snapshot),
 		sessionDir,
 		extraFiles: options.extraFiles,
@@ -79,7 +87,8 @@ export function preflightSnapshotApply(
 
 		const target = snapshotTarget(root, normalized, options.sessionDir);
 		const content = decodeBase64Strict(file.contentBase64, normalized);
-		if (sha256(content) !== file.sha256) throw new Error(`Checksum mismatch in snapshot file: ${normalized}`);
+		if (sha256(content) !== file.sha256)
+			throw new Error(`Checksum mismatch in snapshot file: ${normalized}`);
 		writes.push({ target, content });
 	}
 
@@ -108,7 +117,9 @@ export function protectSnapshotApplyPlan(
 ): SnapshotApplyPlan {
 	if (protectedRelativePaths.size === 0) return plan;
 	const protectedTargets = new Set(
-		[...protectedRelativePaths].map((relativePath) => snapshotTarget(root, relativePath, sessionDir)),
+		[...protectedRelativePaths].map((relativePath) =>
+			snapshotTarget(root, relativePath, sessionDir),
+		),
 	);
 	return {
 		writes: plan.writes.filter((item) => !protectedTargets.has(item.target)),
@@ -141,7 +152,11 @@ export async function addTopLevelCaseVariantDeletes(
 	const deletes = new Set(plan.deletes);
 	for (const entry of entries) {
 		const canonicalPath = topLevelPaths.get(entry.name.toLowerCase());
-		if (canonicalPath && entry.name !== canonicalPath && (entry.isFile() || entry.isSymbolicLink())) {
+		if (
+			canonicalPath &&
+			entry.name !== canonicalPath &&
+			(entry.isFile() || entry.isSymbolicLink())
+		) {
 			deletes.add(safeJoin(root, entry.name));
 		}
 	}
@@ -198,7 +213,11 @@ async function preflightSnapshotMutations(
 		await assertNoSymlinkParents(rootForTarget(root, target, sessionDir), target);
 	}
 	for (const item of plan.writes) {
-		await prepareSnapshotWrite(rootForTarget(root, item.target, sessionDir), item.target, deletePaths);
+		await prepareSnapshotWrite(
+			rootForTarget(root, item.target, sessionDir),
+			item.target,
+			deletePaths,
+		);
 	}
 }
 
@@ -212,7 +231,8 @@ async function prepareSnapshotWrite(root: string, target: string, deletePaths: S
 	await ensureSafeDirectory(root, path.dirname(target));
 	try {
 		const stat = await fs.lstat(target);
-		if (stat.isSymbolicLink()) throw new Error(`Refusing to overwrite symlink during snapshot apply: ${target}`);
+		if (stat.isSymbolicLink())
+			throw new Error(`Refusing to overwrite symlink during snapshot apply: ${target}`);
 		if (stat.isDirectory() && !deletePaths.has(target)) {
 			throw new Error(`Refusing to overwrite directory during snapshot apply: ${target}`);
 		}
@@ -230,8 +250,10 @@ async function ensureSafeDirectory(root: string, directory: string) {
 		current = path.join(current, part);
 		try {
 			const stat = await fs.lstat(current);
-			if (stat.isSymbolicLink()) throw new Error(`Refusing to follow symlink during snapshot apply: ${current}`);
-			if (!stat.isDirectory()) throw new Error(`Snapshot path parent is not a directory: ${current}`);
+			if (stat.isSymbolicLink())
+				throw new Error(`Refusing to follow symlink during snapshot apply: ${current}`);
+			if (!stat.isDirectory())
+				throw new Error(`Snapshot path parent is not a directory: ${current}`);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 			await fs.mkdir(current);
@@ -249,8 +271,10 @@ async function assertNoSymlinkParents(root: string, target: string) {
 		current = path.join(current, part);
 		try {
 			const stat = await fs.lstat(current);
-			if (stat.isSymbolicLink()) throw new Error(`Refusing to follow symlink during snapshot apply: ${current}`);
-			if (!stat.isDirectory()) throw new Error(`Snapshot path parent is not a directory: ${current}`);
+			if (stat.isSymbolicLink())
+				throw new Error(`Refusing to follow symlink during snapshot apply: ${current}`);
+			if (!stat.isDirectory())
+				throw new Error(`Snapshot path parent is not a directory: ${current}`);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
 			throw error;

--- a/extensions/pi-sync/src/snapshot.ts
+++ b/extensions/pi-sync/src/snapshot.ts
@@ -5,20 +5,25 @@ import os from "node:os";
 import path from "node:path";
 import { agentDir, configuredSessionDir } from "./config.js";
 import { isDeniedPath, posixJoin, safeJoin, toPosix } from "./paths.js";
+
 export { isDeniedPath } from "./paths.js";
-import type {
-	Snapshot,
-	SnapshotFile,
-	SnapshotOptions,
-	SyncConfig,
-} from "./types.js";
+
+import {
+	canonicalSnapshotPathForConfig,
+	DEFAULT_SYNC_FILES,
+	extraFilePathsByLower,
+	isConfiguredSnapshotPath,
+	isPreservableUnmanagedSnapshotPath,
+	normalizeExtraFiles,
+	normalizeSyncFiles,
+} from "./sync-policy.js";
+import type { Snapshot, SnapshotFile, SnapshotOptions, SyncConfig } from "./types.js";
+
+export { canonicalSnapshotPathForConfig, isConfiguredSnapshotPath } from "./sync-policy.js";
 
 const VERSION = 1;
-const TOP_LEVEL_FILES = new Set(["settings.json", "keybindings.json", "models.json", "AGENTS.md", "APPEND_SYSTEM.md"]);
-const TOP_LEVEL_DIRS = new Set(["skills", "prompts", "themes", "extensions"]);
-const TOP_LEVEL_FILE_PATHS = new Map([...TOP_LEVEL_FILES].map((name) => [name.toLowerCase(), name]));
-const TOP_LEVEL_FILE_NAMES = new Set(TOP_LEVEL_FILE_PATHS.keys());
-const RESERVED_TOP_LEVEL_NAMES = new Set([...TOP_LEVEL_DIRS, "sessions"]);
+const TOP_LEVEL_FILES: readonly string[] = DEFAULT_SYNC_FILES.filter((name) => name.includes("."));
+const TOP_LEVEL_DIRS = new Set<string>(DEFAULT_SYNC_FILES.filter((name) => !name.includes(".")));
 const SECRET_PATTERNS = [
 	/AWS_SECRET_ACCESS_KEY\s*[=:]\s*['"]?[A-Za-z0-9/+]{35,}/i,
 	/(ANTHROPIC|OPENAI|GEMINI|GOOGLE|FIRECRAWL|GITHUB|CLOUDFLARE|R2|S3)_[A-Z0-9_]*(KEY|TOKEN|SECRET)\s*[=:]\s*['"]?[^\s'"]{12,}/i,
@@ -31,27 +36,6 @@ function expandHome(value: string) {
 	if (value === "~") return process.env.HOME ?? value;
 	if (value.startsWith("~/")) return path.join(process.env.HOME ?? "~", value.slice(2));
 	return value;
-}
-
-export function normalizeExtraFiles(value: unknown) {
-	if (!Array.isArray(value)) return [];
-	const seen = new Set<string>();
-	return value
-		.filter((item): item is string => typeof item === "string")
-		.map((item) => item.trim())
-		.filter((item) => {
-			const lower = item.toLowerCase();
-			if (
-				item === "" || item === "." || item === ".." || item.includes("/") || item.includes("\\") ||
-				TOP_LEVEL_FILE_NAMES.has(lower) || isDeniedPath(item) || RESERVED_TOP_LEVEL_NAMES.has(lower) || seen.has(lower)
-			) return false;
-			seen.add(lower);
-			return true;
-		});
-}
-
-export function extraFilePathsByLower(value: unknown) {
-	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
 }
 
 function selectTopLevelFileEntry(entries: Dirent[], fileName: string) {
@@ -70,15 +54,24 @@ function sha256(value: Buffer) {
 function isSafeSnapshotPath(relativePath: string) {
 	if (relativePath.includes("\\")) return false;
 	const normalized = toPosix(relativePath);
-	return Boolean(normalized) && normalized !== "." && normalized !== ".." && !normalized.startsWith("../") &&
-		!path.posix.isAbsolute(normalized) && path.posix.normalize(normalized) === normalized && !isDeniedPath(normalized);
+	return (
+		Boolean(normalized) &&
+		normalized !== "." &&
+		normalized !== ".." &&
+		!normalized.startsWith("../") &&
+		!path.posix.isAbsolute(normalized) &&
+		path.posix.normalize(normalized) === normalized &&
+		!isDeniedPath(normalized)
+	);
 }
 
 function snapshotsMatch(left: Snapshot, right: Snapshot) {
 	const leftHashes = new Map(left.files.map((file) => [file.path, file.sha256]));
 	const rightHashes = new Map(right.files.map((file) => [file.path, file.sha256]));
-	return leftHashes.size === rightHashes.size &&
-		[...leftHashes].every(([filePath, hash]) => rightHashes.get(filePath) === hash);
+	return (
+		leftHashes.size === rightHashes.size &&
+		[...leftHashes].every(([filePath, hash]) => rightHashes.get(filePath) === hash)
+	);
 }
 
 function snapshotId() {
@@ -91,6 +84,7 @@ export async function createSnapshot(
 ): Promise<Snapshot> {
 	const syncSessions = Boolean(options.syncSessions);
 	const files = await collectFiles(agentDir(), {
+		syncFiles: options.syncFiles,
 		syncSessions,
 		sessionDir: options.sessionDir ?? (await configuredSessionDir()),
 		extraFiles: options.extraFiles,
@@ -112,12 +106,14 @@ export async function collectFiles(
 ): Promise<SnapshotFile[]> {
 	const results: SnapshotFile[] = [];
 	const entries = await fs.readdir(root, { withFileTypes: true });
+	const selectedFiles = new Set<string>(normalizeSyncFiles(options.syncFiles));
 	for (const entry of entries) {
-		if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name)) {
+		if (entry.isDirectory() && TOP_LEVEL_DIRS.has(entry.name) && selectedFiles.has(entry.name)) {
 			await collectDirectory(results, root, entry.name);
 		}
 	}
 	for (const fileName of TOP_LEVEL_FILES) {
+		if (!selectedFiles.has(fileName)) continue;
 		const entry = selectTopLevelFileEntry(entries, fileName);
 		if (entry) await addFile(results, root, entry.name, fileName);
 	}
@@ -168,7 +164,11 @@ async function addFile(
 	if (!isSafeSnapshotPath(snapshotPath)) return;
 	const absolutePath = safeJoin(root, relativePath);
 	const content = await fs.readFile(absolutePath);
-	results.push({ path: snapshotPath, contentBase64: content.toString("base64"), sha256: sha256(content) });
+	results.push({
+		path: snapshotPath,
+		contentBase64: content.toString("base64"),
+		sha256: sha256(content),
+	});
 }
 
 export function isSessionPath(relativePath: string) {
@@ -181,11 +181,18 @@ export function isSessionFilePath(relativePath: string) {
 }
 
 export function sessionStorageRoot(root: string, configuredSessionDir?: string) {
-	return configuredSessionDir ? path.resolve(expandHome(configuredSessionDir)) : path.resolve(root, "sessions");
+	return configuredSessionDir
+		? path.resolve(expandHome(configuredSessionDir))
+		: path.resolve(root, "sessions");
 }
 
-export function sessionSnapshotPathFromAbsolute(sessionFile: string, configuredSessionDir?: string) {
-	const relativePath = toPosix(path.relative(sessionStorageRoot(agentDir(), configuredSessionDir), sessionFile));
+export function sessionSnapshotPathFromAbsolute(
+	sessionFile: string,
+	configuredSessionDir?: string,
+) {
+	const relativePath = toPosix(
+		path.relative(sessionStorageRoot(agentDir(), configuredSessionDir), sessionFile),
+	);
 	if (!relativePath || relativePath.startsWith("../") || path.posix.isAbsolute(relativePath)) {
 		return undefined;
 	}
@@ -195,14 +202,12 @@ export function sessionSnapshotPathFromAbsolute(sessionFile: string, configuredS
 
 export function snapshotTarget(root: string, relativePath: string, configuredSessionDir?: string) {
 	if (isSessionPath(relativePath)) {
-		return safeJoin(sessionStorageRoot(root, configuredSessionDir), relativePath.slice("sessions/".length));
+		return safeJoin(
+			sessionStorageRoot(root, configuredSessionDir),
+			relativePath.slice("sessions/".length),
+		);
 	}
 	return safeJoin(root, relativePath);
-}
-
-function isPathInside(parent: string, child: string) {
-	const relativePath = path.relative(parent, child);
-	return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
 export function snapshotIncludesSessions(snapshot: Snapshot) {
@@ -211,7 +216,7 @@ export function snapshotIncludesSessions(snapshot: Snapshot) {
 
 export function filterSnapshotForConfigPolicy(
 	snapshot: Snapshot,
-	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions" | "extraFiles">,
 	options: { regenerateId?: boolean } = {},
 ) {
 	const extraFilePaths = extraFilePathsByLower(config.extraFiles);
@@ -230,23 +235,9 @@ export function filterSnapshotForConfigPolicy(
 	};
 }
 
-export function isConfiguredSnapshotPath(
-	relativePath: string,
-	config: Pick<SyncConfig, "syncSessions">,
-	extraFiles: Set<string>,
-) {
-	const normalized = toPosix(relativePath);
-	if (isSessionPath(normalized)) return config.syncSessions;
-	if (!normalized.includes("/")) {
-		const lower = normalized.toLowerCase();
-		return TOP_LEVEL_FILE_NAMES.has(lower) || extraFiles.has(lower);
-	}
-	return TOP_LEVEL_DIRS.has(normalized.slice(0, normalized.indexOf("/")));
-}
-
 function canonicalizeSnapshotFilesForConfig(
 	files: SnapshotFile[],
-	config: Pick<SyncConfig, "syncSessions">,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions">,
 	extraFiles: Set<string>,
 	extraFilePaths: Map<string, string>,
 ) {
@@ -257,14 +248,17 @@ function canonicalizeSnapshotFilesForConfig(
 	>();
 	for (const file of files) {
 		const normalized = toPosix(file.path);
-		if (!isSafeSnapshotPath(file.path) || !isConfiguredSnapshotPath(normalized, config, extraFiles)) {
+		if (
+			!isSafeSnapshotPath(file.path) ||
+			!isConfiguredSnapshotPath(normalized, config, extraFiles)
+		) {
 			continue;
 		}
-		const topLevelPath = canonicalTopLevelFilePath(normalized, extraFilePaths);
-		if (!topLevelPath) {
+		if (normalized.includes("/")) {
 			configuredFiles.push(normalized === file.path ? file : { ...file, path: normalized });
 			continue;
 		}
+		const topLevelPath = canonicalSnapshotPathForConfig(normalized, extraFilePaths);
 		const candidate = {
 			exact: normalized === topLevelPath,
 			file: { ...file, path: topLevelPath },
@@ -279,17 +273,6 @@ function canonicalizeSnapshotFilesForConfig(
 		...configuredFiles,
 		...[...extraCandidates.values()].map((candidate) => candidate.file),
 	].sort((left, right) => left.path.localeCompare(right.path));
-}
-
-function canonicalTopLevelFilePath(relativePath: string, extraFilePaths: Map<string, string>) {
-	const normalized = toPosix(relativePath);
-	if (normalized.includes("/")) return undefined;
-	const lower = normalized.toLowerCase();
-	return TOP_LEVEL_FILE_PATHS.get(lower) ?? extraFilePaths.get(lower);
-}
-
-export function canonicalSnapshotPathForConfig(relativePath: string, extraFilePaths: Map<string, string>) {
-	return canonicalTopLevelFilePath(relativePath, extraFilePaths) ?? toPosix(relativePath);
 }
 
 function isPreferredExtraCandidate(
@@ -332,38 +315,36 @@ export function scanSnapshot(snapshot: Snapshot) {
 export function mergeRemotePreservedFiles(
 	local: Snapshot,
 	remote: Snapshot,
-	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions" | "extraFiles">,
 ) {
-	const withSessions = config.syncSessions ? local : mergeRemoteSessionFiles(local, remote);
-	const paths = new Set(withSessions.files.map((file) => file.path));
-	const pathNames = new Set(withSessions.files.map((file) => file.path.toLowerCase()));
-	const extraFileNames = new Set(normalizeExtraFiles(config.extraFiles).map((file) => file.toLowerCase()));
-	const seenRemoteExtraNames = new Set<string>();
-	const remoteExtras = remote.files.filter((file) => {
+	const localPathNames = new Set(local.files.map((file) => file.path.toLowerCase()));
+	const configuredExtraFiles = new Set(
+		normalizeExtraFiles(config.extraFiles).map((file) => file.toLowerCase()),
+	);
+	const preservedPathNames = new Set<string>();
+	const preserved = remote.files.filter((file) => {
 		const normalized = toPosix(file.path);
 		const lower = normalized.toLowerCase();
 		if (
-			paths.has(normalized) ||
-			pathNames.has(lower) ||
+			localPathNames.has(lower) ||
+			preservedPathNames.has(lower) ||
 			!isSafeSnapshotPath(file.path) ||
-			normalized.includes("/") ||
-			TOP_LEVEL_FILE_NAMES.has(lower) ||
-			RESERVED_TOP_LEVEL_NAMES.has(lower) ||
-			extraFileNames.has(lower) ||
-			seenRemoteExtraNames.has(lower)
+			isConfiguredSnapshotPath(normalized, config, configuredExtraFiles) ||
+			!isPreservableUnmanagedSnapshotPath(normalized)
 		) {
 			return false;
 		}
-		seenRemoteExtraNames.add(lower);
+		preservedPathNames.add(lower);
 		return true;
 	});
-	if (remoteExtras.length === 0) return withSessions;
+	if (preserved.length === 0) return local;
 	return {
-		...withSessions,
+		...local,
 		id: snapshotId(),
 		createdAt: new Date().toISOString(),
 		machine: os.hostname(),
-		files: [...withSessions.files, ...remoteExtras].sort((left, right) =>
+		syncSessions: snapshotIncludesSessions(local) || snapshotIncludesSessions(remote),
+		files: [...local.files, ...preserved].sort((left, right) =>
 			left.path.localeCompare(right.path),
 		),
 	};

--- a/extensions/pi-sync/src/sync-policy.ts
+++ b/extensions/pi-sync/src/sync-policy.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+import { isDeniedPath, toPosix } from "./paths.js";
+
+export const DEFAULT_SYNC_FILES = [
+	"settings.json",
+	"keybindings.json",
+	"models.json",
+	"AGENTS.md",
+	"APPEND_SYSTEM.md",
+	"skills",
+	"prompts",
+	"themes",
+	"extensions",
+] as const;
+
+export type BuiltInSyncFile = (typeof DEFAULT_SYNC_FILES)[number];
+
+const BUILT_IN_BY_LOWER = new Map<string, BuiltInSyncFile>(
+	DEFAULT_SYNC_FILES.map((fileName) => [fileName.toLowerCase(), fileName]),
+);
+const TOP_LEVEL_FILE_PATHS = new Map<string, string>(
+	DEFAULT_SYNC_FILES.filter((fileName) => fileName.includes(".")).map((fileName) => [
+		fileName.toLowerCase(),
+		fileName,
+	]),
+);
+const TOP_LEVEL_FILE_NAMES = new Set<string>(TOP_LEVEL_FILE_PATHS.keys());
+const TOP_LEVEL_DIRS = new Set<string>(
+	DEFAULT_SYNC_FILES.filter((fileName) => !fileName.includes(".")),
+);
+const RESERVED_TOP_LEVEL_NAMES = new Set<string>([...TOP_LEVEL_DIRS, "sessions"]);
+
+export function normalizeSyncFiles(value: unknown): BuiltInSyncFile[] {
+	if (value === undefined) return [...DEFAULT_SYNC_FILES];
+	if (!Array.isArray(value)) throw new Error("syncFiles must be an array of built-in file names.");
+
+	const result: BuiltInSyncFile[] = [];
+	const seen = new Set<string>();
+	for (const item of value) {
+		if (typeof item !== "string") throw new Error("syncFiles items must be strings.");
+		const canonical = BUILT_IN_BY_LOWER.get(item.trim().toLowerCase());
+		if (!canonical) throw new Error(`Unknown syncFiles item: ${item}`);
+		const lower = canonical.toLowerCase();
+		if (seen.has(lower)) continue;
+		seen.add(lower);
+		result.push(canonical);
+	}
+	return result;
+}
+
+export function normalizeExtraFiles(value: unknown) {
+	if (!Array.isArray(value)) return [];
+	const seen = new Set<string>();
+	return value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter((item) => {
+			const lower = item.toLowerCase();
+			if (
+				item === "" ||
+				item === "." ||
+				item === ".." ||
+				item.includes("/") ||
+				item.includes("\\") ||
+				TOP_LEVEL_FILE_NAMES.has(lower) ||
+				isDeniedPath(item) ||
+				RESERVED_TOP_LEVEL_NAMES.has(lower) ||
+				seen.has(lower)
+			) {
+				return false;
+			}
+			seen.add(lower);
+			return true;
+		});
+}
+
+export function extraFilePathsByLower(value: unknown) {
+	return new Map(normalizeExtraFiles(value).map((fileName) => [fileName.toLowerCase(), fileName]));
+}
+
+export function selectedSyncFileSet(value: unknown) {
+	return new Set(normalizeSyncFiles(value));
+}
+
+export function isConfiguredSnapshotPath(
+	relativePath: string,
+	config: { syncFiles?: unknown; syncSessions: boolean },
+	extraFiles: Set<string>,
+) {
+	const normalized = toPosix(relativePath);
+	if (normalized.startsWith("sessions/")) return config.syncSessions;
+	const selected = selectedSyncFileSet(config.syncFiles);
+	if (!normalized.includes("/")) {
+		const lower = normalized.toLowerCase();
+		const builtIn = BUILT_IN_BY_LOWER.get(lower);
+		return builtIn ? selected.has(builtIn) && !TOP_LEVEL_DIRS.has(builtIn) : extraFiles.has(lower);
+	}
+	const topLevel = normalized.slice(0, normalized.indexOf("/"));
+	return selected.has(topLevel as BuiltInSyncFile) && TOP_LEVEL_DIRS.has(topLevel);
+}
+
+export function canonicalSnapshotPathForConfig(
+	relativePath: string,
+	extraFilePaths: Map<string, string>,
+) {
+	const normalized = toPosix(relativePath);
+	if (normalized.includes("/")) return normalized;
+	const lower = normalized.toLowerCase();
+	return TOP_LEVEL_FILE_PATHS.get(lower) ?? extraFilePaths.get(lower) ?? normalized;
+}
+
+export function isPreservableUnmanagedSnapshotPath(relativePath: string) {
+	const normalized = toPosix(relativePath);
+	if (!normalized || isDeniedPath(normalized)) return false;
+	if (normalized.startsWith("sessions/")) return normalized.endsWith(".jsonl");
+	if (!normalized.includes("/")) {
+		const lower = normalized.toLowerCase();
+		return TOP_LEVEL_FILE_NAMES.has(lower) || !RESERVED_TOP_LEVEL_NAMES.has(lower);
+	}
+	return TOP_LEVEL_DIRS.has(normalized.slice(0, normalized.indexOf("/")));
+}
+
+export function isSafeExtraFileName(fileName: string) {
+	return normalizeExtraFiles([fileName]).length === 1;
+}
+
+export function isBuiltInTopLevelFile(fileName: string) {
+	return TOP_LEVEL_FILE_NAMES.has(path.posix.basename(fileName).toLowerCase());
+}

--- a/extensions/pi-sync/src/sync-state.ts
+++ b/extensions/pi-sync/src/sync-state.ts
@@ -1,0 +1,167 @@
+import { toPosix } from "./paths.js";
+import {
+	canonicalSnapshotPathForConfig,
+	filterSnapshotForConfigPolicy,
+	isConfiguredSnapshotPath,
+	isSessionPath,
+} from "./snapshot.js";
+import { extraFilePathsByLower, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
+import type { LatestPointer, RemoteObject, Snapshot, SyncConfig, SyncState } from "./types.js";
+
+export function hasLocalChanges(local: Snapshot, state: SyncState, config: SyncConfig) {
+	return !sameHashes(fileHashMap(local), stateHashMapForConfig(state, config));
+}
+
+export function remoteChangedSinceState(
+	latest: RemoteObject<LatestPointer>,
+	state: SyncState,
+	config: SyncConfig,
+) {
+	if (latest.missing) return Boolean(state.lastAppliedSnapshot);
+	if (latest.value?.snapshot !== state.lastAppliedSnapshot) return true;
+	if (syncFilesChanged(state, config) || extraFilesChanged(state, config)) return true;
+	return config.syncSessions && state.syncSessions !== true && latest.value?.syncSessions === true;
+}
+
+export function hasRemoteChanges(
+	remote: Snapshot,
+	state: SyncState,
+	config: SyncConfig,
+	ignoredPaths = new Set<string>(),
+) {
+	if (remote.id === state.lastAppliedSnapshot && !syncPolicyChanged(state, config)) return false;
+	return !snapshotHashesMatchState(
+		filterSnapshotForConfigPolicy(remote, config),
+		state,
+		config,
+		ignoredPaths,
+	);
+}
+
+export function sameHashes(left: Record<string, string>, right: Record<string, string>) {
+	const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+	for (const key of keys) {
+		if (left[key] !== right[key]) return false;
+	}
+	return true;
+}
+
+export function fileHashMap(snapshot: Snapshot) {
+	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
+}
+
+function stateHashMapForConfig(
+	state: SyncState,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions" | "extraFiles">,
+) {
+	const extraFilePaths = extraFilePathsByLower(config.extraFiles);
+	const extraFiles = new Set(extraFilePaths.keys());
+	return Object.fromEntries(
+		Object.entries(state.lastFileHashes)
+			.filter(([filePath]) => isConfiguredSnapshotPath(filePath, config, extraFiles))
+			.map(([filePath, hash]) => [canonicalSnapshotPathForConfig(filePath, extraFilePaths), hash]),
+	);
+}
+
+export function snapshotHashesMatchState(
+	snapshot: Snapshot,
+	state: SyncState,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions" | "extraFiles">,
+	ignoredPaths = new Set<string>(),
+) {
+	return sameHashes(
+		withoutHashPaths(fileHashMap(snapshot), ignoredPaths),
+		withoutHashPaths(stateHashMapForConfig(state, config), ignoredPaths),
+	);
+}
+
+export function snapshotsMatch(left: Snapshot, right: Snapshot) {
+	return (
+		left.syncSessions === right.syncSessions && sameHashes(fileHashMap(left), fileHashMap(right))
+	);
+}
+
+function withoutHashPaths(hashes: Record<string, string>, ignoredPaths: Set<string>) {
+	if (ignoredPaths.size === 0) return hashes;
+	return Object.fromEntries(
+		Object.entries(hashes).filter(([filePath]) => !ignoredPaths.has(toPosix(filePath))),
+	);
+}
+
+export function syncPolicyChanged(
+	state: SyncState,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions" | "extraFiles">,
+) {
+	return (
+		syncFilesChanged(state, config) ||
+		(state.syncSessions ?? false) !== config.syncSessions ||
+		extraFilesChanged(state, config)
+	);
+}
+
+export function shouldRefreshSyncedState(
+	remote: Snapshot,
+	state: SyncState,
+	config: Pick<SyncConfig, "syncFiles" | "syncSessions" | "extraFiles">,
+) {
+	return remote.id !== state.lastAppliedSnapshot || syncPolicyChanged(state, config);
+}
+
+function syncFilesChanged(state: SyncState, config: Pick<SyncConfig, "syncFiles">) {
+	return !sameStringSet(normalizeSyncFiles(state.syncFiles), normalizeSyncFiles(config.syncFiles));
+}
+
+function extraFilesChanged(state: SyncState, config: Pick<SyncConfig, "extraFiles">) {
+	return !sameStringSet(
+		normalizeExtraFiles(state.extraFiles),
+		normalizeExtraFiles(config.extraFiles),
+	);
+}
+
+function sameStringSet(left: string[], right: string[]) {
+	const leftSet = new Set(left);
+	const rightSet = new Set(right);
+	if (leftSet.size !== rightSet.size) return false;
+	return [...leftSet].every((item) => rightSet.has(item));
+}
+
+export function settingsHashMap(snapshot: Snapshot) {
+	return Object.fromEntries(
+		snapshot.files
+			.filter((file) => !isSessionPath(file.path))
+			.map((file) => [file.path, file.sha256]),
+	);
+}
+
+export function sessionHashMap(snapshot: Snapshot) {
+	return Object.fromEntries(
+		snapshot.files
+			.filter((file) => isSessionPath(file.path))
+			.map((file) => [file.path, file.sha256]),
+	);
+}
+
+export function settingsHashMapFromState(state: SyncState) {
+	return Object.fromEntries(
+		Object.entries(state.lastFileHashes).filter(([filePath]) => !isSessionPath(filePath)),
+	);
+}
+
+export function settingsHashesMatchState(remote: Snapshot, state: SyncState) {
+	return sameHashes(settingsHashMap(remote), settingsHashMapFromState(state));
+}
+
+export function canPullRemoteSettingsOnFirstSync(local: Snapshot, remote: Snapshot) {
+	const remoteSettings = settingsHashMap(remote);
+	return Object.entries(settingsHashMap(local)).every(
+		([filePath, hash]) => remoteSettings[filePath] === hash,
+	);
+}
+
+export function canPullRemoteSessionsOnFirstSync(local: Snapshot, remote: Snapshot) {
+	const localSessions = sessionHashMap(local);
+	const remoteSessions = sessionHashMap(remote);
+	return Object.entries(localSessions).every(
+		([filePath, hash]) => remoteSessions[filePath] === hash,
+	);
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1,35 +1,37 @@
 import { createHash } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { gunzip, gzip } from "node:zlib";
 import { promisify } from "node:util";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { gunzip, gzip } from "node:zlib";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { completeSyncArguments, parseOptions, resolveSyncCommand, usage } from "./command.js";
 import {
 	agentDir,
 	ensureStateDir,
-	extraFilePathsByLower,
-	isMissingConfigError,
-	loadPartialConfig,
-	localConfigPath,
-	normalizeExtraFiles,
-	stateDir,
-	writeJson,
-	configuredSessionDir,
-	isCloudflareR2Endpoint,
 	isEnabled,
 	isExplicitlyEnabled,
+	isMissingConfigError,
 	loadConfig,
+	loadPartialConfig,
+	localConfigPath,
+	localConfigTemplate,
+	normalizeExtraFiles,
+	normalizeSyncFiles,
 	readState,
 	sessionDirForApply,
 	sessionTokenWarnings,
+	stateDir,
 	syncSessionsWarnings,
+	writeLocalConfigObject,
 	writeState,
 } from "./config.js";
+import { showFileSelection } from "./file-selection.js";
 import { inspectLock, isLockGuardHeld, isStaleLock, unlock, withLock } from "./lock.js";
-import { encodeKey, posixJoin, safeJoin, safeName, toPosix } from "./paths.js";
 import {
 	historyKey,
 	latestKey,
@@ -39,27 +41,28 @@ import {
 	snapshotKey,
 } from "./s3-client.js";
 import {
-	addTopLevelCaseVariantDeletes,
-	appliedFileHashMap,
-	applySnapshot,
-	preflightSnapshotApply,
-	protectSnapshotApplyPlan,
-} from "./snapshot-apply.js";
-import {
-	collectFiles,
 	createSnapshot,
-	canonicalSnapshotPathForConfig,
 	filterSnapshotForConfigPolicy,
-	isConfiguredSnapshotPath,
-	isDeniedPath,
-	isSessionPath,
-	sessionSnapshotPathFromAbsolute,
 	mergeRemotePreservedFiles,
-	mergeRemoteSessionFiles,
 	scanSnapshot,
+	sessionSnapshotPathFromAbsolute,
 	snapshotIncludesSessions,
 	snapshotWithoutSessions,
 } from "./snapshot.js";
+import { applySnapshot } from "./snapshot-apply.js";
+import {
+	canPullRemoteSessionsOnFirstSync,
+	canPullRemoteSettingsOnFirstSync,
+	fileHashMap,
+	hasLocalChanges,
+	hasRemoteChanges,
+	remoteChangedSinceState,
+	sameHashes,
+	shouldRefreshSyncedState,
+	snapshotHashesMatchState,
+	snapshotsMatch,
+	syncPolicyChanged,
+} from "./sync-state.js";
 import type {
 	CommandOptions,
 	LatestPointer,
@@ -78,7 +81,6 @@ const VERSION = 1;
 const DEFAULT_PROFILE = "default";
 const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
-const LOCK_STALE_MS = 30 * 60 * 1000;
 
 interface PushInput {
 	config: SyncConfig;
@@ -111,7 +113,8 @@ export default function sync(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", async (event, ctx) => {
-		const reason = typeof event === "object" && event ? (event as { reason?: string }).reason : undefined;
+		const reason =
+			typeof event === "object" && event ? (event as { reason?: string }).reason : undefined;
 		if (reason !== "reload") await autoPushSessions(ctx);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
@@ -134,6 +137,9 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
 				return;
 			case "config":
 				await showConfig(ctx);
+				return;
+			case "files":
+				await showFileSelection(ctx);
 				return;
 			case "status":
 				await status(ctx);
@@ -216,19 +222,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 		// Create below.
 	}
 
-	const sample = {
-		endpoint: "https://<account-id>.r2.cloudflarestorage.com",
-		bucket: "pi-sync",
-		region: DEFAULT_REGION,
-		accessKeyId: "<access-key-id>",
-		secretAccessKey: "<secret-access-key>",
-		profile: DEFAULT_PROFILE,
-		prefix: DEFAULT_PREFIX,
-		autoSync: true,
-		syncSessions: false,
-		extraFiles: [],
-	};
-	await writeJson(configPath, sample);
+	await writeLocalConfigObject(localConfigTemplate());
 	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /sync doctor.`, "info");
 }
 
@@ -248,6 +242,7 @@ async function showConfig(ctx: ExtensionCommandContext) {
 			`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
 			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
 			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
+			`syncFiles: ${normalizeSyncFiles(partial.syncFiles).join(", ") || "none"}`,
 			`syncSessions: ${syncSessions ? "enabled" : "disabled"}`,
 			`extraFiles: ${normalizeExtraFiles(partial.extraFiles).join(", ") || "none"}`,
 			`local config: ${localConfigPath()}`,
@@ -267,7 +262,7 @@ async function status(ctx: ExtensionCommandContext) {
 	const localChanged = hasLocalChanges(local, state, config);
 
 	let remoteText = "remote: empty";
-	let remoteChanged = remoteChangedSinceState(latest, state, config);
+	const remoteChanged = remoteChangedSinceState(latest, state, config);
 	if (!latest.missing && latest.value) {
 		remoteText = `remote: ${latest.value.snapshot} from ${latest.value.machine} at ${latest.value.createdAt}`;
 	}
@@ -277,6 +272,8 @@ async function status(ctx: ExtensionCommandContext) {
 	ctx.ui.notify(
 		[
 			`profile: ${config.profile}`,
+			`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
+			`extra files: ${config.extraFiles.join(", ") || "none"}`,
 			`sessions: ${config.syncSessions ? "included" : "excluded"}`,
 			remoteText,
 			`local files: ${local.files.length}`,
@@ -297,9 +294,12 @@ async function diff(ctx: ExtensionCommandContext) {
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 
 	const warnings = syncSessionsWarnings(config);
-	const header = [`sessions: ${config.syncSessions ? "included" : "excluded"}`, ...warnings].join(
-		"\n",
-	);
+	const header = [
+		`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
+		`extra files: ${config.extraFiles.join(", ") || "none"}`,
+		`sessions: ${config.syncSessions ? "included" : "excluded"}`,
+		...warnings,
+	].join("\n");
 	const level = warnings.length > 0 ? "warning" : "info";
 	if (!remote) {
 		ctx.ui.notify(
@@ -323,6 +323,8 @@ async function doctor(ctx: ExtensionCommandContext) {
 		profile = config.profile;
 		snapshotOptions = snapshotOptionsForContext(ctx, config);
 		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
+		messages.push(`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`);
+		messages.push(`extra files: ${config.extraFiles.join(", ") || "none"}`);
 		messages.push(`sessions: ${config.syncSessions ? "included" : "excluded"}`);
 		const warnings = [...sessionTokenWarnings(config), ...syncSessionsWarnings(config)];
 		if (warnings.length > 0) {
@@ -375,7 +377,8 @@ async function push(
 	const config = input?.config ?? (await loadConfig());
 	const client = input?.client ?? new S3Client(config);
 	const state = input?.state ?? (await readState(config.profile));
-	const local = input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
+	const local =
+		input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const remoteForUpload = options.force
@@ -397,7 +400,9 @@ async function push(
 	});
 	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
-		throw new Error(`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`);
+		throw new Error(
+			`Refusing to push possible secrets:\n${secrets.map((s) => `- ${s}`).join("\n")}`,
+		);
 	}
 
 	const preservedRemoteFileCount = countPreservedRemoteFiles(local, upload);
@@ -421,6 +426,7 @@ async function push(
 		lastAppliedSnapshot: pointer.snapshot,
 		lastRemoteEtag: undefined,
 		lastFileHashes: fileHashMap(local),
+		syncFiles: config.syncFiles,
 		syncSessions: config.syncSessions,
 		extraFiles: config.extraFiles,
 	});
@@ -442,7 +448,9 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const localChanged = hasLocalChanges(local, state, config);
 	const remoteChanged = hasRemoteChanges(remote, state, config, protectedSessionPaths(ctx));
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
-		throw new Error("Both local and remote changed since last sync. Run /sync diff, then choose /sync pull --force or /sync push --force.");
+		throw new Error(
+			"Both local and remote changed since last sync. Run /sync diff, then choose /sync pull --force or /sync push --force.",
+		);
 	}
 
 	if (
@@ -460,6 +468,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
 	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), {
+		syncFiles: config.syncFiles,
 		sessionDir: applySessionDir,
 		extraFiles: config.extraFiles,
 	});
@@ -469,12 +478,16 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		lastAppliedSnapshot: remote.id,
 		lastRemoteEtag: undefined,
 		lastFileHashes,
+		syncFiles: config.syncFiles,
 		syncSessions: config.syncSessions,
 		extraFiles: config.extraFiles,
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
-		ctx.ui.notify(`Pulled ${remote.files.length} files from ${remote.id}. Backup: ${backup}`, "info");
+		ctx.ui.notify(
+			`Pulled ${remote.files.length} files from ${remote.id}. Backup: ${backup}`,
+			"info",
+		);
 	} else if (options.auto && config.syncSessions && snapshotIncludesSessions(remote)) {
 		ctx.ui.notify(
 			"Pulled Pi sessions after startup selected the current session. Restart Pi or resume a pulled session to use newly synced conversations.",
@@ -498,11 +511,15 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 
 	if (firstSync && remote && remote.files.length > 0 && local.files.length > 0) {
 		if (!canPullRemoteSettingsOnFirstSync(local, remote)) {
-			throw new Error("Remote settings exist and this machine has different local Pi settings. Run /sync diff, then manually choose /sync pull or /sync push.");
+			throw new Error(
+				"Remote settings exist and this machine has different local Pi settings. Run /sync diff, then manually choose /sync pull or /sync push.",
+			);
 		}
 		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
 			if (!canPullRemoteSessionsOnFirstSync(local, remote)) {
-				throw new Error("Remote settings match, but local and remote Pi sessions differ. Run /sync diff, then manually choose /sync pull or /sync push.");
+				throw new Error(
+					"Remote settings match, but local and remote Pi sessions differ. Run /sync diff, then manually choose /sync pull or /sync push.",
+				);
 			}
 			await pull(ctx, options);
 			return;
@@ -513,10 +530,12 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			lastAppliedSnapshot: remote.id,
 			lastRemoteEtag: undefined,
 			lastFileHashes: fileHashMap(remote),
+			syncFiles: config.syncFiles,
 			syncSessions: config.syncSessions,
 			extraFiles: config.extraFiles,
 		});
-		if (!options.silent) ctx.ui.notify("pi-sync state initialized; local settings already match remote.", "info");
+		if (!options.silent)
+			ctx.ui.notify("pi-sync state initialized; local settings already match remote.", "info");
 		return;
 	}
 	if (localChanged && remoteChanged && remote && snapshotsMatch(local, remote)) {
@@ -526,6 +545,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			lastAppliedSnapshot: remote.id,
 			lastRemoteEtag: undefined,
 			lastFileHashes: fileHashMap(remote),
+			syncFiles: config.syncFiles,
 			syncSessions: config.syncSessions,
 			extraFiles: config.extraFiles,
 		});
@@ -533,7 +553,9 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 		return;
 	}
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
-		throw new Error("Both local and remote changed. Run /sync diff and resolve with push --force or pull --force.");
+		throw new Error(
+			"Both local and remote changed. Run /sync diff and resolve with push --force or pull --force.",
+		);
 	}
 	if (remoteChanged) {
 		await pull(ctx, options);
@@ -550,6 +572,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			lastAppliedSnapshot: remote.id,
 			lastRemoteEtag: undefined,
 			lastFileHashes: fileHashMap(remote),
+			syncFiles: config.syncFiles,
 			syncSessions: config.syncSessions,
 			extraFiles: config.extraFiles,
 		});
@@ -607,6 +630,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
 	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), {
+		syncFiles: config.syncFiles,
 		sessionDir: applySessionDir,
 		extraFiles: config.extraFiles,
 	});
@@ -627,6 +651,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		lastAppliedSnapshot: pointer.snapshot,
 		lastRemoteEtag: undefined,
 		lastFileHashes,
+		syncFiles: config.syncFiles,
 		syncSessions: config.syncSessions,
 		extraFiles: config.extraFiles,
 	});
@@ -649,6 +674,7 @@ function snapshotOptionsForContext(
 	config: SyncConfig,
 ): SnapshotOptions {
 	return {
+		syncFiles: config.syncFiles,
 		syncSessions: config.syncSessions,
 		sessionDir: sessionDirFromContext(ctx),
 		extraFiles: config.extraFiles,
@@ -671,7 +697,13 @@ function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) 
 
 async function maybeReload(ctx: ExtensionCommandContext | ExtensionContext) {
 	if (!("reload" in ctx)) return;
-	if (ctx.hasUI && (await ctx.ui.confirm("Reload Pi resources now?", "This reloads extensions, skills, prompts, themes, and context files."))) {
+	if (
+		ctx.hasUI &&
+		(await ctx.ui.confirm(
+			"Reload Pi resources now?",
+			"This reloads extensions, skills, prompts, themes, and context files.",
+		))
+	) {
 		await ctx.reload();
 	}
 }
@@ -730,7 +762,9 @@ async function uploadSnapshot(
 	await client.putJson(latestKey(config), pointer);
 	const verified = await client.getJson<LatestPointer>(latestKey(config));
 	if (verified.value?.snapshot !== pointer.snapshot) {
-		throw new Error("Remote latest changed immediately after push. Run /sync status before continuing.");
+		throw new Error(
+			"Remote latest changed immediately after push. Run /sync status before continuing.",
+		);
 	}
 	return pointer;
 }
@@ -744,8 +778,10 @@ async function readRemoteSnapshotRaw(client: S3Client, config: SyncConfig) {
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	if (latest.missing || !latest.value) return undefined;
 	const object = await client.getBuffer(snapshotKey(config, latest.value.snapshot));
-	if (!object.value) throw new Error(`Remote latest points to missing snapshot: ${latest.value.snapshot}`);
-	if (sha256(object.value) !== latest.value.sha256) throw new Error("Remote snapshot checksum mismatch.");
+	if (!object.value)
+		throw new Error(`Remote latest points to missing snapshot: ${latest.value.snapshot}`);
+	if (sha256(object.value) !== latest.value.sha256)
+		throw new Error("Remote snapshot checksum mismatch.");
 	return decodeSnapshot(object.value);
 }
 
@@ -756,7 +792,8 @@ async function encodeSnapshot(snapshot: Snapshot) {
 async function decodeSnapshot(buffer: Buffer): Promise<Snapshot> {
 	const decoded = await gunzipAsync(buffer);
 	const parsed = JSON.parse(decoded.toString("utf8")) as Snapshot;
-	if (parsed.version !== VERSION || !Array.isArray(parsed.files)) throw new Error("Unsupported snapshot format.");
+	if (parsed.version !== VERSION || !Array.isArray(parsed.files))
+		throw new Error("Unsupported snapshot format.");
 	return parsed;
 }
 
@@ -770,7 +807,9 @@ export async function backupLocal(profile: string, options: SnapshotOptions = {}
 }
 
 async function updateHistory(client: S3Client, config: SyncConfig, pointer: LatestPointer) {
-	const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(historyKey(config));
+	const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(
+		historyKey(config),
+	);
 	const snapshots = object.value?.snapshots ?? [];
 	const next = [
 		...snapshots.filter((snapshot) => snapshot.snapshot !== pointer.snapshot),
@@ -783,7 +822,11 @@ function formatDiff(local: Snapshot, remote: Snapshot) {
 	const localMap = fileHashMap(local);
 	const remoteMap = fileHashMap(remote);
 	const allPaths = [...new Set([...Object.keys(localMap), ...Object.keys(remoteMap)])].sort();
-	const lines = [`local: ${local.files.length} files`, `remote: ${remote.id} (${remote.files.length} files)`, ""];
+	const lines = [
+		`local: ${local.files.length} files`,
+		`remote: ${remote.id} (${remote.files.length} files)`,
+		"",
+	];
 	let changed = 0;
 	for (const filePath of allPaths) {
 		if (!localMap[filePath]) {
@@ -819,143 +862,13 @@ function formatPushSummary(
 	].join("\n");
 }
 
-function hasLocalChanges(local: Snapshot, state: SyncState, config: SyncConfig) {
-	return !sameHashes(fileHashMap(local), stateHashMapForConfig(state, config));
-}
-
-function remoteChangedSinceState(
-	latest: RemoteObject<LatestPointer>,
-	state: SyncState,
-	config: SyncConfig,
-) {
-	if (latest.missing) return Boolean(state.lastAppliedSnapshot);
-	if (latest.value?.snapshot !== state.lastAppliedSnapshot) return true;
-	if (extraFilesChanged(state, config)) return true;
-	return config.syncSessions && state.syncSessions !== true && latest.value?.syncSessions === true;
-}
-
-export function hasRemoteChanges(
-	remote: Snapshot,
-	state: SyncState,
-	config: SyncConfig,
-	ignoredPaths = new Set<string>(),
-) {
-	if (remote.id === state.lastAppliedSnapshot && !syncPolicyChanged(state, config)) return false;
-	return !snapshotHashesMatchState(filterSnapshotForConfigPolicy(remote, config), state, config, ignoredPaths);
-}
-
 function remoteIdentity(remote: RemoteObject<LatestPointer>) {
 	return remote.missing ? "missing" : (remote.value?.snapshot ?? "unknown");
-}
-
-function sameHashes(left: Record<string, string>, right: Record<string, string>) {
-	const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
-	for (const key of keys) {
-		if (left[key] !== right[key]) return false;
-	}
-	return true;
-}
-
-function fileHashMap(snapshot: Snapshot) {
-	return Object.fromEntries(snapshot.files.map((file) => [file.path, file.sha256]));
-}
-
-function stateHashMapForConfig(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
-	const extraFilePaths = extraFilePathsByLower(config.extraFiles);
-	const extraFiles = new Set(extraFilePaths.keys());
-	return Object.fromEntries(
-		Object.entries(state.lastFileHashes)
-			.filter(([filePath]) => isConfiguredSnapshotPath(filePath, config, extraFiles))
-			.map(([filePath, hash]) => [canonicalSnapshotPathForConfig(filePath, extraFilePaths), hash]),
-	);
-}
-
-function snapshotHashesMatchState(
-	snapshot: Snapshot,
-	state: SyncState,
-	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
-	ignoredPaths = new Set<string>(),
-) {
-	return sameHashes(
-		withoutHashPaths(fileHashMap(snapshot), ignoredPaths),
-		withoutHashPaths(stateHashMapForConfig(state, config), ignoredPaths),
-	);
-}
-
-function snapshotsMatch(left: Snapshot, right: Snapshot) {
-	return left.syncSessions === right.syncSessions && sameHashes(fileHashMap(left), fileHashMap(right));
-}
-
-function withoutHashPaths(hashes: Record<string, string>, ignoredPaths: Set<string>) {
-	if (ignoredPaths.size === 0) return hashes;
-	return Object.fromEntries(
-		Object.entries(hashes).filter(([filePath]) => !ignoredPaths.has(toPosix(filePath))),
-	);
-}
-
-function syncPolicyChanged(state: SyncState, config: Pick<SyncConfig, "syncSessions" | "extraFiles">) {
-	return (state.syncSessions ?? false) !== config.syncSessions || extraFilesChanged(state, config);
-}
-
-function shouldRefreshSyncedState(
-	remote: Snapshot,
-	state: SyncState,
-	config: Pick<SyncConfig, "syncSessions" | "extraFiles">,
-) {
-	return remote.id !== state.lastAppliedSnapshot || syncPolicyChanged(state, config);
-}
-
-function extraFilesChanged(state: SyncState, config: Pick<SyncConfig, "extraFiles">) {
-	return !sameStringSet(normalizeExtraFiles(state.extraFiles), normalizeExtraFiles(config.extraFiles));
-}
-
-function sameStringSet(left: string[], right: string[]) {
-	const leftSet = new Set(left);
-	const rightSet = new Set(right);
-	if (leftSet.size !== rightSet.size) return false;
-	return [...leftSet].every((item) => rightSet.has(item));
 }
 
 function countPreservedRemoteFiles(local: Snapshot, upload: Snapshot) {
 	const localPaths = new Set(local.files.map((file) => file.path));
 	return upload.files.filter((file) => !localPaths.has(file.path)).length;
-}
-
-export function settingsHashMap(snapshot: Snapshot) {
-	return Object.fromEntries(
-		snapshot.files
-			.filter((file) => !isSessionPath(file.path))
-			.map((file) => [file.path, file.sha256]),
-	);
-}
-
-export function sessionHashMap(snapshot: Snapshot) {
-	return Object.fromEntries(
-		snapshot.files.filter((file) => isSessionPath(file.path)).map((file) => [file.path, file.sha256]),
-	);
-}
-
-export function settingsHashMapFromState(state: SyncState) {
-	return Object.fromEntries(
-		Object.entries(state.lastFileHashes).filter(([filePath]) => !isSessionPath(filePath)),
-	);
-}
-
-export function settingsHashesMatchState(remote: Snapshot, state: SyncState) {
-	return sameHashes(settingsHashMap(remote), settingsHashMapFromState(state));
-}
-
-export function canPullRemoteSettingsOnFirstSync(local: Snapshot, remote: Snapshot) {
-	const remoteSettings = settingsHashMap(remote);
-	return Object.entries(settingsHashMap(local)).every(
-		([filePath, hash]) => remoteSettings[filePath] === hash,
-	);
-}
-
-export function canPullRemoteSessionsOnFirstSync(local: Snapshot, remote: Snapshot) {
-	const localSessions = sessionHashMap(local);
-	const remoteSessions = sessionHashMap(remote);
-	return Object.entries(localSessions).every(([filePath, hash]) => remoteSessions[filePath] === hash);
 }
 
 function sha256(value: Buffer) {
@@ -971,8 +884,27 @@ function errorMessage(error: unknown) {
 }
 
 export { completeSyncArguments, parseOptions, splitArgs } from "./command.js";
-export { isCloudflareR2Endpoint, isEnabled, isExplicitlyEnabled, loadConfig, sessionTokenWarnings } from "./config.js";
+export {
+	isCloudflareR2Endpoint,
+	isEnabled,
+	isExplicitlyEnabled,
+	loadConfig,
+	sessionTokenWarnings,
+} from "./config.js";
 export { encodeKey, posixJoin, safeJoin, safeName } from "./paths.js";
+export {
+	canonicalSnapshotPathForConfig,
+	collectFiles,
+	filterSnapshotForConfigPolicy,
+	isConfiguredSnapshotPath,
+	isDeniedPath,
+	isSessionPath,
+	mergeRemotePreservedFiles,
+	mergeRemoteSessionFiles,
+	scanSnapshot,
+	sessionSnapshotPathFromAbsolute,
+	snapshotWithoutSessions,
+} from "./snapshot.js";
 export {
 	addTopLevelCaseVariantDeletes,
 	appliedFileHashMap,
@@ -980,15 +912,11 @@ export {
 	protectSnapshotApplyPlan,
 } from "./snapshot-apply.js";
 export {
-	collectFiles,
-	canonicalSnapshotPathForConfig,
-	filterSnapshotForConfigPolicy,
-	isConfiguredSnapshotPath,
-	isDeniedPath,
-	isSessionPath,
-	sessionSnapshotPathFromAbsolute,
-	mergeRemotePreservedFiles,
-	mergeRemoteSessionFiles,
-	scanSnapshot,
-	snapshotWithoutSessions,
-} from "./snapshot.js";
+	canPullRemoteSessionsOnFirstSync,
+	canPullRemoteSettingsOnFirstSync,
+	hasRemoteChanges,
+	sessionHashMap,
+	settingsHashesMatchState,
+	settingsHashMap,
+	settingsHashMapFromState,
+} from "./sync-state.js";

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -381,9 +381,7 @@ async function push(
 		input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
 
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	const remoteForUpload = options.force
-		? undefined
-		: await readRemoteSnapshotForUpload(client, config, latest, state);
+	const remoteForUpload = await readRemoteSnapshotForUpload(client, config, latest, state);
 	if (remoteChangedSinceState(latest, state, config) && !options.force) {
 		const remoteForConflict = remoteForUpload
 			? filterSnapshotForConfigPolicy(remoteForUpload, config)
@@ -395,9 +393,7 @@ async function push(
 		}
 	}
 
-	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload, {
-		preserveRemote: !options.force,
-	});
+	const upload = await snapshotForUpload(client, config, local, latest, remoteForUpload);
 	const secrets = scanSnapshot(local);
 	if (secrets.length > 0) {
 		throw new Error(
@@ -730,9 +726,9 @@ async function snapshotForUpload(
 	local: Snapshot,
 	latest: RemoteObject<LatestPointer>,
 	remote?: Snapshot,
-	options: { preserveRemote?: boolean; ignoreUnreadableRemote?: boolean } = {},
+	options: { ignoreUnreadableRemote?: boolean } = {},
 ) {
-	if (options.preserveRemote === false || latest.missing || !latest.value) return local;
+	if (latest.missing || !latest.value) return local;
 	let snapshot = remote;
 	if (!snapshot) {
 		try {

--- a/extensions/pi-sync/src/types.ts
+++ b/extensions/pi-sync/src/types.ts
@@ -7,6 +7,7 @@ export interface SyncConfig {
 	sessionToken?: string;
 	profile: string;
 	prefix: string;
+	syncFiles?: string[];
 	syncSessions: boolean;
 	extraFiles: string[];
 }
@@ -21,6 +22,7 @@ export interface PartialConfig {
 	profile?: string;
 	prefix?: string;
 	autoSync?: boolean | string;
+	syncFiles?: unknown;
 	syncSessions?: boolean | string;
 	extraFiles?: unknown;
 }
@@ -63,6 +65,7 @@ export interface SyncState {
 	lastAppliedSnapshot?: string;
 	lastRemoteEtag?: string;
 	lastFileHashes: Record<string, string>;
+	syncFiles?: string[];
 	syncSessions?: boolean;
 	extraFiles?: string[];
 }
@@ -91,6 +94,7 @@ export interface CommandArgumentCompletion {
 }
 
 export interface SnapshotOptions {
+	syncFiles?: string[];
 	syncSessions?: boolean;
 	sessionDir?: string;
 	extraFiles?: string[];

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -14,7 +14,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { gunzipSync } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import {
 	createCustomSelectorHarness,
@@ -550,6 +550,79 @@ test("upload merge preserves remote built-ins and directories that this machine 
 		merged.files.map((file) => file.path),
 		["keybindings.json", "settings.json", "skills/demo.md"],
 	);
+});
+
+test("forced pushes preserve remote files outside this machine's selection", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({ ...requiredConfig(), syncFiles: ["settings.json"] }),
+		);
+
+		const remote = {
+			...snapshot([
+				{ path: "settings.json", content: Buffer.from("remote settings\n") },
+				{ path: "keybindings.json", content: Buffer.from("remote keys\n") },
+			]),
+			id: "remote-snapshot",
+		};
+		const remoteBody = gzipSync(Buffer.from(JSON.stringify(remote), "utf8"));
+		let latest = {
+			version: 1,
+			profile: "default",
+			snapshot: remote.id,
+			sha256: createHash("sha256").update(remoteBody).digest("hex"),
+			createdAt: remote.createdAt,
+			machine: remote.machine,
+			syncSessions: false,
+		};
+		let uploadedBody: Buffer | undefined;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input, init) => {
+			const url = new URL(String(input));
+			const method = init?.method ?? "GET";
+			if (method === "GET" && url.pathname.endsWith("/latest.json")) {
+				return Response.json(latest);
+			}
+			if (method === "GET" && url.pathname.endsWith(`/snapshots/${remote.id}.json.gz`)) {
+				return new Response(new Uint8Array(remoteBody));
+			}
+			if (method === "PUT" && url.pathname.includes("/snapshots/")) {
+				uploadedBody = Buffer.from(init?.body as Uint8Array);
+				return new Response(null, { status: 200 });
+			}
+			if (method === "PUT" && url.pathname.endsWith("/latest.json")) {
+				latest = JSON.parse(Buffer.from(init?.body as Uint8Array).toString("utf8"));
+				return new Response(null, { status: 200 });
+			}
+			if (method === "GET" && url.pathname.endsWith("/history.json")) {
+				return new Response(null, { status: 404 });
+			}
+			if (method === "PUT" && url.pathname.endsWith("/history.json")) {
+				return new Response(null, { status: 200 });
+			}
+			throw new Error(`Unexpected S3 request: ${method} ${url.pathname}`);
+		}) as typeof globalThis.fetch;
+
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext();
+			await mock.commands.get("sync")?.handler("push --yes --force", ctx);
+
+			assert.ok(uploadedBody, JSON.stringify(notifications));
+			const uploaded = JSON.parse(gunzipSync(uploadedBody).toString("utf8"));
+			assert.deepEqual(
+				uploaded.files.map((file: { path: string }) => file.path),
+				["keybindings.json", "settings.json"],
+			);
+			assert.equal(notifications.at(-1)?.level, "info");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });
 
 test("syncSessions config defaults off and supports file plus env overrides", async () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -15,7 +15,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { gunzipSync } from "node:zlib";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import {
 	SYNC_COMMANDS,
 	syncCommandFromMenuOption,
@@ -28,10 +33,13 @@ import {
 	loadPartialConfig,
 	localConfigPath,
 	lockPath,
+	readLocalConfigObject,
 	readState,
+	updateLocalConfig,
 } from "../src/config.js";
 import { lockFileExists, readLock, withLock } from "../src/lock.js";
 import { S3Client } from "../src/s3-client.js";
+import { applySnapshot } from "../src/snapshot-apply.js";
 import sync, {
 	addTopLevelCaseVariantDeletes,
 	appliedFileHashMap,
@@ -63,6 +71,9 @@ import sync, {
 	snapshotWithoutSessions,
 	splitArgs,
 } from "../src/sync.js";
+import { DEFAULT_SYNC_FILES, normalizeSyncFiles } from "../src/sync-policy.js";
+
+initTheme("dark", false);
 
 test("sync registers the sync command and session lifecycle hooks", () => {
 	const mock = createMockPi();
@@ -94,6 +105,7 @@ const expectedSyncMenuOptions = [
 	"help — Show command usage",
 	"init — Create local config template",
 	"config — Show resolved configuration",
+	"files — Choose synced files",
 	"status — Show sync status",
 	"diff — Show local/remote diff",
 	"doctor — Check config, secrets, and lock state",
@@ -177,6 +189,212 @@ test("bare sync command reports usage without an interactive UI", async () => {
 	});
 });
 
+test("sync files persists SettingsList choices and safe extra-file candidates", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "custom-dir"), { recursive: true });
+		writeFileSync(path.join(agentDir, "LOCAL.md"), "local\n");
+		writeFileSync(path.join(agentDir, "secret-notes.md"), "secret\n");
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({ ...requiredConfig(), future: true, extraFiles: ["REMOTE.md"] }),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		let initialRender = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory);
+				initialRender = selector.render().join("\n");
+				selector.handleInput("\r");
+				selector.handleInput("\u001b");
+				return selector.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("files", ctx);
+
+		assert.match(initialRender, /settings\.json/);
+		assert.match(initialRender, /sessions/);
+		assert.match(initialRender, /LOCAL\.md/);
+		assert.match(initialRender, /REMOTE\.md/);
+		assert.doesNotMatch(initialRender, /secret-notes|custom-dir/);
+		const saved = await readLocalConfigObject();
+		assert.equal(saved?.future, true);
+		assert.deepEqual(
+			saved?.syncFiles,
+			DEFAULT_SYNC_FILES.filter((item) => item !== "settings.json"),
+		);
+		if (process.platform !== "win32") {
+			assert.equal((await fs.stat(localConfigPath())).mode & 0o777, 0o600);
+		}
+	});
+});
+
+test("the first file-selection change creates the complete config template", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory);
+				selector.handleInput("\r");
+				selector.handleInput("\u001b");
+				return selector.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("files", ctx);
+		const saved = await readLocalConfigObject();
+		assert.equal(saved?.endpoint, "https://<account-id>.r2.cloudflarestorage.com");
+		assert.equal(saved?.autoSync, true);
+		assert.deepEqual(
+			saved?.syncFiles,
+			DEFAULT_SYNC_FILES.filter((item) => item !== "settings.json"),
+		);
+		assert.deepEqual(saved?.extraFiles, []);
+	});
+});
+
+test("sync files serializes rapid changes in user action order", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory);
+				selector.handleInput("\r");
+				selector.handleInput("\r");
+				selector.handleInput("\u001b");
+				return selector.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("files", ctx);
+		assert.deepEqual((await readLocalConfigObject())?.syncFiles, [...DEFAULT_SYNC_FILES]);
+	});
+});
+
+test("sync files keeps environment-overridden sessions read-only", async () => {
+	await withTempHome(async () => {
+		mkdirSync(path.dirname(localConfigPath()), { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify({ ...requiredConfig(), syncSessions: false }));
+		await withEnv({ PI_SYNC_SESSIONS: "true" }, async () => {
+			const mock = createMockPi();
+			sync(mock.pi);
+			let sessionRender = "";
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				custom: async (factory: unknown) => {
+					const selector = createCustomSelectorHarness(factory);
+					for (const character of "sessions") selector.handleInput(character);
+					sessionRender = selector.render().join("\n");
+					selector.handleInput("\r");
+					selector.handleInput("\u001b");
+					return selector.result;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("files", ctx);
+			assert.match(sessionRender, /included \(environment\)/);
+			assert.equal((await readLocalConfigObject())?.syncSessions, false);
+		});
+	});
+});
+
+test("sync files has a protocol-safe non-TUI summary", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		let customCalls = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			custom: async () => {
+				customCalls += 1;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("files", ctx);
+		assert.equal(customCalls, 0);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/selected files.*syncFiles.*pi-sync\.local\.json/is,
+		);
+	});
+});
+
+test("local config updates preserve unknown fields and reject malformed or symlinked files", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify({ future: { enabled: true } }));
+		await updateLocalConfig((current) => ({ ...current, syncFiles: [] }));
+		assert.deepEqual((await readLocalConfigObject())?.future, { enabled: true });
+
+		writeFileSync(localConfigPath(), "{broken");
+		await assert.rejects(
+			updateLocalConfig((current) => current),
+			SyntaxError,
+		);
+		assert.equal(readFileSync(localConfigPath(), "utf8"), "{broken");
+
+		rmSync(localConfigPath());
+		const target = path.join(agentDir, "target.json");
+		writeFileSync(target, "keep\n");
+		await fs.symlink(target, localConfigPath());
+		await assert.rejects(
+			updateLocalConfig((current) => current),
+			/symlinked pi-sync config/,
+		);
+		assert.equal(readFileSync(target, "utf8"), "keep\n");
+	});
+});
+
+test("sync files rolls back the active row when atomic publication fails", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
+		const originalRename = fs.rename;
+		fs.rename = (async () => {
+			throw new Error("rename failed");
+		}) as typeof fs.rename;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const context = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				custom: async (factory: unknown) => {
+					const selector = createCustomSelectorHarness(factory);
+					selector.handleInput("\r");
+					await waitFor(() => context.notifications.length > 0);
+					assert.ok(
+						selector
+							.render()
+							.some((line) => line.includes("settings.json") && line.includes("included")),
+					);
+					selector.handleInput("\u001b");
+					return selector.result;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("files", context.ctx);
+			assert.match(context.notifications.at(-1)?.message ?? "", /rename failed/);
+			assert.equal((await readLocalConfigObject())?.syncFiles, undefined);
+		} finally {
+			fs.rename = originalRename;
+		}
+	});
+});
+
 test("sync rollback menu requests a snapshot id and cancels empty input", async () => {
 	await withTempHome(async (agentDir) => {
 		const mock = createMockPi();
@@ -184,7 +402,7 @@ test("sync rollback menu requests a snapshot id and cancels empty input", async 
 		let inputCalls = 0;
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
-			select: async () => expectedSyncMenuOptions[10],
+			select: async () => expectedSyncMenuOptions[11],
 			input: async () => {
 				inputCalls += 1;
 				return "  ";
@@ -205,7 +423,7 @@ test("sync rollback menu passes a provided snapshot id to rollback", async () =>
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
-			select: async () => expectedSyncMenuOptions[10],
+			select: async () => expectedSyncMenuOptions[11],
 			input: async () => "snapshot-id",
 		});
 
@@ -223,6 +441,7 @@ test("completeSyncArguments suggests commands and useful flags", () => {
 			"help",
 			"init",
 			"config",
+			"files",
 			"status",
 			"diff",
 			"doctor",
@@ -265,6 +484,72 @@ test("completeSyncArguments suggests commands and useful flags", () => {
 	assert.equal(completeSyncArguments("status "), null);
 	assert.equal(completeSyncArguments("push snapshot"), null);
 	assert.equal(completeSyncArguments("wat"), null);
+});
+
+test("syncFiles keeps the legacy allowlist by default and validates explicit selections safely", async () => {
+	assert.deepEqual(normalizeSyncFiles(undefined), [...DEFAULT_SYNC_FILES]);
+	assert.deepEqual(normalizeSyncFiles([]), []);
+	assert.deepEqual(normalizeSyncFiles(["SETTINGS.JSON", "settings.json", "skills"]), [
+		"settings.json",
+		"skills",
+	]);
+	assert.throws(() => normalizeSyncFiles("settings.json"), /syncFiles must be an array/);
+	assert.throws(
+		() => normalizeSyncFiles(["settings.json", "unknown.json"]),
+		/Unknown syncFiles item/,
+	);
+	assert.throws(() => normalizeSyncFiles(["settings.json", 1]), /syncFiles items must be strings/);
+
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
+		assert.deepEqual((await loadConfig()).syncFiles, [...DEFAULT_SYNC_FILES]);
+
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), syncFiles: [] }),
+		);
+		assert.deepEqual((await loadConfig()).syncFiles, []);
+	});
+});
+
+test("snapshot collection includes only selected built-in files and directory groups", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-selected-"));
+	mkdirSync(path.join(root, "skills"));
+	mkdirSync(path.join(root, "prompts"));
+	writeFileSync(path.join(root, "settings.json"), "{}\n");
+	writeFileSync(path.join(root, "keybindings.json"), "{}\n");
+	writeFileSync(path.join(root, "skills", "demo.md"), "skill\n");
+	writeFileSync(path.join(root, "prompts", "demo.md"), "prompt\n");
+
+	assert.deepEqual(
+		(await collectFiles(root, { syncFiles: ["settings.json", "skills"] })).map((file) => file.path),
+		["settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { syncFiles: [] })).map((file) => file.path),
+		[],
+	);
+});
+
+test("upload merge preserves remote built-ins and directories that this machine does not manage", () => {
+	const local = snapshot([{ path: "settings.json", content: Buffer.from("local") }]);
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("remote") },
+		{ path: "keybindings.json", content: Buffer.from("remote keys") },
+		{ path: "skills/demo.md", content: Buffer.from("remote skill") },
+		{ path: "prompts/demo.md", content: Buffer.from("old prompt") },
+	]);
+	const merged = mergeRemotePreservedFiles(local, remote, {
+		syncFiles: ["settings.json", "prompts"],
+		syncSessions: false,
+		extraFiles: [],
+	});
+
+	assert.deepEqual(
+		merged.files.map((file) => file.path),
+		["keybindings.json", "settings.json", "skills/demo.md"],
+	);
 });
 
 test("syncSessions config defaults off and supports file plus env overrides", async () => {
@@ -573,6 +858,24 @@ test("snapshot preflight validates checksums, duplicate session paths, and delet
 	);
 });
 
+test("snapshot apply leaves unselected local files and directories untouched", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "skills"), { recursive: true });
+		writeFileSync(path.join(agentDir, "keybindings.json"), "local keys\n");
+		writeFileSync(path.join(agentDir, "skills", "local.md"), "local skill\n");
+		const remote = snapshot([{ path: "settings.json", content: Buffer.from("remote settings\n") }]);
+
+		await applySnapshot(remote, new Set(), {
+			syncFiles: ["settings.json"],
+			extraFiles: [],
+		});
+
+		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), "remote settings\n");
+		assert.equal(readFileSync(path.join(agentDir, "keybindings.json"), "utf8"), "local keys\n");
+		assert.equal(readFileSync(path.join(agentDir, "skills", "local.md"), "utf8"), "local skill\n");
+	});
+});
+
 test("snapshot apply deletes stale top-level case variants", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-"));
 	writeFileSync(path.join(root, "append_system.md"), "old\n");
@@ -748,6 +1051,36 @@ test("settings-only uploads preserve remote session files", () => {
 		["settings.json"],
 	);
 	assert.equal(emptySessionSet.syncSessions, true);
+});
+
+test("sync state tracks selection-policy changes without treating deselection as remote deletion", () => {
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "keybindings.json", content: Buffer.from("keys") },
+	]);
+	const selectedSettings = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncFiles: ["settings.json"],
+		syncSessions: false,
+		extraFiles: [],
+	};
+	const legacyState = {
+		version: 1,
+		profile: "default",
+		lastAppliedSnapshot: remote.id,
+		lastFileHashes: Object.fromEntries(remote.files.map((file) => [file.path, file.sha256])),
+	};
+	assert.equal(hasRemoteChanges(remote, legacyState, selectedSettings), false);
+
+	const previouslyEmptyState = {
+		...legacyState,
+		lastFileHashes: {},
+		syncFiles: [],
+	};
+	assert.equal(hasRemoteChanges(remote, previouslyEmptyState, selectedSettings), true);
 });
 
 test("settings hash maps ignore session differences for first sync checks", () => {
@@ -1497,6 +1830,14 @@ async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
 		else process.env.PI_CODING_AGENT_SESSION_DIR = previousSessionDir;
 		rmSync(home, { recursive: true, force: true });
 	}
+}
+
+async function waitFor(predicate: () => boolean) {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for test condition");
 }
 
 async function withEnv<T>(env: Record<string, string>, fn: () => Promise<T>) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4717,8 +4717,13 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.3",
 				"@earendil-works/pi-coding-agent": "0.80.10",
+				"@earendil-works/pi-tui": "0.80.10",
 				"@types/proper-lockfile": "^4.1.4",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"extensions/pi-sync/node_modules/@biomejs/biome": {


### PR DESCRIPTION
## Summary

- add a persistent, searchable `/sync files` selector for built-in Pi files, directories, sessions, and safe extra files
- apply `syncFiles` policy across collection, state comparison, pull/apply, and push while preserving unmanaged local and remote content
- persist selection changes atomically with unknown-field preservation, symlink rejection, POSIX `0600` permissions, documentation, and regression coverage

## Verification

- `npm run check`
- `npm test` (1,154 passing)
- `npm run typecheck`
- `just pack-sync`
- isolated print-mode Pi smoke for `/sync files`
