### PR TITLE
fix(sync): harden multi-target state handling

### DIFF
--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -133,7 +133,7 @@ export function deprecatedPiSyncEnvironmentWarnings() {
 	];
 }
 
-function resolveLegacyPartialConfig(fileConfig: PartialConfig): PartialConfig {
+export function resolveLegacyPartialConfig(fileConfig: PartialConfig): PartialConfig {
 	return {
 		...fileConfig,
 		target: DEFAULT_PROFILE,
@@ -156,7 +156,7 @@ function resolveLegacyPartialConfig(fileConfig: PartialConfig): PartialConfig {
 	};
 }
 
-function resolveV2PartialConfig(
+export function resolveV2PartialConfig(
 	settings: Record<string, unknown>,
 	targetName?: string,
 ): PartialConfig {
@@ -366,8 +366,11 @@ export async function writeState(profile: string, state: SyncState) {
 
 export async function readStateForConfig(config: SyncConfig): Promise<SyncState> {
 	if (config.settingsVersion !== 2) return readState(config.profile);
+	const destination = statePathForConfig(config);
+	const state = await readJsonIfExists<SyncState>(destination);
+	if (state) return state;
 	return (
-		(await readJsonIfExists<SyncState>(statePathForConfig(config))) ?? {
+		(await migrateLegacyV2State(config, destination)) ?? {
 			version: VERSION,
 			profile: config.profile,
 			lastFileHashes: {},
@@ -391,6 +394,58 @@ export function statePathForConfig(config: SyncConfig) {
 	]);
 	const hash = createHash("sha256").update(identity).digest("hex").slice(0, 10);
 	return path.join(stateDir(), "targets", `${safeName(target)}-${hash}.state.json`);
+}
+
+export function statePathForPartialConfig(partial: PartialConfig) {
+	const profile = normalizeOptionalString(partial.profile) ?? DEFAULT_PROFILE;
+	if (partial.settingsVersion !== 2) return statePath(profile);
+	return statePathForConfig({
+		settingsVersion: 2,
+		target: partial.target ?? DEFAULT_PROFILE,
+		endpoint: normalizeConfiguredString(partial.endpoint) ?? "",
+		bucket: normalizeConfiguredString(partial.bucket) ?? "",
+		prefix: trimSlashes(normalizeOptionalString(partial.prefix) ?? DEFAULT_PREFIX),
+		profile,
+	} as SyncConfig);
+}
+
+async function migrateLegacyV2State(config: SyncConfig, destination: string) {
+	const target = config.target ?? DEFAULT_PROFILE;
+	const legacyHash = createHash("sha256").update(target).digest("hex").slice(0, 10);
+	const legacyPath = path.join(
+		stateDir(),
+		"targets",
+		`${safeName(target)}-${legacyHash}.state.json`,
+	);
+	const claimPath = `${legacyPath}.migrating-to-${path.basename(destination)}`;
+	if (!(await pathExists(claimPath))) {
+		try {
+			await fs.rename(legacyPath, claimPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+	if (!(await pathExists(claimPath))) return readJsonIfExists<SyncState>(destination);
+
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	try {
+		await fs.link(claimPath, destination);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+	}
+	const migrated = await readJsonIfExists<SyncState>(destination);
+	if (migrated) await fs.rm(claimPath, { force: true });
+	return migrated;
+}
+
+async function pathExists(filePath: string) {
+	try {
+		await fs.lstat(filePath);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
 }
 
 function normalizeEndpointIdentity(endpoint: string) {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -382,8 +382,24 @@ export async function writeStateForConfig(config: SyncConfig, state: SyncState) 
 export function statePathForConfig(config: SyncConfig) {
 	if (config.settingsVersion !== 2) return statePath(config.profile);
 	const target = config.target ?? DEFAULT_PROFILE;
-	const hash = createHash("sha256").update(target).digest("hex").slice(0, 10);
+	const identity = JSON.stringify([
+		target,
+		normalizeEndpointIdentity(config.endpoint),
+		normalizeRemoteKeySegment(config.bucket),
+		normalizeRemoteKeySegment(config.prefix),
+		normalizeRemoteKeySegment(config.profile),
+	]);
+	const hash = createHash("sha256").update(identity).digest("hex").slice(0, 10);
 	return path.join(stateDir(), "targets", `${safeName(target)}-${hash}.state.json`);
+}
+
+function normalizeEndpointIdentity(endpoint: string) {
+	const normalized = endpoint.trim();
+	try {
+		return new URL(normalized).toString();
+	} catch {
+		return normalized;
+	}
 }
 
 export function agentDir() {

--- a/extensions/pi-sync/src/lock.ts
+++ b/extensions/pi-sync/src/lock.ts
@@ -59,7 +59,11 @@ export type LockInspection =
 	| { status: "unreadable" }
 	| { status: "valid"; lock: LockFile };
 
-export async function withLock<T>(command: string, fn: () => Promise<T>): Promise<T> {
+export async function withLock<T>(
+	command: string,
+	fn: () => Promise<T>,
+	options: { reclaimStale?: boolean } = {},
+): Promise<T> {
 	await ensureStateDir();
 	const lock: LockFile = {
 		id: randomUUID(),
@@ -79,11 +83,24 @@ export async function withLock<T>(command: string, fn: () => Promise<T>): Promis
 			throw await describeHeldLock();
 		}
 
-		const inspection = await inspectLock();
+		let inspection = await inspectLock();
 		if (inspection.status === "valid" && isStaleLock(inspection.lock)) {
-			throw new Error(
-				`pi-sync lock is stale (pid ${inspection.lock.pid}). Run /sync unlock --stale, then retry.`,
-			);
+			if (!options.reclaimStale) {
+				throw new Error(
+					`pi-sync lock is stale (pid ${inspection.lock.pid}). Run /sync unlock --stale, then retry.`,
+				);
+			}
+			guard.throwIfCompromised();
+			const rechecked = await inspectLock();
+			if (
+				rechecked.status !== "valid" ||
+				rechecked.lock.id !== inspection.lock.id ||
+				!isStaleLock(rechecked.lock)
+			) {
+				throw new Error("pi-sync lock changed while preparing transaction recovery; retry.");
+			}
+			await fs.rm(lockPath(), { force: true });
+			inspection = { status: "missing" };
 		}
 		if (inspection.status === "valid") {
 			throw new Error(

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -5,13 +5,14 @@ import {
 	effectiveTargetRemoteIdentity,
 	localConfigPath,
 	readLocalConfigObject,
+	resolveLegacyPartialConfig,
+	resolveV2PartialConfig,
 	stateDir,
-	statePathForConfig,
+	statePathForPartialConfig,
 	writeLocalConfigObject,
 } from "./config.js";
 import { withLock } from "./lock.js";
-import { safeName } from "./paths.js";
-import type { StorageProfileSettings, SyncConfig, SyncTargetSettings } from "./types.js";
+import type { PartialConfig, StorageProfileSettings, SyncTargetSettings } from "./types.js";
 
 const LEGACY_FIELDS = new Set([
 	"endpoint",
@@ -235,8 +236,8 @@ async function adoptLegacyState(
 	next: Record<string, unknown>,
 	targetName: string,
 ) {
-	const legacyProfile = typeof legacy.profile === "string" ? legacy.profile : "default";
-	const source = path.join(stateDir(), `${safeName(legacyProfile)}.state.json`);
+	const legacyConfig = resolveLegacyPartialConfig(legacy as PartialConfig);
+	const source = statePathForPartialConfig(legacyConfig);
 	let bytes: Buffer;
 	try {
 		bytes = await fs.readFile(source);
@@ -244,20 +245,7 @@ async function adoptLegacyState(
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
 		throw error;
 	}
-	const targets = requireObject(next.targets, "targets");
-	const target = requireObject(targets[targetName], "target");
-	const profile = typeof target.namespace === "string" ? target.namespace : targetName;
-	const storageProfileName = typeof target.profile === "string" ? target.profile : "default";
-	const profiles = requireObject(next.profiles, "profiles");
-	const storageProfile = requireObject(profiles[storageProfileName], "storage profile");
-	const destination = statePathForConfig({
-		settingsVersion: 2,
-		target: targetName,
-		endpoint: typeof storageProfile.endpoint === "string" ? storageProfile.endpoint : "",
-		bucket: typeof target.bucket === "string" ? target.bucket : "",
-		prefix: typeof target.prefix === "string" ? target.prefix : "pi-sync",
-		profile,
-	} as SyncConfig);
+	const destination = statePathForPartialConfig(resolveV2PartialConfig(next, targetName));
 	await fs.mkdir(path.dirname(destination), { recursive: true });
 	try {
 		await fs.writeFile(destination, bytes, { flag: "wx", mode: 0o600 });

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -182,7 +182,8 @@ export async function removeSyncTarget(name: string) {
 		return {
 			...settings,
 			targets: nextTargets,
-			activeTarget: Object.keys(nextTargets)[0],
+			activeTarget:
+				settings.activeTarget === name ? Object.keys(nextTargets)[0] : settings.activeTarget,
 		};
 	});
 }
@@ -246,9 +247,15 @@ async function adoptLegacyState(
 	const targets = requireObject(next.targets, "targets");
 	const target = requireObject(targets[targetName], "target");
 	const profile = typeof target.namespace === "string" ? target.namespace : targetName;
+	const storageProfileName = typeof target.profile === "string" ? target.profile : "default";
+	const profiles = requireObject(next.profiles, "profiles");
+	const storageProfile = requireObject(profiles[storageProfileName], "storage profile");
 	const destination = statePathForConfig({
 		settingsVersion: 2,
 		target: targetName,
+		endpoint: typeof storageProfile.endpoint === "string" ? storageProfile.endpoint : "",
+		bucket: typeof target.bucket === "string" ? target.bucket : "",
+		prefix: typeof target.prefix === "string" ? target.prefix : "pi-sync",
 		profile,
 	} as SyncConfig);
 	await fs.mkdir(path.dirname(destination), { recursive: true });

--- a/extensions/pi-sync/src/snapshot-transaction.ts
+++ b/extensions/pi-sync/src/snapshot-transaction.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { agentDir, stateDir } from "./config.js";
+import { withLock } from "./lock.js";
 import { assertWithinRoot, isPathInside } from "./paths.js";
 import { sessionStorageRoot } from "./snapshot.js";
 import type { SnapshotApplyPlan } from "./types.js";
@@ -49,15 +50,14 @@ export async function applySnapshotTransaction(
 	}
 }
 
+export async function recoverSnapshotTransactionsOnStartup() {
+	if (!(await pendingTransactionEntries()).some((entry) => entry.isDirectory())) return;
+	await withLock("recovery", recoverPendingSnapshotTransactions, { reclaimStale: true });
+}
+
 export async function recoverPendingSnapshotTransactions() {
 	const directory = transactionRoot();
-	let entries: import("node:fs").Dirent[];
-	try {
-		entries = await fs.readdir(directory, { withFileTypes: true });
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
+	const entries = await pendingTransactionEntries();
 	for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
 		if (!entry.isDirectory()) continue;
 		const transactionDirectory = path.join(directory, entry.name);
@@ -75,6 +75,15 @@ export async function recoverPendingSnapshotTransactions() {
 			});
 		}
 		await restoreTransaction(transactionDirectory, journal);
+	}
+}
+
+async function pendingTransactionEntries() {
+	try {
+		return await fs.readdir(transactionRoot(), { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
 	}
 }
 

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -58,7 +58,7 @@ import {
 	snapshotWithoutSessions,
 } from "./snapshot.js";
 import { applySnapshot } from "./snapshot-apply.js";
-import { recoverPendingSnapshotTransactions } from "./snapshot-transaction.js";
+import { recoverSnapshotTransactionsOnStartup } from "./snapshot-transaction.js";
 import {
 	countPreservedRemoteFiles,
 	errorMessage,
@@ -133,7 +133,7 @@ export default function sync(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		try {
-			await withLock("recovery", recoverPendingSnapshotTransactions);
+			await recoverSnapshotTransactionsOnStartup();
 		} catch (error) {
 			ctx.ui.notify(`pi-sync recovery required: ${errorMessage(error)}`, "error");
 			return;

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -133,7 +133,7 @@ export default function sync(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		try {
-			await recoverPendingSnapshotTransactions();
+			await withLock("recovery", recoverPendingSnapshotTransactions);
 		} catch (error) {
 			ctx.ui.notify(`pi-sync recovery required: ${errorMessage(error)}`, "error");
 			return;

--- a/extensions/pi-sync/test/review-feedback.test.ts
+++ b/extensions/pi-sync/test/review-feedback.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -15,9 +16,13 @@ import {
 	statePathForConfig,
 	writeStateForConfig,
 } from "../src/config.js";
-import { addSyncTarget, removeSyncTarget } from "../src/settings-management.js";
+import {
+	addSyncTarget,
+	migrateLegacySettings,
+	removeSyncTarget,
+} from "../src/settings-management.js";
 import sync from "../src/sync.js";
-import { requiredConfig, withTempHome } from "./helpers.js";
+import { requiredConfig, withEnv, withTempHome } from "./helpers.js";
 
 test("legacy settings reject explicit target selection before destructive network work", async () => {
 	await withTempHome(async (agentDir) => {
@@ -96,19 +101,7 @@ test("startup does not recover a transaction owned by an active sync", async () 
 		const settings = v2Settings();
 		settings.targets.home.autoSync = false;
 		writeFileSync(localConfigPath(), JSON.stringify(settings));
-		const target = path.join(agentDir, "settings.json");
-		writeFileSync(target, '{"partial":true}\n');
-		const transaction = path.join(stateDir(), "transactions", "active");
-		mkdirSync(path.join(transaction, "before"), { recursive: true });
-		writeFileSync(path.join(transaction, "before", "0"), '{"old":true}\n');
-		writeFileSync(
-			path.join(transaction, "journal.json"),
-			JSON.stringify({
-				version: 1,
-				root: agentDir,
-				entries: [{ target, backupName: "0", kind: "file" }],
-			}),
-		);
+		const { target, transaction } = writeInterruptedTransaction(agentDir, "active");
 		writeFileSync(
 			lockPath(),
 			JSON.stringify({
@@ -128,6 +121,95 @@ test("startup does not recover a transaction owned by an active sync", async () 
 		assert.equal(existsSync(transaction), true);
 		assert.match(notifications.at(-1)?.message ?? "", /already running.*pull/i);
 	});
+});
+
+test("startup recovers a crashed transaction after reclaiming its stale lock", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settings = v2Settings();
+		settings.targets.home.autoSync = false;
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const { target, transaction } = writeInterruptedTransaction(agentDir, "crashed");
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "crashed-pull",
+				pid: 2_147_483_647,
+				command: "pull",
+				startedAt: new Date(0).toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({ hasUI: true });
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.equal(readFileSync(target, "utf8"), '{"old":true}\n');
+		assert.equal(existsSync(transaction), false);
+		assert.equal(existsSync(lockPath()), false);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("existing v2 target state migrates once to its destination-scoped path", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settings = v2Settings();
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const config = await loadConfig();
+		const legacyStatePath = path.join(
+			stateDir(),
+			"targets",
+			`home-${createHash("sha256").update("home").digest("hex").slice(0, 10)}.state.json`,
+		);
+		mkdirSync(path.dirname(legacyStatePath), { recursive: true });
+		writeFileSync(
+			legacyStatePath,
+			JSON.stringify({
+				version: 1,
+				profile: config.profile,
+				lastAppliedSnapshot: "existing-snapshot",
+				lastFileHashes: {},
+			}),
+		);
+
+		assert.equal((await readStateForConfig(config)).lastAppliedSnapshot, "existing-snapshot");
+		assert.equal(existsSync(statePathForConfig(config)), true);
+		assert.equal(existsSync(legacyStatePath), false);
+	});
+});
+
+test("legacy migration adopts state under effective environment overrides", async () => {
+	await withEnv(
+		{
+			PI_SYNC_ENDPOINT: "https://override.r2.cloudflarestorage.com",
+			PI_SYNC_BUCKET: "override-bucket",
+			PI_SYNC_PREFIX: "override-prefix",
+			PI_SYNC_PROFILE: "override-space",
+		},
+		() =>
+			withTempHome(async (agentDir) => {
+				mkdirSync(agentDir, { recursive: true });
+				writeFileSync(localConfigPath(), JSON.stringify(requiredConfig()));
+				const legacy = await loadConfig();
+				await writeStateForConfig(legacy, {
+					version: 1,
+					profile: legacy.profile,
+					lastAppliedSnapshot: "legacy-snapshot",
+					lastFileHashes: {},
+				});
+
+				await migrateLegacySettings("home", "r2");
+				const migrated = await loadConfig();
+
+				assert.equal(migrated.endpoint, "https://override.r2.cloudflarestorage.com");
+				assert.equal(migrated.bucket, "override-bucket");
+				assert.equal(migrated.prefix, "override-prefix");
+				assert.equal(migrated.profile, "override-space");
+				assert.equal((await readStateForConfig(migrated)).lastAppliedSnapshot, "legacy-snapshot");
+			}),
+	);
 });
 
 test("changing a target remote destination starts with fresh sync state", async () => {
@@ -240,6 +322,23 @@ test("history selection acquires the rollback lock before reading or applying a 
 		}
 	});
 });
+
+function writeInterruptedTransaction(agentDir: string, name: string) {
+	const target = path.join(agentDir, "settings.json");
+	writeFileSync(target, '{"partial":true}\n');
+	const transaction = path.join(stateDir(), "transactions", name);
+	mkdirSync(path.join(transaction, "before"), { recursive: true });
+	writeFileSync(path.join(transaction, "before", "0"), '{"old":true}\n');
+	writeFileSync(
+		path.join(transaction, "journal.json"),
+		JSON.stringify({
+			version: 1,
+			root: agentDir,
+			entries: [{ target, backupName: "0", kind: "file" }],
+		}),
+	);
+	return { target, transaction };
+}
 
 function v2Settings() {
 	return {

--- a/extensions/pi-sync/test/review-feedback.test.ts
+++ b/extensions/pi-sync/test/review-feedback.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
@@ -8,8 +9,13 @@ import {
 	loadConfig,
 	localConfigPath,
 	lockPath,
+	readLocalConfigObject,
+	readStateForConfig,
+	stateDir,
+	statePathForConfig,
+	writeStateForConfig,
 } from "../src/config.js";
-import { addSyncTarget } from "../src/settings-management.js";
+import { addSyncTarget, removeSyncTarget } from "../src/settings-management.js";
 import sync from "../src/sync.js";
 import { requiredConfig, withTempHome } from "./helpers.js";
 
@@ -81,6 +87,96 @@ test("recovery menu passes explicit stale confirmation for unreadable lock metad
 
 		assert.equal(existsSync(lockPath()), false);
 		assert.match(notifications.at(-1)?.message ?? "", /Removed unreadable pi-sync lock/);
+	});
+});
+
+test("startup does not recover a transaction owned by an active sync", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settings = v2Settings();
+		settings.targets.home.autoSync = false;
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const target = path.join(agentDir, "settings.json");
+		writeFileSync(target, '{"partial":true}\n');
+		const transaction = path.join(stateDir(), "transactions", "active");
+		mkdirSync(path.join(transaction, "before"), { recursive: true });
+		writeFileSync(path.join(transaction, "before", "0"), '{"old":true}\n');
+		writeFileSync(
+			path.join(transaction, "journal.json"),
+			JSON.stringify({
+				version: 1,
+				root: agentDir,
+				entries: [{ target, backupName: "0", kind: "file" }],
+			}),
+		);
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "active-pull",
+				pid: process.pid,
+				command: "pull",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({ hasUI: true });
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.equal(readFileSync(target, "utf8"), '{"partial":true}\n');
+		assert.equal(existsSync(transaction), true);
+		assert.match(notifications.at(-1)?.message ?? "", /already running.*pull/i);
+	});
+});
+
+test("changing a target remote destination starts with fresh sync state", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settings = v2Settings();
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const original = await loadConfig();
+		await writeStateForConfig(original, {
+			version: 1,
+			profile: original.profile,
+			lastAppliedSnapshot: "original-snapshot",
+			lastFileHashes: {},
+		});
+
+		settings.targets.home.bucket = "replacement-bucket";
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const changedBucket = await loadConfig();
+
+		assert.notEqual(statePathForConfig(changedBucket), statePathForConfig(original));
+		assert.equal((await readStateForConfig(changedBucket)).lastAppliedSnapshot, undefined);
+		await writeStateForConfig(changedBucket, {
+			version: 1,
+			profile: changedBucket.profile,
+			lastAppliedSnapshot: "replacement-snapshot",
+			lastFileHashes: {},
+		});
+
+		settings.profiles.r2.endpoint = "https://replacement.r2.cloudflarestorage.com";
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const changedEndpoint = await loadConfig();
+
+		assert.notEqual(statePathForConfig(changedEndpoint), statePathForConfig(changedBucket));
+		assert.equal((await readStateForConfig(changedEndpoint)).lastAppliedSnapshot, undefined);
+	});
+});
+
+test("removing a non-current target preserves the active target", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		settings.targets.lab = { ...settings.targets.home, namespace: "lab" };
+		settings.activeTarget = "lab";
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+
+		await removeSyncTarget("home");
+
+		assert.equal((await readLocalConfigObject())?.activeTarget, "lab");
 	});
 });
 


### PR DESCRIPTION
## Summary

- guard startup transaction recovery with the pi-sync operation lock
- reset local sync state when a target’s normalized remote destination changes
- preserve the active target when removing a different target

Follow-up to #371 for review feedback submitted after that pull request merged.

## Validation

- focused pi-sync suite: 94 tests passed
- `npm run check`: 1,280 tests passed