### PR TITLE
fix(plan-mode): render plan_mode_complete result as markdown

### DIFF
--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -30,6 +30,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",
 		"@earendil-works/pi-coding-agent": "0.82.1",
+		"@earendil-works/pi-tui": "0.82.1",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/extensions/pi-plan-mode/src/completion-tool.ts
+++ b/extensions/pi-plan-mode/src/completion-tool.ts
@@ -1,3 +1,6 @@
+import { getMarkdownTheme } from "@earendil-works/pi-coding-agent";
+import { Markdown } from "@earendil-works/pi-tui";
+
 export const PLAN_MODE_COMPLETE_TOOL_NAME = "plan_mode_complete";
 export const PLAN_MODE_COMPLETE_VERSION = 1;
 export const PLAN_MODE_MAX_CHARS = 50_000;
@@ -61,6 +64,26 @@ export function planModeCompleted(plan: string) {
 		} satisfies PlanModeCompletionDetails,
 		terminate: true,
 	};
+}
+
+type PlanModeCompletionRenderResult = {
+	content: Array<{ type: string; text?: string }>;
+	details?: unknown;
+};
+
+export function planModeCompletionMarkdown(result: PlanModeCompletionRenderResult) {
+	const content = result.content
+		.filter((block) => block.type === "text" && typeof block.text === "string")
+		.map((block) => block.text)
+		.join("\n")
+		.trim();
+	if (content) return content;
+	const plan = planFromCompletionDetails(result.details);
+	return plan ? `**Proposed Plan**\n\n${plan}` : "";
+}
+
+export function renderPlanModeCompletion(result: PlanModeCompletionRenderResult) {
+	return new Markdown(planModeCompletionMarkdown(result), 0, 0, getMarkdownTheme());
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -4,6 +4,7 @@ import {
 	PLAN_MODE_COMPLETE_PARAMS,
 	PLAN_MODE_COMPLETE_TOOL_NAME,
 	planModeCompleted,
+	renderPlanModeCompletion,
 } from "./completion-tool.js";
 import {
 	isEmptyAssistantMessage,
@@ -157,6 +158,7 @@ export default function planMode(pi: ExtensionAPI) {
 			"Call plan_mode_complete alone as the final action only after the implementation plan is decision-complete.",
 		],
 		parameters: PLAN_MODE_COMPLETE_PARAMS,
+		renderResult: renderPlanModeCompletion,
 		async execute(_toolCallId, params: unknown, _signal, _onUpdate, ctx) {
 			if (!state.enabled) {
 				throw new Error("plan_mode_complete is only available while Plan mode is active");

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -3,7 +3,9 @@ import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { planModeCompleted } from "../src/completion-tool.js";
 import planMode, {
 	buildPlanModePrompt,
 	completePlanArguments,
@@ -27,6 +29,36 @@ test("plan-mode registers flag, question tool, command, and safety hooks", () =>
 	assert.equal(typeof mock.commands.get("plan")?.getArgumentCompletions, "function");
 	assert.ok(mock.events.has("tool_call"));
 	assert.ok(mock.events.has("before_agent_start"));
+});
+
+test("plan_mode_complete result renders the plan as Markdown", () => {
+	initTheme("dark");
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	planMode(mock.pi);
+	const tool = mock.tools.find((candidate) => candidate.name === "plan_mode_complete");
+	assert.equal(typeof tool?.renderResult, "function");
+
+	const renderResult = tool?.renderResult as (
+		result: unknown,
+		options: unknown,
+	) => { render(width: number): string[] };
+	const ansiPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+	const renderMarkdown = (result: unknown) =>
+		renderResult(result, { expanded: false, isPartial: false })
+			.render(80)
+			.map((line) => line.replace(ansiPattern, ""))
+			.join("\n");
+
+	const result = planModeCompleted("# Title\n\n- item\n\n```ts\nconst x = 1;\n```");
+	const rendered = renderMarkdown(result);
+	assert.match(rendered, /Proposed Plan/);
+	assert.match(rendered, /const x = 1;/);
+	assert.doesNotMatch(rendered, /\*\*Proposed Plan\*\*/);
+	assert.doesNotMatch(rendered, /# Title/);
+
+	const fallback = renderMarkdown({ content: [], details: result.details });
+	assert.match(fallback, /Proposed Plan/);
+	assert.match(fallback, /const x = 1;/);
 });
 
 test("completePlanArguments suggests management tokens only", () => {


### PR DESCRIPTION
# PR: fix(plan-mode): render plan_mode_complete result as markdown

**Target repo:** https://github.com/narumiruna/pi-extensions
**Branch/commit:** `fix(plan-mode): render plan_mode_complete result as markdown`
**Patch file:** `upstream-render-result.patch` (apply with `git am` on a fresh clone)

## PR body

### Problem

`plan_mode_complete` returns the full plan as markdown text but registers no `renderResult`. Pi's TUI therefore falls back to a plain `Text` renderer, and the completed plan is displayed as raw markdown source (`**`, `#`, list markers all visible). `/plan show` renders fine because custom messages use the `Markdown` component by default — the initial presentation should match it.

### Change

- `completion-tool.ts`: add `planModeCompletionMarkdown()` and `renderPlanModeCompletion()`; the renderer reads the plan from the tool result's text content and falls back to the versioned `details.plan`, then renders via `Markdown` + `getMarkdownTheme()` (the same approach pi uses for assistant/custom messages).
- `plan-mode.ts`: wire `renderResult: renderPlanModeCompletion` into the `plan_mode_complete` registration.
- `package.json`: add `@earendil-works/pi-tui` devDependency (same pattern as `pi-btw`).
- `plan-mode.test.ts`: new test asserting the registered tool has a `renderResult` that consumes markdown markers (`**Proposed Plan**`, `# Title`) while keeping content.

### Verification

- `npx biome check extensions/pi-plan-mode` — clean
- `npx tsc -p tsconfig.test.json` — clean
- `node --test <compiled pi-plan-mode tests>` — 79/79 pass (incl. the new test)
- Manually via local wrapper of the same renderer in a live pi session: completed plan renders formatted immediately after `plan_mode_complete`; `/plan show`, ready menu, and `/plan implement` unaffected.
