### PR TITLE
fix(image-drop): address post-merge review feedback

### DIFF
--- a/extensions/pi-image-drop/src/menu.ts
+++ b/extensions/pi-image-drop/src/menu.ts
@@ -110,6 +110,7 @@ export function runImageDropMenuLoad<T>(
 			invalidate: () => loader.invalidate(),
 			handleInput(data: string) {
 				if (matchesKey(data, Key.ctrl("c"))) {
+					taskAbort.abort();
 					finish({ kind: "closed" });
 					loader.handleInput(data);
 					return;

--- a/extensions/pi-image-drop/src/menu.ts
+++ b/extensions/pi-image-drop/src/menu.ts
@@ -398,7 +398,7 @@ export function showImageDropLimitsMenu(
 			item("maxImageBytes", "Max file size per image"),
 			item("maxBatchBytes", "Max total size per message"),
 			item("maxImagePixels", "Max image resolution"),
-			item("maxRetainedImages", "Reusable sent images"),
+			item("maxRetainedImages", "Staged + sent image count"),
 			item("maxRetainedBytes", "Staged + sent image memory"),
 			{
 				value: "save",

--- a/extensions/pi-image-drop/src/runtime.ts
+++ b/extensions/pi-image-drop/src/runtime.ts
@@ -850,8 +850,8 @@ function limitLabel(key: LimitKey): string {
 		maxImageBytes: "Per-image upload size",
 		maxBatchBytes: "Total upload size",
 		maxImagePixels: "Maximum image resolution",
-		maxRetainedImages: "Sent history count",
-		maxRetainedBytes: "Sent history memory",
+		maxRetainedImages: "Staged + sent image count",
+		maxRetainedBytes: "Staged + sent image memory",
 	}[key];
 }
 

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -60,6 +60,7 @@ function createHarness(
 		input?: () => Promise<string | undefined>;
 		confirmDialog?: () => Promise<ConfirmDialogResult>;
 		inputDialog?: () => Promise<InputDialogResult>;
+		onConfirm?: (title: string, message: string) => void;
 		onStatus?: (lines: readonly string[]) => void;
 		onLimits?: (state: ImageDropLimitsMenuState) => void;
 		onSave?: (settings: Partial<ImageDropSettings>) => Promise<void>;
@@ -130,9 +131,11 @@ function createHarness(
 			options.onLimits?.(state);
 			return options.limitActions?.shift() ?? "back";
 		},
-		showConfirm:
-			options.confirmDialog ??
-			(async () => (((await options.confirm?.()) ?? true) ? "confirmed" : "cancelled")),
+		showConfirm: async (_ctx, title, message) => {
+			options.onConfirm?.(title, message);
+			if (options.confirmDialog) return options.confirmDialog();
+			return ((await options.confirm?.()) ?? true) ? "confirmed" : "cancelled";
+		},
 		showInput:
 			options.inputDialog ??
 			(async () => {
@@ -476,28 +479,36 @@ test("a failed Status refresh preserves and labels the previous valid policy", a
 
 test("Settings preview and save future limits without changing current-session limits", async () => {
 	let saved: Partial<ImageDropSettings> | undefined;
+	let confirmation = "";
 	const menuStates: ImageDropLimitsMenuState[] = [];
 	const harness = createHarness({
 		menuActions: ["settings", "close"],
 		settingsActions: ["limits", "back"],
-		limitActions: ["maxImages", "save"],
-		input: async () => "12",
+		limitActions: ["maxRetainedImages", "save"],
+		input: async () => "120",
 		confirm: async () => true,
 		onSave: async (settings) => {
 			saved = settings;
+		},
+		onConfirm: (_title, message) => {
+			confirmation = message;
 		},
 		onLimits: (state) => menuStates.push(state),
 	});
 	await emit(harness.mock, "session_start", {}, harness.context.ctx);
 	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
-	assert.deepEqual(saved, { maxImages: 12 });
-	assert.deepEqual(menuStates[0]?.values.maxImages, { current: "8", defaultValue: "8" });
-	assert.deepEqual(menuStates[1]?.values.maxImages, {
-		pending: "12",
-		current: "8",
-		defaultValue: "8",
+	assert.deepEqual(saved, { maxRetainedImages: 120 });
+	assert.deepEqual(menuStates[0]?.values.maxRetainedImages, {
+		current: "128",
+		defaultValue: "128",
+	});
+	assert.deepEqual(menuStates[1]?.values.maxRetainedImages, {
+		pending: "120",
+		current: "128",
+		defaultValue: "128",
 	});
 	assert.equal(harness.runtime.getBatchForTesting()?.publicHistoryState().maxImages, 128);
+	assert.match(confirmation, /Staged \+ sent image count/);
 	assert.match(harness.context.notifications.at(-1)?.message ?? "", /future Pi sessions/i);
 });
 

--- a/extensions/pi-image-drop/test/menu.test.ts
+++ b/extensions/pi-image-drop/test/menu.test.ts
@@ -142,6 +142,38 @@ test("status loading distinguishes Escape back from Ctrl+C close", async () => {
 	assert.equal((await loadWith("\u0003")).kind, "closed");
 });
 
+test("Ctrl+C aborts loader work before closing its UI", async () => {
+	let uiClosed = false;
+	let abortedBeforeClose = false;
+	const context = createMockContext({
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			if (typeof factory !== "function") throw new Error("Expected a custom component factory");
+			let result: unknown;
+			const component = factory(
+				{ requestRender() {} },
+				{ fg: (_color: string, text: string) => text },
+				{},
+				(value: unknown) => {
+					uiClosed = true;
+					result = value;
+				},
+			) as { handleInput(data: string): void; dispose(): void };
+			component.handleInput("\u0003");
+			component.dispose();
+			return result;
+		},
+	});
+	const result = await runImageDropMenuLoad(context.ctx, "Loading…", async (signal) => {
+		signal.addEventListener("abort", () => {
+			abortedBeforeClose = !uiClosed;
+		});
+		return new Promise<never>(() => undefined);
+	});
+	assert.equal(result.kind, "closed");
+	assert.equal(abortedBeforeClose, true);
+});
+
 test("disposing a menu loader aborts its owned task", async () => {
 	let signal: AbortSignal | undefined;
 	const context = createMockContext({

--- a/extensions/pi-image-drop/test/menu.test.ts
+++ b/extensions/pi-image-drop/test/menu.test.ts
@@ -105,7 +105,7 @@ test("resource-limit actions explain their concrete effect and save behavior", a
 		"Current: 40 MiB · Default: 40 MiB",
 		"Max image resolution",
 		"Current: 50 MP · Default: 50 MP",
-		"Reusable sent images",
+		"Staged + sent image count",
 		"Current: 128 · Default: 128",
 		"Staged + sent image memory",
 		"Current: 512 MiB · Default: 512 MiB",


### PR DESCRIPTION
## Summary

- abort Image Drop loader work directly on Ctrl+C before closing its UI
- label retained limits consistently as shared staged-and-sent capacity

## Review feedback

Follow-up to #424 and review [4782091134](https://github.com/narumiruna/pi-extensions/pull/424#pullrequestreview-4782091134):

- [Label retained limits as shared draft and history capacity](https://github.com/narumiruna/pi-extensions/pull/424#discussion_r3652862687)
- [Abort loader work directly on Ctrl+C](https://github.com/narumiruna/pi-extensions/pull/424#discussion_r3652862688)

## Verification

- `npm run check` (1,531 tests passed)
- `npm run check --workspace @narumitw/pi-image-drop`
- focused Image Drop menu and lifecycle tests
