### PR TITLE
fix: include root dependencies in updates

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ format:
 
 # Update, install, rebuild, and verify dependencies across all npm workspaces
 update:
-    npx npm-check-updates --workspaces -u
+    npx npm-check-updates --workspaces --root -u
     npm install
     # Rebuild generated web assets only in workspaces that provide build:web
     npm --workspaces --if-present run build:web


### PR DESCRIPTION
## Summary
- include the root package when updating workspace dependencies
- keep root-owned shared tooling in the dependency update workflow

## Verification
- `just --dry-run update`
- `git diff --check`