### PR TITLE
fix(firecrawl): bound tool response output

### DIFF
--- a/docs/plans/2026-07-26_firecrawl-output-bounding-plan.md
+++ b/docs/plans/2026-07-26_firecrawl-output-bounding-plan.md
@@ -1,0 +1,59 @@
+# Bound pi-firecrawl tool output
+
+## Goal
+
+Keep every `firecrawl_*` tool result within Pi's documented 50 KB / 2,000-line context limit, preserve an actionable path to the complete Firecrawl response when truncation occurs, and stop duplicating large raw payloads in session `details`.
+
+## Context
+
+- `extensions/pi-firecrawl/src/client.ts` currently serializes the complete payload into both `content` and `details`.
+- The BBC Live smoke produced about 32 KB of tool text but a roughly 66 KB session entry because of that duplication.
+- Pi requires custom tools to bound their own output; the limit is not automatically applied to arbitrary extension results.
+- During compaction, serialized tool results are shortened further, so the truncation notice and recovery location must fit inside the bounded visible result.
+
+## Architecture
+
+Add one package-local response formatter/artifact store and route all five tools through it:
+
+1. Serialize the successful Firecrawl payload exactly as today for backward-compatible visible output.
+2. Apply Pi's `truncateHead()` with `DEFAULT_MAX_BYTES` and `DEFAULT_MAX_LINES`.
+3. If truncation is required, save the complete pretty-printed response in a private session-scoped temporary directory, reserve room for an explicit truncation footer, and truncate again so the final `content` including the footer remains within both hard limits.
+4. Return only compact metadata in `details` (`truncated`, counts, and optional full-response path), never the raw response payload.
+5. Best-effort remove the temporary directory on `session_shutdown`.
+6. Bound non-2xx Firecrawl response bodies separately so a large error page cannot bypass the successful-result protection; retain the complete error response in the same private artifact store when needed.
+
+The first iteration will not add settings or another public tool. The full artifact remains available through its reported filesystem path. If real usage shows that long JSON string fields are difficult to page with Pi's file tools, a separate `firecrawl_read_output` cursor tool should be considered as a follow-up rather than expanding this fix prematurely.
+
+## Non-Goals
+
+- Limiting Firecrawl's network response size before it is buffered.
+- Summarizing or semantically rewriting scraped content.
+- Changing Firecrawl request parameters, API versions, or crawl pagination.
+- Adding user-configurable output limits; Pi's canonical limits remain authoritative.
+
+## Risks
+
+- Appending a footer after truncation can accidentally exceed 50 KB; reserve the footer budget before producing final content and test the complete result, not only the excerpt.
+- UTF-8 boundaries and very long JSON string lines can make byte/line behavior non-obvious; cover multibyte and one-line payloads.
+- Temporary responses may contain sensitive scraped content; create directories as `0700`, files as `0600`, use unpredictable names, and remove them on shutdown.
+- Slimming `details` changes an undocumented internal result shape. Preserve the visible `content` for non-truncated responses and document the intentional session-size improvement.
+
+## Plan
+
+- [x] Add focused failing tests in `extensions/pi-firecrawl/test/firecrawl.test.ts` for byte-limit truncation, line-limit truncation, UTF-8 safety, a final result that includes its footer within both limits, exact full-response artifact contents, compact `details`, unique concurrent artifact paths, private permissions, and shutdown cleanup. Evidence: the initial `npm test` compile failed on the missing formatter/cleanup exports; the completed focused suite passes 26/26 tests.
+- [x] Add a package-local response formatter/artifact store under `extensions/pi-firecrawl/src/` using Pi's exported truncation constants/utilities. Evidence: focused tests preserve the exact small visible JSON and cover byte, line, UTF-8, footer-unit, permissions, concurrency, and exact-artifact behavior.
+- [x] Update `extensions/pi-firecrawl/src/tools.ts` and `extensions/pi-firecrawl/src/client.ts` so all successful tool responses and oversized non-2xx bodies use the bounded formatter, cancellation behavior remains unchanged, and error messages remain concise and actionable. Evidence: one execution test invokes all five tools, and the oversized error test covers a huge endpoint prefix plus exact raw-body preservation.
+- [x] Register best-effort artifact cleanup from `extensions/pi-firecrawl/src/firecrawl.ts` on `session_shutdown`, without disturbing the existing status/settings cleanup. Evidence: tests cover owner isolation, registered-write draining, late-write rejection, and session-owned removal.
+- [x] Update tool descriptions and `extensions/pi-firecrawl/README.md` to state the 50 KB / 2,000-line limits, truncation notice, temporary full-response path, cleanup lifetime, and compact session metadata. Evidence: descriptions and README now document the tested behavior.
+- [ ] Run `npm run check`, then run `just pack-firecrawl` and inspect that only intended source/docs/package files are included. Evidence so far: Biome, boundaries, all-workspace typechecks, 26 focused tests, and the pack dry run pass; local `npm run check` reaches 1,509/1,510 tests but is blocked by the unchanged `pi-github-pr` branch-watcher timing test, pending PR CI on the target platform.
+- [x] Run one local Pi smoke against `https://www.bbc.com/news/live/c3r2nz9ed3lt` and one deterministic oversized mocked response. Evidence: BBC returned 32,256 bytes / 62 lines without truncation; the deterministic 100,016-byte response returned a bounded 217-byte / 3-line notice with a readable complete artifact that cleanup removed.
+
+## Completion Checklist
+
+- [x] Every `firecrawl_*` success result is at most 50 KB and 2,000 lines.
+- [x] Oversized non-2xx response text cannot create an unbounded tool error.
+- [x] Truncated results state exactly what was omitted and where the full response is stored.
+- [x] Full-response artifacts are exact, private, collision-safe, and cleaned up on session shutdown.
+- [x] Tool-result `details` no longer duplicates the raw Firecrawl payload.
+- [x] Non-truncated visible output remains compatible with the current pretty-printed JSON.
+- [ ] Focused tests, full repository checks, package dry run, and runtime smoke all pass; PR CI is pending to resolve the unrelated local `pi-github-pr` watcher-test failure.

--- a/docs/plans/archived/2026-07-26_firecrawl-output-bounding-plan.md
+++ b/docs/plans/archived/2026-07-26_firecrawl-output-bounding-plan.md
@@ -45,7 +45,7 @@ The first iteration will not add settings or another public tool. The full artif
 - [x] Update `extensions/pi-firecrawl/src/tools.ts` and `extensions/pi-firecrawl/src/client.ts` so all successful tool responses and oversized non-2xx bodies use the bounded formatter, cancellation behavior remains unchanged, and error messages remain concise and actionable. Evidence: one execution test invokes all five tools, and the oversized error test covers a huge endpoint prefix plus exact raw-body preservation.
 - [x] Register best-effort artifact cleanup from `extensions/pi-firecrawl/src/firecrawl.ts` on `session_shutdown`, without disturbing the existing status/settings cleanup. Evidence: tests cover owner isolation, registered-write draining, late-write rejection, and session-owned removal.
 - [x] Update tool descriptions and `extensions/pi-firecrawl/README.md` to state the 50 KB / 2,000-line limits, truncation notice, temporary full-response path, cleanup lifetime, and compact session metadata. Evidence: descriptions and README now document the tested behavior.
-- [ ] Run `npm run check`, then run `just pack-firecrawl` and inspect that only intended source/docs/package files are included. Evidence so far: Biome, boundaries, all-workspace typechecks, 26 focused tests, and the pack dry run pass; local `npm run check` reaches 1,509/1,510 tests but is blocked by the unchanged `pi-github-pr` branch-watcher timing test, pending PR CI on the target platform.
+- [x] Run `npm run check`, then run `just pack-firecrawl` and inspect that only intended source/docs/package files are included. Evidence: PR #427 CI passed the full repository check; local Biome, boundaries, all-workspace typechecks, 26 focused tests, and the pack dry run also passed. The local macOS run's sole unchanged `pi-github-pr` watcher-test failure did not reproduce in target-platform CI.
 - [x] Run one local Pi smoke against `https://www.bbc.com/news/live/c3r2nz9ed3lt` and one deterministic oversized mocked response. Evidence: BBC returned 32,256 bytes / 62 lines without truncation; the deterministic 100,016-byte response returned a bounded 217-byte / 3-line notice with a readable complete artifact that cleanup removed.
 
 ## Completion Checklist
@@ -56,4 +56,4 @@ The first iteration will not add settings or another public tool. The full artif
 - [x] Full-response artifacts are exact, private, collision-safe, and cleaned up on session shutdown.
 - [x] Tool-result `details` no longer duplicates the raw Firecrawl payload.
 - [x] Non-truncated visible output remains compatible with the current pretty-printed JSON.
-- [ ] Focused tests, full repository checks, package dry run, and runtime smoke all pass; PR CI is pending to resolve the unrelated local `pi-github-pr` watcher-test failure.
+- [x] Focused tests, full repository checks, package dry run, and runtime smoke all pass; PR #427 CI supplied the passing target-platform full repository gate.

--- a/extensions/pi-firecrawl/README.md
+++ b/extensions/pi-firecrawl/README.md
@@ -18,6 +18,7 @@ Use it to give your AI coding agent reliable web research capabilities for docum
 - Provides a `/firecrawl` menu with configuration help and tool controls.
 - Provides a Plan-mode-style selector for choosing individual Firecrawl tools.
 - Persists the selected Firecrawl tools across Pi restarts.
+- Bounds tool output to Pi's 50 KB or 2,000-line limit while preserving oversized responses in private temporary files.
 - Never logs, displays, or stores your Firecrawl API key.
 
 ## 📦 Install
@@ -63,6 +64,13 @@ export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
 - `firecrawl_search` — search the web through Firecrawl and optionally scrape result pages.
 
 All tools fail with a clear configuration error when `FIRECRAWL_API_KEY` is missing.
+
+Tool output is limited to 50 KB or 2,000 lines, whichever is reached first. When a response is
+truncated, the result reports the original and displayed sizes and the path to a complete temporary
+JSON file. These files use private permissions, remain available for the current session, and are
+removed during session shutdown or reload. Tool-result metadata contains only size and artifact
+information rather than a duplicate of the raw Firecrawl response. Oversized Firecrawl error bodies
+are bounded in the same way.
 
 ## 💬 Command
 

--- a/extensions/pi-firecrawl/src/client.ts
+++ b/extensions/pi-firecrawl/src/client.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { boundResponseText, formatJsonResult } from "./response-format.js";
 
 const DEFAULT_API_URL = "https://api.firecrawl.dev/v1";
 const STATUS_KEY = "firecrawl";
@@ -17,7 +18,8 @@ export async function firecrawlRequest(
 	method: "GET" | "POST",
 	path: string,
 	body: unknown,
-	signal?: AbortSignal,
+	signal: AbortSignal | undefined,
+	artifactOwner: object,
 ) {
 	const apiKey = getApiKey();
 	const response = await fetch(`${apiUrl}${path}`, {
@@ -32,9 +34,12 @@ export async function firecrawlRequest(
 	const responseText = await response.text();
 	const payload = parseResponseBody(responseText);
 	if (!response.ok) {
-		throw new Error(
-			`Firecrawl ${method} ${path} failed (${response.status}): ${formatPayload(payload)}`,
-		);
+		const prefix = `Firecrawl ${method} ${path} failed (${response.status}): `;
+		const bounded = await boundResponseText(`${prefix}${formatPayload(payload)}`, artifactOwner, {
+			artifactText: responseText,
+			artifactExtension: "txt",
+		});
+		throw new Error(bounded.text);
 	}
 	return payload;
 }
@@ -67,14 +72,11 @@ export function parseResponseBody(responseText: string) {
 }
 
 export function formatPayload(payload: unknown) {
-	return typeof payload === "string" ? payload : JSON.stringify(payload);
+	return typeof payload === "string" ? payload : (JSON.stringify(payload) ?? String(payload));
 }
 
-export function jsonResult(payload: unknown) {
-	return {
-		content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
-		details: payload,
-	};
+export function jsonResult(payload: unknown, artifactOwner: object) {
+	return formatJsonResult(payload, artifactOwner);
 }
 
 export async function withStatus<T>(

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { hasApiKey } from "./client.js";
+import { cleanupResponseArtifacts, openResponseArtifacts } from "./response-format.js";
 import { loadSettings } from "./settings.js";
 import {
 	allFirecrawlTools,
@@ -59,6 +60,7 @@ export default function firecrawl(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
+		openResponseArtifacts(ctx.sessionManager);
 		clearSettingsNotice();
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		const settings = await loadSettings();
@@ -73,8 +75,9 @@ export default function firecrawl(pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
+	pi.on("session_shutdown", async (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		await cleanupResponseArtifacts(ctx.sessionManager);
 	});
 }
 
@@ -165,10 +168,12 @@ export function commandCompletions(prefix: string) {
 
 export {
 	cleanObject,
+	firecrawlRequest,
 	formatPayload,
 	jsonResult,
 	normalizeApiUrl,
 	parseResponseBody,
 } from "./client.js";
+export { cleanupResponseArtifacts } from "./response-format.js";
 export { installSettingsFileExclusively, normalizeFirecrawlSettings } from "./settings.js";
 export { formatPersistedSelection, orderedFirecrawlTools } from "./tool-selector.js";

--- a/extensions/pi-firecrawl/src/response-format.ts
+++ b/extensions/pi-firecrawl/src/response-format.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	formatSize,
+	truncateHead,
+} from "@earendil-works/pi-coding-agent";
+
+export interface FirecrawlResultDetails {
+	truncated: boolean;
+	truncatedBy?: "lines" | "bytes";
+	totalLines: number;
+	totalBytes: number;
+	outputLines: number;
+	outputBytes: number;
+	fullResponsePath?: string;
+}
+
+interface BoundTextOptions {
+	maxBytes?: number;
+	maxLines?: number;
+	artifactText?: string;
+	artifactExtension?: "json" | "txt";
+}
+
+interface BoundTextResult {
+	text: string;
+	details: FirecrawlResultDetails;
+}
+
+interface ResponseArtifactStore {
+	directoryPromise: Promise<string>;
+	pendingWrites: Set<Promise<unknown>>;
+}
+
+const responseArtifactStores = new WeakMap<object, ResponseArtifactStore>();
+const closedArtifactOwners = new WeakSet<object>();
+
+export async function formatJsonResult(payload: unknown, artifactOwner: object) {
+	const serialized = JSON.stringify(payload, null, 2) ?? String(payload);
+	const bounded = await boundResponseText(serialized, artifactOwner);
+	return {
+		content: [{ type: "text" as const, text: bounded.text }],
+		details: bounded.details,
+	};
+}
+
+export async function boundResponseText(
+	text: string,
+	artifactOwner: object,
+	options: BoundTextOptions = {},
+): Promise<BoundTextResult> {
+	const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+	const initial = truncateHead(text, { maxBytes, maxLines });
+	if (!initial.truncated) {
+		return {
+			text: initial.content,
+			details: {
+				truncated: false,
+				totalLines: initial.totalLines,
+				totalBytes: initial.totalBytes,
+				outputLines: initial.outputLines,
+				outputBytes: initial.outputBytes,
+			},
+		};
+	}
+
+	const fullResponsePath = await writeResponseArtifact(
+		options.artifactText ?? text,
+		options.artifactExtension ?? "json",
+		artifactOwner,
+	);
+	let footer = truncationFooter(initial, fullResponsePath);
+	let excerptByteBudget = Math.max(0, maxBytes - Buffer.byteLength(footer, "utf8") - 2);
+	let excerptLineBudget = Math.max(0, maxLines - countLines(footer) - 1);
+	for (;;) {
+		const excerpt = truncateHead(text, {
+			maxBytes: excerptByteBudget,
+			maxLines: excerptLineBudget,
+		});
+		footer = truncationFooter(excerpt, fullResponsePath);
+		const separator = excerpt.content ? "\n\n" : "";
+		const content = `${excerpt.content}${separator}${footer}`;
+		if (Buffer.byteLength(content, "utf8") <= maxBytes && countLines(content) <= maxLines) {
+			return {
+				text: content,
+				details: {
+					truncated: true,
+					truncatedBy: initial.truncatedBy ?? undefined,
+					totalLines: initial.totalLines,
+					totalBytes: initial.totalBytes,
+					outputLines: excerpt.outputLines,
+					outputBytes: excerpt.outputBytes,
+					fullResponsePath,
+				},
+			};
+		}
+
+		const nextByteBudget = Math.max(
+			0,
+			Math.min(excerptByteBudget, maxBytes - Buffer.byteLength(footer, "utf8") - 2),
+		);
+		const nextLineBudget = Math.max(
+			0,
+			Math.min(excerptLineBudget, maxLines - countLines(footer) - 1),
+		);
+		if (nextByteBudget === excerptByteBudget && nextLineBudget === excerptLineBudget) {
+			throw new Error("Firecrawl could not fit its truncation notice within Pi's output limits");
+		}
+		excerptByteBudget = nextByteBudget;
+		excerptLineBudget = nextLineBudget;
+	}
+}
+
+function truncationFooter(
+	truncation: Pick<
+		FirecrawlResultDetails,
+		"outputLines" | "totalLines" | "outputBytes" | "totalBytes"
+	>,
+	fullResponsePath: string,
+) {
+	return `[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full response saved to: ${fullResponsePath}]`;
+}
+
+function countLines(content: string) {
+	if (!content) return 0;
+	const lines = content.split("\n");
+	if (content.endsWith("\n")) lines.pop();
+	return lines.length;
+}
+
+function writeResponseArtifact(text: string, extension: "json" | "txt", artifactOwner: object) {
+	const store = responseArtifactStore(artifactOwner);
+	const operation = store.directoryPromise.then(async (directory) => {
+		const path = join(directory, `response-${Date.now()}-${randomUUID()}.${extension}`);
+		await writeFile(path, text, { mode: 0o600 });
+		await chmod(path, 0o600);
+		return path;
+	});
+	store.pendingWrites.add(operation);
+	operation.then(
+		() => store.pendingWrites.delete(operation),
+		() => store.pendingWrites.delete(operation),
+	);
+	return operation;
+}
+
+function responseArtifactStore(artifactOwner: object) {
+	if (closedArtifactOwners.has(artifactOwner)) {
+		throw new Error(
+			"Firecrawl response arrived after session shutdown; full response was discarded",
+		);
+	}
+	const existing = responseArtifactStores.get(artifactOwner);
+	if (existing) return existing;
+
+	const store: ResponseArtifactStore = {
+		directoryPromise: Promise.resolve(""),
+		pendingWrites: new Set(),
+	};
+	store.directoryPromise = mkdtemp(join(tmpdir(), "pi-firecrawl-"))
+		.then(async (directory) => {
+			await chmod(directory, 0o700);
+			return directory;
+		})
+		.catch((error) => {
+			if (responseArtifactStores.get(artifactOwner) === store) {
+				responseArtifactStores.delete(artifactOwner);
+			}
+			throw error;
+		});
+	responseArtifactStores.set(artifactOwner, store);
+	return store;
+}
+
+export function openResponseArtifacts(artifactOwner: object) {
+	closedArtifactOwners.delete(artifactOwner);
+}
+
+export async function cleanupResponseArtifacts(artifactOwner: object) {
+	closedArtifactOwners.add(artifactOwner);
+	const store = responseArtifactStores.get(artifactOwner);
+	if (!store) return;
+	responseArtifactStores.delete(artifactOwner);
+	await Promise.allSettled([...store.pendingWrites]);
+	try {
+		await rm(await store.directoryPromise, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup must not make session shutdown fail.
+	}
+}

--- a/extensions/pi-firecrawl/src/tools.ts
+++ b/extensions/pi-firecrawl/src/tools.ts
@@ -1,4 +1,9 @@
-import { defineTool } from "@earendil-works/pi-coding-agent";
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	defineTool,
+	formatSize,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { cleanObject, firecrawlRequest, jsonResult, withStatus } from "./client.js";
 
@@ -12,11 +17,12 @@ export const FIRECRAWL_TOOL_NAMES = [
 export type FirecrawlToolName = (typeof FIRECRAWL_TOOL_NAMES)[number];
 
 const StringArray = Type.Array(Type.String());
+const OUTPUT_LIMIT_DESCRIPTION = `Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}; complete truncated responses are saved temporarily and their path is returned.`;
 
 export const scrapeTool = defineTool({
 	name: FIRECRAWL_TOOL_NAMES[0],
 	label: "Firecrawl: Scrape",
-	description: "Scrape a single URL through Firecrawl and return requested formats.",
+	description: `Scrape a single URL through Firecrawl and return requested formats. ${OUTPUT_LIMIT_DESCRIPTION}`,
 	promptSnippet: "Scrape a URL through Firecrawl",
 	promptGuidelines: [
 		"Use firecrawl_scrape when you need clean markdown, HTML, links, screenshots, or structured extraction for one URL.",
@@ -69,8 +75,14 @@ export const scrapeTool = defineTool({
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		return withStatus(ctx, "scrape", async () => {
-			const payload = await firecrawlRequest("POST", "/scrape", cleanObject(params), signal);
-			return jsonResult(payload);
+			const payload = await firecrawlRequest(
+				"POST",
+				"/scrape",
+				cleanObject(params),
+				signal,
+				ctx.sessionManager,
+			);
+			return await jsonResult(payload, ctx.sessionManager);
 		});
 	},
 });
@@ -78,7 +90,7 @@ export const scrapeTool = defineTool({
 export const crawlTool = defineTool({
 	name: FIRECRAWL_TOOL_NAMES[1],
 	label: "Firecrawl: Crawl",
-	description: "Start a Firecrawl crawl job for a website.",
+	description: `Start a Firecrawl crawl job for a website. ${OUTPUT_LIMIT_DESCRIPTION}`,
 	promptSnippet: "Start a Firecrawl site crawl job",
 	parameters: Type.Object({
 		url: Type.String({ description: "Starting URL for the crawl." }),
@@ -107,8 +119,14 @@ export const crawlTool = defineTool({
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		return withStatus(ctx, "crawl", async () => {
-			const payload = await firecrawlRequest("POST", "/crawl", cleanObject(params), signal);
-			return jsonResult(payload);
+			const payload = await firecrawlRequest(
+				"POST",
+				"/crawl",
+				cleanObject(params),
+				signal,
+				ctx.sessionManager,
+			);
+			return await jsonResult(payload, ctx.sessionManager);
 		});
 	},
 });
@@ -116,7 +134,7 @@ export const crawlTool = defineTool({
 export const crawlStatusTool = defineTool({
 	name: FIRECRAWL_TOOL_NAMES[2],
 	label: "Firecrawl: Crawl Status",
-	description: "Check a Firecrawl crawl job status and retrieve completed crawl data.",
+	description: `Check a Firecrawl crawl job status and retrieve completed crawl data. ${OUTPUT_LIMIT_DESCRIPTION}`,
 	promptSnippet: "Check a Firecrawl crawl job status",
 	parameters: Type.Object({
 		id: Type.String({ description: "Crawl job id returned by firecrawl_crawl." }),
@@ -128,8 +146,9 @@ export const crawlStatusTool = defineTool({
 				`/crawl/${encodeURIComponent(params.id)}`,
 				undefined,
 				signal,
+				ctx.sessionManager,
 			);
-			return jsonResult(payload);
+			return await jsonResult(payload, ctx.sessionManager);
 		});
 	},
 });
@@ -137,7 +156,7 @@ export const crawlStatusTool = defineTool({
 export const mapTool = defineTool({
 	name: FIRECRAWL_TOOL_NAMES[3],
 	label: "Firecrawl: Map",
-	description: "Discover URLs for a site through Firecrawl's map endpoint.",
+	description: `Discover URLs for a site through Firecrawl's map endpoint. ${OUTPUT_LIMIT_DESCRIPTION}`,
 	promptSnippet: "Map/discover URLs for a site through Firecrawl",
 	parameters: Type.Object({
 		url: Type.String({ description: "Website URL to map." }),
@@ -155,8 +174,14 @@ export const mapTool = defineTool({
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		return withStatus(ctx, "map", async () => {
-			const payload = await firecrawlRequest("POST", "/map", cleanObject(params), signal);
-			return jsonResult(payload);
+			const payload = await firecrawlRequest(
+				"POST",
+				"/map",
+				cleanObject(params),
+				signal,
+				ctx.sessionManager,
+			);
+			return await jsonResult(payload, ctx.sessionManager);
 		});
 	},
 });
@@ -164,7 +189,7 @@ export const mapTool = defineTool({
 export const searchTool = defineTool({
 	name: FIRECRAWL_TOOL_NAMES[4],
 	label: "Firecrawl: Search",
-	description: "Search the web through Firecrawl and optionally scrape search results.",
+	description: `Search the web through Firecrawl and optionally scrape search results. ${OUTPUT_LIMIT_DESCRIPTION}`,
 	promptSnippet: "Search the web through Firecrawl",
 	parameters: Type.Object({
 		query: Type.String({ description: "Search query." }),
@@ -179,8 +204,14 @@ export const searchTool = defineTool({
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		return withStatus(ctx, "search", async () => {
-			const payload = await firecrawlRequest("POST", "/search", cleanObject(params), signal);
-			return jsonResult(payload);
+			const payload = await firecrawlRequest(
+				"POST",
+				"/search",
+				cleanObject(params),
+				signal,
+				ctx.sessionManager,
+			);
+			return await jsonResult(payload, ctx.sessionManager);
 		});
 	},
 });

--- a/extensions/pi-firecrawl/test/firecrawl.test.ts
+++ b/extensions/pi-firecrawl/test/firecrawl.test.ts
@@ -5,16 +5,20 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
+	statSync,
 	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import os from "node:os";
-import path from "node:path";
+import path, { dirname } from "node:path";
 import test from "node:test";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
 import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
 import firecrawl, {
 	cleanObject,
+	cleanupResponseArtifacts,
 	commandCompletions,
+	firecrawlRequest,
 	formatPayload,
 	formatPersistedSelection,
 	installSettingsFileExclusively,
@@ -80,15 +84,21 @@ test("firecrawl settings normalize ordered unique valid tool names", () => {
 	]);
 });
 
-test("firecrawl helpers trim URLs, parse payloads, and remove undefined fields", () => {
+test("firecrawl helpers trim URLs, parse payloads, and remove undefined fields", async () => {
 	assert.equal(normalizeApiUrl(" https://example.test/v1/// "), "https://example.test/v1");
 	assert.equal(normalizeApiUrl(undefined), "https://api.firecrawl.dev/v1");
 	assert.deepEqual(parseResponseBody('{"ok":true}'), { ok: true });
 	assert.equal(parseResponseBody("not json"), "not json");
 	assert.equal(formatPayload({ ok: true }), '{"ok":true}');
-	assert.deepEqual(jsonResult({ ok: true }), {
+	assert.deepEqual(await jsonResult({ ok: true }, {}), {
 		content: [{ type: "text", text: '{\n  "ok": true\n}' }],
-		details: { ok: true },
+		details: {
+			truncated: false,
+			totalLines: 3,
+			totalBytes: 16,
+			outputLines: 3,
+			outputBytes: 16,
+		},
 	});
 	assert.deepEqual(
 		cleanObject({
@@ -99,6 +109,227 @@ test("firecrawl helpers trim URLs, parse payloads, and remove undefined fields",
 		}),
 		{ keep: false, nested: { value: null }, list: [undefined, 1] },
 	);
+});
+
+test("jsonResult bounds byte-heavy UTF-8 output and saves the exact full response privately", async () => {
+	const artifactOwner = {};
+	const payload = { markdown: "界".repeat(DEFAULT_MAX_BYTES) };
+	const serialized = JSON.stringify(payload, null, 2);
+	const result = await jsonResult(payload, artifactOwner);
+	const text = result.content[0].text;
+
+	assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
+	assert.ok(text.split("\n").length <= DEFAULT_MAX_LINES);
+	assert.match(text, /Output truncated/);
+	assert.equal(result.details.truncated, true);
+	assert.ok(result.details.fullResponsePath);
+	assert.equal(readFileSync(result.details.fullResponsePath, "utf8"), serialized);
+	assert.equal(statSync(dirname(result.details.fullResponsePath)).mode & 0o777, 0o700);
+	assert.equal(statSync(result.details.fullResponsePath).mode & 0o777, 0o600);
+	assert.equal("markdown" in result.details, false);
+
+	await cleanupResponseArtifacts(artifactOwner);
+});
+
+test("jsonResult bounds line-heavy output including its truncation footer", async () => {
+	const artifactOwner = {};
+	const payload = Array.from({ length: DEFAULT_MAX_LINES + 100 }, (_, index) => ({ index }));
+	const result = await jsonResult(payload, artifactOwner);
+	const text = result.content[0].text;
+
+	assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
+	assert.ok(text.split("\n").length <= DEFAULT_MAX_LINES);
+	assert.match(text, /showing \d+ of \d+ lines/);
+	assert.equal(result.details.truncated, true);
+
+	await cleanupResponseArtifacts(artifactOwner);
+});
+
+test("jsonResult fits its final footer when a multiline response crosses size units", async () => {
+	const artifactOwner = {};
+	const payload = {
+		lines: Array.from({ length: 15_000 }, () => "x".repeat(80)),
+	};
+	const result = await jsonResult(payload, artifactOwner);
+	const text = result.content[0].text;
+
+	assert.ok(result.details.totalBytes > 1024 * 1024);
+	assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
+	assert.ok(text.split("\n").length <= DEFAULT_MAX_LINES);
+	assert.match(text, /Output truncated/);
+
+	await cleanupResponseArtifacts(artifactOwner);
+});
+
+test("jsonResult gives concurrent truncated responses unique artifact paths", async () => {
+	const artifactOwner = {};
+	const payload = { value: "x".repeat(DEFAULT_MAX_BYTES + 1) };
+	const [first, second] = await Promise.all([
+		jsonResult(payload, artifactOwner),
+		jsonResult(payload, artifactOwner),
+	]);
+
+	assert.ok(first.details.fullResponsePath);
+	assert.ok(second.details.fullResponsePath);
+	assert.notEqual(first.details.fullResponsePath, second.details.fullResponsePath);
+
+	await cleanupResponseArtifacts(artifactOwner);
+});
+
+test("response artifact cleanup is isolated by session owner", async () => {
+	const firstOwner = {};
+	const secondOwner = {};
+	const payload = { value: "x".repeat(DEFAULT_MAX_BYTES + 1) };
+	const [first, second] = await Promise.all([
+		jsonResult(payload, firstOwner),
+		jsonResult(payload, secondOwner),
+	]);
+	assert.ok(first.details.fullResponsePath);
+	assert.ok(second.details.fullResponsePath);
+
+	await cleanupResponseArtifacts(firstOwner);
+
+	assert.equal(existsSync(first.details.fullResponsePath), false);
+	assert.equal(existsSync(second.details.fullResponsePath), true);
+	await cleanupResponseArtifacts(secondOwner);
+});
+
+test("cleanup waits for an in-flight artifact write owned by that session", async () => {
+	const artifactOwner = {};
+	const pending = jsonResult({ value: "x".repeat(DEFAULT_MAX_BYTES + 1) }, artifactOwner);
+
+	await cleanupResponseArtifacts(artifactOwner);
+	const result = await pending;
+
+	assert.ok(result.details.fullResponsePath);
+	assert.equal(existsSync(result.details.fullResponsePath), false);
+});
+
+test("all five Firecrawl tools bound oversized successful responses", async () => {
+	const originalFetch = globalThis.fetch;
+	const previousApiKey = process.env.FIRECRAWL_API_KEY;
+	const paths: string[] = [];
+	let artifactOwner: object | undefined;
+	globalThis.fetch = async (input) => {
+		paths.push(new URL(String(input)).pathname);
+		return new Response(JSON.stringify({ data: "x".repeat(DEFAULT_MAX_BYTES * 2) }));
+	};
+	process.env.FIRECRAWL_API_KEY = "test-key";
+	try {
+		const mock = createMockPi();
+		firecrawl(mock.pi);
+		const sessionManager = { getSessionId: () => "tool-test-session" };
+		const { ctx } = createMockContext({ sessionManager });
+		artifactOwner = sessionManager;
+		const inputs = [
+			{ url: "https://example.test" },
+			{ url: "https://example.test" },
+			{ id: "crawl-id" },
+			{ url: "https://example.test" },
+			{ query: "example" },
+		];
+		for (const [index, tool] of mock.tools.entries()) {
+			const execute = tool.execute as (
+				id: string,
+				params: unknown,
+				signal: AbortSignal | undefined,
+				onUpdate: undefined,
+				context: typeof ctx,
+			) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+			const result = await execute(`call-${index}`, inputs[index], undefined, undefined, ctx);
+			const text = result.content.find((item) => item.type === "text")?.text ?? "";
+			assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
+			assert.ok(text.split("\n").length <= DEFAULT_MAX_LINES);
+			assert.match(text, /Output truncated/);
+		}
+		assert.deepEqual(paths, [
+			"/v1/scrape",
+			"/v1/crawl",
+			"/v1/crawl/crawl-id",
+			"/v1/map",
+			"/v1/search",
+		]);
+	} finally {
+		globalThis.fetch = originalFetch;
+		if (previousApiKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+		else process.env.FIRECRAWL_API_KEY = previousApiKey;
+		if (artifactOwner) await cleanupResponseArtifacts(artifactOwner);
+	}
+});
+
+test("firecrawl bounds oversized non-2xx responses and saves their exact raw body", async () => {
+	const originalFetch = globalThis.fetch;
+	const responseText = `{\n  "error": "${"x".repeat(DEFAULT_MAX_BYTES * 2)}",\n  "duplicate": 1,\n  "duplicate": 2\n}`;
+	globalThis.fetch = async () => new Response(responseText, { status: 500 });
+	const previousApiKey = process.env.FIRECRAWL_API_KEY;
+	const artifactOwner = {};
+	process.env.FIRECRAWL_API_KEY = "test-key";
+	try {
+		const hugePath = `/${"a".repeat(DEFAULT_MAX_BYTES * 2)}`;
+		await assert.rejects(
+			firecrawlRequest("GET", hugePath, undefined, undefined, artifactOwner),
+			(error: Error) => {
+				assert.ok(Buffer.byteLength(error.message, "utf8") <= DEFAULT_MAX_BYTES);
+				assert.match(error.message, /Output truncated/);
+				const artifactPath = error.message.match(/Full response saved to: (.+)\]$/)?.[1];
+				assert.ok(artifactPath);
+				assert.equal(readFileSync(artifactPath, "utf8"), responseText);
+				return true;
+			},
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+		if (previousApiKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+		else process.env.FIRECRAWL_API_KEY = previousApiKey;
+		await cleanupResponseArtifacts(artifactOwner);
+	}
+});
+
+test("session shutdown rejects an error artifact write that starts after cleanup", async () => {
+	const originalFetch = globalThis.fetch;
+	const previousApiKey = process.env.FIRECRAWL_API_KEY;
+	let resolveResponse: (response: Response) => void = () => undefined;
+	const pendingResponse = new Promise<Response>((resolve) => {
+		resolveResponse = resolve;
+	});
+	globalThis.fetch = async () => pendingResponse;
+	process.env.FIRECRAWL_API_KEY = "test-key";
+	const artifactOwner = {};
+	const prior = await jsonResult({ value: "x".repeat(DEFAULT_MAX_BYTES + 1) }, artifactOwner);
+	assert.ok(prior.details.fullResponsePath);
+	const priorDirectory = dirname(prior.details.fullResponsePath);
+	const pendingRequest = firecrawlRequest(
+		"GET",
+		"/late-error",
+		undefined,
+		undefined,
+		artifactOwner,
+	);
+	try {
+		await cleanupResponseArtifacts(artifactOwner);
+		resolveResponse(new Response("x".repeat(DEFAULT_MAX_BYTES * 2), { status: 500 }));
+
+		await assert.rejects(pendingRequest, /after session shutdown/);
+		assert.equal(existsSync(priorDirectory), false);
+	} finally {
+		globalThis.fetch = originalFetch;
+		if (previousApiKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+		else process.env.FIRECRAWL_API_KEY = previousApiKey;
+	}
+});
+
+test("session shutdown removes only that session's Firecrawl response artifacts", async () => {
+	const mock = createMockPi();
+	firecrawl(mock.pi);
+	const sessionManager = { getSessionId: () => "shutdown-test-session" };
+	const { ctx } = createMockContext({ sessionManager });
+	const result = await jsonResult({ value: "x".repeat(DEFAULT_MAX_BYTES + 1) }, sessionManager);
+	assert.ok(result.details.fullResponsePath);
+	const directory = dirname(result.details.fullResponsePath);
+
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+
+	assert.equal(existsSync(directory), false);
 });
 
 test("formatPersistedSelection summarizes all, none, and partial selections", () => {


### PR DESCRIPTION
## Summary

- bound all `firecrawl_*` success and non-2xx outputs to Pi's 50 KB / 2,000-line limits
- save exact oversized responses in private, session-owned temporary artifacts and remove them safely on shutdown
- keep tool-result metadata compact, document truncation behavior, and cover all five tools plus lifecycle/error races

## Verification

- `node --test <compiled pi-firecrawl test>` — 26/26 pass
- `npm run biome:check` — pass
- `npm run check:boundaries` — pass
- `npm run typecheck` — pass for all workspaces
- `just pack-firecrawl` — pass; 10 intended package files
- local Pi BBC Live smoke — 32,256 bytes / 62 lines, untruncated
- deterministic oversized smoke — 100,016-byte input bounded to 217 bytes / 3 lines with readable exact artifact and cleanup
- reviewer re-review — Approve

`npm run check` reaches 1,509/1,510 tests locally. The sole failure is the unchanged `pi-github-pr` test `branch changes abort an in-flight periodic refresh`; the same focused test fails against unchanged `main` code on this macOS environment. PR CI is expected to provide the target-platform result.
