### PR TITLE
fix(goal): resolve late manager review feedback

### DIFF
--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -585,6 +585,7 @@ export class GoalCommandController {
 				this.runtime.queuedGoals,
 				this.runtime.settings.experimental.goals,
 				this.runtime.queueFrozen,
+				this.runtime.pendingQueueAction,
 			),
 		);
 	}

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -1063,6 +1063,7 @@ export function goalSummary(
 	queuedGoals: readonly ActiveGoal[] = [],
 	experimentalGoals = false,
 	queueFrozen = false,
+	pendingAction?: PendingQueueAction,
 ) {
 	const summary = [
 		`Goal: ${goal.text}`,
@@ -1077,12 +1078,18 @@ export function goalSummary(
 			`Safety pause: ${goal.safetyPauseCause === "continuation_limit" ? "automatic response limit" : "no progress"}`,
 		);
 	}
-	if (experimentalGoals || queuedGoals.length > 0 || queueFrozen) {
+	if (experimentalGoals || queuedGoals.length > 0 || queueFrozen || pendingAction) {
+		const goals = [goal, ...queuedGoals].map(
+			(queuedGoal, index) => `${index + 1}. [${queuedGoal.status}] ${queuedGoal.text}`,
+		);
+		if (pendingAction?.kind === "prioritize") {
+			goals.push(`${goals.length + 1}. [pending] ${pendingAction.objective}`);
+		}
+		summary.push(`Goals (${goals.length}):`, ...goals);
+	}
+	if (pendingAction?.kind === "advance") {
 		summary.push(
-			`Goals (${queuedGoals.length + 1}):`,
-			...[goal, ...queuedGoals].map(
-				(queuedGoal, index) => `${index + 1}. [${queuedGoal.status}] ${queuedGoal.text}`,
-			),
+			`Pending queue action: ${pendingAction.reason === "complete" ? "complete" : "skip"} current goal when Pi settles.`,
 		);
 	}
 	if (queueFrozen) {

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -1079,13 +1079,15 @@ export function goalSummary(
 		);
 	}
 	if (experimentalGoals || queuedGoals.length > 0 || queueFrozen || pendingAction) {
-		const goals = [goal, ...queuedGoals].map(
-			(queuedGoal, index) => `${index + 1}. [${queuedGoal.status}] ${queuedGoal.text}`,
+		const orderedGoals = [
+			`[${goal.status}] ${goal.text}`,
+			...(pendingAction?.kind === "prioritize" ? [`[pending] ${pendingAction.objective}`] : []),
+			...queuedGoals.map((queuedGoal) => `[${queuedGoal.status}] ${queuedGoal.text}`),
+		];
+		summary.push(
+			`Goals (${orderedGoals.length}):`,
+			...orderedGoals.map((queuedGoal, index) => `${index + 1}. ${queuedGoal}`),
 		);
-		if (pendingAction?.kind === "prioritize") {
-			goals.push(`${goals.length + 1}. [pending] ${pendingAction.objective}`);
-		}
-		summary.push(`Goals (${goals.length}):`, ...goals);
 	}
 	if (pendingAction?.kind === "advance") {
 		summary.push(

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -41,7 +41,7 @@ export async function showGoalSettings(
 		if (!result) return;
 		if (result.kind === "queue") {
 			const next = await nextQueueSettings(runtime, ctx, result.enabled);
-			if (!next) continue;
+			if (!next) return;
 			const wasFrozen = runtime.queueFrozen;
 			try {
 				applyGoalSettings(runtime, next, ctx, {
@@ -61,7 +61,7 @@ export async function showGoalSettings(
 			} catch (error) {
 				ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
 			}
-			continue;
+			return;
 		}
 
 		const previous = runtime.settings.continuationLimits[result.field];

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -20,7 +20,10 @@ interface GoalSettingsApplyOptions {
 }
 
 type LimitField = "automaticTurns" | "noProgressTurns";
-type SettingsScreenResult = { kind: "limit"; field: LimitField } | undefined;
+type SettingsScreenResult =
+	| { kind: "limit"; field: LimitField }
+	| { kind: "queue"; enabled: boolean }
+	| undefined;
 
 export async function showGoalSettings(
 	runtime: GoalRuntime,
@@ -36,6 +39,31 @@ export async function showGoalSettings(
 	while (true) {
 		const result = await showSettingsScreen(runtime, ctx, settingsPath, options);
 		if (!result) return;
+		if (result.kind === "queue") {
+			const next = await nextQueueSettings(runtime, ctx, result.enabled);
+			if (!next) continue;
+			const wasFrozen = runtime.queueFrozen;
+			try {
+				applyGoalSettings(runtime, next, ctx, {
+					save: (settings) => (options.save ?? saveGoalSettings)(settings, settingsPath),
+				});
+				if (wasFrozen && !runtime.queueFrozen) {
+					try {
+						await options.onQueueUnfrozen?.(ctx);
+					} catch (error) {
+						ctx.ui.notify(
+							`Goal queue enabled, but automatic resume failed: ${formatError(error)}. Reopen /goal to retry.`,
+							"warning",
+						);
+					}
+				}
+				ctx.ui.notify(`Ordered goal queue: ${result.enabled ? "Experimental" : "Off"}.`, "info");
+			} catch (error) {
+				ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
+			}
+			continue;
+		}
+
 		const previous = runtime.settings.continuationLimits[result.field];
 		const raw = await ctx.ui.input(
 			result.field === "automaticTurns" ? "Automatic response limit" : "No-progress run limit",
@@ -190,39 +218,23 @@ async function showSettingsScreen(
 					closeAfterSaves({ kind: "limit", field: id });
 					return;
 				}
-				if (id !== "toolVisibility" && id !== "experimentalGoals") return;
+				if (id === "experimentalGoals") {
+					closeAfterSaves({ kind: "queue", enabled: newValue === "Experimental" });
+					return;
+				}
+				if (id !== "toolVisibility") return;
 				latestRequested.set(id, newValue);
 				const operation = saveQueue.then(async () => {
-					const previousValue =
-						id === "toolVisibility"
-							? visibilityLabel(runtime.settings.toolVisibility)
-							: runtime.settings.experimental.goals
-								? "Experimental"
-								: "Off";
+					const previousValue = visibilityLabel(runtime.settings.toolVisibility);
 					try {
-						const next = await nextToggleSettings(runtime, ctx, id, newValue);
-						if (!next) {
-							if (latestRequested.get(id) === newValue) {
-								settingsList.updateValue(id, previousValue);
-							}
-							tui.requestRender();
-							return;
-						}
-						const wasFrozen = runtime.queueFrozen;
+						const next = {
+							...structuredClone(runtime.settings),
+							toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
+						} satisfies GoalSettings;
 						applyGoalSettings(runtime, next, ctx, {
 							save: (value) => (options.save ?? saveGoalSettings)(value, settingsPath),
 						});
-						if (wasFrozen && !runtime.queueFrozen) {
-							try {
-								await options.onQueueUnfrozen?.(ctx);
-							} catch (error) {
-								ctx.ui.notify(
-									`Goal queue enabled, but automatic resume failed: ${formatError(error)}. Reopen /goal to retry.`,
-									"warning",
-								);
-							}
-						}
-						ctx.ui.notify(`${settingLabel(id)}: ${newValue}.`, "info");
+						ctx.ui.notify(`Goal tools: ${newValue}.`, "info");
 					} catch (error) {
 						if (latestRequested.get(id) === newValue) {
 							settingsList.updateValue(id, previousValue);
@@ -252,19 +264,12 @@ async function showSettingsScreen(
 	});
 }
 
-async function nextToggleSettings(
+async function nextQueueSettings(
 	runtime: GoalRuntime,
 	ctx: ExtensionCommandContext,
-	id: "toolVisibility" | "experimentalGoals",
-	newValue: string,
+	enabled: boolean,
 ) {
-	if (id === "toolVisibility") {
-		return {
-			...structuredClone(runtime.settings),
-			toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
-		} satisfies GoalSettings;
-	}
-	const enabled = newValue === "Experimental";
+	if (runtime.settings.experimental.goals === enabled) return undefined;
 	if (enabled && !runtime.settings.experimental.goals) {
 		const confirmed = await ctx.ui.confirm(
 			"Enable experimental goal queue?",
@@ -277,7 +282,7 @@ async function nextToggleSettings(
 		(runtime.queuedGoals.length > 0 || runtime.pendingQueueAction !== undefined) &&
 		!(await ctx.ui.confirm(
 			"Freeze ordered goal queue?",
-			`Disabling the experiment preserves ${runtime.queuedGoals.length + 1} goal(s) but freezes automatic work until the setting is re-enabled. No goal data will be deleted.`,
+			`Disabling the experiment preserves ${retainedGoalCount(runtime)} goal(s) but freezes automatic work until the setting is re-enabled. No goal data will be deleted.`,
 		))
 	) {
 		return undefined;
@@ -402,8 +407,12 @@ function visibilityLabel(value: GoalSettings["toolVisibility"]) {
 	return value === "always" ? "Always" : "After first goal";
 }
 
-function settingLabel(id: "toolVisibility" | "experimentalGoals") {
-	return id === "toolVisibility" ? "Goal tools" : "Ordered goal queue";
+function retainedGoalCount(runtime: GoalRuntime) {
+	return (
+		(runtime.activeGoal ? 1 : 0) +
+		runtime.queuedGoals.length +
+		(runtime.pendingQueueAction?.kind === "prioritize" ? 1 : 0)
+	);
 }
 
 function safeTerminalText(value: string) {

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -511,8 +511,8 @@ test("full goal status includes a pending priority objective", () => {
 	const summary = context.notifications.at(-1)?.message ?? "";
 	assert.match(summary, /Goals \(3\):/);
 	assert.match(summary, /1\. \[active\] current objective/);
-	assert.match(summary, /2\. \[queued\] queued objective/);
-	assert.match(summary, /3\. \[pending\] urgent objective/);
+	assert.match(summary, /2\. \[pending\] urgent objective/);
+	assert.match(summary, /3\. \[queued\] queued objective/);
 });
 
 test("queue confirmations open only after the custom settings screen closes", async () => {
@@ -597,6 +597,7 @@ test("settings screen resumes retained work after enabling the queue", async () 
 	assert.equal(state.queueFrozen, false);
 	assert.equal(state.settings.experimental.goals, true);
 	assert.equal(unfrozen, 1);
+	assert.equal(screens, 1);
 });
 
 test("settings screen fits narrow, normal, and wide terminal widths", async () => {

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -496,22 +496,91 @@ test("lowered limit confirmation cannot apply to a replacement goal", async () =
 	assert.match(context.notifications.at(-1)?.message ?? "", /goal changed/i);
 });
 
+test("full goal status includes a pending priority objective", () => {
+	const state = runtime();
+	state.settings.experimental.goals = true;
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	const queued = createGoal("queued objective", undefined, 0);
+	queued.status = "queued";
+	state.queuedGoals = [queued];
+	state.pendingQueueAction = { kind: "prioritize", objective: "urgent objective" };
+	const context = createMockContext({ mode: "tui", hasUI: true });
+
+	new GoalCommandController(state).showGoal(context.ctx);
+
+	const summary = context.notifications.at(-1)?.message ?? "";
+	assert.match(summary, /Goals \(3\):/);
+	assert.match(summary, /1\. \[active\] current objective/);
+	assert.match(summary, /2\. \[queued\] queued objective/);
+	assert.match(summary, /3\. \[pending\] urgent objective/);
+});
+
+test("queue confirmations open only after the custom settings screen closes", async () => {
+	for (const scenario of ["enable", "disable"] as const) {
+		const state = runtime();
+		if (scenario === "disable") {
+			state.settings.experimental.goals = true;
+			state.activeGoal = createGoal("current objective", undefined, 0);
+			state.queuedGoals = [createGoal("queued objective", undefined, 0)];
+			state.pendingQueueAction = { kind: "prioritize", objective: "urgent objective" };
+		}
+		let customActive = false;
+		let confirmedWhileCustom = false;
+		let confirmationMessage = "";
+		let screens = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async (_title: string, message: string) => {
+				confirmedWhileCustom ||= customActive;
+				confirmationMessage = message;
+				return false;
+			},
+			custom: async (factory: unknown) => {
+				customActive = true;
+				const selector = createCustomSelectorHarness(factory, 80);
+				if (screens++ === 0) {
+					selector.handleInput("\u001b[B");
+					selector.handleInput("\r");
+				} else {
+					selector.handleInput("\u001b");
+				}
+				await new Promise((resolve) => setImmediate(resolve));
+				customActive = false;
+				return selector.result;
+			},
+		});
+
+		await showGoalSettings(state, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save() {},
+		});
+
+		assert.equal(confirmedWhileCustom, false, scenario);
+		assert.equal(state.settings.experimental.goals, scenario === "disable");
+		if (scenario === "disable") assert.match(confirmationMessage, /preserves 3 goal\(s\)/i);
+	}
+});
+
 test("settings screen resumes retained work after enabling the queue", async () => {
 	const state = runtime();
 	state.activeGoal = createGoal("current objective", undefined, 0);
 	state.queuedGoals = [createGoal("queued objective", undefined, 0)];
 	state.queueFrozen = true;
 	let unfrozen = 0;
+	let screens = 0;
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		confirm: async () => true,
 		custom: async (factory: unknown) => {
 			const selector = createCustomSelectorHarness(factory, 80);
-			selector.handleInput("\u001b[B");
-			selector.handleInput("\r");
-			await new Promise((resolve) => setImmediate(resolve));
-			selector.handleInput("\u001b");
+			if (screens++ === 0) {
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				selector.handleInput("\u001b");
+			}
 			await new Promise((resolve) => setImmediate(resolve));
 			return selector.result;
 		},


### PR DESCRIPTION
## Summary

- include pending queue actions in the full goal status and retained-goal count
- close the custom settings screen before opening queue confirmations
- add regressions for both enable/disable confirmation flows and pending priority status

Follow-up to the late review on #391.

## Verification

- `npm run check`
- focused pi-goal regressions (3 passing)