### PR TITLE
feat(github-pr): refresh status periodically

### DIFF
--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -1,4 +1,4 @@
-import { watch, type FSWatcher } from "node:fs";
+import { type FSWatcher, watch } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 import type { ExecResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
@@ -45,6 +45,7 @@ const STATUS_KEY = "github-pr";
 const GH_TIMEOUT_MS = 10_000;
 const GIT_TIMEOUT_MS = 5_000;
 const BRANCH_REFRESH_DEBOUNCE_MS = 100;
+const PR_REFRESH_INTERVAL_MS = 60_000;
 const TERMINAL_PR_LIFETIME_MS = 24 * 60 * 60 * 1000;
 const GH_PR_FIELDS = [
 	"number",
@@ -72,38 +73,68 @@ const GH_PR_COUNT_QUERY = `
 	}
 `;
 
-export default function githubPr(pi: ExtensionAPI) {
-	const branchWatch: BranchWatchState = { generation: 0, session: 0 };
+interface GithubPrOptions {
+	refreshIntervalMs?: number;
+}
+
+export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}) {
+	const refreshIntervalMs = options.refreshIntervalMs ?? PR_REFRESH_INTERVAL_MS;
+	if (!Number.isFinite(refreshIntervalMs) || refreshIntervalMs <= 0) {
+		throw new RangeError("refreshIntervalMs must be a positive finite number");
+	}
+	const branchWatch: BranchWatchState = { generation: 0, request: 0, session: 0 };
 	const refreshStatus = async (
 		ctx: ExtensionContext,
 		signal?: AbortSignal,
 		generation = branchWatch.generation,
 	) => {
+		branchWatch.request += 1;
+		const request = branchWatch.request;
 		try {
 			const status = await runGhPrView(pi, ctx.cwd, signal);
-			if (generation === branchWatch.generation) renderStatus(ctx, status, branchWatch, generation);
+			if (generation === branchWatch.generation && request === branchWatch.request) {
+				renderStatus(ctx, status, branchWatch, generation);
+			}
 		} catch (error) {
-			if (generation === branchWatch.generation) {
+			if (generation === branchWatch.generation && request === branchWatch.request) {
 				clearExpiryTimer(branchWatch);
 				renderAmbientFailure(ctx, error);
 			}
 		}
+		return request;
 	};
-	const scheduleBranchRefresh = (ctx: ExtensionContext) => {
+	const schedulePeriodicRefresh = (ctx: ExtensionContext, session: number) => {
+		clearPeriodicRefresh(branchWatch);
+		branchWatch.refreshTimer = setTimeout(async () => {
+			branchWatch.refreshTimer = undefined;
+			if (session !== branchWatch.session) return;
+			const request = await refreshStatus(ctx, ctx.signal);
+			if (session === branchWatch.session && request === branchWatch.request) {
+				schedulePeriodicRefresh(ctx, session);
+			}
+		}, refreshIntervalMs);
+		branchWatch.refreshTimer.unref?.();
+	};
+	const scheduleBranchRefresh = (ctx: ExtensionContext, session: number) => {
 		branchWatch.generation += 1;
 		const generation = branchWatch.generation;
+		clearPeriodicRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		clearStatus(ctx);
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
-		branchWatch.timer = setTimeout(() => {
+		branchWatch.timer = setTimeout(async () => {
 			branchWatch.timer = undefined;
 			if (generation !== branchWatch.generation) return;
-			void refreshStatus(ctx, ctx.signal, generation);
+			const request = await refreshStatus(ctx, ctx.signal, generation);
+			if (session === branchWatch.session && request === branchWatch.request) {
+				schedulePeriodicRefresh(ctx, session);
+			}
 		}, BRANCH_REFRESH_DEBOUNCE_MS);
 	};
 	const closeBranchWatcher = () => {
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = undefined;
+		clearPeriodicRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		branchWatch.watcher?.close();
 		branchWatch.watcher = undefined;
@@ -115,18 +146,26 @@ export default function githubPr(pi: ExtensionAPI) {
 		const session = branchWatch.session;
 		closeBranchWatcher();
 		const watcher = await createBranchWatcher(pi, ctx.cwd, ctx.signal, () => {
-			if (session === branchWatch.session) scheduleBranchRefresh(ctx);
+			if (session === branchWatch.session) scheduleBranchRefresh(ctx, session);
 		});
 		if (session !== branchWatch.session) {
 			watcher?.close();
 			return;
 		}
 		branchWatch.watcher = watcher;
-		await refreshStatus(ctx, ctx.signal);
+		const request = await refreshStatus(ctx, ctx.signal);
+		if (session === branchWatch.session && request === branchWatch.request) {
+			schedulePeriodicRefresh(ctx, session);
+		}
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
-		await refreshStatus(ctx, ctx.signal);
+		const session = branchWatch.session;
+		clearPeriodicRefresh(branchWatch);
+		const request = await refreshStatus(ctx, ctx.signal);
+		if (session === branchWatch.session && request === branchWatch.request) {
+			schedulePeriodicRefresh(ctx, session);
+		}
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -139,9 +178,11 @@ export default function githubPr(pi: ExtensionAPI) {
 
 interface BranchWatchState {
 	generation: number;
+	request: number;
 	session: number;
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
+	refreshTimer?: ReturnType<typeof setTimeout>;
 	expiryTimer?: ReturnType<typeof setTimeout>;
 }
 
@@ -180,14 +221,7 @@ export async function runGhPrView(
 	signal?: AbortSignal,
 ): Promise<PullRequestStatus> {
 	const invocation = ghPrViewInvocation();
-	const result = await execGh(
-		pi,
-		invocation.command,
-		invocation.args,
-		cwd,
-		signal,
-		"gh pr view",
-	);
+	const result = await execGh(pi, invocation.command, invocation.args, cwd, signal, "gh pr view");
 	if (result.killed) throw new Error("gh pr view timed out or was cancelled.");
 	if (result.code !== 0) throw new Error(formatGhFailure("gh pr view", result));
 
@@ -408,6 +442,11 @@ function pullRequestExpiresAt(status: PullRequestStatus): number | undefined {
 	return Number.isFinite(terminalAt) ? terminalAt + TERMINAL_PR_LIFETIME_MS : undefined;
 }
 
+function clearPeriodicRefresh(branchWatch: BranchWatchState) {
+	if (branchWatch.refreshTimer) clearTimeout(branchWatch.refreshTimer);
+	branchWatch.refreshTimer = undefined;
+}
+
 function clearExpiryTimer(branchWatch: BranchWatchState) {
 	if (branchWatch.expiryTimer) clearTimeout(branchWatch.expiryTimer);
 	branchWatch.expiryTimer = undefined;
@@ -421,6 +460,7 @@ export function formatLinkedStatus(status: PullRequestStatus): string {
 }
 
 function stripTerminalControlChars(value: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Strip untrusted terminal controls.
 	return value.replace(/[\x00-\x1f\x7f]/g, "");
 }
 
@@ -557,9 +597,7 @@ function isGhExecutableMissingMessage(lowerMessage: string): boolean {
 		/\b(?:gh|gh\.exe)\b.*\benoent\b|\benoent\b.*\b(?:gh|gh\.exe)\b/.test(lowerMessage) ||
 		/\b(?:gh|gh\.exe): (?:command )?not found\b/.test(lowerMessage) ||
 		/\bcommand not found: (?:gh|gh\.exe)\b/.test(lowerMessage) ||
-		/\benv:\s+['"‘’]?(?:gh|gh\.exe)['"‘’]?: no such file or directory\b/.test(
-			lowerMessage,
-		) ||
+		/\benv:\s+['"‘’]?(?:gh|gh\.exe)['"‘’]?: no such file or directory\b/.test(lowerMessage) ||
 		/['"‘’]?(?:gh|gh\.exe)['"‘’]? is not recognized as an internal or external command\b/.test(
 			lowerMessage,
 		) ||
@@ -571,9 +609,12 @@ function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-function parsePrCoordinates(
-	pr: JsonRecord,
-): { host: string; owner: string; name: string; number: number } {
+function parsePrCoordinates(pr: JsonRecord): {
+	host: string;
+	owner: string;
+	name: string;
+	number: number;
+} {
 	const number = requiredNumber(pr.number, "number");
 	const url = optionalString(pr.url);
 	if (!url) throw new Error("Missing PR url");

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -454,6 +454,191 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	assert.equal(context.notifications.length, 0);
 });
 
+test("rejects invalid periodic refresh intervals", () => {
+	const mock = createMockPi();
+	for (const refreshIntervalMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+		assert.throws(
+			() => githubPr(mock.pi, { refreshIntervalMs }),
+			/refreshIntervalMs must be a positive finite number/,
+		);
+	}
+});
+
+test("periodically refreshes PR state while the session remains open", async () => {
+	const mock = createMockPi();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			return okResult(
+				prViews === 1
+					? samplePr
+					: {
+							...samplePr,
+							reviewDecision: "CHANGES_REQUESTED",
+							latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+						},
+			);
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		assert.match(context.statuses.get("github-pr") ?? "", /approved/);
+		await waitFor(
+			() => (context.statuses.get("github-pr") ?? "").includes("changes requested"),
+			"periodic refresh updates the PR state",
+		);
+		assert.ok(prViews >= 2);
+	} finally {
+		await sessionShutdown({}, context.ctx);
+	}
+	const viewsAtShutdown = prViews;
+	await wait(50);
+	assert.equal(prViews, viewsAtShutdown);
+});
+
+test("an older periodic refresh cannot overwrite a newer agent-end refresh", async () => {
+	const mock = createMockPi();
+	const periodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			if (prViews === 2) return periodicPrView.promise;
+			return okResult({
+				...samplePr,
+				reviewDecision: "CHANGES_REQUESTED",
+				latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+			});
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		await waitFor(() => prViews === 2, "periodic refresh starts");
+		await agentEnd({}, context.ctx);
+		assert.equal(prViews, 3);
+		assert.match(context.statuses.get("github-pr") ?? "", /changes requested/);
+
+		periodicPrView.resolve(okResult(samplePr));
+		await wait(25);
+		assert.match(context.statuses.get("github-pr") ?? "", /changes requested/);
+	} finally {
+		periodicPrView.resolve(okResult(samplePr));
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("an older refresh cannot postpone a newer refresh timer", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const mock = createMockPi();
+	const oldPeriodicPrView = deferred<ExecResult>();
+	const nextPeriodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			if (prViews === 2) return oldPeriodicPrView.promise;
+			if (prViews === 3) {
+				return okResult({
+					...samplePr,
+					reviewDecision: "CHANGES_REQUESTED",
+					latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+				});
+			}
+			return nextPeriodicPrView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		t.mock.timers.tick(100);
+		assert.equal(prViews, 2);
+
+		await agentEnd({}, context.ctx);
+		assert.equal(prViews, 3);
+		t.mock.timers.tick(50);
+		oldPeriodicPrView.resolve(okResult(samplePr));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		t.mock.timers.tick(50);
+		assert.equal(prViews, 4);
+	} finally {
+		oldPeriodicPrView.resolve(okResult(samplePr));
+		nextPeriodicPrView.resolve(okResult(samplePr));
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("an in-flight periodic refresh cannot restore status after shutdown", async () => {
+	const mock = createMockPi();
+	const periodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			return periodicPrView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	await sessionStart({}, context.ctx);
+	await waitFor(() => prViews === 2, "periodic refresh starts");
+	await sessionShutdown({}, context.ctx);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+
+	periodicPrView.resolve(
+		okResult({
+			...samplePr,
+			reviewDecision: "CHANGES_REQUESTED",
+			latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+		}),
+	);
+	await wait(25);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+	assert.equal(prViews, 2);
+});
+
 test("recent terminal pull request status clears when its 24-hour lifetime expires", async () => {
 	const mock = createMockPi();
 	const mergedAt = new Date(Date.now() - 24 * 60 * 60 * 1000 + 1_000).toISOString();


### PR DESCRIPTION
## Summary

- refresh GitHub pull request status every minute while a session remains open
- prevent stale overlapping refreshes from replacing newer status
- stop and restart refresh timers across branch changes, agent completion, and session shutdown

## Testing

- `npm run check --workspace @narumitw/pi-github-pr`
- `node --test node_modules/.cache/pi-extensions-test/extensions/pi-github-pr/test/github-pr.test.js`
