### PR TITLE
feat(github-pr): refresh status with lifecycle cancellation

### DIFF
--- a/extensions/pi-github-pr/README.md
+++ b/extensions/pi-github-pr/README.md
@@ -11,11 +11,11 @@ It is intentionally ambient: no slash command, no custom tool, no widget, and no
 ## ✨ Features
 
 - Automatically shows compact PR status in Pi's statusline.
-- Refreshes the current branch PR after agent turns.
+- Refreshes the current branch PR every minute and after agent turns.
 - Shows PR number, GitHub checks state, review state, and comment/review count.
 - Does not read or expose PR discussion text; use `gh pr view --comments` or GitHub directly when you need the conversation.
 - Uses GitHub CLI auth and repository resolution; the extension stores no GitHub token.
-- No slash commands, LLM tools, widgets, polling loop, webhook server, or runtime service.
+- No slash commands, LLM tools, widgets, webhook server, or separate runtime service.
 
 Example statusline text:
 
@@ -67,7 +67,8 @@ The extension runs passively:
 
 - On session start, it checks the current branch PR and sets a compact statusline entry.
 - On Git branch change, it clears the old PR immediately and refreshes the new current branch.
-- After each agent turn, it refreshes that same current branch PR status.
+- While the session remains open, it refreshes that same current branch PR every 60 seconds and after each agent turn.
+- On branch change, session replacement, or session shutdown, it cancels the previous refresh timer and any in-flight periodic request.
 - On session shutdown, it clears the statusline entry.
 - If the directory has no GitHub PR, the statusline entry stays empty.
 - If `gh` is missing or unauthenticated, the statusline shows a short hint such as `PR gh missing` or `PR gh auth`.
@@ -78,7 +79,7 @@ The extension runs passively:
 - Only the current branch PR is shown; there is no command or tool for arbitrary PR lookup.
 - Comment count uses `gh pr view` comments and reviews, not precise unresolved review-thread counts.
 - It does not read PR comment bodies, review bodies, inline diff comments, or unresolved review-thread text.
-- No continuous polling; refresh happens on session start, branch change, and after agent turns.
+- While a session is open, refresh runs every 60 seconds in addition to session start, branch changes, and agent turns; each refresh invokes `gh pr view` and one GraphQL count query.
 
 ## 📁 Package layout
 

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -177,6 +177,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (ctx.sessionManager !== branchWatch.sessionManager) return;
+		branchWatch.sessionManager = undefined;
 		branchWatch.generation += 1;
 		branchWatch.session += 1;
 		closeBranchWatcher();

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -148,6 +148,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	pi.on("session_start", async (_event, ctx) => {
 		branchWatch.generation += 1;
 		branchWatch.session += 1;
+		branchWatch.sessionManager = ctx.sessionManager;
 		const session = branchWatch.session;
 		closeBranchWatcher();
 		const watcher = await createBranchWatcher(pi, ctx.cwd, ctx.signal, () => {
@@ -165,6 +166,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
+		if (ctx.sessionManager !== branchWatch.sessionManager) return;
 		const session = branchWatch.session;
 		cancelPeriodicRefresh(branchWatch);
 		const request = await refreshStatus(ctx, ctx.signal);
@@ -174,6 +176,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
+		if (ctx.sessionManager !== branchWatch.sessionManager) return;
 		branchWatch.generation += 1;
 		branchWatch.session += 1;
 		closeBranchWatcher();
@@ -185,6 +188,7 @@ interface BranchWatchState {
 	generation: number;
 	request: number;
 	session: number;
+	sessionManager?: ExtensionContext["sessionManager"];
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
 	refreshTimer?: ReturnType<typeof setTimeout>;

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -45,6 +45,7 @@ const STATUS_KEY = "github-pr";
 const GH_TIMEOUT_MS = 10_000;
 const GIT_TIMEOUT_MS = 5_000;
 const BRANCH_REFRESH_DEBOUNCE_MS = 100;
+const PR_REFRESH_INTERVAL_MS = 60_000;
 const TERMINAL_PR_LIFETIME_MS = 24 * 60 * 60 * 1000;
 const GH_PR_FIELDS = [
 	"number",
@@ -72,38 +73,68 @@ const GH_PR_COUNT_QUERY = `
 	}
 `;
 
-export default function githubPr(pi: ExtensionAPI) {
-	const branchWatch: BranchWatchState = { generation: 0, session: 0 };
+interface GithubPrOptions {
+	refreshIntervalMs?: number;
+}
+
+export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}) {
+	const refreshIntervalMs = options.refreshIntervalMs ?? PR_REFRESH_INTERVAL_MS;
+	if (!Number.isFinite(refreshIntervalMs) || refreshIntervalMs <= 0) {
+		throw new RangeError("refreshIntervalMs must be a positive finite number");
+	}
+	const branchWatch: BranchWatchState = { generation: 0, request: 0, session: 0 };
 	const refreshStatus = async (
 		ctx: ExtensionContext,
 		signal?: AbortSignal,
 		generation = branchWatch.generation,
 	) => {
+		branchWatch.request += 1;
+		const request = branchWatch.request;
 		try {
 			const status = await runGhPrView(pi, ctx.cwd, signal);
-			if (generation === branchWatch.generation) renderStatus(ctx, status, branchWatch, generation);
+			if (generation === branchWatch.generation && request === branchWatch.request) {
+				renderStatus(ctx, status, branchWatch, generation);
+			}
 		} catch (error) {
-			if (generation === branchWatch.generation) {
+			if (generation === branchWatch.generation && request === branchWatch.request) {
 				clearExpiryTimer(branchWatch);
 				renderAmbientFailure(ctx, error);
 			}
 		}
+		return request;
 	};
-	const scheduleBranchRefresh = (ctx: ExtensionContext) => {
+	const schedulePeriodicRefresh = (ctx: ExtensionContext, session: number) => {
+		clearPeriodicRefresh(branchWatch);
+		branchWatch.refreshTimer = setTimeout(async () => {
+			branchWatch.refreshTimer = undefined;
+			if (session !== branchWatch.session) return;
+			const request = await refreshStatus(ctx, ctx.signal);
+			if (session === branchWatch.session && request === branchWatch.request) {
+				schedulePeriodicRefresh(ctx, session);
+			}
+		}, refreshIntervalMs);
+		branchWatch.refreshTimer.unref?.();
+	};
+	const scheduleBranchRefresh = (ctx: ExtensionContext, session: number) => {
 		branchWatch.generation += 1;
 		const generation = branchWatch.generation;
+		clearPeriodicRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		clearStatus(ctx);
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
-		branchWatch.timer = setTimeout(() => {
+		branchWatch.timer = setTimeout(async () => {
 			branchWatch.timer = undefined;
 			if (generation !== branchWatch.generation) return;
-			void refreshStatus(ctx, ctx.signal, generation);
+			const request = await refreshStatus(ctx, ctx.signal, generation);
+			if (session === branchWatch.session && request === branchWatch.request) {
+				schedulePeriodicRefresh(ctx, session);
+			}
 		}, BRANCH_REFRESH_DEBOUNCE_MS);
 	};
 	const closeBranchWatcher = () => {
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = undefined;
+		clearPeriodicRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		branchWatch.watcher?.close();
 		branchWatch.watcher = undefined;
@@ -115,18 +146,26 @@ export default function githubPr(pi: ExtensionAPI) {
 		const session = branchWatch.session;
 		closeBranchWatcher();
 		const watcher = await createBranchWatcher(pi, ctx.cwd, ctx.signal, () => {
-			if (session === branchWatch.session) scheduleBranchRefresh(ctx);
+			if (session === branchWatch.session) scheduleBranchRefresh(ctx, session);
 		});
 		if (session !== branchWatch.session) {
 			watcher?.close();
 			return;
 		}
 		branchWatch.watcher = watcher;
-		await refreshStatus(ctx, ctx.signal);
+		const request = await refreshStatus(ctx, ctx.signal);
+		if (session === branchWatch.session && request === branchWatch.request) {
+			schedulePeriodicRefresh(ctx, session);
+		}
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
-		await refreshStatus(ctx, ctx.signal);
+		const session = branchWatch.session;
+		clearPeriodicRefresh(branchWatch);
+		const request = await refreshStatus(ctx, ctx.signal);
+		if (session === branchWatch.session && request === branchWatch.request) {
+			schedulePeriodicRefresh(ctx, session);
+		}
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -139,9 +178,11 @@ export default function githubPr(pi: ExtensionAPI) {
 
 interface BranchWatchState {
 	generation: number;
+	request: number;
 	session: number;
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
+	refreshTimer?: ReturnType<typeof setTimeout>;
 	expiryTimer?: ReturnType<typeof setTimeout>;
 }
 
@@ -399,6 +440,11 @@ function pullRequestExpiresAt(status: PullRequestStatus): number | undefined {
 	if (!timestamp) return undefined;
 	const terminalAt = Date.parse(timestamp);
 	return Number.isFinite(terminalAt) ? terminalAt + TERMINAL_PR_LIFETIME_MS : undefined;
+}
+
+function clearPeriodicRefresh(branchWatch: BranchWatchState) {
+	if (branchWatch.refreshTimer) clearTimeout(branchWatch.refreshTimer);
+	branchWatch.refreshTimer = undefined;
 }
 
 function clearExpiryTimer(branchWatch: BranchWatchState) {

--- a/extensions/pi-github-pr/src/github-pr.ts
+++ b/extensions/pi-github-pr/src/github-pr.ts
@@ -104,11 +104,16 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		return request;
 	};
 	const schedulePeriodicRefresh = (ctx: ExtensionContext, session: number) => {
-		clearPeriodicRefresh(branchWatch);
+		cancelPeriodicRefresh(branchWatch);
 		branchWatch.refreshTimer = setTimeout(async () => {
 			branchWatch.refreshTimer = undefined;
 			if (session !== branchWatch.session) return;
-			const request = await refreshStatus(ctx, ctx.signal);
+			const controller = new AbortController();
+			branchWatch.refreshController = controller;
+			const request = await refreshStatus(ctx, controller.signal);
+			if (branchWatch.refreshController === controller) {
+				branchWatch.refreshController = undefined;
+			}
 			if (session === branchWatch.session && request === branchWatch.request) {
 				schedulePeriodicRefresh(ctx, session);
 			}
@@ -118,7 +123,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	const scheduleBranchRefresh = (ctx: ExtensionContext, session: number) => {
 		branchWatch.generation += 1;
 		const generation = branchWatch.generation;
-		clearPeriodicRefresh(branchWatch);
+		cancelPeriodicRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		clearStatus(ctx);
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
@@ -134,7 +139,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	const closeBranchWatcher = () => {
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = undefined;
-		clearPeriodicRefresh(branchWatch);
+		cancelPeriodicRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		branchWatch.watcher?.close();
 		branchWatch.watcher = undefined;
@@ -161,7 +166,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 
 	pi.on("agent_end", async (_event, ctx) => {
 		const session = branchWatch.session;
-		clearPeriodicRefresh(branchWatch);
+		cancelPeriodicRefresh(branchWatch);
 		const request = await refreshStatus(ctx, ctx.signal);
 		if (session === branchWatch.session && request === branchWatch.request) {
 			schedulePeriodicRefresh(ctx, session);
@@ -183,6 +188,7 @@ interface BranchWatchState {
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
 	refreshTimer?: ReturnType<typeof setTimeout>;
+	refreshController?: AbortController;
 	expiryTimer?: ReturnType<typeof setTimeout>;
 }
 
@@ -442,9 +448,11 @@ function pullRequestExpiresAt(status: PullRequestStatus): number | undefined {
 	return Number.isFinite(terminalAt) ? terminalAt + TERMINAL_PR_LIFETIME_MS : undefined;
 }
 
-function clearPeriodicRefresh(branchWatch: BranchWatchState) {
+function cancelPeriodicRefresh(branchWatch: BranchWatchState) {
 	if (branchWatch.refreshTimer) clearTimeout(branchWatch.refreshTimer);
 	branchWatch.refreshTimer = undefined;
+	branchWatch.refreshController?.abort();
+	branchWatch.refreshController = undefined;
 }
 
 function clearExpiryTimer(branchWatch: BranchWatchState) {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -602,15 +602,17 @@ test("an older refresh cannot postpone a newer refresh timer", async (t) => {
 	}
 });
 
-test("an in-flight periodic refresh cannot restore status after shutdown", async () => {
+test("session shutdown aborts an in-flight periodic refresh", async () => {
 	const mock = createMockPi();
 	const periodicPrView = deferred<ExecResult>();
 	let prViews = 0;
-	installExec(mock, async (command, args) => {
+	let periodicSignal: AbortSignal | undefined;
+	installExec(mock, async (command, args, options) => {
 		if (command === "git") return textResult("", 128, "not a git repository");
 		if (args[0] === "pr") {
 			prViews += 1;
 			if (prViews === 1) return okResult(samplePr);
+			periodicSignal = options?.signal;
 			return periodicPrView.promise;
 		}
 		return okResult(sampleCounts);
@@ -622,21 +624,72 @@ test("an in-flight periodic refresh cannot restore status after shutdown", async
 	assert.ok(sessionStart);
 	assert.ok(sessionShutdown);
 
-	await sessionStart({}, context.ctx);
-	await waitFor(() => prViews === 2, "periodic refresh starts");
-	await sessionShutdown({}, context.ctx);
-	assert.equal(context.statuses.get("github-pr"), undefined);
+	try {
+		await sessionStart({}, context.ctx);
+		await waitFor(() => prViews === 2, "periodic refresh starts");
+		assert.ok(periodicSignal, "periodic refresh receives a session-owned abort signal");
+		assert.equal(periodicSignal.aborted, false);
 
-	periodicPrView.resolve(
-		okResult({
-			...samplePr,
-			reviewDecision: "CHANGES_REQUESTED",
-			latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
-		}),
-	);
-	await wait(25);
-	assert.equal(context.statuses.get("github-pr"), undefined);
-	assert.equal(prViews, 2);
+		await sessionShutdown({}, context.ctx);
+		assert.equal(periodicSignal.aborted, true);
+		assert.equal(context.statuses.get("github-pr"), undefined);
+
+		periodicPrView.resolve(
+			okResult({
+				...samplePr,
+				reviewDecision: "CHANGES_REQUESTED",
+				latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+			}),
+		);
+		await wait(25);
+		assert.equal(context.statuses.get("github-pr"), undefined);
+		assert.equal(prViews, 2);
+	} finally {
+		periodicPrView.resolve(okResult(samplePr));
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("branch changes abort an in-flight periodic refresh", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-github-pr-test-"));
+	const gitDir = join(root, ".git");
+	const headPath = join(gitDir, "HEAD");
+	mkdirSync(gitDir);
+	writeFileSync(headPath, "ref: refs/heads/feature\n");
+
+	const periodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	let periodicSignal: AbortSignal | undefined;
+	const mock = createMockPi();
+	installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult(".git/HEAD\n");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			periodicSignal = options?.signal;
+			return periodicPrView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: root });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		await waitFor(() => prViews === 2, "periodic refresh starts");
+		assert.ok(periodicSignal, "periodic refresh receives a session-owned abort signal");
+		assert.equal(periodicSignal.aborted, false);
+
+		writeFileSync(headPath, "ref: refs/heads/main\n");
+		await waitFor(() => periodicSignal?.aborted === true, "branch change aborts periodic refresh");
+	} finally {
+		periodicPrView.resolve(okResult(samplePr));
+		await sessionShutdown({}, context.ctx);
+	}
 });
 
 test("recent terminal pull request status clears when its 24-hour lifetime expires", async () => {

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -454,6 +454,191 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	assert.equal(context.notifications.length, 0);
 });
 
+test("rejects invalid periodic refresh intervals", () => {
+	const mock = createMockPi();
+	for (const refreshIntervalMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+		assert.throws(
+			() => githubPr(mock.pi, { refreshIntervalMs }),
+			/refreshIntervalMs must be a positive finite number/,
+		);
+	}
+});
+
+test("periodically refreshes PR state while the session remains open", async () => {
+	const mock = createMockPi();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			return okResult(
+				prViews === 1
+					? samplePr
+					: {
+							...samplePr,
+							reviewDecision: "CHANGES_REQUESTED",
+							latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+						},
+			);
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		assert.match(context.statuses.get("github-pr") ?? "", /approved/);
+		await waitFor(
+			() => (context.statuses.get("github-pr") ?? "").includes("changes requested"),
+			"periodic refresh updates the PR state",
+		);
+		assert.ok(prViews >= 2);
+	} finally {
+		await sessionShutdown({}, context.ctx);
+	}
+	const viewsAtShutdown = prViews;
+	await wait(50);
+	assert.equal(prViews, viewsAtShutdown);
+});
+
+test("an older periodic refresh cannot overwrite a newer agent-end refresh", async () => {
+	const mock = createMockPi();
+	const periodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			if (prViews === 2) return periodicPrView.promise;
+			return okResult({
+				...samplePr,
+				reviewDecision: "CHANGES_REQUESTED",
+				latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+			});
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		await waitFor(() => prViews === 2, "periodic refresh starts");
+		await agentEnd({}, context.ctx);
+		assert.equal(prViews, 3);
+		assert.match(context.statuses.get("github-pr") ?? "", /changes requested/);
+
+		periodicPrView.resolve(okResult(samplePr));
+		await wait(25);
+		assert.match(context.statuses.get("github-pr") ?? "", /changes requested/);
+	} finally {
+		periodicPrView.resolve(okResult(samplePr));
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("an older refresh cannot postpone a newer refresh timer", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const mock = createMockPi();
+	const oldPeriodicPrView = deferred<ExecResult>();
+	const nextPeriodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			if (prViews === 2) return oldPeriodicPrView.promise;
+			if (prViews === 3) {
+				return okResult({
+					...samplePr,
+					reviewDecision: "CHANGES_REQUESTED",
+					latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+				});
+			}
+			return nextPeriodicPrView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		t.mock.timers.tick(100);
+		assert.equal(prViews, 2);
+
+		await agentEnd({}, context.ctx);
+		assert.equal(prViews, 3);
+		t.mock.timers.tick(50);
+		oldPeriodicPrView.resolve(okResult(samplePr));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		t.mock.timers.tick(50);
+		assert.equal(prViews, 4);
+	} finally {
+		oldPeriodicPrView.resolve(okResult(samplePr));
+		nextPeriodicPrView.resolve(okResult(samplePr));
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("an in-flight periodic refresh cannot restore status after shutdown", async () => {
+	const mock = createMockPi();
+	const periodicPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 1) return okResult(samplePr);
+			return periodicPrView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	await sessionStart({}, context.ctx);
+	await waitFor(() => prViews === 2, "periodic refresh starts");
+	await sessionShutdown({}, context.ctx);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+
+	periodicPrView.resolve(
+		okResult({
+			...samplePr,
+			reviewDecision: "CHANGES_REQUESTED",
+			latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+		}),
+	);
+	await wait(25);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+	assert.equal(prViews, 2);
+});
+
 test("recent terminal pull request status clears when its 24-hour lifetime expires", async () => {
 	const mock = createMockPi();
 	const mergedAt = new Date(Date.now() - 24 * 60 * 60 * 1000 + 1_000).toISOString();

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -543,6 +543,35 @@ test("a replaced session's late lifecycle events cannot disrupt its replacement"
 	}
 });
 
+test("agent-end after session shutdown cannot restart polling", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const mock = createMockPi();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") prViews += 1;
+		return okResult(args[0] === "pr" ? samplePr : sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	await sessionStart({}, context.ctx);
+	await sessionShutdown({}, context.ctx);
+	await agentEnd({}, context.ctx);
+	t.mock.timers.tick(100);
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.equal(prViews, 1);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+});
+
 test("an older periodic refresh cannot overwrite a newer agent-end refresh", async () => {
 	const mock = createMockPi();
 	const periodicPrView = deferred<ExecResult>();

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -506,6 +506,43 @@ test("periodically refreshes PR state while the session remains open", async () 
 	assert.equal(prViews, viewsAtShutdown);
 });
 
+test("a replaced session's late lifecycle events cannot disrupt its replacement", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const mock = createMockPi();
+	const prCwds: string[] = [];
+	installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") prCwds.push(options?.cwd ?? "");
+		return okResult(args[0] === "pr" ? samplePr : sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const oldContext = createMockContext({ cwd: "/repo-a" });
+	const currentContext = createMockContext({ cwd: "/repo-b" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, oldContext.ctx);
+		await sessionStart({}, currentContext.ctx);
+		assert.deepEqual(prCwds, ["/repo-a", "/repo-b"]);
+
+		await sessionShutdown({}, oldContext.ctx);
+		await agentEnd({}, oldContext.ctx);
+		assert.deepEqual(prCwds, ["/repo-a", "/repo-b"]);
+
+		t.mock.timers.tick(100);
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.deepEqual(prCwds, ["/repo-a", "/repo-b", "/repo-b"]);
+	} finally {
+		await sessionShutdown({}, currentContext.ctx);
+	}
+});
+
 test("an older periodic refresh cannot overwrite a newer agent-end refresh", async () => {
 	const mock = createMockPi();
 	const periodicPrView = deferred<ExecResult>();


### PR DESCRIPTION
## Summary

- refresh GitHub PR status periodically while a Pi session remains open
- give each periodic refresh a lifecycle-owned abort signal
- cancel in-flight periodic `gh pr view` and GraphQL work when an agent refresh, branch change, or session cleanup supersedes it
- retain stale-result guards and add shutdown and branch-change cancellation coverage

## Root cause

Periodic callbacks reused `ctx.signal`, which can be undefined while Pi is idle. Clearing the next timer during cleanup therefore prevented future refreshes but could not stop an already-running GitHub CLI subprocess.

This supersedes #394 with lifecycle cancellation for the periodic work.

## Impact

Reloading, switching branches or sessions, and shutting down no longer leave obsolete periodic GitHub CLI requests running until completion or timeout.

## Validation

- `pi-github-pr` focused tests: 24 passed
- Biome check, extension boundary check, and all workspace typechecks passed
- compiled repository test suite excluding `extensions/pi-subagents/test/runner-render.test.js`: 1,330 passed


Closes #394 