### PR TITLE
feat(starship): add workspace context modules

### DIFF
--- a/docs/implementation-notes/pi-starship-native-context-design.md
+++ b/docs/implementation-notes/pi-starship-native-context-design.md
@@ -1,0 +1,128 @@
+# pi-starship Pi-native context design
+
+Status: **design decision recorded; no new Pi-native module is approved for implementation**.
+
+Reference runtime: `@earendil-works/pi-coding-agent` 0.80.10 installed typings and the extension
+lifecycle documentation reviewed on 2026-07-24. Starship behavior references are pinned to
+`9f4d07ed45804e280d6884bb8ced7ea3d3033093`.
+
+## Decision
+
+Keep `model`, `context`, `cost`, Git, and `activity` as the canonical owners. Do not add
+provider-specific `claude_model`, `claude_context`, or `claude_cost` modules. Do not publish
+`turn_duration`, `last_result`, or replacement names in this roadmap: Pi can support several precise
+scopes, but the repository has no maintainer-approved user need or reset policy that selects one.
+No implementation plan is created. A future proposal must obtain explicit approval for the exact
+scope and names below before changing product code.
+
+This no-change decision preserves the current compact footer, avoids duplicate information, and is
+compatible with every existing format.
+
+## Lifecycle feasibility matrix
+
+| Signal | Installed event/field | Ordering and ownership | Feasibility / ambiguity |
+| --- | --- | --- | --- |
+| User request start | `before_agent_start.prompt` | After input expansion, before one agent loop | Suitable start for a user-prompt timer, but queued extension messages and retries complicate ownership |
+| Low-level agent run | `agent_start` / `agent_end.messages` | May repeat for retry, compaction, or continuation | Precise run duration; not equivalent to a user turn |
+| Fully settled work | `agent_settled` | After automatic retry, compaction retry, and queued continuation | Precise settled boundary, but the event carries no result payload |
+| Model turn | `turn_start.{turnIndex,timestamp}` / `turn_end.{message,toolResults}` | Repeats for tool-use cycles in one agent run | Precise model-turn duration; not shell-command duration |
+| Tool execution | `tool_execution_start` / `tool_execution_end.{result,isError}` | Parallel tools can overlap; each has a call id | Precise per-tool state; one failure may be recovered later |
+| Cancellation/error | assistant `stopReason` in the latest `agent_end.messages` | `aborted`/`error` may precede a successful Pi retry | Cannot be called final until `agent_settled`; tool errors alone are not a user-turn result |
+| Compaction | `session_before_compact` / `session_compact` with `reason` and `willRetry` | Overflow can be followed by a retry | Must remain inside a settled-work timer if that scope is chosen |
+| Session replacement | `session_shutdown` then new `session_start` | Old contexts become stale | Any timer/result must be generation-owned and reset on replacement |
+| Context use | `ctx.getContextUsage()` → tokens/window/percent or unknown | Current active model/session | Already owned by `context`; unknown immediately after compaction |
+| Cost/tokens | assistant message usage on the active branch | Additive across persisted assistant messages | Already owned by `cost` and `tokens`; nested tool usage is included when Pi records it |
+| Changed lines | cached Git diff shortstat | Workspace snapshot, not provider state | Already owned by `git_metrics`; paths are neither needed nor published |
+| Model identity | `ctx.model.provider/id`, `model_select` | Current session model | Already owned by `provider` and `model` |
+
+## Ownership and reuse matrix
+
+| Candidate concept | Canonical owner | Possible future enhancement | Rejected alternative |
+| --- | --- | --- | --- |
+| Claude model label | `model` + `provider` | Exact user alias map on `model` | `claude_model`: duplicates state and fails for non-Claude providers |
+| Context gauge/threshold | `context` | `$gauge` plus warning/critical thresholds | `claude_context`: provider-specific duplicate |
+| Cost threshold | `cost` | Warning/critical threshold styles while retaining numeric `$cost` | `claude_cost`: provider-specific duplicate |
+| Changed lines | `git_metrics` | None required; `$added`/`$deleted` already exist | A cost/activity changed-lines variable: duplicate ownership |
+| Active/recent tool state | `activity` | A settled failure cue only if final semantics are approved | Shell-style `status`: conflates tool and agent outcome |
+| Duration | No current owner | One precisely scoped future module | `turn_duration`: “turn” already means several different Pi boundaries |
+| Result | No current owner | One settled-agent status if reliable final evidence is approved | `last_result`: does not say tool, model turn, agent run, or user request |
+
+## Candidate future contract (unapproved)
+
+This section fixes vocabulary for later review; it is not a compatibility promise.
+
+### Existing-module enhancements
+
+- `model.aliases`: exact model-id/name map applied before `$model`; no provider-only module.
+- `context`: optional `$gauge`; integer `gauge_width` 1–40; `warning_threshold` and
+  `critical_threshold` 0–100 with `warning < critical`; textual percentage remains visible so color is
+  never the only warning.
+- `cost`: optional nonnegative warning/critical thresholds with critical greater than warning;
+  numeric cost remains visible.
+- `activity`: no raw error, tool arguments, paths, or provider payloads. Any future failure cue must be
+  based on settled final state, not an intermediate tool error.
+
+### New concepts requiring a separate approval
+
+`agent_duration` is preferred over `turn_duration` if the desired scope is from `before_agent_start`
+through `agent_settled`, including tool loops, retries, and overflow compaction. Candidate variables:
+`$duration` (human-readable) and `$milliseconds`; reset at the next accepted user/extension prompt or
+session replacement; empty while no completed scope exists; cancellation still records elapsed time.
+A low-level-run timer would instead be named `agent_run_duration`; a model-cycle timer would be
+`model_turn_duration`. The generic `turn_duration` name is rejected.
+
+`agent_result` is preferred over `last_result` only if “result” means the latest fully settled agent
+scope. Candidate `$status` values are `success`, `failed`, `cancelled`, and `incomplete`; tool errors
+that are recovered before settlement do not produce `failed`; `length` is `incomplete`; a successful
+retry replaces an earlier error. Reset on the next accepted prompt and every session replacement.
+Because `agent_settled` has no payload, implementation would retain the latest generation-owned
+`agent_end` assistant stop reason and must prove retry/compaction ordering in tests. Raw errors are
+never displayed. Generic `last_result` and shell exit-code emulation are rejected.
+
+## Visibility and static examples
+
+Classification:
+
+- Primary: current model and near-limit context state.
+- Supporting: numeric context, cost, and Git line metrics when selected.
+- Contextual: active/recent activity and execution/deployment context.
+- Advanced: aliases, gauges, thresholds, durations, and settled-result history.
+- Safety/status: context warning/critical and a final failure cue; both require text/symbol changes in
+  addition to color.
+
+The existing default remains unchanged. These static examples show hierarchy, not approved syntax:
+
+```text
+wide idle/success:   anthropic sonnet-4  ctx 42%  $0.18
+wide near limit:     anthropic sonnet-4  ctx ! 91% [#########-]  $0.18
+wide final failure:  anthropic sonnet-4  failed  ctx 42%  $0.18
+retry/compaction:    activity: retrying | compacting   (no final failure yet)
+changed worktree:    git +28/-7          (owned only by git_metrics)
+missing usage:       anthropic sonnet-4  (context module empty; no fabricated 0%)
+narrow:              sonnet-4  !91%
+```
+
+At narrow widths, provider, gauge decoration, cost, and changed-line details may be omitted by the
+user's format, but the percentage plus `!` must remain together if threshold behavior is enabled.
+No example relies on color or provider-specific icons.
+
+## Privacy, compatibility, and verification gate
+
+- Never publish prompts, command arguments, tool payloads/results, raw errors, changed paths, API
+  credentials, or provider request data.
+- Model aliases are user-authored labels and may reveal naming choices; remain opt-in.
+- Cost remains local branch usage data. Unknown usage is empty, never zero.
+- Every state must be scoped by session generation; stale `agent_end`, timers, or shutdown callbacks
+  cannot update a replacement session.
+- Existing variables/defaults remain byte-compatible. New options must be catalog-owned, validated,
+  documented, and opt-in.
+- Any implementation plan must test success, tool-error recovery, provider retry, overflow compaction,
+  cancellation, length stop, queued follow-up, missing usage, session replacement, narrow width, and
+  non-color cues.
+
+## Approval record
+
+The roadmap records **no-change** for Pi-native modules. No public candidate name or lifecycle
+semantic above is approved for implementation, and no implementation code was created. A future
+maintainer approval must quote the accepted scope/name/reset contract and then create separate bounded
+plans for existing-module enhancements and any genuinely new module.

--- a/extensions/pi-starship/NOTICES.md
+++ b/extensions/pi-starship/NOTICES.md
@@ -1,6 +1,23 @@
 # Notices
 
-pi-starship's format and style behavior is based in part on Starship.
+pi-starship's format and style behavior is based in part on Starship. It uses the `yaml`
+package to parse kubeconfig and OpenStack metadata as inert local data.
+
+## yaml
+
+Copyright Eemeli Aro <eemeli@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 
 ## Starship
 

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -11,7 +11,10 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 - Automatically creates a readable Tokyo Night configuration on first session start.
 - Starship-style root/module formats, conditional groups, `$all`, styles, and palettes.
 - Pi modules for model, thinking, activity, context, tokens, cost, turn, and extension statuses.
-- Cached Git branch, commit, operation state, line metrics, detailed status, and linked-worktree identity; no subprocess runs during footer rendering.
+- Cached Git branch, commit, operation state, line metrics, detailed status, and linked-worktree identity.
+- Opt-in package, language, development-shell, deployment, cloud, and execution-context modules.
+- Width-aware `$fill` alignment for native multiline left/right layouts.
+- Footer rendering is pure: no subprocess, network, filesystem, timer, or environment work runs from `render()`.
 - Multiline output wraps to the terminal width instead of truncating.
 - Goal-oriented `/starship` menu with configuration health, preview, confirmation, and recovery.
 
@@ -75,12 +78,28 @@ style = "fg:custom"
 [git_branch]
 format = "[ $symbol$branch$pr ]($style)"
 
+[package]
+version_format = "v$raw"
+
+[nodejs]
+detect_files = ["package.json", "!deno.json"]
+detect_extensions = ["js", "ts"]
+
+[hostname]
+ssh_only = true
+trim_at = "."
+aliases = { "build.example.test" = "builder" }
+
 [extension_status]
 format = "([$statuses ]($style))"
 icons = { "github-pr" = "PR", "foo:*" = "🧪", "@narumitw/pi-goal" = "◎", fallback = "•" }
 ```
 
-All module tables support `format`, `symbol`, `style`, and `disabled`.
+All module tables support `format`, `symbol`, `style`, and `disabled`. Module-specific
+options are catalog-owned, type-checked, and listed below; unknown options warn and stay inactive.
+Version formats replace `$raw`. Detection arrays replace defaults when non-empty and inspect only one
+listing of the current directory. A leading `!` is supported by language detection arrays and rejects
+a matching project.
 `[extension_status].icons` accepts arbitrary exact Pi status keys, explicit colon namespace
 wildcards such as `foo:*`, and installed package IDs; `fallback` controls unmatched statuses. Icon
 matching uses exact key, longest `:*` wildcard, unambiguous package alias, leading status emoji,
@@ -139,6 +158,30 @@ An invalid root format falls back to the built-in root format. An invalid module
 | `cost` | `$symbol`, `$cost` | Session cost |
 | `time` | `$symbol`, `$time` | Current local time |
 | `turn` | `$symbol`, `$count` | User turn count |
+| `package` | `$symbol`, `$version`, `$source` | Direct project manifest version |
+| `nodejs` | `$symbol`, `$version`, `$engines_version` | Detected Node.js project/runtime |
+| `python` | `$symbol`, `$version`, `$virtualenv`, `$pyenv_prefix` | Python runtime and allowlisted environment name |
+| `rust` | `$symbol`, `$version`, `$numver`, `$toolchain` | Safe native `rustc` runtime and allowlisted toolchain name |
+| `golang` | `$symbol`, `$version`, `$mod_version` | Go runtime (`$mod_version` is reserved and currently empty) |
+| `bun` / `deno` | `$symbol`, `$version` | Bun or Deno runtime |
+| `mise` | `$symbol`, `$health` | Bounded mise health result |
+| `direnv` | `$symbol`, `$rc_path`, `$allowed`, `$loaded` | Inert direnv status; `.envrc` is never sourced |
+| `conda` | `$symbol`, `$environment` | Active Conda environment name |
+| `pixi` | `$symbol`, `$version`, `$environment`, `$project_name` | Pixi project and environment |
+| `nix_shell` | `$symbol`, `$state`, `$name`, `$level` | Allowlisted Nix shell activation metadata |
+| `guix_shell` | `$symbol`, `$state` | Guix shell activation marker |
+| `docker_context` | `$symbol`, `$context` | Non-default local Docker context |
+| `kubernetes` | `$symbol`, `$context`, `$namespace`, `$cluster`, `$user` | Current inert kubeconfig metadata |
+| `terraform` | `$symbol`, `$workspace`, `$version` | Local Terraform/OpenTofu workspace and optional version |
+| `aws` | `$symbol`, `$profile`, `$region` | AWS profile/region metadata, never credentials |
+| `gcloud` | `$symbol`, `$active`, `$account`, `$domain`, `$project`, `$region` | Active gcloud configuration metadata |
+| `azure` | `$symbol`, `$subscription`, `$username` | Default Azure subscription; username is separately enabled |
+| `openstack` | `$symbol`, `$cloud`, `$project` | Selected OpenStack cloud/project metadata |
+| `os` | `$symbol`, `$type`, `$name`, `$version`, `$edition`, `$codename` | Platform/OS metadata; disabled by default |
+| `container` | `$symbol`, `$name`, `$type` | Known container, WSL, or Dev Container context |
+| `hostname` | `$symbol`, `$hostname`, `$ssh_symbol` | Hostname, SSH-only by default |
+| `username` | `$symbol`, `$user` | Contextual login identity |
+| `fill` | `$symbol` | Flexible width-aware root-layout marker |
 | `extension_status` | `$symbol`, `$statuses`, `$count` | Pi extension statuses |
 
 `git_worktree` is empty in the primary worktree. In a linked worktree it defaults to the top-level directory name; use `$path` when the full absolute path is needed.
@@ -146,6 +189,116 @@ An invalid root format falls back to the built-in root format. An invalid module
 `git_commit`, `git_state`, and `git_metrics` are intentionally not present in the built-in root format. Add their variables to `format` to opt in; also set `[git_metrics].disabled = false`, matching Starship's opt-in metrics default. `$tag` resolves only an exact tag on HEAD and is queried only when the configured `git_commit` format references it.
 
 If `$git_branch.$pr` is present in the module format, its selected PR token is removed from `extension_status` to avoid duplication.
+
+### 📦 Package and language modules
+
+The native behavior is inspired by Starship pinned at
+`9f4d07ed45804e280d6884bb8ced7ea3d3033093`; it is not complete Starship compatibility.
+
+| Area | Adopted | Adapted | Intentionally omitted |
+| --- | --- | --- | --- |
+| `package` | `package.json` → Cargo → PEP 621/Poetry precedence, `$version` | Direct manifests only; Cargo workspace version lookup is capped at eight ancestors | Other package ecosystems, dynamic Python versions, package-manager execution |
+| Node.js | Direct markers/extensions, `node --version`, package engine text | Bun/Deno markers suppress Node's default detection | Constraint checks and manager/shim evaluation |
+| Python | Direct markers, selected interpreter `--version`, virtualenv name | Interpreter selection uses only an existing active virtualenv path or `python` | Python code execution and broad environment discovery |
+| Rust | Direct markers and native `rustc --version` | `.cargo`/`.rustup` shim paths are rejected to avoid toolchain installation | Falling back to rustup or any installing probe |
+| Go | Direct markers and `go version` | `$mod_version` stays empty | `go list`, module downloads, and constraint enforcement |
+| Bun / Deno | Direct markers and `bun --version` / `deno -V` | Negative detection avoids overlapping Node defaults | Runtime installation and recursive source detection |
+
+All runtime commands use argv execution in `ctx.cwd`, a 2-second timeout, and 64 KiB accepted output.
+Commands run only when the reachable module format references the command-backed variable. Missing,
+killed, oversized, or malformed commands clear that value independently. `version_format`,
+`detect_files`, `detect_extensions`, and `detect_folders` are available on language modules; package
+supports `version_format`.
+
+### 🧰 Development environments
+
+| Module | Detection / allowed inputs | Optional command | Options |
+| --- | --- | --- | --- |
+| `mise` | Direct `mise.toml`, `.mise.toml`, or `.tool-versions` | `mise doctor` only for `$health` | Detection arrays |
+| `direnv` | Direct `.envrc`; the file is never read or sourced | `direnv status --json` only for status variables | Detection arrays |
+| `conda` | `CONDA_DEFAULT_ENV` only | None | `ignore_base` (default `true`) |
+| `pixi` | Direct `pixi.toml`/`pixi.lock`, `PIXI_ENVIRONMENT_NAME`, `PIXI_PROJECT_NAME` | `pixi --version` only for `$version` | Detection arrays, `version_format`, `show_default_environment` |
+| `nix_shell` | `IN_NIX_SHELL`, `NIX_SHELL_NAME`, `NIX_SHELL_LEVEL` | None | None |
+| `guix_shell` | Presence of `GUIX_ENVIRONMENT` | None | None |
+
+The extension never enumerates the process environment, activates a shell, evaluates Nix, lists
+installed tools, or publishes arbitrary environment values. Names and paths are control-sanitized and
+bounded before publication.
+
+### 🚢 Deployment and cloud context
+
+These modules read inert local metadata only. They do **not** contact Docker, a Kubernetes cluster,
+a Terraform/OpenTofu backend, a cloud API, an OAuth flow, a credential helper, or a metadata service.
+The deployment/cloud safety review retained opt-in root behavior: context labels may be sensitive and
+there is no usage evidence justifying more default footer density.
+
+- `docker_context`: `DOCKER_CONTEXT`, then `DOCKER_CONFIG/config.json` or `~/.docker/config.json`;
+  `default` is suppressed. `only_with_files` and detection arrays are supported.
+- `kubernetes`: at most `max_config_files` (default 8) from `KUBECONFIG` or `~/.kube/config`, with
+  first-wins merge semantics. Only context, namespace, cluster name, and user name are selected.
+  Exact `context_aliases`, `namespace_aliases`, `cluster_aliases`, and `user_aliases` apply.
+- `terraform`: direct `.tf`, `.tfplan`, `.tfstate`, or `.terraform`; workspace precedence is
+  `TF_WORKSPACE` → `TF_DATA_DIR/environment` → `.terraform/environment`. `terraform version`, then
+  `tofu version`, runs only for `$version`. Workspace, init, provider, and state commands never run.
+- `aws`: `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`, `AWS_REGION`/`AWS_DEFAULT_REGION`, then the selected AWS
+  config section. The credentials file is never read. Exact profile/region aliases are supported.
+- `gcloud`: active selector plus allowlisted `core.account`, `core.project`, and `compute.region` INI
+  keys. Exact project/region aliases are supported.
+- `azure`: the default local `azureProfile.json` subscription name. `show_username` defaults to
+  `false`; exact subscription aliases are supported.
+- `openstack`: `OS_CLOUD`, `OS_PROJECT_NAME`, or the selected `clouds.yaml` `auth.project_name` only;
+  exact cloud/project aliases are supported.
+
+Cloud files often colocate credentials with labels. Parsers allowlist fields while reading and
+discard source documents; token, key, password, auth URL, tenant, and credential-derived duration
+fields never enter snapshots, diagnostics, notifications, or rendered output. Presence indicates only
+selected local metadata—not valid credentials or connectivity.
+
+### 🖥️ Execution context
+
+`hostname` is SSH-only by default and supports `ssh_only`, `trim_at`, and exact `aliases`. `username`
+appears only for `show_always`, SSH, root/Administrator, a login-user mismatch, or configured
+`detect_env_vars`; it supports exact aliases. Negated username detection names are rejected. `os` is
+disabled by default and supports an exact `symbols` map. `container` uses only Dev Container/Codespaces
+markers, WSL metadata, `/.dockerenv`, `/run/.containerenv`, and `/run/systemd/container`; it does not
+scan process tables or cgroups. Ordinary local hostname/username sessions stay empty. All identity
+labels are bounded and stripped of C0/C1 controls, ANSI, newlines, and OSC control bytes.
+
+### ↔️ Fill layout
+
+Add `${fill}` between left and right root content (braces disambiguate adjacent text):
+
+```toml
+format = "$directory$git_branch${fill}$model$context"
+
+[fill]
+symbol = " " # native invisible default; use "·" for a visible pattern
+style = "dimmed"
+```
+
+Fill resolves independently on each logical line before ANSI serialization and wrapping. Multiple
+fills divide remaining cells left-to-right; complete positive-width patterns repeat and any remainder
+uses styled spaces. Empty/zero-width patterns become spaces. Fixed content is never truncated: when it
+already meets or exceeds the width, fill contributes zero and normal ANSI-aware wrapping applies.
+Unicode wide/combining symbols, palettes, `prev_fg`/`prev_bg`, ANSI, and OSC hyperlinks use Pi TUI
+visible-width semantics. `$all` deliberately includes enabled fill, so use `$all` only when that
+whole-catalog layout is intended. There is no `line_break` module; use literal newlines in `format`.
+
+### 🔄 Cached refresh lifecycle
+
+Workspace and Git readers start only in TUI sessions and only for reachable enabled modules. Root
+format reachability, `$all`, module `disabled`, and module-format variables determine file and command
+requirements. Refreshes run at session start, after accepted settings, branch changes, tool/turn
+completion, and a 30-second fallback. One read runs with at most one latest pending refresh; immutable
+snapshot equality suppresses redraws, and session/config generations reject stale results. Shutdown,
+replacement, and footer disposal stop timers, clear pending work, and prevent late publication.
+Execution identity is retained rather than re-read by the periodic fallback. Render and live preview
+consume snapshots synchronously and perform zero reads or commands.
+
+Missing, unreadable, malformed, oversized, timed-out, or unavailable sources fail to empty values.
+Readers cap direct files at 64 KiB, use one bounded current-directory listing, never recurse, and make
+no network calls. Package's explicitly documented Cargo lookup is the only ancestor walk and is capped
+at eight parents.
 
 ## 💬 Commands
 
@@ -162,7 +315,16 @@ Status and help remain safe in TUI, RPC, JSON, and print modes. RPC receives not
 
 ## 📐 Scope
 
-The formatter grammar and style concepts follow Starship, but the module catalog is intentionally Pi-specific. This extension does not claim compatibility with Starship's shell module catalog or execute the Starship binary.
+The formatter, style concepts, and selected contextual modules are Starship-inspired, while Pi owns
+the lifecycle, snapshots, privacy boundary, and footer layout. This extension does not load
+`starship.toml`, claim complete module/config compatibility, invoke the Starship binary, run custom
+shell modules, or expose unrestricted `env_var` behavior. JVM/.NET, other long-tail languages,
+alternative VCS, system-monitor, and additional DevOps modules remain demand-gated; the first-wave
+review found no issue/discussion evidence for a coherent follow-up batch, so no second wave is added.
+
+Pi-native model, context, cost, Git metrics, and activity remain owned by the existing modules. The
+lifecycle design rejects provider-specific duplicates and ambiguous `turn_duration`/`last_result`
+modules until separately approved semantics exist.
 
 ## ➕ Adding a module
 
@@ -173,12 +335,13 @@ Keep `extension_status` last in the catalog so earlier modules can consume exten
 ## 🗂️ Package layout
 
 - `src/index.ts` — Pi package entrypoint.
-- `src/pi-starship.ts` — extension lifecycle, live preview binding, and footer.
+- `src/pi-starship.ts` — extension lifecycle, cached refresh binding, live preview, and footer.
 - `src/commands.ts` — goal-oriented menu, preview/confirmation, diagnostics, and compatibility routes.
 - `src/config.ts` — TOML loading, draft validation, defaults, atomic persistence, and rollback.
 - `src/format/` — native format/style parser and renderer.
-- `src/modules/` — module-per-file definitions, ordered registry, and statusline renderer.
-- `src/modules/git/` — shared Git runtime plus branch, status, and worktree modules.
+- `src/modules/` — domain module definitions, ordered registry, reachability, and width-aware renderer.
+- `src/modules/git/` — bounded Git reader plus branch, status, and worktree modules.
+- `src/runtime/` — shared refresh controller and bounded package/language/context collectors.
 
 ## 🔎 Keywords
 

--- a/extensions/pi-starship/package.json
+++ b/extensions/pi-starship/package.json
@@ -31,7 +31,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"smol-toml": "^1.7.0"
+		"smol-toml": "^1.7.0",
+		"yaml": "^2.9.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",

--- a/extensions/pi-starship/src/config.ts
+++ b/extensions/pi-starship/src/config.ts
@@ -18,6 +18,7 @@ import {
 } from "./format/formatter.js";
 import { type ColorPalette, isValidStyle, parseColor } from "./format/style.js";
 import { MODULE_DEFINITIONS, MODULE_NAMES, type ModuleName } from "./modules/catalog.js";
+import type { ModuleOptionSchema } from "./modules/types.js";
 
 export const CONFIG_FILE_NAME = "pi-starship.toml";
 export { MODULE_NAMES, type ModuleName } from "./modules/catalog.js";
@@ -26,12 +27,20 @@ const MODULE_CONTENT_VARIABLES = Object.fromEntries(
 	MODULE_DEFINITIONS.map((definition) => [definition.name, definition.variables]),
 ) as Record<ModuleName, readonly string[]>;
 
+export type ModuleOptionValue =
+	| string
+	| boolean
+	| number
+	| readonly string[]
+	| Readonly<Record<string, string>>;
+
 export interface ModuleConfig {
 	format: string;
 	formatAst: FormatNode[];
 	symbol: string;
 	style: string;
 	disabled: boolean;
+	options: Record<string, ModuleOptionValue>;
 }
 
 export interface ExtensionStatusConfig {
@@ -103,11 +112,17 @@ const BUILT_IN_PALETTE = {
 };
 
 const BUILT_IN_MODULES = Object.fromEntries(
-	MODULE_DEFINITIONS.map(({ name, defaults }) => [
+	MODULE_DEFINITIONS.map(({ name, defaults, options }) => [
 		name,
 		{
 			...defaults,
 			formatAst: parseFormat(defaults.format),
+			options: Object.fromEntries(
+				Object.entries(options ?? {}).map(([key, schema]) => [
+					key,
+					cloneOptionValue(schema.default),
+				]),
+			),
 		},
 	]),
 ) as Record<ModuleName, ModuleConfig>;
@@ -339,7 +354,9 @@ function normalizeModule(
 	config: StarshipConfig,
 	diagnostics: ConfigDiagnostic[],
 ) {
-	const known = new Set(["format", "symbol", "style", "disabled"]);
+	const definition = MODULE_DEFINITIONS.find((candidate) => candidate.name === name);
+	const optionSchemas: Readonly<Record<string, ModuleOptionSchema>> = definition?.options ?? {};
+	const known = new Set(["format", "symbol", "style", "disabled", ...Object.keys(optionSchemas)]);
 	if (name === "extension_status") {
 		known.add("separator");
 		known.add("max_statuses");
@@ -377,6 +394,12 @@ function normalizeModule(
 		if (typeof value.disabled !== "boolean") {
 			diagnostics.push(typeDiagnostic(`${name}.disabled`, "boolean"));
 		} else module.disabled = value.disabled;
+	}
+	for (const [key, schema] of Object.entries(optionSchemas)) {
+		if (value[key] === undefined) continue;
+		const normalized = normalizeModuleOption(value[key], schema);
+		if (normalized.ok) module.options[key] = normalized.value;
+		else diagnostics.push(diagnostic("warning", `${name}.${key}`, normalized.message));
 	}
 	if (name !== "extension_status") return;
 	if (value.separator !== undefined) {
@@ -494,6 +517,7 @@ function cloneBuiltInConfig(): StarshipConfig {
 				{
 					...BUILT_IN_CONFIG.modules[name],
 					formatAst: structuredClone(BUILT_IN_CONFIG.modules[name].formatAst),
+					options: structuredClone(BUILT_IN_CONFIG.modules[name].options),
 				},
 			]),
 		) as Record<ModuleName, ModuleConfig>,
@@ -538,6 +562,61 @@ function validateStyleVariables(
 			),
 		);
 	}
+}
+
+function normalizeModuleOption(
+	value: unknown,
+	schema: ModuleOptionSchema,
+): { ok: true; value: ModuleOptionValue } | { ok: false; message: string } {
+	switch (schema.kind) {
+		case "string":
+			return typeof value === "string" && (schema.allowEmpty !== false || value.length > 0)
+				? { ok: true, value }
+				: { ok: false, message: "Expected a non-empty string; using the default value" };
+		case "boolean":
+			return typeof value === "boolean"
+				? { ok: true, value }
+				: { ok: false, message: "Expected boolean; using the default value" };
+		case "integer":
+			return typeof value === "number" &&
+				Number.isInteger(value) &&
+				value >= schema.minimum &&
+				value <= schema.maximum
+				? { ok: true, value }
+				: {
+						ok: false,
+						message: `Expected an integer from ${schema.minimum} through ${schema.maximum}; using the default value`,
+					};
+		case "string-array": {
+			if (
+				!Array.isArray(value) ||
+				value.some(
+					(item) =>
+						typeof item !== "string" ||
+						item.length === 0 ||
+						(!schema.allowNegative && item.startsWith("!")),
+				)
+			) {
+				return {
+					ok: false,
+					message: "Expected an array of valid strings; using the default value",
+				};
+			}
+			return { ok: true, value: [...value] as string[] };
+		}
+		case "string-map": {
+			if (!isRecord(value) || Object.values(value).some((item) => typeof item !== "string")) {
+				return { ok: false, message: "Expected a table of strings; using the default value" };
+			}
+			const result: Record<string, string> = {};
+			for (const [key, item] of Object.entries(value)) setOwn(result, key, item as string);
+			return { ok: true, value: result };
+		}
+	}
+}
+
+function cloneOptionValue(value: ModuleOptionValue): ModuleOptionValue {
+	return typeof value === "object" ? structuredClone(value) : value;
 }
 
 function setOwn<T>(record: Record<string, T>, key: string, value: T) {

--- a/extensions/pi-starship/src/format/formatter.ts
+++ b/extensions/pi-starship/src/format/formatter.ts
@@ -1,4 +1,10 @@
-import { type ColorPalette, parseStyle, type StyledChunk, type TextStyle } from "./style.js";
+import {
+	type ColorPalette,
+	isFillChunk,
+	type LayoutChunk,
+	parseStyle,
+	type TextStyle,
+} from "./style.js";
 
 export type FormatNode =
 	| { type: "text"; value: string }
@@ -7,7 +13,7 @@ export type FormatNode =
 	| { type: "conditional"; children: FormatNode[] };
 
 export type StyleNode = { type: "text"; value: string } | { type: "variable"; name: string };
-export type FormatValue = string | readonly StyledChunk[] | undefined;
+export type FormatValue = string | readonly LayoutChunk[] | undefined;
 
 export interface RenderFormatOptions {
 	variables: Readonly<Record<string, FormatValue>>;
@@ -191,7 +197,7 @@ export function styleVariables(nodes: readonly FormatNode[]): Set<string> {
 export function renderFormat(
 	nodes: readonly FormatNode[],
 	options: RenderFormatOptions,
-): StyledChunk[] {
+): LayoutChunk[] {
 	return renderNodes(nodes, options, undefined);
 }
 
@@ -199,8 +205,8 @@ function renderNodes(
 	nodes: readonly FormatNode[],
 	options: RenderFormatOptions,
 	inheritedStyle: TextStyle | undefined,
-): StyledChunk[] {
-	const chunks: StyledChunk[] = [];
+): LayoutChunk[] {
+	const chunks: LayoutChunk[] = [];
 	for (const node of nodes) {
 		switch (node.type) {
 			case "text":
@@ -235,13 +241,20 @@ function ownValue<T>(record: Readonly<Record<string, T>> | undefined, key: strin
 	return record && Object.hasOwn(record, key) ? record[key] : undefined;
 }
 
-function chunksForValue(value: FormatValue, inheritedStyle: TextStyle | undefined): StyledChunk[] {
+function chunksForValue(value: FormatValue, inheritedStyle: TextStyle | undefined): LayoutChunk[] {
 	if (value === undefined) return [];
 	if (typeof value === "string") return [{ text: value, style: inheritedStyle }];
-	return value.map((chunk) => ({
-		...chunk,
-		style: chunk.style ?? inheritedStyle,
-	}));
+	return value.map((chunk) =>
+		isFillChunk(chunk)
+			? {
+					type: "fill" as const,
+					pattern: chunk.pattern.map((part) => ({
+						...part,
+						style: part.style ?? inheritedStyle,
+					})),
+				}
+			: { ...chunk, style: chunk.style ?? inheritedStyle },
+	);
 }
 
 function conditionalVisible(
@@ -251,7 +264,9 @@ function conditionalVisible(
 	for (const variable of formatVariables(nodes)) {
 		const value = ownValue(variables, variable);
 		if (
-			typeof value === "string" ? value.length > 0 : value?.some((chunk) => chunk.text.length > 0)
+			typeof value === "string"
+				? value.length > 0
+				: value?.some((chunk) => isFillChunk(chunk) || chunk.text.length > 0)
 		) {
 			return true;
 		}

--- a/extensions/pi-starship/src/format/style.ts
+++ b/extensions/pi-starship/src/format/style.ts
@@ -40,6 +40,17 @@ export interface StyledChunk {
 	style?: TextStyle;
 }
 
+export interface FillChunk {
+	type: "fill";
+	pattern: readonly StyledChunk[];
+}
+
+export type LayoutChunk = StyledChunk | FillChunk;
+
+export function isFillChunk(chunk: LayoutChunk): chunk is FillChunk {
+	return "type" in chunk && chunk.type === "fill";
+}
+
 export type ColorPalette = Readonly<Record<string, string>>;
 
 const NAMED_COLORS = new Set<NamedColor>([
@@ -176,10 +187,11 @@ interface ResolvedStyle extends Omit<TextStyle, "foreground" | "background"> {
 	background?: Exclude<ColorSpec, { kind: "previous" }>;
 }
 
-export function renderChunksToAnsi(chunks: readonly StyledChunk[]): string {
+export function renderChunksToAnsi(chunks: readonly LayoutChunk[]): string {
 	const runs: Array<{ text: string; style: ResolvedStyle }> = [];
 	let previous: ResolvedStyle | undefined;
 	for (const chunk of chunks) {
+		if (isFillChunk(chunk)) continue;
 		const style = resolveStyle(chunk.style, previous);
 		const last = runs.at(-1);
 		if (chunk.text && last && stylesEqual(last.style, style)) last.text += chunk.text;

--- a/extensions/pi-starship/src/modules/catalog.ts
+++ b/extensions/pi-starship/src/modules/catalog.ts
@@ -1,16 +1,23 @@
 import { activityModule } from "./activity.js";
 import { brandModule } from "./brand.js";
+import { cloudModules } from "./cloud.js";
 import { contextModule } from "./context.js";
 import { costModule } from "./cost.js";
+import { deploymentModules } from "./deployment.js";
+import { developmentModules } from "./development.js";
 import { directoryModule } from "./directory.js";
+import { executionModules } from "./execution.js";
 import { extensionStatusModule } from "./extension-status.js";
+import { fillModule } from "./fill.js";
 import { gitBranchModule } from "./git/branch.js";
 import { gitCommitModule } from "./git/commit.js";
 import { gitMetricsModule } from "./git/metrics.js";
 import { gitStateModule } from "./git/state.js";
 import { gitStatusModule } from "./git/status.js";
 import { gitWorktreeModule } from "./git/worktree.js";
+import { languageModules } from "./languages.js";
 import { modelModule } from "./model.js";
+import { packageModule } from "./package.js";
 import { providerModule } from "./provider.js";
 import { thinkingModule } from "./thinking.js";
 import { timeModule } from "./time.js";
@@ -30,12 +37,19 @@ export const MODULE_DEFINITIONS = [
 	gitStateModule,
 	gitMetricsModule,
 	gitStatusModule,
+	packageModule,
+	...languageModules,
+	...developmentModules,
+	...deploymentModules,
+	...cloudModules,
+	...executionModules,
 	activityModule,
 	contextModule,
 	tokensModule,
 	costModule,
 	timeModule,
 	turnModule,
+	fillModule,
 	// Render last so earlier modules can consume extension-owned status values.
 	extensionStatusModule,
 ] as const satisfies readonly ModuleDefinition<string>[];

--- a/extensions/pi-starship/src/modules/cloud.ts
+++ b/extensions/pi-starship/src/modules/cloud.ts
@@ -1,0 +1,74 @@
+import { defineModule, type ModuleDefinition, type ModuleOptionSchema } from "./types.js";
+import { workspaceModuleValues } from "./workspace-helpers.js";
+
+function cloudModule<const Name extends string>(definition: {
+	name: Name;
+	variables: readonly string[];
+	format: string;
+	symbol: string;
+	style: string;
+	options: Readonly<Record<string, ModuleOptionSchema>>;
+}): ModuleDefinition<Name> {
+	return defineModule({
+		name: definition.name,
+		variables: ["symbol", ...definition.variables],
+		defaults: {
+			format: definition.format,
+			symbol: definition.symbol,
+			style: definition.style,
+			disabled: false,
+		},
+		options: definition.options,
+		values: (context) => workspaceModuleValues(definition.name, context),
+	});
+}
+
+export const awsModule = cloudModule({
+	name: "aws",
+	variables: ["profile", "region"],
+	format: "on [$symbol($profile )(\\($region\\) )]($style)",
+	symbol: "☁️  ",
+	style: "bold yellow",
+	options: {
+		profile_aliases: { kind: "string-map", default: {} },
+		region_aliases: { kind: "string-map", default: {} },
+	},
+});
+
+export const gcloudModule = cloudModule({
+	name: "gcloud",
+	variables: ["active", "account", "domain", "project", "region"],
+	format: "on [$symbol$project]($style) ",
+	symbol: "☁️  ",
+	style: "bold blue",
+	options: {
+		project_aliases: { kind: "string-map", default: {} },
+		region_aliases: { kind: "string-map", default: {} },
+	},
+});
+
+export const azureModule = cloudModule({
+	name: "azure",
+	variables: ["subscription", "username"],
+	format: "on [$symbol$subscription]($style) ",
+	symbol: "󰠅 ",
+	style: "blue bold",
+	options: {
+		subscription_aliases: { kind: "string-map", default: {} },
+		show_username: { kind: "boolean", default: false },
+	},
+});
+
+export const openstackModule = cloudModule({
+	name: "openstack",
+	variables: ["cloud", "project"],
+	format: "on [$symbol$cloud( \\($project\\))]($style) ",
+	symbol: "☁️  ",
+	style: "bold yellow",
+	options: {
+		cloud_aliases: { kind: "string-map", default: {} },
+		project_aliases: { kind: "string-map", default: {} },
+	},
+});
+
+export const cloudModules = [awsModule, gcloudModule, azureModule, openstackModule] as const;

--- a/extensions/pi-starship/src/modules/deployment.ts
+++ b/extensions/pi-starship/src/modules/deployment.ts
@@ -1,0 +1,61 @@
+import { defineModule } from "./types.js";
+import { workspaceModuleValues } from "./workspace-helpers.js";
+
+const directDetection = {
+	detect_files: { kind: "string-array", default: [] },
+	detect_extensions: { kind: "string-array", default: [] },
+	detect_folders: { kind: "string-array", default: [] },
+} as const;
+
+export const dockerContextModule = defineModule({
+	name: "docker_context",
+	variables: ["symbol", "context"],
+	defaults: {
+		format: "via [$symbol$context]($style) ",
+		symbol: " ",
+		style: "blue bold",
+		disabled: false,
+	},
+	options: {
+		...directDetection,
+		only_with_files: { kind: "boolean", default: false },
+	},
+	values: (context) => workspaceModuleValues("docker_context", context),
+});
+
+export const kubernetesModule = defineModule({
+	name: "kubernetes",
+	variables: ["symbol", "context", "namespace", "cluster", "user"],
+	defaults: {
+		format: "on [$symbol$context( \\($namespace\\))]($style) ",
+		symbol: "☸ ",
+		style: "cyan bold",
+		disabled: false,
+	},
+	options: {
+		context_aliases: { kind: "string-map", default: {} },
+		namespace_aliases: { kind: "string-map", default: {} },
+		cluster_aliases: { kind: "string-map", default: {} },
+		user_aliases: { kind: "string-map", default: {} },
+		max_config_files: { kind: "integer", default: 8, minimum: 1, maximum: 32 },
+	},
+	values: (context) => workspaceModuleValues("kubernetes", context),
+});
+
+export const terraformModule = defineModule({
+	name: "terraform",
+	variables: ["symbol", "workspace", "version"],
+	defaults: {
+		format: "via [$symbol$workspace]($style) ",
+		symbol: "💠 ",
+		style: "bold 105",
+		disabled: false,
+	},
+	options: {
+		...directDetection,
+		version_format: { kind: "string", default: "v$raw" },
+	},
+	values: (context) => workspaceModuleValues("terraform", context),
+});
+
+export const deploymentModules = [dockerContextModule, kubernetesModule, terraformModule] as const;

--- a/extensions/pi-starship/src/modules/development.ts
+++ b/extensions/pi-starship/src/modules/development.ts
@@ -1,0 +1,95 @@
+import { defineModule, type ModuleDefinition, type ModuleOptionSchema } from "./types.js";
+import { workspaceModuleValues } from "./workspace-helpers.js";
+
+function developmentModule<const Name extends string>(definition: {
+	name: Name;
+	variables: readonly string[];
+	format: string;
+	symbol: string;
+	style: string;
+	options?: Readonly<Record<string, ModuleOptionSchema>>;
+}): ModuleDefinition<Name> {
+	return defineModule({
+		name: definition.name,
+		variables: ["symbol", ...definition.variables],
+		defaults: {
+			format: definition.format,
+			symbol: definition.symbol,
+			style: definition.style,
+			disabled: false,
+		},
+		options: definition.options,
+		values: (context) => workspaceModuleValues(definition.name, context),
+	});
+}
+
+const directDetection = {
+	detect_files: { kind: "string-array", default: [] },
+	detect_extensions: { kind: "string-array", default: [] },
+	detect_folders: { kind: "string-array", default: [] },
+} as const;
+
+export const miseModule = developmentModule({
+	name: "mise",
+	variables: ["health"],
+	format: "via [$symbol$health]($style) ",
+	symbol: "mise ",
+	style: "bold purple",
+	options: directDetection,
+});
+
+export const direnvModule = developmentModule({
+	name: "direnv",
+	variables: ["rc_path", "allowed", "loaded"],
+	format: "[$symbol$loaded]($style) ",
+	symbol: "direnv ",
+	style: "bold 208",
+	options: directDetection,
+});
+
+export const condaModule = developmentModule({
+	name: "conda",
+	variables: ["environment"],
+	format: "via [$symbol$environment]($style) ",
+	symbol: "🅒 ",
+	style: "green bold",
+	options: { ignore_base: { kind: "boolean", default: true } },
+});
+
+export const pixiModule = developmentModule({
+	name: "pixi",
+	variables: ["version", "environment", "project_name"],
+	format: "via [$symbol$environment]($style) ",
+	symbol: "🧚 ",
+	style: "yellow bold",
+	options: {
+		...directDetection,
+		version_format: { kind: "string", default: "v$raw" },
+		show_default_environment: { kind: "boolean", default: false },
+	},
+});
+
+export const nixShellModule = developmentModule({
+	name: "nix_shell",
+	variables: ["state", "name", "level"],
+	format: "via [$symbol$state( \\($name\\))]($style) ",
+	symbol: " ",
+	style: "bold blue",
+});
+
+export const guixShellModule = developmentModule({
+	name: "guix_shell",
+	variables: ["state"],
+	format: "via [$symbol]($style) ",
+	symbol: "🐃 ",
+	style: "yellow bold",
+});
+
+export const developmentModules = [
+	miseModule,
+	direnvModule,
+	condaModule,
+	pixiModule,
+	nixShellModule,
+	guixShellModule,
+] as const;

--- a/extensions/pi-starship/src/modules/execution.ts
+++ b/extensions/pi-starship/src/modules/execution.ts
@@ -1,0 +1,73 @@
+import { defineModule } from "./types.js";
+import { workspaceModuleValues } from "./workspace-helpers.js";
+
+export const osModule = defineModule({
+	name: "os",
+	variables: ["symbol", "type", "name", "version", "edition", "codename"],
+	defaults: {
+		format: "[$symbol($name )]($style)",
+		symbol: "",
+		style: "bold white",
+		disabled: true,
+	},
+	options: {
+		symbols: {
+			kind: "string-map",
+			default: { linux: "🐧 ", macos: "🍎 ", windows: " ", wsl: " " },
+		},
+	},
+	values: (context) => workspaceModuleValues("os", context),
+});
+
+export const containerModule = defineModule({
+	name: "container",
+	variables: ["symbol", "name", "type"],
+	defaults: {
+		format: "[$symbol$name]($style) ",
+		symbol: "⬢ ",
+		style: "bold red dimmed",
+		disabled: false,
+	},
+	values: (context) => workspaceModuleValues("container", context),
+});
+
+export const hostnameModule = defineModule({
+	name: "hostname",
+	variables: ["symbol", "hostname", "ssh_symbol"],
+	defaults: {
+		format: "[$ssh_symbol$hostname]($style) in ",
+		symbol: "",
+		style: "bold dimmed green",
+		disabled: false,
+	},
+	options: {
+		ssh_only: { kind: "boolean", default: true },
+		trim_at: { kind: "string", default: ".", allowEmpty: false },
+		aliases: { kind: "string-map", default: {} },
+	},
+	values: (context) => workspaceModuleValues("hostname", context),
+});
+
+export const usernameModule = defineModule({
+	name: "username",
+	variables: ["symbol", "user"],
+	defaults: {
+		format: "[$user]($style) in ",
+		symbol: "",
+		style: "yellow bold",
+		disabled: false,
+	},
+	options: {
+		show_always: { kind: "boolean", default: false },
+		aliases: { kind: "string-map", default: {} },
+		detect_env_vars: { kind: "string-array", default: [] },
+	},
+	values: (context) => workspaceModuleValues("username", context),
+});
+
+export const executionModules = [
+	osModule,
+	containerModule,
+	hostnameModule,
+	usernameModule,
+] as const;

--- a/extensions/pi-starship/src/modules/fill.ts
+++ b/extensions/pi-starship/src/modules/fill.ts
@@ -1,0 +1,14 @@
+import { defineModule } from "./types.js";
+
+export const fillModule = defineModule({
+	name: "fill",
+	variables: ["symbol"],
+	defaults: {
+		format: "[$symbol]($style)",
+		symbol: " ",
+		style: "none",
+		disabled: false,
+	},
+	layout: "fill",
+	values: () => ({}),
+});

--- a/extensions/pi-starship/src/modules/index.ts
+++ b/extensions/pi-starship/src/modules/index.ts
@@ -6,7 +6,7 @@ export {
 export { prContextFromStatuses } from "./git/branch.js";
 export { formatCount } from "./helpers.js";
 export { shortenModel } from "./model.js";
-export { renderStatusline } from "./render.js";
+export { reachableModuleRequirements, renderStatusline } from "./render.js";
 export type {
 	ExtensionStatusIconAliasMap,
 	GitBranchSnapshot,
@@ -18,4 +18,5 @@ export type {
 	GitWorktreeSnapshot,
 	RenderedStatusline,
 	StarshipRuntimeSnapshot,
+	WorkspaceSnapshot,
 } from "./types.js";

--- a/extensions/pi-starship/src/modules/languages.ts
+++ b/extensions/pi-starship/src/modules/languages.ts
@@ -1,0 +1,87 @@
+import { defineModule, type ModuleDefinition } from "./types.js";
+import { workspaceModuleValues } from "./workspace-helpers.js";
+
+const detectionOptions = {
+	version_format: { kind: "string", default: "v$raw" },
+	detect_files: { kind: "string-array", default: [], allowNegative: true },
+	detect_extensions: { kind: "string-array", default: [], allowNegative: true },
+	detect_folders: { kind: "string-array", default: [], allowNegative: true },
+} as const;
+
+function languageModule<const Name extends string>(definition: {
+	name: Name;
+	variables: readonly string[];
+	format: string;
+	symbol: string;
+	style: string;
+}): ModuleDefinition<Name> {
+	return defineModule({
+		name: definition.name,
+		variables: ["symbol", ...definition.variables],
+		defaults: {
+			format: definition.format,
+			symbol: definition.symbol,
+			style: definition.style,
+			disabled: false,
+		},
+		options: detectionOptions,
+		values: (context) => workspaceModuleValues(definition.name, context),
+	});
+}
+
+export const nodejsModule = languageModule({
+	name: "nodejs",
+	variables: ["version", "engines_version"],
+	format: "via [$symbol($version )]($style)",
+	symbol: " ",
+	style: "bold green",
+});
+
+export const pythonModule = languageModule({
+	name: "python",
+	variables: ["version", "virtualenv", "pyenv_prefix"],
+	format: "via [$symbol$pyenv_prefix($version )(\\($virtualenv\\) )]($style)",
+	symbol: " ",
+	style: "yellow bold",
+});
+
+export const rustModule = languageModule({
+	name: "rust",
+	variables: ["version", "numver", "toolchain"],
+	format: "via [$symbol($version )]($style)",
+	symbol: " ",
+	style: "bold red",
+});
+
+export const golangModule = languageModule({
+	name: "golang",
+	variables: ["version", "mod_version"],
+	format: "via [$symbol($version )]($style)",
+	symbol: " ",
+	style: "bold cyan",
+});
+
+export const bunModule = languageModule({
+	name: "bun",
+	variables: ["version"],
+	format: "via [$symbol($version )]($style)",
+	symbol: "🍞 ",
+	style: "bold red",
+});
+
+export const denoModule = languageModule({
+	name: "deno",
+	variables: ["version"],
+	format: "via [$symbol($version )]($style)",
+	symbol: "🦕 ",
+	style: "green bold",
+});
+
+export const languageModules = [
+	nodejsModule,
+	pythonModule,
+	rustModule,
+	golangModule,
+	bunModule,
+	denoModule,
+] as const;

--- a/extensions/pi-starship/src/modules/package.ts
+++ b/extensions/pi-starship/src/modules/package.ts
@@ -1,0 +1,17 @@
+import { defineModule } from "./types.js";
+import { workspaceModuleValues } from "./workspace-helpers.js";
+
+export const packageModule = defineModule({
+	name: "package",
+	variables: ["symbol", "version", "source"],
+	defaults: {
+		format: "via [$symbol$version]($style) ",
+		symbol: "📦 ",
+		style: "bold 208",
+		disabled: false,
+	},
+	options: {
+		version_format: { kind: "string", default: "v$raw" },
+	},
+	values: (context) => workspaceModuleValues("package", context),
+});

--- a/extensions/pi-starship/src/modules/render.ts
+++ b/extensions/pi-starship/src/modules/render.ts
@@ -1,16 +1,27 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { activePalette, type ModuleConfig, type StarshipConfig } from "../config.js";
 import { type FormatValue, formatVariables, renderFormat } from "../format/formatter.js";
-import { renderChunksToAnsi, type StyledChunk } from "../format/style.js";
+import {
+	isFillChunk,
+	type LayoutChunk,
+	renderChunksToAnsi,
+	type StyledChunk,
+} from "../format/style.js";
 import { MODULE_DEFINITIONS, MODULE_NAMES, type ModuleName } from "./catalog.js";
 import type { ModuleValueContext, RenderedStatusline, StarshipRuntimeSnapshot } from "./types.js";
 
 export function renderStatusline(
 	config: StarshipConfig,
 	runtime: StarshipRuntimeSnapshot,
+	width = 80,
 ): RenderedStatusline<ModuleName> {
 	const palette = activePalette(config);
 	const modules = {} as Record<ModuleName, StyledChunk[]>;
-	for (const name of MODULE_NAMES) modules[name] = [];
+	const layoutModules = {} as Record<ModuleName, LayoutChunk[]>;
+	for (const name of MODULE_NAMES) {
+		modules[name] = [];
+		layoutModules[name] = [];
+	}
 	const consumedExtensionStatusKeys = new Set<string>();
 
 	for (const definition of MODULE_DEFINITIONS) {
@@ -19,12 +30,17 @@ export function renderStatusline(
 			valueContext(config, name, runtime, consumedExtensionStatusKeys),
 		);
 		if (!values) continue;
-		modules[name] = renderModule(config.modules[name], values, palette);
+		const rendered = renderModule(config.modules[name], values, palette);
+		modules[name] = rendered;
+		layoutModules[name] =
+			definition.layout === "fill" && !config.modules[name].disabled
+				? [{ type: "fill", pattern: rendered }]
+				: rendered;
 		if (
 			name === "git_branch" &&
 			values.pr &&
 			formatVariables(config.modules.git_branch.formatAst).has("pr") &&
-			modules.git_branch.some((chunk) => chunk.text.includes(values.pr ?? ""))
+			rendered.some((chunk) => chunk.text.includes(values.pr ?? ""))
 		) {
 			consumedExtensionStatusKeys.add("github-pr");
 		}
@@ -32,11 +48,12 @@ export function renderStatusline(
 
 	const explicitModules = formatVariables(config.formatAst);
 	const all = MODULE_NAMES.flatMap((name) =>
-		explicitModules.has(name) || config.modules[name].disabled ? [] : modules[name],
+		explicitModules.has(name) || config.modules[name].disabled ? [] : layoutModules[name],
 	);
 	const rootVariables: Record<string, FormatValue> = { all };
-	for (const name of MODULE_NAMES) rootVariables[name] = modules[name];
-	const chunks = renderFormat(config.formatAst, { variables: rootVariables, palette });
+	for (const name of MODULE_NAMES) rootVariables[name] = layoutModules[name];
+	const layout = renderFormat(config.formatAst, { variables: rootVariables, palette });
+	const chunks = resolveFillLayout(layout, width);
 	return {
 		ansi: renderChunksToAnsi(chunks),
 		chunks,
@@ -66,8 +83,79 @@ function renderModule(
 ): StyledChunk[] {
 	if (module.disabled) return [];
 	return renderFormat(module.formatAst, {
-		variables: { ...values, symbol: module.symbol },
+		variables: { symbol: module.symbol, ...values },
 		styleVariables: { style: module.style },
 		palette,
-	});
+	}).filter((chunk): chunk is StyledChunk => !isFillChunk(chunk));
+}
+
+export function reachableModuleRequirements(
+	config: StarshipConfig,
+): ReadonlyMap<ModuleName, ReadonlySet<string>> {
+	const rootVariables = formatVariables(config.formatAst);
+	const includeAll = rootVariables.has("all");
+	const requirements = new Map<ModuleName, ReadonlySet<string>>();
+	for (const definition of MODULE_DEFINITIONS) {
+		if (config.modules[definition.name].disabled) continue;
+		if (!includeAll && !rootVariables.has(definition.name)) continue;
+		requirements.set(definition.name, formatVariables(config.modules[definition.name].formatAst));
+	}
+	return requirements;
+}
+
+function resolveFillLayout(layout: readonly LayoutChunk[], width: number): StyledChunk[] {
+	const lines = splitLogicalLines(layout);
+	const resolved: StyledChunk[] = [];
+	for (const [lineIndex, line] of lines.entries()) {
+		const fills = line.filter(isFillChunk);
+		const fixedWidth = line.reduce(
+			(total, chunk) =>
+				total + (isFillChunk(chunk) ? 0 : visibleWidth(renderChunksToAnsi([chunk]))),
+			0,
+		);
+		const remaining = Math.max(0, width - fixedWidth);
+		const base = fills.length > 0 ? Math.floor(remaining / fills.length) : 0;
+		let remainder = fills.length > 0 ? remaining % fills.length : 0;
+		for (const chunk of line) {
+			if (!isFillChunk(chunk)) {
+				resolved.push(chunk);
+				continue;
+			}
+			const allocation = base + (remainder > 0 ? 1 : 0);
+			if (remainder > 0) remainder -= 1;
+			resolved.push(...expandFill(chunk.pattern, allocation));
+		}
+		if (lineIndex < lines.length - 1) resolved.push({ text: "\n" });
+	}
+	return resolved;
+}
+
+function splitLogicalLines(layout: readonly LayoutChunk[]): LayoutChunk[][] {
+	const lines: LayoutChunk[][] = [[]];
+	for (const chunk of layout) {
+		if (isFillChunk(chunk)) {
+			lines.at(-1)?.push(chunk);
+			continue;
+		}
+		const parts = chunk.text.split("\n");
+		for (const [index, text] of parts.entries()) {
+			if (text) lines.at(-1)?.push({ ...chunk, text });
+			if (index < parts.length - 1) lines.push([]);
+		}
+	}
+	return lines;
+}
+
+function expandFill(pattern: readonly StyledChunk[], width: number): StyledChunk[] {
+	if (width <= 0) return [];
+	const patternWidth = visibleWidth(renderChunksToAnsi(pattern));
+	if (patternWidth <= 0) return [{ text: " ".repeat(width), style: pattern[0]?.style }];
+	const repetitions = Math.floor(width / patternWidth);
+	const result: StyledChunk[] = [];
+	for (let index = 0; index < repetitions; index += 1) {
+		result.push(...pattern.map((chunk) => ({ ...chunk })));
+	}
+	const remainder = width - repetitions * patternWidth;
+	if (remainder > 0) result.push({ text: " ".repeat(remainder), style: pattern.at(-1)?.style });
+	return result;
 }

--- a/extensions/pi-starship/src/modules/types.ts
+++ b/extensions/pi-starship/src/modules/types.ts
@@ -61,6 +61,10 @@ export interface GitSnapshot {
 
 export type ExtensionStatusIconAliasMap = ReadonlyMap<string, readonly string[]>;
 
+export interface WorkspaceSnapshot {
+	modules: Readonly<Record<string, Readonly<Record<string, string>>>>;
+}
+
 export interface StarshipRuntimeSnapshot {
 	cwd: string;
 	model?: { provider: string; id: string };
@@ -85,6 +89,7 @@ export interface StarshipRuntimeSnapshot {
 	extensionStatuses: ReadonlyMap<string, string>;
 	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	now: Date;
+	workspace?: WorkspaceSnapshot;
 }
 
 export interface ExtensionStatusPresentation {
@@ -100,6 +105,13 @@ export interface ModuleValueContext {
 	hiddenExtensionStatusKeys: ReadonlySet<string>;
 }
 
+export type ModuleOptionSchema =
+	| { kind: "string"; default: string; allowEmpty?: boolean }
+	| { kind: "boolean"; default: boolean }
+	| { kind: "integer"; default: number; minimum: number; maximum: number }
+	| { kind: "string-array"; default: readonly string[]; allowNegative?: boolean }
+	| { kind: "string-map"; default: Readonly<Record<string, string>> };
+
 export interface ModuleDefaults {
 	format: string;
 	symbol: string;
@@ -111,6 +123,8 @@ export interface ModuleDefinition<Name extends string> {
 	name: Name;
 	variables: readonly string[];
 	defaults: ModuleDefaults;
+	options?: Readonly<Record<string, ModuleOptionSchema>>;
+	layout?: "fill";
 	values(context: ModuleValueContext): Record<string, string> | undefined;
 }
 

--- a/extensions/pi-starship/src/modules/workspace-helpers.ts
+++ b/extensions/pi-starship/src/modules/workspace-helpers.ts
@@ -1,0 +1,10 @@
+import type { ModuleValueContext } from "./types.js";
+
+export function workspaceModuleValues(
+	name: string,
+	context: ModuleValueContext,
+): Record<string, string> | undefined {
+	const values = context.runtime.workspace?.modules[name];
+	if (!values) return undefined;
+	return { ...values };
+}

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -1,3 +1,4 @@
+import { homedir, hostname, userInfo } from "node:os";
 import {
 	type ExtensionAPI,
 	type ExtensionContext,
@@ -10,20 +11,28 @@ import {
 	type LoadedStarshipConfig,
 	loadOrCreateStarshipConfig,
 	loadStarshipConfig,
+	type StarshipConfig,
 	settingsFilePath,
 } from "./config.js";
-import { formatVariables } from "./format/formatter.js";
 import { readInstalledPackageInfo } from "./installed-packages.js";
 import { gitSnapshotEqual, readGitSnapshot } from "./modules/git/runtime.js";
 import {
 	type ExtensionStatusIconAliasMap,
 	type GitSnapshot,
+	reachableModuleRequirements,
 	renderStatusline,
 	type StarshipRuntimeSnapshot,
+	type WorkspaceSnapshot,
 } from "./modules/index.js";
+import { AsyncRefreshController } from "./runtime/refresh-controller.js";
+import {
+	collectWorkspaceSnapshot,
+	type WorkspaceRefreshInput,
+	workspaceSnapshotEqual,
+} from "./runtime/workspace.js";
 
-const GIT_REFRESH_INTERVAL_MS = 30_000;
-const GIT_EVENT_DEBOUNCE_MS = 250;
+const REFRESH_INTERVAL_MS = 30_000;
+const EVENT_DEBOUNCE_MS = 250;
 const EMPTY_ALIASES: ExtensionStatusIconAliasMap = new Map();
 
 interface RuntimeState {
@@ -32,9 +41,20 @@ interface RuntimeState {
 	thinkingLevel: string;
 	lastCompletedTool?: string;
 	git?: GitSnapshot;
+	workspace?: WorkspaceSnapshot;
 	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	requestRender?: () => void;
 	renderPreview?: (loaded: LoadedStarshipConfig, width: number) => string[];
+}
+
+interface RefreshTarget {
+	cwd: string;
+	generation: number;
+}
+
+interface GitRefreshInput {
+	cwd: string;
+	config: StarshipConfig;
 }
 
 export default function piStarship(pi: ExtensionAPI) {
@@ -47,88 +67,92 @@ export default function piStarship(pi: ExtensionAPI) {
 	};
 	let conflictWarningShown = false;
 	let sessionGeneration = 0;
-	let gitRequestId = 0;
-	let activeGitTarget: { cwd: string; generation: number } | undefined;
-	let gitRefreshInFlight = false;
-	let gitDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-	let pendingGitRefresh: { cwd: string; generation: number; requestId: number } | undefined;
+	let activeTarget: RefreshTarget | undefined;
+	let eventDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
 	const refresh = () => runtime.requestRender?.();
-	const clearDebounce = () => {
-		if (!gitDebounceTimer) return;
-		clearTimeout(gitDebounceTimer);
-		gitDebounceTimer = undefined;
-	};
-	const isActiveTarget = (cwd: string, generation: number) =>
-		activeGitTarget?.cwd === cwd &&
-		activeGitTarget.generation === generation &&
-		generation === sessionGeneration;
-	const isCurrentRequest = (cwd: string, generation: number, requestId: number) =>
-		isActiveTarget(cwd, generation) && requestId === gitRequestId;
-
-	const setGitSnapshot = (snapshot: GitSnapshot | undefined) => {
-		if (gitSnapshotEqual(runtime.git, snapshot)) return;
-		runtime.git = snapshot;
-		refresh();
-	};
-
-	const runGitRefresh = (cwd: string, generation: number, requestId: number) => {
-		if (!isCurrentRequest(cwd, generation, requestId)) return;
-		if (gitRefreshInFlight) {
-			pendingGitRefresh = { cwd, generation, requestId };
-			return;
-		}
-		gitRefreshInFlight = true;
-		void (async () => {
+	const gitController = new AsyncRefreshController<GitRefreshInput, GitSnapshot | undefined>({
+		async read(input) {
+			const requirements = reachableModuleRequirements(input.config);
+			const gitReachable = [...requirements.keys()].some((name) => name.startsWith("git_"));
+			if (!gitReachable) return undefined;
 			try {
-				const config = loaded?.config;
-				const snapshot = await readGitSnapshot(pi, cwd, {
-					includeMetrics: config ? !config.modules.git_metrics.disabled : false,
-					includeTag: config
-						? !config.modules.git_commit.disabled &&
-							formatVariables(config.modules.git_commit.formatAst).has("tag")
-						: false,
+				return await readGitSnapshot(pi, input.cwd, {
+					includeMetrics: requirements.has("git_metrics"),
+					includeTag: requirements.get("git_commit")?.has("tag") ?? false,
 				});
-				if (isCurrentRequest(cwd, generation, requestId)) setGitSnapshot(snapshot);
 			} catch {
-				if (isCurrentRequest(cwd, generation, requestId)) setGitSnapshot(undefined);
-			} finally {
-				gitRefreshInFlight = false;
-				const pending = pendingGitRefresh;
-				pendingGitRefresh = undefined;
-				if (pending) runGitRefresh(pending.cwd, pending.generation, pending.requestId);
+				return undefined;
 			}
-		})();
-	};
+		},
+		equal: gitSnapshotEqual,
+		publish(snapshot) {
+			runtime.git = snapshot;
+			refresh();
+		},
+	});
+	const workspaceController = new AsyncRefreshController<WorkspaceRefreshInput, WorkspaceSnapshot>({
+		async read(input) {
+			try {
+				return await collectWorkspaceSnapshot(input);
+			} catch {
+				return { modules: {} };
+			}
+		},
+		equal: workspaceSnapshotEqual,
+		publish(snapshot) {
+			runtime.workspace = snapshot;
+			refresh();
+		},
+	});
 
-	const refreshGit = (cwd: string, generation = sessionGeneration) => {
-		if (!isActiveTarget(cwd, generation)) return;
-		runGitRefresh(cwd, generation, ++gitRequestId);
+	const clearDebounce = () => {
+		if (!eventDebounceTimer) return;
+		clearTimeout(eventDebounceTimer);
+		eventDebounceTimer = undefined;
 	};
-	const scheduleGit = (ctx: ExtensionContext) => {
-		if (!activeGitTarget || activeGitTarget.cwd !== ctx.cwd) return;
-		const { cwd, generation } = activeGitTarget;
-		const requestId = ++gitRequestId;
+	const isActiveTarget = (target: RefreshTarget) =>
+		activeTarget?.cwd === target.cwd &&
+		activeTarget.generation === target.generation &&
+		target.generation === sessionGeneration;
+
+	const requestRefresh = (
+		target: RefreshTarget,
+		reason: WorkspaceRefreshInput["reason"] = "event",
+	) => {
+		if (!loaded || !isActiveTarget(target)) return;
+		gitController.request({ cwd: target.cwd, config: loaded.config });
+		workspaceController.request(
+			workspaceInput(pi, target.cwd, loaded.config, reason, runtime.workspace),
+		);
+	};
+	const scheduleRefresh = (ctx: ExtensionContext) => {
+		const target = activeTarget;
+		if (!target || target.cwd !== ctx.cwd) return;
 		clearDebounce();
-		gitDebounceTimer = setTimeout(() => {
-			gitDebounceTimer = undefined;
-			runGitRefresh(cwd, generation, requestId);
-		}, GIT_EVENT_DEBOUNCE_MS);
+		eventDebounceTimer = setTimeout(() => {
+			eventDebounceTimer = undefined;
+			requestRefresh(target);
+		}, EVENT_DEBOUNCE_MS);
 	};
 
 	const installFooter = (ctx: ExtensionContext) => {
 		const generation = ++sessionGeneration;
-		const cwd = ctx.cwd;
+		const target = { cwd: ctx.cwd, generation };
 		clearDebounce();
-		pendingGitRefresh = undefined;
+		gitController.stop();
+		workspaceController.stop();
 		runtime.git = undefined;
+		runtime.workspace = undefined;
 		runtime.requestRender = undefined;
 		runtime.renderPreview = undefined;
-		activeGitTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
+		activeTarget = ctx.mode === "tui" ? target : undefined;
 		ctx.ui.setStatus("starship", undefined);
-		if (!activeGitTarget || !loaded) return;
+		if (!activeTarget || !loaded) return;
+		gitController.start(generation);
+		workspaceController.start(generation);
 
-		const installed = readInstalledPackageInfo(getAgentDir(), cwd, ctx.isProjectTrusted());
+		const installed = readInstalledPackageInfo(getAgentDir(), target.cwd, ctx.isProjectTrusted());
 		runtime.extensionStatusIconAliases = installed.aliases;
 		if (installed.hasStatuslineConflict && !conflictWarningShown) {
 			conflictWarningShown = true;
@@ -142,19 +166,23 @@ export default function piStarship(pi: ExtensionAPI) {
 			runtime.requestRender = () => tui.requestRender();
 			runtime.renderPreview = (preview, width) => {
 				const snapshot = runtimeSnapshot(ctx, footerData, runtime);
-				return wrapFormattedStatusline(renderStatusline(preview.config, snapshot).ansi, width);
+				return wrapFormattedStatusline(
+					renderStatusline(preview.config, snapshot, width).ansi,
+					width,
+				);
 			};
 			const unsubscribe = footerData.onBranchChange(() => {
 				runtime.git = undefined;
+				gitController.clear();
 				clearDebounce();
-				refreshGit(cwd, generation);
+				requestRefresh(target);
 				tui.requestRender();
 			});
 			const timer = setInterval(() => {
 				clearDebounce();
-				refreshGit(cwd, generation);
+				requestRefresh(target, "periodic");
 				tui.requestRender();
-			}, GIT_REFRESH_INTERVAL_MS);
+			}, REFRESH_INTERVAL_MS);
 			let disposed = false;
 
 			return {
@@ -163,11 +191,13 @@ export default function piStarship(pi: ExtensionAPI) {
 					disposed = true;
 					unsubscribe();
 					clearInterval(timer);
-					if (isActiveTarget(cwd, generation)) {
-						activeGitTarget = undefined;
+					if (isActiveTarget(target)) {
+						activeTarget = undefined;
 						clearDebounce();
-						pendingGitRefresh = undefined;
+						gitController.stop();
+						workspaceController.stop();
 						runtime.git = undefined;
+						runtime.workspace = undefined;
 						runtime.requestRender = undefined;
 						runtime.renderPreview = undefined;
 					}
@@ -176,11 +206,14 @@ export default function piStarship(pi: ExtensionAPI) {
 				render(width: number): string[] {
 					if (!loaded) return [];
 					const snapshot = runtimeSnapshot(ctx, footerData, runtime);
-					return wrapFormattedStatusline(renderStatusline(loaded.config, snapshot).ansi, width);
+					return wrapFormattedStatusline(
+						renderStatusline(loaded.config, snapshot, width).ansi,
+						width,
+					);
 				},
 			};
 		});
-		refreshGit(cwd, generation);
+		requestRefresh(target, "initial");
 	};
 
 	const configPath = settingsFilePath(getAgentDir());
@@ -189,6 +222,8 @@ export default function piStarship(pi: ExtensionAPI) {
 		getLoaded: () => loaded ?? loadStarshipConfig(configPath),
 		apply(next) {
 			loaded = next;
+			const target = activeTarget;
+			if (target) requestRefresh(target);
 			refresh();
 		},
 		renderPreview(preview, width) {
@@ -216,10 +251,12 @@ export default function piStarship(pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		sessionGeneration += 1;
-		activeGitTarget = undefined;
+		activeTarget = undefined;
 		clearDebounce();
-		pendingGitRefresh = undefined;
+		gitController.stop();
+		workspaceController.stop();
 		runtime.git = undefined;
+		runtime.workspace = undefined;
 		runtime.extensionStatusIconAliases = EMPTY_ALIASES;
 		runtime.requestRender = undefined;
 		runtime.renderPreview = undefined;
@@ -238,7 +275,7 @@ export default function piStarship(pi: ExtensionAPI) {
 	});
 	pi.on("agent_end", (_event, ctx) => {
 		runtime.isStreaming = false;
-		scheduleGit(ctx);
+		scheduleRefresh(ctx);
 		refresh();
 	});
 	pi.on("turn_start", () => {
@@ -246,7 +283,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		refresh();
 	});
 	pi.on("turn_end", (_event, ctx) => {
-		scheduleGit(ctx);
+		scheduleRefresh(ctx);
 		refresh();
 	});
 	pi.on("tool_execution_start", (event) => {
@@ -258,9 +295,90 @@ export default function piStarship(pi: ExtensionAPI) {
 		if (count <= 1) runtime.activeTools.delete(event.toolName);
 		else runtime.activeTools.set(event.toolName, count - 1);
 		runtime.lastCompletedTool = event.toolName;
-		scheduleGit(ctx);
+		scheduleRefresh(ctx);
 		refresh();
 	});
+}
+
+function workspaceInput(
+	pi: ExtensionAPI,
+	cwd: string,
+	config: StarshipConfig,
+	reason: WorkspaceRefreshInput["reason"],
+	previous: WorkspaceSnapshot | undefined,
+): WorkspaceRefreshInput {
+	return {
+		cwd,
+		config,
+		environment: allowlistedEnvironment(config),
+		homeDir: homedir(),
+		platform: process.platform,
+		hostname: hostname(),
+		username: safeUsername(),
+		exec: (command, args, options) => pi.exec(command, args, options),
+		reason,
+		previous,
+	};
+}
+
+const ENVIRONMENT_ALLOWLIST = [
+	"AWS_CONFIG_FILE",
+	"AWS_DEFAULT_PROFILE",
+	"AWS_DEFAULT_REGION",
+	"AWS_PROFILE",
+	"AWS_REGION",
+	"AZURE_CONFIG_DIR",
+	"CLOUDSDK_ACTIVE_CONFIG_NAME",
+	"CLOUDSDK_CONFIG",
+	"CODESPACES",
+	"CONDA_DEFAULT_ENV",
+	"DOCKER_CONFIG",
+	"DOCKER_CONTEXT",
+	"GUIX_ENVIRONMENT",
+	"IN_NIX_SHELL",
+	"KUBECONFIG",
+	"LOGNAME",
+	"NIX_SHELL_LEVEL",
+	"NIX_SHELL_NAME",
+	"OS_CLIENT_CONFIG_FILE",
+	"OS_CLOUD",
+	"OS_PROJECT_NAME",
+	"PATH",
+	"PIXI_ENVIRONMENT_NAME",
+	"PIXI_PROJECT_NAME",
+	"PYENV_VERSION",
+	"REMOTE_CONTAINERS",
+	"RUSTC",
+	"RUSTUP_TOOLCHAIN",
+	"SSH_CONNECTION",
+	"SSH_TTY",
+	"TF_DATA_DIR",
+	"TF_WORKSPACE",
+	"USER",
+	"USERNAME",
+	"VIRTUAL_ENV",
+	"WSL_DISTRO_NAME",
+] as const;
+
+function allowlistedEnvironment(config: StarshipConfig): Record<string, string | undefined> {
+	const result: Record<string, string | undefined> = {};
+	const configured = config.modules.username.options.detect_env_vars;
+	const names = new Set([
+		...ENVIRONMENT_ALLOWLIST,
+		...(Array.isArray(configured)
+			? configured.filter((name): name is string => typeof name === "string")
+			: []),
+	]);
+	for (const name of names) result[name] = process.env[name];
+	return result;
+}
+
+function safeUsername(): string {
+	try {
+		return userInfo().username;
+	} catch {
+		return process.env.USER ?? process.env.USERNAME ?? "";
+	}
 }
 
 function runtimeSnapshot(
@@ -285,6 +403,7 @@ function runtimeSnapshot(
 		gitMetrics: runtime.git?.metrics,
 		gitStatus: runtime.git?.status,
 		gitWorktree: runtime.git?.worktree,
+		workspace: runtime.workspace,
 		extensionStatuses: footerData.getExtensionStatuses(),
 		extensionStatusIconAliases: runtime.extensionStatusIconAliases,
 		now: new Date(),

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -24,6 +24,7 @@ import {
 	type StarshipRuntimeSnapshot,
 	type WorkspaceSnapshot,
 } from "./modules/index.js";
+import { execWorkspaceCommand } from "./runtime/command.js";
 import { AsyncRefreshController } from "./runtime/refresh-controller.js";
 import {
 	collectWorkspaceSnapshot,
@@ -123,7 +124,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		if (!loaded || !isActiveTarget(target)) return;
 		gitController.request({ cwd: target.cwd, config: loaded.config });
 		workspaceController.request(
-			workspaceInput(pi, target.cwd, loaded.config, reason, runtime.workspace),
+			workspaceInput(target.cwd, loaded.config, reason, runtime.workspace),
 		);
 	};
 	const scheduleRefresh = (ctx: ExtensionContext) => {
@@ -301,7 +302,6 @@ export default function piStarship(pi: ExtensionAPI) {
 }
 
 function workspaceInput(
-	pi: ExtensionAPI,
 	cwd: string,
 	config: StarshipConfig,
 	reason: WorkspaceRefreshInput["reason"],
@@ -315,7 +315,7 @@ function workspaceInput(
 		platform: process.platform,
 		hostname: hostname(),
 		username: safeUsername(),
-		exec: (command, args, options) => pi.exec(command, args, options),
+		exec: execWorkspaceCommand,
 		reason,
 		previous,
 	};

--- a/extensions/pi-starship/src/runtime/cloud.ts
+++ b/extensions/pi-starship/src/runtime/cloud.ts
@@ -1,0 +1,166 @@
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import {
+	exactAlias,
+	isRecord,
+	joinHome,
+	MAX_METADATA_FILE_BYTES,
+	optionBoolean,
+	optionMap,
+	parseIni,
+	safeMetadata,
+} from "./helpers.js";
+import type { CollectorContext, MutableModuleSnapshot } from "./types.js";
+
+export async function collectCloud(context: CollectorContext): Promise<MutableModuleSnapshot> {
+	const result: MutableModuleSnapshot = {};
+	if (context.needs("aws")) {
+		const values = await collectAws(context);
+		if (values) result.aws = values;
+	}
+	if (context.needs("gcloud")) {
+		const values = await collectGcloud(context);
+		if (values) result.gcloud = values;
+	}
+	if (context.needs("azure")) {
+		const values = await collectAzure(context);
+		if (values) result.azure = values;
+	}
+	if (context.needs("openstack")) {
+		const values = await collectOpenstack(context);
+		if (values) result.openstack = values;
+	}
+	return result;
+}
+
+async function collectAws(context: CollectorContext): Promise<Record<string, string> | undefined> {
+	const env = context.input.environment;
+	const profile = safeMetadata(env.AWS_PROFILE ?? env.AWS_DEFAULT_PROFILE) ?? "default";
+	let region = safeMetadata(env.AWS_REGION ?? env.AWS_DEFAULT_REGION);
+	if (!region) {
+		const configPath =
+			safeMetadata(env.AWS_CONFIG_FILE, 1_024) ?? joinHome(context.input, ".aws", "config");
+		const source = await context.fs.readFile(configPath, MAX_METADATA_FILE_BYTES);
+		if (source) {
+			const section = profile === "default" ? "default" : `profile ${profile}`;
+			region = safeMetadata(parseIni(source)[section]?.region);
+		}
+	}
+	if (profile === "default" && !region && !env.AWS_PROFILE && !env.AWS_DEFAULT_PROFILE)
+		return undefined;
+	const values: Record<string, string> = {
+		profile: exactAlias(profile, optionMap(context, "aws", "profile_aliases")) ?? profile,
+	};
+	if (region)
+		values.region = exactAlias(region, optionMap(context, "aws", "region_aliases")) ?? region;
+	return values;
+}
+
+async function collectGcloud(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const env = context.input.environment;
+	const directory =
+		safeMetadata(env.CLOUDSDK_CONFIG, 1_024) ?? joinHome(context.input, ".config", "gcloud");
+	const active =
+		safeMetadata(env.CLOUDSDK_ACTIVE_CONFIG_NAME) ??
+		safeMetadata(await context.fs.readFile(join(directory, "active_config"), 256));
+	if (!active || !/^[A-Za-z0-9_-]+$/u.test(active)) return undefined;
+	const source = await context.fs.readFile(
+		join(directory, "configurations", `config_${active}`),
+		MAX_METADATA_FILE_BYTES,
+	);
+	if (!source) return { active };
+	const document = parseIni(source);
+	const account = safeMetadata(document.core?.account);
+	const project = safeMetadata(document.core?.project);
+	const region = safeMetadata(document.compute?.region);
+	const values: Record<string, string> = { active };
+	if (account) {
+		values.account = account;
+		const separator = account.lastIndexOf("@");
+		if (separator >= 0 && separator < account.length - 1)
+			values.domain = account.slice(separator + 1);
+	}
+	if (project) {
+		values.project =
+			exactAlias(project, optionMap(context, "gcloud", "project_aliases")) ?? project;
+	}
+	if (region)
+		values.region = exactAlias(region, optionMap(context, "gcloud", "region_aliases")) ?? region;
+	return values;
+}
+
+async function collectAzure(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const directory =
+		safeMetadata(context.input.environment.AZURE_CONFIG_DIR, 1_024) ??
+		joinHome(context.input, ".azure");
+	const source = await context.fs.readFile(
+		join(directory, "azureProfile.json"),
+		MAX_METADATA_FILE_BYTES,
+	);
+	if (!source) return undefined;
+	try {
+		const document = JSON.parse(source.replace(/^\uFEFF/u, "")) as unknown;
+		const subscriptions =
+			isRecord(document) && Array.isArray(document.subscriptions)
+				? document.subscriptions.filter(isRecord)
+				: [];
+		const selected = subscriptions.find((item) => item.isDefault === true) ?? subscriptions[0];
+		const subscription = safeMetadata(selected?.name);
+		if (!subscription) return undefined;
+		const values: Record<string, string> = {
+			subscription:
+				exactAlias(subscription, optionMap(context, "azure", "subscription_aliases")) ??
+				subscription,
+		};
+		if (optionBoolean(context, "azure", "show_username")) {
+			const user = isRecord(selected?.user) ? selected.user : undefined;
+			const username = safeMetadata(user?.name);
+			if (username) values.username = username;
+		}
+		return values;
+	} catch {
+		return undefined;
+	}
+}
+
+async function collectOpenstack(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const env = context.input.environment;
+	const cloud = safeMetadata(env.OS_CLOUD);
+	let project = safeMetadata(env.OS_PROJECT_NAME);
+	if (!cloud) return undefined;
+	if (!project) {
+		const path =
+			safeMetadata(env.OS_CLIENT_CONFIG_FILE, 1_024) ??
+			joinHome(context.input, ".config", "openstack", "clouds.yaml");
+		const source = await context.fs.readFile(path, MAX_METADATA_FILE_BYTES);
+		if (source) {
+			try {
+				const document = parseYaml(source) as unknown;
+				const clouds =
+					isRecord(document) && isRecord(document.clouds) ? document.clouds : undefined;
+				const selected =
+					clouds && Object.hasOwn(clouds, cloud) && isRecord(clouds[cloud])
+						? clouds[cloud]
+						: undefined;
+				const auth = isRecord(selected?.auth) ? selected.auth : undefined;
+				project = safeMetadata(auth?.project_name);
+			} catch {
+				// Malformed YAML is ignored.
+			}
+		}
+	}
+	const values: Record<string, string> = {
+		cloud: exactAlias(cloud, optionMap(context, "openstack", "cloud_aliases")) ?? cloud,
+	};
+	if (project) {
+		values.project =
+			exactAlias(project, optionMap(context, "openstack", "project_aliases")) ?? project;
+	}
+	return values;
+}

--- a/extensions/pi-starship/src/runtime/command.ts
+++ b/extensions/pi-starship/src/runtime/command.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import type { WorkspaceExec } from "./types.js";
+
+const FORCE_KILL_DELAY_MS = 250;
+
+export const execWorkspaceCommand: WorkspaceExec = async (command, args, options) =>
+	new Promise((resolve) => {
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = spawn(command, args, {
+				cwd: options.cwd,
+				shell: false,
+				stdio: ["ignore", "pipe", "pipe"],
+				windowsHide: true,
+			});
+		} catch {
+			resolve({ stdout: "", stderr: "", code: 1, killed: false });
+			return;
+		}
+
+		const stdout: Buffer[] = [];
+		const stderr: Buffer[] = [];
+		let outputBytes = 0;
+		let killed = false;
+		let settled = false;
+		let forceKillTimer: NodeJS.Timeout | undefined;
+
+		const finish = (code: number) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeoutTimer);
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+			resolve({
+				stdout: Buffer.concat(stdout).toString("utf8"),
+				stderr: Buffer.concat(stderr).toString("utf8"),
+				code,
+				killed,
+			});
+		};
+
+		const terminate = () => {
+			if (killed || settled) return;
+			killed = true;
+			child.kill("SIGTERM");
+			forceKillTimer = setTimeout(() => {
+				child.kill("SIGKILL");
+				child.stdout?.destroy();
+				child.stderr?.destroy();
+				finish(1);
+			}, FORCE_KILL_DELAY_MS);
+		};
+
+		const collect = (target: Buffer[]) => (data: Buffer | string) => {
+			const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
+			const remaining = Math.max(0, options.maxOutputBytes - outputBytes);
+			if (remaining > 0) target.push(chunk.subarray(0, remaining));
+			outputBytes += chunk.byteLength;
+			if (outputBytes > options.maxOutputBytes) terminate();
+		};
+
+		child.stdout?.on("data", collect(stdout));
+		child.stderr?.on("data", collect(stderr));
+		child.once("error", () => finish(1));
+		child.once("close", (code) => finish(code ?? 1));
+		const timeoutTimer = setTimeout(terminate, options.timeout);
+	});

--- a/extensions/pi-starship/src/runtime/command.ts
+++ b/extensions/pi-starship/src/runtime/command.ts
@@ -9,6 +9,7 @@ export const execWorkspaceCommand: WorkspaceExec = async (command, args, options
 		try {
 			child = spawn(command, args, {
 				cwd: options.cwd,
+				env: explicitEnvironment(options.environment),
 				shell: false,
 				stdio: ["ignore", "pipe", "pipe"],
 				windowsHide: true,
@@ -64,3 +65,21 @@ export const execWorkspaceCommand: WorkspaceExec = async (command, args, options
 		child.once("close", (code) => finish(code ?? 1));
 		const timeoutTimer = setTimeout(terminate, options.timeout);
 	});
+
+function explicitEnvironment(
+	source: Readonly<Record<string, string | undefined>>,
+): NodeJS.ProcessEnv {
+	const result: NodeJS.ProcessEnv = Object.create(null);
+	for (const [name, value] of Object.entries(source)) {
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name) || value === undefined || value.includes("\0")) {
+			continue;
+		}
+		Object.defineProperty(result, name, {
+			value,
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		});
+	}
+	return result;
+}

--- a/extensions/pi-starship/src/runtime/deployment.ts
+++ b/extensions/pi-starship/src/runtime/deployment.ts
@@ -1,0 +1,196 @@
+import { extname, isAbsolute, join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import {
+	directMatch,
+	exactAlias,
+	isRecord,
+	joinHome,
+	MAX_METADATA_FILE_BYTES,
+	optionBoolean,
+	optionMap,
+	optionNumber,
+	optionStrings,
+	runBounded,
+	safeMetadata,
+} from "./helpers.js";
+import type { CollectorContext, MutableModuleSnapshot } from "./types.js";
+
+export async function collectDeployment(context: CollectorContext): Promise<MutableModuleSnapshot> {
+	const result: MutableModuleSnapshot = {};
+	if (context.needs("docker_context")) {
+		const docker = await collectDocker(context);
+		if (docker) result.docker_context = docker;
+	}
+	if (context.needs("kubernetes")) {
+		const kubernetes = await collectKubernetes(context);
+		if (kubernetes) result.kubernetes = kubernetes;
+	}
+	if (context.needs("terraform")) {
+		const terraform = await collectTerraform(context);
+		if (terraform) result.terraform = terraform;
+	}
+	return result;
+}
+
+async function collectDocker(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const entries = await context.entries();
+	if (optionBoolean(context, "docker_context", "only_with_files")) {
+		const configuredFiles = optionStrings(context, "docker_context", "detect_files");
+		if (
+			!directMatch(
+				entries,
+				configuredFiles.length > 0
+					? configuredFiles
+					: [
+							"Dockerfile",
+							"docker-compose.yml",
+							"docker-compose.yaml",
+							"compose.yml",
+							"compose.yaml",
+						],
+				optionStrings(context, "docker_context", "detect_extensions"),
+				optionStrings(context, "docker_context", "detect_folders"),
+			)
+		) {
+			return undefined;
+		}
+	}
+	let active = safeMetadata(context.input.environment.DOCKER_CONTEXT);
+	if (!active) {
+		const configDirectory =
+			safeMetadata(context.input.environment.DOCKER_CONFIG, 1_024) ??
+			joinHome(context.input, ".docker");
+		const source = await context.fs.readFile(
+			join(configDirectory, "config.json"),
+			MAX_METADATA_FILE_BYTES,
+		);
+		if (source) {
+			try {
+				const document = JSON.parse(source) as unknown;
+				active = isRecord(document) ? safeMetadata(document.currentContext) : undefined;
+			} catch {
+				// Malformed metadata degrades to an empty module.
+			}
+		}
+	}
+	return active && active !== "default" ? { context: active } : undefined;
+}
+
+async function collectKubernetes(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const selected = safeMetadata(context.input.environment.KUBECONFIG, 4_096);
+	const candidates = selected
+		? selected.split(context.input.platform === "win32" ? ";" : ":").filter(Boolean)
+		: [joinHome(context.input, ".kube", "config")];
+	const limit = optionNumber(context, "kubernetes", "max_config_files") ?? 8;
+	const contexts = new Map<string, Record<string, unknown>>();
+	const clusters = new Set<string>();
+	const users = new Set<string>();
+	let currentContext: string | undefined;
+	for (const path of candidates.slice(0, limit)) {
+		const source = await context.fs.readFile(path, MAX_METADATA_FILE_BYTES);
+		if (!source) continue;
+		try {
+			const document = parseYaml(source) as unknown;
+			if (!isRecord(document)) continue;
+			currentContext ??= safeMetadata(document["current-context"]);
+			for (const item of arrayRecords(document.contexts)) {
+				const name = safeMetadata(item.name);
+				if (name && !contexts.has(name) && isRecord(item.context)) contexts.set(name, item.context);
+			}
+			for (const item of arrayRecords(document.clusters)) {
+				const name = safeMetadata(item.name);
+				if (name) clusters.add(name);
+			}
+			for (const item of arrayRecords(document.users)) {
+				const name = safeMetadata(item.name);
+				if (name) users.add(name);
+			}
+		} catch {
+			// Ignore malformed files independently.
+		}
+	}
+	if (!currentContext) return undefined;
+	const selectedContext = contexts.get(currentContext);
+	const cluster = safeMetadata(selectedContext?.cluster);
+	const user = safeMetadata(selectedContext?.user);
+	const namespace = safeMetadata(selectedContext?.namespace) ?? "default";
+	const values: Record<string, string> = {
+		context:
+			exactAlias(currentContext, optionMap(context, "kubernetes", "context_aliases")) ??
+			currentContext,
+		namespace:
+			exactAlias(namespace, optionMap(context, "kubernetes", "namespace_aliases")) ?? namespace,
+	};
+	if (cluster && clusters.has(cluster)) {
+		values.cluster =
+			exactAlias(cluster, optionMap(context, "kubernetes", "cluster_aliases")) ?? cluster;
+	}
+	if (user && users.has(user)) {
+		values.user = exactAlias(user, optionMap(context, "kubernetes", "user_aliases")) ?? user;
+	}
+	return values;
+}
+
+async function collectTerraform(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const entries = await context.entries();
+	const configuredFiles = optionStrings(context, "terraform", "detect_files");
+	const configuredExtensions = optionStrings(context, "terraform", "detect_extensions");
+	const configuredFolders = optionStrings(context, "terraform", "detect_folders");
+	const detected =
+		configuredFiles.length + configuredExtensions.length + configuredFolders.length > 0
+			? directMatch(entries, configuredFiles, configuredExtensions, configuredFolders)
+			: entries.some(
+					(entry) =>
+						(entry.isFile && [".tf", ".tfplan", ".tfstate"].includes(extname(entry.name))) ||
+						(entry.isDirectory && entry.name === ".terraform"),
+				);
+	if (!detected) return undefined;
+	const values: Record<string, string> = {};
+	const workspace = await terraformWorkspace(context);
+	if (workspace) values.workspace = workspace;
+	if (context.needs("terraform", "version")) {
+		for (const command of ["terraform", "tofu"]) {
+			const output = await runBounded(context, command, ["version"]);
+			const parsed = output ? parseTerraformVersion(output, command) : undefined;
+			if (parsed) {
+				values.version = parsed;
+				break;
+			}
+		}
+	}
+	return values;
+}
+
+async function terraformWorkspace(context: CollectorContext): Promise<string | undefined> {
+	const direct = safeMetadata(context.input.environment.TF_WORKSPACE);
+	if (direct) return direct;
+	const dataDirectory = safeMetadata(context.input.environment.TF_DATA_DIR, 1_024);
+	const candidate = dataDirectory
+		? join(
+				isAbsolute(dataDirectory) ? dataDirectory : resolve(context.input.cwd, dataDirectory),
+				"environment",
+			)
+		: join(context.input.cwd, ".terraform", "environment");
+	return safeMetadata(await context.fs.readFile(candidate, 1_024));
+}
+
+export function parseTerraformVersion(
+	output: string,
+	command: "terraform" | "tofu" | string,
+): string | undefined {
+	const escaped = command === "tofu" ? "OpenTofu" : "Terraform";
+	const match = new RegExp(`^${escaped} v?(\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?)$`, "u").exec(
+		output.trim().split(/\r?\n/u)[0] ?? "",
+	);
+	return match?.[1] ? `v${match[1]}` : undefined;
+}
+
+function arrayRecords(value: unknown): Record<string, unknown>[] {
+	return Array.isArray(value) ? value.filter(isRecord) : [];
+}

--- a/extensions/pi-starship/src/runtime/deployment.ts
+++ b/extensions/pi-starship/src/runtime/deployment.ts
@@ -3,12 +3,14 @@ import { parse as parseYaml } from "yaml";
 import {
 	directMatch,
 	exactAlias,
+	formatVersion,
 	isRecord,
 	joinHome,
 	MAX_METADATA_FILE_BYTES,
 	optionBoolean,
 	optionMap,
 	optionNumber,
+	optionString,
 	optionStrings,
 	runBounded,
 	safeMetadata,
@@ -159,7 +161,10 @@ async function collectTerraform(
 			const output = await runBounded(context, command, ["version"]);
 			const parsed = output ? parseTerraformVersion(output, command) : undefined;
 			if (parsed) {
-				values.version = parsed;
+				values.version = formatVersion(
+					parsed,
+					optionString(context, "terraform", "version_format"),
+				);
 				break;
 			}
 		}

--- a/extensions/pi-starship/src/runtime/development.ts
+++ b/extensions/pi-starship/src/runtime/development.ts
@@ -1,0 +1,154 @@
+import { join } from "node:path";
+import { parse } from "smol-toml";
+import {
+	directMatch,
+	formatVersion,
+	isRecord,
+	MAX_METADATA_FILE_BYTES,
+	optionBoolean,
+	optionString,
+	optionStrings,
+	pathName,
+	runBounded,
+	safeMetadata,
+	setString,
+} from "./helpers.js";
+import type { CollectorContext, MutableModuleSnapshot } from "./types.js";
+
+export async function collectDevelopment(
+	context: CollectorContext,
+): Promise<MutableModuleSnapshot> {
+	const result: MutableModuleSnapshot = {};
+	const directNames = ["mise", "direnv", "pixi"] as const;
+	const needsListing = directNames.some((name) => context.needs(name));
+	const entries = needsListing ? await context.entries() : [];
+
+	if (
+		context.needs("mise") &&
+		detected(context, entries, "mise", ["mise.toml", ".mise.toml", ".tool-versions"])
+	) {
+		const values: Record<string, string> = {};
+		if (context.needs("mise", "health")) {
+			const output = await runBounded(context, "mise", ["doctor"]);
+			const health = output ? parseMiseHealth(output) : undefined;
+			if (health) values.health = health;
+		}
+		result.mise = values;
+	}
+
+	if (context.needs("direnv") && detected(context, entries, "direnv", [".envrc"])) {
+		const values: Record<string, string> = {};
+		if (["rc_path", "allowed", "loaded"].some((variable) => context.needs("direnv", variable))) {
+			const output = await runBounded(context, "direnv", ["status", "--json"]);
+			if (output) Object.assign(values, parseDirenvStatus(output));
+		}
+		result.direnv = values;
+	}
+
+	const conda = safeMetadata(context.input.environment.CONDA_DEFAULT_ENV);
+	if (
+		context.needs("conda") &&
+		conda &&
+		!(optionBoolean(context, "conda", "ignore_base") && conda === "base")
+	) {
+		result.conda = { environment: pathName(conda) };
+	}
+
+	if (context.needs("pixi") && detected(context, entries, "pixi", ["pixi.toml", "pixi.lock"])) {
+		const values: Record<string, string> = {};
+		const environment = safeMetadata(context.input.environment.PIXI_ENVIRONMENT_NAME);
+		if (
+			environment &&
+			(environment !== "default" || optionBoolean(context, "pixi", "show_default_environment"))
+		) {
+			values.environment = environment;
+		}
+		const project =
+			safeMetadata(context.input.environment.PIXI_PROJECT_NAME) ?? (await readPixiProject(context));
+		if (project) values.project_name = project;
+		if (context.needs("pixi", "version")) {
+			const output = await runBounded(context, "pixi", ["--version"]);
+			const version = output ? parsePixiVersion(output) : undefined;
+			if (version)
+				values.version = formatVersion(version, optionString(context, "pixi", "version_format"));
+		}
+		result.pixi = values;
+	}
+
+	const nixState = safeMetadata(context.input.environment.IN_NIX_SHELL);
+	if (context.needs("nix_shell") && (nixState === "pure" || nixState === "impure")) {
+		const values: Record<string, string> = { state: nixState };
+		setString(values, "name", context.input.environment.NIX_SHELL_NAME);
+		setString(values, "level", context.input.environment.NIX_SHELL_LEVEL);
+		result.nix_shell = values;
+	}
+
+	if (context.needs("guix_shell") && safeMetadata(context.input.environment.GUIX_ENVIRONMENT)) {
+		result.guix_shell = { state: "active" };
+	}
+	return result;
+}
+
+function detected(
+	context: CollectorContext,
+	entries: Awaited<ReturnType<CollectorContext["entries"]>>,
+	name: "mise" | "direnv" | "pixi",
+	defaultFiles: string[],
+): boolean {
+	const files = optionStrings(context, name, "detect_files");
+	return directMatch(
+		entries,
+		files.length > 0 ? files : defaultFiles,
+		optionStrings(context, name, "detect_extensions"),
+		optionStrings(context, name, "detect_folders"),
+	);
+}
+
+export function parseMiseHealth(output: string): string | undefined {
+	const text = safeMetadata(output, 8_192)?.toLowerCase();
+	if (!text) return undefined;
+	if (/\b(?:healthy|no problems found|all checks passed)\b/u.test(text)) return "healthy";
+	if (/\b(?:error|unhealthy|problem|warning)\b/u.test(text)) return "issues";
+	return undefined;
+}
+
+export function parseDirenvStatus(output: string): Record<string, string> {
+	try {
+		const document = JSON.parse(output) as unknown;
+		if (!isRecord(document)) return {};
+		const values: Record<string, string> = {};
+		const found = isRecord(document.foundRC) ? document.foundRC : undefined;
+		const loaded = isRecord(document.loadedRC) ? document.loadedRC : undefined;
+		setString(values, "rc_path", found?.path ?? loaded?.path);
+		if (typeof found?.allowed === "number" || typeof found?.allowed === "boolean") {
+			values.allowed = found.allowed ? "allowed" : "denied";
+		}
+		if (loaded) values.loaded = "loaded";
+		else if (found) values.loaded = "not loaded";
+		return values;
+	} catch {
+		const path = /^Found RC path ([^\r\n]+)$/mu.exec(output)?.[1];
+		return path ? { rc_path: safeMetadata(path) ?? "" } : {};
+	}
+}
+
+async function readPixiProject(context: CollectorContext): Promise<string | undefined> {
+	const source = await context.fs.readFile(
+		join(context.input.cwd, "pixi.toml"),
+		MAX_METADATA_FILE_BYTES,
+	);
+	if (!source) return undefined;
+	try {
+		const document = parse(source);
+		const project = isRecord(document.project) ? document.project : undefined;
+		const workspace = isRecord(document.workspace) ? document.workspace : undefined;
+		return safeMetadata(project?.name ?? workspace?.name);
+	} catch {
+		return undefined;
+	}
+}
+
+function parsePixiVersion(output: string): string | undefined {
+	const match = /^(?:pixi\s+)?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/u.exec(output.trim());
+	return match?.[1] ? `v${match[1]}` : undefined;
+}

--- a/extensions/pi-starship/src/runtime/execution.ts
+++ b/extensions/pi-starship/src/runtime/execution.ts
@@ -1,0 +1,141 @@
+import {
+	exactAlias,
+	optionBoolean,
+	optionMap,
+	optionString,
+	optionStrings,
+	safeMetadata,
+} from "./helpers.js";
+import type { CollectorContext, MutableModuleSnapshot } from "./types.js";
+
+export async function collectExecution(context: CollectorContext): Promise<MutableModuleSnapshot> {
+	if (context.input.reason === "periodic" && context.input.previous) {
+		const retained: MutableModuleSnapshot = {};
+		for (const name of ["os", "container", "hostname", "username"] as const) {
+			const values = context.input.previous.modules[name];
+			if (context.needs(name) && values) retained[name] = { ...values };
+		}
+		return retained;
+	}
+	const result: MutableModuleSnapshot = {};
+	if (context.needs("os")) result.os = await osValues(context);
+	const container = context.needs("container") ? await containerValues(context) : undefined;
+	if (container) result.container = container;
+	const hostname = context.needs("hostname") ? hostnameValues(context) : undefined;
+	if (hostname) result.hostname = hostname;
+	const username = context.needs("username") ? usernameValues(context) : undefined;
+	if (username) result.username = username;
+	return result;
+}
+
+async function osValues(context: CollectorContext): Promise<Record<string, string>> {
+	const wsl = Boolean(safeMetadata(context.input.environment.WSL_DISTRO_NAME));
+	const type = wsl ? "wsl" : platformType(context.input.platform);
+	const details = context.input.platform === "linux" ? await linuxRelease(context) : {};
+	const symbols = optionMap(context, "os", "symbols");
+	return {
+		type,
+		name: details.name ?? platformName(context.input.platform, wsl),
+		...(details.version ? { version: details.version } : {}),
+		...(details.edition ? { edition: details.edition } : {}),
+		...(details.codename ? { codename: details.codename } : {}),
+		...(Object.hasOwn(symbols, type) && safeMetadata(symbols[type])
+			? { symbol: safeMetadata(symbols[type]) as string }
+			: {}),
+	};
+}
+
+async function linuxRelease(context: CollectorContext): Promise<{
+	name?: string;
+	version?: string;
+	edition?: string;
+	codename?: string;
+}> {
+	const source = await context.fs.readFile("/etc/os-release", 16 * 1024);
+	if (!source) return {};
+	const values: Record<string, string> = {};
+	for (const line of source.split(/\r?\n/u)) {
+		const match = /^([A-Z_]+)=(.*)$/u.exec(line);
+		if (!match?.[1] || match[2] === undefined) continue;
+		const value = safeMetadata(match[2].replace(/^['"]|['"]$/gu, ""));
+		if (value) values[match[1]] = value;
+	}
+	return {
+		name: values.NAME,
+		version: values.VERSION_ID,
+		edition: values.ID,
+		codename: values.VERSION_CODENAME,
+	};
+}
+
+async function containerValues(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	const env = context.input.environment;
+	if (safeMetadata(env.REMOTE_CONTAINERS) || safeMetadata(env.CODESPACES)) {
+		return { name: "Dev Container", type: "devcontainer" };
+	}
+	const wsl = safeMetadata(env.WSL_DISTRO_NAME);
+	if (wsl) return { name: `WSL ${wsl}`, type: "wsl" };
+	if (await context.fs.fileExists("/.dockerenv")) return { name: "Docker", type: "docker" };
+	if (await context.fs.fileExists("/run/.containerenv")) return { name: "Podman", type: "podman" };
+	const systemd = safeMetadata(await context.fs.readFile("/run/systemd/container", 256));
+	return systemd ? { name: systemd, type: "container" } : undefined;
+}
+
+function hostnameValues(context: CollectorContext): Record<string, string> | undefined {
+	const ssh = isSsh(context);
+	if (optionBoolean(context, "hostname", "ssh_only") && !ssh) return undefined;
+	const raw = safeMetadata(context.input.hostname);
+	if (!raw) return undefined;
+	const aliases = optionMap(context, "hostname", "aliases");
+	let hostname = exactAlias(raw, aliases) ?? raw;
+	if (hostname === raw) {
+		const trimAt = optionString(context, "hostname", "trim_at");
+		const index = trimAt ? hostname.indexOf(trimAt) : -1;
+		if (index > 0) hostname = hostname.slice(0, index);
+	}
+	return { hostname, ssh_symbol: ssh ? "🌐 " : "" };
+}
+
+function usernameValues(context: CollectorContext): Record<string, string> | undefined {
+	const user = safeMetadata(context.input.username);
+	if (!user) return undefined;
+	const env = context.input.environment;
+	const login = safeMetadata(env.LOGNAME ?? env.USER ?? env.USERNAME);
+	const privileged = /^(?:root|administrator)$/iu.test(user);
+	const detected = optionStrings(context, "username", "detect_env_vars").some(
+		(name) => safeMetadata(env[name]) !== undefined,
+	);
+	if (
+		!optionBoolean(context, "username", "show_always") &&
+		!isSsh(context) &&
+		!privileged &&
+		!(login && login !== user) &&
+		!detected
+	) {
+		return undefined;
+	}
+	return { user: exactAlias(user, optionMap(context, "username", "aliases")) ?? user };
+}
+
+function isSsh(context: CollectorContext): boolean {
+	return Boolean(
+		safeMetadata(context.input.environment.SSH_CONNECTION) ||
+			safeMetadata(context.input.environment.SSH_TTY),
+	);
+}
+
+function platformType(platform: NodeJS.Platform): string {
+	if (platform === "darwin") return "macos";
+	if (platform === "win32") return "windows";
+	return platform;
+}
+
+function platformName(platform: NodeJS.Platform, wsl: boolean): string {
+	if (wsl) return "WSL";
+	if (platform === "darwin") return "macOS";
+	if (platform === "win32") return "Windows";
+	if (platform === "linux") return "Linux";
+	return platform;
+}

--- a/extensions/pi-starship/src/runtime/helpers.ts
+++ b/extensions/pi-starship/src/runtime/helpers.ts
@@ -1,0 +1,271 @@
+import { type FileHandle, open, opendir, stat } from "node:fs/promises";
+import { basename, delimiter, dirname, extname, join, resolve } from "node:path";
+import type {
+	CollectorContext,
+	WorkspaceEntry,
+	WorkspaceFileSystem,
+	WorkspaceRefreshInput,
+} from "./types.js";
+
+export const MAX_METADATA_FILE_BYTES = 64 * 1024;
+export const COMMAND_TIMEOUT_MS = 2_000;
+export const MAX_COMMAND_OUTPUT_BYTES = 64 * 1024;
+const MAX_DIRECTORY_ENTRIES = 2_048;
+const MAX_LABEL_LENGTH = 160;
+
+export function createFileSystem(input: WorkspaceRefreshInput): WorkspaceFileSystem {
+	const defaults: WorkspaceFileSystem = {
+		async readFile(path, maxBytes) {
+			let handle: FileHandle | undefined;
+			try {
+				handle = await open(path, "r");
+				const info = await handle.stat();
+				if (!info.isFile() || info.size > maxBytes) return undefined;
+				const buffer = Buffer.alloc(Math.min(maxBytes + 1, Number(info.size) + 1));
+				const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+				if (bytesRead > maxBytes) return undefined;
+				return buffer.subarray(0, bytesRead).toString("utf8");
+			} catch {
+				return undefined;
+			} finally {
+				await handle?.close().catch(() => undefined);
+			}
+		},
+		async readDirectory(path) {
+			const entries: WorkspaceEntry[] = [];
+			try {
+				const directory = await opendir(path);
+				for await (const entry of directory) {
+					entries.push({
+						name: entry.name,
+						isFile: entry.isFile(),
+						isDirectory: entry.isDirectory(),
+					});
+					if (entries.length >= MAX_DIRECTORY_ENTRIES) break;
+				}
+			} catch {
+				return [];
+			}
+			return entries;
+		},
+		async fileExists(path) {
+			try {
+				await stat(path);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+	};
+	return {
+		...defaults,
+		...input.fileSystem,
+		...(input.fileExists ? { fileExists: input.fileExists } : {}),
+	};
+}
+
+export function safeMetadata(value: unknown, maxLength = MAX_LABEL_LENGTH): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const sanitized = Array.from(value, (character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code <= 0x1f || (code >= 0x7f && code <= 0x9f) || (code >= 0xd800 && code <= 0xdfff)
+			? ""
+			: character;
+	})
+		.join("")
+		.trim();
+	if (!sanitized) return undefined;
+	return Array.from(sanitized).slice(0, maxLength).join("");
+}
+
+export function ownString(record: unknown, key: string): string | undefined {
+	if (!isRecord(record) || !Object.hasOwn(record, key)) return undefined;
+	return safeMetadata(record[key]);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function setString(record: Record<string, string>, key: string, value: unknown): void {
+	const safe = safeMetadata(value);
+	if (!safe) return;
+	Object.defineProperty(record, key, {
+		value: safe,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	});
+}
+
+export function optionString(
+	context: CollectorContext,
+	module: Parameters<CollectorContext["options"]>[0],
+	key: string,
+): string | undefined {
+	const value = context.options(module)[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+export function optionBoolean(
+	context: CollectorContext,
+	module: Parameters<CollectorContext["options"]>[0],
+	key: string,
+): boolean {
+	return context.options(module)[key] === true;
+}
+
+export function optionNumber(
+	context: CollectorContext,
+	module: Parameters<CollectorContext["options"]>[0],
+	key: string,
+): number | undefined {
+	const value = context.options(module)[key];
+	return typeof value === "number" ? value : undefined;
+}
+
+export function optionStrings(
+	context: CollectorContext,
+	module: Parameters<CollectorContext["options"]>[0],
+	key: string,
+): readonly string[] {
+	const value = context.options(module)[key];
+	return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : [];
+}
+
+export function optionMap(
+	context: CollectorContext,
+	module: Parameters<CollectorContext["options"]>[0],
+	key: string,
+): Readonly<Record<string, string>> {
+	const value = context.options(module)[key];
+	return isRecord(value) ? (value as Record<string, string>) : {};
+}
+
+export function exactAlias(value: string | undefined, aliases: Readonly<Record<string, string>>) {
+	if (!value) return undefined;
+	return Object.hasOwn(aliases, value) ? safeMetadata(aliases[value]) : value;
+}
+
+export function formatVersion(raw: string, format: string | undefined): string {
+	return (format ?? "v$raw").replaceAll("$raw", raw.replace(/^v/u, ""));
+}
+
+export async function runBounded(
+	context: CollectorContext,
+	command: string,
+	args: string[],
+): Promise<string | undefined> {
+	try {
+		const result = await context.input.exec(command, args, {
+			cwd: context.input.cwd,
+			timeout: COMMAND_TIMEOUT_MS,
+		});
+		if (result.code !== 0 || result.killed) return undefined;
+		const selectedOutput = result.stdout || result.stderr;
+		const output = Buffer.from(selectedOutput).subarray(0, MAX_COMMAND_OUTPUT_BYTES + 1);
+		if (output.byteLength > MAX_COMMAND_OUTPUT_BYTES) return undefined;
+		return output.toString("utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+export function parseIni(source: string): Record<string, Record<string, string>> {
+	const result: Record<string, Record<string, string>> = {};
+	let section = "";
+	for (const rawLine of source.split(/\r?\n/u)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+		const sectionMatch = /^\[([^\]]+)\]$/u.exec(line);
+		if (sectionMatch?.[1]) {
+			section = sectionMatch[1].trim();
+			if (!Object.hasOwn(result, section)) setOwn(result, section, {});
+			continue;
+		}
+		const separator = line.indexOf("=");
+		if (separator <= 0) continue;
+		const key = line.slice(0, separator).trim();
+		const value = safeMetadata(line.slice(separator + 1));
+		if (!value) continue;
+		if (!Object.hasOwn(result, section)) setOwn(result, section, {});
+		setOwn(result[section] as Record<string, string>, key, value);
+	}
+	return result;
+}
+
+export function envPathList(value: string | undefined): string[] {
+	return (value ?? "")
+		.split(delimiter)
+		.map((part) => part.trim())
+		.filter(Boolean);
+}
+
+export function directMatch(
+	entries: readonly WorkspaceEntry[],
+	files: readonly string[],
+	extensions: readonly string[],
+	folders: readonly string[],
+): boolean {
+	const positiveFiles = files.filter((value) => !value.startsWith("!"));
+	const negativeFiles = new Set(
+		files.filter((value) => value.startsWith("!")).map((v) => v.slice(1)),
+	);
+	const positiveExtensions = extensions
+		.filter((value) => !value.startsWith("!"))
+		.map((value) => value.replace(/^\./u, ""));
+	const negativeExtensions = new Set(
+		extensions
+			.filter((value) => value.startsWith("!"))
+			.map((value) => value.slice(1).replace(/^\./u, "")),
+	);
+	const positiveFolders = folders.filter((value) => !value.startsWith("!"));
+	const negativeFolders = new Set(
+		folders.filter((value) => value.startsWith("!")).map((value) => value.slice(1)),
+	);
+	if (
+		entries.some(
+			(entry) =>
+				negativeFiles.has(entry.name) ||
+				(entry.isFile && negativeExtensions.has(extname(entry.name).slice(1))) ||
+				(entry.isDirectory && negativeFolders.has(entry.name)),
+		)
+	) {
+		return false;
+	}
+	return entries.some(
+		(entry) =>
+			positiveFiles.includes(entry.name) ||
+			(entry.isFile && positiveExtensions.includes(extname(entry.name).slice(1))) ||
+			(entry.isDirectory && positiveFolders.includes(entry.name)),
+	);
+}
+
+export function parentDirectories(start: string, limit: number): string[] {
+	const result: string[] = [];
+	let current = resolve(start);
+	for (let index = 0; index < limit; index += 1) {
+		const parent = dirname(current);
+		if (parent === current) break;
+		result.push(parent);
+		current = parent;
+	}
+	return result;
+}
+
+export function pathName(path: string): string {
+	return basename(path.replace(/[\\/]+$/u, "")) || path;
+}
+
+export function joinHome(input: WorkspaceRefreshInput, ...parts: string[]): string {
+	return join(input.homeDir, ...parts);
+}
+
+function setOwn<T>(record: Record<string, T>, key: string, value: T): void {
+	Object.defineProperty(record, key, {
+		value,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	});
+}

--- a/extensions/pi-starship/src/runtime/helpers.ts
+++ b/extensions/pi-starship/src/runtime/helpers.ts
@@ -160,6 +160,7 @@ export async function runBounded(
 		const result = await context.input.exec(command, args, {
 			cwd: context.input.cwd,
 			timeout: COMMAND_TIMEOUT_MS,
+			maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
 		});
 		if (result.code !== 0 || result.killed) return undefined;
 		const selectedOutput = result.stdout || result.stderr;

--- a/extensions/pi-starship/src/runtime/helpers.ts
+++ b/extensions/pi-starship/src/runtime/helpers.ts
@@ -161,6 +161,7 @@ export async function runBounded(
 			cwd: context.input.cwd,
 			timeout: COMMAND_TIMEOUT_MS,
 			maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
+			environment: context.input.environment,
 		});
 		if (result.code !== 0 || result.killed) return undefined;
 		const selectedOutput = result.stdout || result.stderr;

--- a/extensions/pi-starship/src/runtime/languages.ts
+++ b/extensions/pi-starship/src/runtime/languages.ts
@@ -1,0 +1,201 @@
+import { delimiter, join } from "node:path";
+import {
+	directMatch,
+	formatVersion,
+	MAX_METADATA_FILE_BYTES,
+	optionString,
+	optionStrings,
+	pathName,
+	runBounded,
+	safeMetadata,
+} from "./helpers.js";
+import type { CollectorContext, MutableModuleSnapshot } from "./types.js";
+
+const LANGUAGE_NAMES = ["nodejs", "python", "rust", "golang", "bun", "deno"] as const;
+type LanguageName = (typeof LANGUAGE_NAMES)[number];
+
+const DEFAULT_DETECTION: Record<
+	LanguageName,
+	{ files: string[]; extensions: string[]; folders: string[] }
+> = {
+	nodejs: {
+		files: [
+			"package.json",
+			".node-version",
+			".nvmrc",
+			"!bun.lock",
+			"!bun.lockb",
+			"!deno.json",
+			"!deno.jsonc",
+		],
+		extensions: ["js", "mjs", "cjs", "ts", "mts", "cts"],
+		folders: ["node_modules"],
+	},
+	python: {
+		files: ["pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock", ".python-version"],
+		extensions: ["py"],
+		folders: [".venv", "venv"],
+	},
+	rust: { files: ["Cargo.toml"], extensions: ["rs"], folders: [] },
+	golang: { files: ["go.mod", "go.sum", "go.work"], extensions: ["go"], folders: [] },
+	bun: { files: ["bun.lock", "bun.lockb", "bunfig.toml"], extensions: [], folders: [] },
+	deno: { files: ["deno.json", "deno.jsonc", "deno.lock"], extensions: [], folders: [] },
+};
+
+export async function collectLanguages(context: CollectorContext): Promise<MutableModuleSnapshot> {
+	const result: MutableModuleSnapshot = {};
+	if (!LANGUAGE_NAMES.some((name) => context.needs(name))) return result;
+	const entries = await context.entries();
+	for (const name of LANGUAGE_NAMES) {
+		if (!context.needs(name)) continue;
+		const defaults = DEFAULT_DETECTION[name];
+		const files = optionStrings(context, name, "detect_files");
+		const extensions = optionStrings(context, name, "detect_extensions");
+		const folders = optionStrings(context, name, "detect_folders");
+		if (
+			!directMatch(
+				entries,
+				files.length > 0 ? files : defaults.files,
+				extensions.length > 0 ? extensions : defaults.extensions,
+				folders.length > 0 ? folders : defaults.folders,
+			)
+		) {
+			continue;
+		}
+		const values: Record<string, string> = {};
+		addEnvironmentValues(context, name, values);
+		if (context.needs(name, "engines_version")) {
+			const engine = await readNodeEngine(context);
+			if (engine) values.engines_version = engine;
+		}
+		if (context.needs(name, "version")) {
+			const command = await versionCommand(context, name);
+			if (command) {
+				const output = await runBounded(context, command[0], command[1]);
+				const version = output ? parseRuntimeVersion(name, output) : undefined;
+				if (version) {
+					values.version = formatVersion(version, optionString(context, name, "version_format"));
+					if (name === "rust") values.numver = version.replace(/^v/u, "");
+				}
+			}
+		}
+		result[name] = values;
+	}
+	return result;
+}
+
+function addEnvironmentValues(
+	context: CollectorContext,
+	name: LanguageName,
+	values: Record<string, string>,
+): void {
+	const env = context.input.environment;
+	if (name === "python") {
+		const virtualenv = safeMetadata(env.VIRTUAL_ENV ?? env.CONDA_DEFAULT_ENV);
+		if (virtualenv && context.needs(name, "virtualenv")) values.virtualenv = pathName(virtualenv);
+		const pyenv = safeMetadata(env.PYENV_VERSION);
+		if (pyenv && context.needs(name, "pyenv_prefix")) values.pyenv_prefix = pyenv;
+	}
+	if (name === "rust") {
+		const toolchain = safeMetadata(env.RUSTUP_TOOLCHAIN);
+		if (toolchain && context.needs(name, "toolchain")) values.toolchain = toolchain;
+	}
+}
+
+async function readNodeEngine(context: CollectorContext): Promise<string | undefined> {
+	const source = await context.fs.readFile(
+		join(context.input.cwd, "package.json"),
+		MAX_METADATA_FILE_BYTES,
+	);
+	if (!source) return undefined;
+	try {
+		const document = JSON.parse(source) as { engines?: { node?: unknown } };
+		return safeMetadata(document.engines?.node, 80);
+	} catch {
+		return undefined;
+	}
+}
+
+async function versionCommand(
+	context: CollectorContext,
+	name: LanguageName,
+): Promise<[string, string[]] | undefined> {
+	switch (name) {
+		case "nodejs":
+			return ["node", ["--version"]];
+		case "python": {
+			const virtualenv = safeMetadata(context.input.environment.VIRTUAL_ENV);
+			if (virtualenv) {
+				const candidate = join(
+					virtualenv,
+					context.input.platform === "win32" ? "Scripts/python.exe" : "bin/python",
+				);
+				if (await context.fs.fileExists(candidate)) return [candidate, ["--version"]];
+			}
+			return ["python", ["--version"]];
+		}
+		case "rust": {
+			const rustc = await safeRustCompiler(context);
+			return rustc ? [rustc, ["--version"]] : undefined;
+		}
+		case "golang":
+			return ["go", ["version"]];
+		case "bun":
+			return ["bun", ["--version"]];
+		case "deno":
+			return ["deno", ["-V"]];
+	}
+}
+
+async function safeRustCompiler(context: CollectorContext): Promise<string | undefined> {
+	const candidates = [
+		context.input.environment.RUSTC,
+		...(context.input.environment.PATH ?? "")
+			.split(delimiter)
+			.filter(Boolean)
+			.map((directory) =>
+				join(directory, context.input.platform === "win32" ? "rustc.exe" : "rustc"),
+			),
+	];
+	for (const rawCandidate of candidates) {
+		const candidate = safeMetadata(rawCandidate, 1_024);
+		if (!candidate || /(?:^|[\\/])\.(?:cargo|rustup)(?:[\\/]|$)/iu.test(candidate)) continue;
+		if (await context.fs.fileExists(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+export function parseRuntimeVersion(name: LanguageName, output: string): string | undefined {
+	const normalized = output.trim();
+	if (
+		!normalized ||
+		normalized.includes("\n") ||
+		normalized.includes("\r") ||
+		normalized.includes("�")
+	) {
+		return undefined;
+	}
+	let match: RegExpExecArray | null;
+	switch (name) {
+		case "nodejs":
+			match = /^v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/u.exec(normalized);
+			break;
+		case "python":
+			match = /^Python (\d+\.\d+(?:\.\d+)?(?:[0-9A-Za-z.+-]*)?)$/u.exec(normalized);
+			break;
+		case "rust":
+			match = /^rustc (\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)(?: .*)?$/u.exec(normalized);
+			break;
+		case "golang":
+			match = /^go version go(\d+\.\d+(?:\.\d+)?(?:[0-9A-Za-z.+-]*))(?:\s+.*)?$/u.exec(normalized);
+			break;
+		case "bun":
+			match = /^(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/u.exec(normalized);
+			break;
+		case "deno":
+			match = /^(?:deno\s+)?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/u.exec(normalized);
+			break;
+	}
+	const version = match?.[1];
+	return version ? `v${version}` : undefined;
+}

--- a/extensions/pi-starship/src/runtime/languages.ts
+++ b/extensions/pi-starship/src/runtime/languages.ts
@@ -68,14 +68,18 @@ export async function collectLanguages(context: CollectorContext): Promise<Mutab
 			const engine = await readNodeEngine(context);
 			if (engine) values.engines_version = engine;
 		}
-		if (context.needs(name, "version")) {
+		const needsVersion = context.needs(name, "version");
+		const needsNumver = name === "rust" && context.needs(name, "numver");
+		if (needsVersion || needsNumver) {
 			const command = await versionCommand(context, name);
 			if (command) {
 				const output = await runBounded(context, command[0], command[1]);
 				const version = output ? parseRuntimeVersion(name, output) : undefined;
 				if (version) {
-					values.version = formatVersion(version, optionString(context, name, "version_format"));
-					if (name === "rust") values.numver = version.replace(/^v/u, "");
+					if (needsVersion) {
+						values.version = formatVersion(version, optionString(context, name, "version_format"));
+					}
+					if (needsNumver) values.numver = version.replace(/^v/u, "");
 				}
 			}
 		}

--- a/extensions/pi-starship/src/runtime/package.ts
+++ b/extensions/pi-starship/src/runtime/package.ts
@@ -1,0 +1,104 @@
+import { join } from "node:path";
+import { parse } from "smol-toml";
+import {
+	formatVersion,
+	isRecord,
+	MAX_METADATA_FILE_BYTES,
+	optionString,
+	parentDirectories,
+	safeMetadata,
+} from "./helpers.js";
+import type { CollectorContext } from "./types.js";
+
+export async function collectPackage(
+	context: CollectorContext,
+): Promise<Record<string, string> | undefined> {
+	if (!context.needs("package")) return undefined;
+	const versionFormat = optionString(context, "package", "version_format");
+	for (const reader of [readPackageJson, readCargo, readPyproject]) {
+		const result = await reader(context);
+		if (!result) continue;
+		return {
+			source: result.source,
+			version: formatVersion(result.version, versionFormat),
+		};
+	}
+	return undefined;
+}
+
+interface PackageVersion {
+	version: string;
+	source: string;
+}
+
+async function readPackageJson(context: CollectorContext): Promise<PackageVersion | undefined> {
+	const source = await context.fs.readFile(
+		join(context.input.cwd, "package.json"),
+		MAX_METADATA_FILE_BYTES,
+	);
+	if (!source) return undefined;
+	try {
+		const document = JSON.parse(source) as unknown;
+		const version = isRecord(document) ? safeVersion(document.version) : undefined;
+		return version ? { version, source: "package.json" } : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function readCargo(context: CollectorContext): Promise<PackageVersion | undefined> {
+	const path = join(context.input.cwd, "Cargo.toml");
+	const source = await context.fs.readFile(path, MAX_METADATA_FILE_BYTES);
+	if (!source) return undefined;
+	try {
+		const document = parse(source);
+		const packageTable = isRecord(document.package) ? document.package : undefined;
+		const direct = safeVersion(packageTable?.version);
+		if (direct) return { version: direct, source: "Cargo.toml" };
+		const inherited = isRecord(packageTable?.version) && packageTable.version.workspace === true;
+		if (!inherited) return undefined;
+		for (const parent of parentDirectories(context.input.cwd, 8)) {
+			const parentSource = await context.fs.readFile(
+				join(parent, "Cargo.toml"),
+				MAX_METADATA_FILE_BYTES,
+			);
+			if (!parentSource) continue;
+			const parentDocument = parse(parentSource);
+			const workspace = isRecord(parentDocument.workspace) ? parentDocument.workspace : undefined;
+			const workspacePackage = isRecord(workspace?.package) ? workspace.package : undefined;
+			const version = safeVersion(workspacePackage?.version);
+			if (version) return { version, source: "Cargo.toml workspace" };
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function readPyproject(context: CollectorContext): Promise<PackageVersion | undefined> {
+	const source = await context.fs.readFile(
+		join(context.input.cwd, "pyproject.toml"),
+		MAX_METADATA_FILE_BYTES,
+	);
+	if (!source) return undefined;
+	try {
+		const document = parse(source);
+		const project = isRecord(document.project) ? document.project : undefined;
+		if (Array.isArray(project?.dynamic) && project.dynamic.includes("version")) return undefined;
+		const pepVersion = safeVersion(project?.version);
+		if (pepVersion) return { version: pepVersion, source: "pyproject.toml (PEP 621)" };
+		const tool = isRecord(document.tool) ? document.tool : undefined;
+		const poetry = isRecord(tool?.poetry) ? tool.poetry : undefined;
+		const poetryVersion = safeVersion(poetry?.version);
+		return poetryVersion
+			? { version: poetryVersion, source: "pyproject.toml (Poetry)" }
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function safeVersion(value: unknown): string | undefined {
+	const version = safeMetadata(value, 80);
+	return version && /^[0-9A-Za-z][0-9A-Za-z.+_-]*$/u.test(version) ? version : undefined;
+}

--- a/extensions/pi-starship/src/runtime/package.ts
+++ b/extensions/pi-starship/src/runtime/package.ts
@@ -57,6 +57,10 @@ async function readCargo(context: CollectorContext): Promise<PackageVersion | un
 		if (direct) return { version: direct, source: "Cargo.toml" };
 		const inherited = isRecord(packageTable?.version) && packageTable.version.workspace === true;
 		if (!inherited) return undefined;
+		const localWorkspaceVersion = workspacePackageVersion(document);
+		if (localWorkspaceVersion) {
+			return { version: localWorkspaceVersion, source: "Cargo.toml workspace" };
+		}
 		for (const parent of parentDirectories(context.input.cwd, 8)) {
 			const parentSource = await context.fs.readFile(
 				join(parent, "Cargo.toml"),
@@ -64,15 +68,19 @@ async function readCargo(context: CollectorContext): Promise<PackageVersion | un
 			);
 			if (!parentSource) continue;
 			const parentDocument = parse(parentSource);
-			const workspace = isRecord(parentDocument.workspace) ? parentDocument.workspace : undefined;
-			const workspacePackage = isRecord(workspace?.package) ? workspace.package : undefined;
-			const version = safeVersion(workspacePackage?.version);
+			const version = workspacePackageVersion(parentDocument);
 			if (version) return { version, source: "Cargo.toml workspace" };
 		}
 		return undefined;
 	} catch {
 		return undefined;
 	}
+}
+
+function workspacePackageVersion(document: Record<string, unknown>): string | undefined {
+	const workspace = isRecord(document.workspace) ? document.workspace : undefined;
+	const workspacePackage = isRecord(workspace?.package) ? workspace.package : undefined;
+	return safeVersion(workspacePackage?.version);
 }
 
 async function readPyproject(context: CollectorContext): Promise<PackageVersion | undefined> {

--- a/extensions/pi-starship/src/runtime/refresh-controller.ts
+++ b/extensions/pi-starship/src/runtime/refresh-controller.ts
@@ -1,0 +1,85 @@
+export interface AsyncRefreshControllerOptions<Input, Snapshot> {
+	read(input: Input): Promise<Snapshot>;
+	equal(left: Snapshot | undefined, right: Snapshot): boolean;
+	publish(snapshot: Snapshot): void;
+	onError?(error: unknown): void;
+}
+
+interface RefreshRequest<Input> {
+	generation: number;
+	requestId: number;
+	input: Input;
+}
+
+/** Coalesces refreshes to one active read plus the latest pending request. */
+export class AsyncRefreshController<Input, Snapshot> {
+	private generation: number | undefined;
+	private requestId = 0;
+	private inFlight = false;
+	private pending: RefreshRequest<Input> | undefined;
+	private current: Snapshot | undefined;
+
+	constructor(private readonly options: AsyncRefreshControllerOptions<Input, Snapshot>) {}
+
+	start(generation: number): void {
+		this.generation = generation;
+		this.requestId += 1;
+		this.pending = undefined;
+		this.current = undefined;
+	}
+
+	clear(): void {
+		this.current = undefined;
+	}
+
+	request(input: Input): void {
+		if (this.generation === undefined) return;
+		const request = {
+			generation: this.generation,
+			requestId: ++this.requestId,
+			input,
+		};
+		if (this.inFlight) {
+			this.pending = request;
+			return;
+		}
+		this.run(request);
+	}
+
+	stop(): void {
+		this.generation = undefined;
+		this.requestId += 1;
+		this.pending = undefined;
+		this.current = undefined;
+	}
+
+	private run(request: RefreshRequest<Input>): void {
+		if (!this.isCurrentTarget(request)) return;
+		this.inFlight = true;
+		void this.options
+			.read(request.input)
+			.then((snapshot) => {
+				if (!this.isCurrentRequest(request)) return;
+				if (this.options.equal(this.current, snapshot)) return;
+				this.current = snapshot;
+				this.options.publish(snapshot);
+			})
+			.catch((error: unknown) => {
+				if (this.isCurrentRequest(request)) this.options.onError?.(error);
+			})
+			.finally(() => {
+				this.inFlight = false;
+				const pending = this.pending;
+				this.pending = undefined;
+				if (pending) this.run(pending);
+			});
+	}
+
+	private isCurrentTarget(request: RefreshRequest<Input>): boolean {
+		return this.generation !== undefined && request.generation === this.generation;
+	}
+
+	private isCurrentRequest(request: RefreshRequest<Input>): boolean {
+		return this.isCurrentTarget(request) && request.requestId === this.requestId;
+	}
+}

--- a/extensions/pi-starship/src/runtime/types.ts
+++ b/extensions/pi-starship/src/runtime/types.ts
@@ -1,0 +1,54 @@
+import type { StarshipConfig } from "../config.js";
+import type { ModuleName } from "../modules/catalog.js";
+import type { WorkspaceSnapshot } from "../modules/types.js";
+
+export interface WorkspaceExecResult {
+	stdout: string;
+	stderr: string;
+	code: number;
+	killed: boolean;
+}
+
+export type WorkspaceExec = (
+	command: string,
+	args: string[],
+	options: { cwd: string; timeout: number },
+) => Promise<WorkspaceExecResult>;
+
+export interface WorkspaceEntry {
+	name: string;
+	isFile: boolean;
+	isDirectory: boolean;
+}
+
+export interface WorkspaceFileSystem {
+	readFile(path: string, maxBytes: number): Promise<string | undefined>;
+	readDirectory(path: string): Promise<readonly WorkspaceEntry[]>;
+	fileExists(path: string): Promise<boolean>;
+}
+
+export interface WorkspaceRefreshInput {
+	cwd: string;
+	config: StarshipConfig;
+	environment: Readonly<Record<string, string | undefined>>;
+	homeDir: string;
+	platform: NodeJS.Platform;
+	hostname: string;
+	username: string;
+	exec: WorkspaceExec;
+	fileSystem?: Partial<WorkspaceFileSystem>;
+	fileExists?(path: string): Promise<boolean>;
+	reason?: "initial" | "event" | "periodic";
+	previous?: WorkspaceSnapshot;
+}
+
+export interface CollectorContext {
+	input: WorkspaceRefreshInput;
+	fs: WorkspaceFileSystem;
+	requirements: ReadonlyMap<ModuleName, ReadonlySet<string>>;
+	entries(): Promise<readonly WorkspaceEntry[]>;
+	options(name: ModuleName): Readonly<Record<string, unknown>>;
+	needs(name: ModuleName, variable?: string): boolean;
+}
+
+export type MutableModuleSnapshot = Record<string, Record<string, string>>;

--- a/extensions/pi-starship/src/runtime/types.ts
+++ b/extensions/pi-starship/src/runtime/types.ts
@@ -12,7 +12,7 @@ export interface WorkspaceExecResult {
 export type WorkspaceExec = (
 	command: string,
 	args: string[],
-	options: { cwd: string; timeout: number },
+	options: { cwd: string; timeout: number; maxOutputBytes: number },
 ) => Promise<WorkspaceExecResult>;
 
 export interface WorkspaceEntry {

--- a/extensions/pi-starship/src/runtime/types.ts
+++ b/extensions/pi-starship/src/runtime/types.ts
@@ -12,7 +12,12 @@ export interface WorkspaceExecResult {
 export type WorkspaceExec = (
 	command: string,
 	args: string[],
-	options: { cwd: string; timeout: number; maxOutputBytes: number },
+	options: {
+		cwd: string;
+		timeout: number;
+		maxOutputBytes: number;
+		environment: Readonly<Record<string, string | undefined>>;
+	},
 ) => Promise<WorkspaceExecResult>;
 
 export interface WorkspaceEntry {

--- a/extensions/pi-starship/src/runtime/workspace.ts
+++ b/extensions/pi-starship/src/runtime/workspace.ts
@@ -1,0 +1,110 @@
+import type { ModuleName } from "../modules/catalog.js";
+import { reachableModuleRequirements } from "../modules/render.js";
+import type { WorkspaceSnapshot } from "../modules/types.js";
+import { collectCloud } from "./cloud.js";
+import { collectDeployment } from "./deployment.js";
+import { collectDevelopment } from "./development.js";
+import { collectExecution } from "./execution.js";
+import { createFileSystem } from "./helpers.js";
+import { collectLanguages } from "./languages.js";
+import { collectPackage } from "./package.js";
+import type {
+	CollectorContext,
+	MutableModuleSnapshot,
+	WorkspaceEntry,
+	WorkspaceRefreshInput,
+} from "./types.js";
+
+export { parseTerraformVersion } from "./deployment.js";
+export { parseDirenvStatus, parseMiseHealth } from "./development.js";
+export { parseRuntimeVersion } from "./languages.js";
+export type { WorkspaceExec, WorkspaceRefreshInput } from "./types.js";
+
+export async function collectWorkspaceSnapshot(
+	input: WorkspaceRefreshInput,
+): Promise<WorkspaceSnapshot> {
+	const requirements = reachableModuleRequirements(input.config);
+	if (!hasWorkspaceRequirement(requirements)) return freezeSnapshot({});
+	const fs = createFileSystem(input);
+	let listing: Promise<readonly WorkspaceEntry[]> | undefined;
+	const context: CollectorContext = {
+		input,
+		fs,
+		requirements,
+		entries() {
+			listing ??= fs.readDirectory(input.cwd);
+			return listing;
+		},
+		options(name) {
+			return input.config.modules[name].options;
+		},
+		needs(name, variable) {
+			const variables = requirements.get(name);
+			return Boolean(variables && (variable === undefined || variables.has(variable)));
+		},
+	};
+	const modules: MutableModuleSnapshot = {};
+	const packageValues = await collectPackage(context);
+	if (packageValues) modules.package = packageValues;
+	for (const collector of [
+		collectLanguages,
+		collectDevelopment,
+		collectDeployment,
+		collectCloud,
+		collectExecution,
+	]) {
+		mergeModules(modules, await collector(context));
+	}
+	return freezeSnapshot(modules);
+}
+
+export function workspaceSnapshotEqual(
+	left: WorkspaceSnapshot | undefined,
+	right: WorkspaceSnapshot | undefined,
+): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function hasWorkspaceRequirement(
+	requirements: ReadonlyMap<ModuleName, ReadonlySet<string>>,
+): boolean {
+	return [...requirements.keys()].some((name) => !BUILT_IN_ONLY_MODULES.has(name));
+}
+
+const BUILT_IN_ONLY_MODULES = new Set<ModuleName>([
+	"brand",
+	"provider",
+	"model",
+	"thinking",
+	"directory",
+	"git_worktree",
+	"git_branch",
+	"git_commit",
+	"git_state",
+	"git_metrics",
+	"git_status",
+	"activity",
+	"context",
+	"tokens",
+	"cost",
+	"time",
+	"turn",
+	"fill",
+	"extension_status",
+]);
+
+function mergeModules(target: MutableModuleSnapshot, source: MutableModuleSnapshot): void {
+	for (const [name, values] of Object.entries(source)) {
+		Object.defineProperty(target, name, {
+			value: values,
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		});
+	}
+}
+
+function freezeSnapshot(modules: MutableModuleSnapshot): WorkspaceSnapshot {
+	for (const values of Object.values(modules)) Object.freeze(values);
+	return Object.freeze({ modules: Object.freeze(modules) });
+}

--- a/extensions/pi-starship/test/config.test.ts
+++ b/extensions/pi-starship/test/config.test.ts
@@ -82,6 +82,60 @@ test("Git modules use Starship display order", () => {
 	]);
 });
 
+test("first-wave modules are registered in deterministic domain order", () => {
+	for (const name of [
+		"package",
+		"nodejs",
+		"python",
+		"rust",
+		"golang",
+		"bun",
+		"deno",
+		"mise",
+		"direnv",
+		"conda",
+		"pixi",
+		"nix_shell",
+		"guix_shell",
+		"docker_context",
+		"kubernetes",
+		"terraform",
+		"aws",
+		"gcloud",
+		"azure",
+		"openstack",
+		"os",
+		"container",
+		"hostname",
+		"username",
+		"fill",
+	] as const) {
+		assert.ok(MODULE_NAMES.includes(name), name);
+	}
+	assert.ok(MODULE_NAMES.indexOf("package") < MODULE_NAMES.indexOf("nodejs"));
+	assert.ok(MODULE_NAMES.indexOf("openstack") < MODULE_NAMES.indexOf("os"));
+	assert.ok(MODULE_NAMES.indexOf("fill") < MODULE_NAMES.indexOf("extension_status"));
+});
+
+test("catalog-owned module options normalize values and diagnose invalid input", () => {
+	const valid = loadFromText(
+		`format = '$package$hostname'\n\n[package]\nversion_format = 'v$raw'\n\n[nodejs]\ndetect_files = ['package.json']\ndetect_extensions = ['js', 'ts']\n\n[hostname]\nssh_only = false\ntrim_at = '.'\naliases = { workstation = 'dev' }\n`,
+	);
+	assert.equal(valid.config.modules.package.options.version_format, "v$raw");
+	assert.deepEqual(valid.config.modules.nodejs.options.detect_files, ["package.json"]);
+	assert.equal(valid.config.modules.hostname.options.ssh_only, false);
+	assert.deepEqual(valid.config.modules.hostname.options.aliases, { workstation: "dev" });
+	assert.deepEqual(valid.diagnostics, []);
+
+	const invalid = loadFromText(
+		`format = '$package'\n\n[package]\nversion_format = 7\nfuture = true\n\n[nodejs]\ndetect_files = ['ok', 3]\n`,
+	);
+	assert.match(
+		invalid.diagnostics.map((item) => `${item.path}: ${item.message}`).join("\n"),
+		/package\.version_format.*string|package\.future|nodejs\.detect_files/iu,
+	);
+});
+
 test("missing settings are atomically initialized from the readable built-in example", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-config-"));
 	const path = join(root, CONFIG_FILE_NAME);
@@ -326,6 +380,17 @@ test("legacy pi-statusline files and preset environment never affect config", ()
 		rmSync(root, { recursive: true, force: true });
 	}
 });
+
+function loadFromText(raw: string) {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-config-text-"));
+	const path = join(root, CONFIG_FILE_NAME);
+	try {
+		writeFileSync(path, raw);
+		return loadStarshipConfig(path);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
 
 function requireDirectory(path: string): string[] {
 	return readdirSync(path);

--- a/extensions/pi-starship/test/fill.test.ts
+++ b/extensions/pi-starship/test/fill.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { BUILT_IN_CONFIG } from "../src/config.js";
+import { parseFormat } from "../src/format/formatter.js";
+import { renderStatusline, type StarshipRuntimeSnapshot } from "../src/modules/index.js";
+
+function fixture(): StarshipRuntimeSnapshot {
+	return {
+		cwd: "/work",
+		thinkingLevel: "off",
+		turnCount: 0,
+		activeTools: new Map(),
+		isStreaming: false,
+		tokenTotals: { input: 0, output: 0, cost: 0 },
+		gitBranch: null,
+		extensionStatuses: new Map(),
+		extensionStatusIconAliases: new Map(),
+		now: new Date(0),
+	};
+}
+
+const FILL = "${" + "fill}";
+
+function fillConfig(format: string, symbol = " ") {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = format;
+	config.formatAst = parseFormat(format);
+	config.modules.fill.symbol = symbol;
+	config.modules.fill.format = "[$symbol]($style)";
+	config.modules.fill.formatAst = parseFormat("[$symbol]($style)");
+	return config;
+}
+
+test("fill aligns each logical line and divides multiple fills left to right", () => {
+	const single = renderStatusline(fillConfig(`left${FILL}right\nshort${FILL}x`), fixture(), 12);
+	assert.equal(stripAnsi(single.ansi), "left   right\nshort      x");
+	assert.deepEqual(stripAnsi(single.ansi).split("\n").map(visibleWidth), [12, 12]);
+
+	const multiple = renderStatusline(fillConfig(`a${FILL}b${FILL}c`), fixture(), 10);
+	assert.equal(stripAnsi(multiple.ansi), "a    b   c");
+	assert.equal(visibleWidth(multiple.ansi), 10);
+});
+
+test("fill repeats complete wide patterns, pads remainders, and terminates on zero width", () => {
+	assert.equal(
+		stripAnsi(renderStatusline(fillConfig(`L${FILL}R`, "界"), fixture(), 9).ansi),
+		"L界界界 R",
+	);
+	assert.equal(
+		stripAnsi(renderStatusline(fillConfig(`L${FILL}R`, "\u0301"), fixture(), 5).ansi),
+		"L   R",
+	);
+	assert.equal(
+		stripAnsi(renderStatusline(fillConfig(`overflow${FILL}x`), fixture(), 3).ansi),
+		"overflowx",
+	);
+	assert.equal(renderStatusline(fillConfig("$fill"), fixture(), 0).ansi, "");
+	assert.equal(stripAnsi(renderStatusline(fillConfig(`L${FILL}`), fixture(), 1).ansi), "L");
+	assert.equal(stripAnsi(renderStatusline(fillConfig(`L${FILL}R`), fixture(), 2).ansi), "LR");
+});
+
+test("fill uses ANSI-aware Unicode and hyperlink width semantics", () => {
+	const link = "\u001b]8;;https://example.test\u0007·\u001b]8;;\u0007";
+	const config = fillConfig(`L${FILL}R`, link);
+	config.modules.fill.style = "bold red";
+	const rendered = renderStatusline(config, fixture(), 8);
+	assert.equal(visibleWidth(rendered.ansi), 8);
+	assert.match(rendered.ansi, /https:\/\/example\.test/u);
+	assert.ok(rendered.ansi.includes(`${String.fromCharCode(27)}[31;1m`));
+});
+
+test("fill markers never escape into public chunks or ANSI", () => {
+	const rendered = renderStatusline(fillConfig("[$fill](red)"), fixture(), 4);
+	assert.equal(visibleWidth(rendered.ansi), 4);
+	assert.ok(rendered.chunks.every((chunk) => typeof chunk.text === "string"));
+	assert.doesNotMatch(rendered.ansi, /fill|marker/iu);
+});
+
+function stripAnsi(value: string): string {
+	return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "gu"), "");
+}

--- a/extensions/pi-starship/test/modules.test.ts
+++ b/extensions/pi-starship/test/modules.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { BUILT_IN_CONFIG } from "../src/config.js";
+import { parseFormat } from "../src/format/formatter.js";
 import {
 	buildExtensionStatusIconAliases,
 	formatCount,
@@ -268,6 +269,55 @@ test("git worktree renders linked worktree values and stays empty for the primar
 		"pi-extensions-feature:/work/pi-extensions-feature",
 	);
 	assert.equal(renderStatusline(config, fixture({ gitWorktree: undefined })).ansi, "");
+});
+
+test("first-wave workspace modules render documented snapshot variables", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	const names = [
+		"package",
+		"nodejs",
+		"python",
+		"rust",
+		"golang",
+		"bun",
+		"deno",
+		"mise",
+		"direnv",
+		"conda",
+		"pixi",
+		"nix_shell",
+		"guix_shell",
+		"docker_context",
+		"kubernetes",
+		"terraform",
+		"aws",
+		"gcloud",
+		"azure",
+		"openstack",
+		"os",
+		"container",
+		"hostname",
+		"username",
+	] as const;
+	config.format = names.map((name) => `$${name}`).join("|");
+	config.formatAst = parseFormat(config.format);
+	config.modules.os.disabled = false;
+	for (const name of names) {
+		config.modules[name].format = name === "package" || name === "nodejs" ? "$version" : "$symbol";
+		config.modules[name].formatAst = parseFormat(config.modules[name].format);
+	}
+	const workspace: Record<string, Record<string, string>> = {};
+	for (const [index, name] of names.entries()) {
+		workspace[name] =
+			name === "package" || name === "nodejs" ? { version: `v${index + 1}.0.0` } : {};
+	}
+	const rendered = stripAnsi(
+		renderStatusline(config, fixture({ workspace: { modules: workspace } }), 400).ansi,
+	);
+	assert.match(rendered, /v1\.0\.0/);
+	assert.match(rendered, /v2\.0\.0/);
+	assert.match(rendered, /📦|||||🍞|🦕|mise|direnv|🅒|🧚||🐃||☸|💠|☁|󰠅|⬢|🌐/u);
+	assert.equal(rendered.split("|").length, names.length);
 });
 
 test("activity handles parallel active tools, thinking, completed, and idle", () => {

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -1,0 +1,615 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { normalizeConfig } from "../src/config.js";
+import { AsyncRefreshController } from "../src/runtime/refresh-controller.js";
+import {
+	collectWorkspaceSnapshot,
+	parseRuntimeVersion,
+	type WorkspaceExec,
+} from "../src/runtime/workspace.js";
+
+function config(format: string, document: Record<string, unknown> = {}) {
+	return normalizeConfig({ format, ...document }).config;
+}
+
+const noExec: WorkspaceExec = async () => {
+	throw new Error("unexpected command");
+};
+
+test("package metadata is bounded, deterministic, and opt-in", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-package-"));
+	try {
+		writeFileSync(join(root, "package.json"), JSON.stringify({ name: "demo", version: "1.2.3" }));
+		writeFileSync(join(root, "Cargo.toml"), '[package]\nversion = "9.9.9"\n');
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$package"),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.package, { source: "package.json", version: "v1.2.3" });
+
+		const unreachable = await collectWorkspaceSnapshot({
+			cwd: join(root, "missing"),
+			config: config("$model"),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(unreachable.modules, {});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("package parser supports Cargo inheritance and Python metadata without ancestor recursion", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-package-formats-"));
+	try {
+		const child = join(root, "member");
+		mkdirSync(child);
+		writeFileSync(join(root, "Cargo.toml"), '[workspace.package]\nversion = "2.4.0"\n');
+		writeFileSync(join(child, "Cargo.toml"), "[package]\nversion.workspace = true\n");
+		let snapshot = await collectWorkspaceSnapshot({
+			cwd: child,
+			config: config("$package", { package: { version_format: "release-$raw" } }),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.package, {
+			source: "Cargo.toml workspace",
+			version: "release-2.4.0",
+		});
+
+		rmSync(join(child, "Cargo.toml"));
+		writeFileSync(join(child, "pyproject.toml"), "[project]\nversion = '3.1.0'\n");
+		snapshot = await collectWorkspaceSnapshot({
+			cwd: child,
+			config: config("$package"),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.package, {
+			source: "pyproject.toml (PEP 621)",
+			version: "v3.1.0",
+		});
+		writeFileSync(join(child, "pyproject.toml"), "[tool.poetry]\nversion = '4.0.1'\n");
+		snapshot = await collectWorkspaceSnapshot({
+			cwd: child,
+			config: config("$package"),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.package, {
+			source: "pyproject.toml (Poetry)",
+			version: "v4.0.1",
+		});
+
+		writeFileSync(
+			join(child, "pyproject.toml"),
+			"[project]\ndynamic = ['version']\nversion = 'secret'\n",
+		);
+		snapshot = await collectWorkspaceSnapshot({
+			cwd: child,
+			config: config("$package"),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.equal(snapshot.modules.package, undefined);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("language commands are required by active variables and parsed strictly", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-language-"));
+	try {
+		writeFileSync(join(root, "package.json"), "{}");
+		const calls: Array<[string, string[]]> = [];
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$nodejs", { nodejs: { format: "$symbol $version" } }),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: async (command, args) => {
+				calls.push([command, args]);
+				return { stdout: "v22.1.0\r\n", stderr: "", code: 0, killed: false };
+			},
+		});
+		assert.deepEqual(calls, [["node", ["--version"]]]);
+		assert.equal(snapshot.modules.nodejs?.version, "v22.1.0");
+
+		calls.length = 0;
+		await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$nodejs", { nodejs: { format: "$symbol" } }),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: async (command, args) => {
+				calls.push([command, args]);
+				return { stdout: "v22.1.0", stderr: "", code: 0, killed: false };
+			},
+		});
+		assert.deepEqual(calls, []);
+		assert.equal(parseRuntimeVersion("nodejs", "banner\nv1.0.0"), undefined);
+		assert.equal(parseRuntimeVersion("python", "Python 3.13.1\r\n"), "v3.13.1");
+		assert.equal(parseRuntimeVersion("golang", "go version go1.24.0 linux/amd64\n"), "v1.24.0");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("development, deployment, and cloud readers publish only allowlisted local metadata", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-contexts-"));
+	try {
+		mkdirSync(join(root, ".docker"));
+		mkdirSync(join(root, ".config", "gcloud", "configurations"), { recursive: true });
+		mkdirSync(join(root, ".aws"));
+		writeFileSync(
+			join(root, ".docker", "config.json"),
+			JSON.stringify({ currentContext: "prod", auths: { registry: { auth: "SECRET" } } }),
+		);
+		writeFileSync(
+			join(root, ".aws", "config"),
+			"[profile work]\nregion = eu-west-1\naws_secret_access_key = SENTINEL_SECRET\n",
+		);
+		writeFileSync(join(root, ".config", "gcloud", "active_config"), "default\n");
+		writeFileSync(
+			join(root, ".config", "gcloud", "configurations", "config_default"),
+			"[core]\naccount = dev@example.test\nproject = project-one\naccess_token = SENTINEL_TOKEN\n",
+		);
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$docker_context$aws$gcloud"),
+			environment: { AWS_PROFILE: "work" },
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.docker_context, { context: "prod" });
+		assert.deepEqual(snapshot.modules.aws, { profile: "work", region: "eu-west-1" });
+		assert.deepEqual(snapshot.modules.gcloud, {
+			account: "dev@example.test",
+			active: "default",
+			domain: "example.test",
+			project: "project-one",
+		});
+		assert.doesNotMatch(JSON.stringify(snapshot), /SECRET|TOKEN|auth/iu);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("execution context rules are fixture-driven and sanitize terminal metadata", async () => {
+	const snapshot = await collectWorkspaceSnapshot({
+		cwd: "/workspace",
+		config: config("$os$container$hostname$username", {
+			os: { disabled: false },
+			hostname: { aliases: { "build.example": "builder" } },
+		}),
+		environment: {
+			SSH_CONNECTION: "local remote",
+			REMOTE_CONTAINERS: "true",
+			WSL_DISTRO_NAME: "Ubuntu\u001b]8;;bad\u0007\ud800",
+		},
+		homeDir: "/home/user",
+		platform: "linux",
+		hostname: "build.example",
+		username: "root",
+		exec: noExec,
+		fileExists: async () => false,
+	});
+	assert.equal(snapshot.modules.hostname?.hostname, "builder");
+	assert.equal(snapshot.modules.username?.user, "root");
+	assert.equal(snapshot.modules.container?.name, "Dev Container");
+	assert.equal(JSON.stringify(snapshot).includes(String.fromCharCode(27)), false);
+	assert.equal(JSON.stringify(snapshot).includes(String.fromCharCode(7)), false);
+	assert.equal(JSON.stringify(snapshot).includes("\\ud800"), false);
+});
+
+test("execution fixtures cover macOS, Windows, WSL, Docker, Podman, and contextual users", async () => {
+	const run = async (
+		platform: NodeJS.Platform,
+		environment: Record<string, string | undefined>,
+		username: string,
+		markers: ReadonlySet<string> = new Set(),
+	) =>
+		collectWorkspaceSnapshot({
+			cwd: "/workspace",
+			config: config("$os$container$hostname$username", {
+				os: { disabled: false },
+				hostname: { ssh_only: false },
+			}),
+			environment,
+			homeDir: "/home/user",
+			platform,
+			hostname: "fixture.example",
+			username,
+			exec: noExec,
+			fileExists: async (path) => markers.has(path),
+			fileSystem: {
+				readFile: async (path) =>
+					path === "/run/systemd/container" && markers.has(path) ? "systemd-nspawn" : undefined,
+			},
+		});
+	const mac = await run("darwin", {}, "developer");
+	assert.equal(mac.modules.os?.type, "macos");
+	assert.equal(mac.modules.hostname?.hostname, "fixture");
+	assert.equal(mac.modules.username, undefined);
+	const windows = await run("win32", {}, "Administrator");
+	assert.equal(windows.modules.os?.type, "windows");
+	assert.equal(windows.modules.username?.user, "Administrator");
+	const wsl = await run("linux", { WSL_DISTRO_NAME: "Ubuntu" }, "developer");
+	assert.equal(wsl.modules.os?.type, "wsl");
+	assert.equal(wsl.modules.container?.type, "wsl");
+	const docker = await run("linux", {}, "developer", new Set(["/.dockerenv"]));
+	assert.equal(docker.modules.container?.type, "docker");
+	const podman = await run("linux", {}, "developer", new Set(["/run/.containerenv"]));
+	assert.equal(podman.modules.container?.type, "podman");
+	const systemd = await run("linux", {}, "developer", new Set(["/run/systemd/container"]));
+	assert.equal(systemd.modules.container?.name, "systemd-nspawn");
+});
+
+test("all language collectors use bounded exact commands and degrade independently", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-languages-all-"));
+	try {
+		for (const [name, content] of [
+			["pyproject.toml", "[project]\nname = 'x'\n"],
+			["Cargo.toml", "[package]\nname = 'x'\n"],
+			["go.mod", "module example.test/x\n"],
+			["bun.lock", ""],
+			["deno.json", "{}"],
+		] as const)
+			writeFileSync(join(root, name), content);
+		const outputs: Record<string, string> = {
+			python: "Python 3.12.2",
+			go: "go version go1.23.4 linux/amd64",
+			bun: "1.2.3",
+			deno: "deno 2.1.4",
+		};
+		const calls: string[] = [];
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$python$rust$golang$bun$deno", {
+				python: { format: "$version" },
+				rust: { format: "$version" },
+				golang: { format: "$version" },
+				bun: { format: "$version" },
+				deno: { format: "$version" },
+			}),
+			environment: { PATH: "" },
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: async (command, args, options) => {
+				calls.push(`${command} ${args.join(" ")} ${options.timeout}`);
+				if (command === "python")
+					return { stdout: outputs.python ?? "", stderr: "", code: 0, killed: false };
+				if (command === "go")
+					return { stdout: outputs.go ?? "", stderr: "", code: 0, killed: false };
+				if (command === "bun")
+					return { stdout: outputs.bun ?? "", stderr: "", code: 0, killed: false };
+				return { stdout: outputs.deno ?? "", stderr: "", code: 0, killed: false };
+			},
+		});
+		assert.deepEqual(calls, [
+			"python --version 2000",
+			"go version 2000",
+			"bun --version 2000",
+			"deno -V 2000",
+		]);
+		assert.equal(snapshot.modules.python?.version, "v3.12.2");
+		assert.equal(snapshot.modules.rust?.version, undefined);
+		assert.equal(snapshot.modules.golang?.version, "v1.23.4");
+		assert.equal(snapshot.modules.bun?.version, "v1.2.3");
+		assert.equal(snapshot.modules.deno?.version, "v2.1.4");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("development environment modules use allowlisted activation data and lazy commands", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-development-"));
+	try {
+		writeFileSync(join(root, "mise.toml"), "");
+		writeFileSync(join(root, ".envrc"), "export SECRET=never-read\n");
+		writeFileSync(join(root, "pixi.toml"), "[workspace]\nname = 'demo'\n");
+		const calls: string[] = [];
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$mise$direnv$conda$pixi$nix_shell$guix_shell", {
+				mise: { format: "$health" },
+				direnv: { format: "$rc_path$allowed$loaded" },
+				pixi: { format: "$version$environment$project_name", show_default_environment: true },
+			}),
+			environment: {
+				CONDA_DEFAULT_ENV: "/envs/work",
+				PIXI_ENVIRONMENT_NAME: "default",
+				IN_NIX_SHELL: "pure",
+				NIX_SHELL_NAME: "dev",
+				NIX_SHELL_LEVEL: "2",
+				GUIX_ENVIRONMENT: "/gnu/store/profile",
+				UNRELATED_SECRET: "SENTINEL_SECRET",
+			},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: async (command, args) => {
+				calls.push(`${command} ${args.join(" ")}`);
+				if (command === "mise")
+					return { stdout: "all checks passed", stderr: "", code: 0, killed: false };
+				if (command === "direnv")
+					return {
+						stdout: JSON.stringify({
+							foundRC: { path: join(root, ".envrc"), allowed: 1 },
+							loadedRC: { path: join(root, ".envrc") },
+						}),
+						stderr: "",
+						code: 0,
+						killed: false,
+					};
+				return { stdout: "pixi 0.41.0", stderr: "", code: 0, killed: false };
+			},
+		});
+		assert.deepEqual(calls, ["mise doctor", "direnv status --json", "pixi --version"]);
+		assert.deepEqual(snapshot.modules.mise, { health: "healthy" });
+		assert.equal(snapshot.modules.direnv?.allowed, "allowed");
+		assert.deepEqual(snapshot.modules.conda, { environment: "work" });
+		assert.deepEqual(snapshot.modules.pixi, {
+			environment: "default",
+			project_name: "demo",
+			version: "v0.41.0",
+		});
+		assert.deepEqual(snapshot.modules.nix_shell, { level: "2", name: "dev", state: "pure" });
+		assert.deepEqual(snapshot.modules.guix_shell, { state: "active" });
+		assert.doesNotMatch(JSON.stringify(snapshot), /SENTINEL|UNRELATED/iu);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Docker only_with_files suppresses unrelated workspaces", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-docker-detect-"));
+	try {
+		mkdirSync(join(root, ".docker"));
+		writeFileSync(join(root, ".docker", "config.json"), JSON.stringify({ currentContext: "prod" }));
+		const input = {
+			cwd: root,
+			config: config("$docker_context", { docker_context: { only_with_files: true } }),
+			environment: { DOCKER_CONFIG: join(root, ".docker") },
+			homeDir: root,
+			platform: "linux" as const,
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		};
+		assert.equal((await collectWorkspaceSnapshot(input)).modules.docker_context, undefined);
+		writeFileSync(join(root, "Dockerfile"), "FROM scratch\n");
+		assert.deepEqual((await collectWorkspaceSnapshot(input)).modules.docker_context, {
+			context: "prod",
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("kubeconfig and Terraform readers remain local, bounded, and command-lazy", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-deployment-"));
+	try {
+		mkdirSync(join(root, ".kube"));
+		mkdirSync(join(root, ".terraform"));
+		writeFileSync(join(root, "main.tf"), "terraform {}\n");
+		writeFileSync(join(root, ".terraform", "environment"), "production\n");
+		writeFileSync(
+			join(root, ".kube", "config"),
+			`apiVersion: v1\ncurrent-context: prod\ncontexts:\n  - name: prod\n    context:\n      cluster: cluster-a\n      user: deployer\n      namespace: payments\nclusters:\n  - name: cluster-a\n    cluster:\n      server: https://never-contact.invalid\nusers:\n  - name: deployer\n    user:\n      token: SENTINEL_TOKEN\n`,
+		);
+		const calls: string[] = [];
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$kubernetes$terraform", {
+				kubernetes: { context_aliases: { prod: "production" } },
+				terraform: { format: "$workspace" },
+			}),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: async (command, args) => {
+				calls.push(`${command} ${args.join(" ")}`);
+				return { stdout: "", stderr: "", code: 1, killed: false };
+			},
+		});
+		assert.deepEqual(snapshot.modules.kubernetes, {
+			cluster: "cluster-a",
+			context: "production",
+			namespace: "payments",
+			user: "deployer",
+		});
+		assert.deepEqual(snapshot.modules.terraform, { workspace: "production" });
+		assert.deepEqual(calls, []);
+		assert.doesNotMatch(JSON.stringify(snapshot), /TOKEN|server|never-contact/iu);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Azure and OpenStack readers select metadata while discarding adjacent secrets", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-cloud-all-"));
+	try {
+		mkdirSync(join(root, ".azure"));
+		mkdirSync(join(root, ".config", "openstack"), { recursive: true });
+		writeFileSync(
+			join(root, ".azure", "azureProfile.json"),
+			`\uFEFF${JSON.stringify({ subscriptions: [{ isDefault: true, name: "Production", user: { name: "operator@example.test" }, accessToken: "SENTINEL_TOKEN" }] })}`,
+		);
+		writeFileSync(
+			join(root, ".config", "openstack", "clouds.yaml"),
+			`clouds:\n  work:\n    auth:\n      project_name: project-a\n      password: SENTINEL_PASSWORD\n      auth_url: https://secret.invalid\n`,
+		);
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$azure$openstack", {
+				azure: { show_username: true, subscription_aliases: { Production: "prod" } },
+				openstack: { project_aliases: { "project-a": "project" } },
+			}),
+			environment: { OS_CLOUD: "work" },
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.azure, {
+			subscription: "prod",
+			username: "operator@example.test",
+		});
+		assert.deepEqual(snapshot.modules.openstack, { cloud: "work", project: "project" });
+		assert.doesNotMatch(
+			JSON.stringify(snapshot),
+			/SENTINEL|PASSWORD|TOKEN|auth_url|secret\.invalid/iu,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("ordinary local identity stays hidden and periodic refresh retains execution metadata", async () => {
+	const base = {
+		cwd: "/workspace",
+		config: config("$container$hostname$username"),
+		environment: {},
+		homeDir: "/home/user",
+		platform: "linux" as const,
+		hostname: "local.example",
+		username: "developer",
+		exec: noExec,
+		fileExists: async () => false,
+		fileSystem: { readFile: async () => undefined },
+	};
+	const initial = await collectWorkspaceSnapshot(base);
+	assert.deepEqual(initial.modules, {});
+	const contextual = await collectWorkspaceSnapshot({
+		...base,
+		environment: { SSH_CONNECTION: "remote" },
+	});
+	assert.equal(contextual.modules.hostname?.hostname, "local");
+	assert.equal(contextual.modules.username?.user, "developer");
+	const periodic = await collectWorkspaceSnapshot({
+		...base,
+		reason: "periodic",
+		previous: contextual,
+	});
+	assert.deepEqual(periodic.modules, contextual.modules);
+});
+
+test("gcloud selector cannot escape its configuration directory", async () => {
+	const reads: string[] = [];
+	const snapshot = await collectWorkspaceSnapshot({
+		cwd: "/workspace",
+		config: config("$gcloud"),
+		environment: { CLOUDSDK_ACTIVE_CONFIG_NAME: "../../escape" },
+		homeDir: "/home/user",
+		platform: "linux",
+		hostname: "host",
+		username: "user",
+		exec: noExec,
+		fileSystem: {
+			readFile: async (path) => {
+				reads.push(path);
+				return "[core]\nproject = should-not-load\n";
+			},
+		},
+	});
+	assert.equal(snapshot.modules.gcloud, undefined);
+	assert.deepEqual(reads, []);
+});
+
+test("oversized and malformed metadata files fail empty without leaking source text", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-bounds-"));
+	try {
+		writeFileSync(join(root, "package.json"), `{"version":"${"x".repeat(70_000)}"}`);
+		mkdirSync(join(root, ".aws"));
+		writeFileSync(
+			join(root, ".aws", "config"),
+			"[profile broken\naws_secret_access_key=SENTINEL_SECRET\n",
+		);
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$package$aws"),
+			environment: { AWS_PROFILE: "broken" },
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.equal(snapshot.modules.package, undefined);
+		assert.deepEqual(snapshot.modules.aws, { profile: "broken" });
+		assert.doesNotMatch(JSON.stringify(snapshot), /SENTINEL|SECRET/iu);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("refresh controller coalesces, suppresses equality, and rejects stale generations", async () => {
+	const pending: Array<(value: string) => void> = [];
+	const published: string[] = [];
+	const controller = new AsyncRefreshController<string, string>({
+		read: (_input) => new Promise((resolve) => pending.push(resolve)),
+		equal: (left, right) => left === right,
+		publish: (value) => published.push(value),
+	});
+	controller.start(1);
+	controller.request("old");
+	controller.request("coalesced");
+	controller.start(2);
+	controller.request("new");
+	pending.shift()?.("stale");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(pending.length, 1);
+	pending.shift()?.("fresh");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(published, ["fresh"]);
+	controller.request("same");
+	pending.shift()?.("fresh");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(published, ["fresh"]);
+	controller.stop();
+});

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { normalizeConfig } from "../src/config.js";
+import { execWorkspaceCommand } from "../src/runtime/command.js";
 import { AsyncRefreshController } from "../src/runtime/refresh-controller.js";
 import {
 	collectWorkspaceSnapshot,
@@ -18,6 +19,21 @@ function config(format: string, document: Record<string, unknown> = {}) {
 const noExec: WorkspaceExec = async () => {
 	throw new Error("unexpected command");
 };
+
+test("workspace commands stream output and terminate at the byte limit", async () => {
+	const started = Date.now();
+	const result = await execWorkspaceCommand(
+		process.execPath,
+		[
+			"-e",
+			"process.stdout.write(Buffer.alloc(2 * 1024 * 1024, 120)); setInterval(() => {}, 10_000);",
+		],
+		{ cwd: process.cwd(), timeout: 2_000, maxOutputBytes: 1_024 },
+	);
+	assert.equal(result.killed, true);
+	assert.ok(Buffer.byteLength(result.stdout) + Buffer.byteLength(result.stderr) <= 1_024);
+	assert.ok(Date.now() - started < 1_500);
+});
 
 test("package metadata is bounded, deterministic, and opt-in", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-package-"));
@@ -316,7 +332,7 @@ test("all language collectors use bounded exact commands and degrade independent
 			hostname: "host",
 			username: "user",
 			exec: async (command, args, options) => {
-				calls.push(`${command} ${args.join(" ")} ${options.timeout}`);
+				calls.push(`${command} ${args.join(" ")} ${options.timeout}/${options.maxOutputBytes}`);
 				if (command === "python")
 					return { stdout: outputs.python ?? "", stderr: "", code: 0, killed: false };
 				if (command === "go")
@@ -327,10 +343,10 @@ test("all language collectors use bounded exact commands and degrade independent
 			},
 		});
 		assert.deepEqual(calls, [
-			"python --version 2000",
-			"go version 2000",
-			"bun --version 2000",
-			"deno -V 2000",
+			"python --version 2000/65536",
+			"go version 2000/65536",
+			"bun --version 2000/65536",
+			"deno -V 2000/65536",
 		]);
 		assert.equal(snapshot.modules.python?.version, "v3.12.2");
 		assert.equal(snapshot.modules.rust?.version, undefined);
@@ -468,6 +484,30 @@ test("kubeconfig and Terraform readers remain local, bounded, and command-lazy",
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test("Terraform applies version_format to Terraform and OpenTofu versions", async () => {
+	const calls: string[] = [];
+	const snapshot = await collectWorkspaceSnapshot({
+		cwd: "/workspace",
+		config: config("$terraform", {
+			terraform: { format: "$version", version_format: "release-$raw" },
+		}),
+		environment: {},
+		homeDir: "/home/user",
+		platform: "linux",
+		hostname: "host",
+		username: "user",
+		fileSystem: {
+			readDirectory: async () => [{ name: "main.tf", isFile: true, isDirectory: false }],
+		},
+		exec: async (command, args) => {
+			calls.push(`${command} ${args.join(" ")}`);
+			return { stdout: "Terraform v1.12.2\n", stderr: "", code: 0, killed: false };
+		},
+	});
+	assert.deepEqual(calls, ["terraform version"]);
+	assert.equal(snapshot.modules.terraform?.version, "release-1.12.2");
 });
 
 test("Azure and OpenStack readers select metadata while discarding adjacent secrets", async () => {

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -28,11 +28,36 @@ test("workspace commands stream output and terminate at the byte limit", async (
 			"-e",
 			"process.stdout.write(Buffer.alloc(2 * 1024 * 1024, 120)); setInterval(() => {}, 10_000);",
 		],
-		{ cwd: process.cwd(), timeout: 2_000, maxOutputBytes: 1_024 },
+		{ cwd: process.cwd(), timeout: 2_000, maxOutputBytes: 1_024, environment: {} },
 	);
 	assert.equal(result.killed, true);
 	assert.ok(Buffer.byteLength(result.stdout) + Buffer.byteLength(result.stderr) <= 1_024);
 	assert.ok(Date.now() - started < 1_500);
+});
+
+test("workspace commands receive only the explicit allowlisted environment", async () => {
+	const secretName = `PI_STARSHIP_SENTINEL_${process.pid}`;
+	process.env[secretName] = "secret";
+	try {
+		const result = await execWorkspaceCommand(
+			process.execPath,
+			[
+				"-e",
+				`process.stdout.write((process.env.ALLOWED ?? "") + "|" + (process.env[${JSON.stringify(secretName)}] ?? ""));`,
+			],
+			{
+				cwd: process.cwd(),
+				timeout: 2_000,
+				maxOutputBytes: 1_024,
+				environment: { ALLOWED: "visible", OMITTED: undefined },
+			},
+		);
+		assert.equal(result.killed, false);
+		assert.equal(result.code, 0);
+		assert.equal(result.stdout, "visible|");
+	} finally {
+		delete process.env[secretName];
+	}
 });
 
 test("package metadata is bounded, deterministic, and opt-in", async () => {
@@ -71,11 +96,30 @@ test("package metadata is bounded, deterministic, and opt-in", async () => {
 test("package parser supports Cargo inheritance and Python metadata without ancestor recursion", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-package-formats-"));
 	try {
+		writeFileSync(
+			join(root, "Cargo.toml"),
+			'[package]\nversion.workspace = true\n[workspace.package]\nversion = "1.8.0"\n',
+		);
+		let snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$package"),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			exec: noExec,
+		});
+		assert.deepEqual(snapshot.modules.package, {
+			source: "Cargo.toml workspace",
+			version: "v1.8.0",
+		});
+
 		const child = join(root, "member");
 		mkdirSync(child);
 		writeFileSync(join(root, "Cargo.toml"), '[workspace.package]\nversion = "2.4.0"\n');
 		writeFileSync(join(child, "Cargo.toml"), "[package]\nversion.workspace = true\n");
-		let snapshot = await collectWorkspaceSnapshot({
+		snapshot = await collectWorkspaceSnapshot({
 			cwd: child,
 			config: config("$package", { package: { version_format: "release-$raw" } }),
 			environment: {},
@@ -181,6 +225,33 @@ test("language commands are required by active variables and parsed strictly", a
 		assert.equal(parseRuntimeVersion("nodejs", "banner\nv1.0.0"), undefined);
 		assert.equal(parseRuntimeVersion("python", "Python 3.13.1\r\n"), "v3.13.1");
 		assert.equal(parseRuntimeVersion("golang", "go version go1.24.0 linux/amd64\n"), "v1.24.0");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Rust numver runs the version probe without requiring version", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-rust-numver-"));
+	try {
+		writeFileSync(join(root, "Cargo.toml"), '[package]\nname = "demo"\n');
+		const calls: string[] = [];
+		const compiler = join(root, "toolchain", "rustc");
+		const snapshot = await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$rust", { rust: { format: "$numver" } }),
+			environment: { RUSTC: compiler },
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			fileExists: async (path) => path === compiler,
+			exec: async (command, args) => {
+				calls.push(`${command} ${args.join(" ")}`);
+				return { stdout: "rustc 1.88.0 (abc 2025-06-23)", stderr: "", code: 0, killed: false };
+			},
+		});
+		assert.deepEqual(calls, [`${compiler} --version`]);
+		assert.deepEqual(snapshot.modules.rust, { numver: "1.88.0" });
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4578,7 +4578,8 @@
 			"version": "0.28.0",
 			"license": "MIT",
 			"dependencies": {
-				"smol-toml": "^1.7.0"
+				"smol-toml": "^1.7.0",
+				"yaml": "^2.9.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.3",
@@ -11820,7 +11821,6 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"


### PR DESCRIPTION
## Summary

- add 25 opt-in Starship-inspired modules for package metadata, language runtimes, development environments, deployment/cloud contexts, execution context, and width-aware fill
- collect bounded local workspace snapshots asynchronously with shared coalescing, stale-generation guards, lazy command requirements, and failure-to-empty behavior
- add catalog-owned typed options, privacy/source-precedence documentation, deterministic fixtures, and a Pi-native context design that keeps existing modules canonical

## Safety and compatibility

- keep footer rendering synchronous and free of subprocess, network, and filesystem work
- keep the built-in root format unchanged; new modules render only when explicitly referenced or through `$all`
- allowlist environment and file metadata, discard cloud/deployment credential fields, and bound command time/output
- leave ambiguous Pi-native lifecycle modules unimplemented pending explicit API approval

## Verification

- `npm run check` — 1,236 tests passed with Biome, boundary checks, and workspace typechecks
- `npm run pack:starship` — 53 intended package files
- `pi -e ./extensions/pi-starship --list-models`
