### PR TITLE
fix(statusline): drop whole segments when width constrained

### DIFF
--- a/extensions/pi-statusline/src/powerline.ts
+++ b/extensions/pi-statusline/src/powerline.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { ansiStyle } from "./ansi.js";
 import { resolvePreset } from "./presets/index.js";
 import type { BlockColors, PowerlinePreset } from "./presets/types.js";
@@ -79,7 +79,8 @@ function fitPowerlineSegments(
 		}
 		fitted.splice(removalIndex, 1);
 	}
-	return truncateToWidth(joinPowerlineSegments(fitted, config), width, "");
+	const rendered = joinPowerlineSegments(fitted, config);
+	return visibleWidth(rendered) <= width ? rendered : "";
 }
 
 export function powerlineExtensionSeparator(

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -197,14 +197,14 @@ test("responsive fitting preserves explicit row boundaries and fits every render
 	assert.ok(lines.every((line) => visibleWidth(line) <= 15));
 });
 
-test("responsive fitting truncates one oversized segment and preserves empty explicit rows", () => {
+test("responsive fitting removes one oversized segment and preserves empty explicit rows", () => {
 	const config = createDefaultConfig();
 	const oversized = renderPowerlineStatusline(
 		8,
 		[segment("model", "A VERY LONG MODEL", "header")],
 		config,
 	);
-	assert.ok(visibleWidth(oversized) <= 8);
+	assert.equal(oversized, "");
 
 	const multiline = renderPowerlineStatusline(
 		20,


### PR DESCRIPTION
## Summary

- avoid rendering a partially truncated Powerline segment when the available width is too narrow
- preserve the existing priority-based segment fitting behavior
- render an empty row when the final retained segment cannot fit whole

## Testing

- `npm run check --workspace @narumitw/pi-statusline`
- `node --test node_modules/.cache/pi-extensions-test/extensions/pi-statusline/test/renderer.test.js`
