### PR TITLE
fix(file-context): preserve native @ autocomplete

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -124,6 +124,7 @@
 ### General
 
 - Prefer direct, user-owned context selection; avoid dedicated shortcuts or manual copy steps for routine quoting workflows.
+- Preserve Pi's native editor for trigger-based workflows; stack inline autocomplete actions instead of consuming typed trigger characters or immediately replacing the screen.
 - Prefer reading GitHub issue and pull request links with `gh --json` first; use web tools only when `gh` cannot access the needed content.
 - Live provider smokes are acceptable when relevant, but stop after one clear external or entitlement failure; use deterministic tests instead of repeatedly retrying unless the user explicitly asks.
 - Keep a predecessor extension active while its successor soaks; move it to `deprecated/` only after an explicit follow-up decision.

--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -11,8 +11,8 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 ## ✨ Features
 
-- Opens the file explorer when `@` is typed at a word boundary in Pi's normal editor.
-- Provides `/file-context` as a discoverable fallback when another extension owns the editor.
+- Adds a **Quote selected lines…** action to Pi's built-in `@` autocomplete without replacing the editor or immediately taking over the screen.
+- Provides `/file-context` as a discoverable direct route to the explorer.
 - Fuzzy-searches project files with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
@@ -42,13 +42,14 @@ pi -e ./experimental/pi-file-context
 
 ## 🚀 Quick start
 
-1. Type `@` at the start of a word in Pi's editor. If another custom editor is active, run `/file-context` instead.
-2. Type to fuzzy-search files in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
-3. In the preview, move to the first line and press `Space` to anchor the selection.
-4. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
-5. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
-6. Repeat from `@` to attach more ranges from the same or different files.
-7. Write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
+1. Type `@` at the start of a word in Pi's editor. Pi keeps the character in your draft and shows its normal inline autocomplete with **Quote selected lines…** added.
+2. Choose **Quote selected lines…** to open the explorer. To enter a literal `@`, dismiss autocomplete with `Escape` and continue normally. Pi's built-in file suggestions still insert normal whole-file `@path` references.
+3. In the explorer, type to fuzzy-search files in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
+4. In the preview, move to the first line and press `Space` to anchor the selection.
+5. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
+6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
+7. Repeat from `@` to attach more ranges from the same or different files.
+8. Write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
 
 `Escape` returns from a preview to the file list; from the file list it cancels without changing the draft. `Ctrl+C` cancels from either view.
 
@@ -91,7 +92,7 @@ Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), n
 - Keyboard line selection only; mouse drag selection is not implemented.
 - Up to eight pending quotes; there is not yet an interactive remove/reorder action.
 - Pending quotes do not survive `/reload`, session replacement, or shutdown.
-- The `@` trigger is not installed when another extension already owns the custom editor; `/file-context` remains available.
+- Custom editors receive the action only when they support Pi's autocomplete-provider interface; `/file-context` remains available otherwise.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
 - Git integration degrades to the original filesystem-only workflow outside a repository or when Git metadata cannot be read.
 - File history is limited to the 20 most recent commits. Untracked files have status and provenance but no HEAD diff hunk until Git tracks them.

--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -11,7 +11,7 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 ## ✨ Features
 
-- Adds a **Quote selected lines…** action to Pi's built-in `@` autocomplete without replacing the editor or immediately taking over the screen.
+- Extends Pi's built-in `@` autocomplete with a **Quote lines · path** companion for each file while preserving the original `@path` completion.
 - Provides `/file-context` as a discoverable direct route to the explorer.
 - Fuzzy-searches project files with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
@@ -42,9 +42,9 @@ pi -e ./experimental/pi-file-context
 
 ## 🚀 Quick start
 
-1. Type `@` at the start of a word in Pi's editor. Pi keeps the character in your draft and shows its normal inline autocomplete with **Quote selected lines…** added.
-2. Choose **Quote selected lines…** to open the explorer. To enter a literal `@`, dismiss autocomplete with `Escape` and continue normally. Pi's built-in file suggestions still insert normal whole-file `@path` references.
-3. In the explorer, type to fuzzy-search files in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
+1. Type `@` at the start of a word in Pi's editor and continue typing to filter files in Pi's normal inline autocomplete.
+2. Each file keeps its native suggestion and gains a **Quote lines · path** companion. Choose the native item to insert a whole-file `@path` reference, or choose its quote companion to open that file's line preview. To enter a literal `@`, dismiss autocomplete with `Escape` and continue normally.
+3. Alternatively, run `/file-context` to open the full explorer. Type to fuzzy-search, use `Up`/`Down` to navigate, press `Tab` to insert a whole-file reference, or press `Enter` to preview.
 4. In the preview, move to the first line and press `Space` to anchor the selection.
 5. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
 6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.

--- a/experimental/pi-file-context/src/file-context-explorer.ts
+++ b/experimental/pi-file-context/src/file-context-explorer.ts
@@ -39,6 +39,7 @@ interface FileQuoteExplorerOptions {
 	theme: Theme;
 	keybindings: KeybindingsManager;
 	files: readonly string[];
+	initialPath?: string;
 	loadFile: (path: string) => Promise<LoadedProjectTextFile>;
 	gitContext?: GitContext;
 	done: (result: FileQuoteExplorerResult | undefined) => void;
@@ -73,6 +74,10 @@ export class FileQuoteExplorer implements Component, Focusable {
 	constructor(private readonly options: FileQuoteExplorerOptions) {
 		this.fileSearch = new ProjectFileSearch(options.files);
 		this.filteredFiles = [...options.files];
+		if (options.initialPath && options.files.includes(options.initialPath)) {
+			this.selectedFileIndex = options.files.indexOf(options.initialPath);
+			void this.openFile(options.initialPath);
+		}
 	}
 
 	get focused(): boolean {

--- a/experimental/pi-file-context/src/file-context.ts
+++ b/experimental/pi-file-context/src/file-context.ts
@@ -2,17 +2,17 @@ import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
-import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
-import {
-	CustomEditor,
-	type ExtensionAPI,
-	type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
-import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+	AutocompleteItem,
+	AutocompleteProvider,
+	AutocompleteSuggestions,
+} from "@earendil-works/pi-tui";
 import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-explorer.js";
 import { createGitContext } from "./git-context.js";
 
 const WIDGET_KEY = "file-context";
+const QUOTE_ACTION_VALUE = "@__pi_file_context_quote_lines__";
 const DEFAULT_MAX_FILES = 5_000;
 const DEFAULT_MAX_BYTES = 1_000_000;
 const MAX_QUOTE_BYTES = 50_000;
@@ -247,40 +247,51 @@ export function formatQuoteContext(quotes: readonly FileQuote[]): string {
 	return `${blocks.join("\n\n")}\n\n${description}`;
 }
 
-export class FileQuoteTriggerEditor extends CustomEditor {
-	private opening = false;
-
-	constructor(
-		tui: TUI,
-		theme: EditorTheme,
-		keybindings: KeybindingsManager,
-		private readonly openExplorer: () => Promise<void>,
-	) {
-		super(tui, theme, keybindings);
-	}
-
-	override handleInput(data: string): void {
-		if (data === "@" && !this.opening && this.isQuoteTriggerPosition()) {
-			this.opening = true;
-			void this.openExplorer().finally(() => {
-				this.opening = false;
-				this.tui.requestRender();
-			});
-			return;
-		}
-		super.handleInput(data);
-	}
-
-	private isQuoteTriggerPosition(): boolean {
-		const { line, col } = this.getCursor();
-		const currentLine = this.getLines()[line] ?? "";
-		return col === 0 || /\s/.test(currentLine[col - 1] ?? "");
-	}
+export function createFileContextAutocompleteProvider(
+	current: AutocompleteProvider,
+	openExplorer: () => void,
+): AutocompleteProvider {
+	return {
+		triggerCharacters: [...new Set([...(current.triggerCharacters ?? []), "@"])],
+		async getSuggestions(
+			lines,
+			cursorLine,
+			cursorCol,
+			options,
+		): Promise<AutocompleteSuggestions | null> {
+			const suggestions = await current.getSuggestions(lines, cursorLine, cursorCol, options);
+			if (options.signal.aborted) return suggestions;
+			const beforeCursor = (lines[cursorLine] ?? "").slice(0, cursorCol);
+			if (!/(?:^|[ \t])@$/.test(beforeCursor)) return suggestions;
+			const action: AutocompleteItem = {
+				value: QUOTE_ACTION_VALUE,
+				label: "Quote selected lines…",
+				description: "Open File Context",
+			};
+			return {
+				prefix: "@",
+				items: [action, ...(suggestions?.items ?? [])],
+			};
+		},
+		applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+			if (item.value !== QUOTE_ACTION_VALUE || prefix !== "@") {
+				return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+			}
+			const nextLines = [...lines];
+			const currentLine = nextLines[cursorLine] ?? "";
+			const prefixStart = Math.max(0, cursorCol - prefix.length);
+			nextLines[cursorLine] = currentLine.slice(0, prefixStart) + currentLine.slice(cursorCol);
+			queueMicrotask(openExplorer);
+			return { lines: nextLines, cursorLine, cursorCol: prefixStart };
+		},
+		shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
+			return current.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true;
+		},
+	};
 }
 
 export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	let pendingQuotes: FileQuote[] = [];
-	let installedEditorFactory: unknown;
 	let activeSessionManager: unknown;
 	let sessionGeneration = 0;
 
@@ -379,21 +390,14 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		clearPending(ctx);
 		if (ctx.mode !== "tui") return;
 		ctx.ui.notify(
-			"Experimental File Context loaded. Type @ at a word boundary to browse files.",
+			"Experimental File Context loaded. Type @ and choose ‘Quote selected lines…’ to browse files.",
 			"warning",
 		);
-		const previous = ctx.ui.getEditorComponent();
-		if (previous) {
-			ctx.ui.notify(
-				"File Context left the existing custom editor unchanged; use /file-context.",
-				"warning",
-			);
-			return;
-		}
-		const factory = (tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
-			new FileQuoteTriggerEditor(tui, theme, keybindings, () => openExplorer(ctx));
-		installedEditorFactory = factory;
-		ctx.ui.setEditorComponent(factory);
+		ctx.ui.addAutocompleteProvider((current) =>
+			createFileContextAutocompleteProvider(current, () => {
+				void openExplorer(ctx);
+			}),
+		);
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {
@@ -412,11 +416,6 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (ctx.sessionManager !== activeSessionManager) return;
 		clearPending(ctx);
-		if (installedEditorFactory && ctx.mode === "tui") {
-			if (ctx.ui.getEditorComponent() === installedEditorFactory)
-				ctx.ui.setEditorComponent(undefined);
-			installedEditorFactory = undefined;
-		}
 	});
 }
 

--- a/experimental/pi-file-context/src/file-context.ts
+++ b/experimental/pi-file-context/src/file-context.ts
@@ -12,7 +12,7 @@ import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-
 import { createGitContext } from "./git-context.js";
 
 const WIDGET_KEY = "file-context";
-const QUOTE_ACTION_VALUE = "@__pi_file_context_quote_lines__";
+const QUOTE_ACTION_PREFIX = "@__pi_file_context_quote_lines__/";
 const DEFAULT_MAX_FILES = 5_000;
 const DEFAULT_MAX_BYTES = 1_000_000;
 const MAX_QUOTE_BYTES = 50_000;
@@ -249,7 +249,7 @@ export function formatQuoteContext(quotes: readonly FileQuote[]): string {
 
 export function createFileContextAutocompleteProvider(
 	current: AutocompleteProvider,
-	openExplorer: () => void,
+	openPreview: (path: string) => void,
 ): AutocompleteProvider {
 	return {
 		triggerCharacters: [...new Set([...(current.triggerCharacters ?? []), "@"])],
@@ -260,28 +260,41 @@ export function createFileContextAutocompleteProvider(
 			options,
 		): Promise<AutocompleteSuggestions | null> {
 			const suggestions = await current.getSuggestions(lines, cursorLine, cursorCol, options);
-			if (options.signal.aborted) return suggestions;
-			const beforeCursor = (lines[cursorLine] ?? "").slice(0, cursorCol);
-			if (!/(?:^|[ \t])@$/.test(beforeCursor)) return suggestions;
-			const action: AutocompleteItem = {
-				value: QUOTE_ACTION_VALUE,
-				label: "Quote selected lines…",
-				description: "Open File Context",
-			};
-			return {
-				prefix: "@",
-				items: [action, ...(suggestions?.items ?? [])],
-			};
+			if (
+				options.signal.aborted ||
+				!suggestions?.prefix.startsWith("@") ||
+				suggestions.items.length === 0
+			) {
+				return suggestions;
+			}
+			const items = suggestions.items.flatMap((item): AutocompleteItem[] => {
+				if (!item.value.startsWith("@") || item.label.endsWith("/")) return [item];
+				return [
+					item,
+					{
+						value: `${QUOTE_ACTION_PREFIX}${encodeURIComponent(item.label)}`,
+						label: `Quote lines · ${item.label}`,
+						description: "Open line-range preview",
+					},
+				];
+			});
+			return { prefix: suggestions.prefix, items };
 		},
 		applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
-			if (item.value !== QUOTE_ACTION_VALUE || prefix !== "@") {
+			if (!item.value.startsWith(QUOTE_ACTION_PREFIX)) {
+				return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+			}
+			let path: string;
+			try {
+				path = decodeURIComponent(item.value.slice(QUOTE_ACTION_PREFIX.length));
+			} catch {
 				return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
 			}
 			const nextLines = [...lines];
 			const currentLine = nextLines[cursorLine] ?? "";
 			const prefixStart = Math.max(0, cursorCol - prefix.length);
 			nextLines[cursorLine] = currentLine.slice(0, prefixStart) + currentLine.slice(cursorCol);
-			queueMicrotask(openExplorer);
+			queueMicrotask(() => openPreview(path));
 			return { lines: nextLines, cursorLine, cursorCol: prefixStart };
 		},
 		shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
@@ -325,7 +338,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	const isCurrentSession = (owner: unknown, generation: number) =>
 		owner === activeSessionManager && generation === sessionGeneration;
 
-	const openExplorer = async (ctx: ExtensionContext): Promise<void> => {
+	const openExplorer = async (ctx: ExtensionContext, initialPath?: string): Promise<void> => {
 		if (ctx.mode !== "tui") {
 			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
 			return;
@@ -348,6 +361,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 						theme,
 						keybindings,
 						files,
+						...(initialPath ? { initialPath } : {}),
 						loadFile: (path) => loadProjectTextFile(ctx.cwd, path),
 						gitContext,
 						done,
@@ -390,12 +404,12 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		clearPending(ctx);
 		if (ctx.mode !== "tui") return;
 		ctx.ui.notify(
-			"Experimental File Context loaded. Type @ and choose ‘Quote selected lines…’ to browse files.",
+			"Experimental File Context loaded. Type @ to insert a file reference or quote its lines.",
 			"warning",
 		);
 		ctx.ui.addAutocompleteProvider((current) =>
-			createFileContextAutocompleteProvider(current, () => {
-				void openExplorer(ctx);
+			createFileContextAutocompleteProvider(current, (path) => {
+				void openExplorer(ctx, path);
 			}),
 		);
 	});

--- a/experimental/pi-file-context/test/file-context.test.ts
+++ b/experimental/pi-file-context/test/file-context.test.ts
@@ -7,9 +7,9 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import fileQuoteExtension, {
 	appendPendingQuote,
+	createFileContextAutocompleteProvider,
 	createFileQuote,
 	discoverProjectFiles,
-	FileQuoteTriggerEditor,
 	formatPromptWithQuote,
 	formatPromptWithQuotes,
 	loadProjectTextFile,
@@ -590,34 +590,57 @@ test("explorer loads validated revisions and attaches explicit Git diff context"
 	assert.equal(diffResult.quote.git?.base, "HEAD");
 });
 
-test("custom editor opens the explorer on a boundary @ without changing the draft", async () => {
+test("autocomplete keeps @ in the editor until the user chooses the quote action", async () => {
 	let opened = 0;
-	const editor = new FileQuoteTriggerEditor(
-		{ requestRender() {} } as never,
-		{
-			borderColor: (text: string) => text,
-			selectList: {
-				selectedPrefix: (text: string) => text,
-				selectedText: (text: string) => text,
-				description: (text: string) => text,
-				scrollInfo: (text: string) => text,
-				noMatch: (text: string) => text,
+	const baseSuggestions = {
+		prefix: "@",
+		items: [{ value: "@src/main.ts", label: "src/main.ts" }],
+	};
+	const current = {
+		async getSuggestions() {
+			return baseSuggestions;
+		},
+		applyCompletion(lines: string[], cursorLine: number, cursorCol: number) {
+			return { lines, cursorLine, cursorCol };
+		},
+	};
+	const provider = createFileContextAutocompleteProvider(current, async () => {
+		opened += 1;
+	});
+
+	const suggestions = await provider.getSuggestions(["draft @"], 0, 7, {
+		signal: new AbortController().signal,
+	});
+	assert.equal(opened, 0);
+	assert.deepEqual(suggestions, {
+		prefix: "@",
+		items: [
+			{
+				value: "@__pi_file_context_quote_lines__",
+				label: "Quote selected lines…",
+				description: "Open File Context",
 			},
-		},
-		{ matches: () => false } as never,
-		async () => {
-			opened += 1;
-		},
+			...baseSuggestions.items,
+		],
+	});
+
+	const completion = provider.applyCompletion(
+		["draft @"],
+		0,
+		7,
+		suggestions?.items[0] as never,
+		"@",
 	);
-	editor.setText("draft ");
-	editor.handleInput("@");
+	assert.deepEqual(completion, { lines: ["draft "], cursorLine: 0, cursorCol: 6 });
 	await Promise.resolve();
 	assert.equal(opened, 1);
-	assert.equal(editor.getText(), "draft ");
 
-	editor.setText("email");
-	editor.handleInput("@");
-	assert.equal(editor.getText(), "email@");
+	assert.equal(
+		await provider.getSuggestions(["email@"], 0, 6, {
+			signal: new AbortController().signal,
+		}),
+		baseSuggestions,
+	);
 });
 
 test("captures an exact normalized line snapshot and formats one focused prompt", () => {
@@ -698,9 +721,8 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 	);
 
 	let customFactory: unknown;
+	let autocompleteFactory: unknown;
 	const widgets = new Map<string, unknown>();
-	const editorFactories: unknown[] = [];
-	let currentEditorFactory: unknown;
 	let quoteIndex = 0;
 	const quoteResults = [
 		{
@@ -736,12 +758,8 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 			setWidget(key: string, value: unknown) {
 				widgets.set(key, value);
 			},
-			setEditorComponent(factory: unknown) {
-				currentEditorFactory = factory;
-				editorFactories.push(factory);
-			},
-			getEditorComponent() {
-				return currentEditorFactory;
+			addAutocompleteProvider(factory: unknown) {
+				autocompleteFactory = factory;
 			},
 			async custom(factory: unknown) {
 				customFactory = factory;
@@ -753,7 +771,7 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 	});
 
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	assert.equal(editorFactories.length, 1);
+	assert.equal(typeof autocompleteFactory, "function");
 	await mock.commands.get("file-context")?.handler("", context.ctx);
 	await mock.commands.get("file-context")?.handler("", context.ctx);
 	assert.equal(typeof customFactory, "function");
@@ -784,7 +802,6 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 		undefined,
 	);
 	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
-	assert.equal(currentEditorFactory, undefined);
 	assert.equal(widgets.get("file-context"), undefined);
 });
 
@@ -800,10 +817,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 			theme: { fg: (_color: string, text: string) => text },
 			notify() {},
 			setWidget() {},
-			setEditorComponent() {},
-			getEditorComponent() {
-				return undefined;
-			},
+			addAutocompleteProvider() {},
 			async custom() {
 				return { kind: "reference", path: 'docs/my "note".md' };
 			},
@@ -834,10 +848,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 				theme: { fg: (_color: string, text: string) => text },
 				notify() {},
 				setWidget() {},
-				setEditorComponent() {},
-				getEditorComponent() {
-					return undefined;
-				},
+				addAutocompleteProvider() {},
 				custom,
 				pasteToEditor() {},
 			},

--- a/experimental/pi-file-context/test/file-context.test.ts
+++ b/experimental/pi-file-context/test/file-context.test.ts
@@ -167,6 +167,26 @@ test("explorer previews a file, selects a range, and keeps rendered rows width-s
 		},
 	});
 
+	result = undefined;
+	const directPreviewExplorer = new FileQuoteExplorer({
+		tui: tui as never,
+		theme: theme as never,
+		keybindings: keybindings as never,
+		files: ["src/direct.ts"],
+		initialPath: "src/direct.ts",
+		loadFile: async () => ({ path: "src/direct.ts", lines: ["direct"] }),
+		done: (value) => {
+			result = value;
+		},
+	});
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.ok(directPreviewExplorer.render(32).some((line) => line.includes("direct")));
+	directPreviewExplorer.handleInput("enter");
+	assert.deepEqual(result, {
+		kind: "quote",
+		quote: { path: "src/direct.ts", startLine: 1, endLine: 1, text: "direct" },
+	});
+
 	const referenceExplorer = new FileQuoteExplorer({
 		tui: tui as never,
 		theme: theme as never,
@@ -590,57 +610,66 @@ test("explorer loads validated revisions and attaches explicit Git diff context"
 	assert.equal(diffResult.quote.git?.base, "HEAD");
 });
 
-test("autocomplete keeps @ in the editor until the user chooses the quote action", async () => {
-	let opened = 0;
+test("autocomplete preserves native file completions and adds a quote choice per file", async () => {
+	const opened: string[] = [];
+	let delegatedItem: unknown;
 	const baseSuggestions = {
-		prefix: "@",
-		items: [{ value: "@src/main.ts", label: "src/main.ts" }],
+		prefix: "@src",
+		items: [
+			{ value: "@src/main.ts", label: "src/main.ts" },
+			{ value: "@src/components/", label: "src/components/" },
+		],
 	};
 	const current = {
 		async getSuggestions() {
 			return baseSuggestions;
 		},
-		applyCompletion(lines: string[], cursorLine: number, cursorCol: number) {
+		applyCompletion(lines: string[], cursorLine: number, cursorCol: number, item: unknown) {
+			delegatedItem = item;
 			return { lines, cursorLine, cursorCol };
 		},
 	};
-	const provider = createFileContextAutocompleteProvider(current, async () => {
-		opened += 1;
+	const provider = createFileContextAutocompleteProvider(current, (path) => {
+		opened.push(path);
 	});
 
-	const suggestions = await provider.getSuggestions(["draft @"], 0, 7, {
+	const suggestions = await provider.getSuggestions(["draft @src"], 0, 10, {
 		signal: new AbortController().signal,
 	});
-	assert.equal(opened, 0);
 	assert.deepEqual(suggestions, {
-		prefix: "@",
+		prefix: "@src",
 		items: [
+			baseSuggestions.items[0],
 			{
-				value: "@__pi_file_context_quote_lines__",
-				label: "Quote selected lines…",
-				description: "Open File Context",
+				value: "@__pi_file_context_quote_lines__/src%2Fmain.ts",
+				label: "Quote lines · src/main.ts",
+				description: "Open line-range preview",
 			},
-			...baseSuggestions.items,
+			baseSuggestions.items[1],
 		],
 	});
 
-	const completion = provider.applyCompletion(
-		["draft @"],
+	const nativeCompletion = provider.applyCompletion(
+		["draft @src"],
 		0,
-		7,
-		suggestions?.items[0] as never,
-		"@",
+		10,
+		baseSuggestions.items[0] as never,
+		"@src",
 	);
-	assert.deepEqual(completion, { lines: ["draft "], cursorLine: 0, cursorCol: 6 });
-	await Promise.resolve();
-	assert.equal(opened, 1);
+	assert.deepEqual(nativeCompletion, { lines: ["draft @src"], cursorLine: 0, cursorCol: 10 });
+	assert.equal(delegatedItem, baseSuggestions.items[0]);
+	assert.deepEqual(opened, []);
 
-	assert.equal(
-		await provider.getSuggestions(["email@"], 0, 6, {
-			signal: new AbortController().signal,
-		}),
-		baseSuggestions,
+	const quoteCompletion = provider.applyCompletion(
+		["draft @src"],
+		0,
+		10,
+		suggestions?.items[1] as never,
+		"@src",
 	);
+	assert.deepEqual(quoteCompletion, { lines: ["draft "], cursorLine: 0, cursorCol: 6 });
+	await Promise.resolve();
+	assert.deepEqual(opened, ["src/main.ts"]);
 });
 
 test("captures an exact normalized line snapshot and formats one focused prompt", () => {


### PR DESCRIPTION
## Summary

- keep Pi's native `@path` autocomplete behavior and original file suggestion rows
- add a **Quote lines · path** companion beside each file suggestion, while leaving directory suggestions unchanged
- open the selected file's line-range preview only after the quote companion is chosen
- preserve literal `@` input through Pi's normal autocomplete dismissal behavior
- document and test native completion delegation, quote selection, and direct preview loading

## Testing

- `npm run check --workspace @narumitw/pi-file-context`
- focused compiled test run: 26 tests passed

## Local verification note

The repository-wide `npm run check` was attempted but was blocked by unrelated, uncommitted `experimental/pi-jupyter` work in the shared working tree; the file-context package checks pass.