### PR TITLE
feat(starship): add guided configuration menu

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-starship-command-menu-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-starship-command-menu-plan.md
@@ -1,0 +1,23 @@
+# pi-starship command menu plan
+
+## Goal
+
+Replace bare `/starship` help with a goal-oriented TUI menu, add preview and confirmation before configuration writes, and preserve all direct commands, raw TOML data, and non-TUI behavior.
+
+## Plan
+
+- [x] Add failing command/UI tests for stateful main and Advanced menus, Back navigation, draft preview/confirmation, cancellation, failures, narrow rendering, restore, and direct-command compatibility; initial compilation failed on the missing preview option and draft validator.
+- [x] Add in-memory TOML validation and a current-runtime preview callback without changing footer ownership.
+- [x] Implement the shallow TUI menu and edit/restore flows with explicit preview, confirmation, atomic application, cancellation, and rollback behavior.
+- [x] Update `extensions/pi-starship/README.md` for the final command UX and run focused tests, `npm run check`, package dry-run, and Pi load smoke; all passed.
+- [x] Commit and push `6242de9`, create pull request #366, and archive this completed plan.
+
+## Completion Checklist
+
+- [x] Main actions use user goals and expose current configuration health.
+- [x] Advanced is one level deep and has a clear Back path.
+- [x] Drafts and restore operations preview before a separate confirmation.
+- [x] Cancellation and failures preserve the prior file and effective runtime.
+- [x] Existing direct routes, autocomplete, non-TUI behavior, and unknown TOML fields remain compatible.
+- [x] Menu, detail, and preview components fit narrow terminal widths.
+- [x] Documentation and all required verification pass.

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -13,7 +13,7 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 - Pi modules for model, thinking, activity, context, tokens, cost, turn, and extension statuses.
 - Cached Git branch/status rendering and linked-worktree identity; no subprocess runs during footer rendering.
 - Multiline output wraps to the terminal width instead of truncating.
-- Transactional TOML editing through `/starship settings`.
+- Goal-oriented `/starship` menu with configuration health, preview, confirmation, and recovery.
 
 ## 📦 Install
 
@@ -41,13 +41,15 @@ On the first session start, the extension atomically creates this file from its 
 
 The extension does **not** read project overrides, `pi-statusline.json`, `PI_STATUSLINE_PRESET`, or `~/.config/starship.toml`, and does not migrate statusline settings.
 
-Open the file transactionally in TUI mode:
+Open the interactive menu in TUI mode:
 
 ```text
-/starship settings
+/starship
 ```
 
-A successful edit is validated, atomically saved, and applied immediately. Invalid or cancelled edits leave the previous file and effective config unchanged.
+Choose **Customize footer** to edit the TOML. Closing the editor validates the draft and opens a width-aware preview; saving happens only after a separate confirmation. Confirmed changes are atomically saved and applied immediately. Editor cancellation, preview cancellation, invalid drafts, write failures, and runtime application failures preserve the previous file and effective footer.
+
+The **Advanced** menu is one level deep and contains configuration details plus **Restore built-in**. Restore shows the concrete built-in preview and requires explicit overwrite confirmation.
 
 ### 📝 Example
 
@@ -144,11 +146,14 @@ If `$git_branch.$pr` is present in the module format, its selected PR token is r
 
 | Command | Purpose |
 | --- | --- |
-| `/starship settings` | Edit, validate, save, and immediately apply TOML (TUI only) |
+| `/starship` | Open the current-state menu in TUI mode; retain help behavior outside TUI |
+| `/starship settings` | Open the compatible direct edit → preview → confirm flow (TUI only) |
 | `/starship status` | Show config source/path and diagnostics |
 | `/starship help` | Show command and configuration help |
 
-Status and help are safe in TUI, RPC, JSON, and print modes. Footer/timer/Git lifecycle work starts only in TUI mode.
+The main menu keeps frequent goals visible: **Customize footer**, **Check configuration**, and **Help**. It shows whether the footer uses the built-in or custom document and displays the current warning count. **Advanced** contains uncommon details and the confirmed restore action, with an explicit **Back** path.
+
+Status and help remain safe in TUI, RPC, JSON, and print modes. RPC receives notifications but never opens custom terminal UI; print and JSON modes produce no ad hoc output. Footer/timer/Git lifecycle work starts only in TUI mode.
 
 ## 📐 Scope
 
@@ -163,8 +168,9 @@ Keep `extension_status` last in the catalog so earlier modules can consume exten
 ## 🗂️ Package layout
 
 - `src/index.ts` — Pi package entrypoint.
-- `src/pi-starship.ts` — extension lifecycle and footer.
-- `src/config.ts` — TOML loading, validation, defaults, and persistence.
+- `src/pi-starship.ts` — extension lifecycle, live preview binding, and footer.
+- `src/commands.ts` — goal-oriented menu, preview/confirmation, diagnostics, and compatibility routes.
+- `src/config.ts` — TOML loading, draft validation, defaults, atomic persistence, and rollback.
 - `src/format/` — native format/style parser and renderer.
 - `src/modules/` — module-per-file definitions, ordered registry, and statusline renderer.
 - `src/modules/git/` — shared Git runtime plus branch, status, and worktree modules.

--- a/extensions/pi-starship/src/commands.ts
+++ b/extensions/pi-starship/src/commands.ts
@@ -1,30 +1,79 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import type { AutocompleteItem } from "@earendil-works/pi-tui";
-import { atomicSaveConfigDocument, BUILT_IN_EXAMPLE, type LoadedStarshipConfig } from "./config.js";
+import {
+	type AutocompleteItem,
+	type SelectItem,
+	SelectList,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import {
+	atomicRestoreConfigDocument,
+	atomicSaveConfigDocument,
+	BUILT_IN_EXAMPLE,
+	type LoadedStarshipConfig,
+	validateConfigDocument,
+} from "./config.js";
 
 const SUBCOMMANDS: AutocompleteItem[] = [
-	{ value: "settings", label: "settings", description: "Edit pi-starship.toml" },
-	{ value: "status", label: "status", description: "Show the effective settings source" },
+	{ value: "settings", label: "settings", description: "Customize the footer TOML" },
+	{ value: "status", label: "status", description: "Show configuration health and source" },
 	{ value: "help", label: "help", description: "Show configuration help" },
 ];
+
+const MAIN_ACTIONS = {
+	customize: "customize",
+	diagnostics: "diagnostics",
+	help: "help",
+	advanced: "advanced",
+} as const;
+
+const ADVANCED_ACTIONS = {
+	details: "details",
+	restore: "restore",
+	back: "back",
+} as const;
+
+const PREVIEW_ACTIONS = {
+	continue: "continue",
+	edit: "edit",
+	cancel: "cancel",
+} as const;
 
 export interface StarshipCommandOptions {
 	getLoaded(): LoadedStarshipConfig;
 	apply(loaded: LoadedStarshipConfig, ctx: ExtensionCommandContext): void;
 	settingsPath: string;
+	renderPreview?(
+		loaded: LoadedStarshipConfig,
+		width: number,
+		ctx: ExtensionCommandContext,
+	): string[];
 	save?: (settingsPath: string, rawDocument: string) => LoadedStarshipConfig;
+	restore?: (settingsPath: string, rawDocument: string) => void;
+	validate?: (settingsPath: string, rawDocument: string) => LoadedStarshipConfig;
+}
+
+interface MenuItem extends SelectItem {
+	value: string;
 }
 
 export function registerStarshipCommand(pi: ExtensionAPI, options: StarshipCommandOptions) {
 	pi.registerCommand("starship", {
-		description: "Edit or inspect the native Starship-style footer settings",
+		description: "Customize or inspect the native Starship-style footer",
 		getArgumentCompletions(prefix: string): AutocompleteItem[] | null {
 			const normalized = prefix.trim().toLowerCase();
 			const matches = SUBCOMMANDS.filter((item) => item.value.startsWith(normalized));
 			return matches.length > 0 ? matches : null;
 		},
 		handler: async (args, ctx) => {
-			const subcommand = args.trim().split(/\s+/u)[0]?.toLowerCase() || "help";
+			const normalized = args.trim();
+			if (!normalized) {
+				if (ctx.mode === "tui") await showMainMenu(ctx, options);
+				else showHelp(ctx, options.settingsPath);
+				return;
+			}
+
+			const subcommand = normalized.split(/\s+/u)[0]?.toLowerCase() ?? "";
 			switch (subcommand) {
 				case "settings":
 					await editSettings(ctx, options);
@@ -44,28 +93,350 @@ export function registerStarshipCommand(pi: ExtensionAPI, options: StarshipComma
 	});
 }
 
-async function editSettings(ctx: ExtensionCommandContext, options: StarshipCommandOptions) {
+async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipCommandOptions) {
+	while (true) {
+		const loaded = options.getLoaded();
+		const state = configurationState(loaded);
+		const health = configurationHealth(loaded);
+		const selection = await showActionMenu(ctx, "pi-starship", () => [`${state} · ${health}`], [
+			{
+				value: MAIN_ACTIONS.customize,
+				label: "Customize footer",
+				description: `${state} · preview before applying`,
+			},
+			{
+				value: MAIN_ACTIONS.diagnostics,
+				label: "Check configuration",
+				description: health,
+			},
+			{ value: MAIN_ACTIONS.help, label: "Help", description: "Formats, modules, and commands" },
+			{
+				value: MAIN_ACTIONS.advanced,
+				label: "Advanced",
+				description: "Details and restore controls",
+			},
+		]);
+		switch (selection) {
+			case MAIN_ACTIONS.customize:
+				if (await editSettings(ctx, options)) return;
+				break;
+			case MAIN_ACTIONS.diagnostics:
+				await showDiagnosticsScreen(ctx, loaded);
+				break;
+			case MAIN_ACTIONS.help:
+				await showHelpScreen(ctx, options.settingsPath);
+				break;
+			case MAIN_ACTIONS.advanced:
+				if (!(await showAdvancedMenu(ctx, options))) return;
+				break;
+			default:
+				return;
+		}
+	}
+}
+
+async function showAdvancedMenu(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+): Promise<boolean> {
+	while (true) {
+		const loaded = options.getLoaded();
+		const alreadyBuiltIn = loaded.rawDocument === BUILT_IN_EXAMPLE;
+		const selection = await showActionMenu(ctx, "Advanced", () => [configurationState(loaded)], [
+			{
+				value: ADVANCED_ACTIONS.details,
+				label: "Configuration details",
+				description: `${configurationSource(loaded)} · ${fileName(options.settingsPath)}`,
+			},
+			{
+				value: ADVANCED_ACTIONS.restore,
+				label: "Restore built-in",
+				description: alreadyBuiltIn ? "Already active" : "Preview before replacing the document",
+			},
+			{ value: ADVANCED_ACTIONS.back, label: "Back", description: "Return to pi-starship" },
+		]);
+		if (selection === ADVANCED_ACTIONS.details) {
+			await showConfigurationDetails(ctx, loaded, options.settingsPath);
+			continue;
+		}
+		if (selection === ADVANCED_ACTIONS.restore) {
+			if (alreadyBuiltIn) {
+				ctx.ui.notify("The built-in footer configuration is already active.", "info");
+				continue;
+			}
+			if (await restoreBuiltIn(ctx, options)) return false;
+			continue;
+		}
+		return selection === ADVANCED_ACTIONS.back;
+	}
+}
+
+async function editSettings(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+): Promise<boolean> {
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${options.settingsPath}`, "info");
-		return;
+		return false;
 	}
-	const current = options.getLoaded();
-	const edited = await ctx.ui.editor(
-		"pi-starship.toml — save and close to apply",
-		current.rawDocument ?? BUILT_IN_EXAMPLE,
+	let draft = options.getLoaded().rawDocument ?? BUILT_IN_EXAMPLE;
+	while (true) {
+		const edited = await ctx.ui.editor("Customize footer — close to preview", draft);
+		if (edited === undefined) return false;
+		draft = edited;
+		let validated: LoadedStarshipConfig;
+		try {
+			validated = (options.validate ?? validateConfigDocument)(options.settingsPath, draft);
+		} catch (error) {
+			ctx.ui.notify(`Footer draft is invalid: ${safeText(formatError(error))}`, "error");
+			const action = await showActionMenu(
+				ctx,
+				"Configuration needs attention",
+				() => [safeText(formatError(error)), "The current footer has not changed."],
+				[
+					{ value: PREVIEW_ACTIONS.edit, label: "Continue editing" },
+					{ value: PREVIEW_ACTIONS.cancel, label: "Back" },
+				],
+			);
+			if (action === PREVIEW_ACTIONS.edit) continue;
+			return false;
+		}
+
+		const result = await reviewAndApply(ctx, options, validated, "Footer preview", false);
+		if (result === "edit") continue;
+		return result === "applied";
+	}
+}
+
+async function restoreBuiltIn(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+): Promise<boolean> {
+	const validated = (options.validate ?? validateConfigDocument)(
+		options.settingsPath,
+		BUILT_IN_EXAMPLE,
 	);
-	if (edited === undefined) return;
-	try {
-		const loaded = (options.save ?? atomicSaveConfigDocument)(options.settingsPath, edited);
-		options.apply(loaded, ctx);
+	return (await reviewAndApply(ctx, options, validated, "Restore preview", true)) === "applied";
+}
+
+async function reviewAndApply(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	validated: LoadedStarshipConfig,
+	title: string,
+	restore: boolean,
+): Promise<"applied" | "edit" | "cancel"> {
+	while (true) {
+		const selection = await showActionMenu(
+			ctx,
+			title,
+			(width) => previewBody(ctx, options, validated, width),
+			[
+				{ value: PREVIEW_ACTIONS.continue, label: "Continue to apply" },
+				...(restore ? [] : [{ value: PREVIEW_ACTIONS.edit, label: "Continue editing" }]),
+				{ value: PREVIEW_ACTIONS.cancel, label: "Cancel" },
+			],
+		);
+		if (selection === PREVIEW_ACTIONS.edit) return "edit";
+		if (selection !== PREVIEW_ACTIONS.continue) return "cancel";
+
+		const confirmed = await ctx.ui.confirm(
+			restore ? "Restore built-in footer?" : "Apply footer changes?",
+			restore
+				? `Replace ${options.settingsPath} with the built-in configuration?`
+				: "Save this configuration and apply it immediately?",
+		);
+		if (!confirmed) continue;
+
+		const save = options.save ?? atomicSaveConfigDocument;
+		const previous = options.getLoaded();
+		let saved: LoadedStarshipConfig;
+		try {
+			saved = save(options.settingsPath, validated.rawDocument ?? BUILT_IN_EXAMPLE);
+		} catch (error) {
+			ctx.ui.notify(
+				`Footer settings were not saved: ${safeText(formatError(error))}. The previous footer remains active.`,
+				"error",
+			);
+			continue;
+		}
+
+		try {
+			options.apply(saved, ctx);
+		} catch (error) {
+			const rollbackError = restorePreviousConfiguration(ctx, options, previous);
+			ctx.ui.notify(
+				rollbackError
+					? `Footer settings could not be applied: ${safeText(formatError(error))}. Restoring the previous configuration also failed: ${safeText(formatError(rollbackError))}.`
+					: `Footer settings could not be applied: ${safeText(formatError(error))}. The previous configuration was restored.`,
+				"error",
+			);
+			continue;
+		}
+
 		const warningSuffix =
-			loaded.diagnostics.length > 0
-				? ` (${loaded.diagnostics.length} warning${loaded.diagnostics.length === 1 ? "" : "s"})`
+			saved.diagnostics.length > 0
+				? ` (${saved.diagnostics.length} warning${saved.diagnostics.length === 1 ? "" : "s"})`
 				: "";
-		ctx.ui.notify(`pi-starship settings saved and applied${warningSuffix}.`, "info");
-	} catch (error) {
-		ctx.ui.notify(`pi-starship settings were not saved: ${formatError(error)}`, "error");
+		ctx.ui.notify(
+			restore
+				? `Built-in footer restored and applied${warningSuffix}.`
+				: `Footer settings saved and applied${warningSuffix}.`,
+			"info",
+		);
+		return "applied";
 	}
+}
+
+function restorePreviousConfiguration(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	previous: LoadedStarshipConfig,
+): unknown {
+	try {
+		if (previous.rawDocument === undefined) {
+			throw new Error("The previous settings document is unavailable");
+		}
+		(options.restore ?? atomicRestoreConfigDocument)(options.settingsPath, previous.rawDocument);
+		options.apply(previous, ctx);
+		return undefined;
+	} catch (error) {
+		return error;
+	}
+}
+
+function previewBody(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	loaded: LoadedStarshipConfig,
+	width: number,
+): string[] {
+	let lines: string[];
+	try {
+		lines = options.renderPreview?.(loaded, width, ctx) ?? [
+			"Live preview is unavailable until the footer is ready.",
+			"The draft is valid and can still be applied.",
+		];
+	} catch (error) {
+		lines = [`Preview unavailable: ${safeText(formatError(error))}`];
+	}
+	const warning =
+		loaded.diagnostics.length === 0
+			? "Draft validation: Healthy"
+			: `Draft validation: ${loaded.diagnostics.length} warning${loaded.diagnostics.length === 1 ? "" : "s"}`;
+	return [...lines, "", warning];
+}
+
+async function showDiagnosticsScreen(ctx: ExtensionCommandContext, loaded: LoadedStarshipConfig) {
+	await showActionMenu(ctx, "Configuration health", () => diagnosticLines(loaded, false), [
+		{ value: ADVANCED_ACTIONS.back, label: "Back" },
+	]);
+}
+
+async function showConfigurationDetails(
+	ctx: ExtensionCommandContext,
+	loaded: LoadedStarshipConfig,
+	settingsPath: string,
+) {
+	await showActionMenu(
+		ctx,
+		"Configuration details",
+		() => [
+			`State: ${configurationState(loaded)}`,
+			`Source: ${configurationSource(loaded)}`,
+			`Path: ${safeText(settingsPath)}`,
+			...diagnosticLines(loaded, true),
+		],
+		[{ value: ADVANCED_ACTIONS.back, label: "Back" }],
+	);
+}
+
+async function showHelpScreen(ctx: ExtensionCommandContext, settingsPath: string) {
+	await showActionMenu(
+		ctx,
+		"pi-starship help",
+		() => [
+			"Customize footer opens the TOML editor, then previews and confirms before saving.",
+			"Check configuration explains warnings without changing the footer.",
+			`Settings: ${safeText(settingsPath)}`,
+			"Docs: https://github.com/narumiruna/pi-extensions/tree/main/extensions/pi-starship",
+		],
+		[{ value: ADVANCED_ACTIONS.back, label: "Back" }],
+	);
+}
+
+async function showActionMenu(
+	ctx: ExtensionCommandContext,
+	title: string,
+	body: (width: number) => readonly string[],
+	items: readonly MenuItem[],
+): Promise<string | null> {
+	return ctx.ui.custom<string | null>((tui, theme, _keybindings, done) => {
+		const list = new SelectList([...items], Math.min(items.length, 8), {
+			selectedPrefix: (text) => theme.fg("accent", text),
+			selectedText: (text) => theme.fg("accent", text),
+			description: (text) => theme.fg("muted", text),
+			scrollInfo: (text) => theme.fg("dim", text),
+			noMatch: (text) => theme.fg("warning", text),
+		});
+		list.onSelect = (item) => done(String(item.value));
+		list.onCancel = () => done(null);
+		return {
+			render(width: number): string[] {
+				const safeWidth = Math.max(1, width);
+				const content = [
+					...wrapTextWithAnsi(theme.fg("accent", theme.bold(title)), safeWidth),
+					...body(safeWidth).flatMap((line) => (line ? wrapTextWithAnsi(line, safeWidth) : [""])),
+					"",
+					...list.render(safeWidth),
+					...wrapTextWithAnsi(
+						theme.fg("dim", "↑↓ navigate • enter select • esc cancel"),
+						safeWidth,
+					),
+				];
+				return content.map((line) => truncateToWidth(line, safeWidth));
+			},
+			invalidate() {
+				list.invalidate();
+			},
+			handleInput(data: string) {
+				list.handleInput(data);
+				tui.requestRender();
+			},
+		};
+	});
+}
+
+function diagnosticLines(loaded: LoadedStarshipConfig, includeSummary: boolean): string[] {
+	const diagnostics = loaded.diagnostics
+		.slice(0, 8)
+		.map((item) => `${safeText(item.path || "root")}: ${safeText(item.message)}`);
+	const remaining = loaded.diagnostics.length - diagnostics.length;
+	return [
+		...(includeSummary ? [`Health: ${configurationHealth(loaded)}`] : []),
+		...(diagnostics.length > 0 ? diagnostics : ["No configuration warnings."]),
+		...(remaining > 0 ? [`${remaining} additional warnings not shown.`] : []),
+	];
+}
+
+function configurationState(loaded: LoadedStarshipConfig): string {
+	if (loaded.source === "built-in") return "Built-in fallback";
+	return loaded.rawDocument === BUILT_IN_EXAMPLE ? "Built-in footer" : "Custom footer";
+}
+
+function configurationSource(loaded: LoadedStarshipConfig): string {
+	return loaded.source === "user" ? "User file" : "Built-in fallback";
+}
+
+function configurationHealth(loaded: LoadedStarshipConfig): string {
+	const errors = loaded.diagnostics.filter((item) => item.severity === "error").length;
+	if (errors > 0) return `${errors} error${errors === 1 ? "" : "s"}`;
+	const warnings = loaded.diagnostics.length;
+	return warnings === 0 ? "Healthy" : `${warnings} warning${warnings === 1 ? "" : "s"}`;
+}
+
+function fileName(path: string): string {
+	return path.replaceAll("\\", "/").split("/").at(-1) || path;
 }
 
 function showStatus(ctx: ExtensionCommandContext, options: StarshipCommandOptions) {
@@ -73,7 +444,7 @@ function showStatus(ctx: ExtensionCommandContext, options: StarshipCommandOption
 	const loaded = options.getLoaded();
 	const diagnostics = loaded.diagnostics
 		.slice(0, 5)
-		.map((item) => `${item.path || "root"}: ${item.message}`)
+		.map((item) => `${safeText(item.path || "root")}: ${safeText(item.message)}`)
 		.join("; ");
 	ctx.ui.notify(
 		[
@@ -89,7 +460,8 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	if (!canNotify(ctx)) return;
 	ctx.ui.notify(
 		[
-			"/starship settings — edit and apply TOML",
+			"/starship — open the interactive footer menu",
+			"/starship settings — customize, preview, and apply TOML",
 			"/starship status — show source, path, and warnings",
 			"/starship help — show this help",
 			`Settings: ${settingsPath}`,
@@ -101,6 +473,17 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 
 function canNotify(ctx: ExtensionCommandContext): boolean {
 	return ctx.mode === "tui" || ctx.hasUI;
+}
+
+function safeText(value: string): string {
+	return Array.from(value, (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const unsafe =
+			codePoint <= 0x08 ||
+			(codePoint >= 0x0b && codePoint <= 0x1f) ||
+			(codePoint >= 0x7f && codePoint <= 0x9f);
+		return unsafe ? `\\u${codePoint.toString(16).padStart(4, "0")}` : character;
+	}).join("");
 }
 
 function formatError(error: unknown): string {

--- a/extensions/pi-starship/src/config.ts
+++ b/extensions/pi-starship/src/config.ts
@@ -421,10 +421,9 @@ interface AtomicFileSystem {
 	rmSync: typeof rmSync;
 }
 
-export function atomicSaveConfigDocument(
+export function validateConfigDocument(
 	settingsPath: string,
 	rawDocument: string,
-	overrides: Partial<AtomicFileSystem> = {},
 ): LoadedStarshipConfig {
 	let parsed: TomlTable;
 	try {
@@ -436,7 +435,37 @@ export function atomicSaveConfigDocument(
 	if (normalized.diagnostics.some((item) => item.severity === "error")) {
 		throw new Error(normalized.diagnostics.map((item) => item.message).join("\n"));
 	}
+	return {
+		...normalized,
+		source: "user",
+		settingsPath,
+		rawDocument,
+	};
+}
 
+export function atomicSaveConfigDocument(
+	settingsPath: string,
+	rawDocument: string,
+	overrides: Partial<AtomicFileSystem> = {},
+): LoadedStarshipConfig {
+	const validated = validateConfigDocument(settingsPath, rawDocument);
+	atomicWriteConfigDocument(settingsPath, rawDocument, overrides);
+	return validated;
+}
+
+export function atomicRestoreConfigDocument(
+	settingsPath: string,
+	rawDocument: string,
+	overrides: Partial<AtomicFileSystem> = {},
+) {
+	atomicWriteConfigDocument(settingsPath, rawDocument, overrides);
+}
+
+function atomicWriteConfigDocument(
+	settingsPath: string,
+	rawDocument: string,
+	overrides: Partial<AtomicFileSystem>,
+) {
 	const fs = { mkdirSync, writeFileSync, renameSync, rmSync, ...overrides };
 	fs.mkdirSync(dirname(settingsPath), { recursive: true });
 	const tempPath = join(dirname(settingsPath), `.${CONFIG_FILE_NAME}.${randomUUID()}.tmp`);
@@ -447,15 +476,9 @@ export function atomicSaveConfigDocument(
 		try {
 			fs.rmSync(tempPath, { force: true });
 		} catch {
-			// Best-effort cleanup must not replace the original save error.
+			// Best-effort cleanup must not replace the publication result.
 		}
 	}
-	return {
-		...normalized,
-		source: "user",
-		settingsPath,
-		rawDocument,
-	};
 }
 
 function cloneBuiltInConfig(): StarshipConfig {

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -35,6 +35,7 @@ interface RuntimeState {
 	gitWorktree?: GitWorktreeSnapshot;
 	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	requestRender?: () => void;
+	renderPreview?: (loaded: LoadedStarshipConfig, width: number) => string[];
 }
 
 export default function piStarship(pi: ExtensionAPI) {
@@ -137,6 +138,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		runtime.gitStatus = undefined;
 		runtime.gitWorktree = undefined;
 		runtime.requestRender = undefined;
+		runtime.renderPreview = undefined;
 		activeGitTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
 		ctx.ui.setStatus("starship", undefined);
 		if (!activeGitTarget || !loaded) return;
@@ -153,6 +155,10 @@ export default function piStarship(pi: ExtensionAPI) {
 
 		ctx.ui.setFooter((tui, _theme, footerData) => {
 			runtime.requestRender = () => tui.requestRender();
+			runtime.renderPreview = (preview, width) => {
+				const snapshot = runtimeSnapshot(ctx, footerData, runtime);
+				return wrapFormattedStatusline(renderStatusline(preview.config, snapshot).ansi, width);
+			};
 			const unsubscribe = footerData.onBranchChange(() => {
 				runtime.gitStatus = undefined;
 				clearDebounce();
@@ -179,6 +185,7 @@ export default function piStarship(pi: ExtensionAPI) {
 						runtime.gitStatus = undefined;
 						runtime.gitWorktree = undefined;
 						runtime.requestRender = undefined;
+						runtime.renderPreview = undefined;
 					}
 				},
 				invalidate() {},
@@ -200,6 +207,13 @@ export default function piStarship(pi: ExtensionAPI) {
 		apply(next) {
 			loaded = next;
 			refresh();
+		},
+		renderPreview(preview, width) {
+			return (
+				runtime.renderPreview?.(preview, width) ?? [
+					"Live preview is unavailable until the footer is ready.",
+				]
+			);
 		},
 	});
 
@@ -226,6 +240,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		runtime.gitWorktree = undefined;
 		runtime.extensionStatusIconAliases = EMPTY_ALIASES;
 		runtime.requestRender = undefined;
+		runtime.renderPreview = undefined;
 		ctx.ui.setFooter(undefined);
 		ctx.ui.setStatus("starship", undefined);
 	});

--- a/extensions/pi-starship/test/commands.test.ts
+++ b/extensions/pi-starship/test/commands.test.ts
@@ -3,14 +3,21 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
 import { registerStarshipCommand } from "../src/commands.js";
 import { BUILT_IN_EXAMPLE, loadStarshipConfig, settingsFilePath } from "../src/config.js";
 import piStarship from "../src/pi-starship.js";
 
-test("/starship registers settings, status, and help autocomplete", () => {
+test("/starship keeps direct routes and opens a stateful narrow TUI menu", async () => {
 	const mock = createMockPi();
-	piStarship(mock.pi);
+	const fallback = loadStarshipConfig("/tmp/missing-pi-starship-main-menu.toml");
+	const loaded = { ...fallback, source: "user" as const, rawDocument: BUILT_IN_EXAMPLE };
+	registerStarshipCommand(mock.pi, {
+		getLoaded: () => loaded,
+		apply() {},
+		settingsPath: "/tmp/missing-pi-starship-main-menu.toml",
+	});
 	const command = mock.commands.get("starship");
 	assert.ok(command);
 	assert.ok(command.getArgumentCompletions);
@@ -22,6 +29,26 @@ test("/starship registers settings, status, and help autocomplete", () => {
 		(command.getArgumentCompletions("st") as Array<{ value: string }>).map((item) => item.value),
 		["status"],
 	);
+
+	const renders: string[][] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const driven = driveCustomSelector(factory, ["\u001b"], 28);
+			renders.push(...driven.renders);
+			return driven.result;
+		},
+	});
+	await command.handler("", context.ctx);
+	const screen = renders.flat().join("\n");
+	assert.match(screen, /pi-starship/u);
+	assert.match(screen, /Built-in footer · Healthy/u);
+	assert.match(screen, /Customize footer/u);
+	assert.match(screen, /Check configuration/u);
+	assert.match(screen, /Help/u);
+	assert.match(screen, /Advanced/u);
+	assert.ok(renders.flat().every((line) => visibleWidth(line) <= 28));
 });
 
 test("settings opens the raw TOML in TUI, saves atomically, and applies immediately", async () => {
@@ -34,19 +61,22 @@ test("settings opens the raw TOML in TUI, saves atomically, and applies immediat
 			gitResult();
 		piStarship(mock.pi);
 		let initial = "";
+		let preview = "";
 		const context = createMockContext({
 			mode: "tui",
+			hasUI: true,
 			editor: async (_title: string, value: string) => {
 				initial = value;
 				return "format = 'saved'\n";
 			},
+			custom: async (factory: unknown) => {
+				const driven = driveCustomSelector(factory, ["\r"], 40);
+				preview = driven.renders.flat().join("\n");
+				return driven.result;
+			},
+			confirm: async () => true,
 		});
 		await emit(mock.events, "session_start", {}, context.ctx);
-		await mock.commands.get("starship")?.handler("settings", context.ctx);
-		assert.equal(initial, BUILT_IN_EXAMPLE);
-		assert.equal(readFileSync(settingsFilePath(root), "utf8"), "format = 'saved'\n");
-		assert.match(context.notifications.at(-1)?.message ?? "", /saved/i);
-
 		const footer = (context.footer as FooterFactory)(
 			{ requestRender() {} },
 			{},
@@ -56,6 +86,14 @@ test("settings opens the raw TOML in TUI, saves atomically, and applies immediat
 				onBranchChange: () => () => undefined,
 			},
 		);
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.equal(initial, BUILT_IN_EXAMPLE);
+		assert.match(preview, /preview/iu);
+		assert.match(preview, /saved/u);
+		assert.match(preview, /Continue to apply/u);
+		assert.equal(readFileSync(settingsFilePath(root), "utf8"), "format = 'saved'\n");
+		assert.match(context.notifications.at(-1)?.message ?? "", /saved/i);
+
 		assert.deepEqual(footer.render(80), ["saved"]);
 		footer.dispose();
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
@@ -119,11 +157,57 @@ test("save failures retain current state and report the error", async () => {
 				throw new Error("disk full");
 			},
 		});
-		const context = createMockContext({ mode: "tui", editor: async () => "format = 'new'\n" });
+		let previewCalls = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => "format = 'new'\n",
+			custom: async (factory: unknown) => {
+				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
+				return driveCustomSelector(factory, inputs, 40).result;
+			},
+			confirm: async () => true,
+		});
 		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.equal(previewCalls, 2);
 		assert.equal(applied, false);
 		assert.equal(readFileSync(path, "utf8"), "format = 'old'\n");
 		assert.match(context.notifications.at(-1)?.message ?? "", /disk full/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("runtime apply failures restore the previous file and effective configuration", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "format = 'old'\n");
+	try {
+		const mock = createMockPi();
+		let loaded = loadStarshipConfig(path);
+		let previewCalls = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				if (next.config.format === "new") throw new Error("renderer rejected config");
+				loaded = next;
+			},
+			settingsPath: path,
+		});
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => "format = 'new'\n",
+			custom: async (factory: unknown) => {
+				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
+				return driveCustomSelector(factory, inputs, 36).result;
+			},
+			confirm: async () => true,
+		});
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.equal(readFileSync(path, "utf8"), "format = 'old'\n");
+		assert.equal(loaded.config.format, "old");
+		assert.match(context.notifications.at(-1)?.message ?? "", /previous.*restored/iu);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -151,11 +235,289 @@ test("non-TUI settings never opens an editor and status/help are protocol-safe",
 		await mock.commands.get("starship")?.handler("settings", rpc.ctx);
 		assert.equal(editorCalls, 0);
 		assert.match(rpc.notifications.at(-1)?.message ?? "", /pi-starship\.toml/);
+		await mock.commands.get("starship")?.handler("", rpc.ctx);
+		assert.match(rpc.notifications.at(-1)?.message ?? "", /interactive footer menu/iu);
 
 		const print = createMockContext({ mode: "print", hasUI: false });
 		await mock.commands.get("starship")?.handler("status", print.ctx);
 		await mock.commands.get("starship")?.handler("help", print.ctx);
 		assert.deepEqual(print.notifications, []);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preview and confirmation cancellation preserve the previous document and runtime", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "format = 'old'\nfuture = 'preserved'\n");
+	try {
+		const mock = createMockPi();
+		let loaded = loadStarshipConfig(path);
+		let applied = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				applied += 1;
+			},
+			settingsPath: path,
+		});
+
+		let customCalls = 0;
+		let confirmations = 0;
+		const previewCancel = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => "format = 'new'\nfuture = 'preserved'\n",
+			custom: async (factory: unknown) => {
+				customCalls += 1;
+				return driveCustomSelector(factory, ["\u001b"], 30).result;
+			},
+			confirm: async () => {
+				confirmations += 1;
+				return true;
+			},
+		});
+		await mock.commands.get("starship")?.handler("settings", previewCancel.ctx);
+		assert.equal(customCalls, 1);
+		assert.equal(confirmations, 0);
+		assert.equal(applied, 0);
+		assert.equal(readFileSync(path, "utf8"), "format = 'old'\nfuture = 'preserved'\n");
+
+		customCalls = 0;
+		const confirmationCancel = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => "format = 'new'\nfuture = 'preserved'\n",
+			custom: async (factory: unknown) => {
+				const inputs = customCalls++ === 0 ? ["\r"] : ["\u001b"];
+				return driveCustomSelector(factory, inputs, 30).result;
+			},
+			confirm: async () => false,
+		});
+		await mock.commands.get("starship")?.handler("settings", confirmationCancel.ctx);
+		assert.equal(customCalls, 2);
+		assert.equal(applied, 0);
+		assert.equal(readFileSync(path, "utf8"), "format = 'old'\nfuture = 'preserved'\n");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("main and Advanced menus expose current state and a clear Back path", async () => {
+	const mock = createMockPi();
+	const loaded = loadStarshipConfig("/tmp/missing-pi-starship-menu.toml");
+	registerStarshipCommand(mock.pi, {
+		getLoaded: () => loaded,
+		apply() {},
+		settingsPath: "/tmp/missing-pi-starship-menu.toml",
+	});
+	let call = 0;
+	const screens: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const inputs =
+				call === 0
+					? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"]
+					: call === 1
+						? ["\u001b[B", "\u001b[B", "\r"]
+						: ["\u001b"];
+			const driven = driveCustomSelector(factory, inputs, 26);
+			screens[call++] = driven.renders.flat().join("\n");
+			assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 26));
+			return driven.result;
+		},
+	});
+	await mock.commands.get("starship")?.handler("", context.ctx);
+	assert.equal(call, 3);
+	assert.match(screens[1] ?? "", /Advanced/u);
+	assert.match(screens[1] ?? "", /Configuration details/u);
+	assert.match(screens[1] ?? "", /Restore built-in/u);
+	assert.match(screens[1] ?? "", /Back/u);
+	assert.match(screens[2] ?? "", /Customize footer/u);
+});
+
+test("Advanced restore previews, confirms, and atomically applies the built-in footer", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "format = 'custom'\nfuture = true\n");
+	try {
+		const mock = createMockPi();
+		let loaded = loadStarshipConfig(path);
+		let applied = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				applied += 1;
+			},
+			settingsPath: path,
+			renderPreview: (draft, width) => [draft.config.format.slice(0, width)],
+		});
+		let call = 0;
+		let restorePreview = "";
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const inputs =
+					call === 0
+						? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"]
+						: call === 1
+							? ["\u001b[B", "\r"]
+							: ["\r"];
+				const driven = driveCustomSelector(factory, inputs, 32);
+				if (call === 2) restorePreview = driven.renders.flat().join("\n");
+				call += 1;
+				return driven.result;
+			},
+			confirm: async () => true,
+		});
+		await mock.commands.get("starship")?.handler("", context.ctx);
+		assert.match(restorePreview, /Restore preview/u);
+		assert.match(restorePreview, /░▒▓/u);
+		assert.equal(applied, 1);
+		assert.equal(readFileSync(path, "utf8"), BUILT_IN_EXAMPLE);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("invalid drafts can return to editing before preview and atomic apply", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "format = 'old'\nfuture = 'preserved'\n");
+	try {
+		const mock = createMockPi();
+		let loaded = loadStarshipConfig(path);
+		let editorCalls = 0;
+		let menuCalls = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+			},
+			settingsPath: path,
+		});
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => {
+				editorCalls += 1;
+				return editorCalls === 1 ? "format = [" : "format = 'new'\nfuture = 'preserved'\n";
+			},
+			custom: async (factory: unknown) => {
+				assert.equal(readFileSync(path, "utf8"), "format = 'old'\nfuture = 'preserved'\n");
+				menuCalls += 1;
+				return driveCustomSelector(factory, ["\r"], 34).result;
+			},
+			confirm: async () => true,
+		});
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.equal(editorCalls, 2);
+		assert.equal(menuCalls, 2);
+		assert.equal(readFileSync(path, "utf8"), "format = 'new'\nfuture = 'preserved'\n");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("diagnostics, Help, and configuration details stay shallow and fit narrow terminals", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "future = true\n");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+		});
+		let call = 0;
+		const screens: string[] = [];
+		const inputSets = [
+			["\u001b[B", "\r"],
+			["\r"],
+			["\u001b[B", "\u001b[B", "\r"],
+			["\r"],
+			["\u001b[B", "\u001b[B", "\u001b[B", "\r"],
+			["\r"],
+			["\r"],
+			["\u001b[B", "\u001b[B", "\r"],
+			["\u001b"],
+		];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const driven = driveCustomSelector(factory, inputSets[call] ?? ["\u001b"], 24);
+				screens[call++] = driven.renders.flat().join("\n");
+				assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 24));
+				return driven.result;
+			},
+		});
+		await mock.commands.get("starship")?.handler("", context.ctx);
+		assert.equal(call, 9);
+		assert.match(screens[0] ?? "", /1\s+warning/u);
+		assert.match(screens[1] ?? "", /Configuration health/u);
+		assert.match(screens[1] ?? "", /future/u);
+		assert.match(screens[3] ?? "", /pi-starship help/u);
+		assert.match(screens[6] ?? "", /Configuration details/u);
+		assert.match(screens[6] ?? "", /Path:/u);
+		assert.match(screens[7] ?? "", /Back/u);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("restore preview cancellation has no side effects in a narrow terminal", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+	const path = settingsFilePath(root);
+	const original = "format = 'custom'\nfuture = true\n";
+	writeFileSync(path, original);
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		let applied = 0;
+		let confirmations = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {
+				applied += 1;
+			},
+			settingsPath: path,
+			renderPreview: (draft, width) => [draft.config.format.slice(0, width)],
+		});
+		let call = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const inputs =
+					call === 0
+						? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"]
+						: call === 1
+							? ["\u001b[B", "\r"]
+							: ["\u001b"];
+				const driven = driveCustomSelector(factory, inputs, 20);
+				assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 20));
+				call += 1;
+				return driven.result;
+			},
+			confirm: async () => {
+				confirmations += 1;
+				return true;
+			},
+		});
+		await mock.commands.get("starship")?.handler("", context.ctx);
+		assert.equal(call, 4);
+		assert.equal(confirmations, 0);
+		assert.equal(applied, 0);
+		assert.equal(readFileSync(path, "utf8"), original);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/extensions/pi-starship/test/config.test.ts
+++ b/extensions/pi-starship/test/config.test.ts
@@ -11,6 +11,7 @@ import {
 	loadOrCreateStarshipConfig,
 	loadStarshipConfig,
 	settingsFilePath,
+	validateConfigDocument,
 } from "../src/config.js";
 
 test("config path uses the agent directory and missing settings use built-in defaults", () => {
@@ -236,6 +237,24 @@ test("invalid root and module formats fall back at the documented scope", () => 
 		assert.equal(loaded.config.modules.model.format, BUILT_IN_CONFIG.modules.model.format);
 		assert.equal(loaded.config.modules.model.symbol, "custom");
 		assert.equal(loaded.diagnostics.length, 2);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("draft validation never writes and retains unknown TOML fields", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-config-"));
+	const path = join(root, CONFIG_FILE_NAME);
+	try {
+		writeFileSync(path, "format = '$model'\nfuture = 'old'\n");
+		const draft = "format = '$provider'\nfuture = 'preserved'\n";
+		const validated = validateConfigDocument(path, draft);
+		assert.equal(validated.config.format, "$provider");
+		assert.equal(validated.rawDocument, draft);
+		assert.equal(readFileSync(path, "utf8"), "format = '$model'\nfuture = 'old'\n");
+		assert.match(validated.diagnostics.map((item) => item.message).join(" "), /future/u);
+		assert.throws(() => validateConfigDocument(path, "format = ["), /parse TOML/iu);
+		assert.equal(readFileSync(path, "utf8"), "format = '$model'\nfuture = 'old'\n");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- replace bare `/starship` help with a goal-oriented TUI menu that shows the current configuration source and health
- add a shallow Advanced menu with configuration details, built-in restore, and explicit Back navigation
- validate drafts in memory, render the proposed footer with current runtime data, and separate preview, confirmation, atomic persistence, and immediate application
- preserve direct commands, non-TUI behavior, raw TOML and unknown fields, and roll back both the file and runtime when application fails
- wrap menus, diagnostics, help, and previews for narrow terminals and document the final interaction model

## Testing

- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check`
- `npm run pack:starship`
- `pi --no-extensions -e ./extensions/pi-starship --list-models`
