### PR TITLE
feat(starship): add native Git modules

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-starship-git-modules-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-starship-git-modules-plan.md
@@ -1,0 +1,20 @@
+# pi-starship Git modules plan
+
+## Goal
+
+Add native `git_branch`, `git_commit`, `git_state`, `git_metrics`, and `git_status` modules to pi-starship, using the vendored Starship behavior as the reference while keeping footer rendering subprocess-free.
+
+## Plan
+
+- [x] Add focused tests for the five modules and cached Git metadata parsing; the initial `npm test` failed on the missing runtime exports, types, and module registrations.
+- [x] Extend `extensions/pi-starship/src/modules/git/` and the runtime snapshot so one refresh supplies branch, commit, operation state, line metrics, and detailed status values; focused pi-starship tests pass.
+- [x] Register the modules in Starship order, keep commit/state/metrics out of the built-in root format, update English documentation, and cover the public variables and defaults.
+- [x] Run `npm run check`, inspect `npm run pack:starship`, and archive this completed plan; both commands passed and the Pi entrypoint loaded with `--list-models`.
+
+## Completion Checklist
+
+- [x] All five requested Git modules are registered, configurable through module format/style/symbol/disabled fields, and rendered only from cached state.
+- [x] Git subprocess failures and non-repository directories degrade to empty modules without breaking the footer.
+- [x] Lifecycle generation guards and shutdown cleanup still prevent stale Git results from reaching replacement sessions.
+- [x] README module reference and package layout describe the implemented behavior.
+- [x] CI-equivalent checks and the pi-starship package dry run pass.

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -11,7 +11,7 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 - Automatically creates a readable Tokyo Night configuration on first session start.
 - Starship-style root/module formats, conditional groups, `$all`, styles, and palettes.
 - Pi modules for model, thinking, activity, context, tokens, cost, turn, and extension statuses.
-- Cached Git branch/status rendering and linked-worktree identity; no subprocess runs during footer rendering.
+- Cached Git branch, commit, operation state, line metrics, detailed status, and linked-worktree identity; no subprocess runs during footer rendering.
 - Multiline output wraps to the terminal width instead of truncating.
 - Transactional TOML editing through `/starship settings`.
 
@@ -126,8 +126,11 @@ An invalid root format falls back to the built-in root format. An invalid module
 | `thinking` | `$symbol`, `$level` | Thinking level |
 | `directory` | `$symbol`, `$path`, `$full_path` | Current working directory |
 | `git_worktree` | `$symbol`, `$name`, `$path` | Linked worktree name and top-level path |
-| `git_branch` | `$symbol`, `$branch`, `$pr` | Cached branch and actionable PR state |
-| `git_status` | `$symbol`, `$all_status`, `$ahead`, `$behind`, `$staged`, `$modified`, `$untracked`, `$conflicted` | Cached porcelain counters |
+| `git_branch` | `$symbol`, `$branch`, `$remote_name`, `$remote_branch`, `$pr` | Branch, upstream, and actionable PR state |
+| `git_commit` | `$symbol`, `$hash`, `$tag` | Seven-character HEAD hash and optional exact tag |
+| `git_state` | `$symbol`, `$state`, `$progress_current`, `$progress_total` | Rebase, merge, revert, cherry-pick, bisect, or mail-apply state |
+| `git_metrics` | `$symbol`, `$added`, `$deleted` | Added/deleted line totals from the working tree diff |
+| `git_status` | `$symbol`, `$all_status`, `$ahead_behind`, `$ahead`, `$behind`, `$diverged`, `$up_to_date`, `$conflicted`, `$stashed`, `$deleted`, `$renamed`, `$modified`, `$typechanged`, `$staged`, `$untracked`, and detailed index/worktree counters | Cached porcelain-v2 counters |
 | `activity` | `$symbol`, `$state`, `$tool`, `$count`, `$text` | Active tools, streaming, completion, or idle |
 | `context` | `$symbol`, `$percentage`, `$tokens`, `$window` | Context-window use |
 | `tokens` | `$symbol`, `$input`, `$output`, `$total` | Token totals |
@@ -137,6 +140,8 @@ An invalid root format falls back to the built-in root format. An invalid module
 | `extension_status` | `$symbol`, `$statuses`, `$count` | Pi extension statuses |
 
 `git_worktree` is empty in the primary worktree. In a linked worktree it defaults to the top-level directory name; use `$path` when the full absolute path is needed.
+
+`git_commit`, `git_state`, and `git_metrics` are intentionally not present in the built-in root format. Add their variables to `format` to opt in; also set `[git_metrics].disabled = false`, matching Starship's opt-in metrics default. `$tag` resolves only an exact tag on HEAD and is queried only when the configured `git_commit` format references it.
 
 If `$git_branch.$pr` is present in the module format, its selected PR token is removed from `extension_status` to avoid duplication.
 

--- a/extensions/pi-starship/src/modules/catalog.ts
+++ b/extensions/pi-starship/src/modules/catalog.ts
@@ -5,6 +5,9 @@ import { costModule } from "./cost.js";
 import { directoryModule } from "./directory.js";
 import { extensionStatusModule } from "./extension-status.js";
 import { gitBranchModule } from "./git/branch.js";
+import { gitCommitModule } from "./git/commit.js";
+import { gitMetricsModule } from "./git/metrics.js";
+import { gitStateModule } from "./git/state.js";
 import { gitStatusModule } from "./git/status.js";
 import { gitWorktreeModule } from "./git/worktree.js";
 import { modelModule } from "./model.js";
@@ -23,6 +26,9 @@ export const MODULE_DEFINITIONS = [
 	directoryModule,
 	gitWorktreeModule,
 	gitBranchModule,
+	gitCommitModule,
+	gitStateModule,
+	gitMetricsModule,
 	gitStatusModule,
 	activityModule,
 	contextModule,

--- a/extensions/pi-starship/src/modules/git/branch.ts
+++ b/extensions/pi-starship/src/modules/git/branch.ts
@@ -2,7 +2,7 @@ import { defineModule } from "../types.js";
 
 export const gitBranchModule = defineModule({
 	name: "git_branch",
-	variables: ["symbol", "branch", "pr"],
+	variables: ["symbol", "branch", "remote_name", "remote_branch", "pr"],
 	defaults: {
 		format: "[ $symbol $branch( $pr) ]($style)",
 		symbol: "🌿",
@@ -10,9 +10,13 @@ export const gitBranchModule = defineModule({
 		disabled: false,
 	},
 	values: ({ runtime }) => {
-		if (!runtime.gitBranch) return undefined;
+		const branch = runtime.gitBranchDetails;
+		const name = branch?.name ?? runtime.gitBranch;
+		if (!name) return undefined;
 		return {
-			branch: runtime.gitBranch,
+			branch: name,
+			remote_name: branch?.remoteName ?? "",
+			remote_branch: branch?.remoteBranch ?? "",
 			pr: prContextFromStatuses(runtime.extensionStatuses) ?? "",
 		};
 	},

--- a/extensions/pi-starship/src/modules/git/commit.ts
+++ b/extensions/pi-starship/src/modules/git/commit.ts
@@ -1,0 +1,22 @@
+import { defineModule } from "../types.js";
+
+const DEFAULT_HASH_LENGTH = 7;
+
+export const gitCommitModule = defineModule({
+	name: "git_commit",
+	variables: ["symbol", "hash", "tag"],
+	defaults: {
+		format: "[ ($hash) ]($style)",
+		symbol: "",
+		style: "fg:git_fg bg:git",
+		disabled: false,
+	},
+	values: ({ runtime }) => {
+		const commit = runtime.gitCommit;
+		if (!commit) return undefined;
+		return {
+			hash: commit.hash.slice(0, DEFAULT_HASH_LENGTH),
+			tag: commit.tag ? ` 🏷 ${commit.tag}` : "",
+		};
+	},
+});

--- a/extensions/pi-starship/src/modules/git/metrics.ts
+++ b/extensions/pi-starship/src/modules/git/metrics.ts
@@ -1,0 +1,20 @@
+import { defineModule } from "../types.js";
+
+export const gitMetricsModule = defineModule({
+	name: "git_metrics",
+	variables: ["symbol", "added", "deleted"],
+	defaults: {
+		format: "[(+$added)( -$deleted) ]($style)",
+		symbol: "",
+		style: "fg:git_fg bg:git",
+		disabled: true,
+	},
+	values: ({ runtime }) => {
+		const metrics = runtime.gitMetrics;
+		if (!metrics || (metrics.added === 0 && metrics.deleted === 0)) return undefined;
+		return {
+			added: metrics.added > 0 ? metrics.added.toString() : "",
+			deleted: metrics.deleted > 0 ? metrics.deleted.toString() : "",
+		};
+	},
+});

--- a/extensions/pi-starship/src/modules/git/runtime.ts
+++ b/extensions/pi-starship/src/modules/git/runtime.ts
@@ -1,8 +1,85 @@
-import { basename, isAbsolute, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { GitStatusSnapshot, GitWorktreeSnapshot } from "../types.js";
+import type {
+	GitBranchSnapshot,
+	GitCommitSnapshot,
+	GitMetricsSnapshot,
+	GitSnapshot,
+	GitStateSnapshot,
+	GitStatusSnapshot,
+	GitWorktreeSnapshot,
+} from "../types.js";
 
 const GIT_TIMEOUT_MS = 3_000;
+
+export interface ReadGitSnapshotOptions {
+	includeMetrics: boolean;
+	includeTag: boolean;
+}
+
+export async function readGitSnapshot(
+	pi: ExtensionAPI,
+	cwd: string,
+	options: ReadGitSnapshotOptions,
+): Promise<GitSnapshot | undefined> {
+	const statusPromise = pi.exec(
+		"git",
+		[
+			"--no-optional-locks",
+			"status",
+			"--porcelain=v2",
+			"--branch",
+			"--show-stash",
+			"--untracked-files=normal",
+		],
+		{ cwd, timeout: GIT_TIMEOUT_MS },
+	);
+	const metadataPromise = pi.exec(
+		"git",
+		["rev-parse", "--path-format=absolute", "--show-toplevel", "--git-common-dir", "--git-dir"],
+		{ cwd, timeout: GIT_TIMEOUT_MS },
+	);
+	const metricsPromise = options.includeMetrics
+		? pi.exec("git", ["--no-optional-locks", "diff", "--shortstat", "HEAD", "--"], {
+				cwd,
+				timeout: GIT_TIMEOUT_MS,
+			})
+		: Promise.resolve(undefined);
+	const tagPromise = options.includeTag
+		? pi.exec("git", ["describe", "--tags", "--exact-match", "HEAD"], {
+				cwd,
+				timeout: GIT_TIMEOUT_MS,
+			})
+		: Promise.resolve(undefined);
+
+	const [statusResult, metadataResult, metricsResult, tagResult] = await Promise.all([
+		statusPromise,
+		metadataPromise,
+		metricsPromise,
+		tagPromise,
+	]);
+	if (statusResult.code !== 0 || statusResult.killed) return undefined;
+
+	const parsed = parseGitStatusPorcelainV2(statusResult.stdout);
+	const metadata =
+		metadataResult.code === 0 && !metadataResult.killed
+			? parseGitRepositoryMetadata(metadataResult.stdout)
+			: undefined;
+	const commit = withTag(parsed.commit, tagResult);
+	const metrics =
+		metricsResult && metricsResult.code === 0 && !metricsResult.killed
+			? parseGitDiffShortstat(metricsResult.stdout)
+			: undefined;
+
+	return {
+		...parsed,
+		commit,
+		state: metadata ? parseGitState(metadata.gitDirectory) : undefined,
+		metrics,
+		worktree: metadata?.worktree,
+	};
+}
 
 export async function readGitStatus(
 	pi: ExtensionAPI,
@@ -10,11 +87,18 @@ export async function readGitStatus(
 ): Promise<GitStatusSnapshot | undefined> {
 	const result = await pi.exec(
 		"git",
-		["--no-optional-locks", "status", "--porcelain=v1", "--branch", "--untracked-files=normal"],
+		[
+			"--no-optional-locks",
+			"status",
+			"--porcelain=v2",
+			"--branch",
+			"--show-stash",
+			"--untracked-files=normal",
+		],
 		{ cwd, timeout: GIT_TIMEOUT_MS },
 	);
 	if (result.code !== 0 || result.killed) return undefined;
-	return parseGitStatusPorcelain(result.stdout);
+	return parseGitStatusPorcelainV2(result.stdout).status;
 }
 
 export async function readGitWorktree(
@@ -27,51 +111,251 @@ export async function readGitWorktree(
 		{ cwd, timeout: GIT_TIMEOUT_MS },
 	);
 	if (result.code !== 0 || result.killed) return undefined;
-	return parseGitWorktree(result.stdout);
+	return parseGitRepositoryMetadata(result.stdout)?.worktree;
 }
 
-export function parseGitWorktree(output: string): GitWorktreeSnapshot | undefined {
-	const lines = output.trimEnd().split(/\r?\n/u);
-	if (lines.length !== 3) return undefined;
-	const [path, commonDir, gitDir] = lines;
-	if (!path || !commonDir || !gitDir) return undefined;
-	if (![path, commonDir, gitDir].every(isAbsolute)) return undefined;
-	if (samePath(commonDir, gitDir)) return undefined;
-	return { name: basename(path) || path, path };
+interface ParsedGitStatus {
+	branch?: GitBranchSnapshot;
+	commit?: GitCommitSnapshot;
+	status: GitStatusSnapshot;
+}
+
+export function parseGitStatusPorcelainV2(output: string): ParsedGitStatus {
+	const status = emptyGitStatus();
+	let branchName: string | undefined;
+	let commitHash: string | undefined;
+	let upstream: string | undefined;
+
+	for (const line of output.split(/\r?\n/u)) {
+		if (!line) continue;
+		if (line.startsWith("# branch.oid ")) {
+			const value = line.slice("# branch.oid ".length).trim();
+			if (value && value !== "(initial)") commitHash = value;
+			continue;
+		}
+		if (line.startsWith("# branch.head ")) {
+			branchName = line.slice("# branch.head ".length).trim();
+			continue;
+		}
+		if (line.startsWith("# branch.upstream ")) {
+			upstream = line.slice("# branch.upstream ".length).trim();
+			continue;
+		}
+		if (line.startsWith("# branch.ab ")) {
+			const match = /^# branch\.ab \+(\d+) -(\d+)$/u.exec(line);
+			status.ahead = match?.[1] ? Number(match[1]) : 0;
+			status.behind = match?.[2] ? Number(match[2]) : 0;
+			continue;
+		}
+		if (line.startsWith("# stash ")) {
+			const count = Number(line.slice("# stash ".length));
+			status.stashed = Number.isSafeInteger(count) && count > 0 ? count : 0;
+			continue;
+		}
+		addPorcelainV2Status(status, line);
+	}
+	finalizeStatus(status);
+
+	const detached = branchName === "(detached)";
+	const remote = splitUpstream(upstream);
+	const branch = branchName
+		? {
+				name: detached ? "HEAD" : branchName,
+				...remote,
+				detached,
+			}
+		: undefined;
+	const commit = commitHash ? { hash: commitHash, detached } : undefined;
+	return { branch, commit, status };
 }
 
 export function parseGitStatusPorcelain(output: string): GitStatusSnapshot {
-	const summary: GitStatusSnapshot = {
-		ahead: 0,
-		behind: 0,
-		staged: 0,
-		modified: 0,
-		untracked: 0,
-		conflicted: 0,
-	};
+	const status = emptyGitStatus();
 	for (const line of output.split(/\r?\n/u)) {
 		if (!line) continue;
 		if (line.startsWith("## ")) {
 			const ahead = /\bahead (\d+)/u.exec(line);
 			const behind = /\bbehind (\d+)/u.exec(line);
-			summary.ahead = ahead?.[1] ? Number(ahead[1]) : 0;
-			summary.behind = behind?.[1] ? Number(behind[1]) : 0;
+			status.ahead = ahead?.[1] ? Number(ahead[1]) : 0;
+			status.behind = behind?.[1] ? Number(behind[1]) : 0;
 			continue;
 		}
 		const indexStatus = line[0] ?? " ";
 		const worktreeStatus = line[1] ?? " ";
 		if (indexStatus === "?" && worktreeStatus === "?") {
-			summary.untracked += 1;
+			status.untracked += 1;
 			continue;
 		}
 		if (isConflict(indexStatus, worktreeStatus)) {
-			summary.conflicted += 1;
+			status.conflicted += 1;
 			continue;
 		}
-		if (isChanged(indexStatus)) summary.staged += 1;
-		if (isChanged(worktreeStatus)) summary.modified += 1;
+		addNormalStatus(status, indexStatus, worktreeStatus);
+		if (indexStatus === "R" || indexStatus === "C") status.renamed += 1;
 	}
-	return summary;
+	finalizeStatus(status);
+	return status;
+}
+
+export function parseGitDiffShortstat(output: string): GitMetricsSnapshot {
+	const added = /(\d+) insertions?\(\+\)/u.exec(output)?.[1];
+	const deleted = /(\d+) deletions?\(-\)/u.exec(output)?.[1];
+	return {
+		added: added ? Number(added) : 0,
+		deleted: deleted ? Number(deleted) : 0,
+	};
+}
+
+export function parseGitState(gitDirectory: string): GitStateSnapshot | undefined {
+	const rebaseMerge = join(gitDirectory, "rebase-merge");
+	if (existsSync(rebaseMerge))
+		return operationWithProgress("REBASING", rebaseMerge, "msgnum", "end");
+
+	const rebaseApply = join(gitDirectory, "rebase-apply");
+	if (existsSync(rebaseApply)) {
+		const state = existsSync(join(rebaseApply, "applying"))
+			? "AM"
+			: existsSync(join(rebaseApply, "rebasing"))
+				? "REBASING"
+				: "AM/REBASE";
+		return operationWithProgress(state, rebaseApply, "next", "last");
+	}
+	if (existsSync(join(gitDirectory, "MERGE_HEAD"))) return { state: "MERGING" };
+	if (existsSync(join(gitDirectory, "REVERT_HEAD"))) return { state: "REVERTING" };
+	if (existsSync(join(gitDirectory, "CHERRY_PICK_HEAD"))) return { state: "CHERRY-PICKING" };
+	if (existsSync(join(gitDirectory, "BISECT_LOG"))) return { state: "BISECTING" };
+	return undefined;
+}
+
+interface GitRepositoryMetadata {
+	gitDirectory: string;
+	worktree?: GitWorktreeSnapshot;
+}
+
+function parseGitRepositoryMetadata(output: string): GitRepositoryMetadata | undefined {
+	const lines = output.trimEnd().split(/\r?\n/u);
+	if (lines.length !== 3) return undefined;
+	const [path, commonDir, gitDirectory] = lines;
+	if (!path || !commonDir || !gitDirectory) return undefined;
+	if (![path, commonDir, gitDirectory].every(isAbsolute)) return undefined;
+	return {
+		gitDirectory,
+		worktree: samePath(commonDir, gitDirectory)
+			? undefined
+			: { name: basename(path) || path, path },
+	};
+}
+
+export function parseGitWorktree(output: string): GitWorktreeSnapshot | undefined {
+	return parseGitRepositoryMetadata(output)?.worktree;
+}
+
+function addPorcelainV2Status(status: GitStatusSnapshot, line: string) {
+	const kind = line[0];
+	if (kind === "?") {
+		status.untracked += 1;
+		return;
+	}
+	if (kind === "u") {
+		status.conflicted += 1;
+		return;
+	}
+	if (kind !== "1" && kind !== "2") return;
+	const indexStatus = line[2] ?? ".";
+	const worktreeStatus = line[3] ?? ".";
+	addNormalStatus(status, indexStatus, worktreeStatus);
+	if (kind === "2") status.renamed += 1;
+}
+
+function addNormalStatus(status: GitStatusSnapshot, indexStatus: string, worktreeStatus: string) {
+	if (indexStatus === "A") status.indexAdded += 1;
+	if (indexStatus === "D") status.indexDeleted += 1;
+	if (indexStatus === "M") status.indexModified += 1;
+	if (indexStatus === "T") status.indexTypechanged += 1;
+	if (worktreeStatus === "A") status.worktreeAdded += 1;
+	if (worktreeStatus === "D") status.worktreeDeleted += 1;
+	if (worktreeStatus === "M") status.worktreeModified += 1;
+	if (worktreeStatus === "T") status.worktreeTypechanged += 1;
+}
+
+function finalizeStatus(status: GitStatusSnapshot) {
+	status.deleted = status.worktreeDeleted + status.indexDeleted;
+	status.modified = status.worktreeModified + status.worktreeAdded;
+	status.staged = status.indexModified + status.indexAdded + status.indexTypechanged;
+	status.typechanged = status.worktreeTypechanged;
+}
+
+function emptyGitStatus(): GitStatusSnapshot {
+	return {
+		ahead: 0,
+		behind: 0,
+		stashed: 0,
+		conflicted: 0,
+		deleted: 0,
+		renamed: 0,
+		modified: 0,
+		staged: 0,
+		typechanged: 0,
+		untracked: 0,
+		worktreeAdded: 0,
+		worktreeDeleted: 0,
+		worktreeModified: 0,
+		worktreeTypechanged: 0,
+		indexAdded: 0,
+		indexDeleted: 0,
+		indexModified: 0,
+		indexTypechanged: 0,
+	};
+}
+
+function splitUpstream(upstream: string | undefined): {
+	remoteName?: string;
+	remoteBranch?: string;
+} {
+	if (!upstream) return {};
+	const separator = upstream.indexOf("/");
+	if (separator <= 0 || separator === upstream.length - 1) return { remoteBranch: upstream };
+	return {
+		remoteName: upstream.slice(0, separator),
+		remoteBranch: upstream.slice(separator + 1),
+	};
+}
+
+function withTag(
+	commit: GitCommitSnapshot | undefined,
+	result:
+		| {
+				stdout: string;
+				code: number;
+				killed: boolean;
+		  }
+		| undefined,
+): GitCommitSnapshot | undefined {
+	if (!commit || !result || result.code !== 0 || result.killed) return commit;
+	const tag = result.stdout.trim();
+	return tag ? { ...commit, tag: tag.split(/\r?\n/u)[0] } : commit;
+}
+
+function operationWithProgress(
+	state: string,
+	directory: string,
+	currentName: string,
+	totalName: string,
+): GitStateSnapshot {
+	const progressCurrent = readPositiveInteger(join(directory, currentName));
+	const progressTotal = readPositiveInteger(join(directory, totalName));
+	return progressCurrent !== undefined && progressTotal !== undefined
+		? { state, progressCurrent, progressTotal }
+		: { state };
+}
+
+function readPositiveInteger(path: string): number | undefined {
+	try {
+		const value = Number(readFileSync(path, "utf8").trim());
+		return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function samePath(left: string, right: string): boolean {
@@ -91,21 +375,16 @@ function isConflict(indexStatus: string, worktreeStatus: string): boolean {
 	);
 }
 
-function isChanged(status: string): boolean {
-	return status !== " " && status !== "?" && status !== "!";
-}
-
 export function gitStatusEqual(
 	left: GitStatusSnapshot | undefined,
 	right: GitStatusSnapshot | undefined,
 ): boolean {
-	if (!left || !right) return left === right;
-	return (
-		left.ahead === right.ahead &&
-		left.behind === right.behind &&
-		left.staged === right.staged &&
-		left.modified === right.modified &&
-		left.untracked === right.untracked &&
-		left.conflicted === right.conflicted
-	);
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function gitSnapshotEqual(
+	left: GitSnapshot | undefined,
+	right: GitSnapshot | undefined,
+): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/extensions/pi-starship/src/modules/git/state.ts
+++ b/extensions/pi-starship/src/modules/git/state.ts
@@ -1,0 +1,21 @@
+import { defineModule } from "../types.js";
+
+export const gitStateModule = defineModule({
+	name: "git_state",
+	variables: ["symbol", "state", "progress_current", "progress_total"],
+	defaults: {
+		format: "[ ($state( $progress_current/$progress_total)) ]($style)",
+		symbol: "",
+		style: "bold yellow bg:git",
+		disabled: false,
+	},
+	values: ({ runtime }) => {
+		const state = runtime.gitState;
+		if (!state) return undefined;
+		return {
+			state: state.state,
+			progress_current: state.progressCurrent?.toString() ?? "",
+			progress_total: state.progressTotal?.toString() ?? "",
+		};
+	},
+});

--- a/extensions/pi-starship/src/modules/git/status.ts
+++ b/extensions/pi-starship/src/modules/git/status.ts
@@ -6,15 +6,30 @@ export const gitStatusModule = defineModule({
 	variables: [
 		"symbol",
 		"all_status",
+		"ahead_behind",
 		"ahead",
 		"behind",
-		"staged",
-		"modified",
-		"untracked",
+		"up_to_date",
+		"diverged",
 		"conflicted",
+		"stashed",
+		"deleted",
+		"renamed",
+		"modified",
+		"typechanged",
+		"staged",
+		"untracked",
+		"worktree_added",
+		"worktree_deleted",
+		"worktree_modified",
+		"worktree_typechanged",
+		"index_added",
+		"index_deleted",
+		"index_modified",
+		"index_typechanged",
 	],
 	defaults: {
-		format: "[$all_status ]($style)",
+		format: "[$all_status( $ahead_behind) ]($style)",
 		symbol: "",
 		style: "fg:git_fg bg:git",
 		disabled: false,
@@ -22,15 +37,51 @@ export const gitStatusModule = defineModule({
 	values: ({ runtime }) => {
 		if (!runtime.gitBranch || !runtime.gitStatus) return undefined;
 		const status = runtime.gitStatus;
+		const ahead = count("⇡", status.ahead);
+		const behind = count("⇣", status.behind);
+		const diverged =
+			status.ahead > 0 && status.behind > 0
+				? `⇕⇡${formatCount(status.ahead)}⇣${formatCount(status.behind)}`
+				: "";
 		const values = {
-			ahead: status.ahead > 0 ? `⇡${formatCount(status.ahead)}` : "",
-			behind: status.behind > 0 ? `⇣${formatCount(status.behind)}` : "",
-			staged: status.staged > 0 ? `+${formatCount(status.staged)}` : "",
-			modified: status.modified > 0 ? `~${formatCount(status.modified)}` : "",
-			untracked: status.untracked > 0 ? `?${formatCount(status.untracked)}` : "",
-			conflicted: status.conflicted > 0 ? `!${formatCount(status.conflicted)}` : "",
+			ahead,
+			behind,
+			up_to_date: "",
+			diverged,
+			ahead_behind: diverged || ahead || behind,
+			conflicted: count("=", status.conflicted),
+			stashed: count("$", status.stashed),
+			deleted: count("✘", status.deleted),
+			renamed: count("»", status.renamed),
+			modified: count("!", status.modified),
+			typechanged: count("T", status.typechanged),
+			staged: count("+", status.staged),
+			untracked: count("?", status.untracked),
+			worktree_added: count("A", status.worktreeAdded),
+			worktree_deleted: count("D", status.worktreeDeleted),
+			worktree_modified: count("M", status.worktreeModified),
+			worktree_typechanged: count("T", status.worktreeTypechanged),
+			index_added: count("A", status.indexAdded),
+			index_deleted: count("D", status.indexDeleted),
+			index_modified: count("M", status.indexModified),
+			index_typechanged: count("T", status.indexTypechanged),
 		};
-		const allStatus = Object.values(values).filter(Boolean).join(" ");
-		return allStatus ? { ...values, all_status: allStatus } : undefined;
+		const allStatus = [
+			values.conflicted,
+			values.stashed,
+			values.deleted,
+			values.renamed,
+			values.modified,
+			values.typechanged,
+			values.staged,
+			values.untracked,
+		]
+			.filter(Boolean)
+			.join(" ");
+		return allStatus || values.ahead_behind ? { ...values, all_status: allStatus } : undefined;
 	},
 });
+
+function count(symbol: string, value: number): string {
+	return value > 0 ? `${symbol}${formatCount(value)}` : "";
+}

--- a/extensions/pi-starship/src/modules/index.ts
+++ b/extensions/pi-starship/src/modules/index.ts
@@ -9,6 +9,11 @@ export { shortenModel } from "./model.js";
 export { renderStatusline } from "./render.js";
 export type {
 	ExtensionStatusIconAliasMap,
+	GitBranchSnapshot,
+	GitCommitSnapshot,
+	GitMetricsSnapshot,
+	GitSnapshot,
+	GitStateSnapshot,
 	GitStatusSnapshot,
 	GitWorktreeSnapshot,
 	RenderedStatusline,

--- a/extensions/pi-starship/src/modules/types.ts
+++ b/extensions/pi-starship/src/modules/types.ts
@@ -1,17 +1,62 @@
 import type { StyledChunk } from "../format/style.js";
 
+export interface GitBranchSnapshot {
+	name: string;
+	remoteName?: string;
+	remoteBranch?: string;
+	detached: boolean;
+}
+
+export interface GitCommitSnapshot {
+	hash: string;
+	tag?: string;
+	detached: boolean;
+}
+
+export interface GitStateSnapshot {
+	state: string;
+	progressCurrent?: number;
+	progressTotal?: number;
+}
+
+export interface GitMetricsSnapshot {
+	added: number;
+	deleted: number;
+}
+
 export interface GitStatusSnapshot {
 	ahead: number;
 	behind: number;
-	staged: number;
-	modified: number;
-	untracked: number;
+	stashed: number;
 	conflicted: number;
+	deleted: number;
+	renamed: number;
+	modified: number;
+	staged: number;
+	typechanged: number;
+	untracked: number;
+	worktreeAdded: number;
+	worktreeDeleted: number;
+	worktreeModified: number;
+	worktreeTypechanged: number;
+	indexAdded: number;
+	indexDeleted: number;
+	indexModified: number;
+	indexTypechanged: number;
 }
 
 export interface GitWorktreeSnapshot {
 	name: string;
 	path: string;
+}
+
+export interface GitSnapshot {
+	branch?: GitBranchSnapshot;
+	commit?: GitCommitSnapshot;
+	state?: GitStateSnapshot;
+	metrics?: GitMetricsSnapshot;
+	status: GitStatusSnapshot;
+	worktree?: GitWorktreeSnapshot;
 }
 
 export type ExtensionStatusIconAliasMap = ReadonlyMap<string, readonly string[]>;
@@ -31,6 +76,10 @@ export interface StarshipRuntimeSnapshot {
 	};
 	tokenTotals: { input: number; output: number; cost: number };
 	gitBranch: string | null;
+	gitBranchDetails?: GitBranchSnapshot;
+	gitCommit?: GitCommitSnapshot;
+	gitState?: GitStateSnapshot;
+	gitMetrics?: GitMetricsSnapshot;
 	gitStatus?: GitStatusSnapshot;
 	gitWorktree?: GitWorktreeSnapshot;
 	extensionStatuses: ReadonlyMap<string, string>;

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -12,12 +12,12 @@ import {
 	loadStarshipConfig,
 	settingsFilePath,
 } from "./config.js";
+import { formatVariables } from "./format/formatter.js";
 import { readInstalledPackageInfo } from "./installed-packages.js";
-import { gitStatusEqual, readGitStatus, readGitWorktree } from "./modules/git/runtime.js";
+import { gitSnapshotEqual, readGitSnapshot } from "./modules/git/runtime.js";
 import {
 	type ExtensionStatusIconAliasMap,
-	type GitStatusSnapshot,
-	type GitWorktreeSnapshot,
+	type GitSnapshot,
 	renderStatusline,
 	type StarshipRuntimeSnapshot,
 } from "./modules/index.js";
@@ -31,8 +31,7 @@ interface RuntimeState {
 	isStreaming: boolean;
 	thinkingLevel: string;
 	lastCompletedTool?: string;
-	gitStatus?: GitStatusSnapshot;
-	gitWorktree?: GitWorktreeSnapshot;
+	git?: GitSnapshot;
 	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	requestRender?: () => void;
 }
@@ -66,30 +65,10 @@ export default function piStarship(pi: ExtensionAPI) {
 	const isCurrentRequest = (cwd: string, generation: number, requestId: number) =>
 		isActiveTarget(cwd, generation) && requestId === gitRequestId;
 
-	const setGitStatus = (status: GitStatusSnapshot | undefined) => {
-		if (gitStatusEqual(runtime.gitStatus, status)) return;
-		runtime.gitStatus = status;
+	const setGitSnapshot = (snapshot: GitSnapshot | undefined) => {
+		if (gitSnapshotEqual(runtime.git, snapshot)) return;
+		runtime.git = snapshot;
 		refresh();
-	};
-
-	const refreshGitWorktree = (cwd: string, generation: number) => {
-		void (async () => {
-			let worktree: GitWorktreeSnapshot | undefined;
-			try {
-				worktree = await readGitWorktree(pi, cwd);
-			} catch {
-				worktree = undefined;
-			}
-			if (!isActiveTarget(cwd, generation)) return;
-			if (
-				runtime.gitWorktree?.name === worktree?.name &&
-				runtime.gitWorktree?.path === worktree?.path
-			) {
-				return;
-			}
-			runtime.gitWorktree = worktree;
-			refresh();
-		})();
 	};
 
 	const runGitRefresh = (cwd: string, generation: number, requestId: number) => {
@@ -101,10 +80,17 @@ export default function piStarship(pi: ExtensionAPI) {
 		gitRefreshInFlight = true;
 		void (async () => {
 			try {
-				const status = await readGitStatus(pi, cwd);
-				if (isCurrentRequest(cwd, generation, requestId)) setGitStatus(status);
+				const config = loaded?.config;
+				const snapshot = await readGitSnapshot(pi, cwd, {
+					includeMetrics: config ? !config.modules.git_metrics.disabled : false,
+					includeTag: config
+						? !config.modules.git_commit.disabled &&
+							formatVariables(config.modules.git_commit.formatAst).has("tag")
+						: false,
+				});
+				if (isCurrentRequest(cwd, generation, requestId)) setGitSnapshot(snapshot);
 			} catch {
-				if (isCurrentRequest(cwd, generation, requestId)) setGitStatus(undefined);
+				if (isCurrentRequest(cwd, generation, requestId)) setGitSnapshot(undefined);
 			} finally {
 				gitRefreshInFlight = false;
 				const pending = pendingGitRefresh;
@@ -134,8 +120,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		const cwd = ctx.cwd;
 		clearDebounce();
 		pendingGitRefresh = undefined;
-		runtime.gitStatus = undefined;
-		runtime.gitWorktree = undefined;
+		runtime.git = undefined;
 		runtime.requestRender = undefined;
 		activeGitTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
 		ctx.ui.setStatus("starship", undefined);
@@ -154,7 +139,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		ctx.ui.setFooter((tui, _theme, footerData) => {
 			runtime.requestRender = () => tui.requestRender();
 			const unsubscribe = footerData.onBranchChange(() => {
-				runtime.gitStatus = undefined;
+				runtime.git = undefined;
 				clearDebounce();
 				refreshGit(cwd, generation);
 				tui.requestRender();
@@ -176,8 +161,7 @@ export default function piStarship(pi: ExtensionAPI) {
 						activeGitTarget = undefined;
 						clearDebounce();
 						pendingGitRefresh = undefined;
-						runtime.gitStatus = undefined;
-						runtime.gitWorktree = undefined;
+						runtime.git = undefined;
 						runtime.requestRender = undefined;
 					}
 				},
@@ -190,7 +174,6 @@ export default function piStarship(pi: ExtensionAPI) {
 			};
 		});
 		refreshGit(cwd, generation);
-		refreshGitWorktree(cwd, generation);
 	};
 
 	const configPath = settingsFilePath(getAgentDir());
@@ -222,8 +205,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		activeGitTarget = undefined;
 		clearDebounce();
 		pendingGitRefresh = undefined;
-		runtime.gitStatus = undefined;
-		runtime.gitWorktree = undefined;
+		runtime.git = undefined;
 		runtime.extensionStatusIconAliases = EMPTY_ALIASES;
 		runtime.requestRender = undefined;
 		ctx.ui.setFooter(undefined);
@@ -281,9 +263,13 @@ function runtimeSnapshot(
 		lastCompletedTool: runtime.lastCompletedTool,
 		contextUsage: ctx.getContextUsage() ?? undefined,
 		tokenTotals: tokenTotals(ctx),
-		gitBranch: footerData.getGitBranch(),
-		gitStatus: runtime.gitStatus,
-		gitWorktree: runtime.gitWorktree,
+		gitBranch: runtime.git?.branch?.name ?? footerData.getGitBranch(),
+		gitBranchDetails: runtime.git?.branch,
+		gitCommit: runtime.git?.commit,
+		gitState: runtime.git?.state,
+		gitMetrics: runtime.git?.metrics,
+		gitStatus: runtime.git?.status,
+		gitWorktree: runtime.git?.worktree,
 		extensionStatuses: footerData.getExtensionStatuses(),
 		extensionStatusIconAliases: runtime.extensionStatusIconAliases,
 		now: new Date(),
@@ -322,4 +308,10 @@ export function wrapFormattedStatusline(format: string, width: number): string[]
 	return wrapTextWithAnsi(format, width);
 }
 
-export { parseGitStatusPorcelain, parseGitWorktree } from "./modules/git/runtime.js";
+export {
+	parseGitDiffShortstat,
+	parseGitState,
+	parseGitStatusPorcelain,
+	parseGitStatusPorcelainV2,
+	parseGitWorktree,
+} from "./modules/git/runtime.js";

--- a/extensions/pi-starship/test/config.test.ts
+++ b/extensions/pi-starship/test/config.test.ts
@@ -10,6 +10,7 @@ import {
 	CONFIG_FILE_NAME,
 	loadOrCreateStarshipConfig,
 	loadStarshipConfig,
+	MODULE_NAMES,
 	settingsFilePath,
 } from "../src/config.js";
 
@@ -66,6 +67,18 @@ test("built-in example uses readable TOML continuations without changing the for
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test("Git modules use Starship display order", () => {
+	const gitModules = MODULE_NAMES.filter((name) => name.startsWith("git_"));
+	assert.deepEqual(gitModules, [
+		"git_worktree",
+		"git_branch",
+		"git_commit",
+		"git_state",
+		"git_metrics",
+		"git_status",
+	]);
 });
 
 test("missing settings are atomically initialized from the readable built-in example", () => {

--- a/extensions/pi-starship/test/git-runtime.test.ts
+++ b/extensions/pi-starship/test/git-runtime.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createMockPi } from "../../../test/support.js";
+import {
+	parseGitDiffShortstat,
+	parseGitState,
+	parseGitStatusPorcelainV2,
+	readGitSnapshot,
+} from "../src/modules/git/runtime.js";
+
+test("Git porcelain v2 parser supplies branch, commit, and detailed status modules", () => {
+	const parsed = parseGitStatusPorcelainV2(`
+# branch.oid 0123456789abcdef0123456789abcdef01234567
+# branch.head feature/native-git
+# branch.upstream origin/main
+# branch.ab +2 -1
+# stash 3
+1 M. N... 100644 100644 100644 a b index-modified.ts
+1 .M N... 100644 100644 100644 a b worktree-modified.ts
+1 A. N... 000000 100644 100644 a b index-added.ts
+1 .A N... 000000 100644 100644 a b worktree-added.ts
+1 D. N... 100644 000000 000000 a b index-deleted.ts
+1 .D N... 100644 100644 000000 a b worktree-deleted.ts
+1 T. N... 100644 120000 120000 a b index-typechanged.ts
+1 .T N... 100644 100644 120000 a b worktree-typechanged.ts
+2 R. N... 100644 100644 100644 a b R100 renamed.ts\toriginal.ts
+u UU N... 100644 100644 100644 100644 a b c conflicted.ts
+? untracked.ts
+`);
+
+	assert.deepEqual(parsed.branch, {
+		name: "feature/native-git",
+		remoteName: "origin",
+		remoteBranch: "main",
+		detached: false,
+	});
+	assert.deepEqual(parsed.commit, {
+		hash: "0123456789abcdef0123456789abcdef01234567",
+		detached: false,
+	});
+	assert.deepEqual(parsed.status, {
+		ahead: 2,
+		behind: 1,
+		stashed: 3,
+		conflicted: 1,
+		deleted: 2,
+		renamed: 1,
+		modified: 2,
+		staged: 3,
+		typechanged: 1,
+		untracked: 1,
+		worktreeAdded: 1,
+		worktreeDeleted: 1,
+		worktreeModified: 1,
+		worktreeTypechanged: 1,
+		indexAdded: 1,
+		indexDeleted: 1,
+		indexModified: 1,
+		indexTypechanged: 1,
+	});
+});
+
+test("Git porcelain parser represents detached and unborn HEAD safely", () => {
+	const detached = parseGitStatusPorcelainV2(
+		"# branch.oid abcdef1234567890\n# branch.head (detached)\n",
+	);
+	assert.equal(detached.branch?.name, "HEAD");
+	assert.equal(detached.branch?.detached, true);
+	assert.equal(detached.commit?.hash, "abcdef1234567890");
+
+	const unborn = parseGitStatusPorcelainV2(
+		"# branch.oid (initial)\n# branch.head main\n? first-file.ts\n",
+	);
+	assert.equal(unborn.branch?.name, "main");
+	assert.equal(unborn.commit, undefined);
+	assert.equal(unborn.status.untracked, 1);
+});
+
+test("Git diff shortstat parser returns added and deleted line totals", () => {
+	assert.deepEqual(parseGitDiffShortstat(" 2 files changed, 12 insertions(+), 3 deletions(-)\n"), {
+		added: 12,
+		deleted: 3,
+	});
+	assert.deepEqual(parseGitDiffShortstat(" 1 file changed, 1 insertion(+)\n"), {
+		added: 1,
+		deleted: 0,
+	});
+	assert.deepEqual(parseGitDiffShortstat(""), { added: 0, deleted: 0 });
+});
+
+test("Git snapshot refresh collects optional commit tags and line metrics outside render", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-git-snapshot-"));
+	try {
+		const mock = createMockPi();
+		const commands: string[][] = [];
+		(
+			mock.rawPi as typeof mock.rawPi & {
+				exec: (_command: string, args: string[]) => Promise<ExecResult>;
+			}
+		).exec = async (_command, args) => {
+			commands.push(args);
+			if (args.includes("status")) {
+				return gitResult(
+					"# branch.oid 0123456789abcdef\n# branch.head main\n# branch.upstream origin/main\n",
+				);
+			}
+			if (args[0] === "rev-parse") return gitResult(`${root}\n${root}/.git\n${root}/.git\n`);
+			if (args.includes("diff"))
+				return gitResult(" 1 file changed, 8 insertions(+), 2 deletions(-)\n");
+			if (args.includes("describe")) return gitResult("v2.0.0\n");
+			throw new Error(`unexpected git args: ${args.join(" ")}`);
+		};
+
+		const snapshot = await readGitSnapshot(mock.pi, root, {
+			includeMetrics: true,
+			includeTag: true,
+		});
+		assert.equal(snapshot?.commit?.tag, "v2.0.0");
+		assert.deepEqual(snapshot?.metrics, { added: 8, deleted: 2 });
+		assert.equal(commands.length, 4);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Git snapshot refresh degrades a failed status command to no repository", async () => {
+	const mock = createMockPi();
+	(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () => ({
+		stdout: "",
+		stderr: "not a repository",
+		code: 128,
+		killed: false,
+	});
+	assert.equal(
+		await readGitSnapshot(mock.pi, "/not-a-repository", {
+			includeMetrics: false,
+			includeTag: false,
+		}),
+		undefined,
+	);
+});
+
+test("Git state parser detects operations and rebase progress", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-git-state-"));
+	try {
+		mkdirSync(join(root, "rebase-merge"));
+		writeFileSync(join(root, "rebase-merge", "msgnum"), "3\n");
+		writeFileSync(join(root, "rebase-merge", "end"), "10\n");
+		assert.deepEqual(parseGitState(root), {
+			state: "REBASING",
+			progressCurrent: 3,
+			progressTotal: 10,
+		});
+
+		rmSync(join(root, "rebase-merge"), { recursive: true });
+		writeFileSync(join(root, "MERGE_HEAD"), "abc\n");
+		assert.deepEqual(parseGitState(root), { state: "MERGING" });
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+type ExecResult = { stdout: string; stderr: string; code: number; killed: boolean };
+
+function gitResult(stdout: string): ExecResult {
+	return { stdout, stderr: "", code: 0, killed: false };
+}

--- a/extensions/pi-starship/test/lifecycle.test.ts
+++ b/extensions/pi-starship/test/lifecycle.test.ts
@@ -139,7 +139,9 @@ test("TUI footer renders cached state and parallel tool activity without executi
 			worktreeCalls += 1;
 			return gitResult("/work/pi-feature\n/work/pi/.git\n/work/pi/.git/worktrees/pi-feature\n");
 		}
-		return gitResult("## main\n M changed.ts\n");
+		return gitResult(
+			"# branch.oid abcdef1234567890\n# branch.head main\n1 .M N... 100644 100644 100644 a b changed.ts\n",
+		);
 	};
 	piStarship(mock.pi);
 	const context = createMockContext({
@@ -167,13 +169,13 @@ test("TUI footer renders cached state and parallel tool activity without executi
 	await emit(mock.events, "tool_execution_start", { toolName: "bash" }, context.ctx);
 	branchChange?.();
 	await flushAsync();
-	assert.equal(worktreeCalls, 1);
+	assert.equal(worktreeCalls, 2);
 	const beforeRender = calls;
 	const lines = footer.render(300);
 	assert.equal(calls, beforeRender);
 	assert.match(stripAnsi(lines.join("\n")), /pi-feature/);
 	assert.match(stripAnsi(lines.join("\n")), /read×2\+1/);
-	assert.match(stripAnsi(lines.join("\n")), /~1/);
+	assert.match(stripAnsi(lines.join("\n")), /!1/);
 	footer.dispose();
 	await emit(mock.events, "session_shutdown", {}, context.ctx);
 });
@@ -203,9 +205,13 @@ test("stale Git results from a replaced session cannot overwrite the new footer"
 	await emit(mock.events, "session_start", {}, oldContext.ctx);
 	await emit(mock.events, "session_shutdown", {}, oldContext.ctx);
 	await emit(mock.events, "session_start", {}, newContext.ctx);
-	first.resolve(gitResult("## old\n M stale.ts\n"));
+	first.resolve(
+		gitResult(
+			"# branch.oid abcdef1234567890\n# branch.head old\n1 .M N... 100644 100644 100644 a b stale.ts\n",
+		),
+	);
 	await flushAsync();
-	second.resolve(gitResult("## new\n?? fresh.ts\n"));
+	second.resolve(gitResult("# branch.oid abcdef1234567890\n# branch.head new\n? fresh.ts\n"));
 	await flushAsync();
 	const footer = (newContext.footer as FooterFactory)(
 		{ requestRender() {} },
@@ -217,7 +223,7 @@ test("stale Git results from a replaced session cannot overwrite the new footer"
 		},
 	);
 	const output = stripAnsi(footer.render(300).join("\n"));
-	assert.doesNotMatch(output, /~1/);
+	assert.doesNotMatch(output, /!1/);
 	assert.match(output, /\?1/);
 	footer.dispose();
 	await emit(mock.events, "session_shutdown", {}, newContext.ctx);
@@ -331,7 +337,26 @@ test("Git porcelain parser returns all compact counters", () => {
 		parseGitStatusPorcelain(
 			`## main...origin/main [ahead 2, behind 1]\nM  staged\n M modified\n?? new\nUU conflict\n`,
 		),
-		{ ahead: 2, behind: 1, staged: 1, modified: 1, untracked: 1, conflicted: 1 },
+		{
+			ahead: 2,
+			behind: 1,
+			stashed: 0,
+			conflicted: 1,
+			deleted: 0,
+			renamed: 0,
+			modified: 1,
+			staged: 1,
+			typechanged: 0,
+			untracked: 1,
+			worktreeAdded: 0,
+			worktreeDeleted: 0,
+			worktreeModified: 1,
+			worktreeTypechanged: 0,
+			indexAdded: 0,
+			indexDeleted: 0,
+			indexModified: 1,
+			indexTypechanged: 0,
+		},
 	);
 });
 

--- a/extensions/pi-starship/test/modules.test.ts
+++ b/extensions/pi-starship/test/modules.test.ts
@@ -31,13 +31,27 @@ function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRunt
 		contextUsage: { percent: 75, tokens: 750, contextWindow: 1000 },
 		tokenTotals: { input: 1530, output: 200, cost: 0.1234 },
 		gitBranch: "feature",
+		gitBranchDetails: { name: "feature", detached: false },
+		gitCommit: { hash: "0123456789abcdef", detached: false },
 		gitStatus: {
 			ahead: 2,
 			behind: 1,
-			staged: 3,
-			modified: 4,
-			untracked: 5,
+			stashed: 0,
 			conflicted: 1,
+			deleted: 0,
+			renamed: 0,
+			modified: 4,
+			staged: 3,
+			typechanged: 0,
+			untracked: 5,
+			worktreeAdded: 0,
+			worktreeDeleted: 0,
+			worktreeModified: 4,
+			worktreeTypechanged: 0,
+			indexAdded: 3,
+			indexDeleted: 0,
+			indexModified: 0,
+			indexTypechanged: 0,
 		},
 		extensionStatuses: new Map([
 			["github-pr", `PR ${LINK}: checks failing (2), approved`],
@@ -58,7 +72,7 @@ test("built-in modules expose Pi values through the default format", () => {
 	assert.match(plain, /high/);
 	assert.match(plain, /pi-extensions/);
 	assert.match(plain, /feature/);
-	assert.match(plain, /⇡2 ⇣1 \+3 ~4 \?5 !1/);
+	assert.match(plain, /=1 !4 \+3 \?5 ⇕⇡2⇣1/);
 	assert.match(plain, /read/);
 	assert.match(plain, /75%/);
 	assert.match(plain, /↑1\.5k ↓200/);
@@ -98,6 +112,7 @@ test("empty and disabled modules disappear and make conditionals empty", () => {
 		fixture({
 			model: undefined,
 			gitBranch: null,
+			gitBranchDetails: undefined,
 			gitStatus: undefined,
 			extensionStatuses: new Map(),
 		}),
@@ -153,6 +168,78 @@ test("$all expands enabled modules in default order without explicit duplicates"
 	assert.equal(rendered.ansi.split(modelText).length - 1, 1);
 	assert.ok(rendered.ansi.indexOf("π") > rendered.ansi.indexOf(modelText));
 	assert.match(rendered.ansi, /#7/);
+});
+
+test("Starship Git modules expose branch, commit, state, metrics, and detailed status", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$git_branch|$git_commit|$git_state|$git_metrics|$git_status";
+	config.formatAst = [
+		{ type: "variable", name: "git_branch" },
+		{ type: "text", value: "|" },
+		{ type: "variable", name: "git_commit" },
+		{ type: "text", value: "|" },
+		{ type: "variable", name: "git_state" },
+		{ type: "text", value: "|" },
+		{ type: "variable", name: "git_metrics" },
+		{ type: "text", value: "|" },
+		{ type: "variable", name: "git_status" },
+	];
+	config.modules.git_branch.format = "$branch:$remote_name/$remote_branch";
+	config.modules.git_branch.formatAst = [
+		{ type: "variable", name: "branch" },
+		{ type: "text", value: ":" },
+		{ type: "variable", name: "remote_name" },
+		{ type: "text", value: "/" },
+		{ type: "variable", name: "remote_branch" },
+	];
+	config.modules.git_commit.format = "$hash$tag";
+	config.modules.git_commit.formatAst = [
+		{ type: "variable", name: "hash" },
+		{ type: "variable", name: "tag" },
+	];
+	config.modules.git_state.format = "$state:$progress_current/$progress_total";
+	config.modules.git_state.formatAst = [
+		{ type: "variable", name: "state" },
+		{ type: "text", value: ":" },
+		{ type: "variable", name: "progress_current" },
+		{ type: "text", value: "/" },
+		{ type: "variable", name: "progress_total" },
+	];
+	config.modules.git_metrics.disabled = false;
+	config.modules.git_metrics.format = "+$added/-$deleted";
+	config.modules.git_metrics.formatAst = [
+		{ type: "text", value: "+" },
+		{ type: "variable", name: "added" },
+		{ type: "text", value: "/-" },
+		{ type: "variable", name: "deleted" },
+	];
+	config.modules.git_status.format = "$all_status $ahead_behind";
+	config.modules.git_status.formatAst = [
+		{ type: "variable", name: "all_status" },
+		{ type: "text", value: " " },
+		{ type: "variable", name: "ahead_behind" },
+	];
+
+	const rendered = stripAnsi(
+		renderStatusline(
+			config,
+			fixture({
+				gitBranchDetails: {
+					name: "feature/native-git",
+					remoteName: "origin",
+					remoteBranch: "main",
+					detached: true,
+				},
+				gitCommit: { hash: "0123456789abcdef", tag: "v1.2.3", detached: true },
+				gitState: { state: "REBASING", progressCurrent: 3, progressTotal: 10 },
+				gitMetrics: { added: 12, deleted: 3 },
+			}),
+		).ansi,
+	);
+	assert.equal(
+		rendered,
+		"feature/native-git:origin/main|0123456 🏷 v1.2.3|REBASING:3/10|+12/-3|=1 !4 +3 ?5 ⇕⇡2⇣1",
+	);
 });
 
 test("git worktree renders linked worktree values and stays empty for the primary worktree", () => {


### PR DESCRIPTION
## Summary

- add native Git commit, operation state, and line metrics modules, and extend branch/status data to match the vendored Starship concepts
- collect porcelain-v2 status, commit/tag, operation progress, metrics, and worktree identity in a cached refresh so footer rendering stays subprocess-free
- keep `git_commit`, `git_state`, and `git_metrics` out of the built-in root format for explicit opt-in, with metrics disabled by default
- document module variables and cover parsing, rendering, lifecycle isolation, and failure fallback

## Testing

- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check`
- `npm run pack:starship`
- `pi --no-extensions -e ./extensions/pi-starship --list-models`
