### PR TITLE
feat(sync): configure pulls after target switches

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -69,6 +69,7 @@
 - Symptom: PR status shows no issue comments but inline review comments exist. Cause: `gh pr view --json comments,reviews` omits pull review comment bodies. Fix: use `gh api repos/OWNER/REPO/pulls/NUMBER/comments` plus issue comments/reviews when actual PR review comments are needed.
 - Symptom: Chrome DevTools `/json/new` may reject unsafe `GET`. Cause: modern Chrome expects `PUT` for target creation. Fix: use `PUT /json/new?${encodeURIComponent(url)}`.
 - For pi-sync on Cloudflare R2, keep session-token support for temporary credentials but retry once without the token when R2 static keys reject `X-Amz-Security-Token`.
+- Pi-sync post-switch pulls cross a concurrency boundary after changing `activeTarget`; skip already-current targets, carry the selected target explicitly through locking, and retain the exact pull summary before apply.
 - Symptom: Pi extension async/timer/command continuations can crash after reload or session replacement. Cause: captured `ExtensionContext` becomes stale. Fix: pass plain data into delayed callbacks, catch stale-context errors, and scope cleanup to the failing ctx/request.
 - Pi extension `message_end` handlers run before AgentSession persists the assistant message; use `tool_execution_end` when a tool-using turn needs the just-finished assistant usage from the session branch, with `agent_end` as the no-tool fallback.
 - Treat session text rendered in custom TUI components as untrusted terminal input: escape C0/C1 controls before `wrapTextWithAnsi`, while retaining the raw value only for non-rendered payloads.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -101,6 +101,7 @@
 - Treat parsed credential maps as own-property dictionaries: names such as `__proto__` and `constructor` must not mutate or resolve through `Object.prototype`.
 - Active-account API-key conversion failures must fail closed, and user-facing errors must redact the exact current access and refresh secrets rather than relying only on token-shape regexes.
 - Symptom: a compiled pi-webui server smoke serves stale browser assets from another checkout. Cause: when cache-local `src/web` is absent, asset loading falls back through `process.cwd()`. Fix: launch the smoke with cwd set to the target worktree.
+- Symptom: latest-Pi CI reports committed WebUI assets as stale without source changes. Cause: its lockfile-free install can update semver-ranged browser bundle dependencies. Fix: pin bundle inputs that must reproduce committed assets, or regenerate those assets deliberately.
 - Runtime-auth generation guards prevent stale credential mutation but not stale outer status or connection-invalidation publication; overlapping provider syncs also need latest-task ownership at the lifecycle boundary.
 - Credential-file path and permission checks must run on every locked read, not only startup migration; reject symlinks and repair `0600` through the opened descriptor.
 

--- a/docs/plans/archived/2026-07-25_pi-sync-pull-after-target-switch-plan.md
+++ b/docs/plans/archived/2026-07-25_pi-sync-pull-after-target-switch-plan.md
@@ -1,0 +1,22 @@
+# pi-sync pull after target switch
+
+## Goal
+
+Make target switching ask to pull by default, with a persisted setting for always pulling or retaining switch-only behavior, while preserving pi-sync conflict checks, backups, and non-interactive safety.
+
+## Plan
+
+- [x] Add failing pi-sync regression tests for ask, always-pull, switch-only, non-interactive, failure, and settings persistence behavior; focused run failed in the four intended missing-behavior assertions (prompt, pull, switch-only feedback, persistence).
+- [x] Add validated `targetSwitchAction` settings resolution and atomic persistence while preserving unknown fields; focused validation and settings-menu persistence tests pass.
+- [x] Update target-switch and Settings flows to apply the selected policy through the existing locked pull path without forcing conflicts; focused prompt, cancellation, success, non-TUI, and failure tests pass.
+- [x] Update `extensions/pi-sync/README.md` with defaults, accepted values, interaction, and recovery behavior; documented values and safeguards match the implementation.
+- [x] Run focused pi-sync tests, `npm run check`, and review the final diff for bounded scope and preserved compatibility; 33 focused tests and all 1,296 repository tests pass, and `just pack-sync` includes the new module.
+
+## Completion Checklist
+
+- [x] Omitted settings default to asking in TUI and never cause an implicit pull without an interactive confirmation.
+- [x] `pull` skips pull confirmation but retains locking, backup, conflict detection, cancellation, and failure reporting through the existing pull path.
+- [x] `switch-only` preserves the prior switch behavior.
+- [x] Non-TUI ask mode switches without pulling and provides actionable feedback where the mode supports it.
+- [x] Existing settings and unknown fields remain valid and preserved.
+- [x] The completed plan is archived under `docs/plans/archived/`.

--- a/docs/plans/archived/2026-07-25_pi-sync-target-switch-review-plan.md
+++ b/docs/plans/archived/2026-07-25_pi-sync-target-switch-review-plan.md
@@ -1,0 +1,19 @@
+# Resolve pi-sync target-switch review comments
+
+## Goal
+
+Resolve every inline review comment on PR #374 without weakening pull safety or legacy-config compatibility.
+
+## Plan
+
+- [x] Add focused regressions for target pinning, current-target idempotence, concrete pull confirmation, SettingsList behavior, and legacy settings visibility; verified all five focused tests failed for the intended reviewed behavior.
+- [x] Pin post-switch work to the selected target, skip no-op switches, and retain the normal concrete pull confirmation; all 37 focused multi-profile tests pass, including direct and manager concurrency cases.
+- [x] Replace nested settings selectors with a SettingsList that serializes saves, restores failed values, and omits target-switch choices for legacy settings; focused persistence, rollback, and legacy tests pass.
+- [x] Update user documentation and durable repository memory for the corrected safety behavior; README policy and package layout now match the implementation and tests.
+- [x] Run `npm run check`, inspect the PR diff, and package pi-sync; all 1,300 repository tests pass, `git diff --check` passes, and `just pack-sync` includes `src/settings-ui.ts`.
+
+## Completion Checklist
+
+- [x] All five inline review comments are addressed by code, tests, and documentation.
+- [x] The repository CI-equivalent gate passes.
+- [x] The completed plan is archived under `docs/plans/archived/`.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -10,7 +10,7 @@ The extension uses immutable snapshot bundles, a `latest.json` publication point
 
 - Opens a goal-oriented `/sync` manager showing the current target, storage, auto-sync, session scope, and relevant next actions.
 - Supports multiple named **sync targets** and reusable R2/S3 **storage profiles**.
-- Asks to pull after switching targets by default, with settings for always pulling or switching only.
+- Asks to review a pull after switching targets by default, with settings to start that review automatically or switch only.
 - Previews concrete local or remote file changes before push, pull, force resolution, or rollback.
 - Uses transactional synced-content drafts with explicit Save, Discard, and Continue editing choices.
 - Keeps direct `help`, `use`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` routes for compatibility and automation.
@@ -165,9 +165,9 @@ Two targets may intentionally overlap local files, but only one is automatic. pi
 
 ### Target switching
 
-The default `targetSwitchAction: "ask"` changes `activeTarget` atomically, then asks whether to pull that target in TUI mode. Choosing not to pull leaves local files unchanged. In print, JSON, or RPC mode, `ask` switches without pulling and directs interactive users to `/sync pull` where notifications are available.
+The default `targetSwitchAction: "ask"` changes `activeTarget` atomically, then asks in TUI mode whether to review a pull for that target. Choosing not to review leaves local files unchanged. Accepting starts the normal pull flow, which fetches the remote snapshot and shows the exact writes and deletions before apply. In print, JSON, or RPC mode, `ask` switches without pulling and directs interactive users to `/sync pull` where notifications are available.
 
-Set `targetSwitchAction` to `"pull"` to begin a confirmed target switch's pull immediately without a second pull confirmation. Conflict detection remains enabled, a local backup is still created before apply, and pi-sync never adds `--force`; Pi may separately ask whether to reload changed resources after a successful pull. Set it to `"switch-only"` to retain the previous no-pull behavior. If a pull fails, the new target remains active and the error can be resolved before retrying `/sync pull`.
+Set `targetSwitchAction` to `"pull"` to start that reviewed pull automatically after a confirmed target switch. The exact pull summary and apply confirmation remain enabled, conflict detection still stops unsafe merges, a local backup is created before apply, and pi-sync never adds `--force`; Pi may separately ask whether to reload changed resources after a successful pull. Set it to `"switch-only"` to retain the previous no-pull behavior. Selecting an already-current target is a no-op. If a pull fails, the new target remains active and the error can be resolved before retrying `/sync pull`.
 
 ### Synced content
 
@@ -262,7 +262,7 @@ For the current target, startup auto-sync uses conservative decisions:
 - first-sync mismatch or both changed → stop and require review
 - no selected content → report/skip
 
-Switching targets first changes `activeTarget`, then follows `targetSwitchAction`: ask in TUI by default, pull immediately when configured, or stop after switching. Pulls retain normal locking, backup, and conflict safeguards. The next startup uses the new target's `autoSync` regardless of the switch action.
+Switching targets first changes `activeTarget`, then follows `targetSwitchAction`: ask before reviewing a pull in TUI by default, start a reviewed pull automatically when configured, or stop after switching. Pulls remain pinned to the selected target and retain exact summaries, locking, backups, and conflict safeguards. The next startup uses the new target's `autoSync` regardless of the switch action.
 
 Remote layout remains compatible:
 
@@ -321,7 +321,8 @@ extensions/pi-sync/
 │   ├── manager-ui.ts            # Goal-oriented menus and setup/management flows
 │   ├── file-selection.ts        # Transactional synced-content editor
 │   ├── settings-management.ts   # Profiles, targets, migration, and atomic saves
-│   ├── target-switch.ts         # Post-switch prompt, policy, and settings UI
+│   ├── settings-ui.ts           # SettingsList interaction and serialized saves
+│   ├── target-switch.ts         # Post-switch prompt, policy, and target handoff
 │   ├── snapshot-transaction.ts  # Local apply journal, rollback, and recovery
 │   └── *.ts                     # Config, policy, snapshot, S3, lock, and format modules
 ├── test/

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -10,7 +10,7 @@ The extension uses immutable snapshot bundles, a `latest.json` publication point
 
 - Opens a goal-oriented `/sync` manager showing the current target, storage, auto-sync, session scope, and relevant next actions.
 - Supports multiple named **sync targets** and reusable R2/S3 **storage profiles**.
-- Switches targets without syncing or modifying files; only the current target runs automatic startup/shutdown sync.
+- Asks to pull after switching targets by default, with settings for always pulling or switching only.
 - Previews concrete local or remote file changes before push, pull, force resolution, or rollback.
 - Uses transactional synced-content drafts with explicit Save, Discard, and Continue editing choices.
 - Keeps direct `help`, `use`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` routes for compatibility and automation.
@@ -86,9 +86,9 @@ Last known sync: Remote not checked
 Its primary actions are:
 
 - **Sync now** — conservatively decide whether to push, pull, or do nothing
-- **Switch target** — preview and change the current target without syncing
+- **Switch target** — preview the target change, then follow the configured pull behavior
 - **Status & changes** — perform a cancellable read-only remote check
-- **Settings** — control automatic sync and synced content for the current target
+- **Settings** — control post-switch pulling, automatic sync, and synced content
 - **Manage targets & storage** — add, edit, or remove local target/profile definitions
 - **History & recovery** — browse snapshots, preview rollback, diagnose setup, or recover a stale lock
 - **Help**
@@ -109,6 +109,7 @@ A version 2 example:
 {
   "version": 2,
   "activeTarget": "home",
+  "targetSwitchAction": "ask",
   "profiles": {
     "r2": {
       "kind": "r2",
@@ -155,11 +156,18 @@ A version 2 example:
 - A **storage profile** owns connection/authentication fields: `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`.
 - A **sync target** references a storage profile and owns `bucket`, `prefix`, `namespace`, `autoSync`, and its synced-content policy.
 - `activeTarget` is used by bare commands and automatic sync.
+- `targetSwitchAction` controls what happens after a target switch: `ask` (default), `pull`, or `switch-only`.
 - `namespace` is the old flat `profile` concept. The remote layout and snapshot wire field remain named `profiles`/`profile` for compatibility.
 
 When adding another target with the same storage profile, pi-sync recommends reusing the current target's bucket and prefix while deriving a separate namespace from the new target name. For example, `home` and `work` may both use profile `r2`, bucket `pi-sync`, and prefix `pi-sync`, producing `pi-sync/profiles/home/` and `pi-sync/profiles/work/`.
 
 Two targets may intentionally overlap local files, but only one is automatic. pi-sync rejects duplicate effective target remote identities—including deprecated bucket/prefix/namespace environment overrides—to prevent independent local states from controlling the same remote pointer. Removing a target/profile removes local configuration only; it never deletes buckets or snapshots. A referenced profile cannot be removed, and users must switch away before removing one of several current targets.
+
+### Target switching
+
+The default `targetSwitchAction: "ask"` changes `activeTarget` atomically, then asks whether to pull that target in TUI mode. Choosing not to pull leaves local files unchanged. In print, JSON, or RPC mode, `ask` switches without pulling and directs interactive users to `/sync pull` where notifications are available.
+
+Set `targetSwitchAction` to `"pull"` to begin a confirmed target switch's pull immediately without a second pull confirmation. Conflict detection remains enabled, a local backup is still created before apply, and pi-sync never adds `--force`; Pi may separately ask whether to reload changed resources after a successful pull. Set it to `"switch-only"` to retain the previous no-pull behavior. If a pull fails, the new target remains active and the error can be resolved before retrying `/sync pull`.
 
 ### Synced content
 
@@ -254,7 +262,7 @@ For the current target, startup auto-sync uses conservative decisions:
 - first-sync mismatch or both changed → stop and require review
 - no selected content → report/skip
 
-Switching targets changes only `activeTarget`; it never starts sync. The next startup uses the new target's `autoSync`, or the user can choose **Sync now** immediately.
+Switching targets first changes `activeTarget`, then follows `targetSwitchAction`: ask in TUI by default, pull immediately when configured, or stop after switching. Pulls retain normal locking, backup, and conflict safeguards. The next startup uses the new target's `autoSync` regardless of the switch action.
 
 Remote layout remains compatible:
 
@@ -313,6 +321,7 @@ extensions/pi-sync/
 │   ├── manager-ui.ts            # Goal-oriented menus and setup/management flows
 │   ├── file-selection.ts        # Transactional synced-content editor
 │   ├── settings-management.ts   # Profiles, targets, migration, and atomic saves
+│   ├── target-switch.ts         # Post-switch prompt, policy, and settings UI
 │   ├── snapshot-transaction.ts  # Local apply journal, rollback, and recovery
 │   └── *.ts                     # Config, policy, snapshot, S3, lock, and format modules
 ├── test/

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -9,7 +9,13 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { safeName } from "./paths.js";
 import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
-import type { PartialConfig, Snapshot, SyncConfig, SyncState } from "./types.js";
+import type {
+	PartialConfig,
+	Snapshot,
+	SyncConfig,
+	SyncState,
+	TargetSwitchAction,
+} from "./types.js";
 
 export { extraFilePathsByLower, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
 
@@ -17,6 +23,7 @@ const VERSION = 1;
 const DEFAULT_PROFILE = "default";
 const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
+export const DEFAULT_TARGET_SWITCH_ACTION: TargetSwitchAction = "ask";
 
 export const DEPRECATED_PI_SYNC_ENV_NAMES = [
 	"PI_SYNC_ENDPOINT",
@@ -121,6 +128,20 @@ export async function loadPartialConfig(targetName?: string): Promise<PartialCon
 	return resolveLegacyPartialConfig(fileConfig as PartialConfig);
 }
 
+export async function loadTargetSwitchAction(): Promise<TargetSwitchAction> {
+	const settings = await readLocalConfigObject();
+	if (!settings || !isV2SettingsObject(settings)) return DEFAULT_TARGET_SWITCH_ACTION;
+	return normalizeTargetSwitchAction(settings.targetSwitchAction);
+}
+
+export function normalizeTargetSwitchAction(value: unknown): TargetSwitchAction {
+	if (value === undefined) return DEFAULT_TARGET_SWITCH_ACTION;
+	if (value === "ask" || value === "pull" || value === "switch-only") return value;
+	throw new Error(
+		'Invalid pi-sync settings: targetSwitchAction must be "ask", "pull", or "switch-only".',
+	);
+}
+
 export function deprecatedPiSyncEnvironmentNames() {
 	return DEPRECATED_PI_SYNC_ENV_NAMES.filter((name) => hasEnv(name));
 }
@@ -160,6 +181,7 @@ export function resolveV2PartialConfig(
 	settings: Record<string, unknown>,
 	targetName?: string,
 ): PartialConfig {
+	normalizeTargetSwitchAction(settings.targetSwitchAction);
 	const targets = requireNamedObjectMap(settings.targets, "targets");
 	const profiles = requireNamedObjectMap(settings.profiles, "profiles");
 	validateUniqueRemoteTargets(targets);
@@ -477,6 +499,7 @@ export function localConfigTemplate(): Record<string, unknown> {
 	return {
 		version: 2,
 		activeTarget: DEFAULT_PROFILE,
+		targetSwitchAction: DEFAULT_TARGET_SWITCH_ACTION,
 		profiles: {
 			[DEFAULT_PROFILE]: {
 				kind: "r2",

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -7,6 +7,7 @@ import {
 	isEnabled,
 	loadConfig,
 	loadPartialConfig,
+	loadTargetSwitchAction,
 	localConfigPath,
 	normalizeExtraFiles,
 	normalizeSyncFiles,
@@ -25,6 +26,11 @@ import {
 	updateSyncTarget,
 } from "./settings-management.js";
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
+import {
+	showTargetSwitchActionSetting,
+	targetSwitchActionLabel,
+	useSyncTarget,
+} from "./target-switch.js";
 import type { SyncConfig } from "./types.js";
 
 export const MAIN_MENU_ACTIONS = [
@@ -58,9 +64,12 @@ export async function showSyncManager(
 			case "Sync now":
 				await runCancellableOperation(ctx, "Checking current target…", "sync", runRoute, true);
 				break;
-			case "Switch target":
-				if (await showTargetSwitcher(ctx)) continue;
+			case "Switch target": {
+				const result = await showTargetSwitcher(ctx, runRoute);
+				if (result === "pull-attempted") return;
+				if (result === "switched") continue;
 				break;
+			}
 			case "Status & changes":
 				await runCancellableOperation(ctx, "Checking current target…", "diff", runRoute);
 				break;
@@ -90,6 +99,7 @@ async function runCancellableOperation(
 	route: string,
 	runRoute: RunRoute,
 	commitAware = false,
+	cancelledMessage = "Check cancelled; no settings or files were changed.",
 ) {
 	if (ctx.mode !== "tui") {
 		await runRoute(route);
@@ -128,7 +138,7 @@ async function runCancellableOperation(
 	);
 	if (result?.cancelled) {
 		await operation;
-		ctx.ui.notify("Check cancelled; no settings or files were changed.", "info");
+		ctx.ui.notify(cancelledMessage, "info");
 		return;
 	}
 	if (result?.error) throw result.error;
@@ -346,7 +356,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 	return true;
 }
 
-async function showTargetSwitcher(ctx: ExtensionCommandContext) {
+async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRoute) {
 	const raw = await readLocalConfigObject();
 	if (raw?.version !== 2) {
 		ctx.ui.notify("Add a second sync target before switching targets.", "info");
@@ -395,6 +405,13 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext) {
 		);
 		return false;
 	}
+	const targetSwitchAction = await loadTargetSwitchAction();
+	const switchEffect =
+		targetSwitchAction === "ask"
+			? "After switching, pi-sync will ask whether to pull the target."
+			: targetSwitchAction === "pull"
+				? "After switching, pi-sync will immediately pull the target without a pull confirmation."
+				: "After switching, pi-sync will not pull or modify synced files.";
 	const choice = await ctx.ui.select(
 		[
 			"Switch target",
@@ -405,32 +422,27 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext) {
 			`Synced content: ${normalizeSyncFiles(config.syncFiles).length} built-in groups · ${config.extraFiles.length} extra files`,
 			`Auto-sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
 			"",
-			"Switching does not sync or modify files now.",
+			switchEffect,
 		].join("\n"),
 		[`Switch to ${safeTerminalText(name)}`, "Cancel"],
 	);
 	if (choice !== `Switch to ${safeTerminalText(name)}`) return false;
-	await useSyncTarget(ctx, name);
-	return true;
-}
-
-export async function useSyncTarget(ctx: ExtensionCommandContext, name: string) {
-	const normalized = name.trim();
-	if (!normalized) throw new Error("Usage: /sync use <target>");
-	await loadConfig(normalized);
-	await updateLocalConfig((current) => {
-		if (current.version !== 2) throw new Error("Target switching requires version 2 settings.");
-		return { ...current, activeTarget: normalized };
-	});
-	await refreshTargetCompletions();
-	ctx.ui.notify(
-		`Switched to “${safeTerminalText(normalized)}”. No files were synced; use Sync now when ready.`,
-		"info",
+	const result = await useSyncTarget(ctx, name, () =>
+		runCancellableOperation(
+			ctx,
+			`Pulling target “${safeTerminalText(name)}”…`,
+			"pull --yes",
+			runRoute,
+			true,
+			"Pull cancelled; the target was switched, but synced files were not changed.",
+		),
 	);
+	return result.pullAttempted ? "pull-attempted" : "switched";
 }
 
 async function showSettingsMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
 	const partial = await loadPartialConfig();
+	const targetSwitchAction = await loadTargetSwitchAction();
 	const automaticSyncOverridden = Object.hasOwn(process.env, "PI_SYNC_AUTO_SYNC");
 	const selected = await ctx.ui.select(
 		[
@@ -439,10 +451,12 @@ async function showSettingsMenu(ctx: ExtensionCommandContext, runRoute: RunRoute
 			"Automatic sync changes save immediately; synced-content changes use a reviewed draft.",
 			"",
 			`Auto-sync: ${isEnabled(partial.autoSync, true) ? "On" : "Off"}`,
+			`After target switch: ${targetSwitchActionLabel(targetSwitchAction)}`,
 			`Synced content: ${normalizeSyncFiles(partial.syncFiles).length} built-ins · ${normalizeExtraFiles(partial.extraFiles).length} extra`,
 		].join("\n"),
 		[
 			"Choose synced content",
+			"After switching target",
 			automaticSyncOverridden
 				? "Automatic sync (environment override, deprecated)"
 				: "Toggle automatic sync",
@@ -452,6 +466,10 @@ async function showSettingsMenu(ctx: ExtensionCommandContext, runRoute: RunRoute
 	if (!selected || selected === BACK) return;
 	if (selected === "Choose synced content") {
 		await runRoute("files");
+		return;
+	}
+	if (selected === "After switching target") {
+		await showTargetSwitchActionSetting(ctx, targetSwitchAction);
 		return;
 	}
 	if (automaticSyncOverridden) {

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -4,15 +4,12 @@ import {
 	configuredTargetNames,
 	deprecatedPiSyncEnvironmentWarnings,
 	isCloudflareR2Endpoint,
-	isEnabled,
 	loadConfig,
 	loadPartialConfig,
 	loadTargetSwitchAction,
 	localConfigPath,
-	normalizeExtraFiles,
 	normalizeSyncFiles,
 	readLocalConfigObject,
-	updateLocalConfig,
 } from "./config.js";
 import { inspectLock, isStaleLock } from "./lock.js";
 import {
@@ -25,12 +22,9 @@ import {
 	updateStorageProfile,
 	updateSyncTarget,
 } from "./settings-management.js";
+import { showSyncSettings } from "./settings-ui.js";
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
-import {
-	showTargetSwitchActionSetting,
-	targetSwitchActionLabel,
-	useSyncTarget,
-} from "./target-switch.js";
+import { useSyncTarget } from "./target-switch.js";
 import type { SyncConfig } from "./types.js";
 
 export const MAIN_MENU_ACTIONS = [
@@ -46,7 +40,12 @@ export const MAIN_MENU_ACTIONS = [
 const BACK = "Back";
 
 type MainMenuAction = (typeof MAIN_MENU_ACTIONS)[number];
-type RunRoute = (route: string, signal?: AbortSignal, onCommit?: () => void) => Promise<void>;
+type RunRoute = (
+	route: string,
+	signal?: AbortSignal,
+	onCommit?: () => void,
+	target?: string,
+) => Promise<void>;
 
 export async function showSyncManager(
 	ctx: ExtensionCommandContext,
@@ -74,7 +73,7 @@ export async function showSyncManager(
 				await runCancellableOperation(ctx, "Checking current target…", "diff", runRoute);
 				break;
 			case "Settings":
-				await showSettingsMenu(ctx, runRoute);
+				await showSyncSettings(ctx, runRoute);
 				break;
 			case "Manage targets & storage":
 				await showManageMenu(ctx, runRoute);
@@ -100,9 +99,10 @@ async function runCancellableOperation(
 	runRoute: RunRoute,
 	commitAware = false,
 	cancelledMessage = "Check cancelled; no settings or files were changed.",
+	target?: string,
 ) {
 	if (ctx.mode !== "tui") {
-		await runRoute(route);
+		await runRoute(route, undefined, undefined, target);
 		return;
 	}
 	let commitStarted = false;
@@ -126,6 +126,7 @@ async function runCancellableOperation(
 				route,
 				loader.signal,
 				commitAware ? () => (commitStarted = true) : undefined,
+				target,
 			)
 				.then(() => {
 					if (!closed) done({});
@@ -408,9 +409,9 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 	const targetSwitchAction = await loadTargetSwitchAction();
 	const switchEffect =
 		targetSwitchAction === "ask"
-			? "After switching, pi-sync will ask whether to pull the target."
+			? "After switching, pi-sync will ask whether to review a pull for the target."
 			: targetSwitchAction === "pull"
-				? "After switching, pi-sync will immediately pull the target without a pull confirmation."
+				? "After switching, pi-sync will check the target and show exact changes before applying them."
 				: "After switching, pi-sync will not pull or modify synced files.";
 	const choice = await ctx.ui.select(
 		[
@@ -427,66 +428,18 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 		[`Switch to ${safeTerminalText(name)}`, "Cancel"],
 	);
 	if (choice !== `Switch to ${safeTerminalText(name)}`) return false;
-	const result = await useSyncTarget(ctx, name, () =>
+	const result = await useSyncTarget(ctx, name, (selectedTarget) =>
 		runCancellableOperation(
 			ctx,
 			`Pulling target “${safeTerminalText(name)}”…`,
-			"pull --yes",
+			"pull",
 			runRoute,
 			true,
 			"Pull cancelled; the target was switched, but synced files were not changed.",
+			selectedTarget,
 		),
 	);
 	return result.pullAttempted ? "pull-attempted" : "switched";
-}
-
-async function showSettingsMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
-	const partial = await loadPartialConfig();
-	const targetSwitchAction = await loadTargetSwitchAction();
-	const automaticSyncOverridden = Object.hasOwn(process.env, "PI_SYNC_AUTO_SYNC");
-	const selected = await ctx.ui.select(
-		[
-			`Settings for target “${safeTerminalText(partial.target ?? "default")}”`,
-			`Storage: ${storageDescription(partial.storageKind, partial.endpoint, partial.bucket)}`,
-			"Automatic sync changes save immediately; synced-content changes use a reviewed draft.",
-			"",
-			`Auto-sync: ${isEnabled(partial.autoSync, true) ? "On" : "Off"}`,
-			`After target switch: ${targetSwitchActionLabel(targetSwitchAction)}`,
-			`Synced content: ${normalizeSyncFiles(partial.syncFiles).length} built-ins · ${normalizeExtraFiles(partial.extraFiles).length} extra`,
-		].join("\n"),
-		[
-			"Choose synced content",
-			"After switching target",
-			automaticSyncOverridden
-				? "Automatic sync (environment override, deprecated)"
-				: "Toggle automatic sync",
-			BACK,
-		],
-	);
-	if (!selected || selected === BACK) return;
-	if (selected === "Choose synced content") {
-		await runRoute("files");
-		return;
-	}
-	if (selected === "After switching target") {
-		await showTargetSwitchActionSetting(ctx, targetSwitchAction);
-		return;
-	}
-	if (automaticSyncOverridden) {
-		ctx.ui.notify(
-			"Automatic sync is read-only because deprecated PI_SYNC_AUTO_SYNC currently overrides this target. Move it into target settings before the future major removal.",
-			"warning",
-		);
-		return;
-	}
-	await updateCurrentTarget((target) => ({
-		...target,
-		autoSync: !isEnabled(partial.autoSync, true),
-	}));
-	ctx.ui.notify(
-		`Automatic sync ${isEnabled(partial.autoSync, true) ? "disabled" : "enabled"} for “${safeTerminalText(partial.target ?? "default")}”.`,
-		"info",
-	);
 }
 
 async function showManageMenu(ctx: ExtensionCommandContext, _runRoute: RunRoute) {
@@ -919,20 +872,6 @@ async function chooseCustomRemoteLocation(
 
 function formatRemotePath(prefix: string, namespace: string) {
 	return safeTerminalText(`${prefix}/profiles/${namespace}/`);
-}
-
-async function updateCurrentTarget(
-	update: (target: Record<string, unknown>) => Record<string, unknown>,
-) {
-	await updateLocalConfig((current) => {
-		if (current.version !== 2) return update(current);
-		const targets = ownRecord(current.targets);
-		const active = typeof current.activeTarget === "string" ? current.activeTarget : undefined;
-		if (!targets || !active) throw new Error("Current target is not configured.");
-		const target = ownRecord(targets[active]);
-		if (!target) throw new Error(`Current target “${active}” is invalid.`);
-		return { ...current, targets: { ...targets, [active]: update(target) } };
-	});
 }
 
 async function requiredExistingBucket(ctx: ExtensionCommandContext, example: string) {

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+	DEFAULT_TARGET_SWITCH_ACTION,
 	effectiveTargetRemoteIdentity,
 	localConfigPath,
 	readLocalConfigObject,
@@ -112,6 +113,7 @@ export async function saveNewV2Settings(input: {
 	const settings = {
 		version: 2,
 		activeTarget: input.targetName,
+		targetSwitchAction: DEFAULT_TARGET_SWITCH_ACTION,
 		profiles: { [input.storageProfileName]: { ...input.profile } },
 		targets: {
 			[input.targetName]: { ...input.target, profile: input.storageProfileName },

--- a/extensions/pi-sync/src/settings-ui.ts
+++ b/extensions/pi-sync/src/settings-ui.ts
@@ -1,0 +1,199 @@
+import {
+	type ExtensionCommandContext,
+	getSettingsListTheme,
+} from "@earendil-works/pi-coding-agent";
+import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import {
+	isCloudflareR2Endpoint,
+	isEnabled,
+	loadPartialConfig,
+	loadTargetSwitchAction,
+	localConfigPath,
+	normalizeExtraFiles,
+	normalizeSyncFiles,
+	readLocalConfigObject,
+	updateLocalConfig,
+} from "./config.js";
+import { errorMessage, safeTerminalText } from "./sync-format.js";
+import {
+	saveTargetSwitchAction,
+	TARGET_SWITCH_ACTION_OPTIONS,
+	targetSwitchActionFromLabel,
+	targetSwitchActionLabel,
+} from "./target-switch.js";
+
+export type SyncSettingsRoute = (
+	route: string,
+	signal?: AbortSignal,
+	onCommit?: () => void,
+	target?: string,
+) => Promise<void>;
+
+export async function showSyncSettings(ctx: ExtensionCommandContext, runRoute: SyncSettingsRoute) {
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify(`Edit pi-sync settings manually: ${safeTerminalText(localConfigPath())}`, "info");
+		return;
+	}
+	while (true) {
+		const raw = await readLocalConfigObject();
+		const version2 = raw?.version === 2;
+		const partial = await loadPartialConfig();
+		const action = await showSettingsList(ctx, partial, version2);
+		if (action !== "files") return;
+		await runRoute("files", undefined, undefined, version2 ? partial.target : undefined);
+	}
+}
+
+async function showSettingsList(
+	ctx: ExtensionCommandContext,
+	partial: Awaited<ReturnType<typeof loadPartialConfig>>,
+	version2: boolean,
+) {
+	const targetName = version2 ? partial.target : undefined;
+	const automaticSyncOverridden = Object.hasOwn(process.env, "PI_SYNC_AUTO_SYNC");
+	const automaticSyncValue = isEnabled(partial.autoSync, true) ? "On" : "Off";
+	const targetSwitchAction = await loadTargetSwitchAction();
+	const targetSwitchValue = targetSwitchActionLabel(targetSwitchAction);
+	let saveQueue = Promise.resolve();
+	const latestRequested = new Map<string, string>();
+
+	return ctx.ui.custom<"files" | undefined>((tui, theme, _keybindings, done) => {
+		const items: SettingItem[] = [
+			{
+				id: "automaticSync",
+				label: automaticSyncOverridden ? "Automatic sync (environment override)" : "Automatic sync",
+				description: automaticSyncOverridden
+					? "Read-only while deprecated PI_SYNC_AUTO_SYNC overrides this target. Move the value into target settings before the future major removal."
+					: "Run conservative synchronization automatically at session startup and shutdown.",
+				currentValue: automaticSyncValue,
+				...(automaticSyncOverridden ? {} : { values: ["On", "Off"] }),
+			},
+			...(version2
+				? [
+						{
+							id: "targetSwitchAction",
+							label: "After target switch",
+							description:
+								"Ask before starting a pull, start a pull review automatically, or switch without checking remote files. Every pull still shows exact changes before apply.",
+							currentValue: targetSwitchValue,
+							values: TARGET_SWITCH_ACTION_OPTIONS.map(({ label }) => label),
+						},
+					]
+				: []),
+			{
+				id: "syncFiles",
+				label: "Synced content",
+				description: `${normalizeSyncFiles(partial.syncFiles).length} built-in groups and ${normalizeExtraFiles(partial.extraFiles).length} extra files. Opens the reviewed content-selection draft.`,
+				currentValue: "Open editor",
+				values: ["Open editor"],
+			},
+		];
+		const container = new Container();
+		container.addChild(new Text(theme.fg("accent", theme.bold("Pi Sync Settings")), 1, 0));
+		container.addChild(
+			new Text(
+				theme.fg(
+					"muted",
+					`Target: ${safeTerminalText(partial.target ?? "default")} · ${storageDescription(partial.storageKind, partial.endpoint, partial.bucket)}`,
+				),
+				1,
+				0,
+			),
+		);
+		let settingsList: SettingsList;
+		let closing = false;
+		const closeAfterSaves = (result: "files" | undefined) => {
+			if (closing) return;
+			closing = true;
+			void saveQueue.then(() => done(result));
+		};
+		settingsList = new SettingsList(
+			items,
+			Math.min(items.length + 2, 15),
+			getSettingsListTheme(),
+			(id, newValue) => {
+				if (id === "syncFiles") {
+					closeAfterSaves("files");
+					return;
+				}
+				latestRequested.set(id, newValue);
+				const fallbackValue = id === "automaticSync" ? automaticSyncValue : targetSwitchValue;
+				const operation = saveQueue.then(async () => {
+					let previousValue = fallbackValue;
+					try {
+						if (id === "automaticSync") {
+							const latest = await loadPartialConfig(targetName);
+							previousValue = isEnabled(latest.autoSync, true) ? "On" : "Off";
+							const enabled = newValue === "On";
+							await updateSettingsTarget(targetName, (target) => ({
+								...target,
+								autoSync: enabled,
+							}));
+							ctx.ui.notify(
+								`Automatic sync ${enabled ? "enabled" : "disabled"} for “${safeTerminalText(partial.target ?? "default")}”.`,
+								"info",
+							);
+						} else if (id === "targetSwitchAction") {
+							const latest = await loadTargetSwitchAction();
+							previousValue = targetSwitchActionLabel(latest);
+							const action = targetSwitchActionFromLabel(newValue);
+							if (!action) throw new Error(`Invalid target-switch action: ${newValue}`);
+							await saveTargetSwitchAction(action);
+							ctx.ui.notify(`After target switch: ${newValue}.`, "info");
+						}
+					} catch (error) {
+						if (latestRequested.get(id) === newValue) {
+							settingsList.updateValue(id, previousValue);
+						}
+						ctx.ui.notify(`Pi Sync settings save failed: ${errorMessage(error)}`, "error");
+						tui.requestRender();
+					}
+				});
+				saveQueue = operation.catch(() => undefined);
+			},
+			() => closeAfterSaves(undefined),
+			{ enableSearch: true },
+		);
+		container.addChild(settingsList);
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput(data: string) {
+				settingsList.handleInput?.(data);
+				tui.requestRender();
+			},
+		};
+	});
+}
+
+async function updateSettingsTarget(
+	targetName: string | undefined,
+	update: (target: Record<string, unknown>) => Record<string, unknown>,
+) {
+	await updateLocalConfig((current) => {
+		if (current.version !== 2) return update(current);
+		const targets = ownRecord(current.targets);
+		const selected =
+			targetName ?? (typeof current.activeTarget === "string" ? current.activeTarget : undefined);
+		if (!targets || !selected) throw new Error("Settings target is not configured.");
+		const target = ownRecord(targets[selected]);
+		if (!target) throw new Error(`Settings target “${selected}” is invalid.`);
+		return { ...current, targets: { ...targets, [selected]: update(target) } };
+	});
+}
+
+function storageDescription(
+	kind: string | undefined,
+	endpoint: string | undefined,
+	bucket: string | undefined,
+) {
+	const label =
+		kind === "r2" || isCloudflareR2Endpoint(endpoint) ? "Cloudflare R2" : "S3-compatible";
+	return `${label} · ${safeTerminalText(bucket ?? "bucket missing")}`;
+}
+
+function ownRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -39,7 +39,7 @@ import {
 } from "./config.js";
 import { showFileSelection } from "./file-selection.js";
 import { inspectLock, isLockGuardHeld, isStaleLock, unlock, withLock } from "./lock.js";
-import { showSetupWizard, showSyncManager, useSyncTarget } from "./manager-ui.js";
+import { showSetupWizard, showSyncManager } from "./manager-ui.js";
 import {
 	historyKey,
 	latestKey,
@@ -86,6 +86,7 @@ import {
 	snapshotsMatch,
 	syncPolicyChanged,
 } from "./sync-state.js";
+import { useSyncTarget } from "./target-switch.js";
 import type {
 	CommandOptions,
 	LatestPointer,
@@ -96,9 +97,7 @@ import type {
 	SyncState,
 } from "./types.js";
 
-const gzipAsync = promisify(gzip);
-const gunzipAsync = promisify(gunzip);
-
+const [gzipAsync, gunzipAsync] = [promisify(gzip), promisify(gunzip)];
 const STATUS_KEY = "sync";
 const VERSION = 1;
 const DEFAULT_PROFILE = "default";
@@ -191,7 +190,9 @@ async function executeCommand(
 				ctx.ui.notify(usage(), "info");
 				return;
 			case "use":
-				await useSyncTarget(ctx, options.args[0] ?? "");
+				await useSyncTarget(ctx, options.args[0] ?? "", () =>
+					withLock("pull", () => pull(ctx, { ...options, yes: true })),
+				);
 				return;
 			case "init":
 				await initConfig(ctx);

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -158,8 +158,8 @@ export default function sync(pi: ExtensionAPI) {
 async function handleCommand(rawArgs: string, ctx: ExtensionCommandContext) {
 	if (!rawArgs.trim()) {
 		try {
-			await showSyncManager(ctx, (route, signal, onCommit) =>
-				executeCommand(route, ctx, signal, onCommit),
+			await showSyncManager(ctx, (route, signal, onCommit, target) =>
+				executeCommand(route, ctx, signal, onCommit, target),
 			);
 		} catch (error) {
 			ctx.ui.setStatus(STATUS_KEY, undefined);
@@ -175,12 +175,14 @@ async function executeCommand(
 	ctx: ExtensionCommandContext,
 	signal?: AbortSignal,
 	onCommit?: () => void,
+	target?: string,
 ) {
 	try {
 		const command = await resolveSyncCommand(rawArgs, ctx);
 		if (!command) return;
 		const { subcommand, rest } = command;
 		const options = parseOptions(rest);
+		if (target !== undefined) options.target = target;
 		if (signal) options.signal = signal;
 		if (onCommit) options.onCommit = onCommit;
 		validateCommandOptions(subcommand, options);
@@ -190,8 +192,8 @@ async function executeCommand(
 				ctx.ui.notify(usage(), "info");
 				return;
 			case "use":
-				await useSyncTarget(ctx, options.args[0] ?? "", () =>
-					withLock("pull", () => pull(ctx, { ...options, yes: true })),
+				await useSyncTarget(ctx, options.args[0] ?? "", (selectedTarget) =>
+					withLock("pull", () => pull(ctx, { ...options, target: selectedTarget })),
 				);
 				return;
 			case "init":

--- a/extensions/pi-sync/src/target-switch.ts
+++ b/extensions/pi-sync/src/target-switch.ts
@@ -1,0 +1,102 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { setSyncTargetCompletions } from "./command.js";
+import {
+	configuredTargetNames,
+	loadConfig,
+	loadTargetSwitchAction,
+	updateLocalConfig,
+} from "./config.js";
+import { safeTerminalText } from "./sync-format.js";
+import type { TargetSwitchAction } from "./types.js";
+
+const TARGET_SWITCH_ACTION_OPTIONS: Array<{ label: string; value: TargetSwitchAction }> = [
+	{ label: "Ask before pull", value: "ask" },
+	{ label: "Always pull", value: "pull" },
+	{ label: "Switch only", value: "switch-only" },
+];
+
+export function targetSwitchActionLabel(action: TargetSwitchAction) {
+	return TARGET_SWITCH_ACTION_OPTIONS.find((option) => option.value === action)?.label ?? action;
+}
+
+export async function showTargetSwitchActionSetting(
+	ctx: ExtensionCommandContext,
+	current: TargetSwitchAction,
+) {
+	const labels = TARGET_SWITCH_ACTION_OPTIONS.map(({ label, value }) =>
+		value === current ? `${label} (current)` : label,
+	);
+	const selected = await ctx.ui.select(
+		[
+			"After switching target",
+			"",
+			"Ask before pull is the default. Always pull skips pull confirmation but still creates a backup and stops on conflicts.",
+		].join("\n"),
+		[...labels, "Back"],
+	);
+	if (!selected || selected === "Back") return;
+	const selectedLabel = selected.replace(/ \(current\)$/u, "");
+	const action = TARGET_SWITCH_ACTION_OPTIONS.find(
+		(option) => option.label === selectedLabel,
+	)?.value;
+	if (!action || action === current) return;
+	await updateLocalConfig((settings) => {
+		if (settings.version !== 2) {
+			throw new Error("Target-switch settings require version 2 settings.");
+		}
+		return { ...settings, targetSwitchAction: action };
+	});
+	ctx.ui.notify(`After switching target: ${targetSwitchActionLabel(action)}.`, "info");
+}
+
+export interface TargetSwitchResult {
+	pullAttempted: boolean;
+}
+
+export async function useSyncTarget(
+	ctx: ExtensionCommandContext,
+	name: string,
+	pullCurrentTarget?: () => Promise<void>,
+): Promise<TargetSwitchResult> {
+	const normalized = name.trim();
+	if (!normalized) throw new Error("Usage: /sync use <target>");
+	await loadConfig(normalized);
+	const action = await loadTargetSwitchAction();
+	await updateLocalConfig((current) => {
+		if (current.version !== 2) throw new Error("Target switching requires version 2 settings.");
+		return { ...current, activeTarget: normalized };
+	});
+	setSyncTargetCompletions(await configuredTargetNames());
+
+	if (action === "switch-only") {
+		ctx.ui.notify(`Switched to “${safeTerminalText(normalized)}”. No files were pulled.`, "info");
+		return { pullAttempted: false };
+	}
+	if (action === "ask") {
+		if (ctx.mode !== "tui") {
+			ctx.ui.notify(
+				`Switched to “${safeTerminalText(normalized)}”. No files were pulled because confirmation requires TUI mode; run /sync pull to apply the target.`,
+				"info",
+			);
+			return { pullAttempted: false };
+		}
+		const confirmed = await ctx.ui.confirm(
+			`Pull target “${safeTerminalText(normalized)}” now?`,
+			"This replaces selected local files with the target’s remote versions. pi-sync creates a local backup first and stops on unresolved conflicts.",
+		);
+		if (!confirmed) {
+			ctx.ui.notify(
+				`Switched to “${safeTerminalText(normalized)}”; files were not pulled.`,
+				"info",
+			);
+			return { pullAttempted: false };
+		}
+	}
+
+	ctx.ui.notify(`Switched to “${safeTerminalText(normalized)}”. Pulling remote files…`, "info");
+	if (!pullCurrentTarget) {
+		throw new Error(`Switched to “${safeTerminalText(normalized)}”, but pull is unavailable.`);
+	}
+	await pullCurrentTarget();
+	return { pullAttempted: true };
+}

--- a/extensions/pi-sync/src/target-switch.ts
+++ b/extensions/pi-sync/src/target-switch.ts
@@ -4,14 +4,18 @@ import {
 	configuredTargetNames,
 	loadConfig,
 	loadTargetSwitchAction,
+	readLocalConfigObject,
 	updateLocalConfig,
 } from "./config.js";
 import { safeTerminalText } from "./sync-format.js";
 import type { TargetSwitchAction } from "./types.js";
 
-const TARGET_SWITCH_ACTION_OPTIONS: Array<{ label: string; value: TargetSwitchAction }> = [
+export const TARGET_SWITCH_ACTION_OPTIONS: ReadonlyArray<{
+	label: string;
+	value: TargetSwitchAction;
+}> = [
 	{ label: "Ask before pull", value: "ask" },
-	{ label: "Always pull", value: "pull" },
+	{ label: "Start pull", value: "pull" },
 	{ label: "Switch only", value: "switch-only" },
 ];
 
@@ -19,34 +23,17 @@ export function targetSwitchActionLabel(action: TargetSwitchAction) {
 	return TARGET_SWITCH_ACTION_OPTIONS.find((option) => option.value === action)?.label ?? action;
 }
 
-export async function showTargetSwitchActionSetting(
-	ctx: ExtensionCommandContext,
-	current: TargetSwitchAction,
-) {
-	const labels = TARGET_SWITCH_ACTION_OPTIONS.map(({ label, value }) =>
-		value === current ? `${label} (current)` : label,
-	);
-	const selected = await ctx.ui.select(
-		[
-			"After switching target",
-			"",
-			"Ask before pull is the default. Always pull skips pull confirmation but still creates a backup and stops on conflicts.",
-		].join("\n"),
-		[...labels, "Back"],
-	);
-	if (!selected || selected === "Back") return;
-	const selectedLabel = selected.replace(/ \(current\)$/u, "");
-	const action = TARGET_SWITCH_ACTION_OPTIONS.find(
-		(option) => option.label === selectedLabel,
-	)?.value;
-	if (!action || action === current) return;
+export function targetSwitchActionFromLabel(label: string): TargetSwitchAction | undefined {
+	return TARGET_SWITCH_ACTION_OPTIONS.find((option) => option.label === label)?.value;
+}
+
+export async function saveTargetSwitchAction(action: TargetSwitchAction) {
 	await updateLocalConfig((settings) => {
 		if (settings.version !== 2) {
 			throw new Error("Target-switch settings require version 2 settings.");
 		}
 		return { ...settings, targetSwitchAction: action };
 	});
-	ctx.ui.notify(`After switching target: ${targetSwitchActionLabel(action)}.`, "info");
 }
 
 export interface TargetSwitchResult {
@@ -56,16 +43,28 @@ export interface TargetSwitchResult {
 export async function useSyncTarget(
 	ctx: ExtensionCommandContext,
 	name: string,
-	pullCurrentTarget?: () => Promise<void>,
+	pullCurrentTarget?: (target: string) => Promise<void>,
 ): Promise<TargetSwitchResult> {
 	const normalized = name.trim();
 	if (!normalized) throw new Error("Usage: /sync use <target>");
 	await loadConfig(normalized);
+	const before = await readLocalConfigObject();
+	if (before?.version === 2 && before.activeTarget === normalized) {
+		ctx.ui.notify(`Target “${safeTerminalText(normalized)}” is already current.`, "info");
+		return { pullAttempted: false };
+	}
 	const action = await loadTargetSwitchAction();
+	let switched = false;
 	await updateLocalConfig((current) => {
 		if (current.version !== 2) throw new Error("Target switching requires version 2 settings.");
+		if (current.activeTarget === normalized) return current;
+		switched = true;
 		return { ...current, activeTarget: normalized };
 	});
+	if (!switched) {
+		ctx.ui.notify(`Target “${safeTerminalText(normalized)}” is already current.`, "info");
+		return { pullAttempted: false };
+	}
 	setSyncTargetCompletions(await configuredTargetNames());
 
 	if (action === "switch-only") {
@@ -81,8 +80,8 @@ export async function useSyncTarget(
 			return { pullAttempted: false };
 		}
 		const confirmed = await ctx.ui.confirm(
-			`Pull target “${safeTerminalText(normalized)}” now?`,
-			"This replaces selected local files with the target’s remote versions. pi-sync creates a local backup first and stops on unresolved conflicts.",
+			`Review a pull for target “${safeTerminalText(normalized)}” now?`,
+			"pi-sync will check the remote snapshot and show the exact local writes and deletions before applying anything.",
 		);
 		if (!confirmed) {
 			ctx.ui.notify(
@@ -93,10 +92,13 @@ export async function useSyncTarget(
 		}
 	}
 
-	ctx.ui.notify(`Switched to “${safeTerminalText(normalized)}”. Pulling remote files…`, "info");
+	ctx.ui.notify(
+		`Switched to “${safeTerminalText(normalized)}”. Checking remote files for a reviewed pull…`,
+		"info",
+	);
 	if (!pullCurrentTarget) {
 		throw new Error(`Switched to “${safeTerminalText(normalized)}”, but pull is unavailable.`);
 	}
-	await pullCurrentTarget();
+	await pullCurrentTarget(normalized);
 	return { pullAttempted: true };
 }

--- a/extensions/pi-sync/src/types.ts
+++ b/extensions/pi-sync/src/types.ts
@@ -1,4 +1,5 @@
 export type StorageProfileKind = "r2" | "s3-compatible";
+export type TargetSwitchAction = "ask" | "pull" | "switch-only";
 
 export interface StorageProfileSettings {
 	kind?: StorageProfileKind;
@@ -23,6 +24,7 @@ export interface SyncTargetSettings {
 export interface PiSyncSettingsV2 {
 	version: 2;
 	activeTarget?: string;
+	targetSwitchAction?: TargetSwitchAction;
 	profiles?: Record<string, StorageProfileSettings>;
 	targets?: Record<string, SyncTargetSettings>;
 	[key: string]: unknown;

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -24,6 +24,7 @@ import {
 import { migrateLegacySettings } from "../src/settings-management.js";
 import { recoverPendingSnapshotTransactions } from "../src/snapshot-transaction.js";
 import sync, { parseOptions } from "../src/sync.js";
+import { useSyncTarget } from "../src/target-switch.js";
 
 initTheme("dark", false);
 
@@ -293,7 +294,7 @@ test("Sync now read-only check aborts from Escape before any publication", async
 	});
 });
 
-test("switch target previews and atomically changes only the active target", async () => {
+test("switch target asks to pull by default and declining leaves local files unchanged", async () => {
 	await withTempSettings(async () => {
 		const settings = v2Settings();
 		settings.profiles.s3 = {
@@ -317,12 +318,17 @@ test("switch target previews and atomically changes only the active target", asy
 		sync(mock.pi);
 		const selections = ["Switch target", "work", "Switch to work", undefined];
 		const calls: Array<{ title: string; options: string[] }> = [];
+		let pullPrompt = "";
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			select: async (title: string, options: string[]) => {
 				calls.push({ title, options });
 				return selections.shift();
+			},
+			confirm: async (title: string, message: string) => {
+				pullPrompt = `${title}\n${message}`;
+				return false;
 			},
 		});
 
@@ -336,9 +342,224 @@ test("switch target previews and atomically changes only the active target", asy
 		]);
 		assert.match(calls[2]?.title ?? "", /From: home/);
 		assert.match(calls[2]?.title ?? "", /To: work/);
-		assert.match(calls[2]?.title ?? "", /does not sync or modify files/i);
+		assert.match(calls[2]?.title ?? "", /ask whether to pull/i);
+		assert.match(pullPrompt, /Pull target “work” now\?/);
+		assert.match(pullPrompt, /selected local files/i);
 		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
-		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”/);
+		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”.*not pulled/i);
+	});
+});
+
+test("accepting the default post-switch prompt starts a pull", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		let pullCalls = 0;
+		let promptTitle = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async (title: string) => {
+				promptTitle = title;
+				return true;
+			},
+		});
+
+		const result = await useSyncTarget(ctx, "work", async () => {
+			pullCalls += 1;
+		});
+
+		assert.match(promptTitle, /Pull target “work” now\?/);
+		assert.equal(pullCalls, 1);
+		assert.equal(result.pullAttempted, true);
+	});
+});
+
+test("always-pull target switching skips confirmation and applies remote settings", async () => {
+	await withTempSettings(async (agentDir) => {
+		const settings = v2Settings();
+		settings.targetSwitchAction = "pull";
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const remoteSnapshot = snapshotPayload("work-snapshot", '{"remote":true}\n');
+		remoteSnapshot.profile = "work";
+		const encoded = gzipSync(Buffer.from(JSON.stringify(remoteSnapshot)));
+		const pointer = {
+			version: 1,
+			profile: "work",
+			snapshot: remoteSnapshot.id,
+			sha256: createHash("sha256").update(encoded).digest("hex"),
+			createdAt: remoteSnapshot.createdAt,
+			machine: remoteSnapshot.machine,
+		};
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input) => {
+			const url = new URL(String(input));
+			if (url.pathname.endsWith("/profiles/work/latest.json")) return Response.json(pointer);
+			if (url.pathname.endsWith(`/profiles/work/snapshots/${remoteSnapshot.id}.json.gz`)) {
+				return new Response(new Uint8Array(encoded));
+			}
+			throw new Error(`Unexpected request: ${url.pathname}`);
+		}) as typeof globalThis.fetch;
+		try {
+			const confirmationTitles: string[] = [];
+			let reloads = 0;
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				confirm: async (title: string) => {
+					confirmationTitles.push(title);
+					return title === "Reload Pi resources now?";
+				},
+				reload: async () => {
+					reloads += 1;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("use work", ctx);
+
+			assert.deepEqual(confirmationTitles, ["Reload Pi resources now?"]);
+			assert.equal((await readLocalConfigObject())?.activeTarget, "work");
+			assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"remote":true}\n');
+			assert.equal(reloads, 1);
+			assert.match(notifications.map((item) => item.message).join("\n"), /Pulled 1 files/);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("always-pull keeps the switched target and reports a pull failure", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targetSwitchAction = "pull";
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => new Response(null, { status: 404 })) as typeof globalThis.fetch;
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext();
+
+			await mock.commands.get("sync")?.handler("use work", ctx);
+
+			assert.equal((await readLocalConfigObject())?.activeTarget, "work");
+			assert.match(notifications[0]?.message ?? "", /Switched to “work”.*Pulling/);
+			assert.match(notifications.at(-1)?.message ?? "", /Remote is empty/);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("cancelling an automatic post-switch pull reports that the target remains switched", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targetSwitchAction = "pull";
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		writeSettings(settings);
+		const originalFetch = globalThis.fetch;
+		let aborted = false;
+		globalThis.fetch = ((_input, init) =>
+			new Promise<Response>((_resolve, reject) => {
+				if (init?.signal?.aborted) {
+					aborted = true;
+					reject(new DOMException("Aborted", "AbortError"));
+					return;
+				}
+				init?.signal?.addEventListener(
+					"abort",
+					() => {
+						aborted = true;
+						reject(new DOMException("Aborted", "AbortError"));
+					},
+					{ once: true },
+				);
+			})) as typeof globalThis.fetch;
+		try {
+			const selections = ["Switch target", "work", "Switch to work"];
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => selections.shift(),
+				custom: async (factory: unknown) => {
+					const loader = createCustomSelectorHarness(factory, 60);
+					loader.handleInput("\u001b");
+					loader.dispose();
+					return loader.result;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("", ctx);
+
+			assert.equal(aborted, true);
+			assert.equal((await readLocalConfigObject())?.activeTarget, "work");
+			assert.match(
+				notifications.at(-1)?.message ?? "",
+				/Pull cancelled; the target was switched, but synced files were not changed/,
+			);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("switch-only target setting retains the previous no-pull behavior", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targetSwitchAction = "switch-only";
+		settings.targets.work = { ...settings.targets.home, namespace: "work" };
+		settings.future = { retained: true };
+		writeSettings(settings);
+		const mock = createMockPi();
+		sync(mock.pi);
+		let confirmations = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => {
+				confirmations += 1;
+				return true;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("use work", ctx);
+
+		const saved = await readLocalConfigObject();
+		assert.equal(confirmations, 0);
+		assert.equal(saved?.activeTarget, "work");
+		assert.deepEqual(saved?.future, { retained: true });
+		assert.match(notifications.at(-1)?.message ?? "", /No files were pulled/);
+	});
+});
+
+test("settings menu persists the target-switch action and preserves unknown fields", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.future = { retained: true };
+		writeSettings(settings);
+		const selections = ["Settings", "After switching target", "Always pull", undefined];
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		assert.equal(saved?.targetSwitchAction, "pull");
+		assert.deepEqual(saved?.future, { retained: true });
 	});
 });
 
@@ -728,10 +949,20 @@ test("direct use switches targets and target options parse exactly", async () =>
 		await mock.commands.get("sync")?.handler("use work", ctx);
 
 		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
-		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”/);
+		assert.match(notifications.at(-1)?.message ?? "", /confirmation requires TUI mode/);
 		assert.equal(parseOptions(["--target", "home"]).target, "home");
 		assert.throws(() => parseOptions(["--target"]), /requires a target name/);
 		assert.throws(() => parseOptions(["--unknown"]), /Unknown sync option/);
+	});
+});
+
+test("invalid target-switch actions fail settings validation", async () => {
+	await withTempSettings(async () => {
+		writeSettings({ ...v2Settings(), targetSwitchAction: "sometimes" });
+		await assert.rejects(
+			loadConfig(),
+			/targetSwitchAction must be "ask", "pull", or "switch-only"/,
+		);
 	});
 });
 
@@ -927,8 +1158,10 @@ function snapshotPayload(id: string, settings: string) {
 function v2Settings(): {
 	version: 2;
 	activeTarget: string;
+	targetSwitchAction?: "ask" | "pull" | "switch-only";
 	profiles: Record<string, Record<string, unknown>>;
 	targets: Record<string, Record<string, unknown>>;
+	future?: Record<string, unknown>;
 } {
 	return {
 		version: 2,

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -342,9 +352,9 @@ test("switch target asks to pull by default and declining leaves local files unc
 		]);
 		assert.match(calls[2]?.title ?? "", /From: home/);
 		assert.match(calls[2]?.title ?? "", /To: work/);
-		assert.match(calls[2]?.title ?? "", /ask whether to pull/i);
-		assert.match(pullPrompt, /Pull target “work” now\?/);
-		assert.match(pullPrompt, /selected local files/i);
+		assert.match(calls[2]?.title ?? "", /ask whether to review a pull/i);
+		assert.match(pullPrompt, /Review a pull for target “work” now\?/);
+		assert.match(pullPrompt, /exact local writes and deletions/i);
 		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
 		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”.*not pulled/i);
 	});
@@ -356,6 +366,7 @@ test("accepting the default post-switch prompt starts a pull", async () => {
 		settings.targets.work = { ...settings.targets.home, namespace: "work" };
 		writeSettings(settings);
 		let pullCalls = 0;
+		let pulledTarget: unknown;
 		let promptTitle = "";
 		const { ctx } = createMockContext({
 			hasUI: true,
@@ -366,17 +377,37 @@ test("accepting the default post-switch prompt starts a pull", async () => {
 			},
 		});
 
-		const result = await useSyncTarget(ctx, "work", async () => {
+		const result = await useSyncTarget(ctx, "work", async (...args: unknown[]) => {
 			pullCalls += 1;
+			pulledTarget = args[0];
 		});
 
-		assert.match(promptTitle, /Pull target “work” now\?/);
+		assert.match(promptTitle, /Review a pull for target “work” now\?/);
 		assert.equal(pullCalls, 1);
+		assert.equal(pulledTarget, "work");
 		assert.equal(result.pullAttempted, true);
 	});
 });
 
-test("always-pull target switching skips confirmation and applies remote settings", async () => {
+test("selecting the current target is idempotent even when post-switch pulls are enabled", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targetSwitchAction = "pull";
+		writeSettings(settings);
+		let pullCalls = 0;
+		const { ctx, notifications } = createMockContext({ hasUI: true, mode: "tui" });
+
+		const result = await useSyncTarget(ctx, "home", async () => {
+			pullCalls += 1;
+		});
+
+		assert.equal(pullCalls, 0);
+		assert.equal(result.pullAttempted, false);
+		assert.match(notifications.at(-1)?.message ?? "", /already current/i);
+	});
+});
+
+test("pull-after-switch starts a reviewed pull and applies remote settings", async () => {
 	await withTempSettings(async (agentDir) => {
 		const settings = v2Settings();
 		settings.targetSwitchAction = "pull";
@@ -405,16 +436,16 @@ test("always-pull target switching skips confirmation and applies remote setting
 			throw new Error(`Unexpected request: ${url.pathname}`);
 		}) as typeof globalThis.fetch;
 		try {
-			const confirmationTitles: string[] = [];
+			const confirmations: Array<{ title: string; message: string }> = [];
 			let reloads = 0;
 			const mock = createMockPi();
 			sync(mock.pi);
 			const { ctx, notifications } = createMockContext({
 				hasUI: true,
 				mode: "tui",
-				confirm: async (title: string) => {
-					confirmationTitles.push(title);
-					return title === "Reload Pi resources now?";
+				confirm: async (title: string, message: string) => {
+					confirmations.push({ title, message });
+					return true;
 				},
 				reload: async () => {
 					reloads += 1;
@@ -423,7 +454,11 @@ test("always-pull target switching skips confirmation and applies remote setting
 
 			await mock.commands.get("sync")?.handler("use work", ctx);
 
-			assert.deepEqual(confirmationTitles, ["Reload Pi resources now?"]);
+			assert.deepEqual(
+				confirmations.map(({ title }) => title),
+				["Pull pi settings?", "Reload Pi resources now?"],
+			);
+			assert.match(confirmations[0]?.message ?? "", /Update locally: settings\.json/);
 			assert.equal((await readLocalConfigObject())?.activeTarget, "work");
 			assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"remote":true}\n');
 			assert.equal(reloads, 1);
@@ -432,6 +467,63 @@ test("always-pull target switching skips confirmation and applies remote setting
 			globalThis.fetch = originalFetch;
 		}
 	});
+});
+
+test("post-switch pulls stay pinned to the selected target across concurrent active-target changes", async () => {
+	for (const route of ["direct", "manager"] as const) {
+		await withTempSettings(async () => {
+			const settings = v2Settings();
+			settings.targetSwitchAction = "pull";
+			settings.targets.work = { ...settings.targets.home, namespace: "work" };
+			writeSettings(settings);
+			const requestedPaths: string[] = [];
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input) => {
+				requestedPaths.push(new URL(String(input)).pathname);
+				return new Response(null, { status: 404 });
+			}) as typeof globalThis.fetch;
+			try {
+				const selections = ["Switch target", "work", "Switch to work"];
+				const mock = createMockPi();
+				sync(mock.pi);
+				const { ctx } = createMockContext({
+					hasUI: true,
+					mode: "rpc",
+					select: async () => selections.shift(),
+				});
+				const mutableContext = ctx as unknown as {
+					ui: { notify: (message: string, level?: string) => void };
+				};
+				const originalNotify = mutableContext.ui.notify.bind(mutableContext.ui);
+				mutableContext.ui.notify = (message, level) => {
+					originalNotify(message, level);
+					if (/Switched to “work”.*Checking remote files/u.test(message)) {
+						writeSettings({ ...settings, activeTarget: "home" });
+					}
+				};
+
+				await mock.commands.get("sync")?.handler(route === "direct" ? "use work" : "", ctx);
+
+				assert.equal((await readLocalConfigObject())?.activeTarget, "home", route);
+				assert.equal(
+					requestedPaths.some((requestedPath) =>
+						requestedPath.endsWith("/profiles/work/latest.json"),
+					),
+					true,
+					route,
+				);
+				assert.equal(
+					requestedPaths.some((requestedPath) =>
+						requestedPath.endsWith("/profiles/home/latest.json"),
+					),
+					false,
+					route,
+				);
+			} finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
+	}
 });
 
 test("always-pull keeps the switched target and reports a pull failure", async () => {
@@ -450,7 +542,7 @@ test("always-pull keeps the switched target and reports a pull failure", async (
 			await mock.commands.get("sync")?.handler("use work", ctx);
 
 			assert.equal((await readLocalConfigObject())?.activeTarget, "work");
-			assert.match(notifications[0]?.message ?? "", /Switched to “work”.*Pulling/);
+			assert.match(notifications[0]?.message ?? "", /Switched to “work”.*Checking remote files/);
 			assert.match(notifications.at(-1)?.message ?? "", /Remote is empty/);
 		} finally {
 			globalThis.fetch = originalFetch;
@@ -541,25 +633,121 @@ test("switch-only target setting retains the previous no-pull behavior", async (
 	});
 });
 
-test("settings menu persists the target-switch action and preserves unknown fields", async () => {
+test("settings menu uses SettingsList and persists target-switch choices in place", async () => {
 	await withTempSettings(async () => {
 		const settings = v2Settings();
 		settings.future = { retained: true };
 		writeSettings(settings);
-		const selections = ["Settings", "After switching target", "Always pull", undefined];
+		const selections = ["Settings", undefined];
+		let initialRender = "";
 		const mock = createMockPi();
 		sync(mock.pi);
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			select: async () => selections.shift(),
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory, 80);
+				initialRender = selector.render().join("\n");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+				await new Promise((resolve) => setImmediate(resolve));
+				selector.handleInput("\u001b");
+				await new Promise((resolve) => setImmediate(resolve));
+				return selector.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		assert.match(initialRender, /Pi Sync Settings/);
+		assert.match(initialRender, /Automatic sync/);
+		assert.match(initialRender, /After target switch/);
+		const saved = await readLocalConfigObject();
+		assert.equal(saved?.targetSwitchAction, "pull");
+		assert.deepEqual(saved?.future, { retained: true });
+	});
+});
+
+test("settings list restores the displayed value when an atomic save is rejected", {
+	skip: process.platform === "win32",
+}, async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		writeSettings(settings);
+		const configPath = localConfigPath();
+		const backupPath = `${configPath}.backup`;
+		const selections = ["Settings", undefined];
+		let afterFailure = "";
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory, 80);
+				selector.handleInput("\u001b[B");
+				renameSync(configPath, backupPath);
+				symlinkSync(backupPath, configPath);
+				try {
+					selector.handleInput("\r");
+					await new Promise((resolve) => setTimeout(resolve, 20));
+					afterFailure = selector.render().join("\n");
+				} finally {
+					unlinkSync(configPath);
+					renameSync(backupPath, configPath);
+				}
+				selector.handleInput("\u001b");
+				await new Promise((resolve) => setImmediate(resolve));
+				return selector.result;
+			},
 		});
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		const saved = await readLocalConfigObject();
-		assert.equal(saved?.targetSwitchAction, "pull");
-		assert.deepEqual(saved?.future, { retained: true });
+		assert.match(afterFailure, /After target switch/);
+		assert.match(afterFailure, /Ask before pull/);
+		assert.doesNotMatch(afterFailure, /Start pull/);
+		assert.match(notifications.at(-1)?.message ?? "", /settings save failed/i);
+		assert.equal((await readLocalConfigObject())?.targetSwitchAction, undefined);
+	});
+});
+
+test("legacy settings screen omits the unavailable target-switch setting", async () => {
+	await withTempSettings(async () => {
+		writeSettings({
+			endpoint: "https://account.r2.cloudflarestorage.com",
+			bucket: "personal-pi",
+			region: "auto",
+			accessKeyId: "r2-access",
+			secretAccessKey: "r2-secret",
+			profile: "home",
+			autoSync: true,
+			syncFiles: ["settings.json"],
+			extraFiles: [],
+		});
+		const selections = ["Settings", undefined];
+		let rendered = "";
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory, 80);
+				rendered = selector.render().join("\n");
+				selector.handleInput("\u001b");
+				return selector.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(rendered, /Automatic sync/);
+		assert.doesNotMatch(rendered, /After target switch/);
 	});
 });
 

--- a/extensions/pi-webui/package.json
+++ b/extensions/pi-webui/package.json
@@ -36,7 +36,7 @@
 		"@radix-ui/themes": "^3.3.0",
 		"bmp-js": "^0.1.0",
 		"heic-decode": "^2.1.0",
-		"radix-ui": "^1.6.6",
+		"radix-ui": "1.6.6",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
 		"sharp": "^0.35.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6763,7 +6763,7 @@
 				"@radix-ui/themes": "^3.3.0",
 				"bmp-js": "^0.1.0",
 				"heic-decode": "^2.1.0",
-				"radix-ui": "^1.6.6",
+				"radix-ui": "1.6.6",
 				"react": "^19.2.8",
 				"react-dom": "^19.2.8",
 				"sharp": "^0.35.3"


### PR DESCRIPTION
## Summary

- ask whether to pull after switching sync targets by default
- add persisted always-pull and switch-only policies while retaining lock, backup, and conflict safeguards
- document and test TUI, non-interactive, cancellation, failure, and settings-persistence behavior

## Verification

- `npm run check` (1,296 tests passed)
- `just pack-sync`
