### PR TITLE
feat(goal): add current-state goal manager

### DIFF
--- a/docs/plans/archived/2026-07-25_pi-goal-menu-redesign-plan.md
+++ b/docs/plans/archived/2026-07-25_pi-goal-menu-redesign-plan.md
@@ -1,0 +1,63 @@
+# pi-goal Menu Redesign Plan
+
+## Goal
+
+Make bare `/goal` a current-state, menu-first TUI manager while preserving every established direct command, non-TUI behavior, persisted goal/queue data, RPC contract, and failure rollback. Add an interactive settings screen, safe previews for consequential menu actions, focused tests, and updated user documentation.
+
+## Context
+
+- Bare `/goal` currently emits a dense notification containing state and command hints.
+- Direct routes such as `/goal <objective>`, `/goal pause`, `/goal status`, queue routes, and compatibility aliases are public interfaces and remain supported.
+- Goal state is session-owned; settings are user-owned in `pi-goal.json` and currently reload only at session boundaries.
+- The approved UX makes TUI bare `/goal` interactive. Print, JSON, and RPC keep deterministic status behavior.
+
+## Architecture
+
+- Add `extensions/pi-goal/src/menu.ts` to own menu presentation, dynamic action availability, shallow navigation, confirmation previews, help, and delegation to `GoalCommandController`.
+- Add `extensions/pi-goal/src/settings-ui.ts` to own the `SettingsList` interaction and immediate, serialized setting application.
+- Extend `extensions/pi-goal/src/settings.ts` with atomic, unknown-field-preserving persistence.
+- Keep lifecycle/tool contracts in `goal.ts`, goal mutations in `commands.ts`, and runtime safety/state transitions in `runtime.ts`.
+- Use Pi-provided `select`, `editor`, `input`, `confirm`, and `SettingsList`; Escape/cancel returns without mutation.
+
+## Non-Goals
+
+- No new slash command or generic `/settings` command.
+- No removal or semantic rewrite of existing direct subcommands, aliases, RPC channels, or persisted session formats.
+- No project-scoped settings or settings-file migration.
+- No custom visual overlay or replacement selector.
+
+## Assumptions
+
+- The approved proposal authorizes the complete scope, including interactive settings.
+- Direct destructive routes remain immediate for compatibility; confirmations apply to menu-driven routes.
+- Terminal screen-reader support is limited by Pi TUI, so accessibility verification covers text labels, keyboard/IME-compatible built-ins, focus/cancel behavior, non-color cues, and bounded rendering.
+
+## Risks
+
+- Applying tool visibility or queue settings live can conflict with active goal state; application must reuse runtime ownership/safety methods and roll back both the file and effective setting on failure.
+- Settings callbacks can overlap; serialize writes and keep the queue usable after a rejected save.
+- Long or hostile objective text can corrupt terminal presentation; sanitize control characters and use bounded previews while preserving raw objective data for mutations.
+- Bare `/goal` changes in TUI; `/goal status` and all non-TUI invocations must retain status output.
+
+## Plan
+
+- [x] Add focused failing tests for atomic settings saves, nested unknown-field preservation, malformed-file refusal, and write-failure cleanup in `extensions/pi-goal/test/settings.test.ts`; red evidence: `tsc -p tsconfig.test.json` failed because `saveGoalSettings` was absent.
+- [x] Implement atomic unknown-field-preserving settings persistence in `extensions/pi-goal/src/settings.ts`; evidence: focused compiled settings test passes (8/8).
+- [x] Add focused failing menu tests covering empty/active/stopped/budget/frozen action models, terminal-safe bounded state text, cancellation, destructive previews, and delegation in a new `extensions/pi-goal/test/menu.test.ts`; red evidence: test compilation failed because `src/menu.ts` did not exist.
+- [x] Implement `extensions/pi-goal/src/menu.ts` with dynamic current-state menus, start/edit/budget/queue workflows, confirmations, status/help actions, and shallow return/exit behavior; evidence: focused compiled menu test passes (5/5).
+- [x] Add focused failing settings-UI tests for immediate persistence ordering, rollback, arbitrary limits, live limit enforcement, and non-TUI behavior in a new `extensions/pi-goal/test/settings-ui.test.ts`; red evidence: test compilation failed because `src/settings-ui.ts` did not exist.
+- [x] Implement `extensions/pi-goal/src/settings-ui.ts` with `SettingsList`, serialized saves, confirmation-gated experimental/limit changes, and the minimum runtime setting-application boundary needed to preserve tool, queue, goal, and rollback invariants; evidence: focused compiled settings-UI test passes (4/4).
+- [x] Wire bare TUI `/goal` to the manager in `extensions/pi-goal/src/goal.ts`, retain `/goal status` and non-TUI summary behavior, and add integration coverage in `extensions/pi-goal/test/goal.test.ts`; evidence: focused goal/menu/settings suites pass (155/155), including TUI and print dispatch while menu state tests cover pending/frozen guards.
+- [x] Update `extensions/pi-goal/README.md` with the menu-first workflow, direct-route compatibility, confirmations/cancellation, settings behavior, supported modes, and keyboard operation; verified against command parsing, manager actions, and mode-dispatch tests.
+- [x] Format only changed files and run focused pi-goal tests, `npm run typecheck --workspace @narumitw/pi-goal`, `npm run check:boundaries`, the full `npm run check`, `just pack-goal`, and runtime/load smokes; evidence: focused suites passed, workspace typecheck and boundaries passed, `npm run check` passed 1,349 tests, runtime smoke passed, pack contained all 19 intended files, and `pi -ne -p --no-session -e ./extensions/pi-goal "/goal status"` loaded the extension and produced the expected observable status rejection.
+
+## Completion Checklist
+
+- [x] TUI bare `/goal` exposes state-appropriate Start, Pause, Resume, budget recovery, queue, Status, Settings, Help, Clear, and Close actions without hiding the only route to a capability.
+- [x] Empty, active, paused/blocked/usage-limited, budget-limited, complete, pending, queue-enabled, and frozen states have deterministic menu or fallback behavior.
+- [x] Menu cancellation and failed start/edit/settings delivery leave goal IDs, queue data, settings, active tools, safety counters, and prior valid state intact.
+- [x] Menu-driven Replace, Clear, Skip, Drop last, and Prioritize show the exact affected objective(s) and require confirmation.
+- [x] Settings saves are serialized, atomic, preserve unknown fields, refuse malformed input, and roll back display/runtime state on failure.
+- [x] Existing direct commands, hidden aliases, non-TUI status behavior, RPC/events, settings defaults, and persisted formats remain compatible.
+- [x] Menu/status rendering is terminal-safe, non-color-dependent, keyboard operable, IME-compatible through Pi built-ins, and bounded at narrow/normal/wide tested widths.
+- [x] Tests, repository checks, package dry run, documentation review, and applicable runtime smoke all pass with no known required work remaining.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -9,8 +9,8 @@ Goal mode uses Codex-like persistence instructions and sends guarded continuatio
 ## ✨ Features
 
 - Adds `/goal <goal_to_complete>` to start goal mode, with confirmation before replacing an existing goal.
-- Bare `/goal` shows the current goal summary.
-- Keeps advanced goal management inside `/goal` subcommands: `pause`, `resume`, `clear`, and `edit`.
+- Bare `/goal` opens a current-state manager in the TUI, with guided start, pause, resume, edit, queue, settings, status, help, and destructive-action confirmation; non-TUI modes retain deterministic status output.
+- Keeps direct goal management available through `/goal` subcommands: `status`, `pause`, `resume`, `clear`, and `edit`.
 - Exposes only one top-level command: `/goal`, including when ordered goals are enabled.
 - Optionally adds ordered-goal operations through `/goal add`, `prioritize`, `drop-last`, and `skip`, while accepting `push`, `unshift`, `pop`, and `shift` as hidden compatibility aliases.
 - Bounds automatic work by default to 25 normal model responses, including responses inside automatic tool loops and Pi-owned retry/compaction recovery; set `continuationLimits.automaticTurns` explicitly to `null` only when unbounded automatic work is intended.
@@ -70,7 +70,7 @@ with the complete current defaults:
 }
 ```
 
-Edit this generated file only when overriding the defaults.
+Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. Escape closes the settings screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
 
@@ -84,9 +84,7 @@ Edit this generated file only when overriding the defaults.
 - `automaticTurns` is a positive safe integer and defaults to `25`. It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field to `null` to remove the authoritative hard bound.
 - `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
 
-Settings are reread at Pi startup, session replacement, and `/reload`; the file is not watched live.
-A missing file is created during any of those session starts, while an existing file is read without
-being rewritten. Initialization publishes the generated file atomically and never overwrites a file
+Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file is created during any of those session starts, while an existing file is read without being rewritten. Initialization publishes the generated file atomically and never overwrites a file
 created concurrently by another process.
 
 Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten;
@@ -102,6 +100,7 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 
 ```text
 /goal
+/goal status
 /goal implement snake game
 /goal --tokens 100k fix the failing test and verify it
 /goal edit ship the smaller fix first
@@ -116,7 +115,9 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 /goal skip
 ```
 
-- `/goal` shows the current goal, status, lifetime iteration count, automatic model-response count, active elapsed time, token usage, any safety-pause reason, and available `/goal` subcommands.
+- In the TUI, `/goal` opens a state-aware manager. Its first action follows the current state: start when empty, pause when active, resume when stopped, or increase the budget when exhausted. Status, Settings, Help, queue management, Clear, and Close remain shallow, labeled routes. Arrow keys navigate, Enter selects, and Escape cancels or closes without changing state.
+- In print, JSON, and RPC modes, bare `/goal` reports the current summary without opening a terminal UI. `/goal status` provides the same deterministic summary in every mode.
+- Menu-driven Replace, Clear, Prioritize, Skip, and Drop last actions preview the exact affected goals and require confirmation. Existing direct routes remain immediate for compatibility and automation.
 - `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters. Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
 - `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. A successful active edit rotates the stale-turn guard and starts a fresh safety epoch. Paused, blocked, and usage-limited goals stay stopped and retain their safety state until resume. A budget-limited goal reactivates only when `edit --tokens` raises its budget above current usage. Failed prompt delivery restores the exact previous safety counters/cause; it restores a budget-limited goal or restores and pauses a previously active goal.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -70,7 +70,7 @@ with the complete current defaults:
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. Revealing lazy Goal tools is rejected while Pi is busy so the active tool schema cannot change mid-run; retry after Pi settles. Escape closes the settings screen without reverting changes that were already saved.
+Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles. Escape closes the settings screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
 

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -9,7 +9,7 @@ Goal mode uses Codex-like persistence instructions and sends guarded continuatio
 ## ✨ Features
 
 - Adds `/goal <goal_to_complete>` to start goal mode, with confirmation before replacing an existing goal.
-- Bare `/goal` opens a current-state manager in the TUI, with guided start, pause, resume, edit, queue, settings, status, help, and destructive-action confirmation; non-TUI modes retain deterministic status output.
+- Bare `/goal` opens a current-state manager in the TUI, with guided start, pause, resume, edit, queue, settings, status, help, and destructive-action confirmation; RPC mode retains observable status notifications.
 - Keeps direct goal management available through `/goal` subcommands: `status`, `pause`, `resume`, `clear`, and `edit`.
 - Exposes only one top-level command: `/goal`, including when ordered goals are enabled.
 - Optionally adds ordered-goal operations through `/goal add`, `prioritize`, `drop-last`, and `skip`, while accepting `push`, `unshift`, `pop`, and `shift` as hidden compatibility aliases.
@@ -70,7 +70,7 @@ with the complete current defaults:
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. Escape closes the settings screen without reverting changes that were already saved.
+Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. Revealing lazy Goal tools is rejected while Pi is busy so the active tool schema cannot change mid-run; retry after Pi settles. Escape closes the settings screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
 
@@ -116,7 +116,7 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 ```
 
 - In the TUI, `/goal` opens a state-aware manager. Its first action follows the current state: start when empty, pause when active, resume when stopped, or increase the budget when exhausted. Status, Settings, Help, queue management, Clear, and Close remain shallow, labeled routes. Arrow keys navigate, Enter selects, and Escape cancels or closes without changing state.
-- In print, JSON, and RPC modes, bare `/goal` reports the current summary without opening a terminal UI. `/goal status` provides the same deterministic summary in every mode.
+- In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI. Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
 - Menu-driven Replace, Clear, Prioritize, Skip, and Drop last actions preview the exact affected goals and require confirmation. Existing direct routes remain immediate for compatibility and automation.
 - `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters. Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
@@ -144,7 +144,7 @@ Goal state is stored as Pi session state, similar to Codex's thread-owned goals.
 
 Ordered queues use the same canonical `goal-state` session entry as single goals. Every item owns independent usage and safety state. Shelving, priority displacement, automatic advancement, and later reactivation preserve that item's epoch rather than granting more automatic work. The legacy `{ goal }` shape remains valid, and missing safety fields normalize to zero/defaults. Queue fields are written only when needed. Sessions created by the former standalone `pi-goals` experiment can migrate their last `goals-state` array and pending `unshift` intent when the branch has never written a canonical `goal-state`; any canonical entry, including an explicit clear, takes precedence so old plural state cannot be resurrected.
 
-If a session still contains multiple goals or a pending queue transition when `experimental.goals` is disabled, pi-goal freezes that queue. It does not inject Goal prompts or continue work, reports `queue off`, preserves every item, and accepts only `/goal` for inspection or `/goal clear` for removal. Re-enable the setting and run `/reload` to resume. A migrated legacy array containing only one goal becomes an ordinary single goal without requiring the experiment.
+If a session still contains multiple goals or a pending queue transition when `experimental.goals` is disabled, pi-goal freezes that queue. It does not inject Goal prompts or continue work, reports `queue off`, preserves every item, and accepts only `/goal` for inspection or `/goal clear` for removal. Re-enabling the setting in the TUI resumes retained work after any aborted Goal-owned run settles; editing the file directly still requires `/reload`. A migrated legacy array containing only one goal becomes an ordinary single goal without requiring the experiment.
 
 Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed by working directory. This version no longer reads that global file, and `/goal clear` removes any legacy entry for the current working directory.
 

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -32,6 +32,11 @@
 	"dependencies": {
 		"typebox": "^1.3.3"
 	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",
 		"@earendil-works/pi-ai": "0.81.1",

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -1,4 +1,4 @@
-import { currentTokenTotal } from "./accounting.js";
+import { checkpointGoalActiveTime, currentTokenTotal } from "./accounting.js";
 import { validateObjective } from "./command.js";
 import { safeGoalMenuText } from "./menu.js";
 import type { ActiveGoal } from "./persistence.js";
@@ -8,6 +8,7 @@ import {
 	appendGoal,
 	createQueuedGoal,
 	dropLastGoal as dropLastQueuedGoal,
+	goalQueueIdentity,
 	prioritizeGoal as prioritizeQueuedGoal,
 	skipGoal as skipQueuedGoal,
 } from "./queue.js";
@@ -54,13 +55,34 @@ export class GoalCommandController {
 		const existingGoal =
 			this.runtime.activeGoal?.status !== "complete" ? this.runtime.activeGoal : undefined;
 		const existingQueuedGoals = [...this.runtime.queuedGoals];
+		const existingQueueIdentity = goalQueueIdentity(
+			this.runtime.activeGoal,
+			this.runtime.queuedGoals,
+			this.runtime.pendingQueueAction,
+		);
 		if (existingGoal) {
+			const queuedRemovalPreview =
+				existingQueuedGoals.length > 0
+					? `\n\nQueued goals also removed:\n${existingQueuedGoals
+							.map((goal, index) => `${index + 1}. ${safeGoalMenuText(goal.text, 4_000)}`)
+							.join("\n")}`
+					: "";
 			const shouldReplace = await ctx.ui.confirm(
 				"Replace goal?",
-				`Current goal: ${safeGoalMenuText(existingGoal.text, 4_000)}\n\nNew goal: ${safeGoalMenuText(objective, 4_000)}`,
+				`Current goal: ${safeGoalMenuText(existingGoal.text, 4_000)}${queuedRemovalPreview}\n\nNew goal: ${safeGoalMenuText(objective, 4_000)}`,
 			);
 			if (!shouldReplace) {
 				ctx.ui.notify(`Goal kept: ${existingGoal.text}`, "info");
+				return;
+			}
+			if (
+				goalQueueIdentity(
+					this.runtime.activeGoal,
+					this.runtime.queuedGoals,
+					this.runtime.pendingQueueAction,
+				) !== existingQueueIdentity
+			) {
+				ctx.ui.notify("The goal queue changed while confirmation was open. Try again.", "warning");
 				return;
 			}
 		}
@@ -222,6 +244,14 @@ export class GoalCommandController {
 		this.runtime.guardAbortGoalId = undefined;
 		this.runtime.clearStaleGoalToolCallBlock();
 		if (this.runtime.activeGoal) {
+			if (
+				this.runtime.activeGoal.status === "active" &&
+				this.runtime.activeGoal.activeStartedAt === undefined
+			) {
+				const now = Date.now();
+				checkpointGoalActiveTime(this.runtime.activeGoal, now, true);
+				this.runtime.activeGoal.updatedAt = now;
+			}
 			this.runtime.persistGoal(this.runtime.activeGoal);
 			this.runtime.updateStatus(ctx, this.runtime.activeGoal);
 		} else {
@@ -560,7 +590,11 @@ export class GoalCommandController {
 	}
 
 	private reportGoalStatus(ctx: StatusContext, message: string) {
-		if (ctx.mode === "print" || ctx.mode === "json") throw new Error(message);
+		if (ctx.mode === "print" || ctx.mode === "json") {
+			throw new Error(
+				`/goal status is unavailable in ${ctx.mode} mode because Pi does not expose an extension-command output channel. Use TUI or RPC mode.`,
+			);
+		}
 		ctx.ui.notify(message, "info");
 	}
 

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -1,5 +1,6 @@
 import { currentTokenTotal } from "./accounting.js";
 import { validateObjective } from "./command.js";
+import { safeGoalMenuText } from "./menu.js";
 import type { ActiveGoal } from "./persistence.js";
 import { buildGoalPrompt, buildObjectiveUpdatedPrompt, buildResumePrompt } from "./prompts.js";
 import {
@@ -56,7 +57,7 @@ export class GoalCommandController {
 		if (existingGoal) {
 			const shouldReplace = await ctx.ui.confirm(
 				"Replace goal?",
-				`Current goal: ${existingGoal.text}\n\nNew goal: ${objective}`,
+				`Current goal: ${safeGoalMenuText(existingGoal.text, 4_000)}\n\nNew goal: ${safeGoalMenuText(objective, 4_000)}`,
 			);
 			if (!shouldReplace) {
 				ctx.ui.notify(`Goal kept: ${existingGoal.text}`, "info");
@@ -215,8 +216,17 @@ export class GoalCommandController {
 	}
 
 	async resumeQueueAfterUnfreeze(ctx: StatusContext) {
-		this.runtime.clearStaleGoalToolCallBlock();
+		if (this.runtime.queueFreezeAwaitingSettle) return false;
+		this.runtime.queueFrozen = false;
+		this.runtime.queueFreezeAwaitingSettle = false;
 		this.runtime.guardAbortGoalId = undefined;
+		this.runtime.clearStaleGoalToolCallBlock();
+		if (this.runtime.activeGoal) {
+			this.runtime.persistGoal(this.runtime.activeGoal);
+			this.runtime.updateStatus(ctx, this.runtime.activeGoal);
+		} else {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+		}
 		if (this.runtime.pendingQueueAction) {
 			return this.dispatchPendingQueueActionIfSettled(ctx);
 		}

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -214,6 +214,18 @@ export class GoalCommandController {
 		}
 	}
 
+	async resumeQueueAfterUnfreeze(ctx: StatusContext) {
+		this.runtime.clearStaleGoalToolCallBlock();
+		this.runtime.guardAbortGoalId = undefined;
+		if (this.runtime.pendingQueueAction) {
+			return this.dispatchPendingQueueActionIfSettled(ctx);
+		}
+		const goal = this.runtime.activeGoal;
+		if (goal?.status !== "active") return false;
+		this.runtime.requestContinuation(goal);
+		return this.runtime.dispatchContinuationIfSettled(ctx);
+	}
+
 	async dispatchPendingQueueActionIfSettled(ctx: StatusContext) {
 		const pending = this.runtime.pendingQueueAction;
 		if (!pending || this.runtime.queueFrozen) return false;

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -516,8 +516,9 @@ export class GoalCommandController {
 
 	showGoal(ctx: StatusContext) {
 		if (!this.runtime.activeGoal) {
-			ctx.ui.notify("Usage: /goal <objective>\nNo goal is currently set.", "info");
+			const message = "Usage: /goal <objective>\nNo goal is currently set.";
 			ctx.ui.setStatus(STATUS_KEY, undefined);
+			this.reportGoalStatus(ctx, message);
 			return;
 		}
 		if (!this.runtime.queueFrozen) {
@@ -525,15 +526,20 @@ export class GoalCommandController {
 			this.runtime.persistGoal(this.runtime.activeGoal);
 			this.runtime.updateStatus(ctx, this.runtime.activeGoal);
 		}
-		ctx.ui.notify(
+		this.reportGoalStatus(
+			ctx,
 			goalSummary(
 				this.runtime.activeGoal,
 				this.runtime.queuedGoals,
 				this.runtime.settings.experimental.goals,
 				this.runtime.queueFrozen,
 			),
-			"info",
 		);
+	}
+
+	private reportGoalStatus(ctx: StatusContext, message: string) {
+		if (ctx.mode === "print" || ctx.mode === "json") throw new Error(message);
+		ctx.ui.notify(message, "info");
 	}
 
 	private async activatePrioritizedGoal(

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -413,7 +413,12 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			}
 			if (result.kind === "show" && args.trim() === "") {
 				await showGoalManager(runtime, commands, ctx, (menuCtx) =>
-					showGoalSettings(runtime, menuCtx, { settingsPath: options.settingsPath }),
+					showGoalSettings(runtime, menuCtx, {
+						settingsPath: options.settingsPath,
+						onQueueUnfrozen: async (settingsCtx) => {
+							await commands.resumeQueueAfterUnfreeze(settingsCtx);
+						},
+					}),
 				);
 				return;
 			}

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import { currentTokenTotal } from "./accounting.js";
 import { completeGoalArguments, parseCommand } from "./command.js";
 import { GoalCommandController } from "./commands.js";
+import { showGoalManager } from "./menu.js";
 import { type ActiveGoal, loadGoalStateFromSession } from "./persistence.js";
 import { buildGoalPrompt, buildGoalSystemPrompt } from "./prompts.js";
 import { activateQueuedGoal } from "./queue.js";
@@ -31,10 +32,11 @@ import {
 } from "./runtime.js";
 import { hasAssistantToolCall } from "./safety.js";
 import { DEFAULT_GOAL_SETTINGS, loadOrCreateGoalSettings } from "./settings.js";
+import { showGoalSettings } from "./settings-ui.js";
 
-// goal.ts is the Pi-facing composition root: it keeps tool contracts and event
-// ordering together. Per-session mechanisms live in runtime.ts, while user command
-// transitions live in commands.ts. Each factory constructs isolated instances.
+// goal.ts remains the Pi-facing composition root despite its size because tool contracts and
+// lifecycle-event registration share order-sensitive wiring. Per-session mechanisms live in
+// runtime.ts, while user-command transitions live in commands.ts; each factory stays isolated.
 
 interface GoalCompleteDetails {
 	goal: string;
@@ -407,6 +409,12 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			});
 			if (typeof result === "string") {
 				ctx.ui.notify(result, "warning");
+				return;
+			}
+			if (result.kind === "show" && args.trim() === "") {
+				await showGoalManager(runtime, commands, ctx, (menuCtx) =>
+					showGoalSettings(runtime, menuCtx, { settingsPath: options.settingsPath }),
+				);
 				return;
 			}
 			if (runtime.queueFrozen) {

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -483,6 +483,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.queuedGoals = [];
 		runtime.pendingQueueAction = undefined;
 		runtime.queueFrozen = false;
+		runtime.queueFreezeAwaitingSettle = false;
 		runtime.clearTerminalDetails();
 		rpc.bindSession(ctx);
 		const previousToolVisibility = runtime.settings.toolVisibility;
@@ -613,6 +614,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.queuedGoals = [];
 		runtime.pendingQueueAction = undefined;
 		runtime.queueFrozen = false;
+		runtime.queueFreezeAwaitingSettle = false;
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		clearCompletionStatusTimer();
 		runtime.clearTerminalDetails();
@@ -1040,6 +1042,10 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 	pi.on("agent_settled", async (_event, ctx) => {
 		if (runtime.queueFrozen) {
 			runtime.clearSettledSafetyTracking();
+			runtime.queueFreezeAwaitingSettle = false;
+			if (runtime.settings.experimental.goals) {
+				await commands.resumeQueueAfterUnfreeze(ctx);
+			}
 			return;
 		}
 		runtime.finalizeSettledRecovery(ctx);

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -2,7 +2,7 @@ import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { formatDuration } from "./accounting.js";
 import { parseTokenBudget } from "./command.js";
 import type { GoalCommandController } from "./commands.js";
-import type { ActiveGoal } from "./persistence.js";
+import type { ActiveGoal, PendingQueueAction } from "./persistence.js";
 import type { GoalRuntime } from "./runtime.js";
 
 export const GOAL_MENU_ACTIONS = {
@@ -32,7 +32,7 @@ const QUEUE_ACTIONS = {
 interface GoalMenuRuntimeView {
 	activeGoal?: ActiveGoal;
 	queuedGoals: ActiveGoal[];
-	pendingQueueAction?: unknown;
+	pendingQueueAction?: PendingQueueAction;
 	queueFrozen: boolean;
 	settings: GoalRuntime["settings"];
 	recordGoalUsage?: GoalRuntime["recordGoalUsage"];
@@ -95,7 +95,9 @@ export function buildGoalMenuState(runtime: GoalMenuRuntimeView): GoalMenuState 
 		actions.push(GOAL_MENU_ACTIONS.edit, GOAL_MENU_ACTIONS.replace);
 	}
 	if (goal) actions.push(GOAL_MENU_ACTIONS.status);
-	if (runtime.settings.experimental.goals || queueCount > 0) actions.push(GOAL_MENU_ACTIONS.queue);
+	if (goal && (runtime.settings.experimental.goals || queueCount > 0)) {
+		actions.push(GOAL_MENU_ACTIONS.queue);
+	}
 	actions.push(GOAL_MENU_ACTIONS.settings, GOAL_MENU_ACTIONS.help);
 	if (goal) actions.push(GOAL_MENU_ACTIONS.clear);
 	actions.push(GOAL_MENU_ACTIONS.close);
@@ -143,7 +145,7 @@ export async function showGoalManager(
 				commands.showGoal(ctx);
 				return;
 			case GOAL_MENU_ACTIONS.queue:
-				await showQueueMenu(runtime, commands, ctx);
+				if ((await showQueueMenu(runtime, commands, ctx)) === "back") continue;
 				return;
 			case GOAL_MENU_ACTIONS.settings:
 				await showSettings(ctx);
@@ -265,7 +267,7 @@ async function showQueueMenu(
 		`Goal queue · ${runtime.queuedGoals.length + 1} total\nCurrent: ${safeGoalMenuText(goal.text)}`,
 		actions,
 	);
-	if (!selected || selected === QUEUE_ACTIONS.back) return;
+	if (!selected || selected === QUEUE_ACTIONS.back) return "back" as const;
 	if (selected === QUEUE_ACTIONS.add) {
 		const objective = (await ctx.ui.editor("Add goal to queue", ""))?.trim();
 		if (objective) await commands.addGoal(objective, undefined, ctx);
@@ -304,11 +306,19 @@ async function confirmClear(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandC
 	const goals = [runtime.activeGoal, ...runtime.queuedGoals].filter(
 		(goal): goal is ActiveGoal => goal !== undefined,
 	);
-	if (goals.length === 0) return false;
+	const pendingPriority =
+		runtime.pendingQueueAction?.kind === "prioritize"
+			? runtime.pendingQueueAction.objective
+			: undefined;
+	const summaries = [
+		...goals.map((goal) => safeGoalMenuText(goal.text, 4_000)),
+		...(pendingPriority ? [`Pending priority: ${safeGoalMenuText(pendingPriority, 4_000)}`] : []),
+	];
+	if (summaries.length === 0) return false;
 	return ctx.ui.confirm(
-		goals.length > 1 ? "Clear goal queue?" : "Clear goal?",
-		`Remove ${goals.length === 1 ? "this goal" : `all ${goals.length} goals`}:\n\n${goals
-			.map((goal, index) => `${index + 1}. ${safeGoalMenuText(goal.text, 4_000)}`)
+		summaries.length > 1 ? "Clear goal queue?" : "Clear goal?",
+		`Remove ${summaries.length === 1 ? "this goal" : `all ${summaries.length} goals`}:\n\n${summaries
+			.map((summary, index) => `${index + 1}. ${summary}`)
 			.join("\n")}\n\nThis cannot be undone.`,
 	);
 }
@@ -321,13 +331,7 @@ function displayStatus(status?: ActiveGoal["status"]) {
 }
 
 function formatTokenCount(tokens: number) {
-	if (tokens >= 1_000_000) return `${trimNumber(tokens / 1_000_000)}m`;
-	if (tokens >= 1_000) return `${trimNumber(tokens / 1_000)}k`;
 	return String(tokens);
-}
-
-function trimNumber(value: number) {
-	return value.toFixed(value >= 10 ? 0 : 1).replace(/\.0$/u, "");
 }
 
 function isTerminalControl(character: string) {

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -202,14 +202,13 @@ async function editFromMenu(
 	if (!goal) return;
 	const objective = (await ctx.ui.editor("Edit goal objective", goal.text))?.trim();
 	if (!objective || objective === goal.text) return;
-	if (
-		goal.status === "active" &&
-		!(await ctx.ui.confirm(
+	if (!requireCurrentMenuGoal(runtime, goal, ctx)) return;
+	if (goal.status === "active") {
+		const confirmed = await ctx.ui.confirm(
 			"Apply goal edit?",
 			`Current goal:\n${safeGoalMenuText(goal.text, 4_000)}\n\nUpdated goal:\n${safeGoalMenuText(objective, 4_000)}\n\nApplying this edit starts a new guarded goal instance.`,
-		))
-	) {
-		return;
+		);
+		if (!confirmed || !requireCurrentMenuGoal(runtime, goal, ctx)) return;
 	}
 	await commands.editGoal(objective, undefined, ctx);
 }
@@ -222,7 +221,7 @@ async function increaseBudget(
 	const goal = runtime.activeGoal;
 	if (!goal) return;
 	const budget = await askTokenBudget(ctx, goal.tokenBudget);
-	if (budget === undefined) return;
+	if (budget === undefined || !requireCurrentMenuGoal(runtime, goal, ctx)) return;
 	if (budget <= goal.tokensUsed) {
 		ctx.ui.notify(
 			`Token budget must be greater than current usage (${formatTokenCount(goal.tokensUsed)}).`,
@@ -230,14 +229,11 @@ async function increaseBudget(
 		);
 		return;
 	}
-	if (
-		!(await ctx.ui.confirm(
-			"Increase goal budget?",
-			`Goal: ${safeGoalMenuText(goal.text, 4_000)}\n\nBudget: ${formatTokenCount(goal.tokenBudget ?? 0)} → ${formatTokenCount(budget)}\nCurrent usage: ${formatTokenCount(goal.tokensUsed)}\n\nThe goal will resume immediately.`,
-		))
-	) {
-		return;
-	}
+	const confirmed = await ctx.ui.confirm(
+		"Increase goal budget?",
+		`Goal: ${safeGoalMenuText(goal.text, 4_000)}\n\nBudget: ${formatTokenCount(goal.tokenBudget ?? 0)} → ${formatTokenCount(budget)}\nCurrent usage: ${formatTokenCount(goal.tokensUsed)}\n\nThe goal will resume immediately.`,
+	);
+	if (!confirmed || !requireCurrentMenuGoal(runtime, goal, ctx)) return;
 	await commands.editGoal(goal.text, budget, ctx);
 }
 
@@ -326,6 +322,19 @@ async function confirmClear(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandC
 			.map((summary, index) => `${index + 1}. ${summary}`)
 			.join("\n")}\n\nThis cannot be undone.`,
 	);
+}
+
+function requireCurrentMenuGoal(
+	runtime: GoalMenuRuntimeView,
+	expected: ActiveGoal,
+	ctx: ExtensionCommandContext,
+) {
+	if (runtime.activeGoal?.id === expected.id) return true;
+	ctx.ui.notify(
+		"The active goal changed while the dialog was open. Reopen /goal and try again.",
+		"warning",
+	);
+	return false;
 }
 
 function displayStatus(status?: ActiveGoal["status"]) {

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -1,0 +1,348 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { formatDuration } from "./accounting.js";
+import { parseTokenBudget } from "./command.js";
+import type { GoalCommandController } from "./commands.js";
+import type { ActiveGoal } from "./persistence.js";
+import type { GoalRuntime } from "./runtime.js";
+
+export const GOAL_MENU_ACTIONS = {
+	start: "Start a goal…",
+	startBudget: "Start with token budget…",
+	pause: "Pause goal",
+	resume: "Resume goal",
+	increaseBudget: "Increase budget and resume…",
+	edit: "Edit goal…",
+	replace: "Replace goal…",
+	status: "View full status",
+	queue: "Queue…",
+	settings: "Settings…",
+	help: "Help",
+	clear: "Clear goal…",
+	close: "Close",
+} as const;
+
+const QUEUE_ACTIONS = {
+	add: "Add goal…",
+	prioritize: "Prioritize goal…",
+	skip: "Skip current goal…",
+	dropLast: "Drop last goal…",
+	back: "Back",
+} as const;
+
+interface GoalMenuRuntimeView {
+	activeGoal?: ActiveGoal;
+	queuedGoals: ActiveGoal[];
+	pendingQueueAction?: unknown;
+	queueFrozen: boolean;
+	settings: GoalRuntime["settings"];
+	recordGoalUsage?: GoalRuntime["recordGoalUsage"];
+	persistGoal?: GoalRuntime["persistGoal"];
+	updateStatus?: GoalRuntime["updateStatus"];
+}
+
+export interface GoalMenuState {
+	title: string;
+	actions: string[];
+}
+
+type ShowSettings = (ctx: ExtensionCommandContext) => Promise<void>;
+
+export function buildGoalMenuState(runtime: GoalMenuRuntimeView): GoalMenuState {
+	const goal = runtime.activeGoal;
+	const queueCount = runtime.queuedGoals.length;
+	const state = runtime.queueFrozen
+		? "Queue frozen"
+		: runtime.pendingQueueAction
+			? "Waiting for Pi to settle"
+			: displayStatus(goal?.status);
+	const details = goal
+		? [
+				goal.tokenBudget === undefined
+					? formatDuration(goal.timeUsedSeconds)
+					: `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`,
+				`${goal.automaticModelTurns} automatic responses`,
+				...(queueCount > 0 ? [`${queueCount} queued`] : []),
+			].join(" · ")
+		: "No goal is currently set";
+	const title = goal
+		? `Goal · ${state}\n${safeGoalMenuText(goal.text)}\n${details}`
+		: `Goal · ${state}\n${details}`;
+
+	if (runtime.queueFrozen || runtime.pendingQueueAction) {
+		return {
+			title,
+			actions: [
+				GOAL_MENU_ACTIONS.status,
+				GOAL_MENU_ACTIONS.settings,
+				GOAL_MENU_ACTIONS.help,
+				GOAL_MENU_ACTIONS.clear,
+				GOAL_MENU_ACTIONS.close,
+			],
+		};
+	}
+
+	const actions: string[] = [];
+	if (!goal || goal.status === "complete") {
+		actions.push(GOAL_MENU_ACTIONS.start, GOAL_MENU_ACTIONS.startBudget);
+	} else if (goal.status === "active") {
+		actions.push(GOAL_MENU_ACTIONS.pause);
+	} else if (goal.status === "budget_limited") {
+		actions.push(GOAL_MENU_ACTIONS.increaseBudget);
+	} else {
+		actions.push(GOAL_MENU_ACTIONS.resume);
+	}
+	if (goal && goal.status !== "complete") {
+		actions.push(GOAL_MENU_ACTIONS.edit, GOAL_MENU_ACTIONS.replace);
+	}
+	if (goal) actions.push(GOAL_MENU_ACTIONS.status);
+	if (runtime.settings.experimental.goals || queueCount > 0) actions.push(GOAL_MENU_ACTIONS.queue);
+	actions.push(GOAL_MENU_ACTIONS.settings, GOAL_MENU_ACTIONS.help);
+	if (goal) actions.push(GOAL_MENU_ACTIONS.clear);
+	actions.push(GOAL_MENU_ACTIONS.close);
+	return { title, actions };
+}
+
+export async function showGoalManager(
+	runtime: GoalMenuRuntimeView,
+	commands: GoalCommandController,
+	ctx: ExtensionCommandContext,
+	showSettings: ShowSettings,
+): Promise<void> {
+	if (ctx.mode !== "tui") {
+		commands.showGoal(ctx);
+		return;
+	}
+	while (true) {
+		refreshGoalMenuState(runtime, ctx);
+		const state = buildGoalMenuState(runtime);
+		const selected = await ctx.ui.select(state.title, state.actions);
+		if (!selected || selected === GOAL_MENU_ACTIONS.close) return;
+		switch (selected) {
+			case GOAL_MENU_ACTIONS.start:
+				await startFromMenu(commands, ctx);
+				return;
+			case GOAL_MENU_ACTIONS.startBudget:
+				await startFromMenu(commands, ctx, true);
+				return;
+			case GOAL_MENU_ACTIONS.pause:
+				commands.pauseGoal(ctx);
+				return;
+			case GOAL_MENU_ACTIONS.resume:
+				await commands.resumeGoal(ctx);
+				return;
+			case GOAL_MENU_ACTIONS.increaseBudget:
+				await increaseBudget(runtime, commands, ctx);
+				return;
+			case GOAL_MENU_ACTIONS.edit:
+				await editFromMenu(runtime, commands, ctx);
+				return;
+			case GOAL_MENU_ACTIONS.replace:
+				await startFromMenu(commands, ctx);
+				return;
+			case GOAL_MENU_ACTIONS.status:
+				commands.showGoal(ctx);
+				return;
+			case GOAL_MENU_ACTIONS.queue:
+				await showQueueMenu(runtime, commands, ctx);
+				return;
+			case GOAL_MENU_ACTIONS.settings:
+				await showSettings(ctx);
+				continue;
+			case GOAL_MENU_ACTIONS.help:
+				ctx.ui.notify(goalHelp(), "info");
+				return;
+			case GOAL_MENU_ACTIONS.clear:
+				if (await confirmClear(runtime, ctx)) commands.clearGoal(ctx);
+				else continue;
+				return;
+		}
+	}
+}
+
+function refreshGoalMenuState(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandContext) {
+	const goal = runtime.activeGoal;
+	if (!goal || runtime.queueFrozen) return;
+	runtime.recordGoalUsage?.(goal, ctx);
+	runtime.persistGoal?.(goal);
+	runtime.updateStatus?.(ctx, goal);
+}
+
+export function safeGoalMenuText(value: string, maxCharacters = 120) {
+	const sanitized = [...value]
+		.map((character) => (isTerminalControl(character) ? " " : character))
+		.join("")
+		.replace(/\s+/gu, " ")
+		.trim();
+	const characters = [...sanitized];
+	return characters.length <= maxCharacters
+		? sanitized
+		: `${characters.slice(0, maxCharacters).join("")}…`;
+}
+
+async function startFromMenu(
+	commands: GoalCommandController,
+	ctx: ExtensionCommandContext,
+	withBudget = false,
+) {
+	const objective = (await ctx.ui.editor("Goal objective", ""))?.trim();
+	if (!objective) return;
+	const tokenBudget = withBudget ? await askTokenBudget(ctx) : undefined;
+	if (withBudget && tokenBudget === undefined) return;
+	await commands.startGoal(objective, tokenBudget, ctx);
+}
+
+async function editFromMenu(
+	runtime: GoalMenuRuntimeView,
+	commands: GoalCommandController,
+	ctx: ExtensionCommandContext,
+) {
+	const goal = runtime.activeGoal;
+	if (!goal) return;
+	const objective = (await ctx.ui.editor("Edit goal objective", goal.text))?.trim();
+	if (!objective || objective === goal.text) return;
+	if (
+		goal.status === "active" &&
+		!(await ctx.ui.confirm(
+			"Apply goal edit?",
+			`Current goal:\n${safeGoalMenuText(goal.text, 4_000)}\n\nUpdated goal:\n${safeGoalMenuText(objective, 4_000)}\n\nApplying this edit starts a new guarded goal instance.`,
+		))
+	) {
+		return;
+	}
+	await commands.editGoal(objective, undefined, ctx);
+}
+
+async function increaseBudget(
+	runtime: GoalMenuRuntimeView,
+	commands: GoalCommandController,
+	ctx: ExtensionCommandContext,
+) {
+	const goal = runtime.activeGoal;
+	if (!goal) return;
+	const budget = await askTokenBudget(ctx, goal.tokenBudget);
+	if (budget === undefined) return;
+	if (budget <= goal.tokensUsed) {
+		ctx.ui.notify(
+			`Token budget must be greater than current usage (${formatTokenCount(goal.tokensUsed)}).`,
+			"warning",
+		);
+		return;
+	}
+	if (
+		!(await ctx.ui.confirm(
+			"Increase goal budget?",
+			`Goal: ${safeGoalMenuText(goal.text, 4_000)}\n\nBudget: ${formatTokenCount(goal.tokenBudget ?? 0)} → ${formatTokenCount(budget)}\nCurrent usage: ${formatTokenCount(goal.tokensUsed)}\n\nThe goal will resume immediately.`,
+		))
+	) {
+		return;
+	}
+	await commands.editGoal(goal.text, budget, ctx);
+}
+
+async function askTokenBudget(ctx: ExtensionCommandContext, current?: number) {
+	const raw = await ctx.ui.input(
+		"Token budget",
+		current === undefined ? "100k" : formatTokenCount(current),
+	);
+	if (raw === undefined) return undefined;
+	const budget = parseTokenBudget(raw);
+	if (budget === undefined)
+		ctx.ui.notify(`Invalid token budget: ${safeGoalMenuText(raw)}`, "warning");
+	return budget;
+}
+
+async function showQueueMenu(
+	runtime: GoalMenuRuntimeView,
+	commands: GoalCommandController,
+	ctx: ExtensionCommandContext,
+) {
+	const goal = runtime.activeGoal;
+	if (!goal) return;
+	const actions: string[] = [QUEUE_ACTIONS.add, QUEUE_ACTIONS.prioritize];
+	if (runtime.queuedGoals.length > 0) actions.push(QUEUE_ACTIONS.skip, QUEUE_ACTIONS.dropLast);
+	actions.push(QUEUE_ACTIONS.back);
+	const selected = await ctx.ui.select(
+		`Goal queue · ${runtime.queuedGoals.length + 1} total\nCurrent: ${safeGoalMenuText(goal.text)}`,
+		actions,
+	);
+	if (!selected || selected === QUEUE_ACTIONS.back) return;
+	if (selected === QUEUE_ACTIONS.add) {
+		const objective = (await ctx.ui.editor("Add goal to queue", ""))?.trim();
+		if (objective) await commands.addGoal(objective, undefined, ctx);
+		return;
+	}
+	if (selected === QUEUE_ACTIONS.prioritize) {
+		const objective = (await ctx.ui.editor("Prioritize goal", ""))?.trim();
+		if (!objective) return;
+		const confirmed = await ctx.ui.confirm(
+			"Prioritize goal?",
+			`New priority goal:\n${safeGoalMenuText(objective, 4_000)}\n\nCurrent goal moved to the queue:\n${safeGoalMenuText(goal.text, 4_000)}`,
+		);
+		if (confirmed) await commands.prioritizeGoal(objective, undefined, ctx);
+		return;
+	}
+	if (selected === QUEUE_ACTIONS.skip) {
+		const next = runtime.queuedGoals[0];
+		const confirmed = await ctx.ui.confirm(
+			"Skip current goal?",
+			`Remove current goal:\n${safeGoalMenuText(goal.text, 4_000)}\n\nStart next goal:\n${safeGoalMenuText(next?.text ?? "No goal remains", 4_000)}`,
+		);
+		if (confirmed) await commands.skipGoal(ctx);
+		return;
+	}
+	if (selected === QUEUE_ACTIONS.dropLast) {
+		const last = runtime.queuedGoals.at(-1) ?? goal;
+		const confirmed = await ctx.ui.confirm(
+			"Drop last goal?",
+			`Remove from queue:\n${safeGoalMenuText(last.text, 4_000)}`,
+		);
+		if (confirmed) commands.dropLastGoal(ctx);
+	}
+}
+
+async function confirmClear(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandContext) {
+	const goals = [runtime.activeGoal, ...runtime.queuedGoals].filter(
+		(goal): goal is ActiveGoal => goal !== undefined,
+	);
+	if (goals.length === 0) return false;
+	return ctx.ui.confirm(
+		goals.length > 1 ? "Clear goal queue?" : "Clear goal?",
+		`Remove ${goals.length === 1 ? "this goal" : `all ${goals.length} goals`}:\n\n${goals
+			.map((goal, index) => `${index + 1}. ${safeGoalMenuText(goal.text, 4_000)}`)
+			.join("\n")}\n\nThis cannot be undone.`,
+	);
+}
+
+function displayStatus(status?: ActiveGoal["status"]) {
+	if (!status) return "No goal";
+	if (status === "usage_limited") return "Usage limited";
+	if (status === "budget_limited") return "Budget limited";
+	return status[0]?.toUpperCase() + status.slice(1);
+}
+
+function formatTokenCount(tokens: number) {
+	if (tokens >= 1_000_000) return `${trimNumber(tokens / 1_000_000)}m`;
+	if (tokens >= 1_000) return `${trimNumber(tokens / 1_000)}k`;
+	return String(tokens);
+}
+
+function trimNumber(value: number) {
+	return value.toFixed(value >= 10 ? 0 : 1).replace(/\.0$/u, "");
+}
+
+function isTerminalControl(character: string) {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+}
+
+function goalHelp() {
+	return [
+		"Goal menu",
+		"Use the menu for guided status, edits, queue management, settings, and confirmations.",
+		"Direct routes remain available for deterministic workflows:",
+		"/goal <objective>",
+		"/goal status | pause | resume | edit | clear",
+		"/goal --tokens 100k <objective>",
+		"Escape cancels the current menu or input without changing goal state.",
+	].join("\n");
+}

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -285,9 +285,14 @@ async function showQueueMenu(
 	}
 	if (selected === QUEUE_ACTIONS.skip) {
 		const next = runtime.queuedGoals[0];
+		const nextEffect = !next
+			? "No goal remains"
+			: next.status === "queued"
+				? `Start next goal:\n${safeGoalMenuText(next.text, 4_000)}`
+				: `Next goal remains ${displayStatus(next.status).toLowerCase()}:\n${safeGoalMenuText(next.text, 4_000)}`;
 		const confirmed = await ctx.ui.confirm(
 			"Skip current goal?",
-			`Remove current goal:\n${safeGoalMenuText(goal.text, 4_000)}\n\nStart next goal:\n${safeGoalMenuText(next?.text ?? "No goal remains", 4_000)}`,
+			`Remove current goal:\n${safeGoalMenuText(goal.text, 4_000)}\n\n${nextEffect}`,
 		);
 		if (confirmed) await commands.skipGoal(ctx);
 		return;

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -118,6 +118,7 @@ export async function showGoalManager(
 	while (true) {
 		refreshGoalMenuState(runtime, ctx);
 		const state = buildGoalMenuState(runtime);
+		const displayedGoal = runtime.activeGoal;
 		const selected = await ctx.ui.select(state.title, state.actions);
 		if (!selected || selected === GOAL_MENU_ACTIONS.close) return;
 		switch (selected) {
@@ -128,15 +129,19 @@ export async function showGoalManager(
 				await startFromMenu(commands, ctx, true);
 				return;
 			case GOAL_MENU_ACTIONS.pause:
+				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) continue;
 				commands.pauseGoal(ctx);
 				return;
 			case GOAL_MENU_ACTIONS.resume:
+				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) continue;
 				await commands.resumeGoal(ctx);
 				return;
 			case GOAL_MENU_ACTIONS.increaseBudget:
+				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) continue;
 				await increaseBudget(runtime, commands, ctx);
 				return;
 			case GOAL_MENU_ACTIONS.edit:
+				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) continue;
 				await editFromMenu(runtime, commands, ctx);
 				return;
 			case GOAL_MENU_ACTIONS.replace:

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -3,6 +3,7 @@ import { formatDuration } from "./accounting.js";
 import { parseTokenBudget } from "./command.js";
 import type { GoalCommandController } from "./commands.js";
 import type { ActiveGoal, PendingQueueAction } from "./persistence.js";
+import { goalQueueIdentity } from "./queue.js";
 import type { GoalRuntime } from "./runtime.js";
 
 export const GOAL_MENU_ACTIONS = {
@@ -153,10 +154,26 @@ export async function showGoalManager(
 			case GOAL_MENU_ACTIONS.help:
 				ctx.ui.notify(goalHelp(), "info");
 				return;
-			case GOAL_MENU_ACTIONS.clear:
-				if (await confirmClear(runtime, ctx)) commands.clearGoal(ctx);
-				else continue;
+			case GOAL_MENU_ACTIONS.clear: {
+				const previewedQueue = goalQueueIdentity(
+					runtime.activeGoal,
+					runtime.queuedGoals,
+					runtime.pendingQueueAction,
+				);
+				if (!(await confirmClear(runtime, ctx))) continue;
+				if (
+					goalQueueIdentity(runtime.activeGoal, runtime.queuedGoals, runtime.pendingQueueAction) !==
+					previewedQueue
+				) {
+					ctx.ui.notify(
+						"The goal queue changed while the dialog was open. Reopen /goal and try again.",
+						"warning",
+					);
+					continue;
+				}
+				commands.clearGoal(ctx);
 				return;
+			}
 		}
 	}
 }
@@ -271,12 +288,14 @@ async function showQueueMenu(
 	}
 	if (selected === QUEUE_ACTIONS.prioritize) {
 		const objective = (await ctx.ui.editor("Prioritize goal", ""))?.trim();
-		if (!objective) return;
+		if (!objective || !requireCurrentQueueHead(runtime, goal, ctx)) return;
 		const confirmed = await ctx.ui.confirm(
 			"Prioritize goal?",
 			`New priority goal:\n${safeGoalMenuText(objective, 4_000)}\n\nCurrent goal moved to the queue:\n${safeGoalMenuText(goal.text, 4_000)}`,
 		);
-		if (confirmed) await commands.prioritizeGoal(objective, undefined, ctx);
+		if (confirmed && requireCurrentQueueHead(runtime, goal, ctx)) {
+			await commands.prioritizeGoal(objective, undefined, ctx);
+		}
 		return;
 	}
 	if (selected === QUEUE_ACTIONS.skip) {
@@ -290,7 +309,9 @@ async function showQueueMenu(
 			"Skip current goal?",
 			`Remove current goal:\n${safeGoalMenuText(goal.text, 4_000)}\n\n${nextEffect}`,
 		);
-		if (confirmed) await commands.skipGoal(ctx);
+		if (confirmed && requireCurrentQueueSelection(runtime, goal, next, "first", ctx)) {
+			await commands.skipGoal(ctx);
+		}
 		return;
 	}
 	if (selected === QUEUE_ACTIONS.dropLast) {
@@ -299,7 +320,9 @@ async function showQueueMenu(
 			"Drop last goal?",
 			`Remove from queue:\n${safeGoalMenuText(last.text, 4_000)}`,
 		);
-		if (confirmed) commands.dropLastGoal(ctx);
+		if (confirmed && requireCurrentQueueSelection(runtime, goal, last, "last", ctx)) {
+			commands.dropLastGoal(ctx);
+		}
 	}
 }
 
@@ -322,6 +345,43 @@ async function confirmClear(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandC
 			.map((summary, index) => `${index + 1}. ${summary}`)
 			.join("\n")}\n\nThis cannot be undone.`,
 	);
+}
+
+function requireCurrentQueueHead(
+	runtime: GoalMenuRuntimeView,
+	expectedGoal: ActiveGoal,
+	ctx: ExtensionCommandContext,
+) {
+	if (runtime.activeGoal?.id === expectedGoal.id) return true;
+	ctx.ui.notify(
+		"The goal queue changed while the dialog was open. Reopen /goal and try again.",
+		"warning",
+	);
+	return false;
+}
+
+function requireCurrentQueueSelection(
+	runtime: GoalMenuRuntimeView,
+	expectedGoal: ActiveGoal,
+	expectedQueuedGoal: ActiveGoal | undefined,
+	position: "first" | "last",
+	ctx: ExtensionCommandContext,
+) {
+	const currentQueuedGoal =
+		position === "first"
+			? runtime.queuedGoals[0]
+			: (runtime.queuedGoals.at(-1) ?? runtime.activeGoal);
+	if (
+		runtime.activeGoal?.id === expectedGoal.id &&
+		currentQueuedGoal?.id === expectedQueuedGoal?.id
+	) {
+		return true;
+	}
+	ctx.ui.notify(
+		"The goal queue changed while the dialog was open. Reopen /goal and try again.",
+		"warning",
+	);
+	return false;
 }
 
 function requireCurrentMenuGoal(

--- a/extensions/pi-goal/src/queue.ts
+++ b/extensions/pi-goal/src/queue.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { checkpointGoalActiveTime } from "./accounting.js";
-import type { ActiveGoal } from "./persistence.js";
+import type { ActiveGoal, PendingQueueAction } from "./persistence.js";
 import { resetGoalSafetyEpoch } from "./safety.js";
 
 export interface GoalQueueResult {
@@ -10,6 +10,30 @@ export interface GoalQueueResult {
 
 export interface DropLastGoalResult extends GoalQueueResult {
 	removed: ActiveGoal | undefined;
+}
+
+export function goalQueueIdentity(
+	goal: ActiveGoal | undefined,
+	queue: readonly ActiveGoal[],
+	pendingAction: PendingQueueAction | undefined,
+) {
+	const pendingIdentity =
+		pendingAction?.kind === "prioritize"
+			? [
+					pendingAction.kind,
+					pendingAction.objective,
+					pendingAction.tokenBudget,
+					pendingAction.displacedUsageFinalized,
+				]
+			: pendingAction
+				? [
+						pendingAction.kind,
+						pendingAction.goalId,
+						pendingAction.reason,
+						pendingAction.completedText,
+					]
+				: undefined;
+	return JSON.stringify([goal?.id, queue.map((queuedGoal) => queuedGoal.id), pendingIdentity]);
 }
 
 export function createQueuedGoal(

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -123,6 +123,21 @@ interface GoalTerminalDetails {
 	reason?: string;
 }
 
+export interface GoalSettingsRuntimeSnapshot {
+	settings: GoalSettings;
+	activeGoal?: ActiveGoal;
+	queueFrozen: boolean;
+	continuationIntent?: ContinuationTicket;
+	continuationDelivery?: ContinuationTicket;
+	goalRecovery?: GoalRecovery;
+	budgetWrapUp?: BudgetWrapUp;
+	guardAbortGoalId?: string;
+	staleGoalToolCallsBlocked: boolean;
+	cancelledContinuationMarkers: string[];
+	terminalDetails?: GoalTerminalDetails;
+	toolVisibility: GoalToolVisibilitySnapshot;
+}
+
 interface PendingGoalPrompt {
 	goalId: string;
 	resetSafetyEpoch: boolean;
@@ -832,6 +847,48 @@ export class GoalRuntime {
 			goalToolsUnlocked: this.goalToolsUnlocked,
 			goalToolsHiddenByPolicy: [...this.goalToolsHiddenByPolicy],
 		};
+	}
+
+	snapshotSettingsApplicationState(): GoalSettingsRuntimeSnapshot {
+		return {
+			settings: structuredClone(this.settings),
+			activeGoal: this.activeGoal ? structuredClone(this.activeGoal) : undefined,
+			queueFrozen: this.queueFrozen,
+			continuationIntent: this.continuationIntent
+				? structuredClone(this.continuationIntent)
+				: undefined,
+			continuationDelivery: this.continuationDelivery
+				? structuredClone(this.continuationDelivery)
+				: undefined,
+			goalRecovery: this.goalRecovery ? structuredClone(this.goalRecovery) : undefined,
+			budgetWrapUp: this.budgetWrapUp ? structuredClone(this.budgetWrapUp) : undefined,
+			guardAbortGoalId: this.guardAbortGoalId,
+			staleGoalToolCallsBlocked: this.staleGoalToolCallsBlocked,
+			cancelledContinuationMarkers: [...this.cancelledContinuationMarkers],
+			terminalDetails: this.terminalDetails ? structuredClone(this.terminalDetails) : undefined,
+			toolVisibility: this.snapshotGoalToolVisibility(),
+		};
+	}
+
+	restoreSettingsApplicationState(snapshot: GoalSettingsRuntimeSnapshot) {
+		this.settings = structuredClone(snapshot.settings);
+		this.activeGoal = snapshot.activeGoal ? structuredClone(snapshot.activeGoal) : undefined;
+		this.queueFrozen = snapshot.queueFrozen;
+		this.continuationIntent = snapshot.continuationIntent
+			? structuredClone(snapshot.continuationIntent)
+			: undefined;
+		this.continuationDelivery = snapshot.continuationDelivery
+			? structuredClone(snapshot.continuationDelivery)
+			: undefined;
+		this.goalRecovery = snapshot.goalRecovery ? structuredClone(snapshot.goalRecovery) : undefined;
+		this.budgetWrapUp = snapshot.budgetWrapUp ? structuredClone(snapshot.budgetWrapUp) : undefined;
+		this.guardAbortGoalId = snapshot.guardAbortGoalId;
+		this.staleGoalToolCallsBlocked = snapshot.staleGoalToolCallsBlocked;
+		this.cancelledContinuationMarkers = new Set(snapshot.cancelledContinuationMarkers);
+		this.terminalDetails = snapshot.terminalDetails
+			? structuredClone(snapshot.terminalDetails)
+			: undefined;
+		this.restoreGoalToolVisibility(snapshot.toolVisibility);
 	}
 
 	restoreGoalToolVisibility(snapshot: GoalToolVisibilitySnapshot) {

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -57,6 +57,7 @@ export interface CompletedGoalRun {
 
 export interface StatusContext {
 	cwd: string;
+	mode?: "tui" | "rpc" | "json" | "print";
 	ui: {
 		confirm: (title: string, message: string) => Promise<boolean>;
 		notify: (message: string, level?: "info" | "warning" | "error") => void;
@@ -146,6 +147,8 @@ const CONTRADICTORY_COMPLETION_PATTERNS = [
 ] as const;
 // One instance belongs to one extension factory. It owns all mutable session state
 // and the cross-cutting invariants used by command and lifecycle orchestration.
+// Keep this state machine cohesive despite its size: prompt ownership, continuation,
+// budget, safety, and tool-policy transitions share ordering-sensitive invariants.
 export class GoalRuntime {
 	settings: GoalSettings = DEFAULT_GOAL_SETTINGS;
 	activeGoal?: ActiveGoal;

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -127,6 +127,7 @@ export interface GoalSettingsRuntimeSnapshot {
 	settings: GoalSettings;
 	activeGoal?: ActiveGoal;
 	queueFrozen: boolean;
+	queueFreezeAwaitingSettle: boolean;
 	continuationIntent?: ContinuationTicket;
 	continuationDelivery?: ContinuationTicket;
 	goalRecovery?: GoalRecovery;
@@ -172,6 +173,7 @@ export class GoalRuntime {
 	queuedGoals: ActiveGoal[] = [];
 	pendingQueueAction?: PendingQueueAction;
 	queueFrozen = false;
+	queueFreezeAwaitingSettle = false;
 	completionStatusTimer?: NodeJS.Timeout;
 	continuationIntent?: ContinuationTicket;
 	continuationDelivery?: ContinuationTicket;
@@ -752,6 +754,7 @@ export class GoalRuntime {
 		this.queuedGoals = [];
 		this.pendingQueueAction = undefined;
 		this.queueFrozen = false;
+		this.queueFreezeAwaitingSettle = false;
 		this.clearPersistedGoal(ctx.cwd, clearedGoal, reason);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		// Do not clear goalToolsUnlocked: after first activation, keep tools visible
@@ -854,6 +857,7 @@ export class GoalRuntime {
 			settings: structuredClone(this.settings),
 			activeGoal: this.activeGoal ? structuredClone(this.activeGoal) : undefined,
 			queueFrozen: this.queueFrozen,
+			queueFreezeAwaitingSettle: this.queueFreezeAwaitingSettle,
 			continuationIntent: this.continuationIntent
 				? structuredClone(this.continuationIntent)
 				: undefined,
@@ -874,6 +878,7 @@ export class GoalRuntime {
 		this.settings = structuredClone(snapshot.settings);
 		this.activeGoal = snapshot.activeGoal ? structuredClone(snapshot.activeGoal) : undefined;
 		this.queueFrozen = snapshot.queueFrozen;
+		this.queueFreezeAwaitingSettle = snapshot.queueFreezeAwaitingSettle;
 		this.continuationIntent = snapshot.continuationIntent
 			? structuredClone(snapshot.continuationIntent)
 			: undefined;

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -481,13 +481,13 @@ export class GoalRuntime {
 		return this.pauseGoalForSafety(ctx, "continuation_limit", abortTurn);
 	}
 
-	enforceNoProgressLimit(ctx: StatusContext) {
+	enforceNoProgressLimit(ctx: StatusContext, abortTurn = false) {
 		const goal = this.activeGoal;
 		const limit = this.settings.continuationLimits.noProgressTurns;
 		if (goal?.status !== "active" || limit === null || goal.toolFreeRepeatCount < limit) {
 			return false;
 		}
-		return this.pauseGoalForSafety(ctx, "no_progress", false);
+		return this.pauseGoalForSafety(ctx, "no_progress", abortTurn);
 	}
 
 	pauseGoalForSafety(ctx: StatusContext, cause: SafetyPauseCause, abortTurn: boolean) {

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -295,6 +295,9 @@ function applyToolVisibility(runtime: GoalRuntime, previous: GoalSettings, next:
 function applyQueueSetting(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
 	const hasQueueState = runtime.queuedGoals.length > 0 || runtime.pendingQueueAction !== undefined;
 	const shouldFreeze = !runtime.settings.experimental.goals && hasQueueState;
+	// Keep the freeze guard until the aborted Goal-owned run reaches agent_settled.
+	// Releasing it earlier lets the old agent_end pause newly resumed work.
+	if (runtime.queueFrozen && !shouldFreeze && runtime.queueFreezeAwaitingSettle) return;
 	if (runtime.queueFrozen === shouldFreeze) return;
 	const activeGoal = runtime.activeGoal?.status === "active" ? runtime.activeGoal : undefined;
 	if (shouldFreeze && activeGoal) runtime.recordGoalUsage(activeGoal, ctx);
@@ -311,6 +314,7 @@ function applyQueueSetting(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
 	if (activeGoal) {
 		runtime.blockStaleGoalToolCalls();
 		runtime.guardAbortGoalId = activeGoal.id;
+		runtime.queueFreezeAwaitingSettle = runtime.agentRunGoalId !== undefined;
 		runtime.clearAgentRun();
 		abortCurrentTurn(ctx);
 	}

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -5,6 +5,7 @@ import {
 	getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import { checkpointGoalActiveTime } from "./accounting.js";
 import { abortCurrentTurn, type GoalRuntime, STATUS_KEY } from "./runtime.js";
 import { GOAL_SETTINGS_FILE, type GoalSettings, saveGoalSettings } from "./settings.js";
 
@@ -72,7 +73,7 @@ export function applyGoalSettings(
 	let fileSaved = false;
 	try {
 		runtime.settings = structuredClone(next);
-		applyToolVisibility(runtime, snapshot.settings, next);
+		applyToolVisibility(runtime, snapshot.settings, next, ctx);
 		options.save?.(next);
 		fileSaved = options.save !== undefined;
 		applyQueueSetting(runtime, ctx);
@@ -276,9 +277,17 @@ async function nextToggleSettings(
 	} satisfies GoalSettings;
 }
 
-function applyToolVisibility(runtime: GoalRuntime, previous: GoalSettings, next: GoalSettings) {
+function applyToolVisibility(
+	runtime: GoalRuntime,
+	previous: GoalSettings,
+	next: GoalSettings,
+	ctx: ExtensionCommandContext,
+) {
 	if (previous.toolVisibility === next.toolVisibility) return;
 	if (next.toolVisibility === "always") {
+		if (runtime.goalToolsHiddenByPolicy.size > 0 && ctx.isIdle() !== true) {
+			throw new Error("Wait for Pi to become idle before revealing Goal tools.");
+		}
 		runtime.restoreGoalToolsHiddenByPolicy();
 		runtime.goalToolsUnlocked = true;
 		return;
@@ -300,7 +309,15 @@ function applyQueueSetting(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
 	if (runtime.queueFrozen && !shouldFreeze && runtime.queueFreezeAwaitingSettle) return;
 	if (runtime.queueFrozen === shouldFreeze) return;
 	const activeGoal = runtime.activeGoal?.status === "active" ? runtime.activeGoal : undefined;
-	if (shouldFreeze && activeGoal) runtime.recordGoalUsage(activeGoal, ctx);
+	const goalOwnedRun = activeGoal && runtime.agentRunGoalId === activeGoal.id;
+	if (shouldFreeze && activeGoal) {
+		if (goalOwnedRun) runtime.recordGoalUsage(activeGoal, ctx, false);
+		else {
+			const now = Date.now();
+			checkpointGoalActiveTime(activeGoal, now, false);
+			activeGoal.updatedAt = now;
+		}
+	}
 	runtime.queueFrozen = shouldFreeze;
 	if (runtime.activeGoal) runtime.persistGoal(runtime.activeGoal);
 	if (shouldFreeze) ctx.ui.setStatus(STATUS_KEY, "queue off");
@@ -311,10 +328,10 @@ function applyQueueSetting(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
 	runtime.cancelContinuationWork();
 	runtime.clearGoalRecovery();
 	runtime.clearBudgetWrapUp();
-	if (activeGoal) {
+	if (goalOwnedRun) {
 		runtime.blockStaleGoalToolCalls();
 		runtime.guardAbortGoalId = activeGoal.id;
-		runtime.queueFreezeAwaitingSettle = runtime.agentRunGoalId !== undefined;
+		runtime.queueFreezeAwaitingSettle = true;
 		runtime.clearAgentRun();
 		abortCurrentTurn(ctx);
 	}

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -5,13 +5,13 @@ import {
 	getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
-import type { GoalRuntime } from "./runtime.js";
-import { STATUS_KEY } from "./runtime.js";
+import { abortCurrentTurn, type GoalRuntime, STATUS_KEY } from "./runtime.js";
 import { GOAL_SETTINGS_FILE, type GoalSettings, saveGoalSettings } from "./settings.js";
 
 interface GoalSettingsUiOptions {
 	settingsPath?: string;
 	save?: (settings: GoalSettings, settingsPath: string) => void;
+	onQueueUnfrozen?: (ctx: ExtensionCommandContext) => Promise<void>;
 }
 
 interface GoalSettingsApplyOptions {
@@ -33,7 +33,7 @@ export async function showGoalSettings(
 	}
 
 	while (true) {
-		const result = await showSettingsScreen(runtime, ctx, settingsPath, options.save);
+		const result = await showSettingsScreen(runtime, ctx, settingsPath, options);
 		if (!result) return;
 		const previous = runtime.settings.continuationLimits[result.field];
 		const raw = await ctx.ui.input(
@@ -68,23 +68,44 @@ export function applyGoalSettings(
 	ctx: ExtensionCommandContext,
 	options: GoalSettingsApplyOptions = {},
 ) {
-	const previous = runtime.settings;
-	const visibility = runtime.snapshotGoalToolVisibility();
-	const previousQueueFrozen = runtime.queueFrozen;
+	const snapshot = runtime.snapshotSettingsApplicationState();
+	let fileSaved = false;
 	try {
 		runtime.settings = structuredClone(next);
-		applyToolVisibility(runtime, previous, next);
+		applyToolVisibility(runtime, snapshot.settings, next);
 		options.save?.(next);
+		fileSaved = options.save !== undefined;
+		applyQueueSetting(runtime, ctx);
+		const pausedByLimit =
+			runtime.enforceAutomaticTurnLimit(ctx, false) || runtime.enforceNoProgressLimit(ctx);
+		if (pausedByLimit) abortCurrentTurn(ctx);
 	} catch (error) {
-		runtime.settings = previous;
-		runtime.queueFrozen = previousQueueFrozen;
-		runtime.restoreGoalToolVisibility(visibility);
+		const rollbackErrors: unknown[] = [];
+		try {
+			runtime.restoreSettingsApplicationState(snapshot);
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
+		}
+		if (fileSaved) {
+			try {
+				options.save?.(snapshot.settings);
+			} catch (rollbackError) {
+				rollbackErrors.push(rollbackError);
+			}
+			try {
+				restorePersistedRuntime(runtime, ctx);
+			} catch (rollbackError) {
+				rollbackErrors.push(rollbackError);
+			}
+		}
+		if (rollbackErrors.length > 0) {
+			throw new AggregateError(
+				[error, ...rollbackErrors],
+				`pi-goal settings application failed and rollback was incomplete: ${formatError(error)}`,
+			);
+		}
 		throw error;
 	}
-
-	applyQueueSetting(runtime, ctx);
-	runtime.enforceAutomaticTurnLimit(ctx, true);
-	runtime.enforceNoProgressLimit(ctx);
 }
 
 export function parseGoalLimit(value: string): number | null | undefined {
@@ -103,7 +124,7 @@ async function showSettingsScreen(
 	runtime: GoalRuntime,
 	ctx: ExtensionCommandContext,
 	settingsPath: string,
-	save: GoalSettingsUiOptions["save"],
+	options: GoalSettingsUiOptions,
 ): Promise<SettingsScreenResult> {
 	let saveQueue = Promise.resolve();
 	const latestRequested = new Map<string, string>();
@@ -176,9 +197,20 @@ async function showSettingsScreen(
 							tui.requestRender();
 							return;
 						}
+						const wasFrozen = runtime.queueFrozen;
 						applyGoalSettings(runtime, next, ctx, {
-							save: (value) => (save ?? saveGoalSettings)(value, settingsPath),
+							save: (value) => (options.save ?? saveGoalSettings)(value, settingsPath),
 						});
+						if (wasFrozen && !runtime.queueFrozen) {
+							try {
+								await options.onQueueUnfrozen?.(ctx);
+							} catch (error) {
+								ctx.ui.notify(
+									`Goal queue enabled, but automatic resume failed: ${formatError(error)}. Reopen /goal to retry.`,
+									"warning",
+								);
+							}
+						}
 						ctx.ui.notify(`${settingLabel(id)}: ${newValue}.`, "info");
 					} catch (error) {
 						if (latestRequested.get(id) === newValue) {
@@ -264,12 +296,34 @@ function applyQueueSetting(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
 	const hasQueueState = runtime.queuedGoals.length > 0 || runtime.pendingQueueAction !== undefined;
 	const shouldFreeze = !runtime.settings.experimental.goals && hasQueueState;
 	if (runtime.queueFrozen === shouldFreeze) return;
+	const activeGoal = runtime.activeGoal?.status === "active" ? runtime.activeGoal : undefined;
+	if (shouldFreeze && activeGoal) runtime.recordGoalUsage(activeGoal, ctx);
 	runtime.queueFrozen = shouldFreeze;
-	if (shouldFreeze) runtime.cancelContinuationWork();
 	if (runtime.activeGoal) runtime.persistGoal(runtime.activeGoal);
 	if (shouldFreeze) ctx.ui.setStatus(STATUS_KEY, "queue off");
 	else if (runtime.activeGoal) runtime.updateStatus(ctx, runtime.activeGoal);
 	else ctx.ui.setStatus(STATUS_KEY, undefined);
+	if (!shouldFreeze) return;
+
+	runtime.cancelContinuationWork();
+	runtime.clearGoalRecovery();
+	runtime.clearBudgetWrapUp();
+	if (activeGoal) {
+		runtime.blockStaleGoalToolCalls();
+		runtime.guardAbortGoalId = activeGoal.id;
+		runtime.clearAgentRun();
+		abortCurrentTurn(ctx);
+	}
+}
+
+function restorePersistedRuntime(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
+	if (runtime.activeGoal) {
+		runtime.persistGoal(runtime.activeGoal);
+		if (runtime.queueFrozen) ctx.ui.setStatus(STATUS_KEY, "queue off");
+		else runtime.updateStatus(ctx, runtime.activeGoal);
+		return;
+	}
+	ctx.ui.setStatus(STATUS_KEY, undefined);
 }
 
 async function confirmLowerActiveLimit(

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -1,0 +1,329 @@
+import { join } from "node:path";
+import {
+	type ExtensionCommandContext,
+	getAgentDir,
+	getSettingsListTheme,
+} from "@earendil-works/pi-coding-agent";
+import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import type { GoalRuntime } from "./runtime.js";
+import { STATUS_KEY } from "./runtime.js";
+import { GOAL_SETTINGS_FILE, type GoalSettings, saveGoalSettings } from "./settings.js";
+
+interface GoalSettingsUiOptions {
+	settingsPath?: string;
+	save?: (settings: GoalSettings, settingsPath: string) => void;
+}
+
+interface GoalSettingsApplyOptions {
+	save?: (settings: GoalSettings) => void;
+}
+
+type LimitField = "automaticTurns" | "noProgressTurns";
+type SettingsScreenResult = { kind: "limit"; field: LimitField } | undefined;
+
+export async function showGoalSettings(
+	runtime: GoalRuntime,
+	ctx: ExtensionCommandContext,
+	options: GoalSettingsUiOptions = {},
+) {
+	const settingsPath = options.settingsPath ?? join(getAgentDir(), GOAL_SETTINGS_FILE);
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify(`Edit pi-goal settings manually: ${safeTerminalText(settingsPath)}`, "info");
+		return;
+	}
+
+	while (true) {
+		const result = await showSettingsScreen(runtime, ctx, settingsPath, options.save);
+		if (!result) return;
+		const previous = runtime.settings.continuationLimits[result.field];
+		const raw = await ctx.ui.input(
+			result.field === "automaticTurns" ? "Automatic response limit" : "No-progress run limit",
+			formatGoalLimit(previous),
+		);
+		if (raw === undefined) continue;
+		const limit = parseGoalLimit(raw);
+		if (limit === undefined) {
+			ctx.ui.notify("Enter a positive whole number or Unlimited.", "warning");
+			continue;
+		}
+		if (!(await confirmLowerActiveLimit(runtime, ctx, result.field, limit))) continue;
+		const next = withLimit(runtime.settings, result.field, limit);
+		try {
+			applyGoalSettings(runtime, next, ctx, {
+				save: (settings) => (options.save ?? saveGoalSettings)(settings, settingsPath),
+			});
+			ctx.ui.notify(
+				`${result.field === "automaticTurns" ? "Automatic response" : "No-progress"} limit: ${formatGoalLimit(limit)}.`,
+				"info",
+			);
+		} catch (error) {
+			ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
+		}
+	}
+}
+
+export function applyGoalSettings(
+	runtime: GoalRuntime,
+	next: GoalSettings,
+	ctx: ExtensionCommandContext,
+	options: GoalSettingsApplyOptions = {},
+) {
+	const previous = runtime.settings;
+	const visibility = runtime.snapshotGoalToolVisibility();
+	const previousQueueFrozen = runtime.queueFrozen;
+	try {
+		runtime.settings = structuredClone(next);
+		applyToolVisibility(runtime, previous, next);
+		options.save?.(next);
+	} catch (error) {
+		runtime.settings = previous;
+		runtime.queueFrozen = previousQueueFrozen;
+		runtime.restoreGoalToolVisibility(visibility);
+		throw error;
+	}
+
+	applyQueueSetting(runtime, ctx);
+	runtime.enforceAutomaticTurnLimit(ctx, true);
+	runtime.enforceNoProgressLimit(ctx);
+}
+
+export function parseGoalLimit(value: string): number | null | undefined {
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "unlimited" || normalized === "off") return null;
+	if (!/^\d+$/u.test(normalized)) return undefined;
+	const parsed = Number(normalized);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function formatGoalLimit(value: number | null) {
+	return value === null ? "Unlimited" : String(value);
+}
+
+async function showSettingsScreen(
+	runtime: GoalRuntime,
+	ctx: ExtensionCommandContext,
+	settingsPath: string,
+	save: GoalSettingsUiOptions["save"],
+): Promise<SettingsScreenResult> {
+	let saveQueue = Promise.resolve();
+	const latestRequested = new Map<string, string>();
+	return ctx.ui.custom<SettingsScreenResult>((tui, theme, _keybindings, done) => {
+		const settings = runtime.settings;
+		const items: SettingItem[] = [
+			{
+				id: "toolVisibility",
+				label: "Goal tools",
+				description: "Keep terminal Goal tools visible, or reveal them after the first goal.",
+				currentValue: visibilityLabel(settings.toolVisibility),
+				values: ["Always", "After first goal"],
+			},
+			{
+				id: "experimentalGoals",
+				label: "Ordered goal queue",
+				description: "Enable experimental add, prioritize, skip, and drop-last workflows.",
+				currentValue: settings.experimental.goals ? "Experimental" : "Off",
+				values: ["Off", "Experimental"],
+			},
+			limitItem(
+				"automaticTurns",
+				"Automatic response limit",
+				"Pause after this many Goal-owned automatic model responses.",
+				settings.continuationLimits.automaticTurns,
+			),
+			limitItem(
+				"noProgressTurns",
+				"No-progress limit",
+				"Pause after this many repeated or empty tool-free automatic runs.",
+				settings.continuationLimits.noProgressTurns,
+			),
+		];
+		const container = new Container();
+		container.addChild(new Text(theme.fg("accent", theme.bold("Pi Goal Settings")), 1, 0));
+		container.addChild(
+			new Text(theme.fg("muted", `User settings · ${safeTerminalText(settingsPath)}`), 1, 0),
+		);
+		let settingsList: SettingsList;
+		let closing = false;
+		const closeAfterSaves = (result: SettingsScreenResult) => {
+			if (closing) return;
+			closing = true;
+			void saveQueue.then(() => done(result));
+		};
+		settingsList = new SettingsList(
+			items,
+			Math.min(items.length + 2, 15),
+			getSettingsListTheme(),
+			(id, newValue) => {
+				if ((id === "automaticTurns" || id === "noProgressTurns") && newValue === "Edit…") {
+					closeAfterSaves({ kind: "limit", field: id });
+					return;
+				}
+				if (id !== "toolVisibility" && id !== "experimentalGoals") return;
+				latestRequested.set(id, newValue);
+				const operation = saveQueue.then(async () => {
+					const previousValue =
+						id === "toolVisibility"
+							? visibilityLabel(runtime.settings.toolVisibility)
+							: runtime.settings.experimental.goals
+								? "Experimental"
+								: "Off";
+					try {
+						const next = await nextToggleSettings(runtime, ctx, id, newValue);
+						if (!next) {
+							if (latestRequested.get(id) === newValue) {
+								settingsList.updateValue(id, previousValue);
+							}
+							tui.requestRender();
+							return;
+						}
+						applyGoalSettings(runtime, next, ctx, {
+							save: (value) => (save ?? saveGoalSettings)(value, settingsPath),
+						});
+						ctx.ui.notify(`${settingLabel(id)}: ${newValue}.`, "info");
+					} catch (error) {
+						if (latestRequested.get(id) === newValue) {
+							settingsList.updateValue(id, previousValue);
+						}
+						ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
+						tui.requestRender();
+					}
+				});
+				saveQueue = operation.catch(() => undefined);
+			},
+			() => closeAfterSaves(undefined),
+			{ enableSearch: false },
+		);
+		container.addChild(settingsList);
+		container.addChild(
+			new Text(theme.fg("dim", "↑↓ navigate · enter/space change · esc close"), 1, 0),
+		);
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput(data: string) {
+				settingsList.handleInput?.(data);
+				tui.requestRender();
+			},
+		};
+	});
+}
+
+async function nextToggleSettings(
+	runtime: GoalRuntime,
+	ctx: ExtensionCommandContext,
+	id: "toolVisibility" | "experimentalGoals",
+	newValue: string,
+) {
+	if (id === "toolVisibility") {
+		return {
+			...structuredClone(runtime.settings),
+			toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
+		} satisfies GoalSettings;
+	}
+	const enabled = newValue === "Experimental";
+	if (enabled && !runtime.settings.experimental.goals) {
+		const confirmed = await ctx.ui.confirm(
+			"Enable experimental goal queue?",
+			"Queue behavior and persisted state may change between releases. Existing single-goal behavior remains available.",
+		);
+		if (!confirmed) return undefined;
+	}
+	if (
+		!enabled &&
+		(runtime.queuedGoals.length > 0 || runtime.pendingQueueAction !== undefined) &&
+		!(await ctx.ui.confirm(
+			"Freeze ordered goal queue?",
+			`Disabling the experiment preserves ${runtime.queuedGoals.length + 1} goal(s) but freezes automatic work until the setting is re-enabled. No goal data will be deleted.`,
+		))
+	) {
+		return undefined;
+	}
+	return {
+		...structuredClone(runtime.settings),
+		experimental: { goals: enabled },
+	} satisfies GoalSettings;
+}
+
+function applyToolVisibility(runtime: GoalRuntime, previous: GoalSettings, next: GoalSettings) {
+	if (previous.toolVisibility === next.toolVisibility) return;
+	if (next.toolVisibility === "always") {
+		runtime.restoreGoalToolsHiddenByPolicy();
+		runtime.goalToolsUnlocked = true;
+		return;
+	}
+	if (runtime.activeGoal) {
+		runtime.goalToolsUnlocked = true;
+		runtime.goalToolsHiddenByPolicy.clear();
+		return;
+	}
+	runtime.goalToolsUnlocked = false;
+	runtime.hideGoalToolsIfLocked();
+}
+
+function applyQueueSetting(runtime: GoalRuntime, ctx: ExtensionCommandContext) {
+	const hasQueueState = runtime.queuedGoals.length > 0 || runtime.pendingQueueAction !== undefined;
+	const shouldFreeze = !runtime.settings.experimental.goals && hasQueueState;
+	if (runtime.queueFrozen === shouldFreeze) return;
+	runtime.queueFrozen = shouldFreeze;
+	if (shouldFreeze) runtime.cancelContinuationWork();
+	if (runtime.activeGoal) runtime.persistGoal(runtime.activeGoal);
+	if (shouldFreeze) ctx.ui.setStatus(STATUS_KEY, "queue off");
+	else if (runtime.activeGoal) runtime.updateStatus(ctx, runtime.activeGoal);
+	else ctx.ui.setStatus(STATUS_KEY, undefined);
+}
+
+async function confirmLowerActiveLimit(
+	runtime: GoalRuntime,
+	ctx: ExtensionCommandContext,
+	field: LimitField,
+	limit: number | null,
+) {
+	const goal = runtime.activeGoal;
+	if (goal?.status !== "active" || limit === null) return true;
+	const used = field === "automaticTurns" ? goal.automaticModelTurns : goal.toolFreeRepeatCount;
+	if (used < limit) return true;
+	return ctx.ui.confirm(
+		"Apply reached safety limit?",
+		`The active goal has already used ${used}. Setting this limit to ${limit} will pause it immediately without deleting progress.`,
+	);
+}
+
+function withLimit(settings: GoalSettings, field: LimitField, value: number | null): GoalSettings {
+	return {
+		...structuredClone(settings),
+		continuationLimits: { ...settings.continuationLimits, [field]: value },
+	};
+}
+
+function limitItem(id: LimitField, label: string, description: string, value: number | null) {
+	const currentValue = formatGoalLimit(value);
+	return {
+		id,
+		label,
+		description,
+		currentValue,
+		values: [currentValue, "Edit…"],
+	} satisfies SettingItem;
+}
+
+function visibilityLabel(value: GoalSettings["toolVisibility"]) {
+	return value === "always" ? "Always" : "After first goal";
+}
+
+function settingLabel(id: "toolVisibility" | "experimentalGoals") {
+	return id === "toolVisibility" ? "Goal tools" : "Ordered goal queue";
+}
+
+function safeTerminalText(value: string) {
+	return [...value]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+		})
+		.join("")
+		.trim();
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -47,7 +47,15 @@ export async function showGoalSettings(
 			ctx.ui.notify("Enter a positive whole number or Unlimited.", "warning");
 			continue;
 		}
-		if (!(await confirmLowerActiveLimit(runtime, ctx, result.field, limit))) continue;
+		const confirmation = await confirmLowerActiveLimit(runtime, ctx, result.field, limit);
+		if (!confirmation.apply) continue;
+		if (confirmation.goalId !== undefined && runtime.activeGoal?.id !== confirmation.goalId) {
+			ctx.ui.notify(
+				"The active goal changed while confirming the limit. No settings were changed.",
+				"warning",
+			);
+			continue;
+		}
 		const next = withLimit(runtime.settings, result.field, limit);
 		try {
 			applyGoalSettings(runtime, next, ctx, {
@@ -360,13 +368,16 @@ async function confirmLowerActiveLimit(
 	limit: number | null,
 ) {
 	const goal = runtime.activeGoal;
-	if (goal?.status !== "active" || limit === null) return true;
+	if (goal?.status !== "active" || limit === null) return { apply: true };
 	const used = field === "automaticTurns" ? goal.automaticModelTurns : goal.toolFreeRepeatCount;
-	if (used < limit) return true;
-	return ctx.ui.confirm(
-		"Apply reached safety limit?",
-		`The active goal has already used ${used}. Setting this limit to ${limit} will pause it immediately without deleting progress.`,
-	);
+	if (used < limit) return { apply: true };
+	return {
+		apply: await ctx.ui.confirm(
+			"Apply reached safety limit?",
+			`The active goal has already used ${used}. Setting this limit to ${limit} will pause it immediately without deleting progress.`,
+		),
+		goalId: goal.id,
+	};
 }
 
 function withLimit(settings: GoalSettings, field: LimitField, value: number | null): GoalSettings {

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -77,9 +77,10 @@ export function applyGoalSettings(
 		options.save?.(next);
 		fileSaved = options.save !== undefined;
 		applyQueueSetting(runtime, ctx);
-		const pausedByLimit =
-			runtime.enforceAutomaticTurnLimit(ctx, false) || runtime.enforceNoProgressLimit(ctx);
-		if (pausedByLimit) abortCurrentTurn(ctx);
+		const activeGoalId = runtime.activeGoal?.id;
+		const abortOwnedRun = activeGoalId !== undefined && runtime.agentRunGoalId === activeGoalId;
+		const pausedByAutomaticLimit = runtime.enforceAutomaticTurnLimit(ctx, abortOwnedRun);
+		if (!pausedByAutomaticLimit) runtime.enforceNoProgressLimit(ctx, abortOwnedRun);
 	} catch (error) {
 		const rollbackErrors: unknown[] = [];
 		try {
@@ -176,6 +177,7 @@ async function showSettingsScreen(
 			Math.min(items.length + 2, 15),
 			getSettingsListTheme(),
 			(id, newValue) => {
+				if (closing) return;
 				if ((id === "automaticTurns" || id === "noProgressTurns") && newValue === "Edit…") {
 					closeAfterSaves({ kind: "limit", field: id });
 					return;
@@ -234,6 +236,7 @@ async function showSettingsScreen(
 			render: (width: number) => container.render(width),
 			invalidate: () => container.invalidate(),
 			handleInput(data: string) {
+				if (closing) return;
 				settingsList.handleInput?.(data);
 				tui.requestRender();
 			},
@@ -296,6 +299,9 @@ function applyToolVisibility(
 		runtime.goalToolsUnlocked = true;
 		runtime.goalToolsHiddenByPolicy.clear();
 		return;
+	}
+	if (ctx.isIdle() !== true) {
+		throw new Error("Wait for Pi to become idle before hiding Goal tools.");
 	}
 	runtime.goalToolsUnlocked = false;
 	runtime.hideGoalToolsIfLocked();

--- a/extensions/pi-goal/src/settings.ts
+++ b/extensions/pi-goal/src/settings.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { linkSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { linkSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
@@ -41,6 +41,13 @@ interface GoalSettingsInitializationFileSystem {
 	mkdirSync: typeof mkdirSync;
 	writeFileSync: typeof writeFileSync;
 	linkSync: typeof linkSync;
+	rmSync: typeof rmSync;
+}
+
+interface GoalSettingsSaveFileSystem {
+	mkdirSync: typeof mkdirSync;
+	writeFileSync: typeof writeFileSync;
+	renameSync: typeof renameSync;
 	rmSync: typeof rmSync;
 }
 
@@ -154,6 +161,62 @@ export function loadOrCreateGoalSettings(
 	}
 }
 
+export function saveGoalSettings(
+	settings: GoalSettings,
+	settingsPath = join(getAgentDir(), GOAL_SETTINGS_FILE),
+	overrides: Partial<GoalSettingsSaveFileSystem> = {},
+) {
+	const normalized = normalizeGoalSettings(settings);
+	if (!normalized) throw new Error("Refusing to save invalid pi-goal settings.");
+
+	let raw: Record<string, unknown> = {};
+	try {
+		const contents = readFileSync(settingsPath, "utf8");
+		const parsed = JSON.parse(contents) as unknown;
+		if (!normalizeGoalSettings(parsed)) {
+			throw new Error(`${settingsPath}: invalid settings shape`);
+		}
+		raw = ownRecord(parsed) ?? {};
+	} catch (error) {
+		if (!isNodeError(error) || error.code !== "ENOENT") {
+			throw new Error(`Cannot save invalid settings file: ${formatError(error)}`);
+		}
+	}
+
+	const experimental = ownRecord(raw.experimental) ?? {};
+	const continuationLimits = ownRecord(raw.continuationLimits) ?? {};
+	const document = `${JSON.stringify(
+		{
+			...raw,
+			toolVisibility: normalized.toolVisibility,
+			experimental: { ...experimental, goals: normalized.experimental.goals },
+			continuationLimits: {
+				...continuationLimits,
+				automaticTurns: normalized.continuationLimits.automaticTurns,
+				noProgressTurns: normalized.continuationLimits.noProgressTurns,
+			},
+		},
+		null,
+		2,
+	)}\n`;
+	const fs = { mkdirSync, writeFileSync, renameSync, rmSync, ...overrides };
+	const temporaryPath = join(
+		dirname(settingsPath),
+		`.${basename(settingsPath)}.${randomUUID()}.tmp`,
+	);
+	try {
+		fs.mkdirSync(dirname(settingsPath), { recursive: true });
+		fs.writeFileSync(temporaryPath, document, { encoding: "utf8", flag: "wx" });
+		fs.renameSync(temporaryPath, settingsPath);
+	} finally {
+		try {
+			fs.rmSync(temporaryPath, { force: true });
+		} catch {
+			// Best-effort cleanup must not replace the save result.
+		}
+	}
+}
+
 export function readGoalSettings(
 	settingsPath = join(getAgentDir(), GOAL_SETTINGS_FILE),
 ): GoalSettingsLoadResult {
@@ -173,6 +236,12 @@ export function readGoalSettings(
 	} catch (error: unknown) {
 		return { kind: "invalid", reason: `${settingsPath}: ${formatError(error)}` };
 	}
+}
+
+function ownRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -135,6 +135,53 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 	]);
 });
 
+test("bare goal is menu-first only in TUI while status and non-TUI stay deterministic", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	registerGoal(mock.pi);
+	const selections: Array<{ title: string; actions: string[] }> = [];
+	const tui = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async (title: string, actions: string[]) => {
+			selections.push({ title, actions });
+			return undefined;
+		},
+	});
+	mock.events.get("session_start")?.[0]?.({}, tui.ctx);
+
+	await mock.commands.get("goal")?.handler("", tui.ctx);
+	assert.equal(selections.length, 1);
+	assert.match(selections[0]?.title ?? "", /Goal · No goal/i);
+	assert.ok(selections[0]?.actions.includes("Start a goal…"));
+	assert.equal(tui.notifications.length, 0);
+
+	await mock.commands.get("goal")?.handler("status", tui.ctx);
+	assert.equal(selections.length, 1);
+	assert.match(tui.notifications.at(-1)?.message ?? "", /No goal is currently set/i);
+
+	let printSelections = 0;
+	const print = createMockContext({
+		mode: "print",
+		hasUI: false,
+		select: async () => {
+			printSelections++;
+			return undefined;
+		},
+	});
+	await assert.rejects(
+		mock.commands.get("goal")?.handler("", print.ctx) as Promise<unknown>,
+		/No goal is currently set/i,
+	);
+	assert.equal(printSelections, 0);
+	assert.equal(print.notifications.length, 0);
+
+	const json = createMockContext({ mode: "json", hasUI: false });
+	await assert.rejects(
+		mock.commands.get("goal")?.handler("status", json.ctx) as Promise<unknown>,
+		/No goal is currently set/i,
+	);
+});
+
 test("session start creates complete default settings when the file is missing", () => {
 	const settingsPath = join(GOAL_SETTINGS_DIRECTORY, "session-created.json");
 	const mock = createMockPi({

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -135,7 +135,7 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 	]);
 });
 
-test("bare goal is menu-first only in TUI while status and non-TUI stay deterministic", async () => {
+test("bare goal is menu-first in TUI, observable in RPC, and rejects headless modes", async () => {
 	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
 	registerGoal(mock.pi);
 	const selections: Array<{ title: string; actions: string[] }> = [];
@@ -159,6 +159,10 @@ test("bare goal is menu-first only in TUI while status and non-TUI stay determin
 	assert.equal(selections.length, 1);
 	assert.match(tui.notifications.at(-1)?.message ?? "", /No goal is currently set/i);
 
+	const rpc = createMockContext({ mode: "rpc", hasUI: true });
+	await mock.commands.get("goal")?.handler("status", rpc.ctx);
+	assert.match(rpc.notifications.at(-1)?.message ?? "", /No goal is currently set/i);
+
 	let printSelections = 0;
 	const print = createMockContext({
 		mode: "print",
@@ -170,7 +174,7 @@ test("bare goal is menu-first only in TUI while status and non-TUI stay determin
 	});
 	await assert.rejects(
 		mock.commands.get("goal")?.handler("", print.ctx) as Promise<unknown>,
-		/No goal is currently set/i,
+		/\/goal status is unavailable in print mode/i,
 	);
 	assert.equal(printSelections, 0);
 	assert.equal(print.notifications.length, 0);
@@ -178,7 +182,7 @@ test("bare goal is menu-first only in TUI while status and non-TUI stay determin
 	const json = createMockContext({ mode: "json", hasUI: false });
 	await assert.rejects(
 		mock.commands.get("goal")?.handler("status", json.ctx) as Promise<unknown>,
-		/No goal is currently set/i,
+		/\/goal status is unavailable in json mode/i,
 	);
 });
 

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -228,6 +228,27 @@ test("queue menu previews prioritize, skip, and drop-last before delegation", as
 	}
 });
 
+test("Skip preview reflects a stopped next goal without promising activation", async () => {
+	const state = runtime(createGoal("current objective", undefined, 0));
+	state.settings.experimental.goals = true;
+	state.queuedGoals.push(transitionGoal(createGoal("blocked objective", undefined, 0), "blocked"));
+	const tracked = commands();
+	const selections = [GOAL_MENU_ACTIONS.queue, "Skip current goal…"];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => selections.shift(),
+		confirm: async (_title: string, message: string) => {
+			assert.match(message, /Next goal remains blocked/i);
+			assert.doesNotMatch(message, /Start next goal/i);
+			return false;
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+	assert.equal(tracked.calls.length, 0);
+});
+
 test("menu start and edit delegate raw objective data only after explicit input", async () => {
 	const empty = runtime();
 	const started = commands();

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import {
+	buildGoalMenuState,
+	GOAL_MENU_ACTIONS,
+	safeGoalMenuText,
+	showGoalManager,
+} from "../src/menu.js";
+import type { ActiveGoal } from "../src/persistence.js";
+import { createGoal, transitionGoal } from "../src/runtime.js";
+import { DEFAULT_GOAL_SETTINGS } from "../src/settings.js";
+
+function runtime(goal?: ActiveGoal) {
+	return {
+		activeGoal: goal,
+		queuedGoals: [] as ActiveGoal[],
+		pendingQueueAction: undefined,
+		queueFrozen: false,
+		settings: structuredClone(DEFAULT_GOAL_SETTINGS),
+	};
+}
+
+function commands() {
+	const calls: Array<{ name: string; args: unknown[] }> = [];
+	const record =
+		(name: string) =>
+		(...args: unknown[]) =>
+			calls.push({ name, args });
+	return {
+		calls,
+		controller: {
+			startGoal: record("startGoal"),
+			pauseGoal: record("pauseGoal"),
+			resumeGoal: record("resumeGoal"),
+			clearGoal: record("clearGoal"),
+			editGoal: record("editGoal"),
+			showGoal: record("showGoal"),
+			addGoal: record("addGoal"),
+			prioritizeGoal: record("prioritizeGoal"),
+			dropLastGoal: record("dropLastGoal"),
+			skipGoal: record("skipGoal"),
+		},
+	};
+}
+
+test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget, and frozen states", () => {
+	assert.deepEqual(buildGoalMenuState(runtime()).actions.slice(0, 2), [
+		GOAL_MENU_ACTIONS.start,
+		GOAL_MENU_ACTIONS.startBudget,
+	]);
+
+	const active = createGoal("ship the release", 100, 0);
+	active.tokensUsed = 20;
+	assert.equal(buildGoalMenuState(runtime(active)).actions[0], GOAL_MENU_ACTIONS.pause);
+	assert.match(buildGoalMenuState(runtime(active)).title, /Active.*20\/100/is);
+
+	for (const status of ["paused", "blocked", "usage_limited"] as const) {
+		const stopped = runtime(transitionGoal(active, status));
+		assert.equal(buildGoalMenuState(stopped).actions[0], GOAL_MENU_ACTIONS.resume);
+	}
+
+	const limited = runtime(transitionGoal({ ...active, tokensUsed: 100 }, "budget_limited"));
+	assert.equal(buildGoalMenuState(limited).actions[0], GOAL_MENU_ACTIONS.increaseBudget);
+
+	const frozen = runtime(active);
+	frozen.queueFrozen = true;
+	frozen.queuedGoals.push(createGoal("later", undefined, 0));
+	assert.deepEqual(buildGoalMenuState(frozen).actions, [
+		GOAL_MENU_ACTIONS.status,
+		GOAL_MENU_ACTIONS.settings,
+		GOAL_MENU_ACTIONS.help,
+		GOAL_MENU_ACTIONS.clear,
+		GOAL_MENU_ACTIONS.close,
+	]);
+});
+
+test("safeGoalMenuText strips terminal controls and bounds untrusted previews", () => {
+	const safe = safeGoalMenuText(`hello\u001b[31m\u009bworld\n${"界".repeat(200)}`);
+	assert.equal(
+		[...safe].some((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		}),
+		false,
+	);
+	assert.match(safe, /…$/u);
+	assert.ok([...safe].length <= 121);
+});
+
+test("showGoalManager preserves non-TUI status behavior", async () => {
+	const tracked = commands();
+	const context = createMockContext({ mode: "print", hasUI: false });
+	await showGoalManager(runtime(), tracked.controller as never, context.ctx, async () => undefined);
+	assert.deepEqual(
+		tracked.calls.map((call) => call.name),
+		["showGoal"],
+	);
+});
+
+test("menu cancellation has no side effects and clear requires an exact preview", async () => {
+	const goal = createGoal("clear this objective", undefined, 0);
+	const state = runtime(goal);
+	state.queuedGoals.push(createGoal("queued objective", undefined, 0));
+	const tracked = commands();
+	let selects = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => (++selects === 1 ? GOAL_MENU_ACTIONS.clear : undefined),
+		confirm: async (title: string, message: string) => {
+			assert.equal(title, "Clear goal queue?");
+			assert.match(message, /clear this objective/);
+			assert.match(message, /queued objective/);
+			return false;
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+	assert.equal(tracked.calls.length, 0);
+});
+
+test("queue menu previews prioritize, skip, and drop-last before delegation", async () => {
+	for (const scenario of [
+		{
+			action: "Prioritize goal…",
+			method: "prioritizeGoal",
+			editor: "urgent objective",
+			preview: /urgent objective.*current objective/is,
+		},
+		{
+			action: "Skip current goal…",
+			method: "skipGoal",
+			preview: /current objective.*queued objective/is,
+		},
+		{
+			action: "Drop last goal…",
+			method: "dropLastGoal",
+			preview: /queued objective/is,
+		},
+	] as const) {
+		const state = runtime(createGoal("current objective", undefined, 0));
+		state.settings.experimental.goals = true;
+		state.queuedGoals.push(createGoal("queued objective", undefined, 0));
+		const tracked = commands();
+		const selections = [GOAL_MENU_ACTIONS.queue, scenario.action];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => selections.shift(),
+			editor: async () => scenario.editor,
+			confirm: async (_title: string, message: string) => {
+				assert.match(message, scenario.preview);
+				return true;
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+		assert.equal(tracked.calls[0]?.name, scenario.method);
+	}
+});
+
+test("menu start and edit delegate raw objective data only after explicit input", async () => {
+	const empty = runtime();
+	const started = commands();
+	const startContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => GOAL_MENU_ACTIONS.start,
+		editor: async () => "  implement menu  ",
+	});
+	await showGoalManager(
+		empty,
+		started.controller as never,
+		startContext.ctx,
+		async () => undefined,
+	);
+	assert.equal(started.calls[0]?.name, "startGoal");
+	assert.deepEqual(started.calls[0]?.args.slice(0, 2), ["implement menu", undefined]);
+
+	const active = runtime(createGoal("old objective", undefined, 0));
+	const edited = commands();
+	const editContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => GOAL_MENU_ACTIONS.edit,
+		editor: async () => "new objective",
+		confirm: async (title: string, message: string) => {
+			assert.equal(title, "Apply goal edit?");
+			assert.match(message, /old objective/);
+			assert.match(message, /new objective/);
+			return true;
+		},
+	});
+	await showGoalManager(active, edited.controller as never, editContext.ctx, async () => undefined);
+	assert.equal(edited.calls[0]?.name, "editGoal");
+	assert.deepEqual(edited.calls[0]?.args.slice(0, 2), ["new objective", undefined]);
+});

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -330,6 +330,43 @@ test("queue confirmations do not mutate a changed active head or queue selection
 	}
 });
 
+test("main-menu pause and resume do not mutate a replacement goal", async () => {
+	for (const scenario of [
+		{ action: GOAL_MENU_ACTIONS.pause, status: "active" as const, method: "pauseGoal" },
+		{ action: GOAL_MENU_ACTIONS.resume, status: "paused" as const, method: "resumeGoal" },
+	]) {
+		const displayed = transitionGoal(
+			createGoal("displayed objective", undefined, 0),
+			scenario.status,
+		);
+		const state = runtime(displayed);
+		const tracked = commands();
+		const selections = [scenario.action, GOAL_MENU_ACTIONS.close];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => {
+				const selected = selections.shift();
+				if (selected === scenario.action) {
+					state.activeGoal = transitionGoal(
+						createGoal("replacement objective", undefined, 0),
+						scenario.status,
+					);
+				}
+				return selected;
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.equal(
+			tracked.calls.some((call) => call.name === scenario.method),
+			false,
+		);
+		assert.match(context.notifications.at(-1)?.message ?? "", /active goal changed.*reopen/i);
+	}
+});
+
 test("edit dialogs do not mutate a replacement active goal", async () => {
 	const original = createGoal("old objective", undefined, 0);
 	const replacement = createGoal("replacement objective", undefined, 0);

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -7,7 +7,7 @@ import {
 	safeGoalMenuText,
 	showGoalManager,
 } from "../src/menu.js";
-import type { ActiveGoal } from "../src/persistence.js";
+import type { ActiveGoal, PendingQueueAction } from "../src/persistence.js";
 import { createGoal, transitionGoal } from "../src/runtime.js";
 import { DEFAULT_GOAL_SETTINGS } from "../src/settings.js";
 
@@ -15,7 +15,7 @@ function runtime(goal?: ActiveGoal) {
 	return {
 		activeGoal: goal,
 		queuedGoals: [] as ActiveGoal[],
-		pendingQueueAction: undefined,
+		pendingQueueAction: undefined as PendingQueueAction | undefined,
 		queueFrozen: false,
 		settings: structuredClone(DEFAULT_GOAL_SETTINGS),
 	};
@@ -45,10 +45,13 @@ function commands() {
 }
 
 test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget, and frozen states", () => {
-	assert.deepEqual(buildGoalMenuState(runtime()).actions.slice(0, 2), [
+	const empty = runtime();
+	empty.settings.experimental.goals = true;
+	assert.deepEqual(buildGoalMenuState(empty).actions.slice(0, 2), [
 		GOAL_MENU_ACTIONS.start,
 		GOAL_MENU_ACTIONS.startBudget,
 	]);
+	assert.equal(buildGoalMenuState(empty).actions.includes(GOAL_MENU_ACTIONS.queue), false);
 
 	const active = createGoal("ship the release", 100, 0);
 	active.tokensUsed = 20;
@@ -117,6 +120,71 @@ test("menu cancellation has no side effects and clear requires an exact preview"
 	});
 
 	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+	assert.equal(tracked.calls.length, 0);
+});
+
+test("clear preview includes a pending priority objective", async () => {
+	const state = runtime(createGoal("current objective", undefined, 0));
+	state.queuedGoals.push(createGoal("queued objective", undefined, 0));
+	state.pendingQueueAction = { kind: "prioritize", objective: "pending urgent objective" };
+	const tracked = commands();
+	const selections = [GOAL_MENU_ACTIONS.clear, undefined];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => selections.shift(),
+		confirm: async (title: string, message: string) => {
+			assert.equal(title, "Clear goal queue?");
+			assert.match(message, /all 3 goals/i);
+			assert.match(message, /current objective/);
+			assert.match(message, /queued objective/);
+			assert.match(message, /pending urgent objective/);
+			return false;
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+	assert.equal(tracked.calls.length, 0);
+});
+
+test("menu preserves exact token values in status and budget input", async () => {
+	const goal = transitionGoal(createGoal("precise budget", 10_500, 0), "budget_limited");
+	goal.tokensUsed = 10_499;
+	const state = runtime(goal);
+	assert.match(buildGoalMenuState(state).title, /10499\/10500/);
+	let placeholder = "";
+	const tracked = commands();
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => GOAL_MENU_ACTIONS.increaseBudget,
+		input: async (_title: string, value: string) => {
+			placeholder = value;
+			return undefined;
+		},
+	});
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+	assert.equal(placeholder, "10500");
+	assert.equal(tracked.calls.length, 0);
+});
+
+test("Queue Back returns to the refreshed main menu", async () => {
+	const state = runtime(createGoal("current objective", undefined, 0));
+	state.settings.experimental.goals = true;
+	const tracked = commands();
+	const selections = [GOAL_MENU_ACTIONS.queue, "Back", GOAL_MENU_ACTIONS.close];
+	let selectionCount = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => {
+			selectionCount++;
+			return selections.shift();
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+	assert.equal(selectionCount, 3);
 	assert.equal(tracked.calls.length, 0);
 });
 

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -249,6 +249,51 @@ test("Skip preview reflects a stopped next goal without promising activation", a
 	assert.equal(tracked.calls.length, 0);
 });
 
+test("edit dialogs do not mutate a replacement active goal", async () => {
+	const original = createGoal("old objective", undefined, 0);
+	const replacement = createGoal("replacement objective", undefined, 0);
+	const state = runtime(original);
+	const tracked = commands();
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => GOAL_MENU_ACTIONS.edit,
+		editor: async () => {
+			state.activeGoal = replacement;
+			return "edited old objective";
+		},
+		confirm: async () => true,
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.equal(tracked.calls.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /goal changed.*reopen/i);
+});
+
+test("budget dialogs do not mutate a replacement active goal", async () => {
+	const original = transitionGoal(createGoal("old objective", 100, 0), "budget_limited");
+	original.tokensUsed = 100;
+	const replacement = createGoal("replacement objective", undefined, 0);
+	const state = runtime(original);
+	const tracked = commands();
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => GOAL_MENU_ACTIONS.increaseBudget,
+		input: async () => {
+			state.activeGoal = replacement;
+			return "200";
+		},
+		confirm: async () => true,
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.equal(tracked.calls.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /goal changed.*reopen/i);
+});
+
 test("menu start and edit delegate raw objective data only after explicit input", async () => {
 	const empty = runtime();
 	const started = commands();

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -123,6 +123,29 @@ test("menu cancellation has no side effects and clear requires an exact preview"
 	assert.equal(tracked.calls.length, 0);
 });
 
+test("clear confirmation does not erase a queue that changed while open", async () => {
+	const state = runtime(createGoal("previewed objective", undefined, 0));
+	const tracked = commands();
+	const selections = [GOAL_MENU_ACTIONS.clear, undefined];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => selections.shift(),
+		confirm: async () => {
+			state.activeGoal = createGoal("replacement objective", undefined, 0);
+			return true;
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.equal(
+		tracked.calls.some((call) => call.name === "clearGoal"),
+		false,
+	);
+	assert.match(context.notifications.at(-1)?.message ?? "", /goal queue changed.*reopen/i);
+});
+
 test("clear preview includes a pending priority objective", async () => {
 	const state = runtime(createGoal("current objective", undefined, 0));
 	state.queuedGoals.push(createGoal("queued objective", undefined, 0));
@@ -247,6 +270,64 @@ test("Skip preview reflects a stopped next goal without promising activation", a
 
 	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
 	assert.equal(tracked.calls.length, 0);
+});
+
+test("queue confirmations do not mutate a changed active head or queue selection", async () => {
+	for (const scenario of [
+		{
+			action: "Prioritize goal…",
+			expectedMethod: "prioritizeGoal",
+			editor: "urgent objective",
+			mutate(state: ReturnType<typeof runtime>) {
+				state.activeGoal = createGoal("replacement head", undefined, 0);
+			},
+		},
+		{
+			action: "Skip current goal…",
+			expectedMethod: "skipGoal",
+			mutate(state: ReturnType<typeof runtime>) {
+				state.activeGoal = createGoal("replacement head", undefined, 0);
+			},
+		},
+		{
+			action: "Skip current goal…",
+			expectedMethod: "skipGoal",
+			mutate(state: ReturnType<typeof runtime>) {
+				state.queuedGoals = [createGoal("replacement successor", undefined, 0)];
+			},
+		},
+		{
+			action: "Drop last goal…",
+			expectedMethod: "dropLastGoal",
+			mutate(state: ReturnType<typeof runtime>) {
+				state.queuedGoals = [createGoal("replacement tail", undefined, 0)];
+			},
+		},
+	] as const) {
+		const state = runtime(createGoal("current objective", undefined, 0));
+		state.settings.experimental.goals = true;
+		state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+		const tracked = commands();
+		const selections = [GOAL_MENU_ACTIONS.queue, scenario.action];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => selections.shift(),
+			editor: async () => ("editor" in scenario ? scenario.editor : undefined),
+			confirm: async () => {
+				scenario.mutate(state);
+				return true;
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.equal(
+			tracked.calls.some((call) => call.name === scenario.expectedMethod),
+			false,
+		);
+		assert.match(context.notifications.at(-1)?.message ?? "", /goal queue changed.*reopen/i);
+	}
 });
 
 test("edit dialogs do not mutate a replacement active goal", async () => {

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -179,6 +179,65 @@ test("lowering the no-progress limit pauses and aborts in-flight Goal work", () 
 	assert.equal(state.activeGoal?.safetyPauseCause, "no_progress");
 });
 
+test("replacement confirmation sanitizes terminal controls without changing goal data", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.activeGoal = createGoal("current\u001b]8;;bad\u0007 objective", undefined, 0);
+	let preview = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		confirm: async (_title: string, message: string) => {
+			preview = message;
+			return false;
+		},
+	});
+	const controller = new GoalCommandController(state);
+
+	await controller.startGoal("new\u009b31m objective", undefined, context.ctx);
+
+	for (const control of ["\u0007", "\u001b", "\u009b"]) {
+		assert.equal(preview.includes(control), false);
+	}
+	assert.match(preview, /Current goal: current ]8;;bad objective/);
+	assert.match(preview, /New goal: new 31m objective/);
+	assert.equal(state.activeGoal?.text, "current\u001b]8;;bad\u0007 objective");
+});
+
+test("unfreezing waits for an aborted frozen run to settle before dispatching", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		experimental: { goals: false },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+	state.beginAgentRun(state.activeGoal.id, "manual");
+	state.queueFrozen = true;
+	state.guardAbortGoalId = state.activeGoal.id;
+	state.queueFreezeAwaitingSettle = true;
+	const context = createMockContext({ mode: "tui", hasUI: true, isIdle: () => true });
+	const enabled = { ...structuredClone(state.settings), experimental: { goals: true } };
+	const controller = new GoalCommandController(state);
+
+	applyGoalSettings(state, enabled, context.ctx, { save() {} });
+	const dispatchedEarly = await controller.resumeQueueAfterUnfreeze(context.ctx);
+
+	assert.equal(dispatchedEarly, false);
+	assert.equal(state.queueFrozen, true);
+	assert.equal(state.guardAbortGoalId, state.activeGoal.id);
+	assert.equal(mock.sentUserMessages.length, 0);
+
+	state.clearSettledSafetyTracking();
+	state.queueFreezeAwaitingSettle = false;
+	const dispatchedAfterSettle = await controller.resumeQueueAfterUnfreeze(context.ctx);
+
+	assert.equal(dispatchedAfterSettle, true);
+	assert.equal(state.queueFrozen, false);
+	assert.equal(mock.sentUserMessages.length, 1);
+});
+
 test("unfreezing an active retained queue dispatches Goal work immediately", async () => {
 	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
 	const state = new GoalRuntime(mock.pi);

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -135,6 +135,7 @@ test("disabling a retained queue pauses and aborts in-flight Goal work", () => {
 	state.activeGoal = createGoal("current objective", undefined, 0);
 	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
 	state.requestContinuation(state.activeGoal);
+	state.beginAgentRun(state.activeGoal.id, "automatic");
 	let aborts = 0;
 	const context = createMockContext({
 		mode: "tui",
@@ -148,8 +149,63 @@ test("disabling a retained queue pauses and aborts in-flight Goal work", () => {
 	assert.equal(aborts, 1);
 	assert.equal(state.queueFrozen, true);
 	assert.equal(state.activeGoal?.status, "active");
+	assert.equal(state.activeGoal?.activeStartedAt, undefined);
 	assert.equal(state.continuationIntent, undefined);
 	assert.equal(state.staleGoalToolCallsBlocked, true);
+});
+
+test("freezing a queue preserves an unrelated in-flight run", () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		experimental: { goals: true },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+	state.beginAgentRun(null, undefined);
+	let aborts = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		abort: () => aborts++,
+	});
+	const next = { ...structuredClone(state.settings), experimental: { goals: false } };
+
+	applyGoalSettings(state, next, context.ctx, { save() {} });
+
+	assert.equal(aborts, 0);
+	assert.equal(state.queueFrozen, true);
+	assert.equal(state.agentRunGoalId, null);
+	assert.equal(state.activeGoal?.activeStartedAt, undefined);
+	assert.equal(state.guardAbortGoalId, undefined);
+	assert.equal(state.queueFreezeAwaitingSettle, false);
+	assert.equal(state.staleGoalToolCallsBlocked, false);
+});
+
+test("revealing lazy Goal tools rejects a busy unrelated run", () => {
+	const state = runtime();
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		toolVisibility: "after-first-goal",
+	};
+	const before = structuredClone(state.visibility);
+	const next = { ...structuredClone(state.settings), toolVisibility: "always" as const };
+	let saves = 0;
+	const context = createMockContext({ mode: "tui", hasUI: true, isIdle: () => false });
+
+	assert.throws(
+		() =>
+			applyGoalSettings(state, next, context.ctx, {
+				save() {
+					saves++;
+				},
+			}),
+		/wait for Pi to become idle/i,
+	);
+	assert.equal(saves, 0);
+	assert.equal(state.settings.toolVisibility, "after-first-goal");
+	assert.deepEqual(state.visibility, before);
 });
 
 test("lowering the no-progress limit pauses and aborts in-flight Goal work", () => {
@@ -179,10 +235,33 @@ test("lowering the no-progress limit pauses and aborts in-flight Goal work", () 
 	assert.equal(state.activeGoal?.safetyPauseCause, "no_progress");
 });
 
+test("replacement confirmation does not replace a goal that changed while open", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.activeGoal = createGoal("previewed objective", undefined, 0);
+	const replacement = createGoal("replacement objective", undefined, 0);
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		confirm: async () => {
+			state.activeGoal = replacement;
+			return true;
+		},
+	});
+	const controller = new GoalCommandController(state);
+
+	await controller.startGoal("new objective", undefined, context.ctx);
+
+	assert.equal(state.activeGoal?.id, replacement.id);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /goal queue changed.*try again/i);
+});
+
 test("replacement confirmation sanitizes terminal controls without changing goal data", async () => {
 	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
 	const state = new GoalRuntime(mock.pi);
 	state.activeGoal = createGoal("current\u001b]8;;bad\u0007 objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued\u001b objective", undefined, 0)];
 	let preview = "";
 	const context = createMockContext({
 		mode: "tui",
@@ -200,6 +279,7 @@ test("replacement confirmation sanitizes terminal controls without changing goal
 		assert.equal(preview.includes(control), false);
 	}
 	assert.match(preview, /Current goal: current ]8;;bad objective/);
+	assert.match(preview, /Queued goals also removed:\n1\. queued objective/);
 	assert.match(preview, /New goal: new 31m objective/);
 	assert.equal(state.activeGoal?.text, "current\u001b]8;;bad\u0007 objective");
 });
@@ -235,6 +315,7 @@ test("unfreezing waits for an aborted frozen run to settle before dispatching", 
 
 	assert.equal(dispatchedAfterSettle, true);
 	assert.equal(state.queueFrozen, false);
+	assert.equal(typeof state.activeGoal?.activeStartedAt, "number");
 	assert.equal(mock.sentUserMessages.length, 1);
 });
 

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { DEFAULT_GOAL_SETTINGS, type GoalSettings } from "../src/settings.js";
+import {
+	applyGoalSettings,
+	formatGoalLimit,
+	parseGoalLimit,
+	showGoalSettings,
+} from "../src/settings-ui.js";
+
+initTheme("dark", false);
+
+function runtime() {
+	const visibility = {
+		activeTools: ["read"],
+		goalToolsUnlocked: false,
+		goalToolsHiddenByPolicy: ["goal_complete", "goal_blocked"],
+	};
+	return {
+		settings: structuredClone(DEFAULT_GOAL_SETTINGS),
+		activeGoal: undefined,
+		queuedGoals: [],
+		pendingQueueAction: undefined,
+		queueFrozen: false,
+		snapshotGoalToolVisibility: () => structuredClone(visibility),
+		restoreGoalToolVisibility: (snapshot: typeof visibility) => Object.assign(visibility, snapshot),
+		restoreGoalToolsHiddenByPolicy() {
+			visibility.activeTools.push(...visibility.goalToolsHiddenByPolicy);
+			visibility.goalToolsHiddenByPolicy = [];
+		},
+		hideGoalToolsIfLocked() {},
+		cancelContinuationWork() {},
+		persistGoal() {},
+		updateStatus() {},
+		enforceAutomaticTurnLimit() {
+			return false;
+		},
+		enforceNoProgressLimit() {
+			return false;
+		},
+		get visibility() {
+			return visibility;
+		},
+	};
+}
+
+test("goal setting limit parsing preserves arbitrary positive integers and unlimited", () => {
+	assert.equal(parseGoalLimit("40"), 40);
+	assert.equal(parseGoalLimit("unlimited"), null);
+	assert.equal(parseGoalLimit("off"), null);
+	for (const invalid of ["", "0", "-1", "1.5", "many"]) {
+		assert.equal(parseGoalLimit(invalid), undefined);
+	}
+	assert.equal(formatGoalLimit(25), "25");
+	assert.equal(formatGoalLimit(null), "Unlimited");
+});
+
+test("applyGoalSettings saves before committing runtime settings and enforces lower limits", () => {
+	const state = runtime();
+	let saved: GoalSettings | undefined;
+	let enforced = 0;
+	state.enforceAutomaticTurnLimit = () => {
+		enforced++;
+		return true;
+	};
+	const next: GoalSettings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		continuationLimits: { automaticTurns: 10, noProgressTurns: 2 },
+	};
+	const context = createMockContext();
+
+	applyGoalSettings(state as never, next, context.ctx, {
+		save(settings: GoalSettings) {
+			saved = structuredClone(settings);
+		},
+	});
+
+	assert.deepEqual(saved, next);
+	assert.deepEqual(state.settings, next);
+	assert.equal(enforced, 1);
+});
+
+test("applyGoalSettings restores effective tool policy when persistence fails", () => {
+	const state = runtime();
+	const before = structuredClone(state.visibility);
+	const next: GoalSettings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		toolVisibility: "always",
+	};
+	const context = createMockContext();
+
+	assert.throws(
+		() =>
+			applyGoalSettings(state as never, next, context.ctx, {
+				save() {
+					throw new Error("disk full");
+				},
+			}),
+		/disk full/,
+	);
+	assert.deepEqual(state.settings, DEFAULT_GOAL_SETTINGS);
+	assert.deepEqual(state.visibility, before);
+});
+
+test("settings screen saves changes in place and Escape waits for the save queue", async () => {
+	const state = runtime();
+	const saved: GoalSettings[] = [];
+	let initialRender = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 40);
+			initialRender = selector.render().join("\n");
+			selector.handleInput("\r");
+			selector.handleInput("\u001b");
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state as never, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save(settings) {
+			saved.push(structuredClone(settings));
+		},
+	});
+
+	assert.match(initialRender, /Pi Goal Settings/);
+	assert.match(initialRender, /Goal tools/);
+	assert.doesNotMatch(initialRender, /Type to search/);
+	assert.equal(saved.length, 1);
+	assert.equal(saved[0]?.toolVisibility, "after-first-goal");
+	assert.equal(state.settings.toolVisibility, "after-first-goal");
+});
+
+test("settings screen fits narrow, normal, and wide terminal widths", async () => {
+	for (const width of [40, 80, 120]) {
+		const state = runtime();
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const selector = createCustomSelectorHarness(factory, width);
+				const lines = selector.render();
+				assert.ok(lines.every((line) => visibleWidth(line) <= width));
+				selector.handleInput("\u001b");
+				await new Promise((resolve) => setImmediate(resolve));
+				return selector.result;
+			},
+		});
+		await showGoalSettings(state as never, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save() {
+				throw new Error("Escape must not save.");
+			},
+		});
+	}
+});
+
+test("showGoalSettings uses an observable manual fallback outside TUI", async () => {
+	const state = runtime();
+	const context = createMockContext({ mode: "rpc", hasUI: true });
+	await showGoalSettings(state as never, context.ctx, { settingsPath: "/tmp/pi-goal.json" });
+	assert.match(context.notifications[0]?.message ?? "", /edit pi-goal settings manually/i);
+	assert.match(context.notifications[0]?.message ?? "", /\/tmp\/pi-goal\.json/);
+});

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import { GoalCommandController } from "../src/commands.js";
+import { createGoal, GoalRuntime } from "../src/runtime.js";
 import { DEFAULT_GOAL_SETTINGS, type GoalSettings } from "../src/settings.js";
 import {
 	applyGoalSettings,
@@ -14,37 +20,17 @@ import {
 initTheme("dark", false);
 
 function runtime() {
-	const visibility = {
-		activeTools: ["read"],
-		goalToolsUnlocked: false,
-		goalToolsHiddenByPolicy: ["goal_complete", "goal_blocked"],
+	const mock = createMockPi({ activeTools: ["read"] });
+	const state = new GoalRuntime(mock.pi) as GoalRuntime & {
+		readonly visibility: ReturnType<GoalRuntime["snapshotGoalToolVisibility"]>;
 	};
-	return {
-		settings: structuredClone(DEFAULT_GOAL_SETTINGS),
-		activeGoal: undefined,
-		queuedGoals: [],
-		pendingQueueAction: undefined,
-		queueFrozen: false,
-		snapshotGoalToolVisibility: () => structuredClone(visibility),
-		restoreGoalToolVisibility: (snapshot: typeof visibility) => Object.assign(visibility, snapshot),
-		restoreGoalToolsHiddenByPolicy() {
-			visibility.activeTools.push(...visibility.goalToolsHiddenByPolicy);
-			visibility.goalToolsHiddenByPolicy = [];
-		},
-		hideGoalToolsIfLocked() {},
-		cancelContinuationWork() {},
-		persistGoal() {},
-		updateStatus() {},
-		enforceAutomaticTurnLimit() {
-			return false;
-		},
-		enforceNoProgressLimit() {
-			return false;
-		},
-		get visibility() {
-			return visibility;
-		},
-	};
+	state.settings = structuredClone(DEFAULT_GOAL_SETTINGS);
+	state.goalToolsHiddenByPolicy.add("goal_complete");
+	state.goalToolsHiddenByPolicy.add("goal_blocked");
+	Object.defineProperty(state, "visibility", {
+		get: () => state.snapshotGoalToolVisibility(),
+	});
+	return state;
 }
 
 test("goal setting limit parsing preserves arbitrary positive integers and unlimited", () => {
@@ -64,7 +50,7 @@ test("applyGoalSettings saves before committing runtime settings and enforces lo
 	let enforced = 0;
 	state.enforceAutomaticTurnLimit = () => {
 		enforced++;
-		return true;
+		return false;
 	};
 	const next: GoalSettings = {
 		...structuredClone(DEFAULT_GOAL_SETTINGS),
@@ -105,6 +91,107 @@ test("applyGoalSettings restores effective tool policy when persistence fails", 
 	assert.deepEqual(state.visibility, before);
 });
 
+test("applyGoalSettings rolls back file and effective state after runtime application fails", () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		experimental: { goals: true },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+	const previous = structuredClone(state.settings);
+	const next = { ...structuredClone(previous), experimental: { goals: false } };
+	const saved: GoalSettings[] = [];
+	let persistCalls = 0;
+	state.persistGoal = () => {
+		persistCalls++;
+		if (persistCalls === 1) throw new Error("stale context");
+	};
+	const context = createMockContext({ mode: "tui", hasUI: true });
+
+	assert.throws(
+		() =>
+			applyGoalSettings(state, next, context.ctx, {
+				save(settings) {
+					saved.push(structuredClone(settings));
+				},
+			}),
+		/stale context/,
+	);
+	assert.deepEqual(saved, [next, previous]);
+	assert.deepEqual(state.settings, previous);
+	assert.equal(state.queueFrozen, false);
+	assert.equal(state.activeGoal?.status, "active");
+});
+
+test("disabling a retained queue pauses and aborts in-flight Goal work", () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		experimental: { goals: true },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+	state.requestContinuation(state.activeGoal);
+	let aborts = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		abort: () => aborts++,
+	});
+	const next = { ...structuredClone(state.settings), experimental: { goals: false } };
+
+	applyGoalSettings(state, next, context.ctx, { save() {} });
+
+	assert.equal(aborts, 1);
+	assert.equal(state.queueFrozen, true);
+	assert.equal(state.activeGoal?.status, "active");
+	assert.equal(state.continuationIntent, undefined);
+	assert.equal(state.staleGoalToolCallsBlocked, true);
+});
+
+test("unfreezing an active retained queue dispatches Goal work immediately", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		experimental: { goals: true },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+	state.queueFrozen = false;
+	const controller = new GoalCommandController(state);
+	const context = createMockContext({ mode: "tui", hasUI: true, isIdle: () => true });
+
+	const dispatched = await controller.resumeQueueAfterUnfreeze(context.ctx);
+
+	assert.equal(dispatched, true);
+	assert.equal(mock.sentUserMessages.length, 1);
+	assert.match(mock.sentUserMessages[0]?.text ?? "", /Continue the active \/goal/i);
+});
+
+test("unfreezing a pending priority dispatches it at the idle boundary", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		experimental: { goals: true },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.pendingQueueAction = { kind: "prioritize", objective: "urgent objective" };
+	const controller = new GoalCommandController(state);
+	const context = createMockContext({ mode: "tui", hasUI: true, isIdle: () => true });
+
+	const dispatched = await controller.resumeQueueAfterUnfreeze(context.ctx);
+
+	assert.equal(dispatched, true);
+	assert.equal(state.pendingQueueAction, undefined);
+	assert.equal(state.activeGoal?.text, "urgent objective");
+	assert.equal(mock.sentUserMessages.length, 1);
+});
+
 test("settings screen saves changes in place and Escape waits for the save queue", async () => {
 	const state = runtime();
 	const saved: GoalSettings[] = [];
@@ -135,6 +222,40 @@ test("settings screen saves changes in place and Escape waits for the save queue
 	assert.equal(saved.length, 1);
 	assert.equal(saved[0]?.toolVisibility, "after-first-goal");
 	assert.equal(state.settings.toolVisibility, "after-first-goal");
+});
+
+test("settings screen resumes retained work after enabling the queue", async () => {
+	const state = runtime();
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+	state.queueFrozen = true;
+	let unfrozen = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		confirm: async () => true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			selector.handleInput("\u001b[B");
+			selector.handleInput("\r");
+			await new Promise((resolve) => setImmediate(resolve));
+			selector.handleInput("\u001b");
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {},
+		onQueueUnfrozen: async () => {
+			unfrozen++;
+		},
+	});
+
+	assert.equal(state.queueFrozen, false);
+	assert.equal(state.settings.experimental.goals, true);
+	assert.equal(unfrozen, 1);
 });
 
 test("settings screen fits narrow, normal, and wide terminal widths", async () => {

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -208,6 +208,32 @@ test("revealing lazy Goal tools rejects a busy unrelated run", () => {
 	assert.deepEqual(state.visibility, before);
 });
 
+test("hiding always-visible Goal tools rejects a busy unrelated run", () => {
+	const mock = createMockPi({ activeTools: ["read", "goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = structuredClone(DEFAULT_GOAL_SETTINGS);
+	const before = state.snapshotGoalToolVisibility();
+	const next = {
+		...structuredClone(state.settings),
+		toolVisibility: "after-first-goal" as const,
+	};
+	let saves = 0;
+	const context = createMockContext({ mode: "tui", hasUI: true, isIdle: () => false });
+
+	assert.throws(
+		() =>
+			applyGoalSettings(state, next, context.ctx, {
+				save() {
+					saves++;
+				},
+			}),
+		/wait for Pi to become idle/i,
+	);
+	assert.equal(saves, 0);
+	assert.equal(state.settings.toolVisibility, "always");
+	assert.deepEqual(state.snapshotGoalToolVisibility(), before);
+});
+
 test("lowering the no-progress limit pauses and aborts in-flight Goal work", () => {
 	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
 	const state = new GoalRuntime(mock.pi);
@@ -217,6 +243,7 @@ test("lowering the no-progress limit pauses and aborts in-flight Goal work", () 
 	};
 	state.activeGoal = createGoal("current objective", undefined, 0);
 	state.activeGoal.toolFreeRepeatCount = 3;
+	state.beginAgentRun(state.activeGoal.id, "automatic");
 	let aborts = 0;
 	const context = createMockContext({
 		mode: "tui",
@@ -231,6 +258,35 @@ test("lowering the no-progress limit pauses and aborts in-flight Goal work", () 
 	applyGoalSettings(state, next, context.ctx, { save() {} });
 
 	assert.equal(aborts, 1);
+	assert.equal(state.activeGoal?.status, "paused");
+	assert.equal(state.activeGoal?.safetyPauseCause, "no_progress");
+});
+
+test("lowering a reached limit preserves an unrelated in-flight run", () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 5 },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.activeGoal.toolFreeRepeatCount = 3;
+	state.beginAgentRun(null, undefined);
+	let aborts = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		abort: () => aborts++,
+	});
+	const next = {
+		...structuredClone(state.settings),
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+	};
+
+	applyGoalSettings(state, next, context.ctx, { save() {} });
+
+	assert.equal(aborts, 0);
+	assert.equal(state.agentRunGoalId, null);
 	assert.equal(state.activeGoal?.status, "paused");
 	assert.equal(state.activeGoal?.safetyPauseCause, "no_progress");
 });
@@ -371,6 +427,7 @@ test("settings screen saves changes in place and Escape waits for the save queue
 			initialRender = selector.render().join("\n");
 			selector.handleInput("\r");
 			selector.handleInput("\u001b");
+			selector.handleInput("\r");
 			await new Promise((resolve) => setImmediate(resolve));
 			return selector.result;
 		},

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -152,6 +152,33 @@ test("disabling a retained queue pauses and aborts in-flight Goal work", () => {
 	assert.equal(state.staleGoalToolCallsBlocked, true);
 });
 
+test("lowering the no-progress limit pauses and aborts in-flight Goal work", () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	const state = new GoalRuntime(mock.pi);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 5 },
+	};
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.activeGoal.toolFreeRepeatCount = 3;
+	let aborts = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		abort: () => aborts++,
+	});
+	const next = {
+		...structuredClone(state.settings),
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+	};
+
+	applyGoalSettings(state, next, context.ctx, { save() {} });
+
+	assert.equal(aborts, 1);
+	assert.equal(state.activeGoal?.status, "paused");
+	assert.equal(state.activeGoal?.safetyPauseCause, "no_progress");
+});
+
 test("unfreezing an active retained queue dispatches Goal work immediately", async () => {
 	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
 	const state = new GoalRuntime(mock.pi);

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -448,6 +448,54 @@ test("settings screen saves changes in place and Escape waits for the save queue
 	assert.equal(state.settings.toolVisibility, "after-first-goal");
 });
 
+test("lowered limit confirmation cannot apply to a replacement goal", async () => {
+	const state = runtime();
+	const original = createGoal("original objective", undefined, 0);
+	original.automaticModelTurns = 5;
+	state.activeGoal = original;
+	const replacement = createGoal("replacement objective", undefined, 0);
+	replacement.automaticModelTurns = 5;
+	const saved: GoalSettings[] = [];
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		input: async () => "3",
+		confirm: async () => {
+			state.activeGoal = replacement;
+			return true;
+		},
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save(settings) {
+			saved.push(structuredClone(settings));
+		},
+	});
+
+	assert.equal(saved.length, 0);
+	assert.equal(
+		state.settings.continuationLimits.automaticTurns,
+		DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns,
+	);
+	assert.equal(state.activeGoal?.id, replacement.id);
+	assert.equal(state.activeGoal?.status, "active");
+	assert.match(context.notifications.at(-1)?.message ?? "", /goal changed/i);
+});
+
 test("settings screen resumes retained work after enabling the queue", async () => {
 	const state = runtime();
 	state.activeGoal = createGoal("current objective", undefined, 0);

--- a/extensions/pi-goal/test/settings.test.ts
+++ b/extensions/pi-goal/test/settings.test.ts
@@ -10,6 +10,7 @@ import {
 	loadOrCreateGoalSettings,
 	normalizeGoalSettings,
 	readGoalSettings,
+	saveGoalSettings,
 } from "../src/settings.js";
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
@@ -167,6 +168,60 @@ test("loadOrCreateGoalSettings adopts a concurrent winner without overwriting it
 		},
 	});
 	assert.equal(readFileSync(settingsPath, "utf8"), winnerDocument);
+	assert.deepEqual(readdirSync(directory), ["pi-goal.json"]);
+});
+
+test("saveGoalSettings atomically preserves unknown top-level and nested fields", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-save-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const settingsPath = join(directory, "pi-goal.json");
+	writeFileSync(
+		settingsPath,
+		JSON.stringify({
+			future: { enabled: true },
+			toolVisibility: "after-first-goal",
+			experimental: { goals: false, futureQueue: "keep" },
+			continuationLimits: { automaticTurns: 25, noProgressTurns: 3, futureLimit: 9 },
+		}),
+	);
+
+	saveGoalSettings(
+		{
+			toolVisibility: "always",
+			experimental: { goals: true },
+			continuationLimits: { automaticTurns: 40, noProgressTurns: null },
+		},
+		settingsPath,
+	);
+
+	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+		future: { enabled: true },
+		toolVisibility: "always",
+		experimental: { goals: true, futureQueue: "keep" },
+		continuationLimits: { automaticTurns: 40, noProgressTurns: null, futureLimit: 9 },
+	});
+	assert.deepEqual(readdirSync(directory), ["pi-goal.json"]);
+});
+
+test("saveGoalSettings refuses malformed files and cleans a failed atomic write", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-save-failure-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const settingsPath = join(directory, "pi-goal.json");
+	writeFileSync(settingsPath, "{invalid");
+	assert.throws(() => saveGoalSettings(DEFAULT_GOAL_SETTINGS, settingsPath), /invalid settings/i);
+	assert.equal(readFileSync(settingsPath, "utf8"), "{invalid");
+
+	writeFileSync(settingsPath, DEFAULT_GOAL_SETTINGS_DOCUMENT);
+	assert.throws(
+		() =>
+			saveGoalSettings(DEFAULT_GOAL_SETTINGS, settingsPath, {
+				renameSync() {
+					throw new Error("rename failed");
+				},
+			}),
+		/rename failed/,
+	);
+	assert.equal(readFileSync(settingsPath, "utf8"), DEFAULT_GOAL_SETTINGS_DOCUMENT);
 	assert.deepEqual(readdirSync(directory), ["pi-goal.json"]);
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -275,6 +275,11 @@
 				"@earendil-works/pi-ai": "0.81.1",
 				"@earendil-works/pi-coding-agent": "0.82.0",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-ai": "*",
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"extensions/pi-goal/node_modules/@biomejs/biome": {
@@ -5422,7 +5427,6 @@
 			"version": "0.80.10",
 			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
 			"integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -9203,7 +9207,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
 			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -9372,7 +9375,6 @@
 			"version": "18.0.5",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
 			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"


### PR DESCRIPTION
## Summary

- make bare `/goal` open a state-aware TUI manager while preserving direct commands and non-TUI behavior
- add guided goal, budget, queue, status, help, and confirmation workflows
- add an interactive `SettingsList` with serialized atomic persistence and unknown-field preservation
- document the redesigned workflow and retain existing RPC, aliases, and persisted state compatibility

## Verification

- `npm run check` (1,349 tests)
- `npm run typecheck --workspace @narumitw/pi-goal`
- `npm run check:boundaries`
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `just pack-goal`
- `pi -ne -p --no-session -e ./extensions/pi-goal "/goal status"`
