### PR TITLE
feat(file-context)!: remove file-quote command alias

### DIFF
--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -69,9 +69,8 @@ Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), n
 | Command | Mode | Description |
 | --- | --- | --- |
 | `/file-context` | TUI only | Open the file explorer. Arguments are rejected. |
-| `/file-quote` | TUI only | Compatibility alias for `/file-context`. |
 
-`/file-context` is the canonical command. Existing `/file-quote` usage remains supported as a compatibility alias. RPC receives an observable warning. JSON and print modes do not enter custom UI.
+RPC receives an observable warning. JSON and print modes do not enter custom UI.
 
 ## 🔒 Security and limits
 

--- a/experimental/pi-file-context/src/file-context.ts
+++ b/experimental/pi-file-context/src/file-context.ts
@@ -368,10 +368,6 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		description: "Browse project files and attach a selected line range",
 		handler: handleFileContextCommand,
 	});
-	pi.registerCommand("file-quote", {
-		description: "Compatibility alias for /file-context",
-		handler: handleFileContextCommand,
-	});
 
 	pi.on("session_start", (_event, ctx) => {
 		activeSessionManager = ctx.sessionManager;

--- a/experimental/pi-file-context/test/file-context.test.ts
+++ b/experimental/pi-file-context/test/file-context.test.ts
@@ -692,10 +692,7 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 	const mock = createMockPi();
 	fileQuoteExtension(mock.pi);
 	assert.ok(mock.commands.has("file-context"));
-	assert.equal(
-		mock.commands.get("file-quote")?.handler,
-		mock.commands.get("file-context")?.handler,
-	);
+	assert.equal(mock.commands.has("file-quote"), false);
 
 	let customFactory: unknown;
 	const widgets = new Map<string, unknown>();


### PR DESCRIPTION
## Summary
- stop registering the `/file-quote` compatibility alias
- keep `/file-context` as the only slash command
- update documentation and regression coverage

## Breaking change
`/file-quote` is no longer available. Use `/file-context` instead.

## Verification
- `npm run check` (1476 tests passed)