### PR TITLE
fix(plan-mode): declare runtime peer dependencies

### DIFF
--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -27,6 +27,10 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",
 		"@earendil-works/pi-coding-agent": "0.82.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1663,7 +1663,12 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.5",
 				"@earendil-works/pi-coding-agent": "0.82.1",
+				"@earendil-works/pi-tui": "0.82.1",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"extensions/pi-plan-mode/node_modules/@biomejs/biome": {


### PR DESCRIPTION
## Summary

- declare `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` as runtime peer dependencies
- synchronize the workspace lockfile with the `pi-tui` development dependency added in #426

This is a packaging follow-up to #426. The Markdown result renderer imports both Pi packages at runtime, so published metadata must declare them instead of relying on development dependencies being installed.

## Verification

- `npm run check` (1542 tests passed)
- `just pack-plan-mode`
- `npm pkg get peerDependencies --workspace @narumitw/pi-plan-mode`
