### PR TITLE
feat(statusline): make segment palette configurable

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-statusline-default-config-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-statusline-default-config-plan.md
@@ -1,0 +1,33 @@
+# pi-statusline default config and custom palette plan
+
+## Goal
+
+Reduce the first-run `pi-statusline.json` to common settings while keeping advanced defaults discoverable, and make the `custom` palette selection produce an immediately usable editable palette without adding a cumbersome per-color menu.
+
+## Context
+
+- Runtime normalization already accepts partial settings and supplies complete built-in defaults.
+- The current first-run document expands every advanced field, including a palette ignored while a named preset is active.
+- `/statusline` already provides a preset picker with live preview and a JSON editor suitable for free-form color values.
+
+## Non-Goals
+
+- Add a terminal color picker or 24-field foreground/background settings screen.
+- Rewrite existing user settings or remove existing custom palettes.
+- Change the rendering semantics of manually authored partial custom palettes.
+
+## Plan
+
+- [x] Add focused settings and command tests specifying a concise first-run document, custom-palette seeding from the active named preset, preservation of an existing custom palette, and visible custom-editing guidance; focused run failed on the concise document, seeding, and guidance assertions before implementation.
+- [x] Update `extensions/pi-statusline/src/settings.ts` and preset utilities so built-in runtime defaults remain complete while the created document is concise and selecting an unconfigured `custom` palette materializes the active named preset's per-segment colors; all 69 pi-statusline tests pass.
+- [x] Update `extensions/pi-statusline/src/commands.ts` so the custom picker and main menu expose the existing JSON editing path without a blocking warning or a separate per-color menu; command tests pass, including guidance and preservation cases.
+- [x] Update `extensions/pi-statusline/README.md` to document the concise initial document, advanced built-in defaults, custom-palette materialization, and editing workflow; reviewed against the tested field set, seeding behavior, menu labels, and notifications.
+- [x] Run `npm run check`, inspect the final diff for bounded compatibility-safe changes, and archive this completed plan under `docs/plans/archived/`; the full 1,172-test repository gate passed and the diff changes only pi-statusline plus this plan.
+
+## Completion Checklist
+
+- [x] New installations create only `palettePreset`, `density`, `separator`, and `segments` in `pi-statusline.json`, while normalized runtime settings retain all existing defaults.
+- [x] Selecting `custom` with no palette writes a complete palette derived from the currently active named preset; selecting it with an existing palette preserves that palette and unknown fields.
+- [x] The picker and main menu clearly identify where custom colors are edited, with no forced editor or per-color menu.
+- [x] Existing malformed-file, cancellation, atomic-save, legacy, and named-preset behavior remains covered and passing.
+- [x] `npm run check` passes and the plan is archived.

--- a/docs/plans/archived/2026-07-24_pi-statusline-default-config-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-statusline-default-config-plan.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Reduce the first-run `pi-statusline.json` to common settings while keeping advanced defaults discoverable, and make the `custom` palette selection produce an immediately usable editable palette without adding a cumbersome per-color menu.
+Keep the first-run `pi-statusline.json` discoverable without materializing an inactive custom palette, and make the `custom` palette selection produce an immediately usable editable palette without adding a cumbersome per-color menu.
 
 ## Context
 
@@ -18,15 +18,15 @@ Reduce the first-run `pi-statusline.json` to common settings while keeping advan
 
 ## Plan
 
-- [x] Add focused settings and command tests specifying a concise first-run document, custom-palette seeding from the active named preset, preservation of an existing custom palette, and visible custom-editing guidance; focused run failed on the concise document, seeding, and guidance assertions before implementation.
-- [x] Update `extensions/pi-statusline/src/settings.ts` and preset utilities so built-in runtime defaults remain complete while the created document is concise and selecting an unconfigured `custom` palette materializes the active named preset's per-segment colors; all 69 pi-statusline tests pass.
+- [x] Add focused settings and command tests specifying a first-run document without an inactive palette, custom-palette seeding from the active named preset, preservation of an existing custom palette, and visible custom-editing guidance; focused assertions failed before implementation.
+- [x] Update `extensions/pi-statusline/src/settings.ts` and preset utilities so built-in runtime defaults remain complete while the created document omits the inactive palette and selecting an unconfigured `custom` palette materializes the active named preset's per-segment colors; all 69 pi-statusline tests pass.
 - [x] Update `extensions/pi-statusline/src/commands.ts` so the custom picker and main menu expose the existing JSON editing path without a blocking warning or a separate per-color menu; command tests pass, including guidance and preservation cases.
-- [x] Update `extensions/pi-statusline/README.md` to document the concise initial document, advanced built-in defaults, custom-palette materialization, and editing workflow; reviewed against the tested field set, seeding behavior, menu labels, and notifications.
+- [x] Update `extensions/pi-statusline/README.md` to document the editable initial document, active built-in defaults, custom-palette materialization, and editing workflow; reviewed against the tested field set, seeding behavior, menu labels, and notifications.
 - [x] Run `npm run check`, inspect the final diff for bounded compatibility-safe changes, and archive this completed plan under `docs/plans/archived/`; the full 1,172-test repository gate passed and the diff changes only pi-statusline plus this plan.
 
 ## Completion Checklist
 
-- [x] New installations create only `palettePreset`, `density`, `separator`, and `segments` in `pi-statusline.json`, while normalized runtime settings retain all existing defaults.
+- [x] New installations expose `palettePreset`, `density`, `separator`, `segments`, `segmentText`, and `extensionStatusIcons` while omitting only the inactive custom `palette`; normalized runtime settings retain all existing defaults.
 - [x] Selecting `custom` with no palette writes a complete palette derived from the currently active named preset; selecting it with an existing palette preserves that palette and unknown fields.
 - [x] The picker and main menu clearly identify where custom colors are edited, with no forced editor or per-color menu.
 - [x] Existing malformed-file, cancellation, atomic-save, legacy, and named-preset behavior remains covered and passing.

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -45,7 +45,20 @@ There are no project overrides or environment-variable overrides.
 
 ```json
 {
-  "palette": "tokyo-night",
+  "palette": {
+    "brand": { "fg": "#090c0c", "bg": "#a3aed2" },
+    "provider": { "fg": "#090c0c", "bg": "#a3aed2" },
+    "model": { "fg": "#090c0c", "bg": "#a3aed2" },
+    "thinking": { "fg": "#090c0c", "bg": "#a3aed2" },
+    "cwd": { "fg": "#e3e5e5", "bg": "#769ff0" },
+    "branch": { "fg": "#769ff0", "bg": "#394260" },
+    "tools": { "fg": "#769ff0", "bg": "#212736" },
+    "context": { "fg": "#769ff0", "bg": "#212736" },
+    "tokens": { "fg": "#769ff0", "bg": "#212736" },
+    "cost": { "fg": "#a0a9cb", "bg": "#1d2230" },
+    "time": { "fg": "#a0a9cb", "bg": "#1d2230" },
+    "turn": { "fg": "#a0a9cb", "bg": "#1d2230" }
+  },
   "density": "compact",
   "separator": "none",
   "segments": [
@@ -96,11 +109,29 @@ All fields are optional in an existing document. Missing fields use defaults.
 
 ### Appearance
 
-- `palette`: `tokyo-night`, `ocean`, `sunset`, `forest`, `candy`, `neon`, or `mono`.
+- `palette`: maps each segment to foreground (`fg`) and background (`bg`) colors.
 - `density`: `compact` or `cozy`.
 - `separator`: `none`, `dot`, `bar`, `powerline`, or `round`.
 
+Each palette color must be a complete `#RRGGBB` truecolor value. The generated default document contains the complete Tokyo Night palette. Missing segment entries or color fields inherit Tokyo Night defaults, so existing partial documents remain valid. Legacy string palettes—`tokyo-night`, `ocean`, `sunset`, `forest`, `candy`, `neon`, and `mono`—remain accepted for compatibility.
+
 The separator applies only between adjacent segments in the same color block. Color-block transitions always use ``. Extension statuses remain on separate wrapped lines with their own palette-colored separator.
+
+For example, after moving `time` before the header segments, give it the same colors as the Tokyo Night header to keep one continuous block:
+
+```json
+{
+  "segments": ["time", "brand", "provider", "model"],
+  "palette": {
+    "time": {
+      "fg": "#090c0c",
+      "bg": "#a3aed2"
+    }
+  }
+}
+```
+
+Adjacent segments with the same configured foreground and background render as one block. Invalid colors prevent `/statusline settings` from saving. Unknown segment names or palette fields are reported as warnings and ignored.
 
 ### Segments
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -45,6 +45,7 @@ There are no project overrides or environment-variable overrides.
 
 ```json
 {
+  "palettePreset": "tokyo-night",
   "palette": {
     "brand": { "fg": "#090c0c", "bg": "#a3aed2" },
     "provider": { "fg": "#090c0c", "bg": "#a3aed2" },
@@ -109,18 +110,20 @@ All fields are optional in an existing document. Missing fields use defaults.
 
 ### Appearance
 
-- `palette`: maps each segment to foreground (`fg`) and background (`bg`) colors.
+- `palettePreset`: `tokyo-night`, `ocean`, `sunset`, `forest`, `candy`, `neon`, `mono`, or `custom`.
+- `palette`: maps each segment to foreground (`fg`) and background (`bg`) colors used by `custom`.
 - `density`: `compact` or `cozy`.
 - `separator`: `none`, `dot`, `bar`, `powerline`, or `round`.
 
-Each palette color must be a complete `#RRGGBB` truecolor value. The generated default document contains the complete Tokyo Night palette. Missing segment entries or color fields inherit Tokyo Night defaults, so existing partial documents remain valid. Legacy string palettes—`tokyo-night`, `ocean`, `sunset`, `forest`, `candy`, `neon`, and `mono`—remain accepted for compatibility.
+Named presets use their built-in colors while preserving the complete custom `palette` object. Selecting `custom` activates that object. If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
 
-The separator applies only between adjacent segments in the same color block. Color-block transitions always use ``. Extension statuses remain on separate wrapped lines with their own palette-colored separator.
+Each custom palette color must be a complete `#RRGGBB` truecolor value. Missing segment entries or color fields inherit Tokyo Night defaults. The separator applies only between adjacent segments in the same color block, and transitions use ``. Extension statuses remain on separate wrapped lines with their preset-colored separator; `custom` uses the Tokyo Night separator.
 
-For example, after moving `time` before the header segments, give it the same colors as the Tokyo Night header to keep one continuous block:
+For example, after moving `time` before the header segments, select `custom` and give it the same colors as the Tokyo Night header to keep one continuous block:
 
 ```json
 {
+  "palettePreset": "custom",
   "segments": ["time", "brand", "provider", "model"],
   "palette": {
     "time": {
@@ -131,7 +134,7 @@ For example, after moving `time` before the header segments, give it the same co
 }
 ```
 
-Adjacent segments with the same configured foreground and background render as one block. Invalid colors prevent `/statusline settings` from saving. Unknown segment names or palette fields are reported as warnings and ignored.
+Adjacent custom segments with the same configured foreground and background render as one block. Invalid presets or colors prevent `/statusline settings` from saving. Unknown segment names or palette fields are reported as warnings and ignored.
 
 ### Segments
 
@@ -195,11 +198,13 @@ Statuses from other extensions appear below the main powerline. The linked GitHu
 
 | Command | Purpose |
 | --- | --- |
+| `/statusline` | Open the TUI menu for palette presets, JSON settings, status, and help |
+| `/statusline palette` | Choose a named preset or the preserved custom palette |
 | `/statusline settings` | Edit raw JSON in TUI, validate, atomically save, and apply immediately |
 | `/statusline status` | Show settings path/source, effective appearance, segments, and diagnostics |
 | `/statusline help` | Show command and schema guidance |
 
-Invalid or cancelled edits leave both the previous file and effective runtime configuration unchanged. The editor is TUI-only; status and help are safe in TUI, print, JSON, and RPC modes.
+Preset selection and raw editing are TUI-only. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged. Status and help are safe in TUI, print, JSON, and RPC modes.
 
 ## 🌿 Git and activity details
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -190,8 +190,11 @@ Statuses from other extensions appear below the main powerline. The linked GitHu
 | Command | Purpose |
 | --- | --- |
 | `/statusline` | Open the interactive menu for palette presets, settings JSON, status, and help |
+| `/statusline settings` | Open the JSON settings editor in TUI mode |
+| `/statusline status` | Show the settings source, path, appearance, segments, and diagnostics |
+| `/statusline help` | Show command and schema guidance |
 
-`/statusline` does not accept arguments and requires TUI mode. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged.
+Argument-free `/statusline` requires TUI mode. The established `settings`, `status`, and `help` routes remain available for compatibility; RPC receives notifications instead of opening TUI-only controls. Unknown subcommands and trailing arguments are rejected. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged.
 
 ## 🌿 Git and activity details
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -10,7 +10,8 @@
 - Uses one Starship-inspired `░▒▓` / `` Tokyo Night layout.
 - Configures segment order, visibility, multiline breaks, surrounding text, palette, density, separators, and extension icons through JSON.
 - Creates a complete editable default configuration on first session start.
-- Applies validated `/statusline settings` edits immediately after an atomic save.
+- Previews palette presets as the picker cursor moves, then applies the selection only on Enter.
+- Applies validated JSON settings edits from the `/statusline` menu immediately after an atomic save.
 - Caches Git state outside footer rendering and guards stale session results.
 - Wraps extension statuses safely at narrow terminal widths.
 
@@ -115,7 +116,7 @@ All fields are optional in an existing document. Missing fields use defaults.
 - `density`: `compact` or `cozy`.
 - `separator`: `none`, `dot`, `bar`, `powerline`, or `round`.
 
-Named presets use their built-in colors while preserving the custom `palette` object. Selecting `custom` activates that object. If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
+Named presets use cohesive namesake color ramps while preserving the custom `palette` object. Selecting `custom` activates that object. If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
 
 Each custom palette color must be a complete `#RRGGBB` truecolor value. Missing segment entries or `fg`/`bg` fields remain unstyled and do not inherit colors from Tokyo Night. The separator applies only between adjacent segments in the same color block, and transitions use ``. Extension statuses remain on separate wrapped lines with their preset-colored separator; `custom` leaves that separator unstyled.
 
@@ -134,7 +135,7 @@ For example, after moving `time` before the header segments, select `custom` and
 }
 ```
 
-Adjacent custom segments with the same configured foreground and background render as one block. Segments with no configured colors also join into one unstyled block. Invalid presets or colors prevent `/statusline settings` from saving. Unknown segment names or palette fields are reported as warnings and ignored.
+Adjacent custom segments with the same configured foreground and background render as one block. Segments with no configured colors also join into one unstyled block. Invalid presets or colors prevent the menu's JSON settings action from saving. Unknown segment names or palette fields are reported as warnings and ignored.
 
 ### Segments
 
@@ -198,13 +199,9 @@ Statuses from other extensions appear below the main powerline. The linked GitHu
 
 | Command | Purpose |
 | --- | --- |
-| `/statusline` | Open the TUI menu for palette presets, JSON settings, status, and help |
-| `/statusline palette` | Choose a named preset or the preserved custom palette |
-| `/statusline settings` | Edit raw JSON in TUI, validate, atomically save, and apply immediately |
-| `/statusline status` | Show settings path/source, effective appearance, segments, and diagnostics |
-| `/statusline help` | Show command and schema guidance |
+| `/statusline` | Open the interactive menu for palette presets, JSON settings, status, and help |
 
-Preset selection and raw editing are TUI-only. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged. Status and help are safe in TUI, print, JSON, and RPC modes.
+`/statusline` does not accept arguments and requires TUI mode. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged.
 
 ## 🌿 Git and activity details
 
@@ -222,10 +219,22 @@ extensions/pi-statusline/
 │   ├── commands.ts
 │   ├── extension-status.ts
 │   ├── git-status.ts
+│   ├── powerline.ts
+│   ├── presets/
+│   │   ├── candy.ts
+│   │   ├── create-ramp.ts
+│   │   ├── custom.ts
+│   │   ├── forest.ts
+│   │   ├── index.ts
+│   │   ├── mono.ts
+│   │   ├── neon.ts
+│   │   ├── ocean.ts
+│   │   ├── sunset.ts
+│   │   ├── tokyo-night.ts
+│   │   └── types.ts
 │   ├── render.ts
 │   ├── settings.ts
 │   ├── statusline.ts
-│   ├── tokyo-night.ts
 │   └── types.ts
 ├── test/
 ├── README.md

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -37,7 +37,7 @@ The only configuration source is:
 <getAgentDir()>/pi-statusline.json
 ```
 
-On first session start, the extension atomically creates the complete default document. It never overwrites an existing malformed or unreadable file. A valid legacy `pi-statusline-settings.json` is migrated by preserving its original bytes; the canonical filename wins when both exist.
+On first session start, the extension atomically creates the complete default document with `palettePreset` set to `tokyo-night`. It never overwrites an existing malformed or unreadable file. A valid legacy `pi-statusline-settings.json` is migrated by preserving its original bytes; the canonical filename wins when both exist.
 
 There are no project overrides or environment-variable overrides.
 
@@ -115,9 +115,9 @@ All fields are optional in an existing document. Missing fields use defaults.
 - `density`: `compact` or `cozy`.
 - `separator`: `none`, `dot`, `bar`, `powerline`, or `round`.
 
-Named presets use their built-in colors while preserving the complete custom `palette` object. Selecting `custom` activates that object. If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
+Named presets use their built-in colors while preserving the custom `palette` object. Selecting `custom` activates that object. If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
 
-Each custom palette color must be a complete `#RRGGBB` truecolor value. Missing segment entries or color fields inherit Tokyo Night defaults. The separator applies only between adjacent segments in the same color block, and transitions use ``. Extension statuses remain on separate wrapped lines with their preset-colored separator; `custom` uses the Tokyo Night separator.
+Each custom palette color must be a complete `#RRGGBB` truecolor value. Missing segment entries or `fg`/`bg` fields remain unstyled and do not inherit colors from Tokyo Night. The separator applies only between adjacent segments in the same color block, and transitions use ``. Extension statuses remain on separate wrapped lines with their preset-colored separator; `custom` leaves that separator unstyled.
 
 For example, after moving `time` before the header segments, select `custom` and give it the same colors as the Tokyo Night header to keep one continuous block:
 
@@ -134,7 +134,7 @@ For example, after moving `time` before the header segments, select `custom` and
 }
 ```
 
-Adjacent custom segments with the same configured foreground and background render as one block. Invalid presets or colors prevent `/statusline settings` from saving. Unknown segment names or palette fields are reported as warnings and ignored.
+Adjacent custom segments with the same configured foreground and background render as one block. Segments with no configured colors also join into one unstyled block. Invalid presets or colors prevent `/statusline settings` from saving. Unknown segment names or palette fields are reported as warnings and ignored.
 
 ### Segments
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -9,7 +9,7 @@
 - Shows provider, model, thinking, directory, Git/PR state, tools, context, tokens, cost, time, and extension statuses.
 - Uses one Starship-inspired `░▒▓` / `` Tokyo Night layout.
 - Configures segment order, visibility, multiline breaks, surrounding text, palette, density, separators, and extension icons through JSON.
-- Creates a complete editable default configuration on first session start.
+- Creates a concise editable default configuration on first session start.
 - Previews palette presets as the picker cursor moves, then applies the selection only on Enter.
 - Applies validated JSON settings edits from the `/statusline` menu immediately after an atomic save.
 - Caches Git state outside footer rendering and guards stale session results.
@@ -38,7 +38,7 @@ The only configuration source is:
 <getAgentDir()>/pi-statusline.json
 ```
 
-On first session start, the extension atomically creates the complete default document with `palettePreset` set to `tokyo-night`. It never overwrites an existing malformed or unreadable file. A valid legacy `pi-statusline-settings.json` is migrated by preserving its original bytes; the canonical filename wins when both exist.
+On first session start, the extension atomically creates a concise default document containing the common appearance and layout settings. Advanced fields continue to use built-in defaults until explicitly added. It never overwrites an existing malformed or unreadable file. A valid legacy `pi-statusline-settings.json` is migrated by preserving its original bytes; the canonical filename wins when both exist.
 
 There are no project overrides or environment-variable overrides.
 
@@ -47,20 +47,6 @@ There are no project overrides or environment-variable overrides.
 ```json
 {
   "palettePreset": "tokyo-night",
-  "palette": {
-    "brand": { "fg": "#090c0c", "bg": "#a3aed2" },
-    "provider": { "fg": "#090c0c", "bg": "#a3aed2" },
-    "model": { "fg": "#090c0c", "bg": "#a3aed2" },
-    "thinking": { "fg": "#090c0c", "bg": "#a3aed2" },
-    "cwd": { "fg": "#e3e5e5", "bg": "#769ff0" },
-    "branch": { "fg": "#769ff0", "bg": "#394260" },
-    "tools": { "fg": "#769ff0", "bg": "#212736" },
-    "context": { "fg": "#769ff0", "bg": "#212736" },
-    "tokens": { "fg": "#769ff0", "bg": "#212736" },
-    "cost": { "fg": "#a0a9cb", "bg": "#1d2230" },
-    "time": { "fg": "#a0a9cb", "bg": "#1d2230" },
-    "turn": { "fg": "#a0a9cb", "bg": "#1d2230" }
-  },
   "density": "compact",
   "separator": "none",
   "segments": [
@@ -75,35 +61,7 @@ There are no project overrides or environment-variable overrides.
     "tokens",
     "cost",
     "time"
-  ],
-  "segmentText": {
-    "brand": { "prefix": "", "suffix": "" },
-    "provider": { "prefix": "🔌 ", "suffix": "" },
-    "model": { "prefix": "🤖 ", "suffix": "" },
-    "thinking": { "prefix": "🧠 ", "suffix": "" },
-    "cwd": { "prefix": "📁 ", "suffix": "" },
-    "branch": { "prefix": "🌿 ", "suffix": "" },
-    "tools": { "prefix": "", "suffix": "" },
-    "context": { "prefix": "🪟 ctx ", "suffix": "" },
-    "tokens": { "prefix": "🔢 ", "suffix": "" },
-    "cost": { "prefix": "💸 $", "suffix": "" },
-    "time": { "prefix": "🕒 ", "suffix": "" },
-    "turn": { "prefix": "🔁 #", "suffix": "" }
-  },
-  "extensionStatusIcons": {
-    "chrome-devtools": "🌐",
-    "codex-usage": "📊",
-    "usage": "📊",
-    "caffeinate": "💊",
-    "firecrawl": "🔥",
-    "github-pr": "🔎",
-    "goal": "🎯",
-    "lsp": "🧰",
-    "plan-mode": "📝",
-    "pisync": "🔄",
-    "subagents": "🧑‍🤝‍🧑",
-    "unknown-error-retry": "🔁"
-  }
+  ]
 }
 ```
 
@@ -116,9 +74,11 @@ All fields are optional in an existing document. Missing fields use defaults.
 - `density`: `compact` or `cozy`.
 - `separator`: `none`, `dot`, `bar`, `powerline`, or `round`.
 
-Named presets use cohesive namesake color ramps while preserving the custom `palette` object. Selecting `custom` activates that object. If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
+Named presets use cohesive namesake color ramps while preserving an existing custom `palette` object. Selecting `custom` activates that object. When no palette object exists, choosing `custom` from `/statusline` writes a complete per-segment copy of the active named preset before activating it, so customization starts from the current appearance. The picker labels this editing relationship, and the main menu's `Edit settings JSON (custom colors, layout, icons)` action opens the existing JSON editor. It does not force an editor or present a separate per-color menu.
 
-Each custom palette color must be a complete `#RRGGBB` truecolor value. Missing segment entries or `fg`/`bg` fields remain unstyled and do not inherit colors from Tokyo Night. The separator applies only between adjacent segments in the same color block, and transitions use ``. Extension statuses remain on separate wrapped lines with their preset-colored separator; `custom` leaves that separator unstyled.
+If both fields exist, `palettePreset` decides which colors render. A palette object without `palettePreset` selects `custom`; with neither field, the default is `tokyo-night`. A manually authored `"palettePreset": "custom"` without a palette uses the built-in Tokyo Night colors. Legacy string palettes such as `"palette": "ocean"` remain accepted as preset selections.
+
+Each custom palette color must be a complete `#RRGGBB` truecolor value. Within an explicit `palette` object, missing segment entries or `fg`/`bg` fields remain unstyled and do not inherit colors from Tokyo Night. The separator applies only between adjacent segments in the same color block, and transitions use ``. Extension statuses remain on separate wrapped lines with their preset-colored separator; `custom` leaves that separator unstyled.
 
 For example, after moving `time` before the header segments, select `custom` and give it the same colors as the Tokyo Night header to keep one continuous block:
 
@@ -179,7 +139,7 @@ Override either string independently:
 }
 ```
 
-Prefix and suffix values must be single-line text without terminal control characters; use the `line_break` segment for additional rows.
+Prefix and suffix values must be single-line text without terminal control characters; use the `line_break` segment for additional rows. The built-in prefixes are `🔌 ` for provider, `🤖 ` for model, `🧠 ` for thinking, `📁 ` for cwd, `🌿 ` for branch, `🪟 ctx ` for context, `🔢 ` for tokens, `💸 $` for cost, `🕒 ` for time, and `🔁 #` for turn; brand and tools have no built-in prefix, and all built-in suffixes are empty.
 
 This structured model intentionally does not provide variables or a format language. Dynamic Git, PR, activity, usage, token, and cost formatting remains owned by the extension.
 
@@ -193,15 +153,17 @@ This structured model intentionally does not provide variables or a format langu
 - A missing key uses the built-in icon or `🔌` for an unknown key.
 - Ambiguous package aliases require an exact status key.
 
+Built-in icon mappings are `chrome-devtools` → `🌐`, `codex-usage` and `usage` → `📊`, `caffeinate` → `💊`, `firecrawl` → `🔥`, `github-pr` → `🔎`, `goal` → `🎯`, `lsp` → `🧰`, `plan-mode` → `📝`, `pisync` → `🔄`, `subagents` → `🧑‍🤝‍🧑`, and `unknown-error-retry` → `🔁`.
+
 Statuses from other extensions appear below the main powerline. The linked GitHub PR status is hidden from that line when the branch segment already renders it.
 
 ## 💬 Commands
 
 | Command | Purpose |
 | --- | --- |
-| `/statusline` | Open the interactive menu for palette presets, JSON settings, status, and help |
+| `/statusline` | Open the interactive menu for palette presets, settings JSON, status, and help |
 
-`/statusline` does not accept arguments and requires TUI mode. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged.
+`/statusline` does not accept arguments and requires TUI mode. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged.
 
 ## 🌿 Git and activity details
 

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -9,7 +9,7 @@
 - Shows provider, model, thinking, directory, Git/PR state, tools, context, tokens, cost, time, and extension statuses.
 - Uses one Starship-inspired `░▒▓` / `` Tokyo Night layout.
 - Configures segment order, visibility, multiline breaks, surrounding text, palette, density, separators, and extension icons through JSON.
-- Creates a concise editable default configuration on first session start.
+- Creates an editable default configuration without an inactive custom palette on first session start.
 - Previews palette presets as the picker cursor moves, then applies the selection only on Enter.
 - Applies validated JSON settings edits from the `/statusline` menu immediately after an atomic save.
 - Caches Git state outside footer rendering and guards stale session results.
@@ -38,7 +38,7 @@ The only configuration source is:
 <getAgentDir()>/pi-statusline.json
 ```
 
-On first session start, the extension atomically creates a concise default document containing the common appearance and layout settings. Advanced fields continue to use built-in defaults until explicitly added. It never overwrites an existing malformed or unreadable file. A valid legacy `pi-statusline-settings.json` is migrated by preserving its original bytes; the canonical filename wins when both exist.
+On first session start, the extension atomically creates an editable default document containing every active appearance and status-icon setting. The inactive custom `palette` is added only when needed. It never overwrites an existing malformed or unreadable file. A valid legacy `pi-statusline-settings.json` is migrated by preserving its original bytes; the canonical filename wins when both exist.
 
 There are no project overrides or environment-variable overrides.
 
@@ -61,7 +61,35 @@ There are no project overrides or environment-variable overrides.
     "tokens",
     "cost",
     "time"
-  ]
+  ],
+  "segmentText": {
+    "brand": { "prefix": "", "suffix": "" },
+    "provider": { "prefix": "🔌 ", "suffix": "" },
+    "model": { "prefix": "🤖 ", "suffix": "" },
+    "thinking": { "prefix": "🧠 ", "suffix": "" },
+    "cwd": { "prefix": "📁 ", "suffix": "" },
+    "branch": { "prefix": "🌿 ", "suffix": "" },
+    "tools": { "prefix": "", "suffix": "" },
+    "context": { "prefix": "🪟 ctx ", "suffix": "" },
+    "tokens": { "prefix": "🔢 ", "suffix": "" },
+    "cost": { "prefix": "💸 $", "suffix": "" },
+    "time": { "prefix": "🕒 ", "suffix": "" },
+    "turn": { "prefix": "🔁 #", "suffix": "" }
+  },
+  "extensionStatusIcons": {
+    "chrome-devtools": "🌐",
+    "codex-usage": "📊",
+    "usage": "📊",
+    "caffeinate": "💊",
+    "firecrawl": "🔥",
+    "github-pr": "🔎",
+    "goal": "🎯",
+    "lsp": "🧰",
+    "plan-mode": "📝",
+    "pisync": "🔄",
+    "subagents": "🧑‍🤝‍🧑",
+    "unknown-error-retry": "🔁"
+  }
 }
 ```
 

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -1,5 +1,9 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import {
+	DynamicBorder,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import { Container, type SelectItem, SelectList, Text } from "@earendil-works/pi-tui";
 import {
 	DEFAULT_STATUSLINE_DOCUMENT,
 	type LoadedStatuslineSettings,
@@ -7,58 +11,35 @@ import {
 } from "./settings.js";
 import { PALETTE_PRESET_NAMES, type PalettePreset } from "./types.js";
 
-const SUBCOMMANDS: AutocompleteItem[] = [
-	{ value: "palette", label: "palette", description: "Choose a palette preset" },
-	{ value: "settings", label: "settings", description: "Edit pi-statusline.json" },
-	{ value: "status", label: "status", description: "Show effective statusline settings" },
-	{ value: "help", label: "help", description: "Show configuration help" },
-];
-
 export interface StatuslineCommandOptions {
 	settingsPath: string;
 	getLoaded(): LoadedStatuslineSettings;
 	apply(loaded: LoadedStatuslineSettings, ctx: ExtensionCommandContext): void;
+	preview?(palettePreset: PalettePreset | undefined, ctx: ExtensionCommandContext): void;
 	save?: (settingsPath: string, rawDocument: string) => LoadedStatuslineSettings;
 }
 
 export function registerStatuslineCommand(pi: ExtensionAPI, options: StatuslineCommandOptions) {
 	pi.registerCommand("statusline", {
-		description: "Configure or inspect the statusline footer",
-		getArgumentCompletions(prefix: string): AutocompleteItem[] | null {
-			const normalized = prefix.trim().toLowerCase();
-			const matches = SUBCOMMANDS.filter((item) => item.value.startsWith(normalized));
-			return matches.length > 0 ? matches : null;
-		},
+		description: "Open the statusline settings and status menu",
 		handler: async (args, ctx) => {
-			const subcommand = args.trim().split(/\s+/u)[0]?.toLowerCase() ?? "";
-			switch (subcommand) {
-				case "":
-					await showMainMenu(ctx, options);
-					return;
-				case "palette":
-					await choosePalettePreset(ctx, options);
-					return;
-				case "settings":
-					await editSettings(ctx, options);
-					return;
-				case "status":
-					showStatus(ctx, options);
-					return;
-				case "help":
-					showHelp(ctx, options.settingsPath);
-					return;
-				default:
-					if (canNotify(ctx)) {
-						ctx.ui.notify(`Unknown /statusline subcommand: ${subcommand}`, "warning");
-					}
+			if (args.trim()) {
+				if (canNotify(ctx)) {
+					ctx.ui.notify(
+						"/statusline does not accept arguments; run it without arguments to open the menu.",
+						"warning",
+					);
+				}
+				return;
 			}
+			await showMainMenu(ctx, options);
 		},
 	});
 }
 
 async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
 	if (ctx.mode !== "tui") {
-		showHelp(ctx, options.settingsPath);
+		if (ctx.hasUI) ctx.ui.notify("/statusline requires an interactive Pi UI.", "error");
 		return;
 	}
 	const paletteItem = `Palette preset (${options.getLoaded().config.palettePreset})`;
@@ -93,14 +74,16 @@ async function choosePalettePreset(
 		return;
 	}
 	const current = options.getLoaded();
-	const selection = await ctx.ui.select(
-		`Palette preset (current: ${current.config.palettePreset})`,
-		[...PALETTE_PRESET_NAMES],
-	);
+	let selection: PalettePreset | undefined;
+	try {
+		selection = await showPalettePresetPicker(ctx, current.config.palettePreset, options);
+	} finally {
+		options.preview?.(undefined, ctx);
+	}
 	if (selection === undefined) return;
 
 	try {
-		const rawDocument = palettePresetDocument(current, selection as PalettePreset);
+		const rawDocument = palettePresetDocument(current, selection);
 		const loaded = (options.save ?? saveStatuslineSettingsDocument)(
 			options.settingsPath,
 			rawDocument,
@@ -110,6 +93,60 @@ async function choosePalettePreset(
 	} catch (error) {
 		ctx.ui.notify(`Palette preset was not saved: ${formatError(error)}`, "error");
 	}
+}
+
+async function showPalettePresetPicker(
+	ctx: ExtensionCommandContext,
+	current: PalettePreset,
+	options: StatuslineCommandOptions,
+): Promise<PalettePreset | undefined> {
+	const items: SelectItem[] = PALETTE_PRESET_NAMES.map((palettePreset) => ({
+		value: palettePreset,
+		label: palettePreset,
+		description: palettePreset === current ? "current" : undefined,
+	}));
+	const selectedIndex = PALETTE_PRESET_NAMES.indexOf(current);
+	const result = await ctx.ui.custom<PalettePreset | null>((tui, theme, _keybindings, done) => {
+		const container = new Container();
+		container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
+		const title = new Text("", 1, 0);
+		container.addChild(title);
+		const list = new SelectList(items, Math.min(items.length, 10), {
+			selectedPrefix: (text) => theme.fg("accent", text),
+			selectedText: (text) => theme.fg("accent", text),
+			description: (text) => theme.fg("muted", text),
+			scrollInfo: (text) => theme.fg("dim", text),
+			noMatch: (text) => theme.fg("warning", text),
+		});
+		list.setSelectedIndex(selectedIndex);
+		list.onSelectionChange = (item) => {
+			options.preview?.(item.value as PalettePreset, ctx);
+		};
+		list.onSelect = (item) => done(item.value as PalettePreset);
+		list.onCancel = () => done(null);
+		container.addChild(list);
+		const hint = new Text("", 1, 0);
+		container.addChild(hint);
+		container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
+		const updateThemedText = () => {
+			title.setText(theme.fg("accent", theme.bold(`Palette preset (current: ${current})`)));
+			hint.setText(theme.fg("dim", "↑↓ preview • enter apply • esc cancel"));
+		};
+		updateThemedText();
+
+		return {
+			render: (width: number) => container.render(width),
+			invalidate() {
+				container.invalidate();
+				updateThemedText();
+			},
+			handleInput(data: string) {
+				list.handleInput(data);
+				tui.requestRender();
+			},
+		};
+	});
+	return result ?? undefined;
 }
 
 async function editSettings(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
@@ -179,11 +216,8 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	if (!canNotify(ctx)) return;
 	ctx.ui.notify(
 		[
-			"/statusline — open the statusline menu",
-			"/statusline palette — choose a named or custom palette preset",
-			"/statusline settings — edit and apply JSON",
-			"/statusline status — show source, path, and warnings",
-			"/statusline help — show this help",
+			"/statusline — open the interactive statusline menu",
+			"Menu actions: Palette preset, Edit JSON settings, Status, Help",
 			`Settings: ${settingsPath}`,
 			"Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",
 			"Named presets ignore but preserve palette; custom uses its per-segment fg/bg colors.",

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -3,7 +3,13 @@ import {
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
-import { Container, type SelectItem, SelectList, Text } from "@earendil-works/pi-tui";
+import {
+	type AutocompleteItem,
+	Container,
+	type SelectItem,
+	SelectList,
+	Text,
+} from "@earendil-works/pi-tui";
 import { segmentPaletteForPreset } from "./presets/index.js";
 import {
 	DEFAULT_STATUSLINE_DOCUMENT,
@@ -18,6 +24,11 @@ import {
 } from "./types.js";
 
 const EDIT_SETTINGS_LABEL = "Edit settings JSON (custom colors, layout, icons)";
+const SUBCOMMANDS: AutocompleteItem[] = [
+	{ value: "settings", label: "settings", description: "Edit pi-statusline.json" },
+	{ value: "status", label: "status", description: "Show effective statusline settings" },
+	{ value: "help", label: "help", description: "Show configuration help" },
+];
 
 export interface StatuslineCommandOptions {
 	settingsPath: string;
@@ -29,18 +40,43 @@ export interface StatuslineCommandOptions {
 
 export function registerStatuslineCommand(pi: ExtensionAPI, options: StatuslineCommandOptions) {
 	pi.registerCommand("statusline", {
-		description: "Open the statusline settings and status menu",
+		description: "Open or inspect the statusline settings",
+		getArgumentCompletions(prefix: string): AutocompleteItem[] | null {
+			const normalized = prefix.trim().toLowerCase();
+			const matches = SUBCOMMANDS.filter((item) => item.value.startsWith(normalized));
+			return matches.length > 0 ? matches : null;
+		},
 		handler: async (args, ctx) => {
-			if (args.trim()) {
+			const normalized = args.trim();
+			if (!normalized) {
+				await showMainMenu(ctx, options);
+				return;
+			}
+
+			const tokens = normalized.split(/\s+/u);
+			const subcommand = tokens[0]?.toLowerCase() ?? "";
+			if (tokens.length > 1) {
 				if (canNotify(ctx)) {
-					ctx.ui.notify(
-						"/statusline does not accept arguments; run it without arguments to open the menu.",
-						"warning",
-					);
+					ctx.ui.notify(`/statusline ${subcommand} does not accept trailing arguments.`, "warning");
 				}
 				return;
 			}
-			await showMainMenu(ctx, options);
+
+			switch (subcommand) {
+				case "settings":
+					await editSettings(ctx, options);
+					return;
+				case "status":
+					showStatus(ctx, options);
+					return;
+				case "help":
+					showHelp(ctx, options.settingsPath);
+					return;
+				default:
+					if (canNotify(ctx)) {
+						ctx.ui.notify(`Unknown /statusline subcommand: ${subcommand}`, "warning");
+					}
+			}
 		},
 	});
 }
@@ -242,6 +278,9 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	ctx.ui.notify(
 		[
 			"/statusline — open the interactive statusline menu",
+			"/statusline settings — edit and apply JSON",
+			"/statusline status — show source, path, and warnings",
+			"/statusline help — show this help",
 			"Menu actions: Palette preset, Edit settings JSON, Status, Help",
 			`Settings: ${settingsPath}`,
 			"Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -75,6 +75,7 @@ async function editSettings(ctx: ExtensionCommandContext, options: StatuslineCom
 function showStatus(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
 	if (!canNotify(ctx)) return;
 	const loaded = options.getLoaded();
+	const palette = typeof loaded.config.palette === "string" ? loaded.config.palette : "configured";
 	const diagnostics = loaded.diagnostics
 		.slice(0, 5)
 		.map((item) => `${item.path || "root"}: ${item.message}`)
@@ -83,7 +84,7 @@ function showStatus(ctx: ExtensionCommandContext, options: StatuslineCommandOpti
 		[
 			`pi-statusline source: ${loaded.source}`,
 			`path: ${options.settingsPath}`,
-			`palette: ${loaded.config.palette}`,
+			`palette: ${palette}`,
 			`density: ${loaded.config.density}`,
 			`separator: ${loaded.config.separator}`,
 			`segments: ${loaded.config.segments.join(", ") || "none"}`,
@@ -102,6 +103,7 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 			"/statusline help — show this help",
 			`Settings: ${settingsPath}`,
 			"Fields: palette, density, separator, segments, segmentText, extensionStatusIcons",
+			"palette maps segment names to fg/bg full #RRGGBB colors.",
 			"Use line_break between segments for another footer row; repeats must not be consecutive.",
 			"The segmentText entries support prefix and suffix strings around Pi-owned dynamic values.",
 		].join("\n"),

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -4,12 +4,20 @@ import {
 	type ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
 import { Container, type SelectItem, SelectList, Text } from "@earendil-works/pi-tui";
+import { segmentPaletteForPreset } from "./presets/index.js";
 import {
 	DEFAULT_STATUSLINE_DOCUMENT,
 	type LoadedStatuslineSettings,
 	saveStatuslineSettingsDocument,
 } from "./settings.js";
-import { PALETTE_PRESET_NAMES, type PalettePreset } from "./types.js";
+import {
+	PALETTE_NAMES,
+	PALETTE_PRESET_NAMES,
+	type PaletteName,
+	type PalettePreset,
+} from "./types.js";
+
+const EDIT_SETTINGS_LABEL = "Edit settings JSON (custom colors, layout, icons)";
 
 export interface StatuslineCommandOptions {
 	settingsPath: string;
@@ -45,7 +53,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 	const paletteItem = `Palette preset (${options.getLoaded().config.palettePreset})`;
 	const selection = await ctx.ui.select("pi-statusline", [
 		paletteItem,
-		"Edit JSON settings",
+		EDIT_SETTINGS_LABEL,
 		"Status",
 		"Help",
 	]);
@@ -54,7 +62,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 		return;
 	}
 	switch (selection) {
-		case "Edit JSON settings":
+		case EDIT_SETTINGS_LABEL:
 			await editSettings(ctx, options);
 			return;
 		case "Status":
@@ -89,7 +97,11 @@ async function choosePalettePreset(
 			rawDocument,
 		);
 		options.apply(loaded, ctx);
-		ctx.ui.notify(`Palette preset applied: ${loaded.config.palettePreset}.`, "info");
+		const message =
+			loaded.config.palettePreset === "custom"
+				? "Custom palette applied. Edit palette colors via /statusline → Edit settings JSON."
+				: `Palette preset applied: ${loaded.config.palettePreset}.`;
+		ctx.ui.notify(message, "info");
 	} catch (error) {
 		ctx.ui.notify(`Palette preset was not saved: ${formatError(error)}`, "error");
 	}
@@ -103,7 +115,13 @@ async function showPalettePresetPicker(
 	const items: SelectItem[] = PALETTE_PRESET_NAMES.map((palettePreset) => ({
 		value: palettePreset,
 		label: palettePreset,
-		description: palettePreset === current ? "current" : undefined,
+		description:
+			[
+				palettePreset === current ? "current" : undefined,
+				palettePreset === "custom" ? "per-segment colors from settings JSON" : undefined,
+			]
+				.filter((part): part is string => part !== undefined)
+				.join(" • ") || undefined,
 	}));
 	const selectedIndex = PALETTE_PRESET_NAMES.indexOf(current);
 	const result = await ctx.ui.custom<PalettePreset | null>((tui, theme, _keybindings, done) => {
@@ -186,7 +204,14 @@ function palettePresetDocument(
 	}
 	const parsed = JSON.parse(current.rawDocument) as unknown;
 	if (!isRecord(parsed)) throw new Error("Settings must contain a JSON object");
-	if (!isRecord(parsed.palette)) parsed.palette = {};
+	if (palettePreset === "custom" && !isRecord(parsed.palette)) {
+		const seedPreset = isPaletteName(current.config.palettePreset)
+			? current.config.palettePreset
+			: "tokyo-night";
+		parsed.palette = segmentPaletteForPreset(seedPreset);
+	} else if (palettePreset !== "custom" && typeof parsed.palette === "string") {
+		delete parsed.palette;
+	}
 	parsed.palettePreset = palettePreset;
 	return `${JSON.stringify(parsed, null, "\t")}\n`;
 }
@@ -217,7 +242,7 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	ctx.ui.notify(
 		[
 			"/statusline — open the interactive statusline menu",
-			"Menu actions: Palette preset, Edit JSON settings, Status, Help",
+			"Menu actions: Palette preset, Edit settings JSON, Status, Help",
 			`Settings: ${settingsPath}`,
 			"Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",
 			"Named presets ignore but preserve palette; custom uses its per-segment fg/bg colors.",
@@ -230,6 +255,10 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPaletteName(value: PalettePreset): value is PaletteName {
+	return (PALETTE_NAMES as readonly PalettePreset[]).includes(value);
 }
 
 function canNotify(ctx: ExtensionCommandContext): boolean {

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -1,12 +1,15 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import {
+	createDefaultConfig,
 	DEFAULT_STATUSLINE_DOCUMENT,
 	type LoadedStatuslineSettings,
 	saveStatuslineSettingsDocument,
 } from "./settings.js";
+import { PALETTE_PRESET_NAMES, type PalettePreset } from "./types.js";
 
 const SUBCOMMANDS: AutocompleteItem[] = [
+	{ value: "palette", label: "palette", description: "Choose a palette preset" },
 	{ value: "settings", label: "settings", description: "Edit pi-statusline.json" },
 	{ value: "status", label: "status", description: "Show effective statusline settings" },
 	{ value: "help", label: "help", description: "Show configuration help" },
@@ -21,15 +24,21 @@ export interface StatuslineCommandOptions {
 
 export function registerStatuslineCommand(pi: ExtensionAPI, options: StatuslineCommandOptions) {
 	pi.registerCommand("statusline", {
-		description: "Edit or inspect the Tokyo Night footer settings",
+		description: "Configure or inspect the statusline footer",
 		getArgumentCompletions(prefix: string): AutocompleteItem[] | null {
 			const normalized = prefix.trim().toLowerCase();
 			const matches = SUBCOMMANDS.filter((item) => item.value.startsWith(normalized));
 			return matches.length > 0 ? matches : null;
 		},
 		handler: async (args, ctx) => {
-			const subcommand = args.trim().split(/\s+/u)[0]?.toLowerCase() || "help";
+			const subcommand = args.trim().split(/\s+/u)[0]?.toLowerCase() ?? "";
 			switch (subcommand) {
+				case "":
+					await showMainMenu(ctx, options);
+					return;
+				case "palette":
+					await choosePalettePreset(ctx, options);
+					return;
 				case "settings":
 					await editSettings(ctx, options);
 					return;
@@ -46,6 +55,62 @@ export function registerStatuslineCommand(pi: ExtensionAPI, options: StatuslineC
 			}
 		},
 	});
+}
+
+async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
+	if (ctx.mode !== "tui") {
+		showHelp(ctx, options.settingsPath);
+		return;
+	}
+	const paletteItem = `Palette preset (${options.getLoaded().config.palettePreset})`;
+	const selection = await ctx.ui.select("pi-statusline", [
+		paletteItem,
+		"Edit JSON settings",
+		"Status",
+		"Help",
+	]);
+	if (selection === paletteItem) {
+		await choosePalettePreset(ctx, options);
+		return;
+	}
+	switch (selection) {
+		case "Edit JSON settings":
+			await editSettings(ctx, options);
+			return;
+		case "Status":
+			showStatus(ctx, options);
+			return;
+		case "Help":
+			showHelp(ctx, options.settingsPath);
+	}
+}
+
+async function choosePalettePreset(
+	ctx: ExtensionCommandContext,
+	options: StatuslineCommandOptions,
+) {
+	if (ctx.mode !== "tui") {
+		if (ctx.hasUI) ctx.ui.notify(`Edit palettePreset manually: ${options.settingsPath}`, "info");
+		return;
+	}
+	const current = options.getLoaded();
+	const selection = await ctx.ui.select(
+		`Palette preset (current: ${current.config.palettePreset})`,
+		[...PALETTE_PRESET_NAMES],
+	);
+	if (selection === undefined) return;
+
+	try {
+		const rawDocument = palettePresetDocument(current, selection as PalettePreset);
+		const loaded = (options.save ?? saveStatuslineSettingsDocument)(
+			options.settingsPath,
+			rawDocument,
+		);
+		options.apply(loaded, ctx);
+		ctx.ui.notify(`Palette preset applied: ${loaded.config.palettePreset}.`, "info");
+	} catch (error) {
+		ctx.ui.notify(`Palette preset was not saved: ${formatError(error)}`, "error");
+	}
 }
 
 async function editSettings(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
@@ -72,10 +137,27 @@ async function editSettings(ctx: ExtensionCommandContext, options: StatuslineCom
 	}
 }
 
+function palettePresetDocument(
+	current: LoadedStatuslineSettings,
+	palettePreset: PalettePreset,
+): string {
+	if (
+		current.source !== "user" ||
+		current.rawDocument === undefined ||
+		current.diagnostics.some((item) => item.code !== "unknown")
+	) {
+		throw new Error("Fix pi-statusline.json before choosing a palette preset");
+	}
+	const parsed = JSON.parse(current.rawDocument) as unknown;
+	if (!isRecord(parsed)) throw new Error("Settings must contain a JSON object");
+	if (!isRecord(parsed.palette)) parsed.palette = createDefaultConfig().palette;
+	parsed.palettePreset = palettePreset;
+	return `${JSON.stringify(parsed, null, "\t")}\n`;
+}
+
 function showStatus(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
 	if (!canNotify(ctx)) return;
 	const loaded = options.getLoaded();
-	const palette = typeof loaded.config.palette === "string" ? loaded.config.palette : "configured";
 	const diagnostics = loaded.diagnostics
 		.slice(0, 5)
 		.map((item) => `${item.path || "root"}: ${item.message}`)
@@ -84,7 +166,7 @@ function showStatus(ctx: ExtensionCommandContext, options: StatuslineCommandOpti
 		[
 			`pi-statusline source: ${loaded.source}`,
 			`path: ${options.settingsPath}`,
-			`palette: ${palette}`,
+			`palette preset: ${loaded.config.palettePreset}`,
 			`density: ${loaded.config.density}`,
 			`separator: ${loaded.config.separator}`,
 			`segments: ${loaded.config.segments.join(", ") || "none"}`,
@@ -98,17 +180,23 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	if (!canNotify(ctx)) return;
 	ctx.ui.notify(
 		[
+			"/statusline — open the statusline menu",
+			"/statusline palette — choose a named or custom palette preset",
 			"/statusline settings — edit and apply JSON",
 			"/statusline status — show source, path, and warnings",
 			"/statusline help — show this help",
 			`Settings: ${settingsPath}`,
-			"Fields: palette, density, separator, segments, segmentText, extensionStatusIcons",
-			"palette maps segment names to fg/bg full #RRGGBB colors.",
+			"Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",
+			"Named presets ignore but preserve palette; custom uses its per-segment fg/bg colors.",
 			"Use line_break between segments for another footer row; repeats must not be consecutive.",
 			"The segmentText entries support prefix and suffix strings around Pi-owned dynamic values.",
 		].join("\n"),
 		"info",
 	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function canNotify(ctx: ExtensionCommandContext): boolean {

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -1,7 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import {
-	createDefaultConfig,
 	DEFAULT_STATUSLINE_DOCUMENT,
 	type LoadedStatuslineSettings,
 	saveStatuslineSettingsDocument,
@@ -150,7 +149,7 @@ function palettePresetDocument(
 	}
 	const parsed = JSON.parse(current.rawDocument) as unknown;
 	if (!isRecord(parsed)) throw new Error("Settings must contain a JSON object");
-	if (!isRecord(parsed.palette)) parsed.palette = createDefaultConfig().palette;
+	if (!isRecord(parsed.palette)) parsed.palette = {};
 	parsed.palettePreset = palettePreset;
 	return `${JSON.stringify(parsed, null, "\t")}\n`;
 }

--- a/extensions/pi-statusline/src/extension-status.ts
+++ b/extensions/pi-statusline/src/extension-status.ts
@@ -16,7 +16,7 @@ export interface ExtensionStatusRuntime {
 const STATUSLINE_KEY = "statusline";
 const EMPTY_EXTENSION_STATUS_ICON_ALIASES: ExtensionStatusIconAliasMap = new Map();
 function extensionStatusSeparator(config: StatuslineConfig, theme: Theme): string {
-	return tokyoNightExtensionSeparator(theme, config.palette);
+	return tokyoNightExtensionSeparator(theme, config.palettePreset);
 }
 
 export function formatExtensionStatuses(

--- a/extensions/pi-statusline/src/extension-status.ts
+++ b/extensions/pi-statusline/src/extension-status.ts
@@ -3,8 +3,8 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import process from "node:process";
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { powerlineExtensionSeparator } from "./powerline.js";
 import { DEFAULT_EXTENSION_STATUS_ICONS } from "./settings.js";
-import { tokyoNightExtensionSeparator } from "./tokyo-night.js";
 import type { StatuslineConfig } from "./types.js";
 
 export type ExtensionStatusIconAliasMap = ReadonlyMap<string, readonly string[]>;
@@ -16,7 +16,7 @@ export interface ExtensionStatusRuntime {
 const STATUSLINE_KEY = "statusline";
 const EMPTY_EXTENSION_STATUS_ICON_ALIASES: ExtensionStatusIconAliasMap = new Map();
 function extensionStatusSeparator(config: StatuslineConfig, theme: Theme): string {
-	return tokyoNightExtensionSeparator(theme, config.palettePreset);
+	return powerlineExtensionSeparator(theme, config.palettePreset);
 }
 
 export function formatExtensionStatuses(

--- a/extensions/pi-statusline/src/powerline.ts
+++ b/extensions/pi-statusline/src/powerline.ts
@@ -1,80 +1,26 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import { ansiStyle } from "./ansi.js";
+import { resolvePreset } from "./presets/index.js";
+import type { BlockColors, PowerlinePreset } from "./presets/types.js";
 import {
 	LINE_BREAK_SEGMENT_NAME,
-	type PaletteName,
 	type PalettePreset,
+	type PowerlineBlockName,
 	type RenderItem,
 	type RenderSegment,
 	type SegmentPalette,
 	type SeparatorName,
 	type StatuslineConfig,
-	type TokyoNightBlockName,
 } from "./types.js";
 
-interface TokyoNightBlock {
-	baseBlock: TokyoNightBlockName;
+interface PowerlineBlock {
+	baseBlock: PowerlineBlockName;
 	colors: BlockColors;
 	segments: RenderSegment[];
 }
 
-interface BlockColors {
-	fg?: string;
-	bg?: string;
-}
-
-interface PowerlinePalette {
-	lead?: string;
-	blocks: Record<TokyoNightBlockName, BlockColors>;
-	extensionSeparator?: string;
-}
-
-const BLOCK_NAMES: TokyoNightBlockName[] = ["header", "directory", "git", "runtime", "meter"];
-
-const TOKYO_NIGHT_PALETTE: PowerlinePalette = {
-	lead: "#a3aed2",
-	blocks: {
-		header: { fg: "#090c0c", bg: "#a3aed2" },
-		directory: { fg: "#e3e5e5", bg: "#769ff0" },
-		git: { fg: "#769ff0", bg: "#394260" },
-		runtime: { fg: "#769ff0", bg: "#212736" },
-		meter: { fg: "#a0a9cb", bg: "#1d2230" },
-	},
-	extensionSeparator: "#394260",
-};
-
-const UNSTYLED_PALETTE: PowerlinePalette = {
-	blocks: {
-		header: {},
-		directory: {},
-		git: {},
-		runtime: {},
-		meter: {},
-	},
-};
-
-const SEMANTIC_COLORS = {
-	accent: "#7aa2f7",
-	muted: "#565f89",
-	success: "#9ece6a",
-	warning: "#e0af68",
-	error: "#f7768e",
-	dim: "#414868",
-} as const;
-
-type SemanticColor = keyof typeof SEMANTIC_COLORS;
-
-const PALETTE_SEQUENCES: Record<Exclude<PaletteName, "tokyo-night">, SemanticColor[]> = {
-	ocean: ["accent", "muted", "success", "warning"],
-	sunset: ["warning", "accent", "success", "muted"],
-	forest: ["success", "accent", "muted", "warning"],
-	candy: ["accent", "warning", "success", "muted"],
-	neon: ["accent", "success", "warning", "error"],
-	mono: ["muted", "dim"],
-};
-
-export function renderTokyoNightStatusline(
+export function renderPowerlineStatusline(
 	width: number,
 	items: RenderItem[],
 	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
@@ -84,7 +30,7 @@ export function renderTokyoNightStatusline(
 		.map((segments) =>
 			segments.length === 0
 				? ""
-				: truncateToWidth(joinTokyoNightSegments(segments, config), width, ""),
+				: truncateToWidth(joinPowerlineSegments(segments, config), width, ""),
 		)
 		.join("\n");
 }
@@ -98,20 +44,20 @@ function splitLines(items: RenderItem[]): RenderSegment[][] {
 	return lines;
 }
 
-export function tokyoNightExtensionSeparator(
+export function powerlineExtensionSeparator(
 	_theme: Theme,
 	palettePreset: PalettePreset = "tokyo-night",
 ): string {
-	return ansiStyle(" • ", { fg: resolvePalette(palettePreset).extensionSeparator });
+	return ansiStyle(" • ", { fg: resolvePreset(palettePreset).extensionSeparator });
 }
 
-function joinTokyoNightSegments(
+function joinPowerlineSegments(
 	segments: RenderSegment[],
 	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
 ): string {
-	const palette = resolvePalette(config.palettePreset);
-	const blocks = contiguousBlocks(segments, palette, config.palettePreset, config.palette);
-	let line = ansiStyle("░▒▓", { fg: palette.lead });
+	const preset = resolvePreset(config.palettePreset);
+	const blocks = contiguousBlocks(segments, preset, config.palettePreset, config.palette);
+	let line = ansiStyle("░▒▓", { fg: preset.lead });
 
 	for (const [index, block] of blocks.entries()) {
 		const previous = index === 0 ? undefined : blocks[index - 1]?.colors;
@@ -126,16 +72,16 @@ function joinTokyoNightSegments(
 
 function contiguousBlocks(
 	segments: RenderSegment[],
-	palette: PowerlinePalette,
+	preset: PowerlinePreset,
 	palettePreset: PalettePreset,
 	configuredPalette: SegmentPalette,
-): TokyoNightBlock[] {
-	const blocks: TokyoNightBlock[] = [];
+): PowerlineBlock[] {
+	const blocks: PowerlineBlock[] = [];
 	const usesConfiguredColors = palettePreset === "custom";
 	for (const segment of segments) {
 		const colors = usesConfiguredColors
 			? (configuredPalette[segment.name] ?? {})
-			: palette.blocks[segment.block];
+			: preset.blocks[segment.block];
 		const previous = blocks.at(-1);
 		const matchesPrevious =
 			previous !== undefined &&
@@ -153,7 +99,7 @@ function colorsEqual(left: BlockColors, right: BlockColors): boolean {
 }
 
 function formatBlockText(
-	block: TokyoNightBlock,
+	block: PowerlineBlock,
 	config: Pick<StatuslineConfig, "density" | "separator">,
 ): string {
 	const texts = block.segments.map(formatSegmentText);
@@ -181,31 +127,4 @@ function separatorText(separator: SeparatorName, cozy: boolean): string {
 		case "none":
 			return padding;
 	}
-}
-
-function resolvePalette(palettePreset: PalettePreset): PowerlinePalette {
-	if (palettePreset === "custom") return UNSTYLED_PALETTE;
-	if (palettePreset === "tokyo-night") return TOKYO_NIGHT_PALETTE;
-	const sequence = PALETTE_SEQUENCES[palettePreset];
-	const backgrounds = BLOCK_NAMES.map(
-		(_block, index) => SEMANTIC_COLORS[sequence[index % sequence.length] ?? "muted"],
-	);
-	return {
-		lead: backgrounds[0] ?? SEMANTIC_COLORS.accent,
-		blocks: Object.fromEntries(
-			BLOCK_NAMES.map((block, index) => {
-				const background = backgrounds[index] ?? SEMANTIC_COLORS.muted;
-				return [block, { fg: contrastColor(background), bg: background }];
-			}),
-		) as Record<TokyoNightBlockName, BlockColors>,
-		extensionSeparator: backgrounds[2] ?? SEMANTIC_COLORS.muted,
-	};
-}
-
-function contrastColor(hex: string): string {
-	const normalized = hex.slice(1);
-	const red = Number.parseInt(normalized.slice(0, 2), 16);
-	const green = Number.parseInt(normalized.slice(2, 4), 16);
-	const blue = Number.parseInt(normalized.slice(4, 6), 16);
-	return red * 0.299 + green * 0.587 + blue * 0.114 > 150 ? "#090c0c" : "#f0f0f0";
 }

--- a/extensions/pi-statusline/src/presets/candy.ts
+++ b/extensions/pi-statusline/src/presets/candy.ts
@@ -1,0 +1,9 @@
+import { createRampPreset } from "./create-ramp.js";
+
+export const CANDY_PRESET = createRampPreset([
+	"#f5c2e7",
+	"#cba6f7",
+	"#89b4fa",
+	"#745f9a",
+	"#403a5c",
+]);

--- a/extensions/pi-statusline/src/presets/create-ramp.ts
+++ b/extensions/pi-statusline/src/presets/create-ramp.ts
@@ -1,0 +1,41 @@
+import type { PowerlineBlockName } from "../types.js";
+import type { PowerlinePreset } from "./types.js";
+
+const BLOCK_NAMES: PowerlineBlockName[] = ["header", "directory", "git", "runtime", "meter"];
+
+type PaletteRamp = readonly [string, string, string, string, string];
+
+export function createRampPreset(backgrounds: PaletteRamp): PowerlinePreset {
+	return {
+		lead: backgrounds[0],
+		blocks: Object.fromEntries(
+			BLOCK_NAMES.map((block, index) => {
+				const background = backgrounds[index];
+				return [block, { fg: contrastColor(background), bg: background }];
+			}),
+		) as Record<PowerlineBlockName, { fg: string; bg: string }>,
+		extensionSeparator: backgrounds[2],
+	};
+}
+
+function contrastColor(hex: string): string {
+	const background = relativeLuminance(hex);
+	const dark = relativeLuminance("#090c0c");
+	const light = relativeLuminance("#f0f0f0");
+	return contrastRatio(background, dark) >= contrastRatio(background, light)
+		? "#090c0c"
+		: "#f0f0f0";
+}
+
+function contrastRatio(left: number, right: number): number {
+	return (Math.max(left, right) + 0.05) / (Math.min(left, right) + 0.05);
+}
+
+function relativeLuminance(hex: string): number {
+	const normalized = hex.slice(1);
+	const channels = [0, 2, 4].map((offset) => {
+		const value = Number.parseInt(normalized.slice(offset, offset + 2), 16) / 255;
+		return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+	});
+	return 0.2126 * (channels[0] ?? 0) + 0.7152 * (channels[1] ?? 0) + 0.0722 * (channels[2] ?? 0);
+}

--- a/extensions/pi-statusline/src/presets/custom.ts
+++ b/extensions/pi-statusline/src/presets/custom.ts
@@ -1,0 +1,11 @@
+import type { PowerlinePreset } from "./types.js";
+
+export const CUSTOM_PRESET: PowerlinePreset = {
+	blocks: {
+		header: {},
+		directory: {},
+		git: {},
+		runtime: {},
+		meter: {},
+	},
+};

--- a/extensions/pi-statusline/src/presets/forest.ts
+++ b/extensions/pi-statusline/src/presets/forest.ts
@@ -1,0 +1,9 @@
+import { createRampPreset } from "./create-ramp.js";
+
+export const FOREST_PRESET = createRampPreset([
+	"#a7c080",
+	"#83c092",
+	"#5f9f75",
+	"#3f6f55",
+	"#293f35",
+]);

--- a/extensions/pi-statusline/src/presets/index.ts
+++ b/extensions/pi-statusline/src/presets/index.ts
@@ -1,4 +1,11 @@
-import type { PalettePreset } from "../types.js";
+import {
+	type PaletteName,
+	type PalettePreset,
+	type PowerlineBlockName,
+	SEGMENT_NAMES,
+	type SegmentName,
+	type SegmentPalette,
+} from "../types.js";
 import { CANDY_PRESET } from "./candy.js";
 import { CUSTOM_PRESET } from "./custom.js";
 import { FOREST_PRESET } from "./forest.js";
@@ -20,6 +27,28 @@ const PRESETS = {
 	custom: CUSTOM_PRESET,
 } satisfies Record<PalettePreset, PowerlinePreset>;
 
+const SEGMENT_BLOCKS: Record<SegmentName, PowerlineBlockName> = {
+	brand: "header",
+	provider: "header",
+	model: "header",
+	thinking: "header",
+	cwd: "directory",
+	branch: "git",
+	tools: "runtime",
+	context: "runtime",
+	tokens: "runtime",
+	cost: "meter",
+	time: "meter",
+	turn: "meter",
+};
+
 export function resolvePreset(preset: PalettePreset): PowerlinePreset {
 	return PRESETS[preset];
+}
+
+export function segmentPaletteForPreset(preset: PaletteName): SegmentPalette {
+	const blocks = PRESETS[preset].blocks;
+	return Object.fromEntries(
+		SEGMENT_NAMES.map((name) => [name, { ...blocks[SEGMENT_BLOCKS[name]] }]),
+	) as SegmentPalette;
 }

--- a/extensions/pi-statusline/src/presets/index.ts
+++ b/extensions/pi-statusline/src/presets/index.ts
@@ -1,0 +1,25 @@
+import type { PalettePreset } from "../types.js";
+import { CANDY_PRESET } from "./candy.js";
+import { CUSTOM_PRESET } from "./custom.js";
+import { FOREST_PRESET } from "./forest.js";
+import { MONO_PRESET } from "./mono.js";
+import { NEON_PRESET } from "./neon.js";
+import { OCEAN_PRESET } from "./ocean.js";
+import { SUNSET_PRESET } from "./sunset.js";
+import { TOKYO_NIGHT_PRESET } from "./tokyo-night.js";
+import type { PowerlinePreset } from "./types.js";
+
+const PRESETS = {
+	"tokyo-night": TOKYO_NIGHT_PRESET,
+	ocean: OCEAN_PRESET,
+	sunset: SUNSET_PRESET,
+	forest: FOREST_PRESET,
+	candy: CANDY_PRESET,
+	neon: NEON_PRESET,
+	mono: MONO_PRESET,
+	custom: CUSTOM_PRESET,
+} satisfies Record<PalettePreset, PowerlinePreset>;
+
+export function resolvePreset(preset: PalettePreset): PowerlinePreset {
+	return PRESETS[preset];
+}

--- a/extensions/pi-statusline/src/presets/mono.ts
+++ b/extensions/pi-statusline/src/presets/mono.ts
@@ -1,0 +1,9 @@
+import { createRampPreset } from "./create-ramp.js";
+
+export const MONO_PRESET = createRampPreset([
+	"#d4d4d4",
+	"#a3a3a3",
+	"#686868",
+	"#404040",
+	"#262626",
+]);

--- a/extensions/pi-statusline/src/presets/neon.ts
+++ b/extensions/pi-statusline/src/presets/neon.ts
@@ -1,0 +1,9 @@
+import { createRampPreset } from "./create-ramp.js";
+
+export const NEON_PRESET = createRampPreset([
+	"#39ff14",
+	"#00f5ff",
+	"#ff4fd8",
+	"#7a2cf3",
+	"#29134f",
+]);

--- a/extensions/pi-statusline/src/presets/ocean.ts
+++ b/extensions/pi-statusline/src/presets/ocean.ts
@@ -1,0 +1,9 @@
+import { createRampPreset } from "./create-ramp.js";
+
+export const OCEAN_PRESET = createRampPreset([
+	"#7dcfff",
+	"#4f9fba",
+	"#2d6f88",
+	"#23475b",
+	"#182b3a",
+]);

--- a/extensions/pi-statusline/src/presets/sunset.ts
+++ b/extensions/pi-statusline/src/presets/sunset.ts
@@ -1,0 +1,9 @@
+import { createRampPreset } from "./create-ramp.js";
+
+export const SUNSET_PRESET = createRampPreset([
+	"#ffcf70",
+	"#f59e6f",
+	"#dc718a",
+	"#8f5b78",
+	"#493447",
+]);

--- a/extensions/pi-statusline/src/presets/tokyo-night.ts
+++ b/extensions/pi-statusline/src/presets/tokyo-night.ts
@@ -1,4 +1,3 @@
-import type { SegmentPalette } from "../types.js";
 import type { PowerlinePreset } from "./types.js";
 
 export const TOKYO_NIGHT_PRESET: PowerlinePreset = {
@@ -11,19 +10,4 @@ export const TOKYO_NIGHT_PRESET: PowerlinePreset = {
 		meter: { fg: "#a0a9cb", bg: "#1d2230" },
 	},
 	extensionSeparator: "#394260",
-};
-
-export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
-	brand: { fg: "#090c0c", bg: "#a3aed2" },
-	provider: { fg: "#090c0c", bg: "#a3aed2" },
-	model: { fg: "#090c0c", bg: "#a3aed2" },
-	thinking: { fg: "#090c0c", bg: "#a3aed2" },
-	cwd: { fg: "#e3e5e5", bg: "#769ff0" },
-	branch: { fg: "#769ff0", bg: "#394260" },
-	tools: { fg: "#769ff0", bg: "#212736" },
-	context: { fg: "#769ff0", bg: "#212736" },
-	tokens: { fg: "#769ff0", bg: "#212736" },
-	cost: { fg: "#a0a9cb", bg: "#1d2230" },
-	time: { fg: "#a0a9cb", bg: "#1d2230" },
-	turn: { fg: "#a0a9cb", bg: "#1d2230" },
 };

--- a/extensions/pi-statusline/src/presets/tokyo-night.ts
+++ b/extensions/pi-statusline/src/presets/tokyo-night.ts
@@ -1,0 +1,29 @@
+import type { SegmentPalette } from "../types.js";
+import type { PowerlinePreset } from "./types.js";
+
+export const TOKYO_NIGHT_PRESET: PowerlinePreset = {
+	lead: "#a3aed2",
+	blocks: {
+		header: { fg: "#090c0c", bg: "#a3aed2" },
+		directory: { fg: "#e3e5e5", bg: "#769ff0" },
+		git: { fg: "#769ff0", bg: "#394260" },
+		runtime: { fg: "#769ff0", bg: "#212736" },
+		meter: { fg: "#a0a9cb", bg: "#1d2230" },
+	},
+	extensionSeparator: "#394260",
+};
+
+export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
+	brand: { fg: "#090c0c", bg: "#a3aed2" },
+	provider: { fg: "#090c0c", bg: "#a3aed2" },
+	model: { fg: "#090c0c", bg: "#a3aed2" },
+	thinking: { fg: "#090c0c", bg: "#a3aed2" },
+	cwd: { fg: "#e3e5e5", bg: "#769ff0" },
+	branch: { fg: "#769ff0", bg: "#394260" },
+	tools: { fg: "#769ff0", bg: "#212736" },
+	context: { fg: "#769ff0", bg: "#212736" },
+	tokens: { fg: "#769ff0", bg: "#212736" },
+	cost: { fg: "#a0a9cb", bg: "#1d2230" },
+	time: { fg: "#a0a9cb", bg: "#1d2230" },
+	turn: { fg: "#a0a9cb", bg: "#1d2230" },
+};

--- a/extensions/pi-statusline/src/presets/types.ts
+++ b/extensions/pi-statusline/src/presets/types.ts
@@ -1,0 +1,12 @@
+import type { PowerlineBlockName } from "../types.js";
+
+export interface BlockColors {
+	fg?: string;
+	bg?: string;
+}
+
+export interface PowerlinePreset {
+	lead?: string;
+	blocks: Record<PowerlineBlockName, BlockColors>;
+	extensionSeparator?: string;
+}

--- a/extensions/pi-statusline/src/render.ts
+++ b/extensions/pi-statusline/src/render.ts
@@ -12,14 +12,14 @@ import {
 	wrapExtensionStatusline,
 } from "./extension-status.js";
 import { formatGitBranchValue, type GitStatusSummary } from "./git-status.js";
-import { renderTokyoNightStatusline } from "./tokyo-night.js";
+import { renderPowerlineStatusline } from "./powerline.js";
 import {
 	LINE_BREAK_SEGMENT_NAME,
+	type PowerlineBlockName,
 	type RenderItem,
 	type RenderSegment,
 	type SegmentName,
 	type StatuslineConfig,
-	type TokyoNightBlockName,
 } from "./types.js";
 
 type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
@@ -62,7 +62,7 @@ export function renderStatusline(
 				(segment.name === LINE_BREAK_SEGMENT_NAME || segment.text.length > 0),
 		);
 
-	return renderTokyoNightStatusline(width, segments, config);
+	return renderPowerlineStatusline(width, segments, config);
 }
 
 export function renderExtensionStatusline(
@@ -161,7 +161,7 @@ function segment(
 	value: string,
 	config: StatuslineConfig,
 	color: RenderSegment["color"],
-	block: TokyoNightBlockName,
+	block: PowerlineBlockName,
 	emphasis = false,
 ): RenderSegment {
 	return { name, text: formatConfiguredSegment(name, value, config), color, block, emphasis };

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -85,7 +85,9 @@ const DEFAULT_STATUSLINE_DOCUMENT_CONFIG = {
 	density: DEFAULT_STATUSLINE_CONFIG.density,
 	separator: DEFAULT_STATUSLINE_CONFIG.separator,
 	segments: DEFAULT_SEGMENTS,
-} satisfies Pick<StatuslineConfig, "palettePreset" | "density" | "separator" | "segments">;
+	segmentText: DEFAULT_STATUSLINE_CONFIG.segmentText,
+	extensionStatusIcons: DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons,
+} satisfies Omit<StatuslineConfig, "palette">;
 
 export const DEFAULT_STATUSLINE_DOCUMENT = `${JSON.stringify(
 	DEFAULT_STATUSLINE_DOCUMENT_CONFIG,

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -15,6 +15,7 @@ import {
 	DENSITIES,
 	LINE_BREAK_SEGMENT_NAME,
 	PALETTE_NAMES,
+	PALETTE_PRESET_NAMES,
 	SEGMENT_NAMES,
 	SEPARATOR_NAMES,
 	type SegmentName,
@@ -56,6 +57,7 @@ const DEFAULT_SEGMENTS: SegmentName[] = [
 ];
 
 export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
+	palettePreset: "tokyo-night",
 	palette: cloneSegmentPalette(TOKYO_NIGHT_SEGMENT_PALETTE),
 	density: "compact",
 	separator: "none",
@@ -132,6 +134,7 @@ export function normalizeStatuslineConfig(value: unknown): {
 	}
 
 	const knownRoot = new Set([
+		"palettePreset",
 		"palette",
 		"density",
 		"separator",
@@ -144,6 +147,7 @@ export function normalizeStatuslineConfig(value: unknown): {
 	}
 
 	normalizePalette(value.palette, config, diagnostics);
+	normalizeEnum(value, "palettePreset", PALETTE_PRESET_NAMES, config, diagnostics);
 	normalizeEnum(value, "density", DENSITIES, config, diagnostics);
 	normalizeEnum(value, "separator", SEPARATOR_NAMES, config, diagnostics);
 
@@ -431,7 +435,7 @@ function normalizePalette(
 			);
 			return;
 		}
-		config.palette = value as StatuslineConfig["palette"];
+		config.palettePreset = value as (typeof PALETTE_NAMES)[number];
 		return;
 	}
 	if (!isRecord(value)) {
@@ -464,9 +468,13 @@ function normalizePalette(
 		}
 	}
 	config.palette = palette;
+	config.palettePreset = "custom";
 }
 
-function normalizeEnum<K extends "density" | "separator", T extends StatuslineConfig[K]>(
+function normalizeEnum<
+	K extends "palettePreset" | "density" | "separator",
+	T extends StatuslineConfig[K],
+>(
 	value: Record<string, unknown>,
 	field: K,
 	accepted: readonly T[],
@@ -493,8 +501,7 @@ function cloneSegmentPalette(palette: SegmentPalette): SegmentPalette {
 function cloneConfig(config: StatuslineConfig): StatuslineConfig {
 	return {
 		...config,
-		palette:
-			typeof config.palette === "string" ? config.palette : cloneSegmentPalette(config.palette),
+		palette: cloneSegmentPalette(config.palette),
 		segments: [...config.segments],
 		segmentText: Object.fromEntries(
 			SEGMENT_NAMES.map((name) => [name, { ...config.segmentText[name] }]),

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -132,6 +132,7 @@ export function normalizeStatuslineConfig(value: unknown): {
 			diagnostics: [invalidDiagnostic("", "Settings must contain a JSON object", "error")],
 		};
 	}
+	config.palette = {};
 
 	const knownRoot = new Set([
 		"palettePreset",
@@ -443,7 +444,7 @@ function normalizePalette(
 		return;
 	}
 
-	const palette = cloneSegmentPalette(TOKYO_NIGHT_SEGMENT_PALETTE);
+	const palette: SegmentPalette = {};
 	for (const [name, colors] of Object.entries(value)) {
 		const path = `palette.${name}`;
 		if (!isSegmentName(name)) {
@@ -454,6 +455,8 @@ function normalizePalette(
 			diagnostics.push(invalidDiagnostic(path, "Expected an object"));
 			continue;
 		}
+		const normalizedColors: NonNullable<SegmentPalette[SegmentName]> = {};
+		palette[name] = normalizedColors;
 		for (const [field, color] of Object.entries(colors)) {
 			const colorPath = `${path}.${field}`;
 			if (field !== "fg" && field !== "bg") {
@@ -464,7 +467,7 @@ function normalizePalette(
 				diagnostics.push(invalidDiagnostic(colorPath, "Expected a full #RRGGBB hexadecimal color"));
 				continue;
 			}
-			palette[name][field] = color.toLowerCase();
+			normalizedColors[field] = color.toLowerCase();
 		}
 	}
 	config.palette = palette;
@@ -494,7 +497,7 @@ function normalizeEnum<
 
 function cloneSegmentPalette(palette: SegmentPalette): SegmentPalette {
 	return Object.fromEntries(
-		SEGMENT_NAMES.map((name) => [name, { ...palette[name] }]),
+		Object.entries(palette).map(([name, colors]) => [name, { ...colors }]),
 	) as SegmentPalette;
 }
 

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -18,7 +18,9 @@ import {
 	SEGMENT_NAMES,
 	SEPARATOR_NAMES,
 	type SegmentName,
+	type SegmentPalette,
 	type StatuslineConfig,
+	TOKYO_NIGHT_SEGMENT_PALETTE,
 } from "./types.js";
 
 export const SETTINGS_FILE_NAME = "pi-statusline.json";
@@ -54,7 +56,7 @@ const DEFAULT_SEGMENTS: SegmentName[] = [
 ];
 
 export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
-	palette: "tokyo-night",
+	palette: cloneSegmentPalette(TOKYO_NIGHT_SEGMENT_PALETTE),
 	density: "compact",
 	separator: "none",
 	segments: DEFAULT_SEGMENTS,
@@ -141,7 +143,7 @@ export function normalizeStatuslineConfig(value: unknown): {
 		if (!knownRoot.has(key)) diagnostics.push(unknownDiagnostic(key));
 	}
 
-	normalizeEnum(value, "palette", PALETTE_NAMES, config, diagnostics);
+	normalizePalette(value.palette, config, diagnostics);
 	normalizeEnum(value, "density", DENSITIES, config, diagnostics);
 	normalizeEnum(value, "separator", SEPARATOR_NAMES, config, diagnostics);
 
@@ -413,10 +415,58 @@ export function normalizeStatuslineSettings(value: unknown): StatuslineConfig {
 	return normalizeStatuslineConfig(value).config;
 }
 
-function normalizeEnum<
-	K extends "palette" | "density" | "separator",
-	T extends StatuslineConfig[K],
->(
+function normalizePalette(
+	value: unknown,
+	config: StatuslineConfig,
+	diagnostics: StatuslineConfigDiagnostic[],
+) {
+	if (value === undefined) return;
+	if (typeof value === "string") {
+		if (!(PALETTE_NAMES as readonly string[]).includes(value)) {
+			diagnostics.push(
+				invalidDiagnostic(
+					"palette",
+					`Expected a palette object or one of: ${PALETTE_NAMES.join(", ")}`,
+				),
+			);
+			return;
+		}
+		config.palette = value as StatuslineConfig["palette"];
+		return;
+	}
+	if (!isRecord(value)) {
+		diagnostics.push(invalidDiagnostic("palette", "Expected a palette object"));
+		return;
+	}
+
+	const palette = cloneSegmentPalette(TOKYO_NIGHT_SEGMENT_PALETTE);
+	for (const [name, colors] of Object.entries(value)) {
+		const path = `palette.${name}`;
+		if (!isSegmentName(name)) {
+			diagnostics.push(unknownDiagnostic(path));
+			continue;
+		}
+		if (!isRecord(colors)) {
+			diagnostics.push(invalidDiagnostic(path, "Expected an object"));
+			continue;
+		}
+		for (const [field, color] of Object.entries(colors)) {
+			const colorPath = `${path}.${field}`;
+			if (field !== "fg" && field !== "bg") {
+				diagnostics.push(unknownDiagnostic(colorPath));
+				continue;
+			}
+			if (typeof color !== "string" || !/^#[0-9a-f]{6}$/iu.test(color)) {
+				diagnostics.push(invalidDiagnostic(colorPath, "Expected a full #RRGGBB hexadecimal color"));
+				continue;
+			}
+			palette[name][field] = color.toLowerCase();
+		}
+	}
+	config.palette = palette;
+}
+
+function normalizeEnum<K extends "density" | "separator", T extends StatuslineConfig[K]>(
 	value: Record<string, unknown>,
 	field: K,
 	accepted: readonly T[],
@@ -434,9 +484,17 @@ function normalizeEnum<
 	config[field] = candidate as StatuslineConfig[K];
 }
 
+function cloneSegmentPalette(palette: SegmentPalette): SegmentPalette {
+	return Object.fromEntries(
+		SEGMENT_NAMES.map((name) => [name, { ...palette[name] }]),
+	) as SegmentPalette;
+}
+
 function cloneConfig(config: StatuslineConfig): StatuslineConfig {
 	return {
 		...config,
+		palette:
+			typeof config.palette === "string" ? config.palette : cloneSegmentPalette(config.palette),
 		segments: [...config.segments],
 		segmentText: Object.fromEntries(
 			SEGMENT_NAMES.map((name) => [name, { ...config.segmentText[name] }]),

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { TOKYO_NIGHT_SEGMENT_PALETTE } from "./presets/tokyo-night.js";
 import {
 	type ConfigSegmentName,
 	DENSITIES,
@@ -21,7 +22,6 @@ import {
 	type SegmentName,
 	type SegmentPalette,
 	type StatuslineConfig,
-	TOKYO_NIGHT_SEGMENT_PALETTE,
 } from "./types.js";
 
 export const SETTINGS_FILE_NAME = "pi-statusline.json";

--- a/extensions/pi-statusline/src/settings.ts
+++ b/extensions/pi-statusline/src/settings.ts
@@ -10,13 +10,14 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import { TOKYO_NIGHT_SEGMENT_PALETTE } from "./presets/tokyo-night.js";
+import { segmentPaletteForPreset } from "./presets/index.js";
 import {
 	type ConfigSegmentName,
 	DENSITIES,
 	LINE_BREAK_SEGMENT_NAME,
 	PALETTE_NAMES,
 	PALETTE_PRESET_NAMES,
+	type PaletteName,
 	SEGMENT_NAMES,
 	SEPARATOR_NAMES,
 	type SegmentName,
@@ -58,7 +59,7 @@ const DEFAULT_SEGMENTS: SegmentName[] = [
 
 export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
 	palettePreset: "tokyo-night",
-	palette: cloneSegmentPalette(TOKYO_NIGHT_SEGMENT_PALETTE),
+	palette: segmentPaletteForPreset("tokyo-night"),
 	density: "compact",
 	separator: "none",
 	segments: DEFAULT_SEGMENTS,
@@ -79,7 +80,18 @@ export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
 	extensionStatusIcons: DEFAULT_EXTENSION_STATUS_ICONS,
 };
 
-export const DEFAULT_STATUSLINE_DOCUMENT = `${JSON.stringify(DEFAULT_STATUSLINE_CONFIG, null, "\t")}\n`;
+const DEFAULT_STATUSLINE_DOCUMENT_CONFIG = {
+	palettePreset: DEFAULT_STATUSLINE_CONFIG.palettePreset,
+	density: DEFAULT_STATUSLINE_CONFIG.density,
+	separator: DEFAULT_STATUSLINE_CONFIG.separator,
+	segments: DEFAULT_SEGMENTS,
+} satisfies Pick<StatuslineConfig, "palettePreset" | "density" | "separator" | "segments">;
+
+export const DEFAULT_STATUSLINE_DOCUMENT = `${JSON.stringify(
+	DEFAULT_STATUSLINE_DOCUMENT_CONFIG,
+	null,
+	"\t",
+)}\n`;
 
 export interface StatuslineConfigDiagnostic {
 	severity: "warning" | "error";
@@ -132,8 +144,6 @@ export function normalizeStatuslineConfig(value: unknown): {
 			diagnostics: [invalidDiagnostic("", "Settings must contain a JSON object", "error")],
 		};
 	}
-	config.palette = {};
-
 	const knownRoot = new Set([
 		"palettePreset",
 		"palette",
@@ -149,6 +159,9 @@ export function normalizeStatuslineConfig(value: unknown): {
 
 	normalizePalette(value.palette, config, diagnostics);
 	normalizeEnum(value, "palettePreset", PALETTE_PRESET_NAMES, config, diagnostics);
+	if (!isRecord(value.palette) && isPaletteName(config.palettePreset)) {
+		config.palette = segmentPaletteForPreset(config.palettePreset);
+	}
 	normalizeEnum(value, "density", DENSITIES, config, diagnostics);
 	normalizeEnum(value, "separator", SEPARATOR_NAMES, config, diagnostics);
 
@@ -445,6 +458,7 @@ function normalizePalette(
 	}
 
 	const palette: SegmentPalette = {};
+	config.palette = palette;
 	for (const [name, colors] of Object.entries(value)) {
 		const path = `palette.${name}`;
 		if (!isSegmentName(name)) {
@@ -539,6 +553,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isConfigSegmentName(value: string): value is ConfigSegmentName {
 	return value === LINE_BREAK_SEGMENT_NAME || isSegmentName(value);
+}
+
+function isPaletteName(value: StatuslineConfig["palettePreset"]): value is PaletteName {
+	return (PALETTE_NAMES as readonly StatuslineConfig["palettePreset"][]).includes(value);
 }
 
 function isSegmentName(value: string): value is SegmentName {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -19,6 +19,7 @@ import {
 	loadStatuslineSettings,
 	settingsFilePath,
 } from "./settings.js";
+import type { PalettePreset } from "./types.js";
 
 const STATUSLINE_KEY = "statusline";
 const GIT_STATUS_REFRESH_INTERVAL_MS = 30_000;
@@ -27,6 +28,8 @@ const EMPTY_EXTENSION_STATUS_ICON_ALIASES: ExtensionStatusIconAliasMap = new Map
 
 export default function statusline(pi: ExtensionAPI) {
 	let loaded: LoadedStatuslineSettings | undefined;
+	let previewPalettePreset: PalettePreset | undefined;
+	let activeSessionManager: ExtensionContext["sessionManager"] | undefined;
 	const runtime: RuntimeState = {
 		turnCount: 0,
 		activeTools: new Map(),
@@ -111,6 +114,8 @@ export default function statusline(pi: ExtensionAPI) {
 	const installFooter = (ctx: ExtensionContext) => {
 		const generation = ++sessionGeneration;
 		const cwd = ctx.cwd;
+		activeSessionManager = ctx.sessionManager;
+		previewPalettePreset = undefined;
 		clearGitStatusDebounce();
 		activeGitStatusTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
 		runtime.gitStatus = undefined;
@@ -154,7 +159,9 @@ export default function statusline(pi: ExtensionAPI) {
 				invalidate() {},
 				render(width: number): string[] {
 					if (!loaded) return [];
-					const config = loaded.config;
+					const config = previewPalettePreset
+						? { ...loaded.config, palettePreset: previewPalettePreset }
+						: loaded.config;
 					const mainLine = renderStatusline(width, ctx, footerData, theme, config, runtime);
 					const lines = mainLine ? mainLine.split("\n") : [];
 					lines.push(
@@ -172,8 +179,15 @@ export default function statusline(pi: ExtensionAPI) {
 	registerStatuslineCommand(pi, {
 		settingsPath: configPath,
 		getLoaded: () => loaded ?? loadStatuslineSettings(configPath),
-		apply(next) {
+		apply(next, ctx) {
+			if (ctx.sessionManager !== activeSessionManager) return;
+			previewPalettePreset = undefined;
 			loaded = next;
+			refresh();
+		},
+		preview(palettePreset, ctx) {
+			if (ctx.sessionManager !== activeSessionManager) return;
+			previewPalettePreset = palettePreset;
 			refresh();
 		},
 	});
@@ -196,6 +210,8 @@ export default function statusline(pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		sessionGeneration += 1;
+		activeSessionManager = undefined;
+		previewPalettePreset = undefined;
 		activeGitStatusTarget = undefined;
 		clearGitStatusDebounce();
 		pendingGitStatusRefresh = undefined;

--- a/extensions/pi-statusline/src/tokyo-night.ts
+++ b/extensions/pi-statusline/src/tokyo-night.ts
@@ -8,11 +8,13 @@ import {
 	type RenderSegment,
 	type SeparatorName,
 	type StatuslineConfig,
+	type StatuslinePalette,
 	type TokyoNightBlockName,
 } from "./types.js";
 
 interface TokyoNightBlock {
-	name: TokyoNightBlockName;
+	baseBlock: TokyoNightBlockName;
+	colors: BlockColors;
 	segments: RenderSegment[];
 }
 
@@ -87,9 +89,9 @@ function splitLines(items: RenderItem[]): RenderSegment[][] {
 
 export function tokyoNightExtensionSeparator(
 	_theme: Theme,
-	paletteName: PaletteName = "tokyo-night",
+	palette: StatuslinePalette = "tokyo-night",
 ): string {
-	return ansiFg(resolvePalette(paletteName).extensionSeparator, " • ");
+	return ansiFg(resolvePalette(palette).extensionSeparator, " • ");
 }
 
 function joinTokyoNightSegments(
@@ -97,29 +99,45 @@ function joinTokyoNightSegments(
 	config: Pick<StatuslineConfig, "palette" | "density" | "separator">,
 ): string {
 	const palette = resolvePalette(config.palette);
-	const blocks = contiguousBlocks(segments);
+	const blocks = contiguousBlocks(segments, palette, config.palette);
 	let line = ansiFg(palette.lead, "░▒▓");
 
 	for (const [index, block] of blocks.entries()) {
-		const colors = palette.blocks[block.name];
-		const previous = index === 0 ? undefined : palette.blocks[blocks[index - 1]?.name ?? "header"];
-		if (previous) line += ansiStyle("", { fg: previous.bg, bg: colors.bg });
-		line += ansiStyle(formatBlockText(block, config), colors);
+		const previous = index === 0 ? undefined : blocks[index - 1]?.colors;
+		if (previous) line += ansiStyle("", { fg: previous.bg, bg: block.colors.bg });
+		line += ansiStyle(formatBlockText(block, config), block.colors);
 	}
 
 	const lastBlock = blocks.at(-1);
-	if (lastBlock) line += ansiFg(palette.blocks[lastBlock.name].bg, "");
+	if (lastBlock) line += ansiFg(lastBlock.colors.bg, "");
 	return line;
 }
 
-function contiguousBlocks(segments: RenderSegment[]): TokyoNightBlock[] {
+function contiguousBlocks(
+	segments: RenderSegment[],
+	palette: PowerlinePalette,
+	configuredPalette: StatuslinePalette,
+): TokyoNightBlock[] {
 	const blocks: TokyoNightBlock[] = [];
+	const usesConfiguredColors = typeof configuredPalette !== "string";
 	for (const segment of segments) {
+		const colors = usesConfiguredColors
+			? configuredPalette[segment.name]
+			: palette.blocks[segment.block];
 		const previous = blocks.at(-1);
-		if (previous?.name === segment.block) previous.segments.push(segment);
-		else blocks.push({ name: segment.block, segments: [segment] });
+		const matchesPrevious =
+			previous !== undefined &&
+			(usesConfiguredColors
+				? colorsEqual(previous.colors, colors)
+				: previous.baseBlock === segment.block);
+		if (matchesPrevious) previous.segments.push(segment);
+		else blocks.push({ baseBlock: segment.block, colors, segments: [segment] });
 	}
 	return blocks;
+}
+
+function colorsEqual(left: BlockColors, right: BlockColors): boolean {
+	return left.fg === right.fg && left.bg === right.bg;
 }
 
 function formatBlockText(
@@ -153,9 +171,9 @@ function separatorText(separator: SeparatorName, cozy: boolean): string {
 	}
 }
 
-function resolvePalette(name: PaletteName): PowerlinePalette {
-	if (name === "tokyo-night") return TOKYO_NIGHT_PALETTE;
-	const sequence = PALETTE_SEQUENCES[name];
+function resolvePalette(palette: StatuslinePalette): PowerlinePalette {
+	if (typeof palette !== "string" || palette === "tokyo-night") return TOKYO_NIGHT_PALETTE;
+	const sequence = PALETTE_SEQUENCES[palette];
 	const backgrounds = BLOCK_NAMES.map(
 		(_block, index) => SEMANTIC_COLORS[sequence[index % sequence.length] ?? "muted"],
 	);

--- a/extensions/pi-statusline/src/tokyo-night.ts
+++ b/extensions/pi-statusline/src/tokyo-night.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
-import { ansiFg, ansiStyle } from "./ansi.js";
+import { ansiStyle } from "./ansi.js";
 import {
 	LINE_BREAK_SEGMENT_NAME,
 	type PaletteName,
@@ -20,14 +20,14 @@ interface TokyoNightBlock {
 }
 
 interface BlockColors {
-	fg: string;
-	bg: string;
+	fg?: string;
+	bg?: string;
 }
 
 interface PowerlinePalette {
-	lead: string;
+	lead?: string;
 	blocks: Record<TokyoNightBlockName, BlockColors>;
-	extensionSeparator: string;
+	extensionSeparator?: string;
 }
 
 const BLOCK_NAMES: TokyoNightBlockName[] = ["header", "directory", "git", "runtime", "meter"];
@@ -42,6 +42,16 @@ const TOKYO_NIGHT_PALETTE: PowerlinePalette = {
 		meter: { fg: "#a0a9cb", bg: "#1d2230" },
 	},
 	extensionSeparator: "#394260",
+};
+
+const UNSTYLED_PALETTE: PowerlinePalette = {
+	blocks: {
+		header: {},
+		directory: {},
+		git: {},
+		runtime: {},
+		meter: {},
+	},
 };
 
 const SEMANTIC_COLORS = {
@@ -92,7 +102,7 @@ export function tokyoNightExtensionSeparator(
 	_theme: Theme,
 	palettePreset: PalettePreset = "tokyo-night",
 ): string {
-	return ansiFg(resolvePalette(palettePreset).extensionSeparator, " • ");
+	return ansiStyle(" • ", { fg: resolvePalette(palettePreset).extensionSeparator });
 }
 
 function joinTokyoNightSegments(
@@ -101,7 +111,7 @@ function joinTokyoNightSegments(
 ): string {
 	const palette = resolvePalette(config.palettePreset);
 	const blocks = contiguousBlocks(segments, palette, config.palettePreset, config.palette);
-	let line = ansiFg(palette.lead, "░▒▓");
+	let line = ansiStyle("░▒▓", { fg: palette.lead });
 
 	for (const [index, block] of blocks.entries()) {
 		const previous = index === 0 ? undefined : blocks[index - 1]?.colors;
@@ -110,7 +120,7 @@ function joinTokyoNightSegments(
 	}
 
 	const lastBlock = blocks.at(-1);
-	if (lastBlock) line += ansiFg(lastBlock.colors.bg, "");
+	if (lastBlock) line += ansiStyle("", { fg: lastBlock.colors.bg });
 	return line;
 }
 
@@ -124,7 +134,7 @@ function contiguousBlocks(
 	const usesConfiguredColors = palettePreset === "custom";
 	for (const segment of segments) {
 		const colors = usesConfiguredColors
-			? configuredPalette[segment.name]
+			? (configuredPalette[segment.name] ?? {})
 			: palette.blocks[segment.block];
 		const previous = blocks.at(-1);
 		const matchesPrevious =
@@ -174,7 +184,8 @@ function separatorText(separator: SeparatorName, cozy: boolean): string {
 }
 
 function resolvePalette(palettePreset: PalettePreset): PowerlinePalette {
-	if (palettePreset === "custom" || palettePreset === "tokyo-night") return TOKYO_NIGHT_PALETTE;
+	if (palettePreset === "custom") return UNSTYLED_PALETTE;
+	if (palettePreset === "tokyo-night") return TOKYO_NIGHT_PALETTE;
 	const sequence = PALETTE_SEQUENCES[palettePreset];
 	const backgrounds = BLOCK_NAMES.map(
 		(_block, index) => SEMANTIC_COLORS[sequence[index % sequence.length] ?? "muted"],

--- a/extensions/pi-statusline/src/tokyo-night.ts
+++ b/extensions/pi-statusline/src/tokyo-night.ts
@@ -4,11 +4,12 @@ import { ansiFg, ansiStyle } from "./ansi.js";
 import {
 	LINE_BREAK_SEGMENT_NAME,
 	type PaletteName,
+	type PalettePreset,
 	type RenderItem,
 	type RenderSegment,
+	type SegmentPalette,
 	type SeparatorName,
 	type StatuslineConfig,
-	type StatuslinePalette,
 	type TokyoNightBlockName,
 } from "./types.js";
 
@@ -66,7 +67,7 @@ const PALETTE_SEQUENCES: Record<Exclude<PaletteName, "tokyo-night">, SemanticCol
 export function renderTokyoNightStatusline(
 	width: number,
 	items: RenderItem[],
-	config: Pick<StatuslineConfig, "palette" | "density" | "separator">,
+	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
 ): string {
 	if (items.length === 0 || width <= 0) return "";
 	return splitLines(items)
@@ -89,17 +90,17 @@ function splitLines(items: RenderItem[]): RenderSegment[][] {
 
 export function tokyoNightExtensionSeparator(
 	_theme: Theme,
-	palette: StatuslinePalette = "tokyo-night",
+	palettePreset: PalettePreset = "tokyo-night",
 ): string {
-	return ansiFg(resolvePalette(palette).extensionSeparator, " • ");
+	return ansiFg(resolvePalette(palettePreset).extensionSeparator, " • ");
 }
 
 function joinTokyoNightSegments(
 	segments: RenderSegment[],
-	config: Pick<StatuslineConfig, "palette" | "density" | "separator">,
+	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
 ): string {
-	const palette = resolvePalette(config.palette);
-	const blocks = contiguousBlocks(segments, palette, config.palette);
+	const palette = resolvePalette(config.palettePreset);
+	const blocks = contiguousBlocks(segments, palette, config.palettePreset, config.palette);
 	let line = ansiFg(palette.lead, "░▒▓");
 
 	for (const [index, block] of blocks.entries()) {
@@ -116,10 +117,11 @@ function joinTokyoNightSegments(
 function contiguousBlocks(
 	segments: RenderSegment[],
 	palette: PowerlinePalette,
-	configuredPalette: StatuslinePalette,
+	palettePreset: PalettePreset,
+	configuredPalette: SegmentPalette,
 ): TokyoNightBlock[] {
 	const blocks: TokyoNightBlock[] = [];
-	const usesConfiguredColors = typeof configuredPalette !== "string";
+	const usesConfiguredColors = palettePreset === "custom";
 	for (const segment of segments) {
 		const colors = usesConfiguredColors
 			? configuredPalette[segment.name]
@@ -171,9 +173,9 @@ function separatorText(separator: SeparatorName, cozy: boolean): string {
 	}
 }
 
-function resolvePalette(palette: StatuslinePalette): PowerlinePalette {
-	if (typeof palette !== "string" || palette === "tokyo-night") return TOKYO_NIGHT_PALETTE;
-	const sequence = PALETTE_SEQUENCES[palette];
+function resolvePalette(palettePreset: PalettePreset): PowerlinePalette {
+	if (palettePreset === "custom" || palettePreset === "tokyo-night") return TOKYO_NIGHT_PALETTE;
+	const sequence = PALETTE_SEQUENCES[palettePreset];
 	const backgrounds = BLOCK_NAMES.map(
 		(_block, index) => SEMANTIC_COLORS[sequence[index % sequence.length] ?? "muted"],
 	);

--- a/extensions/pi-statusline/src/types.ts
+++ b/extensions/pi-statusline/src/types.ts
@@ -43,8 +43,31 @@ export interface SegmentTextConfig {
 	suffix: string;
 }
 
+export interface SegmentPaletteColor {
+	fg: string;
+	bg: string;
+}
+
+export type SegmentPalette = Record<SegmentName, SegmentPaletteColor>;
+export type StatuslinePalette = PaletteName | SegmentPalette;
+
+export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
+	brand: { fg: "#090c0c", bg: "#a3aed2" },
+	provider: { fg: "#090c0c", bg: "#a3aed2" },
+	model: { fg: "#090c0c", bg: "#a3aed2" },
+	thinking: { fg: "#090c0c", bg: "#a3aed2" },
+	cwd: { fg: "#e3e5e5", bg: "#769ff0" },
+	branch: { fg: "#769ff0", bg: "#394260" },
+	tools: { fg: "#769ff0", bg: "#212736" },
+	context: { fg: "#769ff0", bg: "#212736" },
+	tokens: { fg: "#769ff0", bg: "#212736" },
+	cost: { fg: "#a0a9cb", bg: "#1d2230" },
+	time: { fg: "#a0a9cb", bg: "#1d2230" },
+	turn: { fg: "#a0a9cb", bg: "#1d2230" },
+};
+
 export interface StatuslineConfig {
-	palette: PaletteName;
+	palette: StatuslinePalette;
 	density: Density;
 	separator: SeparatorName;
 	segments: ConfigSegmentName[];

--- a/extensions/pi-statusline/src/types.ts
+++ b/extensions/pi-statusline/src/types.ts
@@ -39,7 +39,7 @@ export type Density = (typeof DENSITIES)[number];
 export const SEPARATOR_NAMES = ["none", "dot", "bar", "powerline", "round"] as const;
 export type SeparatorName = (typeof SEPARATOR_NAMES)[number];
 
-export type TokyoNightBlockName = "header" | "directory" | "git" | "runtime" | "meter";
+export type PowerlineBlockName = "header" | "directory" | "git" | "runtime" | "meter";
 
 export interface SegmentTextConfig {
 	prefix: string;
@@ -52,21 +52,6 @@ export interface SegmentPaletteColor {
 }
 
 export type SegmentPalette = Partial<Record<SegmentName, SegmentPaletteColor>>;
-
-export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
-	brand: { fg: "#090c0c", bg: "#a3aed2" },
-	provider: { fg: "#090c0c", bg: "#a3aed2" },
-	model: { fg: "#090c0c", bg: "#a3aed2" },
-	thinking: { fg: "#090c0c", bg: "#a3aed2" },
-	cwd: { fg: "#e3e5e5", bg: "#769ff0" },
-	branch: { fg: "#769ff0", bg: "#394260" },
-	tools: { fg: "#769ff0", bg: "#212736" },
-	context: { fg: "#769ff0", bg: "#212736" },
-	tokens: { fg: "#769ff0", bg: "#212736" },
-	cost: { fg: "#a0a9cb", bg: "#1d2230" },
-	time: { fg: "#a0a9cb", bg: "#1d2230" },
-	turn: { fg: "#a0a9cb", bg: "#1d2230" },
-};
 
 export interface StatuslineConfig {
 	palettePreset: PalettePreset;
@@ -82,7 +67,7 @@ export interface RenderSegment {
 	name: SegmentName;
 	text: string;
 	color: ThemeColor;
-	block: TokyoNightBlockName;
+	block: PowerlineBlockName;
 	emphasis?: boolean;
 }
 

--- a/extensions/pi-statusline/src/types.ts
+++ b/extensions/pi-statusline/src/types.ts
@@ -47,11 +47,11 @@ export interface SegmentTextConfig {
 }
 
 export interface SegmentPaletteColor {
-	fg: string;
-	bg: string;
+	fg?: string;
+	bg?: string;
 }
 
-export type SegmentPalette = Record<SegmentName, SegmentPaletteColor>;
+export type SegmentPalette = Partial<Record<SegmentName, SegmentPaletteColor>>;
 
 export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
 	brand: { fg: "#090c0c", bg: "#a3aed2" },

--- a/extensions/pi-statusline/src/types.ts
+++ b/extensions/pi-statusline/src/types.ts
@@ -30,6 +30,9 @@ export const PALETTE_NAMES = [
 ] as const;
 export type PaletteName = (typeof PALETTE_NAMES)[number];
 
+export const PALETTE_PRESET_NAMES = [...PALETTE_NAMES, "custom"] as const;
+export type PalettePreset = (typeof PALETTE_PRESET_NAMES)[number];
+
 export const DENSITIES = ["compact", "cozy"] as const;
 export type Density = (typeof DENSITIES)[number];
 
@@ -49,7 +52,6 @@ export interface SegmentPaletteColor {
 }
 
 export type SegmentPalette = Record<SegmentName, SegmentPaletteColor>;
-export type StatuslinePalette = PaletteName | SegmentPalette;
 
 export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
 	brand: { fg: "#090c0c", bg: "#a3aed2" },
@@ -67,7 +69,8 @@ export const TOKYO_NIGHT_SEGMENT_PALETTE: SegmentPalette = {
 };
 
 export interface StatuslineConfig {
-	palette: StatuslinePalette;
+	palettePreset: PalettePreset;
+	palette: SegmentPalette;
 	density: Density;
 	separator: SeparatorName;
 	segments: ConfigSegmentName[];

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -13,19 +13,88 @@ import {
 } from "../src/settings.js";
 import statusline from "../src/statusline.js";
 
-test("/statusline registers palette, settings, status, and help autocomplete", () => {
+interface PickerComponent {
+	render?(width: number): string[];
+	handleInput?(data: string): void;
+}
+
+function customPalettePicker(inputs: string[], inspect?: (lines: string[]) => void) {
+	return async (factory: (...args: unknown[]) => unknown) => {
+		let result: unknown;
+		const component = factory(
+			{ requestRender() {} },
+			{
+				fg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			},
+			{},
+			(value: unknown) => {
+				result = value;
+			},
+		) as PickerComponent;
+		if (inspect && component.render) inspect(component.render(100));
+		for (const input of inputs) component.handleInput?.(input);
+		return result;
+	};
+}
+
+test("/statusline registers an argument-free interactive menu", async () => {
 	const mock = createMockPi();
 	statusline(mock.pi);
 	const command = mock.commands.get("statusline");
-	assert.ok(command?.getArgumentCompletions);
-	assert.deepEqual(
-		(command.getArgumentCompletions("") as Array<{ value: string }>).map((item) => item.value),
-		["palette", "settings", "status", "help"],
-	);
-	assert.deepEqual(
-		(command.getArgumentCompletions("st") as Array<{ value: string }>).map((item) => item.value),
-		["status"],
-	);
+	assert.equal(command?.getArgumentCompletions, undefined);
+	let selectCalls = 0;
+	const context = createMockContext({
+		mode: "tui",
+		select: async () => {
+			selectCalls += 1;
+			return undefined;
+		},
+	});
+
+	await command?.handler("palette", context.ctx);
+
+	assert.equal(selectCalls, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /does not accept arguments/u);
+});
+
+test("palette picker previews cursor movement and restores the saved preset on cancel", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, JSON.stringify({ palettePreset: "sunset" }));
+	try {
+		const mock = createMockPi();
+		const loaded = loadStatuslineSettings(path);
+		const previews: Array<string | undefined> = [];
+		let applied = 0;
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply() {
+				applied += 1;
+			},
+			preview(palettePreset) {
+				previews.push(palettePreset);
+			},
+		});
+		let customCalls = 0;
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) => choices[0],
+			custom: customPalettePicker(["\u001b[B", "\u001b"], () => {
+				customCalls += 1;
+			}),
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.equal(customCalls, 1);
+		assert.deepEqual(previews, ["forest", undefined]);
+		assert.equal(applied, 0);
+		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), { palettePreset: "sunset" });
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("settings edits raw JSON transactionally and applies it immediately", async () => {
@@ -52,12 +121,13 @@ test("settings edits raw JSON transactionally and applies it immediately", async
 		)}\n`;
 		const context = createMockContext({
 			mode: "tui",
+			select: async () => "Edit JSON settings",
 			editor: async (_title: string, value: string) => {
 				initial = value;
 				return edited;
 			},
 		});
-		await mock.commands.get("statusline")?.handler("settings", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.equal(initial, DEFAULT_STATUSLINE_DOCUMENT);
 		assert.equal(readFileSync(path, "utf8"), edited);
 		assert.deepEqual(loaded.config.segments, ["model"]);
@@ -92,13 +162,17 @@ test("palette picker preserves custom colors and unknown fields while applying a
 			},
 		});
 		const selections: Array<{ title: string; choices: string[] }> = [];
+		let pickerText = "";
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
 			select: async (title: string, choices: string[]) => {
 				selections.push({ title, choices });
-				return title === "pi-statusline" ? choices[0] : "ocean";
+				return choices[0];
 			},
+			custom: customPalettePicker(["\u001b[B", "\u001b[B", "\r"], (lines) => {
+				pickerText = lines.join("\n");
+			}),
 		});
 
 		await mock.commands.get("statusline")?.handler("", context.ctx);
@@ -109,8 +183,8 @@ test("palette picker preserves custom colors and unknown fields while applying a
 			"Status",
 			"Help",
 		]);
-		assert.match(selections[1]?.title ?? "", /current: custom/u);
-		assert.deepEqual(selections[1]?.choices, [
+		assert.match(pickerText, /current: custom/u);
+		for (const palettePreset of [
 			"tokyo-night",
 			"ocean",
 			"sunset",
@@ -119,7 +193,9 @@ test("palette picker preserves custom colors and unknown fields while applying a
 			"neon",
 			"mono",
 			"custom",
-		]);
+		]) {
+			assert.match(pickerText, new RegExp(palettePreset, "u"));
+		}
 		assert.equal(loaded.config.palettePreset, "ocean");
 		assert.deepEqual(loaded.config.palette.time, { fg: "#112233", bg: "#445566" });
 		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
@@ -149,10 +225,11 @@ test("palette picker migrates a legacy string without losing unknown fields", as
 		});
 		const context = createMockContext({
 			mode: "tui",
-			select: async () => "custom",
+			select: async (_title: string, choices: string[]) => choices[0],
+			custom: customPalettePicker(["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]),
 		});
 
-		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 
 		const saved = JSON.parse(readFileSync(path, "utf8"));
 		assert.equal(saved.palettePreset, "custom");
@@ -181,11 +258,16 @@ test("palette picker cancellation and malformed settings leave the file unchange
 			},
 		});
 		let selection: string | undefined;
-		const context = createMockContext({ mode: "tui", select: async () => selection });
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) => choices[0],
+			custom: (factory: (...args: unknown[]) => unknown) =>
+				customPalettePicker(selection ? ["\u001b[B", "\r"] : ["\u001b"])(factory),
+		});
 
-		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		selection = "ocean";
-		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 
 		assert.equal(readFileSync(path, "utf8"), "{broken");
 		assert.equal(applied, 0);
@@ -217,17 +299,21 @@ test("cancelled, invalid, and failed settings edits preserve file and runtime st
 				return saveStatuslineSettingsDocument(settingsPath, rawDocument);
 			},
 		});
-		const context = createMockContext({ mode: "tui", editor: async () => nextEdit });
+		const context = createMockContext({
+			mode: "tui",
+			select: async () => "Edit JSON settings",
+			editor: async () => nextEdit,
+		});
 
-		await mock.commands.get("statusline")?.handler("settings", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		nextEdit = JSON.stringify({ palette: "invalid" });
-		await mock.commands.get("statusline")?.handler("settings", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*palette/i);
 		nextEdit = JSON.stringify({ palette: { time: { fg: "red" } } });
-		await mock.commands.get("statusline")?.handler("settings", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*palette\.time\.fg/i);
 		nextEdit = JSON.stringify({ future: "publish" });
-		await mock.commands.get("statusline")?.handler("settings", context.ctx);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /publish failed/i);
 		assert.equal(readFileSync(path, "utf8"), original);
 		assert.deepEqual(loaded.config.segments, ["model"]);
@@ -237,7 +323,7 @@ test("cancelled, invalid, and failed settings edits preserve file and runtime st
 	}
 });
 
-test("settings is TUI-only while status and help are protocol-safe", async () => {
+test("status and help remain available from the main menu", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
 	const path = settingsFilePath(root);
 	writeFileSync(path, DEFAULT_STATUSLINE_DOCUMENT);
@@ -249,30 +335,35 @@ test("settings is TUI-only while status and help are protocol-safe", async () =>
 			getLoaded: () => loaded,
 			apply() {},
 		});
-		let editorCalls = 0;
-		const context = createMockContext({
-			mode: "rpc",
-			hasUI: true,
-			editor: async () => {
-				editorCalls += 1;
-				return undefined;
-			},
-		});
-		await mock.commands.get("statusline")?.handler("settings", context.ctx);
-		assert.equal(editorCalls, 0);
-		assert.match(context.notifications.at(-1)?.message ?? "", /Edit settings manually/u);
-		await mock.commands.get("statusline")?.handler("palette", context.ctx);
-		assert.match(context.notifications.at(-1)?.message ?? "", /Edit palettePreset manually/u);
+		let selection = "Status";
+		const context = createMockContext({ mode: "tui", select: async () => selection });
+
 		await mock.commands.get("statusline")?.handler("", context.ctx);
-		assert.match(context.notifications.at(-1)?.message ?? "", /open the statusline menu/u);
-		await mock.commands.get("statusline")?.handler("status", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /source: user/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /palette preset: tokyo-night/u);
-		await mock.commands.get("statusline")?.handler("help", context.ctx);
+
+		selection = "Help";
+		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /segmentText/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /palettePreset/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /line_break/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test("/statusline safely rejects non-TUI mode and textual arguments", async () => {
+	const mock = createMockPi();
+	registerStatuslineCommand(mock.pi, {
+		settingsPath: "/tmp/pi-statusline.json",
+		getLoaded: () => loadStatuslineSettings("/tmp/missing-pi-statusline.json"),
+		apply() {},
+	});
+	const context = createMockContext({ mode: "rpc", hasUI: true });
+
+	await mock.commands.get("statusline")?.handler("", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /requires an interactive Pi UI/u);
+
+	await mock.commands.get("statusline")?.handler("status", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /does not accept arguments/u);
 });

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -97,6 +97,9 @@ test("cancelled, invalid, and failed settings edits preserve file and runtime st
 		nextEdit = JSON.stringify({ palette: "invalid" });
 		await mock.commands.get("statusline")?.handler("settings", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*palette/i);
+		nextEdit = JSON.stringify({ palette: { time: { fg: "red" } } });
+		await mock.commands.get("statusline")?.handler("settings", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*palette\.time\.fg/i);
 		nextEdit = JSON.stringify({ future: "publish" });
 		await mock.commands.get("statusline")?.handler("settings", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /publish failed/i);
@@ -134,9 +137,10 @@ test("settings is TUI-only while status and help are protocol-safe", async () =>
 		assert.match(context.notifications.at(-1)?.message ?? "", /Edit settings manually/u);
 		await mock.commands.get("statusline")?.handler("status", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /source: user/u);
-		assert.match(context.notifications.at(-1)?.message ?? "", /palette: tokyo-night/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /palette: configured/u);
 		await mock.commands.get("statusline")?.handler("help", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /segmentText/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /palette maps/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /line_break/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -121,7 +121,7 @@ test("settings edits raw JSON transactionally and applies it immediately", async
 		)}\n`;
 		const context = createMockContext({
 			mode: "tui",
-			select: async () => "Edit JSON settings",
+			select: async () => "Edit settings JSON (custom colors, layout, icons)",
 			editor: async (_title: string, value: string) => {
 				initial = value;
 				return edited;
@@ -179,7 +179,7 @@ test("palette picker preserves custom colors and unknown fields while applying a
 
 		assert.deepEqual(selections[0]?.choices, [
 			"Palette preset (custom)",
-			"Edit JSON settings",
+			"Edit settings JSON (custom colors, layout, icons)",
 			"Status",
 			"Help",
 		]);
@@ -196,6 +196,7 @@ test("palette picker preserves custom colors and unknown fields while applying a
 		]) {
 			assert.match(pickerText, new RegExp(palettePreset, "u"));
 		}
+		assert.match(pickerText, /per-segment colors from settings JSON/u);
 		assert.equal(loaded.config.palettePreset, "ocean");
 		assert.deepEqual(loaded.config.palette.time, { fg: "#112233", bg: "#445566" });
 		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
@@ -209,7 +210,41 @@ test("palette picker preserves custom colors and unknown fields while applying a
 	}
 });
 
-test("palette picker migrates a legacy string without losing unknown fields", async () => {
+test("custom selection preserves an existing custom palette", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	const palette = { time: { fg: "#112233", bg: "#445566" } };
+	writeFileSync(path, JSON.stringify({ palettePreset: "custom", palette, future: true }));
+	try {
+		const mock = createMockPi();
+		let loaded = loadStatuslineSettings(path);
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+			},
+		});
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) => choices[0],
+			custom: customPalettePicker(["\r"]),
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+			palettePreset: "custom",
+			palette,
+			future: true,
+		});
+		assert.deepEqual(loaded.config.palette, palette);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("custom selection materializes the active legacy preset without losing unknown fields", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
 	const path = settingsFilePath(root);
 	writeFileSync(path, JSON.stringify({ palette: "forest", future: true }));
@@ -234,9 +269,15 @@ test("palette picker migrates a legacy string without losing unknown fields", as
 		const saved = JSON.parse(readFileSync(path, "utf8"));
 		assert.equal(saved.palettePreset, "custom");
 		assert.equal(saved.future, true);
-		assert.deepEqual(saved.palette, {});
-		assert.deepEqual(loaded.config.palette, {});
+		assert.equal(Object.keys(saved.palette).length, 12);
+		assert.equal(saved.palette.model.bg, "#a7c080");
+		assert.equal(saved.palette.cwd.bg, "#83c092");
+		assert.equal(saved.palette.branch.bg, "#5f9f75");
+		assert.equal(saved.palette.tools.bg, "#3f6f55");
+		assert.equal(saved.palette.time.bg, "#293f35");
+		assert.deepEqual(loaded.config.palette, saved.palette);
 		assert.equal(loaded.config.palettePreset, "custom");
+		assert.match(context.notifications.at(-1)?.message ?? "", /Edit settings JSON/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -301,7 +342,7 @@ test("cancelled, invalid, and failed settings edits preserve file and runtime st
 		});
 		const context = createMockContext({
 			mode: "tui",
-			select: async () => "Edit JSON settings",
+			select: async () => "Edit settings JSON (custom colors, layout, icons)",
 			editor: async () => nextEdit,
 		});
 

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -38,11 +38,19 @@ function customPalettePicker(inputs: string[], inspect?: (lines: string[]) => vo
 	};
 }
 
-test("/statusline registers an argument-free interactive menu", async () => {
+test("/statusline keeps compatibility subcommands and an argument-free interactive menu", async () => {
 	const mock = createMockPi();
 	statusline(mock.pi);
 	const command = mock.commands.get("statusline");
-	assert.equal(command?.getArgumentCompletions, undefined);
+	assert.ok(command?.getArgumentCompletions);
+	assert.deepEqual(
+		(command.getArgumentCompletions("") as Array<{ value: string }>).map((item) => item.value),
+		["settings", "status", "help"],
+	);
+	assert.deepEqual(
+		(command.getArgumentCompletions("st") as Array<{ value: string }>).map((item) => item.value),
+		["status"],
+	);
 	let selectCalls = 0;
 	const context = createMockContext({
 		mode: "tui",
@@ -52,10 +60,12 @@ test("/statusline registers an argument-free interactive menu", async () => {
 		},
 	});
 
-	await command?.handler("palette", context.ctx);
+	await command.handler("", context.ctx);
+	assert.equal(selectCalls, 1);
 
-	assert.equal(selectCalls, 0);
-	assert.match(context.notifications.at(-1)?.message ?? "", /does not accept arguments/u);
+	await command.handler("palette", context.ctx);
+	assert.equal(selectCalls, 1);
+	assert.match(context.notifications.at(-1)?.message ?? "", /unknown.*palette/iu);
 });
 
 test("palette picker previews cursor movement and restores the saved preset on cancel", async () => {
@@ -121,13 +131,12 @@ test("settings edits raw JSON transactionally and applies it immediately", async
 		)}\n`;
 		const context = createMockContext({
 			mode: "tui",
-			select: async () => "Edit settings JSON (custom colors, layout, icons)",
 			editor: async (_title: string, value: string) => {
 				initial = value;
 				return edited;
 			},
 		});
-		await mock.commands.get("statusline")?.handler("", context.ctx);
+		await mock.commands.get("statusline")?.handler("settings", context.ctx);
 		assert.equal(initial, DEFAULT_STATUSLINE_DOCUMENT);
 		assert.equal(readFileSync(path, "utf8"), edited);
 		assert.deepEqual(loaded.config.segments, ["model"]);
@@ -393,7 +402,7 @@ test("status and help remain available from the main menu", async () => {
 	}
 });
 
-test("/statusline safely rejects non-TUI mode and textual arguments", async () => {
+test("/statusline compatibility routes work in RPC and reject unknown or trailing input", async () => {
 	const mock = createMockPi();
 	registerStatuslineCommand(mock.pi, {
 		settingsPath: "/tmp/pi-statusline.json",
@@ -401,10 +410,23 @@ test("/statusline safely rejects non-TUI mode and textual arguments", async () =
 		apply() {},
 	});
 	const context = createMockContext({ mode: "rpc", hasUI: true });
+	const command = mock.commands.get("statusline");
 
-	await mock.commands.get("statusline")?.handler("", context.ctx);
+	await command?.handler("", context.ctx);
 	assert.match(context.notifications.at(-1)?.message ?? "", /requires an interactive Pi UI/u);
 
-	await mock.commands.get("statusline")?.handler("status", context.ctx);
-	assert.match(context.notifications.at(-1)?.message ?? "", /does not accept arguments/u);
+	await command?.handler("settings", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Edit settings manually/u);
+
+	await command?.handler("status", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /source: built-in/u);
+
+	await command?.handler("help", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Menu actions/u);
+
+	await command?.handler("status extra", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /does not accept trailing arguments/u);
+
+	await command?.handler("palette", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /unknown.*palette/iu);
 });

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -157,8 +157,8 @@ test("palette picker migrates a legacy string without losing unknown fields", as
 		const saved = JSON.parse(readFileSync(path, "utf8"));
 		assert.equal(saved.palettePreset, "custom");
 		assert.equal(saved.future, true);
-		assert.equal(typeof saved.palette, "object");
-		assert.deepEqual(saved.palette.time, { fg: "#a0a9cb", bg: "#1d2230" });
+		assert.deepEqual(saved.palette, {});
+		assert.deepEqual(loaded.config.palette, {});
 		assert.equal(loaded.config.palettePreset, "custom");
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -13,14 +13,14 @@ import {
 } from "../src/settings.js";
 import statusline from "../src/statusline.js";
 
-test("/statusline registers settings, status, and help autocomplete", () => {
+test("/statusline registers palette, settings, status, and help autocomplete", () => {
 	const mock = createMockPi();
 	statusline(mock.pi);
 	const command = mock.commands.get("statusline");
 	assert.ok(command?.getArgumentCompletions);
 	assert.deepEqual(
 		(command.getArgumentCompletions("") as Array<{ value: string }>).map((item) => item.value),
-		["settings", "status", "help"],
+		["palette", "settings", "status", "help"],
 	);
 	assert.deepEqual(
 		(command.getArgumentCompletions("st") as Array<{ value: string }>).map((item) => item.value),
@@ -64,6 +64,132 @@ test("settings edits raw JSON transactionally and applies it immediately", async
 		assert.equal(loaded.config.segmentText.model.prefix, "Model: ");
 		assert.equal(renders, 1);
 		assert.match(context.notifications.at(-1)?.message ?? "", /saved.*applied/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("palette picker preserves custom colors and unknown fields while applying a preset", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(
+		path,
+		JSON.stringify({
+			palette: { time: { fg: "#112233", bg: "#445566" } },
+			future: { retained: true },
+		}),
+	);
+	try {
+		const mock = createMockPi();
+		let loaded = loadStatuslineSettings(path);
+		let applied = 0;
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				applied += 1;
+			},
+		});
+		const selections: Array<{ title: string; choices: string[] }> = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async (title: string, choices: string[]) => {
+				selections.push({ title, choices });
+				return title === "pi-statusline" ? choices[0] : "ocean";
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.deepEqual(selections[0]?.choices, [
+			"Palette preset (custom)",
+			"Edit JSON settings",
+			"Status",
+			"Help",
+		]);
+		assert.match(selections[1]?.title ?? "", /current: custom/u);
+		assert.deepEqual(selections[1]?.choices, [
+			"tokyo-night",
+			"ocean",
+			"sunset",
+			"forest",
+			"candy",
+			"neon",
+			"mono",
+			"custom",
+		]);
+		assert.equal(loaded.config.palettePreset, "ocean");
+		assert.deepEqual(loaded.config.palette.time, { fg: "#112233", bg: "#445566" });
+		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+			palette: { time: { fg: "#112233", bg: "#445566" } },
+			future: { retained: true },
+			palettePreset: "ocean",
+		});
+		assert.equal(applied, 1);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("palette picker migrates a legacy string without losing unknown fields", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, JSON.stringify({ palette: "forest", future: true }));
+	try {
+		const mock = createMockPi();
+		let loaded = loadStatuslineSettings(path);
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+			},
+		});
+		const context = createMockContext({
+			mode: "tui",
+			select: async () => "custom",
+		});
+
+		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+
+		const saved = JSON.parse(readFileSync(path, "utf8"));
+		assert.equal(saved.palettePreset, "custom");
+		assert.equal(saved.future, true);
+		assert.equal(typeof saved.palette, "object");
+		assert.deepEqual(saved.palette.time, { fg: "#a0a9cb", bg: "#1d2230" });
+		assert.equal(loaded.config.palettePreset, "custom");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("palette picker cancellation and malformed settings leave the file unchanged", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "{broken");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStatuslineSettings(path);
+		let applied = 0;
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply() {
+				applied += 1;
+			},
+		});
+		let selection: string | undefined;
+		const context = createMockContext({ mode: "tui", select: async () => selection });
+
+		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+		selection = "ocean";
+		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+
+		assert.equal(readFileSync(path, "utf8"), "{broken");
+		assert.equal(applied, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Fix pi-statusline\.json/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -135,12 +261,16 @@ test("settings is TUI-only while status and help are protocol-safe", async () =>
 		await mock.commands.get("statusline")?.handler("settings", context.ctx);
 		assert.equal(editorCalls, 0);
 		assert.match(context.notifications.at(-1)?.message ?? "", /Edit settings manually/u);
+		await mock.commands.get("statusline")?.handler("palette", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Edit palettePreset manually/u);
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /open the statusline menu/u);
 		await mock.commands.get("statusline")?.handler("status", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /source: user/u);
-		assert.match(context.notifications.at(-1)?.message ?? "", /palette: configured/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /palette preset: tokyo-night/u);
 		await mock.commands.get("statusline")?.handler("help", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /segmentText/u);
-		assert.match(context.notifications.at(-1)?.message ?? "", /palette maps/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /palettePreset/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /line_break/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/extensions/pi-statusline/test/lifecycle-settings.test.ts
+++ b/extensions/pi-statusline/test/lifecycle-settings.test.ts
@@ -37,7 +37,7 @@ function createFooter(factory: FooterFactory) {
 	);
 }
 
-test("session start creates the complete default statusline settings", async () => {
+test("session start creates the concise default statusline settings", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-lifecycle-"));
 	const previous = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = root;

--- a/extensions/pi-statusline/test/lifecycle-settings.test.ts
+++ b/extensions/pi-statusline/test/lifecycle-settings.test.ts
@@ -37,7 +37,7 @@ function createFooter(factory: FooterFactory) {
 	);
 }
 
-test("session start creates the concise default statusline settings", async () => {
+test("session start creates the editable default statusline settings", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-lifecycle-"));
 	const previous = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = root;

--- a/extensions/pi-statusline/test/lifecycle-settings.test.ts
+++ b/extensions/pi-statusline/test/lifecycle-settings.test.ts
@@ -57,6 +57,61 @@ test("session start creates the complete default statusline settings", async () 
 	}
 });
 
+test("palette picker previews the highlighted preset and restores on cancel", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-lifecycle-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		writeFileSync(
+			join(root, "pi-statusline.json"),
+			JSON.stringify({ palettePreset: "sunset", segments: ["model"] }),
+		);
+		const mock = createMockPi();
+		statusline(mock.pi);
+		let footer: ReturnType<typeof createFooter> | undefined;
+		let preview = "";
+		const context = createMockContext({
+			mode: "tui",
+			model: { id: "claude-sonnet-4", provider: "anthropic" },
+			select: async (_title: string, choices: string[]) => choices[0],
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				let result: unknown;
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{},
+					(value: unknown) => {
+						result = value;
+					},
+				) as { handleInput?(data: string): void };
+				component.handleInput?.("\u001b[B");
+				preview = footer?.render(200)[0] ?? "";
+				component.handleInput?.("\u001b");
+				return result;
+			},
+		});
+		await emit(mock.events, "session_start", {}, context.ctx);
+		footer = createFooter(context.footer as FooterFactory);
+		const before = footer.render(200)[0] ?? "";
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		const after = footer.render(200)[0] ?? "";
+		assert.match(before, /48;2;255;207;112/u);
+		assert.match(preview, /48;2;167;192;128/u);
+		assert.equal(after, before);
+		footer.dispose();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("line breaks become separate footer rows", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-lifecycle-"));
 	const previous = process.env.PI_CODING_AGENT_DIR;

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { formatConfiguredSegment } from "../src/render.js";
-import { createDefaultConfig } from "../src/settings.js";
+import { createDefaultConfig, normalizeStatuslineConfig } from "../src/settings.js";
 import { renderTokyoNightStatusline } from "../src/tokyo-night.js";
 import type { RenderItem, RenderSegment, SegmentName } from "../src/types.js";
 
@@ -42,6 +42,37 @@ test("Tokyo Night default retains the exact powerline colors", () => {
 			"\u001b[38;2;9;12;12;48;2;163;174;210m model\u001b[0m" +
 			"\u001b[38;2;163;174;210m\u001b[0m",
 	);
+});
+
+test("configured palette joins reordered time to an adjacent header block", () => {
+	const config = createDefaultConfig();
+	if (typeof config.palette === "string") assert.fail("expected palette object");
+	config.palette.time = { fg: "#090c0c", bg: "#a3aed2" };
+	const rendered = renderTokyoNightStatusline(
+		300,
+		[segment("time", "time", "meter"), segment("brand", "brand", "header")],
+		config,
+	);
+	assert.equal(plain(rendered), "░▒▓ time brand");
+	assert.equal((plain(rendered).match(//gu) ?? []).length, 1);
+});
+
+test("partial configured palette inherits omitted Tokyo Night colors", () => {
+	const config = normalizeStatuslineConfig({ palette: { time: { fg: "#ffffff" } } }).config;
+	const rendered = renderTokyoNightStatusline(300, [segment("time", "time", "meter")], config);
+	assert.ok(rendered.includes(`${ESCAPE}[38;2;255;255;255;48;2;29;34;48m time${ESCAPE}[0m`));
+});
+
+test("different final segment colors retain the powerline transition", () => {
+	const config = createDefaultConfig();
+	if (typeof config.palette === "string") assert.fail("expected palette object");
+	config.palette.time = { ...config.palette.time, bg: "#123456" };
+	const rendered = renderTokyoNightStatusline(
+		300,
+		[segment("time", "time", "meter"), segment("brand", "brand", "header")],
+		config,
+	);
+	assert.equal(plain(rendered), "░▒▓ time brand");
 });
 
 test("line breaks render separated repeated markers as independent powerline rows", () => {

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import { formatConfiguredSegment } from "../src/render.js";
 import { createDefaultConfig, normalizeStatuslineConfig } from "../src/settings.js";
-import { renderTokyoNightStatusline } from "../src/tokyo-night.js";
+import { renderTokyoNightStatusline, tokyoNightExtensionSeparator } from "../src/tokyo-night.js";
 import type { RenderItem, RenderSegment, SegmentName } from "../src/types.js";
 
 const ESCAPE = String.fromCharCode(27);
@@ -57,10 +58,21 @@ test("configured palette joins reordered time to an adjacent header block", () =
 	assert.equal((plain(rendered).match(//gu) ?? []).length, 1);
 });
 
-test("partial configured palette inherits omitted Tokyo Night colors", () => {
+test("partial custom palette leaves omitted colors unstyled", () => {
 	const config = normalizeStatuslineConfig({ palette: { time: { fg: "#ffffff" } } }).config;
 	const rendered = renderTokyoNightStatusline(300, [segment("time", "time", "meter")], config);
-	assert.ok(rendered.includes(`${ESCAPE}[38;2;255;255;255;48;2;29;34;48m time${ESCAPE}[0m`));
+	assert.equal(rendered, `░▒▓${ESCAPE}[38;2;255;255;255m time${ESCAPE}[0m`);
+});
+
+test("empty custom palette renders without ANSI color fallback", () => {
+	const config = normalizeStatuslineConfig({ palette: {} }).config;
+	const rendered = renderTokyoNightStatusline(
+		300,
+		[segment("model", "model", "header"), segment("cwd", "cwd", "directory")],
+		config,
+	);
+	assert.equal(rendered, "░▒▓ model cwd");
+	assert.equal(tokyoNightExtensionSeparator({} as Theme, "custom"), " • ");
 });
 
 test("different final segment colors retain the powerline transition", () => {

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -46,7 +46,7 @@ test("Tokyo Night default retains the exact powerline colors", () => {
 
 test("configured palette joins reordered time to an adjacent header block", () => {
 	const config = createDefaultConfig();
-	if (typeof config.palette === "string") assert.fail("expected palette object");
+	config.palettePreset = "custom";
 	config.palette.time = { fg: "#090c0c", bg: "#a3aed2" };
 	const rendered = renderTokyoNightStatusline(
 		300,
@@ -65,7 +65,7 @@ test("partial configured palette inherits omitted Tokyo Night colors", () => {
 
 test("different final segment colors retain the powerline transition", () => {
 	const config = createDefaultConfig();
-	if (typeof config.palette === "string") assert.fail("expected palette object");
+	config.palettePreset = "custom";
 	config.palette.time = { ...config.palette.time, bg: "#123456" };
 	const rendered = renderTokyoNightStatusline(
 		300,
@@ -127,7 +127,8 @@ test("all named palettes render deterministic distinct ANSI output", () => {
 		"mono",
 	] as const) {
 		const config = createDefaultConfig();
-		config.palette = palette;
+		config.palettePreset = palette;
+		config.palette.model = { fg: "#ffffff", bg: "#ffffff" };
 		const output = renderTokyoNightStatusline(
 			300,
 			[segment("model", "model", "header"), segment("cwd", "cwd", "directory")],

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { Theme } from "@earendil-works/pi-coding-agent";
+import { powerlineExtensionSeparator, renderPowerlineStatusline } from "../src/powerline.js";
 import { formatConfiguredSegment } from "../src/render.js";
 import { createDefaultConfig, normalizeStatuslineConfig } from "../src/settings.js";
-import { renderTokyoNightStatusline, tokyoNightExtensionSeparator } from "../src/tokyo-night.js";
 import type { RenderItem, RenderSegment, SegmentName } from "../src/types.js";
 
 const ESCAPE = String.fromCharCode(27);
@@ -17,9 +17,9 @@ function segment(name: SegmentName, text: string, block: RenderSegment["block"])
 	return { name, text, block, color: "accent" };
 }
 
-test("Tokyo Night renderer preserves configured segment order across repeated blocks", () => {
+test("powerline renderer preserves configured segment order across repeated blocks", () => {
 	const config = createDefaultConfig();
-	const rendered = renderTokyoNightStatusline(
+	const rendered = renderPowerlineStatusline(
 		300,
 		[
 			segment("model", "model", "header"),
@@ -32,7 +32,7 @@ test("Tokyo Night renderer preserves configured segment order across repeated bl
 });
 
 test("Tokyo Night default retains the exact powerline colors", () => {
-	const rendered = renderTokyoNightStatusline(
+	const rendered = renderPowerlineStatusline(
 		300,
 		[segment("model", "model", "header")],
 		createDefaultConfig(),
@@ -49,7 +49,7 @@ test("configured palette joins reordered time to an adjacent header block", () =
 	const config = createDefaultConfig();
 	config.palettePreset = "custom";
 	config.palette.time = { fg: "#090c0c", bg: "#a3aed2" };
-	const rendered = renderTokyoNightStatusline(
+	const rendered = renderPowerlineStatusline(
 		300,
 		[segment("time", "time", "meter"), segment("brand", "brand", "header")],
 		config,
@@ -60,26 +60,26 @@ test("configured palette joins reordered time to an adjacent header block", () =
 
 test("partial custom palette leaves omitted colors unstyled", () => {
 	const config = normalizeStatuslineConfig({ palette: { time: { fg: "#ffffff" } } }).config;
-	const rendered = renderTokyoNightStatusline(300, [segment("time", "time", "meter")], config);
+	const rendered = renderPowerlineStatusline(300, [segment("time", "time", "meter")], config);
 	assert.equal(rendered, `░▒▓${ESCAPE}[38;2;255;255;255m time${ESCAPE}[0m`);
 });
 
 test("empty custom palette renders without ANSI color fallback", () => {
 	const config = normalizeStatuslineConfig({ palette: {} }).config;
-	const rendered = renderTokyoNightStatusline(
+	const rendered = renderPowerlineStatusline(
 		300,
 		[segment("model", "model", "header"), segment("cwd", "cwd", "directory")],
 		config,
 	);
 	assert.equal(rendered, "░▒▓ model cwd");
-	assert.equal(tokyoNightExtensionSeparator({} as Theme, "custom"), " • ");
+	assert.equal(powerlineExtensionSeparator({} as Theme, "custom"), " • ");
 });
 
 test("different final segment colors retain the powerline transition", () => {
 	const config = createDefaultConfig();
 	config.palettePreset = "custom";
 	config.palette.time = { ...config.palette.time, bg: "#123456" };
-	const rendered = renderTokyoNightStatusline(
+	const rendered = renderPowerlineStatusline(
 		300,
 		[segment("time", "time", "meter"), segment("brand", "brand", "header")],
 		config,
@@ -96,7 +96,7 @@ test("line breaks render separated repeated markers as independent powerline row
 		{ name: "line_break" },
 		segment("branch", "branch", "git"),
 	];
-	const rendered = renderTokyoNightStatusline(300, items, config);
+	const rendered = renderPowerlineStatusline(300, items, config);
 	assert.deepEqual(plain(rendered).split("\n"), ["░▒▓ model", "░▒▓ cwd", "░▒▓ branch"]);
 });
 
@@ -106,7 +106,7 @@ test("density and separator configure text inside a contiguous block", () => {
 	config.density = "compact";
 	assert.equal(
 		plain(
-			renderTokyoNightStatusline(
+			renderPowerlineStatusline(
 				300,
 				[segment("provider", "one", "header"), segment("model", "two", "header")],
 				config,
@@ -117,7 +117,7 @@ test("density and separator configure text inside a contiguous block", () => {
 	config.density = "cozy";
 	assert.equal(
 		plain(
-			renderTokyoNightStatusline(
+			renderPowerlineStatusline(
 				300,
 				[segment("provider", "one", "header"), segment("model", "two", "header")],
 				config,
@@ -141,7 +141,7 @@ test("all named palettes render deterministic distinct ANSI output", () => {
 		const config = createDefaultConfig();
 		config.palettePreset = palette;
 		config.palette.model = { fg: "#ffffff", bg: "#ffffff" };
-		const output = renderTokyoNightStatusline(
+		const output = renderPowerlineStatusline(
 			300,
 			[segment("model", "model", "header"), segment("cwd", "cwd", "directory")],
 			config,
@@ -151,6 +151,93 @@ test("all named palettes render deterministic distinct ANSI output", () => {
 	}
 	assert.equal(outputs.size, 7);
 });
+
+test("named palettes use cohesive preset-specific background ramps", () => {
+	const expected = {
+		ocean: ["#7dcfff", "#4f9fba", "#2d6f88", "#23475b", "#182b3a"],
+		sunset: ["#ffcf70", "#f59e6f", "#dc718a", "#8f5b78", "#493447"],
+		forest: ["#a7c080", "#83c092", "#5f9f75", "#3f6f55", "#293f35"],
+		candy: ["#f5c2e7", "#cba6f7", "#89b4fa", "#745f9a", "#403a5c"],
+		neon: ["#39ff14", "#00f5ff", "#ff4fd8", "#7a2cf3", "#29134f"],
+		mono: ["#d4d4d4", "#a3a3a3", "#686868", "#404040", "#262626"],
+	} as const;
+	const samples = [
+		segment("model", "model", "header"),
+		segment("cwd", "cwd", "directory"),
+		segment("branch", "branch", "git"),
+		segment("tools", "tools", "runtime"),
+		segment("time", "time", "meter"),
+	];
+
+	for (const [palettePreset, colors] of Object.entries(expected)) {
+		const config = createDefaultConfig();
+		config.palettePreset = palettePreset as keyof typeof expected;
+		const actual = samples.map((item) =>
+			backgroundColor(renderPowerlineStatusline(80, [item], config)),
+		);
+		assert.deepEqual(actual, colors, palettePreset);
+	}
+});
+
+test("named palette block text meets WCAG AA contrast", () => {
+	const samples = [
+		segment("model", "model", "header"),
+		segment("cwd", "cwd", "directory"),
+		segment("branch", "branch", "git"),
+		segment("tools", "tools", "runtime"),
+		segment("time", "time", "meter"),
+	];
+
+	for (const palettePreset of ["ocean", "sunset", "forest", "candy", "neon", "mono"] as const) {
+		const config = createDefaultConfig();
+		config.palettePreset = palettePreset;
+		for (const item of samples) {
+			const rendered = renderPowerlineStatusline(80, [item], config);
+			const colors = blockColors(rendered);
+			assert.ok(colors, `${palettePreset} ${item.block} colors`);
+			assert.ok(
+				contrastRatio(colors.fg, colors.bg) >= 4.5,
+				`${palettePreset} ${item.block} contrast`,
+			);
+		}
+	}
+});
+
+function backgroundColor(rendered: string): string | undefined {
+	const match = /48;2;(\d+);(\d+);(\d+)/u.exec(rendered);
+	return match ? rgbMatchToHex(match.slice(1)) : undefined;
+}
+
+function blockColors(rendered: string): { fg: string; bg: string } | undefined {
+	const match = /38;2;(\d+);(\d+);(\d+);48;2;(\d+);(\d+);(\d+)/u.exec(rendered);
+	return match
+		? { fg: rgbMatchToHex(match.slice(1, 4)), bg: rgbMatchToHex(match.slice(4, 7)) }
+		: undefined;
+}
+
+function rgbMatchToHex(components: string[]): string {
+	return `#${components
+		.map((component) => Number(component).toString(16).padStart(2, "0"))
+		.join("")}`;
+}
+
+function contrastRatio(left: string, right: string): number {
+	const luminances = [left, right].map(relativeLuminance);
+	const lighter = Math.max(...luminances);
+	const darker = Math.min(...luminances);
+	return (lighter + 0.05) / (darker + 0.05);
+}
+
+function relativeLuminance(hex: string): number {
+	const channels = hex
+		.slice(1)
+		.match(/../gu)
+		?.map((component) => Number.parseInt(component, 16) / 255)
+		.map((value) => (value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4)) ?? [
+		0, 0, 0,
+	];
+	return 0.2126 * (channels[0] ?? 0) + 0.7152 * (channels[1] ?? 0) + 0.0722 * (channels[2] ?? 0);
+}
 
 test("segment presentation wraps canonical dynamic values with configured text", () => {
 	const config = createDefaultConfig();
@@ -162,5 +249,5 @@ test("segment presentation wraps canonical dynamic values with configured text",
 });
 
 test("empty segment arrays render no powerline content", () => {
-	assert.equal(renderTokyoNightStatusline(80, [], createDefaultConfig()), "");
+	assert.equal(renderPowerlineStatusline(80, [], createDefaultConfig()), "");
 });

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -13,13 +13,11 @@ import {
 } from "../src/settings.js";
 
 test("statusline defaults describe the complete Tokyo Night JSON document", () => {
-	assert.equal(typeof DEFAULT_STATUSLINE_CONFIG.palette, "object");
-	assert.deepEqual(
-		typeof DEFAULT_STATUSLINE_CONFIG.palette === "string"
-			? undefined
-			: DEFAULT_STATUSLINE_CONFIG.palette.time,
-		{ fg: "#a0a9cb", bg: "#1d2230" },
-	);
+	assert.equal(DEFAULT_STATUSLINE_CONFIG.palettePreset, "tokyo-night");
+	assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.palette.time, {
+		fg: "#a0a9cb",
+		bg: "#1d2230",
+	});
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.density, "compact");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.separator, "none");
 	assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.segments, [
@@ -56,7 +54,7 @@ test("normalization supports partial icon-only settings and structured overrides
 		},
 		extensionStatusIcons: { goal: "", custom: "🧪" },
 	});
-	assert.equal(normalized.config.palette, "ocean");
+	assert.equal(normalized.config.palettePreset, "ocean");
 	assert.equal(normalized.config.density, "cozy");
 	assert.equal(normalized.config.separator, "dot");
 	assert.deepEqual(normalized.config.segments, ["model", "cwd", "turn"]);
@@ -67,7 +65,7 @@ test("normalization supports partial icon-only settings and structured overrides
 	assert.deepEqual(normalized.diagnostics, []);
 
 	const iconOnly = normalizeStatuslineConfig({ extensionStatusIcons: { goal: "◎" } });
-	assert.equal(typeof iconOnly.config.palette, "object");
+	assert.equal(iconOnly.config.palettePreset, "tokyo-night");
 	assert.deepEqual(iconOnly.config.segments, DEFAULT_STATUSLINE_CONFIG.segments);
 	assert.equal(iconOnly.config.extensionStatusIcons.goal, "◎");
 });
@@ -80,12 +78,21 @@ test("palette object normalizes segment colors and inherits omitted Tokyo Night 
 			cwd: { bg: "#123ABC" },
 		},
 	});
-	assert.equal(typeof normalized.config.palette, "object");
-	if (typeof normalized.config.palette === "string") assert.fail("expected palette object");
+	assert.equal(normalized.config.palettePreset, "custom");
 	assert.deepEqual(normalized.config.palette.time, { fg: "#090c0c", bg: "#a3aed2" });
 	assert.deepEqual(normalized.config.palette.model, { fg: "#ffffff", bg: "#a3aed2" });
 	assert.deepEqual(normalized.config.palette.cwd, { fg: "#e3e5e5", bg: "#123abc" });
 	assert.deepEqual(normalized.config.palette.brand, { fg: "#090c0c", bg: "#a3aed2" });
+	assert.deepEqual(normalized.diagnostics, []);
+});
+
+test("explicit palette preset takes precedence while preserving custom colors", () => {
+	const normalized = normalizeStatuslineConfig({
+		palettePreset: "forest",
+		palette: { time: { fg: "#112233", bg: "#445566" } },
+	});
+	assert.equal(normalized.config.palettePreset, "forest");
+	assert.deepEqual(normalized.config.palette.time, { fg: "#112233", bg: "#445566" });
 	assert.deepEqual(normalized.diagnostics, []);
 });
 
@@ -97,8 +104,7 @@ test("palette object reports invalid colors and forward-compatible unknown field
 			unknown: { fg: "#123456" },
 		},
 	});
-	assert.equal(typeof normalized.config.palette, "object");
-	if (typeof normalized.config.palette === "string") assert.fail("expected palette object");
+	assert.equal(normalized.config.palettePreset, "custom");
 	assert.deepEqual(normalized.config.palette.time, { fg: "#a0a9cb", bg: "#1d2230" });
 	assert.deepEqual(
 		normalized.diagnostics.map(({ code, path }) => ({ code, path })),
@@ -148,6 +154,7 @@ test("segment text rejects embedded line breaks and terminal control sequences",
 test("normalization falls back by field and reports unknown, duplicate, and invalid values", () => {
 	const normalized = normalizeStatuslineConfig({
 		palette: "invalid",
+		palettePreset: "invalid",
 		density: 3,
 		separator: "bar",
 		segments: ["model", "unknown", "model", 3, "time"],
@@ -160,7 +167,7 @@ test("normalization falls back by field and reports unknown, duplicate, and inva
 		showLabels: true,
 		future: true,
 	});
-	assert.equal(typeof normalized.config.palette, "object");
+	assert.equal(normalized.config.palettePreset, "tokyo-night");
 	assert.equal(normalized.config.density, "compact");
 	assert.equal(normalized.config.separator, "bar");
 	assert.deepEqual(normalized.config.segments, ["model", "time"]);
@@ -170,6 +177,7 @@ test("normalization falls back by field and reports unknown, duplicate, and inva
 	const paths = normalized.diagnostics.map((item) => item.path);
 	for (const path of [
 		"palette",
+		"palettePreset",
 		"density",
 		"segments[1]",
 		"segments[2]",
@@ -199,14 +207,29 @@ test("all named palettes, separators, empty segments, and environment independen
 	const previous = process.env.PI_STATUSLINE_PRESET;
 	process.env.PI_STATUSLINE_PRESET = "classic";
 	try {
-		for (const palette of ["tokyo-night", "ocean", "sunset", "forest", "candy", "neon", "mono"]) {
-			assert.equal(normalizeStatuslineConfig({ palette }).config.palette, palette);
+		for (const palettePreset of [
+			"tokyo-night",
+			"ocean",
+			"sunset",
+			"forest",
+			"candy",
+			"neon",
+			"mono",
+		]) {
+			assert.equal(
+				normalizeStatuslineConfig({ palettePreset }).config.palettePreset,
+				palettePreset,
+			);
+			assert.equal(
+				normalizeStatuslineConfig({ palette: palettePreset }).config.palettePreset,
+				palettePreset,
+			);
 		}
 		for (const separator of ["none", "dot", "bar", "powerline", "round"]) {
 			assert.equal(normalizeStatuslineConfig({ separator }).config.separator, separator);
 		}
 		assert.deepEqual(normalizeStatuslineConfig({ segments: [] }).config.segments, []);
-		assert.equal(typeof normalizeStatuslineConfig({}).config.palette, "object");
+		assert.equal(normalizeStatuslineConfig({}).config.palettePreset, "tokyo-night");
 	} finally {
 		if (previous === undefined) delete process.env.PI_STATUSLINE_PRESET;
 		else process.env.PI_STATUSLINE_PRESET = previous;
@@ -316,6 +339,10 @@ test("invalid recognized fields are rejected on save while unknown fields remain
 		assert.throws(
 			() => saveStatuslineSettingsDocument(path, JSON.stringify({ palette: "bad" })),
 			/palette/i,
+		);
+		assert.throws(
+			() => saveStatuslineSettingsDocument(path, JSON.stringify({ palettePreset: "bad" })),
+			/palettePreset/i,
 		);
 		assert.throws(
 			() =>

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -70,7 +70,7 @@ test("normalization supports partial icon-only settings and structured overrides
 	assert.equal(iconOnly.config.extensionStatusIcons.goal, "◎");
 });
 
-test("palette object normalizes segment colors and inherits omitted Tokyo Night details", () => {
+test("palette object normalizes colors without filling omitted custom colors", () => {
 	const normalized = normalizeStatuslineConfig({
 		palette: {
 			time: { fg: "#090c0c", bg: "#A3AED2" },
@@ -80,9 +80,9 @@ test("palette object normalizes segment colors and inherits omitted Tokyo Night 
 	});
 	assert.equal(normalized.config.palettePreset, "custom");
 	assert.deepEqual(normalized.config.palette.time, { fg: "#090c0c", bg: "#a3aed2" });
-	assert.deepEqual(normalized.config.palette.model, { fg: "#ffffff", bg: "#a3aed2" });
-	assert.deepEqual(normalized.config.palette.cwd, { fg: "#e3e5e5", bg: "#123abc" });
-	assert.deepEqual(normalized.config.palette.brand, { fg: "#090c0c", bg: "#a3aed2" });
+	assert.deepEqual(normalized.config.palette.model, { fg: "#ffffff" });
+	assert.deepEqual(normalized.config.palette.cwd, { bg: "#123abc" });
+	assert.equal(normalized.config.palette.brand, undefined);
 	assert.deepEqual(normalized.diagnostics, []);
 });
 
@@ -94,6 +94,10 @@ test("explicit palette preset takes precedence while preserving custom colors", 
 	assert.equal(normalized.config.palettePreset, "forest");
 	assert.deepEqual(normalized.config.palette.time, { fg: "#112233", bg: "#445566" });
 	assert.deepEqual(normalized.diagnostics, []);
+
+	const emptyCustom = normalizeStatuslineConfig({ palettePreset: "custom" });
+	assert.equal(emptyCustom.config.palettePreset, "custom");
+	assert.deepEqual(emptyCustom.config.palette, {});
 });
 
 test("palette object reports invalid colors and forward-compatible unknown fields", () => {
@@ -105,7 +109,7 @@ test("palette object reports invalid colors and forward-compatible unknown field
 		},
 	});
 	assert.equal(normalized.config.palettePreset, "custom");
-	assert.deepEqual(normalized.config.palette.time, { fg: "#a0a9cb", bg: "#1d2230" });
+	assert.deepEqual(normalized.config.palette.time, {});
 	assert.deepEqual(
 		normalized.diagnostics.map(({ code, path }) => ({ code, path })),
 		[

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -12,7 +12,7 @@ import {
 	settingsFilePath,
 } from "../src/settings.js";
 
-test("statusline defaults describe the complete Tokyo Night JSON document", () => {
+test("runtime defaults remain complete while the initial JSON document stays concise", () => {
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.palettePreset, "tokyo-night");
 	assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.palette.time, {
 		fg: "#a0a9cb",
@@ -38,7 +38,27 @@ test("statusline defaults describe the complete Tokyo Night JSON document", () =
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons.goal, "🎯");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons.usage, "📊");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons["codex-usage"], "📊");
-	assert.deepEqual(JSON.parse(DEFAULT_STATUSLINE_DOCUMENT), DEFAULT_STATUSLINE_CONFIG);
+	assert.deepEqual(JSON.parse(DEFAULT_STATUSLINE_DOCUMENT), {
+		palettePreset: "tokyo-night",
+		density: "compact",
+		separator: "none",
+		segments: [
+			"brand",
+			"provider",
+			"model",
+			"thinking",
+			"cwd",
+			"branch",
+			"tools",
+			"context",
+			"tokens",
+			"cost",
+			"time",
+		],
+	});
+	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"palette"'), false);
+	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"segmentText"'), false);
+	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"extensionStatusIcons"'), false);
 	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.endsWith("\n"), true);
 });
 
@@ -70,6 +90,17 @@ test("normalization supports partial icon-only settings and structured overrides
 	assert.equal(iconOnly.config.extensionStatusIcons.goal, "◎");
 });
 
+test("a named preset without custom colors prepares that preset as the custom starting point", () => {
+	const normalized = normalizeStatuslineConfig({ palettePreset: "forest" });
+	assert.equal(normalized.config.palettePreset, "forest");
+	assert.equal(normalized.config.palette.model?.bg, "#a7c080");
+	assert.equal(normalized.config.palette.cwd?.bg, "#83c092");
+	assert.equal(normalized.config.palette.branch?.bg, "#5f9f75");
+	assert.equal(normalized.config.palette.tools?.bg, "#3f6f55");
+	assert.equal(normalized.config.palette.time?.bg, "#293f35");
+	assert.deepEqual(normalized.diagnostics, []);
+});
+
 test("palette object normalizes colors without filling omitted custom colors", () => {
 	const normalized = normalizeStatuslineConfig({
 		palette: {
@@ -95,9 +126,9 @@ test("explicit palette preset takes precedence while preserving custom colors", 
 	assert.deepEqual(normalized.config.palette.time, { fg: "#112233", bg: "#445566" });
 	assert.deepEqual(normalized.diagnostics, []);
 
-	const emptyCustom = normalizeStatuslineConfig({ palettePreset: "custom" });
-	assert.equal(emptyCustom.config.palettePreset, "custom");
-	assert.deepEqual(emptyCustom.config.palette, {});
+	const defaultedCustom = normalizeStatuslineConfig({ palettePreset: "custom" });
+	assert.equal(defaultedCustom.config.palettePreset, "custom");
+	assert.deepEqual(defaultedCustom.config.palette, DEFAULT_STATUSLINE_CONFIG.palette);
 });
 
 test("palette object reports invalid colors and forward-compatible unknown fields", () => {
@@ -240,7 +271,7 @@ test("all named palettes, separators, empty segments, and environment independen
 	}
 });
 
-test("missing settings are atomically initialized with the complete default document", () => {
+test("missing settings are atomically initialized with the concise default document", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-settings-"));
 	try {
 		const loaded = loadOrCreateStatuslineSettings(root);

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -12,7 +12,7 @@ import {
 	settingsFilePath,
 } from "../src/settings.js";
 
-test("runtime defaults remain complete while the initial JSON document stays concise", () => {
+test("initial JSON exposes active defaults without materializing an inactive palette", () => {
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.palettePreset, "tokyo-night");
 	assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.palette.time, {
 		fg: "#a0a9cb",
@@ -55,10 +55,12 @@ test("runtime defaults remain complete while the initial JSON document stays con
 			"cost",
 			"time",
 		],
+		segmentText: DEFAULT_STATUSLINE_CONFIG.segmentText,
+		extensionStatusIcons: DEFAULT_STATUSLINE_CONFIG.extensionStatusIcons,
 	});
 	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"palette"'), false);
-	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"segmentText"'), false);
-	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"extensionStatusIcons"'), false);
+	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"segmentText"'), true);
+	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.includes('"extensionStatusIcons"'), true);
 	assert.equal(DEFAULT_STATUSLINE_DOCUMENT.endsWith("\n"), true);
 });
 
@@ -271,7 +273,7 @@ test("all named palettes, separators, empty segments, and environment independen
 	}
 });
 
-test("missing settings are atomically initialized with the concise default document", () => {
+test("missing settings are atomically initialized with the editable default document", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-settings-"));
 	try {
 		const loaded = loadOrCreateStatuslineSettings(root);

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -13,7 +13,13 @@ import {
 } from "../src/settings.js";
 
 test("statusline defaults describe the complete Tokyo Night JSON document", () => {
-	assert.equal(DEFAULT_STATUSLINE_CONFIG.palette, "tokyo-night");
+	assert.equal(typeof DEFAULT_STATUSLINE_CONFIG.palette, "object");
+	assert.deepEqual(
+		typeof DEFAULT_STATUSLINE_CONFIG.palette === "string"
+			? undefined
+			: DEFAULT_STATUSLINE_CONFIG.palette.time,
+		{ fg: "#a0a9cb", bg: "#1d2230" },
+	);
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.density, "compact");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.separator, "none");
 	assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.segments, [
@@ -61,9 +67,49 @@ test("normalization supports partial icon-only settings and structured overrides
 	assert.deepEqual(normalized.diagnostics, []);
 
 	const iconOnly = normalizeStatuslineConfig({ extensionStatusIcons: { goal: "◎" } });
-	assert.equal(iconOnly.config.palette, "tokyo-night");
+	assert.equal(typeof iconOnly.config.palette, "object");
 	assert.deepEqual(iconOnly.config.segments, DEFAULT_STATUSLINE_CONFIG.segments);
 	assert.equal(iconOnly.config.extensionStatusIcons.goal, "◎");
+});
+
+test("palette object normalizes segment colors and inherits omitted Tokyo Night details", () => {
+	const normalized = normalizeStatuslineConfig({
+		palette: {
+			time: { fg: "#090c0c", bg: "#A3AED2" },
+			model: { fg: "#ffffff" },
+			cwd: { bg: "#123ABC" },
+		},
+	});
+	assert.equal(typeof normalized.config.palette, "object");
+	if (typeof normalized.config.palette === "string") assert.fail("expected palette object");
+	assert.deepEqual(normalized.config.palette.time, { fg: "#090c0c", bg: "#a3aed2" });
+	assert.deepEqual(normalized.config.palette.model, { fg: "#ffffff", bg: "#a3aed2" });
+	assert.deepEqual(normalized.config.palette.cwd, { fg: "#e3e5e5", bg: "#123abc" });
+	assert.deepEqual(normalized.config.palette.brand, { fg: "#090c0c", bg: "#a3aed2" });
+	assert.deepEqual(normalized.diagnostics, []);
+});
+
+test("palette object reports invalid colors and forward-compatible unknown fields", () => {
+	const normalized = normalizeStatuslineConfig({
+		palette: {
+			time: { fg: "#fff", bg: 7, future: "#ffffff" },
+			model: "#ffffff",
+			unknown: { fg: "#123456" },
+		},
+	});
+	assert.equal(typeof normalized.config.palette, "object");
+	if (typeof normalized.config.palette === "string") assert.fail("expected palette object");
+	assert.deepEqual(normalized.config.palette.time, { fg: "#a0a9cb", bg: "#1d2230" });
+	assert.deepEqual(
+		normalized.diagnostics.map(({ code, path }) => ({ code, path })),
+		[
+			{ code: "invalid", path: "palette.time.fg" },
+			{ code: "invalid", path: "palette.time.bg" },
+			{ code: "unknown", path: "palette.time.future" },
+			{ code: "invalid", path: "palette.model" },
+			{ code: "unknown", path: "palette.unknown" },
+		],
+	);
 });
 
 test("line breaks may repeat when separated but consecutive line breaks are invalid", () => {
@@ -114,7 +160,7 @@ test("normalization falls back by field and reports unknown, duplicate, and inva
 		showLabels: true,
 		future: true,
 	});
-	assert.equal(normalized.config.palette, "tokyo-night");
+	assert.equal(typeof normalized.config.palette, "object");
 	assert.equal(normalized.config.density, "compact");
 	assert.equal(normalized.config.separator, "bar");
 	assert.deepEqual(normalized.config.segments, ["model", "time"]);
@@ -160,7 +206,7 @@ test("all named palettes, separators, empty segments, and environment independen
 			assert.equal(normalizeStatuslineConfig({ separator }).config.separator, separator);
 		}
 		assert.deepEqual(normalizeStatuslineConfig({ segments: [] }).config.segments, []);
-		assert.equal(normalizeStatuslineConfig({}).config.palette, "tokyo-night");
+		assert.equal(typeof normalizeStatuslineConfig({}).config.palette, "object");
 	} finally {
 		if (previous === undefined) delete process.env.PI_STATUSLINE_PRESET;
 		else process.env.PI_STATUSLINE_PRESET = previous;
@@ -270,6 +316,14 @@ test("invalid recognized fields are rejected on save while unknown fields remain
 		assert.throws(
 			() => saveStatuslineSettingsDocument(path, JSON.stringify({ palette: "bad" })),
 			/palette/i,
+		);
+		assert.throws(
+			() =>
+				saveStatuslineSettingsDocument(
+					path,
+					JSON.stringify({ palette: { time: { bg: "#abcd" } } }),
+				),
+			/palette\.time\.bg/i,
 		);
 		assert.throws(
 			() =>

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -563,7 +563,7 @@ test("statusline settings load extension icon overrides", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-test-"));
 	const settingsPath = join(root, "pi-statusline.json");
 
-	assert.equal(readStatuslineSettings(settingsPath).palette, "tokyo-night");
+	assert.equal(typeof readStatuslineSettings(settingsPath).palette, "object");
 
 	writeFileSync(
 		settingsPath,
@@ -575,7 +575,7 @@ test("statusline settings load extension icon overrides", () => {
 	assert.equal(Object.hasOwn(configured.extensionStatusIcons, "bad"), false);
 
 	writeFileSync(settingsPath, "not json");
-	assert.equal(readStatuslineSettings(settingsPath).palette, "tokyo-night");
+	assert.equal(typeof readStatuslineSettings(settingsPath).palette, "object");
 });
 
 test("statusline settings migrate to the canonical package filename", async () => {
@@ -602,7 +602,7 @@ test("statusline settings migrate to the canonical package filename", async () =
 		assert.equal(existsSync(legacyPath), true);
 
 		writeFileSync(canonicalPath, "invalid");
-		assert.equal(readStatuslineSettings().palette, "tokyo-night");
+		assert.equal(typeof readStatuslineSettings().palette, "object");
 		assert.equal(readFileSync(legacyPath, "utf8").includes("old"), true);
 		unlinkSync(legacyPath);
 		writeFileSync(canonicalPath, JSON.stringify({ extensionStatusIcons: { goal: "fixed" } }));
@@ -610,12 +610,12 @@ test("statusline settings migrate to the canonical package filename", async () =
 		assert.equal(consumeStatuslineSettingsNotice(), undefined);
 		unlinkSync(canonicalPath);
 		writeFileSync(legacyPath, "invalid");
-		assert.equal(readStatuslineSettings().palette, "tokyo-night");
+		assert.equal(typeof readStatuslineSettings().palette, "object");
 		assert.equal(existsSync(canonicalPath), false);
 
 		writeFileSync(legacyPath, JSON.stringify({ extensionStatusIcons: { goal: "fallback" } }));
 		symlinkSync("missing-target", canonicalPath);
-		assert.equal(readStatuslineSettings().palette, "tokyo-night");
+		assert.equal(typeof readStatuslineSettings().palette, "object");
 		assert.equal(existsSync(legacyPath), true);
 		const mock = createMockPi();
 		statusline(mock.pi);


### PR DESCRIPTION
## Summary

- write the complete Tokyo Night per-segment palette into the initial `pi-statusline.json`
- add `palettePreset` with seven built-in presets plus `custom`, preserving custom colors while switching
- make argument-free `/statusline` a TUI menu for palette presets, JSON settings, status, and help
- reject textual arguments instead of exposing menu actions as subcommands
- keep legacy string palettes compatible and preserve unknown JSON fields during picker saves
- leave omitted custom colors unstyled instead of falling back to Tokyo Night
- merge adjacent custom segments with matching colors so reordered segments remain visually continuous

## Verification

- `npm run check --workspace @narumitw/pi-statusline`
- `npm run check`
- `npm run pack:statusline`
- `git diff --check`