### PR TITLE
fix(subagents): ignore empty aggregators

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -178,6 +178,10 @@ Run multiple agents in parallel with a shared thinking level and one per-task ov
 }
 ```
 
+Omit `aggregator` entirely when parallel worker outputs should return directly. Do not send `null`,
+empty strings, or an empty object for an unused optional field; for compatibility, an aggregator with
+an empty or whitespace-only `agent` or `task` is treated as absent.
+
 Run parallel workers, then aggregate their results:
 
 ```json
@@ -338,6 +342,9 @@ Existing `subagent` requests remain unchanged:
 | Chain | Input order. | Stops at the first failed step; completed steps remain in details. |
 | Parallel | Input order, with at most four active children. | Collects all task results; partial worker failure is reported in summaries but does not discard successful results. |
 | Parallel + aggregator | Source input order, then aggregator. | The aggregator runs with both successful outputs and failure descriptions; aggregator failure marks the tool result as an error. |
+
+An aggregator whose `agent` or `task` is empty or whitespace-only is treated as absent, so successful
+parallel outputs remain available instead of being replaced by a malformed fan-in failure.
 
 Timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Blocking thinking precedence remains: task/step/aggregator → call → agent setting → child default. Stateful spawn thinking precedence is: `subagent_spawn.thinkingLevel` → agent setting → transport fallback. Project-agent resolution and confirmation behavior is unchanged.
 

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -1,13 +1,13 @@
 import type { AgentToolResult, AgentToolUpdateCallback } from "@earendil-works/pi-agent-core";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
-	discoverAgents,
 	type AgentConfig,
 	type AgentScope,
+	discoverAgents,
 	type SubagentThinkingLevel,
 } from "./agents.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
-import type { SubagentParams } from "./params.js";
+import { hasUsableAggregator, type SubagentParams } from "./params.js";
 import {
 	buildFanInContext,
 	formatResultFailure,
@@ -107,6 +107,7 @@ export async function executeSubagent(
 ): Promise<AgentToolResult<SubagentDetails> & { isError?: boolean }> {
 			assertSubagentDepthAllowed();
 			const agentScope: AgentScope = params.agentScope ?? "user";
+			const aggregator = hasUsableAggregator(params.aggregator) ? params.aggregator : undefined;
 			const config = readSubagentSettings();
 			const discovery = discoverAgents(ctx.cwd, agentScope, config);
 			const agents = discovery.agents;
@@ -134,7 +135,7 @@ export async function executeSubagent(
 					aggregator,
 				});
 
-			if (modeCount !== 1 || (params.aggregator && !hasTasks)) {
+			if (modeCount !== 1 || (aggregator && !hasTasks)) {
 				const available = agents.map((a) => `${a.name} (${a.source})`).join(", ") || "none";
 				const reason =
 					modeCount !== 1
@@ -155,7 +156,7 @@ export async function executeSubagent(
 				const requestedAgentNames = new Set<string>();
 				if (params.chain) for (const step of params.chain) requestedAgentNames.add(step.agent);
 				if (params.tasks) for (const t of params.tasks) requestedAgentNames.add(t.agent);
-				if (params.aggregator) requestedAgentNames.add(params.aggregator.agent);
+				if (aggregator) requestedAgentNames.add(aggregator.agent);
 				if (params.agent) requestedAgentNames.add(params.agent);
 
 				const projectAgentsRequested = Array.from(requestedAgentNames)
@@ -286,7 +287,6 @@ export async function executeSubagent(
 					const emitParallelUpdate = () => {
 						status.update(parallelStatus(doneCount, allResults.length, runningCount));
 						if (onUpdate) {
-							const aggregator = params.aggregator;
 							const pendingAggregator: SingleResult | undefined =
 								aggregator && !signal?.aborted && doneCount === allResults.length
 									? {
@@ -368,8 +368,7 @@ export async function executeSubagent(
 					});
 
 					let aggregatorResult: SingleResult | undefined;
-					if (params.aggregator && !signal?.aborted) {
-						const aggregator = params.aggregator;
+					if (aggregator && !signal?.aborted) {
 						status.update(fanInStatus(aggregator.agent));
 						const fanInContext = buildFanInContext(results);
 						const aggregatorTask = truncateUtf8(

--- a/extensions/pi-subagents/src/params.ts
+++ b/extensions/pi-subagents/src/params.ts
@@ -29,13 +29,19 @@ const ChainItem = Type.Object({
 	thinkingLevel: Type.Optional(ThinkingLevelSchema),
 });
 
-const AggregatorItem = Type.Object({
-	agent: Type.String({ description: "Name of the fan-in agent to invoke after parallel tasks complete" }),
-	task: Type.String({ description: "Fan-in task. Use {previous} to include all parallel outputs." }),
-	cwd: Type.Optional(Type.String({ description: "Working directory for the aggregator process" })),
-	timeoutMs: Type.Optional(TimeoutMs),
-	thinkingLevel: Type.Optional(ThinkingLevelSchema),
-});
+const AggregatorItem = Type.Object(
+	{
+		agent: Type.String({ description: "Name of the fan-in agent to invoke after parallel tasks complete" }),
+		task: Type.String({ description: "Fan-in task. Use {previous} to include all parallel outputs." }),
+		cwd: Type.Optional(Type.String({ description: "Working directory for the aggregator process" })),
+		timeoutMs: Type.Optional(TimeoutMs),
+		thinkingLevel: Type.Optional(ThinkingLevelSchema),
+	},
+	{
+		description:
+			"Optional fan-in step for parallel mode. Omit this key entirely when no aggregation is needed; empty or whitespace-only agent/task values are treated as absent.",
+	},
+);
 
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
 	description:
@@ -59,3 +65,16 @@ export const SubagentParams = Type.Object({
 });
 
 export type SubagentParams = Static<typeof SubagentParams>;
+
+export function hasUsableAggregator(
+	aggregator: unknown,
+): aggregator is { agent: string; task: string } {
+	if (!aggregator || typeof aggregator !== "object") return false;
+	const candidate = aggregator as { agent?: unknown; task?: unknown };
+	return (
+		typeof candidate.agent === "string" &&
+		candidate.agent.trim().length > 0 &&
+		typeof candidate.task === "string" &&
+		candidate.task.trim().length > 0
+	);
+}

--- a/extensions/pi-subagents/src/render.ts
+++ b/extensions/pi-subagents/src/render.ts
@@ -9,7 +9,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import type { AgentScope, SubagentThinkingLevel } from "./agents.js";
-import type { SubagentParams } from "./params.js";
+import { hasUsableAggregator, type SubagentParams } from "./params.js";
 import {
 	getResultFinalOutput,
 	isResultError,
@@ -215,8 +215,8 @@ export function renderSubagentCall(args: SubagentParams, theme: Theme) {
 		}
 		if (args.tasks.length > 3)
 			text += `\n  ${theme.fg("muted", `... +${args.tasks.length - 3} more`)}`;
-		if (args.aggregator) {
-			const aggregator = args.aggregator as { agent?: unknown; task?: unknown };
+		if (hasUsableAggregator(args.aggregator)) {
+			const aggregator = args.aggregator;
 			text += `\n  ${theme.fg("muted", "fan-in → ")}${theme.fg("accent", previewAgent(aggregator.agent))}${theme.fg(
 				"dim",
 				` ${previewTask(aggregator.task)}`,

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -41,6 +41,7 @@ export default function (pi: ExtensionAPI) {
 			"Use the blocking subagent tool only when delegated outputs are required before the main agent's next action and waiting is intentional; the main agent cannot process queued steering until the call returns.",
 			"Use a blocking subagent single, parallel, chain, or fan-in call only when synchronous context or output isolation is worth making the main agent unavailable while it runs.",
 			"If a blocking parallel subagent call is genuinely required, keep tasks independent, stay within the hard max 8, and avoid write-heavy implementation touching the same files or shared state.",
+			"For parallel subagent calls, omit the aggregator key entirely unless a fan-in step is required; do not send null, empty strings, or an empty object for unused optional fields.",
 			'Do not use subagent with project-local agents unless the user explicitly wants project agents or sets agentScope to "project" or "both"; keep confirmation enabled for untrusted repositories.',
 			"When using subagent, write self-contained tasks with file paths, context, expected output, and whether the subagent may edit files.",
 		],

--- a/extensions/pi-subagents/test/runner-render.test.ts
+++ b/extensions/pi-subagents/test/runner-render.test.ts
@@ -36,14 +36,33 @@ test("renderSubagentCall handles partial streaming arguments", () => {
 		render({ chain: [{ agent: "calculation-checker" }] }),
 		/chain \(1 steps\).*calculation-checker \.\.\./s,
 	);
-	assert.match(
+	assert.doesNotMatch(
 		render({
 			tasks: [{ agent: "proof-auditor", task: "Review the proof" }],
 			aggregator: { agent: "reviewer" },
 		}),
-		/fan-in → reviewer \.\.\./,
+		/fan-in/,
 	);
 	assert.match(render({ tasks: [{ task: "Review the proof" }] }), /\.\.\. Review the proof/);
+});
+
+test("renderSubagentCall omits an empty optional aggregator", () => {
+	const identityTheme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+	const rendered = renderSubagentCall(
+		{
+			tasks: [{ agent: "scout", task: "Inspect the implementation" }],
+			aggregator: { agent: "  ", task: "\t" },
+		},
+		identityTheme as never,
+	)
+		.render(120)
+		.join("\n");
+
+	assert.match(rendered, /parallel \(1 tasks\)/);
+	assert.doesNotMatch(rendered, /fan-in/);
 });
 
 test("runSingleAgent normalizes invalid cwd without spawning or throwing", async () => {

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -22,6 +22,7 @@ import {
 	type SubagentSettingsRuntime,
 	ToolToggleList,
 } from "../src/config-ui.js";
+import { hasUsableAggregator } from "../src/params.js";
 import type { ManagedAgent } from "../src/registry.js";
 import { consumeSubagentSettingsNotice } from "../src/settings.js";
 import subagents, {
@@ -87,6 +88,8 @@ test("subagents registers consistent blocking guidance and configuration command
 	assert.doesNotMatch(guidanceText, /subagent_spawn/i);
 	assert.doesNotMatch(guidanceText, /use subagent parallel mode with 2-4/i);
 	assert.match(guidanceText, /hard max 8/i);
+	assert.match(guidanceText, /omit the aggregator key entirely/i);
+	assert.match(guidanceText, /null, empty strings, or an empty object/i);
 
 	const parameters = tool?.parameters as SchemaObject | undefined;
 	const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
@@ -108,6 +111,8 @@ test("subagents registers consistent blocking guidance and configuration command
 		parameters?.properties?.aggregator?.properties?.thinkingLevel?.enum,
 		thinkingLevels,
 	);
+	assert.match(parameters?.properties?.aggregator?.description ?? "", /omit this key entirely/i);
+	assert.match(parameters?.properties?.aggregator?.description ?? "", /treated as absent/i);
 	assert.ok(mock.commands.has("subagents"));
 	assert.ok(mock.commands.has("subagents:config"));
 	assert.deepEqual(mock.commands.get("subagents")?.getArgumentCompletions?.("s"), [
@@ -846,6 +851,57 @@ test("buildPiArgs passes thinking only when requested", () => {
 		"--no-tools",
 		"Task: no tools",
 	]);
+});
+
+test("aggregator usability requires non-whitespace agent and task values", () => {
+	assert.equal(hasUsableAggregator(undefined), false);
+	assert.equal(hasUsableAggregator({ agent: "", task: "Synthesize" }), false);
+	assert.equal(hasUsableAggregator({ agent: "reviewer", task: " \t" }), false);
+	assert.equal(hasUsableAggregator({ agent: "reviewer", task: "Synthesize" }), true);
+});
+
+test("parallel execution ignores an empty optional aggregator and preserves worker outputs", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools[0] as SubagentTool;
+	const { ctx } = createMockContext();
+	const signal = new AbortController().signal;
+	const dir = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-empty-aggregator-"));
+	const fakePi = path.join(dir, "fake-pi.mjs");
+	writeFileSync(
+		fakePi,
+		[
+			"const task=process.argv.at(-1) ?? '';",
+			"const output=task.includes('PROOF')?'PROOF_OK':'CALC_OK';",
+			"const message={role:'assistant',content:[{type:'text',text:output}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const originalScript = process.argv[1];
+	process.argv[1] = fakePi;
+	try {
+		const result = await tool.execute(
+			"empty-aggregator",
+			{
+				tasks: [
+					{ agent: "scout", task: "PROOF" },
+					{ agent: "scout", task: "CALC" },
+				],
+				aggregator: { agent: " ", task: "\t", thinkingLevel: "off", timeoutMs: 1 },
+			},
+			signal,
+			() => undefined,
+			ctx,
+		);
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details?.aggregator, undefined);
+		assert.match(result.content?.[0]?.text ?? "", /Parallel: 2\/2 succeeded/);
+		assert.match(result.content?.[0]?.text ?? "", /PROOF_OK/);
+		assert.match(result.content?.[0]?.text ?? "", /CALC_OK/);
+	} finally {
+		process.argv[1] = originalScript;
+		rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 test("subagent execute resolves thinking level in single, chain, parallel, and aggregator modes", async () => {


### PR DESCRIPTION
## Summary

- treat aggregators with an empty or whitespace-only `agent` or `task` as absent
- preserve successful parallel worker summaries instead of replacing them with a malformed fan-in failure
- omit unusable fan-in rows from call rendering and clarify schema, prompt, and README guidance
- add regression coverage for execution, rendering, and aggregator normalization

## Verification

- focused compiled pi-subagents tests (35 tests)
- `npm run typecheck --workspace @narumitw/pi-subagents`
- `npm run check` (1,334 tests)

Closes #380