### PR TITLE
feat(sync): add push and pull menu actions

### DIFF
--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -79,21 +79,27 @@ A configured manager shows:
 ```text
 Current target: home
 Storage: Cloudflare R2 · personal-pi
-Auto-sync: On · Sessions: Off
-Last known sync: Remote not checked
+Synced content: 9 built-in groups · 0 extra files · Sessions: Off
+Auto-sync: On
+Last applied snapshot: snapshot-id (or Never synced)
+Remote changes: Not checked
 ```
 
 Its primary actions are:
 
-- **Sync now** — conservatively decide whether to push, pull, or do nothing
+- **Sync now (recommended)** — conservatively decide whether to push, pull, or do nothing
+- **Pull from remote** — check the remote snapshot, preview exact local writes/deletes, then confirm
+- **Push to remote** — scan and preview exact remote publication changes, then confirm
 - **Switch target** — preview the target change, then follow the configured pull behavior
 - **Status & changes** — perform a cancellable read-only remote check
 - **Settings** — control post-switch pulling, automatic sync, and synced content
-- **Manage targets & storage** — add, edit, or remove local target/profile definitions
-- **History & recovery** — browse snapshots, preview rollback, diagnose setup, or recover a stale lock
-- **Help**
+- **More…** — open one shallow level containing target/storage management, history/recovery, Help, and Back
 
-Escape exits the main menu. Secondary menus provide Back; dirty synced-content drafts provide Save, Discard, and Continue editing. Cancellation before publication has no side effects.
+The menu does not query remote storage merely to open. It shows the last locally applied snapshot and marks remote changes as unchecked until an operation runs. When no synced content is selected, transfer actions are hidden and Settings becomes the first action. During an active or recoverable lock, mutation actions remain unavailable.
+
+Push and pull keep their existing concrete previews and confirmation prompts. Pull creates a local backup before applying; push scans locally managed content for likely secrets before publication. Escape cancels a pre-commit check without changing local or remote files. Once publication or apply begins, cancellation is disabled. Conflicts never force automatically; inspect **Status & changes** and use an explicit direct route only after reviewing the conflict.
+
+Escape exits the main menu. **More…** and secondary menus provide Back; dirty synced-content drafts provide Save, Discard, and Continue editing. Cancellation before publication has no side effects.
 
 ## ⚙️ Settings
 

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -10,6 +10,7 @@ import {
 	localConfigPath,
 	normalizeSyncFiles,
 	readLocalConfigObject,
+	readStateForConfig,
 } from "./config.js";
 import { inspectLock, isStaleLock } from "./lock.js";
 import {
@@ -28,18 +29,25 @@ import { type TargetPullOutcome, useSyncTarget } from "./target-switch.js";
 import type { SyncConfig } from "./types.js";
 
 export const MAIN_MENU_ACTIONS = [
-	"Sync now",
+	"Sync now (recommended)",
+	"Pull from remote",
+	"Push to remote",
 	"Switch target",
 	"Status & changes",
 	"Settings",
+	"More…",
+] as const;
+
+const MORE_MENU_ACTIONS = [
 	"Manage targets & storage",
 	"History & recovery",
 	"Help",
+	"Back",
 ] as const;
-
 const BACK = "Back";
 
 type MainMenuAction = (typeof MAIN_MENU_ACTIONS)[number];
+type ContextualMenuAction = "Manage targets & storage" | "History & recovery" | "Help";
 type RunRoute = (
 	route: string,
 	signal?: AbortSignal,
@@ -59,9 +67,33 @@ export async function showSyncManager(
 		const state = await describeManagerState();
 		const selected = await ctx.ui.select(state.title, state.actions);
 		if (!selected) return;
-		switch (selected as MainMenuAction | "Set up sync" | "Use existing settings") {
-			case "Sync now":
+		switch (
+			selected as MainMenuAction | ContextualMenuAction | "Set up sync" | "Use existing settings"
+		) {
+			case "Sync now (recommended)":
 				await runCancellableOperation(ctx, "Checking current target…", "sync", runRoute, true);
+				break;
+			case "Pull from remote": {
+				const result = await runCancellableOperation(
+					ctx,
+					"Checking remote changes…",
+					"pull",
+					runRoute,
+					true,
+					"Pull check cancelled; no local files were changed.",
+				);
+				if (result === "applied") return;
+				break;
+			}
+			case "Push to remote":
+				await runCancellableOperation(
+					ctx,
+					"Preparing push preview…",
+					"push",
+					runRoute,
+					true,
+					"Push preparation cancelled; no remote files were changed.",
+				);
 				break;
 			case "Switch target": {
 				const result = await showTargetSwitcher(ctx, runRoute);
@@ -75,20 +107,34 @@ export async function showSyncManager(
 			case "Settings":
 				await showSyncSettings(ctx, runRoute);
 				break;
+			case "More…":
+				if ((await showMoreMenu(ctx, runRoute)) === "exit") return;
+				break;
 			case "Manage targets & storage":
 				await showManageMenu(ctx, runRoute);
 				break;
 			case "History & recovery":
 				await showRecoveryMenu(ctx, runRoute);
 				break;
+			case "Help":
+				await runRoute("help");
+				return;
 			case "Set up sync":
 			case "Use existing settings":
 				await runRoute("init");
 				continue;
-			case "Help":
-				await runRoute("help");
-				return;
 		}
+	}
+}
+
+async function showMoreMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
+	const selected = await ctx.ui.select("More options", [...MORE_MENU_ACTIONS]);
+	if (!selected || selected === BACK) return;
+	if (selected === "Manage targets & storage") await showManageMenu(ctx, runRoute);
+	else if (selected === "History & recovery") await showRecoveryMenu(ctx, runRoute);
+	else {
+		await runRoute("help");
+		return "exit" as const;
 	}
 }
 
@@ -194,15 +240,34 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 		const liveLock = lock.status === "valid" && !isStaleLock(lock.lock);
 		const recoverableLock =
 			lock.status === "unreadable" || (lock.status === "valid" && isStaleLock(lock.lock));
+		const builtInCount = normalizeSyncFiles(config.syncFiles).length;
+		const extraFileCount = config.extraFiles.length;
+		const noSyncedContent = builtInCount === 0 && extraFileCount === 0 && !config.syncSessions;
+		const stateReadDisabled = liveLock || recoverableLock;
+		const syncState = stateReadDisabled
+			? undefined
+			: await readStateForConfig(config).catch(() => undefined);
+		const lastAppliedSnapshot = stateReadDisabled
+			? "Unavailable while operations are locked"
+			: syncState?.lastAppliedSnapshot
+				? safeTerminalText(syncState.lastAppliedSnapshot)
+				: syncState
+					? "Never synced"
+					: "Unavailable";
 		return {
 			title: [
 				"Pi Sync",
 				"",
 				`Current target: ${safeTerminalText(target)}`,
 				`Storage: ${storage}`,
-				`Auto-sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
-				"Last known sync: Remote not checked",
+				`Synced content: ${builtInCount} built-in group${builtInCount === 1 ? "" : "s"} · ${extraFileCount} extra file${extraFileCount === 1 ? "" : "s"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
+				`Auto-sync: ${config.autoSync ? "On" : "Off"}`,
+				`Last applied snapshot: ${lastAppliedSnapshot}`,
+				"Remote changes: Not checked",
 				...warnings.map((warning) => `Warning: ${safeTerminalText(warning)}`),
+				...(noSyncedContent
+					? ["", "No synced content is selected. Choose synced content in Settings before syncing."]
+					: []),
 				...(liveLock
 					? [
 							"",
@@ -218,7 +283,9 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 			actions:
 				liveLock || recoverableLock
 					? ["Status & changes", "History & recovery", "Help"]
-					: [...MAIN_MENU_ACTIONS],
+					: noSyncedContent
+						? ["Settings", "Switch target", "Status & changes", "More…"]
+						: [...MAIN_MENU_ACTIONS],
 		};
 	} catch (error) {
 		const targets = ownRecord(raw.targets);

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -31,6 +31,7 @@ import {
 	stateDir,
 	writeStateForConfig,
 } from "../src/config.js";
+import { showSyncManager } from "../src/manager-ui.js";
 import { migrateLegacySettings } from "../src/settings-management.js";
 import { recoverPendingSnapshotTransactions } from "../src/snapshot-transaction.js";
 import sync, { parseOptions } from "../src/sync.js";
@@ -160,9 +161,16 @@ test("deprecated PI_SYNC variables retain precedence and warnings never reveal v
 	});
 });
 
-test("bare sync menu shows the current target and goal-oriented actions", async () => {
+test("bare sync menu shows current state and goal-oriented actions", async () => {
 	await withTempSettings(async () => {
 		writeSettings(v2Settings());
+		const config = await loadConfig();
+		await writeStateForConfig(config, {
+			version: 1,
+			profile: config.profile,
+			lastAppliedSnapshot: "snapshot-home-123",
+			lastFileHashes: {},
+		});
 		const mock = createMockPi();
 		sync(mock.pi);
 		const calls: Array<{ title: string; options: string[] }> = [];
@@ -179,16 +187,100 @@ test("bare sync menu shows the current target and goal-oriented actions", async 
 
 		assert.match(calls[0]?.title ?? "", /Current target: home/);
 		assert.match(calls[0]?.title ?? "", /Cloudflare R2.*personal-pi/);
-		assert.match(calls[0]?.title ?? "", /Auto-sync: On.*Sessions: Off/);
+		assert.match(calls[0]?.title ?? "", /Synced content: 1 built-in group.*Sessions: Off/);
+		assert.match(calls[0]?.title ?? "", /Auto-sync: On/);
+		assert.match(calls[0]?.title ?? "", /Last applied snapshot: snapshot-home-123/);
+		assert.match(calls[0]?.title ?? "", /Remote changes: Not checked/);
 		assert.deepEqual(calls[0]?.options, [
-			"Sync now",
+			"Sync now (recommended)",
+			"Pull from remote",
+			"Push to remote",
 			"Switch target",
 			"Status & changes",
 			"Settings",
+			"More…",
+		]);
+	});
+});
+
+test("main menu exposes shallow secondary navigation with Back", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const mock = createMockPi();
+		sync(mock.pi);
+		const choices = ["More…", "Back", undefined];
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return choices.shift();
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(calls[1]?.title ?? "", /More options/);
+		assert.deepEqual(calls[1]?.options, [
 			"Manage targets & storage",
 			"History & recovery",
 			"Help",
+			"Back",
 		]);
+		assert.match(calls[2]?.title ?? "", /Current target: home/);
+	});
+});
+
+test("main menu dispatches explicit pull and push routes", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const choices = ["Pull from remote", "Push to remote", undefined];
+		const routes: string[] = [];
+		const titles: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			select: async (title: string) => {
+				titles.push(title);
+				return choices.shift();
+			},
+		});
+
+		await showSyncManager(ctx, async (route) => {
+			routes.push(route);
+			const config = await loadConfig();
+			await writeStateForConfig(config, {
+				version: 1,
+				profile: config.profile,
+				lastAppliedSnapshot: `after-${route}`,
+				lastFileHashes: {},
+			});
+			return undefined;
+		});
+
+		assert.deepEqual(routes, ["pull", "push"]);
+		assert.match(titles[1] ?? "", /Last applied snapshot: after-pull/);
+		assert.match(titles[2] ?? "", /Last applied snapshot: after-push/);
+	});
+});
+
+test("main menu exits the stale continuation after an applied pull", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		let selectCalls = 0;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			select: async () => {
+				selectCalls += 1;
+				return "Pull from remote";
+			},
+		});
+
+		await showSyncManager(ctx, async () => "applied");
+
+		assert.equal(selectCalls, 1);
 	});
 });
 
@@ -246,8 +338,225 @@ test("bare sync disables mutations and exposes recovery while a live lock is hel
 		await mock.commands.get("sync")?.handler("", ctx);
 
 		assert.match(title, /Operation in progress: pull/);
-		assert.doesNotMatch(options.join("\n"), /Sync now|Settings|Switch target/);
+		assert.doesNotMatch(options.join("\n"), /Sync now|Pull|Push|Settings|Switch target/);
 		assert.deepEqual(options, ["Status & changes", "History & recovery", "Help"]);
+	});
+});
+
+test("menu hides transfer actions when no synced content is selected", async () => {
+	await withTempSettings(async () => {
+		const settings = v2Settings();
+		settings.targets.home.syncFiles = [];
+		settings.targets.home.extraFiles = [];
+		settings.targets.home.syncSessions = false;
+		writeSettings(settings);
+		const mock = createMockPi();
+		sync(mock.pi);
+		let title = "";
+		let options: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			select: async (nextTitle: string, nextOptions: string[]) => {
+				title = nextTitle;
+				options = nextOptions;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		assert.match(title, /No synced content is selected/);
+		assert.deepEqual(options, ["Settings", "Switch target", "Status & changes", "More…"]);
+	});
+});
+
+test("menu pull and push checks cancel before commit with distinct feedback", async () => {
+	for (const scenario of [
+		{
+			label: "Pull from remote",
+			route: "pull",
+			loading: /Checking remote changes/,
+			cancelled: /Pull check cancelled; no local files were changed/,
+		},
+		{
+			label: "Push to remote",
+			route: "push",
+			loading: /Preparing push preview/,
+			cancelled: /Push preparation cancelled; no remote files were changed/,
+		},
+	] as const) {
+		await withTempSettings(async () => {
+			writeSettings(v2Settings());
+			const choices = [scenario.label, undefined];
+			let requestedRoute = "";
+			let signalAborted = false;
+			let commitStarted = false;
+			let loadingLines: string[] = [];
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => choices.shift(),
+				custom: async (factory: unknown) => {
+					const loader = createCustomSelectorHarness(factory, 32);
+					loadingLines = loader.render();
+					loader.handleInput("\u001b");
+					loader.dispose();
+					return loader.result;
+				},
+			});
+
+			await showSyncManager(ctx, (route, signal, onCommit) => {
+				requestedRoute = route;
+				return new Promise<undefined>((resolve, reject) => {
+					const commitTimer = setTimeout(() => {
+						onCommit?.();
+						commitStarted = true;
+						resolve(undefined);
+					}, 100);
+					const cancel = () => {
+						clearTimeout(commitTimer);
+						signalAborted = true;
+						reject(new DOMException("Aborted", "AbortError"));
+					};
+					if (signal?.aborted) cancel();
+					else signal?.addEventListener("abort", cancel, { once: true });
+				});
+			});
+
+			assert.equal(requestedRoute, scenario.route);
+			assert.ok(loadingLines.every((line) => visibleWidth(line) <= 32));
+			assert.match(loadingLines.join("\n"), scenario.loading);
+			assert.equal(signalAborted, true);
+			assert.equal(commitStarted, false);
+			assert.match(notifications.at(-1)?.message ?? "", scenario.cancelled);
+		});
+	}
+});
+
+test("menu push and pull preview concrete effects and cancellation is read-only", async () => {
+	await withTempSettings(async (agentDir) => {
+		writeSettings(v2Settings());
+		mkdirSync(agentDir, { recursive: true });
+		const settingsPath = path.join(agentDir, "settings.json");
+		writeFileSync(settingsPath, '{"local":true}\n');
+		const originalFetch = globalThis.fetch;
+		let putCalls = 0;
+		globalThis.fetch = (async (_input, init) => {
+			if (init?.method === "PUT") putCalls += 1;
+			return new Response(null, { status: 404 });
+		}) as typeof globalThis.fetch;
+		try {
+			const choices = ["Push to remote", undefined];
+			let confirmTitle = "";
+			let confirmMessage = "";
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async () => choices.shift(),
+				confirm: async (title: string, message: string) => {
+					confirmTitle = title;
+					confirmMessage = message;
+					return false;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("", ctx);
+
+			assert.match(confirmTitle, /Push pi settings/);
+			assert.match(confirmMessage, /Add remotely: settings\.json/);
+			assert.equal(putCalls, 0);
+			assert.equal(readFileSync(settingsPath, "utf8"), '{"local":true}\n');
+			assert.match(notifications.at(-1)?.message ?? "", /Push cancelled/);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	await withTempSettings(async (agentDir) => {
+		writeSettings(v2Settings());
+		mkdirSync(agentDir, { recursive: true });
+		const settingsPath = path.join(agentDir, "settings.json");
+		writeFileSync(settingsPath, '{"local":true}\n');
+		const remoteSnapshot = snapshotPayload("remote-snapshot", '{"remote":true}\n');
+		const encoded = gzipSync(Buffer.from(JSON.stringify(remoteSnapshot)));
+		const pointer = {
+			version: 1,
+			profile: "home",
+			snapshot: remoteSnapshot.id,
+			sha256: createHash("sha256").update(encoded).digest("hex"),
+			createdAt: remoteSnapshot.createdAt,
+			machine: remoteSnapshot.machine,
+		};
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input) => {
+			const url = new URL(String(input));
+			if (url.pathname.endsWith("/latest.json")) return Response.json(pointer);
+			if (url.pathname.endsWith(`/snapshots/${remoteSnapshot.id}.json.gz`)) {
+				return new Response(new Uint8Array(encoded));
+			}
+			throw new Error(`Unexpected request: ${url.pathname}`);
+		}) as typeof globalThis.fetch;
+		try {
+			const choices = ["Pull from remote", undefined];
+			let confirmTitle = "";
+			let confirmMessage = "";
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async () => choices.shift(),
+				confirm: async (title: string, message: string) => {
+					confirmTitle = title;
+					confirmMessage = message;
+					return false;
+				},
+			});
+
+			await mock.commands.get("sync")?.handler("", ctx);
+
+			assert.match(confirmTitle, /Pull pi settings/);
+			assert.match(confirmMessage, /Update locally: settings\.json/);
+			assert.match(confirmMessage, /local backup is created/);
+			assert.equal(readFileSync(settingsPath, "utf8"), '{"local":true}\n');
+			assert.equal(existsSync(path.join(stateDir(), "backups")), false);
+			assert.match(notifications.at(-1)?.message ?? "", /Pull cancelled/);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+test("menu pull failure preserves local files and suggests the next action", async () => {
+	await withTempSettings(async (agentDir) => {
+		writeSettings(v2Settings());
+		mkdirSync(agentDir, { recursive: true });
+		const settingsPath = path.join(agentDir, "settings.json");
+		writeFileSync(settingsPath, '{"local":true}\n');
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => new Response(null, { status: 404 })) as typeof globalThis.fetch;
+		try {
+			const choices = ["Pull from remote", undefined];
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async () => choices.shift(),
+			});
+
+			await mock.commands.get("sync")?.handler("", ctx);
+
+			assert.equal(readFileSync(settingsPath, "utf8"), '{"local":true}\n');
+			assert.match(
+				notifications.map(({ message }) => message).join("\n"),
+				/Remote is empty.*\/sync push/s,
+			);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
 	});
 });
 
@@ -283,7 +592,7 @@ test("Sync now read-only check aborts from Escape before any publication", async
 			const { ctx, notifications } = createMockContext({
 				hasUI: true,
 				mode: "tui",
-				select: async () => (selectCount++ === 0 ? "Sync now" : undefined),
+				select: async () => (selectCount++ === 0 ? "Sync now (recommended)" : undefined),
 				custom: async (factory: unknown) => {
 					const loader = createCustomSelectorHarness(factory, 60);
 					loader.handleInput("\u001b");
@@ -1026,6 +1335,7 @@ test("manage flow recommends the current profile bucket and derives a separate n
 		const mock = createMockPi();
 		sync(mock.pi);
 		const selections = [
+			"More…",
 			"Manage targets & storage",
 			"Add sync target",
 			"r2",


### PR DESCRIPTION
## Summary

- add explicit **Pull from remote** and **Push to remote** actions beside the recommended automatic sync flow
- surface the active target, selected content, local snapshot state, and lock/empty-content restrictions before users act
- move lower-frequency management, recovery, and help actions into a shallow **More…** menu
- preserve concrete previews, confirmations, cancellation safety, direct-command compatibility, and existing settings data
- document the redesigned workflow and add regression coverage for navigation, loading, previews, cancellation, failures, responsive rendering, and compatibility

## Verification

- `npm run check` — 1,314 tests passed
- `npm run pack:sync` — passed; 22 expected files
