### PR TITLE
docs: clarify menu-first command conventions

### DIFF
--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -9,6 +9,7 @@ The Pi guidance was last reviewed against the latest published
 
 - [Extension API](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md)
 - [Package format](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md)
+- [RPC mode](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/rpc.md)
 - [TUI components](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/tui.md)
 
 Review this section when the repository updates its Pi dependencies or latest-release CI target.
@@ -137,7 +138,8 @@ lines for responsibility-based decomposition rather than mechanical splitting.
 
 ### Slash commands and menus
 
-A command's default shape depends on its product role:
+A command's default shape depends on its product role. A manager can be menu-first without being
+menu-only:
 
 - A multi-action manager extension **SHOULD** expose one primary slash command whose no-argument form
   opens a current-state menu. Do not mirror menu actions into textual subcommands by default.
@@ -145,22 +147,33 @@ A command's default shape depends on its product role:
   such as `/btw <question>` or `/goal <goal>`; a supported non-TUI, RPC, or automation workflow needs
   a deterministic route; an existing public interface requires compatibility; or the command is a
   frequent, single, unambiguous primary action.
-- A passive extension MAY expose no command. A menu-only manager MAY reject all arguments explicitly.
+- A passive extension MAY expose no command. A manager with none of those direct-route needs MAY be
+  menu-only and reject all arguments explicitly.
 - The primary command **SHOULD** usually derive from the unscoped package name by removing `pi-`.
   Preserve an established or clearer product name when compatibility or meaning outweighs symmetry.
-- **MUST:** Treat every accepted argument or subcommand as a public interface: document it, provide
-  `getArgumentCompletions` for known values, reject unknown input clearly, preserve applicable safety
-  checks, and test its supported TUI and non-TUI behavior. **Verification:** `Test` of direct command
-  routes plus `Review` of documentation, completion, compatibility, and safety behavior.
+- **MUST:** Treat every accepted argument or subcommand as a public interface: document its supported
+  modes, provide `getArgumentCompletions` for known routes and values, reject unknown or trailing input
+  instead of silently ignoring it, preserve applicable safety checks, and test every claimed TUI and
+  non-TUI behavior. **Verification:** `Test` of exact direct-command routes and claimed modes plus
+  `Review` of documentation, completion, compatibility, and safety behavior.
+- **MUST:** Do not remove an established or documented route merely to make a manager menu-first.
+  Preserve it as a compatibility route unless an explicitly approved breaking change includes its
+  migration path, release documentation, and updated compatibility tests. **Verification:** `Test` of
+  retained routes or intentionally changed behavior plus `Review` of breaking-change approval,
+  migration, and release documentation.
 - A main menu **SHOULD** show current state and the most relevant next actions. Prioritize current
   session context and label cross-provider, cross-workspace, destructive, or externally visible
   effects explicitly.
 - Destructive actions **SHOULD** show an exact summary and ask for confirmation. Cancellation should
   leave state unchanged.
 
-- **MUST:** Provide a safe non-TUI result for every command that can run outside the TUI: execute a
-  direct operation, return status/help through a supported UI channel, or clearly reject the mode.
-  **Verification:** `Test` for supported command modes plus `Review` of the fallback.
+- **MUST:** Provide safe behavior in every non-TUI mode a command can receive: execute a direct
+  operation, expose status/help through a channel supported by that mode, or reject before entering
+  TUI-only work. Claim a mode as supported only when its result or rejection is observable there.
+  `ctx.hasUI` is true in TUI and RPC modes, where `ctx.ui.notify()` is observable, and false in print
+  and JSON modes, where UI methods are no-ops; a notify-only path therefore does not provide a print
+  or JSON result. **Verification:** `Test` for each claimed command mode plus `Review` of every
+  unsupported-mode fallback.
 
 Use `ctx.ui.select()` for a small action menu. Use `SelectList` for richer selection and
 `SettingsList` for editable settings; do not repeatedly reopen `ctx.ui.select()` after each toggle,
@@ -219,9 +232,11 @@ fragile regular expressions. Until then, label the real verification method hone
       installable.
 - [ ] Add the thin `src/index.ts` forwarder and canonical `pi.extensions` manifest entry.
 - [ ] Separate factory registration from session-owned startup and idempotent shutdown cleanup.
-- [ ] Choose the primary command and no-argument behavior from the extension's product role; add
-      direct routes only for a concrete need, then document, complete, reject, and test them as public
-      interfaces.
+- [ ] Choose the primary command and no-argument behavior from the extension's product role; use a
+      menu-first manager unless a concrete reason supports another shape, and add direct routes only
+      for concrete payload, automation, compatibility, or frequent-action needs.
+- [ ] Document accepted command routes and modes, complete known values, reject unknown or trailing
+      input, preserve safety checks, and test each claimed execution mode.
 - [ ] Follow `docs/extension-settings.md` for every user or project setting.
 - [ ] Bound tool output, cancellation, state persistence, and file mutation where applicable.
 - [ ] Document installation, behavior, settings, security, limitations, and source responsibilities.
@@ -233,6 +248,8 @@ fragile regular expressions. Until then, label the real verification method hone
 - [ ] Identify which sections the change touches; do not expand an unrelated change into a full
       package migration.
 - [ ] Apply every relevant MUST and review SHOULD deviations near their owning package.
+- [ ] For command-surface changes, preserve established routes or explicitly own an approved breaking
+      migration, and test every claimed execution mode.
 - [ ] Update focused tests and run the verification method named by each relevant MUST.
 - [ ] Run `npm run check`; add pack or Pi runtime smokes when metadata or loading changed.
 - [ ] Report any skipped check, accepted exception, or follow-up validator opportunity in the change

--- a/docs/plans/archived/2026-07-24_menu-first-command-conventions-plan.md
+++ b/docs/plans/archived/2026-07-24_menu-first-command-conventions-plan.md
@@ -1,0 +1,36 @@
+# Menu-first command conventions plan
+
+## Goal
+
+Clarify that extension managers are menu-first rather than necessarily menu-only, while keeping direct subcommands bounded to concrete payload, automation, compatibility, or frequent-action needs and making public-route compatibility and mode support explicit.
+
+## Context
+
+- `docs/extension-conventions.md` already prefers a no-argument current-state menu and says not to mirror every menu action into subcommands by default.
+- The guide already recognizes deterministic RPC/automation routes and existing-interface compatibility as valid reasons for direct subcommands.
+- The current wording does not explicitly say that adopting a menu must not silently remove documented routes, and its non-TUI rule does not spell out that `ctx.ui.notify()` is unavailable when `ctx.hasUI` is false.
+
+## Non-Goals
+
+- Require every menu action to have a textual subcommand.
+- Require new manager extensions to add automation routes without a concrete need.
+- Change any extension implementation, README, package metadata, or release behavior in this documentation-only branch.
+- Add a validator for product-level command semantics.
+
+## Plan
+
+- [x] Verify Pi's current TUI, RPC, JSON, and print UI observability against the installed official documentation, then record only mode claims supported by that evidence in `docs/extension-conventions.md`. Evidence: the installed `extensions.md` mode table and `rpc.md` Extension UI Protocol confirm `ctx.hasUI` and notification behavior.
+- [x] Revise `docs/extension-conventions.md` under “Slash commands and menus” to define manager commands as menu-first rather than menu-only, retain the default against speculative menu-action mirroring, and keep the existing concrete exceptions for payload, deterministic RPC/automation, compatibility, and frequent unambiguous actions; verify the paragraph has one coherent default and exception model.
+- [x] Add an explicit public-interface compatibility rule stating that a menu-first migration does not itself justify removing documented arguments or subcommands, and that removal requires an intentionally approved breaking change with migration, documentation, release, and test ownership; verify the rule names `Review` and `Test` evidence consistently with the guide's authority model.
+- [x] Strengthen the direct-route and non-TUI guidance so accepted routes reject trailing or unknown input, document and complete known values, test each claimed mode, and do not treat `ctx.ui.notify()` as observable in print or JSON mode; verify TUI and RPC support are distinguished from `ctx.hasUI === false` modes without prescribing unsupported output mechanisms.
+- [x] Update the new-extension and touched-area checklists only where needed to surface menu-first/public-route compatibility and mode verification without duplicating the normative rules; review the settings cross-reference for consistency without editing `docs/extension-settings.md` unless the central wording would otherwise conflict. Evidence: the existing settings cross-reference remains consistent and requires no edit.
+- [x] Run `git diff --check` and `npm run check`, review the final diff for concise non-duplicative guidance, then archive this completed plan under `docs/plans/archived/`. Evidence: both commands passed; `npm run check` completed with 1,155 passing tests.
+
+## Completion Checklist
+
+- [x] The guide explicitly distinguishes menu-first from menu-only.
+- [x] Menu actions remain unmirrored by default, while concrete RPC/automation and compatibility routes remain allowed.
+- [x] Existing documented routes cannot be removed merely to adopt a menu; intentional breaking removal has explicit ownership requirements.
+- [x] Accepted direct routes must handle exact input, documentation, completions, safety, compatibility, and per-mode tests.
+- [x] The non-TUI rule accurately explains `ctx.hasUI` observability and does not claim print/JSON output from `ctx.ui.notify()`.
+- [x] No extension behavior or unrelated guidance changes, repository checks pass, and the plan is archived.


### PR DESCRIPTION
## Summary

- define manager commands as menu-first without requiring them to be menu-only
- preserve established direct routes unless an approved breaking change owns their migration
- require exact argument handling, documented mode support, and per-mode verification
- clarify that extension UI notifications are observable in TUI/RPC but not print/JSON modes
- update command checklists and archive the completed implementation plan

## Verification

- `git diff --check`
- `npm run check` (1,155 tests passed)
