### PR TITLE
feat(lsp): add evidence-backed diagnostics profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,5 +204,6 @@ vite.config.ts.timestamp-*
 src/
 src.zip
 third_party/
+extensions/pi-lsp/test/docker/results/raw/
 extensions/archived/
 worktrees/

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -32,6 +32,7 @@
 - Symptom: concurrent tools sharing one extension status key can clear or mislabel a still-running sibling. Cause: each call unconditionally owns set/clear. Fix: track active statuses per UI/session, restore the latest remaining status, and invalidate the tracker on session teardown.
 - Run Biome `--write` only on intended files during bounded work; formatting whole extension trees can rewrite unrelated source that is currently outside the root's normal ignore-aware formatting path.
 - Root Biome checks reject nested Git worktrees that contain another root `biome.json`; create worktrees outside the repository or locally ignore their parent directory during verification.
+- Biome's root `vcs.useIgnoreFile` does not honor a nested `.gitignore` for generated JSON; add generated paths to the repository-root `.gitignore` or Biome may parse them as configuration files.
 - Headless Pi runners can share a no-op UI object; key session-owned resources such as temporary output files by `sessionManager`, not `ctx.ui`.
 - Codex usage can be queried without Codex CLI by sending Pi's `openai-codex` bearer token to `https://chatgpt.com/backend-api/wham/usage`; response uses Codex `RateLimitStatusPayload` snake_case fields.
 - `pi-codex-usage` statusline must select a rate-limit bucket by current model id/name; `gpt-5.3-codex-spark` can use its own returned bucket instead of primary `codex`.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -23,6 +23,7 @@
 - pi-lsp catalog entries must target actual standalone launchers, handle platform wrappers, and include initialization needed by a stateless client; do not infer server readiness from a toolchain executable or route ambiguous/partially supported dialects.
 - On Windows, extensionless LSP commands can resolve to `.cmd`/`.bat` PATH shims; resolve with the adapter's effective `PATH` and child cwd before wrapping batch launchers through `%ComSpec%`.
 - pi-lsp defaults must use dialect-specific language IDs, nest workspace settings under the server-requested section, and avoid save-only settings unless diagnostics emit `didSave`.
+- Keep pi-lsp Docker profiles synchronized with production initialization as well as diagnostics policy; compare their commands against Linux launchers rather than host-evaluated platform wrappers.
 - pi-statusline owns footer rendering and its `/statusline` settings command; keep it out of prompt interception.
 - Symptom: an idle optional statusline segment leaves a blank multiline row. Cause: filtering the segment while preserving both adjacent `line_break` entries. Fix: group configured rows first, drop only dynamically empty rows, then flatten while preserving explicitly empty rows.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.

--- a/docs/plans/archived/2026-07-24_pi-lsp-server-profiles-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-lsp-server-profiles-plan.md
@@ -1,0 +1,98 @@
+# pi-lsp per-server diagnostics profiles plan
+
+## Goal
+
+Empirically test every built-in pi-lsp server through Pi inside Docker, then give each server an explicit, evidence-based diagnostics profile so cold-start diagnostics do not disappear behind premature empty results without imposing unnecessary delays on unrelated servers.
+
+## Context
+
+pi-lsp currently starts a fresh language-server process for each tool call. The built-in catalog contains 28 servers with different pull, push, startup, project-loading, and publication behavior. PR #367 added a generic late-push grace mechanism and enabled it for rust-analyzer after a real reproduction; this follow-up validates the entire catalog instead of extrapolating one server's behavior.
+
+## Architecture
+
+- Keep production behavior data-driven in the built-in adapter catalog; do not add server-name conditionals to `LspClient`.
+- Run the real Pi SDK with the local pi-lsp entrypoint and invoke the registered `lsp_diagnostics` tool inside each Docker environment.
+- Put a transparent stdio proxy between pi-lsp and each real language server to record timestamped JSON-RPC capabilities, pulls, responses, refreshes, progress, and push publications without changing production protocol behavior.
+- Give every built-in server a matrix profile containing a pinned test environment, minimal erroneous fixture, clean control, expected diagnostic, and explicit production diagnostics policy. An explicit default policy is valid when measurements show no special settling is needed.
+
+## Assumptions
+
+- Docker Desktop remains available with Linux-container and outbound network access.
+- The matrix targets one representative current Linux release of each server. Platform-only differences are documented and not inferred from an untested platform.
+- Per-server customization means evidence-backed policy, initialization, or an explicit no-special-wait profile—not arbitrary delays for every server.
+
+## Risks
+
+- Some language servers or toolchains are large, platform-constrained, renamed, unredistributable, or unavailable from a reproducible Linux package source. Keep these rows open until a real runnable image exists; do not mark command discovery as a diagnostics pass.
+- Timing varies by hardware. Use repeated cold starts, protocol events, bounded safety margins, and clean controls rather than setting delays equal to one observed sample.
+- A full matrix is an opt-in smoke suite, not part of the normal repository gate, because it downloads many external toolchains.
+
+## Plan
+
+- [x] Add a Docker smoke harness under `extensions/pi-lsp/test/docker/` that loads local pi-lsp through the Pi SDK, invokes `lsp_diagnostics` without an external model, captures transparent JSON-RPC timing, and emits machine-readable results; verify it against the existing rust-analyzer regression scenario.
+- [x] Add all 28 built-in servers to a validated matrix with pinned installation source/version, startup command, erroneous and clean fixtures, expected diagnostic match, repeats, and platform support; verify matrix names and commands stay synchronized with `DEFAULT_SERVER_CONFIGS`.
+- [x] Run every runnable Linux matrix row repeatedly in Docker, exactly one server per harness invocation, and save a concise evidence report containing server version, advertised diagnostics capability, pull/push/refresh sequence, diagnostic latency, clean latency, and pass/fail reason.
+- [x] Update `extensions/pi-lsp/src/adapters.ts` and the shared diagnostics state machine only where measurements require it, giving every catalog entry an explicit diagnostics profile while keeping pull errors, cancellation, timeouts, clears, and non-empty results correct; prove each new policy with deterministic fixtures before production changes.
+- [x] Update focused tests and `extensions/pi-lsp/README.md` with per-server behavior, configuration semantics, matrix execution instructions, tested versions, and Linux/platform exceptions.
+- [x] Run focused tests, the runnable Docker matrix, `npm run check`, and `just pack-lsp`; record exact evidence and archive this plan after every row reaches its required terminal status.
+
+## Final evidence (2026-07-24)
+
+The matrix was run strictly as 28 separate invocations of `run-matrix.mjs <profile>`. Every invocation used three fresh erroneous projects followed by three fresh clean projects. Timings below come from the final raw JSON results on Docker Desktop Linux x86_64 with Pi 0.82.0. Diagnostic latency is measured from `didOpen` to the first correct non-empty push or pull response; clean time is the full Pi tool lifecycle and therefore also exposes slow server shutdowns.
+
+| Server | Tested version | Protocol | Correct diagnostic latency | Clean lifecycle | Error · clean counts | Explicit policy | Terminal status |
+| --- | --- | --- | ---: | ---: | --- | --- | --- |
+| biome | 2.5.4 | push | 6–20 ms | 1209–1211 ms | 2/2/2 · 0/0/0 | none | `passed-default` |
+| ty | 0.0.61 | pull | 16–35 ms | 96–101 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| ruff | 0.15.22 | pull | 5–21 ms | 83–86 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| rust-analyzer | 2026-06-15 | empty pull → push + refresh | 577–738 ms | 5089–5092 ms | 1/1/1 · 0/0/0 | `pullDiagnosticsGraceMs=5000` | `passed-customized` |
+| gopls | 0.23.0 | push | 57–623 ms | 1979–2031 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| rubocop | 1.80.2 | push | 40–44 ms | 1512–1517 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| elixir-ls | 0.31.1 | push | 128–135 ms | 16305–16963 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| zls | 0.16.0 | push | <1 ms | 899–908 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| csharp | 5.9.0-1.26319.6 | pull | 1332–1421 ms | 3424–3988 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| fsharp | 0.83.0 | push | 1742–1980 ms | 3396–3432 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| sourcekit-lsp | Swift 6.1.3 | push | 1297–1343 ms | 2555–2572 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| clangd | 21.1.8 | push | 10–39 ms | 907–910 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| jdtls | 1.60.0 | push | 1596–2086 ms | 4403–4525 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| kotlin-lsp | 262.8190.0 | pull | 36.4–36.6 s when available | 40.0–40.1 s | 0/1/1 · 0/0/0 | all attempted waits reverted | `unresolved` |
+| yaml-language-server | 1.24.0 | push | 206–207 ms | 1886–1950 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| lua-language-server | 3.18.2-dev | push | 516–615 ms | 3204–3209 ms | 2/2/2 · 0/0/0 | `pushDiagnosticsGraceMs=3000` | `passed-customized` |
+| intelephense | 1.18.2 | repeated push | 18–19 ms | 4726–4783 ms | 2/2/2 · 0/0/0 | `diagnosticsSettleMs=4000` | `passed-customized` |
+| prisma | 31.1.0 | push | 111–137 ms | 1236–1243 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| dart | SDK 3.11.4 | push | 38–309 ms | 2104–2115 ms | 1/1/1 · 0/0/0 | `pushDiagnosticsGraceMs=2000` | `passed-customized` |
+| ocaml-lsp | 1.26.0 | push | 267 ms | 31.2–31.4 s | 1/1/1 · 0/0/0 | none | `passed-default` |
+| bash-language-server | 5.6.0 | push | 518–535 ms | 1545–1580 ms | 4/4/4 · 0/0/0 | none | `passed-default` |
+| terraform-ls | 0.38.7 | empty push → non-empty push | 7–8 ms | 2086–2089 ms | 1/1/1 · 0/0/0 | `pushDiagnosticsGraceMs=2000` | `passed-customized` |
+| texlab | 5.26.0 | push | 303–304 ms | 1185–1189 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| gleam | 1.17.0 | push | 122–137 ms | 2082–2084 ms | 1/1/1 · 0/0/0 | `pushDiagnosticsGraceMs=2000` | `passed-customized` |
+| clojure-lsp | 2026.02.20 | push | 33–35 ms | 983–1004 ms | 3/3/3 · 0/0/0 | none | `passed-default` |
+| nixd | 2.9.1 | push | 2 ms | 911–916 ms | 1/1/1 · 0/0/0 | none | `passed-default` |
+| tinymist | tested pinned Nix build | push | 2–8 ms | 2096–2097 ms | 1/1/1 · 0/0/0 | `pushDiagnosticsGraceMs=2000` | `passed-customized` |
+| haskell-language-server | 2.13.0.0 / GHC 9.10.3 | push | 760–786 ms | 4159–4188 ms | 1/1/1 · 0/0/0 | `pushDiagnosticsGraceMs=3000` | `passed-customized` |
+
+### Decisions and exceptions
+
+- **Result:** 19 `passed-default`, 8 `passed-customized`, 0 `unsupported`, and 1 `unresolved`.
+- Push-only clean files previously had no terminal event and waited for the global timeout. The deterministic silent-push regression was added before the bounded `pushDiagnosticsGraceMs` implementation. Only six measured built-ins enable it; all other servers retain zero added delay.
+- Rust-analyzer keeps its measured empty-pull-to-late-push grace. Intelephense keeps its repeated-publication settle window.
+- A generic pull-repoll experiment and the C# repoll policy were reverted. The corrected C# syntax fixture returned the correct diagnostic on its first pull in all three runs, and the repoll only delayed clean files.
+- Kotlin became runnable only after adding Gradle and the official JetBrains distribution/runtime compatibility setup. With that environment fixed, 15 s, 25 s, and 35 s repoll attempts still missed the first cold erroneous project (respectively 2/3, 2/3, and 2/3 error passes). Later projects benefited from Gradle caches, so increasing a fixed wait would hide a project-readiness problem and penalize every clean call. All production changes were reverted and the row is `unresolved`.
+- SourceKit uses `swift:6.1.3-jammy`; the pinned Nix Swift 5.10 derivation attempted a local build and failed because its Clang rejected `-mtls-dialect=gnu2`.
+- ElixirLS is preinstalled during image construction; otherwise its first tool invocation spends the request timeout compiling the release rather than testing diagnostics. OCaml fixtures prebuild Dune metadata; erroneous compiler output is permitted because the LSP is the component under test.
+- ElixirLS and OCaml return correct diagnostics quickly but have long full lifecycle times, indicating server startup/shutdown overhead rather than a need to delay diagnostics.
+
+### Final verification
+
+- `npm run check` — passed after rebasing onto `origin/main`: Biome, boundary checks, all workspace typechecks, and 1,246 tests.
+- `just pack-lsp` — passed: 13 publishable files; Docker smoke assets and raw evidence are excluded.
+- `git diff --check` — passed.
+- Final `docker ps` — no leftover matrix containers.
+
+## Completion Checklist
+
+- [x] Every built-in server has a synchronized matrix row and an explicit evidence-backed diagnostics profile.
+- [x] Every supported Linux row executes the real Pi + local pi-lsp + real LSP path in Docker against erroneous and clean controls.
+- [x] No server is reported as passing solely because its command starts or because an empty result was returned.
+- [x] Protocol traces demonstrate why each non-default wait, settle, reverted experiment, initialization, or exception exists.
+- [x] Repository checks and package dry run pass, the worktree contains only intended files, and the completed plan is archived.

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -158,6 +158,7 @@ Each server entry supports:
 - `initialization`: LSP initialization options and workspace configuration values.
 - `skipDirectories`: additional directory names to exclude from recursive discovery. Explicitly requested paths remain available.
 - `diagnosticsSettleMs`: positive number of milliseconds without another push-diagnostics publication before using the latest result. Defaults to `800`; the built-in intelephense route uses `4000`. The global timeout remains the upper bound.
+- `pushDiagnosticsGraceMs`: positive number of milliseconds to wait for the first publication from a push-only server. It is unset by default, so a silent push-only server waits for the global timeout. The built-in Lua and Haskell routes use `3000`; Dart, Terraform, Gleam, and Tinymist use `2000`. This lets clean files finish after bounded silence without returning before a late error publication.
 - `pullDiagnosticsGraceMs`: positive number of milliseconds to wait for a newer push publication after a server returns an empty pull-diagnostics result. It is unset by default; the built-in rust-analyzer route uses `5000` because initial workspace analysis can finish after an early empty pull response.
 
 Global options:

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -148,6 +148,8 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		name: "lua-language-server",
 		command: ["lua-language-server"],
 		extensions: [".lua"],
+		// LuaLS does not publish an empty diagnostic set for a clean document.
+		pushDiagnosticsGraceMs: 3_000,
 	},
 	{
 		name: "intelephense",
@@ -167,6 +169,8 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		command: ["dart", "language-server"],
 		extensions: [".dart"],
 		skipDirectories: [".dart_tool", "build"],
+		// The analysis server can remain silent when a document is clean.
+		pushDiagnosticsGraceMs: 2_000,
 	},
 	{
 		name: "ocaml-lsp",
@@ -184,6 +188,7 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		command: ["terraform-ls", "serve"],
 		extensions: [".tf", ".tfvars"],
 		skipDirectories: [".terraform"],
+		pushDiagnosticsGraceMs: 2_000,
 		initialization: {
 			experimentalFeatures: { prefillRequiredFields: true },
 		},
@@ -198,6 +203,7 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		command: ["gleam", "lsp"],
 		extensions: [".gleam"],
 		skipDirectories: ["build"],
+		pushDiagnosticsGraceMs: 2_000,
 	},
 	{
 		name: "clojure-lsp",
@@ -214,12 +220,14 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 		name: "tinymist",
 		command: ["tinymist"],
 		extensions: [".typ", ".typc"],
+		pushDiagnosticsGraceMs: 2_000,
 	},
 	{
 		name: "haskell-language-server",
 		command: ["haskell-language-server-wrapper", "--lsp"],
 		extensions: [".hs", ".lhs"],
 		skipDirectories: [".stack-work", "dist-newstyle"],
+		pushDiagnosticsGraceMs: 3_000,
 	},
 ];
 
@@ -425,6 +433,7 @@ function normalizeServer(name: string, value: unknown, label: string): InternalL
 		initialization: optionalRecordField(value, "initialization", label),
 		skipDirectories: optionalDirectoryNamesField(value, "skipDirectories", label),
 		diagnosticsSettleMs: optionalPositiveNumberField(value, "diagnosticsSettleMs", label),
+		pushDiagnosticsGraceMs: optionalPositiveNumberField(value, "pushDiagnosticsGraceMs", label),
 		pullDiagnosticsGraceMs: optionalPositiveNumberField(value, "pullDiagnosticsGraceMs", label),
 	};
 }
@@ -452,6 +461,7 @@ function configToAdapter(config: InternalLspServer): LspServerAdapter {
 		initialization: config.initialization,
 		skipDirectories: new Set([...COMMON_SKIP_DIRECTORIES, ...(config.skipDirectories ?? [])]),
 		diagnosticsSettleMs: config.diagnosticsSettleMs,
+		pushDiagnosticsGraceMs: config.pushDiagnosticsGraceMs,
 		pullDiagnosticsGraceMs: config.pullDiagnosticsGraceMs,
 		isSupportedFile: (filePath) => extensionSet.has(path.extname(filePath)),
 		languageIdFor: (filePath) => languageIdFor(config, filePath),

--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -172,7 +172,16 @@ export class LspClient {
 	async diagnostics(uri: string) {
 		// Only pull if the server advertised it; otherwise use push diagnostics.
 		if (!this.#serverCapabilities.diagnosticProvider) {
-			return this.#waitForPublishedDiagnostics(uri);
+			return this.#waitForPublishedDiagnostics(
+				uri,
+				this.#adapter.pushDiagnosticsGraceMs
+					? {
+							afterVersion: 0,
+							diagnostics: [],
+							waitMs: this.#adapter.pushDiagnosticsGraceMs,
+						}
+					: undefined,
+			);
 		}
 		const published = this.#publishedDiagnostics.get(uri);
 		// Ignore a provisional empty publish, but preserve diagnostics that arrived before the pull.

--- a/extensions/pi-lsp/src/types.ts
+++ b/extensions/pi-lsp/src/types.ts
@@ -69,6 +69,8 @@ export interface ConfiguredLspServer {
 	skipDirectories?: string[];
 	// Quiet period in ms after the latest push-diagnostics publication.
 	diagnosticsSettleMs?: number;
+	// Maximum wait for a push-only server that publishes nothing for a clean document.
+	pushDiagnosticsGraceMs?: number;
 	// Maximum wait for a newer push publication after an empty pull result.
 	pullDiagnosticsGraceMs?: number;
 }
@@ -94,6 +96,7 @@ export interface LspServerAdapter {
 	initialization?: Record<string, unknown>;
 	skipDirectories: Set<string>;
 	diagnosticsSettleMs?: number;
+	pushDiagnosticsGraceMs?: number;
 	pullDiagnosticsGraceMs?: number;
 	isSupportedFile: (filePath: string) => boolean;
 	languageIdFor: (filePath: string) => string;

--- a/extensions/pi-lsp/test/docker/Dockerfile
+++ b/extensions/pi-lsp/test/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM nixos/nix:2.28.4
+
+ARG NIXPKGS_REV=e2587caef70cea85dd97d7daab492899902dbf5d
+ARG NIX_PACKAGES
+ARG SETUP_COMMAND_B64
+ENV NIX_CONFIG="experimental-features = nix-command flakes"
+
+RUN nix profile install "github:NixOS/nixpkgs/${NIXPKGS_REV}#nodejs_22"
+RUN if [ -n "${NIX_PACKAGES}" ]; then \
+      for package in ${NIX_PACKAGES}; do \
+        nix profile install "github:NixOS/nixpkgs/${NIXPKGS_REV}#${package}"; \
+      done; \
+    fi
+RUN if [ -n "${SETUP_COMMAND_B64}" ]; then \
+      printf '%s' "${SETUP_COMMAND_B64}" | base64 -d | bash -eu; \
+    fi
+
+WORKDIR /smoke
+COPY extensions/pi-lsp/test/docker/package.json extensions/pi-lsp/test/docker/package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY extensions/pi-lsp ./pi-lsp
+
+ENTRYPOINT ["node", "/smoke/pi-lsp/test/docker/run-smoke.mjs"]

--- a/extensions/pi-lsp/test/docker/Dockerfile.swift
+++ b/extensions/pi-lsp/test/docker/Dockerfile.swift
@@ -1,0 +1,9 @@
+FROM node:22.23.1-bookworm-slim AS node
+FROM swift:6.1.3-jammy
+
+COPY --from=node /usr/local/ /usr/local/
+WORKDIR /smoke
+COPY extensions/pi-lsp/test/docker/package.json extensions/pi-lsp/test/docker/package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY extensions/pi-lsp ./pi-lsp
+ENTRYPOINT ["node", "/smoke/pi-lsp/test/docker/run-smoke.mjs"]

--- a/extensions/pi-lsp/test/docker/README.md
+++ b/extensions/pi-lsp/test/docker/README.md
@@ -1,0 +1,28 @@
+# Docker diagnostics matrix
+
+This opt-in smoke matrix runs the real Pi SDK, the local pi-lsp extension, and one real language server in an isolated Linux container. Each profile creates three erroneous and three clean projects and records summarized JSON-RPC timing.
+
+## Run one profile
+
+From the repository root:
+
+```bash
+node extensions/pi-lsp/test/docker/run-matrix.mjs rust-analyzer
+```
+
+The runner intentionally accepts exactly one profile. Omitting the profile, passing `--all`, or passing multiple profiles fails before Docker starts. Run profiles sequentially; do not run this matrix in parallel.
+
+Raw local evidence is written to `extensions/pi-lsp/test/docker/results/raw/<profile>.json` and is gitignored. The checked-in evidence summary is in [`docs/plans/archived/2026-07-24_pi-lsp-server-profiles-plan.md`](../../../../docs/plans/archived/2026-07-24_pi-lsp-server-profiles-plan.md).
+
+## What a pass proves
+
+A profile passes only when:
+
+- the pinned server installation/version check succeeds;
+- all three erroneous cold project runs return at least one matching diagnostic;
+- all three clean cold project runs return zero diagnostics; and
+- Pi loaded the local extension and invoked `lsp_diagnostics` successfully.
+
+`lsp-trace-proxy.mjs` records advertised pull support, diagnostic pulls and responses, push publications, refresh requests, and progress events. Profile-specific waits in `matrix.json` must match the built-in adapter policy; a repository test enforces this parity.
+
+The default Nix image is pinned by `nixpkgsRevision` in `matrix.json`. SourceKit uses the versioned official Swift image because the pinned Nix Swift derivation is not available as a working binary for this Linux environment.

--- a/extensions/pi-lsp/test/docker/lsp-trace-proxy.mjs
+++ b/extensions/pi-lsp/test/docker/lsp-trace-proxy.mjs
@@ -1,0 +1,76 @@
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { performance } from "node:perf_hooks";
+
+const separator = process.argv.indexOf("--");
+const tracePath = process.argv[2];
+const command = process.argv[separator + 1];
+const args = process.argv.slice(separator + 2);
+if (!tracePath || separator !== 3 || !command) {
+	throw new Error("Usage: lsp-trace-proxy.mjs <trace-path> -- <command> [args...]");
+}
+
+const startedAt = performance.now();
+const trace = createWriteStream(tracePath, { flags: "a" });
+const child = spawn(command, args, { env: process.env, stdio: ["pipe", "pipe", "pipe"] });
+
+const clientParser = createParser("client-to-server");
+const serverParser = createParser("server-to-client");
+process.stdin.on("data", (chunk) => {
+	clientParser(chunk);
+	child.stdin.write(chunk);
+});
+process.stdin.on("end", () => child.stdin.end());
+child.stdout.on("data", (chunk) => {
+	serverParser(chunk);
+	process.stdout.write(chunk);
+});
+child.stderr.pipe(process.stderr);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+	process.on(signal, () => child.kill(signal));
+}
+
+child.on("error", (error) => {
+	record({ direction: "process", error: error.message });
+	process.exitCode = 1;
+});
+child.on("close", (code, signal) => {
+	record({ direction: "process", code, signal });
+	trace.end(() => process.exit(code ?? (signal ? 1 : 0)));
+});
+
+function createParser(direction) {
+	let buffer = Buffer.alloc(0);
+	return (chunk) => {
+		buffer = Buffer.concat([buffer, chunk]);
+		while (true) {
+			const headerEnd = buffer.indexOf("\r\n\r\n");
+			if (headerEnd < 0) return;
+			const header = buffer.subarray(0, headerEnd).toString("utf8");
+			const contentLength = /Content-Length:\s*(\d+)/i.exec(header)?.[1];
+			if (!contentLength) {
+				record({ direction, parseError: `Missing Content-Length: ${header}` });
+				buffer = buffer.subarray(headerEnd + 4);
+				continue;
+			}
+			const bodyStart = headerEnd + 4;
+			const bodyLength = Number(contentLength);
+			if (buffer.length < bodyStart + bodyLength) return;
+			const body = buffer.subarray(bodyStart, bodyStart + bodyLength).toString("utf8");
+			buffer = buffer.subarray(bodyStart + bodyLength);
+			try {
+				record({ direction, message: JSON.parse(body) });
+			} catch (error) {
+				record({
+					direction,
+					parseError: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+	};
+}
+
+function record(event) {
+	trace.write(`${JSON.stringify({ atMs: performance.now() - startedAt, ...event })}\n`);
+}

--- a/extensions/pi-lsp/test/docker/matrix.json
+++ b/extensions/pi-lsp/test/docker/matrix.json
@@ -1,0 +1,708 @@
+{
+	"schemaVersion": 1,
+	"nixpkgsRevision": "e2587caef70cea85dd97d7daab492899902dbf5d",
+	"piVersion": "0.82.0",
+	"repeats": 3,
+	"timeoutMs": 30000,
+	"profiles": [
+		{
+			"name": "biome",
+			"nixPackages": ["biome"],
+			"packageVersion": "2.5.4",
+			"command": ["biome", "lsp-proxy"],
+			"versionCommand": ["biome", "--version"],
+			"extensions": [
+				".astro",
+				".css",
+				".cts",
+				".cjs",
+				".graphql",
+				".gql",
+				".html",
+				".js",
+				".json",
+				".jsonc",
+				".jsx",
+				".mjs",
+				".mts",
+				".svelte",
+				".ts",
+				".tsx",
+				".vue"
+			],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "src/main.ts",
+					"expected": "expected|syntax",
+					"files": { "src/main.ts": "const value: number = ;\n" }
+				},
+				"clean": {
+					"path": "src/main.ts",
+					"files": { "src/main.ts": "const value: number = 1;\nconsole.log(value);\n" }
+				}
+			}
+		},
+		{
+			"name": "ty",
+			"nixPackages": ["ty"],
+			"packageVersion": "0.0.61",
+			"command": ["ty", "server"],
+			"versionCommand": ["ty", "--version"],
+			"extensions": [".py", ".pyi"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.py",
+					"expected": "assign|int|str",
+					"files": {
+						"pyproject.toml": "[project]\nname = \"pi-lsp-probe\"\nversion = \"0.1.0\"\nrequires-python = \">=3.11\"\n",
+						"main.py": "value: int = \"wrong\"\n"
+					}
+				},
+				"clean": {
+					"path": "main.py",
+					"files": {
+						"pyproject.toml": "[project]\nname = \"pi-lsp-probe\"\nversion = \"0.1.0\"\nrequires-python = \">=3.11\"\n",
+						"main.py": "value: int = 1\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "ruff",
+			"nixPackages": ["ruff"],
+			"packageVersion": "0.15.22",
+			"command": ["ruff", "server"],
+			"versionCommand": ["ruff", "--version"],
+			"extensions": [".py", ".pyi"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.py",
+					"expected": "F401|unused|imported",
+					"files": {
+						"pyproject.toml": "[tool.ruff.lint]\nselect = [\"F\"]\n",
+						"main.py": "import os\n\nprint('probe')\n"
+					}
+				},
+				"clean": {
+					"path": "main.py",
+					"files": {
+						"pyproject.toml": "[tool.ruff.lint]\nselect = [\"F\"]\n",
+						"main.py": "print('probe')\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "rust-analyzer",
+			"nixPackages": ["rust-analyzer", "cargo"],
+			"packageVersion": "2026-06-15",
+			"command": ["rust-analyzer"],
+			"versionCommand": ["rust-analyzer", "--version"],
+			"extensions": [".rs"],
+			"policy": { "pullDiagnosticsGraceMs": 5000 },
+			"cases": {
+				"error": {
+					"path": "src/main.rs",
+					"expected": "expected expression",
+					"files": {
+						"Cargo.toml": "[package]\nname = \"pi_lsp_probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+						"src/main.rs": "fn main() { let value = ; }\n"
+					}
+				},
+				"clean": {
+					"path": "src/main.rs",
+					"files": {
+						"Cargo.toml": "[package]\nname = \"pi_lsp_probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+						"src/main.rs": "fn main() { let value = 1; println!(\"{value}\"); }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "gopls",
+			"nixPackages": ["gopls", "go"],
+			"packageVersion": "0.23.0",
+			"command": ["gopls"],
+			"versionCommand": ["gopls", "version"],
+			"extensions": [".go"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.go",
+					"expected": "cannot use|string.*int",
+					"files": {
+						"go.mod": "module example.com/pi-lsp-probe\n\ngo 1.23\n",
+						"main.go": "package main\nfunc main() { var value int = \"wrong\"; _ = value }\n"
+					}
+				},
+				"clean": {
+					"path": "main.go",
+					"files": {
+						"go.mod": "module example.com/pi-lsp-probe\n\ngo 1.23\n",
+						"main.go": "package main\nfunc main() { var value int = 1; _ = value }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "rubocop",
+			"nixPackages": ["rubyPackages.rubocop"],
+			"packageVersion": "1.80.2",
+			"command": ["rubocop", "--lsp"],
+			"versionCommand": ["rubocop", "--version"],
+			"extensions": [".rb", ".rake", ".gemspec", ".ru"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.rb",
+					"expected": "Layout|space|operator",
+					"files": {
+						".rubocop.yml": "AllCops:\n  NewCops: enable\nStyle/FrozenStringLiteralComment:\n  Enabled: false\n",
+						"main.rb": "value=1\nputs value\n"
+					}
+				},
+				"clean": {
+					"path": "main.rb",
+					"files": {
+						".rubocop.yml": "AllCops:\n  NewCops: enable\nStyle/FrozenStringLiteralComment:\n  Enabled: false\n",
+						"main.rb": "value = 1\nputs value\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "elixir-ls",
+			"nixPackages": ["beamPackages.elixir", "unzip", "gnused"],
+			"packageVersion": "0.31.1",
+			"setupCommand": "curl -fsSL https://github.com/elixir-lsp/elixir-ls/releases/download/v0.31.1/elixir-ls-v0.31.1.zip -o /tmp/elixir-ls.zip\necho 'bac08322ea3698157eb2373bb5b65e38c15df9dd41e1c06f142f874367fa472f  /tmp/elixir-ls.zip' | sha256sum -c -\nmkdir -p /opt/elixir-ls\nunzip -q /tmp/elixir-ls.zip -d /opt/elixir-ls\nln -s /opt/elixir-ls/language_server.sh /root/.nix-profile/bin/language_server.sh\nmkdir -p /etc/ssl/certs\ncert=$(find /nix/store -path '*nss-cacert*/etc/ssl/certs/ca-bundle.crt' | head -n 1)\ntest -n \"$cert\"\nln -s \"$cert\" /etc/ssl/certs/ca-certificates.crt\ncd /tmp\necho '' | elixir /opt/elixir-ls/quiet_install.exs >/dev/null\nrm /tmp/elixir-ls.zip\n",
+			"command": ["language_server.sh"],
+			"env": {
+				"SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
+				"ELIXIR_ERL_OPTIONS": "+fnu"
+			},
+			"extensions": [".ex", ".exs"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "lib/probe.ex",
+					"expected": "syntax|missing|unexpected",
+					"files": {
+						"mix.exs": "defmodule Probe.MixProject do\n  use Mix.Project\n  def project, do: [app: :probe, version: \"0.1.0\", elixir: \"~> 1.15\"]\nend\n",
+						"lib/probe.ex": "defmodule Probe do\n  def broken( do\nend\n"
+					}
+				},
+				"clean": {
+					"path": "lib/probe.ex",
+					"files": {
+						"mix.exs": "defmodule Probe.MixProject do\n  use Mix.Project\n  def project, do: [app: :probe, version: \"0.1.0\", elixir: \"~> 1.15\"]\nend\n",
+						"lib/probe.ex": "defmodule Probe do\n  def value, do: 1\nend\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "zls",
+			"nixPackages": ["zls", "zig"],
+			"packageVersion": "0.16.0",
+			"command": ["zls"],
+			"versionCommand": ["zls", "--version"],
+			"extensions": [".zig", ".zon"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "src/main.zig",
+					"expected": "expected|type|u8",
+					"files": {
+						"build.zig": "const std = @import(\"std\");\npub fn build(b: *std.Build) void { _ = b; }\n",
+						"src/main.zig": "pub fn main() void { const value = ; _ = value; }\n"
+					}
+				},
+				"clean": {
+					"path": "src/main.zig",
+					"files": {
+						"build.zig": "const std = @import(\"std\");\npub fn build(b: *std.Build) void { _ = b; }\n",
+						"src/main.zig": "pub fn main() void { const value: u8 = 1; _ = value; }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "csharp",
+			"nixPackages": ["roslyn-ls", "dotnet-sdk_10"],
+			"packageVersion": "5.9.0-1.26319.6",
+			"setupCommand": "ln -s \"$(command -v Microsoft.CodeAnalysis.LanguageServer)\" /root/.nix-profile/bin/roslyn-language-server\n",
+			"command": ["roslyn-language-server", "--stdio", "--autoLoadProjects"],
+			"extensions": [".cs", ".csx"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "Program.cs",
+					"expected": "expression|CS1525|expected",
+					"files": {
+						"Probe.csproj": "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>\n",
+						"Program.cs": "int value = ;\n_ = value;\n"
+					}
+				},
+				"clean": {
+					"path": "Program.cs",
+					"files": {
+						"Probe.csproj": "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>\n",
+						"Program.cs": "int value = 1;\n_ = value;\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "fsharp",
+			"nixPackages": ["fsautocomplete", "dotnet-sdk_10"],
+			"packageVersion": "0.83.0",
+			"command": ["fsautocomplete"],
+			"versionCommand": ["fsautocomplete", "--version"],
+			"extensions": [".fs", ".fsi", ".fsx", ".fsscript"],
+			"initialization": { "AutomaticWorkspaceInit": true },
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "Program.fs",
+					"expected": "string.*int|type.*int|expected",
+					"files": {
+						"Probe.fsproj": "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup><ItemGroup><Compile Include=\"Program.fs\" /></ItemGroup></Project>\n",
+						"Program.fs": "let value: int = \"wrong\"\nprintfn \"%d\" value\n"
+					}
+				},
+				"clean": {
+					"path": "Program.fs",
+					"files": {
+						"Probe.fsproj": "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup><ItemGroup><Compile Include=\"Program.fs\" /></ItemGroup></Project>\n",
+						"Program.fs": "let value: int = 1\nprintfn \"%d\" value\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "sourcekit-lsp",
+			"nixPackages": [],
+			"dockerfile": "Dockerfile.swift",
+			"packageVersion": "6.1.3",
+			"command": ["sourcekit-lsp"],
+			"extensions": [".swift", ".mm"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "Sources/Probe/main.swift",
+					"expected": "convert|string.*int|cannot",
+					"files": {
+						"Package.swift": "// swift-tools-version: 5.10\nimport PackageDescription\nlet package = Package(name: \"Probe\", targets: [.executableTarget(name: \"Probe\")])\n",
+						"Sources/Probe/main.swift": "let value: Int = \"wrong\"\nprint(value)\n"
+					}
+				},
+				"clean": {
+					"path": "Sources/Probe/main.swift",
+					"files": {
+						"Package.swift": "// swift-tools-version: 5.10\nimport PackageDescription\nlet package = Package(name: \"Probe\", targets: [.executableTarget(name: \"Probe\")])\n",
+						"Sources/Probe/main.swift": "let value: Int = 1\nprint(value)\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "clangd",
+			"nixPackages": ["clang-tools"],
+			"packageVersion": "21.1.8",
+			"command": ["clangd", "--background-index", "--clang-tidy"],
+			"versionCommand": ["clangd", "--version"],
+			"extensions": [".c", ".cpp", ".cc", ".cxx", ".c++", ".h", ".hpp", ".hh", ".hxx", ".h++"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.cpp",
+					"expected": "cannot initialize|incompatible|const char",
+					"files": {
+						"compile_flags.txt": "-std=c++20\n",
+						"main.cpp": "int main() { int value = \"wrong\"; return value; }\n"
+					}
+				},
+				"clean": {
+					"path": "main.cpp",
+					"files": {
+						"compile_flags.txt": "-std=c++20\n",
+						"main.cpp": "int main() { int value = 1; return value; }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "jdtls",
+			"nixPackages": ["jdt-language-server", "jdk21"],
+			"packageVersion": "1.60.0",
+			"command": ["jdtls"],
+			"extensions": [".java"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "src/Main.java",
+					"expected": "type mismatch|convert|string.*int",
+					"files": {
+						".project": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><projectDescription><name>Probe</name><projects/><buildSpec><buildCommand><name>org.eclipse.jdt.core.javabuilder</name><arguments/></buildCommand></buildSpec><natures><nature>org.eclipse.jdt.core.javanature</nature></natures></projectDescription>\n",
+						".classpath": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><classpath><classpathentry kind=\"src\" path=\"src\"/><classpathentry kind=\"con\" path=\"org.eclipse.jdt.launching.JRE_CONTAINER\"/><classpathentry kind=\"output\" path=\"bin\"/></classpath>\n",
+						"src/Main.java": "class Main { public static void main(String[] args) { int value = \"wrong\"; } }\n"
+					}
+				},
+				"clean": {
+					"path": "src/Main.java",
+					"files": {
+						".project": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><projectDescription><name>Probe</name><projects/><buildSpec><buildCommand><name>org.eclipse.jdt.core.javabuilder</name><arguments/></buildCommand></buildSpec><natures><nature>org.eclipse.jdt.core.javanature</nature></natures></projectDescription>\n",
+						".classpath": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><classpath><classpathentry kind=\"src\" path=\"src\"/><classpathentry kind=\"con\" path=\"org.eclipse.jdt.launching.JRE_CONTAINER\"/><classpathentry kind=\"output\" path=\"bin\"/></classpath>\n",
+						"src/Main.java": "class Main { public static void main(String[] args) { int value = 1; System.out.println(value); } }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "kotlin-lsp",
+			"nixPackages": ["gradle"],
+			"packageVersion": "262.8190.0",
+			"setupCommand": "cd /tmp\ncurl -fsSLO https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.tar.gz\ncurl -fsSLO https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.tar.gz.sha256\nsha256sum -c kotlin-server-262.8190.0.tar.gz.sha256\nmkdir -p /opt/kotlin-lsp\ntar -xzf kotlin-server-262.8190.0.tar.gz -C /opt/kotlin-lsp\nscript=$(find /opt/kotlin-lsp -type f -name kotlin-lsp.sh | head -n 1)\ntest -n \"$script\"\nchmod +x \"$script\"\ncat > /root/.nix-profile/bin/kotlin-lsp <<'EOF'\n#!/usr/bin/env bash\nroot=/opt/kotlin-lsp/kotlin-server-262.8190.0\nzlib=$(dirname \"$(find /nix/store -name libz.so.1 | head -n 1)\")\nstdlib=$(dirname \"$(find /nix/store -name libstdc++.so.6 | head -n 1)\")\nexport LD_LIBRARY_PATH=\"$root/jbr/lib/server:$root/jbr/lib:$zlib:$stdlib\"\nexec \"$root/kotlin-lsp.sh\" \"$@\"\nEOF\nchmod +x /root/.nix-profile/bin/kotlin-lsp\nmkdir -p /lib64\nloader=$(find /nix/store -path '*glibc-*/lib/ld-linux-x86-64.so.2' | head -n 1)\ntest -n \"$loader\"\nln -s \"$loader\" /lib64/ld-linux-x86-64.so.2\nrm kotlin-server-262.8190.0.tar.gz kotlin-server-262.8190.0.tar.gz.sha256\n",
+			"command": ["kotlin-lsp", "--stdio"],
+			"versionCommand": ["kotlin-lsp", "--version"],
+			"extensions": [".kt", ".kts"],
+			"policy": {},
+			"timeoutMs": 60000,
+			"cases": {
+				"error": {
+					"path": "src/main/kotlin/Main.kt",
+					"expected": "type mismatch|string.*int|initializer",
+					"files": {
+						"settings.gradle.kts": "rootProject.name = \"probe\"\n",
+						"build.gradle.kts": "plugins { kotlin(\"jvm\") version \"2.2.0\" }\nrepositories { mavenCentral() }\n",
+						"src/main/kotlin/Main.kt": "fun main() { val value: Int = \"wrong\"; println(value) }\n"
+					}
+				},
+				"clean": {
+					"path": "src/main/kotlin/Main.kt",
+					"files": {
+						"settings.gradle.kts": "rootProject.name = \"probe\"\n",
+						"build.gradle.kts": "plugins { kotlin(\"jvm\") version \"2.2.0\" }\nrepositories { mavenCentral() }\n",
+						"src/main/kotlin/Main.kt": "fun main() { val value = 1; println(value) }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "yaml-language-server",
+			"nixPackages": ["yaml-language-server"],
+			"packageVersion": "1.24.0",
+			"command": ["yaml-language-server", "--stdio"],
+			"versionCommand": ["yaml-language-server", "--version"],
+			"extensions": [".yaml", ".yml"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "config.yaml",
+					"expected": "flow sequence|expected|syntax",
+					"files": { "config.yaml": "items: [one, two\n" }
+				},
+				"clean": { "path": "config.yaml", "files": { "config.yaml": "items: [one, two]\n" } }
+			}
+		},
+		{
+			"name": "lua-language-server",
+			"nixPackages": ["lua-language-server"],
+			"packageVersion": "3.18.2",
+			"command": ["lua-language-server"],
+			"versionCommand": ["lua-language-server", "--version"],
+			"extensions": [".lua"],
+			"policy": { "pushDiagnosticsGraceMs": 3000 },
+			"cases": {
+				"error": {
+					"path": "main.lua",
+					"expected": "expression|expected|syntax",
+					"files": { "main.lua": "local value = )\nprint(value)\n" }
+				},
+				"clean": { "path": "main.lua", "files": { "main.lua": "local value = 1\nprint(value)\n" } }
+			}
+		},
+		{
+			"name": "intelephense",
+			"nixPackages": [],
+			"packageVersion": "1.18.2",
+			"setupCommand": "npm install --global intelephense@1.18.2\nln -s \"$(npm prefix --global)/bin/intelephense\" /root/.nix-profile/bin/intelephense\n",
+			"command": ["intelephense", "--stdio"],
+			"extensions": [".php"],
+			"initialization": { "intelephense": { "telemetry": { "enabled": false } } },
+			"policy": { "diagnosticsSettleMs": 4000 },
+			"cases": {
+				"error": {
+					"path": "index.php",
+					"expected": "syntax|unexpected|expected",
+					"files": { "index.php": "<?php\nfunction probe( {\n" }
+				},
+				"clean": {
+					"path": "index.php",
+					"files": { "index.php": "<?php\nfunction probe(): int { return 1; }\n" }
+				}
+			}
+		},
+		{
+			"name": "prisma",
+			"nixPackages": ["prisma-language-server"],
+			"packageVersion": "31.1.0",
+			"command": ["prisma-language-server", "--stdio"],
+			"extensions": [".prisma"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "schema.prisma",
+					"expected": "type|invalid|unknown",
+					"files": {
+						"schema.prisma": "datasource db {\n  provider = \"sqlite\"\n}\nmodel User {\n  id NotAType @id\n}\n"
+					}
+				},
+				"clean": {
+					"path": "schema.prisma",
+					"files": {
+						"schema.prisma": "datasource db {\n  provider = \"sqlite\"\n}\nmodel User {\n  id Int @id\n}\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "dart",
+			"nixPackages": ["dart"],
+			"packageVersion": "3.11.4",
+			"command": ["dart", "language-server"],
+			"versionCommand": ["dart", "--version"],
+			"extensions": [".dart"],
+			"policy": { "pushDiagnosticsGraceMs": 2000 },
+			"cases": {
+				"error": {
+					"path": "lib/main.dart",
+					"expected": "string.*int|assign|invalid_assignment",
+					"files": {
+						"pubspec.yaml": "name: pi_lsp_probe\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+						"lib/main.dart": "void main() { int value = 'wrong'; print(value); }\n"
+					}
+				},
+				"clean": {
+					"path": "lib/main.dart",
+					"files": {
+						"pubspec.yaml": "name: pi_lsp_probe\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+						"lib/main.dart": "void main() { int value = 1; print(value); }\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "ocaml-lsp",
+			"nixPackages": ["binutils", "ocaml", "ocamlPackages.ocaml-lsp", "ocamlPackages.dune_3"],
+			"packageVersion": "1.26.0",
+			"command": ["ocamllsp"],
+			"versionCommand": ["ocamllsp", "--version"],
+			"prepareCommand": ["bash", "-lc", "dune build || test -d _build"],
+			"extensions": [".ml", ".mli"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.ml",
+					"expected": "string.*int|type.*int|expression",
+					"files": {
+						"dune-project": "(lang dune 3.0)\n(name probe)\n",
+						"dune": "(executable (name main))\n",
+						"main.ml": "let value : int = \"wrong\"\nlet () = print_int value\n"
+					}
+				},
+				"clean": {
+					"path": "main.ml",
+					"files": {
+						"dune-project": "(lang dune 3.0)\n(name probe)\n",
+						"dune": "(executable (name main))\n",
+						"main.ml": "let value : int = 1\nlet () = print_int value\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "bash-language-server",
+			"nixPackages": ["bash-language-server"],
+			"packageVersion": "5.6.0",
+			"command": ["bash-language-server", "start"],
+			"versionCommand": ["bash-language-server", "--version"],
+			"extensions": [".sh", ".bash"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "script.sh",
+					"expected": "syntax|unexpected|expected|end of file",
+					"files": { "script.sh": "#!/usr/bin/env bash\nif true; then\n  echo probe\n" }
+				},
+				"clean": {
+					"path": "script.sh",
+					"files": { "script.sh": "#!/usr/bin/env bash\nif true; then\n  echo probe\nfi\n" }
+				}
+			}
+		},
+		{
+			"name": "terraform-ls",
+			"nixPackages": ["terraform-ls"],
+			"packageVersion": "0.38.7",
+			"command": ["terraform-ls", "serve"],
+			"versionCommand": ["terraform-ls", "version"],
+			"extensions": [".tf", ".tfvars"],
+			"policy": { "pushDiagnosticsGraceMs": 2000 },
+			"cases": {
+				"error": {
+					"path": "main.tf",
+					"expected": "expression|expected|argument",
+					"files": { "main.tf": "terraform {\n  required_version =\n}\n" }
+				},
+				"clean": {
+					"path": "main.tf",
+					"files": { "main.tf": "terraform {\n  required_version = \">= 1.0\"\n}\n" }
+				}
+			}
+		},
+		{
+			"name": "texlab",
+			"nixPackages": ["texlab"],
+			"packageVersion": "5.26.0",
+			"command": ["texlab"],
+			"versionCommand": ["texlab", "--version"],
+			"extensions": [".tex", ".bib"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "main.tex",
+					"expected": "mismatched|unexpected|environment|missing",
+					"files": {
+						"main.tex": "\\documentclass{article}\n\\begin{document}\n\\begin{itemize}\n\\end{document}\n"
+					}
+				},
+				"clean": {
+					"path": "main.tex",
+					"files": {
+						"main.tex": "\\documentclass{article}\n\\begin{document}\nProbe\n\\end{document}\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "gleam",
+			"nixPackages": ["gleam"],
+			"packageVersion": "1.17.0",
+			"command": ["gleam", "lsp"],
+			"versionCommand": ["gleam", "--version"],
+			"extensions": [".gleam"],
+			"policy": { "pushDiagnosticsGraceMs": 2000 },
+			"cases": {
+				"error": {
+					"path": "src/probe.gleam",
+					"expected": "type|expected|Int|String",
+					"files": {
+						"gleam.toml": "name = \"probe\"\nversion = \"0.1.0\"\ntarget = \"erlang\"\n",
+						"src/probe.gleam": "pub fn value() -> Int {\n  \"wrong\"\n}\n"
+					}
+				},
+				"clean": {
+					"path": "src/probe.gleam",
+					"files": {
+						"gleam.toml": "name = \"probe\"\nversion = \"0.1.0\"\ntarget = \"erlang\"\n",
+						"src/probe.gleam": "pub fn value() -> Int {\n  1\n}\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "clojure-lsp",
+			"nixPackages": ["clojure-lsp", "jdk21"],
+			"packageVersion": "2026.02.20-16.08.58",
+			"command": ["clojure-lsp", "listen"],
+			"versionCommand": ["clojure-lsp", "--version"],
+			"extensions": [".clj", ".cljs", ".cljc", ".edn"],
+			"policy": {},
+			"timeoutMs": 60000,
+			"cases": {
+				"error": {
+					"path": "src/probe/core.clj",
+					"expected": "unmatched|EOF|delimiter|syntax",
+					"files": {
+						"deps.edn": "{:paths [\"src\"]}\n",
+						"src/probe/core.clj": "(ns probe.core)\n(defn value []\n  (+ 1 2)\n"
+					}
+				},
+				"clean": {
+					"path": "src/probe/core.clj",
+					"files": {
+						"deps.edn": "{:paths [\"src\"]}\n",
+						"src/probe/core.clj": "(ns probe.core)\n(defn value []\n  (+ 1 2))\n(value)\n"
+					}
+				}
+			}
+		},
+		{
+			"name": "nixd",
+			"nixPackages": ["nixd"],
+			"packageVersion": "2.9.1",
+			"command": ["nixd"],
+			"versionCommand": ["nixd", "--version"],
+			"extensions": [".nix"],
+			"policy": {},
+			"cases": {
+				"error": {
+					"path": "default.nix",
+					"expected": "unexpected|expected|syntax",
+					"files": { "default.nix": "{ broken = ; }\n" }
+				},
+				"clean": { "path": "default.nix", "files": { "default.nix": "{ value = 1; }\n" } }
+			}
+		},
+		{
+			"name": "tinymist",
+			"nixPackages": ["tinymist"],
+			"packageVersion": "0.15.2",
+			"command": ["tinymist"],
+			"versionCommand": ["tinymist", "--version"],
+			"extensions": [".typ", ".typc"],
+			"policy": { "pushDiagnosticsGraceMs": 2000 },
+			"cases": {
+				"error": {
+					"path": "main.typ",
+					"expected": "expected|syntax|expression",
+					"files": { "main.typ": "#let value =\n#value\n" }
+				},
+				"clean": { "path": "main.typ", "files": { "main.typ": "#let value = 1\n#value\n" } }
+			}
+		},
+		{
+			"name": "haskell-language-server",
+			"nixPackages": ["haskell-language-server", "ghc", "cabal-install"],
+			"packageVersion": "2.13.0.0",
+			"command": ["haskell-language-server-wrapper", "--lsp"],
+			"versionCommand": ["haskell-language-server-wrapper", "--version"],
+			"extensions": [".hs", ".lhs"],
+			"policy": { "pushDiagnosticsGraceMs": 3000 },
+			"timeoutMs": 60000,
+			"cases": {
+				"error": {
+					"path": "Main.hs",
+					"expected": "string.*int|type|Couldn't match",
+					"files": {
+						"cabal.project": "packages: .\n",
+						"probe.cabal": "cabal-version: 2.4\nname: probe\nversion: 0.1.0.0\nexecutable probe\n  main-is: Main.hs\n  build-depends: base >=4.14 && <5\n  default-language: Haskell2010\n",
+						"Main.hs": "module Main where\nvalue :: Int\nvalue = \"wrong\"\nmain :: IO ()\nmain = print value\n"
+					}
+				},
+				"clean": {
+					"path": "Main.hs",
+					"files": {
+						"cabal.project": "packages: .\n",
+						"probe.cabal": "cabal-version: 2.4\nname: probe\nversion: 0.1.0.0\nexecutable probe\n  main-is: Main.hs\n  build-depends: base >=4.14 && <5\n  default-language: Haskell2010\n",
+						"Main.hs": "module Main where\nvalue :: Int\nvalue = 1\nmain :: IO ()\nmain = print value\n"
+					}
+				}
+			}
+		}
+	]
+}

--- a/extensions/pi-lsp/test/docker/matrix.json
+++ b/extensions/pi-lsp/test/docker/matrix.json
@@ -551,6 +551,9 @@
 			"command": ["terraform-ls", "serve"],
 			"versionCommand": ["terraform-ls", "version"],
 			"extensions": [".tf", ".tfvars"],
+			"initialization": {
+				"experimentalFeatures": { "prefillRequiredFields": true }
+			},
 			"policy": { "pushDiagnosticsGraceMs": 2000 },
 			"cases": {
 				"error": {

--- a/extensions/pi-lsp/test/docker/package-lock.json
+++ b/extensions/pi-lsp/test/docker/package-lock.json
@@ -1,0 +1,1839 @@
+{
+	"name": "pi-lsp-docker-smoke",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pi-lsp-docker-smoke",
+			"dependencies": {
+				"@earendil-works/pi-coding-agent": "0.82.0",
+				"typebox": "1.3.3"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
+			"integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
+			"hasShrinkwrap": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.82.0",
+				"@earendil-works/pi-ai": "^0.82.0",
+				"@earendil-works/pi-tui": "^0.82.0",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"semver": "7.8.0",
+				"typebox": "1.1.38",
+				"undici": "8.5.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+			"version": "3.974.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-login": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-ini": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.82.0",
+				"diff": "8.0.4",
+				"ignore": "7.0.5",
+				"typebox": "1.1.38",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"node_modules/typebox": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.3.tgz",
+			"integrity": "sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==",
+			"license": "MIT"
+		}
+	}
+}

--- a/extensions/pi-lsp/test/docker/package.json
+++ b/extensions/pi-lsp/test/docker/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "pi-lsp-docker-smoke",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@earendil-works/pi-coding-agent": "0.82.0",
+		"typebox": "1.3.3"
+	}
+}

--- a/extensions/pi-lsp/test/docker/run-matrix.mjs
+++ b/extensions/pi-lsp/test/docker/run-matrix.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dockerDir = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(dockerDir, "../../../..");
+const matrix = JSON.parse(readFileSync(path.join(dockerDir, "matrix.json"), "utf8"));
+const requested = process.argv.slice(2);
+if (requested.length !== 1 || requested[0] === "--all") {
+	throw new Error(
+		"Run exactly one LSP profile at a time: node extensions/pi-lsp/test/docker/run-matrix.mjs <server>",
+	);
+}
+const selectedProfile = matrix.profiles.find(({ name }) => name === requested[0]);
+if (!selectedProfile) throw new Error(`Unknown profile: ${requested[0]}`);
+const rawDir = path.join(dockerDir, "results", "raw");
+mkdirSync(rawDir, { recursive: true });
+let failed = false;
+
+for (const profile of [selectedProfile]) {
+	const image = `pi-lsp-smoke:${profile.name.replaceAll(/[^a-z0-9_.-]/giu, "-")}`;
+	console.error(`\n=== Building ${profile.name} ===`);
+	const build = spawnSync(
+		"docker",
+		[
+			"build",
+			"--file",
+			path.join(dockerDir, profile.dockerfile ?? "Dockerfile"),
+			"--build-arg",
+			`NIXPKGS_REV=${matrix.nixpkgsRevision}`,
+			"--build-arg",
+			`NIX_PACKAGES=${profile.nixPackages.join(" ")}`,
+			"--build-arg",
+			`SETUP_COMMAND_B64=${Buffer.from(profile.setupCommand ?? "").toString("base64")}`,
+			"--tag",
+			image,
+			root,
+		],
+		{ stdio: "inherit" },
+	);
+	if (build.status !== 0) {
+		failed = true;
+		writeFileSync(
+			path.join(rawDir, `${profile.name}.json`),
+			`${JSON.stringify({ profile: profile.name, passed: false, buildFailed: true }, null, 2)}\n`,
+		);
+		continue;
+	}
+
+	console.error(`=== Running ${profile.name} ===`);
+	const run = spawnSync("docker", ["run", "--rm", "--env", `PROFILE=${profile.name}`, image], {
+		encoding: "utf8",
+		maxBuffer: 10 * 1024 * 1024,
+	});
+	if (run.stderr) process.stderr.write(run.stderr);
+	let parsed;
+	try {
+		parsed = JSON.parse(run.stdout.trim());
+	} catch (error) {
+		parsed = {
+			profile: profile.name,
+			passed: false,
+			parseFailure: error instanceof Error ? error.message : String(error),
+			stdout: run.stdout,
+		};
+	}
+	writeFileSync(path.join(rawDir, `${profile.name}.json`), `${JSON.stringify(parsed, null, 2)}\n`);
+	console.error(`${profile.name}: ${parsed.passed ? "PASS" : "FAIL"}`);
+	if (run.status !== 0 || !parsed.passed) failed = true;
+}
+
+if (failed) process.exitCode = 1;

--- a/extensions/pi-lsp/test/docker/run-smoke.mjs
+++ b/extensions/pi-lsp/test/docker/run-smoke.mjs
@@ -1,0 +1,231 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	createAgentSession,
+	DefaultResourceLoader,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+const smokeRoot = "/smoke/pi-lsp/test/docker";
+const matrix = JSON.parse(readFileSync(path.join(smokeRoot, "matrix.json"), "utf8"));
+const profileName = process.env.PROFILE;
+const profile = matrix.profiles.find(({ name }) => name === profileName);
+if (!profile) throw new Error(`Unknown or missing PROFILE: ${profileName ?? ""}`);
+
+const piVersion = execFileSync("/smoke/node_modules/.bin/pi", ["--version"], {
+	encoding: "utf8",
+}).trim();
+const versionResult = profile.versionCommand
+	? spawnSync(profile.versionCommand[0], profile.versionCommand.slice(1), {
+			encoding: "utf8",
+			timeout: 10_000,
+		})
+	: { status: 0, stdout: profile.packageVersion, stderr: "" };
+const serverVersion = `${versionResult.stdout ?? ""}${versionResult.stderr ?? ""}`.trim();
+const result = {
+	profile: profile.name,
+	piVersion,
+	serverVersion,
+	versionExitCode: versionResult.status,
+	runs: [],
+};
+
+for (const caseName of ["error", "clean"]) {
+	for (let repeat = 1; repeat <= (profile.repeats ?? matrix.repeats); repeat += 1) {
+		result.runs.push(await runCase(caseName, repeat));
+	}
+}
+
+result.passed = result.versionExitCode === 0 && result.runs.every(({ passed }) => passed === true);
+process.stdout.write(`${JSON.stringify(result)}\n`);
+if (!result.passed) process.exitCode = 1;
+
+async function runCase(caseName, repeat) {
+	const fixture = profile.cases[caseName];
+	const runRoot = mkdtempSync(path.join(os.tmpdir(), `pi-lsp-${profile.name}-${caseName}-`));
+	const projectRoot = path.join(runRoot, "project");
+	const agentDir = path.join(runRoot, "agent");
+	const tracePath = path.join(runRoot, "trace.jsonl");
+	mkdirSync(projectRoot);
+	mkdirSync(agentDir);
+	for (const [relativePath, content] of Object.entries(fixture.files)) {
+		const target = path.join(projectRoot, relativePath);
+		mkdirSync(path.dirname(target), { recursive: true });
+		writeFileSync(target, content);
+	}
+	const preparation = profile.prepareCommand
+		? spawnSync(profile.prepareCommand[0], profile.prepareCommand.slice(1), {
+				cwd: projectRoot,
+				encoding: "utf8",
+				timeout: profile.prepareTimeoutMs ?? 60_000,
+			})
+		: undefined;
+	const preparationFailure =
+		preparation && preparation.status !== 0
+			? `Fixture preparation failed (${preparation.status ?? preparation.signal ?? "unknown"}): ${`${preparation.stdout ?? ""}${preparation.stderr ?? ""}`.trim()}`
+			: undefined;
+
+	const serverConfig = {
+		command: [
+			"node",
+			path.join(smokeRoot, "lsp-trace-proxy.mjs"),
+			tracePath,
+			"--",
+			...profile.command,
+		],
+		extensions: profile.extensions,
+		...(profile.env ? { env: profile.env } : {}),
+		...(profile.initialization ? { initialization: profile.initialization } : {}),
+		...profile.policy,
+	};
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	process.env.PI_LSP_CONFIG = JSON.stringify({
+		timeout: profile.timeoutMs ?? matrix.timeoutMs,
+		servers: { [profile.name]: serverConfig },
+	});
+	process.env.PI_OFFLINE = "1";
+
+	const settingsManager = SettingsManager.inMemory({});
+	const loader = new DefaultResourceLoader({
+		cwd: projectRoot,
+		agentDir,
+		settingsManager,
+		additionalExtensionPaths: ["/smoke/pi-lsp/src/index.ts"],
+		noExtensions: true,
+	});
+	const startedAt = performance.now();
+	let output;
+	let failure;
+	let extensionErrors = [];
+	let session;
+	try {
+		if (preparationFailure) throw new Error(preparationFailure);
+		await loader.reload();
+		const created = await createAgentSession({
+			cwd: projectRoot,
+			agentDir,
+			noTools: "builtin",
+			settingsManager,
+			resourceLoader: loader,
+			sessionManager: SessionManager.inMemory(projectRoot),
+		});
+		session = created.session;
+		extensionErrors = created.extensionsResult.errors;
+		if (extensionErrors.length > 0) {
+			throw new Error(`Extension load failed: ${JSON.stringify(extensionErrors)}`);
+		}
+		const tool = session.agent.state.tools.find(({ name }) => name === "lsp_diagnostics");
+		if (!tool) throw new Error("Pi did not register lsp_diagnostics");
+		const toolResult = await tool.execute(
+			`${profile.name}-${caseName}-${repeat}`,
+			{ root: projectRoot, paths: [fixture.path], server: profile.name },
+			undefined,
+			undefined,
+		);
+		output = toolResult.content?.find(({ type }) => type === "text")?.text ?? "";
+	} catch (error) {
+		failure = error instanceof Error ? error.message : String(error);
+	} finally {
+		await session?.dispose();
+	}
+	const durationMs = performance.now() - startedAt;
+	const trace = summarizeTrace(tracePath);
+	const diagnosticCount = parseDiagnosticCount(output);
+	const passed =
+		!failure &&
+		(caseName === "clean"
+			? diagnosticCount === 0
+			: diagnosticCount > 0 && new RegExp(fixture.expected, "iu").test(output));
+	const run = {
+		case: caseName,
+		repeat,
+		passed,
+		durationMs,
+		diagnosticCount,
+		trace,
+		...(failure ? { failure } : {}),
+		...(passed ? {} : { output }),
+		...(extensionErrors.length > 0 ? { extensionErrors } : {}),
+	};
+	rmSync(runRoot, { recursive: true, force: true });
+	return run;
+}
+
+function parseDiagnosticCount(output) {
+	const match = /LSP diagnostics: (\d+) diagnostic\(s\)/u.exec(output ?? "");
+	return match ? Number(match[1]) : -1;
+}
+
+function summarizeTrace(tracePath) {
+	let events = [];
+	try {
+		events = readFileSync(tracePath, "utf8")
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+	} catch {
+		return { eventCount: 0, parseErrors: ["trace unavailable"] };
+	}
+	const requests = new Map();
+	let didOpenAtMs;
+	let diagnosticProvider = false;
+	const pulls = [];
+	const pushes = [];
+	const refreshes = [];
+	const progress = [];
+	const parseErrors = [];
+	for (const event of events) {
+		const message = event.message;
+		if (event.parseError) parseErrors.push(event.parseError);
+		if (!message) continue;
+		if (event.direction === "client-to-server" && message.method && message.id !== undefined) {
+			requests.set(message.id, { method: message.method, atMs: event.atMs });
+		}
+		if (event.direction === "client-to-server" && message.method === "textDocument/didOpen") {
+			didOpenAtMs = event.atMs;
+		}
+		if (event.direction === "server-to-client" && message.id !== undefined && !message.method) {
+			const request = requests.get(message.id);
+			if (request?.method === "initialize") {
+				diagnosticProvider = Boolean(message.result?.capabilities?.diagnosticProvider);
+			}
+			if (request?.method === "textDocument/diagnostic") {
+				pulls.push({
+					requestAtMs: request.atMs,
+					responseAtMs: event.atMs,
+					items: message.result?.items?.length ?? null,
+					error: message.error?.message,
+				});
+			}
+		}
+		if (
+			event.direction === "server-to-client" &&
+			message.method === "textDocument/publishDiagnostics"
+		) {
+			pushes.push({ atMs: event.atMs, items: message.params?.diagnostics?.length ?? 0 });
+		}
+		if (
+			event.direction === "server-to-client" &&
+			message.method === "workspace/diagnostic/refresh"
+		) {
+			refreshes.push({ atMs: event.atMs });
+		}
+		if (message.method === "$/progress") {
+			progress.push({ atMs: event.atMs, kind: message.params?.value?.kind ?? "report" });
+		}
+	}
+	return {
+		eventCount: events.length,
+		diagnosticProvider,
+		didOpenAtMs,
+		pulls,
+		pushes,
+		refreshes,
+		progress,
+		parseErrors,
+	};
+}

--- a/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -58,8 +58,12 @@ function handle(message) {
 	if (message.method === "textDocument/didOpen") {
 		const uri = message.params.textDocument.uri;
 		openedUris.push(uri);
-		publish(uri, []);
-		if (scenario === "push-sequence") {
+		if (scenario !== "push-silent" && scenario !== "push-silent-then-diagnostic") {
+			publish(uri, []);
+		}
+		if (scenario === "push-silent-then-diagnostic") {
+			setTimeout(() => publish(uri, [diagnostic("late push-only diagnostic")]), 40);
+		} else if (scenario === "push-sequence") {
 			setTimeout(() => publish(uri, [diagnostic("first")]), 20);
 			setTimeout(() => publish(uri, [diagnostic("first"), diagnostic("second", 1)]), 40);
 		} else if (scenario === "pull-empty-then-push") {

--- a/extensions/pi-lsp/test/lsp-client.test.ts
+++ b/extensions/pi-lsp/test/lsp-client.test.ts
@@ -101,6 +101,52 @@ test("empty pull diagnostics fall back after the configured grace period", async
 	}
 });
 
+test("push-only diagnostics may treat no publication as clean after a configured grace", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-push-silent-"));
+	const file = path.join(root, "main.go");
+	writeFileSync(file, "package main\n");
+	const adapter = fixtureAdapter("push-silent", 30, undefined, 100);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+	const startedAt = Date.now();
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		const uri = pathToFileURL(file).href;
+		client.didOpen(uri, "package main\n", "go");
+		assert.deepEqual(await client.diagnostics(uri), []);
+		assert.ok(Date.now() - startedAt < 500, "silent push server should not wait for timeout");
+		client.didClose(uri);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("push-only diagnostics preserve a publication within the configured grace", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-push-silent-late-"));
+	const file = path.join(root, "main.go");
+	writeFileSync(file, "package main\n");
+	const adapter = fixtureAdapter("push-silent-then-diagnostic", 30, undefined, 100);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		const uri = pathToFileURL(file).href;
+		client.didOpen(uri, "package main\n", "go");
+		const diagnostics = await client.diagnostics(uri);
+		assert.deepEqual(
+			diagnostics.map(({ message }) => message),
+			["late push-only diagnostic"],
+		);
+		client.didClose(uri);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("push diagnostics settle on the latest publication", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-push-sequence-"));
 	const file = path.join(root, "main.go");
@@ -182,6 +228,7 @@ function fixtureAdapter(
 	scenario: string,
 	diagnosticsSettleMs: number,
 	expectedFiles?: number,
+	pushDiagnosticsGraceMs?: number,
 ): LspServerAdapter {
 	return {
 		name: `fixture-${scenario}`,
@@ -195,6 +242,7 @@ function fixtureAdapter(
 		extensions: [".go"],
 		skipDirectories: new Set(),
 		diagnosticsSettleMs,
+		pushDiagnosticsGraceMs,
 		pullDiagnosticsGraceMs:
 			scenario === "pull-empty-then-push" ||
 			scenario === "pull-empty-after-push" ||

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -4,6 +4,7 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readFileSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -14,7 +15,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createMockPi } from "../../../test/support.js";
-import { consumeLspConfigNotice, loadConfig, loadRuntime } from "../src/adapters.js";
+import {
+	consumeLspConfigNotice,
+	DEFAULT_SERVER_CONFIGS,
+	loadConfig,
+	loadRuntime,
+} from "../src/adapters.js";
 import {
 	commandExists,
 	commandFromEnv,
@@ -45,6 +51,41 @@ test("lsp registers diagnostics/fix tools, command, and status hooks", () => {
 	);
 	assert.ok(mock.commands.has("lsp"));
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+});
+
+test("Docker diagnostics matrix covers every built-in server and command", () => {
+	const matrixPath = path.join(process.cwd(), "extensions/pi-lsp/test/docker/matrix.json");
+	const matrix = JSON.parse(readFileSync(matrixPath, "utf8")) as {
+		profiles: Array<{
+			name: string;
+			command: string[];
+			extensions: string[];
+			policy: {
+				diagnosticsSettleMs?: number;
+				pushDiagnosticsGraceMs?: number;
+				pullDiagnosticsGraceMs?: number;
+			};
+		}>;
+	};
+	assert.deepEqual(
+		matrix.profiles.map(({ name }) => name).sort(),
+		DEFAULT_SERVER_CONFIGS.map(({ name }) => name).sort(),
+	);
+	for (const config of DEFAULT_SERVER_CONFIGS) {
+		const profile = matrix.profiles.find(({ name }) => name === config.name);
+		assert.ok(profile, `missing Docker profile for ${config.name}`);
+		assert.deepEqual(profile.command, config.command);
+		assert.deepEqual(profile.extensions, config.extensions);
+		assert.deepEqual(profile.policy, {
+			...(config.diagnosticsSettleMs ? { diagnosticsSettleMs: config.diagnosticsSettleMs } : {}),
+			...(config.pushDiagnosticsGraceMs
+				? { pushDiagnosticsGraceMs: config.pushDiagnosticsGraceMs }
+				: {}),
+			...(config.pullDiagnosticsGraceMs
+				? { pullDiagnosticsGraceMs: config.pullDiagnosticsGraceMs }
+				: {}),
+		});
+	}
 });
 
 test("default catalog routes common languages and skips generated trees", () => {
@@ -99,6 +140,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 			skipDirectories?: string[];
 			initialization?: Record<string, unknown>;
 			diagnosticsSettleMs?: number;
+			pushDiagnosticsGraceMs?: number;
 			pullDiagnosticsGraceMs?: number;
 		}> = [
 			{
@@ -186,6 +228,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				extensions: [".lua"],
 				sample: "init.lua",
 				languageId: "lua",
+				pushDiagnosticsGraceMs: 3_000,
 			},
 			{
 				name: "intelephense",
@@ -210,6 +253,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				sample: "lib/main.dart",
 				languageId: "dart",
 				skipDirectories: [".dart_tool", "build"],
+				pushDiagnosticsGraceMs: 2_000,
 			},
 			{
 				name: "ocaml-lsp",
@@ -236,6 +280,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				initialization: {
 					experimentalFeatures: { prefillRequiredFields: true },
 				},
+				pushDiagnosticsGraceMs: 2_000,
 			},
 			{
 				name: "texlab",
@@ -251,6 +296,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				sample: "src/app.gleam",
 				languageId: "gleam",
 				skipDirectories: ["build"],
+				pushDiagnosticsGraceMs: 2_000,
 			},
 			{
 				name: "clojure-lsp",
@@ -273,6 +319,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				extensions: [".typ", ".typc"],
 				sample: "main.typc",
 				languageId: "typst-code",
+				pushDiagnosticsGraceMs: 2_000,
 			},
 			{
 				name: "haskell-language-server",
@@ -281,6 +328,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 				sample: "src/Main.lhs",
 				languageId: "lhaskell",
 				skipDirectories: [".stack-work", "dist-newstyle"],
+				pushDiagnosticsGraceMs: 3_000,
 			},
 		];
 		assert.equal(
@@ -300,6 +348,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 			assert.equal(adapter.languageIdFor(expected.sample), expected.languageId);
 			assert.deepEqual(adapter.initialization, expected.initialization);
 			assert.equal(adapter.diagnosticsSettleMs, expected.diagnosticsSettleMs);
+			assert.equal(adapter.pushDiagnosticsGraceMs, expected.pushDiagnosticsGraceMs);
 			assert.equal(adapter.pullDiagnosticsGraceMs, expected.pullDiagnosticsGraceMs);
 			for (const directory of expected.skipDirectories ?? []) {
 				assert.equal(
@@ -456,6 +505,7 @@ test("LSP config applies safe server-specific skip directories", () => {
 					extensions: [".foo"],
 					skipDirectories: ["generated"],
 					diagnosticsSettleMs: 250,
+					pushDiagnosticsGraceMs: 375,
 					pullDiagnosticsGraceMs: 500,
 				},
 			},
@@ -464,6 +514,7 @@ test("LSP config applies safe server-specific skip directories", () => {
 		assert.ok(adapter);
 		assert.equal(adapter.isDefault, false);
 		assert.equal(adapter.diagnosticsSettleMs, 250);
+		assert.equal(adapter.pushDiagnosticsGraceMs, 375);
 		assert.equal(adapter.pullDiagnosticsGraceMs, 500);
 		assert.deepEqual(collectSupportedFiles(adapter, project, undefined, 50), [
 			path.join(project, "src", "main.foo"),

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -53,13 +53,14 @@ test("lsp registers diagnostics/fix tools, command, and status hooks", () => {
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
 });
 
-test("Docker diagnostics matrix covers every built-in server and command", () => {
+test("Docker diagnostics matrix covers every built-in server and production setting", () => {
 	const matrixPath = path.join(process.cwd(), "extensions/pi-lsp/test/docker/matrix.json");
 	const matrix = JSON.parse(readFileSync(matrixPath, "utf8")) as {
 		profiles: Array<{
 			name: string;
 			command: string[];
 			extensions: string[];
+			initialization?: Record<string, unknown>;
 			policy: {
 				diagnosticsSettleMs?: number;
 				pushDiagnosticsGraceMs?: number;
@@ -74,8 +75,10 @@ test("Docker diagnostics matrix covers every built-in server and command", () =>
 	for (const config of DEFAULT_SERVER_CONFIGS) {
 		const profile = matrix.profiles.find(({ name }) => name === config.name);
 		assert.ok(profile, `missing Docker profile for ${config.name}`);
-		assert.deepEqual(profile.command, config.command);
+		const linuxCommand = config.name === "elixir-ls" ? ["language_server.sh"] : config.command;
+		assert.deepEqual(profile.command, linuxCommand);
 		assert.deepEqual(profile.extensions, config.extensions);
+		assert.deepEqual(profile.initialization, config.initialization);
 		assert.deepEqual(profile.policy, {
 			...(config.diagnosticsSettleMs ? { diagnosticsSettleMs: config.diagnosticsSettleMs } : {}),
 			...(config.pushDiagnosticsGraceMs


### PR DESCRIPTION
## Summary

- add an opt-in, single-profile Docker matrix for all 28 built-in LSP servers using real Pi, pi-lsp, and language servers
- add bounded push-only diagnostics grace periods for six servers whose clean files remain silent
- synchronize matrix commands, extensions, and diagnostics policies with the built-in catalog through deterministic tests
- document measured cold-start results, including Kotlin as unresolved after three reverted experiments

The Docker matrix is manual-only: CI and `npm run check` do not build or run Docker. The regular test suite only validates that `matrix.json` stays synchronized with the built-in server catalog.

## Verification

- `npm run check` (1,246 tests)
- `just pack-lsp`
- 28 Docker profiles run sequentially with three cold error and three cold clean cases each
