### PR TITLE
feat(sync): rename settings file to pi-sync.json

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -106,6 +106,7 @@
 - Runtime-auth generation guards prevent stale credential mutation but not stale outer status or connection-invalidation publication; overlapping provider syncs also need latest-task ownership at the lifecycle boundary.
 - Credential-file path and permission checks must run on every locked read, not only startup migration; reject symlinks and repair `0600` through the opened descriptor.
 - Credential filename migrations cannot safely delete a legacy path while uncoordinated older writers may still replace it; install the canonical file exclusively, retain a private legacy recovery copy, and deny canonical, legacy, temporary, and recovery names from sync/export paths.
+- Pi-sync v2 settings may legitimately have no targets or active target after removing the last target. Filename migration can also keep the legacy path active when exclusive canonical installation is unavailable, so repair and schema-migration flows must resolve the effective settings path.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -106,7 +106,7 @@
 - Runtime-auth generation guards prevent stale credential mutation but not stale outer status or connection-invalidation publication; overlapping provider syncs also need latest-task ownership at the lifecycle boundary.
 - Credential-file path and permission checks must run on every locked read, not only startup migration; reject symlinks and repair `0600` through the opened descriptor.
 - Credential filename migrations cannot safely delete a legacy path while uncoordinated older writers may still replace it; install the canonical file exclusively, retain a private legacy recovery copy, and deny canonical, legacy, temporary, and recovery names from sync/export paths.
-- Pi-sync v2 settings may legitimately have no targets or active target after removing the last target. Filename migration can also keep the legacy path active when exclusive canonical installation is unavailable, so repair and schema-migration flows must resolve the effective settings path.
+- Pi-sync v2 settings may legitimately have no targets or active target after removing the last target. Filename migration can keep the legacy path active when exclusive canonical installation is unavailable, so resolve the effective path and cross-process lock any cleanup that temporarily vacates the canonical path.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -105,6 +105,7 @@
 - Symptom: latest-Pi CI reports committed WebUI assets as stale without source changes. Cause: its lockfile-free install can update semver-ranged browser bundle dependencies. Fix: pin bundle inputs that must reproduce committed assets, or regenerate those assets deliberately.
 - Runtime-auth generation guards prevent stale credential mutation but not stale outer status or connection-invalidation publication; overlapping provider syncs also need latest-task ownership at the lifecycle boundary.
 - Credential-file path and permission checks must run on every locked read, not only startup migration; reject symlinks and repair `0600` through the opened descriptor.
+- Credential filename migrations cannot safely delete a legacy path while uncoordinated older writers may still replace it; install the canonical file exclusively, retain a private legacy recovery copy, and deny canonical, legacy, temporary, and recovery names from sync/export paths.
 
 ## TASTE
 

--- a/docs/plans/archived/2026-07-25_pi-sync-settings-filename-plan.md
+++ b/docs/plans/archived/2026-07-25_pi-sync-settings-filename-plan.md
@@ -1,0 +1,32 @@
+## Goal
+
+Rename pi-sync's canonical private settings file from `pi-sync.local.json` to `pi-sync.json` without losing or exposing existing credentials.
+
+## Non-Goals
+
+- Do not split credentials into a second file or change the settings schema.
+- Do not change environment-variable precedence, remote snapshot formats, or sync behavior.
+
+## Plan
+
+- [x] Add focused filename-migration tests covering the canonical path, exact-byte legacy migration, private permissions, canonical precedence, malformed/symlink safety, snapshot exclusion, and one-time startup notice; the initial `npm test` compile failed on the intentionally missing canonical-path and notice exports.
+- [x] Update pi-sync settings persistence to use `pi-sync.json`, safely migrate `pi-sync.local.json` without overwriting a concurrent canonical file, retain legacy fallback on migration failure, and surface a redacted one-time notice; 103 focused pi-sync tests pass, including semantic-invalid, permission, and replacement-race cases.
+- [x] Update command/help text and `extensions/pi-sync/README.md` with the canonical path and compatibility behavior; repository search leaves the old filename only in intentional migration, exclusion, test, and historical-plan references.
+- [x] Run formatting, diagnostics, the full repository check, and `npm run pack:sync`; `npm run check` passed all 1,313 tests and `pack:sync` included `src/config-file.ts` plus the expected 23 package files. The Biome LSP route timed out during initialization on three attempts, while the equivalent Biome and TypeScript gates passed inside `npm run check`.
+
+## Risks
+
+- A migration race could overwrite a newly created canonical file or discard changed credentials; use exclusive installation, identity/content rechecks, and retain the legacy recovery copy.
+- The file contains credentials; create migrated and rewritten files with POSIX `0600` permissions and never include values in notices.
+- Renaming the file could make credentials eligible for pi-sync snapshots; deny canonical, legacy, temporary, and recovery filenames explicitly.
+
+## Rollback / Recovery
+
+The migration copies and syncs the exact legacy bytes while retaining `pi-sync.local.json` as a private recovery copy, avoiding cross-process deletion races. If installation or verification fails, pi-sync keeps using the legacy file for that read and does not overwrite it. When both files exist, `pi-sync.json` wins and the legacy file remains untouched for manual recovery.
+
+## Completion Checklist
+
+- [x] Existing valid `pi-sync.local.json` installations move safely to `pi-sync.json` while retaining a private recovery copy; invalid or unsafe legacy files remain untouched.
+- [x] All active UI, command, help, and documentation paths name `pi-sync.json`, while compatibility behavior is documented.
+- [x] Credentials remain private and canonical, legacy, temporary, and recovery filenames cannot enter a snapshot.
+- [x] Focused tests, `npm run check`, and `npm run pack:sync` pass.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -100,8 +100,14 @@ Escape exits the main menu. Secondary menus provide Back; dirty synced-content d
 The private user settings file is:
 
 ```text
-${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-sync.local.json
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-sync.json
 ```
+
+On first read, an existing `pi-sync.local.json` is migrated byte-for-byte to `pi-sync.json`
+with private POSIX `0600` permissions. The private legacy file is retained as a recovery copy and may
+be deleted after verifying the new file. If both files exist, `pi-sync.json` takes precedence and the
+legacy file remains untouched. Malformed, invalid, symlinked, changed, or otherwise unsafe legacy
+files are never overwritten automatically.
 
 A version 2 example:
 
@@ -208,7 +214,7 @@ Environment-overridden fields are read-only in interactive settings. Cloudflare 
 
 ### Legacy flat settings
 
-Existing flat `pi-sync.local.json` files continue to work unchanged as a synthetic `default` target/profile. The old flat `profile` remains the remote namespace.
+Existing flat settings continue to work unchanged as a synthetic `default` target/profile, including settings migrated from the legacy `pi-sync.local.json` filename. The old flat `profile` remains the remote namespace.
 
 Adding a second target offers an explicit migration preview. On confirmation pi-sync:
 
@@ -292,7 +298,7 @@ Sessions can contain prompts, model output, tool results, file paths, images, an
 
 ## 🛡️ Safety notes
 
-- Credentials stay local and are never included in snapshots.
+- Credentials stay local; `pi-sync.json` and the legacy `pi-sync.local.json` are always excluded from snapshots.
 - Push refuses common secret patterns in locally managed files.
 - Pull/rollback reject unsafe paths, duplicate paths, checksum mismatches, symlink parents, and file/directory replacement hazards before mutation.
 - Unmanaged local/remote files remain preserved.
@@ -320,6 +326,7 @@ extensions/pi-sync/
 │   ├── sync.ts                  # Command and lifecycle orchestration
 │   ├── manager-ui.ts            # Goal-oriented menus and setup/management flows
 │   ├── file-selection.ts        # Transactional synced-content editor
+│   ├── config-file.ts           # Private settings I/O and legacy filename migration
 │   ├── settings-management.ts   # Profiles, targets, migration, and atomic saves
 │   ├── settings-ui.ts           # SettingsList interaction and serialized saves
 │   ├── target-switch.ts         # Post-switch prompt, policy, and target handoff

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -298,7 +298,7 @@ Sessions can contain prompts, model output, tool results, file paths, images, an
 
 ## 🛡️ Safety notes
 
-- Credentials stay local; `pi-sync.json` and the legacy `pi-sync.local.json` are always excluded from snapshots.
+- Credentials stay local; canonical, legacy, temporary, and migration-recovery settings files are always excluded from snapshots.
 - Push refuses common secret patterns in locally managed files.
 - Pull/rollback reject unsafe paths, duplicate paths, checksum mismatches, symlink parents, and file/directory replacement hazards before mutation.
 - Unmanaged local/remote files remain preserved.

--- a/extensions/pi-sync/src/command.ts
+++ b/extensions/pi-sync/src/command.ts
@@ -230,6 +230,6 @@ export function usage() {
 	return [
 		"Usage: /sync <command>",
 		`Commands: ${commands}`,
-		"Settings: use /sync init or edit profiles and targets in ~/.pi/agent/pi-sync.local.json (or $PI_CODING_AGENT_DIR/pi-sync.local.json). Existing PI_SYNC_* overrides still work but are deprecated for future major-version removal.",
+		"Settings: use /sync init or edit profiles and targets in ~/.pi/agent/pi-sync.json (or $PI_CODING_AGENT_DIR/pi-sync.json). Existing PI_SYNC_* overrides still work but are deprecated for future major-version removal.",
 	].join("\n");
 }

--- a/extensions/pi-sync/src/config-file.ts
+++ b/extensions/pi-sync/src/config-file.ts
@@ -1,17 +1,45 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import {
+	constants as fsConstants,
+	mkdir,
+	mkdirSync,
+	realpath,
+	realpathSync,
+	rmdir,
+	rmdirSync,
+	stat,
+	statSync,
+	utimes,
+	utimesSync,
+} from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import lockfile from "proper-lockfile";
 
 const CONFIG_FILE_NAME = "pi-sync.json";
 const LEGACY_CONFIG_FILE_NAME = "pi-sync.local.json";
 const configMigrationNotices = new Map<string, string>();
 const legacyPresenceNoticed = new Set<string>();
+const CONFIG_LOCK_STALE_MS = 30_000;
+const CONFIG_LOCK_UPDATE_MS = 10_000;
+const LOCKFILE_FS_ADAPTER = {
+	mkdir,
+	mkdirSync,
+	realpath,
+	realpathSync,
+	rmdir,
+	rmdirSync,
+	stat,
+	statSync,
+	utimes,
+	utimesSync,
+};
 
 type LinkFile = (source: string, destination: string) => Promise<void>;
 let linkConfigFile: LinkFile = (source, destination) => fs.link(source, destination);
 let afterReplacementInstalledHook: () => Promise<void> = async () => undefined;
+let afterConfigQuarantinedHook: () => Promise<void> = async () => undefined;
 
 export type FileIdentity = { dev: number; ino: number };
 
@@ -41,6 +69,19 @@ export async function withConfigReplacementInstalledHookForTest<T>(
 	}
 }
 
+export async function withConfigQuarantinedHookForTest<T>(
+	hook: () => Promise<void>,
+	run: () => Promise<T>,
+): Promise<T> {
+	const previous = afterConfigQuarantinedHook;
+	afterConfigQuarantinedHook = hook;
+	try {
+		return await run();
+	} finally {
+		afterConfigQuarantinedHook = previous;
+	}
+}
+
 type ConfigSnapshot = {
 	bytes: Buffer;
 	identity: FileIdentity;
@@ -58,10 +99,12 @@ export function legacyLocalConfigPath() {
 }
 
 export async function activeLocalConfigPath() {
-	const canonicalPath = localConfigPath();
-	if (await pathExists(canonicalPath)) return canonicalPath;
-	const legacyPath = legacyLocalConfigPath();
-	return (await pathExists(legacyPath)) ? legacyPath : canonicalPath;
+	return withLocalConfigFileLock(async () => {
+		const canonicalPath = localConfigPath();
+		if (await pathExists(canonicalPath)) return canonicalPath;
+		const legacyPath = legacyLocalConfigPath();
+		return (await pathExists(legacyPath)) ? legacyPath : canonicalPath;
+	});
 }
 
 export function consumeLocalConfigMigrationNotice() {
@@ -74,12 +117,21 @@ export function consumeLocalConfigMigrationNotice() {
 export async function readMigratingLocalConfigDocument(
 	validateForMigration: (settings: Record<string, unknown>) => void,
 ): Promise<LocalConfigDocument | undefined> {
-	const configPath = await prepareLocalConfigPath(validateForMigration);
-	const snapshot = await readConfigSnapshotIfExists(configPath);
-	return snapshot ? { path: configPath, ...snapshot } : undefined;
+	return withLocalConfigFileLock(async () => {
+		const configPath = await prepareLocalConfigPath(validateForMigration);
+		const snapshot = await readConfigSnapshotIfExists(configPath);
+		return snapshot ? { path: configPath, ...snapshot } : undefined;
+	});
 }
 
-export async function replaceLocalConfigDocument(
+export function replaceLocalConfigDocument(
+	document: LocalConfigDocument,
+	value: Record<string, unknown>,
+) {
+	return withLocalConfigFileLock(() => replaceLocalConfigDocumentUnlocked(document, value));
+}
+
+async function replaceLocalConfigDocumentUnlocked(
 	document: LocalConfigDocument,
 	value: Record<string, unknown>,
 ) {
@@ -97,7 +149,7 @@ export async function replaceLocalConfigDocument(
 			throw error;
 		}
 		if (!(await configDocumentStillMatches(document))) {
-			await quarantineAndRemoveConfigIfMatches(canonicalPath, installed, nextBytes);
+			await quarantineAndRemoveConfigIfMatchesUnlocked(canonicalPath, installed, nextBytes);
 			throw settingsChangedError();
 		}
 		return;
@@ -116,7 +168,7 @@ export async function replaceLocalConfigDocument(
 	}
 	await afterReplacementInstalledHook();
 	if (!(await fileIdentityAndContentsMatch(quarantinePath, document.identity, document.bytes))) {
-		await quarantineAndRemoveConfigIfMatches(canonicalPath, installed, nextBytes);
+		await quarantineAndRemoveConfigIfMatchesUnlocked(canonicalPath, installed, nextBytes);
 		await restoreQuarantinedConfig(canonicalPath, quarantinePath);
 		throw settingsChangedError();
 	}
@@ -166,7 +218,7 @@ async function prepareLocalConfigPath(
 	}
 
 	if (!(await configSnapshotStillMatches(legacyPath, legacy))) {
-		const removed = await quarantineAndRemoveConfigIfMatches(
+		const removed = await quarantineAndRemoveConfigIfMatchesUnlocked(
 			canonicalPath,
 			installedIdentity,
 			legacy.bytes,
@@ -291,7 +343,7 @@ async function installPrivateConfigExclusively(
 			if (process.platform !== "win32") await fs.chmod(filePath, 0o600);
 			await syncParentDirectory(filePath).catch(() => undefined);
 		} catch (error) {
-			await quarantineAndRemoveConfigIfMatches(
+			await quarantineAndRemoveConfigIfMatchesUnlocked(
 				filePath,
 				{ dev: installed.dev, ino: installed.ino },
 				bytes,
@@ -345,7 +397,17 @@ async function configSnapshotStillMatches(filePath: string, snapshot: ConfigSnap
 	return fileIdentityAndContentsMatch(filePath, snapshot.identity, snapshot.bytes);
 }
 
-export async function quarantineAndRemoveConfigIfMatches(
+export function quarantineAndRemoveConfigIfMatches(
+	filePath: string,
+	identity: FileIdentity,
+	expectedBytes: Buffer,
+) {
+	return withLocalConfigFileLock(() =>
+		quarantineAndRemoveConfigIfMatchesUnlocked(filePath, identity, expectedBytes),
+	);
+}
+
+async function quarantineAndRemoveConfigIfMatchesUnlocked(
 	filePath: string,
 	identity: FileIdentity,
 	expectedBytes: Buffer,
@@ -359,6 +421,7 @@ export async function quarantineAndRemoveConfigIfMatches(
 	} catch {
 		return false;
 	}
+	await afterConfigQuarantinedHook();
 	try {
 		await syncParentDirectory(filePath);
 	} catch {
@@ -429,6 +492,30 @@ async function restoreQuarantinedConfig(filePath: string, quarantinePath: string
 		await syncParentDirectory(filePath);
 	} catch {
 		// Preserve the quarantine rather than risk deleting settings that changed concurrently.
+	}
+}
+
+export async function withLocalConfigFileLock<T>(run: () => Promise<T>): Promise<T> {
+	const configPath = localConfigPath();
+	await fs.mkdir(path.dirname(configPath), { recursive: true });
+	let compromisedError: Error | undefined;
+	const release = await lockfile.lock(configPath, {
+		fs: LOCKFILE_FS_ADAPTER,
+		lockfilePath: `${configPath}.mutation-lock`,
+		realpath: false,
+		stale: CONFIG_LOCK_STALE_MS,
+		update: CONFIG_LOCK_UPDATE_MS,
+		retries: { retries: 100, factor: 1.2, minTimeout: 10, maxTimeout: 100 },
+		onCompromised: (error) => {
+			compromisedError = error;
+		},
+	});
+	try {
+		const result = await run();
+		if (compromisedError) throw compromisedError;
+		return result;
+	} finally {
+		await release();
 	}
 }
 

--- a/extensions/pi-sync/src/config-file.ts
+++ b/extensions/pi-sync/src/config-file.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -8,13 +9,45 @@ const LEGACY_CONFIG_FILE_NAME = "pi-sync.local.json";
 const configMigrationNotices = new Map<string, string>();
 const legacyPresenceNoticed = new Set<string>();
 
+type LinkFile = (source: string, destination: string) => Promise<void>;
+let linkConfigFile: LinkFile = (source, destination) => fs.link(source, destination);
+let afterReplacementInstalledHook: () => Promise<void> = async () => undefined;
+
 export type FileIdentity = { dev: number; ino: number };
+
+export async function withConfigFileLinkForTest<T>(
+	link: LinkFile,
+	run: () => Promise<T>,
+): Promise<T> {
+	const previous = linkConfigFile;
+	linkConfigFile = link;
+	try {
+		return await run();
+	} finally {
+		linkConfigFile = previous;
+	}
+}
+
+export async function withConfigReplacementInstalledHookForTest<T>(
+	hook: () => Promise<void>,
+	run: () => Promise<T>,
+): Promise<T> {
+	const previous = afterReplacementInstalledHook;
+	afterReplacementInstalledHook = hook;
+	try {
+		return await run();
+	} finally {
+		afterReplacementInstalledHook = previous;
+	}
+}
 
 type ConfigSnapshot = {
 	bytes: Buffer;
 	identity: FileIdentity;
 	parsed: Record<string, unknown>;
 };
+
+export type LocalConfigDocument = ConfigSnapshot & { path: string };
 
 export function localConfigPath() {
 	return path.join(getAgentDir(), CONFIG_FILE_NAME);
@@ -24,6 +57,13 @@ export function legacyLocalConfigPath() {
 	return path.join(getAgentDir(), LEGACY_CONFIG_FILE_NAME);
 }
 
+export async function activeLocalConfigPath() {
+	const canonicalPath = localConfigPath();
+	if (await pathExists(canonicalPath)) return canonicalPath;
+	const legacyPath = legacyLocalConfigPath();
+	return (await pathExists(legacyPath)) ? legacyPath : canonicalPath;
+}
+
 export function consumeLocalConfigMigrationNotice() {
 	const configPath = localConfigPath();
 	const notice = configMigrationNotices.get(configPath);
@@ -31,12 +71,57 @@ export function consumeLocalConfigMigrationNotice() {
 	return notice;
 }
 
-export async function readMigratingLocalConfig(
+export async function readMigratingLocalConfigDocument(
 	validateForMigration: (settings: Record<string, unknown>) => void,
-) {
+): Promise<LocalConfigDocument | undefined> {
 	const configPath = await prepareLocalConfigPath(validateForMigration);
 	const snapshot = await readConfigSnapshotIfExists(configPath);
-	return snapshot?.parsed;
+	return snapshot ? { path: configPath, ...snapshot } : undefined;
+}
+
+export async function replaceLocalConfigDocument(
+	document: LocalConfigDocument,
+	value: Record<string, unknown>,
+) {
+	const nextBytes = Buffer.from(`${JSON.stringify(value, null, "\t")}\n`, "utf8");
+	const canonicalPath = localConfigPath();
+	if (document.path !== canonicalPath) {
+		if (!(await configDocumentStillMatches(document))) throw settingsChangedError();
+		let installed: FileIdentity;
+		try {
+			installed = await installPrivateConfigExclusively(canonicalPath, nextBytes, true);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+				throw new Error("Canonical settings were created concurrently; no settings were replaced.");
+			}
+			throw error;
+		}
+		if (!(await configDocumentStillMatches(document))) {
+			await quarantineAndRemoveConfigIfMatches(canonicalPath, installed, nextBytes);
+			throw settingsChangedError();
+		}
+		return;
+	}
+
+	const quarantinePath = await claimCanonicalConfigDocument(document);
+	let installed: FileIdentity;
+	try {
+		installed = await installPrivateConfigExclusively(canonicalPath, nextBytes, true);
+	} catch (error) {
+		await restoreQuarantinedConfig(canonicalPath, quarantinePath);
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			throw new Error("Canonical settings changed concurrently; no settings were replaced.");
+		}
+		throw error;
+	}
+	await afterReplacementInstalledHook();
+	if (!(await fileIdentityAndContentsMatch(quarantinePath, document.identity, document.bytes))) {
+		await quarantineAndRemoveConfigIfMatches(canonicalPath, installed, nextBytes);
+		await restoreQuarantinedConfig(canonicalPath, quarantinePath);
+		throw settingsChangedError();
+	}
+	if (process.platform !== "win32") await fs.chmod(quarantinePath, 0o600);
+	await syncParentDirectory(canonicalPath).catch(() => undefined);
 }
 
 async function prepareLocalConfigPath(
@@ -177,7 +262,11 @@ function parseConfigObject(bytes: Buffer, filePath: string) {
 	return parsed as Record<string, unknown>;
 }
 
-async function installPrivateConfigExclusively(filePath: string, bytes: Buffer) {
+async function installPrivateConfigExclusively(
+	filePath: string,
+	bytes: Buffer,
+	allowCopyFallback = false,
+) {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	const temporaryPath = path.join(
 		path.dirname(filePath),
@@ -191,14 +280,65 @@ async function installPrivateConfigExclusively(filePath: string, bytes: Buffer) 
 		await handle.sync();
 		await handle.close();
 		handle = undefined;
-		const identity = await fs.lstat(temporaryPath);
-		await fs.link(temporaryPath, filePath);
-		await syncParentDirectory(filePath).catch(() => undefined);
-		return { dev: identity.dev, ino: identity.ino };
+		try {
+			await linkConfigFile(temporaryPath, filePath);
+		} catch (error) {
+			if (!allowCopyFallback || !isUnsupportedLinkError(error)) throw error;
+			await fs.copyFile(temporaryPath, filePath, fsConstants.COPYFILE_EXCL);
+		}
+		const installed = await fs.lstat(filePath);
+		try {
+			if (process.platform !== "win32") await fs.chmod(filePath, 0o600);
+			await syncParentDirectory(filePath).catch(() => undefined);
+		} catch (error) {
+			await quarantineAndRemoveConfigIfMatches(
+				filePath,
+				{ dev: installed.dev, ino: installed.ino },
+				bytes,
+			);
+			throw error;
+		}
+		return { dev: installed.dev, ino: installed.ino };
 	} finally {
 		await handle?.close().catch(() => undefined);
 		await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
 	}
+}
+
+async function configDocumentStillMatches(document: LocalConfigDocument) {
+	return fileIdentityAndContentsMatch(document.path, document.identity, document.bytes);
+}
+
+async function claimCanonicalConfigDocument(document: LocalConfigDocument) {
+	const quarantinePath = path.join(
+		path.dirname(document.path),
+		`.${path.basename(document.path)}.${randomUUID()}.schema-migration-source`,
+	);
+	try {
+		await fs.rename(document.path, quarantinePath);
+		await syncParentDirectory(document.path);
+	} catch (error) {
+		await restoreQuarantinedConfig(document.path, quarantinePath);
+		throw error;
+	}
+	if (!(await fileIdentityAndContentsMatch(quarantinePath, document.identity, document.bytes))) {
+		await restoreQuarantinedConfig(document.path, quarantinePath);
+		throw settingsChangedError();
+	}
+	if (await pathExists(document.path)) {
+		await restoreQuarantinedConfig(document.path, quarantinePath);
+		throw new Error("Canonical settings changed concurrently; no settings were replaced.");
+	}
+	return quarantinePath;
+}
+
+function settingsChangedError() {
+	return new Error("pi-sync settings changed during migration; no settings were replaced.");
+}
+
+function isUnsupportedLinkError(error: unknown) {
+	const code = (error as NodeJS.ErrnoException).code;
+	return code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EXDEV" || code === "EPERM";
 }
 
 async function configSnapshotStillMatches(filePath: string, snapshot: ConfigSnapshot) {
@@ -258,12 +398,26 @@ async function fileIdentityAndContentsMatch(
 
 async function restoreQuarantinedConfig(filePath: string, quarantinePath: string) {
 	try {
-		await fs.link(quarantinePath, filePath);
+		await linkConfigFile(quarantinePath, filePath);
 		await fs.rm(quarantinePath);
 		await syncParentDirectory(filePath);
 		return;
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "EEXIST") return;
+		if (isUnsupportedLinkError(error)) {
+			try {
+				await fs.copyFile(quarantinePath, filePath, fsConstants.COPYFILE_EXCL);
+				if (process.platform !== "win32") {
+					await fs.chmod(filePath, 0o600);
+					await fs.chmod(quarantinePath, 0o600);
+				}
+				await syncParentDirectory(filePath);
+				return;
+			} catch (copyError) {
+				if ((copyError as NodeJS.ErrnoException).code !== "EEXIST") return;
+			}
+		} else if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+			return;
+		}
 	}
 	try {
 		const [current, quarantined] = await Promise.all([

--- a/extensions/pi-sync/src/config-file.ts
+++ b/extensions/pi-sync/src/config-file.ts
@@ -1,0 +1,304 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+const CONFIG_FILE_NAME = "pi-sync.json";
+const LEGACY_CONFIG_FILE_NAME = "pi-sync.local.json";
+const configMigrationNotices = new Map<string, string>();
+const legacyPresenceNoticed = new Set<string>();
+
+export type FileIdentity = { dev: number; ino: number };
+
+type ConfigSnapshot = {
+	bytes: Buffer;
+	identity: FileIdentity;
+	parsed: Record<string, unknown>;
+};
+
+export function localConfigPath() {
+	return path.join(getAgentDir(), CONFIG_FILE_NAME);
+}
+
+export function legacyLocalConfigPath() {
+	return path.join(getAgentDir(), LEGACY_CONFIG_FILE_NAME);
+}
+
+export function consumeLocalConfigMigrationNotice() {
+	const configPath = localConfigPath();
+	const notice = configMigrationNotices.get(configPath);
+	configMigrationNotices.delete(configPath);
+	return notice;
+}
+
+export async function readMigratingLocalConfig(
+	validateForMigration: (settings: Record<string, unknown>) => void,
+) {
+	const configPath = await prepareLocalConfigPath(validateForMigration);
+	const snapshot = await readConfigSnapshotIfExists(configPath);
+	return snapshot?.parsed;
+}
+
+async function prepareLocalConfigPath(
+	validateForMigration: (settings: Record<string, unknown>) => void,
+) {
+	const canonicalPath = localConfigPath();
+	const legacyPath = legacyLocalConfigPath();
+	if (await pathExists(canonicalPath)) {
+		const legacyStatus = await secureIgnoredLegacyIfPresent(legacyPath);
+		if (legacyStatus !== "missing" && !legacyPresenceNoticed.has(canonicalPath)) {
+			legacyPresenceNoticed.add(canonicalPath);
+			recordConfigMigrationNotice(
+				canonicalPath,
+				legacyStatus === "private"
+					? `${LEGACY_CONFIG_FILE_NAME} legacy settings were ignored because ${CONFIG_FILE_NAME} takes precedence. Delete ${LEGACY_CONFIG_FILE_NAME} after confirming your settings.`
+					: `${LEGACY_CONFIG_FILE_NAME} legacy settings were ignored because ${CONFIG_FILE_NAME} takes precedence, but pi-sync could not verify them as a private regular file. Secure or delete the legacy path after confirming your settings.`,
+			);
+		}
+		return canonicalPath;
+	}
+
+	const legacy = await readConfigSnapshotIfExists(legacyPath);
+	if (!legacy) return canonicalPath;
+	validateForMigration(legacy.parsed);
+
+	let installedIdentity: FileIdentity;
+	try {
+		installedIdentity = await installPrivateConfigExclusively(canonicalPath, legacy.bytes);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			recordConfigMigrationNotice(
+				canonicalPath,
+				`${LEGACY_CONFIG_FILE_NAME} legacy settings were ignored because ${CONFIG_FILE_NAME} was created concurrently and takes precedence.`,
+			);
+			return canonicalPath;
+		}
+		recordConfigMigrationNotice(
+			canonicalPath,
+			`Could not migrate ${LEGACY_CONFIG_FILE_NAME} to ${CONFIG_FILE_NAME}; the legacy settings were used for this session and were not changed.`,
+		);
+		return legacyPath;
+	}
+
+	if (!(await configSnapshotStillMatches(legacyPath, legacy))) {
+		const removed = await quarantineAndRemoveConfigIfMatches(
+			canonicalPath,
+			installedIdentity,
+			legacy.bytes,
+		);
+		recordConfigMigrationNotice(
+			canonicalPath,
+			removed
+				? `${LEGACY_CONFIG_FILE_NAME} changed during migration; the stale ${CONFIG_FILE_NAME} copy was removed and the legacy settings were used for this session.`
+				: `${LEGACY_CONFIG_FILE_NAME} changed during migration, but ${CONFIG_FILE_NAME} was replaced concurrently and takes precedence.`,
+		);
+		return removed ? legacyPath : canonicalPath;
+	}
+
+	legacyPresenceNoticed.add(canonicalPath);
+	recordConfigMigrationNotice(
+		canonicalPath,
+		`pi-sync settings migrated from ${LEGACY_CONFIG_FILE_NAME} to ${CONFIG_FILE_NAME}; the private legacy file was retained as a recovery copy and can be deleted after verification.`,
+	);
+	return canonicalPath;
+}
+
+async function secureIgnoredLegacyIfPresent(filePath: string) {
+	let pathStat: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		pathStat = await fs.lstat(filePath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing" as const;
+		return "unsafe" as const;
+	}
+	if (pathStat.isSymbolicLink() || !pathStat.isFile()) return "unsafe" as const;
+
+	let handle: fs.FileHandle | undefined;
+	try {
+		handle = await fs.open(filePath, "r");
+		const openedStat = await handle.stat();
+		if (openedStat.dev !== pathStat.dev || openedStat.ino !== pathStat.ino) {
+			return "unsafe" as const;
+		}
+		if (process.platform !== "win32" && (openedStat.mode & 0o777) !== 0o600) {
+			await handle.chmod(0o600);
+		}
+		return "private" as const;
+	} catch {
+		return "unsafe" as const;
+	} finally {
+		await handle?.close().catch(() => undefined);
+	}
+}
+
+async function readConfigSnapshotIfExists(filePath: string): Promise<ConfigSnapshot | undefined> {
+	let pathStat: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		pathStat = await fs.lstat(filePath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+	if (pathStat.isSymbolicLink()) {
+		throw new Error(`Refusing to read symlinked pi-sync config: ${filePath}`);
+	}
+	if (!pathStat.isFile()) throw new Error(`pi-sync config is not a regular file: ${filePath}`);
+
+	const handle = await fs.open(filePath, "r");
+	try {
+		const openedStat = await handle.stat();
+		if (openedStat.dev !== pathStat.dev || openedStat.ino !== pathStat.ino) {
+			throw new Error(`pi-sync config changed while opening: ${filePath}`);
+		}
+		if (process.platform !== "win32" && (openedStat.mode & 0o777) !== 0o600) {
+			await handle.chmod(0o600);
+		}
+		const bytes = await handle.readFile();
+		return {
+			bytes,
+			identity: { dev: openedStat.dev, ino: openedStat.ino },
+			parsed: parseConfigObject(bytes, filePath),
+		};
+	} finally {
+		await handle.close();
+	}
+}
+
+function parseConfigObject(bytes: Buffer, filePath: string) {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(bytes.toString("utf8"));
+	} catch {
+		throw new SyntaxError(`Invalid JSON in pi-sync config: ${filePath}`);
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`pi-sync config must contain a JSON object: ${filePath}`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+async function installPrivateConfigExclusively(filePath: string, bytes: Buffer) {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	const temporaryPath = path.join(
+		path.dirname(filePath),
+		`.${path.basename(filePath)}.${process.pid}.${randomUUID()}.migrate`,
+	);
+	let handle: fs.FileHandle | undefined;
+	try {
+		handle = await fs.open(temporaryPath, "wx", 0o600);
+		await handle.writeFile(bytes);
+		if (process.platform !== "win32") await handle.chmod(0o600);
+		await handle.sync();
+		await handle.close();
+		handle = undefined;
+		const identity = await fs.lstat(temporaryPath);
+		await fs.link(temporaryPath, filePath);
+		await syncParentDirectory(filePath).catch(() => undefined);
+		return { dev: identity.dev, ino: identity.ino };
+	} finally {
+		await handle?.close().catch(() => undefined);
+		await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+}
+
+async function configSnapshotStillMatches(filePath: string, snapshot: ConfigSnapshot) {
+	return fileIdentityAndContentsMatch(filePath, snapshot.identity, snapshot.bytes);
+}
+
+export async function quarantineAndRemoveConfigIfMatches(
+	filePath: string,
+	identity: FileIdentity,
+	expectedBytes: Buffer,
+) {
+	const quarantinePath = path.join(
+		path.dirname(filePath),
+		`.${path.basename(filePath)}.${randomUUID()}.migration-retired`,
+	);
+	try {
+		await fs.rename(filePath, quarantinePath);
+	} catch {
+		return false;
+	}
+	try {
+		await syncParentDirectory(filePath);
+	} catch {
+		await restoreQuarantinedConfig(filePath, quarantinePath);
+		return false;
+	}
+
+	const matches = await fileIdentityAndContentsMatch(quarantinePath, identity, expectedBytes);
+	if (!matches) {
+		await restoreQuarantinedConfig(filePath, quarantinePath);
+		return false;
+	}
+	if (await pathExists(filePath)) {
+		await fs.rm(quarantinePath, { force: true });
+		await syncParentDirectory(filePath);
+		return false;
+	}
+	await fs.rm(quarantinePath);
+	await syncParentDirectory(filePath);
+	return true;
+}
+
+async function fileIdentityAndContentsMatch(
+	filePath: string,
+	identity: FileIdentity,
+	expectedBytes: Buffer,
+) {
+	try {
+		const current = await fs.lstat(filePath);
+		if (current.isSymbolicLink()) return false;
+		if (current.dev !== identity.dev || current.ino !== identity.ino) return false;
+		return (await fs.readFile(filePath)).equals(expectedBytes);
+	} catch {
+		return false;
+	}
+}
+
+async function restoreQuarantinedConfig(filePath: string, quarantinePath: string) {
+	try {
+		await fs.link(quarantinePath, filePath);
+		await fs.rm(quarantinePath);
+		await syncParentDirectory(filePath);
+		return;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EEXIST") return;
+	}
+	try {
+		const [current, quarantined] = await Promise.all([
+			fs.readFile(filePath),
+			fs.readFile(quarantinePath),
+		]);
+		if (current.equals(quarantined)) await fs.rm(quarantinePath);
+		else if (process.platform !== "win32") await fs.chmod(quarantinePath, 0o600);
+		await syncParentDirectory(filePath);
+	} catch {
+		// Preserve the quarantine rather than risk deleting settings that changed concurrently.
+	}
+}
+
+async function syncParentDirectory(filePath: string) {
+	if (process.platform === "win32") return;
+	let handle: fs.FileHandle | undefined;
+	try {
+		handle = await fs.open(path.dirname(filePath), "r");
+		await handle.sync();
+	} finally {
+		await handle?.close().catch(() => undefined);
+	}
+}
+
+async function pathExists(filePath: string) {
+	try {
+		await fs.lstat(filePath);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function recordConfigMigrationNotice(configPath: string, notice: string) {
+	if (!configMigrationNotices.has(configPath)) configMigrationNotices.set(configPath, notice);
+}

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -8,11 +8,13 @@ import {
 	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
 import {
+	activeLocalConfigPath,
 	consumeLocalConfigMigrationNotice,
 	legacyLocalConfigPath,
 	localConfigPath,
 	quarantineAndRemoveConfigIfMatches,
-	readMigratingLocalConfig,
+	readMigratingLocalConfigDocument,
+	replaceLocalConfigDocument,
 } from "./config-file.js";
 import { safeName } from "./paths.js";
 import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
@@ -33,10 +35,12 @@ const DEFAULT_REGION = "auto";
 export const DEFAULT_TARGET_SWITCH_ACTION: TargetSwitchAction = "ask";
 
 export {
+	activeLocalConfigPath,
 	consumeLocalConfigMigrationNotice,
 	legacyLocalConfigPath,
 	localConfigPath,
 	quarantineAndRemoveConfigIfMatches,
+	replaceLocalConfigDocument,
 };
 
 export const DEPRECATED_PI_SYNC_ENV_NAMES = [
@@ -534,8 +538,12 @@ export function localConfigTemplate(): Record<string, unknown> {
 	};
 }
 
+export async function readLocalConfigDocument() {
+	return readMigratingLocalConfigDocument(validateConfigDocumentForMigration);
+}
+
 export async function readLocalConfigObject(): Promise<Record<string, unknown> | undefined> {
-	return readMigratingLocalConfig(validateConfigDocumentForMigration);
+	return (await readLocalConfigDocument())?.parsed;
 }
 
 function validateConfigDocumentForMigration(settings: Record<string, unknown>) {
@@ -606,6 +614,12 @@ function validateConfigDocumentForMigration(settings: Record<string, unknown>) {
 		normalizeExtraFiles(target.extraFiles);
 	}
 	const activeTarget = normalizeOptionalString(asOptionalString(settings.activeTarget));
+	if (Object.keys(targets).length === 0) {
+		if (activeTarget) {
+			throw new Error("Invalid pi-sync settings: targetless settings cannot have activeTarget.");
+		}
+		return;
+	}
 	if (!activeTarget || !Object.hasOwn(targets, activeTarget)) {
 		throw new Error("Invalid pi-sync settings: activeTarget must reference an existing target.");
 	}

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -15,6 +15,7 @@ import {
 	quarantineAndRemoveConfigIfMatches,
 	readMigratingLocalConfigDocument,
 	replaceLocalConfigDocument,
+	withLocalConfigFileLock,
 } from "./config-file.js";
 import { safeName } from "./paths.js";
 import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
@@ -647,7 +648,11 @@ async function performLocalConfigUpdate(
 	return next;
 }
 
-export async function writeLocalConfigObject(value: Record<string, unknown>) {
+export function writeLocalConfigObject(value: Record<string, unknown>) {
+	return withLocalConfigFileLock(() => writeLocalConfigObjectUnlocked(value));
+}
+
+async function writeLocalConfigObjectUnlocked(value: Record<string, unknown>) {
 	const configPath = localConfigPath();
 	await fs.mkdir(path.dirname(configPath), { recursive: true });
 	try {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -7,6 +7,13 @@ import {
 	type ExtensionContext,
 	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
+import {
+	consumeLocalConfigMigrationNotice,
+	legacyLocalConfigPath,
+	localConfigPath,
+	quarantineAndRemoveConfigIfMatches,
+	readMigratingLocalConfig,
+} from "./config-file.js";
 import { safeName } from "./paths.js";
 import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
 import type {
@@ -24,6 +31,13 @@ const DEFAULT_PROFILE = "default";
 const DEFAULT_PREFIX = "pi-sync";
 const DEFAULT_REGION = "auto";
 export const DEFAULT_TARGET_SWITCH_ACTION: TargetSwitchAction = "ask";
+
+export {
+	consumeLocalConfigMigrationNotice,
+	legacyLocalConfigPath,
+	localConfigPath,
+	quarantineAndRemoveConfigIfMatches,
+};
 
 export const DEPRECATED_PI_SYNC_ENV_NAMES = [
 	"PI_SYNC_ENDPOINT",
@@ -491,10 +505,6 @@ export function stateDir() {
 	return path.join(agentDir(), ".pisync");
 }
 
-export function localConfigPath() {
-	return path.join(agentDir(), "pi-sync.local.json");
-}
-
 export function localConfigTemplate(): Record<string, unknown> {
 	return {
 		version: 2,
@@ -525,21 +535,80 @@ export function localConfigTemplate(): Record<string, unknown> {
 }
 
 export async function readLocalConfigObject(): Promise<Record<string, unknown> | undefined> {
-	const configPath = localConfigPath();
-	try {
-		const stat = await fs.lstat(configPath);
-		if (stat.isSymbolicLink())
-			throw new Error(`Refusing to read symlinked pi-sync config: ${configPath}`);
-		if (!stat.isFile()) throw new Error(`pi-sync config is not a regular file: ${configPath}`);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		throw error;
+	return readMigratingLocalConfig(validateConfigDocumentForMigration);
+}
+
+function validateConfigDocumentForMigration(settings: Record<string, unknown>) {
+	if (!isV2SettingsObject(settings)) {
+		for (const field of [
+			"endpoint",
+			"bucket",
+			"region",
+			"accessKeyId",
+			"secretAccessKey",
+			"sessionToken",
+			"profile",
+			"prefix",
+		] as const) {
+			asOptionalString(settings[field]);
+		}
+		for (const field of ["autoSync", "syncSessions"] as const) {
+			const value = settings[field];
+			if (value !== undefined && typeof value !== "boolean" && typeof value !== "string") {
+				throw new Error(`Invalid pi-sync settings: ${field} must be a boolean or string.`);
+			}
+		}
+		normalizeSyncFiles(settings.syncFiles);
+		normalizeExtraFiles(settings.extraFiles);
+		return;
 	}
-	const parsed = JSON.parse(await fs.readFile(configPath, "utf8")) as unknown;
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		throw new Error(`pi-sync config must contain a JSON object: ${configPath}`);
+
+	normalizeTargetSwitchAction(settings.targetSwitchAction);
+	const profiles = requireNamedObjectMap(settings.profiles, "profiles");
+	const targets = requireNamedObjectMap(settings.targets, "targets");
+	validateUniqueRemoteTargets(targets);
+	for (const [name, value] of Object.entries(profiles)) {
+		const profile = ownObject(profiles, name);
+		if (!profile || value !== profile) {
+			throw new Error(`Invalid pi-sync settings: storage profile "${name}" must be an object.`);
+		}
+		const kind = asOptionalString(profile.kind);
+		if (kind !== undefined && kind !== "r2" && kind !== "s3-compatible") {
+			throw new Error(
+				`Invalid pi-sync settings: profile "${name}" has unsupported kind "${kind}".`,
+			);
+		}
+		for (const field of [
+			"endpoint",
+			"region",
+			"accessKeyId",
+			"secretAccessKey",
+			"sessionToken",
+		] as const) {
+			asOptionalString(profile[field]);
+		}
 	}
-	return parsed as Record<string, unknown>;
+	for (const [name, value] of Object.entries(targets)) {
+		const target = ownObject(targets, name);
+		if (!target || value !== target) {
+			throw new Error(`Invalid pi-sync settings: target "${name}" must be an object.`);
+		}
+		const profileName = normalizeOptionalString(asOptionalString(target.profile));
+		if (!profileName || !Object.hasOwn(profiles, profileName)) {
+			throw new Error(`Invalid pi-sync settings: target "${name}" references a missing profile.`);
+		}
+		for (const field of ["bucket", "prefix", "namespace"] as const) {
+			asOptionalString(target[field]);
+		}
+		asOptionalBoolean(target.autoSync);
+		asOptionalBoolean(target.syncSessions);
+		normalizeSyncFiles(target.syncFiles);
+		normalizeExtraFiles(target.extraFiles);
+	}
+	const activeTarget = normalizeOptionalString(asOptionalString(settings.activeTarget));
+	if (!activeTarget || !Object.hasOwn(targets, activeTarget)) {
+		throw new Error("Invalid pi-sync settings: activeTarget must reference an existing target.");
+	}
 }
 
 let configUpdateQueue: Promise<void> = Promise.resolve();

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -1,6 +1,7 @@
 import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { setSyncTargetCompletions } from "./command.js";
 import {
+	activeLocalConfigPath,
 	configuredTargetNames,
 	deprecatedPiSyncEnvironmentWarnings,
 	isCloudflareR2Endpoint,
@@ -158,7 +159,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 				"",
 				"Settings file needs repair. Automatic sync and settings writes are paused.",
 				`Error: ${safeTerminalText(errorMessage(error))}`,
-				`File: ${safeTerminalText(localConfigPath())}`,
+				`File: ${safeTerminalText(await activeLocalConfigPath())}`,
 				"",
 				"Repair the JSON file, then reopen /sync.",
 			].join("\n"),
@@ -229,7 +230,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 				"Settings need attention. Automatic sync is paused.",
 				`Current target: ${safeTerminalText(typeof raw.activeTarget === "string" ? raw.activeTarget : "default")}`,
 				`Error: ${safeTerminalText(errorMessage(error))}`,
-				`File: ${safeTerminalText(localConfigPath())}`,
+				`File: ${safeTerminalText(await activeLocalConfigPath())}`,
 				"",
 				"What do you want to do?",
 			].join("\n"),

--- a/extensions/pi-sync/src/paths.ts
+++ b/extensions/pi-sync/src/paths.ts
@@ -14,7 +14,12 @@ export function isDeniedPath(relativePath: string) {
 		base.endsWith(".env") ||
 		base.includes("secret") ||
 		base.includes("token") ||
-		base === "pi-sync.local.json"
+		base === "pi-sync.json" ||
+		base.startsWith("pi-sync.json.") ||
+		base.startsWith(".pi-sync.json.") ||
+		base === "pi-sync.local.json" ||
+		base.startsWith("pi-sync.local.json.") ||
+		base.startsWith(".pi-sync.local.json.")
 	);
 }
 

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -5,7 +5,9 @@ import {
 	DEFAULT_TARGET_SWITCH_ACTION,
 	effectiveTargetRemoteIdentity,
 	localConfigPath,
+	readLocalConfigDocument,
 	readLocalConfigObject,
+	replaceLocalConfigDocument,
 	resolveLegacyPartialConfig,
 	resolveV2PartialConfig,
 	stateDir,
@@ -14,6 +16,21 @@ import {
 } from "./config.js";
 import { withLock } from "./lock.js";
 import type { PartialConfig, StorageProfileSettings, SyncTargetSettings } from "./types.js";
+
+let afterLegacySettingsReadHook: () => Promise<void> = async () => undefined;
+
+export async function withLegacySettingsReadHookForTest<T>(
+	hook: () => Promise<void>,
+	run: () => Promise<T>,
+) {
+	const previous = afterLegacySettingsReadHook;
+	afterLegacySettingsReadHook = hook;
+	try {
+		return await run();
+	} finally {
+		afterLegacySettingsReadHook = previous;
+	}
+}
 
 const LEGACY_FIELDS = new Set([
 	"endpoint",
@@ -42,21 +59,17 @@ export async function migrateLegacySettings(
 	validateName(targetName, "target");
 	validateName(storageProfileName, "storage profile");
 	return withLock("settings-migration", async () => {
-		const configPath = localConfigPath();
-		const originalBytes = await fs.readFile(configPath);
-		const current = await readLocalConfigObject();
-		if (!current) throw new Error("No legacy pi-sync settings are available to migrate.");
+		const document = await readLocalConfigDocument();
+		if (!document) throw new Error("No legacy pi-sync settings are available to migrate.");
+		const { bytes: originalBytes, parsed: current } = document;
 		if (current.version === 2) {
 			throw new Error("pi-sync settings already use profiles and targets.");
 		}
+		await afterLegacySettingsReadHook();
 		const next = legacySettingsAsV2(current, targetName, storageProfileName);
 		const backupPath = await writeMigrationBackup(originalBytes);
 		await adoptLegacyState(current, next, targetName);
-		const latestBytes = await fs.readFile(configPath);
-		if (!latestBytes.equals(originalBytes)) {
-			throw new Error("pi-sync settings changed during migration; no settings were replaced.");
-		}
-		await writeLocalConfigObject(next);
+		await replaceLocalConfigDocument(document, next);
 		return { settings: next, backupPath };
 	});
 }

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -1,4 +1,3 @@
-import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -18,17 +17,20 @@ import {
 } from "./command.js";
 import {
 	configuredTargetNames,
+	consumeLocalConfigMigrationNotice,
 	deprecatedPiSyncEnvironmentWarnings,
 	ensureStateDir,
 	isEnabled,
 	isExplicitlyEnabled,
 	isMissingConfigError,
+	legacyLocalConfigPath,
 	loadConfig,
 	loadPartialConfig,
 	localConfigPath,
 	localConfigTemplate,
 	normalizeExtraFiles,
 	normalizeSyncFiles,
+	readLocalConfigObject,
 	readStateForConfig,
 	sessionDirForApply,
 	sessionTokenWarnings,
@@ -142,6 +144,8 @@ export default function sync(pi: ExtensionAPI) {
 		} catch {
 			setSyncTargetCompletions([]);
 		}
+		const migrationNotice = consumeLocalConfigMigrationNotice();
+		if (migrationNotice) ctx.ui.notify(migrationNotice, "warning");
 		const warnings = deprecatedPiSyncEnvironmentWarnings();
 		if (warnings.length > 0) ctx.ui.notify(warnings.join("\n"), "warning");
 		await autoSync(ctx);
@@ -279,12 +283,15 @@ async function autoPushSessions(ctx: ExtensionContext) {
 
 async function initConfig(ctx: ExtensionCommandContext) {
 	const configPath = localConfigPath();
-	try {
-		await fs.access(configPath, fsConstants.F_OK);
-		ctx.ui.notify(`Config already exists: ${configPath}`, "info");
+	if (await readLocalConfigObject()) {
+		let existingPath = configPath;
+		try {
+			await fs.access(configPath);
+		} catch {
+			existingPath = legacyLocalConfigPath();
+		}
+		ctx.ui.notify(`Config already exists: ${existingPath}`, "info");
 		return;
-	} catch {
-		// Create or guide setup below.
 	}
 
 	if (ctx.mode === "tui") {

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -16,6 +16,7 @@ import {
 	validateCommandOptions,
 } from "./command.js";
 import {
+	activeLocalConfigPath,
 	configuredTargetNames,
 	consumeLocalConfigMigrationNotice,
 	deprecatedPiSyncEnvironmentWarnings,
@@ -23,7 +24,6 @@ import {
 	isEnabled,
 	isExplicitlyEnabled,
 	isMissingConfigError,
-	legacyLocalConfigPath,
 	loadConfig,
 	loadPartialConfig,
 	localConfigPath,
@@ -284,13 +284,7 @@ async function autoPushSessions(ctx: ExtensionContext) {
 async function initConfig(ctx: ExtensionCommandContext) {
 	const configPath = localConfigPath();
 	if (await readLocalConfigObject()) {
-		let existingPath = configPath;
-		try {
-			await fs.access(configPath);
-		} catch {
-			existingPath = legacyLocalConfigPath();
-		}
-		ctx.ui.notify(`Config already exists: ${existingPath}`, "info");
+		ctx.ui.notify(`Config already exists: ${await activeLocalConfigPath()}`, "info");
 		return;
 	}
 

--- a/extensions/pi-sync/test/config-filename.test.ts
+++ b/extensions/pi-sync/test/config-filename.test.ts
@@ -15,6 +15,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
 	consumeLocalConfigMigrationNotice,
@@ -25,6 +26,7 @@ import {
 } from "../src/config.js";
 import {
 	withConfigFileLinkForTest,
+	withConfigQuarantinedHookForTest,
 	withConfigReplacementInstalledHookForTest,
 } from "../src/config-file.js";
 import { isDeniedPath } from "../src/paths.js";
@@ -386,6 +388,43 @@ test("migration cleanup preserves a config path replaced after validation", asyn
 			),
 			false,
 		);
+		assert.deepEqual(readFileSync(configPath), replacement);
+	});
+});
+
+test("migration cleanup keeps concurrent readers from installing legacy settings", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const configPath = localConfigPath();
+		const legacyPath = legacyLocalConfigPath();
+		const replacementPath = path.join(agentDir, "replacement.json");
+		const original = Buffer.from(JSON.stringify({ original: true }));
+		const replacement = Buffer.from(JSON.stringify({ replacement: true }));
+		writeFileSync(configPath, original);
+		const originalStat = statSync(configPath);
+		writeFileSync(legacyPath, JSON.stringify(requiredConfig()));
+		writeFileSync(replacementPath, replacement);
+		renameSync(replacementPath, configPath);
+
+		let concurrentRead: Promise<Record<string, unknown> | undefined> | undefined;
+		await withConfigQuarantinedHookForTest(
+			async () => {
+				concurrentRead = readLocalConfigObject();
+				await delay(25);
+			},
+			async () => {
+				assert.equal(
+					await quarantineAndRemoveConfigIfMatches(
+						configPath,
+						{ dev: originalStat.dev, ino: originalStat.ino },
+						original,
+					),
+					false,
+				);
+			},
+		);
+
+		assert.deepEqual(await concurrentRead, { replacement: true });
 		assert.deepEqual(readFileSync(configPath), replacement);
 	});
 });

--- a/extensions/pi-sync/test/config-filename.test.ts
+++ b/extensions/pi-sync/test/config-filename.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	consumeLocalConfigMigrationNotice,
+	legacyLocalConfigPath,
+	localConfigPath,
+	quarantineAndRemoveConfigIfMatches,
+	readLocalConfigObject,
+} from "../src/config.js";
+import { isDeniedPath } from "../src/paths.js";
+import sync from "../src/sync.js";
+import { requiredConfig, withTempHome } from "./helpers.js";
+
+test("pi-sync uses the canonical settings filename and migrates legacy bytes privately", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const legacyPath = path.join(agentDir, "pi-sync.local.json");
+		const original = `${JSON.stringify({ ...requiredConfig(), future: { retained: true } }, null, 2)}\n`;
+		writeFileSync(legacyPath, original, { mode: 0o644 });
+
+		assert.equal(localConfigPath(), path.join(agentDir, "pi-sync.json"));
+		assert.equal(legacyLocalConfigPath(), legacyPath);
+		assert.deepEqual(await readLocalConfigObject(), JSON.parse(original));
+		assert.equal(existsSync(legacyPath), true);
+		assert.equal(readFileSync(legacyPath, "utf8"), original);
+		assert.equal(readFileSync(localConfigPath(), "utf8"), original);
+		if (process.platform !== "win32") {
+			assert.equal(statSync(localConfigPath()).mode & 0o777, 0o600);
+			assert.equal(statSync(legacyPath).mode & 0o777, 0o600);
+		}
+		assert.match(
+			consumeLocalConfigMigrationNotice() ?? "",
+			/migrated.*pi-sync\.local\.json.*pi-sync\.json.*recovery copy/i,
+		);
+		assert.equal(consumeLocalConfigMigrationNotice(), undefined);
+	});
+});
+
+test("canonical pi-sync settings take precedence without removing a legacy file", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "pi-sync.json"), JSON.stringify({ canonical: true }), {
+			mode: 0o644,
+		});
+		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify({ legacy: true }), {
+			mode: 0o644,
+		});
+
+		assert.deepEqual(await readLocalConfigObject(), { canonical: true });
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.local.json")), true);
+		if (process.platform !== "win32") {
+			assert.equal(statSync(localConfigPath()).mode & 0o777, 0o600);
+			assert.equal(statSync(path.join(agentDir, "pi-sync.local.json")).mode & 0o777, 0o600);
+		}
+		assert.match(consumeLocalConfigMigrationNotice() ?? "", /legacy.*ignored.*takes precedence/i);
+	});
+});
+
+test("canonical settings remain usable when an ignored legacy path is unsafe", async (t) => {
+	if (process.platform === "win32") {
+		t.diagnostic("symlink precedence safety is covered on POSIX");
+		return;
+	}
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "pi-sync.json"), JSON.stringify({ canonical: true }));
+		const target = path.join(agentDir, "outside.json");
+		writeFileSync(target, JSON.stringify({ legacy: true }));
+		symlinkSync(target, path.join(agentDir, "pi-sync.local.json"));
+
+		assert.deepEqual(await readLocalConfigObject(), { canonical: true });
+		assert.match(
+			consumeLocalConfigMigrationNotice() ?? "",
+			/could not verify.*private regular file/i,
+		);
+	});
+});
+
+test("malformed and symlinked legacy settings are not migrated", async (t) => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "pi-sync.local.json"), "{not-json\n");
+
+		await assert.rejects(readLocalConfigObject(), /JSON/);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.json")), false);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.local.json")), true);
+	});
+
+	if (process.platform === "win32") {
+		t.diagnostic("symlink migration safety is covered on POSIX");
+		return;
+	}
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ version: 2, profiles: [], targets: {} }),
+		);
+
+		await assert.rejects(readLocalConfigObject(), /profiles must be an object/);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.json")), false);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.local.json")), true);
+	});
+
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const target = path.join(agentDir, "outside.json");
+		writeFileSync(target, JSON.stringify(requiredConfig()));
+		symlinkSync(target, path.join(agentDir, "pi-sync.local.json"));
+
+		await assert.rejects(readLocalConfigObject(), /symlinked pi-sync config/);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.json")), false);
+	});
+});
+
+test("legacy v2 references keep their runtime whitespace normalization during migration", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({
+				version: 2,
+				activeTarget: " home ",
+				profiles: {
+					r2: {
+						endpoint: "https://account.r2.cloudflarestorage.com",
+						accessKeyId: "access",
+						secretAccessKey: "secret",
+					},
+				},
+				targets: {
+					home: { profile: " r2 ", bucket: "pi-sync" },
+				},
+			}),
+		);
+
+		const settings = await readLocalConfigObject();
+		assert.equal(settings?.activeTarget, " home ");
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.json")), true);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.local.json")), true);
+	});
+});
+
+test("migration cleanup preserves a config path replaced after validation", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const configPath = path.join(agentDir, "pi-sync.local.json");
+		const replacementPath = path.join(agentDir, "replacement.json");
+		const original = Buffer.from(JSON.stringify(requiredConfig()));
+		const replacement = Buffer.from(JSON.stringify({ replacement: true }));
+		writeFileSync(configPath, original);
+		const originalStat = statSync(configPath);
+		writeFileSync(replacementPath, replacement);
+		renameSync(replacementPath, configPath);
+
+		assert.equal(
+			await quarantineAndRemoveConfigIfMatches(
+				configPath,
+				{ dev: originalStat.dev, ino: originalStat.ino },
+				original,
+			),
+			false,
+		);
+		assert.deepEqual(readFileSync(configPath), replacement);
+	});
+});
+
+test("session startup reports a filename migration once without exposing settings", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ ...requiredConfig(), autoSync: false }),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+		const sessionStart = mock.events.get("session_start")?.[0];
+
+		await sessionStart?.({}, ctx);
+		await sessionStart?.({}, ctx);
+
+		const migrationNotices = notifications.filter((notice) =>
+			notice.message.includes("pi-sync.local.json"),
+		);
+		assert.equal(migrationNotices.length, 1);
+		assert.equal(migrationNotices[0]?.level, "warning");
+		assert.match(migrationNotices[0]?.message ?? "", /pi-sync\.json/);
+		assert.doesNotMatch(migrationNotices[0]?.message ?? "", /access-key|secret-key/);
+	});
+});
+
+test("pi-sync snapshots deny canonical, legacy, and migration-recovery settings files", () => {
+	assert.equal(isDeniedPath("pi-sync.json"), true);
+	assert.equal(isDeniedPath("pi-sync.json.example.migration-retired"), true);
+	assert.equal(isDeniedPath(".pi-sync.json.example.migrate"), true);
+	assert.equal(isDeniedPath(".pi-sync.json.example.tmp"), true);
+	assert.equal(isDeniedPath("pi-sync.local.json"), true);
+	assert.equal(isDeniedPath("pi-sync.local.json.example.migration-retired"), true);
+	assert.equal(isDeniedPath(".pi-sync.local.json.example.migration-retired"), true);
+});

--- a/extensions/pi-sync/test/config-filename.test.ts
+++ b/extensions/pi-sync/test/config-filename.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
 import {
+	closeSync,
 	existsSync,
+	ftruncateSync,
 	mkdirSync,
+	openSync,
+	readdirSync,
 	readFileSync,
 	renameSync,
 	statSync,
 	symlinkSync,
 	writeFileSync,
+	writeSync,
 } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -18,7 +23,15 @@ import {
 	quarantineAndRemoveConfigIfMatches,
 	readLocalConfigObject,
 } from "../src/config.js";
+import {
+	withConfigFileLinkForTest,
+	withConfigReplacementInstalledHookForTest,
+} from "../src/config-file.js";
 import { isDeniedPath } from "../src/paths.js";
+import {
+	migrateLegacySettings,
+	withLegacySettingsReadHookForTest,
+} from "../src/settings-management.js";
 import sync from "../src/sync.js";
 import { requiredConfig, withTempHome } from "./helpers.js";
 
@@ -124,6 +137,61 @@ test("malformed and symlinked legacy settings are not migrated", async (t) => {
 	});
 });
 
+test("targetless v2 legacy settings migrate and retain the recoverable manager flow", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "pi-sync.local.json"),
+			JSON.stringify({ version: 2, profiles: { r2: {} }, targets: {} }),
+		);
+
+		const settings = await readLocalConfigObject();
+		assert.deepEqual(settings?.targets, {});
+		assert.equal(settings?.activeTarget, undefined);
+		assert.equal(existsSync(path.join(agentDir, "pi-sync.json")), true);
+
+		const mock = createMockPi();
+		sync(mock.pi);
+		let options: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (_title: string, nextOptions: string[]) => {
+				options = nextOptions;
+				return undefined;
+			},
+		});
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.deepEqual(options, ["Manage targets & storage", "Help"]);
+	});
+});
+
+test("legacy validation errors identify the file that needs repair", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const legacyPath = path.join(agentDir, "pi-sync.local.json");
+		writeFileSync(legacyPath, JSON.stringify({ version: 2, profiles: [], targets: {} }));
+		const mock = createMockPi();
+		sync(mock.pi);
+		let title = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (nextTitle: string) => {
+				title = nextTitle;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(title, /Settings file needs repair/);
+		assert.match(title, new RegExp(`File: ${legacyPath.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}`));
+		assert.doesNotMatch(title, /File: .*pi-sync\.json/);
+	});
+});
+
 test("legacy v2 references keep their runtime whitespace normalization during migration", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
@@ -149,6 +217,152 @@ test("legacy v2 references keep their runtime whitespace normalization during mi
 		assert.equal(settings?.activeTarget, " home ");
 		assert.equal(existsSync(path.join(agentDir, "pi-sync.json")), true);
 		assert.equal(existsSync(path.join(agentDir, "pi-sync.local.json")), true);
+	});
+});
+
+test("flat settings can upgrade while filename migration falls back to the legacy path", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const legacyPath = path.join(agentDir, "pi-sync.local.json");
+		const original = `${JSON.stringify(requiredConfig(), null, 2)}\n`;
+		writeFileSync(legacyPath, original);
+
+		await withConfigFileLinkForTest(
+			async () => {
+				throw Object.assign(new Error("hard links are unavailable"), { code: "ENOTSUP" });
+			},
+			async () => {
+				const result = await migrateLegacySettings("home", "r2");
+				assert.equal(readFileSync(result.backupPath, "utf8"), original);
+				assert.equal(result.settings.version, 2);
+				assert.equal(existsSync(localConfigPath()), true);
+				assert.equal(existsSync(legacyPath), true);
+				assert.equal((await readLocalConfigObject())?.activeTarget, "home");
+			},
+		);
+	});
+});
+
+test("flat settings upgrade preserves a canonical file created before commit", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const legacyPath = path.join(agentDir, "pi-sync.local.json");
+		const canonicalPath = localConfigPath();
+		const concurrent = `${JSON.stringify({ concurrent: true }, null, 2)}\n`;
+		writeFileSync(legacyPath, `${JSON.stringify(requiredConfig(), null, 2)}\n`);
+
+		await withConfigFileLinkForTest(
+			async () => {
+				throw Object.assign(new Error("hard links are unavailable"), { code: "ENOTSUP" });
+			},
+			() =>
+				withLegacySettingsReadHookForTest(
+					async () => writeFileSync(canonicalPath, concurrent),
+					async () => {
+						await assert.rejects(
+							migrateLegacySettings("home", "r2"),
+							/canonical settings.*created concurrently/i,
+						);
+						assert.equal(readFileSync(canonicalPath, "utf8"), concurrent);
+						assert.equal(existsSync(legacyPath), true);
+					},
+				),
+		);
+	});
+});
+
+test("flat settings upgrade rejects an edit that lands after its source snapshot", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const legacyPath = path.join(agentDir, "pi-sync.local.json");
+		const original = `${JSON.stringify(requiredConfig(), null, 2)}\n`;
+		const replacement = `${JSON.stringify({ ...requiredConfig(), bucket: "new-bucket" }, null, 2)}\n`;
+		writeFileSync(legacyPath, original);
+
+		await withConfigFileLinkForTest(
+			async () => {
+				throw Object.assign(new Error("hard links are unavailable"), { code: "ENOTSUP" });
+			},
+			() =>
+				withLegacySettingsReadHookForTest(
+					async () => writeFileSync(legacyPath, replacement),
+					async () => {
+						await assert.rejects(
+							migrateLegacySettings("home", "r2"),
+							/settings changed during migration/,
+						);
+						assert.equal(existsSync(localConfigPath()), false);
+						assert.equal(readFileSync(legacyPath, "utf8"), replacement);
+					},
+				),
+		);
+	});
+});
+
+test("canonical schema migration restores source edits when hard links are unavailable", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const canonicalPath = localConfigPath();
+		const original = `${JSON.stringify(requiredConfig(), null, 2)}\n`;
+		const replacement = `${JSON.stringify({ ...requiredConfig(), bucket: "late-edit" }, null, 2)}\n`;
+		writeFileSync(canonicalPath, original);
+		const descriptor = openSync(canonicalPath, "r+");
+		try {
+			await withConfigFileLinkForTest(
+				async () => {
+					throw Object.assign(new Error("hard links are unavailable"), { code: "ENOTSUP" });
+				},
+				() =>
+					withConfigReplacementInstalledHookForTest(
+						async () => {
+							ftruncateSync(descriptor, 0);
+							writeSync(descriptor, replacement, 0, "utf8");
+						},
+						async () => {
+							await assert.rejects(
+								migrateLegacySettings("home", "r2"),
+								/settings changed during migration/,
+							);
+						},
+					),
+			);
+		} finally {
+			closeSync(descriptor);
+		}
+		assert.equal(readFileSync(canonicalPath, "utf8"), replacement);
+	});
+});
+
+test("canonical schema migration retains writes made through the original descriptor", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const canonicalPath = localConfigPath();
+		writeFileSync(canonicalPath, `${JSON.stringify(requiredConfig(), null, 2)}\n`);
+		const descriptor = openSync(canonicalPath, "r+");
+		try {
+			await withConfigFileLinkForTest(
+				async () => {
+					throw Object.assign(new Error("hard links are unavailable"), { code: "ENOTSUP" });
+				},
+				async () => {
+					await migrateLegacySettings("home", "r2");
+					ftruncateSync(descriptor, 0);
+					writeSync(descriptor, "late descriptor edit\n", 0, "utf8");
+				},
+			);
+		} finally {
+			closeSync(descriptor);
+		}
+
+		const recoveryFiles = readdirSync(agentDir).filter(
+			(name) => name.startsWith(".pi-sync.json.") && name.endsWith(".schema-migration-source"),
+		);
+		assert.equal(recoveryFiles.length, 1);
+		assert.equal(
+			readFileSync(path.join(agentDir, recoveryFiles[0] ?? ""), "utf8"),
+			"late descriptor edit\n",
+		);
+		assert.equal((await readLocalConfigObject())?.activeTarget, "home");
 	});
 });
 

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -301,10 +301,7 @@ test("sync files has a protocol-safe non-TUI summary", async () => {
 
 		await mock.commands.get("sync")?.handler("files", ctx);
 		assert.equal(customCalls, 0);
-		assert.match(
-			notifications.at(-1)?.message ?? "",
-			/selected files.*syncFiles.*pi-sync\.local\.json/is,
-		);
+		assert.match(notifications.at(-1)?.message ?? "", /selected files.*syncFiles.*pi-sync\.json/is);
 	});
 });
 
@@ -496,11 +493,11 @@ test("syncFiles keeps the legacy allowlist by default and validates explicit sel
 
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
-		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
+		writeFileSync(path.join(agentDir, "pi-sync.json"), JSON.stringify(requiredConfig()));
 		assert.deepEqual((await loadConfig()).syncFiles, [...DEFAULT_SYNC_FILES]);
 
 		writeFileSync(
-			path.join(agentDir, "pi-sync.local.json"),
+			path.join(agentDir, "pi-sync.json"),
 			JSON.stringify({ ...requiredConfig(), syncFiles: [] }),
 		);
 		assert.deepEqual((await loadConfig()).syncFiles, []);
@@ -636,7 +633,7 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(
-			path.join(agentDir, "pi-sync.local.json"),
+			path.join(agentDir, "pi-sync.json"),
 			JSON.stringify({ ...requiredConfig(), syncSessions: true }),
 		);
 
@@ -656,16 +653,16 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 			assert.equal((await loadConfig()).syncSessions, true);
 		});
 
-		rmSync(path.join(agentDir, "pi-sync.local.json"));
+		rmSync(path.join(agentDir, "pi-sync.json"));
 		writeFileSync(
-			path.join(agentDir, "pi-sync.local.json"),
+			path.join(agentDir, "pi-sync.json"),
 			JSON.stringify({ ...requiredConfig(), extraFiles: "APPEND_SYSTEM.md" }),
 		);
 		await withEnv({}, async () => {
 			assert.deepEqual((await loadConfig()).extraFiles, []);
 		});
 		writeFileSync(
-			path.join(agentDir, "pi-sync.local.json"),
+			path.join(agentDir, "pi-sync.json"),
 			JSON.stringify({
 				...requiredConfig(),
 				extraFiles: [
@@ -686,7 +683,7 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 					"node_modules",
 					".pisync",
 					".env",
-					"pi-sync.local.json",
+					"pi-sync.json",
 					"secret.txt",
 					"token.json",
 					1,
@@ -701,7 +698,7 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 		const customAgentDir = path.join(agentDir, "custom-agent");
 		mkdirSync(customAgentDir, { recursive: true });
 		writeFileSync(
-			path.join(customAgentDir, "pi-sync.local.json"),
+			path.join(customAgentDir, "pi-sync.json"),
 			JSON.stringify({ ...requiredConfig(), profile: "custom" }),
 		);
 		await withEnv({ PI_CODING_AGENT_DIR: customAgentDir }, async () => {
@@ -711,15 +708,15 @@ test("syncSessions config defaults off and supports file plus env overrides", as
 		const tildeAgentDir = path.join(path.dirname(agentDir), "agent-tilde");
 		mkdirSync(tildeAgentDir, { recursive: true });
 		writeFileSync(
-			path.join(tildeAgentDir, "pi-sync.local.json"),
+			path.join(tildeAgentDir, "pi-sync.json"),
 			JSON.stringify({ ...requiredConfig(), profile: "tilde" }),
 		);
 		await withEnv({ PI_CODING_AGENT_DIR: "~/.pi/agent-tilde" }, async () => {
 			assert.equal((await loadConfig()).profile, "tilde");
 		});
 
-		rmSync(path.join(agentDir, "pi-sync.local.json"));
-		writeFileSync(path.join(agentDir, "pi-sync.local.json"), JSON.stringify(requiredConfig()));
+		rmSync(path.join(agentDir, "pi-sync.json"));
+		writeFileSync(path.join(agentDir, "pi-sync.json"), JSON.stringify(requiredConfig()));
 		await withEnv({}, async () => {
 			assert.equal((await loadConfig()).syncSessions, false);
 		});
@@ -730,7 +727,7 @@ test("sync config output reports session sync and privacy warning", async () => 
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(
-			path.join(agentDir, "pi-sync.local.json"),
+			path.join(agentDir, "pi-sync.json"),
 			JSON.stringify({ ...requiredConfig(), syncSessions: true }),
 		);
 		const mock = createMockPi();


### PR DESCRIPTION
## Summary

- make `pi-sync.json` the canonical private settings file
- migrate valid `pi-sync.local.json` settings byte-for-byte while retaining a private recovery copy
- enforce private permissions, canonical precedence, migration race safety, and redacted notices
- exclude canonical, legacy, temporary, and recovery credential files from snapshots
- update pi-sync help, documentation, and focused migration coverage

## Verification

- `npm run check` (1,313 tests passed)
- `npm run pack:sync` (23 expected package files)
