### PR TITLE
feat(file-context): rank file search with Fuse.js

### DIFF
--- a/docs/plans/archived/2026-07-26_pi-file-context-fuse-basic-plan.md
+++ b/docs/plans/archived/2026-07-26_pi-file-context-fuse-basic-plan.md
@@ -1,0 +1,68 @@
+# pi-file-context Fuse.js Basic Plan
+
+## Goal
+
+Replace `pi-file-context`'s hand-written ordered-subsequence file filter with a reusable, relevance-ranked `fuse.js/basic` search index while preserving empty-query behavior and the explorer's navigation/reset behavior.
+
+## Context
+
+- File discovery is bounded to 5,000 paths.
+- `filterProjectFiles()` in `experimental/pi-file-context/src/file-context.ts` currently lowercases the query and retains every path containing its characters in order, without relevance scoring.
+- `FileQuoteExplorer` calls that helper after each search-input change; constructing a Fuse index on each keystroke would add avoidable work.
+- Fuse.js provides a zero-dependency basic build containing fuzzy search without extended, logical, or token search features.
+- This changes fuzzy-match semantics intentionally: results become typo-tolerant and relevance-ranked rather than preserving discovery order for every ordered-subsequence match.
+
+## Architecture
+
+- Add `experimental/pi-file-context/src/file-search.ts` as the owner of Fuse configuration and path-entry preparation.
+- Expose a small project-file search abstraction that constructs one `Fuse` instance from the discovered paths and provides `search(query): string[]`.
+- Represent each indexed item with its full path and basename so basename matches can receive more weight while full-path matches remain available.
+- Trim queries explicitly; return the original file order for an empty query, and otherwise return Fuse's relevance order.
+- Construct the abstraction once in `FileQuoteExplorer` and reuse it for every input update.
+
+## Tech Stack
+
+- Import the fuzzy engine from `fuse.js/basic`.
+- Declare `fuse.js` in `experimental/pi-file-context/package.json#dependencies`, because extension consumers need it at runtime.
+- Keep Fuse options local to `file-search.ts`; start with weighted basename/full-path keys, `ignoreLocation: true`, and a test-calibrated threshold rather than exposing settings in this change.
+
+## Non-Goals
+
+- Forking or rewriting Fuse.js.
+- Adding user-configurable fuzzy-search settings.
+- Searching file contents, Git metadata, or fields other than basename and project-relative path.
+- Adding match highlighting to the explorer.
+- Changing file discovery limits, preview behavior, quoting, Git context, commands, or keybindings.
+
+## Assumptions
+
+- Typo tolerance and relevance ranking are desired even where results differ from the current ordered-subsequence matcher.
+- Exact and strong basename matches should rank ahead of weaker directory/full-path matches.
+- The default 5,000-file bound is small enough for one in-memory Fuse index per explorer instance.
+
+## Risks
+
+- Fuse's Bitap scoring may reject abbreviation-style queries accepted by the current matcher; characterize representative queries in tests and tune only the threshold/weights needed for the agreed file-path behavior.
+- Overly permissive thresholds can return noisy paths; include both positive and no-match cases before selecting the threshold.
+- Importing the default full build accidentally would retain unused search features; verify the source imports exactly `fuse.js/basic` and that NodeNext typechecking passes.
+- Dependency metadata or the lockfile can drift if modified with the wrong npm release; use the repository-pinned npm declared in root `package.json#packageManager` and inspect only intended manifest/lockfile changes.
+
+## Plan
+
+- [x] Added focused search-behavior coverage in `experimental/pi-file-context/test/file-context.test.ts` for empty-query order, case/whitespace normalization, exact basename priority, full-path matching, typo tolerance, deterministic ordering, and no matches; `npm test` failed against the old matcher because it retained `docs/file-context-notes.md` ahead of the exact basename.
+- [x] Added `fuse.js` to `experimental/pi-file-context/package.json#dependencies` and regenerated the workspace lock entry; the final manifest/lock diff contains only the workspace dependency and one `node_modules/fuse.js` record (the pinned npm was attempted first, then its unrelated lockfile rewrite was discarded before the bounded regeneration).
+- [x] Created `experimental/pi-file-context/src/file-search.ts` with one reusable `fuse.js/basic` index, weighted basename/full-path entries, explicit trimmed-empty-query handling, and a `0.2` threshold calibrated by positive/no-match coverage; `npm test` passed all 1,457 tests.
+- [x] Updated `experimental/pi-file-context/src/file-context-explorer.ts` to construct and reuse `ProjectFileSearch`, removed `filterProjectFiles()` and `isOrderedSubsequence()` from `experimental/pi-file-context/src/file-context.ts`, and verified all existing explorer and repository tests with `npm test` (1,457 passed).
+- [x] Updated `experimental/pi-file-context/README.md` to describe typo tolerance and relevance ranking without exposing tuning values; diff review confirms the warning, install commands, and quick-start workflow remain intact.
+- [x] Ran `npm run check` successfully; Biome, extension boundaries, all workspace typechecks, and all 1,457 tests passed.
+- [x] Ran `npm pack --workspace @narumitw/pi-file-context --dry-run --json`; the eight expected package files include `src/file-search.ts`, `package.json` carries the runtime dependency, and the dry run reports no bundled dependencies.
+- [x] Ran `git diff --check` and reviewed the bounded source, test, README, manifest, lockfile, and plan diff; the lockfile is a 16-line additive change and no unrelated paths are modified.
+
+## Completion Checklist
+
+- [x] `file-search.ts` imports exactly `fuse.js/basic`, and `FileQuoteExplorer` constructs one `ProjectFileSearch` in its constructor rather than on input.
+- [x] Tests prove empty-query order plus deterministic basename/full-path relevance, typo tolerance, case/whitespace handling, and no-match behavior.
+- [x] Repository search confirms `filterProjectFiles` and `isOrderedSubsequence` have no remaining references.
+- [x] `npm ls` resolves `fuse.js` beneath the workspace runtime dependency, and the package dry run includes the new source with no bundled dependencies.
+- [x] README feature and quick-start copy document relevance-ranked typo-tolerant search without adding settings.
+- [x] `npm run check` passed all gates and 1,457 tests; package dry run and final diff checks also passed.

--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -13,7 +13,7 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 - Opens the file explorer when `@` is typed at a word boundary in Pi's normal editor.
 - Provides `/file-context` as a discoverable fallback when another extension owns the editor.
-- Fuzzy-filters project files, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
+- Fuzzy-searches project files with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
 - Discloses current-line blame and bounded file history, opens a validated commit/branch/tag version, and attaches explicit Git diff hunks.
@@ -43,7 +43,7 @@ pi -e ./experimental/pi-file-context
 ## 🚀 Quick start
 
 1. Type `@` at the start of a word in Pi's editor. If another custom editor is active, run `/file-context` instead.
-2. Type to filter files and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
+2. Type to fuzzy-search files in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
 3. In the preview, move to the first line and press `Space` to anchor the selection.
 4. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
 5. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.

--- a/experimental/pi-file-context/package.json
+++ b/experimental/pi-file-context/package.json
@@ -43,5 +43,8 @@
 		"type": "git",
 		"url": "https://github.com/narumiruna/pi-extensions",
 		"directory": "experimental/pi-file-context"
+	},
+	"dependencies": {
+		"fuse.js": "^7.5.0"
 	}
 }

--- a/experimental/pi-file-context/src/file-context-explorer.ts
+++ b/experimental/pi-file-context/src/file-context-explorer.ts
@@ -13,9 +13,9 @@ import {
 	createFileQuote,
 	createFileQuoteSnapshot,
 	type FileQuote,
-	filterProjectFiles,
 	type LoadedProjectTextFile,
 } from "./file-context.js";
+import { ProjectFileSearch } from "./file-search.js";
 import type {
 	GitBlameInfo,
 	GitContext,
@@ -47,7 +47,7 @@ interface FileQuoteExplorerOptions {
 export class FileQuoteExplorer implements Component, Focusable {
 	private readonly search = new Input();
 	private readonly revisionInput = new Input();
-	private readonly files: readonly string[];
+	private readonly fileSearch: ProjectFileSearch;
 	private filteredFiles: string[];
 	private selectedFileIndex = 0;
 	private fileScrollOffset = 0;
@@ -71,7 +71,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 	private isFocused = false;
 
 	constructor(private readonly options: FileQuoteExplorerOptions) {
-		this.files = options.files;
+		this.fileSearch = new ProjectFileSearch(options.files);
 		this.filteredFiles = [...options.files];
 	}
 
@@ -392,7 +392,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.search.handleInput(data);
 		const query = this.search.getValue();
 		if (query !== previousQuery) {
-			this.filteredFiles = filterProjectFiles(this.files, query);
+			this.filteredFiles = this.fileSearch.search(query);
 			this.selectedFileIndex = 0;
 			this.fileScrollOffset = 0;
 			this.error = undefined;

--- a/experimental/pi-file-context/src/file-context.ts
+++ b/experimental/pi-file-context/src/file-context.ts
@@ -95,12 +95,6 @@ export async function discoverProjectFiles(
 	return files.sort(compareStrings);
 }
 
-export function filterProjectFiles(files: readonly string[], query: string): string[] {
-	const needle = query.trim().toLocaleLowerCase();
-	if (!needle) return [...files];
-	return files.filter((file) => isOrderedSubsequence(file.toLocaleLowerCase(), needle));
-}
-
 export async function loadProjectTextFile(
 	root: string,
 	projectPath: string,
@@ -444,15 +438,6 @@ function compareStrings(left: string, right: string): number {
 
 function estimateTokens(bytes: number): number {
 	return Math.max(1, Math.ceil(bytes / 4));
-}
-
-function isOrderedSubsequence(value: string, query: string): boolean {
-	let queryIndex = 0;
-	for (const character of value) {
-		if (character === query[queryIndex]) queryIndex += 1;
-		if (queryIndex === query.length) return true;
-	}
-	return false;
 }
 
 function isInside(root: string, candidate: string): boolean {

--- a/experimental/pi-file-context/src/file-search.ts
+++ b/experimental/pi-file-context/src/file-search.ts
@@ -1,0 +1,39 @@
+import Fuse from "fuse.js/basic";
+
+const SEARCH_THRESHOLD = 0.2;
+const BASENAME_WEIGHT = 0.7;
+const PATH_WEIGHT = 0.3;
+
+interface ProjectFileEntry {
+	path: string;
+	basename: string;
+}
+
+export class ProjectFileSearch {
+	private readonly files: readonly string[];
+	private readonly index: Fuse<ProjectFileEntry>;
+
+	constructor(files: readonly string[]) {
+		this.files = [...files];
+		this.index = new Fuse(
+			this.files.map((path) => ({
+				path,
+				basename: path.slice(path.lastIndexOf("/") + 1),
+			})),
+			{
+				keys: [
+					{ name: "basename", weight: BASENAME_WEIGHT },
+					{ name: "path", weight: PATH_WEIGHT },
+				],
+				ignoreLocation: true,
+				threshold: SEARCH_THRESHOLD,
+			},
+		);
+	}
+
+	search(query: string): string[] {
+		const normalizedQuery = query.trim();
+		if (!normalizedQuery) return [...this.files];
+		return this.index.search(normalizedQuery).map((result) => result.item.path);
+	}
+}

--- a/experimental/pi-file-context/test/file-context.test.ts
+++ b/experimental/pi-file-context/test/file-context.test.ts
@@ -10,12 +10,12 @@ import fileQuoteExtension, {
 	createFileQuote,
 	discoverProjectFiles,
 	FileQuoteTriggerEditor,
-	filterProjectFiles,
 	formatPromptWithQuote,
 	formatPromptWithQuotes,
 	loadProjectTextFile,
 } from "../src/file-context.js";
 import { FileQuoteExplorer } from "../src/file-context-explorer.js";
+import { ProjectFileSearch } from "../src/file-search.js";
 
 async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
 	const root = await mkdtemp(join(tmpdir(), "pi-file-context-test-"));
@@ -86,10 +86,23 @@ test("rejects a validated file replaced by a symlink before descriptor open", as
 	});
 });
 
-test("filters files by ordered fuzzy characters", () => {
-	const files = ["src/runtime.ts", "src/settings.ts", "test/runtime.test.ts"];
-	assert.deepEqual(filterProjectFiles(files, "settings"), ["src/settings.ts"]);
-	assert.deepEqual(filterProjectFiles(files, "rtt"), files);
+test("ranks fuzzy file matches and tolerates typos", () => {
+	const files = [
+		"file-context.ts-notes/README.md",
+		"src/file-context.ts",
+		"src/settings.ts",
+		"docs/guide.md",
+	];
+
+	const search = new ProjectFileSearch(files);
+	assert.deepEqual(search.search("  FILE-context.ts  "), [
+		"src/file-context.ts",
+		"file-context.ts-notes/README.md",
+	]);
+	assert.deepEqual(search.search("src/settings"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("setxings"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("zzzzzz"), []);
+	assert.deepEqual(search.search("  "), files);
 });
 
 test("explorer previews a file, selects a range, and keeps rendered rows width-safe", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
 			"name": "@narumitw/pi-file-context",
 			"version": "0.32.0",
 			"license": "MIT",
+			"dependencies": {
+				"fuse.js": "^7.5.0"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.5",
 				"@earendil-works/pi-coding-agent": "0.82.1",
@@ -9043,6 +9046,19 @@
 			},
 			"engines": {
 				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/fuse.js": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+			"integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/krisk"
 			}
 		},
 		"node_modules/gaxios": {


### PR DESCRIPTION
## Summary

- replace the ordered-subsequence file filter with a reusable `fuse.js/basic` index
- rank basename and full-path matches while preserving empty-query order
- document and test typo-tolerant, relevance-ranked file search

## Verification

- `npm run check` (1,457 tests passed)
- `npm pack --workspace @narumitw/pi-file-context --dry-run --json`
- `git diff --check`
