### PR TITLE
feat(jupyter): migrate extension into monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Choose either `pi-starship` or `pi-statusline`; do not enable both footer extens
 | Package | Use it for | Install |
 | --- | --- | --- |
 | [`pi-file-context`](./experimental/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it by typing `@` at a word boundary or running `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
+| [`pi-jupyter`](./experimental/pi-jupyter) | Preview saved Jupyter notebooks in a terminal-native side panel without running a kernel. | `pi install npm:@narumitw/pi-jupyter` |
 
 ## 🔧 Advanced installation
 

--- a/docs/plans/archived/2026-07-26_pi-jupyter-monorepo-migration-plan.md
+++ b/docs/plans/archived/2026-07-26_pi-jupyter-monorepo-migration-plan.md
@@ -1,0 +1,27 @@
+# pi-jupyter monorepo migration plan
+
+## Goal
+
+Migrate the independently developed `pi-jupyter` extension into `experimental/pi-jupyter` without deleting its original checkout, and adapt its package, source, tests, documentation, and root discovery to this monorepo's conventions.
+
+## Assumptions
+
+- Preserve `/home/narumi/workspace/pi-jupyter` as an unchanged standalone repository, per user choice.
+- Preserve the published package name and existing command/shortcut surface while marking the migrated package experimental.
+- Keep development notebooks out of the publishable package; use a small deterministic notebook fixture in tests instead.
+
+## Plan
+
+- [x] Add `experimental/pi-jupyter` package scaffolding, focused tests, and a thin `src/index.ts`; `npm test` initially failed on the intentionally absent `jupyter-preview.js` and `notebook.js` modules.
+- [x] Split and adapt the extension implementation under `experimental/pi-jupyter/src/`, preserving preview behavior while enforcing TUI-only UI, scoped lifecycle cleanup, strict command arguments, current Pi imports, and an experimental warning; the first full `npm test` after implementation passed 1,474 tests.
+- [x] Rewrite package metadata and README for workspace publishing, shared commands, security/limitations, package layout, and experimental status; `npm run check:boundaries` passed for 22 active packages and the package typecheck passed.
+- [x] Add pi-jupyter to root discovery/documentation and update the workspace lockfile without unrelated dependency churn; `package-lock.json` contains only the new workspace and link records for pi-jupyter.
+- [x] Run clean-install validation, focused tests, `npm run check`, an npm pack dry run, and a non-interactive Pi load smoke; `npm ci --dry-run` succeeded, eight focused tests and all 1,476 repository tests passed, the package contains only the intended eight publishable files, and Pi loaded the extension while listing 24 model lines.
+
+## Completion Checklist
+
+- [x] `experimental/pi-jupyter` is independently installable and follows active experimental package boundaries; the boundary validator and pack dry run passed.
+- [x] Existing commands and shortcuts remain documented, and eight focused tests cover TUI overlay creation plus watcher, mouse-listener, overlay, and status cleanup.
+- [x] The root README, `pack:jupyter` script, and generic/root convenience workflows expose the package consistently; `just --list` includes all four jupyter aliases.
+- [x] The source checkout remains present and unchanged; its Git status is clean.
+- [x] All required checks and smokes pass; `npm ci --dry-run`, `npm run check`, the pack dry run, and the non-interactive Pi load smoke completed successfully.

--- a/experimental/pi-jupyter/LICENSE
+++ b/experimental/pi-jupyter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/experimental/pi-jupyter/README.md
+++ b/experimental/pi-jupyter/README.md
@@ -1,0 +1,119 @@
+# 📓 pi-jupyter
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-jupyter)](https://www.npmjs.com/package/@narumitw/pi-jupyter)
+[![Pi Extension](https://img.shields.io/badge/Pi-extension-blue)](https://github.com/earendil-works/pi)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+> [!WARNING]
+> This extension is experimental. Its preview behavior, interaction model, and shortcuts may change between releases.
+
+Preview a Jupyter notebook (`.ipynb`) in a terminal-native panel beside Pi's editor. The panel renders the notebook saved on disk; it does not run a Jupyter kernel or open a browser webview.
+
+## ✨ Features
+
+- Opens a non-capturing right-side preview while the normal Pi editor remains usable.
+- Detects notebooks used by Pi file tools and refreshes after matching tool results.
+- Watches the selected notebook's parent directory so ordinary and atomic external saves refresh the panel.
+- Renders markdown and code cells, execution counts, bounded text/error output, and inline image output.
+- Displays PNG output as truecolor ANSI half-block thumbnails; other image formats use Pi TUI terminal-image support when available.
+- Supports keyboard scrolling, focused scrolling, and mouse resizing from the panel's left border.
+- Auto-hides the overlay when the terminal is narrower than 90 columns.
+
+## 📦 Install
+
+Install persistently from npm:
+
+```bash
+pi install npm:@narumitw/pi-jupyter
+```
+
+Try from npm without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-jupyter
+```
+
+Try the local working tree from this repository checkout:
+
+```bash
+pi -e ./experimental/pi-jupyter
+# or
+just try jupyter
+```
+
+Avoid loading both a global npm installation and the local workspace at the same time; duplicate instances register the same shortcuts.
+
+## 🚀 Quick start
+
+1. Start Pi in a directory containing a notebook.
+2. Run `/jupyter-preview` to discover the first top-level `.ipynb`, or `/jupyter-preview path/to/notebook.ipynb` to select one explicitly.
+3. Keep editing normally while the preview follows saved changes.
+4. Press `Shift+F8` to focus the panel for scrolling, then `Escape` or `F8` to return to the editor.
+5. Press `F8` or run `/jupyter-preview-close` to close the panel.
+
+## 💬 Commands
+
+All commands require Pi's interactive TUI mode. Commands documented without arguments reject trailing input.
+
+| Command | Description |
+| --- | --- |
+| `/jupyter-preview [path]` | Open or refresh the preview; discover a top-level notebook when no path has been selected. |
+| `/jupyter-preview-toggle [path]` | Toggle the current preview, or open the supplied notebook. |
+| `/jupyter-preview-focus` | Focus the panel for keyboard scrolling. |
+| `/jupyter-preview-refresh` | Reload the selected notebook from disk. |
+| `/jupyter-preview-close` | Close the panel. |
+| `/jupyter-preview-up [lines]` | Scroll up by a positive line count; defaults to 3. |
+| `/jupyter-preview-down [lines]` | Scroll down by a positive line count; defaults to 3. |
+| `/jupyter-preview-page-up` | Scroll up 12 lines. |
+| `/jupyter-preview-page-down` | Scroll down 12 lines. |
+| `/jupyter-preview-top` | Return to the first rendered line. |
+
+## ⌨️ Shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `F8` | Toggle the preview. |
+| `Shift+F8` | Focus the preview. |
+| `Ctrl+Alt+J` / `Ctrl+Alt+K` | Scroll down/up without focusing. |
+| `Ctrl+Alt+D` / `Ctrl+Alt+U` | Page down/up without focusing. |
+| Drag the left border | Resize the panel. |
+
+While focused, use `Up`, `Down`, `PgUp`, `PgDn`, `Home`, or `j`, `k`, `u`, `d`, `g`. Use `Escape` or `F8` to release focus.
+
+## 🔒 Security and limits
+
+- Pi extensions run with your full user permissions; install only trusted code.
+- An explicitly supplied notebook path may point outside the current project. The extension only reads and watches the selected file; review the path before opening it.
+- Notebook previews are limited to regular files no larger than 10 MB.
+- Source display is limited to 12 lines per cell and rendered output to 24 lines per code cell.
+- PNG decoding accepts non-interlaced 8-bit images and rejects decoded images above 16 million pixels.
+- Notebook text, paths, errors, and output are escaped before terminal rendering to prevent embedded terminal controls.
+- The extension does not execute notebook code, contact a Jupyter server, or send notebook contents to a separate service.
+
+## 🧪 Experimental limitations
+
+- Preview rendering is intentionally static and does not provide notebook editing or kernel execution.
+- Notebook discovery scans only files directly inside Pi's current working directory.
+- Rich HTML, JavaScript, widgets, LaTeX, and most MIME-specific output are not rendered.
+- Long cells and outputs are summarized rather than interactively expanded.
+- Mouse resizing depends on terminal SGR mouse reporting and may require the terminal's selection modifier for text selection.
+
+## 🗂️ Package layout
+
+```text
+src/index.ts               Thin Pi entrypoint
+src/jupyter-preview.ts     Commands, shortcuts, tool hooks, watcher, and lifecycle
+src/notebook-panel.ts      Overlay component, scrolling, and mouse resizing
+src/notebook.ts            Notebook loading, validation, and cell/output rendering
+src/png-thumbnail.ts       Bounded PNG decoding and ANSI thumbnail rendering
+
+test/jupyter-preview.test.ts  Paths, validation, commands, modes, and lifecycle
+```
+
+## 🔎 Keywords
+
+Pi extension, Jupyter notebook, ipynb preview, terminal UI, notebook side panel.
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/experimental/pi-jupyter/package.json
+++ b/experimental/pi-jupyter/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@narumitw/pi-jupyter",
+	"version": "0.32.0",
+	"description": "Experimental Pi extension for previewing Jupyter notebooks in a terminal side panel.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"jupyter",
+		"notebook",
+		"preview"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.5",
+		"@earendil-works/pi-coding-agent": "0.82.1",
+		"@earendil-works/pi-tui": "0.82.1",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "experimental/pi-jupyter"
+	}
+}

--- a/experimental/pi-jupyter/src/index.ts
+++ b/experimental/pi-jupyter/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./jupyter-preview.js";

--- a/experimental/pi-jupyter/src/jupyter-preview.ts
+++ b/experimental/pi-jupyter/src/jupyter-preview.ts
@@ -1,0 +1,429 @@
+import { watch } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { OverlayHandle, OverlayOptions } from "@earendil-works/pi-tui";
+import { loadNotebook, sanitizeTerminalText } from "./notebook.js";
+import {
+	applyLoadedNotebook,
+	DEFAULT_PANEL_WIDTH_PERCENT,
+	installMouseResize,
+	MIN_PANEL_WIDTH,
+	NotebookPreviewPanel,
+	type PreviewState,
+	RIGHT_MARGIN,
+} from "./notebook-panel.js";
+
+const STATUS_KEY = "jupyter";
+const NOTEBOOK_EXTENSION = ".ipynb";
+const EXPERIMENTAL_WARNING =
+	"pi-jupyter is experimental; its preview behavior and shortcuts may change.";
+
+type NotebookWatcher = { close(): void };
+type WatchNotebook = (
+	directory: string,
+	listener: (eventType: string, filename: string | Buffer | null) => void,
+) => NotebookWatcher;
+
+export type JupyterPreviewDependencies = {
+	watchNotebook: WatchNotebook;
+};
+
+const DEFAULT_DEPENDENCIES: JupyterPreviewDependencies = {
+	watchNotebook: (directory, listener) => watch(directory, { persistent: false }, listener),
+};
+
+export function createJupyterPreview(
+	dependencies: JupyterPreviewDependencies,
+): (pi: ExtensionAPI) => void {
+	return (pi) => registerJupyterPreview(pi, dependencies);
+}
+
+export default function jupyterPreview(pi: ExtensionAPI): void {
+	registerJupyterPreview(pi, DEFAULT_DEPENDENCIES);
+}
+
+function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDependencies): void {
+	const state: PreviewState = {
+		cwd: process.cwd(),
+		visible: false,
+		focused: false,
+		scroll: 0,
+	};
+	let overlayHandle: OverlayHandle | undefined;
+	let closeOverlay: (() => void) | undefined;
+	let requestRender: (() => void) | undefined;
+	let removeMouseResize: (() => void) | undefined;
+	let currentWatcher: NotebookWatcher | undefined;
+	let cancelWatchDebounce: (() => void) | undefined;
+	let watchGeneration = 0;
+
+	function stopWatcher(): void {
+		watchGeneration += 1;
+		cancelWatchDebounce?.();
+		cancelWatchDebounce = undefined;
+		currentWatcher?.close();
+		currentWatcher = undefined;
+	}
+
+	async function reloadSelectedNotebook(): Promise<void> {
+		if (!state.path) return;
+		try {
+			applyLoadedNotebook(state, await loadNotebook(state.path));
+		} catch (cause) {
+			state.model = undefined;
+			state.lastLoadedAt = new Date();
+			state.lastError = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	function startWatcher(path: string): void {
+		stopWatcher();
+		const generation = watchGeneration;
+		const targetName = basename(path);
+		const debounced = debounce(() => {
+			if (generation !== watchGeneration || state.path !== path) return;
+			void reloadSelectedNotebook().finally(() => requestRender?.());
+		}, 150);
+		cancelWatchDebounce = debounced.cancel;
+		try {
+			currentWatcher = dependencies.watchNotebook(dirname(path), (_event, changedName) => {
+				if (changedName === null || changedName.toString() === targetName) debounced.run();
+			});
+		} catch {
+			currentWatcher = undefined;
+		}
+	}
+
+	async function setNotebookPath(rawPath: string, ctx: ExtensionContext): Promise<void> {
+		const path = resolveNotebookPath(rawPath, ctx.cwd);
+		if (!path.endsWith(NOTEBOOK_EXTENSION)) throw new Error("Notebook path must end in .ipynb.");
+		state.cwd = ctx.cwd;
+		state.path = path;
+		state.scroll = 0;
+		await reloadSelectedNotebook();
+		startWatcher(path);
+	}
+
+	async function showPanel(ctx: ExtensionContext, rawPath?: string): Promise<void> {
+		requireTui(ctx);
+		if (rawPath?.trim()) await setNotebookPath(rawPath, ctx);
+		else if (!state.path) {
+			const discovered = await findFirstNotebook(ctx.cwd);
+			if (!discovered) {
+				ctx.ui.notify("No .ipynb file found. Use /jupyter-preview <path>.", "warning");
+				return;
+			}
+			await setNotebookPath(discovered, ctx);
+		} else {
+			state.cwd = ctx.cwd;
+			await reloadSelectedNotebook();
+		}
+
+		state.visible = true;
+		ctx.ui.setStatus(STATUS_KEY, "previewing notebook");
+		if (overlayHandle) {
+			overlayHandle.setHidden(false);
+			requestRender?.();
+			return;
+		}
+
+		const overlayOptions: OverlayOptions = {
+			anchor: "right-center",
+			width: state.panelWidth ?? `${DEFAULT_PANEL_WIDTH_PERCENT}%`,
+			minWidth: MIN_PANEL_WIDTH,
+			maxHeight: "96%",
+			margin: { right: RIGHT_MARGIN },
+			nonCapturing: true,
+			visible: (termWidth) => termWidth >= 90,
+		};
+		void ctx.ui
+			.custom<void>(
+				(tui, theme, _keybindings, done) => {
+					const panel = new NotebookPreviewPanel(tui, theme, state, () => {
+						state.focused = false;
+						overlayHandle?.unfocus();
+						tui.requestRender();
+					});
+					requestRender = () => tui.requestRender();
+					removeMouseResize = installMouseResize(tui, state, overlayOptions, requestRender);
+					closeOverlay = () => {
+						state.visible = false;
+						state.focused = false;
+						state.resizing = false;
+						done(undefined);
+					};
+					return panel;
+				},
+				{
+					overlay: true,
+					overlayOptions,
+					onHandle: (handle) => {
+						overlayHandle = handle;
+					},
+				},
+			)
+			.catch((cause: unknown) => {
+				try {
+					ctx.ui.notify(
+						`Jupyter preview closed after a UI error: ${sanitizeTerminalText(cause instanceof Error ? cause.message : String(cause))}`,
+						"error",
+					);
+				} catch {
+					// A replacement session can invalidate the context before error reporting.
+				}
+			})
+			.finally(() => {
+				removeMouseResize?.();
+				removeMouseResize = undefined;
+				overlayHandle = undefined;
+				closeOverlay = undefined;
+				requestRender = undefined;
+				state.visible = false;
+				state.focused = false;
+				state.resizing = false;
+				try {
+					ctx.ui.setStatus(STATUS_KEY, undefined);
+				} catch {
+					// A replacement session can invalidate the context before overlay disposal settles.
+				}
+			});
+	}
+
+	function hidePanel(ctx?: ExtensionContext): void {
+		state.visible = false;
+		state.focused = false;
+		state.resizing = false;
+		if (ctx?.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+		closeOverlay?.();
+	}
+
+	function focusPanel(ctx: ExtensionContext): void {
+		requireTui(ctx);
+		if (!overlayHandle) {
+			ctx.ui.notify("Jupyter preview is not open. Use /jupyter-preview <path>.", "warning");
+			return;
+		}
+		state.focused = true;
+		overlayHandle.focus();
+		requestRender?.();
+		ctx.ui.notify(
+			"Notebook preview focused. Use arrow keys or j/k/u/d to scroll; Esc/F8 returns.",
+			"info",
+		);
+	}
+
+	function scrollPreview(delta: number | "top", ctx: ExtensionContext): void {
+		requireTui(ctx);
+		if (!state.visible || !overlayHandle) {
+			ctx.ui.notify("Jupyter preview is not open. Use /jupyter-preview <path>.", "warning");
+			return;
+		}
+		state.scroll = delta === "top" ? 0 : Math.max(0, state.scroll + delta);
+		requestRender?.();
+	}
+
+	registerCommands(pi, {
+		showPanel,
+		hidePanel,
+		focusPanel,
+		scrollPreview,
+		reload: async (ctx) => {
+			requireTui(ctx);
+			if (!state.path) {
+				ctx.ui.notify("No notebook selected. Use /jupyter-preview <path>.", "warning");
+				return;
+			}
+			await reloadSelectedNotebook();
+			requestRender?.();
+		},
+		isVisible: () => state.visible && overlayHandle !== undefined,
+	});
+
+	pi.registerShortcut("f8", {
+		description: "Toggle Jupyter notebook preview",
+		handler: async (ctx) => {
+			if (state.visible && overlayHandle) hidePanel(ctx);
+			else await showPanel(ctx);
+		},
+	});
+	pi.registerShortcut("shift+f8", {
+		description: "Focus Jupyter notebook preview for scrolling",
+		handler: async (ctx) => focusPanel(ctx),
+	});
+	for (const [shortcut, delta, description] of [
+		["ctrl+alt+j", 3, "Scroll Jupyter notebook preview down"],
+		["ctrl+alt+k", -3, "Scroll Jupyter notebook preview up"],
+		["ctrl+alt+d", 12, "Page down Jupyter notebook preview"],
+		["ctrl+alt+u", -12, "Page up Jupyter notebook preview"],
+	] as const) {
+		pi.registerShortcut(shortcut, {
+			description,
+			handler: async (ctx) => scrollPreview(delta, ctx),
+		});
+	}
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (ctx.hasUI) ctx.ui.notify(EXPERIMENTAL_WARNING, "warning");
+	});
+	pi.on("tool_call", async (event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		const candidate = extractNotebookPath(event.input);
+		if (!candidate) return;
+		state.cwd = ctx.cwd;
+		state.path = resolveNotebookPath(candidate, ctx.cwd);
+		startWatcher(state.path);
+	});
+	pi.on("tool_result", async (event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		const candidate = extractNotebookPath(event.input);
+		if (!candidate) return;
+		if (state.visible) {
+			await setNotebookPath(candidate, ctx);
+			requestRender?.();
+		} else await showPanel(ctx, candidate);
+	});
+	pi.on("session_shutdown", async (_event, ctx) => {
+		stopWatcher();
+		hidePanel(ctx);
+		if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}
+
+type CommandActions = {
+	showPanel(ctx: ExtensionContext, path?: string): Promise<void>;
+	hidePanel(ctx: ExtensionContext): void;
+	focusPanel(ctx: ExtensionContext): void;
+	scrollPreview(delta: number | "top", ctx: ExtensionContext): void;
+	reload(ctx: ExtensionContext): Promise<void>;
+	isVisible(): boolean;
+};
+
+function registerCommands(pi: ExtensionAPI, actions: CommandActions): void {
+	pi.registerCommand("jupyter-preview", {
+		description: "Open or refresh a right-side .ipynb preview. Usage: /jupyter-preview [path]",
+		handler: async (args, ctx) => actions.showPanel(ctx, args),
+	});
+	pi.registerCommand("jupyter-preview-close", {
+		description: "Close the right-side Jupyter notebook preview",
+		handler: async (args, ctx) => {
+			assertNoArguments("/jupyter-preview-close", args);
+			requireTui(ctx);
+			actions.hidePanel(ctx);
+		},
+	});
+	pi.registerCommand("jupyter-preview-toggle", {
+		description:
+			"Toggle the right-side Jupyter notebook preview. Usage: /jupyter-preview-toggle [path]",
+		handler: async (args, ctx) => {
+			requireTui(ctx);
+			if (actions.isVisible() && !args.trim()) actions.hidePanel(ctx);
+			else await actions.showPanel(ctx, args);
+		},
+	});
+	pi.registerCommand("jupyter-preview-focus", {
+		description: "Focus the notebook preview for keyboard scrolling",
+		handler: async (args, ctx) => {
+			assertNoArguments("/jupyter-preview-focus", args);
+			actions.focusPanel(ctx);
+		},
+	});
+	pi.registerCommand("jupyter-preview-refresh", {
+		description: "Reload the current notebook preview from disk",
+		handler: async (args, ctx) => {
+			assertNoArguments("/jupyter-preview-refresh", args);
+			await actions.reload(ctx);
+		},
+	});
+	for (const [name, direction, fallback] of [
+		["jupyter-preview-up", -1, 3],
+		["jupyter-preview-down", 1, 3],
+	] as const) {
+		pi.registerCommand(name, {
+			description: `Scroll the notebook preview ${direction < 0 ? "up" : "down"}. Usage: /${name} [lines]`,
+			handler: async (args, ctx) => {
+				actions.scrollPreview(direction * parsePositiveLineCount(args, fallback), ctx);
+			},
+		});
+	}
+	for (const [name, delta] of [
+		["jupyter-preview-page-up", -12],
+		["jupyter-preview-page-down", 12],
+	] as const) {
+		pi.registerCommand(name, {
+			description: `Scroll the notebook preview one page ${delta < 0 ? "up" : "down"}`,
+			handler: async (args, ctx) => {
+				assertNoArguments(`/${name}`, args);
+				actions.scrollPreview(delta, ctx);
+			},
+		});
+	}
+	pi.registerCommand("jupyter-preview-top", {
+		description: "Scroll the notebook preview to the top",
+		handler: async (args, ctx) => {
+			assertNoArguments("/jupyter-preview-top", args);
+			actions.scrollPreview("top", ctx);
+		},
+	});
+}
+
+export function parsePositiveLineCount(args: string, fallback: number): number {
+	const value = args.trim();
+	if (!value) return fallback;
+	if (!/^[1-9]\d*$/.test(value)) throw new Error("Scroll amount must be one positive integer.");
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed)) throw new Error("Scroll amount must be one positive integer.");
+	return parsed;
+}
+
+function assertNoArguments(command: string, args: string): void {
+	if (args.trim()) throw new Error(`${command} does not accept arguments.`);
+}
+
+function requireTui(ctx: ExtensionContext): void {
+	if (ctx.mode !== "tui") throw new Error("pi-jupyter preview requires Pi's interactive TUI mode.");
+}
+
+export function resolveNotebookPath(rawPath: string, cwd: string): string {
+	return resolve(cwd, rawPath.trim().replace(/^@/, ""));
+}
+
+export function extractNotebookPath(input: unknown): string | undefined {
+	if (!input || typeof input !== "object") return undefined;
+	const object = input as Record<string, unknown>;
+	for (const key of ["path", "file", "filename"] as const) {
+		const value = object[key];
+		if (typeof value === "string" && value.endsWith(NOTEBOOK_EXTENSION)) return value;
+	}
+	return undefined;
+}
+
+async function findFirstNotebook(cwd: string): Promise<string | undefined> {
+	try {
+		const entries = await readdir(cwd, { withFileTypes: true });
+		const name = entries
+			.filter((entry) => entry.isFile() && entry.name.endsWith(NOTEBOOK_EXTENSION))
+			.map((entry) => entry.name)
+			.sort()[0];
+		return name ? resolve(cwd, name) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function debounce(callback: () => void, milliseconds: number): { run(): void; cancel(): void } {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	return {
+		run() {
+			if (timer) clearTimeout(timer);
+			timer = setTimeout(() => {
+				timer = undefined;
+				callback();
+			}, milliseconds);
+		},
+		cancel() {
+			if (timer) clearTimeout(timer);
+			timer = undefined;
+		},
+	};
+}

--- a/experimental/pi-jupyter/src/notebook-panel.ts
+++ b/experimental/pi-jupyter/src/notebook-panel.ts
@@ -1,0 +1,184 @@
+import { basename, relative } from "node:path";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	Key,
+	matchesKey,
+	type OverlayOptions,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import {
+	type LoadedNotebook,
+	type Notebook,
+	renderNotebookBody,
+	sanitizeTerminalText,
+	wrapBoxLines,
+} from "./notebook.js";
+
+export const DEFAULT_PANEL_WIDTH_PERCENT = 42;
+export const MIN_PANEL_WIDTH = 42;
+export const MIN_EDITOR_WIDTH = 24;
+export const RIGHT_MARGIN = 1;
+
+export type PreviewState = {
+	path?: string;
+	cwd: string;
+	visible: boolean;
+	focused: boolean;
+	scroll: number;
+	lastLoadedAt?: Date;
+	lastMtime?: Date;
+	lastError?: string;
+	model?: Notebook;
+	panelWidth?: number;
+	resizing?: boolean;
+};
+
+export function applyLoadedNotebook(state: PreviewState, loaded: LoadedNotebook): void {
+	state.model = loaded.model;
+	state.lastMtime = loaded.lastMtime;
+	state.lastLoadedAt = loaded.lastLoadedAt;
+	state.lastError = undefined;
+}
+
+export class NotebookPreviewPanel implements Component {
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private readonly state: PreviewState;
+	private readonly releaseFocus: () => void;
+
+	constructor(tui: TUI, theme: Theme, state: PreviewState, releaseFocus: () => void) {
+		this.tui = tui;
+		this.theme = theme;
+		this.state = state;
+		this.releaseFocus = releaseFocus;
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.escape) || matchesKey(data, "f8")) {
+			this.releaseFocus();
+			return;
+		}
+		const page = 10;
+		if (matchesKey(data, Key.up) || data === "k")
+			this.state.scroll = Math.max(0, this.state.scroll - 1);
+		else if (matchesKey(data, Key.down) || data === "j") this.state.scroll += 1;
+		else if (matchesKey(data, Key.home) || data === "g") this.state.scroll = 0;
+		else if (matchesKey(data, Key.pageUp) || data === "u") {
+			this.state.scroll = Math.max(0, this.state.scroll - page);
+		} else if (matchesKey(data, Key.pageDown) || data === "d") this.state.scroll += page;
+		else return;
+		this.tui.requestRender();
+	}
+
+	render(width: number): string[] {
+		const inner = Math.max(1, width - 2);
+		const border = (text: string) => this.theme.fg("border", text);
+		const accent = (text: string) => this.theme.fg("accent", text);
+		const dim = (text: string) => this.theme.fg("dim", text);
+		const error = (text: string) => this.theme.fg("error", text);
+		const pad = (text = "") => {
+			const truncated = truncateToWidth(text, inner, "…", true);
+			return `${border("│")}${truncated}${" ".repeat(Math.max(0, inner - visibleWidth(truncated)))}${border("│")}`;
+		};
+		const pathLabel = this.state.path
+			? sanitizeTerminalText(relative(this.state.cwd, this.state.path) || basename(this.state.path))
+			: "no notebook";
+		const title = `${this.state.resizing ? "↔ " : this.state.focused ? "● " : ""}Jupyter Preview`;
+		const lines = [border(`╭${"─".repeat(inner)}╮`), pad(` ${accent(title)} ${dim(pathLabel)}`)];
+		lines.push(`${border("├")}${border("─".repeat(inner))}${border("┤")}`);
+
+		if (!this.state.path) {
+			lines.push(pad(" No notebook selected."), pad(dim(" /jupyter-preview <file.ipynb>")));
+		} else if (this.state.lastError) {
+			lines.push(
+				...wrapBoxLines(error(sanitizeTerminalText(this.state.lastError)), inner).map(pad),
+			);
+		} else if (!this.state.model) lines.push(pad(dim(" Loading…")));
+		else {
+			const body = renderNotebookBody(this.state, inner, this.theme);
+			lines.push(...body.slice(this.state.scroll).map(pad));
+		}
+
+		lines.push(`${border("├")}${border("─".repeat(inner))}${border("┤")}`);
+		const footer = this.state.resizing
+			? " Drag to resize width"
+			: this.state.focused
+				? " ↑↓ PgUp/PgDn or j/k/u/d scroll • Esc/F8 return"
+				: " Drag left border resize • Ctrl+Alt+j/k scroll • Shift+F8 focus";
+		lines.push(pad(dim(footer)), border(`╰${"─".repeat(inner)}╯`));
+		return lines;
+	}
+
+	invalidate(): void {}
+}
+
+type MouseEvent = { button: number; x: number; y: number; released: boolean };
+
+export function installMouseResize(
+	tui: TUI,
+	state: PreviewState,
+	overlayOptions: OverlayOptions,
+	requestRender: () => void,
+): () => void {
+	const terminal = tui.terminal;
+	terminal.write("\x1b[?1000h\x1b[?1002h\x1b[?1006h");
+	const removeListener = tui.addInputListener((data) => {
+		const event = parseSgrMouseEvent(data);
+		if (!event) return undefined;
+		const isPrimaryButton = (event.button & 3) === 0;
+		const isMotion = (event.button & 32) !== 0;
+		const handleX = getPanelLeftBorderX(terminal.columns, state);
+		if (event.released && state.resizing) {
+			state.resizing = false;
+			requestRender();
+			return { consume: true };
+		}
+		if (!state.resizing && isPrimaryButton && Math.abs(event.x - handleX) <= 1)
+			state.resizing = true;
+		if (!state.resizing || !isPrimaryButton) return undefined;
+		if (isMotion || event.x !== handleX) {
+			const width = clampPanelWidth(
+				terminal.columns - RIGHT_MARGIN - (event.x - 1),
+				terminal.columns,
+			);
+			state.panelWidth = width;
+			overlayOptions.width = width;
+			requestRender();
+		}
+		return { consume: true };
+	});
+	return () => {
+		state.resizing = false;
+		removeListener();
+		terminal.write("\x1b[?1006l\x1b[?1002l\x1b[?1000l");
+	};
+}
+
+export function parseSgrMouseEvent(data: string): MouseEvent | undefined {
+	const prefix = "\x1b[<";
+	if (!data.startsWith(prefix)) return undefined;
+	const suffix = data.at(-1);
+	if (suffix !== "M" && suffix !== "m") return undefined;
+	const parts = data.slice(prefix.length, -1).split(";");
+	if (parts.length !== 3) return undefined;
+	const [button, x, y] = parts.map((part) => Number.parseInt(part, 10));
+	if (button === undefined || x === undefined || y === undefined) return undefined;
+	if (![button, x, y].every(Number.isFinite)) return undefined;
+	return { button, x, y, released: suffix === "m" };
+}
+
+function getPanelLeftBorderX(termWidth: number, state: PreviewState): number {
+	const width = clampPanelWidth(
+		state.panelWidth ?? Math.floor((termWidth * DEFAULT_PANEL_WIDTH_PERCENT) / 100),
+		termWidth,
+	);
+	return termWidth - RIGHT_MARGIN - width + 1;
+}
+
+export function clampPanelWidth(width: number, termWidth: number): number {
+	const maxWidth = Math.max(MIN_PANEL_WIDTH, termWidth - RIGHT_MARGIN - MIN_EDITOR_WIDTH);
+	return Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, Math.round(width)));
+}

--- a/experimental/pi-jupyter/src/notebook.ts
+++ b/experimental/pi-jupyter/src/notebook.ts
@@ -1,0 +1,233 @@
+import { type FileHandle, open } from "node:fs/promises";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Image, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { decodePng, renderPngThumbnail } from "./png-thumbnail.js";
+
+export const MAX_NOTEBOOK_BYTES = 10 * 1024 * 1024;
+
+export type NotebookCell = {
+	cell_type?: string;
+	execution_count?: number | null;
+	source?: string | string[];
+	outputs?: Array<Record<string, unknown>>;
+};
+
+export type Notebook = {
+	cells?: NotebookCell[];
+	metadata?: Record<string, unknown>;
+	nbformat?: number;
+	nbformat_minor?: number;
+};
+
+export type LoadedNotebook = {
+	model: Notebook;
+	lastMtime: Date;
+	lastLoadedAt: Date;
+};
+
+export type NotebookRenderState = Partial<LoadedNotebook> & {
+	model?: Notebook;
+};
+
+export async function loadNotebook(path: string): Promise<LoadedNotebook> {
+	const file = await open(path, "r");
+	try {
+		const info = await file.stat();
+		if (!info.isFile()) throw new Error("notebook path is not a regular file");
+		if (info.size > MAX_NOTEBOOK_BYTES) {
+			throw new Error(`notebook exceeds the ${MAX_NOTEBOOK_BYTES / 1024 / 1024} MB preview limit`);
+		}
+		const model = JSON.parse(await readBoundedUtf8(file)) as Notebook;
+		validateNotebook(model);
+		return { model, lastMtime: info.mtime, lastLoadedAt: new Date() };
+	} finally {
+		await file.close();
+	}
+}
+
+async function readBoundedUtf8(file: FileHandle): Promise<string> {
+	const chunks: Buffer[] = [];
+	let total = 0;
+	while (total <= MAX_NOTEBOOK_BYTES) {
+		const buffer = Buffer.alloc(Math.min(64 * 1024, MAX_NOTEBOOK_BYTES + 1 - total));
+		const { bytesRead } = await file.read(buffer, 0, buffer.length, null);
+		if (bytesRead === 0) break;
+		chunks.push(buffer.subarray(0, bytesRead));
+		total += bytesRead;
+	}
+	if (total > MAX_NOTEBOOK_BYTES) {
+		throw new Error(`notebook exceeds the ${MAX_NOTEBOOK_BYTES / 1024 / 1024} MB preview limit`);
+	}
+	return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function validateNotebook(value: unknown): asserts value is Notebook {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("notebook root must be an object");
+	}
+	const notebook = value as Notebook;
+	if (notebook.cells !== undefined && !Array.isArray(notebook.cells)) {
+		throw new Error("notebook cells must be an array");
+	}
+}
+
+export function renderNotebookBody(
+	state: NotebookRenderState,
+	width: number,
+	theme: Theme,
+): string[] {
+	const notebook = state.model;
+	if (!notebook) return [];
+	const cells = Array.isArray(notebook.cells) ? notebook.cells : [];
+	const dim = (text: string) => theme.fg("dim", text);
+	const accent = (text: string) => theme.fg("accent", text);
+	const success = (text: string) => theme.fg("success", text);
+	const warning = (text: string) => theme.fg("warning", text);
+	const error = (text: string) => theme.fg("error", text);
+	const loaded = state.lastLoadedAt?.toLocaleTimeString() ?? "unknown";
+	const mtime = state.lastMtime?.toLocaleTimeString() ?? "unknown";
+	const lines = [
+		` ${success("✓")} ${cells.length} cells ${dim(`loaded ${loaded}, mtime ${mtime}`)}`,
+		"",
+	];
+
+	cells.forEach((cell, index) => {
+		const type = sanitizeTerminalText(cell.cell_type ?? "unknown");
+		const execution = cell.execution_count == null ? "" : ` In [${cell.execution_count}]`;
+		const color = type === "markdown" ? accent : type === "code" ? success : warning;
+		lines.push(color(` ${index + 1}. ${type}${execution}`));
+
+		const source = sanitizeTerminalText(normalizeSource(cell.source)).trimEnd();
+		const sourceLines = source.length > 0 ? source.split("\n") : [dim("(empty)")];
+		for (const line of sourceLines.slice(0, 12)) lines.push(...wrapBoxLines(`   ${line}`, width));
+		if (sourceLines.length > 12)
+			lines.push(dim(`   … ${sourceLines.length - 12} more source lines`));
+
+		if (type === "code" && Array.isArray(cell.outputs) && cell.outputs.length > 0) {
+			const outputLines = renderOutputs(cell.outputs, width, theme);
+			if (outputLines.length > 0) {
+				lines.push(dim("   output:"));
+				for (const outputLine of outputLines.slice(0, 24)) {
+					const styled = outputLine.startsWith("Error:") ? error(outputLine) : outputLine;
+					lines.push(...wrapBoxLines(`     ${styled}`, width));
+				}
+				if (outputLines.length > 24) {
+					lines.push(dim(`     … ${outputLines.length - 24} more output lines`));
+				}
+			}
+		}
+		lines.push("");
+	});
+	return lines;
+}
+
+function renderOutputs(
+	outputs: Array<Record<string, unknown>>,
+	width: number,
+	theme: Theme,
+): string[] {
+	const lines: string[] = [];
+	const dim = (text: string) => theme.fg("dim", text);
+	for (const output of outputs) {
+		const outputType = sanitizeTerminalText(String(output.output_type ?? "output"));
+		if (outputType === "stream") {
+			lines.push(
+				...sanitizeTerminalText(normalizeSource(output.text as string | string[] | undefined))
+					.split("\n")
+					.filter(Boolean)
+					.map(dim),
+			);
+			continue;
+		}
+		if (outputType === "error") {
+			const name = sanitizeTerminalText(String(output.ename ?? "Error"));
+			const value = sanitizeTerminalText(String(output.evalue ?? ""));
+			lines.push(`Error: ${name}${value ? `: ${value}` : ""}`);
+			continue;
+		}
+
+		const data = output.data as Record<string, unknown> | undefined;
+		if (data) {
+			const imageMime = Object.keys(data).find((key) => key.startsWith("image/"));
+			if (imageMime) {
+				lines.push(dim(`${sanitizeTerminalText(imageMime)}:`));
+				lines.push(
+					...renderInlineImage(
+						normalizeSource(data[imageMime] as string | string[]),
+						imageMime,
+						width,
+						theme,
+					),
+				);
+			}
+			const text = data["text/plain"] ?? data["text/markdown"];
+			if (typeof text === "string" || Array.isArray(text)) {
+				lines.push(
+					...sanitizeTerminalText(normalizeSource(text as string | string[]))
+						.split("\n")
+						.filter(Boolean)
+						.map(dim),
+				);
+			}
+			if (imageMime || typeof text === "string" || Array.isArray(text)) continue;
+		}
+		lines.push(dim(`[${outputType}]`));
+	}
+	return lines;
+}
+
+function renderInlineImage(
+	base64Data: string,
+	mimeType: string,
+	width: number,
+	theme: Theme,
+): string[] {
+	const cleanBase64 = base64Data.replace(/\s+/g, "");
+	if (!cleanBase64) return [theme.fg("warning", `[empty ${mimeType} output]`)];
+	if (mimeType === "image/png") {
+		try {
+			return renderPngThumbnail(decodePng(cleanBase64), Math.max(8, Math.min(60, width - 8)), 16);
+		} catch (cause) {
+			return [theme.fg("warning", `[${mimeType} thumbnail failed: ${errorMessage(cause)}]`)];
+		}
+	}
+	try {
+		const image = new Image(
+			cleanBase64,
+			mimeType,
+			{ fallbackColor: (text: string) => theme.fg("muted", text) },
+			{ maxWidthCells: Math.max(8, Math.min(60, width - 8)), maxHeightCells: 16 },
+		);
+		return image.render(Math.max(10, width - 8));
+	} catch (cause) {
+		return [theme.fg("warning", `[${mimeType} output: ${errorMessage(cause)}]`)];
+	}
+}
+
+export function sanitizeTerminalText(text: string): string {
+	let sanitized = "";
+	for (const character of text) {
+		const code = character.codePointAt(0) ?? 0;
+		const isUnsafe =
+			(code < 0x20 && code !== 0x09 && code !== 0x0a) || (code >= 0x7f && code <= 0x9f);
+		sanitized += isUnsafe ? `\\x${code.toString(16).padStart(2, "0")}` : character;
+	}
+	return sanitized;
+}
+
+function errorMessage(cause: unknown): string {
+	return sanitizeTerminalText(cause instanceof Error ? cause.message : String(cause));
+}
+
+function normalizeSource(source: string | string[] | undefined): string {
+	if (Array.isArray(source)) return source.join("");
+	return typeof source === "string" ? source : "";
+}
+
+export function wrapBoxLines(text: string, width: number): string[] {
+	const max = Math.max(1, width - 1);
+	return wrapTextWithAnsi(text, max).map((line) => {
+		if (visibleWidth(line) <= max) return line;
+		return truncateToWidth(line, max, "…", true);
+	});
+}

--- a/experimental/pi-jupyter/src/png-thumbnail.ts
+++ b/experimental/pi-jupyter/src/png-thumbnail.ts
@@ -1,0 +1,237 @@
+import { inflateSync } from "node:zlib";
+
+export type DecodedPng = {
+	width: number;
+	height: number;
+	pixels: Uint8ClampedArray;
+};
+
+const MAX_PNG_PIXELS = 16_000_000;
+const MAX_INFLATED_BYTES = MAX_PNG_PIXELS * 4 + 4096;
+
+export function decodePng(base64Data: string): DecodedPng {
+	const bytes = Buffer.from(base64Data, "base64");
+	const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	if (bytes.length < signature.length || !bytes.subarray(0, signature.length).equals(signature)) {
+		throw new Error("not a PNG");
+	}
+
+	let offset = 8;
+	let width = 0;
+	let height = 0;
+	let bitDepth = 0;
+	let colorType = 0;
+	let palette: Buffer | undefined;
+	let transparency: Buffer | undefined;
+	const idat: Buffer[] = [];
+
+	while (offset + 12 <= bytes.length) {
+		const length = bytes.readUInt32BE(offset);
+		const chunkEnd = offset + 12 + length;
+		if (chunkEnd > bytes.length) throw new Error("truncated PNG chunk");
+		const type = bytes.subarray(offset + 4, offset + 8).toString("ascii");
+		const data = bytes.subarray(offset + 8, offset + 8 + length);
+		offset = chunkEnd;
+
+		if (type === "IHDR") {
+			if (data.length !== 13) throw new Error("invalid PNG header");
+			width = data.readUInt32BE(0);
+			height = data.readUInt32BE(4);
+			bitDepth = data[8] ?? 0;
+			colorType = data[9] ?? 0;
+			if (data[10] !== 0 || data[11] !== 0 || data[12] !== 0) {
+				throw new Error("unsupported PNG format");
+			}
+		} else if (type === "PLTE") palette = Buffer.from(data);
+		else if (type === "tRNS") transparency = Buffer.from(data);
+		else if (type === "IDAT") idat.push(Buffer.from(data));
+		else if (type === "IEND") break;
+	}
+
+	if (!width || !height || idat.length === 0) throw new Error("missing PNG data");
+	if (width * height > MAX_PNG_PIXELS) throw new Error("PNG dimensions are too large");
+	if (bitDepth !== 8) throw new Error(`unsupported PNG bit depth ${bitDepth}`);
+
+	const channels = pngChannels(colorType);
+	const stride = width * channels;
+	const expectedBytes = height * (stride + 1);
+	if (expectedBytes > MAX_INFLATED_BYTES) throw new Error("PNG output is too large");
+	const inflated = inflateSync(Buffer.concat(idat), { maxOutputLength: expectedBytes });
+	if (inflated.length !== expectedBytes) throw new Error("invalid PNG scanline data");
+
+	const raw = Buffer.alloc(height * stride);
+	let inOffset = 0;
+	let outOffset = 0;
+	let previous = Buffer.alloc(stride);
+	for (let y = 0; y < height; y++) {
+		const filter = inflated[inOffset++];
+		const scanline = inflated.subarray(inOffset, inOffset + stride);
+		inOffset += stride;
+		const recon = Buffer.alloc(stride);
+		for (let x = 0; x < stride; x++) {
+			const left = x >= channels ? (recon[x - channels] ?? 0) : 0;
+			const up = previous[x] ?? 0;
+			const upLeft = x >= channels ? (previous[x - channels] ?? 0) : 0;
+			const value = scanline[x] ?? 0;
+			switch (filter) {
+				case 0:
+					recon[x] = value;
+					break;
+				case 1:
+					recon[x] = (value + left) & 0xff;
+					break;
+				case 2:
+					recon[x] = (value + up) & 0xff;
+					break;
+				case 3:
+					recon[x] = (value + Math.floor((left + up) / 2)) & 0xff;
+					break;
+				case 4:
+					recon[x] = (value + paeth(left, up, upLeft)) & 0xff;
+					break;
+				default:
+					throw new Error(`unsupported PNG filter ${filter}`);
+			}
+		}
+		recon.copy(raw, outOffset);
+		outOffset += stride;
+		previous = recon;
+	}
+
+	return {
+		width,
+		height,
+		pixels: convertToRgba(raw, width, height, colorType, palette, transparency),
+	};
+}
+
+function convertToRgba(
+	raw: Buffer,
+	width: number,
+	height: number,
+	colorType: number,
+	palette?: Buffer,
+	transparency?: Buffer,
+): Uint8ClampedArray {
+	const pixels = new Uint8ClampedArray(width * height * 4);
+	for (let i = 0, p = 0; i < raw.length; p++) {
+		let r = 0;
+		let g = 0;
+		let b = 0;
+		let a = 255;
+		if (colorType === 0) {
+			r = g = b = raw[i++] ?? 0;
+			if (transparency?.length === 2 && r === transparency.readUInt16BE(0)) a = 0;
+		} else if (colorType === 2) {
+			r = raw[i++] ?? 0;
+			g = raw[i++] ?? 0;
+			b = raw[i++] ?? 0;
+			if (
+				transparency?.length === 6 &&
+				r === transparency.readUInt16BE(0) &&
+				g === transparency.readUInt16BE(2) &&
+				b === transparency.readUInt16BE(4)
+			)
+				a = 0;
+		} else if (colorType === 3) {
+			const index = raw[i++] ?? 0;
+			if (!palette || index * 3 + 2 >= palette.length) throw new Error("invalid PNG palette");
+			r = palette[index * 3] ?? 0;
+			g = palette[index * 3 + 1] ?? 0;
+			b = palette[index * 3 + 2] ?? 0;
+			a = transparency?.[index] ?? 255;
+		} else if (colorType === 4) {
+			r = g = b = raw[i++] ?? 0;
+			a = raw[i++] ?? 0;
+		} else {
+			r = raw[i++] ?? 0;
+			g = raw[i++] ?? 0;
+			b = raw[i++] ?? 0;
+			a = raw[i++] ?? 0;
+		}
+		const output = p * 4;
+		pixels[output] = r;
+		pixels[output + 1] = g;
+		pixels[output + 2] = b;
+		pixels[output + 3] = a;
+	}
+	return pixels;
+}
+
+function pngChannels(colorType: number): number {
+	switch (colorType) {
+		case 0:
+		case 3:
+			return 1;
+		case 2:
+			return 3;
+		case 4:
+			return 2;
+		case 6:
+			return 4;
+		default:
+			throw new Error(`unsupported PNG color type ${colorType}`);
+	}
+}
+
+function paeth(a: number, b: number, c: number): number {
+	const p = a + b - c;
+	const pa = Math.abs(p - a);
+	const pb = Math.abs(p - b);
+	const pc = Math.abs(p - c);
+	if (pa <= pb && pa <= pc) return a;
+	return pb <= pc ? b : c;
+}
+
+export function renderPngThumbnail(
+	png: DecodedPng,
+	maxWidthCells: number,
+	maxHeightCells: number,
+): string[] {
+	let targetWidth = Math.max(1, Math.min(maxWidthCells, png.width));
+	let targetPixelHeight = Math.max(1, Math.round((png.height / png.width) * targetWidth));
+	if (Math.ceil(targetPixelHeight / 2) > maxHeightCells) {
+		targetPixelHeight = maxHeightCells * 2;
+		targetWidth = Math.max(
+			1,
+			Math.min(maxWidthCells, Math.round((png.width / png.height) * targetPixelHeight)),
+		);
+	}
+
+	const lines: string[] = [];
+	for (let row = 0; row < Math.ceil(targetPixelHeight / 2); row++) {
+		let line = "";
+		for (let x = 0; x < targetWidth; x++) {
+			const upper = samplePngPixel(png, x, row * 2, targetWidth, targetPixelHeight);
+			const lower =
+				row * 2 + 1 < targetPixelHeight
+					? samplePngPixel(png, x, row * 2 + 1, targetWidth, targetPixelHeight)
+					: ([255, 255, 255] as const);
+			line += `\x1b[38;2;${upper[0]};${upper[1]};${upper[2]}m\x1b[48;2;${lower[0]};${lower[1]};${lower[2]}m▀`;
+		}
+		lines.push(`${line}\x1b[0m`);
+	}
+	return lines;
+}
+
+function samplePngPixel(
+	png: DecodedPng,
+	x: number,
+	y: number,
+	targetWidth: number,
+	targetHeight: number,
+): readonly [number, number, number] {
+	const sx = Math.min(
+		png.width - 1,
+		Math.max(0, Math.floor(((x + 0.5) / targetWidth) * png.width)),
+	);
+	const sy = Math.min(
+		png.height - 1,
+		Math.max(0, Math.floor(((y + 0.5) / targetHeight) * png.height)),
+	);
+	const offset = (sy * png.width + sx) * 4;
+	const alpha = (png.pixels[offset + 3] ?? 0) / 255;
+	const blend = (channel: number) =>
+		Math.round((png.pixels[offset + channel] ?? 0) * alpha + 255 * (1 - alpha));
+	return [blend(0), blend(1), blend(2)];
+}

--- a/experimental/pi-jupyter/test/jupyter-preview.test.ts
+++ b/experimental/pi-jupyter/test/jupyter-preview.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import jupyterPreview, {
+	createJupyterPreview,
+	extractNotebookPath,
+	parsePositiveLineCount,
+	resolveNotebookPath,
+} from "../src/jupyter-preview.js";
+import { loadNotebook, sanitizeTerminalText } from "../src/notebook.js";
+import { clampPanelWidth, parseSgrMouseEvent } from "../src/notebook-panel.js";
+
+async function emit(
+	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
+	name: string,
+	...args: unknown[]
+) {
+	for (const handler of events.get(name) ?? []) await handler(...args);
+}
+
+async function invoke(handler: ((...args: unknown[]) => unknown) | undefined, ...args: unknown[]) {
+	return Promise.resolve(handler?.(...args));
+}
+
+function createJupyterMock() {
+	const mock = createMockPi();
+	Object.assign(mock.rawPi, { registerShortcut() {} });
+	return mock;
+}
+
+test("path helpers normalize Pi references and recognize notebook tool inputs", () => {
+	assert.equal(
+		resolveNotebookPath("@notes/demo.ipynb", "/workspace"),
+		"/workspace/notes/demo.ipynb",
+	);
+	assert.equal(extractNotebookPath({ path: "demo.ipynb" }), "demo.ipynb");
+	assert.equal(extractNotebookPath({ filename: "README.md" }), undefined);
+});
+
+test("scroll counts accept only one positive integer", () => {
+	assert.equal(parsePositiveLineCount("", 3), 3);
+	assert.equal(parsePositiveLineCount("12", 3), 12);
+	assert.throws(() => parsePositiveLineCount("12 extra", 3), /positive integer/);
+	assert.throws(() => parsePositiveLineCount("0", 3), /positive integer/);
+});
+
+test("terminal-owned notebook text cannot inject control sequences", () => {
+	assert.equal(sanitizeTerminalText("safe\x1b[31mred\x07"), "safe\\x1b[31mred\\x07");
+	assert.equal(sanitizeTerminalText("line one\nline two\tcell"), "line one\nline two\tcell");
+});
+
+test("panel geometry stays usable and parses only complete SGR mouse reports", () => {
+	assert.equal(clampPanelWidth(70, 100), 70);
+	assert.equal(clampPanelWidth(90, 100), 75);
+	assert.deepEqual(parseSgrMouseEvent("\x1b[<32;42;7M"), {
+		button: 32,
+		x: 42,
+		y: 7,
+		released: false,
+	});
+	assert.equal(parseSgrMouseEvent("\x1b[<32;42M"), undefined);
+});
+
+test("loadNotebook validates the notebook shape and reports file metadata", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-jupyter-test-"));
+	try {
+		const path = join(directory, "demo.ipynb");
+		await writeFile(path, JSON.stringify({ cells: [], nbformat: 4, nbformat_minor: 5 }));
+		const loaded = await loadNotebook(path);
+		assert.equal(loaded.model.cells?.length, 0);
+		assert.equal(loaded.lastMtime instanceof Date, true);
+
+		await writeFile(path, JSON.stringify({ cells: "invalid", nbformat: 4 }));
+		await assert.rejects(loadNotebook(path), /cells must be an array/);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("extension warns on session start and rejects preview UI outside TUI mode", async () => {
+	const mock = createJupyterMock();
+	jupyterPreview(mock.pi);
+	const rpc = createMockContext({ hasUI: true, mode: "rpc" });
+
+	await emit(mock.events, "session_start", {}, rpc.ctx);
+	assert.deepEqual(rpc.notifications, [
+		{
+			message: "pi-jupyter is experimental; its preview behavior and shortcuts may change.",
+			level: "warning",
+		},
+	]);
+
+	const command = mock.commands.get("jupyter-preview");
+	await assert.rejects(
+		() => invoke(command?.handler, "", rpc.ctx),
+		/requires Pi's interactive TUI mode/,
+	);
+});
+
+test("commands reject unsupported trailing arguments before changing UI", async () => {
+	const mock = createJupyterMock();
+	jupyterPreview(mock.pi);
+	const context = createMockContext({ hasUI: true, mode: "tui" });
+
+	await assert.rejects(
+		() => invoke(mock.commands.get("jupyter-preview-close")?.handler, "unexpected", context.ctx),
+		/does not accept arguments/,
+	);
+	assert.equal(context.statuses.size, 0);
+});
+
+test("tool-driven TUI preview releases its watcher, overlay, mouse listener, and status", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-jupyter-lifecycle-test-"));
+	try {
+		const notebookPath = join(directory, "demo.ipynb");
+		await writeFile(notebookPath, JSON.stringify({ cells: [], nbformat: 4 }));
+		const watchedDirectories: string[] = [];
+		let watcherCloses = 0;
+		let inputListenerRemovals = 0;
+		const terminalWrites: string[] = [];
+		let overlayCloses = 0;
+		const extension = createJupyterPreview({
+			watchNotebook(watchedDirectory) {
+				watchedDirectories.push(watchedDirectory);
+				return { close: () => watcherCloses++ };
+			},
+		});
+		const mock = createJupyterMock();
+		extension(mock.pi);
+		const context = createMockContext({
+			cwd: directory,
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown, options: unknown) => {
+				const overlayOptions = options as {
+					onHandle(handle: {
+						focus(): void;
+						unfocus(): void;
+						setHidden(hidden: boolean): void;
+					}): void;
+				};
+				overlayOptions.onHandle({ focus() {}, unfocus() {}, setHidden() {} });
+				await new Promise<void>((resolveOverlay) => {
+					const build = factory as (...args: unknown[]) => unknown;
+					build(
+						{
+							terminal: {
+								columns: 120,
+								write(data: string) {
+									terminalWrites.push(data);
+								},
+							},
+							addInputListener() {
+								return () => inputListenerRemovals++;
+							},
+							requestRender() {},
+						},
+						{ fg: (_color: string, text: string) => text },
+						{},
+						() => {
+							overlayCloses++;
+							resolveOverlay();
+						},
+					);
+				});
+			},
+		});
+
+		await emit(mock.events, "tool_call", { input: { path: "demo.ipynb" } }, context.ctx);
+		assert.deepEqual(watchedDirectories, [directory]);
+		await emit(mock.events, "tool_result", { input: { path: "demo.ipynb" } }, context.ctx);
+		assert.deepEqual(watchedDirectories, [directory, directory]);
+		assert.equal(watcherCloses, 1);
+		assert.equal(context.statuses.get("jupyter"), "previewing notebook");
+		assert.equal(terminalWrites.join("").includes("\x1b[?1000h"), true);
+
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(watcherCloses, 2);
+		assert.equal(overlayCloses, 1);
+		assert.equal(inputListenerRemovals, 1);
+		assert.equal(terminalWrites.join("").includes("\x1b[?1000l"), true);
+		assert.equal(context.statuses.get("jupyter"), undefined);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});

--- a/experimental/pi-jupyter/tsconfig.json
+++ b/experimental/pi-jupyter/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -112,6 +112,9 @@ pack-goal:
 pack-image-drop:
     just pack image-drop
 
+pack-jupyter:
+    just pack jupyter
+
 pack-langfuse:
     just pack langfuse
 
@@ -172,6 +175,9 @@ try-goal:
 
 try-image-drop:
     just try image-drop
+
+try-jupyter:
+    just try jupyter
 
 try-langfuse:
     just try langfuse
@@ -234,6 +240,9 @@ install-goal:
 install-image-drop:
     just install image-drop
 
+install-jupyter:
+    just install jupyter
+
 install-langfuse:
     just install langfuse
 
@@ -291,6 +300,9 @@ publish-goal:
 
 publish-image-drop:
     just publish image-drop
+
+publish-jupyter:
+    just publish jupyter
 
 publish-langfuse:
     just publish langfuse

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,21 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"experimental/pi-jupyter": {
+			"name": "@narumitw/pi-jupyter",
+			"version": "0.32.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.5",
+				"@earendil-works/pi-coding-agent": "0.82.1",
+				"@earendil-works/pi-tui": "0.82.1",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
 		"extensions/pi-accounts": {
 			"name": "@narumitw/pi-accounts",
 			"version": "0.32.0",
@@ -6437,6 +6452,10 @@
 		},
 		"node_modules/@narumitw/pi-image-drop": {
 			"resolved": "extensions/pi-image-drop",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-jupyter": {
+			"resolved": "experimental/pi-jupyter",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-langfuse": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"pack:google-genai": "npm --workspace @narumitw/pi-google-genai pack --dry-run",
 		"pack:goal": "npm --workspace @narumitw/pi-goal pack --dry-run",
 		"pack:image-drop": "npm --workspace @narumitw/pi-image-drop pack --dry-run",
+		"pack:jupyter": "npm --workspace @narumitw/pi-jupyter pack --dry-run",
 		"pack:langfuse": "npm --workspace @narumitw/pi-langfuse pack --dry-run",
 		"pack:lsp": "npm --workspace @narumitw/pi-lsp pack --dry-run",
 		"pack:plan-mode": "npm --workspace @narumitw/pi-plan-mode pack --dry-run",


### PR DESCRIPTION
## Summary

- migrate `@narumitw/pi-jupyter` into `experimental/pi-jupyter` with an explicit experimental warning
- adapt notebook preview rendering, commands, shortcuts, file watching, and TUI lifecycle cleanup to current Pi APIs and monorepo boundaries
- add focused tests, package documentation, workspace lock records, root discovery, and pack/try/install/publish recipes

## Verification

- `npm ci --dry-run --ignore-scripts`
- `npm run check` (1,476 tests)
- `just pack-jupyter` (8 intended package files)
- `pi -ne ./experimental/pi-jupyter --list-models` (load succeeded; 24 output lines)
- `git diff --check`
