### PR TITLE
fix: skip non-package directories in try-all

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,9 +63,9 @@ pack name: (_validate-extension-name name)
 try name: (_validate-extension-name name)
     name={{quote(name)}}; pi -e "./extensions/pi-$name"
 
-# Start a fresh Pi session with every local extension loaded
+# Start a fresh Pi session with every local extension package loaded
 try-all:
-    args=(); for dir in ./extensions/pi-*; do args+=(-e "$dir"); done; pi -ne "${args[@]}"
+    args=(); for package_json in ./extensions/pi-*/package.json; do args+=(-e "$(dirname "$package_json")"); done; pi -ne "${args[@]}"
 
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents


### PR DESCRIPTION
## Summary

- discover local extension packages through their `package.json` manifests
- skip stale or empty `pi-*` directories such as `pi-telegraph`

## Verification

- mocked `pi` smoke confirmed all 20 valid extension packages are passed and `pi-telegraph` is skipped
- `npm run check` (1,380 tests passed)
- `git diff --check`