### PR TITLE
fix(lsp): omit unset pull diagnostic params

### DIFF
--- a/extensions/pi-lsp/src/lsp-client.ts
+++ b/extensions/pi-lsp/src/lsp-client.ts
@@ -190,8 +190,6 @@ export class LspClient {
 			: (published?.version ?? 0);
 		const response = await this.request("textDocument/diagnostic", {
 			textDocument: { uri },
-			identifier: null,
-			previousResultId: null,
 		});
 		const result = response.result as { items?: LspDiagnostic[] } | undefined;
 		const diagnostics = result?.items ?? [];

--- a/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -36,6 +36,7 @@ function handle(message) {
 			result: {
 				capabilities:
 					scenario === "pull-error" ||
+					scenario === "pull-strict-optional-params" ||
 					scenario === "pull-empty-then-push" ||
 					scenario === "pull-empty-after-push" ||
 					scenario === "pull-empty-only"
@@ -81,6 +82,25 @@ function handle(message) {
 	}
 
 	if (message.method === "textDocument/diagnostic") {
+		if (scenario === "pull-strict-optional-params") {
+			const hasUnsupportedOptionalParam =
+				Object.hasOwn(message.params, "identifier") ||
+				Object.hasOwn(message.params, "previousResultId");
+			send(
+				hasUnsupportedOptionalParam
+					? {
+							jsonrpc: "2.0",
+							id: message.id,
+							error: { code: -32602, message: "optional diagnostic params must be omitted" },
+						}
+					: {
+							jsonrpc: "2.0",
+							id: message.id,
+							result: { kind: "full", items: [diagnostic("strict pull diagnostic")] },
+						},
+			);
+			return;
+		}
 		send(
 			scenario === "pull-empty-then-push" ||
 				scenario === "pull-empty-after-push" ||

--- a/extensions/pi-lsp/test/lsp-client.test.ts
+++ b/extensions/pi-lsp/test/lsp-client.test.ts
@@ -10,6 +10,30 @@ import type { LspServerAdapter } from "../src/types.js";
 
 const fixture = path.resolve("extensions/pi-lsp/test/fixtures/diagnostics-server.mjs");
 
+test("pull diagnostics omit optional params when no values are available", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-pull-strict-optional-params-"));
+	const file = path.join(root, "main.go");
+	writeFileSync(file, "package main\n");
+	const adapter = fixtureAdapter("pull-strict-optional-params", 30);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		const uri = pathToFileURL(file).href;
+		client.didOpen(uri, "package main\n", "go");
+		const diagnostics = await client.diagnostics(uri);
+		assert.deepEqual(
+			diagnostics.map(({ message }) => message),
+			["strict pull diagnostic"],
+		);
+		client.didClose(uri);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("advertised pull diagnostic errors propagate", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-pull-error-"));
 	const file = path.join(root, "main.go");


### PR DESCRIPTION
## Summary

- omit unset `identifier` and `previousResultId` fields from `textDocument/diagnostic` requests
- add a strict pull-diagnostics fixture that rejects unexpected optional parameters
- cover successful diagnostics from spec-strict language servers

Closes #407

## Verification

- `npm run check` (1410 tests passed)
- TypeScript 7.0.2 LSP smoke returned the expected TS2322 diagnostic