### PR TITLE
feat(sync): add multi-target profile manager

### DIFF
--- a/docs/plans/archived/2026-07-24_pi-sync-multi-profile-target-ux-plan.md
+++ b/docs/plans/archived/2026-07-24_pi-sync-multi-profile-target-ux-plan.md
@@ -1,0 +1,508 @@
+# pi-sync multi-profile and multi-target UX plan
+
+## Goal
+
+Redesign pi-sync around the user goals of setting up safe sync, seeing the active context, switching between `home`/`work`-style sync targets, reviewing changes, syncing, and recovering. Add reusable R2/S3 storage profiles and named sync targets without exposing that data model as the primary workflow, while preserving existing commands, configuration, remote objects, state, environment overrides, and safety behavior. Deprecate the extension-specific `PI_SYNC_*` environment-variable family with value-free migration guidance, but preserve its current precedence and behavior until a future major version.
+
+This document is a proposal only. Product code, tests, stored data, and user-facing documentation must not change until the user explicitly approves it.
+
+## Context
+
+### Evidence inspected
+
+- Current package interface and behavior in `extensions/pi-sync/src/command.ts`, `file-selection.ts`, `config.ts`, `sync.ts`, `lock.ts`, `s3-client.ts`, snapshot/apply/state modules, and `types.ts`.
+- Current user-facing behavior in `extensions/pi-sync/README.md`.
+- Existing deterministic coverage in `extensions/pi-sync/test/sync.test.ts` and the shared TUI harness in `test/support.ts`.
+- Repository conventions in `docs/extension-conventions.md` and `docs/extension-settings.md`.
+- Pi 0.80.10 project typings/components plus current installed Pi documentation for extension modes, RPC UI, TUI components, focus, keyboard handling, widths, `SelectList`, `SettingsList`, and `BorderedLoader`.
+- Prior pi-sync menu and file-selection plans, current Git history, and the repository memory notes.
+
+### Current experience
+
+- Bare `/sync` opens a flat 13-item menu mirroring internal subcommands: `help`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock`.
+- The menu does not show whether sync is configured, which remote profile is active, whether sessions are included, whether auto-sync is enabled, or what the last known state is.
+- First-time setup creates a JSON template and asks the user to edit it manually.
+- `/sync files` is the only rich settings screen. Every toggle saves immediately; Escape closes rather than cancels, and the hint explains that behavior.
+- Push, pull, and rollback use confirmations, but long previews are notification/dialog text and do not have a bounded, responsive detail viewer.
+- Rollback from the menu requires the user to type a snapshot id instead of selecting from history.
+- Network work exposes a footer status but no cancellable loading surface.
+- The implementation supports one effective endpoint/bucket/remote namespace/file policy at a time. The current `profile` means a remote namespace under `prefix/profiles/<profile>`, not a reusable storage connection.
+- Flat configuration, `PI_SYNC_*`/AWS/R2 environment variables, remote snapshot format/layout, local state, direct subcommands, and automation flags are public compatibility surfaces. `PI_SYNC_*` remains functional in this release but becomes explicitly deprecated ahead of future major-version removal.
+
+### Primary user groups and goals
+
+1. **Single-destination, multi-machine user** — evidenced by the current README and conflict model. They want setup once, quiet automatic sync, a quick health check, safe manual sync, and understandable conflict recovery.
+2. **Multi-context user** — directly requested in this conversation. They want reusable R2/S3 connections and named targets such as `home` and `work`, with a safe way to switch the active target.
+3. **Privacy-sensitive session-sync user** — evidenced by the opt-in session behavior and repeated warnings. They need session scope and risk visible before enabling or applying it.
+4. **Automation/expert user** — evidenced by documented direct routes, flags, environment overrides, and manual JSON configuration. They need deterministic target selection plus actionable migration from deprecated `PI_SYNC_*` variables without an immediate break.
+5. **Recovery user** — evidenced by history, rollback, backups, conflict handling, and stale-lock recovery. They need diagnosis and recovery without memorizing internal ids or flags.
+
+Frequency statements below are design assumptions inferred from product behavior rather than analytics. They should be validated through maintainer/user feedback after implementation.
+
+## Capability classification
+
+| Capability | Classification | Rationale |
+| --- | --- | --- |
+| Automatic sync of the active target | Primary | Runs at every normal startup today and is the product's default behavior. |
+| Safe `Sync now` decision | Primary | Core user goal; chooses push/pull/up-to-date conservatively. |
+| Current target and consequential state | Primary safety/status | Affects every sync decision and must be visible. |
+| Switch active target | Primary for multi-context users | Requested `home`/`work` workflow; reversible but changes future sync behavior. |
+| Status and concrete change preview | Supporting | Important before consequential operations; no mutation. |
+| Choose synced content | Supporting/settings | Existing capability that controls scope and privacy. |
+| Target settings and automatic-sync toggle | Supporting/settings | Important but changed less often than syncing. |
+| Add/edit targets | Secondary | Infrequent setup/maintenance. |
+| Add/edit reusable storage profiles | Advanced | Connection reuse is useful but is an implementation concept for most users. |
+| Connection diagnostics (`doctor`) | Advanced/recovery | Used mainly during setup or failure. |
+| Explicit push/pull and force resolution | Advanced/high-risk | Needed for conflicts and automation, not the normal primary flow. |
+| History | Secondary/recovery | Useful context for rollback. |
+| Rollback | Destructive/recovery | Overwrites local files and changes the active remote pointer, though a backup is created. |
+| Stale unlock | Destructive/advanced recovery | Must remain gated because an incorrect unlock can permit concurrent mutations. |
+| Remove target/profile | Destructive settings | Removes local configuration only; remote snapshots must remain untouched. |
+| Existing direct subcommands and flags | Compatibility-only in the TUI hierarchy | Preserve for scripts and expert use, but do not mirror them into the primary menu. |
+| Flat config, current `profile`, environment aliases, remote `profiles/` path, snapshot fields | Compatibility-only data/wire format | Must continue to load and address the same remote objects. |
+| All `PI_SYNC_*` variables | Deprecated compatibility | Preserve effective precedence, show value-free migration guidance, and reserve removal for a future major version. |
+
+## Flow evaluation
+
+| Flow | Expected frequency | Importance | Complexity | Risk | Reversibility |
+| --- | --- | --- | --- | --- | --- |
+| Startup auto-sync | Very high | High | Medium | High when pulling | Pull has backup; remote publication is pointer-based. |
+| Manual smart sync | Medium | High | Low user complexity | Variable | Pull/rollback recoverable; push can require force resolution. |
+| Switch target | Medium for multi-context users | High | Low | Low immediately, medium for later auto-sync | Easily switched back; must not sync on switch. |
+| Review status/changes | Medium | High | Medium network work | None | Fully reversible/cancellable. |
+| Change synced content | Low/medium | Medium/high | Medium | Medium because future scope changes | Settings can be restored; no sync occurs while editing. |
+| Add/edit target | Low | High | Medium | Medium | Atomic settings write; old valid state retained on failure. |
+| Add/edit storage profile | Low | High | High | High if credentials/destination are wrong | Atomic settings write; connection must be checked before activation. |
+| Force push/pull | Rare | Critical | Medium | High | Pull has backup; force push may supersede remote state. |
+| Rollback | Rare | Critical | Medium | High | A new backup is created before local mutation. |
+| Unlock stale operation | Rare | Critical | Medium | High | Not inherently reversible; liveness guard remains mandatory. |
+
+## Usability findings
+
+1. **The primary menu reflects commands, not goals.** Thirteen equal-weight routes make users translate `config`, `doctor`, `diff`, `push`, and `pull` into a workflow.
+2. **Consequential current state is hidden.** The active remote namespace, storage destination, selected scope, session inclusion, auto-sync state, and stale/unchecked status are not shown before choosing an action.
+3. **Setup is implementation-led.** `init` exposes a template rather than guiding the user toward “sync my home settings to R2.” Placeholder values can progress as non-empty configuration and fail later at the network layer.
+4. **Preview quality is inconsistent.** Pull shows a path diff, push emphasizes counts, rollback requires an id, and large path sets can overflow dialog/notification surfaces.
+5. **Save/close/cancel semantics vary.** File toggles persist immediately while Escape merely closes; setup and rollback cancellation behave differently. The current text is technically explicit, but it does not support drafting and reviewing a consequential scope change.
+6. **Navigation is shallow but not continuous.** Every action exits the menu, so related tasks require repeatedly entering `/sync`.
+7. **Long operations are not interactively cancellable.** Footer status indicates activity but does not give the user a bounded loading/cancel state.
+8. **Failure recovery is mostly textual.** Errors often name a command to run, but there is no context-aware route back to status, conflict resolution, history, or stale-lock recovery.
+9. **The current namespace term blocks the proposed model.** Existing `profile` cannot simultaneously mean “R2/S3 connection profile” and “remote namespace”; `PI_SYNC_PROFILE` must retain its namespace meaning during the deprecation period and must never select a storage profile or active target.
+10. **The current local apply is preflighted but not transactionally atomic across multiple files.** A failure after some deletes/writes can leave partial local state. A redesign that promises atomic confirmed changes must add rollback and crash recovery rather than only relabel the UI.
+11. **Mode support needs explicit boundaries.** TUI supports custom components; RPC supports dialogs/notifications but `custom()` returns `undefined`; print/JSON have no extension UI output. The README currently describes a non-interactive usage notification that is not observable when `ctx.hasUI` is false.
+12. **Responsive/accessibility coverage is narrow.** Existing file-selection tests render at 100 columns. Pi requires every line to fit the supplied width and input-containing wrappers to forward focus for IME; terminal UIs expose no ARIA-like screen-reader API.
+13. **Source/test cohesion will degrade if features are added in place.** `src/sync.ts` is already 918 lines and `test/sync.test.ts` is 1,962 lines, so the redesign should split responsibilities instead of extending both monoliths.
+
+## Proposed information architecture
+
+### User-facing terminology
+
+- **Sync target**: the named context the user chooses, such as `home` or `work`. It answers “what should sync, and where?”
+- **Storage profile**: a reusable R2/S3 connection, such as `r2` or `s3`. This wording appears only in setup/management.
+- **Current target**: the one target used by bare/manual commands and startup/shutdown auto-sync.
+- **Remote namespace**: the advanced target field that preserves the old `profile` meaning and remote layout.
+
+Primary surfaces should say `Current target: home` and `Storage: Cloudflare R2 · personal-pi`, not lead with `profiles`, `targets`, buckets, or JSON fields.
+
+### Bare `/sync` menu
+
+The title shows local, immediately available state without blocking on network access:
+
+```text
+Pi Sync
+
+Current target: home
+Storage: Cloudflare R2 · personal-pi
+Auto-sync: On · Sessions: Off
+Last known sync: 2 hours ago · Remote not checked
+
+What do you want to do?
+```
+
+The configured menu is ordered by user goal:
+
+1. `Sync now` — safely determine whether to push, pull, or do nothing.
+2. `Switch target` — show `home`/`work` choices and their storage/scope summaries.
+3. `Status & changes` — check the remote and review a concrete diff without mutation.
+4. `Settings` — edit the current target's auto-sync and synced content.
+5. `Manage targets & storage` — add/edit/remove targets and storage profiles.
+6. `History & recovery` — browse snapshots, rollback, diagnose, or unlock stale work.
+7. `Help` — concise workflow guidance plus compatibility commands.
+
+The main menu has at most seven stable actions. It embeds status rather than forcing users into a separate status screen before every decision. `Settings`, status, and help remain discoverable as required by repository conventions.
+
+The unconfigured/empty menu is smaller:
+
+1. `Set up sync`
+2. `Use existing settings` when a legacy flat config is present but needs review/migration
+3. `Help`
+
+Malformed settings are not treated as empty; they produce a repair state so the extension never overwrites them silently.
+
+### Navigation model
+
+- Main-menu Escape exits pi-sync with no side effects.
+- Secondary menus include an explicit `Back` row; Escape also returns to the parent menu.
+- Transactional editors use explicit `Save changes`, `Discard changes`, and `Continue editing` choices. Escape from the editor enters that decision only when the draft is dirty; otherwise it returns.
+- Confirmation screens use action-specific verbs (`Switch to work`, `Push 4 changes`, `Apply 3 remote changes`, `Restore snapshot …`) and `Cancel`, never generic `OK`.
+- Navigation depth is limited to main menu → one management/recovery submenu → one focused editor/preview.
+- After success or recoverable failure, return to the relevant menu with refreshed local state; a direct textual subcommand completes without opening an unrelated menu.
+
+## Proposed interaction flows
+
+### 1. First-time setup
+
+1. Select `Set up sync`.
+2. Choose a supported preset: `Cloudflare R2` or `Other S3-compatible storage`. Presets provide only verified defaults; expert fields remain editable.
+3. Name the first target (suggest `default`) and storage profile (suggest `r2` or `s3`).
+4. Enter non-secret destination fields, choose synced content, and decide whether auto-sync is enabled. Sessions remain off by default and require an explicit privacy acknowledgement before inclusion.
+5. Choose a credential source:
+   - use detected `PI_SYNC_*` or standard AWS credential variables, showing source/presence only; or
+   - create a private settings template and show the exact fields/path to complete manually.
+6. Preview the effective target: storage type, endpoint host, bucket, remote namespace, selected groups, session risk, auto-sync behavior, and environment overrides. Never render credential values.
+7. `Save setup` writes one complete valid configuration atomically. Cancellation before save writes nothing. A connection check is read-only and cancellable; failure keeps the draft and previous config.
+8. Success shows `Target “home” is ready` and offers `Sync now` or `Back to Pi Sync`.
+
+**Security decision proposed for approval:** Pi's extension `input()` and bundled `Input` have no masked-secret mode. This proposal does not collect a secret through an unmasked dialog. A custom masked credential editor is deferred unless explicitly added to the approved scope; existing environment credentials and private manual JSON remain supported.
+
+### 2. Switch current target
+
+1. Open a searchable target list. Every row shows the full target name, current marker in text, storage label, bucket, synced-content summary, session state, and validity.
+2. Invalid targets remain visible with an actionable reason but cannot be activated.
+3. Selecting another target opens a preview showing `From`, `To`, destination, scope differences, auto-sync/session state, and the statement: `Switching does not sync or modify files now.`
+4. `Switch to <name>` atomically changes only `activeTarget`; `Cancel` changes nothing.
+5. Do not run network sync as a side effect of switching. The success message states when auto-sync will next run and offers an explicit `Sync now` action.
+6. If an environment override changes the effective destination or scope, show that source before confirmation.
+
+Only the current target participates in automatic startup/shutdown sync. This avoids two remotes independently pulling into the same local Pi agent directory. Manual `--target <name>` operations may address a non-current target without switching it.
+
+### 3. Sync now
+
+1. Show a cancellable `Checking <target>…` loader. Cancellation during read-only collection/network checks changes nothing.
+2. Resolve to one of these explicit outcomes:
+   - **Up to date:** success feedback; no confirmation.
+   - **Local changes only / empty remote:** preview destination and every add/change/delete or preserved-unmanaged count; confirm `Push N changes`.
+   - **Remote changes only:** preview every local write/delete, protected current session, session warning, and backup location; confirm `Apply N remote changes`.
+   - **First-sync mismatch or two-sided conflict:** do not mutate. Show both sides and offer `Keep local (force push)`, `Use remote (force pull)`, or `Cancel`; force choices receive a final exact consequence confirmation.
+   - **Nothing selected:** explain that the target manages no files and link to Settings; do not imply a successful useful sync.
+3. After confirmation, use an operation surface with target/action state. Do not offer cancellation once the commit boundary begins unless cancellation can guarantee no externally visible change.
+4. Apply/publish transactionally. Success names the target, direction, changed file count, snapshot, backup if any, and reload requirement. Failure preserves or recovers the previous valid local/remote active state and gives a target-specific retry/recovery action.
+5. Pulled resource changes offer `Reload now` or `Later`; choosing Later is not called cancellation and does not undo the completed pull.
+
+### 4. Status & changes
+
+- Start with a cancellable read-only check.
+- Show target, storage destination, effective setting sources, last local state, remote snapshot/time/machine, selected scope, session risk, and a categorized diff (`Will add locally`, `Will update locally`, `Will remove locally`, or remote equivalents).
+- Full changed paths remain accessible in a bounded scrollable/searchable detail view. Counts alone are not the only preview.
+- From the result, offer context-aware next actions: `Sync now`, `Push local`, `Pull remote`, `Resolve conflict`, or `Back`. Explicit push/pull remain progressive disclosure rather than main-menu peers.
+
+### 5. Settings and synced content
+
+- Header: `Settings for target “home”` with storage summary.
+- Simple rows such as auto-sync save immediately and are labeled `Changes save immediately`; Escape is labeled `Close`, not Cancel. Each write is serialized, atomic, preserves unknown fields/private permissions, and rolls the row back on failure.
+- `Synced content` opens a transactional draft based on the current selector:
+  - built-in files/groups are always recognizable;
+  - sessions remain visibly risky and read-only when `PI_SYNC_SESSIONS` overrides the target during the deprecation period;
+  - extra safe files remain searchable;
+  - edits do not write or start sync;
+  - exiting a dirty draft shows exact included/excluded changes and `Save changes`, `Discard changes`, `Continue editing`;
+  - save is one atomic config write, and discard/cancel has no side effects.
+- Changing content does not immediately perform network sync. Success says it applies to the next manual or automatic sync.
+
+### 6. Manage targets & storage
+
+The submenu is goal-labeled:
+
+- `Add sync target`
+- `Edit current target`
+- `Manage storage profiles`
+- `Remove sync target` (advanced/destructive)
+- `Back`
+
+Target setup asks where and what to sync, then previews one atomic save. Storage profile management is one level deeper and exposes endpoint, region, credential source/presence, and targets using the profile.
+
+Safety rules:
+
+- A profile referenced by a target cannot be removed.
+- The current target cannot be removed until another target is selected, unless it is the only target and removal returns pi-sync to a clearly unconfigured state.
+- Removing a target/profile never deletes remote objects; confirmation says so.
+- Duplicate target remote identities (same effective profile, bucket, prefix, and namespace) are rejected by default to prevent two local state records controlling the same pointer.
+- Overlapping local file selections across different targets are allowed but visibly warned because the requested work/home workflow may intentionally share files.
+
+### 7. History & recovery
+
+- `Browse history` lists recent snapshots with readable time, machine, current marker, and session presence; snapshot ids remain visible as secondary text and searchable.
+- Selecting a snapshot opens a concrete rollback preview, not a free-form id prompt.
+- Rollback confirmation names target, snapshot, local writes/deletes, remote pointer change, session effect, and backup behavior.
+- `Check setup` replaces the primary-menu `doctor` label but routes to the same diagnostic capability.
+- `Recover stale operation` appears only when the lock is stale/unreadable; it retains process-liveness checks and exact confirmation. A live lock shows who/what is running and disables removal.
+- Direct `/sync history`, `/sync rollback <id>`, `/sync doctor`, and `/sync unlock --stale` remain compatibility routes.
+
+## Proposed configuration and compatibility architecture
+
+### Canonical v2 shape
+
+The exact schema should be finalized in tests before implementation, but the approved semantic boundary is:
+
+```json
+{
+  "version": 2,
+  "activeTarget": "home",
+  "profiles": {
+    "r2": {
+      "kind": "r2",
+      "endpoint": "https://<account-id>.r2.cloudflarestorage.com",
+      "region": "auto",
+      "accessKeyId": "...",
+      "secretAccessKey": "..."
+    },
+    "s3": {
+      "kind": "s3-compatible",
+      "endpoint": "https://s3.example.com",
+      "region": "ap-northeast-1",
+      "accessKeyId": "...",
+      "secretAccessKey": "..."
+    }
+  },
+  "targets": {
+    "home": {
+      "profile": "r2",
+      "bucket": "personal-pi",
+      "prefix": "pi-sync",
+      "namespace": "home",
+      "autoSync": true,
+      "syncFiles": ["settings.json", "skills", "prompts", "themes"],
+      "syncSessions": false,
+      "extraFiles": []
+    },
+    "work": {
+      "profile": "s3",
+      "bucket": "company-pi",
+      "prefix": "developers/narumi",
+      "namespace": "work",
+      "autoSync": true,
+      "syncFiles": ["AGENTS.md", "prompts"],
+      "syncSessions": false,
+      "extraFiles": []
+    }
+  }
+}
+```
+
+`profiles` describe reusable connection/authentication. `targets` own bucket, remote namespace, sync policy, and automatic behavior. New target namespaces default to the target id at creation but remain stable if the display/id is later renamed.
+
+### Legacy behavior
+
+- A flat v1 file loads as one synthetic current target without rewriting the file or changing its effective destination.
+- The old flat `profile` maps to the target's `namespace`; it is not reinterpreted as a storage-profile name.
+- Every `PI_SYNC_*` variable retains its current effective precedence in this release. When any is present, status/setup/settings surfaces show one value-free deprecation warning and per-field migration guidance; warnings never render or copy values, while existing effective non-secret status fields retain their compatibility behavior. Removal is reserved for a future major version and documented in migration/release notes.
+- Migration guidance maps `PI_SYNC_ENDPOINT`, `PI_SYNC_REGION`, `PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` to storage-profile fields; `PI_SYNC_BUCKET`, `PI_SYNC_PROFILE` (namespace), `PI_SYNC_PREFIX`, `PI_SYNC_AUTO_SYNC`, and `PI_SYNC_SESSIONS` map to target fields. Flat-v1 users receive the equivalent flat-field names.
+- `PI_SYNC_PROFILE` continues to override only flat `profile` or v2 target `namespace`; it never selects `activeTarget` or a storage profile.
+- Existing fallback aliases remain below `PI_SYNC_*` precedence: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `AWS_REGION` override the selected storage profile; `R2_ENDPOINT` and `R2_BUCKET` override the applicable profile/target. UI shows source/presence without secrets.
+- No new extension-specific environment variables are introduced.
+- Nested v2 data takes precedence when both v2 and flat recognized fields are present; legacy fields are identified as ignored compatibility data rather than silently merged ambiguously.
+- Legacy-to-v2 migration occurs only when the user confirms a feature that requires v2 (for example adding a second target). The preview names the conversion. The original JSON bytes receive a private local backup, known fields are copied without semantic change, unknown top-level fields are preserved, and the canonical file is installed atomically.
+- Malformed/invalid/symlinked configuration is never overwritten or auto-migrated.
+- Existing remote layout `prefix/profiles/<namespace>`, snapshot `profile` fields, pointer/history formats, and snapshot ids remain unchanged. The physical `profiles/` path is compatibility-only and is not relabeled in place.
+- Existing local sync state is adopted by the migrated synthetic/default target so first use does not manufacture a false first-sync conflict. New targets get independent state identities that include target id and effective remote identity; old state remains recoverable during migration.
+- Existing direct routes remain accepted and documented. Add `--target <name>` to deterministic read/mutation routes and a concise `/sync use <name>` compatibility/automation route for changing `activeTarget`; provide completions and reject unknown/trailing flags instead of silently ignoring them.
+- Existing `--yes`, `-y`, `--force`, and `--stale` semantics remain. `--yes` skips confirmation only on explicit direct commands; it does not make bare interactive menu selections destructive without preview.
+
+## State behavior
+
+### Loading
+
+- Main menu uses validated local state immediately; it must not block on remote status.
+- Remote checks use `BorderedLoader` in TUI with Escape cancellation and an `AbortSignal` threaded through S3 requests and local collection where practical.
+- RPC uses dialog/notification fallbacks because `custom()` is unsupported. It must not call TUI-only components.
+
+### Empty
+
+- Missing config shows `Not set up` and only setup/help actions.
+- A valid profile with no targets shows `No sync targets` and prioritizes `Add sync target`.
+- A target selecting no content shows `Nothing selected` rather than `Up to date` as the sole message.
+- Empty remote is clearly distinguished from unavailable remote.
+
+### Success
+
+- Feedback uses a verb and object: `Switched to “work”`, `Saved settings for “home”`, `Pushed 4 files from “home”`, `Applied snapshot … to “home”`.
+- The relevant menu state refreshes immediately after local settings/state changes.
+- Footer status uses the stable `sync` key only for active work (`checking home`, `pushing work`) and is always cleared.
+
+### Error
+
+- Keep the previous valid in-memory and on-disk settings when validation, connection check, persistence, migration, or runtime application fails.
+- Errors name the target/profile and a next action without exposing access keys, secret keys, session tokens, synced secret content, or terminal control characters.
+- Network failure keeps local navigation available and labels remote status `Unavailable` or `Not checked`, not `Empty`.
+- Transaction failure reports whether automatic recovery completed and where the backup/journal is located.
+
+### Disabled
+
+- Invalid targets appear but cannot be activated or synced; their row states the missing profile/field.
+- Auto-sync off remains visible in the menu and settings.
+- Environment-overridden fields are read-only and show `environment` as source.
+- Sync actions are disabled while a live local lock is held; recovery is available only for stale/unreadable locks under existing safeguards.
+- A profile cannot be removed while referenced.
+
+### Partial
+
+- If some targets are valid and others invalid, valid targets continue to work; invalid targets remain visible for repair. No target is silently discarded.
+- A malformed top-level settings file blocks all writes and preserves the file unchanged.
+- If the active target is invalid, auto-sync is paused and the menu prioritizes repair/switch actions.
+- If auxiliary history update fails after remote pointer publication, report the sync as published with history needing repair rather than falsely claiming no remote change; a later diagnostic can reconcile it.
+- A pulled current session file remains protected as today and the preview/success message says it was skipped.
+
+## Atomicity and recovery requirements
+
+- Settings, active-target changes, and migrations use private (`0600` POSIX) temporary-file plus rename publication, preserve unknown fields, and retain the previous valid runtime state on failure.
+- Local multi-file pull/rollback must become transactional: preflight all operations, stage writes, journal original identities/paths, commit, roll back every completed mutation on any error, and recover an interrupted journal before the next sync. Tests inject failures at each mutation boundary. Filesystem-wide true atomic rename is impossible; the product promise is no accepted partial final state after in-process rollback or next-start recovery.
+- Remote push/rollback keeps immutable snapshot upload as staging and `latest.json` as the active publication boundary. Failure before pointer publication preserves the prior active snapshot; orphan staged objects are safe and may be diagnosed/cleaned later. History is auxiliary and recoverable.
+- Cancellation is offered only before the mutation/publication boundary unless the operation can abort without a visible commit. Once commitment begins, the UI says `Applying`/`Publishing` rather than presenting a misleading Cancel action.
+- Existing best-effort remote re-read race guard remains documented; this design does not claim true cross-machine compare-and-swap on R2/S3.
+
+## Responsive and accessibility behavior
+
+- Use Pi's `ctx.ui.select()` for the small main/submenus, searchable `SelectList` for targets/history, `SettingsList` for settings, and `BorderedLoader` for cancellable checks. Do not create an overlay dependency for a core workflow.
+- Every custom render line must fit the supplied width. Deterministic render tests cover at least 32, 60, and 100 columns plus long Unicode target/profile/path names. Critical target, destination, risk, and action text wraps on its own line rather than being ambiguously truncated.
+- Long change/history lists use bounded vertical windows with visible position/count and search or paging; no critical warning exists only below an unbounded viewport.
+- Preserve stable reading order: title/current state → warning/preview → choices → keyboard help. Avoid layout shifts during async work by using a dedicated loader and then replacing it with a complete result.
+- Use injected Pi keybindings and textual key hints. Arrow/Page keys navigate, Enter activates, Space toggles settings where conventional, Escape cancels/returns, and focus is restored to the invoking Pi editor when the flow closes.
+- Any custom component containing `Input`/`Editor` implements `Focusable` and forwards `focused` for IME support. Target/profile names accept Unicode while storage ids/paths receive explicit validation.
+- State is never conveyed only by color or a checkmark: use text such as `(current)`, `Warning: sessions included`, `Invalid: missing profile`, and `Cancelled`/`Saved`/`Applied`.
+- Sanitize untrusted config, remote, machine, path, and error text before terminal rendering.
+- Pi's terminal extension API exposes no semantic tree or ARIA announcement API. Automated accessibility tests therefore verify plain-text meaning, logical order, key operation, focus forwarding, non-color cues, and width; a real terminal/screen-reader smoke is recorded as manual/conditional rather than falsely claimed as deterministic coverage.
+- Themes come from the callback, and status/warning/success colors use Pi theme roles so contrast follows the active Pi theme. No custom hard-coded colors or motion are introduced.
+
+## Acceptance criteria
+
+### Primary flows
+
+- [x] Bare `/sync` in TUI shows configuration-aware current-target state and no more than seven goal-oriented actions in the proposed order; cancelling it performs no filesystem/network mutation.
+- [x] Empty, legacy, malformed, invalid-active-target, live-lock, remote-unavailable, and valid configured menus each expose the appropriate next action without hiding the current state.
+- [x] A user can create R2/S3-compatible profiles, create `home` and `work` targets that reuse them, preview the effective result, and save once atomically without any secret appearing in rendered text, notifications, errors, logs, or snapshots.
+- [x] Switching target previews from/to state, performs no sync, writes `activeTarget` atomically only after confirmation, and leaves the prior target active on cancel/failure.
+- [x] Only the current target auto-syncs; a manual operation can address another valid target explicitly without switching.
+- [x] Smart sync produces deterministic up-to-date, local-only, remote-only, first-sync mismatch, conflict, empty-remote, and nothing-selected outcomes with concrete previews and proportionate confirmation.
+
+### Preview, confirmation, cancellation, and recovery
+
+- [x] Every push/pull/force/rollback preview identifies target, destination, changed paths, writes/deletes, session effect, protected live session, preserved unmanaged files, backup behavior, and active snapshot effect as applicable.
+- [x] Read-only checks can be cancelled with no state change; settings/content drafts can be discarded with byte-for-byte unchanged config; confirmed commits do not expose a misleading cancellable phase.
+- [x] Settings/migrations survive write/rename/concurrency failures with previous bytes, effective state, unknown fields, and private permissions preserved.
+- [x] Pull/rollback failure injection at each mutation boundary yields either the complete new state or the complete previous state after rollback/recovery, never an accepted partial state.
+- [x] Remote publication failure before `latest.json` commit leaves the prior active pointer; post-publication history failure is detected and recoverable.
+- [x] Rollback is selectable from history in TUI while direct snapshot-id rollback remains compatible.
+
+### Navigation, responsive behavior, and accessibility
+
+- [x] Main Escape exits; submenu Back/Escape returns; dirty editor Escape offers Save/Discard/Continue; success/failure returns to the relevant menu; navigation depth does not exceed the proposed limit.
+- [x] All custom screens render with no line wider than 32, 60, or 100 columns under long Unicode names, hosts, paths, warnings, and large lists; full critical values remain available without ambiguous truncation.
+- [x] Keyboard-only tests cover arrows, paging/search, Enter, Space, Escape, and configured keybinding injection; focus returns correctly and any input wrapper forwards `focused` for IME.
+- [x] Rendered plain text carries current/invalid/warning/success meaning without relying on color/symbol/position, and untrusted terminal controls are escaped.
+- [x] A conditional manual screen-reader/IME/theme smoke is documented; unsupported Pi semantic-announcement capabilities are not claimed.
+
+### Compatibility and modes
+
+- [x] Flat config, omitted `syncFiles`, old `profile`, all current environment aliases/precedence, old local state, remote `profiles/<profile>` layout, snapshot/pointer/history formats, and unknown JSON fields retain their current meaning.
+- [x] When any `PI_SYNC_*` variable is set, its override still works and status/setup/settings expose one redacted deprecation warning with per-variable migration guidance; no warning or error reveals a value, and `PI_SYNC_PROFILE` affects only namespace.
+- [x] Legacy migration is explicit, previewed, backed up, private, atomic, concurrency-safe, and adopts the existing state without a false first-sync conflict.
+- [x] Every current documented subcommand and flag remains tested; new `--target`/`use` routes have completions, exact validation, safety checks, and documentation.
+- [x] TUI and RPC use only supported UI methods; RPC receives protocol-safe dialog/notification fallbacks. Print/JSON support is documented honestly and never writes ad hoc protocol-corrupting output.
+- [x] Session privacy warnings, secret scan, symlink/path protections, unmanaged-file preservation, live-session protection, local lock/liveness behavior, remote race guard, and backups remain intact.
+
+### Quality and documentation
+
+- [x] Source responsibilities are split so no newly expanded source exceeds 1,000 lines; the 1,962-line test suite is decomposed by configuration/UI, sync flows, snapshot/apply, S3, and lock behavior.
+- [x] Deterministic tests cover primary flows, previews, confirmations, cancellations, navigation, loading/abort, all state classes, failure recovery, responsive rendering, accessibility proxies, RPC fallback, and compatibility.
+- [x] `extensions/pi-sync/README.md` documents the goal-oriented menu, profiles/targets/current target, setup, switching, presets, settings semantics, direct compatibility routes, `PI_SYNC_*` deprecation/current precedence/future-major removal, AWS/R2 fallback precedence, migration, mode support, privacy, atomic recovery limits, and remote race limitation.
+- [x] `npm run check`, `just pack-sync`, and an isolated Pi runtime smoke pass after implementation.
+
+## Implementation evidence
+
+Completed on `feat/pi-sync-multi-profile-target-ux`:
+
+- Focused pi-sync coverage passes across configuration/UI, publication, snapshot/apply, S3, and lock suites, including cancellation, 32/60/100-column rendering, malformed/live-lock repair states, current/non-current target behavior, exact migration backups, every planned local mutation boundary, interrupted-journal recovery, pre-pointer publication failure, and post-pointer history failure.
+- `npm run check` passes with 1,270 tests and all formatting, boundary, and workspace typecheck gates.
+- `just pack-sync` passes; the 20-file dry-run tarball contains every new source module and the updated README.
+- An isolated `PI_CODING_AGENT_DIR=<temporary> pi --mode rpc --no-session -e ./extensions/pi-sync` smoke exits 0 with protocol-safe JSON and no stderr.
+- Expanded source and test responsibilities are decomposed; no changed source or test file exceeds 1,000 lines.
+- Pi has no terminal semantic/ARIA API and no controlled screen-reader/IME environment was available for deterministic automation. The README records the conditional manual smoke, while automated proxy tests cover logical text, non-color cues, Unicode, keyboard cancellation, theme components, terminal sanitization, and responsive widths.
+
+## Main design decisions and trade-offs
+
+1. **Target is primary; storage profile is advanced.** This supports the requested model without making users manage connection objects before they can sync.
+2. **Switching never syncs.** It adds one explicit `Sync now` step but guarantees target selection cannot unexpectedly overwrite local files.
+3. **Only one target auto-syncs.** This prevents multiple remotes racing over the same local Pi directory. Simultaneous multi-target mirroring is deliberately out of scope.
+4. **The old `profile` becomes user-facing `namespace`, but its wire/storage representation remains unchanged.** This avoids a remote migration while resolving terminology.
+5. **Simple settings may save immediately only when the UI says `Close`; complex content editing is transactional.** This follows Pi's settings convention while making cancellation unambiguous.
+6. **Force operations remain available but move behind conflict/status context.** Capability is preserved without making high-risk choices primary.
+7. **No unmasked secret entry.** This makes setup without environment credentials less seamless, but avoids exposing credentials through a platform dialog that has no password mode. A masked custom component can be a separately approved addition.
+8. **“Atomic” local multi-file apply means journaled transaction plus rollback/recovery.** A filesystem cannot atomically replace an arbitrary file set in one primitive; the design states the actual guarantee instead of overpromising.
+9. **Main menu status is last-known until checked.** This avoids network latency/failure blocking navigation and labels freshness honestly.
+10. **Existing commands remain compatibility routes.** The primary UI improves without breaking automation or forcing a command-surface migration.
+
+## Non-Goals
+
+- Sync multiple targets automatically or concurrently into the same local Pi directory.
+- Switch the local Pi agent directory or create separate local work/home sandboxes.
+- Delete remote snapshots/buckets when a local target or profile is removed.
+- Encrypt snapshots or credentials beyond existing private-file/storage transport behavior.
+- Replace S3/R2 with a new backend or claim atomic cross-machine compare-and-swap.
+- Rename the existing remote `profiles/` folder or snapshot `profile` field.
+- Add project-scoped pi-sync settings.
+- Add speculative new environment variables.
+- Remove any `PI_SYNC_*` variable in this release; deprecation warning and migration documentation come first.
+- Implement a custom masked secret editor unless separately approved.
+
+## Assumptions and unknowns
+
+- **Assumption:** `home`/`work` targets share the same local Pi agent directory and select different remote destinations/policies; target switching itself is not intended to switch local roots.
+- **Assumption:** one current target is the desired default for bare commands and auto-sync.
+- **Assumption:** preserving existing flat config, remote objects, and direct commands is more important than immediately cleaning up old terminology in stored data.
+- **Unknown:** there is no usage telemetry validating action frequency; menu priority is based on current defaults, documented workflows, and the user's multi-target request.
+- **Unknown:** actual screen-reader behavior varies by terminal and Pi exposes no semantic announcement API; manual validation environment availability must be recorded during implementation.
+- **Approval decision:** accept environment/manual private-file credential completion for this redesign, or explicitly expand scope to a custom masked secret input.
+
+## Risks
+
+- Migration precedence can silently redirect sync if old flat fields, new profiles/targets, and environment aliases are conflated; parsing and previews must keep these concepts separate. Deprecated `PI_SYNC_*` variables must retain exact precedence while warning, and `PI_SYNC_PROFILE` must never be reinterpreted.
+- Independent target state can collide if two targets resolve to the same remote identity; validation should reject duplicates.
+- Work/home targets may intentionally overlap local files; warnings must inform without blocking the core use case.
+- Transactional local apply and crash recovery materially increase implementation scope and require failure-injection tests before UI promises are changed.
+- Direct-route argument tightening can reveal scripts that relied on ignored junk flags; retain all documented input and describe rejection as a safety correction.
+- RPC cannot render custom viewers/loaders, and print/JSON cannot observe `ctx.ui.notify()`; mode-specific behavior must be designed and tested rather than assumed.
+- The repository uses Pi 0.80.10 typings while central docs track newer Pi releases; implementation must stay within installed/tested APIs or explicitly update dependencies as separate approved work.
+
+## Rollback / Recovery
+
+- Keep legacy flat config loading for at least the migration release; do not require a one-way startup migration.
+- Back up exact legacy config bytes before an explicitly confirmed v2 conversion and leave remote data untouched.
+- Preserve legacy local state while adopting it into the first migrated target so a code rollback can still use it.
+- Keep the remote object layout and snapshot formats unchanged so reverting the extension does not require remote rollback.
+- Use journaled local apply recovery before any new sync after an interrupted pull/rollback.
+- If the redesign must be reverted, nested v2 config cannot be understood by old versions; therefore README/release notes must state the minimum pi-sync version and retain the backed-up flat config for manual downgrade recovery.
+
+## Plan
+
+- [x] After explicit approval, finalize the v2 config/state schema and precedence in focused red tests covering flat compatibility, namespace semantics, profile/target validation, retained `PI_SYNC_*`/AWS/R2 precedence, value-free deprecation warnings, duplicate remote identities, unknown fields, private atomic writes, and explicit migration; evidence: focused configuration tests fail before implementation and pass after it.
+- [x] Decompose `extensions/pi-sync/src/sync.ts` and `extensions/pi-sync/test/sync.test.ts` along command UI, settings/migration, operation orchestration, snapshot/apply, S3, and lock responsibilities without changing behavior; evidence: existing tests and workspace typecheck pass before adding the approved UX.
+- [x] Implement normalized storage profiles, named targets, current-target resolution, independent state identity, legacy synthetic-target loading, and explicit backed-up migration; evidence: schema/compatibility tests plus old remote-key fixtures pass.
+- [x] Implement the configuration-aware main menu, empty/invalid/partial states, shallow Back/Escape navigation, target selector, switch preview, and atomic current-target save with no sync side effect; evidence: primary-flow, cancellation, failure, and navigation tests pass in TUI and RPC fallbacks.
+- [x] Implement setup and target/storage management around Cloudflare R2 and generic S3-compatible presets, effective-source display, safe credential completion, validation, previews, reference guards, and local-only removal; evidence: setup/edit/remove tests prove secret redaction, cancel/no-write, invalid-state recovery, and unknown-field preservation.
+- [x] Convert current-target settings to the approved immediate-vs-transactional semantics and make synced-content changes draft, preview, save/discard, and rollback on failure; evidence: settings tests cover rapid edits, environment-read-only rows including deprecated overrides, exact discard, one atomic save, and runtime state retention.
+- [x] Implement cancellable read-only status checks, bounded responsive concrete change previews, smart-sync outcomes, progressive explicit push/pull/force actions, and target-aware activity/success/error feedback; evidence: outcome matrix, abort, preview, confirmation, secret/control sanitization, and RPC tests pass.
+- [x] Implement transactional journaled local pull/rollback with in-process rollback and next-start recovery, and make remote pointer publication/history failure states explicit; evidence: failure injection at each commit boundary and interrupted-journal recovery tests prove no accepted partial final state.
+- [x] Replace free-form TUI rollback with searchable history selection and add context-aware diagnostics/stale-lock recovery while preserving direct routes; evidence: history selection, preview, cancel, rollback, live/stale/unreadable lock, and compatibility tests pass.
+- [x] Add exact argument validation, target completions, `--target`, and `/sync use` while retaining every documented route/flag and mode safety; evidence: command catalog/completion tests and TUI/RPC/print/JSON behavior tests pass without ad hoc protocol output.
+- [x] Add responsive and accessibility-focused rendering tests at 32/60/100 columns, long Unicode/extreme content, keyboard/search/page flows, focus forwarding/IME markers, non-color textual cues, theme invalidation, and terminal-control escaping; evidence: deterministic render/input tests plus recorded conditional manual TUI/IME/screen-reader smoke.
+- [x] Update `extensions/pi-sync/README.md` and release-facing migration guidance for the approved behavior, then verify package contents and runtime loading; evidence: README review, `npm run check`, `just pack-sync`, and an isolated `pi -e ./extensions/pi-sync` smoke pass.
+
+## Completion Checklist
+
+- [x] The approved user goals, menu hierarchy, terminology, state model, previews, and navigation are implemented without exposing profile/target internals as the primary flow.
+- [x] `home`/`work` targets and reusable R2/S3 profiles work, current target is always visible, switching has no sync side effect, and only the current target auto-syncs.
+- [x] Confirmed settings and sync mutations are atomic at their documented publication boundary; cancellation has no side effects; failures retain or recover the previous valid state.
+- [x] All existing stored data, remote objects, environment behavior, unknown fields, safety policies, direct workflows, and recovery paths remain compatible; every `PI_SYNC_*` variable remains effective with tested value-free deprecation guidance.
+- [x] Loading, empty, success, error, disabled, and partial states are exercised in supported modes.
+- [x] Responsive, keyboard, focus/IME, non-color, terminal-safety, and realistic screen-reader proxy criteria pass.
+- [x] Tests, documentation, CI-equivalent checks, package dry run, and Pi runtime smoke pass with no known required work remaining.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -2,26 +2,26 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-sync` is a native [Pi coding agent](https://pi.dev) extension that syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage.
+`@narumitw/pi-sync` syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage. Named sync targets such as `home` and `work` can reuse storage profiles such as `r2` and `s3`.
 
-It syncs automatically by default when Pi starts, then uses immutable snapshot bundles, a `latest.json` pointer, local locking, secret scanning, and pre-apply backups. Conversation/session syncing is opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets. Cross-machine pushes use a best-effort remote re-read guard because R2 rejected conditional `latest.json` writes during testing.
+The extension uses immutable snapshot bundles, a `latest.json` publication pointer, local locking, secret scanning, pre-apply backups, and recoverable local apply transactions. Conversation/session syncing remains opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets.
 
 ## ✨ Features
 
-- Opens every pi-sync action from the bare `/sync` menu and keeps direct `help`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` subcommands for automation and advanced flags.
-- Uses `/sync files` to choose which top-level Pi files and recursive directory groups are managed by this machine.
-- Syncs selected, allowlisted Pi configuration from `~/.pi/agent`:
+- Opens a goal-oriented `/sync` manager showing the current target, storage, auto-sync, session scope, and relevant next actions.
+- Supports multiple named **sync targets** and reusable R2/S3 **storage profiles**.
+- Switches targets without syncing or modifying files; only the current target runs automatic startup/shutdown sync.
+- Previews concrete local or remote file changes before push, pull, force resolution, or rollback.
+- Uses transactional synced-content drafts with explicit Save, Discard, and Continue editing choices.
+- Keeps direct `help`, `use`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` routes for compatibility and automation.
+- Syncs allowlisted Pi configuration from the Pi agent directory:
   - `settings.json`, `keybindings.json`, `models.json`, `AGENTS.md`, and `APPEND_SYSTEM.md`
   - recursive `skills/`, `prompts/`, `themes/`, and `extensions/` groups
   - safe top-level files selected through `extraFiles`
-  - optionally denylist-filtered `sessions/**/*.jsonl` when `syncSessions` is enabled
-- Stores each remote version as an immutable gzip-compressed JSON snapshot bundle.
-- Updates remote state through `latest.json` after re-reading remote state to reject already-visible remote changes.
-- Creates local backups before `pull` and `rollback` under `~/.pi/agent/.pisync/backups/`.
-- Runs `/sync sync` automatically on Pi startup when R2/S3 config is present.
-- Uses a local exclusive lock at `~/.pi/agent/.pisync/lock` for destructive sync operations and only treats locks as stale after checking process liveness.
-- Refuses to push common secret patterns and denylisted paths such as `.env`, `.env.local`, token/secret files, `.pisync`, `.git`, and `node_modules`.
-- Preflights snapshot apply operations before mutating local files, refuses symlink path escapes, and rejects writes over symlinks or directories.
+  - optionally denylist-filtered `sessions/**/*.jsonl`
+- Preserves files outside the addressed target's selection locally and in remote uploads.
+- Creates backups before pull/rollback and journals multi-file applies so failures roll back; interrupted transactions recover before the next sync.
+- Refuses common secret patterns, unsafe paths, symlink escapes, live-lock removal, and unreviewed conflict overwrites.
 
 ## 📦 Install
 
@@ -35,212 +35,282 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-sync
 ```
 
-Try this package locally from the repository root:
+Try this package from a local checkout:
 
 ```bash
 pi -e ./extensions/pi-sync
 ```
 
-## ⚙️ Configuration
+## 🚀 Quick start
 
-Run:
-
-```text
-/sync init
-```
-
-Then edit:
-
-```text
-~/.pi/agent/pi-sync.local.json
-```
-
-If `PI_CODING_AGENT_DIR` is set, pi-sync uses that directory instead of `~/.pi/agent` for config, state, backups, and synced files.
-
-Example:
-
-```json
-{
-  "endpoint": "https://<account-id>.r2.cloudflarestorage.com",
-  "bucket": "pi-sync",
-  "region": "auto",
-  "accessKeyId": "<access-key-id>",
-  "secretAccessKey": "<secret-access-key>",
-  "profile": "default",
-  "prefix": "pi-sync",
-  "autoSync": true,
-  "syncFiles": [
-    "settings.json",
-    "keybindings.json",
-    "models.json",
-    "AGENTS.md",
-    "APPEND_SYSTEM.md",
-    "skills",
-    "prompts",
-    "themes",
-    "extensions"
-  ],
-  "syncSessions": false,
-  "extraFiles": []
-}
-```
-
-Environment variables override the local config file:
-
-```bash
-export PI_SYNC_ENDPOINT="https://<account-id>.r2.cloudflarestorage.com"
-export PI_SYNC_BUCKET="pi-sync"
-export PI_SYNC_REGION="auto"
-export PI_SYNC_ACCESS_KEY_ID="..."
-export PI_SYNC_SECRET_ACCESS_KEY="..."
-export PI_SYNC_SESSION_TOKEN="..." # optional, for temporary credentials that require a session token
-export PI_SYNC_PROFILE="default"
-export PI_SYNC_PREFIX="pi-sync"
-export PI_SYNC_AUTO_SYNC="true"
-export PI_SYNC_SESSIONS="false" # opt in with true to sync Pi conversation JSONL files
-```
-
-Run `/sync files` in TUI mode to edit `syncFiles`, `syncSessions`, and `extraFiles` with a searchable selector. Enter or Space toggles an item and Escape closes the screen. Each successful change is saved immediately to `pi-sync.local.json`, preserving unknown fields through an atomic replacement with `0600` permissions on POSIX. No network sync starts until the next manual `push`, `pull`, or `sync`, or the existing automatic sync lifecycle.
-
-`syncFiles` accepts the built-in names shown above and has no environment-variable override. Directory names select the complete recursive group. Omitting `syncFiles` preserves the legacy default of selecting every built-in item; an empty array is valid and means this machine manages none of them. Unknown values make configuration validation fail instead of silently narrowing the selection.
-
-The selector always shows built-in items, even when they are absent locally, so another machine can provide them on pull. It also shows safe top-level regular files found locally and configured `extraFiles` that may only exist remotely. It excludes directories, symlinks, reserved names, and denylisted names. You can still edit `extraFiles` manually to select additional safe top-level file names.
-
-An unselected item is unmanaged by this machine: pi-sync does not collect, compare, pull, overwrite, or delete its local content, and pushes preserve its existing remote snapshot content for other machines. This applies to built-ins, directory groups, sessions, and extra files. Selecting nothing therefore does not delete unmanaged local or remote files.
-
-`PI_SYNC_ACCESS_KEY_ID`, `PI_SYNC_SECRET_ACCESS_KEY`, and `PI_SYNC_SESSION_TOKEN` are local-only credentials. Do not put them in files that pi-sync syncs. `PI_SYNC_SESSION_TOKEN` is optional and only needed for temporary credentials such as AWS STS, AWS SSO, assumed roles, or S3-compatible providers that issue short-lived credentials.
-
-Cloudflare R2 static access keys do not use a session token and usually reject requests signed with `X-Amz-Security-Token`. R2 temporary credentials that require a token are still supported. For R2 endpoints (`*.r2.cloudflarestorage.com`), pi-sync first sends the configured session token; if R2 rejects it with `InvalidArgument: X-Amz-Security-Token`, pi-sync retries that request once without the token and omits the token for the rest of the same command after a successful retry.
-
-pi-sync also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `R2_ENDPOINT`, and `R2_BUCKET` as compatibility aliases when the matching `PI_SYNC_*` variable is not set.
-
-### Session syncing
-
-`syncSessions` defaults to `false`. Set it to `true`, or set `PI_SYNC_SESSIONS=true`, to include Pi's configured session JSONL files in snapshots. pi-sync uses `PI_CODING_AGENT_SESSION_DIR`, Pi's `sessionDir` setting, or the default `${PI_CODING_AGENT_DIR:-~/.pi/agent}/sessions/**/*.jsonl` storage. Empty or misspelled `PI_SYNC_SESSIONS` values stay disabled. Only JSONL session files are included; other session-directory files and denylisted paths such as `.env*`, `.pisync`, `node_modules`, and names containing `token` or `secret` are ignored.
-
-Session sync is snapshot-based, not live collaboration. If the same session changes on two machines, `/sync sync` uses the same conflict rules as settings sync and skips when both local and remote changed. Run `/sync diff`, then choose `/sync pull --force` or `/sync push --force` if needed.
-
-When both `autoSync` and `syncSessions` are enabled, pi-sync syncs on startup and attempts a quiet session push on shutdown when local files changed. Startup session pulls happen after Pi has already selected the current session, so restart Pi or resume a pulled session to use newly synced conversations. If the remote changed first, the shutdown push is skipped with a warning instead of overwriting it.
-
-Session files can contain prompts, model output, tool results, file paths, images, and secrets. Use trusted R2/S3 storage, keep credentials local, and recover local files from `${PI_CODING_AGENT_DIR:-~/.pi/agent}/.pisync/backups/` if a pull or rollback overwrites something unexpectedly.
-
-## 🚀 Usage
-
-Run `/sync` without arguments to open the interactive menu containing every pi-sync action. The **files — Choose synced files** action opens the persistent selector. Choosing rollback asks for the snapshot id before showing the existing confirmation. Cancelling either action leaves unmodified state unchanged; file-selection changes that were already saved are not rolled back when the screen closes.
+Run the manager:
 
 ```text
 /sync
 ```
 
-The same actions remain available as direct routes for automation, non-interactive use, and advanced flags:
+When pi-sync is not configured, choose **Set up sync**. The TUI guides you through:
+
+1. Cloudflare R2 or another S3-compatible service
+2. a target name such as `home`
+3. a reusable storage-profile name such as `r2`
+4. endpoint, bucket, prefix, and remote namespace
+5. environment credentials or a private settings-file template
+6. a synced-content preset
+7. an exact setup preview and **Save setup** confirmation
+
+Pi's extension input API does not provide masked secret entry, so pi-sync never asks for a secret in an unmasked dialog. Use existing environment credentials or add credentials manually to the private settings file. Secret values are never shown in menus, status, warnings, or errors.
+
+A configured manager shows:
 
 ```text
-/sync help
-/sync init
-/sync config
-/sync files
-/sync status
-/sync diff
-/sync doctor
-/sync push
-/sync pull
-/sync sync
-/sync history
-/sync rollback <snapshot-id>
-/sync unlock --stale
+Current target: home
+Storage: Cloudflare R2 · personal-pi
+Auto-sync: On · Sessions: Off
+Last known sync: Remote not checked
 ```
 
-Bare `/sync` reports command usage when an interactive UI is unavailable; use a direct route for the desired operation. Outside TUI mode, `/sync files` does not open a custom component and instead reports the effective selection, config path, and manual editing fields. When `PI_SYNC_SESSIONS` is set, the sessions row is read-only and identifies the environment override.
+Its primary actions are:
 
-Useful flags:
+- **Sync now** — conservatively decide whether to push, pull, or do nothing
+- **Switch target** — preview and change the current target without syncing
+- **Status & changes** — perform a cancellable read-only remote check
+- **Settings** — control automatic sync and synced content for the current target
+- **Manage targets & storage** — add, edit, or remove local target/profile definitions
+- **History & recovery** — browse snapshots, preview rollback, diagnose setup, or recover a stale lock
+- **Help**
 
-- `--yes` / `-y`: skip confirmation prompts.
-- `--force`: allow push or pull when both local and remote state changed.
-- `--stale`: remove a stale local lock with `/sync unlock --stale`.
+Escape exits the main menu. Secondary menus provide Back; dirty synced-content drafts provide Save, Discard, and Continue editing. Cancellation before publication has no side effects.
 
-## 🔄 Automatic sync
+## ⚙️ Settings
 
-`autoSync` defaults to `true`. When Pi starts, pi-sync runs the same conservative decision logic as `/sync sync`:
+The private user settings file is:
 
-- only local changed or remote is empty → push
-- first sync with existing local settings and an identical remote snapshot → initialize local sync state without rewriting files
-- first sync with existing local settings and a different remote snapshot → skip and show a warning so you manually choose `/sync pull` or `/sync push`
-- only remote changed after an established sync → pull with a backup
-- both local and remote changed after a previous sync → skip and show a warning
-- no config present → do nothing
+```text
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-sync.local.json
+```
 
-Disable startup sync with either:
+A version 2 example:
 
 ```json
 {
-  "autoSync": false
+  "version": 2,
+  "activeTarget": "home",
+  "profiles": {
+    "r2": {
+      "kind": "r2",
+      "endpoint": "https://<account-id>.r2.cloudflarestorage.com",
+      "region": "auto",
+      "accessKeyId": "<access-key-id>",
+      "secretAccessKey": "<secret-access-key>"
+    },
+    "s3": {
+      "kind": "s3-compatible",
+      "endpoint": "https://s3.example.com",
+      "region": "ap-northeast-1",
+      "accessKeyId": "<access-key-id>",
+      "secretAccessKey": "<secret-access-key>"
+    }
+  },
+  "targets": {
+    "home": {
+      "profile": "r2",
+      "bucket": "personal-pi",
+      "prefix": "pi-sync",
+      "namespace": "home",
+      "autoSync": true,
+      "syncFiles": ["settings.json", "skills", "prompts", "themes"],
+      "syncSessions": false,
+      "extraFiles": []
+    },
+    "work": {
+      "profile": "s3",
+      "bucket": "company-pi",
+      "prefix": "developers/narumi",
+      "namespace": "work",
+      "autoSync": true,
+      "syncFiles": ["AGENTS.md", "prompts"],
+      "syncSessions": false,
+      "extraFiles": []
+    }
+  }
 }
 ```
 
-or:
+### Terminology
 
-```bash
-export PI_SYNC_AUTO_SYNC=false
+- A **storage profile** owns connection/authentication fields: `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`.
+- A **sync target** references a storage profile and owns `bucket`, `prefix`, `namespace`, `autoSync`, and its synced-content policy.
+- `activeTarget` is used by bare commands and automatic sync.
+- `namespace` is the old flat `profile` concept. The remote layout and snapshot wire field remain named `profiles`/`profile` for compatibility.
+
+Two targets may intentionally overlap local files, but only one is automatic. pi-sync rejects duplicate target remote identities to prevent independent local states from controlling the same remote pointer. Removing a target/profile removes local configuration only; it never deletes buckets or snapshots. A referenced profile cannot be removed, and users must switch away before removing one of several current targets.
+
+### Synced content
+
+The **Settings → Choose synced content** screen edits a draft. Enter or Space toggles, typing searches, and Escape opens the Save/Discard/Continue decision. A single Save atomically updates the target while preserving unknown fields and POSIX `0600` permissions. Saving settings never starts network sync.
+
+Omitting `syncFiles` preserves the legacy default of every built-in item. An empty array is valid and means the target manages nothing; **Sync now** reports that state instead of publishing an empty sync. Unknown built-in names fail validation.
+
+Unselected items are unmanaged: pi-sync does not compare, pull, overwrite, or delete their local content, and pushes preserve their existing remote content.
+
+### Environment precedence and deprecation
+
+The existing `PI_SYNC_*` family still works in this release with its existing highest precedence, but it is deprecated and will be removed in a future major version. pi-sync shows variable names—not values—and migration guidance when any are active.
+
+Move these fields into a storage profile:
+
+- `PI_SYNC_ENDPOINT`
+- `PI_SYNC_REGION`
+- `PI_SYNC_ACCESS_KEY_ID`
+- `PI_SYNC_SECRET_ACCESS_KEY`
+- `PI_SYNC_SESSION_TOKEN`
+
+Move these fields into a sync target:
+
+- `PI_SYNC_BUCKET`
+- `PI_SYNC_PROFILE` → `namespace`
+- `PI_SYNC_PREFIX`
+- `PI_SYNC_AUTO_SYNC`
+- `PI_SYNC_SESSIONS`
+
+`PI_SYNC_PROFILE` continues to mean only the remote namespace during the deprecation period; it never selects a storage profile or current target.
+
+Standard compatibility aliases remain below `PI_SYNC_*` precedence:
+
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`
+- `R2_ENDPOINT`, `R2_BUCKET`
+
+Environment-overridden fields are read-only in interactive settings. Cloudflare R2 static keys commonly reject `X-Amz-Security-Token`; pi-sync retains its one-time retry without the configured token for that R2 response.
+
+### Legacy flat settings
+
+Existing flat `pi-sync.local.json` files continue to work unchanged as a synthetic `default` target/profile. The old flat `profile` remains the remote namespace.
+
+Adding a second target offers an explicit migration preview. On confirmation pi-sync:
+
+1. takes an exact private backup of the original JSON bytes;
+2. preserves unknown top-level fields;
+3. maps existing connection and policy fields without changing the remote destination;
+4. adopts the existing local sync state for the migrated target;
+5. publishes the version 2 file atomically.
+
+Malformed, invalid, symlinked, or concurrently changed settings are never overwritten automatically. Version 2 settings require the multi-target pi-sync release or newer. For a manual downgrade, restore the exact `.legacy-<timestamp>.bak` flat-config backup; no remote migration or rollback is needed.
+
+## 💬 Commands
+
+The menu is the preferred interactive workflow. Existing deterministic routes remain available:
+
+```text
+/sync help
+/sync use <target>
+/sync init
+/sync config [--target <name>]
+/sync files [--target <name>]
+/sync status [--target <name>]
+/sync diff [--target <name>]
+/sync doctor [--target <name>]
+/sync push [--target <name>]
+/sync pull [--target <name>]
+/sync sync [--target <name>]
+/sync history [--target <name>]
+/sync rollback <snapshot-id> [--target <name>]
+/sync unlock --stale
 ```
 
-## 🧠 Sync model
+Flags:
 
-Remote layout:
+- `--target <name>` addresses a target without switching it.
+- `--yes` / `-y` skips an explicit direct command's confirmation.
+- `--force` resolves a reviewed conflict for push/pull/sync.
+- `--stale` requests guarded stale-lock recovery.
 
-```txt
-pi-sync/
+Unknown flags, unexpected values, and missing target/snapshot values are rejected. Argument completion includes configured target names after session start.
+
+TUI mode provides the full manager and custom settings components. RPC uses Pi's dialog/notification protocol and does not call TUI-only components. Print/JSON modes cannot display extension UI; use explicit direct routes for compatible automation and do not expect notification-only status output.
+
+## 🔄 Sync and recovery model
+
+For the current target, startup auto-sync uses conservative decisions:
+
+- local changed or remote empty → preview/confirm manually, or push in the existing quiet automatic path
+- identical first sync → initialize local state
+- safe remote-only change → pull with backup
+- first-sync mismatch or both changed → stop and require review
+- no selected content → report/skip
+
+Switching targets changes only `activeTarget`; it never starts sync. The next startup uses the new target's `autoSync`, or the user can choose **Sync now** immediately.
+
+Remote layout remains compatible:
+
+```text
+<prefix>/
 └── profiles/
-    └── default/
+    └── <namespace>/
         ├── latest.json
         ├── history.json
         └── snapshots/
-            └── 2026-05-21T12-00-00-000Z-abcd1234.json.gz
+            └── <snapshot-id>.json.gz
 ```
 
-Each snapshot contains the selected file tree and SHA-256 hashes. `latest.json` points to the active snapshot. Rollback applies an older snapshot locally and moves `latest.json` back to that snapshot.
+Snapshot upload is staging; `latest.json` is the active publication boundary. A failed history update after publication is reported as “snapshot active, history needs repair” instead of falsely claiming no remote change.
 
-Before updating `latest.json`, pi-sync re-reads the current pointer and rejects the push if it already differs from the version seen at the start of the command. This prevents overwriting changes that are visible before the final write. It is not a true atomic cross-machine compare-and-swap on R2, so two machines that push at the same instant can still race; run `/sync status` before important manual pushes if you use multiple machines heavily.
+Before pull/rollback, pi-sync writes a backup under `.pisync/backups/`. It then preflights all paths, stages a private transaction journal, applies changes, and restores every affected path if a later mutation fails. An interrupted journal is recovered before the next session/snapshot apply. Filesystem-wide replacement cannot be one OS primitive, so the guarantee is a complete previous or complete new accepted state after rollback/recovery—not an unrecoverable partial accepted state.
+
+R2/S3 does not provide the true cross-machine compare-and-swap used here. pi-sync re-reads `latest.json` immediately before publication and verifies afterward, but simultaneous writers can still race. Review status before important forced updates.
+
+## 🔒 Session syncing
+
+`syncSessions` defaults to `false`. Enabling it includes configured Pi session JSONL files and makes the privacy warning visible in settings, status, previews, and confirmations.
+
+Only JSONL session files are included. Denylisted names and paths such as `.env*`, `.pisync`, `node_modules`, `token`, and `secret` are ignored. The currently open session file is protected during pull; restart Pi or resume a pulled session to use newly synced conversations.
+
+Sessions can contain prompts, model output, tool results, file paths, images, and secrets. Use only storage you trust.
 
 ## 🛡️ Safety notes
 
-- pi-sync auto-syncs on startup by default, but skips instead of overwriting when first-run local settings and a remote snapshot both exist, or when both local and remote changed after a previous sync.
-- Unselected built-in files, directory groups, sessions, and extra files are unmanaged locally and preserved remotely; selecting nothing does not delete them.
-- With `syncSessions`/`PI_SYNC_SESSIONS` disabled, pi-sync does not collect or apply local Pi sessions, though settings-only pushes may preserve session files already present in remote snapshots. It never syncs OAuth state, npm caches, `.env`, `.env.local`, `node_modules`, or `.pisync` state.
-- If another Pi process is already syncing on the same machine, destructive commands stop at the local lock. `/sync unlock --stale` is intended for locks whose process is gone or invalid.
-- If another machine's update is visible before this machine updates `latest.json`, push is rejected unless you explicitly use `--force`.
-- Pull and rollback create backups before writing local files, then preflight deletes and writes before mutating the local settings tree.
-- Pull and rollback refuse to follow symlinked parent paths during snapshot apply and refuse to overwrite a symlink or directory with file content.
+- Credentials stay local and are never included in snapshots.
+- Push refuses common secret patterns in locally managed files.
+- Pull/rollback reject unsafe paths, duplicate paths, checksum mismatches, symlink parents, and file/directory replacement hazards before mutation.
+- Unmanaged local/remote files remain preserved.
+- A live local lock disables destructive work. Stale/unreadable lock recovery retains process-liveness and guard checks.
+- Force operations remain explicit direct/conflict-recovery actions and retain exact confirmations.
+- Terminal-bound config, remote metadata, machine names, paths, and errors are control-character sanitized.
+
+## ♿ Conditional terminal accessibility smoke
+
+Pi exposes terminal components rather than a semantic/ARIA tree, so automated tests verify textual state, keyboard paths, control-character escaping, and 32/60/100-column fitting rather than claiming semantic announcements. When validating a release in a supported environment:
+
+1. open `/sync` using only the keyboard and verify arrows, Enter, Space, search typing, paging where available, Back, and Escape;
+2. enter a Unicode target/profile name with an IME and confirm focus returns to Pi after closing;
+3. check the main, warning, preview, saved, cancelled, and invalid states with the terminal screen reader in use;
+4. repeat under a light and dark Pi theme and at 32, 60, and 100 columns.
+
+Critical meaning is always present in text such as `(current)`, `Warning`, `Invalid`, `Saved`, `Cancelled`, or `Applied`; color is supplementary.
 
 ## 🗂️ Package layout
 
-```txt
+```text
 extensions/pi-sync/
 ├── src/
-│   ├── index.ts       # Pi package entrypoint
-│   ├── sync.ts        # Extension registration and command orchestration
-│   ├── file-selection.ts # Persistent SettingsList selector
-│   ├── sync-policy.ts # Shared built-in catalog and path policy
-│   └── *.ts           # Package-local config, snapshot, path, and S3 modules
+│   ├── index.ts                 # Thin Pi entrypoint
+│   ├── sync.ts                  # Command and lifecycle orchestration
+│   ├── manager-ui.ts            # Goal-oriented menus and setup/management flows
+│   ├── file-selection.ts        # Transactional synced-content editor
+│   ├── settings-management.ts   # Profiles, targets, migration, and atomic saves
+│   ├── snapshot-transaction.ts  # Local apply journal, rollback, and recovery
+│   └── *.ts                     # Config, policy, snapshot, S3, lock, and format modules
+├── test/
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json
 └── package.json
 ```
 
-`index.ts` is the Pi entrypoint and forwards to `sync.ts`; the other source modules are internal. The package exposes its Pi extension through `package.json`:
-
-```json
-{
-  "pi": {
-    "extensions": ["./src/index.ts"]
-  }
-}
-```
-
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, settings sync, Cloudflare R2, S3-compatible storage, snapshot sync, dotfiles sync.
+Pi extension, Pi coding agent, settings sync, Cloudflare R2, S3-compatible storage, multi-profile sync, sync targets, snapshot sync, dotfiles sync.
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -52,12 +52,25 @@ Run the manager:
 When pi-sync is not configured, choose **Set up sync**. The TUI guides you through:
 
 1. Cloudflare R2 or another S3-compatible service
-2. a target name such as `home`
-3. a reusable storage-profile name such as `r2`
-4. endpoint, bucket, prefix, and remote namespace
+2. `Personal / Home`, `Work`, or a custom target purpose
+3. an endpoint and, for S3, the existing bucket name
+4. a recommended remote location or advanced customization
 5. environment credentials or a private settings-file template
 6. a synced-content preset
 7. an exact setup preview and **Save setup** confirmation
+
+For a first Cloudflare R2 target, the recommended location requires no raw path questions:
+
+```json
+{
+  "profile": "r2",
+  "bucket": "pi-sync",
+  "prefix": "pi-sync",
+  "namespace": "home"
+}
+```
+
+The R2 bucket must already exist; pi-sync never creates buckets. Generic S3 setup asks for one existing, potentially globally unique bucket and derives storage profile `s3`, prefix `pi-sync`, and namespace `home` or `work`. **Customize remote location** retains direct control over profile name, bucket, prefix, and namespace.
 
 Pi's extension input API does not provide masked secret entry, so pi-sync never asks for a secret in an unmasked dialog. Use existing environment credentials or add credentials manually to the private settings file. Secret values are never shown in menus, status, warnings, or errors.
 
@@ -144,7 +157,9 @@ A version 2 example:
 - `activeTarget` is used by bare commands and automatic sync.
 - `namespace` is the old flat `profile` concept. The remote layout and snapshot wire field remain named `profiles`/`profile` for compatibility.
 
-Two targets may intentionally overlap local files, but only one is automatic. pi-sync rejects duplicate target remote identities to prevent independent local states from controlling the same remote pointer. Removing a target/profile removes local configuration only; it never deletes buckets or snapshots. A referenced profile cannot be removed, and users must switch away before removing one of several current targets.
+When adding another target with the same storage profile, pi-sync recommends reusing the current target's bucket and prefix while deriving a separate namespace from the new target name. For example, `home` and `work` may both use profile `r2`, bucket `pi-sync`, and prefix `pi-sync`, producing `pi-sync/profiles/home/` and `pi-sync/profiles/work/`.
+
+Two targets may intentionally overlap local files, but only one is automatic. pi-sync rejects duplicate effective target remote identities—including deprecated bucket/prefix/namespace environment overrides—to prevent independent local states from controlling the same remote pointer. Removing a target/profile removes local configuration only; it never deletes buckets or snapshots. A referenced profile cannot be removed, and users must switch away before removing one of several current targets.
 
 ### Synced content
 

--- a/extensions/pi-sync/src/command.ts
+++ b/extensions/pi-sync/src/command.ts
@@ -7,6 +7,7 @@ const YES_FLAG_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 ];
 export const SYNC_COMMANDS = [
 	{ name: "help", description: "Show command usage" },
+	{ name: "use", description: "Switch the current sync target", usageSuffix: " <target>" },
 	{ name: "init", description: "Create local config template" },
 	{ name: "config", description: "Show resolved configuration" },
 	{ name: "files", description: "Choose synced files" },
@@ -26,20 +27,39 @@ export type SyncCommandName = (typeof SYNC_COMMANDS)[number]["name"];
 const SYNC_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = SYNC_COMMANDS.map(
 	({ name, description }) => ({ value: name, label: name, description }),
 );
+let targetCompletionNames: string[] = [];
+
+export function setSyncTargetCompletions(names: readonly string[]) {
+	targetCompletionNames = [...new Set(names)].sort((left, right) => left.localeCompare(right));
+}
+const TARGET_FLAG_COMPLETION = {
+	value: "--target",
+	label: "--target",
+	description: "Address a target without switching",
+} as const;
 const SYNC_FLAG_COMPLETIONS: Record<string, readonly CommandArgumentCompletion[]> = {
+	config: [TARGET_FLAG_COMPLETION],
+	files: [TARGET_FLAG_COMPLETION],
+	status: [TARGET_FLAG_COMPLETION],
+	diff: [TARGET_FLAG_COMPLETION],
+	doctor: [TARGET_FLAG_COMPLETION],
 	push: [
 		...YES_FLAG_COMPLETIONS,
 		{ value: "--force", label: "--force", description: "Overwrite visible remote changes" },
+		TARGET_FLAG_COMPLETION,
 	],
 	pull: [
 		...YES_FLAG_COMPLETIONS,
 		{ value: "--force", label: "--force", description: "Overwrite local changes" },
+		TARGET_FLAG_COMPLETION,
 	],
 	sync: [
 		...YES_FLAG_COMPLETIONS,
 		{ value: "--force", label: "--force", description: "Resolve conflicts by forcing action" },
+		TARGET_FLAG_COMPLETION,
 	],
-	rollback: YES_FLAG_COMPLETIONS,
+	history: [TARGET_FLAG_COMPLETION],
+	rollback: [...YES_FLAG_COMPLETIONS, TARGET_FLAG_COMPLETION],
 	unlock: [{ value: "--stale", label: "--stale", description: "Remove only a stale lock" }],
 };
 
@@ -51,15 +71,67 @@ export function splitArgs(input: string) {
 }
 
 export function parseOptions(args: string[]): CommandOptions {
+	const values: string[] = [];
+	let yes = false;
+	let force = false;
+	let stale = false;
+	let target: string | undefined;
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--yes" || arg === "-y") yes = true;
+		else if (arg === "--force") force = true;
+		else if (arg === "--stale") stale = true;
+		else if (arg === "--target") {
+			const name = args[index + 1];
+			if (!name || name.startsWith("-")) throw new Error("--target requires a target name.");
+			if (target !== undefined) throw new Error("--target may be provided only once.");
+			target = name;
+			index += 1;
+		} else if (arg.startsWith("-")) {
+			throw new Error(`Unknown sync option: ${arg}`);
+		} else values.push(arg);
+	}
 	return {
-		yes: args.includes("--yes") || args.includes("-y"),
-		force: args.includes("--force"),
-		stale: args.includes("--stale"),
+		yes,
+		force,
+		stale,
 		silent: false,
 		reload: true,
 		auto: false,
-		args: args.filter((arg) => !arg.startsWith("-")),
+		...(target === undefined ? {} : { target }),
+		args: values,
 	};
+}
+
+export function validateCommandOptions(command: string, options: CommandOptions) {
+	const targetAllowed = new Set([
+		"config",
+		"files",
+		"status",
+		"diff",
+		"doctor",
+		"push",
+		"pull",
+		"sync",
+		"history",
+		"rollback",
+	]);
+	if (options.target && !targetAllowed.has(command)) {
+		throw new Error(`--target is not supported by /sync ${command}.`);
+	}
+	if ((options.yes || options.force) && !["push", "pull", "sync", "rollback"].includes(command)) {
+		throw new Error(`Confirmation/force options are not supported by /sync ${command}.`);
+	}
+	if (options.stale && command !== "unlock") {
+		throw new Error(`--stale is not supported by /sync ${command}.`);
+	}
+	const expectedValues = command === "rollback" || command === "use" ? 1 : 0;
+	if (options.args.length !== expectedValues) {
+		if (command === "rollback")
+			throw new Error("Usage: /sync rollback <snapshot-id> [--yes] [--target <name>]");
+		if (command === "use") throw new Error("Usage: /sync use <target>");
+		throw new Error(`Unexpected argument for /sync ${command}: ${options.args.join(" ")}`);
+	}
 }
 
 export function completeSyncArguments(argumentPrefix: string): CommandArgumentCompletion[] | null {
@@ -76,10 +148,20 @@ export function completeSyncArguments(argumentPrefix: string): CommandArgumentCo
 		return matches.length > 0 ? [...matches] : null;
 	}
 
+	const args = tokens.slice(1);
+	if (command === "use") {
+		if (args.length > 1 || (trailingSpace && args.length > 0)) return null;
+		return completeTargetValue(prefix, trailingSpace ? "" : (args[0] ?? ""));
+	}
+	const targetFlagIndex = args.lastIndexOf("--target");
+	if (targetFlagIndex >= 0 && targetFlagIndex === args.length - (trailingSpace ? 1 : 2)) {
+		const currentTarget = trailingSpace ? "" : (args.at(-1) ?? "");
+		if (!currentTarget.startsWith("-")) return completeTargetValue(prefix, currentTarget);
+	}
+
 	const flagCompletions = SYNC_FLAG_COMPLETIONS[command];
 	if (!flagCompletions) return null;
 
-	const args = tokens.slice(1);
 	const completedArgs = trailingSpace ? args : args.slice(0, -1);
 	const completedValues = completedArgs.filter((arg) => !arg.startsWith("-"));
 	if (command === "rollback" ? completedValues.length > 1 : completedValues.length > 0) {
@@ -96,6 +178,19 @@ export function completeSyncArguments(argumentPrefix: string): CommandArgumentCo
 	const matches = flagCompletions.filter((item) => item.value.startsWith(current));
 	return matches.length > 0
 		? matches.map((item) => ({ ...item, value: `${completionPrefix}${item.value}` }))
+		: null;
+}
+
+function completeTargetValue(prefix: string, current: string) {
+	const currentRaw = current ? (prefix.match(/\S+$/u)?.[0] ?? "") : "";
+	const completionPrefix = currentRaw ? prefix.slice(0, prefix.length - currentRaw.length) : prefix;
+	const matches = targetCompletionNames.filter((name) => name.startsWith(current));
+	return matches.length > 0
+		? matches.map((name) => ({
+				value: `${completionPrefix}${name}`,
+				label: name,
+				description: "Sync target",
+			}))
 		: null;
 }
 
@@ -135,6 +230,6 @@ export function usage() {
 	return [
 		"Usage: /sync <command>",
 		`Commands: ${commands}`,
-		"Config: set PI_SYNC_ENDPOINT, PI_SYNC_BUCKET, PI_SYNC_ACCESS_KEY_ID, PI_SYNC_SECRET_ACCESS_KEY, optional PI_SYNC_SESSION_TOKEN, PI_SYNC_SESSIONS/syncSessions, region/profile/prefix, or edit syncFiles/extraFiles in ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json when PI_CODING_AGENT_DIR is set).",
+		"Settings: use /sync init or edit profiles and targets in ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json). Existing PI_SYNC_* overrides still work but are deprecated for future major-version removal.",
 	].join("\n");
 }

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -106,7 +106,7 @@ export async function loadConfig(targetName?: string): Promise<SyncConfig> {
 export async function configuredTargetNames() {
 	const settings = await readLocalConfigObject();
 	if (!settings) return [];
-	if (!isV2SettingsObject(settings)) return [DEFAULT_PROFILE];
+	if (!isV2SettingsObject(settings)) return [];
 	return Object.keys(requireNamedObjectMap(settings.targets, "targets")).sort((left, right) =>
 		left.localeCompare(right),
 	);
@@ -114,9 +114,11 @@ export async function configuredTargetNames() {
 
 export async function loadPartialConfig(targetName?: string): Promise<PartialConfig> {
 	const fileConfig = (await readLocalConfigObject()) ?? {};
-	return isV2SettingsObject(fileConfig)
-		? resolveV2PartialConfig(fileConfig, targetName)
-		: resolveLegacyPartialConfig(fileConfig as PartialConfig);
+	if (isV2SettingsObject(fileConfig)) return resolveV2PartialConfig(fileConfig, targetName);
+	if (targetName !== undefined) {
+		throw new Error("--target requires version 2 pi-sync settings with named targets.");
+	}
+	return resolveLegacyPartialConfig(fileConfig as PartialConfig);
 }
 
 export function deprecatedPiSyncEnvironmentNames() {
@@ -231,12 +233,7 @@ function validateUniqueRemoteTargets(targets: Record<string, unknown>) {
 		const target = ownObject(targets, name);
 		if (!target || typeof target.profile !== "string" || typeof target.bucket !== "string")
 			continue;
-		const identity = JSON.stringify([
-			target.profile,
-			process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? target.bucket,
-			process.env.PI_SYNC_PREFIX ?? target.prefix ?? DEFAULT_PREFIX,
-			process.env.PI_SYNC_PROFILE ?? target.namespace ?? name,
-		]);
+		const identity = effectiveTargetRemoteIdentity(target, name);
 		const existing = identities.get(identity);
 		if (existing) {
 			throw new Error(
@@ -245,6 +242,27 @@ function validateUniqueRemoteTargets(targets: Record<string, unknown>) {
 		}
 		identities.set(identity, name);
 	}
+}
+
+export function effectiveTargetRemoteIdentity(target: Record<string, unknown>, name: string) {
+	const profile = typeof target.profile === "string" ? target.profile.trim() : "";
+	const bucket = normalizeRemoteKeySegment(
+		process.env.PI_SYNC_BUCKET ??
+			process.env.R2_BUCKET ??
+			(typeof target.bucket === "string" ? target.bucket : ""),
+	);
+	const prefix = normalizeRemoteKeySegment(
+		process.env.PI_SYNC_PREFIX ??
+			(typeof target.prefix === "string" ? target.prefix : DEFAULT_PREFIX),
+	);
+	const namespace = normalizeRemoteKeySegment(
+		process.env.PI_SYNC_PROFILE ?? (typeof target.namespace === "string" ? target.namespace : name),
+	);
+	return JSON.stringify([profile, bucket, prefix, namespace]);
+}
+
+function normalizeRemoteKeySegment(value: string) {
+	return trimSlashes(value.trim());
 }
 
 function requireNamedObjectMap(value: unknown, field: string): Record<string, unknown> {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -1,8 +1,12 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	type ExtensionCommandContext,
+	type ExtensionContext,
+	getAgentDir,
+} from "@earendil-works/pi-coding-agent";
 import { safeName } from "./paths.js";
 import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
 import type { PartialConfig, Snapshot, SyncConfig, SyncState } from "./types.js";
@@ -13,6 +17,19 @@ const VERSION = 1;
 const DEFAULT_PROFILE = "default";
 const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
+
+export const DEPRECATED_PI_SYNC_ENV_NAMES = [
+	"PI_SYNC_ENDPOINT",
+	"PI_SYNC_BUCKET",
+	"PI_SYNC_REGION",
+	"PI_SYNC_ACCESS_KEY_ID",
+	"PI_SYNC_SECRET_ACCESS_KEY",
+	"PI_SYNC_SESSION_TOKEN",
+	"PI_SYNC_PROFILE",
+	"PI_SYNC_PREFIX",
+	"PI_SYNC_AUTO_SYNC",
+	"PI_SYNC_SESSIONS",
+] as const;
 
 function trimSlashes(value: string) {
 	return value.replace(/^\/+|\/+$/g, "");
@@ -39,12 +56,12 @@ function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) 
 		: undefined;
 }
 
-export async function loadConfigInternal(): Promise<SyncConfig> {
-	const partial = await loadPartialConfig();
-	const endpoint = partial.endpoint;
-	const bucket = partial.bucket;
-	const accessKeyId = partial.accessKeyId;
-	const secretAccessKey = partial.secretAccessKey;
+export async function loadConfigInternal(targetName?: string): Promise<SyncConfig> {
+	const partial = await loadPartialConfig(targetName);
+	const endpoint = normalizeConfiguredString(partial.endpoint);
+	const bucket = normalizeConfiguredString(partial.bucket);
+	const accessKeyId = normalizeConfiguredString(partial.accessKeyId);
+	const secretAccessKey = normalizeConfiguredString(partial.secretAccessKey);
 	const missing = [
 		["endpoint", endpoint],
 		["bucket", bucket],
@@ -55,7 +72,7 @@ export async function loadConfigInternal(): Promise<SyncConfig> {
 		.map(([name]) => name);
 	if (missing.length > 0) {
 		throw new Error(
-			`Missing pi-sync config: ${missing.join(", ")}. Run /sync init or set PI_SYNC_* environment variables.`,
+			`Missing pi-sync config: ${missing.join(", ")}. Use /sync setup or edit ${localConfigPath()}.`,
 		);
 	}
 	if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
@@ -65,26 +82,61 @@ export async function loadConfigInternal(): Promise<SyncConfig> {
 	return {
 		endpoint,
 		bucket,
-		region: partial.region ?? DEFAULT_REGION,
+		region: normalizeOptionalString(partial.region) ?? DEFAULT_REGION,
 		accessKeyId,
 		secretAccessKey,
-		sessionToken: partial.sessionToken,
-		profile: partial.profile ?? DEFAULT_PROFILE,
-		prefix: trimSlashes(partial.prefix ?? DEFAULT_PREFIX),
+		sessionToken: normalizeOptionalString(partial.sessionToken),
+		profile: normalizeOptionalString(partial.profile) ?? DEFAULT_PROFILE,
+		prefix: trimSlashes(normalizeOptionalString(partial.prefix) ?? DEFAULT_PREFIX),
+		target: partial.target ?? DEFAULT_PROFILE,
+		storageProfile: partial.storageProfile ?? DEFAULT_PROFILE,
+		storageKind: partial.storageKind,
+		autoSync: isEnabled(partial.autoSync, true),
+		settingsVersion: partial.settingsVersion ?? 1,
 		syncFiles: normalizeSyncFiles(partial.syncFiles),
 		syncSessions: isExplicitlyEnabled(partial.syncSessions),
 		extraFiles: normalizeExtraFiles(partial.extraFiles),
 	};
 }
 
-export async function loadConfig(): Promise<SyncConfig> {
-	return loadConfigInternal();
+export async function loadConfig(targetName?: string): Promise<SyncConfig> {
+	return loadConfigInternal(targetName);
 }
 
-export async function loadPartialConfig(): Promise<PartialConfig> {
-	const fileConfig = ((await readLocalConfigObject()) ?? {}) as PartialConfig;
+export async function configuredTargetNames() {
+	const settings = await readLocalConfigObject();
+	if (!settings) return [];
+	if (!isV2SettingsObject(settings)) return [DEFAULT_PROFILE];
+	return Object.keys(requireNamedObjectMap(settings.targets, "targets")).sort((left, right) =>
+		left.localeCompare(right),
+	);
+}
+
+export async function loadPartialConfig(targetName?: string): Promise<PartialConfig> {
+	const fileConfig = (await readLocalConfigObject()) ?? {};
+	return isV2SettingsObject(fileConfig)
+		? resolveV2PartialConfig(fileConfig, targetName)
+		: resolveLegacyPartialConfig(fileConfig as PartialConfig);
+}
+
+export function deprecatedPiSyncEnvironmentNames() {
+	return DEPRECATED_PI_SYNC_ENV_NAMES.filter((name) => hasEnv(name));
+}
+
+export function deprecatedPiSyncEnvironmentWarnings() {
+	const names = deprecatedPiSyncEnvironmentNames();
+	if (names.length === 0) return [];
+	return [
+		`deprecated environment: ${names.join(", ")} still override pi-sync settings but will be removed in a future major version. Move them to ${localConfigPath()}; values are not shown.`,
+	];
+}
+
+function resolveLegacyPartialConfig(fileConfig: PartialConfig): PartialConfig {
 	return {
 		...fileConfig,
+		target: DEFAULT_PROFILE,
+		storageProfile: DEFAULT_PROFILE,
+		settingsVersion: 1,
 		endpoint: process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? fileConfig.endpoint,
 		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? fileConfig.bucket,
 		region: process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? fileConfig.region,
@@ -98,10 +150,146 @@ export async function loadPartialConfig(): Promise<PartialConfig> {
 		profile: process.env.PI_SYNC_PROFILE ?? fileConfig.profile,
 		prefix: process.env.PI_SYNC_PREFIX ?? fileConfig.prefix,
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? fileConfig.autoSync,
-		syncFiles: fileConfig.syncFiles,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? fileConfig.syncSessions,
-		extraFiles: fileConfig.extraFiles,
 	};
+}
+
+function resolveV2PartialConfig(
+	settings: Record<string, unknown>,
+	targetName?: string,
+): PartialConfig {
+	const targets = requireNamedObjectMap(settings.targets, "targets");
+	const profiles = requireNamedObjectMap(settings.profiles, "profiles");
+	validateUniqueRemoteTargets(targets);
+	const selectedTarget =
+		targetName ?? normalizeOptionalString(asOptionalString(settings.activeTarget));
+	if (!selectedTarget) throw new Error("Invalid pi-sync settings: activeTarget is required.");
+	validateConfigName(selectedTarget, "target");
+	const target = ownObject(targets, selectedTarget);
+	if (!target)
+		throw new Error(`Invalid pi-sync settings: target "${selectedTarget}" was not found.`);
+	const storageProfile = normalizeOptionalString(asOptionalString(target.profile));
+	if (!storageProfile) {
+		throw new Error(`Invalid pi-sync settings: target "${selectedTarget}" is missing profile.`);
+	}
+	validateConfigName(storageProfile, "storage profile");
+	const profile = ownObject(profiles, storageProfile);
+	if (!profile) {
+		throw new Error(
+			`Invalid pi-sync settings: target "${selectedTarget}" references missing profile "${storageProfile}".`,
+		);
+	}
+	const kind = asOptionalString(profile.kind);
+	if (kind !== undefined && kind !== "r2" && kind !== "s3-compatible") {
+		throw new Error(
+			`Invalid pi-sync settings: profile "${storageProfile}" has unsupported kind "${kind}".`,
+		);
+	}
+	return {
+		target: selectedTarget,
+		storageProfile,
+		storageKind: kind,
+		settingsVersion: 2,
+		endpoint:
+			process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? asOptionalString(profile.endpoint),
+		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? asOptionalString(target.bucket),
+		region:
+			process.env.PI_SYNC_REGION ?? process.env.AWS_REGION ?? asOptionalString(profile.region),
+		accessKeyId:
+			process.env.PI_SYNC_ACCESS_KEY_ID ??
+			process.env.AWS_ACCESS_KEY_ID ??
+			asOptionalString(profile.accessKeyId),
+		secretAccessKey:
+			process.env.PI_SYNC_SECRET_ACCESS_KEY ??
+			process.env.AWS_SECRET_ACCESS_KEY ??
+			asOptionalString(profile.secretAccessKey),
+		sessionToken: selectSessionToken(asOptionalString(profile.sessionToken)),
+		profile: process.env.PI_SYNC_PROFILE ?? asOptionalString(target.namespace) ?? selectedTarget,
+		prefix: process.env.PI_SYNC_PREFIX ?? asOptionalString(target.prefix),
+		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? asOptionalBoolean(target.autoSync),
+		syncFiles: target.syncFiles,
+		syncSessions: process.env.PI_SYNC_SESSIONS ?? asOptionalBoolean(target.syncSessions),
+		extraFiles: target.extraFiles,
+	};
+}
+
+function isV2SettingsObject(value: Record<string, unknown>) {
+	const hasV2Fields =
+		Object.hasOwn(value, "profiles") ||
+		Object.hasOwn(value, "targets") ||
+		Object.hasOwn(value, "activeTarget");
+	if (!hasV2Fields) return false;
+	if (value.version !== 2) {
+		throw new Error("Invalid pi-sync settings: version must be 2 for profiles and targets.");
+	}
+	return true;
+}
+
+function validateUniqueRemoteTargets(targets: Record<string, unknown>) {
+	const identities = new Map<string, string>();
+	for (const name of Object.keys(targets)) {
+		const target = ownObject(targets, name);
+		if (!target || typeof target.profile !== "string" || typeof target.bucket !== "string")
+			continue;
+		const identity = JSON.stringify([
+			target.profile,
+			target.bucket,
+			target.prefix ?? DEFAULT_PREFIX,
+			target.namespace ?? name,
+		]);
+		const existing = identities.get(identity);
+		if (existing) {
+			throw new Error(
+				`Invalid pi-sync settings: targets "${existing}" and "${name}" use the same remote destination.`,
+			);
+		}
+		identities.set(identity, name);
+	}
+}
+
+function requireNamedObjectMap(value: unknown, field: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`Invalid pi-sync settings: ${field} must be an object.`);
+	}
+	for (const name of Object.keys(value)) validateConfigName(name, field.slice(0, -1));
+	return value as Record<string, unknown>;
+}
+
+function ownObject(
+	value: Record<string, unknown>,
+	key: string,
+): Record<string, unknown> | undefined {
+	if (!Object.hasOwn(value, key)) return undefined;
+	const item = value[key];
+	return item && typeof item === "object" && !Array.isArray(item)
+		? (item as Record<string, unknown>)
+		: undefined;
+}
+
+function validateConfigName(value: string, field: string) {
+	if (
+		!value.trim() ||
+		value.length > 100 ||
+		value === "__proto__" ||
+		value === "prototype" ||
+		value === "constructor" ||
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: Config identifiers cannot render terminal controls.
+		/[\u0000-\u001f\u007f-\u009f]/u.test(value)
+	) {
+		throw new Error(`Invalid pi-sync settings: invalid ${field} name.`);
+	}
+}
+
+function asOptionalString(value: unknown) {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") throw new Error("Invalid pi-sync settings: expected a string.");
+	return value;
+}
+
+function asOptionalBoolean(value: unknown) {
+	if (value === undefined) return undefined;
+	if (typeof value !== "boolean") throw new Error("Invalid pi-sync settings: expected a boolean.");
+	return value;
 }
 
 export async function configuredSessionDir() {
@@ -158,9 +346,30 @@ export async function writeState(profile: string, state: SyncState) {
 	await writeJson(statePath(profile), state);
 }
 
+export async function readStateForConfig(config: SyncConfig): Promise<SyncState> {
+	if (config.settingsVersion !== 2) return readState(config.profile);
+	return (
+		(await readJsonIfExists<SyncState>(statePathForConfig(config))) ?? {
+			version: VERSION,
+			profile: config.profile,
+			lastFileHashes: {},
+		}
+	);
+}
+
+export async function writeStateForConfig(config: SyncConfig, state: SyncState) {
+	await writeJson(statePathForConfig(config), state);
+}
+
+export function statePathForConfig(config: SyncConfig) {
+	if (config.settingsVersion !== 2) return statePath(config.profile);
+	const target = config.target ?? DEFAULT_PROFILE;
+	const hash = createHash("sha256").update(target).digest("hex").slice(0, 10);
+	return path.join(stateDir(), "targets", `${safeName(target)}-${hash}.state.json`);
+}
+
 export function agentDir() {
-	const configured = normalizeOptionalString(process.env.PI_CODING_AGENT_DIR);
-	return configured ? expandHome(configured) : path.join(os.homedir(), ".pi", "agent");
+	return getAgentDir();
 }
 
 function expandHome(value: string) {
@@ -177,17 +386,29 @@ export function localConfigPath() {
 
 export function localConfigTemplate(): Record<string, unknown> {
 	return {
-		endpoint: "https://<account-id>.r2.cloudflarestorage.com",
-		bucket: "pi-sync",
-		region: DEFAULT_REGION,
-		accessKeyId: "<access-key-id>",
-		secretAccessKey: "<secret-access-key>",
-		profile: DEFAULT_PROFILE,
-		prefix: DEFAULT_PREFIX,
-		autoSync: true,
-		syncFiles: [...DEFAULT_SYNC_FILES],
-		syncSessions: false,
-		extraFiles: [],
+		version: 2,
+		activeTarget: DEFAULT_PROFILE,
+		profiles: {
+			[DEFAULT_PROFILE]: {
+				kind: "r2",
+				endpoint: "https://<account-id>.r2.cloudflarestorage.com",
+				region: DEFAULT_REGION,
+				accessKeyId: "<access-key-id>",
+				secretAccessKey: "<secret-access-key>",
+			},
+		},
+		targets: {
+			[DEFAULT_PROFILE]: {
+				profile: DEFAULT_PROFILE,
+				bucket: "pi-sync",
+				namespace: DEFAULT_PROFILE,
+				prefix: DEFAULT_PREFIX,
+				autoSync: true,
+				syncFiles: [...DEFAULT_SYNC_FILES],
+				syncSessions: false,
+				extraFiles: [],
+			},
+		},
 	};
 }
 
@@ -209,7 +430,20 @@ export async function readLocalConfigObject(): Promise<Record<string, unknown> |
 	return parsed as Record<string, unknown>;
 }
 
-export async function updateLocalConfig(
+let configUpdateQueue: Promise<void> = Promise.resolve();
+
+export function updateLocalConfig(
+	update: (current: Record<string, unknown>) => Record<string, unknown>,
+) {
+	const operation = configUpdateQueue.then(() => performLocalConfigUpdate(update));
+	configUpdateQueue = operation.then(
+		() => undefined,
+		() => undefined,
+	);
+	return operation;
+}
+
+async function performLocalConfigUpdate(
 	update: (current: Record<string, unknown>) => Record<string, unknown>,
 ) {
 	const current = (await readLocalConfigObject()) ?? localConfigTemplate();
@@ -315,6 +549,13 @@ export function isCloudflareR2Endpoint(endpoint: string | undefined) {
 function normalizeOptionalString(value: string | undefined) {
 	const normalized = value?.trim();
 	return normalized ? normalized : undefined;
+}
+
+function normalizeConfiguredString(value: string | undefined) {
+	const normalized = normalizeOptionalString(value);
+	return normalized && !/^<[^>]+>$/u.test(normalized) && !normalized.includes("<account-id>")
+		? normalized
+		: undefined;
 }
 
 function hasEnv(name: string) {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -233,9 +233,9 @@ function validateUniqueRemoteTargets(targets: Record<string, unknown>) {
 			continue;
 		const identity = JSON.stringify([
 			target.profile,
-			target.bucket,
-			target.prefix ?? DEFAULT_PREFIX,
-			target.namespace ?? name,
+			process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? target.bucket,
+			process.env.PI_SYNC_PREFIX ?? target.prefix ?? DEFAULT_PREFIX,
+			process.env.PI_SYNC_PROFILE ?? target.namespace ?? name,
 		]);
 		const existing = identities.get(identity);
 		if (existing) {

--- a/extensions/pi-sync/src/file-selection.ts
+++ b/extensions/pi-sync/src/file-selection.ts
@@ -75,7 +75,7 @@ export async function showFileSelection(ctx: ExtensionCommandContext, targetName
 			return;
 		}
 		try {
-			await persistSelectionDraft(draft, targetName);
+			await persistSelectionDraft(draft, targetName, sessionEnvironmentOverride);
 			ctx.ui.notify(
 				`Saved synced content for target “${safeTerminalText(partial.target ?? "default")}”. It applies to the next manual or automatic sync.`,
 				"info",
@@ -185,11 +185,15 @@ function updateDraft(draft: SelectionDraft, id: string, included: boolean) {
 	throw new Error(`Unknown file selection: ${id}`);
 }
 
-async function persistSelectionDraft(draft: SelectionDraft, targetName?: string) {
+async function persistSelectionDraft(
+	draft: SelectionDraft,
+	targetName: string | undefined,
+	sessionEnvironmentOverride: boolean,
+) {
 	await updateLocalConfig((current) => {
 		const selection = {
 			syncFiles: DEFAULT_SYNC_FILES.filter((candidate) => draft.builtIns.has(candidate)),
-			syncSessions: draft.sessions,
+			...(!sessionEnvironmentOverride ? { syncSessions: draft.sessions } : {}),
 			extraFiles: [...draft.extras],
 		};
 		if (current.version !== 2) return { ...current, ...selection };

--- a/extensions/pi-sync/src/file-selection.ts
+++ b/extensions/pi-sync/src/file-selection.ts
@@ -4,6 +4,7 @@ import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
 import {
 	agentDir,
+	deprecatedPiSyncEnvironmentWarnings,
 	isExplicitlyEnabled,
 	loadPartialConfig,
 	localConfigPath,
@@ -22,28 +23,77 @@ const BUILT_IN_PREFIX = "builtin:";
 const EXTRA_PREFIX = "extra:";
 const SESSIONS_ID = "sessions";
 
-export async function showFileSelection(ctx: ExtensionCommandContext) {
-	const partial = await loadPartialConfig();
-	const selectedBuiltIns = new Set(normalizeSyncFiles(partial.syncFiles));
-	const selectedExtras = new Set(normalizeExtraFiles(partial.extraFiles));
+interface SelectionDraft {
+	builtIns: Set<string>;
+	extras: Set<string>;
+	sessions: boolean;
+}
+
+export async function showFileSelection(ctx: ExtensionCommandContext, targetName?: string) {
+	const partial = await loadPartialConfig(targetName);
+	const original: SelectionDraft = {
+		builtIns: new Set(normalizeSyncFiles(partial.syncFiles)),
+		extras: new Set(normalizeExtraFiles(partial.extraFiles)),
+		sessions: isExplicitlyEnabled(partial.syncSessions),
+	};
+	const draft = cloneDraft(original);
 	const sessionEnvironmentOverride = Object.hasOwn(process.env, "PI_SYNC_SESSIONS");
-	const sessionsIncluded = isExplicitlyEnabled(partial.syncSessions);
-	const extraCandidates = await listExtraFileCandidates(selectedExtras);
+	const extraCandidates = await listExtraFileCandidates(draft.extras);
 
 	if (ctx.mode !== "tui") {
 		ctx.ui.notify(
 			[
-				"pi-sync selected files:",
-				`built-ins: ${[...selectedBuiltIns].join(", ") || "none"}`,
-				`sessions: ${sessionsIncluded ? "included" : "excluded"}${sessionEnvironmentOverride ? " (PI_SYNC_SESSIONS)" : ""}`,
-				`extra files: ${[...selectedExtras].map(safeTerminalText).join(", ") || "none"}`,
+				`pi-sync selected files for target ${safeTerminalText(partial.target ?? "default")}:`,
+				`built-ins: ${[...draft.builtIns].join(", ") || "none"}`,
+				`sessions: ${draft.sessions ? INCLUDED : EXCLUDED}${sessionEnvironmentOverride ? " (PI_SYNC_SESSIONS, deprecated)" : ""}`,
+				`extra files: ${[...draft.extras].map(safeTerminalText).join(", ") || "none"}`,
 				`Edit syncFiles, syncSessions, and extraFiles in ${safeTerminalText(localConfigPath())}.`,
+				...deprecatedPiSyncEnvironmentWarnings(),
 			].join("\n"),
 			"info",
 		);
 		return;
 	}
 
+	while (true) {
+		await showDraftEditor(
+			ctx,
+			partial.target ?? "default",
+			draft,
+			extraCandidates,
+			sessionEnvironmentOverride,
+		);
+		if (sameDraft(original, draft)) return;
+		const choice = await ctx.ui.select(formatDraftPreview(original, draft), [
+			"Save changes",
+			"Discard changes",
+			"Continue editing",
+		]);
+		if (choice === "Continue editing") continue;
+		if (choice !== "Save changes") {
+			ctx.ui.notify("Synced-content changes discarded.", "info");
+			return;
+		}
+		try {
+			await persistSelectionDraft(draft, targetName);
+			ctx.ui.notify(
+				`Saved synced content for target “${safeTerminalText(partial.target ?? "default")}”. It applies to the next manual or automatic sync.`,
+				"info",
+			);
+		} catch (error) {
+			ctx.ui.notify(`Could not save pi-sync file selection: ${errorMessage(error)}`, "error");
+		}
+		return;
+	}
+}
+
+async function showDraftEditor(
+	ctx: ExtensionCommandContext,
+	targetName: string,
+	draft: SelectionDraft,
+	extraCandidates: string[],
+	sessionEnvironmentOverride: boolean,
+) {
 	const items: SettingItem[] = [
 		...DEFAULT_SYNC_FILES.map((fileName) => ({
 			id: `${BUILT_IN_PREFIX}${fileName}`,
@@ -51,18 +101,18 @@ export async function showFileSelection(ctx: ExtensionCommandContext) {
 			description: fileName.includes(".")
 				? `Sync the top-level ${fileName} file when present.`
 				: `Recursively sync every safe file under ${fileName}/.`,
-			currentValue: selectedBuiltIns.has(fileName) ? INCLUDED : EXCLUDED,
+			currentValue: draft.builtIns.has(fileName) ? INCLUDED : EXCLUDED,
 			values: [INCLUDED, EXCLUDED],
 		})),
 		{
 			id: SESSIONS_ID,
 			label: "sessions",
 			description: sessionEnvironmentOverride
-				? "Read-only here because PI_SYNC_SESSIONS overrides the local setting. Session JSONL may contain prompts, tool output, paths, images, and secrets."
+				? "Read-only because deprecated PI_SYNC_SESSIONS currently overrides this target. Move it into target settings before the future major removal."
 				: "Session JSONL may contain prompts, tool output, paths, images, and secrets. Sync only to storage you trust.",
 			currentValue: sessionEnvironmentOverride
-				? `${sessionsIncluded ? INCLUDED : EXCLUDED} (environment)`
-				: sessionsIncluded
+				? `${draft.sessions ? INCLUDED : EXCLUDED} (environment, deprecated)`
+				: draft.sessions
 					? INCLUDED
 					: EXCLUDED,
 			...(sessionEnvironmentOverride ? {} : { values: [INCLUDED, EXCLUDED] }),
@@ -72,59 +122,33 @@ export async function showFileSelection(ctx: ExtensionCommandContext) {
 			label: safeTerminalText(fileName),
 			description:
 				"Additional safe top-level file. It may be absent locally and pulled from another machine.",
-			currentValue: selectedExtras.has(fileName) ? INCLUDED : EXCLUDED,
+			currentValue: draft.extras.has(fileName) ? INCLUDED : EXCLUDED,
 			values: [INCLUDED, EXCLUDED],
 		})),
 	];
-
-	let saveQueue = Promise.resolve();
-	let nextOwner = 0;
-	const owners = new Map<string, number>();
-	let closed = false;
 
 	await ctx.ui.custom((tui, theme, _keybindings, done) => {
 		const container = new Container();
 		const title = new Text("", 1, 0);
 		const hint = new Text("", 1, 0);
 		const updateChrome = () => {
-			title.setText(theme.fg("accent", theme.bold("pi-sync Files")));
-			hint.setText(
-				theme.fg("dim", "Changes save immediately and apply to the next manual or automatic sync."),
+			title.setText(
+				theme.fg("accent", theme.bold(`Synced Content · ${safeTerminalText(targetName)}`)),
 			);
+			hint.setText(theme.fg("dim", "Draft only · Esc reviews Save, Discard, or Continue editing."));
 		};
 		updateChrome();
 		container.addChild(title);
-
-		let settingsList: SettingsList;
-		const queueChange = (id: string, newValue: string) => {
-			const previousValue = newValue === INCLUDED ? EXCLUDED : INCLUDED;
-			const owner = ++nextOwner;
-			owners.set(id, owner);
-			const save = async () => {
-				try {
-					await persistSelectionChange(id, newValue === INCLUDED);
-				} catch (error) {
-					if (owners.get(id) === owner && !closed) {
-						settingsList.updateValue(id, previousValue);
-						tui.requestRender();
-					}
-					ctx.ui.notify(`Could not save pi-sync file selection: ${errorMessage(error)}`, "error");
-				}
-			};
-			saveQueue = saveQueue.then(save, save);
-		};
-
-		settingsList = new SettingsList(
+		const settingsList = new SettingsList(
 			items,
 			Math.min(items.length + 2, 15),
 			getSettingsListTheme(),
-			queueChange,
+			(id, newValue) => updateDraft(draft, id, newValue === INCLUDED),
 			() => done(undefined),
 			{ enableSearch: true },
 		);
 		container.addChild(settingsList);
 		container.addChild(hint);
-
 		return {
 			render(width: number) {
 				return container.render(width);
@@ -139,8 +163,66 @@ export async function showFileSelection(ctx: ExtensionCommandContext) {
 			},
 		};
 	});
-	closed = true;
-	await saveQueue;
+}
+
+function updateDraft(draft: SelectionDraft, id: string, included: boolean) {
+	if (id.startsWith(BUILT_IN_PREFIX)) {
+		const fileName = id.slice(BUILT_IN_PREFIX.length);
+		if (included) draft.builtIns.add(fileName);
+		else draft.builtIns.delete(fileName);
+		return;
+	}
+	if (id.startsWith(EXTRA_PREFIX)) {
+		const fileName = id.slice(EXTRA_PREFIX.length);
+		if (included) draft.extras.add(fileName);
+		else draft.extras.delete(fileName);
+		return;
+	}
+	if (id === SESSIONS_ID) {
+		draft.sessions = included;
+		return;
+	}
+	throw new Error(`Unknown file selection: ${id}`);
+}
+
+async function persistSelectionDraft(draft: SelectionDraft, targetName?: string) {
+	await updateLocalConfig((current) => {
+		const selection = {
+			syncFiles: DEFAULT_SYNC_FILES.filter((candidate) => draft.builtIns.has(candidate)),
+			syncSessions: draft.sessions,
+			extraFiles: [...draft.extras],
+		};
+		if (current.version !== 2) return { ...current, ...selection };
+		const targets = asObject(current.targets);
+		const selectedTarget =
+			targetName ?? (typeof current.activeTarget === "string" ? current.activeTarget : undefined);
+		if (!targets || !selectedTarget) throw new Error("Current sync target is not configured.");
+		const target = asObject(targets[selectedTarget]);
+		if (!target) throw new Error(`Sync target not found: ${selectedTarget}`);
+		return {
+			...current,
+			targets: { ...targets, [selectedTarget]: { ...target, ...selection } },
+		};
+	});
+}
+
+function formatDraftPreview(original: SelectionDraft, draft: SelectionDraft) {
+	const lines = ["Review synced-content changes", ""];
+	for (const item of DEFAULT_SYNC_FILES) {
+		if (original.builtIns.has(item) === draft.builtIns.has(item)) continue;
+		lines.push(`${draft.builtIns.has(item) ? "Include" : "Exclude"}: ${item}`);
+	}
+	for (const item of new Set([...original.extras, ...draft.extras])) {
+		if (original.extras.has(item) === draft.extras.has(item)) continue;
+		lines.push(`${draft.extras.has(item) ? "Include" : "Exclude"}: ${safeTerminalText(item)}`);
+	}
+	if (original.sessions !== draft.sessions) {
+		lines.push(`${draft.sessions ? "Include" : "Exclude"}: sessions`);
+		if (draft.sessions)
+			lines.push("Warning: sessions may contain prompts, tool output, images, and secrets.");
+	}
+	lines.push("", "Saving does not start a network sync.");
+	return lines.join("\n");
 }
 
 async function listExtraFileCandidates(configured: Set<string>) {
@@ -158,28 +240,30 @@ async function listExtraFileCandidates(configured: Set<string>) {
 	return [...candidates.values()].sort((left, right) => left.localeCompare(right));
 }
 
-async function persistSelectionChange(id: string, included: boolean) {
-	await updateLocalConfig((current) => {
-		if (id.startsWith(BUILT_IN_PREFIX)) {
-			const fileName = id.slice(BUILT_IN_PREFIX.length);
-			const selected = new Set(normalizeSyncFiles(current.syncFiles));
-			if (included) selected.add(fileName as (typeof DEFAULT_SYNC_FILES)[number]);
-			else selected.delete(fileName as (typeof DEFAULT_SYNC_FILES)[number]);
-			return {
-				...current,
-				syncFiles: DEFAULT_SYNC_FILES.filter((candidate) => selected.has(candidate)),
-			};
-		}
-		if (id.startsWith(EXTRA_PREFIX)) {
-			const fileName = id.slice(EXTRA_PREFIX.length);
-			const selected = new Set(normalizeExtraFiles(current.extraFiles));
-			if (included) selected.add(fileName);
-			else selected.delete(fileName);
-			return { ...current, extraFiles: [...selected] };
-		}
-		if (id === SESSIONS_ID) return { ...current, syncSessions: included };
-		throw new Error(`Unknown file selection: ${id}`);
-	});
+function cloneDraft(value: SelectionDraft): SelectionDraft {
+	return {
+		builtIns: new Set(value.builtIns),
+		extras: new Set(value.extras),
+		sessions: value.sessions,
+	};
+}
+
+function sameDraft(left: SelectionDraft, right: SelectionDraft) {
+	return (
+		left.sessions === right.sessions &&
+		sameSet(left.builtIns, right.builtIns) &&
+		sameSet(left.extras, right.extras)
+	);
+}
+
+function sameSet(left: Set<string>, right: Set<string>) {
+	return left.size === right.size && [...left].every((item) => right.has(item));
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
 }
 
 function safeTerminalText(value: string) {

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -1,0 +1,790 @@
+import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { setSyncTargetCompletions } from "./command.js";
+import {
+	configuredTargetNames,
+	deprecatedPiSyncEnvironmentWarnings,
+	isCloudflareR2Endpoint,
+	isEnabled,
+	loadConfig,
+	loadPartialConfig,
+	localConfigPath,
+	normalizeExtraFiles,
+	normalizeSyncFiles,
+	readLocalConfigObject,
+	updateLocalConfig,
+} from "./config.js";
+import { inspectLock, isStaleLock } from "./lock.js";
+import {
+	addStorageProfile,
+	addSyncTarget,
+	migrateLegacySettings,
+	removeStorageProfile,
+	removeSyncTarget,
+	saveNewV2Settings,
+	updateStorageProfile,
+	updateSyncTarget,
+} from "./settings-management.js";
+import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
+import type { SyncConfig } from "./types.js";
+
+export const MAIN_MENU_ACTIONS = [
+	"Sync now",
+	"Switch target",
+	"Status & changes",
+	"Settings",
+	"Manage targets & storage",
+	"History & recovery",
+	"Help",
+] as const;
+
+const BACK = "Back";
+
+type MainMenuAction = (typeof MAIN_MENU_ACTIONS)[number];
+type RunRoute = (route: string, signal?: AbortSignal, onCommit?: () => void) => Promise<void>;
+
+export async function showSyncManager(
+	ctx: ExtensionCommandContext,
+	runRoute: RunRoute,
+): Promise<void> {
+	if (!ctx.hasUI) {
+		await runRoute("help");
+		return;
+	}
+	while (true) {
+		const state = await describeManagerState();
+		const selected = await ctx.ui.select(state.title, state.actions);
+		if (!selected) return;
+		switch (selected as MainMenuAction | "Set up sync" | "Use existing settings") {
+			case "Sync now":
+				await runCancellableOperation(ctx, "Checking current target…", "sync", runRoute, true);
+				break;
+			case "Switch target":
+				if (await showTargetSwitcher(ctx)) continue;
+				break;
+			case "Status & changes":
+				await runCancellableOperation(ctx, "Checking current target…", "diff", runRoute);
+				break;
+			case "Settings":
+				await showSettingsMenu(ctx, runRoute);
+				break;
+			case "Manage targets & storage":
+				await showManageMenu(ctx, runRoute);
+				break;
+			case "History & recovery":
+				await showRecoveryMenu(ctx, runRoute);
+				break;
+			case "Set up sync":
+			case "Use existing settings":
+				await runRoute("init");
+				continue;
+			case "Help":
+				await runRoute("help");
+				return;
+		}
+	}
+}
+
+async function runCancellableOperation(
+	ctx: ExtensionCommandContext,
+	message: string,
+	route: string,
+	runRoute: RunRoute,
+	commitAware = false,
+) {
+	if (ctx.mode !== "tui") {
+		await runRoute(route);
+		return;
+	}
+	let commitStarted = false;
+	let operation: Promise<void> | undefined;
+	const result = await ctx.ui.custom<{ cancelled?: boolean; error?: unknown }>(
+		(tui, theme, _kb, done) => {
+			const loader = new BorderedLoader(tui, theme, message, { cancellable: true });
+			let closed = false;
+			loader.onAbort = () => {
+				if (commitStarted) {
+					ctx.ui.notify(
+						"Applying or publishing has started and cannot be cancelled safely.",
+						"warning",
+					);
+					return;
+				}
+				closed = true;
+				done({ cancelled: true });
+			};
+			operation = runRoute(
+				route,
+				loader.signal,
+				commitAware ? () => (commitStarted = true) : undefined,
+			)
+				.then(() => {
+					if (!closed) done({});
+				})
+				.catch((error) => {
+					if (!closed) done({ error });
+				});
+			return loader;
+		},
+	);
+	if (result?.cancelled) {
+		await operation;
+		ctx.ui.notify("Check cancelled; no settings or files were changed.", "info");
+		return;
+	}
+	if (result?.error) throw result.error;
+}
+
+async function describeManagerState(): Promise<{ title: string; actions: string[] }> {
+	let raw: Record<string, unknown> | undefined;
+	try {
+		raw = await readLocalConfigObject();
+	} catch (error) {
+		return {
+			title: [
+				"Pi Sync",
+				"",
+				"Settings file needs repair. Automatic sync and settings writes are paused.",
+				`Error: ${safeTerminalText(errorMessage(error))}`,
+				`File: ${safeTerminalText(localConfigPath())}`,
+				"",
+				"Repair the JSON file, then reopen /sync.",
+			].join("\n"),
+			actions: ["Help"],
+		};
+	}
+	if (!raw) {
+		return {
+			title: ["Pi Sync", "", "Not set up.", "", "What do you want to do?"].join("\n"),
+			actions: ["Set up sync", "Help"],
+		};
+	}
+	const configuredTargets = ownRecord(raw.targets);
+	if (raw.version === 2 && configuredTargets && Object.keys(configuredTargets).length === 0) {
+		return {
+			title: [
+				"Pi Sync",
+				"",
+				"No sync targets are configured.",
+				"Add a target using an existing storage profile.",
+				"",
+				"What do you want to do?",
+			].join("\n"),
+			actions: ["Manage targets & storage", "Help"],
+		};
+	}
+	try {
+		const config = await loadConfig();
+		const target = config.target ?? "default";
+		const storage = storageDescription(config.storageKind, config.endpoint, config.bucket);
+		const warnings = deprecatedPiSyncEnvironmentWarnings();
+		const lock = await inspectLock();
+		const liveLock = lock.status === "valid" && !isStaleLock(lock.lock);
+		const recoverableLock =
+			lock.status === "unreadable" || (lock.status === "valid" && isStaleLock(lock.lock));
+		return {
+			title: [
+				"Pi Sync",
+				"",
+				`Current target: ${safeTerminalText(target)}`,
+				`Storage: ${storage}`,
+				`Auto-sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
+				"Last known sync: Remote not checked",
+				...warnings.map((warning) => `Warning: ${safeTerminalText(warning)}`),
+				...(liveLock
+					? [
+							"",
+							`Operation in progress: ${safeTerminalText(lock.lock.command)} (pid ${lock.lock.pid}). Sync and settings changes are disabled.`,
+						]
+					: []),
+				...(recoverableLock
+					? ["", "Recovery required: lock metadata is stale or unreadable."]
+					: []),
+				"",
+				"What do you want to do?",
+			].join("\n"),
+			actions:
+				liveLock || recoverableLock
+					? ["Status & changes", "History & recovery", "Help"]
+					: [...MAIN_MENU_ACTIONS],
+		};
+	} catch (error) {
+		const targets = ownRecord(raw.targets);
+		return {
+			title: [
+				"Pi Sync",
+				"",
+				"Settings need attention. Automatic sync is paused.",
+				`Current target: ${safeTerminalText(typeof raw.activeTarget === "string" ? raw.activeTarget : "default")}`,
+				`Error: ${safeTerminalText(errorMessage(error))}`,
+				`File: ${safeTerminalText(localConfigPath())}`,
+				"",
+				"What do you want to do?",
+			].join("\n"),
+			actions: [
+				...(targets && Object.keys(targets).length > 1 ? ["Switch target"] : []),
+				"Manage targets & storage",
+				"Help",
+			],
+		};
+	}
+}
+
+export async function showSetupWizard(ctx: ExtensionCommandContext) {
+	if (ctx.mode !== "tui") return false;
+	const preset = await ctx.ui.select("Set up sync\n\nWhere will Pi settings be stored?", [
+		"Cloudflare R2",
+		"Other S3-compatible storage",
+		"Cancel",
+	]);
+	if (!preset || preset === "Cancel") return false;
+	const targetName = await requiredInput(ctx, "Name this sync target", "default");
+	if (!targetName) return false;
+	const profileName = await requiredInput(
+		ctx,
+		"Name this reusable storage profile",
+		preset === "Cloudflare R2" ? "r2" : "s3",
+	);
+	if (!profileName) return false;
+	const endpoint = await requiredInput(
+		ctx,
+		preset === "Cloudflare R2" ? "Cloudflare R2 endpoint" : "S3-compatible endpoint",
+		preset === "Cloudflare R2"
+			? "https://<account-id>.r2.cloudflarestorage.com"
+			: "https://s3.example.com",
+	);
+	if (!endpoint) return false;
+	let region = "auto";
+	if (preset !== "Cloudflare R2") {
+		const selectedRegion = await requiredInput(ctx, "Storage region", "us-east-1");
+		if (!selectedRegion) return false;
+		region = selectedRegion;
+	}
+	const bucket = await requiredInput(ctx, "Bucket", "pi-sync");
+	if (!bucket) return false;
+	const prefix = await requiredInput(ctx, "Remote prefix", "pi-sync");
+	if (!prefix) return false;
+	const namespace = await requiredInput(ctx, "Remote namespace", targetName);
+	if (!namespace) return false;
+	const credentialChoice = await ctx.ui.select(
+		"Credentials\n\nSecret values are never shown in pi-sync screens.",
+		["Use environment credentials", "Create private settings template", "Cancel"],
+	);
+	if (!credentialChoice || credentialChoice === "Cancel") return false;
+	const contentChoice = await ctx.ui.select("Choose an initial sync preset", [
+		"Recommended Pi settings",
+		"Minimal settings",
+		"Cancel",
+	]);
+	if (!contentChoice || contentChoice === "Cancel") return false;
+	const syncFiles =
+		contentChoice === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
+	const automaticChoice = await ctx.ui.select("Automatic sync for this target", [
+		"Enable automatic sync",
+		"Keep automatic sync off",
+		"Cancel",
+	]);
+	if (!automaticChoice || automaticChoice === "Cancel") return false;
+	const sessionChoice = await ctx.ui.select(
+		"Session conversations\n\nSessions can contain prompts, tool output, paths, screenshots, and secrets.",
+		["Keep sessions off (recommended)", "Include session conversations", "Cancel"],
+	);
+	if (!sessionChoice || sessionChoice === "Cancel") return false;
+	const syncSessions = sessionChoice === "Include session conversations";
+	if (
+		syncSessions &&
+		!(await ctx.ui.confirm(
+			"Include session conversations?",
+			"I understand that session JSONL can contain prompts, tool output, paths, screenshots, and secrets.",
+		))
+	) {
+		return false;
+	}
+	const autoSync = automaticChoice === "Enable automatic sync";
+	const hasEnvironmentCredentials = Boolean(
+		(process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID) &&
+			(process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY),
+	);
+	const credentialSummary =
+		credentialChoice === "Use environment credentials"
+			? hasEnvironmentCredentials
+				? "Environment credentials detected"
+				: "Environment credentials are currently missing"
+			: `Complete accessKeyId and secretAccessKey in ${localConfigPath()}`;
+	const choice = await ctx.ui.select(
+		[
+			"Review setup",
+			"",
+			`Target: ${safeTerminalText(targetName)}`,
+			`Storage profile: ${safeTerminalText(profileName)} (${preset})`,
+			`Endpoint: ${safeTerminalText(endpoint)}`,
+			`Bucket: ${safeTerminalText(bucket)}`,
+			`Remote: ${safeTerminalText(prefix)}/${safeTerminalText(namespace)}`,
+			`Synced content: ${syncFiles.length} built-in groups · Sessions: ${syncSessions ? "On — privacy warning acknowledged" : "Off"}`,
+			`Auto-sync: ${autoSync ? "On" : "Off"}`,
+			`Credentials: ${safeTerminalText(credentialSummary)}`,
+		].join("\n"),
+		["Save setup", "Cancel"],
+	);
+	if (choice !== "Save setup") return false;
+	await saveNewV2Settings({
+		targetName,
+		storageProfileName: profileName,
+		profile: {
+			kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
+			endpoint,
+			region,
+		},
+		target: {
+			bucket,
+			prefix,
+			namespace,
+			autoSync,
+			syncFiles,
+			syncSessions,
+			extraFiles: [],
+		},
+	});
+	await refreshTargetCompletions();
+	ctx.ui.notify(
+		hasEnvironmentCredentials || credentialChoice !== "Use environment credentials"
+			? `Target “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
+			: `Saved target “${safeTerminalText(targetName)}”; add credentials before syncing.`,
+		"info",
+	);
+	return true;
+}
+
+async function showTargetSwitcher(ctx: ExtensionCommandContext) {
+	const raw = await readLocalConfigObject();
+	if (raw?.version !== 2) {
+		ctx.ui.notify("Add a second sync target before switching targets.", "info");
+		return false;
+	}
+	const targets = ownRecord(raw.targets);
+	if (!targets) {
+		ctx.ui.notify("No sync targets are configured.", "warning");
+		return false;
+	}
+	const active = typeof raw.activeTarget === "string" ? raw.activeTarget : undefined;
+	const profiles = ownRecord(raw.profiles);
+	const names = Object.keys(targets).sort((left, right) => left.localeCompare(right));
+	const labels = new Map<string, string>();
+	for (const name of names) {
+		const target = ownRecord(targets[name]);
+		const profileName = typeof target?.profile === "string" ? target.profile : undefined;
+		const profile = profileName && profiles ? ownRecord(profiles[profileName]) : undefined;
+		const label = [
+			`${safeTerminalText(name)}${name === active ? " (current)" : ""}`,
+			profile
+				? `${safeTerminalText(profileName ?? "unknown")} · ${safeTerminalText(String(target?.bucket ?? "missing bucket"))}`
+				: `Invalid: missing storage profile ${safeTerminalText(profileName ?? "reference")}`,
+			`${normalizeSyncFiles(target?.syncFiles as string[] | undefined).length} groups · Sessions: ${target?.syncSessions === true ? "On" : "Off"}`,
+		].join(" · ");
+		labels.set(label, name);
+	}
+	const options = [...labels.keys(), BACK];
+	const selected = await ctx.ui.select(
+		`Switch target\n\nCurrent target: ${safeTerminalText(active ?? "none")}`,
+		options,
+	);
+	if (!selected || selected === BACK) return false;
+	const name = labels.get(selected) ?? selected.replace(/ \(current\)$/u, "");
+	if (name === active) {
+		ctx.ui.notify(`Target “${safeTerminalText(name)}” is already current.`, "info");
+		return false;
+	}
+	let config: SyncConfig;
+	try {
+		config = await loadConfig(name);
+	} catch (error) {
+		ctx.ui.notify(
+			`Cannot use target “${safeTerminalText(name)}”: ${safeTerminalText(errorMessage(error))}`,
+			"error",
+		);
+		return false;
+	}
+	const choice = await ctx.ui.select(
+		[
+			"Switch target",
+			"",
+			`From: ${safeTerminalText(active ?? "none")}`,
+			`To: ${safeTerminalText(name)}`,
+			`Storage: ${storageDescription(config.storageKind, config.endpoint, config.bucket)}`,
+			`Synced content: ${normalizeSyncFiles(config.syncFiles).length} built-in groups · ${config.extraFiles.length} extra files`,
+			`Auto-sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
+			"",
+			"Switching does not sync or modify files now.",
+		].join("\n"),
+		[`Switch to ${safeTerminalText(name)}`, "Cancel"],
+	);
+	if (choice !== `Switch to ${safeTerminalText(name)}`) return false;
+	await useSyncTarget(ctx, name);
+	return true;
+}
+
+export async function useSyncTarget(ctx: ExtensionCommandContext, name: string) {
+	const normalized = name.trim();
+	if (!normalized) throw new Error("Usage: /sync use <target>");
+	await loadConfig(normalized);
+	await updateLocalConfig((current) => {
+		if (current.version !== 2) throw new Error("Target switching requires version 2 settings.");
+		return { ...current, activeTarget: normalized };
+	});
+	await refreshTargetCompletions();
+	ctx.ui.notify(
+		`Switched to “${safeTerminalText(normalized)}”. No files were synced; use Sync now when ready.`,
+		"info",
+	);
+}
+
+async function showSettingsMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
+	const partial = await loadPartialConfig();
+	const automaticSyncOverridden = Object.hasOwn(process.env, "PI_SYNC_AUTO_SYNC");
+	const selected = await ctx.ui.select(
+		[
+			`Settings for target “${safeTerminalText(partial.target ?? "default")}”`,
+			`Storage: ${storageDescription(partial.storageKind, partial.endpoint, partial.bucket)}`,
+			"Automatic sync changes save immediately; synced-content changes use a reviewed draft.",
+			"",
+			`Auto-sync: ${isEnabled(partial.autoSync, true) ? "On" : "Off"}`,
+			`Synced content: ${normalizeSyncFiles(partial.syncFiles).length} built-ins · ${normalizeExtraFiles(partial.extraFiles).length} extra`,
+		].join("\n"),
+		[
+			"Choose synced content",
+			automaticSyncOverridden
+				? "Automatic sync (environment override, deprecated)"
+				: "Toggle automatic sync",
+			BACK,
+		],
+	);
+	if (!selected || selected === BACK) return;
+	if (selected === "Choose synced content") {
+		await runRoute("files");
+		return;
+	}
+	if (automaticSyncOverridden) {
+		ctx.ui.notify(
+			"Automatic sync is read-only because deprecated PI_SYNC_AUTO_SYNC currently overrides this target. Move it into target settings before the future major removal.",
+			"warning",
+		);
+		return;
+	}
+	await updateCurrentTarget((target) => ({
+		...target,
+		autoSync: !isEnabled(partial.autoSync, true),
+	}));
+	ctx.ui.notify(
+		`Automatic sync ${isEnabled(partial.autoSync, true) ? "disabled" : "enabled"} for “${safeTerminalText(partial.target ?? "default")}”.`,
+		"info",
+	);
+}
+
+async function showManageMenu(ctx: ExtensionCommandContext, _runRoute: RunRoute) {
+	const selected = await ctx.ui.select("Manage targets & storage", [
+		"Add sync target",
+		"Edit current target",
+		"Manage storage profiles",
+		"Remove sync target",
+		BACK,
+	]);
+	if (!selected || selected === BACK) return;
+	if (selected === "Add sync target") await showAddTarget(ctx);
+	else if (selected === "Edit current target") await showEditCurrentTarget(ctx);
+	else if (selected === "Manage storage profiles") await showStorageProfiles(ctx);
+	else await showRemoveTarget(ctx);
+}
+
+async function showAddTarget(ctx: ExtensionCommandContext) {
+	let raw = await readLocalConfigObject();
+	if (!raw)
+		return void ctx.ui.notify("Set up the first sync target before adding another.", "info");
+	if (raw.version !== 2) {
+		const choice = await ctx.ui.select(
+			[
+				"Upgrade settings for multiple targets",
+				"",
+				"The existing destination, unknown fields, and local sync state will be preserved.",
+				"An exact private backup is created before the atomic conversion.",
+			].join("\n"),
+			["Upgrade settings", "Cancel"],
+		);
+		if (choice !== "Upgrade settings") return;
+		const currentTarget = await requiredInput(ctx, "Name the existing sync target", "default");
+		if (!currentTarget) return;
+		const currentProfile = await requiredInput(ctx, "Name the existing storage profile", "default");
+		if (!currentProfile) return;
+		const migration = await migrateLegacySettings(currentTarget, currentProfile);
+		ctx.ui.notify(
+			`Upgraded pi-sync settings. Backup: ${safeTerminalText(migration.backupPath)}`,
+			"info",
+		);
+		raw = migration.settings;
+	}
+	const profiles = ownRecord(raw.profiles);
+	if (!profiles || Object.keys(profiles).length === 0) {
+		ctx.ui.notify("Add a storage profile before adding a sync target.", "warning");
+		return;
+	}
+	const name = await requiredInput(ctx, "Name the new sync target", "work");
+	if (!name) return;
+	const profile = await ctx.ui.select("Choose storage for this target", [
+		...Object.keys(profiles).sort(),
+		"Cancel",
+	]);
+	if (!profile || profile === "Cancel") return;
+	const bucket = await requiredInput(ctx, "Bucket", "pi-sync");
+	if (!bucket) return;
+	const prefix = await requiredInput(ctx, "Remote prefix", "pi-sync");
+	if (!prefix) return;
+	const namespace = await requiredInput(ctx, "Remote namespace", name);
+	if (!namespace) return;
+	const preset = await ctx.ui.select("Choose synced content", [
+		"Recommended Pi settings",
+		"Minimal settings",
+		"Cancel",
+	]);
+	if (!preset || preset === "Cancel") return;
+	const syncFiles =
+		preset === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
+	const overlapsExistingTarget = Object.values(ownRecord(raw.targets) ?? {}).some((value) => {
+		const existing = value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+		const selected = normalizeSyncFiles(existing?.syncFiles as string[] | undefined);
+		return selected.some((item) => syncFiles.includes(item));
+	});
+	const choice = await ctx.ui.select(
+		[
+			"Review new sync target",
+			"",
+			`Target: ${safeTerminalText(name)}`,
+			`Storage profile: ${safeTerminalText(profile)}`,
+			`Destination: ${safeTerminalText(bucket)}/${safeTerminalText(prefix)}/${safeTerminalText(namespace)}`,
+			`Synced content: ${syncFiles.length} built-in groups · Sessions: Off`,
+			...(overlapsExistingTarget
+				? ["Warning: this target shares local content with another target; only the current target auto-syncs."]
+				: []),
+			"Switching to this target later will not sync automatically.",
+		].join("\n"),
+		["Add target", "Cancel"],
+	);
+	if (choice !== "Add target") return;
+	await addSyncTarget(name, {
+		profile,
+		bucket,
+		prefix,
+		namespace,
+		autoSync: true,
+		syncFiles,
+		syncSessions: false,
+		extraFiles: [],
+	});
+	await refreshTargetCompletions();
+	ctx.ui.notify(`Added sync target “${safeTerminalText(name)}”.`, "info");
+}
+
+async function showEditCurrentTarget(ctx: ExtensionCommandContext) {
+	const partial = await loadPartialConfig();
+	if (partial.settingsVersion !== 2 || !partial.target) {
+		ctx.ui.notify("Upgrade settings before editing a named target.", "info");
+		return;
+	}
+	const bucket = await requiredInput(ctx, "Bucket", partial.bucket ?? "pi-sync");
+	if (!bucket) return;
+	const prefix = await requiredInput(ctx, "Remote prefix", partial.prefix ?? "pi-sync");
+	if (!prefix) return;
+	const namespace = await requiredInput(ctx, "Remote namespace", partial.profile ?? partial.target);
+	if (!namespace) return;
+	const choice = await ctx.ui.select(
+		[
+			`Review target “${safeTerminalText(partial.target)}”`,
+			"",
+			`Bucket: ${safeTerminalText(partial.bucket ?? "missing")} → ${safeTerminalText(bucket)}`,
+			`Prefix: ${safeTerminalText(partial.prefix ?? "pi-sync")} → ${safeTerminalText(prefix)}`,
+			`Namespace: ${safeTerminalText(partial.profile ?? partial.target)} → ${safeTerminalText(namespace)}`,
+			"Saving changes future sync destination only; it does not move or delete remote data.",
+		].join("\n"),
+		["Save target", "Cancel"],
+	);
+	if (choice !== "Save target") return;
+	await updateSyncTarget(partial.target, (target) => ({ ...target, bucket, prefix, namespace }));
+	ctx.ui.notify(`Saved target “${safeTerminalText(partial.target)}”.`, "info");
+}
+
+async function showStorageProfiles(ctx: ExtensionCommandContext) {
+	const raw = await readLocalConfigObject();
+	if (raw?.version !== 2) {
+		ctx.ui.notify("Upgrade settings before managing storage profiles.", "info");
+		return;
+	}
+	const profiles = ownRecord(raw.profiles) ?? {};
+	const selected = await ctx.ui.select("Storage profiles", [
+		"Add storage profile",
+		...Object.keys(profiles).sort(),
+		BACK,
+	]);
+	if (!selected || selected === BACK) return;
+	if (selected === "Add storage profile") {
+		await showAddStorageProfile(ctx);
+		return;
+	}
+	const action = await ctx.ui.select(`Storage profile “${safeTerminalText(selected)}”`, [
+		"Edit connection",
+		"Remove storage profile",
+		BACK,
+	]);
+	if (!action || action === BACK) return;
+	if (action === "Remove storage profile") {
+		const confirmed = await ctx.ui.confirm(
+			"Remove storage profile?",
+			`Remove local profile “${safeTerminalText(selected)}”? Remote buckets and snapshots are not deleted.`,
+		);
+		if (!confirmed) return;
+		await removeStorageProfile(selected);
+		ctx.ui.notify(`Removed storage profile “${safeTerminalText(selected)}”.`, "info");
+		return;
+	}
+	const profile = ownRecord(profiles[selected]);
+	if (!profile) return;
+	const endpoint = await requiredInput(
+		ctx,
+		"Endpoint",
+		String(profile.endpoint ?? "https://s3.example.com"),
+	);
+	if (!endpoint) return;
+	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
+	if (!region) return;
+	const save = await ctx.ui.select(
+		`Review connection\n\nProfile: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials remain unchanged and are never shown.`,
+		["Save profile", "Cancel"],
+	);
+	if (save !== "Save profile") return;
+	await updateStorageProfile(selected, (current) => ({ ...current, endpoint, region }));
+	ctx.ui.notify(`Saved storage profile “${safeTerminalText(selected)}”.`, "info");
+}
+
+async function showAddStorageProfile(ctx: ExtensionCommandContext) {
+	const preset = await ctx.ui.select("Storage type", [
+		"Cloudflare R2",
+		"Other S3-compatible storage",
+		"Cancel",
+	]);
+	if (!preset || preset === "Cancel") return;
+	const name = await requiredInput(
+		ctx,
+		"Name the storage profile",
+		preset === "Cloudflare R2" ? "r2" : "s3",
+	);
+	if (!name) return;
+	const endpoint = await requiredInput(
+		ctx,
+		"Endpoint",
+		preset === "Cloudflare R2"
+			? "https://<account-id>.r2.cloudflarestorage.com"
+			: "https://s3.example.com",
+	);
+	if (!endpoint) return;
+	const region =
+		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
+	if (!region) return;
+	const save = await ctx.ui.select(
+		`Review storage profile\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nAdd credentials privately in ${safeTerminalText(localConfigPath())} or use environment credentials.`,
+		["Add profile", "Cancel"],
+	);
+	if (save !== "Add profile") return;
+	await addStorageProfile(name, {
+		kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
+		endpoint,
+		region,
+	});
+	ctx.ui.notify(`Added storage profile “${safeTerminalText(name)}”.`, "info");
+}
+
+async function showRemoveTarget(ctx: ExtensionCommandContext) {
+	const raw = await readLocalConfigObject();
+	const targets = ownRecord(raw?.targets);
+	if (raw?.version !== 2 || !targets || Object.keys(targets).length === 0) {
+		ctx.ui.notify("No named sync targets are available to remove.", "info");
+		return;
+	}
+	const selected = await ctx.ui.select("Remove sync target", [
+		...Object.keys(targets).sort(),
+		"Cancel",
+	]);
+	if (!selected || selected === "Cancel") return;
+	const confirmed = await ctx.ui.confirm(
+		"Remove sync target?",
+		`Remove local target “${safeTerminalText(selected)}”? Remote buckets and snapshots are not deleted.`,
+	);
+	if (!confirmed) return;
+	await removeSyncTarget(selected);
+	await refreshTargetCompletions();
+	ctx.ui.notify(
+		`Removed sync target “${safeTerminalText(selected)}”; remote data was not deleted.`,
+		"info",
+	);
+}
+
+async function refreshTargetCompletions() {
+	setSyncTargetCompletions(await configuredTargetNames());
+}
+
+async function showRecoveryMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
+	const lock = await inspectLock();
+	const canRecover =
+		lock.status === "unreadable" || (lock.status === "valid" && isStaleLock(lock.lock));
+	const selected = await ctx.ui.select("History & recovery", [
+		"Browse history",
+		"Check setup",
+		...(canRecover ? ["Recover stale operation"] : []),
+		BACK,
+	]);
+	if (!selected || selected === BACK) return;
+	if (selected === "Browse history") await runRoute("history");
+	else if (selected === "Check setup") await runRoute("doctor");
+	else await runRoute("unlock");
+}
+
+async function updateCurrentTarget(
+	update: (target: Record<string, unknown>) => Record<string, unknown>,
+) {
+	await updateLocalConfig((current) => {
+		if (current.version !== 2) return update(current);
+		const targets = ownRecord(current.targets);
+		const active = typeof current.activeTarget === "string" ? current.activeTarget : undefined;
+		if (!targets || !active) throw new Error("Current target is not configured.");
+		const target = ownRecord(targets[active]);
+		if (!target) throw new Error(`Current target “${active}” is invalid.`);
+		return { ...current, targets: { ...targets, [active]: update(target) } };
+	});
+}
+
+async function requiredInput(ctx: ExtensionCommandContext, title: string, placeholder: string) {
+	const value = await ctx.ui.input(title, placeholder);
+	if (value === undefined) return undefined;
+	const normalized = value.trim() || placeholder;
+	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
+}
+
+function storageDescription(
+	kind: string | undefined,
+	endpoint: string | undefined,
+	bucket: string | undefined,
+) {
+	const label =
+		kind === "r2" || isCloudflareR2Endpoint(endpoint) ? "Cloudflare R2" : "S3-compatible";
+	return `${label} · ${safeTerminalText(bucket ?? "bucket missing")}`;
+}
+
+function ownRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function safeTerminalText(value: string) {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "?");
+}
+
+function errorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -237,14 +237,8 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 		"Cancel",
 	]);
 	if (!preset || preset === "Cancel") return false;
-	const targetName = await requiredInput(ctx, "Name this sync target", "default");
+	const targetName = await chooseInitialTargetName(ctx);
 	if (!targetName) return false;
-	const profileName = await requiredInput(
-		ctx,
-		"Name this reusable storage profile",
-		preset === "Cloudflare R2" ? "r2" : "s3",
-	);
-	if (!profileName) return false;
 	const endpoint = await requiredInput(
 		ctx,
 		preset === "Cloudflare R2" ? "Cloudflare R2 endpoint" : "S3-compatible endpoint",
@@ -259,12 +253,9 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 		if (!selectedRegion) return false;
 		region = selectedRegion;
 	}
-	const bucket = await requiredInput(ctx, "Bucket", "pi-sync");
-	if (!bucket) return false;
-	const prefix = await requiredInput(ctx, "Remote prefix", "pi-sync");
-	if (!prefix) return false;
-	const namespace = await requiredInput(ctx, "Remote namespace", targetName);
-	if (!namespace) return false;
+	const location = await chooseInitialRemoteLocation(ctx, preset, targetName);
+	if (!location) return false;
+	const { profileName, bucket, prefix, namespace } = location;
 	const credentialChoice = await ctx.ui.select(
 		"Credentials\n\nSecret values are never shown in pi-sync screens.",
 		["Use environment credentials", "Create private settings template", "Cancel"],
@@ -318,7 +309,8 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 			`Storage profile: ${safeTerminalText(profileName)} (${preset})`,
 			`Endpoint: ${safeTerminalText(endpoint)}`,
 			`Bucket: ${safeTerminalText(bucket)}`,
-			`Remote: ${safeTerminalText(prefix)}/${safeTerminalText(namespace)}`,
+			`Remote path: ${formatRemotePath(prefix, namespace)}`,
+			"Bucket must already exist. pi-sync will not create it.",
 			`Synced content: ${syncFiles.length} built-in groups · Sessions: ${syncSessions ? "On — privacy warning acknowledged" : "Off"}`,
 			`Auto-sync: ${autoSync ? "On" : "Off"}`,
 			`Credentials: ${safeTerminalText(credentialSummary)}`,
@@ -532,12 +524,9 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 		"Cancel",
 	]);
 	if (!profile || profile === "Cancel") return;
-	const bucket = await requiredInput(ctx, "Bucket", "pi-sync");
-	if (!bucket) return;
-	const prefix = await requiredInput(ctx, "Remote prefix", "pi-sync");
-	if (!prefix) return;
-	const namespace = await requiredInput(ctx, "Remote namespace", name);
-	if (!namespace) return;
+	const location = await chooseAdditionalRemoteLocation(ctx, raw, profile, name);
+	if (!location) return;
+	const { bucket, prefix, namespace } = location;
 	const preset = await ctx.ui.select("Choose synced content", [
 		"Recommended Pi settings",
 		"Minimal settings",
@@ -547,7 +536,8 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 	const syncFiles =
 		preset === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
 	const overlapsExistingTarget = Object.values(ownRecord(raw.targets) ?? {}).some((value) => {
-		const existing = value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+		const existing =
+			value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 		const selected = normalizeSyncFiles(existing?.syncFiles as string[] | undefined);
 		return selected.some((item) => syncFiles.includes(item));
 	});
@@ -557,10 +547,14 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 			"",
 			`Target: ${safeTerminalText(name)}`,
 			`Storage profile: ${safeTerminalText(profile)}`,
-			`Destination: ${safeTerminalText(bucket)}/${safeTerminalText(prefix)}/${safeTerminalText(namespace)}`,
+			`Bucket: ${safeTerminalText(bucket)}`,
+			`Remote path: ${formatRemotePath(prefix, namespace)}`,
+			"Bucket must already exist. pi-sync will not create it.",
 			`Synced content: ${syncFiles.length} built-in groups · Sessions: Off`,
 			...(overlapsExistingTarget
-				? ["Warning: this target shares local content with another target; only the current target auto-syncs."]
+				? [
+						"Warning: this target shares local content with another target; only the current target auto-syncs.",
+					]
 				: []),
 			"Switching to this target later will not sync automatically.",
 		].join("\n"),
@@ -743,6 +737,172 @@ async function showRecoveryMenu(ctx: ExtensionCommandContext, runRoute: RunRoute
 	else await runRoute("unlock");
 }
 
+interface ChosenRemoteLocation {
+	profileName: string;
+	bucket: string;
+	prefix: string;
+	namespace: string;
+}
+
+async function chooseInitialTargetName(ctx: ExtensionCommandContext) {
+	const purpose = await ctx.ui.select("What will this target be used for?", [
+		"Personal / Home",
+		"Work",
+		"Custom",
+		"Cancel",
+	]);
+	if (!purpose || purpose === "Cancel") return undefined;
+	if (purpose === "Personal / Home") return "home";
+	if (purpose === "Work") return "work";
+	return requiredInput(ctx, "Name this sync target", "default");
+}
+
+async function chooseInitialRemoteLocation(
+	ctx: ExtensionCommandContext,
+	preset: string,
+	targetName: string,
+): Promise<ChosenRemoteLocation | undefined> {
+	const profileName = preset === "Cloudflare R2" ? "r2" : "s3";
+	const suggested = {
+		profileName,
+		bucket: "pi-sync",
+		prefix: "pi-sync",
+		namespace: targetName,
+	};
+	if (preset === "Cloudflare R2") {
+		const choice = await ctx.ui.select(
+			[
+				"Choose remote location",
+				"",
+				`Suggested storage profile: ${profileName}`,
+				`Suggested bucket: ${suggested.bucket}`,
+				`Remote path: ${formatRemotePath(suggested.prefix, suggested.namespace)}`,
+				"Bucket must already exist. pi-sync will not create it.",
+			].join("\n"),
+			["Use suggested location (recommended)", "Customize remote location", "Cancel"],
+		);
+		if (!choice || choice === "Cancel") return undefined;
+		if (choice === "Use suggested location (recommended)") return suggested;
+		return chooseCustomRemoteLocation(ctx, targetName, profileName, true);
+	}
+
+	const choice = await ctx.ui.select(
+		[
+			"Choose remote location",
+			"",
+			`Suggested storage profile: ${profileName}`,
+			`Suggested path: ${formatRemotePath("pi-sync", targetName)}`,
+			"S3 bucket names may need to be globally unique and the bucket must already exist.",
+		].join("\n"),
+		[
+			"Use existing bucket with suggested path (recommended)",
+			"Customize remote location",
+			"Cancel",
+		],
+	);
+	if (!choice || choice === "Cancel") return undefined;
+	if (choice === "Customize remote location") {
+		return chooseCustomRemoteLocation(ctx, targetName, profileName, true);
+	}
+	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name");
+	return bucket ? { ...suggested, bucket } : undefined;
+}
+
+async function chooseAdditionalRemoteLocation(
+	ctx: ExtensionCommandContext,
+	settings: Record<string, unknown>,
+	profileName: string,
+	targetName: string,
+): Promise<Omit<ChosenRemoteLocation, "profileName"> | undefined> {
+	const targets = ownRecord(settings.targets) ?? {};
+	const activeTarget =
+		typeof settings.activeTarget === "string" ? settings.activeTarget : undefined;
+	const candidates = Object.entries(targets)
+		.map(([name, value]) => ({ name, target: ownRecord(value) }))
+		.filter(
+			(item): item is { name: string; target: Record<string, unknown> } =>
+				item.target?.profile === profileName && typeof item.target.bucket === "string",
+		);
+	const source =
+		candidates.find((item) => item.name === activeTarget) ??
+		candidates.sort((left, right) => left.name.localeCompare(right.name))[0];
+	if (source) {
+		const sourcePrefix =
+			typeof source.target.prefix === "string" ? source.target.prefix : "pi-sync";
+		const sameBucketLabel = `Same bucket as “${safeTerminalText(source.name)}” (recommended)`;
+		const choice = await ctx.ui.select(
+			[
+				`Remote location for “${safeTerminalText(targetName)}”`,
+				"",
+				`Recommended bucket: ${safeTerminalText(String(source.target.bucket))}`,
+				`Remote path: ${formatRemotePath(sourcePrefix, targetName)}`,
+				"The namespace and local sync state remain separate.",
+			].join("\n"),
+			[sameBucketLabel, "Use a different bucket", "Customize remote location", "Cancel"],
+		);
+		if (!choice || choice === "Cancel") return undefined;
+		if (choice === sameBucketLabel) {
+			return {
+				bucket: String(source.target.bucket),
+				prefix: sourcePrefix,
+				namespace: targetName,
+			};
+		}
+		if (choice === "Use a different bucket") {
+			const bucket = await requiredExistingBucket(ctx, "pi-sync");
+			return bucket ? { bucket, prefix: "pi-sync", namespace: targetName } : undefined;
+		}
+		const custom = await chooseCustomRemoteLocation(ctx, targetName, profileName, false);
+		return custom
+			? { bucket: custom.bucket, prefix: custom.prefix, namespace: custom.namespace }
+			: undefined;
+	}
+
+	const profileSettings = ownRecord(ownRecord(settings.profiles)?.[profileName]);
+	const isR2 =
+		profileSettings?.kind === "r2" ||
+		isCloudflareR2Endpoint(String(profileSettings?.endpoint ?? ""));
+	const suggestedLabel = isR2
+		? "Use suggested location (recommended)"
+		: "Use existing bucket with suggested path (recommended)";
+	const choice = await ctx.ui.select(
+		`Remote location for “${safeTerminalText(targetName)}”\n\nSuggested path: ${formatRemotePath("pi-sync", targetName)}`,
+		[suggestedLabel, "Customize remote location", "Cancel"],
+	);
+	if (!choice || choice === "Cancel") return undefined;
+	if (choice === "Customize remote location") {
+		const custom = await chooseCustomRemoteLocation(ctx, targetName, profileName, false);
+		return custom
+			? { bucket: custom.bucket, prefix: custom.prefix, namespace: custom.namespace }
+			: undefined;
+	}
+	if (isR2) return { bucket: "pi-sync", prefix: "pi-sync", namespace: targetName };
+	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name");
+	return bucket ? { bucket, prefix: "pi-sync", namespace: targetName } : undefined;
+}
+
+async function chooseCustomRemoteLocation(
+	ctx: ExtensionCommandContext,
+	targetName: string,
+	initialProfileName: string,
+	customizeProfileName: boolean,
+): Promise<ChosenRemoteLocation | undefined> {
+	const profileName = customizeProfileName
+		? await requiredInput(ctx, "Storage profile name", initialProfileName)
+		: initialProfileName;
+	if (!profileName) return undefined;
+	const bucket = await requiredExistingBucket(ctx, "pi-sync");
+	if (!bucket) return undefined;
+	const prefix = await requiredInput(ctx, "Remote prefix", "pi-sync");
+	if (!prefix) return undefined;
+	const namespace = await requiredInput(ctx, "Remote namespace", targetName);
+	return namespace ? { profileName, bucket, prefix, namespace } : undefined;
+}
+
+function formatRemotePath(prefix: string, namespace: string) {
+	return safeTerminalText(`${prefix}/profiles/${namespace}/`);
+}
+
 async function updateCurrentTarget(
 	update: (target: Record<string, unknown>) => Record<string, unknown>,
 ) {
@@ -755,6 +915,17 @@ async function updateCurrentTarget(
 		if (!target) throw new Error(`Current target “${active}” is invalid.`);
 		return { ...current, targets: { ...targets, [active]: update(target) } };
 	});
+}
+
+async function requiredExistingBucket(ctx: ExtensionCommandContext, example: string) {
+	const value = await ctx.ui.input("Existing bucket", `Example: ${example}`);
+	if (value === undefined) return undefined;
+	const normalized = value.trim();
+	if (!normalized) {
+		ctx.ui.notify("Enter the name of an existing R2/S3 bucket, or cancel setup.", "warning");
+		return undefined;
+	}
+	return normalized;
 }
 
 async function requiredInput(ctx: ExtensionCommandContext, title: string, placeholder: string) {

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -734,7 +734,7 @@ async function showRecoveryMenu(ctx: ExtensionCommandContext, runRoute: RunRoute
 	if (!selected || selected === BACK) return;
 	if (selected === "Browse history") await runRoute("history");
 	else if (selected === "Check setup") await runRoute("doctor");
-	else await runRoute("unlock");
+	else await runRoute("unlock --stale");
 }
 
 interface ChosenRemoteLocation {

--- a/extensions/pi-sync/src/s3-client.ts
+++ b/extensions/pi-sync/src/s3-client.ts
@@ -10,7 +10,10 @@ function iso8601Basic(date: Date) {
 }
 
 function snapshotIncludesSessions(snapshot: Snapshot) {
-	return snapshot.syncSessions === true || snapshot.files.some((file) => file.path.startsWith("sessions/"));
+	return (
+		snapshot.syncSessions === true ||
+		snapshot.files.some((file) => file.path.startsWith("sessions/"))
+	);
 }
 
 function isCloudflareR2Endpoint(endpoint: string | undefined) {
@@ -18,7 +21,9 @@ function isCloudflareR2Endpoint(endpoint: string | undefined) {
 	if (!value) return false;
 	try {
 		const hostname = new URL(value).hostname.toLowerCase();
-		return hostname === "r2.cloudflarestorage.com" || hostname.endsWith(".r2.cloudflarestorage.com");
+		return (
+			hostname === "r2.cloudflarestorage.com" || hostname.endsWith(".r2.cloudflarestorage.com")
+		);
 	} catch {
 		return false;
 	}
@@ -27,11 +32,13 @@ function isCloudflareR2Endpoint(endpoint: string | undefined) {
 export class S3Client {
 	private config: SyncConfig;
 	private endpoint: URL;
+	private signal?: AbortSignal;
 	private omitSessionTokenAfterRejection = false;
 
-	constructor(config: SyncConfig) {
+	constructor(config: SyncConfig, signal?: AbortSignal) {
 		this.config = config;
 		this.endpoint = new URL(config.endpoint);
+		this.signal = signal;
 	}
 
 	async getJson<T>(key: string): Promise<RemoteObject<T>> {
@@ -48,11 +55,15 @@ export class S3Client {
 			// Retry so the transient blip is absorbed instead of surfacing as a
 			// "pi-sync auto sync skipped" warning on every session start.
 			if (body.length > 0) {
-				return { value: JSON.parse(body) as T, etag: normalizeEtag(object.headers.get("etag")), missing: false };
+				return {
+					value: JSON.parse(body) as T,
+					etag: normalizeEtag(object.headers.get("etag")),
+					missing: false,
+				};
 			}
 			lastError = new Error(`S3 GET returned an empty body for ${key}`);
 			if (attempt < maxAttempts) {
-				await sleep(250 * attempt);
+				await sleep(250 * attempt, undefined, { signal: this.signal });
 			}
 		}
 		throw lastError;
@@ -78,7 +89,7 @@ export class S3Client {
 			}
 			lastError = new Error(`S3 GET returned an empty body for ${key}`);
 			if (attempt < maxAttempts) {
-				await sleep(250 * attempt);
+				await sleep(250 * attempt, undefined, { signal: this.signal });
 			}
 		}
 		throw lastError;
@@ -92,7 +103,8 @@ export class S3Client {
 	async putBuffer(key: string, body: Buffer, contentType: string) {
 		const headers: Record<string, string> = { "content-type": contentType };
 		const response = await this.request("PUT", key, body, headers);
-		if (!response.ok) throw new Error(`S3 PUT failed (${response.status}): ${await response.text()}`);
+		if (!response.ok)
+			throw new Error(`S3 PUT failed (${response.status}): ${await response.text()}`);
 	}
 
 	private async request(
@@ -114,7 +126,12 @@ export class S3Client {
 				sessionToken,
 				region: this.config.region,
 			});
-			return fetch(url, { method, headers, body: body ? new Uint8Array(body) : undefined });
+			return fetch(url, {
+				method,
+				headers,
+				body: body ? new Uint8Array(body) : undefined,
+				signal: this.signal,
+			});
 		};
 		const sessionToken = this.omitSessionTokenAfterRejection ? undefined : this.config.sessionToken;
 		const response = await send(sessionToken);
@@ -125,7 +142,10 @@ export class S3Client {
 		return retry;
 	}
 
-	private async shouldRetryWithoutSessionToken(response: Response, sessionToken: string | undefined) {
+	private async shouldRetryWithoutSessionToken(
+		response: Response,
+		sessionToken: string | undefined,
+	) {
 		if (
 			!sessionToken ||
 			!isCloudflareR2Endpoint(this.config.endpoint) ||
@@ -160,7 +180,9 @@ async function signedHeaders(input: {
 	};
 	if (input.sessionToken) headers["x-amz-security-token"] = input.sessionToken;
 	const signedHeaderNames = Object.keys(headers).sort();
-	const canonicalHeaders = signedHeaderNames.map((name) => `${name}:${headers[name]?.trim()}\n`).join("");
+	const canonicalHeaders = signedHeaderNames
+		.map((name) => `${name}:${headers[name]?.trim()}\n`)
+		.join("");
 	const canonicalRequest = [
 		input.method,
 		input.url.pathname,
@@ -170,7 +192,12 @@ async function signedHeaders(input: {
 		payloadHash,
 	].join("\n");
 	const scope = `${dateStamp}/${input.region}/s3/aws4_request`;
-	const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, sha256(Buffer.from(canonicalRequest))].join("\n");
+	const stringToSign = [
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		scope,
+		sha256(Buffer.from(canonicalRequest)),
+	].join("\n");
 	const signingKey = hmac(
 		hmac(hmac(hmac(Buffer.from(`AWS4${input.secretAccessKey}`), dateStamp), input.region), "s3"),
 		"aws4_request",
@@ -206,7 +233,11 @@ export function profilePrefix(config: SyncConfig) {
 	return posixJoin(config.prefix, "profiles", config.profile);
 }
 
-export function pointerFor(config: SyncConfig, snapshot: Snapshot, checksum: string): LatestPointer {
+export function pointerFor(
+	config: SyncConfig,
+	snapshot: Snapshot,
+	checksum: string,
+): LatestPointer {
 	return {
 		version: VERSION,
 		profile: config.profile,
@@ -227,5 +258,8 @@ function normalizeEtag(value: string | null) {
 }
 
 function isSecurityTokenInvalidArgument(text: string) {
-	return text.includes("<Code>InvalidArgument</Code>") && text.includes("<Message>X-Amz-Security-Token</Message>");
+	return (
+		text.includes("<Code>InvalidArgument</Code>") &&
+		text.includes("<Message>X-Amz-Security-Token</Message>")
+	);
 }

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -274,9 +274,9 @@ function assertUniqueRemoteIdentity(
 function remoteIdentity(target: SyncTargetSettings | Record<string, unknown>) {
 	return JSON.stringify([
 		target.profile,
-		target.bucket,
-		target.prefix ?? "pi-sync",
-		"namespace" in target ? target.namespace : undefined,
+		process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? target.bucket,
+		process.env.PI_SYNC_PREFIX ?? target.prefix ?? "pi-sync",
+		process.env.PI_SYNC_PROFILE ?? ("namespace" in target ? target.namespace : undefined),
 	]);
 }
 

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -1,0 +1,312 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+	localConfigPath,
+	readLocalConfigObject,
+	stateDir,
+	statePathForConfig,
+	writeLocalConfigObject,
+} from "./config.js";
+import { withLock } from "./lock.js";
+import { safeName } from "./paths.js";
+import type { StorageProfileSettings, SyncConfig, SyncTargetSettings } from "./types.js";
+
+const LEGACY_FIELDS = new Set([
+	"endpoint",
+	"bucket",
+	"region",
+	"accessKeyId",
+	"secretAccessKey",
+	"sessionToken",
+	"profile",
+	"prefix",
+	"autoSync",
+	"syncFiles",
+	"syncSessions",
+	"extraFiles",
+]);
+
+export interface MigrationResult {
+	settings: Record<string, unknown>;
+	backupPath: string;
+}
+
+export async function migrateLegacySettings(
+	targetName: string,
+	storageProfileName: string,
+): Promise<MigrationResult> {
+	validateName(targetName, "target");
+	validateName(storageProfileName, "storage profile");
+	return withLock("settings-migration", async () => {
+		const configPath = localConfigPath();
+		const originalBytes = await fs.readFile(configPath);
+		const current = await readLocalConfigObject();
+		if (!current) throw new Error("No legacy pi-sync settings are available to migrate.");
+		if (current.version === 2) {
+			throw new Error("pi-sync settings already use profiles and targets.");
+		}
+		const next = legacySettingsAsV2(current, targetName, storageProfileName);
+		const backupPath = await writeMigrationBackup(originalBytes);
+		await adoptLegacyState(current, next, targetName);
+		const latestBytes = await fs.readFile(configPath);
+		if (!latestBytes.equals(originalBytes)) {
+			throw new Error("pi-sync settings changed during migration; no settings were replaced.");
+		}
+		await writeLocalConfigObject(next);
+		return { settings: next, backupPath };
+	});
+}
+
+export function legacySettingsAsV2(
+	legacy: Record<string, unknown>,
+	targetName: string,
+	storageProfileName: string,
+) {
+	validateName(targetName, "target");
+	validateName(storageProfileName, "storage profile");
+	const unknown = Object.fromEntries(
+		Object.entries(legacy).filter(([key]) => !LEGACY_FIELDS.has(key) && key !== "version"),
+	);
+	const profile = compactObject({
+		kind: inferKind(legacy.endpoint),
+		endpoint: legacy.endpoint,
+		region: legacy.region,
+		accessKeyId: legacy.accessKeyId,
+		secretAccessKey: legacy.secretAccessKey,
+		sessionToken: legacy.sessionToken,
+	});
+	const target = compactObject({
+		profile: storageProfileName,
+		bucket: legacy.bucket,
+		prefix: legacy.prefix,
+		namespace: legacy.profile ?? targetName,
+		autoSync: legacy.autoSync,
+		syncFiles: legacy.syncFiles,
+		syncSessions: legacy.syncSessions,
+		extraFiles: legacy.extraFiles,
+		legacyStateProfile: legacy.profile ?? "default",
+	});
+	return {
+		...unknown,
+		version: 2,
+		activeTarget: targetName,
+		profiles: { [storageProfileName]: profile },
+		targets: { [targetName]: target },
+	};
+}
+
+export async function saveNewV2Settings(input: {
+	targetName: string;
+	storageProfileName: string;
+	profile: StorageProfileSettings;
+	target: SyncTargetSettings;
+}) {
+	validateName(input.targetName, "target");
+	validateName(input.storageProfileName, "storage profile");
+	const current = (await readLocalConfigObject()) ?? {};
+	if (Object.keys(current).length > 0)
+		throw new Error(`Settings already exist: ${localConfigPath()}`);
+	const settings = {
+		version: 2,
+		activeTarget: input.targetName,
+		profiles: { [input.storageProfileName]: { ...input.profile } },
+		targets: {
+			[input.targetName]: { ...input.target, profile: input.storageProfileName },
+		},
+	};
+	await writeLocalConfigObject(settings);
+	return settings;
+}
+
+export async function addStorageProfile(name: string, profile: StorageProfileSettings) {
+	validateName(name, "storage profile");
+	await updateV2Settings((settings) => {
+		const profiles = requireObject(settings.profiles, "profiles");
+		if (Object.hasOwn(profiles, name)) throw new Error(`Storage profile already exists: ${name}`);
+		return { ...settings, profiles: { ...profiles, [name]: { ...profile } } };
+	});
+}
+
+export async function updateStorageProfile(
+	name: string,
+	update: (profile: Record<string, unknown>) => Record<string, unknown>,
+) {
+	validateName(name, "storage profile");
+	await updateV2Settings((settings) => {
+		const profiles = requireObject(settings.profiles, "profiles");
+		const profile = requireObject(profiles[name], "storage profile");
+		return { ...settings, profiles: { ...profiles, [name]: update(profile) } };
+	});
+}
+
+export async function addSyncTarget(name: string, target: SyncTargetSettings) {
+	validateName(name, "target");
+	await updateV2Settings((settings) => {
+		const targets = requireObject(settings.targets, "targets");
+		const profiles = requireObject(settings.profiles, "profiles");
+		if (Object.hasOwn(targets, name)) throw new Error(`Sync target already exists: ${name}`);
+		if (!target.profile || !Object.hasOwn(profiles, target.profile)) {
+			throw new Error(`Storage profile not found: ${target.profile ?? "missing"}`);
+		}
+		assertUniqueRemoteIdentity(targets, name, target);
+		return { ...settings, targets: { ...targets, [name]: { ...target } } };
+	});
+}
+
+export async function updateSyncTarget(
+	name: string,
+	update: (target: Record<string, unknown>) => Record<string, unknown>,
+) {
+	validateName(name, "target");
+	await updateV2Settings((settings) => {
+		const targets = requireObject(settings.targets, "targets");
+		const target = requireObject(targets[name], "target");
+		const nextTarget = update(target);
+		assertUniqueRemoteIdentity(targets, name, nextTarget);
+		return { ...settings, targets: { ...targets, [name]: nextTarget } };
+	});
+}
+
+export async function removeSyncTarget(name: string) {
+	validateName(name, "target");
+	await updateV2Settings((settings) => {
+		const targets = requireObject(settings.targets, "targets");
+		if (!Object.hasOwn(targets, name)) throw new Error(`Sync target not found: ${name}`);
+		if (settings.activeTarget === name && Object.keys(targets).length > 1) {
+			throw new Error("Switch to another target before removing the current target.");
+		}
+		const nextTargets = { ...targets };
+		delete nextTargets[name];
+		return {
+			...settings,
+			targets: nextTargets,
+			activeTarget: Object.keys(nextTargets)[0],
+		};
+	});
+}
+
+export async function removeStorageProfile(name: string) {
+	validateName(name, "storage profile");
+	await updateV2Settings((settings) => {
+		const profiles = requireObject(settings.profiles, "profiles");
+		const targets = requireObject(settings.targets, "targets");
+		const referenced = Object.entries(targets).find(
+			([, target]) => requireObject(target, "target").profile === name,
+		)?.[0];
+		if (referenced) throw new Error(`Storage profile “${name}” is used by target “${referenced}”.`);
+		if (!Object.hasOwn(profiles, name)) throw new Error(`Storage profile not found: ${name}`);
+		const nextProfiles = { ...profiles };
+		delete nextProfiles[name];
+		return { ...settings, profiles: nextProfiles };
+	});
+}
+
+async function updateV2Settings(
+	update: (settings: Record<string, unknown>) => Record<string, unknown>,
+) {
+	return withLock("settings", async () => {
+		const current = await readLocalConfigObject();
+		if (current?.version !== 2) {
+			throw new Error("Profiles and targets require version 2 pi-sync settings.");
+		}
+		const next = update(current);
+		await writeLocalConfigObject(next);
+		return next;
+	});
+}
+
+async function writeMigrationBackup(bytes: Buffer) {
+	const directory = path.join(stateDir(), "backups", "config");
+	await fs.mkdir(directory, { recursive: true });
+	const backupPath = path.join(
+		directory,
+		`pi-sync.local.${new Date().toISOString().replace(/[:.]/gu, "-")}.${randomUUID().slice(0, 8)}.json`,
+	);
+	await fs.writeFile(backupPath, bytes, { flag: "wx", mode: 0o600 });
+	if (process.platform !== "win32") await fs.chmod(backupPath, 0o600);
+	return backupPath;
+}
+
+async function adoptLegacyState(
+	legacy: Record<string, unknown>,
+	next: Record<string, unknown>,
+	targetName: string,
+) {
+	const legacyProfile = typeof legacy.profile === "string" ? legacy.profile : "default";
+	const source = path.join(stateDir(), `${safeName(legacyProfile)}.state.json`);
+	let bytes: Buffer;
+	try {
+		bytes = await fs.readFile(source);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	const targets = requireObject(next.targets, "targets");
+	const target = requireObject(targets[targetName], "target");
+	const profile = typeof target.namespace === "string" ? target.namespace : targetName;
+	const destination = statePathForConfig({
+		settingsVersion: 2,
+		target: targetName,
+		profile,
+	} as SyncConfig);
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	try {
+		await fs.writeFile(destination, bytes, { flag: "wx", mode: 0o600 });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+	}
+}
+
+function assertUniqueRemoteIdentity(
+	targets: Record<string, unknown>,
+	name: string,
+	target: SyncTargetSettings,
+) {
+	const identity = remoteIdentity(target);
+	for (const [otherName, value] of Object.entries(targets)) {
+		if (otherName !== name && remoteIdentity(requireObject(value, "target")) === identity) {
+			throw new Error(`Target “${name}” duplicates the remote destination of “${otherName}”.`);
+		}
+	}
+}
+
+function remoteIdentity(target: SyncTargetSettings | Record<string, unknown>) {
+	return JSON.stringify([
+		target.profile,
+		target.bucket,
+		target.prefix ?? "pi-sync",
+		"namespace" in target ? target.namespace : undefined,
+	]);
+}
+
+function compactObject(value: Record<string, unknown>) {
+	return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));
+}
+
+function inferKind(endpoint: unknown) {
+	return typeof endpoint === "string" && endpoint.includes(".r2.cloudflarestorage.com")
+		? "r2"
+		: "s3-compatible";
+}
+
+function requireObject(value: unknown, name: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`Invalid pi-sync settings: ${name} must be an object.`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function validateName(value: string, label: string) {
+	if (
+		!value.trim() ||
+		value.length > 100 ||
+		value === "__proto__" ||
+		value === "prototype" ||
+		value === "constructor" ||
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: Stored identifiers cannot contain controls.
+		/[\u0000-\u001f\u007f-\u009f]/u.test(value)
+	) {
+		throw new Error(`Invalid ${label} name.`);
+	}
+}

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+	effectiveTargetRemoteIdentity,
 	localConfigPath,
 	readLocalConfigObject,
 	stateDir,
@@ -263,21 +264,15 @@ function assertUniqueRemoteIdentity(
 	name: string,
 	target: SyncTargetSettings,
 ) {
-	const identity = remoteIdentity(target);
+	const identity = effectiveTargetRemoteIdentity(target as Record<string, unknown>, name);
 	for (const [otherName, value] of Object.entries(targets)) {
-		if (otherName !== name && remoteIdentity(requireObject(value, "target")) === identity) {
+		if (
+			otherName !== name &&
+			effectiveTargetRemoteIdentity(requireObject(value, "target"), otherName) === identity
+		) {
 			throw new Error(`Target “${name}” duplicates the remote destination of “${otherName}”.`);
 		}
 	}
-}
-
-function remoteIdentity(target: SyncTargetSettings | Record<string, unknown>) {
-	return JSON.stringify([
-		target.profile,
-		process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? target.bucket,
-		process.env.PI_SYNC_PREFIX ?? target.prefix ?? "pi-sync",
-		process.env.PI_SYNC_PROFILE ?? ("namespace" in target ? target.namespace : undefined),
-	]);
 }
 
 function compactObject(value: Record<string, unknown>) {

--- a/extensions/pi-sync/src/snapshot-apply.ts
+++ b/extensions/pi-sync/src/snapshot-apply.ts
@@ -19,6 +19,10 @@ import {
 	snapshotIncludesSessions,
 	snapshotTarget,
 } from "./snapshot.js";
+import {
+	applySnapshotTransaction,
+	recoverPendingSnapshotTransactions,
+} from "./snapshot-transaction.js";
 import type { Snapshot, SnapshotApplyPlan, SnapshotOptions } from "./types.js";
 
 function sha256(value: Buffer) {
@@ -36,6 +40,7 @@ export async function applySnapshot(
 ) {
 	const root = agentDir();
 	const { sessionDir } = options;
+	await recoverPendingSnapshotTransactions();
 	const current = await createSnapshot(snapshot.profile, {
 		syncFiles: options.syncFiles,
 		syncSessions: snapshotIncludesSessions(snapshot),
@@ -53,12 +58,7 @@ export async function applySnapshot(
 		snapshot,
 	);
 	await preflightSnapshotMutations(root, plan, sessionDir);
-	for (const target of plan.deletes) {
-		await fs.rm(target, { force: true, recursive: true });
-	}
-	for (const item of plan.writes) {
-		await fs.writeFile(item.target, item.content);
-	}
+	await applySnapshotTransaction(plan, { sessionDir });
 	return appliedFileHashMap(snapshot, current, protectedRelativePaths);
 }
 

--- a/extensions/pi-sync/src/snapshot-transaction.ts
+++ b/extensions/pi-sync/src/snapshot-transaction.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { agentDir, stateDir } from "./config.js";
+import { assertWithinRoot, isPathInside } from "./paths.js";
+import { sessionStorageRoot } from "./snapshot.js";
+import type { SnapshotApplyPlan } from "./types.js";
+
+const JOURNAL_VERSION = 1;
+
+interface TransactionEntry {
+	target: string;
+	backupName: string;
+	kind: "missing" | "file" | "directory" | "symlink";
+	linkTarget?: string;
+}
+
+interface TransactionJournal {
+	version: number;
+	root: string;
+	sessionRoot?: string;
+	entries: TransactionEntry[];
+}
+
+export async function applySnapshotTransaction(
+	plan: SnapshotApplyPlan,
+	options: { sessionDir?: string } = {},
+) {
+	await recoverPendingSnapshotTransactions();
+	const transaction = await prepareTransaction(plan, options.sessionDir);
+	try {
+		for (const target of plan.deletes) {
+			await fs.rm(target, { force: true, recursive: true });
+		}
+		for (const item of plan.writes) {
+			await fs.writeFile(item.target, item.content);
+		}
+		await fs.rm(transaction.directory, { recursive: true, force: true });
+	} catch (error) {
+		try {
+			await restoreTransaction(transaction.directory, transaction.journal);
+		} catch (recoveryError) {
+			throw new AggregateError(
+				[error, recoveryError],
+				`Snapshot apply failed and automatic recovery also failed. Transaction retained at ${transaction.directory}.`,
+			);
+		}
+		throw error;
+	}
+}
+
+export async function recoverPendingSnapshotTransactions() {
+	const directory = transactionRoot();
+	let entries: import("node:fs").Dirent[];
+	try {
+		entries = await fs.readdir(directory, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+		if (!entry.isDirectory()) continue;
+		const transactionDirectory = path.join(directory, entry.name);
+		const journalPath = path.join(transactionDirectory, "journal.json");
+		let journal: TransactionJournal;
+		try {
+			journal = JSON.parse(await fs.readFile(journalPath, "utf8")) as TransactionJournal;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				await fs.rm(transactionDirectory, { recursive: true, force: true });
+				continue;
+			}
+			throw new Error(`Cannot recover malformed pi-sync transaction: ${journalPath}`, {
+				cause: error,
+			});
+		}
+		await restoreTransaction(transactionDirectory, journal);
+	}
+}
+
+async function prepareTransaction(plan: SnapshotApplyPlan, sessionDir?: string) {
+	const root = path.resolve(agentDir());
+	const sessionRoot = sessionDir ? path.resolve(sessionStorageRoot(root, sessionDir)) : undefined;
+	const directory = path.join(transactionRoot(), randomUUID());
+	const backupDirectory = path.join(directory, "before");
+	await fs.mkdir(backupDirectory, { recursive: true, mode: 0o700 });
+	const targets = [...new Set([...plan.deletes, ...plan.writes.map((item) => item.target)])].sort();
+	const entries: TransactionEntry[] = [];
+	for (let index = 0; index < targets.length; index += 1) {
+		const target = targets[index];
+		if (!target) continue;
+		assertAllowedTarget(root, sessionRoot, target);
+		const backupName = `${index}`;
+		const backupPath = path.join(backupDirectory, backupName);
+		try {
+			const stat = await fs.lstat(target);
+			if (stat.isSymbolicLink()) {
+				entries.push({
+					target,
+					backupName,
+					kind: "symlink",
+					linkTarget: await fs.readlink(target),
+				});
+			} else if (stat.isDirectory()) {
+				await fs.cp(target, backupPath, {
+					recursive: true,
+					dereference: false,
+					preserveTimestamps: true,
+				});
+				entries.push({ target, backupName, kind: "directory" });
+			} else if (stat.isFile()) {
+				await fs.copyFile(target, backupPath);
+				await fs.chmod(backupPath, stat.mode);
+				entries.push({ target, backupName, kind: "file" });
+			} else {
+				throw new Error(`Unsupported existing snapshot target: ${target}`);
+			}
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			entries.push({ target, backupName, kind: "missing" });
+		}
+	}
+	const journal: TransactionJournal = {
+		version: JOURNAL_VERSION,
+		root,
+		sessionRoot,
+		entries,
+	};
+	await fs.writeFile(
+		path.join(directory, "journal.json"),
+		`${JSON.stringify(journal, null, "\t")}\n`,
+		{
+			mode: 0o600,
+		},
+	);
+	return { directory, journal };
+}
+
+async function restoreTransaction(directory: string, journal: TransactionJournal) {
+	validateJournal(directory, journal);
+	for (const entry of [...journal.entries].sort(
+		(left, right) => right.target.length - left.target.length,
+	)) {
+		await fs.rm(entry.target, { recursive: true, force: true });
+	}
+	for (const entry of journal.entries) {
+		if (entry.kind === "missing") continue;
+		await fs.mkdir(path.dirname(entry.target), { recursive: true });
+		const backupPath = path.join(directory, "before", entry.backupName);
+		assertWithinRoot(directory, backupPath);
+		if (entry.kind === "file") await fs.copyFile(backupPath, entry.target);
+		else if (entry.kind === "directory") {
+			await fs.cp(backupPath, entry.target, {
+				recursive: true,
+				dereference: false,
+				preserveTimestamps: true,
+			});
+		} else if (entry.kind === "symlink" && entry.linkTarget !== undefined) {
+			await fs.symlink(entry.linkTarget, entry.target);
+		}
+	}
+	await fs.rm(directory, { recursive: true, force: true });
+}
+
+function validateJournal(directory: string, journal: TransactionJournal) {
+	if (journal.version !== JOURNAL_VERSION || !Array.isArray(journal.entries)) {
+		throw new Error(`Unsupported pi-sync transaction journal: ${directory}`);
+	}
+	const expectedRoot = path.resolve(agentDir());
+	if (path.resolve(journal.root) !== expectedRoot) {
+		throw new Error(`Transaction root no longer matches the Pi agent directory: ${directory}`);
+	}
+	for (const entry of journal.entries) {
+		if (
+			!entry ||
+			typeof entry.target !== "string" ||
+			typeof entry.backupName !== "string" ||
+			!/^\d+$/u.test(entry.backupName)
+		) {
+			throw new Error(`Invalid pi-sync transaction entry: ${directory}`);
+		}
+		assertAllowedTarget(journal.root, journal.sessionRoot, entry.target);
+	}
+}
+
+function assertAllowedTarget(root: string, sessionRoot: string | undefined, target: string) {
+	const resolved = path.resolve(target);
+	if (isPathInside(root, resolved)) {
+		assertWithinRoot(root, resolved);
+		return;
+	}
+	if (sessionRoot && isPathInside(sessionRoot, resolved)) {
+		assertWithinRoot(sessionRoot, resolved);
+		return;
+	}
+	throw new Error(`Transaction target is outside configured roots: ${target}`);
+}
+
+function transactionRoot() {
+	return path.join(stateDir(), "transactions");
+}

--- a/extensions/pi-sync/src/sync-format.ts
+++ b/extensions/pi-sync/src/sync-format.ts
@@ -1,0 +1,168 @@
+import { createHash } from "node:crypto";
+import { agentDir } from "./config.js";
+import { fileHashMap } from "./sync-state.js";
+import type { LatestPointer, RemoteObject, Snapshot, SyncConfig } from "./types.js";
+
+export function formatDiff(local: Snapshot, remote: Snapshot) {
+	const localMap = fileHashMap(local);
+	const remoteMap = fileHashMap(remote);
+	const allPaths = [...new Set([...Object.keys(localMap), ...Object.keys(remoteMap)])].sort();
+	const lines = [
+		`local: ${local.files.length} files`,
+		`remote: ${remote.id} (${remote.files.length} files)`,
+		"",
+	];
+	let changed = 0;
+	for (const filePath of allPaths) {
+		if (!localMap[filePath]) {
+			lines.push(`Remote only: ${filePath}`);
+			changed += 1;
+		} else if (!remoteMap[filePath]) {
+			lines.push(`Local only: ${filePath}`);
+			changed += 1;
+		} else if (localMap[filePath] !== remoteMap[filePath]) {
+			lines.push(`Different: ${filePath}`);
+			changed += 1;
+		}
+	}
+	if (changed === 0) lines.push("No file differences.");
+	return lines.join("\n");
+}
+
+export function formatSnapshotOnlyDiff(title: string, snapshot: Snapshot) {
+	return [`${title}: ${snapshot.id}`, ...snapshot.files.map((file) => `Add: ${file.path}`)].join(
+		"\n",
+	);
+}
+
+export function formatPushSummary(
+	config: SyncConfig,
+	upload: Snapshot,
+	latest: RemoteObject<LatestPointer>,
+	preservedRemoteFileCount = 0,
+	remote?: Snapshot,
+) {
+	return [
+		`Target: ${safeTerminalText(config.target ?? "default")}`,
+		`Destination: ${formatDestination(config)}`,
+		`Upload ${upload.files.length} files from ${safeTerminalText(agentDir())}.`,
+		`Sessions: ${upload.syncSessions ? "included — may contain private conversations" : "not included"}`,
+		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
+		"Publication effect: latest.json will point to the new immutable snapshot.",
+		formatPublicationPreview(remote, upload),
+		preservedRemoteFileCount > 0
+			? `Possible secrets in locally managed files were scanned before this prompt; ${preservedRemoteFileCount} preserved remote file(s) were not rescanned.`
+			: "Possible secrets were scanned before this prompt.",
+	].join("\n");
+}
+
+export function formatApplyPreview(local: Snapshot, remote: Snapshot) {
+	return formatDirectionalChanges(local, remote, {
+		add: "Add locally",
+		update: "Update locally",
+		remove: "Remove locally",
+	});
+}
+
+export function formatPullSummary(
+	config: SyncConfig,
+	local: Snapshot,
+	remote: Snapshot,
+	protectedSessionCount: number,
+) {
+	return [
+		`Target: ${safeTerminalText(config.target ?? "default")}`,
+		`Destination: ${formatDestination(config)}`,
+		`Snapshot: ${safeTerminalText(remote.id)}`,
+		`Sessions: ${remote.syncSessions ? "included — may contain private conversations" : "not included"}`,
+		`Protected live sessions: ${protectedSessionCount || "none"}`,
+		formatApplyPreview(local, remote),
+		"A local backup is created before these writes/deletes. The remote active snapshot is unchanged.",
+	].join("\n");
+}
+
+export function formatRollbackSummary(
+	config: SyncConfig,
+	local: Snapshot,
+	remote: Snapshot,
+	requestedSnapshot: string,
+	protectedSessionCount: number,
+) {
+	return [
+		`Target: ${safeTerminalText(config.target ?? "default")}`,
+		`Destination: ${formatDestination(config)}`,
+		`Snapshot: ${safeTerminalText(requestedSnapshot)}`,
+		`Sessions: ${remote.syncSessions ? "included — may contain private conversations" : "not included"}`,
+		`Protected live sessions: ${protectedSessionCount || "none"}`,
+		formatApplyPreview(local, remote),
+		"A local backup is created before applying; the remote latest pointer will change.",
+	].join("\n");
+}
+
+function formatPublicationPreview(remote: Snapshot | undefined, upload: Snapshot) {
+	if (!remote) {
+		return ["Remote is empty.", ...upload.files.map((file) => `Add remotely: ${file.path}`)].join(
+			"\n",
+		);
+	}
+	return formatDirectionalChanges(remote, upload, {
+		add: "Add remotely",
+		update: "Update remotely",
+		remove: "Remove remotely",
+	});
+}
+
+function formatDirectionalChanges(
+	before: Snapshot,
+	after: Snapshot,
+	labels: { add: string; update: string; remove: string },
+) {
+	const beforeMap = fileHashMap(before);
+	const afterMap = fileHashMap(after);
+	const paths = [...new Set([...Object.keys(beforeMap), ...Object.keys(afterMap)])].sort();
+	const lines: string[] = [];
+	for (const filePath of paths) {
+		if (!beforeMap[filePath]) lines.push(`${labels.add}: ${filePath}`);
+		else if (!afterMap[filePath]) lines.push(`${labels.remove}: ${filePath}`);
+		else if (beforeMap[filePath] !== afterMap[filePath])
+			lines.push(`${labels.update}: ${filePath}`);
+	}
+	if (lines.length === 0) lines.push("No file changes.");
+	return lines.join("\n");
+}
+
+export function formatDestination(config: SyncConfig) {
+	let host = config.endpoint;
+	try {
+		host = new URL(config.endpoint).hostname;
+	} catch {
+		// Preserve a sanitized invalid endpoint for actionable repair output.
+	}
+	return safeTerminalText(`${host} · ${config.bucket}/${config.prefix}/profiles/${config.profile}`);
+}
+
+export function countPreservedRemoteFiles(local: Snapshot, upload: Snapshot) {
+	const localPaths = new Set(local.files.map((file) => file.path));
+	return upload.files.filter((file) => !localPaths.has(file.path)).length;
+}
+
+export function safeTerminalText(value: string) {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "?");
+}
+
+export function redact(value: string) {
+	return value.length <= 8 ? "configured" : `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+export function remoteIdentity(remote: RemoteObject<LatestPointer>) {
+	return remote.missing ? "missing" : (remote.value?.snapshot ?? "unknown");
+}
+
+export function sha256(value: Buffer) {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+export function errorMessage(error: unknown) {
+	return safeTerminalText(error instanceof Error ? error.message : String(error));
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -9,9 +8,17 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { completeSyncArguments, parseOptions, resolveSyncCommand, usage } from "./command.js";
 import {
-	agentDir,
+	completeSyncArguments,
+	parseOptions,
+	resolveSyncCommand,
+	setSyncTargetCompletions,
+	usage,
+	validateCommandOptions,
+} from "./command.js";
+import {
+	configuredTargetNames,
+	deprecatedPiSyncEnvironmentWarnings,
 	ensureStateDir,
 	isEnabled,
 	isExplicitlyEnabled,
@@ -22,16 +29,17 @@ import {
 	localConfigTemplate,
 	normalizeExtraFiles,
 	normalizeSyncFiles,
-	readState,
+	readStateForConfig,
 	sessionDirForApply,
 	sessionTokenWarnings,
 	stateDir,
 	syncSessionsWarnings,
 	writeLocalConfigObject,
-	writeState,
+	writeStateForConfig,
 } from "./config.js";
 import { showFileSelection } from "./file-selection.js";
 import { inspectLock, isLockGuardHeld, isStaleLock, unlock, withLock } from "./lock.js";
+import { showSetupWizard, showSyncManager, useSyncTarget } from "./manager-ui.js";
 import {
 	historyKey,
 	latestKey,
@@ -50,6 +58,21 @@ import {
 	snapshotWithoutSessions,
 } from "./snapshot.js";
 import { applySnapshot } from "./snapshot-apply.js";
+import { recoverPendingSnapshotTransactions } from "./snapshot-transaction.js";
+import {
+	countPreservedRemoteFiles,
+	errorMessage,
+	formatDestination,
+	formatDiff,
+	formatPullSummary,
+	formatPushSummary,
+	formatRollbackSummary,
+	formatSnapshotOnlyDiff,
+	redact,
+	remoteIdentity,
+	safeTerminalText,
+	sha256,
+} from "./sync-format.js";
 import {
 	canPullRemoteSessionsOnFirstSync,
 	canPullRemoteSettingsOnFirstSync,
@@ -109,6 +132,19 @@ export default function sync(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		try {
+			await recoverPendingSnapshotTransactions();
+		} catch (error) {
+			ctx.ui.notify(`pi-sync recovery required: ${errorMessage(error)}`, "error");
+			return;
+		}
+		try {
+			setSyncTargetCompletions(await configuredTargetNames());
+		} catch {
+			setSyncTargetCompletions([]);
+		}
+		const warnings = deprecatedPiSyncEnvironmentWarnings();
+		if (warnings.length > 0) ctx.ui.notify(warnings.join("\n"), "warning");
 		await autoSync(ctx);
 	});
 
@@ -121,34 +157,59 @@ export default function sync(pi: ExtensionAPI) {
 }
 
 async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
+	if (!rawArgs.trim()) {
+		try {
+			await showSyncManager(ctx, (route, signal, onCommit) =>
+				executeCommand(route, ctx, signal, onCommit),
+			);
+		} catch (error) {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			ctx.ui.notify(errorMessage(error), "error");
+		}
+		return;
+	}
+	await executeCommand(rawArgs, ctx);
+}
+
+async function executeCommand(
+	rawArgs: string,
+	ctx: ExtensionCommandContext,
+	signal?: AbortSignal,
+	onCommit?: () => void,
+) {
 	try {
 		const command = await resolveSyncCommand(rawArgs, ctx);
 		if (!command) return;
 		const { subcommand, rest } = command;
 		const options = parseOptions(rest);
-		await ensureStateDir();
+		if (signal) options.signal = signal;
+		if (onCommit) options.onCommit = onCommit;
+		validateCommandOptions(subcommand, options);
 
 		switch (subcommand) {
 			case "help":
 				ctx.ui.notify(usage(), "info");
 				return;
+			case "use":
+				await useSyncTarget(ctx, options.args[0] ?? "");
+				return;
 			case "init":
 				await initConfig(ctx);
 				return;
 			case "config":
-				await showConfig(ctx);
+				await showConfig(ctx, options);
 				return;
 			case "files":
-				await showFileSelection(ctx);
+				await showFileSelection(ctx, options.target);
 				return;
 			case "status":
-				await status(ctx);
+				await status(ctx, options);
 				return;
 			case "diff":
-				await diff(ctx);
+				await diff(ctx, options);
 				return;
 			case "doctor":
-				await doctor(ctx);
+				await doctor(ctx, options);
 				return;
 			case "push":
 				await withLock("push", () => push(ctx, options));
@@ -160,7 +221,7 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
 				await withLock("sync", () => syncBoth(ctx, options));
 				return;
 			case "history":
-				await history(ctx);
+				await history(ctx, options);
 				return;
 			case "rollback":
 				await withLock("rollback", () => rollback(ctx, options));
@@ -173,6 +234,7 @@ async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
 		}
 	} catch (error) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (signal?.aborted && error instanceof Error && error.name === "AbortError") return;
 		ctx.ui.notify(errorMessage(error), "error");
 	}
 }
@@ -200,7 +262,7 @@ async function autoPushSessions(ctx: ExtensionContext) {
 		const config = await loadConfig();
 		if (!config.syncSessions) return;
 		await withLock("auto-session-push", async () => {
-			const state = await readState(config.profile);
+			const state = await readStateForConfig(config);
 			const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 			if (!hasLocalChanges(local, state, config)) return;
 			await push(ctx, AUTO_SYNC_OPTIONS, { config, state, local });
@@ -219,20 +281,30 @@ async function initConfig(ctx: ExtensionCommandContext) {
 		ctx.ui.notify(`Config already exists: ${configPath}`, "info");
 		return;
 	} catch {
-		// Create below.
+		// Create or guide setup below.
 	}
 
+	if (ctx.mode === "tui") {
+		await showSetupWizard(ctx);
+		return;
+	}
 	await writeLocalConfigObject(localConfigTemplate());
 	ctx.ui.notify(`Created ${configPath}. Fill in R2 credentials, then run /sync doctor.`, "info");
 }
 
-async function showConfig(ctx: ExtensionCommandContext) {
-	const partial = await loadPartialConfig();
+async function showConfig(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const partial = await loadPartialConfig(options.target);
 	const syncSessions = isExplicitlyEnabled(partial.syncSessions);
-	const warnings = [...sessionTokenWarnings(partial), ...syncSessionsWarnings({ syncSessions })];
+	const warnings = [
+		...deprecatedPiSyncEnvironmentWarnings(),
+		...sessionTokenWarnings(partial),
+		...syncSessionsWarnings({ syncSessions }),
+	];
 	ctx.ui.notify(
 		[
 			"pi-sync config:",
+			`target: ${partial.target ?? "default"}`,
+			`storage profile: ${partial.storageProfile ?? "default"}`,
 			`endpoint: ${partial.endpoint ?? "missing"}`,
 			`bucket: ${partial.bucket ?? "missing"}`,
 			`region: ${partial.region ?? DEFAULT_REGION}`,
@@ -252,12 +324,12 @@ async function showConfig(ctx: ExtensionCommandContext) {
 	);
 }
 
-async function status(ctx: ExtensionCommandContext) {
-	ctx.ui.setStatus(STATUS_KEY, "checking");
-	const config = await loadConfig();
-	const client = new S3Client(config);
+async function status(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const config = await loadConfig(options.target);
+	ctx.ui.setStatus(STATUS_KEY, `checking ${config.target ?? "default"}`);
+	const client = new S3Client(config, options.signal);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
-	const state = await readState(config.profile);
+	const state = await readStateForConfig(config);
 	const latest = await client.getJson<LatestPointer>(latestKey(config));
 	const localChanged = hasLocalChanges(local, state, config);
 
@@ -267,11 +339,14 @@ async function status(ctx: ExtensionCommandContext) {
 		remoteText = `remote: ${latest.value.snapshot} from ${latest.value.machine} at ${latest.value.createdAt}`;
 	}
 
-	const warnings = syncSessionsWarnings(config);
+	const warnings = [...deprecatedPiSyncEnvironmentWarnings(), ...syncSessionsWarnings(config)];
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	ctx.ui.notify(
 		[
-			`profile: ${config.profile}`,
+			`target: ${config.target ?? "default"}`,
+			`storage profile: ${config.storageProfile ?? "default"}`,
+			`destination: ${formatDestination(config)}`,
+			`remote namespace: ${config.profile}`,
 			`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
 			`extra files: ${config.extraFiles.join(", ") || "none"}`,
 			`sessions: ${config.syncSessions ? "included" : "excluded"}`,
@@ -285,16 +360,19 @@ async function status(ctx: ExtensionCommandContext) {
 	);
 }
 
-async function diff(ctx: ExtensionCommandContext) {
-	ctx.ui.setStatus(STATUS_KEY, "diff");
-	const config = await loadConfig();
-	const client = new S3Client(config);
+async function diff(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const config = await loadConfig(options.target);
+	ctx.ui.setStatus(STATUS_KEY, `checking ${config.target ?? "default"}`);
+	const client = new S3Client(config, options.signal);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 
-	const warnings = syncSessionsWarnings(config);
+	const warnings = [...deprecatedPiSyncEnvironmentWarnings(), ...syncSessionsWarnings(config)];
 	const header = [
+		`target: ${config.target ?? "default"}`,
+		`storage profile: ${config.storageProfile ?? "default"}`,
+		`destination: ${formatDestination(config)}`,
 		`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
 		`extra files: ${config.extraFiles.join(", ") || "none"}`,
 		`sessions: ${config.syncSessions ? "included" : "excluded"}`,
@@ -312,21 +390,27 @@ async function diff(ctx: ExtensionCommandContext) {
 	ctx.ui.notify(`${header}\n\n${formatDiff(local, remote)}`, level);
 }
 
-async function doctor(ctx: ExtensionCommandContext) {
+async function doctor(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const messages: string[] = [];
 	let level: "info" | "warning" = "info";
 	let snapshotOptions: SnapshotOptions = {};
 	let profile = DEFAULT_PROFILE;
 
 	try {
-		const config = await loadConfig();
+		const config = await loadConfig(options.target);
 		profile = config.profile;
 		snapshotOptions = snapshotOptionsForContext(ctx, config);
-		messages.push(`config: ok (${config.bucket}/${profilePrefix(config)})`);
+		messages.push(
+			`config: ok (target ${config.target ?? "default"}; ${config.bucket}/${profilePrefix(config)})`,
+		);
 		messages.push(`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`);
 		messages.push(`extra files: ${config.extraFiles.join(", ") || "none"}`);
 		messages.push(`sessions: ${config.syncSessions ? "included" : "excluded"}`);
-		const warnings = [...sessionTokenWarnings(config), ...syncSessionsWarnings(config)];
+		const warnings = [
+			...deprecatedPiSyncEnvironmentWarnings(),
+			...sessionTokenWarnings(config),
+			...syncSessionsWarnings(config),
+		];
 		if (warnings.length > 0) {
 			level = "warning";
 			messages.push(...warnings);
@@ -373,10 +457,10 @@ async function push(
 	options: CommandOptions,
 	input?: PushInput,
 ) {
-	ctx.ui.setStatus(STATUS_KEY, "pushing");
-	const config = input?.config ?? (await loadConfig());
-	const client = input?.client ?? new S3Client(config);
-	const state = input?.state ?? (await readState(config.profile));
+	const config = input?.config ?? (await loadConfig(options.target));
+	ctx.ui.setStatus(STATUS_KEY, `pushing ${config.target ?? "default"}`);
+	const client = input?.client ?? new S3Client(config, options.signal);
+	const state = input?.state ?? (await readStateForConfig(config));
 	const local =
 		input?.local ?? (await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config)));
 
@@ -406,7 +490,7 @@ async function push(
 		!options.yes &&
 		!(await ctx.ui.confirm(
 			snapshotIncludesSessions(upload) ? "Push pi settings and sessions?" : "Push pi settings?",
-			formatPushSummary(upload, latest, preservedRemoteFileCount),
+			formatPushSummary(config, upload, latest, preservedRemoteFileCount, remoteForUpload),
 		))
 	) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -414,9 +498,11 @@ async function push(
 		return;
 	}
 
-	const pointer = await uploadSnapshot(client, config, upload, latest, options.force);
-	await updateHistory(client, config, pointer);
-	await writeState(config.profile, {
+	options.onCommit?.();
+	const publicationClient = options.onCommit ? new S3Client(config) : client;
+	const pointer = await uploadSnapshot(publicationClient, config, upload, latest, options.force);
+	const historyWarning = await updateHistorySafely(publicationClient, config, pointer);
+	await writeStateForConfig(config, {
 		version: VERSION,
 		profile: config.profile,
 		lastAppliedSnapshot: pointer.snapshot,
@@ -428,15 +514,23 @@ async function push(
 	});
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	if (!options.silent) {
-		ctx.ui.notify(`Pushed ${upload.files.length} files as ${pointer.snapshot}.`, "info");
+		ctx.ui.notify(
+			[
+				`Pushed ${upload.files.length} files from target “${config.target ?? "default"}” as ${pointer.snapshot}.`,
+				historyWarning,
+			]
+				.filter(Boolean)
+				.join("\n"),
+			historyWarning ? "warning" : "info",
+		);
 	}
 }
 
 async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
-	ctx.ui.setStatus(STATUS_KEY, "pulling");
-	const config = await loadConfig();
-	const client = new S3Client(config);
-	const state = await readState(config.profile);
+	const config = await loadConfig(options.target);
+	ctx.ui.setStatus(STATUS_KEY, `pulling ${config.target ?? "default"}`);
+	const client = new S3Client(config, options.signal);
+	const state = await readStateForConfig(config);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 	const remote = await readRemoteSnapshot(client, config);
 	if (!remote) throw new Error("Remote is empty. Run /sync push from a configured machine first.");
@@ -453,7 +547,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		!options.yes &&
 		!(await ctx.ui.confirm(
 			snapshotIncludesSessions(remote) ? "Pull pi settings and sessions?" : "Pull pi settings?",
-			formatDiff(local, remote),
+			formatPullSummary(config, local, remote, protectedSessionPaths(ctx).size),
 		))
 	) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -461,6 +555,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		return;
 	}
 
+	options.onCommit?.();
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
 	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), {
@@ -468,7 +563,7 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 		sessionDir: applySessionDir,
 		extraFiles: config.extraFiles,
 	});
-	await writeState(config.profile, {
+	await writeStateForConfig(config, {
 		version: VERSION,
 		profile: config.profile,
 		lastAppliedSnapshot: remote.id,
@@ -494,10 +589,23 @@ async function pull(ctx: ExtensionCommandContext | ExtensionContext, options: Co
 }
 
 async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options: CommandOptions) {
-	const config = await loadConfig();
-	const client = new S3Client(config);
-	const state = await readState(config.profile);
+	const config = await loadConfig(options.target);
+	const client = new S3Client(config, options.signal);
+	const state = await readStateForConfig(config);
 	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
+	if (
+		normalizeSyncFiles(config.syncFiles).length === 0 &&
+		config.extraFiles.length === 0 &&
+		!config.syncSessions
+	) {
+		if (!options.silent) {
+			ctx.ui.notify(
+				`Target “${config.target ?? "default"}” manages no files. Choose synced content in /sync Settings before syncing.`,
+				"warning",
+			);
+		}
+		return;
+	}
 	const remote = await readRemoteSnapshot(client, config);
 	const localChanged = hasLocalChanges(local, state, config);
 	const remoteChanged = remote
@@ -520,7 +628,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 			await pull(ctx, options);
 			return;
 		}
-		await writeState(config.profile, {
+		await writeStateForConfig(config, {
 			version: VERSION,
 			profile: config.profile,
 			lastAppliedSnapshot: remote.id,
@@ -535,7 +643,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 		return;
 	}
 	if (localChanged && remoteChanged && remote && snapshotsMatch(local, remote)) {
-		await writeState(config.profile, {
+		await writeStateForConfig(config, {
 			version: VERSION,
 			profile: config.profile,
 			lastAppliedSnapshot: remote.id,
@@ -562,7 +670,7 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 		return;
 	}
 	if (shouldRefreshSyncedState(remote, state, config)) {
-		await writeState(config.profile, {
+		await writeStateForConfig(config, {
 			version: VERSION,
 			profile: config.profile,
 			lastAppliedSnapshot: remote.id,
@@ -576,20 +684,36 @@ async function syncBoth(ctx: ExtensionCommandContext | ExtensionContext, options
 	if (!options.silent) ctx.ui.notify("pi-sync is already up to date.", "info");
 }
 
-async function history(ctx: ExtensionCommandContext) {
-	const config = await loadConfig();
-	const client = new S3Client(config);
+async function history(ctx: ExtensionCommandContext, options: CommandOptions) {
+	const config = await loadConfig(options.target);
+	const client = new S3Client(config, options.signal);
 	const remote = await client.getJson<{ snapshots?: LatestPointer[] }>(historyKey(config));
 	if (remote.missing || !remote.value?.snapshots?.length) {
 		ctx.ui.notify("No remote pi-sync history found.", "info");
 		return;
 	}
 
+	const snapshots = remote.value.snapshots.slice(-20).reverse();
+	const currentSnapshot = snapshots[0]?.snapshot;
+	if (ctx.mode === "tui") {
+		const labels = snapshots.map(
+			(item, index) =>
+				`${index + 1}. ${item.createdAt} · ${safeTerminalText(item.machine)} · ${item.snapshot}${item.snapshot === currentSnapshot ? " (current)" : ""}${item.syncSessions ? " · sessions" : ""}`,
+		);
+		const selected = await ctx.ui.select(
+			`History for target “${safeTerminalText(config.target ?? "default")}”\n\nChoose a snapshot to preview rollback.`,
+			[...labels, "Back"],
+		);
+		if (!selected || selected === "Back") return;
+		const index = labels.indexOf(selected);
+		const snapshot = snapshots[index];
+		if (!snapshot) return;
+		await rollback(ctx, { ...options, args: [snapshot.snapshot], yes: false });
+		return;
+	}
 	ctx.ui.notify(
-		remote.value.snapshots
-			.slice(-20)
-			.reverse()
-			.map((item) => `${item.snapshot} ${item.createdAt} ${item.machine}`)
+		snapshots
+			.map((item) => `${item.snapshot} ${item.createdAt} ${safeTerminalText(item.machine)}`)
 			.join("\n"),
 		"info",
 	);
@@ -599,8 +723,8 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const target = options.args[0];
 	if (!target) throw new Error("Usage: /sync rollback <snapshot-id> [--yes]");
 
-	const config = await loadConfig();
-	const client = new S3Client(config);
+	const config = await loadConfig(options.target);
+	const client = new S3Client(config, options.signal);
 	const snapshot = await client.getBuffer(snapshotKey(config, target));
 	if (!snapshot.value) throw new Error(`Snapshot not found: ${target}`);
 	const decoded = await decodeSnapshot(snapshot.value);
@@ -609,6 +733,7 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		config,
 		{ regenerateId: true },
 	);
+	const local = await createSnapshot(config.profile, snapshotOptionsForContext(ctx, config));
 
 	if (
 		!options.yes &&
@@ -616,13 +741,14 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 			snapshotIncludesSessions(remote)
 				? "Rollback pi settings and sessions?"
 				: "Rollback pi settings?",
-			formatSnapshotOnlyDiff("Rollback would apply", remote),
+			formatRollbackSummary(config, local, remote, target, protectedSessionPaths(ctx).size),
 		))
 	) {
 		ctx.ui.notify("Rollback cancelled.", "info");
 		return;
 	}
 
+	options.onCommit?.();
 	const backup = await backupLocal(config.profile, snapshotOptionsForContext(ctx, config));
 	const applySessionDir = await sessionDirForApply(ctx, remote);
 	const lastFileHashes = await applySnapshot(remote, protectedSessionPaths(ctx), {
@@ -630,18 +756,19 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		sessionDir: applySessionDir,
 		extraFiles: config.extraFiles,
 	});
-	const latest = await client.getJson<LatestPointer>(latestKey(config));
-	const upload = await snapshotForUpload(client, config, remote, latest, undefined, {
+	const publicationClient = options.onCommit ? new S3Client(config) : client;
+	const latest = await publicationClient.getJson<LatestPointer>(latestKey(config));
+	const upload = await snapshotForUpload(publicationClient, config, remote, latest, undefined, {
 		ignoreUnreadableRemote: true,
 	});
 	const encoded = upload.id === decoded.id ? snapshot.value : await encodeSnapshot(upload);
 	if (upload.id !== decoded.id) {
-		await client.putBuffer(snapshotKey(config, upload.id), encoded, "application/gzip");
+		await publicationClient.putBuffer(snapshotKey(config, upload.id), encoded, "application/gzip");
 	}
 	const pointer = pointerFor(config, upload, sha256(encoded));
-	await client.putJson(latestKey(config), pointer);
-	await updateHistory(client, config, pointer);
-	await writeState(config.profile, {
+	await publicationClient.putJson(latestKey(config), pointer);
+	const historyWarning = await updateHistorySafely(publicationClient, config, pointer);
+	await writeStateForConfig(config, {
 		version: VERSION,
 		profile: config.profile,
 		lastAppliedSnapshot: pointer.snapshot,
@@ -651,7 +778,15 @@ async function rollback(ctx: ExtensionCommandContext, options: CommandOptions) {
 		syncSessions: config.syncSessions,
 		extraFiles: config.extraFiles,
 	});
-	ctx.ui.notify(`Rolled back to ${target}; latest: ${pointer.snapshot}. Backup: ${backup}`, "info");
+	ctx.ui.notify(
+		[
+			`Rolled back target “${config.target ?? "default"}” to ${target}; latest: ${pointer.snapshot}. Backup: ${backup}`,
+			historyWarning,
+		]
+			.filter(Boolean)
+			.join("\n"),
+		historyWarning ? "warning" : "info",
+	);
 	await maybeReload(ctx);
 }
 
@@ -802,6 +937,15 @@ export async function backupLocal(profile: string, options: SnapshotOptions = {}
 	return backupPath;
 }
 
+async function updateHistorySafely(client: S3Client, config: SyncConfig, pointer: LatestPointer) {
+	try {
+		await updateHistory(client, config, pointer);
+		return undefined;
+	} catch (error) {
+		return `Remote snapshot is active, but history could not be updated: ${errorMessage(error)}. Run /sync doctor before relying on history.`;
+	}
+}
+
 async function updateHistory(client: S3Client, config: SyncConfig, pointer: LatestPointer) {
 	const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(
 		historyKey(config),
@@ -812,71 +956,6 @@ async function updateHistory(client: S3Client, config: SyncConfig, pointer: Late
 		pointer,
 	].slice(-100);
 	await client.putJson(historyKey(config), { version: VERSION, snapshots: next });
-}
-
-function formatDiff(local: Snapshot, remote: Snapshot) {
-	const localMap = fileHashMap(local);
-	const remoteMap = fileHashMap(remote);
-	const allPaths = [...new Set([...Object.keys(localMap), ...Object.keys(remoteMap)])].sort();
-	const lines = [
-		`local: ${local.files.length} files`,
-		`remote: ${remote.id} (${remote.files.length} files)`,
-		"",
-	];
-	let changed = 0;
-	for (const filePath of allPaths) {
-		if (!localMap[filePath]) {
-			lines.push(`+ ${filePath}`);
-			changed += 1;
-		} else if (!remoteMap[filePath]) {
-			lines.push(`- ${filePath}`);
-			changed += 1;
-		} else if (localMap[filePath] !== remoteMap[filePath]) {
-			lines.push(`~ ${filePath}`);
-			changed += 1;
-		}
-	}
-	if (changed === 0) lines.push("No file differences.");
-	return lines.join("\n");
-}
-
-function formatSnapshotOnlyDiff(title: string, snapshot: Snapshot) {
-	return [`${title}: ${snapshot.id}`, ...snapshot.files.map((file) => `+ ${file.path}`)].join("\n");
-}
-
-function formatPushSummary(
-	local: Snapshot,
-	latest: RemoteObject<LatestPointer>,
-	preservedRemoteFileCount = 0,
-) {
-	return [
-		`Upload ${local.files.length} files from ${agentDir()}.`,
-		latest.value ? `Remote latest: ${latest.value.snapshot}` : "Remote latest: empty",
-		preservedRemoteFileCount > 0
-			? `Possible secrets in locally managed files were scanned before this prompt; ${preservedRemoteFileCount} preserved remote file(s) were not rescanned.`
-			: "Possible secrets were scanned before this prompt.",
-	].join("\n");
-}
-
-function remoteIdentity(remote: RemoteObject<LatestPointer>) {
-	return remote.missing ? "missing" : (remote.value?.snapshot ?? "unknown");
-}
-
-function countPreservedRemoteFiles(local: Snapshot, upload: Snapshot) {
-	const localPaths = new Set(local.files.map((file) => file.path));
-	return upload.files.filter((file) => !localPaths.has(file.path)).length;
-}
-
-function sha256(value: Buffer) {
-	return createHash("sha256").update(value).digest("hex");
-}
-
-function redact(value: string) {
-	return value.length <= 8 ? "configured" : `${value.slice(0, 4)}…${value.slice(-4)}`;
-}
-
-function errorMessage(error: unknown) {
-	return error instanceof Error ? error.message : String(error);
 }
 
 export { completeSyncArguments, parseOptions, splitArgs } from "./command.js";

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -708,7 +708,9 @@ async function history(ctx: ExtensionCommandContext, options: CommandOptions) {
 		const index = labels.indexOf(selected);
 		const snapshot = snapshots[index];
 		if (!snapshot) return;
-		await rollback(ctx, { ...options, args: [snapshot.snapshot], yes: false });
+		await withLock("rollback", () =>
+			rollback(ctx, { ...options, args: [snapshot.snapshot], yes: false }),
+		);
 		return;
 	}
 	ctx.ui.notify(

--- a/extensions/pi-sync/src/types.ts
+++ b/extensions/pi-sync/src/types.ts
@@ -1,3 +1,33 @@
+export type StorageProfileKind = "r2" | "s3-compatible";
+
+export interface StorageProfileSettings {
+	kind?: StorageProfileKind;
+	endpoint?: string;
+	region?: string;
+	accessKeyId?: string;
+	secretAccessKey?: string;
+	sessionToken?: string;
+}
+
+export interface SyncTargetSettings {
+	profile?: string;
+	bucket?: string;
+	prefix?: string;
+	namespace?: string;
+	autoSync?: boolean;
+	syncFiles?: unknown;
+	syncSessions?: boolean;
+	extraFiles?: unknown;
+}
+
+export interface PiSyncSettingsV2 {
+	version: 2;
+	activeTarget?: string;
+	profiles?: Record<string, StorageProfileSettings>;
+	targets?: Record<string, SyncTargetSettings>;
+	[key: string]: unknown;
+}
+
 export interface SyncConfig {
 	endpoint: string;
 	bucket: string;
@@ -5,14 +35,24 @@ export interface SyncConfig {
 	accessKeyId: string;
 	secretAccessKey: string;
 	sessionToken?: string;
+	/** Remote namespace retained as `profile` for snapshot/wire compatibility. */
 	profile: string;
 	prefix: string;
+	target?: string;
+	storageProfile?: string;
+	storageKind?: StorageProfileKind;
+	autoSync?: boolean;
+	settingsVersion?: 1 | 2;
 	syncFiles?: string[];
 	syncSessions: boolean;
 	extraFiles: string[];
 }
 
 export interface PartialConfig {
+	target?: string;
+	storageProfile?: string;
+	storageKind?: StorageProfileKind;
+	settingsVersion?: 1 | 2;
 	endpoint?: string;
 	bucket?: string;
 	region?: string;
@@ -84,6 +124,9 @@ export interface CommandOptions {
 	silent: boolean;
 	reload: boolean;
 	auto: boolean;
+	target?: string;
+	signal?: AbortSignal;
+	onCommit?: () => void;
 	args: string[];
 }
 

--- a/extensions/pi-sync/test/helpers.ts
+++ b/extensions/pi-sync/test/helpers.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { lockPath } from "../src/config.js";
+
+export function writeOldLock(contents: string) {
+	writeFileSync(lockPath(), contents);
+	const old = new Date(Date.now() - 60_000);
+	utimesSync(lockPath(), old, old);
+}
+
+export function snapshot(files: Array<{ path: string; content: Buffer }>) {
+	return {
+		version: 1,
+		id: "snap",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		machine: "test",
+		profile: "default",
+		files: files.map((file) => ({
+			path: file.path,
+			contentBase64: file.content.toString("base64"),
+			sha256: createHash("sha256").update(file.content).digest("hex"),
+		})),
+	};
+}
+
+export function requiredConfig() {
+	return {
+		endpoint: "https://example.r2.cloudflarestorage.com",
+		bucket: "pi-sync-test",
+		accessKeyId: "access-key",
+		secretAccessKey: "secret-key",
+		extraFiles: [],
+	};
+}
+
+export async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
+	const previousHome = process.env.HOME;
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
+	const home = mkdtempSync(path.join(os.tmpdir(), "pi-sync-home-"));
+	const agentDir = path.join(home, ".pi", "agent");
+	process.env.HOME = home;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env.PI_CODING_AGENT_SESSION_DIR;
+	try {
+		return await fn(agentDir);
+	} finally {
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		if (previousSessionDir === undefined) delete process.env.PI_CODING_AGENT_SESSION_DIR;
+		else process.env.PI_CODING_AGENT_SESSION_DIR = previousSessionDir;
+		rmSync(home, { recursive: true, force: true });
+	}
+}
+
+export async function withEnv<T>(env: Record<string, string>, fn: () => Promise<T>) {
+	const keys = [
+		"PI_SYNC_ENDPOINT",
+		"PI_SYNC_BUCKET",
+		"PI_SYNC_ACCESS_KEY_ID",
+		"PI_SYNC_SECRET_ACCESS_KEY",
+		"PI_SYNC_SESSIONS",
+		"PI_SYNC_SESSION_TOKEN",
+		"PI_SYNC_REGION",
+		"PI_SYNC_PROFILE",
+		"PI_SYNC_PREFIX",
+		"PI_SYNC_AUTO_SYNC",
+		"PI_CODING_AGENT_DIR",
+		"PI_CODING_AGENT_SESSION_DIR",
+		"R2_ENDPOINT",
+		"R2_BUCKET",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+	];
+	const previous = new Map(keys.map((key) => [key, process.env[key]]));
+	for (const key of keys) delete process.env[key];
+	Object.assign(process.env, env);
+	try {
+		return await fn();
+	} finally {
+		for (const key of keys) {
+			const value = previous.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
+}

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -363,7 +363,7 @@ test("cancelling a target switch leaves settings byte-for-byte unchanged", async
 	});
 });
 
-test("first-time setup saves one previewed v2 target without rendering credentials", async () => {
+test("first-time R2 setup recommends home/r2/pi-sync defaults without raw path questions", async () => {
 	await withTempSettings(async () => {
 		process.env.AWS_ACCESS_KEY_ID = "setup-access-secret";
 		process.env.AWS_SECRET_ACCESS_KEY = "setup-secret-value";
@@ -372,21 +372,18 @@ test("first-time setup saves one previewed v2 target without rendering credentia
 		const selections = [
 			"Set up sync",
 			"Cloudflare R2",
+			"Personal / Home",
+			"Use suggested location (recommended)",
 			"Use environment credentials",
 			"Recommended Pi settings",
 			"Enable automatic sync",
 			"Keep sessions off (recommended)",
 			"Save setup",
+			undefined,
 		];
-		const inputs = [
-			"home",
-			"r2",
-			"https://account.r2.cloudflarestorage.com",
-			"personal-pi",
-			"pi-sync",
-			"home",
-		];
+		const inputs = ["https://account.r2.cloudflarestorage.com"];
 		const rendered: string[] = [];
+		const inputTitles: string[] = [];
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
 			mode: "tui",
@@ -395,7 +392,7 @@ test("first-time setup saves one previewed v2 target without rendering credentia
 				return selections.shift();
 			},
 			input: async (title: string) => {
-				rendered.push(title);
+				inputTitles.push(title);
 				return inputs.shift();
 			},
 		});
@@ -403,18 +400,111 @@ test("first-time setup saves one previewed v2 target without rendering credentia
 		await mock.commands.get("sync")?.handler("", ctx);
 
 		const saved = await readLocalConfigObject();
+		const profile = (saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.r2;
+		const target = (saved?.targets as Record<string, Record<string, unknown>> | undefined)?.home;
 		assert.equal(saved?.version, 2);
 		assert.equal(saved?.activeTarget, "home");
-		assert.equal(
-			(saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.r2?.kind,
-			"r2",
-		);
-		assert.equal(
-			(saved?.targets as Record<string, Record<string, unknown>> | undefined)?.home?.bucket,
-			"personal-pi",
-		);
+		assert.equal(profile?.kind, "r2");
+		assert.equal(target?.profile, "r2");
+		assert.equal(target?.bucket, "pi-sync");
+		assert.equal(target?.prefix, "pi-sync");
+		assert.equal(target?.namespace, "home");
+		assert.deepEqual(inputTitles, ["Cloudflare R2 endpoint"]);
+		assert.match(rendered.join("\n"), /Bucket must already exist/);
+		assert.match(rendered.join("\n"), /pi-sync\/profiles\/home/);
 		assert.match(notifications.at(-1)?.message ?? "", /Target “home” is ready/);
 		assert.doesNotMatch(rendered.join("\n"), /setup-access-secret|setup-secret-value/);
+	});
+});
+
+test("first-time S3 setup asks only for the existing bucket and derives work defaults", async () => {
+	await withTempSettings(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Set up sync",
+			"Other S3-compatible storage",
+			"Work",
+			"Use existing bucket with suggested path (recommended)",
+			"Create private settings template",
+			"Minimal settings",
+			"Keep automatic sync off",
+			"Keep sessions off (recommended)",
+			"Save setup",
+			undefined,
+		];
+		const inputs = ["https://s3.example.com", "ap-northeast-1", "company-pi"];
+		const inputTitles: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			input: async (title: string) => {
+				inputTitles.push(title);
+				return inputs.shift();
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		const profile = (saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.s3;
+		const target = (saved?.targets as Record<string, Record<string, unknown>> | undefined)?.work;
+		assert.equal(saved?.activeTarget, "work");
+		assert.equal(profile?.kind, "s3-compatible");
+		assert.equal(target?.bucket, "company-pi");
+		assert.equal(target?.prefix, "pi-sync");
+		assert.equal(target?.namespace, "work");
+		assert.deepEqual(inputTitles, ["S3-compatible endpoint", "Storage region", "Existing bucket"]);
+	});
+});
+
+test("first-time setup keeps advanced profile and remote-location customization", async () => {
+	await withTempSettings(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Set up sync",
+			"Cloudflare R2",
+			"Custom",
+			"Customize remote location",
+			"Create private settings template",
+			"Minimal settings",
+			"Keep automatic sync off",
+			"Keep sessions off (recommended)",
+			"Save setup",
+			undefined,
+		];
+		const inputs = [
+			"lab",
+			"https://account.r2.cloudflarestorage.com",
+			"archive",
+			"custom-bucket",
+			"custom-prefix",
+			"custom-space",
+		];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			input: async () => inputs.shift(),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		const target = (saved?.targets as Record<string, Record<string, unknown>> | undefined)?.lab;
+		assert.equal(saved?.activeTarget, "lab");
+		assert.ok(
+			Object.hasOwn(
+				(saved?.profiles as Record<string, Record<string, unknown>> | undefined) ?? {},
+				"archive",
+			),
+		);
+		assert.equal(target?.profile, "archive");
+		assert.equal(target?.bucket, "custom-bucket");
+		assert.equal(target?.prefix, "custom-prefix");
+		assert.equal(target?.namespace, "custom-space");
 	});
 });
 
@@ -436,7 +526,7 @@ test("cancelling first-time setup creates no settings or state", async () => {
 	});
 });
 
-test("manage flow adds a previewed target without switching or syncing", async () => {
+test("manage flow recommends the current profile bucket and derives a separate namespace", async () => {
 	await withTempSettings(async () => {
 		writeSettings(v2Settings());
 		const mock = createMockPi();
@@ -445,26 +535,33 @@ test("manage flow adds a previewed target without switching or syncing", async (
 			"Manage targets & storage",
 			"Add sync target",
 			"r2",
+			"Same bucket as “home” (recommended)",
 			"Recommended Pi settings",
 			"Add target",
 			undefined,
 		];
-		const inputs = ["work", "company-pi", "pi-sync", "work"];
+		const inputs = ["work"];
+		const rendered: string[] = [];
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
 			mode: "tui",
-			select: async () => selections.shift(),
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
 			input: async () => inputs.shift(),
 		});
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
 		const saved = await readLocalConfigObject();
+		const work = (saved?.targets as Record<string, Record<string, unknown>> | undefined)?.work;
 		assert.equal(saved?.activeTarget, "home");
-		assert.equal(
-			(saved?.targets as Record<string, Record<string, unknown>> | undefined)?.work?.bucket,
-			"company-pi",
-		);
+		assert.equal(work?.profile, "r2");
+		assert.equal(work?.bucket, "personal-pi");
+		assert.equal(work?.prefix, "pi-sync");
+		assert.equal(work?.namespace, "work");
+		assert.match(rendered.join("\n"), /personal-pi.*pi-sync\/profiles\/work/s);
 		assert.match(notifications.at(-1)?.message ?? "", /Added sync target “work”/);
 	});
 });
@@ -643,6 +740,17 @@ test("duplicate target remote identities fail validation", async () => {
 		const settings = v2Settings();
 		settings.targets.work = { ...settings.targets.home };
 		writeSettings(settings);
+		await assert.rejects(loadConfig(), /targets "home" and "work" use the same remote destination/);
+	});
+});
+
+test("deprecated namespace overrides cannot collapse distinct targets onto one destination", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		process.env.PI_SYNC_PROFILE = "forced-namespace";
+
 		await assert.rejects(loadConfig(), /targets "home" and "work" use the same remote destination/);
 	});
 });

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -1,0 +1,874 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import {
+	deprecatedPiSyncEnvironmentWarnings,
+	loadConfig,
+	localConfigPath,
+	readLocalConfigObject,
+	readStateForConfig,
+	stateDir,
+	writeStateForConfig,
+} from "../src/config.js";
+import { migrateLegacySettings } from "../src/settings-management.js";
+import { recoverPendingSnapshotTransactions } from "../src/snapshot-transaction.js";
+import sync, { parseOptions } from "../src/sync.js";
+
+initTheme("dark", false);
+
+const ENV_KEYS = [
+	"PI_CODING_AGENT_DIR",
+	"PI_SYNC_ENDPOINT",
+	"PI_SYNC_BUCKET",
+	"PI_SYNC_REGION",
+	"PI_SYNC_ACCESS_KEY_ID",
+	"PI_SYNC_SECRET_ACCESS_KEY",
+	"PI_SYNC_SESSION_TOKEN",
+	"PI_SYNC_PROFILE",
+	"PI_SYNC_PREFIX",
+	"PI_SYNC_AUTO_SYNC",
+	"PI_SYNC_SESSIONS",
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_SESSION_TOKEN",
+	"AWS_REGION",
+	"R2_ENDPOINT",
+	"R2_BUCKET",
+] as const;
+
+test("v2 settings resolve reusable storage profiles and named targets", async () => {
+	await withTempSettings(async () => {
+		writeSettings({
+			version: 2,
+			activeTarget: "home",
+			profiles: {
+				r2: {
+					kind: "r2",
+					endpoint: "https://account.r2.cloudflarestorage.com",
+					region: "auto",
+					accessKeyId: "r2-access",
+					secretAccessKey: "r2-secret",
+				},
+				s3: {
+					kind: "s3-compatible",
+					endpoint: "https://s3.example.com",
+					region: "ap-northeast-1",
+					accessKeyId: "s3-access",
+					secretAccessKey: "s3-secret",
+				},
+			},
+			targets: {
+				home: {
+					profile: "r2",
+					bucket: "personal-pi",
+					prefix: "pi-sync",
+					namespace: "home-space",
+					autoSync: true,
+					syncFiles: ["settings.json", "skills"],
+					syncSessions: false,
+					extraFiles: [],
+				},
+				work: {
+					profile: "s3",
+					bucket: "company-pi",
+					prefix: "developers/narumi",
+					namespace: "work-space",
+					autoSync: false,
+					syncFiles: ["AGENTS.md"],
+					syncSessions: true,
+					extraFiles: ["LOCAL.md"],
+				},
+			},
+			future: { retained: true },
+		});
+
+		const home = await loadConfig();
+		assert.equal(home.target, "home");
+		assert.equal(home.storageProfile, "r2");
+		assert.equal(home.profile, "home-space");
+		assert.equal(home.bucket, "personal-pi");
+		assert.equal(home.autoSync, true);
+		assert.deepEqual(home.syncFiles, ["settings.json", "skills"]);
+
+		const work = await loadConfig("work");
+		assert.equal(work.target, "work");
+		assert.equal(work.storageProfile, "s3");
+		assert.equal(work.profile, "work-space");
+		assert.equal(work.bucket, "company-pi");
+		assert.equal(work.autoSync, false);
+		assert.equal(work.syncSessions, true);
+		assert.deepEqual(work.extraFiles, ["LOCAL.md"]);
+	});
+});
+
+test("standard AWS and R2 aliases still override the selected profile and target", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		process.env.AWS_ACCESS_KEY_ID = "aws-access";
+		process.env.AWS_SECRET_ACCESS_KEY = "aws-secret";
+		process.env.AWS_SESSION_TOKEN = "aws-session";
+		process.env.AWS_REGION = "us-west-2";
+		process.env.R2_ENDPOINT = "https://override.r2.cloudflarestorage.com";
+		process.env.R2_BUCKET = "override-bucket";
+
+		const config = await loadConfig();
+		assert.equal(config.endpoint, "https://override.r2.cloudflarestorage.com");
+		assert.equal(config.bucket, "override-bucket");
+		assert.equal(config.region, "us-west-2");
+		assert.equal(config.accessKeyId, "aws-access");
+		assert.equal(config.secretAccessKey, "aws-secret");
+		assert.equal(config.sessionToken, "aws-session");
+	});
+});
+
+test("deprecated PI_SYNC variables retain precedence and warnings never reveal values", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		process.env.PI_SYNC_BUCKET = "deprecated-bucket-value";
+		process.env.PI_SYNC_PROFILE = "deprecated-namespace-value";
+
+		const config = await loadConfig();
+		assert.equal(config.bucket, "deprecated-bucket-value");
+		assert.equal(config.profile, "deprecated-namespace-value");
+		const warning = deprecatedPiSyncEnvironmentWarnings().join("\n");
+		assert.match(warning, /PI_SYNC_BUCKET/);
+		assert.match(warning, /PI_SYNC_PROFILE/);
+		assert.match(warning, /future major version/);
+		assert.doesNotMatch(warning, /deprecated-(bucket|namespace)-value/);
+	});
+});
+
+test("bare sync menu shows the current target and goal-oriented actions", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const mock = createMockPi();
+		sync(mock.pi);
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(calls[0]?.title ?? "", /Current target: home/);
+		assert.match(calls[0]?.title ?? "", /Cloudflare R2.*personal-pi/);
+		assert.match(calls[0]?.title ?? "", /Auto-sync: On.*Sessions: Off/);
+		assert.deepEqual(calls[0]?.options, [
+			"Sync now",
+			"Switch target",
+			"Status & changes",
+			"Settings",
+			"Manage targets & storage",
+			"History & recovery",
+			"Help",
+		]);
+	});
+});
+
+test("bare sync presents malformed settings as a read-only repair state", async () => {
+	await withTempSettings(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), "{broken");
+		let title = "";
+		let options: string[] = [];
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			select: async (nextTitle: string, nextOptions: string[]) => {
+				title = nextTitle;
+				options = nextOptions;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(title, /Settings file needs repair/);
+		assert.deepEqual(options, ["Help"]);
+		assert.equal(readFileSync(localConfigPath(), "utf8"), "{broken");
+	});
+});
+
+test("bare sync disables mutations and exposes recovery while a live lock is held", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		mkdirSync(stateDir(), { recursive: true });
+		writeFileSync(
+			path.join(stateDir(), "lock"),
+			JSON.stringify({
+				id: "live-operation",
+				pid: process.pid,
+				command: "pull",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		let title = "";
+		let options: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			select: async (nextTitle: string, nextOptions: string[]) => {
+				title = nextTitle;
+				options = nextOptions;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(title, /Operation in progress: pull/);
+		assert.doesNotMatch(options.join("\n"), /Sync now|Settings|Switch target/);
+		assert.deepEqual(options, ["Status & changes", "History & recovery", "Help"]);
+	});
+});
+
+test("Sync now read-only check aborts from Escape before any publication", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const before = readFileSync(localConfigPath(), "utf8");
+		const originalFetch = globalThis.fetch;
+		let putCalls = 0;
+		let aborted = false;
+		globalThis.fetch = ((_input, init) => {
+			if (init?.method === "PUT") putCalls += 1;
+			return new Promise<Response>((_resolve, reject) => {
+				if (init?.signal?.aborted) {
+					aborted = true;
+					reject(new DOMException("Aborted", "AbortError"));
+					return;
+				}
+				init?.signal?.addEventListener(
+					"abort",
+					() => {
+						aborted = true;
+						reject(new DOMException("Aborted", "AbortError"));
+					},
+					{ once: true },
+				);
+			});
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			let selectCount = 0;
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => (selectCount++ === 0 ? "Sync now" : undefined),
+				custom: async (factory: unknown) => {
+					const loader = createCustomSelectorHarness(factory, 60);
+					loader.handleInput("\u001b");
+					loader.dispose();
+					return loader.result;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("", ctx);
+
+			assert.equal(aborted, true);
+			assert.equal(putCalls, 0);
+			assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+			assert.match(notifications.map((item) => item.message).join("\n"), /cancelled/);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("switch target previews and atomically changes only the active target", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.profiles.s3 = {
+			endpoint: "https://s3.example.com",
+			region: "ap-northeast-1",
+			accessKeyId: "s3-access",
+			secretAccessKey: "s3-secret",
+		};
+		settings.targets.work = {
+			profile: "s3",
+			bucket: "company-pi",
+			namespace: "work",
+			prefix: "pi-sync",
+			autoSync: false,
+			syncFiles: ["AGENTS.md"],
+			syncSessions: false,
+			extraFiles: [],
+		};
+		writeSettings(settings);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = ["Switch target", "work", "Switch to work", undefined];
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return selections.shift();
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(calls[1]?.title ?? "", /Current target: home/);
+		assert.deepEqual(calls[1]?.options, [
+			"home (current) · r2 · personal-pi · 1 groups · Sessions: Off",
+			"work · s3 · company-pi · 1 groups · Sessions: Off",
+			"Back",
+		]);
+		assert.match(calls[2]?.title ?? "", /From: home/);
+		assert.match(calls[2]?.title ?? "", /To: work/);
+		assert.match(calls[2]?.title ?? "", /does not sync or modify files/i);
+		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
+		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”/);
+	});
+});
+
+test("cancelling a target switch leaves settings byte-for-byte unchanged", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		const before = JSON.stringify(await readLocalConfigObject());
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = ["Switch target", "work", "Cancel", undefined];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.equal(JSON.stringify(await readLocalConfigObject()), before);
+	});
+});
+
+test("first-time setup saves one previewed v2 target without rendering credentials", async () => {
+	await withTempSettings(async () => {
+		process.env.AWS_ACCESS_KEY_ID = "setup-access-secret";
+		process.env.AWS_SECRET_ACCESS_KEY = "setup-secret-value";
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Set up sync",
+			"Cloudflare R2",
+			"Use environment credentials",
+			"Recommended Pi settings",
+			"Enable automatic sync",
+			"Keep sessions off (recommended)",
+			"Save setup",
+		];
+		const inputs = [
+			"home",
+			"r2",
+			"https://account.r2.cloudflarestorage.com",
+			"personal-pi",
+			"pi-sync",
+			"home",
+		];
+		const rendered: string[] = [];
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async (title: string) => {
+				rendered.push(title);
+				return inputs.shift();
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		assert.equal(saved?.version, 2);
+		assert.equal(saved?.activeTarget, "home");
+		assert.equal(
+			(saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.r2?.kind,
+			"r2",
+		);
+		assert.equal(
+			(saved?.targets as Record<string, Record<string, unknown>> | undefined)?.home?.bucket,
+			"personal-pi",
+		);
+		assert.match(notifications.at(-1)?.message ?? "", /Target “home” is ready/);
+		assert.doesNotMatch(rendered.join("\n"), /setup-access-secret|setup-secret-value/);
+	});
+});
+
+test("cancelling first-time setup creates no settings or state", async () => {
+	await withTempSettings(async (agentDir) => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = ["Set up sync", undefined];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.equal(await readLocalConfigObject(), undefined);
+		assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
+	});
+});
+
+test("manage flow adds a previewed target without switching or syncing", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Manage targets & storage",
+			"Add sync target",
+			"r2",
+			"Recommended Pi settings",
+			"Add target",
+			undefined,
+		];
+		const inputs = ["work", "company-pi", "pi-sync", "work"];
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			input: async () => inputs.shift(),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		assert.equal(saved?.activeTarget, "home");
+		assert.equal(
+			(saved?.targets as Record<string, Record<string, unknown>> | undefined)?.work?.bucket,
+			"company-pi",
+		);
+		assert.match(notifications.at(-1)?.message ?? "", /Added sync target “work”/);
+	});
+});
+
+test("synced-content UI fits narrow and wide terminal widths with textual state", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.activeTarget = "家庭與工作設定";
+		settings.targets[settings.activeTarget] = settings.targets.home ?? {};
+		delete settings.targets.home;
+		writeSettings(settings);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const rendered = new Map<number, string[]>();
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				for (const width of [32, 60, 100]) {
+					const selector = createCustomSelectorHarness(factory, width);
+					rendered.set(width, selector.render());
+				}
+				const selector = createCustomSelectorHarness(factory, 60);
+				selector.handleInput("\u001b");
+				return selector.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("files", ctx);
+
+		for (const [width, lines] of rendered) {
+			assert.ok(lines.length > 0);
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(lines.join("\n"), /included|excluded/);
+		}
+	});
+});
+
+test("TUI history selects a snapshot, previews concrete rollback, and cancellation is read-only", async () => {
+	await withTempSettings(async (agentDir) => {
+		writeSettings(v2Settings());
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const remoteSnapshot = snapshotPayload("remote-snapshot", '{"remote":true}\n');
+		const encoded = gzipSync(Buffer.from(JSON.stringify(remoteSnapshot)));
+		const pointer = {
+			version: 1,
+			profile: "home",
+			snapshot: remoteSnapshot.id,
+			sha256: createHash("sha256").update(encoded).digest("hex"),
+			createdAt: remoteSnapshot.createdAt,
+			machine: "remote-machine",
+		};
+		const originalFetch = globalThis.fetch;
+		let putCalls = 0;
+		globalThis.fetch = (async (input, init) => {
+			const url = new URL(String(input));
+			if (init?.method === "PUT") {
+				putCalls += 1;
+				return new Response(null, { status: 200 });
+			}
+			if (url.pathname.endsWith("/history.json")) {
+				return Response.json({ version: 1, snapshots: [pointer] });
+			}
+			if (url.pathname.endsWith(`/snapshots/${remoteSnapshot.id}.json.gz`)) {
+				return new Response(new Uint8Array(encoded));
+			}
+			throw new Error(`Unexpected request: ${url.pathname}`);
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			let historyTitle = "";
+			let confirmMessage = "";
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async (title: string, options: string[]) => {
+					historyTitle = title;
+					return options[0];
+				},
+				confirm: async (_title: string, message: string) => {
+					confirmMessage = message;
+					return false;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("history", ctx);
+
+			assert.match(historyTitle, /History for target “home”/);
+			assert.match(confirmMessage, /Snapshot: remote-snapshot/);
+			assert.match(confirmMessage, /Update locally: settings\.json/);
+			assert.equal(putCalls, 0);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("Sync now reports nothing selected without network or state mutation", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.home.syncFiles = [];
+		settings.targets.home.extraFiles = [];
+		settings.targets.home.syncSessions = false;
+		writeSettings(settings);
+		const originalFetch = globalThis.fetch;
+		let requests = 0;
+		globalThis.fetch = (async () => {
+			requests += 1;
+			throw new Error("Nothing-selected sync must not use the network");
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({ hasUI: true });
+
+			await mock.commands.get("sync")?.handler("sync", ctx);
+
+			assert.equal(requests, 0);
+			assert.match(notifications.at(-1)?.message ?? "", /manages no files/);
+			assert.equal(existsSync(path.join(stateDir(), "targets")), false);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("manual target operation addresses a non-current target without switching", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		const originalFetch = globalThis.fetch;
+		let requestedPath = "";
+		globalThis.fetch = (async (input) => {
+			requestedPath = new URL(String(input)).pathname;
+			return new Response(null, { status: 404 });
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx } = createMockContext({ hasUI: true });
+
+			await mock.commands.get("sync")?.handler("status --target work", ctx);
+
+			assert.match(requestedPath, /\/profiles\/work\/latest\.json$/);
+			assert.equal((await readLocalConfigObject())?.activeTarget, "home");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("direct use switches targets and target options parse exactly", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("use work", ctx);
+
+		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
+		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”/);
+		assert.equal(parseOptions(["--target", "home"]).target, "home");
+		assert.throws(() => parseOptions(["--target"]), /requires a target name/);
+		assert.throws(() => parseOptions(["--unknown"]), /Unknown sync option/);
+	});
+});
+
+test("duplicate target remote identities fail validation", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home };
+		writeSettings(settings);
+		await assert.rejects(loadConfig(), /targets "home" and "work" use the same remote destination/);
+	});
+});
+
+test("legacy migration preserves unknown fields, exact backup bytes, remote identity, and state", async () => {
+	await withTempSettings(async () => {
+		const original = `${JSON.stringify(
+			{
+				endpoint: "https://legacy.r2.cloudflarestorage.com",
+				bucket: "legacy-bucket",
+				region: "auto",
+				accessKeyId: "legacy-access",
+				secretAccessKey: "legacy-secret",
+				profile: "legacy-space",
+				prefix: "legacy-prefix",
+				autoSync: false,
+				syncFiles: ["settings.json"],
+				syncSessions: false,
+				extraFiles: ["LOCAL.md"],
+				future: { retained: true },
+			},
+			null,
+			"\t",
+		)}\n`;
+		mkdirSync(path.dirname(localConfigPath()), { recursive: true });
+		writeFileSync(localConfigPath(), original);
+		const legacy = await loadConfig();
+		await writeStateForConfig(legacy, {
+			version: 1,
+			profile: legacy.profile,
+			lastAppliedSnapshot: "legacy-snapshot",
+			lastFileHashes: { "settings.json": "hash" },
+		});
+
+		const result = await migrateLegacySettings("home", "r2");
+		const saved = await readLocalConfigObject();
+
+		assert.equal(readFileSync(result.backupPath, "utf8"), original);
+		assert.deepEqual(saved?.future, { retained: true });
+		assert.equal(saved?.activeTarget, "home");
+		assert.equal(
+			(saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.r2?.endpoint,
+			"https://legacy.r2.cloudflarestorage.com",
+		);
+		assert.equal(
+			(saved?.targets as Record<string, Record<string, unknown>> | undefined)?.home?.namespace,
+			"legacy-space",
+		);
+		assert.equal(Object.hasOwn(saved ?? {}, "secretAccessKey"), false);
+		const migrated = await loadConfig();
+		assert.equal(migrated.profile, "legacy-space");
+		assert.equal((await readStateForConfig(migrated)).lastAppliedSnapshot, "legacy-snapshot");
+	});
+});
+
+test("startup recovery restores an interrupted local snapshot transaction", async () => {
+	await withTempSettings(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const target = path.join(agentDir, "settings.json");
+		writeFileSync(target, '{"partial":true}\n');
+		const transaction = path.join(stateDir(), "transactions", "interrupted");
+		mkdirSync(path.join(transaction, "before"), { recursive: true });
+		writeFileSync(path.join(transaction, "before", "0"), '{"old":true}\n');
+		writeFileSync(
+			path.join(transaction, "journal.json"),
+			JSON.stringify({
+				version: 1,
+				root: agentDir,
+				entries: [{ target, backupName: "0", kind: "file" }],
+			}),
+		);
+
+		await recoverPendingSnapshotTransactions();
+
+		assert.equal(readFileSync(target, "utf8"), '{"old":true}\n');
+		assert.equal(existsSync(transaction), false);
+	});
+});
+
+test("automatic sync consults only the current target", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.home.autoSync = false;
+		settings.targets.work = { ...settings.targets.home, namespace: "work", autoSync: true };
+		writeSettings(settings);
+		const originalFetch = globalThis.fetch;
+		let requests = 0;
+		globalThis.fetch = (async () => {
+			requests += 1;
+			throw new Error("Non-current target should not auto-sync");
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx } = createMockContext();
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			assert.equal(requests, 0);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("v2 targets keep independent local sync state even when namespaces match", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = {
+			...settings.targets.home,
+			bucket: "work-bucket",
+			namespace: "home",
+		};
+		writeSettings(settings);
+		const home = await loadConfig("home");
+		const work = await loadConfig("work");
+
+		await writeStateForConfig(home, {
+			version: 1,
+			profile: home.profile,
+			lastAppliedSnapshot: "home-snapshot",
+			lastFileHashes: {},
+		});
+		await writeStateForConfig(work, {
+			version: 1,
+			profile: work.profile,
+			lastAppliedSnapshot: "work-snapshot",
+			lastFileHashes: {},
+		});
+
+		assert.equal((await readStateForConfig(home)).lastAppliedSnapshot, "home-snapshot");
+		assert.equal((await readStateForConfig(work)).lastAppliedSnapshot, "work-snapshot");
+	});
+});
+
+test("flat v1 settings retain their remote namespace and defaults", async () => {
+	await withTempSettings(async () => {
+		writeSettings({
+			endpoint: "https://legacy.example.com",
+			bucket: "legacy-bucket",
+			region: "legacy-region",
+			accessKeyId: "legacy-access",
+			secretAccessKey: "legacy-secret",
+			profile: "legacy-space",
+			prefix: "legacy-prefix",
+			autoSync: false,
+		});
+
+		const config = await loadConfig();
+		assert.equal(config.target, "default");
+		assert.equal(config.storageProfile, "default");
+		assert.equal(config.profile, "legacy-space");
+		assert.equal(config.autoSync, false);
+	});
+});
+
+function snapshotPayload(id: string, settings: string) {
+	const content = Buffer.from(settings);
+	return {
+		version: 1,
+		id,
+		createdAt: "2026-07-24T00:00:00.000Z",
+		machine: "remote-machine",
+		profile: "home",
+		syncSessions: false,
+		files: [
+			{
+				path: "settings.json",
+				contentBase64: content.toString("base64"),
+				sha256: createHash("sha256").update(content).digest("hex"),
+			},
+		],
+	};
+}
+
+function v2Settings(): {
+	version: 2;
+	activeTarget: string;
+	profiles: Record<string, Record<string, unknown>>;
+	targets: Record<string, Record<string, unknown>>;
+} {
+	return {
+		version: 2,
+		activeTarget: "home",
+		profiles: {
+			r2: {
+				endpoint: "https://account.r2.cloudflarestorage.com",
+				region: "auto",
+				accessKeyId: "r2-access",
+				secretAccessKey: "r2-secret",
+			},
+		},
+		targets: {
+			home: {
+				profile: "r2",
+				bucket: "personal-pi",
+				namespace: "home",
+				prefix: "pi-sync",
+				autoSync: true,
+				syncFiles: ["settings.json"],
+				syncSessions: false,
+				extraFiles: [],
+			},
+		},
+	};
+}
+
+async function withTempSettings(fn: (agentDir: string) => Promise<void>) {
+	const previous = new Map<string, string | undefined>(
+		ENV_KEYS.map((key) => [key, process.env[key]]),
+	);
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-profile-test-"));
+	const agentDir = path.join(root, "agent");
+	for (const key of ENV_KEYS) delete process.env[key];
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		await fn(agentDir);
+	} finally {
+		for (const key of ENV_KEYS) {
+			const value = previous.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+function writeSettings(value: unknown) {
+	mkdirSync(path.dirname(localConfigPath()), { recursive: true });
+	writeFileSync(localConfigPath(), `${JSON.stringify(value, null, "\t")}\n`);
+}

--- a/extensions/pi-sync/test/publication.test.ts
+++ b/extensions/pi-sync/test/publication.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { localConfigPath } from "../src/config.js";
+import sync from "../src/sync.js";
+import { requiredConfig, snapshot, withTempHome } from "./helpers.js";
+
+test("snapshot staging failure leaves the prior latest pointer active", async () => {
+	await withPublicationHarness({ failSnapshot: true }, async ({ counts, notifications }) => {
+		assert.equal(counts.snapshotPuts, 1);
+		assert.equal(counts.latestPuts, 0);
+		assert.match(notifications(), /S3 PUT failed/);
+	});
+});
+
+test("history failure reports the newly published snapshot as active and repairable", async () => {
+	await withPublicationHarness({ failHistory: true }, async ({ counts, notifications }) => {
+		assert.equal(counts.snapshotPuts, 1);
+		assert.equal(counts.latestPuts, 1);
+		assert.equal(counts.historyPuts, 1);
+		assert.match(notifications(), /Remote snapshot is active, but history could not be updated/);
+	});
+});
+
+async function withPublicationHarness(
+	failures: { failSnapshot?: boolean; failHistory?: boolean },
+	assertions: (state: {
+		counts: { snapshotPuts: number; latestPuts: number; historyPuts: number };
+		notifications: () => string;
+	}) => Promise<void>,
+) {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":"new"}\n');
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({ ...requiredConfig(), syncFiles: ["settings.json"] }),
+		);
+		const remote = snapshot([
+			{ path: "settings.json", content: Buffer.from('{"remote":"old"}\n') },
+		]);
+		const remoteEncoded = gzipSync(Buffer.from(JSON.stringify(remote)));
+		let activePointer: Record<string, unknown> = {
+			version: 1,
+			profile: "default",
+			snapshot: remote.id,
+			sha256: createHash("sha256").update(remoteEncoded).digest("hex"),
+			createdAt: remote.createdAt,
+			machine: remote.machine,
+		};
+		const counts = { snapshotPuts: 0, latestPuts: 0, historyPuts: 0 };
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input, init) => {
+			const url = new URL(String(input));
+			const method = init?.method ?? "GET";
+			if (url.pathname.endsWith("/latest.json")) {
+				if (method === "PUT") {
+					counts.latestPuts += 1;
+					activePointer = parseRequestJson(init?.body);
+					return new Response(null, { status: 200 });
+				}
+				return Response.json(activePointer, { headers: { etag: '"latest"' } });
+			}
+			if (url.pathname.includes("/snapshots/")) {
+				if (method === "PUT") {
+					counts.snapshotPuts += 1;
+					return failures.failSnapshot
+						? new Response("staging failed", { status: 503 })
+						: new Response(null, { status: 200 });
+				}
+				return new Response(new Uint8Array(remoteEncoded), { headers: { etag: '"snapshot"' } });
+			}
+			if (url.pathname.endsWith("/history.json")) {
+				if (method === "PUT") {
+					counts.historyPuts += 1;
+					return failures.failHistory
+						? new Response("history failed", { status: 503 })
+						: new Response(null, { status: 200 });
+				}
+				return new Response(null, { status: 404 });
+			}
+			throw new Error(`Unexpected request: ${method} ${url.pathname}`);
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({ hasUI: true });
+
+			await mock.commands.get("sync")?.handler("push --yes --force", ctx);
+
+			await assertions({
+				counts,
+				notifications: () => notifications.map((item) => item.message).join("\n"),
+			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+}
+
+function parseRequestJson(body: BodyInit | null | undefined) {
+	if (!body) throw new Error("Expected request body");
+	if (typeof body === "string") return JSON.parse(body) as Record<string, unknown>;
+	if (body instanceof Uint8Array) {
+		return JSON.parse(Buffer.from(body).toString("utf8")) as Record<string, unknown>;
+	}
+	throw new Error("Unexpected request body");
+}

--- a/extensions/pi-sync/test/review-feedback.test.ts
+++ b/extensions/pi-sync/test/review-feedback.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	configuredTargetNames,
+	ensureStateDir,
+	loadConfig,
+	localConfigPath,
+	lockPath,
+} from "../src/config.js";
+import { addSyncTarget } from "../src/settings-management.js";
+import sync from "../src/sync.js";
+import { requiredConfig, withTempHome } from "./helpers.js";
+
+test("legacy settings reject explicit target selection before destructive network work", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
+		let requests = 0;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => {
+			requests += 1;
+			throw new Error("network must not be reached");
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({ hasUI: true });
+
+			await mock.commands.get("sync")?.handler("push --target work --yes", ctx);
+
+			assert.equal(requests, 0);
+			assert.deepEqual(await configuredTargetNames(), []);
+			assert.match(notifications.at(-1)?.message ?? "", /--target.*version 2/i);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("duplicate destination validation uses normalized S3 key segments", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settings = v2Settings();
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const duplicate = {
+			...settings.targets.home,
+			bucket: " /personal-pi/ ",
+			prefix: " /pi-sync/ ",
+			namespace: " /home/ ",
+		};
+
+		await assert.rejects(
+			addSyncTarget("work", duplicate),
+			/duplicates the remote destination of “home”/,
+		);
+
+		settings.targets.work = duplicate;
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		await assert.rejects(loadConfig(), /targets "home" and "work" use the same remote destination/);
+	});
+});
+
+test("recovery menu passes explicit stale confirmation for unreadable lock metadata", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v2Settings()));
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = ["History & recovery", "Recover stale operation", undefined];
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.equal(existsSync(lockPath()), false);
+		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable pi-sync lock/);
+	});
+});
+
+test("history selection acquires the rollback lock before reading or applying a snapshot", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v2Settings()));
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "active-push",
+				pid: process.pid,
+				command: "push",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		let requests = 0;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input) => {
+			requests += 1;
+			const url = new URL(String(input));
+			if (!url.pathname.endsWith("/history.json")) {
+				throw new Error(`Unexpected unlocked snapshot request: ${url.pathname}`);
+			}
+			return Response.json({
+				version: 1,
+				snapshots: [
+					{
+						version: 1,
+						profile: "home",
+						snapshot: "snapshot-1",
+						sha256: "checksum",
+						createdAt: "2026-07-24T00:00:00.000Z",
+						machine: "remote",
+					},
+				],
+			});
+		}) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			let confirmations = 0;
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async (_title: string, options: string[]) => options[0],
+				confirm: async () => {
+					confirmations += 1;
+					return false;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("history", ctx);
+
+			assert.equal(requests, 1);
+			assert.equal(confirmations, 0);
+			assert.match(notifications.at(-1)?.message ?? "", /already running.*push/i);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+function v2Settings() {
+	return {
+		version: 2,
+		activeTarget: "home",
+		profiles: {
+			r2: {
+				kind: "r2",
+				endpoint: "https://account.r2.cloudflarestorage.com",
+				region: "auto",
+				accessKeyId: "access-key",
+				secretAccessKey: "secret-key",
+			},
+		},
+		targets: {
+			home: {
+				profile: "r2",
+				bucket: "personal-pi",
+				prefix: "pi-sync",
+				namespace: "home",
+				autoSync: true,
+				syncFiles: ["settings.json"],
+				syncSessions: false,
+				extraFiles: [],
+			},
+		} as Record<string, Record<string, unknown>>,
+	};
+}

--- a/extensions/pi-sync/test/sync-snapshot.test.ts
+++ b/extensions/pi-sync/test/sync-snapshot.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { applySnapshot } from "../src/snapshot-apply.js";
+import {
+	addTopLevelCaseVariantDeletes,
+	collectFiles,
+	preflightSnapshotApply,
+} from "../src/sync.js";
+
+import { snapshot, withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+test("snapshot collection includes session jsonl files only when enabled", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-"));
+	mkdirSync(path.join(root, "skills"), { recursive: true });
+	mkdirSync(path.join(root, "sessions", "--project--"), { recursive: true });
+	mkdirSync(path.join(root, "sessions", "token-project"), { recursive: true });
+	writeFileSync(path.join(root, "APPEND_SYSTEM.md"), "append\n");
+	writeFileSync(path.join(root, "LOCAL.md"), "local\n");
+	writeFileSync(path.join(root, "local-case.md"), "local case\n");
+	writeFileSync(path.join(root, "settings.json"), "{}\n");
+	writeFileSync(path.join(root, "skills", "demo.md"), "demo\n");
+	if (path.sep === "/") writeFileSync(path.join(root, "skills", "foo\\bar.md"), "skip\n");
+	writeFileSync(path.join(root, "sessions", "--project--", "session.jsonl"), "{}\n");
+	writeFileSync(path.join(root, "sessions", "--project--", "notes.txt"), "skip\n");
+	writeFileSync(path.join(root, "sessions", "token-project", "session.jsonl"), "skip\n");
+	const customSessionDir = mkdtempSync(path.join(os.tmpdir(), "pi-sync-sessions-"));
+	writeFileSync(path.join(customSessionDir, "custom.jsonl"), "{}\n");
+
+	assert.deepEqual(
+		(await collectFiles(root)).map((file) => file.path),
+		["APPEND_SYSTEM.md", "settings.json", "skills/demo.md"],
+	);
+	const caseRoot = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-case-"));
+	writeFileSync(path.join(caseRoot, "append_system.md"), "append\n");
+	assert.deepEqual(
+		(await collectFiles(caseRoot)).map((file) => file.path),
+		["APPEND_SYSTEM.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { extraFiles: ["LOCAL.md"] })).map((file) => file.path),
+		["APPEND_SYSTEM.md", "LOCAL.md", "settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] })).map((file) => file.path),
+		["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
+	);
+	writeFileSync(path.join(root, "LOCAL-CASE.md"), "local exact case\n");
+	if (readdirSync(root).includes("LOCAL-CASE.md")) {
+		const exactCaseFiles = await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] });
+		assert.deepEqual(
+			exactCaseFiles.map((file) => file.path),
+			["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
+		);
+		assert.equal(
+			Buffer.from(
+				exactCaseFiles.find((file) => file.path === "LOCAL-CASE.md")?.contentBase64 ?? "",
+				"base64",
+			).toString("utf8"),
+			"local exact case\n",
+		);
+	}
+	assert.deepEqual(
+		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
+		["APPEND_SYSTEM.md", "sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
+	);
+	assert.deepEqual(
+		(await collectFiles(root, { syncSessions: true, sessionDir: customSessionDir })).map(
+			(file) => file.path,
+		),
+		["APPEND_SYSTEM.md", "sessions/custom.jsonl", "settings.json", "skills/demo.md"],
+	);
+	const nestedSessionDir = path.join(root, "sessions", "work");
+	mkdirSync(nestedSessionDir, { recursive: true });
+	writeFileSync(path.join(nestedSessionDir, "nested.jsonl"), "{}\n");
+	assert.deepEqual(
+		(await collectFiles(root, { syncSessions: true, sessionDir: nestedSessionDir })).map(
+			(file) => file.path,
+		),
+		["APPEND_SYSTEM.md", "sessions/nested.jsonl", "settings.json", "skills/demo.md"],
+	);
+});
+
+test("snapshot preflight validates checksums, duplicate session paths, and deletes stale files", () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-"));
+	const content = Buffer.from("hello");
+	const remote = snapshot([{ path: "settings.json", content }]);
+	const current = snapshot([
+		{ path: "settings.json", content },
+		{ path: "sessions/--project--/old.jsonl", content: Buffer.from("old") },
+	]);
+
+	const plan = preflightSnapshotApply(root, remote, current);
+	assert.deepEqual(
+		plan.writes.map((item) => item.target),
+		[path.join(root, "settings.json")],
+	);
+	assert.deepEqual(plan.deletes, [path.join(root, "sessions", "--project--", "old.jsonl")]);
+	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: "../bad", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: ".", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: "..", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(root, snapshot([{ path: "sessions\\bad.jsonl", content }]), current),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				snapshot([{ path: "sessions/../settings.json", content }]),
+				current,
+			),
+		/Unsafe path/,
+	);
+	assert.throws(
+		() => preflightSnapshotApply(root, snapshot([{ path: ".env", content }]), current),
+		/Unsafe path/,
+	);
+	const sessionSnapshot = snapshot([{ path: "sessions/--project--/session.jsonl", content }]);
+	const customSessionDir = mkdtempSync(path.join(os.tmpdir(), "pi-sync-session-apply-"));
+	assert.deepEqual(
+		preflightSnapshotApply(root, sessionSnapshot, snapshot([]), {
+			sessionDir: customSessionDir,
+		}).writes.map((item) => item.target),
+		[path.join(customSessionDir, "--project--", "session.jsonl")],
+	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				{ ...sessionSnapshot, files: [sessionSnapshot.files[0], sessionSnapshot.files[0]] },
+				current,
+			),
+		/Duplicate path/,
+	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				{
+					...sessionSnapshot,
+					files: [{ ...sessionSnapshot.files[0], sha256: "bad" }],
+				},
+				current,
+			),
+		/Checksum mismatch/,
+	);
+	assert.throws(
+		() =>
+			preflightSnapshotApply(
+				root,
+				snapshot([{ path: "sessions/--project--/notes.txt", content }]),
+				current,
+			),
+		/Unsafe session path/,
+	);
+});
+
+test("snapshot apply restores the complete prior state at every mutation boundary", async () => {
+	for (const boundary of [
+		{ method: "rm", file: "AGENTS.md" },
+		{ method: "writeFile", file: "keybindings.json" },
+		{ method: "writeFile", file: "settings.json" },
+	] as const) {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			writeFileSync(path.join(agentDir, "AGENTS.md"), "old agents\n");
+			writeFileSync(path.join(agentDir, "settings.json"), '{"old":true}\n');
+			writeFileSync(path.join(agentDir, "keybindings.json"), '{"oldKeys":true}\n');
+			const remote = snapshot([
+				{ path: "settings.json", content: Buffer.from('{"new":true}\n') },
+				{ path: "keybindings.json", content: Buffer.from('{"newKeys":true}\n') },
+			]);
+			const originalRm = fs.rm;
+			const originalWriteFile = fs.writeFile;
+			let injected = false;
+			fs.rm = (async (...args: Parameters<typeof fs.rm>) => {
+				if (
+					!injected &&
+					boundary.method === "rm" &&
+					String(args[0]) === path.join(agentDir, boundary.file)
+				) {
+					injected = true;
+					throw new Error(`injected ${boundary.method} failure at ${boundary.file}`);
+				}
+				return originalRm(...args);
+			}) as typeof fs.rm;
+			fs.writeFile = (async (...args: Parameters<typeof fs.writeFile>) => {
+				if (
+					!injected &&
+					boundary.method === "writeFile" &&
+					String(args[0]) === path.join(agentDir, boundary.file)
+				) {
+					injected = true;
+					throw new Error(`injected ${boundary.method} failure at ${boundary.file}`);
+				}
+				return originalWriteFile(...args);
+			}) as typeof fs.writeFile;
+			try {
+				await assert.rejects(
+					applySnapshot(remote, new Set(), {
+						syncFiles: ["AGENTS.md", "settings.json", "keybindings.json"],
+						extraFiles: [],
+					}),
+					/injected .* failure/,
+				);
+			} finally {
+				fs.rm = originalRm;
+				fs.writeFile = originalWriteFile;
+			}
+			assert.equal(injected, true);
+			assert.equal(readFileSync(path.join(agentDir, "AGENTS.md"), "utf8"), "old agents\n");
+			assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"old":true}\n');
+			assert.equal(
+				readFileSync(path.join(agentDir, "keybindings.json"), "utf8"),
+				'{"oldKeys":true}\n',
+			);
+		});
+	}
+});
+
+test("snapshot apply leaves unselected local files and directories untouched", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "skills"), { recursive: true });
+		writeFileSync(path.join(agentDir, "keybindings.json"), "local keys\n");
+		writeFileSync(path.join(agentDir, "skills", "local.md"), "local skill\n");
+		const remote = snapshot([{ path: "settings.json", content: Buffer.from("remote settings\n") }]);
+
+		await applySnapshot(remote, new Set(), {
+			syncFiles: ["settings.json"],
+			extraFiles: [],
+		});
+
+		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), "remote settings\n");
+		assert.equal(readFileSync(path.join(agentDir, "keybindings.json"), "utf8"), "local keys\n");
+		assert.equal(readFileSync(path.join(agentDir, "skills", "local.md"), "utf8"), "local skill\n");
+	});
+});
+
+test("snapshot apply deletes stale top-level case variants", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-"));
+	writeFileSync(path.join(root, "append_system.md"), "old\n");
+	const remote = snapshot([{ path: "APPEND_SYSTEM.md", content: Buffer.from("new\n") }]);
+	const current = snapshot([{ path: "APPEND_SYSTEM.md", content: Buffer.from("old\n") }]);
+	const plan = preflightSnapshotApply(root, remote, current);
+	assert.deepEqual(plan.deletes, []);
+
+	const withCaseDeletes = await addTopLevelCaseVariantDeletes(root, plan, remote);
+	assert.deepEqual(withCaseDeletes.deletes, [path.join(root, "append_system.md")]);
+
+	const directoryRoot = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-dir-"));
+	mkdirSync(path.join(directoryRoot, "append_system.md"));
+	const directoryPlan = preflightSnapshotApply(directoryRoot, remote, current);
+	const withoutDirectoryDelete = await addTopLevelCaseVariantDeletes(
+		directoryRoot,
+		directoryPlan,
+		remote,
+	);
+	assert.deepEqual(withoutDirectoryDelete.deletes, []);
+});

--- a/extensions/pi-sync/test/sync-storage.test.ts
+++ b/extensions/pi-sync/test/sync-storage.test.ts
@@ -1,0 +1,923 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { gunzipSync } from "node:zlib";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	configuredSessionDir,
+	ensureStateDir,
+	loadPartialConfig,
+	localConfigPath,
+	lockPath,
+	readState,
+} from "../src/config.js";
+import { lockFileExists, readLock, withLock } from "../src/lock.js";
+import { S3Client } from "../src/s3-client.js";
+import sync, {
+	appliedFileHashMap,
+	backupLocal,
+	canPullRemoteSessionsOnFirstSync,
+	canPullRemoteSettingsOnFirstSync,
+	filterSnapshotForConfigPolicy,
+	hasRemoteChanges,
+	isCloudflareR2Endpoint,
+	isEnabled,
+	isExplicitlyEnabled,
+	mergeRemotePreservedFiles,
+	mergeRemoteSessionFiles,
+	protectSnapshotApplyPlan,
+	scanSnapshot,
+	sessionTokenWarnings,
+	settingsHashesMatchState,
+	settingsHashMap,
+	snapshotWithoutSessions,
+} from "../src/sync.js";
+
+import { requiredConfig, snapshot, withEnv, withTempHome, writeOldLock } from "./helpers.js";
+
+initTheme("dark", false);
+
+test("unconfigured extra top-level files are filtered locally and preserved on upload", () => {
+	const settings = { path: "settings.json", content: Buffer.from("settings") };
+	const custom = { path: "LOCAL.md", content: Buffer.from("custom") };
+	const configured = { path: "CONFIGURED.md", content: Buffer.from("configured") };
+	const session = { path: "sessions/--project--/session.jsonl", content: Buffer.from("session") };
+	const unsafeSession = { path: "sessions/../evil.jsonl", content: Buffer.from("evil") };
+	const reservedExtra = { path: "skills", content: Buffer.from("reserved") };
+	const builtInCaseExtra = { path: "Settings.json", content: Buffer.from("duplicate") };
+	const remote = {
+		...snapshot([
+			custom,
+			configured,
+			session,
+			unsafeSession,
+			reservedExtra,
+			builtInCaseExtra,
+			settings,
+		]),
+		syncSessions: true,
+	};
+	const config = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncSessions: false,
+		extraFiles: ["CONFIGURED.md"],
+	};
+
+	const filtered = filterSnapshotForConfigPolicy(remote, config);
+	assert.deepEqual(filtered.files.map((file) => file.path).sort(), [
+		"CONFIGURED.md",
+		"settings.json",
+	]);
+	assert.deepEqual(
+		filterSnapshotForConfigPolicy(
+			snapshot([{ path: "append_system.md", content: Buffer.from("append") }]),
+			config,
+		).files.map((file) => file.path),
+		["APPEND_SYSTEM.md"],
+	);
+	assert.notEqual(
+		filterSnapshotForConfigPolicy(remote, config, { regenerateId: true }).id,
+		remote.id,
+	);
+	assert.deepEqual(
+		filterSnapshotForConfigPolicy(remote, { ...config, syncSessions: true })
+			.files.map((file) => file.path)
+			.sort(),
+		["CONFIGURED.md", "sessions/--project--/session.jsonl", "settings.json"],
+	);
+	const lowerCaseRemoteExtra = filterSnapshotForConfigPolicy(
+		snapshot([{ path: "local.md", content: Buffer.from("local") }]),
+		{
+			...config,
+			extraFiles: ["LOCAL.md"],
+		},
+	);
+	assert.deepEqual(
+		lowerCaseRemoteExtra.files.map((file) => file.path),
+		["LOCAL.md"],
+	);
+	assert.equal(
+		hasRemoteChanges(
+			lowerCaseRemoteExtra,
+			{
+				version: 1,
+				profile: "default",
+				lastAppliedSnapshot: lowerCaseRemoteExtra.id,
+				lastFileHashes: Object.fromEntries(
+					snapshot([{ path: "local.md", content: Buffer.from("local") }]).files.map((file) => [
+						file.path,
+						file.sha256,
+					]),
+				),
+				extraFiles: ["LOCAL.md"],
+			},
+			{ ...config, extraFiles: ["LOCAL.md"] },
+		),
+		false,
+	);
+	assert.deepEqual(
+		mergeRemotePreservedFiles(snapshot([settings]), remote, config).files.map((file) => file.path),
+		["LOCAL.md", "sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.deepEqual(
+		mergeRemotePreservedFiles(snapshot([settings]), remote, {
+			...config,
+			extraFiles: ["CONFIGURED.md", "LOCAL.md"],
+		}).files.map((file) => file.path),
+		["sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.deepEqual(
+		mergeRemotePreservedFiles(
+			snapshot([settings, { path: "local.md", content: Buffer.from("local") }]),
+			remote,
+			config,
+		).files.map((file) => file.path),
+		["local.md", "sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.equal(
+		hasRemoteChanges(
+			filtered,
+			{
+				version: 1,
+				profile: "default",
+				lastAppliedSnapshot: remote.id,
+				lastFileHashes: Object.fromEntries(
+					snapshot([settings]).files.map((file) => [file.path, file.sha256]),
+				),
+				extraFiles: [],
+			},
+			config,
+		),
+		true,
+	);
+});
+
+test("settings-only uploads preserve remote session files", () => {
+	const settings = { path: "settings.json", content: Buffer.from("local") };
+	const remoteSession = {
+		path: "sessions/--project--/session.jsonl",
+		content: Buffer.from("remote"),
+	};
+	const invalidSession = {
+		path: "sessions/--project--/notes.txt",
+		content: Buffer.from("skip"),
+	};
+	const deniedSession = {
+		path: "sessions/--project--/token.jsonl",
+		content: Buffer.from("skip"),
+	};
+	const local = snapshot([settings]);
+
+	const merged = mergeRemoteSessionFiles(
+		local,
+		snapshot([remoteSession, invalidSession, deniedSession]),
+	);
+
+	assert.notEqual(merged.id, local.id);
+	assert.deepEqual(
+		merged.files.map((file) => file.path),
+		["sessions/--project--/session.jsonl", "settings.json"],
+	);
+	assert.equal(merged.syncSessions, true);
+
+	const emptySessionSet = mergeRemoteSessionFiles(local, { ...snapshot([]), syncSessions: true });
+	assert.notEqual(emptySessionSet.id, local.id);
+	assert.deepEqual(
+		emptySessionSet.files.map((file) => file.path),
+		["settings.json"],
+	);
+	assert.equal(emptySessionSet.syncSessions, true);
+});
+
+test("sync state tracks selection-policy changes without treating deselection as remote deletion", () => {
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "keybindings.json", content: Buffer.from("keys") },
+	]);
+	const selectedSettings = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncFiles: ["settings.json"],
+		syncSessions: false,
+		extraFiles: [],
+	};
+	const legacyState = {
+		version: 1,
+		profile: "default",
+		lastAppliedSnapshot: remote.id,
+		lastFileHashes: Object.fromEntries(remote.files.map((file) => [file.path, file.sha256])),
+	};
+	assert.equal(hasRemoteChanges(remote, legacyState, selectedSettings), false);
+
+	const previouslyEmptyState = {
+		...legacyState,
+		lastFileHashes: {},
+		syncFiles: [],
+	};
+	assert.equal(hasRemoteChanges(remote, previouslyEmptyState, selectedSettings), true);
+});
+
+test("settings hash maps ignore session differences for first sync checks", () => {
+	const local = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "sessions/--project--/local.jsonl", content: Buffer.from("local") },
+	]);
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("remote") },
+	]);
+
+	assert.deepEqual(settingsHashMap(local), settingsHashMap(remote));
+	const state = {
+		version: 1,
+		profile: "default",
+		lastAppliedSnapshot: "old",
+		lastFileHashes: Object.fromEntries(local.files.map((file) => [file.path, file.sha256])),
+	};
+	const config = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncSessions: false,
+	};
+
+	assert.equal(settingsHashesMatchState(remote, state), true);
+	assert.equal(hasRemoteChanges(remote, state, config), false);
+	assert.equal(hasRemoteChanges(remote, state, { ...config, syncSessions: true }), true);
+	assert.equal(
+		hasRemoteChanges(
+			snapshot([{ path: "settings.json", content: Buffer.from("changed") }]),
+			state,
+			config,
+		),
+		true,
+	);
+});
+
+test("first sync only auto-pulls remote files when local files are not at risk", () => {
+	const settings = { path: "settings.json", content: Buffer.from("settings") };
+	const appendSystem = { path: "APPEND_SYSTEM.md", content: Buffer.from("append") };
+	const changedSettings = { path: "settings.json", content: Buffer.from("changed") };
+	const remoteOnly = snapshot([
+		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("r") },
+	]);
+	const shared = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("same") };
+	const changed = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("changed") };
+
+	assert.equal(
+		canPullRemoteSettingsOnFirstSync(snapshot([settings]), snapshot([settings, appendSystem])),
+		true,
+	);
+	assert.equal(
+		canPullRemoteSettingsOnFirstSync(snapshot([settings]), snapshot([changedSettings])),
+		false,
+	);
+	assert.equal(
+		canPullRemoteSettingsOnFirstSync(snapshot([appendSystem]), snapshot([settings])),
+		false,
+	);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([]), remoteOnly), true);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), snapshot([shared])), true);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), remoteOnly), false);
+	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([changed]), snapshot([shared])), false);
+});
+
+test("snapshotWithoutSessions clears session opt-in even when no session files exist", () => {
+	const source = {
+		...snapshot([{ path: "settings.json", content: Buffer.from("{}") }]),
+		syncSessions: true,
+	};
+	const filtered = snapshotWithoutSessions(source);
+
+	assert.equal(filtered.syncSessions, false);
+	assert.notEqual(filtered.id, source.id);
+	assert.deepEqual(
+		filtered.files.map((file) => file.path),
+		["settings.json"],
+	);
+});
+
+test("protected session apply plans keep the live session file", () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-protect-"));
+	const live = path.join(root, "sessions", "--project--", "live.jsonl");
+	const old = path.join(root, "sessions", "--project--", "old.jsonl");
+	const plan = protectSnapshotApplyPlan(
+		root,
+		{
+			writes: [
+				{ target: live, content: Buffer.from("remote") },
+				{ target: path.join(root, "settings.json"), content: Buffer.from("{}") },
+			],
+			deletes: [live, old],
+		},
+		new Set(["sessions/--project--/live.jsonl"]),
+	);
+
+	assert.deepEqual(
+		plan.writes.map((item) => item.target),
+		[path.join(root, "settings.json")],
+	);
+	assert.deepEqual(plan.deletes, [old]);
+
+	const current = snapshot([
+		{ path: "sessions/--project--/live.jsonl", content: Buffer.from("local") },
+		{ path: "sessions/--project--/old.jsonl", content: Buffer.from("old") },
+	]);
+	const remote = snapshot([
+		{ path: "settings.json", content: Buffer.from("{}") },
+		{ path: "sessions/--project--/live.jsonl", content: Buffer.from("remote") },
+	]);
+	const hashes = appliedFileHashMap(remote, current, new Set(["sessions/--project--/live.jsonl"]));
+
+	assert.equal(
+		hashes["sessions/--project--/live.jsonl"],
+		current.files.find((file) => file.path === "sessions/--project--/live.jsonl")?.sha256,
+	);
+	assert.equal(
+		hashes["settings.json"],
+		remote.files.find((file) => file.path === "settings.json")?.sha256,
+	);
+	const config = {
+		...requiredConfig(),
+		region: "auto",
+		profile: "default",
+		prefix: "pi-sync",
+		syncSessions: true,
+	};
+	const protectedState = {
+		version: 1,
+		profile: "default",
+		lastAppliedSnapshot: remote.id,
+		lastFileHashes: hashes,
+		syncSessions: true,
+		extraFiles: [],
+	};
+	assert.equal(hasRemoteChanges(remote, protectedState, config), false);
+
+	const advancedRemote = { ...remote, id: "advanced" };
+	assert.equal(hasRemoteChanges(advancedRemote, protectedState, config), true);
+	assert.equal(
+		hasRemoteChanges(
+			advancedRemote,
+			protectedState,
+			config,
+			new Set(["sessions/--project--/live.jsonl"]),
+		),
+		false,
+	);
+});
+
+test("session backups include session jsonl files when enabled", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "sessions", "--project--"), { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), "{}\n");
+		writeFileSync(path.join(agentDir, "sessions", "--project--", "session.jsonl"), "{}\n");
+
+		const backupPath = await backupLocal("default", { syncSessions: true });
+		const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
+
+		assert.ok(
+			backup.files.some(
+				(file: { path: string }) => file.path === "sessions/--project--/session.jsonl",
+			),
+		);
+	});
+});
+
+test("snapshot backups expand a tilde-configured agent directory", async () => {
+	await withTempHome(async (defaultAgentDir) => {
+		const home = path.resolve(defaultAgentDir, "../../");
+		const tildeAgentDir = path.join(home, ".pi", "agent-tilde");
+		mkdirSync(tildeAgentDir, { recursive: true });
+		writeFileSync(path.join(tildeAgentDir, "settings.json"), '{"tilde":true}\n');
+
+		await withEnv({ PI_CODING_AGENT_DIR: "~/.pi/agent-tilde" }, async () => {
+			const backupPath = await backupLocal("tilde");
+			const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
+			assert.ok(backup.files.some((file: { path: string }) => file.path === "settings.json"));
+			assert.equal(backupPath.startsWith(tildeAgentDir), true);
+		});
+	});
+});
+
+test("session backups honor the configured session directory fallback", async () => {
+	await withTempHome(async (agentDir) => {
+		const sessionDir = path.join(path.dirname(agentDir), "custom-sessions");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(path.join(sessionDir, "--project--"), { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), `${JSON.stringify({ sessionDir })}\n`);
+		writeFileSync(path.join(sessionDir, "--project--", "configured.jsonl"), "{}\n");
+
+		const backupPath = await backupLocal("configured", { syncSessions: true });
+		const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
+		assert.ok(
+			backup.files.some(
+				(file: { path: string }) => file.path === "sessions/--project--/configured.jsonl",
+			),
+		);
+	});
+});
+
+test("security and configuration helpers detect secrets and R2 session-token warnings", () => {
+	const secret = Buffer.from("FIRECRAWL_API_KEY=sk-12345678901234567890");
+	assert.deepEqual(scanSnapshot(snapshot([{ path: "settings.json", content: secret }])), [
+		"settings.json",
+	]);
+	assert.equal(isCloudflareR2Endpoint("https://abc.r2.cloudflarestorage.com"), true);
+	assert.equal(isCloudflareR2Endpoint("https://s3.amazonaws.com"), false);
+	assert.equal(
+		sessionTokenWarnings({ endpoint: "https://abc.r2.cloudflarestorage.com", sessionToken: "x" })
+			.length,
+		1,
+	);
+	assert.equal(isEnabled("off", true), false);
+	assert.equal(isEnabled(undefined, true), true);
+	assert.equal(isExplicitlyEnabled("true"), true);
+	assert.equal(isExplicitlyEnabled("tru"), false);
+	assert.equal(isExplicitlyEnabled(""), false);
+});
+
+test("getJson retries on empty R2 response body and eventually succeeds", async () => {
+	const originalFetch = globalThis.fetch;
+	const responses = [
+		new Response("", { status: 200, headers: { etag: "w/empty1" } }),
+		new Response("", { status: 200, headers: { etag: "w/empty2" } }),
+		new Response(JSON.stringify({ snapshot: "snap-1", sha256: "abc" }), {
+			status: 200,
+			headers: { etag: "w/ok" },
+		}),
+	];
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		const response = responses[Math.min(calls, responses.length - 1)];
+		calls += 1;
+		return response;
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		const result = await client.getJson<{ snapshot: string; sha256: string }>("latest.json");
+		assert.equal(result.missing, false);
+		assert.equal(result.value?.snapshot, "snap-1");
+		assert.equal(result.etag, "w/ok");
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("getJson throws after retrying a persistently empty R2 response body", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls += 1;
+		return new Response("", { status: 200, headers: { etag: "w/empty" } });
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		await assert.rejects(client.getJson("latest.json"), /empty body/);
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("getJson does not retry a non-empty malformed response body", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls += 1;
+		return new Response("{", { status: 200, headers: { etag: "w/malformed" } });
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		await assert.rejects(client.getJson("latest.json"), SyntaxError);
+		assert.equal(calls, 1);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("getBuffer retries on empty R2 response body and eventually succeeds", async () => {
+	const originalFetch = globalThis.fetch;
+	const payload = Buffer.from("snapshot-payload");
+	const responses = [
+		new Response("", { status: 200, headers: { etag: "w/empty1" } }),
+		new Response("", { status: 200, headers: { etag: "w/empty2" } }),
+		new Response(new Uint8Array(payload), { status: 200, headers: { etag: "w/ok" } }),
+	];
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		const response = responses[Math.min(calls, responses.length - 1)];
+		calls += 1;
+		return response;
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		const result = await client.getBuffer("snapshots/snap-1.json.gz");
+		assert.equal(result.missing, false);
+		assert.deepEqual(result.value, payload);
+		assert.equal(result.etag, "w/ok");
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("getBuffer throws after retrying a persistently empty R2 response body", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls += 1;
+		return new Response("", { status: 200, headers: { etag: "w/empty" } });
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new S3Client({
+			...requiredConfig(),
+			region: "auto",
+			profile: "default",
+			prefix: "pi-sync",
+			syncSessions: false,
+		});
+		await assert.rejects(client.getBuffer("snapshots/snap-1.json.gz"), /empty body/);
+		assert.equal(calls, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("old unreadable locks require explicit stale unlock before recovery", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext();
+
+		for (const contents of ["", "{not valid json"]) {
+			writeOldLock(contents);
+			let ran = false;
+			await assert.rejects(
+				withLock("test", async () => {
+					ran = true;
+				}),
+				/unreadable/,
+			);
+			assert.equal(ran, false);
+			assert.equal(await lockFileExists(), true);
+
+			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
+			assert.equal(await lockFileExists(), false);
+			assert.equal(await withLock("test", async () => "ok"), "ok");
+		}
+	});
+});
+
+test("withLock never reclaims an aged lock that a legacy writer still owns", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		const legacyHandle = await fs.open(lockPath(), "wx");
+		const old = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath(), old, old);
+		let ran = false;
+		try {
+			await assert.rejects(
+				withLock("test", async () => {
+					ran = true;
+				}),
+				/unreadable/,
+			);
+			assert.equal(ran, false);
+
+			await legacyHandle.writeFile(
+				JSON.stringify({
+					id: "legacy",
+					pid: process.pid,
+					command: "sync",
+					startedAt: new Date().toISOString(),
+				}),
+			);
+			await assert.rejects(
+				withLock("test", async () => undefined),
+				/already running/,
+			);
+		} finally {
+			await legacyHandle.close();
+			await fs.rm(lockPath(), { force: true });
+		}
+	});
+});
+
+test("withLock does not reclaim a lock file that may still be initializing", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		let ran = false;
+		await assert.rejects(
+			withLock("test", async () => {
+				ran = true;
+			}),
+			/unreadable/,
+		);
+		assert.equal(ran, false);
+	});
+});
+
+test("unlock keeps a fresh unreadable lock unless stale removal is explicit", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("unlock", ctx);
+		assert.equal(await lockFileExists(), true);
+		assert.match(notifications.at(-1)?.message ?? "", /unreadable/);
+
+		await mock.commands.get("sync")?.handler("unlock --stale", ctx);
+		assert.equal(await lockFileExists(), false);
+		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable/);
+	});
+});
+
+test("stale unlock rechecks unreadable metadata before removing it", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "");
+		const originalReadFile = fs.readFile;
+		let lockReads = 0;
+		fs.readFile = (async (...args: Parameters<typeof fs.readFile>) => {
+			const result = await originalReadFile(...args);
+			if (args[0] === lockPath() && lockReads++ === 0) {
+				await fs.writeFile(
+					lockPath(),
+					JSON.stringify({
+						id: "legacy",
+						pid: process.pid,
+						command: "sync",
+						startedAt: new Date().toISOString(),
+					}),
+				);
+			}
+			return result;
+		}) as typeof fs.readFile;
+
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext();
+			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
+
+			assert.equal(await lockFileExists(), true);
+			assert.match(notifications.at(-1)?.message ?? "", /not stale|still live/);
+		} finally {
+			fs.readFile = originalReadFile;
+			await fs.rm(lockPath(), { force: true });
+		}
+	});
+});
+
+test("unlock cannot remove the lock for an active guarded sync", async () => {
+	await withTempHome(async () => {
+		let releaseRun: (() => void) | undefined;
+		const keepRunning = new Promise<void>((resolve) => {
+			releaseRun = resolve;
+		});
+		let markStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const running = withLock("test", async () => {
+			markStarted?.();
+			await keepRunning;
+		});
+		await started;
+
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+		try {
+			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
+			assert.equal(await lockFileExists(), true);
+			assert.match(notifications.at(-1)?.message ?? "", /currently running/);
+		} finally {
+			releaseRun?.();
+			await running;
+		}
+		assert.equal(await lockFileExists(), false);
+	});
+});
+
+test("unlock reports when a dead owner's guard is still expiring", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "dead-owner",
+				pid: 2_147_483_647,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		mkdirSync(`${lockPath()}.guard`);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("unlock --stale", ctx);
+		assert.equal(await lockFileExists(), true);
+		assert.match(notifications.at(-1)?.message ?? "", /owner exited.*guard expires/);
+	});
+});
+
+test("concurrent withLock calls never execute together", async () => {
+	await withTempHome(async () => {
+		let active = 0;
+		let maxActive = 0;
+		const run = () =>
+			withLock("test", async () => {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				active -= 1;
+			});
+
+		const results = await Promise.allSettled([run(), run()]);
+		assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+		assert.equal(maxActive, 1);
+	});
+});
+
+test("withLock rejects when a valid foreign lock is held", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "other",
+				pid: process.pid,
+				command: "push",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		await assert.rejects(
+			withLock("test", async () => "ok"),
+			/already running/,
+		);
+	});
+});
+
+test("readLock treats empty, whitespace, and corrupt lock files as absent", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		for (const contents of [
+			"",
+			"  \n  ",
+			"{broken",
+			"{}",
+			"[]",
+			"null",
+			"1",
+			JSON.stringify({
+				id: "invalid-pid",
+				pid: 2_147_483_648,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		]) {
+			writeFileSync(lockPath(), contents);
+			assert.equal(
+				await readLock(),
+				undefined,
+				`expected undefined for ${JSON.stringify(contents)}`,
+			);
+		}
+	});
+});
+
+test("doctor warns when lock metadata is unreadable", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{broken");
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: unreadable/);
+		assert.equal(notifications.at(-1)?.level, "warning");
+	});
+});
+
+test("doctor warns when a lock guard is active without metadata", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		mkdirSync(`${lockPath()}.guard`);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: guard active.*metadata/);
+		assert.equal(notifications.at(-1)?.level, "warning");
+	});
+});
+
+test("doctor warns when a valid lock owner has exited", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "dead-owner",
+				pid: 2_147_483_647,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: stale.*unlock/);
+		assert.equal(notifications.at(-1)?.level, "warning");
+	});
+});
+
+test("doctor reports live and free lock states", async () => {
+	await withTempHome(async () => {
+		await ensureStateDir();
+		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "live-owner",
+				pid: process.pid,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: held by pid/);
+		assert.equal(notifications.at(-1)?.level, "info");
+
+		await fs.rm(lockPath());
+		await mock.commands.get("sync")?.handler("doctor", ctx);
+		assert.match(notifications.at(-1)?.message ?? "", /lock: free/);
+		assert.equal(notifications.at(-1)?.level, "info");
+	});
+});
+
+test("malformed non-lock JSON remains an explicit error", async () => {
+	await withTempHome(async (agentDir) => {
+		await ensureStateDir();
+
+		writeFileSync(localConfigPath(), "{broken");
+		await assert.rejects(loadPartialConfig(), SyntaxError);
+
+		writeFileSync(path.join(agentDir, ".pisync", "default.state.json"), "{broken");
+		await assert.rejects(readState("default"), SyntaxError);
+
+		writeFileSync(path.join(agentDir, "settings.json"), "{broken");
+		await assert.rejects(configuredSessionDir(), SyntaxError);
+	});
+});

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -1,15 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import {
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	readdirSync,
-	readFileSync,
-	rmSync,
-	utimesSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -23,55 +14,28 @@ import {
 } from "../../../test/support.js";
 import {
 	SYNC_COMMANDS,
+	setSyncTargetCompletions,
 	syncCommandFromMenuOption,
 	syncMenuOptions,
 	usage,
 } from "../src/command.js";
-import {
-	configuredSessionDir,
-	ensureStateDir,
-	loadPartialConfig,
-	localConfigPath,
-	lockPath,
-	readLocalConfigObject,
-	readState,
-	updateLocalConfig,
-} from "../src/config.js";
-import { lockFileExists, readLock, withLock } from "../src/lock.js";
-import { S3Client } from "../src/s3-client.js";
-import { applySnapshot } from "../src/snapshot-apply.js";
+import { localConfigPath, readLocalConfigObject, updateLocalConfig } from "../src/config.js";
 import sync, {
-	addTopLevelCaseVariantDeletes,
-	appliedFileHashMap,
-	backupLocal,
-	canPullRemoteSessionsOnFirstSync,
-	canPullRemoteSettingsOnFirstSync,
 	collectFiles,
 	completeSyncArguments,
 	encodeKey,
-	filterSnapshotForConfigPolicy,
-	hasRemoteChanges,
-	isCloudflareR2Endpoint,
 	isDeniedPath,
-	isEnabled,
-	isExplicitlyEnabled,
 	loadConfig,
 	mergeRemotePreservedFiles,
-	mergeRemoteSessionFiles,
 	parseOptions,
 	posixJoin,
-	preflightSnapshotApply,
-	protectSnapshotApplyPlan,
 	safeJoin,
 	safeName,
-	scanSnapshot,
-	sessionTokenWarnings,
-	settingsHashesMatchState,
-	settingsHashMap,
-	snapshotWithoutSessions,
 	splitArgs,
 } from "../src/sync.js";
 import { DEFAULT_SYNC_FILES, normalizeSyncFiles } from "../src/sync-policy.js";
+
+import { requiredConfig, snapshot, withEnv, withTempHome } from "./helpers.js";
 
 initTheme("dark", false);
 
@@ -103,6 +67,7 @@ test("sync command help and errors use the public command name", async () => {
 
 const expectedSyncMenuOptions = [
 	"help — Show command usage",
+	"use — Switch the current sync target",
 	"init — Create local config template",
 	"config — Show resolved configuration",
 	"files — Choose synced files",
@@ -117,7 +82,7 @@ const expectedSyncMenuOptions = [
 	"unlock — Remove a stale local lock",
 ];
 
-test("bare sync command opens an all-subcommand menu and cancellation is a no-op", async () => {
+test("bare sync command opens a goal-oriented empty-state menu and cancellation is a no-op", async () => {
 	await withTempHome(async (agentDir) => {
 		const mock = createMockPi();
 		sync(mock.pi);
@@ -134,8 +99,8 @@ test("bare sync command opens an all-subcommand menu and cancellation is a no-op
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.equal(selectedTitle, "pi-sync");
-		assert.deepEqual(selectedOptions, expectedSyncMenuOptions);
+		assert.match(selectedTitle ?? "", /Not set up/);
+		assert.deepEqual(selectedOptions, ["Set up sync", "Help"]);
 		assert.deepEqual(notifications, []);
 		assert.equal(statuses.size, 0);
 		assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
@@ -154,13 +119,13 @@ test("sync menu options map one-to-one to the canonical command catalog", () => 
 	}
 });
 
-test("sync menu dispatches its selected subcommand through the public command path", async () => {
+test("sync menu dispatches help through the public command path", async () => {
 	await withTempHome(async () => {
 		const mock = createMockPi();
 		sync(mock.pi);
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
-			select: async () => expectedSyncMenuOptions[0],
+			select: async () => "Help",
 		});
 
 		await mock.commands.get("sync")?.handler("", ctx);
@@ -204,6 +169,7 @@ test("sync files persists SettingsList choices and safe extra-file candidates", 
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
+			select: async () => "Save changes",
 			custom: async (factory: unknown) => {
 				const selector = createCustomSelectorHarness(factory);
 				initialRender = selector.render().join("\n");
@@ -239,6 +205,7 @@ test("the first file-selection change creates the complete config template", asy
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
+			select: async () => "Save changes",
 			custom: async (factory: unknown) => {
 				const selector = createCustomSelectorHarness(factory);
 				selector.handleInput("\r");
@@ -249,17 +216,20 @@ test("the first file-selection change creates the complete config template", asy
 
 		await mock.commands.get("sync")?.handler("files", ctx);
 		const saved = await readLocalConfigObject();
-		assert.equal(saved?.endpoint, "https://<account-id>.r2.cloudflarestorage.com");
-		assert.equal(saved?.autoSync, true);
+		const profile = (saved?.profiles as Record<string, Record<string, unknown>> | undefined)
+			?.default;
+		const target = (saved?.targets as Record<string, Record<string, unknown>> | undefined)?.default;
+		assert.equal(profile?.endpoint, "https://<account-id>.r2.cloudflarestorage.com");
+		assert.equal(target?.autoSync, true);
 		assert.deepEqual(
-			saved?.syncFiles,
+			target?.syncFiles,
 			DEFAULT_SYNC_FILES.filter((item) => item !== "settings.json"),
 		);
-		assert.deepEqual(saved?.extraFiles, []);
+		assert.deepEqual(target?.extraFiles, []);
 	});
 });
 
-test("sync files serializes rapid changes in user action order", async () => {
+test("sync files leaves settings unchanged when draft toggles cancel each other", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
@@ -278,7 +248,7 @@ test("sync files serializes rapid changes in user action order", async () => {
 		});
 
 		await mock.commands.get("sync")?.handler("files", ctx);
-		assert.deepEqual((await readLocalConfigObject())?.syncFiles, [...DEFAULT_SYNC_FILES]);
+		assert.equal((await readLocalConfigObject())?.syncFiles, undefined);
 	});
 });
 
@@ -304,7 +274,7 @@ test("sync files keeps environment-overridden sessions read-only", async () => {
 			});
 
 			await mock.commands.get("sync")?.handler("files", ctx);
-			assert.match(sessionRender, /included \(environment\)/);
+			assert.match(sessionRender, /included \(environment, deprecated\)/);
 			assert.equal((await readLocalConfigObject())?.syncSessions, false);
 		});
 	});
@@ -358,7 +328,7 @@ test("local config updates preserve unknown fields and reject malformed or symli
 	});
 });
 
-test("sync files rolls back the active row when atomic publication fails", async () => {
+test("sync files keeps prior settings when atomic publication fails", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
@@ -372,15 +342,10 @@ test("sync files rolls back the active row when atomic publication fails", async
 			const context = createMockContext({
 				hasUI: true,
 				mode: "tui",
+				select: async () => "Save changes",
 				custom: async (factory: unknown) => {
 					const selector = createCustomSelectorHarness(factory);
 					selector.handleInput("\r");
-					await waitFor(() => context.notifications.length > 0);
-					assert.ok(
-						selector
-							.render()
-							.some((line) => line.includes("settings.json") && line.includes("included")),
-					);
 					selector.handleInput("\u001b");
 					return selector.result;
 				},
@@ -395,50 +360,62 @@ test("sync files rolls back the active row when atomic publication fails", async
 	});
 });
 
-test("sync rollback menu requests a snapshot id and cancels empty input", async () => {
+test("sync files discard leaves the config byte-for-byte unchanged", async () => {
 	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const original = `${JSON.stringify({ ...requiredConfig(), future: true }, null, "\t")}\n`;
+		writeFileSync(localConfigPath(), original);
 		const mock = createMockPi();
 		sync(mock.pi);
-		let inputCalls = 0;
-		const { ctx, notifications } = createMockContext({
+		const { ctx } = createMockContext({
 			hasUI: true,
-			select: async () => expectedSyncMenuOptions[11],
-			input: async () => {
-				inputCalls += 1;
-				return "  ";
+			mode: "tui",
+			select: async () => "Discard changes",
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory);
+				selector.handleInput("\r");
+				selector.handleInput("\u001b");
+				return selector.result;
 			},
 		});
 
-		await mock.commands.get("sync")?.handler("", ctx);
-
-		assert.equal(inputCalls, 1);
-		assert.match(notifications[0]?.message ?? "", /Rollback cancelled/);
-		assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
+		await mock.commands.get("sync")?.handler("files", ctx);
+		assert.equal(readFileSync(localConfigPath(), "utf8"), original);
 	});
 });
 
-test("sync rollback menu passes a provided snapshot id to rollback", async () => {
+test("sync rollback direct route requires a snapshot id", async () => {
 	await withTempHome(async () => {
 		const mock = createMockPi();
 		sync(mock.pi);
-		const { ctx, notifications } = createMockContext({
-			hasUI: true,
-			select: async () => expectedSyncMenuOptions[11],
-			input: async () => "snapshot-id",
-		});
+		const { ctx, notifications } = createMockContext();
 
-		await mock.commands.get("sync")?.handler("", ctx);
+		await mock.commands.get("sync")?.handler("rollback", ctx);
+
+		assert.match(notifications[0]?.message ?? "", /Usage: \/sync rollback/);
+	});
+});
+
+test("sync rollback direct route passes a provided snapshot id to rollback", async () => {
+	await withTempHome(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+
+		await mock.commands.get("sync")?.handler("rollback snapshot-id", ctx);
 
 		assert.match(notifications[0]?.message ?? "", /Missing pi-sync config/);
 		assert.doesNotMatch(notifications[0]?.message ?? "", /Usage: \/sync rollback/);
 	});
 });
 
-test("completeSyncArguments suggests commands and useful flags", () => {
+test("completeSyncArguments suggests commands, targets, and useful flags", () => {
+	setSyncTargetCompletions(["work", "home"]);
 	assert.deepEqual(
 		completeSyncArguments("")?.map((item) => item.label),
 		[
 			"help",
+			"use",
 			"init",
 			"config",
 			"files",
@@ -459,7 +436,7 @@ test("completeSyncArguments suggests commands and useful flags", () => {
 	);
 	assert.deepEqual(
 		completeSyncArguments("push ")?.map((item) => item.value),
-		["push --yes", "push -y", "push --force"],
+		["push --yes", "push -y", "push --force", "push --target"],
 	);
 	assert.deepEqual(
 		completeSyncArguments("pull --f")?.map((item) => item.value),
@@ -467,7 +444,7 @@ test("completeSyncArguments suggests commands and useful flags", () => {
 	);
 	assert.deepEqual(
 		completeSyncArguments("sync -")?.map((item) => item.value),
-		["sync --yes", "sync -y", "sync --force"],
+		["sync --yes", "sync -y", "sync --force", "sync --target"],
 	);
 	assert.deepEqual(
 		completeSyncArguments("push --yes --f")?.map((item) => item.value),
@@ -481,7 +458,18 @@ test("completeSyncArguments suggests commands and useful flags", () => {
 		completeSyncArguments("unlock --s")?.map((item) => item.value),
 		["unlock --stale"],
 	);
-	assert.equal(completeSyncArguments("status "), null);
+	assert.deepEqual(
+		completeSyncArguments("use w")?.map((item) => item.value),
+		["use work"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("status --target h")?.map((item) => item.value),
+		["status --target home"],
+	);
+	assert.deepEqual(
+		completeSyncArguments("status ")?.map((item) => item.value),
+		["status --target"],
+	);
 	assert.equal(completeSyncArguments("push snapshot"), null);
 	assert.equal(completeSyncArguments("wat"), null);
 });
@@ -622,7 +610,7 @@ test("forced pushes preserve remote files outside this machine's selection", asy
 			await mock.commands.get("sync")?.handler("push --yes --force", ctx);
 
 			assert.deepEqual(statusUpdates, [
-				["sync", "pushing"],
+				["sync", "pushing default"],
 				["sync", undefined],
 			]);
 			assert.ok(uploadedBody, JSON.stringify(notifications));
@@ -787,1176 +775,3 @@ test("path and key helpers normalize safe names and reject escapes", () => {
 	assert.equal(posixJoin("/prefix/", "profile", "/latest.json"), "prefix/profile/latest.json");
 	assert.equal(safeName("team/prod"), "team_prod");
 });
-
-test("snapshot collection includes session jsonl files only when enabled", async () => {
-	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-"));
-	mkdirSync(path.join(root, "skills"), { recursive: true });
-	mkdirSync(path.join(root, "sessions", "--project--"), { recursive: true });
-	mkdirSync(path.join(root, "sessions", "token-project"), { recursive: true });
-	writeFileSync(path.join(root, "APPEND_SYSTEM.md"), "append\n");
-	writeFileSync(path.join(root, "LOCAL.md"), "local\n");
-	writeFileSync(path.join(root, "local-case.md"), "local case\n");
-	writeFileSync(path.join(root, "settings.json"), "{}\n");
-	writeFileSync(path.join(root, "skills", "demo.md"), "demo\n");
-	if (path.sep === "/") writeFileSync(path.join(root, "skills", "foo\\bar.md"), "skip\n");
-	writeFileSync(path.join(root, "sessions", "--project--", "session.jsonl"), "{}\n");
-	writeFileSync(path.join(root, "sessions", "--project--", "notes.txt"), "skip\n");
-	writeFileSync(path.join(root, "sessions", "token-project", "session.jsonl"), "skip\n");
-	const customSessionDir = mkdtempSync(path.join(os.tmpdir(), "pi-sync-sessions-"));
-	writeFileSync(path.join(customSessionDir, "custom.jsonl"), "{}\n");
-
-	assert.deepEqual(
-		(await collectFiles(root)).map((file) => file.path),
-		["APPEND_SYSTEM.md", "settings.json", "skills/demo.md"],
-	);
-	const caseRoot = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-case-"));
-	writeFileSync(path.join(caseRoot, "append_system.md"), "append\n");
-	assert.deepEqual(
-		(await collectFiles(caseRoot)).map((file) => file.path),
-		["APPEND_SYSTEM.md"],
-	);
-	assert.deepEqual(
-		(await collectFiles(root, { extraFiles: ["LOCAL.md"] })).map((file) => file.path),
-		["APPEND_SYSTEM.md", "LOCAL.md", "settings.json", "skills/demo.md"],
-	);
-	assert.deepEqual(
-		(await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] })).map((file) => file.path),
-		["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
-	);
-	writeFileSync(path.join(root, "LOCAL-CASE.md"), "local exact case\n");
-	if (readdirSync(root).includes("LOCAL-CASE.md")) {
-		const exactCaseFiles = await collectFiles(root, { extraFiles: ["LOCAL-CASE.md"] });
-		assert.deepEqual(
-			exactCaseFiles.map((file) => file.path),
-			["APPEND_SYSTEM.md", "LOCAL-CASE.md", "settings.json", "skills/demo.md"],
-		);
-		assert.equal(
-			Buffer.from(
-				exactCaseFiles.find((file) => file.path === "LOCAL-CASE.md")?.contentBase64 ?? "",
-				"base64",
-			).toString("utf8"),
-			"local exact case\n",
-		);
-	}
-	assert.deepEqual(
-		(await collectFiles(root, { syncSessions: true })).map((file) => file.path),
-		["APPEND_SYSTEM.md", "sessions/--project--/session.jsonl", "settings.json", "skills/demo.md"],
-	);
-	assert.deepEqual(
-		(await collectFiles(root, { syncSessions: true, sessionDir: customSessionDir })).map(
-			(file) => file.path,
-		),
-		["APPEND_SYSTEM.md", "sessions/custom.jsonl", "settings.json", "skills/demo.md"],
-	);
-	const nestedSessionDir = path.join(root, "sessions", "work");
-	mkdirSync(nestedSessionDir, { recursive: true });
-	writeFileSync(path.join(nestedSessionDir, "nested.jsonl"), "{}\n");
-	assert.deepEqual(
-		(await collectFiles(root, { syncSessions: true, sessionDir: nestedSessionDir })).map(
-			(file) => file.path,
-		),
-		["APPEND_SYSTEM.md", "sessions/nested.jsonl", "settings.json", "skills/demo.md"],
-	);
-});
-
-test("snapshot preflight validates checksums, duplicate session paths, and deletes stale files", () => {
-	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-"));
-	const content = Buffer.from("hello");
-	const remote = snapshot([{ path: "settings.json", content }]);
-	const current = snapshot([
-		{ path: "settings.json", content },
-		{ path: "sessions/--project--/old.jsonl", content: Buffer.from("old") },
-	]);
-
-	const plan = preflightSnapshotApply(root, remote, current);
-	assert.deepEqual(
-		plan.writes.map((item) => item.target),
-		[path.join(root, "settings.json")],
-	);
-	assert.deepEqual(plan.deletes, [path.join(root, "sessions", "--project--", "old.jsonl")]);
-	assert.throws(
-		() => preflightSnapshotApply(root, snapshot([{ path: "../bad", content }]), current),
-		/Unsafe path/,
-	);
-	assert.throws(
-		() => preflightSnapshotApply(root, snapshot([{ path: ".", content }]), current),
-		/Unsafe path/,
-	);
-	assert.throws(
-		() => preflightSnapshotApply(root, snapshot([{ path: "..", content }]), current),
-		/Unsafe path/,
-	);
-	assert.throws(
-		() =>
-			preflightSnapshotApply(root, snapshot([{ path: "sessions\\bad.jsonl", content }]), current),
-		/Unsafe path/,
-	);
-	assert.throws(
-		() =>
-			preflightSnapshotApply(
-				root,
-				snapshot([{ path: "sessions/../settings.json", content }]),
-				current,
-			),
-		/Unsafe path/,
-	);
-	assert.throws(
-		() => preflightSnapshotApply(root, snapshot([{ path: ".env", content }]), current),
-		/Unsafe path/,
-	);
-	const sessionSnapshot = snapshot([{ path: "sessions/--project--/session.jsonl", content }]);
-	const customSessionDir = mkdtempSync(path.join(os.tmpdir(), "pi-sync-session-apply-"));
-	assert.deepEqual(
-		preflightSnapshotApply(root, sessionSnapshot, snapshot([]), {
-			sessionDir: customSessionDir,
-		}).writes.map((item) => item.target),
-		[path.join(customSessionDir, "--project--", "session.jsonl")],
-	);
-	assert.throws(
-		() =>
-			preflightSnapshotApply(
-				root,
-				{ ...sessionSnapshot, files: [sessionSnapshot.files[0], sessionSnapshot.files[0]] },
-				current,
-			),
-		/Duplicate path/,
-	);
-	assert.throws(
-		() =>
-			preflightSnapshotApply(
-				root,
-				{
-					...sessionSnapshot,
-					files: [{ ...sessionSnapshot.files[0], sha256: "bad" }],
-				},
-				current,
-			),
-		/Checksum mismatch/,
-	);
-	assert.throws(
-		() =>
-			preflightSnapshotApply(
-				root,
-				snapshot([{ path: "sessions/--project--/notes.txt", content }]),
-				current,
-			),
-		/Unsafe session path/,
-	);
-});
-
-test("snapshot apply leaves unselected local files and directories untouched", async () => {
-	await withTempHome(async (agentDir) => {
-		mkdirSync(path.join(agentDir, "skills"), { recursive: true });
-		writeFileSync(path.join(agentDir, "keybindings.json"), "local keys\n");
-		writeFileSync(path.join(agentDir, "skills", "local.md"), "local skill\n");
-		const remote = snapshot([{ path: "settings.json", content: Buffer.from("remote settings\n") }]);
-
-		await applySnapshot(remote, new Set(), {
-			syncFiles: ["settings.json"],
-			extraFiles: [],
-		});
-
-		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), "remote settings\n");
-		assert.equal(readFileSync(path.join(agentDir, "keybindings.json"), "utf8"), "local keys\n");
-		assert.equal(readFileSync(path.join(agentDir, "skills", "local.md"), "utf8"), "local skill\n");
-	});
-});
-
-test("snapshot apply deletes stale top-level case variants", async () => {
-	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-"));
-	writeFileSync(path.join(root, "append_system.md"), "old\n");
-	const remote = snapshot([{ path: "APPEND_SYSTEM.md", content: Buffer.from("new\n") }]);
-	const current = snapshot([{ path: "APPEND_SYSTEM.md", content: Buffer.from("old\n") }]);
-	const plan = preflightSnapshotApply(root, remote, current);
-	assert.deepEqual(plan.deletes, []);
-
-	const withCaseDeletes = await addTopLevelCaseVariantDeletes(root, plan, remote);
-	assert.deepEqual(withCaseDeletes.deletes, [path.join(root, "append_system.md")]);
-
-	const directoryRoot = mkdtempSync(path.join(os.tmpdir(), "pi-sync-apply-case-dir-"));
-	mkdirSync(path.join(directoryRoot, "append_system.md"));
-	const directoryPlan = preflightSnapshotApply(directoryRoot, remote, current);
-	const withoutDirectoryDelete = await addTopLevelCaseVariantDeletes(
-		directoryRoot,
-		directoryPlan,
-		remote,
-	);
-	assert.deepEqual(withoutDirectoryDelete.deletes, []);
-});
-
-test("unconfigured extra top-level files are filtered locally and preserved on upload", () => {
-	const settings = { path: "settings.json", content: Buffer.from("settings") };
-	const custom = { path: "LOCAL.md", content: Buffer.from("custom") };
-	const configured = { path: "CONFIGURED.md", content: Buffer.from("configured") };
-	const session = { path: "sessions/--project--/session.jsonl", content: Buffer.from("session") };
-	const unsafeSession = { path: "sessions/../evil.jsonl", content: Buffer.from("evil") };
-	const reservedExtra = { path: "skills", content: Buffer.from("reserved") };
-	const builtInCaseExtra = { path: "Settings.json", content: Buffer.from("duplicate") };
-	const remote = {
-		...snapshot([
-			custom,
-			configured,
-			session,
-			unsafeSession,
-			reservedExtra,
-			builtInCaseExtra,
-			settings,
-		]),
-		syncSessions: true,
-	};
-	const config = {
-		...requiredConfig(),
-		region: "auto",
-		profile: "default",
-		prefix: "pi-sync",
-		syncSessions: false,
-		extraFiles: ["CONFIGURED.md"],
-	};
-
-	const filtered = filterSnapshotForConfigPolicy(remote, config);
-	assert.deepEqual(filtered.files.map((file) => file.path).sort(), [
-		"CONFIGURED.md",
-		"settings.json",
-	]);
-	assert.deepEqual(
-		filterSnapshotForConfigPolicy(
-			snapshot([{ path: "append_system.md", content: Buffer.from("append") }]),
-			config,
-		).files.map((file) => file.path),
-		["APPEND_SYSTEM.md"],
-	);
-	assert.notEqual(
-		filterSnapshotForConfigPolicy(remote, config, { regenerateId: true }).id,
-		remote.id,
-	);
-	assert.deepEqual(
-		filterSnapshotForConfigPolicy(remote, { ...config, syncSessions: true })
-			.files.map((file) => file.path)
-			.sort(),
-		["CONFIGURED.md", "sessions/--project--/session.jsonl", "settings.json"],
-	);
-	const lowerCaseRemoteExtra = filterSnapshotForConfigPolicy(
-		snapshot([{ path: "local.md", content: Buffer.from("local") }]),
-		{
-			...config,
-			extraFiles: ["LOCAL.md"],
-		},
-	);
-	assert.deepEqual(
-		lowerCaseRemoteExtra.files.map((file) => file.path),
-		["LOCAL.md"],
-	);
-	assert.equal(
-		hasRemoteChanges(
-			lowerCaseRemoteExtra,
-			{
-				version: 1,
-				profile: "default",
-				lastAppliedSnapshot: lowerCaseRemoteExtra.id,
-				lastFileHashes: Object.fromEntries(
-					snapshot([{ path: "local.md", content: Buffer.from("local") }]).files.map((file) => [
-						file.path,
-						file.sha256,
-					]),
-				),
-				extraFiles: ["LOCAL.md"],
-			},
-			{ ...config, extraFiles: ["LOCAL.md"] },
-		),
-		false,
-	);
-	assert.deepEqual(
-		mergeRemotePreservedFiles(snapshot([settings]), remote, config).files.map((file) => file.path),
-		["LOCAL.md", "sessions/--project--/session.jsonl", "settings.json"],
-	);
-	assert.deepEqual(
-		mergeRemotePreservedFiles(snapshot([settings]), remote, {
-			...config,
-			extraFiles: ["CONFIGURED.md", "LOCAL.md"],
-		}).files.map((file) => file.path),
-		["sessions/--project--/session.jsonl", "settings.json"],
-	);
-	assert.deepEqual(
-		mergeRemotePreservedFiles(
-			snapshot([settings, { path: "local.md", content: Buffer.from("local") }]),
-			remote,
-			config,
-		).files.map((file) => file.path),
-		["local.md", "sessions/--project--/session.jsonl", "settings.json"],
-	);
-	assert.equal(
-		hasRemoteChanges(
-			filtered,
-			{
-				version: 1,
-				profile: "default",
-				lastAppliedSnapshot: remote.id,
-				lastFileHashes: Object.fromEntries(
-					snapshot([settings]).files.map((file) => [file.path, file.sha256]),
-				),
-				extraFiles: [],
-			},
-			config,
-		),
-		true,
-	);
-});
-
-test("settings-only uploads preserve remote session files", () => {
-	const settings = { path: "settings.json", content: Buffer.from("local") };
-	const remoteSession = {
-		path: "sessions/--project--/session.jsonl",
-		content: Buffer.from("remote"),
-	};
-	const invalidSession = {
-		path: "sessions/--project--/notes.txt",
-		content: Buffer.from("skip"),
-	};
-	const deniedSession = {
-		path: "sessions/--project--/token.jsonl",
-		content: Buffer.from("skip"),
-	};
-	const local = snapshot([settings]);
-
-	const merged = mergeRemoteSessionFiles(
-		local,
-		snapshot([remoteSession, invalidSession, deniedSession]),
-	);
-
-	assert.notEqual(merged.id, local.id);
-	assert.deepEqual(
-		merged.files.map((file) => file.path),
-		["sessions/--project--/session.jsonl", "settings.json"],
-	);
-	assert.equal(merged.syncSessions, true);
-
-	const emptySessionSet = mergeRemoteSessionFiles(local, { ...snapshot([]), syncSessions: true });
-	assert.notEqual(emptySessionSet.id, local.id);
-	assert.deepEqual(
-		emptySessionSet.files.map((file) => file.path),
-		["settings.json"],
-	);
-	assert.equal(emptySessionSet.syncSessions, true);
-});
-
-test("sync state tracks selection-policy changes without treating deselection as remote deletion", () => {
-	const remote = snapshot([
-		{ path: "settings.json", content: Buffer.from("settings") },
-		{ path: "keybindings.json", content: Buffer.from("keys") },
-	]);
-	const selectedSettings = {
-		...requiredConfig(),
-		region: "auto",
-		profile: "default",
-		prefix: "pi-sync",
-		syncFiles: ["settings.json"],
-		syncSessions: false,
-		extraFiles: [],
-	};
-	const legacyState = {
-		version: 1,
-		profile: "default",
-		lastAppliedSnapshot: remote.id,
-		lastFileHashes: Object.fromEntries(remote.files.map((file) => [file.path, file.sha256])),
-	};
-	assert.equal(hasRemoteChanges(remote, legacyState, selectedSettings), false);
-
-	const previouslyEmptyState = {
-		...legacyState,
-		lastFileHashes: {},
-		syncFiles: [],
-	};
-	assert.equal(hasRemoteChanges(remote, previouslyEmptyState, selectedSettings), true);
-});
-
-test("settings hash maps ignore session differences for first sync checks", () => {
-	const local = snapshot([
-		{ path: "settings.json", content: Buffer.from("settings") },
-		{ path: "sessions/--project--/local.jsonl", content: Buffer.from("local") },
-	]);
-	const remote = snapshot([
-		{ path: "settings.json", content: Buffer.from("settings") },
-		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("remote") },
-	]);
-
-	assert.deepEqual(settingsHashMap(local), settingsHashMap(remote));
-	const state = {
-		version: 1,
-		profile: "default",
-		lastAppliedSnapshot: "old",
-		lastFileHashes: Object.fromEntries(local.files.map((file) => [file.path, file.sha256])),
-	};
-	const config = {
-		...requiredConfig(),
-		region: "auto",
-		profile: "default",
-		prefix: "pi-sync",
-		syncSessions: false,
-	};
-
-	assert.equal(settingsHashesMatchState(remote, state), true);
-	assert.equal(hasRemoteChanges(remote, state, config), false);
-	assert.equal(hasRemoteChanges(remote, state, { ...config, syncSessions: true }), true);
-	assert.equal(
-		hasRemoteChanges(
-			snapshot([{ path: "settings.json", content: Buffer.from("changed") }]),
-			state,
-			config,
-		),
-		true,
-	);
-});
-
-test("first sync only auto-pulls remote files when local files are not at risk", () => {
-	const settings = { path: "settings.json", content: Buffer.from("settings") };
-	const appendSystem = { path: "APPEND_SYSTEM.md", content: Buffer.from("append") };
-	const changedSettings = { path: "settings.json", content: Buffer.from("changed") };
-	const remoteOnly = snapshot([
-		{ path: "sessions/--project--/remote.jsonl", content: Buffer.from("r") },
-	]);
-	const shared = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("same") };
-	const changed = { path: "sessions/--project--/shared.jsonl", content: Buffer.from("changed") };
-
-	assert.equal(
-		canPullRemoteSettingsOnFirstSync(snapshot([settings]), snapshot([settings, appendSystem])),
-		true,
-	);
-	assert.equal(
-		canPullRemoteSettingsOnFirstSync(snapshot([settings]), snapshot([changedSettings])),
-		false,
-	);
-	assert.equal(
-		canPullRemoteSettingsOnFirstSync(snapshot([appendSystem]), snapshot([settings])),
-		false,
-	);
-	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([]), remoteOnly), true);
-	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), snapshot([shared])), true);
-	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([shared]), remoteOnly), false);
-	assert.equal(canPullRemoteSessionsOnFirstSync(snapshot([changed]), snapshot([shared])), false);
-});
-
-test("snapshotWithoutSessions clears session opt-in even when no session files exist", () => {
-	const source = {
-		...snapshot([{ path: "settings.json", content: Buffer.from("{}") }]),
-		syncSessions: true,
-	};
-	const filtered = snapshotWithoutSessions(source);
-
-	assert.equal(filtered.syncSessions, false);
-	assert.notEqual(filtered.id, source.id);
-	assert.deepEqual(
-		filtered.files.map((file) => file.path),
-		["settings.json"],
-	);
-});
-
-test("protected session apply plans keep the live session file", () => {
-	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-protect-"));
-	const live = path.join(root, "sessions", "--project--", "live.jsonl");
-	const old = path.join(root, "sessions", "--project--", "old.jsonl");
-	const plan = protectSnapshotApplyPlan(
-		root,
-		{
-			writes: [
-				{ target: live, content: Buffer.from("remote") },
-				{ target: path.join(root, "settings.json"), content: Buffer.from("{}") },
-			],
-			deletes: [live, old],
-		},
-		new Set(["sessions/--project--/live.jsonl"]),
-	);
-
-	assert.deepEqual(
-		plan.writes.map((item) => item.target),
-		[path.join(root, "settings.json")],
-	);
-	assert.deepEqual(plan.deletes, [old]);
-
-	const current = snapshot([
-		{ path: "sessions/--project--/live.jsonl", content: Buffer.from("local") },
-		{ path: "sessions/--project--/old.jsonl", content: Buffer.from("old") },
-	]);
-	const remote = snapshot([
-		{ path: "settings.json", content: Buffer.from("{}") },
-		{ path: "sessions/--project--/live.jsonl", content: Buffer.from("remote") },
-	]);
-	const hashes = appliedFileHashMap(remote, current, new Set(["sessions/--project--/live.jsonl"]));
-
-	assert.equal(
-		hashes["sessions/--project--/live.jsonl"],
-		current.files.find((file) => file.path === "sessions/--project--/live.jsonl")?.sha256,
-	);
-	assert.equal(
-		hashes["settings.json"],
-		remote.files.find((file) => file.path === "settings.json")?.sha256,
-	);
-	const config = {
-		...requiredConfig(),
-		region: "auto",
-		profile: "default",
-		prefix: "pi-sync",
-		syncSessions: true,
-	};
-	const protectedState = {
-		version: 1,
-		profile: "default",
-		lastAppliedSnapshot: remote.id,
-		lastFileHashes: hashes,
-		syncSessions: true,
-		extraFiles: [],
-	};
-	assert.equal(hasRemoteChanges(remote, protectedState, config), false);
-
-	const advancedRemote = { ...remote, id: "advanced" };
-	assert.equal(hasRemoteChanges(advancedRemote, protectedState, config), true);
-	assert.equal(
-		hasRemoteChanges(
-			advancedRemote,
-			protectedState,
-			config,
-			new Set(["sessions/--project--/live.jsonl"]),
-		),
-		false,
-	);
-});
-
-test("session backups include session jsonl files when enabled", async () => {
-	await withTempHome(async (agentDir) => {
-		mkdirSync(path.join(agentDir, "sessions", "--project--"), { recursive: true });
-		writeFileSync(path.join(agentDir, "settings.json"), "{}\n");
-		writeFileSync(path.join(agentDir, "sessions", "--project--", "session.jsonl"), "{}\n");
-
-		const backupPath = await backupLocal("default", { syncSessions: true });
-		const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
-
-		assert.ok(
-			backup.files.some(
-				(file: { path: string }) => file.path === "sessions/--project--/session.jsonl",
-			),
-		);
-	});
-});
-
-test("snapshot backups expand a tilde-configured agent directory", async () => {
-	await withTempHome(async (defaultAgentDir) => {
-		const home = path.resolve(defaultAgentDir, "../../");
-		const tildeAgentDir = path.join(home, ".pi", "agent-tilde");
-		mkdirSync(tildeAgentDir, { recursive: true });
-		writeFileSync(path.join(tildeAgentDir, "settings.json"), '{"tilde":true}\n');
-
-		await withEnv({ PI_CODING_AGENT_DIR: "~/.pi/agent-tilde" }, async () => {
-			const backupPath = await backupLocal("tilde");
-			const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
-			assert.ok(backup.files.some((file: { path: string }) => file.path === "settings.json"));
-			assert.equal(backupPath.startsWith(tildeAgentDir), true);
-		});
-	});
-});
-
-test("session backups honor the configured session directory fallback", async () => {
-	await withTempHome(async (agentDir) => {
-		const sessionDir = path.join(path.dirname(agentDir), "custom-sessions");
-		mkdirSync(agentDir, { recursive: true });
-		mkdirSync(path.join(sessionDir, "--project--"), { recursive: true });
-		writeFileSync(path.join(agentDir, "settings.json"), `${JSON.stringify({ sessionDir })}\n`);
-		writeFileSync(path.join(sessionDir, "--project--", "configured.jsonl"), "{}\n");
-
-		const backupPath = await backupLocal("configured", { syncSessions: true });
-		const backup = JSON.parse(gunzipSync(readFileSync(backupPath)).toString("utf8"));
-		assert.ok(
-			backup.files.some(
-				(file: { path: string }) => file.path === "sessions/--project--/configured.jsonl",
-			),
-		);
-	});
-});
-
-test("security and configuration helpers detect secrets and R2 session-token warnings", () => {
-	const secret = Buffer.from("FIRECRAWL_API_KEY=sk-12345678901234567890");
-	assert.deepEqual(scanSnapshot(snapshot([{ path: "settings.json", content: secret }])), [
-		"settings.json",
-	]);
-	assert.equal(isCloudflareR2Endpoint("https://abc.r2.cloudflarestorage.com"), true);
-	assert.equal(isCloudflareR2Endpoint("https://s3.amazonaws.com"), false);
-	assert.equal(
-		sessionTokenWarnings({ endpoint: "https://abc.r2.cloudflarestorage.com", sessionToken: "x" })
-			.length,
-		1,
-	);
-	assert.equal(isEnabled("off", true), false);
-	assert.equal(isEnabled(undefined, true), true);
-	assert.equal(isExplicitlyEnabled("true"), true);
-	assert.equal(isExplicitlyEnabled("tru"), false);
-	assert.equal(isExplicitlyEnabled(""), false);
-});
-
-test("getJson retries on empty R2 response body and eventually succeeds", async () => {
-	const originalFetch = globalThis.fetch;
-	const responses = [
-		new Response("", { status: 200, headers: { etag: "w/empty1" } }),
-		new Response("", { status: 200, headers: { etag: "w/empty2" } }),
-		new Response(JSON.stringify({ snapshot: "snap-1", sha256: "abc" }), {
-			status: 200,
-			headers: { etag: "w/ok" },
-		}),
-	];
-	let calls = 0;
-	globalThis.fetch = (async () => {
-		const response = responses[Math.min(calls, responses.length - 1)];
-		calls += 1;
-		return response;
-	}) as typeof globalThis.fetch;
-	try {
-		const client = new S3Client({
-			...requiredConfig(),
-			region: "auto",
-			profile: "default",
-			prefix: "pi-sync",
-			syncSessions: false,
-		});
-		const result = await client.getJson<{ snapshot: string; sha256: string }>("latest.json");
-		assert.equal(result.missing, false);
-		assert.equal(result.value?.snapshot, "snap-1");
-		assert.equal(result.etag, "w/ok");
-		assert.equal(calls, 3);
-	} finally {
-		globalThis.fetch = originalFetch;
-	}
-});
-
-test("getJson throws after retrying a persistently empty R2 response body", async () => {
-	const originalFetch = globalThis.fetch;
-	let calls = 0;
-	globalThis.fetch = (async () => {
-		calls += 1;
-		return new Response("", { status: 200, headers: { etag: "w/empty" } });
-	}) as typeof globalThis.fetch;
-	try {
-		const client = new S3Client({
-			...requiredConfig(),
-			region: "auto",
-			profile: "default",
-			prefix: "pi-sync",
-			syncSessions: false,
-		});
-		await assert.rejects(client.getJson("latest.json"), /empty body/);
-		assert.equal(calls, 3);
-	} finally {
-		globalThis.fetch = originalFetch;
-	}
-});
-
-test("getJson does not retry a non-empty malformed response body", async () => {
-	const originalFetch = globalThis.fetch;
-	let calls = 0;
-	globalThis.fetch = (async () => {
-		calls += 1;
-		return new Response("{", { status: 200, headers: { etag: "w/malformed" } });
-	}) as typeof globalThis.fetch;
-	try {
-		const client = new S3Client({
-			...requiredConfig(),
-			region: "auto",
-			profile: "default",
-			prefix: "pi-sync",
-			syncSessions: false,
-		});
-		await assert.rejects(client.getJson("latest.json"), SyntaxError);
-		assert.equal(calls, 1);
-	} finally {
-		globalThis.fetch = originalFetch;
-	}
-});
-
-test("getBuffer retries on empty R2 response body and eventually succeeds", async () => {
-	const originalFetch = globalThis.fetch;
-	const payload = Buffer.from("snapshot-payload");
-	const responses = [
-		new Response("", { status: 200, headers: { etag: "w/empty1" } }),
-		new Response("", { status: 200, headers: { etag: "w/empty2" } }),
-		new Response(new Uint8Array(payload), { status: 200, headers: { etag: "w/ok" } }),
-	];
-	let calls = 0;
-	globalThis.fetch = (async () => {
-		const response = responses[Math.min(calls, responses.length - 1)];
-		calls += 1;
-		return response;
-	}) as typeof globalThis.fetch;
-	try {
-		const client = new S3Client({
-			...requiredConfig(),
-			region: "auto",
-			profile: "default",
-			prefix: "pi-sync",
-			syncSessions: false,
-		});
-		const result = await client.getBuffer("snapshots/snap-1.json.gz");
-		assert.equal(result.missing, false);
-		assert.deepEqual(result.value, payload);
-		assert.equal(result.etag, "w/ok");
-		assert.equal(calls, 3);
-	} finally {
-		globalThis.fetch = originalFetch;
-	}
-});
-
-test("getBuffer throws after retrying a persistently empty R2 response body", async () => {
-	const originalFetch = globalThis.fetch;
-	let calls = 0;
-	globalThis.fetch = (async () => {
-		calls += 1;
-		return new Response("", { status: 200, headers: { etag: "w/empty" } });
-	}) as typeof globalThis.fetch;
-	try {
-		const client = new S3Client({
-			...requiredConfig(),
-			region: "auto",
-			profile: "default",
-			prefix: "pi-sync",
-			syncSessions: false,
-		});
-		await assert.rejects(client.getBuffer("snapshots/snap-1.json.gz"), /empty body/);
-		assert.equal(calls, 3);
-	} finally {
-		globalThis.fetch = originalFetch;
-	}
-});
-
-test("old unreadable locks require explicit stale unlock before recovery", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx } = createMockContext();
-
-		for (const contents of ["", "{not valid json"]) {
-			writeOldLock(contents);
-			let ran = false;
-			await assert.rejects(
-				withLock("test", async () => {
-					ran = true;
-				}),
-				/unreadable/,
-			);
-			assert.equal(ran, false);
-			assert.equal(await lockFileExists(), true);
-
-			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
-			assert.equal(await lockFileExists(), false);
-			assert.equal(await withLock("test", async () => "ok"), "ok");
-		}
-	});
-});
-
-test("withLock never reclaims an aged lock that a legacy writer still owns", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		const legacyHandle = await fs.open(lockPath(), "wx");
-		const old = new Date(Date.now() - 60_000);
-		await fs.utimes(lockPath(), old, old);
-		let ran = false;
-		try {
-			await assert.rejects(
-				withLock("test", async () => {
-					ran = true;
-				}),
-				/unreadable/,
-			);
-			assert.equal(ran, false);
-
-			await legacyHandle.writeFile(
-				JSON.stringify({
-					id: "legacy",
-					pid: process.pid,
-					command: "sync",
-					startedAt: new Date().toISOString(),
-				}),
-			);
-			await assert.rejects(
-				withLock("test", async () => undefined),
-				/already running/,
-			);
-		} finally {
-			await legacyHandle.close();
-			await fs.rm(lockPath(), { force: true });
-		}
-	});
-});
-
-test("withLock does not reclaim a lock file that may still be initializing", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(lockPath(), "");
-		let ran = false;
-		await assert.rejects(
-			withLock("test", async () => {
-				ran = true;
-			}),
-			/unreadable/,
-		);
-		assert.equal(ran, false);
-	});
-});
-
-test("unlock keeps a fresh unreadable lock unless stale removal is explicit", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(lockPath(), "");
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-
-		await mock.commands.get("sync")?.handler("unlock", ctx);
-		assert.equal(await lockFileExists(), true);
-		assert.match(notifications.at(-1)?.message ?? "", /unreadable/);
-
-		await mock.commands.get("sync")?.handler("unlock --stale", ctx);
-		assert.equal(await lockFileExists(), false);
-		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable/);
-	});
-});
-
-test("stale unlock rechecks unreadable metadata before removing it", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(lockPath(), "");
-		const originalReadFile = fs.readFile;
-		let lockReads = 0;
-		fs.readFile = (async (...args: Parameters<typeof fs.readFile>) => {
-			const result = await originalReadFile(...args);
-			if (args[0] === lockPath() && lockReads++ === 0) {
-				await fs.writeFile(
-					lockPath(),
-					JSON.stringify({
-						id: "legacy",
-						pid: process.pid,
-						command: "sync",
-						startedAt: new Date().toISOString(),
-					}),
-				);
-			}
-			return result;
-		}) as typeof fs.readFile;
-
-		try {
-			const mock = createMockPi();
-			sync(mock.pi);
-			const { ctx, notifications } = createMockContext();
-			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
-
-			assert.equal(await lockFileExists(), true);
-			assert.match(notifications.at(-1)?.message ?? "", /not stale|still live/);
-		} finally {
-			fs.readFile = originalReadFile;
-			await fs.rm(lockPath(), { force: true });
-		}
-	});
-});
-
-test("unlock cannot remove the lock for an active guarded sync", async () => {
-	await withTempHome(async () => {
-		let releaseRun: (() => void) | undefined;
-		const keepRunning = new Promise<void>((resolve) => {
-			releaseRun = resolve;
-		});
-		let markStarted: (() => void) | undefined;
-		const started = new Promise<void>((resolve) => {
-			markStarted = resolve;
-		});
-		const running = withLock("test", async () => {
-			markStarted?.();
-			await keepRunning;
-		});
-		await started;
-
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-		try {
-			await mock.commands.get("sync")?.handler("unlock --stale", ctx);
-			assert.equal(await lockFileExists(), true);
-			assert.match(notifications.at(-1)?.message ?? "", /currently running/);
-		} finally {
-			releaseRun?.();
-			await running;
-		}
-		assert.equal(await lockFileExists(), false);
-	});
-});
-
-test("unlock reports when a dead owner's guard is still expiring", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(
-			lockPath(),
-			JSON.stringify({
-				id: "dead-owner",
-				pid: 2_147_483_647,
-				command: "sync",
-				startedAt: new Date().toISOString(),
-			}),
-		);
-		mkdirSync(`${lockPath()}.guard`);
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-
-		await mock.commands.get("sync")?.handler("unlock --stale", ctx);
-		assert.equal(await lockFileExists(), true);
-		assert.match(notifications.at(-1)?.message ?? "", /owner exited.*guard expires/);
-	});
-});
-
-test("concurrent withLock calls never execute together", async () => {
-	await withTempHome(async () => {
-		let active = 0;
-		let maxActive = 0;
-		const run = () =>
-			withLock("test", async () => {
-				active += 1;
-				maxActive = Math.max(maxActive, active);
-				await new Promise((resolve) => setTimeout(resolve, 25));
-				active -= 1;
-			});
-
-		const results = await Promise.allSettled([run(), run()]);
-		assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
-		assert.equal(maxActive, 1);
-	});
-});
-
-test("withLock rejects when a valid foreign lock is held", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(
-			lockPath(),
-			JSON.stringify({
-				id: "other",
-				pid: process.pid,
-				command: "push",
-				startedAt: new Date().toISOString(),
-			}),
-		);
-		await assert.rejects(
-			withLock("test", async () => "ok"),
-			/already running/,
-		);
-	});
-});
-
-test("readLock treats empty, whitespace, and corrupt lock files as absent", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		for (const contents of [
-			"",
-			"  \n  ",
-			"{broken",
-			"{}",
-			"[]",
-			"null",
-			"1",
-			JSON.stringify({
-				id: "invalid-pid",
-				pid: 2_147_483_648,
-				command: "sync",
-				startedAt: new Date().toISOString(),
-			}),
-		]) {
-			writeFileSync(lockPath(), contents);
-			assert.equal(
-				await readLock(),
-				undefined,
-				`expected undefined for ${JSON.stringify(contents)}`,
-			);
-		}
-	});
-});
-
-test("doctor warns when lock metadata is unreadable", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(lockPath(), "{broken");
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-
-		await mock.commands.get("sync")?.handler("doctor", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /lock: unreadable/);
-		assert.equal(notifications.at(-1)?.level, "warning");
-	});
-});
-
-test("doctor warns when a lock guard is active without metadata", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		mkdirSync(`${lockPath()}.guard`);
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-
-		await mock.commands.get("sync")?.handler("doctor", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /lock: guard active.*metadata/);
-		assert.equal(notifications.at(-1)?.level, "warning");
-	});
-});
-
-test("doctor warns when a valid lock owner has exited", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(
-			lockPath(),
-			JSON.stringify({
-				id: "dead-owner",
-				pid: 2_147_483_647,
-				command: "sync",
-				startedAt: new Date().toISOString(),
-			}),
-		);
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-
-		await mock.commands.get("sync")?.handler("doctor", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /lock: stale.*unlock/);
-		assert.equal(notifications.at(-1)?.level, "warning");
-	});
-});
-
-test("doctor reports live and free lock states", async () => {
-	await withTempHome(async () => {
-		await ensureStateDir();
-		writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
-		writeFileSync(
-			lockPath(),
-			JSON.stringify({
-				id: "live-owner",
-				pid: process.pid,
-				command: "sync",
-				startedAt: new Date().toISOString(),
-			}),
-		);
-		const mock = createMockPi();
-		sync(mock.pi);
-		const { ctx, notifications } = createMockContext();
-
-		await mock.commands.get("sync")?.handler("doctor", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /lock: held by pid/);
-		assert.equal(notifications.at(-1)?.level, "info");
-
-		await fs.rm(lockPath());
-		await mock.commands.get("sync")?.handler("doctor", ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /lock: free/);
-		assert.equal(notifications.at(-1)?.level, "info");
-	});
-});
-
-test("malformed non-lock JSON remains an explicit error", async () => {
-	await withTempHome(async (agentDir) => {
-		await ensureStateDir();
-
-		writeFileSync(localConfigPath(), "{broken");
-		await assert.rejects(loadPartialConfig(), SyntaxError);
-
-		writeFileSync(path.join(agentDir, ".pisync", "default.state.json"), "{broken");
-		await assert.rejects(readState("default"), SyntaxError);
-
-		writeFileSync(path.join(agentDir, "settings.json"), "{broken");
-		await assert.rejects(configuredSessionDir(), SyntaxError);
-	});
-});
-
-function writeOldLock(contents: string) {
-	writeFileSync(lockPath(), contents);
-	const old = new Date(Date.now() - 60_000);
-	utimesSync(lockPath(), old, old);
-}
-
-function snapshot(files: Array<{ path: string; content: Buffer }>) {
-	return {
-		version: 1,
-		id: "snap",
-		createdAt: "2026-01-01T00:00:00.000Z",
-		machine: "test",
-		profile: "default",
-		files: files.map((file) => ({
-			path: file.path,
-			contentBase64: file.content.toString("base64"),
-			sha256: createHash("sha256").update(file.content).digest("hex"),
-		})),
-	};
-}
-
-function requiredConfig() {
-	return {
-		endpoint: "https://example.r2.cloudflarestorage.com",
-		bucket: "pi-sync-test",
-		accessKeyId: "access-key",
-		secretAccessKey: "secret-key",
-		extraFiles: [],
-	};
-}
-
-async function withTempHome<T>(fn: (agentDir: string) => Promise<T>) {
-	const previousHome = process.env.HOME;
-	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	const previousSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
-	const home = mkdtempSync(path.join(os.tmpdir(), "pi-sync-home-"));
-	const agentDir = path.join(home, ".pi", "agent");
-	process.env.HOME = home;
-	process.env.PI_CODING_AGENT_DIR = agentDir;
-	delete process.env.PI_CODING_AGENT_SESSION_DIR;
-	try {
-		return await fn(agentDir);
-	} finally {
-		if (previousHome === undefined) delete process.env.HOME;
-		else process.env.HOME = previousHome;
-		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		if (previousSessionDir === undefined) delete process.env.PI_CODING_AGENT_SESSION_DIR;
-		else process.env.PI_CODING_AGENT_SESSION_DIR = previousSessionDir;
-		rmSync(home, { recursive: true, force: true });
-	}
-}
-
-async function waitFor(predicate: () => boolean) {
-	for (let attempt = 0; attempt < 100; attempt += 1) {
-		if (predicate()) return;
-		await new Promise((resolve) => setTimeout(resolve, 5));
-	}
-	throw new Error("Timed out waiting for test condition");
-}
-
-async function withEnv<T>(env: Record<string, string>, fn: () => Promise<T>) {
-	const keys = [
-		"PI_SYNC_ENDPOINT",
-		"PI_SYNC_BUCKET",
-		"PI_SYNC_ACCESS_KEY_ID",
-		"PI_SYNC_SECRET_ACCESS_KEY",
-		"PI_SYNC_SESSIONS",
-		"PI_SYNC_SESSION_TOKEN",
-		"PI_SYNC_REGION",
-		"PI_SYNC_PROFILE",
-		"PI_SYNC_PREFIX",
-		"PI_SYNC_AUTO_SYNC",
-		"PI_CODING_AGENT_DIR",
-		"PI_CODING_AGENT_SESSION_DIR",
-		"R2_ENDPOINT",
-		"R2_BUCKET",
-		"AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY",
-		"AWS_SESSION_TOKEN",
-		"AWS_REGION",
-	];
-	const previous = new Map(keys.map((key) => [key, process.env[key]]));
-	for (const key of keys) delete process.env[key];
-	Object.assign(process.env, env);
-	try {
-		return await fn();
-	} finally {
-		for (const key of keys) {
-			const value = previous.get(key);
-			if (value === undefined) delete process.env[key];
-			else process.env[key] = value;
-		}
-	}
-}

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -263,10 +263,11 @@ test("sync files keeps environment-overridden sessions read-only", async () => {
 			const { ctx } = createMockContext({
 				hasUI: true,
 				mode: "tui",
+				select: async () => "Save changes",
 				custom: async (factory: unknown) => {
 					const selector = createCustomSelectorHarness(factory);
-					for (const character of "sessions") selector.handleInput(character);
 					sessionRender = selector.render().join("\n");
+					for (const character of "settings.json") selector.handleInput(character);
 					selector.handleInput("\r");
 					selector.handleInput("\u001b");
 					return selector.result;
@@ -274,8 +275,13 @@ test("sync files keeps environment-overridden sessions read-only", async () => {
 			});
 
 			await mock.commands.get("sync")?.handler("files", ctx);
+			const saved = await readLocalConfigObject();
 			assert.match(sessionRender, /included \(environment, deprecated\)/);
-			assert.equal((await readLocalConfigObject())?.syncSessions, false);
+			assert.deepEqual(
+				saved?.syncFiles,
+				DEFAULT_SYNC_FILES.filter((item) => item !== "settings.json"),
+			);
+			assert.equal(saved?.syncSessions, false);
 		});
 	});
 });

--- a/test/support.ts
+++ b/test/support.ts
@@ -288,6 +288,9 @@ export function createCustomSelectorHarness(factory: unknown, width = 100) {
 		render() {
 			return component.render(width);
 		},
+		dispose() {
+			(component as { dispose?: () => void }).dispose?.();
+		},
 		get result() {
 			return result;
 		},


### PR DESCRIPTION
## Summary

- redesign `/sync` around a configuration-aware, goal-oriented manager with guided R2/S3 setup, reusable storage profiles, named targets, safe switching, transactional synced-content settings, and selectable history
- recommend `home`/`work`, `r2`/`s3`, bucket/prefix, and derived namespace defaults; new R2 setup avoids raw path questions, S3 asks only for an existing bucket, and additional targets can reuse the current profile destination
- preserve flat configuration, remote/state formats, direct commands, AWS/R2 aliases, and current `PI_SYNC_*` precedence while adding value-free deprecation guidance and target-aware `--target`/`use` routes
- add cancellable read-only checks, target-aware previews, atomic settings/migration writes, journaled pull/rollback recovery, and explicit remote publication/history failure handling
- decompose sync orchestration and tests into focused modules and document migration, mode, privacy, recovery, race, responsive, and accessibility behavior

## Verification

- `npm run check` (1,273 tests)
- `just pack-sync` (20 expected package files)
- isolated `PI_CODING_AGENT_DIR=<temp> pi --mode rpc --no-session -e ./extensions/pi-sync` smoke (exit 0, protocol-safe JSON, no stderr)
