### PR TITLE
feat(webui)!: add current-state command menu

### DIFF
--- a/docs/plans/archived/2026-07-26_pi-webui-menu-redesign-plan.md
+++ b/docs/plans/archived/2026-07-26_pi-webui-menu-redesign-plan.md
@@ -1,0 +1,184 @@
+# Pi WebUI Menu Redesign Plan
+
+## Goal
+
+Make bare `/webui` open a current-state, goal-oriented menu in interactive Pi modes while
+preserving the direct browser-opening workflow as `/webui open`, retaining existing settings and
+command compatibility, and keeping cancellation, failure, session lifecycle, and stored settings
+safe.
+
+## Context
+
+- Bare `/webui` currently starts or reuses the session-owned loopback server and issues a fresh
+  one-time bootstrap link.
+- `/webui settings`, `/webui status`, `/webui help`, and `/webui init` are established public routes.
+- Issuing a fresh link invalidates any unused earlier bootstrap link, so that consequence must be
+  visible before confirmation.
+- The only routine interactive setting is automatic startup. Retention and image resource limits are
+  intentionally advanced JSON settings.
+- Settings writes are serialized and atomic, preserve unknown fields, restore the previous effective
+  value on failure, and leave malformed files untouched.
+- `ctx.ui.custom()` is TUI-only. RPC can expose supported dialog interactions, while print and JSON
+  modes have no safe channel for an interactive menu or browser link.
+- The approved implementation must follow `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, and Pi's TUI/keybinding contracts.
+
+## Architecture
+
+- Keep `extensions/pi-webui/src/runtime.ts` responsible for command routing, session/server state,
+  and applying confirmed actions.
+- Put reusable main-menu and read-only detail-screen presentation in a cohesive module such as
+  `extensions/pi-webui/src/menu.ts` if keeping it in `runtime.ts` would mix rendering and lifecycle
+  responsibilities.
+- Build TUI selection with Pi's `SelectList`, callback-provided theme, and configured selection
+  keybindings. Use `SettingsList` for the existing immediate-save preference.
+- Derive every menu model from the runtime's authoritative state: server running/stopped, effective
+  startup preference and source, settings validity/path, and effective image limits.
+- Treat selection as confirmation: opening the menu only previews state; mutation starts only after
+  the user confirms Open or Get a fresh link.
+- Preserve the existing atomic settings loader/writer and server generation guards; this redesign
+  changes orchestration and presentation, not storage or browser protocol.
+
+## Non-Goals
+
+- Redesigning the browser chat page or browser protocol.
+- Adding presets, browser auto-launch, project settings, persistent browser state, or new image
+  settings.
+- Moving advanced retention/image limits into the primary menu.
+- Changing the settings schema, defaults, file path, precedence, or unknown-field behavior.
+- Removing `/webui settings`, `/webui status`, `/webui help`, or `/webui init`.
+
+## Assumptions
+
+- Explicit approval of this plan also approves the intentional public behavior change from bare
+  `/webui` opening a link to bare `/webui` opening the menu.
+- `/webui open` is the documented migration path for scripts or users that require the former direct
+  action.
+- TUI and interactive RPC are the only modes in which the menu can be meaningfully supported; print
+  and JSON must remain side-effect-free for bare `/webui` rather than starting an invisible server.
+
+## Risks
+
+- **Public command behavior:** Existing muscle memory and scripts using bare `/webui` gain a menu.
+  Mitigate with `/webui open`, completions, compatibility tests, and README migration guidance.
+- **Mode divergence:** TUI, RPC, print, and JSON expose different UI capabilities. Keep routing
+  explicit and test every claimed behavior without calling `custom()` outside TUI.
+- **False cancellation:** A dismissed menu must not start a server, rotate a token, or write settings.
+  Do not present server startup as cancellable after selection unless the underlying operation gains
+  real cancellation.
+- **Terminal safety and reflow:** Paths and errors can be long or contain terminal controls. Escape
+  unsafe controls, wrap detail text, and assert every rendered line fits the supplied width.
+- **Navigation regression:** Returning from Settings, Status, or Help can accidentally reopen or
+  mutate state. Track the screen origin and restore a stable main-menu selection without duplicating
+  actions.
+
+## Rollback / Recovery
+
+- Code rollback restores the previous command routing; no data migration or settings rollback is
+  required.
+- A failed server action leaves the previous stopped/running state intact and reports a retry route.
+- A failed settings save keeps the previous effective/displayed value and the previous settings file.
+- Invalid settings remain untouched and continue using safe defaults until manually repaired.
+
+## Plan
+
+- [x] Record explicit user approval for the bare `/webui` behavior change before editing production
+      code. Evidence: the active goal explicitly requests implementing this plan and creating a PR.
+
+- [x] Add focused failing command/menu tests in `extensions/pi-webui/test/commands.test.ts` proving
+      that TUI bare `/webui` opens a menu without starting a server or issuing a link, that
+      `/webui open` performs the former direct action, and that completions retain
+      `settings|status|help|init`; verify the focused tests fail for the expected missing menu/open
+      behavior through the repository test runner.
+
+- [x] Add the main menu model and responsive TUI presentation in
+      `extensions/pi-webui/src/menu.ts` (or a justified cohesive equivalent) with visible server,
+      startup, source, and invalid-settings state; dynamic `Open WebUI`/`Get a fresh link` labels;
+      consequence previews; configured navigation/confirm/cancel behavior; and stable selection;
+      verify component tests at 30, 40, 80, and 120 columns show no line wider than the supplied
+      width and retain all critical consequences.
+
+- [x] Update command routing in `extensions/pi-webui/src/runtime.ts` so bare `/webui` opens the menu,
+      confirmed primary actions alone call the existing server/link path, `/webui open` directly
+      invokes that path, Escape/cancel causes no mutation, and unknown/trailing arguments remain
+      rejected; verify command tests cover stopped, running, cancellation, repeated invocation, and
+      fresh-link token rotation without regressing server deduplication.
+
+- [x] Implement shallow secondary navigation from the menu to Settings, Status & diagnostics, Help,
+      and invalid-file repair guidance, with Escape returning to the menu while direct subcommands
+      still exit to Pi; verify tests cover focus/selection restoration, return versus exit, and no
+      side effects from read-only screens.
+
+- [x] Revise the existing Settings presentation in `extensions/pi-webui/src/runtime.ts` to use
+      user-facing `Manual`/`Every session` terminology and explicitly state that changes save
+      immediately but apply on the next session initialization or reload; block known-failing edits
+      for an invalid settings document and show its preserved path/recovery instructions; verify
+      existing ordered-save, unknown-field, atomic-write, and rollback tests plus new invalid-file
+      UI tests pass.
+
+- [x] Add transient applying and actionable outcome feedback around confirmed Open/Get-link actions
+      without adding fake cancellation, ensuring activity status is cleared on success, error,
+      replacement, and shutdown; verify lifecycle tests prove startup failure preserves stopped
+      state, fresh-link failure preserves an existing server, and stale generations cannot publish
+      success or leave status/widget state behind.
+
+- [x] Define and test mode-specific behavior in `extensions/pi-webui/src/runtime.ts`: full custom menu
+      only in TUI, an observable supported selection/fallback in RPC without `custom()`, and
+      side-effect-free rejection for bare `/webui` in print/JSON; verify tests cover each mode and
+      `/webui open` only claims modes where the resulting link is observable.
+
+- [x] Add accessibility and terminal-safety coverage in the focused menu tests: configured selection
+      keybindings, logical initial focus and restoration, text labels independent of color/icons,
+      non-color running/error/invalid cues, escaped C0/C1 controls, long-path wrapping, and no hidden
+      critical state at narrow widths; verify all assertions pass with Pi's current theme/component
+      contracts.
+
+- [x] Update `extensions/pi-webui/README.md` to document the menu-first bare command, `/webui open`
+      migration route, menu states and navigation, immediate-save versus next-session apply behavior,
+      link rotation consequence, invalid-settings recovery, supported modes, and unchanged Advanced
+      JSON fields; verify command tables, Quick start, Settings, accessibility, and limitations use
+      consistent final labels without removing existing compatibility/security guidance.
+
+- [x] Run focused package checks with
+      `npm --workspace @narumitw/pi-webui run check`, then run the CI-equivalent root gate with
+      `npm run check`; record both successful command results in this plan.
+
+- [x] Run `just pack webui` and inspect the dry-run contents for the new source module and updated
+      README with no tests, fixtures, cache, or `node_modules`; record the successful inspection in
+      this plan.
+
+- [x] Not applicable as an interactive TUI command: repository guidance prohibits launching a TUI.
+      Equivalent deterministic runtime/component tests covered menu entry, Escape with no side
+      effects, Open success, fresh-link preview/rotation, Settings/Help/Status return, responsive
+      rendering, and actionable failures. A non-interactive package load smoke passed with
+      `pi --no-extensions --no-session --print --extension ./extensions/pi-webui '/webui open'`
+      (exit 0, no protocol output or server side effect).
+
+## Execution Evidence
+
+- TDD red state: the first `npm test` run failed because bare `/webui` still started the server and
+  `open` was absent from completions; the final post-rebase suite passes 1,466/1,466 tests.
+- `npm --workspace @narumitw/pi-webui run check` passed with current browser assets and TypeScript.
+- `npm run check` passed on the final tree, including Biome, boundaries, workspace typechecks, and
+  all 1,466 tests.
+- `just pack webui` passed; the 30-file preview includes `src/menu.ts` and updated README/source, and
+  excludes tests, fixtures, cache, and `node_modules`.
+- `git diff --check` passed.
+
+## Completion Checklist
+
+- [x] Bare `/webui` opens the current-state menu in every claimed interactive mode and does not mutate
+      state until confirmation.
+- [x] `/webui open` preserves the former direct browser-link workflow, and every established
+      subcommand remains documented, completed, rejected safely, and tested in its claimed modes.
+- [x] Primary, preview, confirmation, cancellation, navigation, success, failure, disabled, partial,
+      and compatibility states satisfy the approved proposal.
+- [x] Settings persistence, unknown fields, malformed files, server lifecycle, browser protocol, and
+      stored user data remain backward compatible without migration.
+- [x] Responsive width, keyboard/focus, terminal-safety, non-color-cue, and theme checks pass.
+- [x] `npm --workspace @narumitw/pi-webui run check`, `npm run check`, `just pack webui`, and the
+      applicable Pi runtime smoke have recorded passing evidence.
+- [x] `extensions/pi-webui/README.md` accurately describes the final behavior and migration route.
+- [x] After every item is complete, move this plan to
+      `docs/plans/archived/2026-07-26_pi-webui-menu-redesign-plan.md` without overwriting an existing
+      archive.

--- a/extensions/pi-webui/README.md
+++ b/extensions/pi-webui/README.md
@@ -36,11 +36,12 @@ The package targets the latest Pi release.
 
 ## 🚀 Usage
 
-1. Start Pi in a terminal and run `/webui`.
-2. Open the one-time `http://127.0.0.1:<port>/bootstrap?...` link shown by Pi. The extension does not open a browser itself.
-3. Continue typing in either the terminal or browser. Accepted messages from both surfaces appear in the browser transcript.
-4. While Pi is idle, **Send** starts a turn immediately. While Pi is working, **Queue next** queues a follow-up. Use **Steer** only when the new instruction should reach Pi after the current tool batch.
-5. Refreshing or opening the link in another tab takes the editing lease. Older tabs remain readable and clearly become read-only.
+1. Start Pi in a terminal and run `/webui` to open the current-state menu.
+2. Select **Open WebUI**. If the server is already running, select **Get a fresh link** instead; this invalidates any earlier unused bootstrap link.
+3. Open the one-time `http://127.0.0.1:<port>/bootstrap?...` link shown by Pi. The extension does not open a browser itself. Use `/webui open` when you intentionally want to skip the menu.
+4. Continue typing in either the terminal or browser. Accepted messages from both surfaces appear in the browser transcript.
+5. While Pi is idle, **Send** starts a turn immediately. While Pi is working, **Queue next** queues a follow-up. Use **Steer** only when the new instruction should reach Pi after the current tool batch.
+6. Refreshing or opening the link in another tab takes the editing lease. Older tabs remain readable and clearly become read-only.
 
 If another installed extension also registers `/webui`, Pi assigns numeric command suffixes according to extension load order. Check Pi's command provenance and invoke the WebUI entry.
 
@@ -48,13 +49,16 @@ If another installed extension also registers `/webui`, Pi assigns numeric comma
 
 | Command | Behavior |
 | --- | --- |
-| `/webui` | Start or reuse the current session server and display a fresh one-time link. |
+| `/webui` | Open the current-state menu in TUI or an interactive RPC client. Opening or cancelling the menu has no side effects. |
+| `/webui open` | Start or reuse the current session server and display a fresh one-time link without opening the menu. Unsupported print/JSON modes remain side-effect free because they cannot expose the link. |
 | `/webui settings` | Open the interactive settings screen in TUI mode. Other modes report the manual settings path when notifications are available. |
 | `/webui status` | Show the effective startup preference and source, settings path, and whether the current session server is running. It never issues a bootstrap link. |
 | `/webui help` | Show command and manual-settings help. |
 | `/webui init` | Create the defaults file without overwriting existing content, then open settings in TUI mode. |
 
-Argument completion is available for all subcommands. Bare `/webui` remains the direct browser-link action.
+Argument completion is available for all subcommands. Bare `/webui` is menu-first; scripts and users migrating from the earlier direct behavior should use `/webui open`.
+
+The menu keeps the consequential current state beside each decision: whether the session server is running, whether startup is **Manual** or **Every session**, and whether values come from defaults or the settings file. **Open WebUI** previews that it starts a private session server. **Get a fresh link** previews that it keeps the server but invalidates any earlier unused bootstrap link. Escape closes the main menu without starting a server, issuing a link, or saving settings. Settings, Status & diagnostics, and Help are one level deep and return to the menu.
 
 ## ⚙️ Settings
 
@@ -90,7 +94,9 @@ The normal default path is `~/.pi/agent/pi-webui.json`. Pi installations that us
 | `maxBatchBytes` | `41943040` (40 MiB) | Combined source/processed draft bytes; hard ceiling 209715200 (200 MiB). |
 | `maxImagePixels` | `50000000` | Decoded pixels per image; hard ceiling 100000000. Animated-image frame area participates in this limit. |
 
-A missing file uses defaults. The file must contain a top-level JSON object; recognized booleans and positive integer limits must have the documented types and remain within their hard ceilings. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility. The settings screen exposes only the frequent startup toggle; there is not yet user-testing evidence that `maxImages` is adjusted often enough to justify another routine row. Retention and image-limit fields remain in Advanced JSON at the reported path.
+A missing file uses defaults. The file must contain a top-level JSON object; recognized booleans and positive integer limits must have the documented types and remain within their hard ceilings. Malformed JSON or an invalid recognized value causes the file to be ignored with a warning and leaves it untouched. Unknown fields are accepted and preserved by the settings screen for forward compatibility. The settings screen exposes only **Start WebUI automatically**, with the user-facing values **Manual** and **Every session**. Changes save immediately; Escape closes or returns and does not roll back changes that already succeeded. The startup behavior applies on the next session initialization or `/reload` and does not start or stop the current server. There is not yet user-testing evidence that `maxImages` is adjusted often enough to justify another routine row. Retention and image-limit fields remain in Advanced JSON at the reported path.
+
+If the settings file is malformed or contains an invalid recognized value, the menu presents a read-only **Repair settings file** flow. Safe defaults remain active, the original bytes stay untouched, and settings writes remain paused until the file is repaired and Pi is reloaded.
 
 ### Advanced image limits
 
@@ -98,7 +104,7 @@ Omitting all four image-limit fields exactly reproduces the original 8 image / 1
 
 Settings are reloaded on every `session_start`. Changes made in `/webui settings` are saved atomically and update the in-memory preference immediately, but they intentionally do not start or stop the server in the current session; they take effect at the next session initialization or `/reload`. `/webui init` creates formatted defaults once and refuses to overwrite valid or invalid existing content.
 
-In print, JSON, and RPC modes, `/webui settings` does not open custom TUI or write protocol-breaking output. Use `/webui status`, `/webui help`, or edit the reported path manually.
+In RPC mode, `/webui` uses the client's observable selection dialogs without opening custom TUI. In print and JSON modes, bare `/webui` and `/webui open` remain side-effect free because those modes cannot safely expose an interactive menu or bootstrap link. `/webui settings` does not open custom TUI or write protocol-breaking output outside TUI mode. Use an interactive TUI/RPC client for the menu and link, or use `/webui status`, `/webui help`, and the reported path where notifications are available.
 
 ## 🔄 What synchronization means
 
@@ -143,7 +149,9 @@ A loopback page is local to the operating-system network namespace. WebUI does n
 
 ## ♿ Accessibility and browsers
 
-The page uses semantic headings, native disclosure/dialog controls, concise status/alert live regions, accessible labels, visible keyboard focus, at least 44 px controls, keyboard image preview/removal/reordering, `Ctrl/Command+Enter` submission, reduced-motion handling, dark mode, and responsive reflow. It targets current stable desktop Chrome, Edge, Firefox, and Safari.
+The terminal menu uses Pi's configured selection keybindings, textual state that does not depend on color, stable focus when returning from a secondary screen, and responsive wrapping without hiding consequential previews. Pi's terminal accessibility remains subject to terminal and screen-reader capabilities.
+
+The browser page uses semantic headings, native disclosure/dialog controls, concise status/alert live regions, accessible labels, visible keyboard focus, at least 44 px controls, keyboard image preview/removal/reordering, `Ctrl/Command+Enter` submission, reduced-motion handling, dark mode, and responsive reflow. It targets current stable desktop Chrome, Edge, Firefox, and Safari.
 
 ## 🚧 Limitations
 
@@ -158,7 +166,8 @@ The page uses semantic headings, native disclosure/dialog controls, concise stat
 ```text
 src/index.ts         Pi package entrypoint
 src/webui.ts         extension registration and command orchestration
-src/runtime.ts       Pi lifecycle, commands, event projection, and browser message routing
+src/runtime.ts       Pi lifecycle, commands, menu orchestration, event projection, and browser routing
+src/menu.ts          responsive current-state menu and read-only detail presentation
 src/settings.ts      global WebUI settings validation and atomic persistence
 src/conversation.ts  bounded transcript snapshot and ordered event replay
 src/drafts.ts        authoritative in-memory text and attachment-reference revisions

--- a/extensions/pi-webui/src/menu.ts
+++ b/extensions/pi-webui/src/menu.ts
@@ -1,0 +1,194 @@
+import { keyHint, type Theme } from "@earendil-works/pi-coding-agent";
+import {
+	Container,
+	type KeybindingsManager,
+	type SelectItem,
+	SelectList,
+	Text,
+} from "@earendil-works/pi-tui";
+
+export type WebUIMenuAction = "open" | "settings" | "repair" | "status" | "help";
+
+export interface WebUIMenuState {
+	serverRunning: boolean;
+	startupAutomatic: boolean;
+	settingsSource: string;
+	settingsPath: string;
+	settingsInvalid: boolean;
+}
+
+export interface WebUIMenuItem extends SelectItem {
+	value: WebUIMenuAction;
+}
+
+interface TuiRenderHost {
+	requestRender(): void;
+}
+
+export function webUIMenuItems(state: WebUIMenuState): WebUIMenuItem[] {
+	const primary: WebUIMenuItem = state.serverRunning
+		? {
+				value: "open",
+				label: "Get a fresh link",
+				description: "Keep the current server and invalidate any unused earlier bootstrap link.",
+			}
+		: {
+				value: "open",
+				label: "Open WebUI",
+				description:
+					"Start a private browser companion for this Pi session and create a one-time link.",
+			};
+	const settings: WebUIMenuItem = state.settingsInvalid
+		? {
+				value: "repair",
+				label: "Repair settings file",
+				description:
+					"Safe defaults are active; inspect the preserved invalid JSON before reloading.",
+			}
+		: {
+				value: "settings",
+				label: "Settings",
+				description: `Startup: ${startupLabel(state)}. Changes save immediately and apply on the next session initialization.`,
+			};
+	return [
+		primary,
+		settings,
+		{
+			value: "status",
+			label: "Status & diagnostics",
+			description: "Review effective startup, settings source, image limits, and server state.",
+		},
+		{
+			value: "help",
+			label: "Help",
+			description: "Review the browser workflow, direct commands, and advanced settings path.",
+		},
+	];
+}
+
+export function webUIMenuTitle(state: WebUIMenuState): string {
+	const lines = [
+		"Pi WebUI",
+		`Server: ${state.serverRunning ? "Running" : "Stopped"} · Startup: ${startupLabel(state)} · Source: ${safeTerminalText(state.settingsSource)}`,
+	];
+	if (state.settingsInvalid) {
+		lines.push(
+			"Settings need repair · Safe defaults are active",
+			`File: ${safeTerminalText(state.settingsPath)}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+export function createWebUIMenuComponent(
+	state: WebUIMenuState,
+	tui: TuiRenderHost,
+	theme: Theme,
+	done: (action: WebUIMenuAction | undefined) => void,
+	selectedAction?: WebUIMenuAction,
+) {
+	const items = webUIMenuItems(state);
+	const container = new Container();
+	const title = new Text(theme.fg("accent", theme.bold("Pi WebUI")), 1, 1);
+	container.addChild(title);
+	container.addChild(
+		new Text(
+			[
+				`Server: ${state.serverRunning ? "Running" : "Stopped"}`,
+				`Startup: ${startupLabel(state)} · Source: ${safeTerminalText(state.settingsSource)}`,
+				...(state.settingsInvalid
+					? [
+							"Settings need repair · Safe defaults are active",
+							`File: ${safeTerminalText(state.settingsPath)}`,
+						]
+					: []),
+			].join("\n"),
+			1,
+			0,
+		),
+	);
+	const preview = new Text("", 1, 1);
+	const list = new SelectList(items, items.length, {
+		selectedPrefix: (text) => theme.fg("accent", text),
+		selectedText: (text) => theme.fg("accent", text),
+		description: (text) => theme.fg("muted", text),
+		scrollInfo: (text) => theme.fg("dim", text),
+		noMatch: (text) => theme.fg("warning", text),
+	});
+	const updatePreview = (item: SelectItem) => {
+		preview.setText(`Effect: ${safeTerminalText(item.description ?? item.label)}`);
+	};
+	const selectedIndex = Math.max(
+		0,
+		items.findIndex((item) => item.value === selectedAction),
+	);
+	list.setSelectedIndex(selectedIndex);
+	updatePreview(items[selectedIndex]);
+	list.onSelectionChange = updatePreview;
+	list.onSelect = (item) => done(item.value as WebUIMenuAction);
+	list.onCancel = () => done(undefined);
+	container.addChild(list);
+	container.addChild(preview);
+	const hintText = () =>
+		theme.fg(
+			"dim",
+			`${keyHint("tui.select.confirm", "select")} · ${keyHint("tui.select.cancel", "close")}`,
+		);
+	const hint = new Text(hintText(), 1, 0);
+	container.addChild(hint);
+	return {
+		render: (width: number) => container.render(width),
+		invalidate: () => {
+			title.setText(theme.fg("accent", theme.bold("Pi WebUI")));
+			hint.setText(hintText());
+			container.invalidate();
+		},
+		handleInput(data: string) {
+			list.handleInput(data);
+			tui.requestRender();
+		},
+	};
+}
+
+export function createWebUIDetailComponent(
+	title: string,
+	lines: readonly string[],
+	tui: TuiRenderHost,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: () => void,
+) {
+	const container = new Container();
+	const heading = new Text(theme.fg("accent", theme.bold(safeTerminalText(title))), 1, 1);
+	const hint = new Text(theme.fg("dim", keyHint("tui.select.cancel", "back")), 1, 1);
+	container.addChild(heading);
+	container.addChild(new Text(lines.map((line) => safeTerminalText(line)).join("\n"), 1, 0));
+	container.addChild(hint);
+	return {
+		render: (width: number) => container.render(width),
+		invalidate: () => {
+			heading.setText(theme.fg("accent", theme.bold(safeTerminalText(title))));
+			hint.setText(theme.fg("dim", keyHint("tui.select.cancel", "back")));
+			container.invalidate();
+		},
+		handleInput(data: string) {
+			if (keybindings.matches(data, "tui.select.cancel")) done();
+			tui.requestRender();
+		},
+	};
+}
+
+export function safeTerminalText(value: unknown): string {
+	return [...String(value)]
+		.map((character) => {
+			const code = character.charCodeAt(0);
+			return code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? " " : character;
+		})
+		.join("")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function startupLabel(state: WebUIMenuState): string {
+	return state.startupAutomatic ? "Every session" : "Manual";
+}

--- a/extensions/pi-webui/src/runtime.ts
+++ b/extensions/pi-webui/src/runtime.ts
@@ -261,6 +261,8 @@ export class WebUIRuntime {
 		previousConversation?.close();
 		await this.releaseServer();
 		if (generation !== this.generation) return;
+		await this.settingsSaveQueue;
+		if (generation !== this.generation) return;
 		const settingsResult = await this.dependencies.loadSettings();
 		if (generation !== this.generation) return;
 		this.applySettingsResult(settingsResult);
@@ -418,8 +420,9 @@ export class WebUIRuntime {
 
 	private async showMenu(ctx: ExtensionCommandContext): Promise<void> {
 		if (!ctx.hasUI) return;
+		const generation = this.generation;
 		let selectedAction: WebUIMenuAction | undefined;
-		while (true) {
+		while (generation === this.generation) {
 			const state = this.menuState();
 			let action: WebUIMenuAction | undefined;
 			if (ctx.mode === "tui") {
@@ -434,7 +437,7 @@ export class WebUIRuntime {
 				const selectedIndex = selected === undefined ? -1 : options.indexOf(selected);
 				action = items[selectedIndex]?.value;
 			}
-			if (!action) return;
+			if (generation !== this.generation || !action) return;
 			selectedAction = action;
 			if (action === "open") {
 				await this.openWebUI(ctx);
@@ -442,17 +445,21 @@ export class WebUIRuntime {
 			}
 			if (action === "settings") {
 				await this.showSettings(ctx);
+				if (generation !== this.generation) return;
 				continue;
 			}
 			if (action === "repair") {
 				await this.showDetail(ctx, "Repair WebUI settings", this.repairLines());
+				if (generation !== this.generation) return;
 				continue;
 			}
 			if (action === "status") {
 				await this.showDetail(ctx, "Pi WebUI status", this.statusLines());
+				if (generation !== this.generation) return;
 				continue;
 			}
 			await this.showDetail(ctx, "Pi WebUI help", this.helpLines());
+			if (generation !== this.generation) return;
 		}
 	}
 
@@ -486,6 +493,7 @@ export class WebUIRuntime {
 			return;
 		}
 
+		const settingsGeneration = this.generation;
 		const items: SettingItem[] = [
 			{
 				id: "startOnSessionStart",
@@ -530,9 +538,11 @@ export class WebUIRuntime {
 							this.settingsDocument = document;
 							this.settingsSource = "settings file";
 						} catch (error) {
-							list.updateValue(id, previous ? "Every session" : "Manual");
-							ctx.ui.notify(`WebUI settings save failed: ${formatError(error)}`, "error");
-							tui.requestRender();
+							if (settingsGeneration === this.generation) {
+								list.updateValue(id, previous ? "Every session" : "Manual");
+								ctx.ui.notify(`WebUI settings save failed: ${formatError(error)}`, "error");
+								tui.requestRender();
+							}
 						}
 					});
 					this.settingsSaveQueue = operation.catch(() => undefined);
@@ -553,6 +563,7 @@ export class WebUIRuntime {
 				},
 			};
 		});
+		await this.settingsSaveQueue;
 	}
 
 	private statusLines(): string[] {

--- a/extensions/pi-webui/src/runtime.ts
+++ b/extensions/pi-webui/src/runtime.ts
@@ -19,6 +19,15 @@ import {
 	processStagedImage,
 	validateStagedBrowserImages,
 } from "./images.js";
+import {
+	createWebUIDetailComponent,
+	createWebUIMenuComponent,
+	safeTerminalText,
+	type WebUIMenuAction,
+	type WebUIMenuState,
+	webUIMenuItems,
+	webUIMenuTitle,
+} from "./menu.js";
 import { type EffectivePiImageSettings, readEffectivePiImageSettings } from "./pi-settings.js";
 import {
 	type WebSendRequest,
@@ -36,10 +45,12 @@ import {
 } from "./settings.js";
 
 const WIDGET_KEY = "webui";
+const ACTIVITY_STATUS_KEY = "webui:activity";
 const INPUT_HEADER = /^<pi-webui-input nonce="([0-9a-f-]+)">\n/;
 const INPUT_FOOTER = "\n</pi-webui-input>";
-const COMMAND_USAGE = "Usage: /webui [settings|status|help|init]";
+const COMMAND_USAGE = "Usage: /webui [open|settings|status|help|init]";
 const COMMAND_COMPLETIONS = [
+	{ value: "open", label: "open", description: "Open WebUI and display a fresh link" },
 	{ value: "settings", label: "settings", description: "Open WebUI settings" },
 	{ value: "status", label: "status", description: "Show effective WebUI settings and state" },
 	{ value: "help", label: "help", description: "Show WebUI command help" },
@@ -111,6 +122,7 @@ export class WebUIRuntime {
 	private settingsPath = "pi-webui.json";
 	private settingsSource: SettingsLoadResult["source"] = "defaults";
 	private settingsSaveQueue: Promise<void> = Promise.resolve();
+	private activityId = 0;
 
 	constructor(
 		private readonly pi: ExtensionAPI,
@@ -121,7 +133,7 @@ export class WebUIRuntime {
 
 	register(): void {
 		this.pi.registerCommand("webui", {
-			description: "Open or configure the local web companion for this Pi session",
+			description: "Manage the local web companion for this Pi session",
 			getArgumentCompletions: (prefix) => {
 				const normalized = prefix.trimStart().toLowerCase();
 				if (/\s/.test(normalized)) return null;
@@ -133,7 +145,11 @@ export class WebUIRuntime {
 				const action = args.trim().toLowerCase();
 				try {
 					if (!action) {
-						await this.presentLink(ctx);
+						await this.showMenu(ctx);
+						return;
+					}
+					if (action === "open") {
+						await this.openWebUI(ctx);
 						return;
 					}
 					if (action === "settings") {
@@ -154,10 +170,12 @@ export class WebUIRuntime {
 					}
 					if (ctx.hasUI) ctx.ui.notify(COMMAND_USAGE, "warning");
 				} catch (error) {
-					if (!action) {
-						ctx.ui.notify(`Pi WebUI could not start: ${formatError(error)}`, "error");
-					} else if (ctx.hasUI) {
-						ctx.ui.notify(`Pi WebUI command failed: ${formatError(error)}`, "error");
+					if (ctx.hasUI) {
+						const message = `Pi WebUI command failed: ${formatError(error)}`;
+						ctx.ui.notify(
+							action === "open" || !action ? `${message}. Retry with /webui open.` : message,
+							"error",
+						);
 					}
 				}
 			},
@@ -262,6 +280,8 @@ export class WebUIRuntime {
 		this.closed = false;
 		this.lastSettingsWarning = "";
 		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		this.activityId += 1;
+		ctx.ui.setStatus(ACTIVITY_STATUS_KEY, undefined);
 		if (settingsResult.warning) ctx.ui.notify(settingsResult.warning, "warning");
 		if (!this.settings.startOnSessionStart) return;
 		try {
@@ -285,6 +305,8 @@ export class WebUIRuntime {
 		this.context = undefined;
 		this.conversation = undefined;
 		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		this.activityId += 1;
+		ctx.ui.setStatus(ACTIVITY_STATUS_KEY, undefined);
 	}
 
 	private captureContext(ctx: ExtensionContext): void {
@@ -363,7 +385,100 @@ export class WebUIRuntime {
 		ctx.ui.notify(`Pi WebUI: ${link}`, "info");
 	}
 
+	private async openWebUI(ctx: ExtensionCommandContext): Promise<void> {
+		if (ctx.mode === "print" || ctx.mode === "json") return;
+		const activityId = ++this.activityId;
+		ctx.ui.setStatus(
+			ACTIVITY_STATUS_KEY,
+			this.server ? "Creating fresh WebUI link…" : "Starting WebUI…",
+		);
+		try {
+			await this.presentLink(ctx);
+		} finally {
+			if (activityId === this.activityId) {
+				ctx.ui.setStatus(ACTIVITY_STATUS_KEY, undefined);
+			}
+		}
+	}
+
+	private menuState(): WebUIMenuState {
+		return {
+			serverRunning: this.server !== undefined,
+			startupAutomatic: this.settings.startOnSessionStart,
+			settingsSource:
+				this.settingsDocument === undefined
+					? "Defaults (invalid file ignored)"
+					: this.settingsSource === "settings file"
+						? "Settings file"
+						: "Defaults",
+			settingsPath: this.settingsPath,
+			settingsInvalid: this.settingsDocument === undefined,
+		};
+	}
+
+	private async showMenu(ctx: ExtensionCommandContext): Promise<void> {
+		if (!ctx.hasUI) return;
+		let selectedAction: WebUIMenuAction | undefined;
+		while (true) {
+			const state = this.menuState();
+			let action: WebUIMenuAction | undefined;
+			if (ctx.mode === "tui") {
+				action = await ctx.ui.custom<WebUIMenuAction | undefined>(
+					(tui, theme, _keybindings, done) =>
+						createWebUIMenuComponent(state, tui, theme, done, selectedAction),
+				);
+			} else {
+				const items = webUIMenuItems(state);
+				const options = items.map((item) => `${item.label} — ${item.description ?? ""}`);
+				const selected = await ctx.ui.select(webUIMenuTitle(state), options);
+				const selectedIndex = selected === undefined ? -1 : options.indexOf(selected);
+				action = items[selectedIndex]?.value;
+			}
+			if (!action) return;
+			selectedAction = action;
+			if (action === "open") {
+				await this.openWebUI(ctx);
+				return;
+			}
+			if (action === "settings") {
+				await this.showSettings(ctx);
+				continue;
+			}
+			if (action === "repair") {
+				await this.showDetail(ctx, "Repair WebUI settings", this.repairLines());
+				continue;
+			}
+			if (action === "status") {
+				await this.showDetail(ctx, "Pi WebUI status", this.statusLines());
+				continue;
+			}
+			await this.showDetail(ctx, "Pi WebUI help", this.helpLines());
+		}
+	}
+
+	private async showDetail(
+		ctx: ExtensionCommandContext,
+		title: string,
+		lines: readonly string[],
+	): Promise<void> {
+		if (ctx.mode === "tui") {
+			await ctx.ui.custom<void>((tui, theme, keybindings, done) =>
+				createWebUIDetailComponent(title, lines, tui, theme, keybindings, done),
+			);
+			return;
+		}
+		await ctx.ui.select([title, "", ...lines].join("\n"), ["Back"]);
+	}
+
 	private async showSettings(ctx: ExtensionCommandContext): Promise<void> {
+		if (this.settingsDocument === undefined) {
+			if (ctx.mode === "tui") {
+				await this.showDetail(ctx, "Repair WebUI settings", this.repairLines());
+			} else if (ctx.hasUI) {
+				ctx.ui.notify(this.repairLines().join("\n"), "warning");
+			}
+			return;
+		}
 		if (ctx.mode !== "tui") {
 			if (ctx.hasUI) {
 				ctx.ui.notify(`Edit WebUI settings manually: ${this.settingsPath}`, "info");
@@ -374,23 +489,31 @@ export class WebUIRuntime {
 		const items: SettingItem[] = [
 			{
 				id: "startOnSessionStart",
-				label: "Start on session start",
-				description: "Start WebUI and display a link for each newly initialized Pi session",
-				currentValue: String(this.settings.startOnSessionStart),
-				values: ["true", "false"],
+				label: "Start WebUI automatically",
+				description: "Choose whether future Pi session initializations display a WebUI link",
+				currentValue: this.settings.startOnSessionStart ? "Every session" : "Manual",
+				values: ["Manual", "Every session"],
 			},
 		];
 
 		await ctx.ui.custom((tui, theme, _keybindings, done) => {
 			const container = new Container();
-			container.addChild(new Text(theme.fg("accent", theme.bold("Pi WebUI Settings")), 1, 1));
+			const title = new Text(theme.fg("accent", theme.bold("Pi WebUI Settings")), 1, 1);
+			container.addChild(title);
+			container.addChild(
+				new Text(
+					`Changes save immediately. Startup changes apply on the next session initialization or reload.\nAdvanced settings: ${safeTerminalText(this.settingsPath)}`,
+					1,
+					0,
+				),
+			);
 			const list = new SettingsList(
 				items,
 				Math.min(items.length + 2, 15),
 				getSettingsListTheme(),
 				(id, value) => {
 					if (id !== "startOnSessionStart") return;
-					const requested = value === "true";
+					const requested = value === "Every session";
 					const operation = this.settingsSaveQueue.then(async () => {
 						const previous = this.settings.startOnSessionStart;
 						try {
@@ -407,7 +530,7 @@ export class WebUIRuntime {
 							this.settingsDocument = document;
 							this.settingsSource = "settings file";
 						} catch (error) {
-							list.updateValue(id, String(previous));
+							list.updateValue(id, previous ? "Every session" : "Manual");
 							ctx.ui.notify(`WebUI settings save failed: ${formatError(error)}`, "error");
 							tui.requestRender();
 						}
@@ -415,12 +538,15 @@ export class WebUIRuntime {
 					this.settingsSaveQueue = operation.catch(() => undefined);
 				},
 				() => done(undefined),
-				{ enableSearch: true },
+				{ enableSearch: false },
 			);
 			container.addChild(list);
 			return {
 				render: (width: number) => container.render(width),
-				invalidate: () => container.invalidate(),
+				invalidate: () => {
+					title.setText(theme.fg("accent", theme.bold("Pi WebUI Settings")));
+					container.invalidate();
+				},
 				handleInput(data: string) {
 					list.handleInput?.(data);
 					tui.requestRender();
@@ -429,38 +555,49 @@ export class WebUIRuntime {
 		});
 	}
 
+	private statusLines(): string[] {
+		const source =
+			this.settingsDocument === undefined ? "Defaults (invalid file ignored)" : this.settingsSource;
+		return [
+			`Server: ${this.server ? "Running" : "Stopped"}`,
+			`Startup: ${this.settings.startOnSessionStart ? "Every session" : "Manual"} (${source})`,
+			`Image limits (${source}): ${this.effectiveImageLimits.maxImages} images, ${formatMib(this.effectiveImageLimits.maxImageBytes)}/image, ${formatMib(this.effectiveImageLimits.maxBatchBytes)}/batch, ${this.effectiveImageLimits.maxImagePixels.toLocaleString("en-US")} pixels/image`,
+			`Settings: ${safeTerminalText(this.settingsPath)}`,
+		];
+	}
+
 	private showStatus(ctx: ExtensionCommandContext): void {
 		if (!ctx.hasUI) return;
-		const source =
-			this.settingsDocument === undefined ? "defaults (invalid file ignored)" : this.settingsSource;
-		ctx.ui.notify(
-			[
-				"Pi WebUI status",
-				`startOnSessionStart: ${this.settings.startOnSessionStart} (${source})`,
-				`Image limits (${source}): ${this.effectiveImageLimits.maxImages} images, ${formatMib(this.effectiveImageLimits.maxImageBytes)}/image, ${formatMib(this.effectiveImageLimits.maxBatchBytes)}/batch, ${this.effectiveImageLimits.maxImagePixels.toLocaleString("en-US")} pixels/image`,
-				`Settings: ${this.settingsPath}`,
-				`Server: ${this.server ? "running" : "stopped"}`,
-			].join("\n"),
-			"info",
-		);
+		ctx.ui.notify(["Pi WebUI status", ...this.statusLines()].join("\n"), "info");
+	}
+
+	private helpLines(): string[] {
+		return [
+			COMMAND_USAGE,
+			"/webui: open the current-state menu",
+			"open: start or reuse the current session server and display a fresh one-time link",
+			"settings: edit WebUI settings in TUI mode",
+			"status: show effective settings, source, path, and current server state",
+			"init: create the defaults file without overwriting existing content",
+			'Accepted JSON starts with { "startOnSessionStart": false } and may include advanced maxImages, maxImageBytes, maxBatchBytes, and maxImagePixels fields.',
+			`Settings path: ${safeTerminalText(this.settingsPath)}`,
+			"Image byte/pixel limits stay in Advanced JSON; Pi provider-ready dimension/Base64 limits are fixed.",
+			"Settings changes save immediately; startup changes apply on the next session initialization or reload.",
+		];
+	}
+
+	private repairLines(): string[] {
+		return [
+			"The settings file is invalid and was preserved without changes.",
+			"Safe defaults remain active; settings writes are paused.",
+			`File: ${safeTerminalText(this.settingsPath)}`,
+			"Repair the JSON file, then run /reload before editing settings again.",
+		];
 	}
 
 	private showHelp(ctx: ExtensionCommandContext): void {
 		if (!ctx.hasUI) return;
-		ctx.ui.notify(
-			[
-				COMMAND_USAGE,
-				"/webui: start or reuse the current session server and display a fresh one-time link",
-				"settings: edit WebUI settings in TUI mode",
-				"status: show effective settings, source, path, and current server state",
-				"init: create the defaults file without overwriting existing content",
-				'Accepted JSON starts with { "startOnSessionStart": false } and may include advanced maxImages, maxImageBytes, maxBatchBytes, and maxImagePixels fields.',
-				`Settings path: ${this.settingsPath}`,
-				"Image byte/pixel limits stay in Advanced JSON; Pi provider-ready dimension/Base64 limits are fixed.",
-				"Changes apply on the next session initialization or reload.",
-			].join("\n"),
-			"info",
-		);
+		ctx.ui.notify(this.helpLines().join("\n"), "info");
 	}
 
 	private async initializeSettings(ctx: ExtensionCommandContext): Promise<void> {

--- a/extensions/pi-webui/test/commands.test.ts
+++ b/extensions/pi-webui/test/commands.test.ts
@@ -132,6 +132,80 @@ test("webui command completes and routes settings, status, help, and invalid arg
 	assert.doesNotMatch(runningStatus, /token=/i);
 });
 
+test("a menu selection cannot dispatch into a replacement session", async () => {
+	const selection = deferred<string | undefined>();
+	let options: string[] = [];
+	let starts = 0;
+	const { mock, runtime } = createRuntime({
+		startServer: async () => {
+			starts += 1;
+			return {
+				issueLink: () => "http://127.0.0.1:1234/bootstrap?token=stale",
+				close: async () => undefined,
+			};
+		},
+	});
+	const original = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		select: async (_title: string, items: string[]) => {
+			options = items;
+			return selection.promise;
+		},
+	});
+	await runtime.start(original.ctx);
+	const opening = mock.commands.get("webui")?.handler("", original.ctx);
+	await waitFor(() => options.length > 0);
+
+	const replacement = createMockContext({ hasUI: true, mode: "rpc" });
+	await runtime.start(replacement.ctx);
+	selection.resolve(options[0]);
+	await opening;
+
+	assert.equal(starts, 0);
+	assert.equal(original.notifications.length, 0);
+	assert.equal(replacement.notifications.length, 0);
+});
+
+test("menu waits for settings persistence before rebuilding current state", async () => {
+	const saved = deferred<void>();
+	let customCalls = 0;
+	let saveStarted = false;
+	const { mock, runtime } = createRuntime({
+		saveSettings: async (settings, document) => {
+			saveStarted = true;
+			await saved.promise;
+			return { ...document, ...settings };
+		},
+	});
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const selector = createCustomSelectorHarness(factory);
+			if (customCalls === 1) {
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else if (customCalls === 2) {
+				selector.handleInput("\r");
+				selector.handleInput("\u001b");
+			} else {
+				assert.match(selector.render().join("\n"), /Startup: Every session/);
+				selector.handleInput("\u001b");
+			}
+			return selector.result;
+		},
+	});
+	await runtime.start(context.ctx);
+	const showing = mock.commands.get("webui")?.handler("", context.ctx);
+	await waitFor(() => saveStarted);
+	assert.equal(customCalls, 2);
+	saved.resolve(undefined);
+	await showing;
+	assert.equal(customCalls, 3);
+});
+
 test("menu secondary screens return with stable selection and no server side effects", async () => {
 	let starts = 0;
 	let customCalls = 0;

--- a/extensions/pi-webui/test/commands.test.ts
+++ b/extensions/pi-webui/test/commands.test.ts
@@ -55,6 +55,42 @@ function createRuntime(
 	return { mock, runtime };
 }
 
+test("bare webui opens a cancellable TUI menu while open preserves the direct link flow", async () => {
+	let starts = 0;
+	let links = 0;
+	const { mock, runtime } = createRuntime({
+		startServer: async () => {
+			starts += 1;
+			return {
+				issueLink: () => `http://127.0.0.1:1234/bootstrap?token=${++links}`,
+				close: async () => undefined,
+			};
+		},
+	});
+	const tui = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory);
+			assert.match(selector.render().join("\n"), /server: stopped/i);
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+	await runtime.start(tui.ctx);
+	const command = mock.commands.get("webui");
+	assert.ok(command);
+
+	await command.handler("", tui.ctx);
+	assert.equal(starts, 0);
+	assert.equal(links, 0);
+
+	await command.handler("open", tui.ctx);
+	assert.equal(starts, 1);
+	assert.equal(links, 1);
+	assert.match(tui.notifications.at(-1)?.message ?? "", /token=1/);
+});
+
 test("webui command completes and routes settings, status, help, and invalid arguments", async () => {
 	const { mock, runtime } = createRuntime();
 	const context = createMockContext({ hasUI: true, mode: "rpc" });
@@ -65,14 +101,14 @@ test("webui command completes and routes settings, status, help, and invalid arg
 	assert.ok(completions);
 	assert.deepEqual(
 		completions.map((item) => item.value),
-		["settings", "status", "help", "init"],
+		["open", "settings", "status", "help", "init"],
 	);
 
 	await command.handler("settings", context.ctx);
 	assert.match(context.notifications.at(-1)?.message ?? "", /manual.*pi-webui\.json/i);
 	await command.handler("status", context.ctx);
 	const status = context.notifications.at(-1)?.message ?? "";
-	assert.match(status, /startOnSessionStart: false.*defaults/is);
+	assert.match(status, /Startup: Manual.*defaults/is);
 	assert.match(
 		status,
 		/Image limits \(defaults\): 8 images, 10 MiB\/image, 40 MiB\/batch, 50,000,000 pixels\/image/,
@@ -81,7 +117,7 @@ test("webui command completes and routes settings, status, help, and invalid arg
 	assert.doesNotMatch(status, /token=/i);
 	await command.handler("help", context.ctx);
 	const help = context.notifications.at(-1)?.message ?? "";
-	assert.match(help, /\/webui \[settings\|status\|help\|init\]/i);
+	assert.match(help, /\/webui \[open\|settings\|status\|help\|init\]/i);
 	assert.match(help, /"startOnSessionStart": false/);
 	assert.match(help, /maxImages.*maxImageBytes.*maxBatchBytes.*maxImagePixels/i);
 	assert.match(help, /provider-ready dimension\/Base64 limits are fixed/i);
@@ -89,11 +125,181 @@ test("webui command completes and routes settings, status, help, and invalid arg
 	await command.handler("unknown", context.ctx);
 	assert.match(context.notifications.at(-1)?.message ?? "", /usage:/i);
 
-	await command.handler("", context.ctx);
+	await command.handler("open", context.ctx);
 	await command.handler("status", context.ctx);
 	const runningStatus = context.notifications.at(-1)?.message ?? "";
 	assert.match(runningStatus, /server: running/i);
 	assert.doesNotMatch(runningStatus, /token=/i);
+});
+
+test("menu secondary screens return with stable selection and no server side effects", async () => {
+	let starts = 0;
+	let customCalls = 0;
+	const { mock, runtime } = createRuntime({
+		startServer: async () => {
+			starts += 1;
+			return {
+				issueLink: () => "http://127.0.0.1:1234/bootstrap?token=unused",
+				close: async () => undefined,
+			};
+		},
+	});
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const selector = createCustomSelectorHarness(factory);
+			if (customCalls === 1) {
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else if (customCalls === 2) {
+				assert.match(selector.render().join("\n"), /Image limits/);
+				selector.handleInput("tui.select.cancel");
+			} else {
+				assert.match(selector.render().join("\n"), /Effect: Review effective startup/);
+				selector.handleInput("\u001b");
+			}
+			return selector.result;
+		},
+	});
+	await runtime.start(context.ctx);
+	await mock.commands.get("webui")?.handler("", context.ctx);
+	assert.equal(customCalls, 3);
+	assert.equal(starts, 0);
+});
+
+test("bare webui is side-effect free without UI and RPC cancellation stays observable", async () => {
+	let starts = 0;
+	const { mock, runtime } = createRuntime({
+		startServer: async () => {
+			starts += 1;
+			return {
+				issueLink: () => "http://127.0.0.1:1234/bootstrap?token=unused",
+				close: async () => undefined,
+			};
+		},
+	});
+	for (const mode of ["print", "json"] as const) {
+		const context = createMockContext({ hasUI: false, mode });
+		await runtime.start(context.ctx);
+		await mock.commands.get("webui")?.handler("", context.ctx);
+		await mock.commands.get("webui")?.handler("open", context.ctx);
+	}
+	const rpc = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		select: async () => undefined,
+	});
+	await runtime.start(rpc.ctx);
+	await mock.commands.get("webui")?.handler("", rpc.ctx);
+	assert.equal(starts, 0);
+});
+
+test("invalid settings expose read-only repair guidance instead of a failing toggle", async () => {
+	let saves = 0;
+	let customCalls = 0;
+	const { mock, runtime } = createRuntime(
+		{
+			saveSettings: async () => {
+				saves += 1;
+				return {};
+			},
+		},
+		{
+			kind: "invalid",
+			path: "/agent/broken-pi-webui.json",
+			settings: { ...DEFAULT_SETTINGS },
+			source: "defaults",
+			warning: "invalid settings preserved",
+		},
+	);
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const selector = createCustomSelectorHarness(factory);
+			if (customCalls === 1) {
+				assert.match(selector.render().join("\n"), /Repair settings file/);
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else if (customCalls === 2) {
+				assert.match(selector.render().join("\n"), /preserved without changes/);
+				selector.handleInput("tui.select.cancel");
+			} else {
+				selector.handleInput("\u001b");
+			}
+			return selector.result;
+		},
+	});
+	await runtime.start(context.ctx);
+	await mock.commands.get("webui")?.handler("", context.ctx);
+	assert.equal(customCalls, 3);
+	assert.equal(saves, 0);
+});
+
+test("open exposes distinct applying state before publishing success", async () => {
+	const starting = deferred<{
+		issueLink(): string;
+		close(): Promise<void>;
+	}>();
+	const { mock, runtime } = createRuntime({ startServer: async () => starting.promise });
+	const context = createMockContext({ hasUI: true, mode: "rpc" });
+	await runtime.start(context.ctx);
+	const opening = mock.commands.get("webui")?.handler("open", context.ctx);
+	assert.equal(context.statuses.get("webui:activity"), "Starting WebUI…");
+	starting.resolve({
+		issueLink: () => "http://127.0.0.1:1234/bootstrap?token=ready",
+		close: async () => undefined,
+	});
+	await opening;
+	assert.equal(context.statuses.get("webui:activity"), undefined);
+	assert.match(context.notifications.at(-1)?.message ?? "", /token=ready/);
+
+	const refreshing = mock.commands.get("webui")?.handler("open", context.ctx);
+	assert.equal(context.statuses.get("webui:activity"), "Creating fresh WebUI link…");
+	await refreshing;
+	assert.equal(context.statuses.get("webui:activity"), undefined);
+});
+
+test("open failures preserve valid server state and clear actionable activity feedback", async () => {
+	let issues = 0;
+	const { mock, runtime } = createRuntime({
+		startServer: async () => ({
+			issueLink: () => {
+				issues += 1;
+				if (issues === 2) throw new Error("token source unavailable");
+				return "http://127.0.0.1:1234/bootstrap?token=first";
+			},
+			close: async () => undefined,
+		}),
+	});
+	const context = createMockContext({ hasUI: true, mode: "rpc" });
+	await runtime.start(context.ctx);
+	const command = mock.commands.get("webui");
+	await command?.handler("open", context.ctx);
+	await command?.handler("open", context.ctx);
+	assert.match(
+		context.notifications.at(-1)?.message ?? "",
+		/token source unavailable.*Retry with \/webui open/i,
+	);
+	assert.equal(context.statuses.get("webui:activity"), undefined);
+	await command?.handler("status", context.ctx);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Server: Running/);
+
+	const failed = createRuntime({
+		startServer: async () => {
+			throw new Error("listener unavailable");
+		},
+	});
+	const failedContext = createMockContext({ hasUI: true, mode: "rpc" });
+	await failed.runtime.start(failedContext.ctx);
+	await failed.mock.commands.get("webui")?.handler("open", failedContext.ctx);
+	assert.equal(failedContext.statuses.get("webui:activity"), undefined);
+	await failed.mock.commands.get("webui")?.handler("status", failedContext.ctx);
+	assert.match(failedContext.notifications.at(-1)?.message ?? "", /Server: Stopped/);
 });
 
 test("settings never opens custom TUI in RPC, JSON, or print modes", async () => {
@@ -188,10 +394,7 @@ test("settings changes save in action order and update effective status", async 
 		context.notifications.map((item) => item.message).join("\n"),
 	);
 	await mock.commands.get("webui")?.handler("status", context.ctx);
-	assert.match(
-		context.notifications.at(-1)?.message ?? "",
-		/startOnSessionStart: false.*settings file/is,
-	);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Startup: Manual.*settings file/is);
 });
 
 test("failed settings save rolls back the displayed and effective value", async () => {
@@ -207,7 +410,7 @@ test("failed settings save rolls back the displayed and effective value", async 
 			const selector = createCustomSelectorHarness(factory);
 			selector.handleInput("\r");
 			await waitFor(() => context.notifications.some((item) => /disk full/i.test(item.message)));
-			assert.ok(selector.render().some((line) => /false/.test(line)));
+			assert.ok(selector.render().some((line) => /Manual/.test(line)));
 			selector.handleInput("\u001b");
 			return selector.result;
 		},
@@ -215,8 +418,5 @@ test("failed settings save rolls back the displayed and effective value", async 
 	await runtime.start(context.ctx);
 	await mock.commands.get("webui")?.handler("settings", context.ctx);
 	await mock.commands.get("webui")?.handler("status", context.ctx);
-	assert.match(
-		context.notifications.at(-1)?.message ?? "",
-		/startOnSessionStart: false.*defaults/is,
-	);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Startup: Manual.*defaults/is);
 });

--- a/extensions/pi-webui/test/lifecycle.test.ts
+++ b/extensions/pi-webui/test/lifecycle.test.ts
@@ -99,6 +99,8 @@ function harness(overrides: Partial<RuntimeDependencies> = {}) {
 	};
 	const ctx = {
 		cwd: "/workspace/demo",
+		hasUI: true,
+		mode: "rpc",
 		get model() {
 			return model;
 		},
@@ -122,6 +124,10 @@ function harness(overrides: Partial<RuntimeDependencies> = {}) {
 			notify(message: string) {
 				notifications.push(message);
 			},
+			async select(_title: string, options: string[]) {
+				return options[0];
+			},
+			setStatus() {},
 			setWidget(key: string, value: unknown) {
 				if (value === undefined) widgets.delete(key);
 				else widgets.set(key, value);
@@ -834,7 +840,7 @@ test("replacement and shutdown close stale servers and invalidate send callbacks
 	const gate = deferred<ReturnType<typeof harness>["server"]>();
 	const h = harness({ startServer: async () => gate.promise });
 	await h.emit("session_start");
-	const opening = h.commands.get("webui")?.handler("", h.ctx as never);
+	const opening = h.commands.get("webui")?.handler("open", h.ctx as never);
 	const replacing = h.emit("session_start", { reason: "reload" });
 	gate.resolve(h.server);
 	await Promise.all([opening, replacing]);

--- a/extensions/pi-webui/test/menu.test.ts
+++ b/extensions/pi-webui/test/menu.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createCustomSelectorHarness } from "../../../test/support.js";
+import {
+	createWebUIMenuComponent,
+	safeTerminalText,
+	type WebUIMenuState,
+	webUIMenuItems,
+	webUIMenuTitle,
+} from "../src/menu.js";
+
+initTheme("dark", false);
+
+const STOPPED: WebUIMenuState = {
+	serverRunning: false,
+	startupAutomatic: false,
+	settingsSource: "Defaults",
+	settingsPath: "/agent/pi-webui.json",
+	settingsInvalid: false,
+};
+
+function menuFactory(state: WebUIMenuState = STOPPED, selectedAction?: "status") {
+	return (tui: never, theme: never, _keybindings: never, done: never) =>
+		createWebUIMenuComponent(state, tui, theme, done, selectedAction);
+}
+
+test("menu keeps primary state and selected-effect previews visible at supported widths", () => {
+	for (const width of [30, 40, 80, 120]) {
+		const selector = createCustomSelectorHarness(menuFactory(), width);
+		const lines = selector.render();
+		assert.ok(
+			lines.every((line) => visibleWidth(line) <= width),
+			`${width}: ${lines.join("\n")}`,
+		);
+		assert.match(lines.join("\n"), /Server: Stopped/);
+		assert.match(lines.join(" ").replace(/\s+/g, " "), /Effect: Start a private browser companion/);
+	}
+});
+
+test("menu previews link rotation, preserves selection, and cancels without an action", () => {
+	const running = { ...STOPPED, serverRunning: true, startupAutomatic: true };
+	const items = webUIMenuItems(running);
+	assert.equal(items[0]?.label, "Get a fresh link");
+	assert.match(items[0]?.description ?? "", /invalidate any unused earlier bootstrap link/i);
+
+	const selected = createCustomSelectorHarness(menuFactory(running, "status"));
+	assert.match(selected.render().join("\n"), /Effect: Review effective startup/);
+	selected.handleInput("\u001b");
+	assert.equal(selected.result, undefined);
+});
+
+test("invalid settings become a repair flow and terminal-owned text is escaped", () => {
+	const state = {
+		...STOPPED,
+		settingsInvalid: true,
+		settingsPath: "/agent/\u001b[31munsafe\u0007.json",
+	};
+	assert.equal(webUIMenuItems(state)[1]?.label, "Repair settings file");
+	const title = webUIMenuTitle(state);
+	assert.equal(title.includes("\u001b"), false);
+	assert.equal(title.includes("\u0007"), false);
+	assert.match(title, /Settings need repair/);
+	assert.equal(safeTerminalText("before\u001b[31m\u0007after"), "before [31m after");
+});


### PR DESCRIPTION
## Summary

- make bare `/webui` open a goal-oriented menu with visible server, startup, settings-source, and repair state
- add `/webui open` as the direct-link compatibility route, with explicit link-rotation previews and applying/error feedback
- keep settings, status, help, invalid-file recovery, keyboard navigation, and narrow-terminal behavior shallow and testable
- update the WebUI README and archive the completed implementation plan

## Breaking change

Bare `/webui` now opens the interactive menu. Use `/webui open` for the previous direct link behavior.

## Verification

- `npm --workspace @narumitw/pi-webui run check`
- `npm run check` (1,466 tests passed)
- `just pack webui` (30 expected package files; no tests, fixtures, cache, or `node_modules`)
- `pi --no-extensions --no-session --print --extension ./extensions/pi-webui '/webui open'`
- `git diff --check`
