### PR TITLE
feat: publish experimental packages with releases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -51,7 +51,7 @@ jobs:
           new_version="$(node scripts/bump-shared-version.mjs "${{ inputs.version_bump }}" | tail -n 1)"
           tag="v${new_version}"
 
-          git add package.json package-lock.json extensions/*/package.json
+          git add package.json package-lock.json extensions/*/package.json experimental/*/package.json
           git commit -m "chore(release): ${tag}"
           git tag "${tag}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Run commands from the repository root unless noted otherwise.
 - Before adding or changing extension-owned settings files, precedence, validation, persistence, migration, commands, or interactive settings UI, also read and follow `docs/extension-settings.md`.
 - Every active extension package exposes Pi through a thin `src/index.ts` default-export forwarding entrypoint, and its `package.json` declares exactly `"pi": { "extensions": ["./src/index.ts"] }`; keep implementation in descriptive modules and run `npm run check:boundaries` to enforce this for production and experimental packages.
 - Production extensions include source in `pi.extensions`, publish `files`, and root workspace-aware scripts/recipes when users need them.
-- Standalone experimental extension packages must live under `experimental/`, show a user-facing warning, remain covered by root checks, and stay excluded from automated publish/version workflows. An opt-in experimental feature may remain inside a production package only when its default behavior stays compatible, configuration explicitly gates it, and enabling it shows a warning.
+- Standalone experimental extension packages must live under `experimental/`, show a user-facing warning, remain covered by root checks, and participate in shared versioning and publishing unless marked `private`. An opt-in experimental feature may remain inside a production package only when its default behavior stays compatible, configuration explicitly gates it, and enabling it shows a warning.
 - When a source file exceeds 1,000 lines, it must be reviewed for decomposition. Split it along clear responsibility boundaries when doing so improves cohesion, maintainability, or testability. Do not split files mechanically solely to satisfy the line limit. Generated, vendored, migration, snapshot, and primarily declarative files may be exempt.
 
 ## Testing and verification
@@ -41,7 +41,7 @@ Run commands from the repository root unless noted otherwise.
 
 ## Publishing and release safety
 
-- Experimental packages may be published only by an explicit maintainer using `just publish <name>`; never add them to `publish-all` or GitHub publish workflows.
+- Publishable experimental packages follow the same shared version-bump, `publish-all`, and GitHub publishing workflows as production packages; preserve their experimental warning in user-facing documentation and runtime behavior.
 - If npm shows a scoped package dist-tag but `npm view <package>` returns 404, use `just npm-public <package> <otp>` to set public visibility before bumping or republishing.
 - Use `just bump <package> patch|minor|major` for a no-tag workspace bump. The GitHub `bump-version` workflow bumps all package versions together and tags `v*.*.*`.
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ extensions/
 └── pi-worktree/
 ```
 
-Each production extension package contains its own `package.json`, `README.md`, `LICENSE`, `tsconfig.json`, and TypeScript source under `src/`. Experimental extensions live under the root `experimental/` directory, remain covered by root checks, and may be published only through an explicit local maintainer recipe—not `publish-all` or GitHub workflows. Deprecated packages live under the root `deprecated/` directory and are excluded from workspace scripts.
+Each production extension package contains its own `package.json`, `README.md`, `LICENSE`, `tsconfig.json`, and TypeScript source under `src/`. Experimental extensions live under the root `experimental/` directory, remain covered by root checks, retain a visible experimental warning, and participate in shared versioning and publishing unless marked private. Deprecated packages live under the root `deprecated/` directory and are excluded from workspace scripts.
 
 ## 📄 License
 

--- a/docs/plans/archived/2026-07-26_publish-experimental-packages-plan.md
+++ b/docs/plans/archived/2026-07-26_publish-experimental-packages-plan.md
@@ -1,0 +1,29 @@
+# Publish experimental packages plan
+
+## Goal
+
+Include publishable packages under `experimental/` in shared version bumps, release-tag publishing, manual recovery publishing, and `just publish-all`, while preserving their experimental user-facing warning and excluding private/deprecated packages.
+
+## Plan
+
+- [x] Update focused release-script tests to specify shared versioning and publish selection for experimental packages; focused run failed in the five expected production-only paths.
+- [x] Update shared version discovery, release selection, workflow staging, and `just publish-all` to include non-private `experimental/*` packages; all 1,457 tests passed in the focused-name run.
+- [x] Update repository guidance and user documentation to describe automated experimental publishing without weakening the requirement for a visible experimental warning; targeted search found no stale manual-only claim outside archived historical plans.
+- [x] Run the repository CI-equivalent `npm run check` and dry-run pack the experimental package; 1,457 tests and all repository gates passed, and the `@narumitw/pi-file-context@0.1.0` tarball contained the expected seven files.
+
+## Risks
+
+- Experimental packages become externally visible on npm whenever an eligible version has not already been published. Existing npm version checks remain the duplicate-publication guard.
+- Release selection could miss experimental changes if package roots are handled inconsistently. Fixture tests must cover changed, unchanged, private, fallback, and all-package modes.
+
+## Rollback / Recovery
+
+Revert the selector, bump script, workflow, `justfile`, and policy/documentation changes. Already-published npm versions cannot be reused or removed by this repository rollback.
+
+## Completion Checklist
+
+- [x] Tag releases bump and select changed publishable packages from both `extensions/` and `experimental/`.
+- [x] Manual workflow recovery and `just publish-all` consider both roots.
+- [x] Private and deprecated packages remain excluded.
+- [x] Documentation and repository instructions match the implemented policy.
+- [x] Focused tests, full checks, and experimental package dry-run pass.

--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > [!WARNING]
-> This extension is experimental. Its interaction model and package API may change, and it is excluded from automated repository publishing.
+> This extension is experimental. Its interaction model and package API may change between releases.
 
 Browse project files inside Pi, preview text, select a line range, and attach the exact snapshot to the next prompt.
 

--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -12,7 +12,7 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 ## ✨ Features
 
 - Opens the file explorer when `@` is typed at a word boundary in Pi's normal editor.
-- Provides `/file-quote` as a discoverable fallback when another extension owns the editor.
+- Provides `/file-context` as a discoverable fallback when another extension owns the editor.
 - Fuzzy-filters project files, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
@@ -32,7 +32,7 @@ For persistent local use, add its absolute directory to the `extensions` array i
 
 ## 🚀 Quick start
 
-1. Type `@` at the start of a word in Pi's editor. If another custom editor is active, run `/file-quote` instead.
+1. Type `@` at the start of a word in Pi's editor. If another custom editor is active, run `/file-context` instead.
 2. Type to filter files and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
 3. In the preview, move to the first line and press `Space` to anchor the selection.
 4. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
@@ -58,9 +58,10 @@ Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), n
 
 | Command | Mode | Description |
 | --- | --- | --- |
-| `/file-quote` | TUI only | Open the file explorer. Arguments are rejected. |
+| `/file-context` | TUI only | Open the file explorer. Arguments are rejected. |
+| `/file-quote` | TUI only | Compatibility alias for `/file-context`. |
 
-RPC receives an observable warning. JSON and print modes do not enter custom UI.
+`/file-context` is the canonical command. Existing `/file-quote` usage remains supported as a compatibility alias. RPC receives an observable warning. JSON and print modes do not enter custom UI.
 
 ## 🔒 Security and limits
 
@@ -80,7 +81,7 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 - Keyboard line selection only; mouse drag selection is not implemented.
 - Up to eight pending quotes; there is not yet an interactive remove/reorder action.
 - Pending quotes do not survive `/reload`, session replacement, or shutdown.
-- The `@` trigger is not installed when another extension already owns the custom editor; `/file-quote` remains available.
+- The `@` trigger is not installed when another extension already owns the custom editor; `/file-context` remains available.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
 - Git integration degrades to the original filesystem-only workflow outside a repository or when Git metadata cannot be read.
 - File history is limited to the 20 most recent commits. Untracked files have status and provenance but no HEAD diff hunk until Git tracks them.

--- a/experimental/pi-file-context/src/file-context.ts
+++ b/experimental/pi-file-context/src/file-context.ts
@@ -12,7 +12,7 @@ import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-explorer.js";
 import { createGitContext } from "./git-context.js";
 
-const WIDGET_KEY = "file-quote";
+const WIDGET_KEY = "file-context";
 const DEFAULT_MAX_FILES = 5_000;
 const DEFAULT_MAX_BYTES = 1_000_000;
 const MAX_QUOTE_BYTES = 50_000;
@@ -363,15 +363,20 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		}
 	};
 
-	pi.registerCommand("file-quote", {
+	const handleFileContextCommand = async (args: string, ctx: ExtensionContext) => {
+		if (args.trim()) {
+			rejectCommand(ctx, "Usage: /file-context");
+			return;
+		}
+		await openExplorer(ctx);
+	};
+	pi.registerCommand("file-context", {
 		description: "Browse project files and attach a selected line range",
-		handler: async (args, ctx) => {
-			if (args.trim()) {
-				rejectCommand(ctx, "Usage: /file-quote");
-				return;
-			}
-			await openExplorer(ctx);
-		},
+		handler: handleFileContextCommand,
+	});
+	pi.registerCommand("file-quote", {
+		description: "Compatibility alias for /file-context",
+		handler: handleFileContextCommand,
 	});
 
 	pi.on("session_start", (_event, ctx) => {
@@ -386,7 +391,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		const previous = ctx.ui.getEditorComponent();
 		if (previous) {
 			ctx.ui.notify(
-				"File Context left the existing custom editor unchanged; use /file-quote.",
+				"File Context left the existing custom editor unchanged; use /file-context.",
 				"warning",
 			);
 			return;

--- a/experimental/pi-file-context/test/file-context.test.ts
+++ b/experimental/pi-file-context/test/file-context.test.ts
@@ -678,7 +678,11 @@ test("accumulates ordered pending quotes within aggregate limits", () => {
 test("registers a TUI fallback command and injects all pending quotes only once", async () => {
 	const mock = createMockPi();
 	fileQuoteExtension(mock.pi);
-	assert.ok(mock.commands.has("file-quote"));
+	assert.ok(mock.commands.has("file-context"));
+	assert.equal(
+		mock.commands.get("file-quote")?.handler,
+		mock.commands.get("file-context")?.handler,
+	);
 
 	let customFactory: unknown;
 	const widgets = new Map<string, unknown>();
@@ -737,17 +741,17 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	assert.equal(editorFactories.length, 1);
-	await mock.commands.get("file-quote")?.handler("", context.ctx);
-	await mock.commands.get("file-quote")?.handler("", context.ctx);
+	await mock.commands.get("file-context")?.handler("", context.ctx);
+	await mock.commands.get("file-context")?.handler("", context.ctx);
 	assert.equal(typeof customFactory, "function");
-	assert.deepEqual(widgets.get("file-quote"), [
+	assert.deepEqual(widgets.get("file-context"), [
 		"Quotes (2) · ~13 tokens:",
 		"• src/example.ts · lines 1-1 · ~6 tokens",
 		"• test/example.test.ts · lines 2-3 · ~8 tokens",
 	]);
 
 	assert.equal(mock.events.get("input"), undefined);
-	assert.notEqual(widgets.get("file-quote"), undefined);
+	assert.notEqual(widgets.get("file-context"), undefined);
 	const beforeStart = mock.events.get("before_agent_start")?.[0];
 	const injection = await beforeStart?.(
 		{ prompt: "/skill:explain Explain this", images: [], systemPrompt: "base" },
@@ -761,14 +765,14 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 			display: false,
 		},
 	});
-	assert.equal(widgets.get("file-quote"), undefined);
+	assert.equal(widgets.get("file-context"), undefined);
 	assert.equal(
 		await beforeStart?.({ prompt: "Again", systemPrompt: "base" }, context.ctx),
 		undefined,
 	);
 	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 	assert.equal(currentEditorFactory, undefined);
-	assert.equal(widgets.get("file-quote"), undefined);
+	assert.equal(widgets.get("file-context"), undefined);
 });
 
 test("quotes whole-file references and rejects picker results from replaced sessions", async () => {
@@ -796,7 +800,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 		},
 	});
 	await referenceMock.events.get("session_start")?.[0]?.({}, referenceContext.ctx);
-	await referenceMock.commands.get("file-quote")?.handler("", referenceContext.ctx);
+	await referenceMock.commands.get("file-context")?.handler("", referenceContext.ctx);
 	assert.deepEqual(pasted, ['@"docs/my \\"note\\".md" ']);
 
 	const staleMock = createMockPi();
@@ -828,7 +832,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 	const oldContext = makeContext(oldManager, async () => picker);
 	const newContext = makeContext(newManager, async () => undefined);
 	await staleMock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
-	const command = staleMock.commands.get("file-quote")?.handler("", oldContext.ctx);
+	const command = staleMock.commands.get("file-context")?.handler("", oldContext.ctx);
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	await staleMock.events.get("session_start")?.[0]?.({}, newContext.ctx);
 	resolvePicker?.({
@@ -849,15 +853,15 @@ test("rejects the fallback command observably outside TUI mode", async () => {
 	const mock = createMockPi();
 	fileQuoteExtension(mock.pi);
 	const rpc = createMockContext({ mode: "rpc", hasUI: true });
-	await mock.commands.get("file-quote")?.handler("", rpc.ctx);
+	await mock.commands.get("file-context")?.handler("", rpc.ctx);
 	assert.match(rpc.notifications[0]?.message ?? "", /interactive TUI/);
 	assert.equal(rpc.notifications[0]?.level, "warning");
 
 	const print = createMockContext({ mode: "print", hasUI: false });
 	await assert.rejects(async () => {
-		await mock.commands.get("file-quote")?.handler("", print.ctx);
+		await mock.commands.get("file-context")?.handler("", print.ctx);
 	}, /interactive TUI/);
 	await assert.rejects(async () => {
-		await mock.commands.get("file-quote")?.handler("unexpected", print.ctx);
+		await mock.commands.get("file-context")?.handler("unexpected", print.ctx);
 	}, /Usage/);
 });

--- a/justfile
+++ b/justfile
@@ -75,11 +75,11 @@ install name: (_validate-extension-name name)
 # Manually publish one production or experimental package, skipping an existing version
 # Usage: just publish subagents
 publish name: (_validate-extension-name name)
-    name={{quote(name)}}; package_json="./extensions/pi-$name/package.json"; if [[ ! -f "$package_json" ]]; then package_json="./experimental/pi-$name/package.json"; fi; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; if [[ "$package_json" == ./experimental/* ]]; then echo "WARNING: manually publishing experimental Pi extension pi-$name; automated workflows exclude it." >&2; fi; package="$(node -p "require(process.argv[1]).name" "$package_json")"; version="$(node -p "require(process.argv[1]).version" "$package_json")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public; fi
+    name={{quote(name)}}; package_json="./extensions/pi-$name/package.json"; if [[ ! -f "$package_json" ]]; then package_json="./experimental/pi-$name/package.json"; fi; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; if [[ "$package_json" == ./experimental/* ]]; then echo "WARNING: publishing experimental Pi extension pi-$name." >&2; fi; package="$(node -p "require(process.argv[1]).name" "$package_json")"; version="$(node -p "require(process.argv[1]).version" "$package_json")"; if npm view "$package@$version" version >/dev/null 2>&1; then echo "$package@$version already exists; skipping publish."; else npm --workspace "$package" pack --dry-run; npm --workspace "$package" publish --access public; fi
 
-# Publish all production extension packages to npm; experimental packages are excluded
+# Publish all production and experimental extension packages to npm
 publish-all:
-    for package_json in extensions/*/package.json; do dir="$(basename "$(dirname "$package_json")")"; just publish "${dir#pi-}"; done
+    for package_json in extensions/*/package.json experimental/*/package.json; do dir="$(basename "$(dirname "$package_json")")"; just publish "${dir#pi-}"; done
 
 # Preview individual packages that npm would publish
 pack-btw:

--- a/scripts/bump-shared-version.mjs
+++ b/scripts/bump-shared-version.mjs
@@ -27,8 +27,7 @@ for (const workspace of rootPackage.workspaces ?? []) {
 		if (!entry.isDirectory()) continue;
 
 		const packagePath = path.join(workspaceRoot, entry.name, "package.json");
-		if (!fs.existsSync(packagePath)) continue;
-		if (isExperimentalPackagePath(packagePath) || readPackage(packagePath).private) continue;
+		if (!fs.existsSync(packagePath) || readPackage(packagePath).private) continue;
 		packagePaths.add(packagePath);
 	}
 }
@@ -61,11 +60,6 @@ execFileSync("npm", ["install", "--package-lock-only", "--ignore-scripts"], {
 });
 
 console.log(newVersion);
-
-function isExperimentalPackagePath(packagePath) {
-	const [topLevel] = path.normalize(packagePath).split(path.sep);
-	return topLevel === "experimental";
-}
 
 function readPackage(packagePath) {
 	return JSON.parse(fs.readFileSync(packagePath, "utf8"));

--- a/scripts/list-publish-workspaces.mjs
+++ b/scripts/list-publish-workspaces.mjs
@@ -4,27 +4,27 @@ import { spawnSync } from "node:child_process";
 import { isDeepStrictEqual } from "node:util";
 
 const releaseTagPattern = /^v(\d+)\.(\d+)\.(\d+)$/;
-const extensionsDirectory = "extensions";
+const packageRoots = ["extensions", "experimental"];
 const [mode, ...args] = process.argv.slice(2);
 
 let releaseCommit;
-let selectedDirectories;
+let selectedPackagePaths;
 
 if (mode === "--all" && args.length === 0) {
 	releaseCommit = resolveCommit("HEAD");
 } else if (mode === "--release" && args.length === 1) {
 	const [tag] = args;
 	releaseCommit = resolveTagCommit(tag);
-	selectedDirectories = selectChangedDirectories(tag, releaseCommit);
+	selectedPackagePaths = selectChangedPackagePaths(tag, releaseCommit);
 } else {
 	throw new Error(
 		"Usage: scripts/list-publish-workspaces.mjs --all | --release <vMAJOR.MINOR.PATCH>",
 	);
 }
 
-const packages = listProductionPackages(releaseCommit);
-const selectedPackages = selectedDirectories
-	? packages.filter(({ directory }) => selectedDirectories.has(directory))
+const packages = listPublishablePackages(releaseCommit);
+const selectedPackages = selectedPackagePaths
+	? packages.filter(({ packagePath }) => selectedPackagePaths.has(packagePath))
 	: packages;
 
 process.stdout.write(
@@ -33,7 +33,7 @@ process.stdout.write(
 		: "",
 );
 
-function selectChangedDirectories(tag, commit) {
+function selectChangedPackagePaths(tag, commit) {
 	const match = releaseTagPattern.exec(tag);
 	if (!match) return fallbackToAll(`tag ${JSON.stringify(tag)} is not a stable release tag`);
 
@@ -43,13 +43,13 @@ function selectChangedDirectories(tag, commit) {
 	const previousRelease = findPreviousRelease(parent);
 	if (!previousRelease) return fallbackToAll(`release ${tag} has no previous release tag`);
 
-	const packages = listProductionPackages(commit);
+	const packages = listPublishablePackages(commit);
 	const releaseVersion = match.slice(1).join(".");
 	if (!isCanonicalReleaseCommit(tag, releaseVersion, commit, parent, packages)) {
 		return fallbackToAll(`release ${tag} was not created by the shared version-bump workflow`);
 	}
 
-	const changedDirectories = new Set();
+	const changedPackagePaths = new Set();
 	for (const changedPath of gitNullList([
 		"diff",
 		"--name-only",
@@ -57,16 +57,18 @@ function selectChangedDirectories(tag, commit) {
 		previousRelease.commit,
 		parent,
 		"--",
-		extensionsDirectory,
+		...packageRoots,
 	])) {
 		const [topLevel, directory, child] = changedPath.split("/");
-		if (topLevel === extensionsDirectory && directory && child) changedDirectories.add(directory);
+		if (packageRoots.includes(topLevel) && directory && child) {
+			changedPackagePaths.add(`${topLevel}/${directory}`);
+		}
 	}
-	return changedDirectories;
+	return changedPackagePaths;
 }
 
 function fallbackToAll(reason) {
-	console.error(`Publish selection fallback: ${reason}; considering all production packages.`);
+	console.error(`Publish selection fallback: ${reason}; considering all publishable packages.`);
 	return undefined;
 }
 
@@ -117,7 +119,7 @@ function isCanonicalReleaseCommit(tag, version, commit, parent, packages) {
 	const beforeLock = tryReadJsonAt(parent, "package-lock.json");
 	const afterLock = tryReadJsonAt(commit, "package-lock.json");
 	if (!beforeLock || !afterLock) return false;
-	const workspacePaths = packages.map(({ directory }) => `${extensionsDirectory}/${directory}`);
+	const workspacePaths = packages.map(({ packagePath }) => packagePath);
 	if (!normalizeLockfileVersions(beforeLock, workspacePaths)) return false;
 	if (!normalizeLockfileVersions(afterLock, workspacePaths, version)) return false;
 	return isDeepStrictEqual(beforeLock, afterLock);
@@ -141,35 +143,39 @@ function normalizeVersion(value, expectedVersion) {
 	return true;
 }
 
-function listProductionPackages(commit) {
+function listPublishablePackages(commit) {
 	const packages = [];
-	for (const directory of gitNullList([
-		"ls-tree",
-		"-z",
-		"--name-only",
-		`${commit}:${extensionsDirectory}`,
-	])) {
-		if (directory.includes("/")) continue;
-		const manifestPath = `${extensionsDirectory}/${directory}/package.json`;
-		const packageJson = tryReadJsonAt(commit, manifestPath);
-		if (!packageJson || packageJson.private) continue;
+	for (const packageRoot of packageRoots) {
+		for (const directory of listTreeDirectories(commit, packageRoot)) {
+			if (directory.includes("/")) continue;
+			const packagePath = `${packageRoot}/${directory}`;
+			const manifestPath = `${packagePath}/package.json`;
+			const packageJson = tryReadJsonAt(commit, manifestPath);
+			if (!packageJson || packageJson.private) continue;
 
-		const { name, version } = packageJson;
-		if (!isTsvValue(name) || !isTsvValue(version)) {
-			throw new Error(`${manifestPath} must contain string name and version fields without tabs`);
+			const { name, version } = packageJson;
+			if (!isTsvValue(name) || !isTsvValue(version)) {
+				throw new Error(`${manifestPath} must contain string name and version fields without tabs`);
+			}
+			packages.push({ directory, manifestPath, name, packagePath, version });
 		}
-		packages.push({ directory, manifestPath, name, version });
 	}
 
 	packages.sort(
-		(a, b) => compareStrings(a.name, b.name) || compareStrings(a.directory, b.directory),
+		(a, b) => compareStrings(a.name, b.name) || compareStrings(a.packagePath, b.packagePath),
 	);
 	for (let index = 1; index < packages.length; index += 1) {
 		if (packages[index - 1].name === packages[index].name) {
-			throw new Error(`Duplicate production package name: ${packages[index].name}`);
+			throw new Error(`Duplicate publishable package name: ${packages[index].name}`);
 		}
 	}
 	return packages;
+}
+
+function listTreeDirectories(commit, packageRoot) {
+	const result = runGit(["ls-tree", "-z", "--name-only", `${commit}:${packageRoot}`], true);
+	if (result.status !== 0) return [];
+	return result.stdout.split("\0").filter(Boolean);
 }
 
 function isTsvValue(value) {

--- a/test/publish-workspaces.test.ts
+++ b/test/publish-workspaces.test.ts
@@ -23,7 +23,7 @@ const gitEnvironment = {
 	GIT_COMMITTER_NAME: "Fixture Author",
 };
 
-test("canonical releases select only changed production extensions in deterministic order", () => {
+test("canonical releases select changed publishable extensions in deterministic order", () => {
 	withRepository(
 		[
 			{ directory: "pi-zulu", name: "@fixture/zulu" },
@@ -47,6 +47,7 @@ test("canonical releases select only changed production extensions in determinis
 			createRelease(repository, "v1.1.0");
 
 			assert.deepEqual(select(repository, "--release", "v1.1.0"), [
+				["@fixture/experiment", "1.1.0"],
 				["@fixture/middle", "1.1.0"],
 				["@fixture/zulu", "1.1.0"],
 			]);
@@ -89,7 +90,7 @@ test("release selection omits deleted and unchanged packages", () => {
 	);
 });
 
-test("first and nonstandard releases safely select every production package", () => {
+test("first and nonstandard releases safely select every publishable package", () => {
 	withRepository(
 		[
 			{ directory: "pi-beta", name: "@fixture/beta" },
@@ -102,6 +103,7 @@ test("first and nonstandard releases safely select every production package", ()
 			assert.deepEqual(select(repository, "--release", "v1.0.0"), [
 				["@fixture/alpha", "1.0.0"],
 				["@fixture/beta", "1.0.0"],
+				["@fixture/experiment", "1.0.0"],
 			]);
 		},
 	);
@@ -160,7 +162,7 @@ test("a package introduced inside the release commit falls back to all packages"
 	});
 });
 
-test("all-packages mode is deterministic and excludes non-production workspaces", () => {
+test("all-packages mode includes experimental packages and excludes private and deprecated ones", () => {
 	withRepository(
 		[
 			{ directory: "pi-zulu", name: "@fixture/zulu" },
@@ -172,6 +174,7 @@ test("all-packages mode is deterministic and excludes non-production workspaces"
 		(repository) => {
 			assert.deepEqual(select(repository, "--all"), [
 				["@fixture/alpha", "0.0.0"],
+				["@fixture/experiment", "0.0.0"],
 				["@fixture/zulu", "0.0.0"],
 			]);
 		},
@@ -220,8 +223,7 @@ function createRelease(repository: string, tagName: string) {
 	rootPackage.version = version;
 	writeJson(repository, "package.json", rootPackage);
 
-	for (const directory of productionPackageDirectories(repository)) {
-		const packagePath = path.join(repository, "extensions", directory, "package.json");
+	for (const packagePath of publishablePackagePaths(repository)) {
 		const packageJson = readJson(packagePath);
 		packageJson.version = version;
 		writeJson(repository, path.relative(repository, packagePath), packageJson);
@@ -271,27 +273,27 @@ function readdirPackageDirectories(root: string) {
 		.sort();
 }
 
-function productionPackageDirectories(repository: string) {
-	return listPackageDirectories(repository).filter((directory) => {
-		if (directory.includes("/")) return false;
-		const packageJson = readJson(path.join(repository, "extensions", directory, "package.json"));
-		return packageJson.private !== true;
-	});
+function publishablePackagePaths(repository: string) {
+	return ["extensions", "experimental"].flatMap((workspaceRoot) =>
+		listPackageDirectories(repository, workspaceRoot)
+			.map((directory) => path.join(repository, workspaceRoot, directory, "package.json"))
+			.filter((packagePath) => readJson(packagePath).private !== true),
+	);
 }
 
-function listPackageDirectories(repository: string) {
-	const output = git(repository, "ls-files", "extensions/**/package.json");
+function listPackageDirectories(repository: string, workspaceRoot: string) {
+	const output = git(repository, "ls-files", `${workspaceRoot}/**/package.json`);
 	const tracked = output
 		.split("\n")
 		.filter(Boolean)
-		.map((file) => path.posix.dirname(file).slice("extensions/".length));
-	const untracked = git(repository, "ls-files", "--others", "--exclude-standard", "extensions")
+		.map((file) => path.posix.dirname(file).slice(workspaceRoot.length + 1));
+	const untracked = git(repository, "ls-files", "--others", "--exclude-standard", workspaceRoot)
 		.split("\n")
 		.filter((file) => file.endsWith("/package.json"))
-		.map((file) => path.posix.dirname(file).slice("extensions/".length));
+		.map((file) => path.posix.dirname(file).slice(workspaceRoot.length + 1));
 	return [...new Set([...tracked, ...untracked])]
 		.filter((directory) =>
-			existsSync(path.join(repository, "extensions", directory, "package.json")),
+			existsSync(path.join(repository, workspaceRoot, directory, "package.json")),
 		)
 		.sort();
 }

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -11,7 +11,7 @@ const checkScript = path.join(repositoryRoot, "scripts", "run-checks.mjs");
 const setPiVersionScript = path.join(repositoryRoot, "scripts", "set-pi-version.mjs");
 const expectedChecks = ["biome:check", "check:boundaries", "test", "typecheck"];
 
-test("shared-version discovery skips publishable experimental workspaces", () => {
+test("shared-version discovery includes publishable experimental workspaces", () => {
 	const fixture = mkdtempSync(path.join(tmpdir(), "pi-workspaces-"));
 	try {
 		writeJson(path.join(fixture, "package.json"), {
@@ -33,7 +33,11 @@ test("shared-version discovery skips publishable experimental workspaces", () =>
 			cwd: fixture,
 			encoding: "utf8",
 		});
-		assert.deepEqual(JSON.parse(output), ["extensions/pi-public/package.json", "package.json"]);
+		assert.deepEqual(JSON.parse(output), [
+			"experimental/pi-manual/package.json",
+			"extensions/pi-public/package.json",
+			"package.json",
+		]);
 	} finally {
 		rmSync(fixture, { recursive: true, force: true });
 	}
@@ -115,15 +119,23 @@ test("publish workflow selects changed tag packages and all manual recovery pack
 	assert.match(workflow, />> "\$GITHUB_STEP_SUMMARY"/);
 });
 
-test("experimental publishing is manual-only", () => {
+test("experimental packages participate in automated and manual publishing", () => {
 	const selector = readFileSync(
 		path.join(repositoryRoot, "scripts/list-publish-workspaces.mjs"),
 		"utf8",
 	);
 	const justfile = readFileSync(path.join(repositoryRoot, "justfile"), "utf8");
-	assert.match(selector, /const extensionsDirectory = "extensions"/);
+	const bumpWorkflow = readFileSync(
+		path.join(repositoryRoot, ".github/workflows/bump-version.yml"),
+		"utf8",
+	);
+	assert.match(selector, /const packageRoots = \["extensions", "experimental"\]/);
 	assert.match(justfile, /package_json="\.\/experimental\/pi-\$name\/package\.json"/);
-	assert.match(justfile, /WARNING: manually publishing experimental Pi extension/);
+	assert.match(
+		justfile,
+		/for package_json in extensions\/\*\/package\.json experimental\/\*\/package\.json/,
+	);
+	assert.match(bumpWorkflow, /experimental\/\*\/package\.json/);
 	assert.match(justfile, /^publish name:/m);
 	assert.doesNotMatch(justfile, /\botp\b|--otp/);
 });


### PR DESCRIPTION
## Summary

- include non-private `experimental/*` packages in shared version bumps and release publishing
- include experimental packages in `just publish-all` while retaining their warning
- make `/file-context` the canonical command for `pi-file-context` while preserving `/file-quote` as a compatibility alias
- update repository policy, documentation, and release-selector coverage

## Verification

- `npm run check`
- `npm --workspace @narumitw/pi-file-context pack --dry-run --json`
- `git diff --check`
