### PR TITLE
feat(jupyter)!: consolidate preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Choose either `pi-starship` or `pi-statusline`; do not enable both footer extens
 | Package | Use it for | Install |
 | --- | --- | --- |
 | [`pi-file-context`](./experimental/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it by typing `@` at a word boundary or running `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
-| [`pi-jupyter`](./experimental/pi-jupyter) | Preview saved Jupyter notebooks in a terminal-native side panel without running a kernel. | `pi install npm:@narumitw/pi-jupyter` |
+| [`pi-jupyter`](./experimental/pi-jupyter) | Choose and preview saved Jupyter notebooks from one `/jupyter` current-state menu without running a kernel. | `pi install npm:@narumitw/pi-jupyter` |
 
 ## 🔧 Advanced installation
 

--- a/docs/plans/archived/2026-07-26_pi-jupyter-single-command-ux-plan.md
+++ b/docs/plans/archived/2026-07-26_pi-jupyter-single-command-ux-plan.md
@@ -1,0 +1,22 @@
+# pi-jupyter single-command UX plan
+
+## Goal
+
+Replace pi-jupyter's fragmented slash-command surface with one current-state `/jupyter` manager while preserving shortcuts and direct capabilities, making notebook transitions atomic, and keeping preview state visible and recoverable.
+
+## Plan
+
+- [x] Add failing command/parser/menu tests for the sole `/jupyter` registration, progressive completions, strict direct routes, current-state menu variants, back/close navigation, and non-TUI rejection; the old command surface failed the updated focused tests because `/jupyter` was absent.
+- [x] Implement the `/jupyter` current-state manager and direct routes in focused command/menu modules, with a two-level notebook picker, path entry, injected keybindings, exact state labels, and side-effect-free cancellation; 12 focused command and preview tests pass.
+- [x] Add failing transition tests for successful switch, cancelled load, failed switch/refresh preservation, stale async completion, scroll clamping, tool-hook compatibility, and lifecycle cleanup; failures showed candidate state replacing the active preview before validation and refresh errors clearing the last valid model.
+- [x] Make notebook loading and watcher replacement generation-safe and atomic, retain the last valid preview on refresh failure, expose loading/stale/hidden-width status, and keep shortcut behavior compatible; 21 focused command, transition, rendering, mode, and lifecycle tests pass.
+- [x] Update the panel's responsive hints and the package README for `/jupyter`, advanced direct routes, state/recovery behavior, shortcut compatibility, and the old-command migration table; focused rendering tests prove 42-column output stays width-safe with long untrusted paths.
+- [x] Run focused tests, `npm run check`, `npm ci --dry-run --ignore-scripts`, `just pack-jupyter`, a non-interactive Pi load smoke, and final diff/command-surface audits; 21 focused and all 1,489 repository tests passed, clean-install validation succeeded, the tarball contains the intended 10 files, Pi loaded with 24 model lines, and the source audit finds exactly one `registerCommand("jupyter")`.
+
+## Completion Checklist
+
+- [x] Pi registers exactly one pi-jupyter slash command, `/jupyter`, with tested menu and direct routes.
+- [x] Primary, empty, loading, success, stale/error, narrow, cancellation, navigation, and failure states are deterministic and preserve the previous valid preview where required.
+- [x] Keyboard/focus behavior, responsive width safety, terminal escaping, shortcuts, tool hooks, and resource cleanup remain covered.
+- [x] User-facing documentation and migration guidance match the implemented behavior.
+- [x] Clean-install, CI-equivalent, package, runtime-load, and final diff checks pass.

--- a/experimental/pi-jupyter/README.md
+++ b/experimental/pi-jupyter/README.md
@@ -11,9 +11,11 @@ Preview a Jupyter notebook (`.ipynb`) in a terminal-native panel beside Pi's edi
 
 ## ✨ Features
 
+- Exposes one `/jupyter` current-state menu for choosing, opening, focusing, refreshing, switching, or closing a preview.
 - Opens a non-capturing right-side preview while the normal Pi editor remains usable.
-- Detects notebooks used by Pi file tools and refreshes after matching tool results.
+- Detects notebooks used by successful Pi file tools and refreshes after matching tool results.
 - Watches the selected notebook's parent directory so ordinary and atomic external saves refresh the panel.
+- Loads notebook changes atomically and preserves the last valid preview after cancellation, partial saves, or parse failures.
 - Renders markdown and code cells, execution counts, bounded text/error output, and inline image output.
 - Displays PNG output as truecolor ANSI half-block thumbnails; other image formats use Pi TUI terminal-image support when available.
 - Supports keyboard scrolling, focused scrolling, and mouse resizing from the panel's left border.
@@ -46,27 +48,55 @@ Avoid loading both a global npm installation and the local workspace at the same
 ## 🚀 Quick start
 
 1. Start Pi in a directory containing a notebook.
-2. Run `/jupyter-preview` to discover the first top-level `.ipynb`, or `/jupyter-preview path/to/notebook.ipynb` to select one explicitly.
-3. Keep editing normally while the preview follows saved changes.
+2. Run `/jupyter` and choose a notebook. The picker lists top-level `.ipynb` files and also accepts an explicit path.
+3. Keep editing normally while the preview follows valid saved changes.
 4. Press `Shift+F8` to focus the panel for scrolling, then `Escape` or `F8` to return to the editor.
-5. Press `F8` or run `/jupyter-preview-close` to close the panel.
+5. Press `F8` or choose **Close preview** from `/jupyter` when finished.
 
-## 💬 Commands
+## 💬 Command
 
-All commands require Pi's interactive TUI mode. Commands documented without arguments reject trailing input.
+Pi-jupyter registers only `/jupyter`, and it requires Pi's interactive TUI mode. With no arguments it opens a shallow current-state menu. The menu shows the selected filename, open/closed state, cell count, load time, stale errors, and whether an open preview is hidden below 90 terminal columns.
 
-| Command | Description |
+Primary menu actions depend on the current state:
+
+- **Choose a notebook…** lists top-level notebooks or accepts an explicit path; Escape returns without changing the preview.
+- **Open / Focus preview** performs the most relevant next viewing action.
+- **Refresh from disk** keeps the last valid version when a save is incomplete or invalid.
+- **Switch notebook…** commits the new path and watcher only after the candidate loads successfully.
+- **Close preview** closes the panel and watcher but retains the selection for a later reopen.
+- **Controls and shortcuts** shows keyboard help; Escape goes back and Ctrl+C closes the flow.
+
+Loading from the menu is cancellable with Escape. A cancelled or failed load leaves the previous path, content, watcher, scroll position, and panel state unchanged.
+
+### Advanced direct routes
+
+Known actions and nested scroll controls complete after `/jupyter `. Unknown actions, invalid counts, and trailing arguments are rejected.
+
+| Route | Effect |
 | --- | --- |
-| `/jupyter-preview [path]` | Open or refresh the preview; discover a top-level notebook when no path has been selected. |
-| `/jupyter-preview-toggle [path]` | Toggle the current preview, or open the supplied notebook. |
-| `/jupyter-preview-focus` | Focus the panel for keyboard scrolling. |
-| `/jupyter-preview-refresh` | Reload the selected notebook from disk. |
-| `/jupyter-preview-close` | Close the panel. |
-| `/jupyter-preview-up [lines]` | Scroll up by a positive line count; defaults to 3. |
-| `/jupyter-preview-down [lines]` | Scroll down by a positive line count; defaults to 3. |
-| `/jupyter-preview-page-up` | Scroll up 12 lines. |
-| `/jupyter-preview-page-down` | Scroll down 12 lines. |
-| `/jupyter-preview-top` | Return to the first rendered line. |
+| `/jupyter open [path]` | Open a path, the current selection, or the first discovered top-level notebook. |
+| `/jupyter toggle [path]` | Toggle the current preview, or open a supplied path. |
+| `/jupyter focus` | Focus the open panel for keyboard scrolling. |
+| `/jupyter refresh` | Reload the current selection while preserving the last valid version on failure. |
+| `/jupyter close` | Close the panel and watcher. |
+| `/jupyter scroll up [lines]` / `down [lines]` | Scroll by a positive line count; defaults to 3. |
+| `/jupyter scroll page-up` / `page-down` | Scroll by 12 lines. |
+| `/jupyter scroll top` | Return to the first rendered line. |
+
+### Migration from preview commands
+
+The experimental package no longer registers the old slash names. Equivalent routes are:
+
+| Previous command | Replacement |
+| --- | --- |
+| `/jupyter-preview [path]` | `/jupyter open [path]` |
+| `/jupyter-preview-toggle [path]` | `/jupyter toggle [path]` |
+| `/jupyter-preview-focus` | `/jupyter focus` |
+| `/jupyter-preview-refresh` | `/jupyter refresh` |
+| `/jupyter-preview-close` | `/jupyter close` |
+| `/jupyter-preview-up [lines]` / `-down [lines]` | `/jupyter scroll up [lines]` / `down [lines]` |
+| `/jupyter-preview-page-up` / `-page-down` | `/jupyter scroll page-up` / `page-down` |
+| `/jupyter-preview-top` | `/jupyter scroll top` |
 
 ## ⌨️ Shortcuts
 
@@ -96,18 +126,23 @@ While focused, use `Up`, `Down`, `PgUp`, `PgDn`, `Home`, or `j`, `k`, `u`, `d`, 
 - Notebook discovery scans only files directly inside Pi's current working directory.
 - Rich HTML, JavaScript, widgets, LaTeX, and most MIME-specific output are not rendered.
 - Long cells and outputs are summarized rather than interactively expanded.
+- An open overlay is hidden below 90 terminal columns and reappears when the terminal is widened; `/jupyter` reports this hidden state.
 - Mouse resizing depends on terminal SGR mouse reporting and may require the terminal's selection modifier for text selection.
 
 ## 🗂️ Package layout
 
 ```text
-src/index.ts               Thin Pi entrypoint
-src/jupyter-preview.ts     Commands, shortcuts, tool hooks, watcher, and lifecycle
-src/notebook-panel.ts      Overlay component, scrolling, and mouse resizing
-src/notebook.ts            Notebook loading, validation, and cell/output rendering
-src/png-thumbnail.ts       Bounded PNG decoding and ANSI thumbnail rendering
+src/index.ts                Thin Pi entrypoint
+src/jupyter-command.ts      Single-command parser, completions, and direct-route dispatch
+src/jupyter-menu.ts         Current-state menu, picker, help, and responsive state summaries
+src/jupyter-preview.ts      Shortcuts, tool hooks, atomic transitions, watcher, and lifecycle
+src/notebook-panel.ts       Overlay component, adaptive hints, scrolling, and mouse resizing
+src/notebook.ts             Cancellable loading, validation, and cell/output rendering
+src/png-thumbnail.ts        Bounded PNG decoding and ANSI thumbnail rendering
 
-test/jupyter-preview.test.ts  Paths, validation, commands, modes, and lifecycle
+test/jupyter-command.test.ts      Command, completion, menu, navigation, and help behavior
+test/jupyter-preview.test.ts      Paths, validation, modes, rendering, hooks, and lifecycle
+test/jupyter-transitions.test.ts  Cancellation, failure preservation, races, and reopen behavior
 ```
 
 ## 🔎 Keywords

--- a/experimental/pi-jupyter/src/jupyter-command.ts
+++ b/experimental/pi-jupyter/src/jupyter-command.ts
@@ -1,0 +1,138 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+
+export type JupyterScrollDirection = "up" | "down" | "page-up" | "page-down" | "top";
+
+export type JupyterCommand =
+	| { action: "menu" }
+	| { action: "open"; path?: string }
+	| { action: "toggle"; path?: string }
+	| { action: "focus" | "refresh" | "close" }
+	| { action: "scroll"; direction: JupyterScrollDirection; lines?: number };
+
+export type JupyterCommandActions = {
+	showMenu(ctx: ExtensionCommandContext): Promise<void>;
+	open(ctx: ExtensionCommandContext, path?: string): Promise<void>;
+	toggle(ctx: ExtensionCommandContext, path?: string): Promise<void>;
+	focus(ctx: ExtensionCommandContext): void;
+	refresh(ctx: ExtensionCommandContext): Promise<void>;
+	close(ctx: ExtensionCommandContext): void | Promise<void>;
+	scroll(
+		direction: JupyterScrollDirection,
+		lines: number | undefined,
+		ctx: ExtensionCommandContext,
+	): void;
+};
+
+const ROOT_COMPLETIONS: AutocompleteItem[] = [
+	{ value: "open ", label: "open", description: "Open a notebook preview" },
+	{ value: "focus", label: "focus", description: "Focus the open preview" },
+	{ value: "refresh", label: "refresh", description: "Reload the selected notebook" },
+	{ value: "close", label: "close", description: "Close the preview" },
+	{ value: "toggle ", label: "toggle", description: "Toggle the preview" },
+	{ value: "scroll ", label: "scroll", description: "Advanced scrolling controls" },
+];
+
+const SCROLL_COMPLETIONS: AutocompleteItem[] = [
+	{ value: "scroll up ", label: "scroll up", description: "Scroll up by lines" },
+	{ value: "scroll down ", label: "scroll down", description: "Scroll down by lines" },
+	{ value: "scroll page-up", label: "scroll page-up", description: "Scroll up one page" },
+	{ value: "scroll page-down", label: "scroll page-down", description: "Scroll down one page" },
+	{ value: "scroll top", label: "scroll top", description: "Return to the top" },
+];
+
+export function registerJupyterCommand(pi: ExtensionAPI, actions: JupyterCommandActions): void {
+	pi.registerCommand("jupyter", {
+		description: "Manage the current Jupyter notebook preview",
+		getArgumentCompletions: completeJupyterArguments,
+		handler: async (args, ctx) => {
+			const command = parseJupyterCommand(args);
+			switch (command.action) {
+				case "menu":
+					await actions.showMenu(ctx);
+					return;
+				case "open":
+					await actions.open(ctx, command.path);
+					return;
+				case "toggle":
+					await actions.toggle(ctx, command.path);
+					return;
+				case "focus":
+					actions.focus(ctx);
+					return;
+				case "refresh":
+					await actions.refresh(ctx);
+					return;
+				case "close":
+					await actions.close(ctx);
+					return;
+				case "scroll":
+					actions.scroll(command.direction, command.lines, ctx);
+			}
+		},
+	});
+}
+
+export function completeJupyterArguments(prefix: string): AutocompleteItem[] | null {
+	if (
+		prefix.startsWith("open ") ||
+		prefix.startsWith("toggle ") ||
+		prefix.startsWith("scroll up ") ||
+		prefix.startsWith("scroll down ")
+	) {
+		return null;
+	}
+	const completions = prefix.startsWith("scroll ") ? SCROLL_COMPLETIONS : ROOT_COMPLETIONS;
+	const filtered = completions.filter((item) => item.value.startsWith(prefix));
+	return filtered.length > 0 ? filtered : null;
+}
+
+export function parseJupyterCommand(rawArgs: string): JupyterCommand {
+	const args = rawArgs.trim();
+	if (!args) return { action: "menu" };
+	const [action = "", ...rest] = args.split(/\s+/);
+	const remainder = args.slice(action.length).trim();
+	switch (action) {
+		case "open":
+		case "toggle":
+			return remainder ? { action, path: remainder } : { action };
+		case "focus":
+		case "refresh":
+		case "close":
+			assertNoArguments(`/jupyter ${action}`, remainder);
+			return { action };
+		case "scroll":
+			return parseScrollCommand(rest);
+		default:
+			throw new Error(`Unknown /jupyter action: ${action}. Run /jupyter to see available actions.`);
+	}
+}
+
+function parseScrollCommand(parts: string[]): JupyterCommand {
+	const [direction, ...rest] = parts;
+	if (!direction || !["up", "down", "page-up", "page-down", "top"].includes(direction)) {
+		throw new Error(`Unknown /jupyter scroll action: ${direction ?? "(missing)"}.`);
+	}
+	if (direction === "up" || direction === "down") {
+		if (rest.length > 1)
+			throw new Error(`/jupyter scroll ${direction} accepts at most one line count.`);
+		return {
+			action: "scroll",
+			direction,
+			lines: rest[0] === undefined ? undefined : parsePositiveLineCount(rest[0]),
+		};
+	}
+	assertNoArguments(`/jupyter scroll ${direction}`, rest.join(" "));
+	return { action: "scroll", direction: direction as JupyterScrollDirection };
+}
+
+function parsePositiveLineCount(value: string): number {
+	if (!/^[1-9]\d*$/.test(value)) throw new Error("Scroll amount must be one positive integer.");
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed)) throw new Error("Scroll amount must be one positive integer.");
+	return parsed;
+}
+
+function assertNoArguments(command: string, args: string): void {
+	if (args) throw new Error(`${command} does not accept arguments.`);
+}

--- a/experimental/pi-jupyter/src/jupyter-menu.ts
+++ b/experimental/pi-jupyter/src/jupyter-menu.ts
@@ -1,0 +1,310 @@
+import { basename, relative } from "node:path";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	Container,
+	Key,
+	matchesKey,
+	type SelectItem,
+	SelectList,
+	Text,
+} from "@earendil-works/pi-tui";
+import { sanitizeTerminalText } from "./notebook.js";
+
+export const MIN_PREVIEW_TERMINAL_WIDTH = 90;
+
+export type JupyterMenuAction = "open" | "choose" | "focus" | "refresh" | "close" | "help";
+
+export type JupyterMenuState = {
+	cwd: string;
+	path?: string;
+	visible: boolean;
+	focused: boolean;
+	scroll: number;
+	cellCount?: number;
+	lastLoadedAt?: Date;
+	lastError?: string;
+};
+
+export interface JupyterMenuItem extends SelectItem {
+	value: JupyterMenuAction;
+}
+
+export type NotebookPickerResult =
+	| { action: "select"; path: string }
+	| { action: "enter-path" }
+	| { action: "back" }
+	| { action: "close" };
+
+type TuiRenderHost = { requestRender(): void };
+
+export function jupyterMenuItems(state: JupyterMenuState): JupyterMenuItem[] {
+	if (!state.path) {
+		return [
+			{
+				value: "choose",
+				label: "Choose a notebook…",
+				description: "Select a top-level notebook or enter an explicit path.",
+			},
+			helpItem(),
+		];
+	}
+	if (!state.visible) {
+		return [
+			{
+				value: "open",
+				label: `Open ${displayPath(state)}`,
+				description: "Open the selected notebook in the right-side preview.",
+			},
+			{
+				value: "choose",
+				label: "Choose another notebook…",
+				description: "Keep the current selection unless another notebook loads successfully.",
+			},
+			helpItem(),
+		];
+	}
+	return [
+		{
+			value: "focus",
+			label: `Focus ${displayPath(state)}`,
+			description: "Move keyboard scrolling to the preview; Escape returns to the editor.",
+		},
+		{
+			value: "refresh",
+			label: state.lastError ? "Retry refresh" : "Refresh from disk",
+			description: "Keep the last valid preview if the notebook cannot be reloaded.",
+		},
+		{
+			value: "choose",
+			label: "Switch notebook…",
+			description: "Replace the preview only after another notebook loads successfully.",
+		},
+		{
+			value: "close",
+			label: "Close preview",
+			description: "Close the panel and stop watching the selected notebook.",
+		},
+		helpItem(),
+	];
+}
+
+export function jupyterMenuSummary(state: JupyterMenuState, terminalWidth: number): string {
+	if (!state.path) return "No notebook selected";
+	const parts = [state.focused ? "Focused" : state.visible ? "Open" : "Closed", displayPath(state)];
+	if (state.cellCount !== undefined) parts.push(`${state.cellCount} cells`);
+	if (state.lastError)
+		parts.push("showing last valid version", sanitizeTerminalText(state.lastError));
+	else if (state.lastLoadedAt) parts.push(`loaded ${state.lastLoadedAt.toLocaleTimeString()}`);
+	if (state.visible && terminalWidth < MIN_PREVIEW_TERMINAL_WIDTH) {
+		parts.push(`hidden below ${MIN_PREVIEW_TERMINAL_WIDTH} columns`);
+	}
+	return parts.join(" · ");
+}
+
+export function createJupyterMenuComponent(
+	state: JupyterMenuState,
+	terminalWidth: number,
+	tui: TuiRenderHost,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (action: JupyterMenuAction | undefined) => void,
+	selectedAction?: JupyterMenuAction,
+) {
+	const items = jupyterMenuItems(state);
+	const container = new Container();
+	const title = new Text(theme.fg("accent", theme.bold("Jupyter Preview")), 1, 1);
+	const summary = new Text(jupyterMenuSummary(state, terminalWidth), 1, 0);
+	const preview = new Text("", 1, 1);
+	const list = createSelectList(items, theme);
+	const selectedIndex = Math.max(
+		0,
+		items.findIndex((item) => item.value === selectedAction),
+	);
+	list.setSelectedIndex(selectedIndex);
+	const updatePreview = (item: SelectItem) =>
+		preview.setText(`Effect: ${item.description ?? item.label}`);
+	updatePreview(items[selectedIndex]);
+	list.onSelectionChange = updatePreview;
+	list.onSelect = (item) => done(item.value as JupyterMenuAction);
+	list.onCancel = () => done(undefined);
+	container.addChild(title);
+	container.addChild(summary);
+	container.addChild(list);
+	container.addChild(preview);
+	container.addChild(
+		new Text(
+			theme.fg(
+				"dim",
+				`${keybindingHint(keybindings, "tui.select.confirm", "Enter", "select")} · ${keybindingHint(keybindings, "tui.select.cancel", "Esc", "close")}`,
+			),
+			1,
+			0,
+		),
+	);
+	return selectorComponent(container, list, tui, keybindings, {
+		onCancel: () => done(undefined),
+		onClose: () => done(undefined),
+	});
+}
+
+export function createNotebookPickerComponent(
+	paths: readonly string[],
+	selectedPath: string | undefined,
+	tui: TuiRenderHost,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (result: NotebookPickerResult) => void,
+) {
+	const items: SelectItem[] = [
+		...paths.map((path) => ({
+			value: path,
+			label: sanitizeTerminalText(basename(path)),
+			description: path === selectedPath ? "Currently selected" : sanitizeTerminalText(path),
+		})),
+		{
+			value: "__enter_path__",
+			label: "Enter a path…",
+			description: "Open an explicit .ipynb path, including a path outside this workspace.",
+		},
+	];
+	const container = new Container();
+	container.addChild(new Text(theme.fg("accent", theme.bold("Choose a notebook")), 1, 1));
+	const list = createSelectList(items, theme);
+	const preview = new Text("", 1, 1);
+	const selectedIndex = Math.max(
+		0,
+		items.findIndex((item) => item.value === selectedPath),
+	);
+	list.setSelectedIndex(selectedIndex);
+	const updatePreview = (item: SelectItem) => {
+		preview.setText(
+			item.value === "__enter_path__"
+				? "Effect: enter and validate an explicit notebook path."
+				: `Open after successful validation: ${sanitizeTerminalText(item.value)}`,
+		);
+	};
+	updatePreview(items[selectedIndex]);
+	list.onSelectionChange = updatePreview;
+	list.onSelect = (item) => {
+		if (item.value === "__enter_path__") done({ action: "enter-path" });
+		else done({ action: "select", path: item.value });
+	};
+	list.onCancel = () => done({ action: "back" });
+	container.addChild(list);
+	container.addChild(preview);
+	container.addChild(
+		new Text(
+			theme.fg(
+				"dim",
+				`${keybindingHint(keybindings, "tui.select.confirm", "Enter", "select")} · ${keybindingHint(keybindings, "tui.select.cancel", "Esc", "back")} · Ctrl+C close`,
+			),
+			1,
+			1,
+		),
+	);
+	return selectorComponent(container, list, tui, keybindings, {
+		onCancel: () => done({ action: "back" }),
+		onClose: () => done({ action: "close" }),
+	});
+}
+
+export function createJupyterHelpComponent(
+	tui: TuiRenderHost,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (result: "back" | "close") => void,
+) {
+	const container = new Container();
+	container.addChild(new Text(theme.fg("accent", theme.bold("Jupyter controls")), 1, 1));
+	container.addChild(new Text(jupyterHelpLines().join("\n"), 1, 0));
+	container.addChild(
+		new Text(
+			theme.fg(
+				"dim",
+				`${keybindingHint(keybindings, "tui.select.cancel", "Esc", "back")} · Ctrl+C close`,
+			),
+			1,
+			1,
+		),
+	);
+	return {
+		render: (width: number) => container.render(width),
+		invalidate: () => container.invalidate(),
+		handleInput(data: string) {
+			if (matchesKey(data, Key.ctrl("c"))) done("close");
+			else if (keybindings.matches(data, "tui.select.cancel")) done("back");
+			tui.requestRender();
+		},
+	};
+}
+
+export function jupyterHelpLines(): string[] {
+	return [
+		"F8 toggles the preview; Shift+F8 focuses it.",
+		"Ctrl+Alt+J/K scroll; Ctrl+Alt+D/U page.",
+		"While focused: arrows, PgUp/PgDn, Home, j/k/u/d/g; Escape returns.",
+		"Direct routes: /jupyter open, focus, refresh, close, toggle, and scroll.",
+	];
+}
+
+function selectorComponent(
+	container: Container,
+	list: SelectList,
+	tui: TuiRenderHost,
+	keybindings: KeybindingsManager,
+	actions: { onCancel(): void; onClose(): void },
+) {
+	return {
+		render: (width: number) => container.render(width),
+		invalidate: () => container.invalidate(),
+		handleInput(data: string) {
+			if (matchesKey(data, Key.ctrl("c"))) actions.onClose();
+			else if (keybindings.matches(data, "tui.select.cancel")) actions.onCancel();
+			else if (keybindings.matches(data, "tui.select.confirm")) {
+				const item = list.getSelectedItem();
+				if (item) list.onSelect?.(item);
+			} else if (keybindings.matches(data, "tui.select.up")) list.handleInput(Key.up);
+			else if (keybindings.matches(data, "tui.select.down")) list.handleInput(Key.down);
+			else if (keybindings.matches(data, "tui.select.pageUp")) list.handleInput(Key.pageUp);
+			else if (keybindings.matches(data, "tui.select.pageDown")) list.handleInput(Key.pageDown);
+			else list.handleInput(data);
+			tui.requestRender();
+		},
+	};
+}
+
+function createSelectList(items: SelectItem[], theme: Theme): SelectList {
+	return new SelectList(items, Math.min(items.length, 8), {
+		selectedPrefix: (text) => theme.fg("accent", text),
+		selectedText: (text) => theme.fg("accent", text),
+		description: (text) => theme.fg("muted", text),
+		scrollInfo: (text) => theme.fg("dim", text),
+		noMatch: (text) => theme.fg("warning", text),
+	});
+}
+
+function helpItem(): JupyterMenuItem {
+	return {
+		value: "help",
+		label: "Controls and shortcuts",
+		description: "Review keyboard controls and advanced direct routes.",
+	};
+}
+
+function keybindingHint(
+	keybindings: KeybindingsManager,
+	id: "tui.select.confirm" | "tui.select.cancel",
+	fallback: string,
+	action: string,
+): string {
+	const keys = (
+		keybindings as KeybindingsManager & { getKeys?: (key: string) => string[] }
+	).getKeys?.(id);
+	return `${keys?.[0] ?? fallback} ${action}`;
+}
+
+function displayPath(state: JupyterMenuState): string {
+	if (!state.path) return "no notebook";
+	const local = relative(state.cwd, state.path);
+	return sanitizeTerminalText(local && !local.startsWith("..") ? local : state.path);
+}

--- a/experimental/pi-jupyter/src/jupyter-preview.ts
+++ b/experimental/pi-jupyter/src/jupyter-preview.ts
@@ -72,7 +72,9 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	let currentWatcher: NotebookWatcher | undefined;
 	let cancelWatchDebounce: (() => void) | undefined;
 	let watchGeneration = 0;
-	let loadGeneration = 0;
+	let selectionGeneration = 0;
+	let refreshGeneration = 0;
+	let pendingSelectionPath: string | undefined;
 
 	function stopWatcher(): void {
 		watchGeneration += 1;
@@ -85,16 +87,15 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	async function reloadSelectedNotebook(ctx?: ExtensionContext): Promise<boolean> {
 		const path = state.path;
 		if (!path) return false;
-		const generation = ++loadGeneration;
+		const generation = ++refreshGeneration;
 		try {
 			const loaded = await dependencies.loadNotebook(path);
-			if (generation !== loadGeneration || state.path !== path) return false;
+			if (generation !== refreshGeneration || state.path !== path) return false;
 			applyLoadedNotebook(state, loaded);
-			state.scroll = 0;
 			updateStatus(ctx);
 			return true;
 		} catch (cause) {
-			if (generation !== loadGeneration || state.path !== path) return false;
+			if (generation !== refreshGeneration || state.path !== path) return false;
 			state.lastError = errorMessage(cause);
 			updateStatus(ctx);
 			return false;
@@ -137,13 +138,17 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 			ctx.ui.notify("Notebook path must end in .ipynb.", "error");
 			return false;
 		}
-		const generation = ++loadGeneration;
-		updateStatus(ctx, path);
+		const generation = ++selectionGeneration;
+		refreshGeneration += 1;
+		pendingSelectionPath = path;
+		updateStatus(ctx);
 		try {
 			const loaded = await dependencies.loadNotebook(path, signal);
 			signal?.throwIfAborted();
-			if (generation !== loadGeneration) return false;
+			if (generation !== selectionGeneration) return false;
+			refreshGeneration += 1;
 			if (!startWatcher(path, ctx)) {
+				pendingSelectionPath = undefined;
 				updateStatus(ctx);
 				return false;
 			}
@@ -151,10 +156,12 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 			state.path = path;
 			state.scroll = 0;
 			applyLoadedNotebook(state, loaded);
+			pendingSelectionPath = undefined;
 			updateStatus(ctx);
 			return true;
 		} catch (cause) {
-			if (generation !== loadGeneration) return false;
+			if (generation !== selectionGeneration) return false;
+			pendingSelectionPath = undefined;
 			updateStatus(ctx);
 			if (signal?.aborted) return false;
 			ctx.ui.notify(
@@ -243,7 +250,9 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 			.finally(() => {
 				if (overlayTask !== task) return;
 				overlayTask = undefined;
-				loadGeneration += 1;
+				selectionGeneration += 1;
+				refreshGeneration += 1;
+				pendingSelectionPath = undefined;
 				stopWatcher();
 				removeMouseResize?.();
 				removeMouseResize = undefined;
@@ -264,7 +273,9 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	}
 
 	async function hidePanel(ctx?: ExtensionContext): Promise<void> {
-		loadGeneration += 1;
+		selectionGeneration += 1;
+		refreshGeneration += 1;
+		pendingSelectionPath = undefined;
 		stopWatcher();
 		state.visible = false;
 		state.focused = false;
@@ -299,7 +310,7 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 		requestRender?.();
 	}
 
-	function updateStatus(ctx?: ExtensionContext, loadingPath?: string): void {
+	function updateStatus(ctx?: ExtensionContext, loadingPath = pendingSelectionPath): void {
 		if (!ctx?.hasUI) return;
 		if (loadingPath) {
 			ctx.ui.setStatus(

--- a/experimental/pi-jupyter/src/jupyter-preview.ts
+++ b/experimental/pi-jupyter/src/jupyter-preview.ts
@@ -1,9 +1,21 @@
 import { watch } from "node:fs";
 import { readdir } from "node:fs/promises";
-import { basename, dirname, resolve } from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import {
+	BorderedLoader,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import type { OverlayHandle, OverlayOptions } from "@earendil-works/pi-tui";
-import { loadNotebook, sanitizeTerminalText } from "./notebook.js";
+import { type JupyterScrollDirection, registerJupyterCommand } from "./jupyter-command.js";
+import {
+	createJupyterHelpComponent,
+	createJupyterMenuComponent,
+	createNotebookPickerComponent,
+	type JupyterMenuAction,
+} from "./jupyter-menu.js";
+import { type LoadedNotebook, loadNotebook, sanitizeTerminalText } from "./notebook.js";
 import {
 	applyLoadedNotebook,
 	DEFAULT_PANEL_WIDTH_PERCENT,
@@ -27,16 +39,18 @@ type WatchNotebook = (
 
 export type JupyterPreviewDependencies = {
 	watchNotebook: WatchNotebook;
+	loadNotebook(path: string, signal?: AbortSignal): Promise<LoadedNotebook>;
 };
 
 const DEFAULT_DEPENDENCIES: JupyterPreviewDependencies = {
 	watchNotebook: (directory, listener) => watch(directory, { persistent: false }, listener),
+	loadNotebook,
 };
 
 export function createJupyterPreview(
-	dependencies: JupyterPreviewDependencies,
+	dependencies: Partial<JupyterPreviewDependencies>,
 ): (pi: ExtensionAPI) => void {
-	return (pi) => registerJupyterPreview(pi, dependencies);
+	return (pi) => registerJupyterPreview(pi, { ...DEFAULT_DEPENDENCIES, ...dependencies });
 }
 
 export default function jupyterPreview(pi: ExtensionAPI): void {
@@ -54,9 +68,11 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	let closeOverlay: (() => void) | undefined;
 	let requestRender: (() => void) | undefined;
 	let removeMouseResize: (() => void) | undefined;
+	let overlayTask: Promise<void> | undefined;
 	let currentWatcher: NotebookWatcher | undefined;
 	let cancelWatchDebounce: (() => void) | undefined;
 	let watchGeneration = 0;
+	let loadGeneration = 0;
 
 	function stopWatcher(): void {
 		watchGeneration += 1;
@@ -66,62 +82,113 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 		currentWatcher = undefined;
 	}
 
-	async function reloadSelectedNotebook(): Promise<void> {
-		if (!state.path) return;
+	async function reloadSelectedNotebook(ctx?: ExtensionContext): Promise<boolean> {
+		const path = state.path;
+		if (!path) return false;
+		const generation = ++loadGeneration;
 		try {
-			applyLoadedNotebook(state, await loadNotebook(state.path));
+			const loaded = await dependencies.loadNotebook(path);
+			if (generation !== loadGeneration || state.path !== path) return false;
+			applyLoadedNotebook(state, loaded);
+			state.scroll = 0;
+			updateStatus(ctx);
+			return true;
 		} catch (cause) {
-			state.model = undefined;
-			state.lastLoadedAt = new Date();
-			state.lastError = cause instanceof Error ? cause.message : String(cause);
+			if (generation !== loadGeneration || state.path !== path) return false;
+			state.lastError = errorMessage(cause);
+			updateStatus(ctx);
+			return false;
 		}
 	}
 
-	function startWatcher(path: string): void {
-		stopWatcher();
-		const generation = watchGeneration;
+	function startWatcher(path: string, ctx: ExtensionContext): boolean {
+		const generation = watchGeneration + 1;
 		const targetName = basename(path);
 		const debounced = debounce(() => {
 			if (generation !== watchGeneration || state.path !== path) return;
-			void reloadSelectedNotebook().finally(() => requestRender?.());
+			void reloadSelectedNotebook(ctx).finally(() => requestRender?.());
 		}, 150);
-		cancelWatchDebounce = debounced.cancel;
+		let watcher: NotebookWatcher;
 		try {
-			currentWatcher = dependencies.watchNotebook(dirname(path), (_event, changedName) => {
+			watcher = dependencies.watchNotebook(dirname(path), (_event, changedName) => {
 				if (changedName === null || changedName.toString() === targetName) debounced.run();
 			});
-		} catch {
-			currentWatcher = undefined;
+		} catch (cause) {
+			debounced.cancel();
+			ctx.ui.notify(
+				`Could not watch ${sanitizeTerminalText(path)}: ${errorMessage(cause)}. The previous preview was preserved.`,
+				"error",
+			);
+			return false;
 		}
+		stopWatcher();
+		currentWatcher = watcher;
+		cancelWatchDebounce = debounced.cancel;
+		return true;
 	}
 
-	async function setNotebookPath(rawPath: string, ctx: ExtensionContext): Promise<void> {
+	async function setNotebookPath(
+		rawPath: string,
+		ctx: ExtensionContext,
+		signal?: AbortSignal,
+	): Promise<boolean> {
 		const path = resolveNotebookPath(rawPath, ctx.cwd);
-		if (!path.endsWith(NOTEBOOK_EXTENSION)) throw new Error("Notebook path must end in .ipynb.");
-		state.cwd = ctx.cwd;
-		state.path = path;
-		state.scroll = 0;
-		await reloadSelectedNotebook();
-		startWatcher(path);
+		if (!path.endsWith(NOTEBOOK_EXTENSION)) {
+			ctx.ui.notify("Notebook path must end in .ipynb.", "error");
+			return false;
+		}
+		const generation = ++loadGeneration;
+		updateStatus(ctx, path);
+		try {
+			const loaded = await dependencies.loadNotebook(path, signal);
+			signal?.throwIfAborted();
+			if (generation !== loadGeneration) return false;
+			if (!startWatcher(path, ctx)) {
+				updateStatus(ctx);
+				return false;
+			}
+			state.cwd = ctx.cwd;
+			state.path = path;
+			state.scroll = 0;
+			applyLoadedNotebook(state, loaded);
+			updateStatus(ctx);
+			return true;
+		} catch (cause) {
+			if (generation !== loadGeneration) return false;
+			updateStatus(ctx);
+			if (signal?.aborted) return false;
+			ctx.ui.notify(
+				`Could not open ${sanitizeTerminalText(path)}: ${errorMessage(cause)}. The previous preview was preserved.`,
+				"error",
+			);
+			return false;
+		}
 	}
 
 	async function showPanel(ctx: ExtensionContext, rawPath?: string): Promise<void> {
 		requireTui(ctx);
-		if (rawPath?.trim()) await setNotebookPath(rawPath, ctx);
-		else if (!state.path) {
+		if (rawPath?.trim()) {
+			if (!(await setNotebookPath(rawPath, ctx))) return;
+		} else if (!state.path) {
 			const discovered = await findFirstNotebook(ctx.cwd);
 			if (!discovered) {
-				ctx.ui.notify("No .ipynb file found. Use /jupyter-preview <path>.", "warning");
+				ctx.ui.notify("No top-level .ipynb file found. Run /jupyter to enter a path.", "warning");
 				return;
 			}
-			await setNotebookPath(discovered, ctx);
+			if (!(await setNotebookPath(discovered, ctx))) return;
 		} else {
 			state.cwd = ctx.cwd;
-			await reloadSelectedNotebook();
+			const loaded = await reloadSelectedNotebook(ctx);
+			if (!loaded && !state.model) return;
+			startWatcher(state.path, ctx);
 		}
 
+		openPanel(ctx);
+	}
+
+	function openPanel(ctx: ExtensionContext): void {
 		state.visible = true;
-		ctx.ui.setStatus(STATUS_KEY, "previewing notebook");
+		updateStatus(ctx);
 		if (overlayHandle) {
 			overlayHandle.setHidden(false);
 			requestRender?.();
@@ -137,7 +204,7 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 			nonCapturing: true,
 			visible: (termWidth) => termWidth >= 90,
 		};
-		void ctx.ui
+		const task = ctx.ui
 			.custom<void>(
 				(tui, theme, _keybindings, done) => {
 					const panel = new NotebookPreviewPanel(tui, theme, state, () => {
@@ -174,6 +241,10 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 				}
 			})
 			.finally(() => {
+				if (overlayTask !== task) return;
+				overlayTask = undefined;
+				loadGeneration += 1;
+				stopWatcher();
 				removeMouseResize?.();
 				removeMouseResize = undefined;
 				overlayHandle = undefined;
@@ -188,20 +259,25 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 					// A replacement session can invalidate the context before overlay disposal settles.
 				}
 			});
+		overlayTask = task;
+		void task;
 	}
 
-	function hidePanel(ctx?: ExtensionContext): void {
+	async function hidePanel(ctx?: ExtensionContext): Promise<void> {
+		loadGeneration += 1;
+		stopWatcher();
 		state.visible = false;
 		state.focused = false;
 		state.resizing = false;
 		if (ctx?.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
 		closeOverlay?.();
+		await overlayTask;
 	}
 
 	function focusPanel(ctx: ExtensionContext): void {
 		requireTui(ctx);
 		if (!overlayHandle) {
-			ctx.ui.notify("Jupyter preview is not open. Use /jupyter-preview <path>.", "warning");
+			ctx.ui.notify("Jupyter preview is not open. Run /jupyter to open it.", "warning");
 			return;
 		}
 		state.focused = true;
@@ -216,34 +292,165 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	function scrollPreview(delta: number | "top", ctx: ExtensionContext): void {
 		requireTui(ctx);
 		if (!state.visible || !overlayHandle) {
-			ctx.ui.notify("Jupyter preview is not open. Use /jupyter-preview <path>.", "warning");
+			ctx.ui.notify("Jupyter preview is not open. Run /jupyter to open it.", "warning");
 			return;
 		}
 		state.scroll = delta === "top" ? 0 : Math.max(0, state.scroll + delta);
 		requestRender?.();
 	}
 
-	registerCommands(pi, {
-		showPanel,
-		hidePanel,
-		focusPanel,
-		scrollPreview,
-		reload: async (ctx) => {
+	function updateStatus(ctx?: ExtensionContext, loadingPath?: string): void {
+		if (!ctx?.hasUI) return;
+		if (loadingPath) {
+			ctx.ui.setStatus(
+				STATUS_KEY,
+				`loading notebook: ${sanitizeTerminalText(basename(loadingPath))}`,
+			);
+			return;
+		}
+		if (!state.visible || !state.path) {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+		const stale = state.lastError ? " (stale)" : "";
+		ctx.ui.setStatus(STATUS_KEY, `notebook: ${sanitizeTerminalText(basename(state.path))}${stale}`);
+	}
+
+	async function loadFromMenu(ctx: ExtensionCommandContext, path: string): Promise<boolean> {
+		return ctx.ui.custom<boolean>((tui, theme, _keybindings, done) => {
+			const loader = new BorderedLoader(
+				tui,
+				theme,
+				`Loading ${sanitizeTerminalText(basename(resolveNotebookPath(path, ctx.cwd)))}…`,
+				{ cancellable: true },
+			);
+			let settled = false;
+			const finish = (result: boolean) => {
+				if (settled) return;
+				settled = true;
+				done(result);
+			};
+			loader.onAbort = () => finish(false);
+			void setNotebookPath(path, ctx, loader.signal).then(finish);
+			return loader;
+		});
+	}
+
+	async function showJupyterMenu(ctx: ExtensionCommandContext): Promise<void> {
+		requireTui(ctx);
+		let selectedAction: JupyterMenuAction | undefined;
+		while (true) {
+			const action = await ctx.ui.custom<JupyterMenuAction | undefined>(
+				(tui, theme, keybindings, done) =>
+					createJupyterMenuComponent(
+						{
+							...state,
+							cellCount: state.model?.cells?.length,
+						},
+						tui.terminal.columns,
+						tui,
+						theme,
+						keybindings,
+						done,
+						selectedAction,
+					),
+			);
+			if (!action) return;
+			selectedAction = action;
+			switch (action) {
+				case "open":
+					if (state.path && (await loadFromMenu(ctx, state.path))) openPanel(ctx);
+					return;
+				case "choose": {
+					const selection = await chooseNotebook(ctx);
+					if (selection === "back") continue;
+					return;
+				}
+				case "focus":
+					focusPanel(ctx);
+					return;
+				case "refresh":
+					await reloadSelectedNotebook(ctx);
+					requestRender?.();
+					return;
+				case "close":
+					await hidePanel(ctx);
+					ctx.ui.notify("Jupyter preview closed.", "info");
+					return;
+				case "help": {
+					const result = await ctx.ui.custom<"back" | "close">((tui, theme, keybindings, done) =>
+						createJupyterHelpComponent(tui, theme, keybindings, done),
+					);
+					if (result === "close") return;
+					continue;
+				}
+			}
+		}
+	}
+
+	async function chooseNotebook(ctx: ExtensionCommandContext): Promise<"back" | "closed"> {
+		const paths = await findNotebooks(ctx.cwd);
+		const result = await ctx.ui.custom<
+			| { action: "select"; path: string }
+			| { action: "enter-path" }
+			| { action: "back" }
+			| { action: "close" }
+		>((tui, theme, keybindings, done) =>
+			createNotebookPickerComponent(paths, state.path, tui, theme, keybindings, done),
+		);
+		if (result.action === "back") return "back";
+		if (result.action === "close") return "closed";
+		let selectedPath = result.action === "select" ? result.path : undefined;
+		if (!selectedPath) {
+			const entered = await ctx.ui.input("Notebook path", "path/to/notebook.ipynb");
+			if (!entered?.trim()) return "back";
+			selectedPath = entered.trim();
+			const resolved = resolveNotebookPath(selectedPath, ctx.cwd);
+			const local = relative(ctx.cwd, resolved);
+			if (local === ".." || local.startsWith(`..${sep}`) || isAbsolute(local)) {
+				const confirmed = await ctx.ui.confirm(
+					"Open notebook outside workspace?",
+					sanitizeTerminalText(resolved),
+				);
+				if (!confirmed) return "back";
+			}
+		}
+		if (await loadFromMenu(ctx, selectedPath)) openPanel(ctx);
+		return "closed";
+	}
+
+	registerJupyterCommand(pi, {
+		showMenu: showJupyterMenu,
+		open: showPanel,
+		toggle: async (ctx, path) => {
+			requireTui(ctx);
+			if (state.visible && overlayHandle && !path?.trim()) await hidePanel(ctx);
+			else await showPanel(ctx, path);
+		},
+		focus: focusPanel,
+		refresh: async (ctx) => {
 			requireTui(ctx);
 			if (!state.path) {
-				ctx.ui.notify("No notebook selected. Use /jupyter-preview <path>.", "warning");
+				ctx.ui.notify("No notebook selected. Run /jupyter to choose one.", "warning");
 				return;
 			}
-			await reloadSelectedNotebook();
+			await reloadSelectedNotebook(ctx);
 			requestRender?.();
 		},
-		isVisible: () => state.visible && overlayHandle !== undefined,
+		close: async (ctx) => {
+			requireTui(ctx);
+			await hidePanel(ctx);
+		},
+		scroll: (direction, lines, ctx) => {
+			const delta = scrollDelta(direction, lines);
+			scrollPreview(delta, ctx);
+		},
 	});
 
 	pi.registerShortcut("f8", {
 		description: "Toggle Jupyter notebook preview",
 		handler: async (ctx) => {
-			if (state.visible && overlayHandle) hidePanel(ctx);
+			if (state.visible && overlayHandle) await hidePanel(ctx);
 			else await showPanel(ctx);
 		},
 	});
@@ -266,16 +473,8 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	pi.on("session_start", async (_event, ctx) => {
 		if (ctx.hasUI) ctx.ui.notify(EXPERIMENTAL_WARNING, "warning");
 	});
-	pi.on("tool_call", async (event, ctx) => {
-		if (ctx.mode !== "tui") return;
-		const candidate = extractNotebookPath(event.input);
-		if (!candidate) return;
-		state.cwd = ctx.cwd;
-		state.path = resolveNotebookPath(candidate, ctx.cwd);
-		startWatcher(state.path);
-	});
 	pi.on("tool_result", async (event, ctx) => {
-		if (ctx.mode !== "tui") return;
+		if (ctx.mode !== "tui" || event.isError) return;
 		const candidate = extractNotebookPath(event.input);
 		if (!candidate) return;
 		if (state.visible) {
@@ -284,87 +483,24 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 		} else await showPanel(ctx, candidate);
 	});
 	pi.on("session_shutdown", async (_event, ctx) => {
-		stopWatcher();
-		hidePanel(ctx);
+		await hidePanel(ctx);
 		if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 }
 
-type CommandActions = {
-	showPanel(ctx: ExtensionContext, path?: string): Promise<void>;
-	hidePanel(ctx: ExtensionContext): void;
-	focusPanel(ctx: ExtensionContext): void;
-	scrollPreview(delta: number | "top", ctx: ExtensionContext): void;
-	reload(ctx: ExtensionContext): Promise<void>;
-	isVisible(): boolean;
-};
-
-function registerCommands(pi: ExtensionAPI, actions: CommandActions): void {
-	pi.registerCommand("jupyter-preview", {
-		description: "Open or refresh a right-side .ipynb preview. Usage: /jupyter-preview [path]",
-		handler: async (args, ctx) => actions.showPanel(ctx, args),
-	});
-	pi.registerCommand("jupyter-preview-close", {
-		description: "Close the right-side Jupyter notebook preview",
-		handler: async (args, ctx) => {
-			assertNoArguments("/jupyter-preview-close", args);
-			requireTui(ctx);
-			actions.hidePanel(ctx);
-		},
-	});
-	pi.registerCommand("jupyter-preview-toggle", {
-		description:
-			"Toggle the right-side Jupyter notebook preview. Usage: /jupyter-preview-toggle [path]",
-		handler: async (args, ctx) => {
-			requireTui(ctx);
-			if (actions.isVisible() && !args.trim()) actions.hidePanel(ctx);
-			else await actions.showPanel(ctx, args);
-		},
-	});
-	pi.registerCommand("jupyter-preview-focus", {
-		description: "Focus the notebook preview for keyboard scrolling",
-		handler: async (args, ctx) => {
-			assertNoArguments("/jupyter-preview-focus", args);
-			actions.focusPanel(ctx);
-		},
-	});
-	pi.registerCommand("jupyter-preview-refresh", {
-		description: "Reload the current notebook preview from disk",
-		handler: async (args, ctx) => {
-			assertNoArguments("/jupyter-preview-refresh", args);
-			await actions.reload(ctx);
-		},
-	});
-	for (const [name, direction, fallback] of [
-		["jupyter-preview-up", -1, 3],
-		["jupyter-preview-down", 1, 3],
-	] as const) {
-		pi.registerCommand(name, {
-			description: `Scroll the notebook preview ${direction < 0 ? "up" : "down"}. Usage: /${name} [lines]`,
-			handler: async (args, ctx) => {
-				actions.scrollPreview(direction * parsePositiveLineCount(args, fallback), ctx);
-			},
-		});
+function scrollDelta(direction: JupyterScrollDirection, lines?: number): number | "top" {
+	switch (direction) {
+		case "up":
+			return -(lines ?? 3);
+		case "down":
+			return lines ?? 3;
+		case "page-up":
+			return -12;
+		case "page-down":
+			return 12;
+		case "top":
+			return "top";
 	}
-	for (const [name, delta] of [
-		["jupyter-preview-page-up", -12],
-		["jupyter-preview-page-down", 12],
-	] as const) {
-		pi.registerCommand(name, {
-			description: `Scroll the notebook preview one page ${delta < 0 ? "up" : "down"}`,
-			handler: async (args, ctx) => {
-				assertNoArguments(`/${name}`, args);
-				actions.scrollPreview(delta, ctx);
-			},
-		});
-	}
-	pi.registerCommand("jupyter-preview-top", {
-		description: "Scroll the notebook preview to the top",
-		handler: async (args, ctx) => {
-			assertNoArguments("/jupyter-preview-top", args);
-			actions.scrollPreview("top", ctx);
-		},
-	});
 }
 
 export function parsePositiveLineCount(args: string, fallback: number): number {
@@ -374,10 +510,6 @@ export function parsePositiveLineCount(args: string, fallback: number): number {
 	const parsed = Number(value);
 	if (!Number.isSafeInteger(parsed)) throw new Error("Scroll amount must be one positive integer.");
 	return parsed;
-}
-
-function assertNoArguments(command: string, args: string): void {
-	if (args.trim()) throw new Error(`${command} does not accept arguments.`);
 }
 
 function requireTui(ctx: ExtensionContext): void {
@@ -399,16 +531,23 @@ export function extractNotebookPath(input: unknown): string | undefined {
 }
 
 async function findFirstNotebook(cwd: string): Promise<string | undefined> {
+	return (await findNotebooks(cwd))[0];
+}
+
+async function findNotebooks(cwd: string): Promise<string[]> {
 	try {
 		const entries = await readdir(cwd, { withFileTypes: true });
-		const name = entries
+		return entries
 			.filter((entry) => entry.isFile() && entry.name.endsWith(NOTEBOOK_EXTENSION))
-			.map((entry) => entry.name)
-			.sort()[0];
-		return name ? resolve(cwd, name) : undefined;
+			.map((entry) => resolve(cwd, entry.name))
+			.sort();
 	} catch {
-		return undefined;
+		return [];
 	}
+}
+
+function errorMessage(cause: unknown): string {
+	return sanitizeTerminalText(cause instanceof Error ? cause.message : String(cause));
 }
 
 function debounce(callback: () => void, milliseconds: number): { run(): void; cancel(): void } {

--- a/experimental/pi-jupyter/src/notebook-panel.ts
+++ b/experimental/pi-jupyter/src/notebook-panel.ts
@@ -91,24 +91,30 @@ export class NotebookPreviewPanel implements Component {
 		lines.push(`${border("├")}${border("─".repeat(inner))}${border("┤")}`);
 
 		if (!this.state.path) {
-			lines.push(pad(" No notebook selected."), pad(dim(" /jupyter-preview <file.ipynb>")));
-		} else if (this.state.lastError) {
+			lines.push(pad(" No notebook selected."), pad(dim(" Run /jupyter to choose one.")));
+		} else if (this.state.lastError && !this.state.model) {
 			lines.push(
 				...wrapBoxLines(error(sanitizeTerminalText(this.state.lastError)), inner).map(pad),
 			);
 		} else if (!this.state.model) lines.push(pad(dim(" Loading…")));
 		else {
+			if (this.state.lastError) {
+				lines.push(
+					...wrapBoxLines(
+						error(
+							` Refresh failed; showing last valid version: ${sanitizeTerminalText(this.state.lastError)}`,
+						),
+						inner,
+					).map(pad),
+					pad(),
+				);
+			}
 			const body = renderNotebookBody(this.state, inner, this.theme);
 			lines.push(...body.slice(this.state.scroll).map(pad));
 		}
 
 		lines.push(`${border("├")}${border("─".repeat(inner))}${border("┤")}`);
-		const footer = this.state.resizing
-			? " Drag to resize width"
-			: this.state.focused
-				? " ↑↓ PgUp/PgDn or j/k/u/d scroll • Esc/F8 return"
-				: " Drag left border resize • Ctrl+Alt+j/k scroll • Shift+F8 focus";
-		lines.push(pad(dim(footer)), border(`╰${"─".repeat(inner)}╯`));
+		lines.push(pad(dim(previewFooter(this.state, inner))), border(`╰${"─".repeat(inner)}╯`));
 		return lines;
 	}
 
@@ -155,6 +161,18 @@ export function installMouseResize(
 		removeListener();
 		terminal.write("\x1b[?1006l\x1b[?1002l\x1b[?1000l");
 	};
+}
+
+export function previewFooter(state: PreviewState, width: number): string {
+	if (state.resizing) return " Drag to resize width";
+	if (state.focused) {
+		return width >= 58
+			? " ↑↓ PgUp/PgDn or j/k/u/d scroll • Esc/F8 return"
+			: " ↑↓ scroll • Esc/F8 return";
+	}
+	return width >= 58
+		? " Drag left border resize • Ctrl+Alt+j/k scroll • Shift+F8 focus"
+		: " Shift+F8 focus • F8 close";
 }
 
 export function parseSgrMouseEvent(data: string): MouseEvent | undefined {

--- a/experimental/pi-jupyter/src/notebook-panel.ts
+++ b/experimental/pi-jupyter/src/notebook-panel.ts
@@ -110,6 +110,8 @@ export class NotebookPreviewPanel implements Component {
 				);
 			}
 			const body = renderNotebookBody(this.state, inner, this.theme);
+			const maximumScroll = Math.max(0, body.length - 3);
+			this.state.scroll = Math.min(this.state.scroll, maximumScroll);
 			lines.push(...body.slice(this.state.scroll).map(pad));
 		}
 

--- a/experimental/pi-jupyter/src/notebook.ts
+++ b/experimental/pi-jupyter/src/notebook.ts
@@ -1,3 +1,4 @@
+import { constants } from "node:fs";
 import { type FileHandle, open } from "node:fs/promises";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Image, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
@@ -31,7 +32,7 @@ export type NotebookRenderState = Partial<LoadedNotebook> & {
 
 export async function loadNotebook(path: string, signal?: AbortSignal): Promise<LoadedNotebook> {
 	signal?.throwIfAborted();
-	const file = await open(path, "r");
+	const file = await open(path, constants.O_RDONLY | constants.O_NONBLOCK);
 	try {
 		signal?.throwIfAborted();
 		const info = await file.stat();

--- a/experimental/pi-jupyter/src/notebook.ts
+++ b/experimental/pi-jupyter/src/notebook.ts
@@ -29,15 +29,17 @@ export type NotebookRenderState = Partial<LoadedNotebook> & {
 	model?: Notebook;
 };
 
-export async function loadNotebook(path: string): Promise<LoadedNotebook> {
+export async function loadNotebook(path: string, signal?: AbortSignal): Promise<LoadedNotebook> {
+	signal?.throwIfAborted();
 	const file = await open(path, "r");
 	try {
+		signal?.throwIfAborted();
 		const info = await file.stat();
 		if (!info.isFile()) throw new Error("notebook path is not a regular file");
 		if (info.size > MAX_NOTEBOOK_BYTES) {
 			throw new Error(`notebook exceeds the ${MAX_NOTEBOOK_BYTES / 1024 / 1024} MB preview limit`);
 		}
-		const model = JSON.parse(await readBoundedUtf8(file)) as Notebook;
+		const model = JSON.parse(await readBoundedUtf8(file, signal)) as Notebook;
 		validateNotebook(model);
 		return { model, lastMtime: info.mtime, lastLoadedAt: new Date() };
 	} finally {
@@ -45,10 +47,11 @@ export async function loadNotebook(path: string): Promise<LoadedNotebook> {
 	}
 }
 
-async function readBoundedUtf8(file: FileHandle): Promise<string> {
+async function readBoundedUtf8(file: FileHandle, signal?: AbortSignal): Promise<string> {
 	const chunks: Buffer[] = [];
 	let total = 0;
 	while (total <= MAX_NOTEBOOK_BYTES) {
+		signal?.throwIfAborted();
 		const buffer = Buffer.alloc(Math.min(64 * 1024, MAX_NOTEBOOK_BYTES + 1 - total));
 		const { bytesRead } = await file.read(buffer, 0, buffer.length, null);
 		if (bytesRead === 0) break;

--- a/experimental/pi-jupyter/test/jupyter-command.test.ts
+++ b/experimental/pi-jupyter/test/jupyter-command.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCustomSelectorHarness, createMockPi } from "../../../test/support.js";
+import { parseJupyterCommand, registerJupyterCommand } from "../src/jupyter-command.js";
+import {
+	createJupyterHelpComponent,
+	createJupyterMenuComponent,
+	createNotebookPickerComponent,
+	jupyterMenuItems,
+	jupyterMenuSummary,
+} from "../src/jupyter-menu.js";
+
+function createActions() {
+	return {
+		showMenu: async () => {},
+		open: async () => {},
+		toggle: async () => {},
+		focus: () => {},
+		refresh: async () => {},
+		close: () => {},
+		scroll: () => {},
+	};
+}
+
+test("pi-jupyter registers only /jupyter and progressively completes direct routes", () => {
+	const mock = createMockPi();
+	registerJupyterCommand(mock.pi, createActions());
+	assert.deepEqual([...mock.commands.keys()], ["jupyter"]);
+	const command = mock.commands.get("jupyter");
+	assert.ok(command?.getArgumentCompletions);
+	const complete = command.getArgumentCompletions;
+	assert.deepEqual(
+		(complete("") as Array<{ value: string }>).map((item) => item.value),
+		["open ", "focus", "refresh", "close", "toggle ", "scroll "],
+	);
+	assert.deepEqual(
+		(complete("scroll ") as Array<{ value: string }>).map((item) => item.value),
+		["scroll up ", "scroll down ", "scroll page-up", "scroll page-down", "scroll top"],
+	);
+	assert.equal(complete("open "), null);
+	assert.equal(complete("scroll down "), null);
+	assert.equal(complete("unknown"), null);
+});
+
+test("/jupyter parser keeps the primary menu shallow and validates every direct route", () => {
+	assert.deepEqual(parseJupyterCommand(""), { action: "menu" });
+	assert.deepEqual(parseJupyterCommand("open notebooks/demo notebook.ipynb"), {
+		action: "open",
+		path: "notebooks/demo notebook.ipynb",
+	});
+	assert.deepEqual(parseJupyterCommand("toggle"), { action: "toggle" });
+	assert.deepEqual(parseJupyterCommand("scroll up 12"), {
+		action: "scroll",
+		direction: "up",
+		lines: 12,
+	});
+	assert.deepEqual(parseJupyterCommand("scroll page-down"), {
+		action: "scroll",
+		direction: "page-down",
+	});
+	assert.throws(() => parseJupyterCommand("close now"), /does not accept arguments/);
+	assert.throws(() => parseJupyterCommand("scroll sideways"), /Unknown \/jupyter scroll action/);
+	assert.throws(() => parseJupyterCommand("unknown"), /Unknown \/jupyter action/);
+});
+
+test("current-state menu prioritizes the next notebook goal and exposes exact status", () => {
+	assert.deepEqual(
+		jupyterMenuItems({ cwd: "/workspace", visible: false, focused: false, scroll: 0 }),
+		[
+			{
+				value: "choose",
+				label: "Choose a notebook…",
+				description: "Select a top-level notebook or enter an explicit path.",
+			},
+			{
+				value: "help",
+				label: "Controls and shortcuts",
+				description: "Review keyboard controls and advanced direct routes.",
+			},
+		],
+	);
+	const openState = {
+		cwd: "/workspace",
+		path: "/workspace/demo.ipynb",
+		visible: true,
+		focused: false,
+		scroll: 0,
+		cellCount: 3,
+		lastLoadedAt: new Date("2026-07-26T07:00:00Z"),
+	};
+	assert.deepEqual(
+		jupyterMenuItems(openState).map((item) => item.value),
+		["focus", "refresh", "choose", "close", "help"],
+	);
+	assert.match(jupyterMenuSummary(openState, 120), /Open · demo\.ipynb · 3 cells/);
+	assert.match(
+		jupyterMenuSummary({ ...openState, lastError: "invalid JSON" }, 72),
+		/last valid version/,
+	);
+	assert.match(jupyterMenuSummary(openState, 72), /hidden below 90 columns/);
+});
+
+test("menu and notebook picker distinguish back from closing the flow", () => {
+	const state = { cwd: "/workspace", visible: false, focused: false, scroll: 0 };
+	let mainResult: unknown;
+	const menu = createCustomSelectorHarness((tui: unknown, theme: unknown, keys: unknown) =>
+		createJupyterMenuComponent(state, 120, tui as never, theme as never, keys as never, (value) => {
+			mainResult = value;
+		}),
+	);
+	menu.handleInput("tui.select.confirm");
+	assert.equal(mainResult, "choose");
+
+	let pickerResult: unknown;
+	const picker = createCustomSelectorHarness((tui: unknown, theme: unknown, keys: unknown) =>
+		createNotebookPickerComponent(
+			["/workspace/a.ipynb"],
+			undefined,
+			tui as never,
+			theme as never,
+			keys as never,
+			(value) => {
+				pickerResult = value;
+			},
+		),
+	);
+	picker.handleInput("tui.select.cancel");
+	assert.deepEqual(pickerResult, { action: "back" });
+	pickerResult = undefined;
+	picker.handleInput("\u0003");
+	assert.deepEqual(pickerResult, { action: "close" });
+
+	let helpResult: unknown;
+	const help = createCustomSelectorHarness((tui: unknown, theme: unknown, keys: unknown) =>
+		createJupyterHelpComponent(tui as never, theme as never, keys as never, (value) => {
+			helpResult = value;
+		}),
+	);
+	help.handleInput("tui.select.cancel");
+	assert.equal(helpResult, "back");
+	helpResult = undefined;
+	help.handleInput("\u0003");
+	assert.equal(helpResult, "close");
+});

--- a/experimental/pi-jupyter/test/jupyter-preview.test.ts
+++ b/experimental/pi-jupyter/test/jupyter-preview.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import jupyterPreview, {
@@ -105,6 +108,46 @@ test("preview panel remains width-safe with long untrusted paths and narrow adap
 		true,
 	);
 	assert.equal(lines.at(-2)?.includes("Shift+F8 focus"), true);
+});
+
+test("loadNotebook rejects a FIFO without waiting for a writer", async (context) => {
+	if (process.platform === "win32") {
+		context.skip("named pipes do not expose POSIX FIFO open semantics on Windows");
+		return;
+	}
+	const directory = await mkdtemp(join(tmpdir(), "pi-jupyter-fifo-test-"));
+	let child: ReturnType<typeof spawn> | undefined;
+	try {
+		const path = join(directory, "blocked.ipynb");
+		await promisify(execFile)("mkfifo", [path]);
+		const moduleUrl = new URL("../src/notebook.js", import.meta.url).href;
+		const script = `
+			import { loadNotebook } from ${JSON.stringify(moduleUrl)};
+			try { await loadNotebook(${JSON.stringify(path)}); }
+			catch (error) { console.log(error instanceof Error ? error.message : String(error)); }
+		`;
+		child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		child.stdout?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+		const outcome = await Promise.race([
+			once(child, "close").then(() => "closed" as const),
+			new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 500)),
+		]);
+		if (outcome === "timeout") {
+			child.kill("SIGKILL");
+			await once(child, "close");
+		}
+		assert.equal(outcome, "closed", "FIFO load remained blocked waiting for a writer");
+		assert.match(stdout, /not a regular file/);
+	} finally {
+		if (child && child.exitCode === null) child.kill("SIGKILL");
+		await rm(directory, { recursive: true, force: true });
+	}
 });
 
 test("loadNotebook validates the notebook shape and reports file metadata", async () => {

--- a/experimental/pi-jupyter/test/jupyter-preview.test.ts
+++ b/experimental/pi-jupyter/test/jupyter-preview.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import jupyterPreview, {
 	createJupyterPreview,
@@ -11,7 +12,12 @@ import jupyterPreview, {
 	resolveNotebookPath,
 } from "../src/jupyter-preview.js";
 import { loadNotebook, sanitizeTerminalText } from "../src/notebook.js";
-import { clampPanelWidth, parseSgrMouseEvent } from "../src/notebook-panel.js";
+import {
+	clampPanelWidth,
+	NotebookPreviewPanel,
+	parseSgrMouseEvent,
+	previewFooter,
+} from "../src/notebook-panel.js";
 
 async function emit(
 	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
@@ -62,6 +68,43 @@ test("panel geometry stays usable and parses only complete SGR mouse reports", (
 		released: false,
 	});
 	assert.equal(parseSgrMouseEvent("\x1b[<32;42M"), undefined);
+	assert.equal(
+		previewFooter({ cwd: "/workspace", visible: true, focused: false, scroll: 0 }, 40),
+		" Shift+F8 focus • F8 close",
+	);
+	assert.equal(
+		previewFooter({ cwd: "/workspace", visible: true, focused: true, scroll: 0 }, 40),
+		" ↑↓ scroll • Esc/F8 return",
+	);
+});
+
+test("preview panel remains width-safe with long untrusted paths and narrow adaptive hints", () => {
+	const panel = new NotebookPreviewPanel(
+		{ requestRender() {} } as never,
+		{
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		{
+			cwd: "/workspace",
+			path: `/workspace/\x1b[31m-${"very-long-".repeat(8)}.ipynb`,
+			visible: true,
+			focused: false,
+			scroll: 0,
+			model: { cells: [] },
+		},
+		() => {},
+	);
+	const lines = panel.render(42);
+	assert.equal(
+		lines.every((line) => visibleWidth(line) <= 42),
+		true,
+	);
+	assert.equal(
+		lines.some((line) => line.includes("\\x1b")),
+		true,
+	);
+	assert.equal(lines.at(-2)?.includes("Shift+F8 focus"), true);
 });
 
 test("loadNotebook validates the notebook shape and reports file metadata", async () => {
@@ -72,6 +115,9 @@ test("loadNotebook validates the notebook shape and reports file metadata", asyn
 		const loaded = await loadNotebook(path);
 		assert.equal(loaded.model.cells?.length, 0);
 		assert.equal(loaded.lastMtime instanceof Date, true);
+		const controller = new AbortController();
+		controller.abort();
+		await assert.rejects(loadNotebook(path, controller.signal), /aborted/i);
 
 		await writeFile(path, JSON.stringify({ cells: "invalid", nbformat: 4 }));
 		await assert.rejects(loadNotebook(path), /cells must be an array/);
@@ -93,11 +139,21 @@ test("extension warns on session start and rejects preview UI outside TUI mode",
 		},
 	]);
 
-	const command = mock.commands.get("jupyter-preview");
-	await assert.rejects(
-		() => invoke(command?.handler, "", rpc.ctx),
-		/requires Pi's interactive TUI mode/,
-	);
+	const command = mock.commands.get("jupyter");
+	for (const args of [
+		"",
+		"open demo.ipynb",
+		"toggle",
+		"focus",
+		"refresh",
+		"close",
+		"scroll down 3",
+	]) {
+		await assert.rejects(
+			() => invoke(command?.handler, args, rpc.ctx),
+			/requires Pi's interactive TUI mode/,
+		);
+	}
 });
 
 test("commands reject unsupported trailing arguments before changing UI", async () => {
@@ -106,7 +162,7 @@ test("commands reject unsupported trailing arguments before changing UI", async 
 	const context = createMockContext({ hasUI: true, mode: "tui" });
 
 	await assert.rejects(
-		() => invoke(mock.commands.get("jupyter-preview-close")?.handler, "unexpected", context.ctx),
+		() => invoke(mock.commands.get("jupyter")?.handler, "close unexpected", context.ctx),
 		/does not accept arguments/,
 	);
 	assert.equal(context.statuses.size, 0);
@@ -170,16 +226,28 @@ test("tool-driven TUI preview releases its watcher, overlay, mouse listener, and
 		});
 
 		await emit(mock.events, "tool_call", { input: { path: "demo.ipynb" } }, context.ctx);
+		assert.deepEqual(watchedDirectories, []);
+		await emit(
+			mock.events,
+			"tool_result",
+			{ input: { path: "demo.ipynb" }, isError: true },
+			context.ctx,
+		);
+		assert.deepEqual(watchedDirectories, []);
+		await emit(
+			mock.events,
+			"tool_result",
+			{ input: { path: "demo.ipynb" }, isError: false },
+			context.ctx,
+		);
 		assert.deepEqual(watchedDirectories, [directory]);
-		await emit(mock.events, "tool_result", { input: { path: "demo.ipynb" } }, context.ctx);
-		assert.deepEqual(watchedDirectories, [directory, directory]);
-		assert.equal(watcherCloses, 1);
-		assert.equal(context.statuses.get("jupyter"), "previewing notebook");
+		assert.equal(watcherCloses, 0);
+		assert.equal(context.statuses.get("jupyter"), "notebook: demo.ipynb");
 		assert.equal(terminalWrites.join("").includes("\x1b[?1000h"), true);
 
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
 		await new Promise((resolve) => setImmediate(resolve));
-		assert.equal(watcherCloses, 2);
+		assert.equal(watcherCloses, 1);
 		assert.equal(overlayCloses, 1);
 		assert.equal(inputListenerRemovals, 1);
 		assert.equal(terminalWrites.join("").includes("\x1b[?1000l"), true);

--- a/experimental/pi-jupyter/test/jupyter-transitions.test.ts
+++ b/experimental/pi-jupyter/test/jupyter-transitions.test.ts
@@ -30,12 +30,14 @@ function createTransitionHarness(
 	const mock = createMockPi();
 	Object.assign(mock.rawPi, { registerShortcut() {} });
 	const watchedDirectories: string[] = [];
+	const watcherListeners: Array<(event: string, filename: string | Buffer | null) => void> = [];
 	let watcherCloses = 0;
 	let component: { render(width: number): string[] } | undefined;
 	const extension = createJupyterPreview({
 		loadNotebook: load,
-		watchNotebook(directory) {
+		watchNotebook(directory, listener) {
 			watchedDirectories.push(directory);
+			watcherListeners.push(listener);
 			return { close: () => watcherCloses++ };
 		},
 	});
@@ -71,6 +73,9 @@ function createTransitionHarness(
 		mock,
 		context,
 		watchedDirectories,
+		fireWatch(index: number, filename: string) {
+			watcherListeners[index]?.("change", filename);
+		},
 		get watcherCloses() {
 			return watcherCloses;
 		},
@@ -282,6 +287,36 @@ test("a slower notebook load cannot overwrite a newer selection", async () => {
 	}
 });
 
+test("a watcher refresh cannot cancel an explicit notebook switch", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-switch-vs-refresh-"));
+	try {
+		let resolveSwitch: ((value: LoadedNotebook) => void) | undefined;
+		const switchLoad = new Promise<LoadedNotebook>((resolve) => {
+			resolveSwitch = resolve;
+		});
+		let currentLoads = 0;
+		const harness = createTransitionHarness(async (path) => {
+			if (path.endsWith("next.ipynb")) return switchLoad;
+			currentLoads++;
+			return loaded(3);
+		}, cwd);
+		await invokeJupyter(harness, "open current.ipynb");
+		const switching = invokeJupyter(harness, "open next.ipynb");
+		await Promise.resolve();
+		harness.fireWatch(0, "current.ipynb");
+		await new Promise((resolve) => setTimeout(resolve, 180));
+		assert.equal(currentLoads, 2);
+		resolveSwitch?.(loaded(2));
+		await switching;
+
+		assert.match(harness.render(), /next\.ipynb/);
+		assert.match(harness.render(), /2 cells/);
+		assert.equal(harness.watchedDirectories.length, 2);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
 test("cancelling the menu loader leaves notebook state and watchers unchanged", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-load-cancel-"));
 	try {
@@ -368,7 +403,21 @@ test("closing and immediately reopening waits for old overlay cleanup before rep
 	}
 });
 
-test("refreshing shorter content resets an out-of-range scroll position", async () => {
+test("refreshing equally long content preserves a valid scroll position", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-scroll-preserve-"));
+	try {
+		const harness = createTransitionHarness(async () => loaded(20), cwd);
+		await invokeJupyter(harness, "open demo.ipynb");
+		await invokeJupyter(harness, "scroll down 5");
+		await invokeJupyter(harness, "refresh");
+		assert.doesNotMatch(harness.render(), / 1\. markdown/);
+		assert.match(harness.render(), / 2\. markdown/);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("refreshing shorter content clamps an out-of-range scroll position", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-scroll-clamp-"));
 	try {
 		let cells = 20;

--- a/experimental/pi-jupyter/test/jupyter-transitions.test.ts
+++ b/experimental/pi-jupyter/test/jupyter-transitions.test.ts
@@ -1,0 +1,384 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createJupyterPreview } from "../src/jupyter-preview.js";
+import type { LoadedNotebook } from "../src/notebook.js";
+
+initTheme("dark", false);
+
+function loaded(cellCount: number): LoadedNotebook {
+	return {
+		model: {
+			cells: Array.from({ length: cellCount }, (_, index) => ({
+				cell_type: "markdown",
+				source: `cell ${index + 1}`,
+			})),
+		},
+		lastLoadedAt: new Date("2026-07-26T07:00:00Z"),
+		lastMtime: new Date("2026-07-26T06:59:00Z"),
+	};
+}
+
+function createTransitionHarness(
+	load: (path: string, signal?: AbortSignal) => Promise<LoadedNotebook>,
+	cwd: string,
+) {
+	const mock = createMockPi();
+	Object.assign(mock.rawPi, { registerShortcut() {} });
+	const watchedDirectories: string[] = [];
+	let watcherCloses = 0;
+	let component: { render(width: number): string[] } | undefined;
+	const extension = createJupyterPreview({
+		loadNotebook: load,
+		watchNotebook(directory) {
+			watchedDirectories.push(directory);
+			return { close: () => watcherCloses++ };
+		},
+	});
+	extension(mock.pi);
+	const context = createMockContext({
+		cwd,
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown, options: unknown) => {
+			(options as { onHandle(handle: unknown): void }).onHandle({
+				focus() {},
+				unfocus() {},
+				setHidden() {},
+			});
+			await new Promise<void>((resolveOverlay) => {
+				component = (factory as (...args: unknown[]) => typeof component)(
+					{
+						terminal: { columns: 120, write() {} },
+						addInputListener: () => () => {},
+						requestRender() {},
+					},
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{},
+					resolveOverlay,
+				);
+			});
+		},
+	});
+	return {
+		mock,
+		context,
+		watchedDirectories,
+		get watcherCloses() {
+			return watcherCloses;
+		},
+		render: () => component?.render(60).join("\n") ?? "",
+	};
+}
+
+async function invokeJupyter(
+	harness: ReturnType<typeof createTransitionHarness>,
+	args: string,
+): Promise<void> {
+	await harness.mock.commands.get("jupyter")?.handler(args, harness.context.ctx);
+}
+
+function createMenuCustomDriver(inputs: Array<string | undefined>) {
+	let step = 0;
+	let overlayLines: string[] = [];
+	return {
+		async custom(factory: unknown, options?: unknown) {
+			const overlay = options as
+				| { overlay?: boolean; onHandle?(handle: unknown): void }
+				| undefined;
+			if (overlay?.overlay) {
+				overlay.onHandle?.({ focus() {}, unfocus() {}, setHidden() {} });
+				return new Promise<void>((resolveOverlay) => {
+					const component = (
+						factory as (...args: unknown[]) => { render(width: number): string[] }
+					)(
+						{
+							terminal: { columns: 120, write() {} },
+							addInputListener: () => () => {},
+							requestRender() {},
+						},
+						{
+							fg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+						},
+						{},
+						resolveOverlay,
+					);
+					overlayLines = component.render(60);
+				});
+			}
+			const input = inputs[step++];
+			return new Promise((resolve) => {
+				let component: { handleInput?(data: string): void; dispose?(): void };
+				const done = (value: unknown) => {
+					component.dispose?.();
+					resolve(value);
+				};
+				component = (factory as (...args: unknown[]) => typeof component)(
+					{ terminal: { columns: 120 }, requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{ matches: (data: string, key: string) => data === key },
+					done,
+				);
+				if (input !== undefined) queueMicrotask(() => component.handleInput?.(input));
+			});
+		},
+		get step() {
+			return step;
+		},
+		get overlayText() {
+			return overlayLines.join("\n");
+		},
+	};
+}
+
+test("the primary menu chooses, loads, and opens a notebook atomically", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-menu-open-"));
+	try {
+		await writeFile(join(cwd, "demo.ipynb"), "{}");
+		const mock = createMockPi();
+		Object.assign(mock.rawPi, { registerShortcut() {} });
+		let watcherStarts = 0;
+		const driver = createMenuCustomDriver(["tui.select.confirm", "tui.select.confirm", undefined]);
+		createJupyterPreview({
+			loadNotebook: async () => loaded(2),
+			watchNotebook() {
+				watcherStarts++;
+				return { close() {} };
+			},
+		})(mock.pi);
+		const context = createMockContext({
+			cwd,
+			hasUI: true,
+			mode: "tui",
+			custom: driver.custom.bind(driver),
+		});
+
+		await mock.commands.get("jupyter")?.handler("", context.ctx);
+		assert.equal(driver.step, 3);
+		assert.equal(watcherStarts, 1);
+		assert.equal(context.statuses.get("jupyter"), "notebook: demo.ipynb");
+		assert.match(driver.overlayText, /demo\.ipynb/);
+		assert.match(driver.overlayText, /2 cells/);
+		await mock.commands.get("jupyter")?.handler("close", context.ctx);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("cancelling explicit path entry returns to the menu without loading or watching", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-path-cancel-"));
+	try {
+		const mock = createMockPi();
+		Object.assign(mock.rawPi, { registerShortcut() {} });
+		let loadStarts = 0;
+		let watcherStarts = 0;
+		const driver = createMenuCustomDriver(["tui.select.confirm", "tui.select.confirm", "\u0003"]);
+		createJupyterPreview({
+			loadNotebook: async () => {
+				loadStarts++;
+				return loaded(1);
+			},
+			watchNotebook() {
+				watcherStarts++;
+				return { close() {} };
+			},
+		})(mock.pi);
+		const context = createMockContext({
+			cwd,
+			hasUI: true,
+			mode: "tui",
+			input: async () => undefined,
+			custom: driver.custom.bind(driver),
+		});
+
+		await mock.commands.get("jupyter")?.handler("", context.ctx);
+		assert.equal(driver.step, 3);
+		assert.equal(loadStarts, 0);
+		assert.equal(watcherStarts, 0);
+		assert.equal(context.statuses.get("jupyter"), undefined);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("failed notebook switch preserves the prior path, model, watcher, and visible panel", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-atomic-switch-"));
+	try {
+		const harness = createTransitionHarness(async (path) => {
+			if (path.endsWith("bad.ipynb")) throw new Error("invalid notebook JSON");
+			return loaded(2);
+		}, cwd);
+		await invokeJupyter(harness, "open good.ipynb");
+		await invokeJupyter(harness, "open bad.ipynb");
+
+		assert.match(harness.render(), /good\.ipynb/);
+		assert.match(harness.render(), /2 cells/);
+		assert.equal(harness.watchedDirectories.length, 1);
+		assert.equal(harness.watcherCloses, 0);
+		assert.equal(harness.context.statuses.get("jupyter"), "notebook: good.ipynb");
+		assert.match(
+			harness.context.notifications.at(-1)?.message ?? "",
+			/bad\.ipynb.*invalid notebook JSON/,
+		);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("failed refresh retains the last valid notebook and marks it stale", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-atomic-refresh-"));
+	try {
+		let fail = false;
+		const harness = createTransitionHarness(async () => {
+			if (fail) throw new Error("partial save");
+			return loaded(2);
+		}, cwd);
+		await invokeJupyter(harness, "open demo.ipynb");
+		fail = true;
+		await invokeJupyter(harness, "refresh");
+
+		assert.match(harness.render(), /2 cells/);
+		assert.match(harness.render(), /partial save/);
+		assert.equal(harness.context.statuses.get("jupyter"), "notebook: demo.ipynb (stale)");
+		assert.equal(harness.watchedDirectories.length, 1);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("a slower notebook load cannot overwrite a newer selection", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-generation-"));
+	try {
+		let resolveSlow: ((value: LoadedNotebook) => void) | undefined;
+		const slow = new Promise<LoadedNotebook>((resolve) => {
+			resolveSlow = resolve;
+		});
+		const harness = createTransitionHarness(
+			async (path) => (path.endsWith("slow.ipynb") ? slow : loaded(2)),
+			cwd,
+		);
+		const slowOpen = invokeJupyter(harness, "open slow.ipynb");
+		await Promise.resolve();
+		await invokeJupyter(harness, "open fast.ipynb");
+		resolveSlow?.(loaded(1));
+		await slowOpen;
+
+		assert.match(harness.render(), /fast\.ipynb/);
+		assert.match(harness.render(), /2 cells/);
+		assert.doesNotMatch(harness.render(), /1 cells/);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("cancelling the menu loader leaves notebook state and watchers unchanged", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-load-cancel-"));
+	try {
+		await writeFile(join(cwd, "demo.ipynb"), "{}");
+		const mock = createMockPi();
+		Object.assign(mock.rawPi, { registerShortcut() {} });
+		let watcherStarts = 0;
+		let loadAborted = false;
+		let customStep = 0;
+		createJupyterPreview({
+			watchNotebook() {
+				watcherStarts++;
+				return { close() {} };
+			},
+			loadNotebook: async (_path, signal) =>
+				new Promise<LoadedNotebook>((_resolve, reject) => {
+					signal?.addEventListener(
+						"abort",
+						() => {
+							loadAborted = true;
+							reject(signal.reason);
+						},
+						{ once: true },
+					);
+				}),
+		})(mock.pi);
+		const context = createMockContext({
+			cwd,
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const input = customStep++ < 2 ? "tui.select.confirm" : "\x1b";
+				return new Promise((resolve) => {
+					let component: { handleInput?(data: string): void; dispose?(): void };
+					const done = (value: unknown) => {
+						component.dispose?.();
+						resolve(value);
+					};
+					component = (factory as (...args: unknown[]) => typeof component)(
+						{
+							terminal: { columns: 120 },
+							requestRender() {},
+						},
+						{
+							fg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+						},
+						{
+							matches: (data: string, key: string) => data === key,
+						},
+						done,
+					);
+					queueMicrotask(() => component.handleInput?.(input));
+				});
+			},
+		});
+
+		await mock.commands.get("jupyter")?.handler("", context.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(customStep, 3);
+		assert.equal(loadAborted, true);
+		assert.equal(watcherStarts, 0);
+		assert.equal(context.statuses.get("jupyter"), undefined);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("closing and immediately reopening waits for old overlay cleanup before replacing resources", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-reopen-"));
+	try {
+		const harness = createTransitionHarness(async () => loaded(2), cwd);
+		await invokeJupyter(harness, "open demo.ipynb");
+		await invokeJupyter(harness, "close");
+		assert.equal(harness.context.statuses.get("jupyter"), undefined);
+		assert.equal(harness.watcherCloses, 1);
+
+		await invokeJupyter(harness, "open");
+		assert.equal(harness.context.statuses.get("jupyter"), "notebook: demo.ipynb");
+		assert.equal(harness.watchedDirectories.length, 2);
+		assert.match(harness.render(), /demo\.ipynb/);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("refreshing shorter content resets an out-of-range scroll position", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "pi-jupyter-scroll-clamp-"));
+	try {
+		let cells = 20;
+		const harness = createTransitionHarness(async () => loaded(cells), cwd);
+		await invokeJupyter(harness, "open demo.ipynb");
+		await invokeJupyter(harness, "scroll down 100");
+		cells = 1;
+		await invokeJupyter(harness, "refresh");
+		assert.match(harness.render(), /1\. markdown/);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- replace the fragmented pi-jupyter slash-command surface with one `/jupyter` current-state menu
- preserve expert workflows through completed `/jupyter open`, `toggle`, `focus`, `refresh`, `close`, and nested `scroll` routes
- add a shallow notebook picker, cancellable loading, explicit state/effect previews, adaptive panel hints, and exact filename/stale status
- make notebook/model/watcher transitions generation-safe and atomic so cancellation, failed switches, partial saves, and stale async completions preserve the last valid preview
- retain existing F8, focus, scrolling, tool-result, resizing, and lifecycle workflows

## Breaking change

The experimental `/jupyter-preview*` slash commands are removed. The README includes a route-by-route migration table to the single `/jupyter` command.

## Verification

- 21 focused pi-jupyter tests
- `npm run check` (1,489 tests)
- `npm ci --dry-run --ignore-scripts`
- `just pack-jupyter` (10 intended package files)
- `pi -ne ./experimental/pi-jupyter --list-models` (load succeeded; 24 output lines)
- Biome, `git diff --check`, and static single-command audit
