### PR TITLE
perf: run repository checks in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"check:boundaries": "node ./scripts/check-extension-boundaries.mjs",
 		"typecheck": "npm --workspaces run typecheck",
 		"test": "node ./scripts/run-tests.mjs",
-		"check": "npm run biome:check && npm run check:boundaries && npm run typecheck && npm test",
+		"check": "node ./scripts/run-checks.mjs",
 		"pack:btw": "npm --workspace @narumitw/pi-btw pack --dry-run",
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",

--- a/scripts/run-checks.mjs
+++ b/scripts/run-checks.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const checks = ["biome:check", "check:boundaries", "typecheck", "test"];
+
+console.log(`Running checks in parallel: ${checks.join(", ")}`);
+
+const results = await Promise.all(checks.map(runCheck));
+const failures = results.filter(({ code, error }) => error || code !== 0);
+
+for (const { check, code, error, signal } of failures) {
+	if (error) {
+		console.error(`${check} failed to start: ${error.message}`);
+	} else if (signal) {
+		console.error(`${check} failed after receiving ${signal}`);
+	} else {
+		console.error(`${check} failed with exit code ${code}`);
+	}
+}
+
+if (failures.length > 0) process.exitCode = 1;
+
+function runCheck(check) {
+	const { command, args } = npmRunCommand(check);
+	return new Promise((resolve) => {
+		const child = spawn(command, args, {
+			cwd: process.cwd(),
+			env: process.env,
+			stdio: "inherit",
+		});
+		let settled = false;
+		const finish = (result) => {
+			if (settled) return;
+			settled = true;
+			resolve({ check, ...result });
+		};
+
+		child.once("error", (error) => finish({ code: null, error, signal: null }));
+		child.once("close", (code, signal) => finish({ code, error: null, signal }));
+	});
+}
+
+function npmRunCommand(check) {
+	if (process.env.npm_execpath) {
+		return {
+			command: process.execPath,
+			args: [process.env.npm_execpath, "run", check],
+		};
+	}
+	return {
+		command: process.platform === "win32" ? "npm.cmd" : "npm",
+		args: ["run", check],
+	};
+}

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -7,6 +7,8 @@ import test from "node:test";
 
 const repositoryRoot = process.cwd();
 const bumpScript = path.join(repositoryRoot, "scripts", "bump-shared-version.mjs");
+const checkScript = path.join(repositoryRoot, "scripts", "run-checks.mjs");
+const expectedChecks = ["biome:check", "check:boundaries", "test", "typecheck"];
 
 test("shared-version discovery skips publishable experimental workspaces", () => {
 	const fixture = mkdtempSync(path.join(tmpdir(), "pi-workspaces-"));
@@ -87,6 +89,69 @@ test("experimental publishing is manual-only", () => {
 	assert.match(justfile, /^publish name:/m);
 	assert.doesNotMatch(justfile, /\botp\b|--otp/);
 });
+
+test("repository checks start in parallel", () => {
+	const result = runFakeChecks();
+	assert.equal(result.status, 0, result.stderr);
+	assert.deepEqual(traceEntries(result.trace, "start"), expectedChecks);
+	assert.deepEqual(traceEntries(result.trace, "finish"), expectedChecks);
+});
+
+test("repository checks report a failing gate after all gates run", () => {
+	const result = runFakeChecks("typecheck");
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /typecheck failed/);
+	assert.deepEqual(traceEntries(result.trace, "start"), expectedChecks);
+	assert.deepEqual(traceEntries(result.trace, "finish"), expectedChecks);
+});
+
+function runFakeChecks(failingCheck = "") {
+	const fixture = mkdtempSync(path.join(tmpdir(), "pi-checks-"));
+	try {
+		const tracePath = path.join(fixture, "trace.log");
+		const fakeNpmPath = path.join(fixture, "fake-npm.mjs");
+		writeFileSync(
+			fakeNpmPath,
+			`import fs from "node:fs";
+const check = process.argv.at(-1);
+const tracePath = process.env.FAKE_CHECK_TRACE;
+fs.appendFileSync(tracePath, \`start:\${check}\\n\`);
+const deadline = Date.now() + 2_000;
+while (fs.readFileSync(tracePath, "utf8").match(/^start:/gm)?.length !== 4) {
+	if (Date.now() > deadline) process.exit(70);
+	await new Promise((resolve) => setTimeout(resolve, 10));
+}
+fs.appendFileSync(tracePath, \`finish:\${check}\\n\`);
+if (check === process.env.FAKE_CHECK_FAILURE) process.exit(23);
+`,
+		);
+
+		const result = spawnSync(process.execPath, [checkScript], {
+			cwd: repositoryRoot,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				FAKE_CHECK_FAILURE: failingCheck,
+				FAKE_CHECK_TRACE: tracePath,
+				npm_execpath: fakeNpmPath,
+			},
+		});
+		return {
+			...result,
+			trace: readFileSync(tracePath, "utf8"),
+		};
+	} finally {
+		rmSync(fixture, { recursive: true, force: true });
+	}
+}
+
+function traceEntries(trace: string, event: string) {
+	return trace
+		.split("\n")
+		.filter((line) => line.startsWith(`${event}:`))
+		.map((line) => line.slice(event.length + 1))
+		.sort();
+}
 
 function writeJson(filePath: string, value: unknown) {
 	mkdirSync(path.dirname(filePath), { recursive: true });


### PR DESCRIPTION
## Summary

- run Biome, boundary checks, workspace typechecks, and tests concurrently
- keep the check runner dependency-free and report every failed gate
- add deterministic coverage for parallel startup and failure propagation

## Benchmark

- before: ~18.8 seconds
- after: ~11.7 seconds
- improvement: ~38%

## Testing

- `npm run check` (1,187 tests passed)
- `git diff --check`
