### PR TITLE
feat(statusline): add TUI segment ordering

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-statusline-segment-order-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-statusline-segment-order-plan.md
@@ -1,0 +1,23 @@
+## Goal
+
+Let TUI users reorder visible pi-statusline segments as well as show or hide them, with each change persisted and applied immediately.
+
+## Architecture
+
+- Replace the toggle-only `SettingsList` screen with a bounded segment list that presents visible segments in their effective order followed by hidden segments.
+- Keep standard navigation, toggle, and cancellation on Pi's injected keybindings; use `Alt+Up` and `Alt+Down` for the screen-specific reorder action.
+- Reorder only visible data segments. Swap their positions around existing `line_break` markers so multiline row boundaries remain intact.
+- Reuse the existing atomic settings save and runtime rollback behavior for both toggles and reorders.
+
+## Plan
+
+- [x] Add focused failing command tests for visible ordering, `Alt+Up`/`Alt+Down` persistence, immediate runtime application, multiline preservation, and save rollback; the focused run failed on unchanged order and missing save feedback before implementation.
+- [x] Implement the sortable segment TUI and transactional document update in `extensions/pi-statusline/src/commands.ts`; all five focused segment-menu tests and the package typecheck pass.
+- [x] Update `extensions/pi-statusline/README.md` and command help, format intended files, and run `npm run check` plus `just pack-statusline`; the full gate passed all 1,183 tests and the 24-file dry-run tarball includes the updated source and README.
+
+## Completion Checklist
+
+- [x] The Segments screen exposes current effective order and discoverable reorder keys while retaining show/hide controls.
+- [x] Reorders save and render immediately, preserve unknown JSON fields and `line_break` positions, and leave hidden segments unchanged.
+- [x] Failed saves or runtime application leave the file, runtime state, and displayed order unchanged.
+- [x] Repository checks and the statusline package dry run pass.

--- a/docs/plans/archived/2026-07-24_pi-statusline-segment-tui-polish-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-statusline-segment-tui-polish-plan.md
@@ -1,0 +1,25 @@
+## Goal
+
+Resolve the segment TUI usability findings by making multiline layout, visible/hidden grouping, controls, unavailable actions, and low-height behavior explicit without weakening immediate persistence or rollback.
+
+## Architecture
+
+- Keep one segment screen, but render visible and hidden sections through a six-item viewport.
+- Label each visible segment with its footer row derived from `line_break` positions.
+- Wrap control hints instead of truncating them and retain `Alt+Up`/`Alt+Down` as quick actions.
+- Add a modifier-free Move mode so terminals that cannot report modified arrows can reorder with ordinary Up/Down.
+- Show contextual in-screen feedback when a hidden or boundary segment cannot move.
+
+## Plan
+
+- [x] Add focused failing command tests for row labels, section headings, wrapped narrow-width hints, bounded viewport height, Move mode, and unavailable-move feedback; the focused run failed on unbounded height and absent contextual feedback before implementation.
+- [x] Implement the polished segment component in `extensions/pi-statusline/src/commands.ts`; all six focused segment-menu tests pass.
+- [x] Update `extensions/pi-statusline/README.md` and command help, format intended files, then run `npm run check` and `just pack-statusline`; the full gate passed all 1,184 tests and the 24-file dry-run tarball includes the updated source and README.
+
+## Completion Checklist
+
+- [x] Multiline row boundaries and visible/hidden ownership are recognizable without relying on color.
+- [x] Every control remains discoverable at narrow widths, and reordering works without modified-arrow support.
+- [x] Hidden and boundary moves explain why no change occurred.
+- [x] The list remains bounded while preserving selection context, immediate saves, rollback, and Escape behavior.
+- [x] Repository checks and the statusline package dry run pass.

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -9,7 +9,7 @@
 - Shows provider, model, thinking, directory, Git/PR state, tools, context, tokens, cost, time, and extension statuses.
 - Uses one Starship-inspired `░▒▓` / `` Tokyo Night layout.
 - Configures segment order, visibility, multiline breaks, surrounding text, palette, density, separators, and extension icons through JSON.
-- Chooses displayed data segments from the `/statusline` menu and applies each toggle immediately.
+- Shows, hides, and reorders data segments from a grouped, row-aware `/statusline` menu, applying each change immediately.
 - Creates an editable default configuration without an inactive custom palette on first session start.
 - Previews palette presets as the picker cursor moves, then applies the selection only on Enter.
 - Applies validated JSON settings edits from the `/statusline` menu immediately after an atomic save.
@@ -137,7 +137,9 @@ brand provider model thinking cwd branch tools context tokens cost time turn lin
 
 The array controls visibility and actual rendering order. Data segments must remain unique. The special `line_break` segment starts another footer row and may repeat when another segment separates each occurrence; consecutive `line_break` entries are invalid. Each row receives its own powerline start and end. `line_break` has no `segmentText` entry.
 
-Use `/statusline` → `Segments` to show or hide any data segment without editing JSON. The screen supports arrow-key navigation, Enter or Space to toggle, and Escape to close. Every successful toggle is atomically saved and applied immediately; Escape does not undo earlier toggles. Remaining segments keep their relative order, newly shown segments are appended to the final row, and leading, trailing, or newly consecutive `line_break` entries are removed. Continue using the JSON editor when you need to place segments or line breaks at exact positions.
+Use `/statusline` → `Segments` to show, hide, or reorder data segments without editing JSON. The bounded screen groups visible segments in their effective render order and hidden segments separately, labels every visible segment with the footer row derived from `line_break`, and keeps the selected segment in view. Use Up and Down to navigate, Page Up and Page Down for larger jumps, and Enter or Space to show or hide. Press `M` to enter Move mode, where ordinary Up and Down move the selected visible segment; Enter, Space, or Escape leaves Move mode. `Alt+Up` and `Alt+Down` remain quick-move accelerators, and Escape closes the normal screen. Hidden segments and first/last boundaries explain in place why a move is unavailable.
+
+Every successful toggle or move is atomically saved and applied immediately; leaving Move mode or closing the screen does not undo earlier changes. Remaining segments keep their relative order, newly shown segments are appended to the final row, and leading, trailing, or newly consecutive `line_break` entries are removed after a toggle. Reordering swaps data segments around existing `line_break` positions, so displayed row boundaries stay in place while a segment can move between rows. Continue using the JSON editor when you need to place line breaks at exact positions.
 
 An empty array hides the main powerline while still allowing extension statuses to render. `turn` is available but omitted by default.
 
@@ -244,7 +246,7 @@ from that line when the branch segment already renders it.
 | `/statusline status` | Show the settings source, path, appearance, segments, and diagnostics |
 | `/statusline help` | Show command and schema guidance |
 
-Argument-free `/statusline` requires TUI mode. The established `settings`, `status`, and `help` routes remain available for compatibility; RPC receives notifications instead of opening TUI-only controls. Unknown subcommands and trailing arguments are rejected. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. In the Segments screen, each Enter or Space toggle saves immediately, while Escape only closes the screen. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled unsaved changes leave both the previous file and effective runtime configuration unchanged.
+Argument-free `/statusline` requires TUI mode. The established `settings`, `status`, and `help` routes remain available for compatibility; RPC receives notifications instead of opening TUI-only controls. Unknown subcommands and trailing arguments are rejected. In the palette picker, Up and Down preview the highlighted preset immediately, Enter saves it, and Escape restores the saved preset. In the Segments screen, each Enter or Space toggle and each Move-mode or `Alt+Up`/`Alt+Down` move saves immediately. Escape leaves Move mode first and closes the normal screen; neither action rolls back saved changes. Applying `custom` also points to the settings JSON palette editor. Invalid or cancelled unsaved changes leave both the previous file and effective runtime configuration unchanged.
 
 ## 🌿 Git and activity details
 

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -2,16 +2,17 @@ import {
 	DynamicBorder,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
-	getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
 import {
 	type AutocompleteItem,
 	Container,
+	Key,
+	matchesKey,
 	type SelectItem,
 	SelectList,
-	type SettingItem,
-	SettingsList,
 	Text,
+	truncateToWidth,
+	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { segmentPaletteForPreset } from "./presets/index.js";
 import {
@@ -31,6 +32,8 @@ import {
 } from "./types.js";
 
 const EDIT_SETTINGS_LABEL = "Edit settings JSON (custom colors, layout, icons)";
+const SEGMENT_VIEWPORT_SIZE = 6;
+const NARROW_SEGMENT_VIEWPORT_SIZE = 3;
 const SEGMENT_DESCRIPTIONS: Record<SegmentName, string> = {
 	brand: "Pi brand mark",
 	provider: "Current model provider",
@@ -239,58 +242,137 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
 		return;
 	}
 	let current = options.getLoaded();
-	const visible = new Set(current.config.segments);
-	const items: SettingItem[] = SEGMENT_NAMES.map((name) => ({
-		id: name,
-		label: name,
-		description: SEGMENT_DESCRIPTIONS[name],
-		currentValue: visible.has(name) ? "visible" : "hidden",
-		values: ["visible", "hidden"],
-	}));
+	let names = segmentMenuOrder(current);
+	let selectedIndex = 0;
+	let moveMode = false;
+	let feedback: string | undefined;
 
-	await ctx.ui.custom((tui, theme, _keybindings, done) => {
+	await ctx.ui.custom((tui, theme, keybindings, done) => {
+		const commit = (
+			name: SegmentName,
+			change: { nextDocument: string; previousDocument: string },
+		): boolean => {
+			try {
+				current = applySegmentsDocumentChange(change, ctx, options);
+				names = segmentMenuOrder(current);
+				selectedIndex = Math.max(0, names.indexOf(name));
+				feedback = undefined;
+				return true;
+			} catch (error) {
+				ctx.ui.notify(`Statusline segments were not saved: ${formatError(error)}`, "error");
+				return false;
+			}
+		};
+
+		const toggleSelected = () => {
+			const name = names[selectedIndex];
+			if (!name) return;
+			moveMode = false;
+			commit(name, segmentsDocument(current, name, !current.config.segments.includes(name)));
+		};
+
+		const reorderSelected = (direction: -1 | 1) => {
+			const name = names[selectedIndex];
+			if (!name) return;
+			const visibleNames = visibleSegmentNames(current);
+			const currentIndex = visibleNames.indexOf(name);
+			if (currentIndex < 0) {
+				feedback = `Show ${name} before moving it.`;
+				return;
+			}
+			const targetIndex = currentIndex + direction;
+			if (targetIndex < 0 || targetIndex >= visibleNames.length) {
+				feedback = `${name} is already the ${direction < 0 ? "first" : "last"} visible segment.`;
+				return;
+			}
+			const change = reorderedSegmentsDocument(current, name, direction);
+			if (change) commit(name, change);
+		};
+
+		const enterMoveMode = () => {
+			const name = names[selectedIndex];
+			if (!name) return;
+			if (!current.config.segments.includes(name)) {
+				feedback = `Show ${name} before moving it.`;
+				return;
+			}
+			moveMode = true;
+			feedback = undefined;
+		};
+
+		const moveSelection = (offset: number) => {
+			selectedIndex = Math.max(0, Math.min(names.length - 1, selectedIndex + offset));
+			feedback = undefined;
+		};
+
+		const renderList = (width: number): string[] => {
+			const safeWidth = Math.max(1, width);
+			const visibleNames = visibleSegmentNames(current);
+			const visible = new Set(visibleNames);
+			const placements = segmentPlacements(current.config.segments);
+			const viewportSize = safeWidth < 30 ? NARROW_SEGMENT_VIEWPORT_SIZE : SEGMENT_VIEWPORT_SIZE;
+			const startIndex = Math.max(
+				0,
+				Math.min(
+					selectedIndex - Math.floor(viewportSize / 2),
+					Math.max(0, names.length - viewportSize),
+				),
+			);
+			const endIndex = Math.min(names.length, startIndex + viewportSize);
+			const lines: string[] = [];
+			let previousSection: "visible" | "hidden" | undefined;
+			for (let index = startIndex; index < endIndex; index += 1) {
+				const name = names[index];
+				if (!name) continue;
+				const section = visible.has(name) ? "visible" : "hidden";
+				if (section !== previousSection) {
+					const heading =
+						section === "visible" ? "Visible — render order" : "Hidden — not rendered";
+					lines.push(theme.fg("muted", theme.bold(truncateToWidth(`  ${heading}`, safeWidth))));
+					previousSection = section;
+				}
+				const isSelected = index === selectedIndex;
+				const prefix = isSelected ? "→ " : "  ";
+				const placement = placements.get(name);
+				const row = placement
+					? `${prefix}${`${placement.order}.`.padStart(3)} row ${placement.row} · ${name.padEnd(8)} · visible`
+					: `${prefix}  · ${name.padEnd(8)} · hidden`;
+				const truncated = truncateToWidth(row, safeWidth);
+				if (isSelected) lines.push(theme.fg("accent", truncated));
+				else lines.push(section === "visible" ? truncated : theme.fg("muted", truncated));
+			}
+			if (startIndex > 0 || endIndex < names.length) {
+				lines.push(
+					theme.fg(
+						"dim",
+						truncateToWidth(`  (${startIndex + 1}-${endIndex}/${names.length})`, safeWidth),
+					),
+				);
+			}
+
+			const selected = names[selectedIndex];
+			if (selected) {
+				lines.push("");
+				const detail = feedback ?? SEGMENT_DESCRIPTIONS[selected];
+				const color = feedback ? "warning" : "muted";
+				for (const line of wrapTextWithAnsi(detail, Math.max(1, safeWidth - 2))) {
+					lines.push(theme.fg(color, truncateToWidth(`  ${line}`, safeWidth)));
+				}
+			}
+
+			lines.push("");
+			const hints = segmentControlHints(safeWidth, moveMode, selected);
+			for (const hint of hints) {
+				lines.push(theme.fg("dim", truncateToWidth(`  ${hint}`, safeWidth)));
+			}
+			return lines;
+		};
+
 		const container = new Container();
 		container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
 		const title = new Text("", 1, 0);
 		container.addChild(title);
-		let list: SettingsList;
-		list = new SettingsList(
-			items,
-			Math.min(items.length, 12),
-			getSettingsListTheme(),
-			(id, newValue) => {
-				const name = id as SegmentName;
-				const previousValue = newValue === "visible" ? "hidden" : "visible";
-				try {
-					const { nextDocument, previousDocument } = segmentsDocument(
-						current,
-						name,
-						newValue === "visible",
-					);
-					const save = options.save ?? saveStatuslineSettingsDocument;
-					const next = save(options.settingsPath, nextDocument);
-					try {
-						options.apply(next, ctx);
-					} catch (applyError) {
-						try {
-							const restored = save(options.settingsPath, previousDocument);
-							options.apply(restored, ctx);
-						} catch (rollbackError) {
-							throw new Error(
-								`runtime update failed: ${formatError(applyError)}; rollback failed: ${formatError(rollbackError)}`,
-							);
-						}
-						throw applyError;
-					}
-					current = next;
-				} catch (error) {
-					list.updateValue(id, previousValue);
-					ctx.ui.notify(`Statusline segments were not saved: ${formatError(error)}`, "error");
-				}
-			},
-			() => done(undefined),
-		);
-		container.addChild(list);
+		container.addChild({ render: renderList, invalidate() {} });
 		container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
 		const updateThemedText = () => {
 			title.setText(theme.fg("accent", theme.bold("Statusline segments")));
@@ -304,7 +386,42 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
 				updateThemedText();
 			},
 			handleInput(data: string) {
-				list.handleInput(data);
+				const moveModeKey = matchesKey(data, "m") || matchesKey(data, Key.shift("m"));
+				if (matchesKey(data, Key.alt("up"))) {
+					reorderSelected(-1);
+				} else if (matchesKey(data, Key.alt("down"))) {
+					reorderSelected(1);
+				} else if (moveMode) {
+					if (keybindings.matches(data, "tui.select.up")) {
+						reorderSelected(-1);
+					} else if (keybindings.matches(data, "tui.select.down")) {
+						reorderSelected(1);
+					} else if (
+						moveModeKey ||
+						keybindings.matches(data, "tui.select.confirm") ||
+						data === " " ||
+						keybindings.matches(data, "tui.select.cancel")
+					) {
+						moveMode = false;
+						feedback = undefined;
+					}
+				} else if (keybindings.matches(data, "tui.select.up")) {
+					selectedIndex = selectedIndex === 0 ? names.length - 1 : selectedIndex - 1;
+					feedback = undefined;
+				} else if (keybindings.matches(data, "tui.select.down")) {
+					selectedIndex = selectedIndex === names.length - 1 ? 0 : selectedIndex + 1;
+					feedback = undefined;
+				} else if (keybindings.matches(data, "tui.select.pageUp")) {
+					moveSelection(-SEGMENT_VIEWPORT_SIZE);
+				} else if (keybindings.matches(data, "tui.select.pageDown")) {
+					moveSelection(SEGMENT_VIEWPORT_SIZE);
+				} else if (moveModeKey) {
+					enterMoveMode();
+				} else if (keybindings.matches(data, "tui.select.confirm") || data === " ") {
+					toggleSelected();
+				} else if (keybindings.matches(data, "tui.select.cancel")) {
+					done(undefined);
+				}
 				tui.requestRender();
 			},
 		};
@@ -352,6 +469,57 @@ function palettePresetDocument(
 	return `${JSON.stringify(parsed, null, "\t")}\n`;
 }
 
+function visibleSegmentNames(current: LoadedStatuslineSettings): SegmentName[] {
+	return current.config.segments.filter(
+		(segment): segment is SegmentName => segment !== LINE_BREAK_SEGMENT_NAME,
+	);
+}
+
+function segmentMenuOrder(current: LoadedStatuslineSettings): SegmentName[] {
+	const visible = visibleSegmentNames(current);
+	const visibleSet = new Set(visible);
+	return [...visible, ...SEGMENT_NAMES.filter((name) => !visibleSet.has(name))];
+}
+
+function segmentPlacements(
+	segments: readonly ConfigSegmentName[],
+): Map<SegmentName, { order: number; row: number }> {
+	const placements = new Map<SegmentName, { order: number; row: number }>();
+	let order = 0;
+	let row = 1;
+	for (const segment of segments) {
+		if (segment === LINE_BREAK_SEGMENT_NAME) {
+			row += 1;
+			continue;
+		}
+		placements.set(segment, { order: ++order, row });
+	}
+	return placements;
+}
+
+function segmentControlHints(
+	width: number,
+	moveMode: boolean,
+	selected: SegmentName | undefined,
+): string[] {
+	if (moveMode) {
+		return width < 30
+			? [
+					`Move mode: ${selected ?? "segment"}`,
+					"↑↓ move segment",
+					"Enter/Space finish",
+					"Esc leave move mode",
+				]
+			: [
+					`Move mode — ${selected ?? "segment"}`,
+					"↑↓ move · Enter/Space finish · Esc leave move mode",
+				];
+	}
+	return width < 30
+		? ["↑↓ navigate", "Enter/Space toggle", "M move mode", "Alt+↑/↓ quick move", "Esc close"]
+		: ["↑↓ navigate · Enter/Space show/hide · M move mode", "Alt+↑/↓ quick move · Esc close"];
+}
+
 function segmentsDocument(
 	current: LoadedStatuslineSettings,
 	name: SegmentName,
@@ -366,6 +534,60 @@ function segmentsDocument(
 		nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
 		previousDocument,
 	};
+}
+
+function reorderedSegmentsDocument(
+	current: LoadedStatuslineSettings,
+	name: SegmentName,
+	direction: -1 | 1,
+): { nextDocument: string; previousDocument: string } | undefined {
+	const dataIndexes = current.config.segments.flatMap((segment, index) =>
+		segment === LINE_BREAK_SEGMENT_NAME ? [] : [index],
+	);
+	const currentDataIndex = dataIndexes.findIndex(
+		(index) => current.config.segments[index] === name,
+	);
+	const targetDataIndex = currentDataIndex + direction;
+	if (currentDataIndex < 0 || targetDataIndex < 0 || targetDataIndex >= dataIndexes.length) {
+		return undefined;
+	}
+	const { parsed, rawDocument: previousDocument } = editableSettings(
+		current,
+		"reordering segments",
+	);
+	const segments = [...current.config.segments];
+	const currentIndex = dataIndexes[currentDataIndex];
+	const targetIndex = dataIndexes[targetDataIndex];
+	if (currentIndex === undefined || targetIndex === undefined) return undefined;
+	[segments[currentIndex], segments[targetIndex]] = [segments[targetIndex], segments[currentIndex]];
+	parsed.segments = segments;
+	return {
+		nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
+		previousDocument,
+	};
+}
+
+function applySegmentsDocumentChange(
+	change: { nextDocument: string; previousDocument: string },
+	ctx: ExtensionCommandContext,
+	options: StatuslineCommandOptions,
+): LoadedStatuslineSettings {
+	const save = options.save ?? saveStatuslineSettingsDocument;
+	const next = save(options.settingsPath, change.nextDocument);
+	try {
+		options.apply(next, ctx);
+	} catch (applyError) {
+		try {
+			const restored = save(options.settingsPath, change.previousDocument);
+			options.apply(restored, ctx);
+		} catch (rollbackError) {
+			throw new Error(
+				`runtime update failed: ${formatError(applyError)}; rollback failed: ${formatError(rollbackError)}`,
+			);
+		}
+		throw applyError;
+	}
+	return next;
 }
 
 function normalizeLineBreaks(segments: readonly ConfigSegmentName[]): ConfigSegmentName[] {
@@ -433,7 +655,9 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 			`Settings: ${settingsPath}`,
 			"Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",
 			"Named presets ignore but preserve palette; custom uses its per-segment fg/bg colors.",
-			"Use the Segments menu to show or hide data segments; changes save and apply immediately.",
+			"Use the Segments menu to show, hide, or reorder data segments; changes save and apply immediately.",
+			"Rows and visible/hidden sections reflect the effective layout; unavailable moves explain why.",
+			"Press M for move mode with ordinary arrows, or Alt+Up/Alt+Down for a quick move.",
 			"Use line_break between segments for another footer row; repeats must not be consecutive.",
 			"The segmentText entries support prefix and suffix strings around Pi-owned dynamic values.",
 		].join("\n"),

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
+import { getKeybindings, visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerStatuslineCommand } from "../src/commands.js";
 import {
@@ -30,7 +31,7 @@ function customPalettePicker(inputs: string[], inspect?: (lines: string[]) => vo
 				fg: (_color: string, text: string) => text,
 				bold: (text: string) => text,
 			},
-			{},
+			getKeybindings(),
 			(value: unknown) => {
 				result = value;
 			},
@@ -110,7 +111,7 @@ test("segment menu toggles displayed segments and preserves JSON fields and layo
 						fg: (_color: string, text: string) => text,
 						bold: (text: string) => text,
 					},
-					{},
+					getKeybindings(),
 					(value: unknown) => {
 						result = value;
 					},
@@ -118,9 +119,10 @@ test("segment menu toggles displayed segments and preserves JSON fields and layo
 				initialScreen = component.render?.(100).join("\n") ?? "";
 				component.handleInput?.("\r");
 				changedScreen = component.render?.(100).join("\n") ?? "";
-				for (let index = 0; index < 4; index += 1) component.handleInput?.("\u001b[B");
+				component.handleInput?.("\u001b[A");
+				component.handleInput?.("\u001b[A");
 				component.handleInput?.("\r");
-				for (let index = 0; index < 8; index += 1) component.handleInput?.("\u001b[B");
+				component.handleInput?.("\u001b[A");
 				component.handleInput?.("\r");
 				component.handleInput?.("\u001b");
 				return result;
@@ -143,20 +145,209 @@ test("segment menu toggles displayed segments and preserves JSON fields and layo
 			/visible/u,
 		);
 		assert.doesNotMatch(initialScreen, /line_break/u);
-		assert.match(
-			changedScreen.split("\n").find((line) => line.includes("brand")) ?? "",
-			/visible/u,
-		);
-		assert.deepEqual(appliedSegments, [
-			["model", "line_break", "cwd", "brand"],
-			["model", "line_break", "brand"],
-			["model"],
-		]);
-		assert.deepEqual(loaded.config.segments, ["model"]);
+		assert.match(changedScreen.split("\n").find((line) => line.includes("model")) ?? "", /hidden/u);
+		assert.deepEqual(appliedSegments, [["cwd"], ["cwd", "brand"], ["brand"]]);
+		assert.deepEqual(loaded.config.segments, ["brand"]);
 		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
-			segments: ["model"],
+			segments: ["brand"],
 			future: { retained: true },
 		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("segment menu reorders visible segments immediately while preserving multiline layout", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(
+		path,
+		`${JSON.stringify({ segments: ["model", "line_break", "cwd", "branch"], future: true })}\n`,
+	);
+	try {
+		const mock = createMockPi();
+		let loaded = loadStatuslineSettings(path);
+		const appliedSegments: string[][] = [];
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				appliedSegments.push([...next.config.segments]);
+			},
+		});
+		let initialScreen = "";
+		let narrowScreen = "";
+		let finalScreen = "";
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) =>
+				choices.find((choice) => choice.startsWith("Segments (")),
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				let result: unknown;
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					getKeybindings(),
+					(value: unknown) => {
+						result = value;
+					},
+				) as PickerComponent;
+				const initialLines = component.render?.(100) ?? [];
+				initialScreen = initialLines.join("\n");
+				assert.ok(initialLines.length <= 17);
+				const narrowLines = component.render?.(20) ?? [];
+				narrowScreen = narrowLines.join("\n");
+				assert.ok(narrowLines.length <= 17);
+				for (const line of narrowLines) assert.ok(visibleWidth(line) <= 20);
+				component.handleInput?.("\u001b[1;3B");
+				component.handleInput?.("\u001b[1;3A");
+				component.handleInput?.("\u001b[1;3B");
+				finalScreen = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\u001b");
+				return result;
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.ok(initialScreen.indexOf("model") < initialScreen.indexOf("cwd"));
+		assert.ok(finalScreen.indexOf("cwd") < finalScreen.indexOf("model"));
+		assert.match(initialScreen, /Visible.*render order/u);
+		assert.match(initialScreen, /Hidden.*not rendered/u);
+		assert.match(initialScreen.split("\n").find((line) => line.includes("model")) ?? "", /row 1/u);
+		assert.match(initialScreen.split("\n").find((line) => line.includes("cwd")) ?? "", /row 2/u);
+		assert.match(finalScreen.split("\n").find((line) => line.includes("cwd")) ?? "", /row 1/u);
+		assert.match(finalScreen.split("\n").find((line) => line.includes("model")) ?? "", /row 2/u);
+		assert.match(narrowScreen, /Enter\/Space toggle/u);
+		assert.match(narrowScreen, /M move mode/u);
+		assert.match(narrowScreen, /Alt\+↑\/↓ quick move/u);
+		assert.match(narrowScreen, /Esc close/u);
+		assert.deepEqual(appliedSegments, [
+			["cwd", "line_break", "model", "branch"],
+			["model", "line_break", "cwd", "branch"],
+			["cwd", "line_break", "model", "branch"],
+		]);
+		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+			segments: ["cwd", "line_break", "model", "branch"],
+			future: true,
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("segment menu offers Move mode and explains unavailable moves", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, `${JSON.stringify({ segments: ["model", "cwd"] })}\n`);
+	try {
+		const mock = createMockPi();
+		let loaded = loadStatuslineSettings(path);
+		const appliedSegments: string[][] = [];
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				appliedSegments.push([...next.config.segments]);
+			},
+		});
+		let boundaryScreen = "";
+		let moveModeScreen = "";
+		let hiddenScreen = "";
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) =>
+				choices.find((choice) => choice.startsWith("Segments (")),
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				let result: unknown;
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					getKeybindings(),
+					(value: unknown) => {
+						result = value;
+					},
+				) as PickerComponent;
+				component.handleInput?.("\u001b[1;3A");
+				boundaryScreen = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("m");
+				moveModeScreen = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\u001b[B");
+				component.handleInput?.("\r");
+				component.handleInput?.("\r");
+				component.handleInput?.("m");
+				hiddenScreen = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\u001b");
+				return result;
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.match(boundaryScreen, /already the first visible segment/iu);
+		assert.match(moveModeScreen, /Move mode.*model/iu);
+		assert.match(hiddenScreen, /show.*before moving/iu);
+		assert.deepEqual(appliedSegments, [["cwd", "model"], ["cwd"]]);
+		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), { segments: ["cwd"] });
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("segment menu keeps displayed order when reordering cannot be saved", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+	const path = settingsFilePath(root);
+	const original = `${JSON.stringify({ segments: ["model", "cwd"] })}\n`;
+	writeFileSync(path, original);
+	try {
+		const mock = createMockPi();
+		const loaded = loadStatuslineSettings(path);
+		let applied = 0;
+		registerStatuslineCommand(mock.pi, {
+			settingsPath: path,
+			getLoaded: () => loaded,
+			apply() {
+				applied += 1;
+			},
+			save() {
+				throw new Error("disk full");
+			},
+		});
+		let screenAfterFailure = "";
+		const context = createMockContext({
+			mode: "tui",
+			select: async (_title: string, choices: string[]) =>
+				choices.find((choice) => choice.startsWith("Segments (")),
+			custom: async (factory: (...args: unknown[]) => unknown) => {
+				const component = factory(
+					{ requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					getKeybindings(),
+					() => undefined,
+				) as PickerComponent;
+				component.handleInput?.("\u001b[1;3B");
+				screenAfterFailure = component.render?.(100).join("\n") ?? "";
+				component.handleInput?.("\u001b");
+			},
+		});
+
+		await mock.commands.get("statusline")?.handler("", context.ctx);
+
+		assert.ok(screenAfterFailure.indexOf("model") < screenAfterFailure.indexOf("cwd"));
+		assert.equal(readFileSync(path, "utf8"), original);
+		assert.equal(applied, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*disk full/iu);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -193,7 +384,7 @@ test("segment menu rolls back its displayed value when saving fails", async () =
 						fg: (_color: string, text: string) => text,
 						bold: (text: string) => text,
 					},
-					{},
+					getKeybindings(),
 					() => undefined,
 				) as PickerComponent;
 				component.handleInput?.("\r");
@@ -219,7 +410,7 @@ test("segment menu rolls back its displayed value when saving fails", async () =
 test("segment menu restores persisted and runtime settings when application fails", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
 	const path = settingsFilePath(root);
-	const original = `${JSON.stringify({ segments: ["model"], future: true })}\n`;
+	const original = `${JSON.stringify({ segments: ["model", "cwd"], future: true })}\n`;
 	writeFileSync(path, original);
 	try {
 		const mock = createMockPi();
@@ -246,10 +437,10 @@ test("segment menu restores persisted and runtime settings when application fail
 						fg: (_color: string, text: string) => text,
 						bold: (text: string) => text,
 					},
-					{},
+					getKeybindings(),
 					() => undefined,
 				) as PickerComponent;
-				component.handleInput?.("\r");
+				component.handleInput?.("\u001b[1;3B");
 				screenAfterFailure = component.render?.(100).join("\n") ?? "";
 				component.handleInput?.("\u001b");
 			},
@@ -257,12 +448,9 @@ test("segment menu restores persisted and runtime settings when application fail
 
 		await mock.commands.get("statusline")?.handler("", context.ctx);
 
-		assert.match(
-			screenAfterFailure.split("\n").find((line) => line.includes("brand")) ?? "",
-			/hidden/u,
-		);
+		assert.ok(screenAfterFailure.indexOf("model") < screenAfterFailure.indexOf("cwd"));
 		assert.equal(readFileSync(path, "utf8"), original);
-		assert.deepEqual(runtime.config.segments, ["model"]);
+		assert.deepEqual(runtime.config.segments, ["model", "cwd"]);
 		assert.equal(applyCalls, 2);
 		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*render failed/iu);
 	} finally {
@@ -600,6 +788,8 @@ test("status and help remain available from the main menu", async () => {
 		assert.match(context.notifications.at(-1)?.message ?? "", /segmentText/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /palettePreset/u);
 		assert.match(context.notifications.at(-1)?.message ?? "", /line_break/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /M.*move mode/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Alt\+Up.*Alt\+Down/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- add immediate segment reordering with `Alt+Up`/`Alt+Down` quick actions and a modifier-free Move mode
- group visible and hidden segments, expose `line_break`-derived footer rows, and keep the list bounded at narrow widths
- preserve atomic persistence and runtime rollback while adding contextual unavailable-move feedback and updated documentation

## Verification

- `npm run check` (1,184 tests passed)
- `just pack-statusline` (24-file dry-run package inspected)
