### PR TITLE
feat(statusline): add segment visibility menu

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-statusline-segment-menu-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-statusline-segment-menu-plan.md
@@ -1,0 +1,39 @@
+## Goal
+
+Let TUI users choose which data segments pi-statusline currently displays from the `/statusline`
+menu, with immediate persistent application and safe recovery when settings cannot be saved.
+
+## Architecture
+
+- Add a `Segments` action to the existing argument-free `/statusline` menu.
+- Use Pi's `SettingsList` for one visible/hidden toggle per data segment; keep `line_break` in the
+  advanced JSON layout editor because it controls rows rather than displayed data.
+- Preserve the relative order of segments that remain visible. Append newly enabled segments to the
+  final row, and remove leading, trailing, or newly consecutive `line_break` entries after a toggle.
+- Update only the root `segments` field in the existing raw JSON document so unknown fields and all
+  other settings remain unchanged.
+- Save through the existing atomic validator, apply the loaded settings immediately, and restore the
+  displayed toggle on any validation or persistence failure.
+
+## Plan
+
+- [x] Add focused failing command tests for opening the Segments screen, immediate visible/hidden
+  toggles, order/layout normalization, unknown-field preservation, cancellation, and save rollback.
+  Red evidence: `npm test` failed only the three menu expectations introduced/updated for this UI.
+- [x] Implement the Segments `SettingsList` screen and transactional `segments` document update in
+  `extensions/pi-statusline/src/commands.ts`; `npm test` passes all 1,181 tests, including save and
+  runtime-application rollback.
+- [x] Update `extensions/pi-statusline/README.md` and menu help to document interactive segment
+  selection, immediate persistence, ordering behavior, and `line_break` ownership.
+- [x] Format intended files and run `npm run check` plus `just pack-statusline`; the full gate passed
+  all 1,181 tests and the 24-file tarball includes `src/commands.ts` and `README.md`.
+
+## Completion Checklist
+
+- [x] `/statusline` exposes a discoverable Segments action showing the current visible count.
+- [x] Every data segment can be enabled or disabled without reopening the screen, and the footer
+  receives each successful change immediately.
+- [x] Existing order, valid line breaks, unknown JSON fields, and unrelated settings are preserved;
+  failed writes leave file, runtime state, and displayed state unchanged.
+- [x] Non-TUI behavior and established `/statusline settings|status|help` routes remain unchanged.
+- [x] Focused tests, repository CI-equivalent checks, and the statusline pack dry run pass.

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -9,6 +9,7 @@
 - Shows provider, model, thinking, directory, Git/PR state, tools, context, tokens, cost, time, and extension statuses.
 - Uses one Starship-inspired `░▒▓` / `` Tokyo Night layout.
 - Configures segment order, visibility, multiline breaks, surrounding text, palette, density, separators, and extension icons through JSON.
+- Chooses displayed data segments from the `/statusline` menu and applies each toggle immediately.
 - Creates an editable default configuration without an inactive custom palette on first session start.
 - Previews palette presets as the picker cursor moves, then applies the selection only on Enter.
 - Applies validated JSON settings edits from the `/statusline` menu immediately after an atomic save.
@@ -136,6 +137,8 @@ brand provider model thinking cwd branch tools context tokens cost time turn lin
 
 The array controls visibility and actual rendering order. Data segments must remain unique. The special `line_break` segment starts another footer row and may repeat when another segment separates each occurrence; consecutive `line_break` entries are invalid. Each row receives its own powerline start and end. `line_break` has no `segmentText` entry.
 
+Use `/statusline` → `Segments` to show or hide any data segment without editing JSON. The screen supports arrow-key navigation, Enter or Space to toggle, and Escape to close. Every successful toggle is atomically saved and applied immediately; Escape does not undo earlier toggles. Remaining segments keep their relative order, newly shown segments are appended to the final row, and leading, trailing, or newly consecutive `line_break` entries are removed. Continue using the JSON editor when you need to place segments or line breaks at exact positions.
+
 An empty array hides the main powerline while still allowing extension statuses to render. `turn` is available but omitted by default.
 
 Example multiline layout:
@@ -236,12 +239,12 @@ from that line when the branch segment already renders it.
 
 | Command | Purpose |
 | --- | --- |
-| `/statusline` | Open the interactive menu for palette presets, settings JSON, status, and help |
+| `/statusline` | Open the interactive menu for palette presets, displayed segments, settings JSON, status, and help |
 | `/statusline settings` | Open the JSON settings editor in TUI mode |
 | `/statusline status` | Show the settings source, path, appearance, segments, and diagnostics |
 | `/statusline help` | Show command and schema guidance |
 
-Argument-free `/statusline` requires TUI mode. The established `settings`, `status`, and `help` routes remain available for compatibility; RPC receives notifications instead of opening TUI-only controls. Unknown subcommands and trailing arguments are rejected. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled changes leave both the previous file and effective runtime configuration unchanged.
+Argument-free `/statusline` requires TUI mode. The established `settings`, `status`, and `help` routes remain available for compatibility; RPC receives notifications instead of opening TUI-only controls. Unknown subcommands and trailing arguments are rejected. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. In the Segments screen, each Enter or Space toggle saves immediately, while Escape only closes the screen. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled unsaved changes leave both the previous file and effective runtime configuration unchanged.
 
 ## 🌿 Git and activity details
 

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -2,12 +2,15 @@ import {
 	DynamicBorder,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
+	getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
 import {
 	type AutocompleteItem,
 	Container,
 	type SelectItem,
 	SelectList,
+	type SettingItem,
+	SettingsList,
 	Text,
 } from "@earendil-works/pi-tui";
 import { segmentPaletteForPreset } from "./presets/index.js";
@@ -17,13 +20,31 @@ import {
 	saveStatuslineSettingsDocument,
 } from "./settings.js";
 import {
+	type ConfigSegmentName,
+	LINE_BREAK_SEGMENT_NAME,
 	PALETTE_NAMES,
 	PALETTE_PRESET_NAMES,
 	type PaletteName,
 	type PalettePreset,
+	SEGMENT_NAMES,
+	type SegmentName,
 } from "./types.js";
 
 const EDIT_SETTINGS_LABEL = "Edit settings JSON (custom colors, layout, icons)";
+const SEGMENT_DESCRIPTIONS: Record<SegmentName, string> = {
+	brand: "Pi brand mark",
+	provider: "Current model provider",
+	model: "Current model name",
+	thinking: "Current thinking level",
+	cwd: "Current working directory",
+	branch: "Git branch, status, and linked pull request",
+	tools: "Current tool and streaming activity",
+	context: "Current context-window usage",
+	tokens: "Session token totals",
+	cost: "Session cost",
+	time: "Current local time",
+	turn: "Current session turn count",
+};
 const SUBCOMMANDS: AutocompleteItem[] = [
 	{ value: "settings", label: "settings", description: "Edit pi-statusline.json" },
 	{ value: "status", label: "status", description: "Show effective statusline settings" },
@@ -86,9 +107,15 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 		if (ctx.hasUI) ctx.ui.notify("/statusline requires an interactive Pi UI.", "error");
 		return;
 	}
-	const paletteItem = `Palette preset (${options.getLoaded().config.palettePreset})`;
+	const config = options.getLoaded().config;
+	const paletteItem = `Palette preset (${config.palettePreset})`;
+	const visibleSegmentCount = config.segments.filter(
+		(segment): segment is SegmentName => segment !== LINE_BREAK_SEGMENT_NAME,
+	).length;
+	const segmentsItem = `Segments (${visibleSegmentCount}/${SEGMENT_NAMES.length} shown)`;
 	const selection = await ctx.ui.select("pi-statusline", [
 		paletteItem,
+		segmentsItem,
 		EDIT_SETTINGS_LABEL,
 		"Status",
 		"Help",
@@ -98,6 +125,9 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 		return;
 	}
 	switch (selection) {
+		case segmentsItem:
+			await chooseSegments(ctx, options);
+			return;
 		case EDIT_SETTINGS_LABEL:
 			await editSettings(ctx, options);
 			return;
@@ -203,6 +233,84 @@ async function showPalettePresetPicker(
 	return result ?? undefined;
 }
 
+async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
+	if (ctx.mode !== "tui") {
+		if (ctx.hasUI) ctx.ui.notify(`Edit segments manually: ${options.settingsPath}`, "info");
+		return;
+	}
+	let current = options.getLoaded();
+	const visible = new Set(current.config.segments);
+	const items: SettingItem[] = SEGMENT_NAMES.map((name) => ({
+		id: name,
+		label: name,
+		description: SEGMENT_DESCRIPTIONS[name],
+		currentValue: visible.has(name) ? "visible" : "hidden",
+		values: ["visible", "hidden"],
+	}));
+
+	await ctx.ui.custom((tui, theme, _keybindings, done) => {
+		const container = new Container();
+		container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
+		const title = new Text("", 1, 0);
+		container.addChild(title);
+		let list: SettingsList;
+		list = new SettingsList(
+			items,
+			Math.min(items.length, 12),
+			getSettingsListTheme(),
+			(id, newValue) => {
+				const name = id as SegmentName;
+				const previousValue = newValue === "visible" ? "hidden" : "visible";
+				try {
+					const { nextDocument, previousDocument } = segmentsDocument(
+						current,
+						name,
+						newValue === "visible",
+					);
+					const save = options.save ?? saveStatuslineSettingsDocument;
+					const next = save(options.settingsPath, nextDocument);
+					try {
+						options.apply(next, ctx);
+					} catch (applyError) {
+						try {
+							const restored = save(options.settingsPath, previousDocument);
+							options.apply(restored, ctx);
+						} catch (rollbackError) {
+							throw new Error(
+								`runtime update failed: ${formatError(applyError)}; rollback failed: ${formatError(rollbackError)}`,
+							);
+						}
+						throw applyError;
+					}
+					current = next;
+				} catch (error) {
+					list.updateValue(id, previousValue);
+					ctx.ui.notify(`Statusline segments were not saved: ${formatError(error)}`, "error");
+				}
+			},
+			() => done(undefined),
+		);
+		container.addChild(list);
+		container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
+		const updateThemedText = () => {
+			title.setText(theme.fg("accent", theme.bold("Statusline segments")));
+		};
+		updateThemedText();
+
+		return {
+			render: (width: number) => container.render(width),
+			invalidate() {
+				container.invalidate();
+				updateThemedText();
+			},
+			handleInput(data: string) {
+				list.handleInput(data);
+				tui.requestRender();
+			},
+		};
+	});
+}
+
 async function editSettings(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${options.settingsPath}`, "info");
@@ -231,15 +339,7 @@ function palettePresetDocument(
 	current: LoadedStatuslineSettings,
 	palettePreset: PalettePreset,
 ): string {
-	if (
-		current.source !== "user" ||
-		current.rawDocument === undefined ||
-		current.diagnostics.some((item) => item.code !== "unknown")
-	) {
-		throw new Error("Fix pi-statusline.json before choosing a palette preset");
-	}
-	const parsed = JSON.parse(current.rawDocument) as unknown;
-	if (!isRecord(parsed)) throw new Error("Settings must contain a JSON object");
+	const { parsed } = editableSettings(current, "choosing a palette preset");
 	if (palettePreset === "custom" && !isRecord(parsed.palette)) {
 		const seedPreset = isPaletteName(current.config.palettePreset)
 			? current.config.palettePreset
@@ -250,6 +350,54 @@ function palettePresetDocument(
 	}
 	parsed.palettePreset = palettePreset;
 	return `${JSON.stringify(parsed, null, "\t")}\n`;
+}
+
+function segmentsDocument(
+	current: LoadedStatuslineSettings,
+	name: SegmentName,
+	shouldShow: boolean,
+): { nextDocument: string; previousDocument: string } {
+	const { parsed, rawDocument: previousDocument } = editableSettings(current, "changing segments");
+	const segments = shouldShow
+		? [...current.config.segments, ...(current.config.segments.includes(name) ? [] : [name])]
+		: current.config.segments.filter((segment) => segment !== name);
+	parsed.segments = normalizeLineBreaks(segments);
+	return {
+		nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
+		previousDocument,
+	};
+}
+
+function normalizeLineBreaks(segments: readonly ConfigSegmentName[]): ConfigSegmentName[] {
+	const normalized: ConfigSegmentName[] = [];
+	for (const segment of segments) {
+		if (
+			segment === LINE_BREAK_SEGMENT_NAME &&
+			(normalized.length === 0 || normalized.at(-1) === LINE_BREAK_SEGMENT_NAME)
+		) {
+			continue;
+		}
+		normalized.push(segment);
+	}
+	if (normalized.at(-1) === LINE_BREAK_SEGMENT_NAME) normalized.pop();
+	return normalized;
+}
+
+function editableSettings(
+	current: LoadedStatuslineSettings,
+	action: string,
+): { parsed: Record<string, unknown>; rawDocument: string } {
+	if (
+		current.source !== "user" ||
+		current.rawDocument === undefined ||
+		current.diagnostics.some((item) => item.code !== "unknown")
+	) {
+		throw new Error(`Fix pi-statusline.json before ${action}`);
+	}
+	const rawDocument = current.rawDocument;
+	const parsed = JSON.parse(rawDocument) as unknown;
+	if (!isRecord(parsed)) throw new Error("Settings must contain a JSON object");
+	return { parsed, rawDocument };
 }
 
 function showStatus(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {
@@ -281,10 +429,11 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 			"/statusline settings — edit and apply JSON",
 			"/statusline status — show source, path, and warnings",
 			"/statusline help — show this help",
-			"Menu actions: Palette preset, Edit settings JSON, Status, Help",
+			"Menu actions: Palette preset, Segments, Edit settings JSON, Status, Help",
 			`Settings: ${settingsPath}`,
 			"Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",
 			"Named presets ignore but preserve palette; custom uses its per-segment fg/bg colors.",
+			"Use the Segments menu to show or hide data segments; changes save and apply immediately.",
 			"Use line_break between segments for another footer row; repeats must not be consecutive.",
 			"The segmentText entries support prefix and suffix strings around Pi-owned dynamic values.",
 		].join("\n"),

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerStatuslineCommand } from "../src/commands.js";
 import {
@@ -12,6 +13,8 @@ import {
 	settingsFilePath,
 } from "../src/settings.js";
 import statusline from "../src/statusline.js";
+
+initTheme("dark", false);
 
 interface PickerComponent {
 	render?(width: number): string[];
@@ -66,6 +69,205 @@ test("/statusline keeps compatibility subcommands and an argument-free interacti
 	await command.handler("palette", context.ctx);
 	assert.equal(selectCalls, 1);
 	assert.match(context.notifications.at(-1)?.message ?? "", /unknown.*palette/iu);
+});
+
+test("segment menu toggles displayed segments and preserves JSON fields and layout order", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(
+		path,
+		JSON.stringify({
+			segments: ["model", "line_break", "cwd"],
+			future: { retained: true },
+		}),
+	);
+	try {
+		const mock = createMockPi();
+		let loaded = loadStatuslineSettings(path);
+		const appliedSegments: string[][] = [];
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				appliedSegments.push([...next.config.segments]);
+			},
+		});
+		let menuChoices: string[] = [];
+		let initialScreen = "";
+		let changedScreen = "";
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) => {
+				menuChoices = choices;
+				return choices.find((choice) => choice.startsWith("Segments ("));
+			},
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				let result: unknown;
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{},
+					(value: unknown) => {
+						result = value;
+					},
+				) as PickerComponent;
+				initialScreen = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\r");
+				changedScreen = component.render?.(100).join("\n") ?? "";
+				for (let index = 0; index < 4; index += 1) component.handleInput?.("\u001b[B");
+				component.handleInput?.("\r");
+				for (let index = 0; index < 8; index += 1) component.handleInput?.("\u001b[B");
+				component.handleInput?.("\r");
+				component.handleInput?.("\u001b");
+				return result;
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.deepEqual(menuChoices, [
+			"Palette preset (tokyo-night)",
+			"Segments (2/12 shown)",
+			"Edit settings JSON (custom colors, layout, icons)",
+			"Status",
+			"Help",
+		]);
+		assert.match(initialScreen, /Statusline segments/u);
+		assert.match(initialScreen.split("\n").find((line) => line.includes("brand")) ?? "", /hidden/u);
+		assert.match(
+			initialScreen.split("\n").find((line) => line.includes("model")) ?? "",
+			/visible/u,
+		);
+		assert.doesNotMatch(initialScreen, /line_break/u);
+		assert.match(
+			changedScreen.split("\n").find((line) => line.includes("brand")) ?? "",
+			/visible/u,
+		);
+		assert.deepEqual(appliedSegments, [
+			["model", "line_break", "cwd", "brand"],
+			["model", "line_break", "brand"],
+			["model"],
+		]);
+		assert.deepEqual(loaded.config.segments, ["model"]);
+		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+			segments: ["model"],
+			future: { retained: true },
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("segment menu rolls back its displayed value when saving fails", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	const original = `${JSON.stringify({ segments: ["model"] })}\n`;
+	writeFileSync(path, original);
+	try {
+		const mock = createMockPi();
+		const loaded = loadStatuslineSettings(path);
+		let applied = 0;
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply() {
+				applied += 1;
+			},
+			save() {
+				throw new Error("disk full");
+			},
+		});
+		let screenAfterFailure = "";
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) =>
+				choices.find((choice) => choice.startsWith("Segments (")),
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{},
+					() => undefined,
+				) as PickerComponent;
+				component.handleInput?.("\r");
+				screenAfterFailure = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\u001b");
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.match(
+			screenAfterFailure.split("\n").find((line) => line.includes("brand")) ?? "",
+			/hidden/u,
+		);
+		assert.equal(readFileSync(path, "utf8"), original);
+		assert.equal(applied, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*disk full/iu);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("segment menu restores persisted and runtime settings when application fails", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	const original = `${JSON.stringify({ segments: ["model"], future: true })}\n`;
+	writeFileSync(path, original);
+	try {
+		const mock = createMockPi();
+		let runtime = loadStatuslineSettings(path);
+		let applyCalls = 0;
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => runtime,
+			apply(next) {
+				runtime = next;
+				applyCalls += 1;
+				if (applyCalls === 1) throw new Error("render failed");
+			},
+		});
+		let screenAfterFailure = "";
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) =>
+				choices.find((choice) => choice.startsWith("Segments (")),
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{},
+					() => undefined,
+				) as PickerComponent;
+				component.handleInput?.("\r");
+				screenAfterFailure = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\u001b");
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.match(
+			screenAfterFailure.split("\n").find((line) => line.includes("brand")) ?? "",
+			/hidden/u,
+		);
+		assert.equal(readFileSync(path, "utf8"), original);
+		assert.deepEqual(runtime.config.segments, ["model"]);
+		assert.equal(applyCalls, 2);
+		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*render failed/iu);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("palette picker previews cursor movement and restores the saved preset on cancel", async () => {
@@ -188,6 +390,7 @@ test("palette picker preserves custom colors and unknown fields while applying a
 
 		assert.deepEqual(selections[0]?.choices, [
 			"Palette preset (custom)",
+			"Segments (11/12 shown)",
 			"Edit settings JSON (custom colors, layout, icons)",
 			"Status",
 			"Help",


### PR DESCRIPTION
## Summary

- add a Segments action to `/statusline` with visible/hidden toggles for every data segment
- atomically persist each toggle, apply it immediately, and roll back UI/runtime state on failure
- preserve segment order, unrelated JSON fields, and valid multiline layout while documenting the interaction

## Testing

- `npm run check`
- `just pack-statusline`
- `npm run typecheck --workspace @narumitw/pi-statusline`