### PR TITLE
feat(usage)!: remove codex-status compatibility alias

### DIFF
--- a/extensions/pi-usage/README.md
+++ b/extensions/pi-usage/README.md
@@ -16,7 +16,6 @@
 - Keeps the compact statusline scoped to the current provider and runtime account.
 - Isolates its five-minute in-memory cache by provider and a process-salted credential fingerprint.
 - Resolves credentials through Pi and never reads Pi, account-extension, Codex CLI, or provider auth files.
-- Retains `/codex-status` as a temporary argument-free compatibility alias.
 
 ## 📦 Install
 
@@ -56,8 +55,6 @@ Close
 ```
 
 There are intentionally no `/usage --refresh`, `/usage <provider>`, or `/usage --all` argument paths. Cross-provider traffic requires an explicit interactive choice.
-
-`/codex-status` opens the same menu during the migration period. Its former flags are not supported by `pi-usage`.
 
 ## 📋 Provider semantics
 
@@ -102,12 +99,11 @@ pi remove npm:@narumitw/pi-codex-usage
 pi install npm:@narumitw/pi-usage
 ```
 
-Do not load both packages together: both register `/codex-status`, so Pi must suffix duplicate commands and the two packages can publish overlapping usage status.
+Remove the deprecated package rather than loading both usage extensions together.
 
 Behavior changes:
 
-- Use `/usage` as the primary entry point.
-- `/codex-status` is an argument-free compatibility alias.
+- Use `/usage` as the only entry point; `/codex-status` is no longer registered.
 - Refresh and cross-provider operations are menu actions rather than flags.
 - Codex CLI fallback is removed to preserve active-runtime-account correctness.
 - The status key changes from `codex-usage` to `usage`.

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -606,10 +606,6 @@ export default function usageExtension(pi: ExtensionAPI) {
 		description: "Show usage for the current runtime account",
 		handler: commandHandler,
 	});
-	pi.registerCommand("codex-status", {
-		description: "Open /usage (temporary compatibility alias)",
-		handler: commandHandler,
-	});
 
 	pi.on("session_start", (_event, ctx) => {
 		sessionActive = true;

--- a/extensions/pi-usage/test/usage.test.ts
+++ b/extensions/pi-usage/test/usage.test.ts
@@ -56,14 +56,13 @@ function usageFetch(input: string | URL | Request): Promise<Response> {
 	);
 }
 
-test("pi-usage registers one primary command, compatibility alias, and lifecycle hooks", () => {
+test("pi-usage registers only its primary command and lifecycle hooks", () => {
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 
 	assert.ok(mock.commands.has("usage"));
-	assert.ok(mock.commands.has("codex-status"));
+	assert.equal(mock.commands.has("codex-status"), false);
 	assert.equal(mock.commands.get("usage")?.getArgumentCompletions, undefined);
-	assert.equal(mock.commands.get("codex-status")?.getArgumentCompletions, undefined);
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"model_select",
 		"session_shutdown",


### PR DESCRIPTION
## Summary

- stop registering the temporary `/codex-status` compatibility alias in `pi-usage`
- keep `/usage` as the package's only command entry point
- update the migration documentation and command-registration regression test

## Breaking change

`@narumitw/pi-usage` no longer registers `/codex-status`; users must invoke `/usage` instead.

## Verification

- `npm run check --workspace @narumitw/pi-usage`
- focused `pi-usage` test file (16 tests passed)
- `npm run biome:check`
- `npm run check:boundaries`
- `npm run typecheck`
- `npm run pack:usage` (11 intended package files)
- `git diff --check`

## Known unrelated failure

- `npm run check` reaches the full test suite but the existing `pi-github-pr` test `branch changes abort an in-flight periodic refresh` fails; it also fails in isolation and is unrelated to this diff.
