### PR TITLE
feat(sync): add safe WebDAV backend

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -125,6 +125,7 @@
 
 ### General
 
+- Prefer destination-oriented pi-sync setup that completes credentials in a masked TUI; keep the profile/target split as an advanced persistence detail rather than a required user concept.
 - Prefer direct, user-owned context selection; avoid dedicated shortcuts or manual copy steps for routine quoting workflows.
 - Prefer reading GitHub issue and pull request links with `gh --json` first; use web tools only when `gh` cannot access the needed content.
 - Live provider smokes are acceptable when relevant, but stop after one clear external or entitlement failure; use deterministic tests instead of repeatedly retrying unless the user explicitly asks.

--- a/docs/plans/archived/2026-07-27_sync-destination-tui-plan.md
+++ b/docs/plans/archived/2026-07-27_sync-destination-tui-plan.md
@@ -1,0 +1,28 @@
+# Pi Sync destination TUI plan
+
+## Goal
+
+Make a new or existing pi-sync destination fully configurable from the TUI, including masked credentials, without requiring users to understand the internal profile/target split or manually edit JSON.
+
+## Architecture
+
+Keep the version 2 `profiles` and `targets` persistence schema unchanged. Present a destination-oriented manager that composes a reusable storage connection (profile) with a remote destination and sync policy (target). A package-owned masked input component handles secrets without ever rendering their plaintext. Existing atomic settings writers remain the only publication path.
+
+## Plan
+
+- [x] Add focused failing tests for masked secret entry, complete WebDAV setup, credential editing, cancellation, narrow rendering, and invalid WebDAV destination repair; the initial missing-module and missing-password failures established the red states.
+- [x] Add a focus-aware masked secret TUI component and credential helpers that honor callback keybindings, paste/edit safely, validate before returning, clear component-owned secret state on disposal, and never render plaintext; covered by `secret-input.test.ts`.
+- [x] Update WebDAV setup/profile editing to collect or replace passwords in TUI and save complete usable profiles atomically while preserving existing secrets and unknown fields; covered by WebDAV setup, edit, cancellation, and manager-flow tests.
+- [x] Replace profile-first management labels with destination-oriented primary flows, retain saved connections as advanced reuse, and add a reviewed WebDAV repair flow for S3-only target fields; covered by manager navigation and repair tests.
+- [x] Extend R2/S3 setup and connection editing with a private-settings credential option using masked secret input while preserving environment-credential behavior; covered by first-time S3 and existing environment-credential tests.
+- [x] Update `extensions/pi-sync/README.md` for the destination workflow, masked credential behavior, recovery, and unchanged settings schema.
+- [x] Run focused pi-sync tests, then `npm run check`, and audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md` touched-area checklists; `npm run check` passed with 1,618 tests and `just pack-sync` included all new runtime modules.
+
+## Completion Checklist
+
+- [x] A new WebDAV destination saved through TUI loads without manual JSON edits.
+- [x] Secret plaintext never appears in rendered lines, reviews, notifications, or errors.
+- [x] Cancellation and write failure retain the previous settings.
+- [x] Existing version 1/version 2 settings, unknown fields, and environment credentials remain compatible.
+- [x] The invalid local `webdav` target can be repaired through the TUI without changing unrelated destinations.
+- [x] Required tests and repository checks pass, and this completed plan is archived.

--- a/docs/plans/archived/2026-07-27_webdav-backend-plan.md
+++ b/docs/plans/archived/2026-07-27_webdav-backend-plan.md
@@ -1,0 +1,81 @@
+# WebDAV Backend Plan
+
+## Goal
+
+Add a vendor-neutral WebDAV backend to `@narumitw/pi-sync` that fits version 2 storage profiles and named targets, preserves the existing immutable snapshot/pointer model and backend-neutral sync orchestration, uses verified atomic HTTP preconditions for publication, and integrates with every existing `/sync` menu and direct route without regressing S3/R2 behavior.
+
+## Context
+
+- GitHub issue [#271](https://github.com/narumiruna/pi-extensions/issues/271) depends on the completed backend-contract work in [#270](https://github.com/narumiruna/pi-extensions/issues/270).
+- `extensions/pi-sync/src/sync-backend.ts`, `s3-backend.ts`, and `backend-factory.ts` now isolate storage from orchestration. `status`, `diff`, `push`, `pull`, `sync`, `history`, `rollback`, and `doctor` already operate through `SyncBackend`.
+- Version 2 settings currently accept only `r2` and `s3-compatible` profiles and S3-shaped targets. Legacy flat settings and deprecated `PI_SYNC_*`/AWS/R2 variables must remain S3-only compatibility paths.
+- The current remote wire layout is `<root>/profiles/<namespace>/{latest.json,history.json,snapshots/*.json.gz}`. Reusing it keeps snapshot validation, history behavior, rollback-as-new-publication, and unmanaged-file preservation backend-neutral.
+- `manager-ui.ts` is already 996 lines, so WebDAV setup/management work must be extracted along a clear responsibility boundary rather than extending that file beyond the repository threshold.
+- Applicable guides read before planning: `docs/extension-conventions.md` and `docs/extension-settings.md`.
+
+## Architecture
+
+- Add a discriminated `webdav` profile with `url`, `username`, and `password`, paired only with a WebDAV target destination containing `path` and `namespace`. Reject S3-only fields on WebDAV objects and WebDAV-only fields on S3 objects instead of silently ignoring them.
+- Resolve settings into `ResolvedS3Backend | ResolvedWebDavBackend`; select the implementation in `backend-factory.ts`. Legacy flat settings and compatibility environment overrides continue resolving only to S3.
+- Map a WebDAV target to `<url>/<path>/profiles/<namespace>/`. Store `latest.json`, `history.json`, and immutable gzip bundles under the same relative layout used by S3.
+- Implement a bounded WebDAV transport over `fetch` for `GET`, `PUT`, `MKCOL`, `PROPFIND`, and probe cleanup with `DELETE`. Encode path segments, parse namespace-tolerant multistatus XML with a small runtime XML dependency, combine caller cancellation with request timeouts, cap all response/error bodies, and manually follow only a bounded number of same-origin redirects. Never forward authentication across origins.
+- Use HTTP Basic authentication only over HTTPS, except loopback HTTP used by deterministic tests. Reject embedded URL credentials and redact usernames, passwords, authorization data, and URL query/fragment data from identities, destinations, diagnostics, and errors.
+- Stage snapshot bundles immutably with `If-None-Match: *`; if the resource already exists, read it back and require identical encoded content. Publish `latest.json` with `If-None-Match: *` for a missing head or `If-Match: <strong-etag>` for an observed head. Carry the raw strong ETag inside a versioned, backend-scoped opaque revision so a fresh backend instance can enforce the condition without confusing snapshot IDs, references, and revisions.
+- Treat successful WebDAV publication as `atomic-conditional` only after a private probe proves the server rejects stale `If-Match` and existing-resource `If-None-Match` writes. Cache the result only for the backend instance and revalidate before publication. If conditions or strong ETags are unavailable, keep reads available but fail publication before the active-head commit with an actionable error; do not silently fall back to weak automatic writes. `doctor` reports this read-only degradation explicitly.
+- Keep the existing commit boundary: user cancellation can stop collection preparation, probing, and immutable staging; immediately before the conditional `latest.json` PUT call `onCommit`, then use an internal bounded signal to verify the committed head or return a conflict/outcome-unknown error accurately.
+- Preserve backend-neutral orchestration. Only configuration, backend construction, storage descriptions, diagnostics, and setup/management UI branch by backend kind.
+
+## Non-Goals
+
+- Supporting WebDAV `LOCK`/`UNLOCK`, digest authentication, client certificates, OAuth, or vendor SDKs.
+- Adding WebDAV-specific environment variables or placing credentials in project settings.
+- Changing the snapshot schema, local apply transaction, policy/secret scanning, session opt-in, force semantics, or existing S3/R2 remote layout.
+- Migrating legacy flat settings to WebDAV automatically or deleting remote WebDAV content when a local target/profile is removed.
+
+## Assumptions
+
+- A standards-compliant server that supports strong ETags and honors `If-Match`/`If-None-Match` can provide the required atomic active-pointer publication.
+- Basic authentication covers the generic, Nextcloud, ownCloud, and Synology setup targeted by this issue; unsupported authentication schemes fail with actionable diagnostics.
+- `fast-xml-parser` (or an equivalently bounded, entity-safe parser selected during implementation) is acceptable as the package's only new runtime dependency for `207 Multi-Status` responses.
+
+## Risks
+
+- WebDAV implementations vary in redirect, collection, ETag, and precondition behavior. A configurable local HTTP mock must model supported, ignored, and rejected conditional requests rather than testing only a happy path.
+- A transport error after the conditional pointer PUT can leave publication outcome unknown. Post-commit reads must use an independent timeout and must not report clean cancellation.
+- Probe files can remain after crashes or cleanup failures. Use unpredictable names inside a dedicated probe collection, never overwrite existing resources, attempt cleanup in `finally`, and report exact redacted cleanup guidance.
+- Backend-aware state identity changes can strand existing S3 state. Preserve the exact current S3 state-path input tuple and add regression fixtures before adding the WebDAV tuple.
+- Setup UI changes can regress non-TUI commands or settings write safety. Keep network probes out of settings writes, preserve unknown fields/private permissions, and test TUI and non-TUI routes separately.
+
+## Plan
+
+- [x] Extend `extensions/pi-sync/src/types.ts`, `config.ts`, and `settings-management.ts` with discriminated S3/WebDAV profile-target pairs, strict incompatible-field validation, WebDAV URL/path/namespace normalization, S3-only legacy/environment compatibility, and a WebDAV-specific state identity while preserving existing S3 state paths; verify with expanded `backend-config.test.ts`, `multi-profile.test.ts`, `config-filename.test.ts`, and `sync-state-revision.test.ts` cases covering valid/malformed profiles, secret preservation, unknown fields, duplicate destinations, and byte-for-byte S3 path regressions.
+- [x] Add `fast-xml-parser` as a runtime dependency and implement `extensions/pi-sync/src/webdav-client.ts` with bounded `GET`/`PUT`/`MKCOL`/`PROPFIND`/`DELETE`, recursive collection preparation, safe URL construction, Basic-auth/TLS policy, combined timeout/cancellation signals, same-origin-only redirect handling, namespace-tolerant XML parsing, and centralized redaction; verify with a new `webdav-client.test.ts` using a local mock server for authentication, redirects, malformed/oversized responses, timeout, cancellation, status mapping, path encoding, and secret-free errors.
+- [x] Add a reusable configurable local WebDAV server fixture under `extensions/pi-sync/test/` that records requests and can emulate strong/weak/missing ETags, honored/ignored preconditions, permissions, redirects, delayed/interrupted bodies, malformed multistatus XML, and cleanup failures; verify the fixture itself with focused assertions that each mode produces the intended HTTP exchange and always closes its listener during teardown.
+- [x] Implement `extensions/pi-sync/src/webdav-backend.ts` against `SyncBackend`, retaining the shared pointer/history/snapshot codec, immutable bundle staging, backend-scoped opaque ETag revisions, atomic conditional publication, post-commit verification, bounded history updates, and typed conflict/outcome-unknown errors; register it in `backend-factory.ts` and verify it with the shared `backend-contract-suite.ts` plus new `webdav-backend-contract.test.ts` and `webdav-backend.test.ts` cases for fresh/existing publication, stale writers, snapshot identity/checksum validation, rollback-as-new-publication, history repair warnings, cancellation on both sides of commit, and fresh-instance revision reuse.
+- [x] Implement WebDAV capability and `doctor` probes in `webdav-backend.ts` using isolated conditional writes and reliable `finally` cleanup, with structured results for URL/TLS/auth, collection access, read/write, strong ETags, stale `If-Match`, existing-resource `If-None-Match`, and cleanup; verify supported servers report `atomic-conditional`, unsupported/ignored conditions reject publication before `latest.json` changes, and authentication/permission/missing-collection/precondition/cleanup failures remain actionable and redacted in `webdav-backend.test.ts` and `backend-orchestration.test.ts`.
+- [x] Audit `sync-operations.ts` and `sync.ts` for the dynamic WebDAV probe and commit lifecycle while keeping operation decisions backend-neutral; ensure automatic sync fails closed before any active-head write on unsupported servers, `--force` re-reads and retains `If-Match`, and session replacement/shutdown cancels pre-commit requests but not post-commit verification; verify with `backend-orchestration.test.ts`, `backend-lifecycle.test.ts`, and route coverage for `status`, `diff`, `push`, `pull`, `sync`, `history`, `rollback`, and `doctor` against a WebDAV target.
+- [x] Extract backend-specific setup and storage-profile management from `manager-ui.ts` into a cohesive module, then add WebDAV choices and fields to first-time setup, profile add/edit/remove, target add/edit/switch, Settings, Status, and Help without ever requesting an unmasked password; verify `manager-ui.ts` remains below 1,000 lines and `sync.test.ts`/`multi-profile.test.ts` cover WebDAV menu state, safe manual credential guidance, persistence rollback, target completion/switching, cancellation, narrow rendering, and print/JSON/RPC rejection or direct-route behavior.
+- [x] Update `extensions/pi-sync/README.md` and `package.json` to advertise R2/S3/WebDAV accurately, document the version 2 schema, generic and Nextcloud/Synology URL examples, local-only credential handling, TLS/auth and redirect rules, conditional-publication/read-only degradation, doctor probes/cleanup, unchanged wire model, session sensitivity, and package layout; verify documented commands and manifest metadata match implementation and `npm run pack:sync` includes only the declared source, README, and license plus the required runtime dependency metadata.
+- [x] Run the semantic lifecycle/settings audit required by `docs/extension-conventions.md` and `docs/extension-settings.md` across cancellation, disposal, session replacement, shutdown, settings ordering/failure recovery, malformed-file protection, unknown-field preservation, atomic private writes, and secret redaction; verify every applicable MUST has a named test/review/smoke result and record any accepted deviation directly in this plan before completion.
+
+## Completion Checklist
+
+- [x] The WebDAV backend passes the shared contract suite and local capability matrix, including stale conditional writes failing as typed conflicts without overwriting the current head.
+- [x] All existing manager/direct routes and automatic lifecycle paths work with a WebDAV target, while unsupported conditional servers remain read-only and visibly diagnosed.
+- [x] S3/R2 settings, environment compatibility, state paths, backend behavior, and regression tests remain unchanged.
+- [x] Authentication, permissions, missing collections, redirects, timeouts, malformed/oversized bodies, interrupted publication, and probe cleanup failures have deterministic redacted test coverage.
+- [x] `npm run check` passes from the repository root.
+- [x] `npm run pack:sync` passes and the dry-run contents/dependency metadata are inspected.
+- [x] The final handoff names the guides read, touched areas audited, checks/smokes run, and any accepted deviation or unverified external-vendor path.
+
+## Execution Evidence
+
+- Settings/backend integration: `webdav-config.test.ts` covers discriminated resolution, S3-only environment compatibility, mixed-field rejection, HTTPS policy, and backend-scoped state; the existing S3/R2 suites retained their state-path and behavior coverage.
+- Transport and capability safety: `webdav-client.test.ts` and `webdav-backend.test.ts` cover authentication, encoded paths, collection listing, redirects, body bounds, timeouts, cancellation, malformed XML, strong/weak/missing ETags, ignored preconditions, outcome-unknown publication, cleanup, and redaction.
+- Contract and routes: `webdav-backend-contract.test.ts` passes the shared backend contract; `webdav-routes.test.ts` exercises doctor, status, diff, push, pull, sync, history, and rollback against the local WebDAV server.
+- UI/settings: `webdav-ui.test.ts` covers first-time setup plus profile/target add and edit, hidden credentials, and unknown-field preservation. `manager-ui.ts` is 995 lines after extracting shared and WebDAV-specific responsibilities.
+- Lifecycle/settings audit: WebDAV requests use caller cancellation before the active-head boundary, an independent bounded post-commit signal afterward, bounded cleanup, and existing session replacement/shutdown orchestration. Settings continue through the existing serialized, locked, atomic `0600`, unknown-field-preserving protocol; WebDAV adds no environment-variable or project-secret path.
+- Verification: `npm run check` passed initially with 1,603 tests, Biome, boundary checks, and all workspace typechecks; the final post-review gate is recorded below. `npm run pack:sync -- --json` passed with 32 expected package entries and included the new source modules plus runtime dependency metadata. `npm audit --omit=dev --json` reported zero production vulnerabilities.
+- Accepted external verification limit: no live Nextcloud, ownCloud, or Synology account was used. The issue explicitly requires account-free tests; interoperability is represented by the configurable local HTTP/WebDAV protocol fixture and generic wire behavior, with vendor-specific setup documented for user validation.
+- Independent review follow-up: fixed every reported class—S3-only environment compatibility, bounded/control-free metadata, alias destination detection, ambiguous redirect rejection, per-publication capability revalidation, pre-save UI normalization, exact password-byte preservation, WebDAV-aware `/sync config`, and WebDAV lifecycle/commit-boundary coverage.
+- Final verification after review fixes: `npm run check` passed with 1,613 tests; `npm run pack:sync -- --json` was rerun and inspected.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -73,7 +73,7 @@ For a first Cloudflare R2 target, the recommended location requires no raw path 
 
 The R2 bucket must already exist; pi-sync never creates buckets. Generic S3 setup asks for one existing, potentially globally unique bucket and derives storage profile `s3`, prefix `pi-sync`, and namespace `home` or `work`. **Customize remote location** retains direct control over profile name, bucket, prefix, and namespace.
 
-Pi's extension input API does not provide masked secret entry, so pi-sync never asks for a secret in an unmasked dialog. Use existing S3 environment credentials or add credentials manually to the private settings file. WebDAV credentials are settings-file only; there are no WebDAV environment-variable mirrors. Secret values are never shown in menus, status, warnings, or errors.
+The setup wizard can store WebDAV passwords and S3-compatible static credentials entirely through the TUI. Its package-owned masked input renders only bullets, and secret values are never shown in reviews, menus, status, notifications, warnings, or errors. S3 environment credentials and a manual private-settings template remain available; WebDAV has no environment-variable credential mirrors.
 
 ### WebDAV setup
 
@@ -124,7 +124,7 @@ Its primary actions are:
 - **Switch target** — preview the target change, then follow the configured pull behavior
 - **Status & changes** — perform a cancellable read-only remote check
 - **Settings** — control post-switch pulling, automatic sync, and synced content
-- **More…** — open one shallow level containing target/storage management, history/recovery, Help, and Back
+- **More…** — open one shallow level containing destination management, history/recovery, Help, and Back
 
 The menu does not query remote storage merely to open. It shows the last locally applied snapshot and marks remote changes as unchecked until an operation runs. When no synced content is selected, transfer actions are hidden and Settings becomes the first action. During an active or recoverable lock, mutation actions remain unavailable.
 
@@ -195,6 +195,8 @@ A version 2 example:
 ```
 
 ### Terminology
+
+The TUI presents each profile/target pair as a **destination**. **Add destination** is the primary flow; reusable **saved connections** are available as an advanced action. The version 2 JSON names remain unchanged for compatibility.
 
 - An S3/R2 **storage profile** owns `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`; a WebDAV profile owns `kind: "webdav"`, `url`, `username`, and `password`.
 - An S3/R2 **sync target** owns `bucket`, `prefix`, and `namespace`; a WebDAV target owns `path` and `namespace`. Every target also owns `autoSync` and its synced-content policy.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -1,15 +1,16 @@
-# ☁️ pi-sync — R2/S3 Pi Settings Sync
+# ☁️ pi-sync — WebDAV/R2/S3 Pi Settings Sync
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-sync` syncs selected Pi configuration through Cloudflare R2 or other S3-compatible object storage. Named sync targets such as `home` and `work` can reuse storage profiles such as `r2` and `s3`.
+`@narumitw/pi-sync` syncs selected Pi configuration through WebDAV, Cloudflare R2, or other S3-compatible storage. Named sync targets such as `home` and `work` can reuse storage profiles such as `webdav`, `r2`, and `s3`.
 
-The extension uses immutable snapshot bundles, a `latest.json` publication pointer, local locking, secret scanning, pre-apply backups, and recoverable local apply transactions. Remote persistence is isolated behind a backend-neutral contract; normalized runtime config pairs a discriminated backend profile with its matching destination before factory selection, while the persisted settings shape remains compatible. S3/R2 remains the only production backend in this release. Conversation/session syncing remains opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets.
+The extension uses immutable snapshot bundles, a `latest.json` publication pointer, local locking, secret scanning, pre-apply backups, and recoverable local apply transactions. Remote persistence is isolated behind a backend-neutral contract; normalized runtime config pairs a discriminated backend profile with its matching destination before factory selection, while the persisted settings shape remains compatible. WebDAV and S3/R2 are production backends in this release. Conversation/session syncing remains opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets.
 
 ## ✨ Features
 
 - Opens a goal-oriented `/sync` manager showing the current target, storage, auto-sync, session scope, and relevant next actions.
-- Supports multiple named **sync targets** and reusable R2/S3 **storage profiles**.
+- Supports multiple named **sync targets** and reusable WebDAV/R2/S3 **storage profiles**.
+- Uses verified `ETag`, `If-Match`, and `If-None-Match` preconditions for atomic WebDAV publication and fails closed when a server ignores them.
 - Asks to review a pull after switching targets by default, with settings to start that review automatically or switch only.
 - Previews concrete local or remote file changes before push, pull, force resolution, or rollback.
 - Uses transactional synced-content drafts with explicit Save, Discard, and Continue editing choices.
@@ -51,7 +52,7 @@ Run the manager:
 
 When pi-sync is not configured, choose **Set up sync**. The TUI guides you through:
 
-1. Cloudflare R2 or another S3-compatible service
+1. WebDAV, Cloudflare R2, or another S3-compatible service
 2. `Personal / Home`, `Work`, or a custom target purpose
 3. an endpoint and, for S3, the existing bucket name
 4. a recommended remote location or advanced customization
@@ -72,7 +73,37 @@ For a first Cloudflare R2 target, the recommended location requires no raw path 
 
 The R2 bucket must already exist; pi-sync never creates buckets. Generic S3 setup asks for one existing, potentially globally unique bucket and derives storage profile `s3`, prefix `pi-sync`, and namespace `home` or `work`. **Customize remote location** retains direct control over profile name, bucket, prefix, and namespace.
 
-Pi's extension input API does not provide masked secret entry, so pi-sync never asks for a secret in an unmasked dialog. Use existing environment credentials or add credentials manually to the private settings file. Secret values are never shown in menus, status, warnings, or errors.
+Pi's extension input API does not provide masked secret entry, so pi-sync never asks for a secret in an unmasked dialog. Use existing S3 environment credentials or add credentials manually to the private settings file. WebDAV credentials are settings-file only; there are no WebDAV environment-variable mirrors. Secret values are never shown in menus, status, warnings, or errors.
+
+### WebDAV setup
+
+Generic WebDAV profiles use the authenticated collection URL, a username, and a password. Targets add a relative `path` and `namespace`:
+
+```json
+{
+  "profiles": {
+    "webdav": {
+      "kind": "webdav",
+      "url": "https://cloud.example.com/remote.php/dav/files/user",
+      "username": "user",
+      "password": "<app-password>"
+    }
+  },
+  "targets": {
+    "home": {
+      "profile": "webdav",
+      "path": "pi-sync",
+      "namespace": "home"
+    }
+  }
+}
+```
+
+- **Nextcloud/ownCloud:** use the user DAV collection, commonly `https://HOST/remote.php/dav/files/USERNAME`, and prefer an app password.
+- **Synology:** use the HTTPS WebDAV Server endpoint and user collection exposed by your DSM configuration. Confirm its exact path and certificate in a browser or WebDAV client first.
+- **Generic servers:** Basic authentication is supported over HTTPS. Plain HTTP is rejected except on loopback for local tests. URL-embedded credentials, query strings, fragments, and cross-origin authenticated redirects are rejected.
+
+Run `/sync doctor` after setup. It creates an unpredictable temporary probe, verifies collection listing/read/write/cleanup plus strong ETags and stale conditional writes, and removes the probe. A server without working strong `If-Match` and `If-None-Match` remains readable but publication is rejected before `latest.json` changes; pi-sync never silently degrades WebDAV automatic sync to an unsafe overwrite.
 
 A configured manager shows:
 
@@ -165,8 +196,8 @@ A version 2 example:
 
 ### Terminology
 
-- A **storage profile** owns connection/authentication fields: `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`.
-- A **sync target** references a storage profile and owns `bucket`, `prefix`, `namespace`, `autoSync`, and its synced-content policy.
+- An S3/R2 **storage profile** owns `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`; a WebDAV profile owns `kind: "webdav"`, `url`, `username`, and `password`.
+- An S3/R2 **sync target** owns `bucket`, `prefix`, and `namespace`; a WebDAV target owns `path` and `namespace`. Every target also owns `autoSync` and its synced-content policy.
 - `activeTarget` is used by bare commands and automatic sync.
 - `targetSwitchAction` controls what happens after a target switch: `ask` (default), `pull`, or `switch-only`.
 - `namespace` is the old flat `profile` concept. The remote layout and snapshot wire field remain named `profiles`/`profile` for compatibility.
@@ -292,6 +323,8 @@ Snapshot upload is staging; `latest.json` is the active publication boundary. pi
 
 Before pull/rollback, pi-sync writes a backup under `.pisync/backups/`. It then preflights all paths, stages a private transaction journal, applies changes, and restores every affected path if a later mutation fails. An interrupted journal is recovered before the next session/snapshot apply. Filesystem-wide replacement cannot be one OS primitive, so the guarantee is a complete previous or complete new accepted state after rollback/recovery—not an unrecoverable partial accepted state.
 
+WebDAV is conservatively reported as `conditional-required` until an isolated probe passes, then as `atomic-conditional`: each publication verifies the server's precondition behavior, stages the immutable bundle with `If-None-Match: *`, and changes `latest.json` with `If-Match` or `If-None-Match: *`. Unsupported servers remain read-only and are reported by doctor.
+
 R2/S3 is explicitly reported as `read-check-write-verify`, not atomic compare-and-swap. pi-sync re-reads `latest.json` immediately before publication and verifies afterward, but simultaneous writers can still race. `--force` accepts a reviewed content conflict, re-reads the head, and never disables the backend revision check; it is not an unconditional overwrite. Review status before important forced updates.
 
 ## 🔒 Session syncing
@@ -306,7 +339,7 @@ Sessions can contain prompts, model output, tool results, file paths, images, an
 
 - Credentials stay local; canonical, legacy, temporary, and migration-recovery settings files are always excluded from snapshots.
 - Push refuses common secret patterns in locally managed files.
-- Pull/rollback reject unsafe paths, duplicate paths, checksum mismatches, symlink parents, and file/directory replacement hazards before mutation. Remote JSON responses are limited to 1 MiB, error bodies to 64 KiB, compressed snapshot downloads to 256 MiB, and decompressed snapshot bundles to 512 MiB.
+- Pull/rollback reject unsafe paths, duplicate paths, checksum mismatches, symlink parents, and file/directory replacement hazards before mutation. Remote JSON and WebDAV XML responses are limited to 1 MiB, error bodies to 64 KiB, compressed snapshot downloads to 256 MiB, and decompressed snapshot bundles to 512 MiB.
 - Unmanaged local/remote files remain preserved.
 - A live local lock disables destructive work. Stale/unreadable lock recovery retains process-liveness and guard checks.
 - Force operations remain explicit direct/conflict-recovery actions and retain exact confirmations.
@@ -335,6 +368,9 @@ extensions/pi-sync/
 │   ├── backend-factory.ts       # Backend selection from normalized settings
 │   ├── s3-backend.ts            # S3/R2 persistence, publication, history, and diagnostics
 │   ├── s3-client.ts             # Bounded, signed S3 transport
+│   ├── webdav-backend.ts        # Conditional WebDAV publication and diagnostics
+│   ├── webdav-client.ts         # Bounded authenticated WebDAV transport
+│   ├── webdav-ui.ts             # WebDAV setup and profile/target management
 │   ├── snapshot-codec.ts        # Shared immutable snapshot bundle codec
 │   ├── manager-ui.ts            # Goal-oriented menus and setup/management flows
 │   ├── file-selection.ts        # Transactional synced-content editor
@@ -353,7 +389,7 @@ extensions/pi-sync/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, settings sync, Cloudflare R2, S3-compatible storage, multi-profile sync, sync targets, snapshot sync, dotfiles sync.
+Pi extension, Pi coding agent, settings sync, WebDAV, Nextcloud, ownCloud, Synology, Cloudflare R2, S3-compatible storage, multi-profile sync, sync targets, snapshot sync, dotfiles sync.
 
 ## 📄 License
 

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-sync",
 	"version": "0.33.0",
-	"description": "Pi extension that syncs Pi configuration through Cloudflare R2 or S3-compatible storage.",
+	"description": "Pi extension that syncs Pi configuration through WebDAV, Cloudflare R2, or S3-compatible storage.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -11,7 +11,10 @@
 		"pi",
 		"sync",
 		"r2",
-		"s3"
+		"s3",
+		"webdav",
+		"nextcloud",
+		"synology"
 	],
 	"files": [
 		"src",
@@ -29,6 +32,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"fast-xml-parser": "^5.10.1",
 		"proper-lockfile": "^4.1.2"
 	},
 	"devDependencies": {

--- a/extensions/pi-sync/src/backend-factory.ts
+++ b/extensions/pi-sync/src/backend-factory.ts
@@ -1,12 +1,17 @@
 import { S3SyncBackend } from "./s3-backend.js";
 import type { SyncBackend } from "./sync-backend.js";
-import type { SyncConfig } from "./types.js";
+import type { AnySyncConfig } from "./types.js";
+import { WebDavSyncBackend } from "./webdav-backend.js";
 
-export type SyncBackendFactory = (config: SyncConfig) => SyncBackend;
+export type SyncBackendFactory = {
+	bivarianceHack(config: AnySyncConfig): SyncBackend;
+}["bivarianceHack"];
 
 export const createSyncBackend: SyncBackendFactory = (config) => {
 	switch (config.backend.type) {
 		case "s3":
 			return new S3SyncBackend(config.backend);
+		case "webdav":
+			return new WebDavSyncBackend(config.backend);
 	}
 };

--- a/extensions/pi-sync/src/config-file.ts
+++ b/extensions/pi-sync/src/config-file.ts
@@ -114,6 +114,17 @@ export function consumeLocalConfigMigrationNotice() {
 	return notice;
 }
 
+export async function readActiveLocalConfigDocumentForRepair(): Promise<
+	LocalConfigDocument | undefined
+> {
+	return withLocalConfigFileLock(async () => {
+		const canonicalPath = localConfigPath();
+		const filePath = (await pathExists(canonicalPath)) ? canonicalPath : legacyLocalConfigPath();
+		const snapshot = await readConfigSnapshotIfExists(filePath);
+		return snapshot ? { path: filePath, ...snapshot } : undefined;
+	});
+}
+
 export async function readMigratingLocalConfigDocument(
 	validateForMigration: (settings: Record<string, unknown>) => void,
 ): Promise<LocalConfigDocument | undefined> {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -364,6 +364,7 @@ export function effectiveTargetRemoteIdentity(
 		return JSON.stringify([
 			"webdav",
 			normalizeWebDavIdentityUrl(typeof profile?.url === "string" ? profile.url : profileName),
+			typeof profile?.username === "string" ? profile.username.trim() : "",
 			normalizeRemoteKeySegment(typeof target.path === "string" ? target.path : DEFAULT_PREFIX),
 			normalizeRemoteKeySegment(typeof target.namespace === "string" ? target.namespace : name),
 		]);

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -13,6 +13,7 @@ import {
 	legacyLocalConfigPath,
 	localConfigPath,
 	quarantineAndRemoveConfigIfMatches,
+	readActiveLocalConfigDocumentForRepair,
 	readMigratingLocalConfigDocument,
 	replaceLocalConfigDocument,
 	withLocalConfigFileLock,
@@ -42,6 +43,7 @@ export {
 	legacyLocalConfigPath,
 	localConfigPath,
 	quarantineAndRemoveConfigIfMatches,
+	readActiveLocalConfigDocumentForRepair,
 	replaceLocalConfigDocument,
 };
 

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -533,6 +533,7 @@ export function statePathForConfig(config: AnySyncConfig) {
 			: JSON.stringify([
 					target,
 					normalizeEndpointIdentity(config.backend.profile.url),
+					config.backend.profile.username,
 					normalizeRemoteKeySegment(config.backend.destination.path),
 					normalizeRemoteKeySegment(config.profile),
 				]);
@@ -550,7 +551,10 @@ export function statePathForPartialConfig(partial: PartialConfig) {
 			profile,
 			backend: {
 				type: "webdav",
-				profile: { url: normalizeConfiguredString(partial.url) ?? "" },
+				profile: {
+					url: normalizeConfiguredString(partial.url) ?? "",
+					username: normalizeConfiguredString(partial.username) ?? "",
+				},
 				destination: {
 					path: normalizeWebDavPath(partial.path),
 					namespace: profile,

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -20,9 +20,10 @@ import {
 import { safeName } from "./paths.js";
 import { DEFAULT_SYNC_FILES, normalizeExtraFiles, normalizeSyncFiles } from "./sync-policy.js";
 import type {
+	AnySyncConfig,
 	PartialConfig,
 	Snapshot,
-	SyncConfig,
+	StorageProfileKind,
 	SyncState,
 	TargetSwitchAction,
 } from "./types.js";
@@ -82,8 +83,48 @@ function sessionDirFromContext(ctx: ExtensionCommandContext | ExtensionContext) 
 		: undefined;
 }
 
-export async function loadConfigInternal(targetName?: string): Promise<SyncConfig> {
+export async function loadConfigInternal(targetName?: string): Promise<AnySyncConfig> {
 	const partial = await loadPartialConfig(targetName);
+	const namespace = normalizeOptionalString(partial.profile) ?? DEFAULT_PROFILE;
+	const common = {
+		profile: namespace,
+		target: partial.target ?? DEFAULT_PROFILE,
+		storageProfile: partial.storageProfile ?? DEFAULT_PROFILE,
+		autoSync: isEnabled(partial.autoSync, true),
+		settingsVersion: partial.settingsVersion ?? 1,
+		syncFiles: normalizeSyncFiles(partial.syncFiles),
+		syncSessions: isExplicitlyEnabled(partial.syncSessions),
+		extraFiles: normalizeExtraFiles(partial.extraFiles),
+	};
+	if (partial.storageKind === "webdav") {
+		validateWebDavNamespace(namespace);
+		const url = normalizeWebDavUrl(partial.url);
+		const username = normalizeConfiguredString(partial.username);
+		const password = normalizeConfiguredSecret(partial.password);
+		const remotePath = normalizeWebDavPath(partial.path);
+		const missing = [
+			["url", url],
+			["username", username],
+			["password", password],
+		]
+			.filter(([, value]) => !value)
+			.map(([name]) => name);
+		if (missing.length > 0 || !url || !username || !password) {
+			throw new Error(
+				`Missing pi-sync WebDAV config: ${missing.join(", ")}. Use /sync setup or edit ${localConfigPath()}.`,
+			);
+		}
+		validateWebDavCredentials(username, password);
+		return {
+			...common,
+			backend: {
+				type: "webdav",
+				profile: { kind: "webdav", url, username, password },
+				destination: { path: remotePath, namespace },
+			},
+		};
+	}
+
 	const endpoint = normalizeConfiguredString(partial.endpoint);
 	const bucket = normalizeConfiguredString(partial.bucket);
 	const accessKeyId = normalizeConfiguredString(partial.accessKeyId);
@@ -96,18 +137,14 @@ export async function loadConfigInternal(targetName?: string): Promise<SyncConfi
 	]
 		.filter(([, value]) => !value)
 		.map(([name]) => name);
-	if (missing.length > 0) {
+	if (missing.length > 0 || !endpoint || !bucket || !accessKeyId || !secretAccessKey) {
 		throw new Error(
 			`Missing pi-sync config: ${missing.join(", ")}. Use /sync setup or edit ${localConfigPath()}.`,
 		);
 	}
-	if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
-		throw new Error("Missing pi-sync config after validation.");
-	}
-
-	const namespace = normalizeOptionalString(partial.profile) ?? DEFAULT_PROFILE;
 	const prefix = trimSlashes(normalizeOptionalString(partial.prefix) ?? DEFAULT_PREFIX);
 	return {
+		...common,
 		backend: {
 			type: "s3",
 			profile: {
@@ -120,18 +157,10 @@ export async function loadConfigInternal(targetName?: string): Promise<SyncConfi
 			},
 			destination: { bucket, prefix, namespace },
 		},
-		profile: namespace,
-		target: partial.target ?? DEFAULT_PROFILE,
-		storageProfile: partial.storageProfile ?? DEFAULT_PROFILE,
-		autoSync: isEnabled(partial.autoSync, true),
-		settingsVersion: partial.settingsVersion ?? 1,
-		syncFiles: normalizeSyncFiles(partial.syncFiles),
-		syncSessions: isExplicitlyEnabled(partial.syncSessions),
-		extraFiles: normalizeExtraFiles(partial.extraFiles),
 	};
 }
 
-export async function loadConfig(targetName?: string): Promise<SyncConfig> {
+export async function loadConfig(targetName?: string): Promise<AnySyncConfig> {
 	return loadConfigInternal(targetName);
 }
 
@@ -209,7 +238,7 @@ export function resolveV2PartialConfig(
 	normalizeTargetSwitchAction(settings.targetSwitchAction);
 	const targets = requireNamedObjectMap(settings.targets, "targets");
 	const profiles = requireNamedObjectMap(settings.profiles, "profiles");
-	validateUniqueRemoteTargets(targets);
+	validateUniqueRemoteTargets(targets, profiles);
 	const selectedTarget =
 		targetName ?? normalizeOptionalString(asOptionalString(settings.activeTarget));
 	if (!selectedTarget) throw new Error("Invalid pi-sync settings: activeTarget is required.");
@@ -229,16 +258,47 @@ export function resolveV2PartialConfig(
 		);
 	}
 	const kind = asOptionalString(profile.kind);
-	if (kind !== undefined && kind !== "r2" && kind !== "s3-compatible") {
+	if (kind !== undefined && kind !== "r2" && kind !== "s3-compatible" && kind !== "webdav") {
 		throw new Error(
 			`Invalid pi-sync settings: profile "${storageProfile}" has unsupported kind "${kind}".`,
 		);
 	}
-	return {
+	const common = {
 		target: selectedTarget,
 		storageProfile,
-		storageKind: kind,
-		settingsVersion: 2,
+		storageKind: kind as StorageProfileKind | undefined,
+		settingsVersion: 2 as const,
+		syncFiles: target.syncFiles,
+		extraFiles: target.extraFiles,
+	};
+	if (kind === "webdav") {
+		if (
+			["endpoint", "region", "accessKeyId", "secretAccessKey", "sessionToken"].some((field) =>
+				Object.hasOwn(profile, field),
+			) ||
+			["bucket", "prefix"].some((field) => Object.hasOwn(target, field))
+		) {
+			throw new Error("Invalid pi-sync settings: WebDAV profile or target mixes backend fields.");
+		}
+		return {
+			...common,
+			url: asOptionalString(profile.url),
+			username: asOptionalString(profile.username),
+			password: asOptionalString(profile.password),
+			path: asOptionalString(target.path),
+			profile: asOptionalString(target.namespace) ?? selectedTarget,
+			autoSync: asOptionalBoolean(target.autoSync),
+			syncSessions: asOptionalBoolean(target.syncSessions),
+		};
+	}
+	if (
+		["url", "username", "password"].some((field) => Object.hasOwn(profile, field)) ||
+		Object.hasOwn(target, "path")
+	) {
+		throw new Error("Invalid pi-sync settings: S3 profile or target mixes backend fields.");
+	}
+	return {
+		...common,
 		endpoint:
 			process.env.PI_SYNC_ENDPOINT ?? process.env.R2_ENDPOINT ?? asOptionalString(profile.endpoint),
 		bucket: process.env.PI_SYNC_BUCKET ?? process.env.R2_BUCKET ?? asOptionalString(target.bucket),
@@ -256,9 +316,7 @@ export function resolveV2PartialConfig(
 		profile: process.env.PI_SYNC_PROFILE ?? asOptionalString(target.namespace) ?? selectedTarget,
 		prefix: process.env.PI_SYNC_PREFIX ?? asOptionalString(target.prefix),
 		autoSync: process.env.PI_SYNC_AUTO_SYNC ?? asOptionalBoolean(target.autoSync),
-		syncFiles: target.syncFiles,
 		syncSessions: process.env.PI_SYNC_SESSIONS ?? asOptionalBoolean(target.syncSessions),
-		extraFiles: target.extraFiles,
 	};
 }
 
@@ -274,13 +332,16 @@ function isV2SettingsObject(value: Record<string, unknown>) {
 	return true;
 }
 
-export function validateUniqueRemoteTargets(targets: Record<string, unknown>) {
+export function validateUniqueRemoteTargets(
+	targets: Record<string, unknown>,
+	profiles?: Record<string, unknown>,
+) {
 	const identities = new Map<string, string>();
 	for (const name of Object.keys(targets)) {
 		const target = ownObject(targets, name);
-		if (!target || typeof target.profile !== "string" || typeof target.bucket !== "string")
-			continue;
-		const identity = effectiveTargetRemoteIdentity(target, name);
+		if (!target || typeof target.profile !== "string") continue;
+		const profile = profiles ? ownObject(profiles, target.profile) : undefined;
+		const identity = effectiveTargetRemoteIdentity(target, name, profile);
 		const existing = identities.get(identity);
 		if (existing) {
 			throw new Error(
@@ -291,8 +352,20 @@ export function validateUniqueRemoteTargets(targets: Record<string, unknown>) {
 	}
 }
 
-export function effectiveTargetRemoteIdentity(target: Record<string, unknown>, name: string) {
+export function effectiveTargetRemoteIdentity(
+	target: Record<string, unknown>,
+	name: string,
+	profile?: Record<string, unknown>,
+) {
 	const profileName = typeof target.profile === "string" ? target.profile.trim() : "";
+	if (profile?.kind === "webdav" || Object.hasOwn(target, "path")) {
+		return JSON.stringify([
+			"webdav",
+			normalizeWebDavIdentityUrl(typeof profile?.url === "string" ? profile.url : profileName),
+			normalizeRemoteKeySegment(typeof target.path === "string" ? target.path : DEFAULT_PREFIX),
+			normalizeRemoteKeySegment(typeof target.namespace === "string" ? target.namespace : name),
+		]);
+	}
 	const bucket = normalizeRemoteKeySegment(
 		process.env.PI_SYNC_BUCKET ??
 			process.env.R2_BUCKET ??
@@ -306,6 +379,20 @@ export function effectiveTargetRemoteIdentity(target: Record<string, unknown>, n
 		process.env.PI_SYNC_PROFILE ?? (typeof target.namespace === "string" ? target.namespace : name),
 	);
 	return JSON.stringify([profileName, bucket, prefix, namespace]);
+}
+
+function normalizeWebDavIdentityUrl(value: string) {
+	try {
+		const url = new URL(value.trim());
+		url.username = "";
+		url.password = "";
+		url.search = "";
+		url.hash = "";
+		url.pathname = `${url.pathname.replace(/\/+$/u, "")}/`;
+		return url.toString();
+	} catch {
+		return value.trim();
+	}
 }
 
 function normalizeRemoteKeySegment(value: string) {
@@ -411,7 +498,7 @@ export async function writeState(profile: string, state: SyncState) {
 	await writeJson(statePath(profile), state);
 }
 
-export async function readStateForConfig(config: SyncConfig): Promise<SyncState> {
+export async function readStateForConfig(config: AnySyncConfig): Promise<SyncState> {
 	if (config.settingsVersion !== 2) return readState(config.profile);
 	const destination = statePathForConfig(config);
 	const state = await readJsonIfExists<SyncState>(destination);
@@ -425,20 +512,28 @@ export async function readStateForConfig(config: SyncConfig): Promise<SyncState>
 	);
 }
 
-export async function writeStateForConfig(config: SyncConfig, state: SyncState) {
+export async function writeStateForConfig(config: AnySyncConfig, state: SyncState) {
 	await writeJson(statePathForConfig(config), state);
 }
 
-export function statePathForConfig(config: SyncConfig) {
+export function statePathForConfig(config: AnySyncConfig) {
 	if (config.settingsVersion !== 2) return statePath(config.profile);
 	const target = config.target ?? DEFAULT_PROFILE;
-	const identity = JSON.stringify([
-		target,
-		normalizeEndpointIdentity(config.backend.profile.endpoint),
-		normalizeRemoteKeySegment(config.backend.destination.bucket),
-		normalizeRemoteKeySegment(config.backend.destination.prefix),
-		normalizeRemoteKeySegment(config.profile),
-	]);
+	const identity =
+		config.backend.type === "s3"
+			? JSON.stringify([
+					target,
+					normalizeEndpointIdentity(config.backend.profile.endpoint),
+					normalizeRemoteKeySegment(config.backend.destination.bucket),
+					normalizeRemoteKeySegment(config.backend.destination.prefix),
+					normalizeRemoteKeySegment(config.profile),
+				])
+			: JSON.stringify([
+					target,
+					normalizeEndpointIdentity(config.backend.profile.url),
+					normalizeRemoteKeySegment(config.backend.destination.path),
+					normalizeRemoteKeySegment(config.profile),
+				]);
 	const hash = createHash("sha256").update(identity).digest("hex").slice(0, 10);
 	return path.join(stateDir(), "targets", `${safeName(target)}-${hash}.state.json`);
 }
@@ -446,25 +541,38 @@ export function statePathForConfig(config: SyncConfig) {
 export function statePathForPartialConfig(partial: PartialConfig) {
 	const profile = normalizeOptionalString(partial.profile) ?? DEFAULT_PROFILE;
 	if (partial.settingsVersion !== 2) return statePath(profile);
+	if (partial.storageKind === "webdav") {
+		return statePathForConfig({
+			settingsVersion: 2,
+			target: partial.target ?? DEFAULT_PROFILE,
+			profile,
+			backend: {
+				type: "webdav",
+				profile: { url: normalizeConfiguredString(partial.url) ?? "" },
+				destination: {
+					path: normalizeWebDavPath(partial.path),
+					namespace: profile,
+				},
+			},
+		} as AnySyncConfig);
+	}
 	return statePathForConfig({
 		settingsVersion: 2,
 		target: partial.target ?? DEFAULT_PROFILE,
 		profile,
 		backend: {
 			type: "s3",
-			profile: {
-				endpoint: normalizeConfiguredString(partial.endpoint) ?? "",
-			},
+			profile: { endpoint: normalizeConfiguredString(partial.endpoint) ?? "" },
 			destination: {
 				bucket: normalizeConfiguredString(partial.bucket) ?? "",
 				prefix: trimSlashes(normalizeOptionalString(partial.prefix) ?? DEFAULT_PREFIX),
 				namespace: profile,
 			},
 		},
-	} as SyncConfig);
+	} as AnySyncConfig);
 }
 
-async function migrateLegacyV2State(config: SyncConfig, destination: string) {
+async function migrateLegacyV2State(config: AnySyncConfig, destination: string) {
 	const target = config.target ?? DEFAULT_PROFILE;
 	const legacyHash = createHash("sha256").update(target).digest("hex").slice(0, 10);
 	const legacyPath = path.join(
@@ -589,26 +697,29 @@ function validateConfigDocumentForMigration(settings: Record<string, unknown>) {
 	normalizeTargetSwitchAction(settings.targetSwitchAction);
 	const profiles = requireNamedObjectMap(settings.profiles, "profiles");
 	const targets = requireNamedObjectMap(settings.targets, "targets");
-	validateUniqueRemoteTargets(targets);
+	validateUniqueRemoteTargets(targets, profiles);
 	for (const [name, value] of Object.entries(profiles)) {
 		const profile = ownObject(profiles, name);
 		if (!profile || value !== profile) {
 			throw new Error(`Invalid pi-sync settings: storage profile "${name}" must be an object.`);
 		}
 		const kind = asOptionalString(profile.kind);
-		if (kind !== undefined && kind !== "r2" && kind !== "s3-compatible") {
+		if (kind !== undefined && kind !== "r2" && kind !== "s3-compatible" && kind !== "webdav") {
 			throw new Error(
 				`Invalid pi-sync settings: profile "${name}" has unsupported kind "${kind}".`,
 			);
 		}
-		for (const field of [
-			"endpoint",
-			"region",
-			"accessKeyId",
-			"secretAccessKey",
-			"sessionToken",
-		] as const) {
-			asOptionalString(profile[field]);
+		const fields =
+			kind === "webdav"
+				? (["url", "username", "password"] as const)
+				: (["endpoint", "region", "accessKeyId", "secretAccessKey", "sessionToken"] as const);
+		for (const field of fields) asOptionalString(profile[field]);
+		const incompatible =
+			kind === "webdav"
+				? ["endpoint", "region", "accessKeyId", "secretAccessKey", "sessionToken"]
+				: ["url", "username", "password"];
+		if (incompatible.some((field) => Object.hasOwn(profile, field))) {
+			throw new Error(`Invalid pi-sync settings: profile "${name}" mixes backend fields.`);
 		}
 	}
 	for (const [name, value] of Object.entries(targets)) {
@@ -620,8 +731,16 @@ function validateConfigDocumentForMigration(settings: Record<string, unknown>) {
 		if (!profileName || !Object.hasOwn(profiles, profileName)) {
 			throw new Error(`Invalid pi-sync settings: target "${name}" references a missing profile.`);
 		}
-		for (const field of ["bucket", "prefix", "namespace"] as const) {
+		const linkedProfile = ownObject(profiles, profileName);
+		const webdav = linkedProfile?.kind === "webdav";
+		for (const field of webdav
+			? (["path", "namespace"] as const)
+			: (["bucket", "prefix", "namespace"] as const)) {
 			asOptionalString(target[field]);
+		}
+		const incompatible = webdav ? ["bucket", "prefix"] : ["path"];
+		if (incompatible.some((field) => Object.hasOwn(target, field))) {
+			throw new Error(`Invalid pi-sync settings: target "${name}" mixes backend fields.`);
 		}
 		asOptionalBoolean(target.autoSync);
 		asOptionalBoolean(target.syncSessions);
@@ -760,6 +879,74 @@ export function isCloudflareR2Endpoint(endpoint: string | undefined) {
 	}
 }
 
+export function normalizeWebDavUrl(value: string | undefined) {
+	const normalized = normalizeConfiguredString(value);
+	if (!normalized) return undefined;
+	let url: URL;
+	try {
+		url = new URL(normalized);
+	} catch {
+		throw new Error("Invalid pi-sync WebDAV URL.");
+	}
+	if (url.username || url.password || url.search || url.hash) {
+		throw new Error(
+			"Invalid pi-sync WebDAV URL: credentials, query, and fragment are not allowed.",
+		);
+	}
+	const loopback =
+		url.hostname === "127.0.0.1" ||
+		url.hostname === "localhost" ||
+		url.hostname === "[::1]" ||
+		url.hostname === "::1";
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+		throw new Error("Invalid pi-sync WebDAV URL: HTTPS is required except for loopback.");
+	}
+	url.pathname = `${url.pathname.replace(/\/+$/u, "")}/`;
+	return url.toString();
+}
+
+export function normalizeWebDavPath(value: string | undefined) {
+	const normalized = trimSlashes(normalizeOptionalString(value) ?? DEFAULT_PREFIX);
+	if (
+		!normalized ||
+		normalized.includes("\\") ||
+		hasControlCharacter(normalized) ||
+		normalized.split("/").some((segment) => !segment || segment === "." || segment === "..")
+	) {
+		throw new Error("Invalid pi-sync WebDAV path.");
+	}
+	return normalized;
+}
+
+export function validateWebDavNamespace(value: string) {
+	if (
+		value === "." ||
+		value === ".." ||
+		value.includes("/") ||
+		value.includes("\\") ||
+		hasControlCharacter(value)
+	) {
+		throw new Error("Invalid pi-sync WebDAV namespace.");
+	}
+}
+
+export function validateWebDavCredentials(username: string, password?: string) {
+	if (
+		username.includes(":") ||
+		hasControlCharacter(username) ||
+		(password !== undefined && hasControlCharacter(password))
+	) {
+		throw new Error("Invalid pi-sync WebDAV credentials.");
+	}
+}
+
+function hasControlCharacter(value: string) {
+	return [...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+	});
+}
+
 function normalizeOptionalString(value: string | undefined) {
 	const normalized = value?.trim();
 	return normalized ? normalized : undefined;
@@ -770,6 +957,11 @@ function normalizeConfiguredString(value: string | undefined) {
 	return normalized && !/^<[^>]+>$/u.test(normalized) && !normalized.includes("<account-id>")
 		? normalized
 		: undefined;
+}
+
+function normalizeConfiguredSecret(value: string | undefined) {
+	if (!value?.trim() || /^<[^>]+>$/u.test(value.trim())) return undefined;
+	return value;
 }
 
 function hasEnv(name: string) {
@@ -788,5 +980,9 @@ export function isExplicitlyEnabled(value: boolean | string | undefined) {
 }
 
 export function isMissingConfigError(error: unknown) {
-	return error instanceof Error && error.message.startsWith("Missing pi-sync config:");
+	return (
+		error instanceof Error &&
+		(error.message.startsWith("Missing pi-sync config:") ||
+			error.message.startsWith("Missing pi-sync WebDAV config:"))
+	);
 }

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -579,6 +579,7 @@ export function statePathForPartialConfig(partial: PartialConfig) {
 }
 
 async function migrateLegacyV2State(config: AnySyncConfig, destination: string) {
+	if (config.backend.type !== "s3") return readJsonIfExists<SyncState>(destination);
 	const target = config.target ?? DEFAULT_PROFILE;
 	const legacyHash = createHash("sha256").update(target).digest("hex").slice(0, 10);
 	const legacyPath = path.join(

--- a/extensions/pi-sync/src/manager-helpers.ts
+++ b/extensions/pi-sync/src/manager-helpers.ts
@@ -1,0 +1,53 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { isCloudflareR2Endpoint } from "./config.js";
+
+export function formatRemotePath(prefix: string, namespace: string) {
+	return safeTerminalText(`${prefix}/profiles/${namespace}/`);
+}
+
+export async function requiredExistingBucket(ctx: ExtensionCommandContext, example: string) {
+	const value = await ctx.ui.input("Existing bucket", `Example: ${example}`);
+	if (value === undefined) return undefined;
+	const normalized = value.trim();
+	if (!normalized) {
+		ctx.ui.notify("Enter the name of an existing R2/S3 bucket, or cancel setup.", "warning");
+		return undefined;
+	}
+	return normalized;
+}
+
+export async function requiredInput(
+	ctx: ExtensionCommandContext,
+	title: string,
+	placeholder: string,
+) {
+	const value = await ctx.ui.input(title, placeholder);
+	if (value === undefined) return undefined;
+	const normalized = value.trim() || placeholder;
+	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
+}
+
+export function storageDescription(
+	kind: string | undefined,
+	endpoint: string | undefined,
+	bucket: string | undefined,
+) {
+	const label =
+		kind === "r2" || isCloudflareR2Endpoint(endpoint) ? "Cloudflare R2" : "S3-compatible";
+	return `${label} · ${safeTerminalText(bucket ?? "bucket missing")}`;
+}
+
+export function ownRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+export function safeTerminalText(value: string) {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "?");
+}
+
+export function errorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -67,14 +67,17 @@ type RunRoute = (
 export async function showSyncManager(
 	ctx: ExtensionCommandContext,
 	runRoute: RunRoute,
+	sessionSignal?: AbortSignal,
 ): Promise<void> {
 	if (!ctx.hasUI) {
 		await runRoute("help");
 		return;
 	}
 	while (true) {
-		const state = await describeManagerState();
-		const selected = await ctx.ui.select(state.title, state.actions);
+		const state = await describeManagerState(sessionSignal);
+		if (sessionSignal?.aborted) return;
+		const selected = await ctx.ui.select(state.title, state.actions, { signal: sessionSignal });
+		if (sessionSignal?.aborted) return;
 		if (!selected) return;
 		switch (
 			selected as
@@ -122,13 +125,13 @@ export async function showSyncManager(
 				await showSyncSettings(ctx, runRoute);
 				break;
 			case "More…":
-				if ((await showMoreMenu(ctx, runRoute)) === "exit") return;
+				if ((await showMoreMenu(ctx, runRoute, sessionSignal)) === "exit") return;
 				break;
 			case "Manage destinations":
-				await showManageMenu(ctx, runRoute);
+				await showManageMenu(ctx, runRoute, sessionSignal);
 				break;
 			case "Repair WebDAV destination":
-				await showRepairableWebDavDestination(ctx);
+				await showRepairableWebDavDestination(ctx, sessionSignal);
 				break;
 			case "History & recovery":
 				await showRecoveryMenu(ctx, runRoute);
@@ -144,10 +147,14 @@ export async function showSyncManager(
 	}
 }
 
-async function showMoreMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
-	const selected = await ctx.ui.select("More options", [...MORE_MENU_ACTIONS]);
+async function showMoreMenu(
+	ctx: ExtensionCommandContext,
+	runRoute: RunRoute,
+	signal?: AbortSignal,
+) {
+	const selected = await ctx.ui.select("More options", [...MORE_MENU_ACTIONS], { signal });
 	if (!selected || selected === BACK) return;
-	if (selected === "Manage destinations") await showManageMenu(ctx, runRoute);
+	if (selected === "Manage destinations") await showManageMenu(ctx, runRoute, signal);
 	else if (selected === "History & recovery") await showRecoveryMenu(ctx, runRoute);
 	else {
 		await runRoute("help");
@@ -210,12 +217,14 @@ async function runCancellableOperation(
 	return routeResult;
 }
 
-async function describeManagerState(): Promise<{ title: string; actions: string[] }> {
+async function describeManagerState(
+	signal?: AbortSignal,
+): Promise<{ title: string; actions: string[] }> {
 	let raw: Record<string, unknown> | undefined;
 	try {
 		raw = await readLocalConfigObject();
 	} catch (error) {
-		const repairableWebDav = await repairableWebDavDestinationName().catch(() => undefined);
+		const repairableWebDav = await repairableWebDavDestinationName(signal).catch(() => undefined);
 		return {
 			title: [
 				"Pi Sync",
@@ -334,18 +343,17 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 	}
 }
 
-export async function showSetupWizard(ctx: ExtensionCommandContext) {
+export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	if (ctx.mode !== "tui") return false;
-	const preset = await ctx.ui.select("Set up sync\n\nWhere will Pi settings be stored?", [
-		"Cloudflare R2",
-		"Other S3-compatible storage",
-		"WebDAV",
-		"Cancel",
-	]);
-	if (!preset || preset === "Cancel") return false;
+	const preset = await ctx.ui.select(
+		"Set up sync\n\nWhere will Pi settings be stored?",
+		["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Cancel"],
+		{ signal },
+	);
+	if (signal?.aborted || !preset || preset === "Cancel") return false;
 	const targetName = await chooseInitialTargetName(ctx);
 	if (!targetName) return false;
-	if (preset === "WebDAV") return showWebDavSetup(ctx, targetName);
+	if (preset === "WebDAV") return showWebDavSetup(ctx, targetName, signal);
 	const endpoint = await requiredInput(
 		ctx,
 		preset === "Cloudflare R2" ? "Cloudflare R2 endpoint" : "S3-compatible endpoint",
@@ -538,22 +546,30 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 	return result.pullApplied ? "pull-attempted" : "switched";
 }
 
-async function showManageMenu(ctx: ExtensionCommandContext, _runRoute: RunRoute) {
-	const selected = await ctx.ui.select("Manage destinations", [
-		"Add destination",
-		"Edit current destination",
-		"Saved connections…",
-		"Remove destination",
-		BACK,
-	]);
+async function showManageMenu(
+	ctx: ExtensionCommandContext,
+	_runRoute: RunRoute,
+	signal?: AbortSignal,
+) {
+	const selected = await ctx.ui.select(
+		"Manage destinations",
+		[
+			"Add destination",
+			"Edit current destination",
+			"Saved connections…",
+			"Remove destination",
+			BACK,
+		],
+		{ signal },
+	);
 	if (!selected || selected === BACK) return;
-	if (selected === "Add destination") await showAddTarget(ctx);
-	else if (selected === "Edit current destination") await showEditCurrentTarget(ctx);
-	else if (selected === "Saved connections…") await showStorageConnections(ctx);
+	if (selected === "Add destination") await showAddTarget(ctx, signal);
+	else if (selected === "Edit current destination") await showEditCurrentTarget(ctx, signal);
+	else if (selected === "Saved connections…") await showStorageConnections(ctx, signal);
 	else await showRemoveTarget(ctx);
 }
 
-async function showAddTarget(ctx: ExtensionCommandContext) {
+async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	let raw = await readLocalConfigObject();
 	if (!raw)
 		return void ctx.ui.notify("Set up the first sync target before adding another.", "info");
@@ -591,14 +607,14 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 	if (!profile || profile === "Cancel") return;
 	if (profile === createConnection) {
 		const previousNames = new Set(Object.keys(profiles));
-		if (!(await showAddStorageConnection(ctx))) return;
+		if (!(await showAddStorageConnection(ctx, signal))) return;
 		raw = (await readLocalConfigObject()) ?? raw;
 		profiles = ownRecord(raw.profiles) ?? {};
 		profile = Object.keys(profiles).find((candidate) => !previousNames.has(candidate));
 		if (!profile) return;
 	}
 	if (ownRecord(profiles[profile])?.kind === "webdav") {
-		if (await showAddWebDavTarget(ctx, name, profile)) await refreshTargetCompletions();
+		if (await showAddWebDavTarget(ctx, name, profile, signal)) await refreshTargetCompletions();
 		return;
 	}
 	const location = await chooseAdditionalRemoteLocation(ctx, raw, profile, name);
@@ -652,14 +668,14 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 	ctx.ui.notify(`Added sync target “${safeTerminalText(name)}”.`, "info");
 }
 
-async function showEditCurrentTarget(ctx: ExtensionCommandContext) {
+async function showEditCurrentTarget(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	const partial = await loadPartialConfig();
 	if (partial.settingsVersion !== 2 || !partial.target) {
 		ctx.ui.notify("Upgrade settings before editing a named target.", "info");
 		return;
 	}
 	if (partial.storageKind === "webdav") {
-		await showEditWebDavTarget(ctx, partial);
+		await showEditWebDavTarget(ctx, partial, signal);
 		return;
 	}
 	const bucket = await requiredInput(ctx, "Bucket", partial.bucket ?? "pi-sync");

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -353,7 +353,11 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	if (signal?.aborted || !preset || preset === "Cancel") return false;
 	const targetName = await chooseInitialTargetName(ctx);
 	if (!targetName) return false;
-	if (preset === "WebDAV") return showWebDavSetup(ctx, targetName, signal);
+	if (preset === "WebDAV") {
+		const saved = await showWebDavSetup(ctx, targetName, signal);
+		if (saved) await refreshTargetCompletions();
+		return saved;
+	}
 	const endpoint = await requiredInput(
 		ctx,
 		preset === "Cloudflare R2" ? "Cloudflare R2 endpoint" : "S3-compatible endpoint",
@@ -371,33 +375,35 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	const location = await chooseInitialRemoteLocation(ctx, preset, targetName);
 	if (!location) return false;
 	const { profileName, bucket, prefix, namespace } = location;
-	const credentials = await chooseS3Credentials(ctx);
+	const credentials = await chooseS3Credentials(ctx, signal);
 	if (!credentials) return false;
-	const contentChoice = await ctx.ui.select("Choose an initial sync preset", [
-		"Recommended Pi settings",
-		"Minimal settings",
-		"Cancel",
-	]);
-	if (!contentChoice || contentChoice === "Cancel") return false;
+	const contentChoice = await ctx.ui.select(
+		"Choose an initial sync preset",
+		["Recommended Pi settings", "Minimal settings", "Cancel"],
+		{ signal },
+	);
+	if (signal?.aborted || !contentChoice || contentChoice === "Cancel") return false;
 	const syncFiles =
 		contentChoice === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
-	const automaticChoice = await ctx.ui.select("Automatic sync for this target", [
-		"Enable automatic sync",
-		"Keep automatic sync off",
-		"Cancel",
-	]);
-	if (!automaticChoice || automaticChoice === "Cancel") return false;
+	const automaticChoice = await ctx.ui.select(
+		"Automatic sync for this target",
+		["Enable automatic sync", "Keep automatic sync off", "Cancel"],
+		{ signal },
+	);
+	if (signal?.aborted || !automaticChoice || automaticChoice === "Cancel") return false;
 	const sessionChoice = await ctx.ui.select(
 		"Session conversations\n\nSessions can contain prompts, tool output, paths, screenshots, and secrets.",
 		["Keep sessions off (recommended)", "Include session conversations", "Cancel"],
+		{ signal },
 	);
-	if (!sessionChoice || sessionChoice === "Cancel") return false;
+	if (signal?.aborted || !sessionChoice || sessionChoice === "Cancel") return false;
 	const syncSessions = sessionChoice === "Include session conversations";
 	if (
 		syncSessions &&
 		!(await ctx.ui.confirm(
 			"Include session conversations?",
 			"I understand that session JSONL can contain prompts, tool output, paths, screenshots, and secrets.",
+			{ signal },
 		))
 	) {
 		return false;
@@ -418,8 +424,9 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 			`Credentials: ${safeTerminalText(credentials.summary)}`,
 		].join("\n"),
 		["Save setup", "Cancel"],
+		{ signal },
 	);
-	if (choice !== "Save setup") return false;
+	if (signal?.aborted || choice !== "Save setup") return false;
 	await saveNewV2Settings({
 		targetName,
 		storageProfileName: profileName,
@@ -439,6 +446,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 			extraFiles: [],
 		},
 	});
+	if (signal?.aborted) return false;
 	await refreshTargetCompletions();
 	ctx.ui.notify(
 		credentials.ready

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -15,6 +15,15 @@ import {
 } from "./config.js";
 import { inspectLock, isStaleLock } from "./lock.js";
 import {
+	errorMessage,
+	formatRemotePath,
+	ownRecord,
+	requiredExistingBucket,
+	requiredInput,
+	safeTerminalText,
+	storageDescription,
+} from "./manager-helpers.js";
+import {
 	addStorageProfile,
 	addSyncTarget,
 	migrateLegacySettings,
@@ -27,7 +36,14 @@ import {
 import { showSyncSettings } from "./settings-ui.js";
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
 import { type TargetPullOutcome, useSyncTarget } from "./target-switch.js";
-import type { SyncConfig } from "./types.js";
+import type { AnySyncConfig } from "./types.js";
+import {
+	showAddWebDavStorageProfile,
+	showAddWebDavTarget,
+	showEditWebDavStorageProfile,
+	showEditWebDavTarget,
+	showWebDavSetup,
+} from "./webdav-ui.js";
 
 export const MAIN_MENU_ACTIONS = [
 	"Sync now (recommended)",
@@ -235,11 +251,14 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 	try {
 		const config = await loadConfig();
 		const target = config.target ?? "default";
-		const storage = storageDescription(
-			config.backend.profile.kind,
-			config.backend.profile.endpoint,
-			config.backend.destination.bucket,
-		);
+		const storage =
+			config.backend.type === "webdav"
+				? `WebDAV · ${safeTerminalText(config.backend.destination.path)}`
+				: storageDescription(
+						config.backend.profile.kind,
+						config.backend.profile.endpoint,
+						config.backend.destination.bucket,
+					);
 		const warnings = deprecatedPiSyncEnvironmentWarnings();
 		const lock = await inspectLock();
 		const liveLock = lock.status === "valid" && !isStaleLock(lock.lock);
@@ -319,11 +338,13 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 	const preset = await ctx.ui.select("Set up sync\n\nWhere will Pi settings be stored?", [
 		"Cloudflare R2",
 		"Other S3-compatible storage",
+		"WebDAV",
 		"Cancel",
 	]);
 	if (!preset || preset === "Cancel") return false;
 	const targetName = await chooseInitialTargetName(ctx);
 	if (!targetName) return false;
+	if (preset === "WebDAV") return showWebDavSetup(ctx, targetName);
 	const endpoint = await requiredInput(
 		ctx,
 		preset === "Cloudflare R2" ? "Cloudflare R2 endpoint" : "S3-compatible endpoint",
@@ -453,7 +474,11 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 		const label = [
 			`${safeTerminalText(name)}${name === active ? " (current)" : ""}`,
 			profile
-				? `${safeTerminalText(profileName ?? "unknown")} · ${safeTerminalText(String(target?.bucket ?? "missing bucket"))}`
+				? `${safeTerminalText(profileName ?? "unknown")} · ${safeTerminalText(
+						profile.kind === "webdav"
+							? String(target?.path ?? "pi-sync")
+							: String(target?.bucket ?? "missing bucket"),
+					)}`
 				: `Invalid: missing storage profile ${safeTerminalText(profileName ?? "reference")}`,
 			`${normalizeSyncFiles(target?.syncFiles as string[] | undefined).length} groups · Sessions: ${target?.syncSessions === true ? "On" : "Off"}`,
 		].join(" · ");
@@ -470,7 +495,7 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 		ctx.ui.notify(`Target “${safeTerminalText(name)}” is already current.`, "info");
 		return false;
 	}
-	let config: SyncConfig;
+	let config: AnySyncConfig;
 	try {
 		config = await loadConfig(name);
 	} catch (error) {
@@ -493,11 +518,15 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 			"",
 			`From: ${safeTerminalText(active ?? "none")}`,
 			`To: ${safeTerminalText(name)}`,
-			`Storage: ${storageDescription(
-				config.backend.profile.kind,
-				config.backend.profile.endpoint,
-				config.backend.destination.bucket,
-			)}`,
+			`Storage: ${
+				config.backend.type === "webdav"
+					? `WebDAV · ${safeTerminalText(config.backend.destination.path)}`
+					: storageDescription(
+							config.backend.profile.kind,
+							config.backend.profile.endpoint,
+							config.backend.destination.bucket,
+						)
+			}`,
 			`Synced content: ${normalizeSyncFiles(config.syncFiles).length} built-in groups · ${config.extraFiles.length} extra files`,
 			`Auto-sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
 			"",
@@ -573,6 +602,10 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 		"Cancel",
 	]);
 	if (!profile || profile === "Cancel") return;
+	if (ownRecord(profiles[profile])?.kind === "webdav") {
+		if (await showAddWebDavTarget(ctx, name, profile)) await refreshTargetCompletions();
+		return;
+	}
 	const location = await chooseAdditionalRemoteLocation(ctx, raw, profile, name);
 	if (!location) return;
 	const { bucket, prefix, namespace } = location;
@@ -628,6 +661,10 @@ async function showEditCurrentTarget(ctx: ExtensionCommandContext) {
 	const partial = await loadPartialConfig();
 	if (partial.settingsVersion !== 2 || !partial.target) {
 		ctx.ui.notify("Upgrade settings before editing a named target.", "info");
+		return;
+	}
+	if (partial.storageKind === "webdav") {
+		await showEditWebDavTarget(ctx, partial);
 		return;
 	}
 	const bucket = await requiredInput(ctx, "Bucket", partial.bucket ?? "pi-sync");
@@ -687,6 +724,10 @@ async function showStorageProfiles(ctx: ExtensionCommandContext) {
 	}
 	const profile = ownRecord(profiles[selected]);
 	if (!profile) return;
+	if (profile.kind === "webdav") {
+		await showEditWebDavStorageProfile(ctx, selected, profile);
+		return;
+	}
 	const endpoint = await requiredInput(
 		ctx,
 		"Endpoint",
@@ -708,9 +749,14 @@ async function showAddStorageProfile(ctx: ExtensionCommandContext) {
 	const preset = await ctx.ui.select("Storage type", [
 		"Cloudflare R2",
 		"Other S3-compatible storage",
+		"WebDAV",
 		"Cancel",
 	]);
 	if (!preset || preset === "Cancel") return;
+	if (preset === "WebDAV") {
+		await showAddWebDavStorageProfile(ctx);
+		return;
+	}
 	const name = await requiredInput(
 		ctx,
 		"Name the storage profile",
@@ -946,51 +992,4 @@ async function chooseCustomRemoteLocation(
 	if (!prefix) return undefined;
 	const namespace = await requiredInput(ctx, "Remote namespace", targetName);
 	return namespace ? { profileName, bucket, prefix, namespace } : undefined;
-}
-
-function formatRemotePath(prefix: string, namespace: string) {
-	return safeTerminalText(`${prefix}/profiles/${namespace}/`);
-}
-
-async function requiredExistingBucket(ctx: ExtensionCommandContext, example: string) {
-	const value = await ctx.ui.input("Existing bucket", `Example: ${example}`);
-	if (value === undefined) return undefined;
-	const normalized = value.trim();
-	if (!normalized) {
-		ctx.ui.notify("Enter the name of an existing R2/S3 bucket, or cancel setup.", "warning");
-		return undefined;
-	}
-	return normalized;
-}
-
-async function requiredInput(ctx: ExtensionCommandContext, title: string, placeholder: string) {
-	const value = await ctx.ui.input(title, placeholder);
-	if (value === undefined) return undefined;
-	const normalized = value.trim() || placeholder;
-	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
-}
-
-function storageDescription(
-	kind: string | undefined,
-	endpoint: string | undefined,
-	bucket: string | undefined,
-) {
-	const label =
-		kind === "r2" || isCloudflareR2Endpoint(endpoint) ? "Cloudflare R2" : "S3-compatible";
-	return `${label} · ${safeTerminalText(bucket ?? "bucket missing")}`;
-}
-
-function ownRecord(value: unknown): Record<string, unknown> | undefined {
-	return value && typeof value === "object" && !Array.isArray(value)
-		? (value as Record<string, unknown>)
-		: undefined;
-}
-
-function safeTerminalText(value: string) {
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
-	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "?");
-}
-
-function errorMessage(error: unknown) {
-	return error instanceof Error ? error.message : String(error);
 }

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -8,7 +8,6 @@ import {
 	loadConfig,
 	loadPartialConfig,
 	loadTargetSwitchAction,
-	localConfigPath,
 	normalizeSyncFiles,
 	readLocalConfigObject,
 	readStateForConfig,
@@ -23,25 +22,24 @@ import {
 	safeTerminalText,
 	storageDescription,
 } from "./manager-helpers.js";
+import { chooseS3Credentials } from "./s3-credentials-ui.js";
 import {
-	addStorageProfile,
 	addSyncTarget,
 	migrateLegacySettings,
-	removeStorageProfile,
 	removeSyncTarget,
 	saveNewV2Settings,
-	updateStorageProfile,
 	updateSyncTarget,
 } from "./settings-management.js";
 import { showSyncSettings } from "./settings-ui.js";
+import { showAddStorageConnection, showStorageConnections } from "./storage-connections-ui.js";
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
 import { type TargetPullOutcome, useSyncTarget } from "./target-switch.js";
 import type { AnySyncConfig } from "./types.js";
 import {
-	showAddWebDavStorageProfile,
+	repairableWebDavDestinationName,
 	showAddWebDavTarget,
-	showEditWebDavStorageProfile,
 	showEditWebDavTarget,
+	showRepairableWebDavDestination,
 	showWebDavSetup,
 } from "./webdav-ui.js";
 
@@ -54,17 +52,11 @@ export const MAIN_MENU_ACTIONS = [
 	"Settings",
 	"More…",
 ] as const;
-
-const MORE_MENU_ACTIONS = [
-	"Manage targets & storage",
-	"History & recovery",
-	"Help",
-	"Back",
-] as const;
+const MORE_MENU_ACTIONS = ["Manage destinations", "History & recovery", "Help", "Back"] as const;
 const BACK = "Back";
 
 type MainMenuAction = (typeof MAIN_MENU_ACTIONS)[number];
-type ContextualMenuAction = "Manage targets & storage" | "History & recovery" | "Help";
+type ContextualMenuAction = "Manage destinations" | "History & recovery" | "Help";
 type RunRoute = (
 	route: string,
 	signal?: AbortSignal,
@@ -85,7 +77,12 @@ export async function showSyncManager(
 		const selected = await ctx.ui.select(state.title, state.actions);
 		if (!selected) return;
 		switch (
-			selected as MainMenuAction | ContextualMenuAction | "Set up sync" | "Use existing settings"
+			selected as
+				| MainMenuAction
+				| ContextualMenuAction
+				| "Set up sync"
+				| "Use existing settings"
+				| "Repair WebDAV destination"
 		) {
 			case "Sync now (recommended)":
 				await runCancellableOperation(ctx, "Checking current target…", "sync", runRoute, true);
@@ -127,8 +124,11 @@ export async function showSyncManager(
 			case "More…":
 				if ((await showMoreMenu(ctx, runRoute)) === "exit") return;
 				break;
-			case "Manage targets & storage":
+			case "Manage destinations":
 				await showManageMenu(ctx, runRoute);
+				break;
+			case "Repair WebDAV destination":
+				await showRepairableWebDavDestination(ctx);
 				break;
 			case "History & recovery":
 				await showRecoveryMenu(ctx, runRoute);
@@ -147,7 +147,7 @@ export async function showSyncManager(
 async function showMoreMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
 	const selected = await ctx.ui.select("More options", [...MORE_MENU_ACTIONS]);
 	if (!selected || selected === BACK) return;
-	if (selected === "Manage targets & storage") await showManageMenu(ctx, runRoute);
+	if (selected === "Manage destinations") await showManageMenu(ctx, runRoute);
 	else if (selected === "History & recovery") await showRecoveryMenu(ctx, runRoute);
 	else {
 		await runRoute("help");
@@ -215,6 +215,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 	try {
 		raw = await readLocalConfigObject();
 	} catch (error) {
+		const repairableWebDav = await repairableWebDavDestinationName().catch(() => undefined);
 		return {
 			title: [
 				"Pi Sync",
@@ -225,7 +226,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 				"",
 				"Repair the JSON file, then reopen /sync.",
 			].join("\n"),
-			actions: ["Help"],
+			actions: repairableWebDav ? ["Repair WebDAV destination", "Help"] : ["Help"],
 		};
 	}
 	if (!raw) {
@@ -245,7 +246,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 				"",
 				"What do you want to do?",
 			].join("\n"),
-			actions: ["Manage targets & storage", "Help"],
+			actions: ["Manage destinations", "Help"],
 		};
 	}
 	try {
@@ -326,7 +327,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 			].join("\n"),
 			actions: [
 				...(targets && Object.keys(targets).length > 1 ? ["Switch target"] : []),
-				"Manage targets & storage",
+				"Manage destinations",
 				"Help",
 			],
 		};
@@ -362,11 +363,8 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 	const location = await chooseInitialRemoteLocation(ctx, preset, targetName);
 	if (!location) return false;
 	const { profileName, bucket, prefix, namespace } = location;
-	const credentialChoice = await ctx.ui.select(
-		"Credentials\n\nSecret values are never shown in pi-sync screens.",
-		["Use environment credentials", "Create private settings template", "Cancel"],
-	);
-	if (!credentialChoice || credentialChoice === "Cancel") return false;
+	const credentials = await chooseS3Credentials(ctx);
+	if (!credentials) return false;
 	const contentChoice = await ctx.ui.select("Choose an initial sync preset", [
 		"Recommended Pi settings",
 		"Minimal settings",
@@ -397,16 +395,6 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 		return false;
 	}
 	const autoSync = automaticChoice === "Enable automatic sync";
-	const hasEnvironmentCredentials = Boolean(
-		(process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID) &&
-			(process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY),
-	);
-	const credentialSummary =
-		credentialChoice === "Use environment credentials"
-			? hasEnvironmentCredentials
-				? "Environment credentials detected"
-				: "Environment credentials are currently missing"
-			: `Complete accessKeyId and secretAccessKey in ${localConfigPath()}`;
 	const choice = await ctx.ui.select(
 		[
 			"Review setup",
@@ -419,7 +407,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 			"Bucket must already exist. pi-sync will not create it.",
 			`Synced content: ${syncFiles.length} built-in groups · Sessions: ${syncSessions ? "On — privacy warning acknowledged" : "Off"}`,
 			`Auto-sync: ${autoSync ? "On" : "Off"}`,
-			`Credentials: ${safeTerminalText(credentialSummary)}`,
+			`Credentials: ${safeTerminalText(credentials.summary)}`,
 		].join("\n"),
 		["Save setup", "Cancel"],
 	);
@@ -431,6 +419,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 			kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
 			endpoint,
 			region,
+			...credentials.profileFields,
 		},
 		target: {
 			bucket,
@@ -444,9 +433,9 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 	});
 	await refreshTargetCompletions();
 	ctx.ui.notify(
-		hasEnvironmentCredentials || credentialChoice !== "Use environment credentials"
-			? `Target “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
-			: `Saved target “${safeTerminalText(targetName)}”; add credentials before syncing.`,
+		credentials.ready
+			? `Destination “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
+			: `Saved destination “${safeTerminalText(targetName)}”; add credentials before syncing.`,
 		"info",
 	);
 	return true;
@@ -550,17 +539,17 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 }
 
 async function showManageMenu(ctx: ExtensionCommandContext, _runRoute: RunRoute) {
-	const selected = await ctx.ui.select("Manage targets & storage", [
-		"Add sync target",
-		"Edit current target",
-		"Manage storage profiles",
-		"Remove sync target",
+	const selected = await ctx.ui.select("Manage destinations", [
+		"Add destination",
+		"Edit current destination",
+		"Saved connections…",
+		"Remove destination",
 		BACK,
 	]);
 	if (!selected || selected === BACK) return;
-	if (selected === "Add sync target") await showAddTarget(ctx);
-	else if (selected === "Edit current target") await showEditCurrentTarget(ctx);
-	else if (selected === "Manage storage profiles") await showStorageProfiles(ctx);
+	if (selected === "Add destination") await showAddTarget(ctx);
+	else if (selected === "Edit current destination") await showEditCurrentTarget(ctx);
+	else if (selected === "Saved connections…") await showStorageConnections(ctx);
 	else await showRemoveTarget(ctx);
 }
 
@@ -590,18 +579,24 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 		);
 		raw = migration.settings;
 	}
-	const profiles = ownRecord(raw.profiles);
-	if (!profiles || Object.keys(profiles).length === 0) {
-		ctx.ui.notify("Add a storage profile before adding a sync target.", "warning");
-		return;
-	}
-	const name = await requiredInput(ctx, "Name the new sync target", "work");
+	let profiles = ownRecord(raw.profiles) ?? {};
+	const name = await requiredInput(ctx, "Name the new destination", "work");
 	if (!name) return;
-	const profile = await ctx.ui.select("Choose storage for this target", [
+	const createConnection = "Create a new saved connection…";
+	let profile = await ctx.ui.select("Choose a saved connection", [
 		...Object.keys(profiles).sort(),
+		createConnection,
 		"Cancel",
 	]);
 	if (!profile || profile === "Cancel") return;
+	if (profile === createConnection) {
+		const previousNames = new Set(Object.keys(profiles));
+		if (!(await showAddStorageConnection(ctx))) return;
+		raw = (await readLocalConfigObject()) ?? raw;
+		profiles = ownRecord(raw.profiles) ?? {};
+		profile = Object.keys(profiles).find((candidate) => !previousNames.has(candidate));
+		if (!profile) return;
+	}
 	if (ownRecord(profiles[profile])?.kind === "webdav") {
 		if (await showAddWebDavTarget(ctx, name, profile)) await refreshTargetCompletions();
 		return;
@@ -687,104 +682,6 @@ async function showEditCurrentTarget(ctx: ExtensionCommandContext) {
 	if (choice !== "Save target") return;
 	await updateSyncTarget(partial.target, (target) => ({ ...target, bucket, prefix, namespace }));
 	ctx.ui.notify(`Saved target “${safeTerminalText(partial.target)}”.`, "info");
-}
-
-async function showStorageProfiles(ctx: ExtensionCommandContext) {
-	const raw = await readLocalConfigObject();
-	if (raw?.version !== 2) {
-		ctx.ui.notify("Upgrade settings before managing storage profiles.", "info");
-		return;
-	}
-	const profiles = ownRecord(raw.profiles) ?? {};
-	const selected = await ctx.ui.select("Storage profiles", [
-		"Add storage profile",
-		...Object.keys(profiles).sort(),
-		BACK,
-	]);
-	if (!selected || selected === BACK) return;
-	if (selected === "Add storage profile") {
-		await showAddStorageProfile(ctx);
-		return;
-	}
-	const action = await ctx.ui.select(`Storage profile “${safeTerminalText(selected)}”`, [
-		"Edit connection",
-		"Remove storage profile",
-		BACK,
-	]);
-	if (!action || action === BACK) return;
-	if (action === "Remove storage profile") {
-		const confirmed = await ctx.ui.confirm(
-			"Remove storage profile?",
-			`Remove local profile “${safeTerminalText(selected)}”? Remote buckets and snapshots are not deleted.`,
-		);
-		if (!confirmed) return;
-		await removeStorageProfile(selected);
-		ctx.ui.notify(`Removed storage profile “${safeTerminalText(selected)}”.`, "info");
-		return;
-	}
-	const profile = ownRecord(profiles[selected]);
-	if (!profile) return;
-	if (profile.kind === "webdav") {
-		await showEditWebDavStorageProfile(ctx, selected, profile);
-		return;
-	}
-	const endpoint = await requiredInput(
-		ctx,
-		"Endpoint",
-		String(profile.endpoint ?? "https://s3.example.com"),
-	);
-	if (!endpoint) return;
-	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
-	if (!region) return;
-	const save = await ctx.ui.select(
-		`Review connection\n\nProfile: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials remain unchanged and are never shown.`,
-		["Save profile", "Cancel"],
-	);
-	if (save !== "Save profile") return;
-	await updateStorageProfile(selected, (current) => ({ ...current, endpoint, region }));
-	ctx.ui.notify(`Saved storage profile “${safeTerminalText(selected)}”.`, "info");
-}
-
-async function showAddStorageProfile(ctx: ExtensionCommandContext) {
-	const preset = await ctx.ui.select("Storage type", [
-		"Cloudflare R2",
-		"Other S3-compatible storage",
-		"WebDAV",
-		"Cancel",
-	]);
-	if (!preset || preset === "Cancel") return;
-	if (preset === "WebDAV") {
-		await showAddWebDavStorageProfile(ctx);
-		return;
-	}
-	const name = await requiredInput(
-		ctx,
-		"Name the storage profile",
-		preset === "Cloudflare R2" ? "r2" : "s3",
-	);
-	if (!name) return;
-	const endpoint = await requiredInput(
-		ctx,
-		"Endpoint",
-		preset === "Cloudflare R2"
-			? "https://<account-id>.r2.cloudflarestorage.com"
-			: "https://s3.example.com",
-	);
-	if (!endpoint) return;
-	const region =
-		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
-	if (!region) return;
-	const save = await ctx.ui.select(
-		`Review storage profile\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nAdd credentials privately in ${safeTerminalText(localConfigPath())} or use environment credentials.`,
-		["Add profile", "Cancel"],
-	);
-	if (save !== "Add profile") return;
-	await addStorageProfile(name, {
-		kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
-		endpoint,
-		region,
-	});
-	ctx.ui.notify(`Added storage profile “${safeTerminalText(name)}”.`, "info");
 }
 
 async function showRemoveTarget(ctx: ExtensionCommandContext) {

--- a/extensions/pi-sync/src/s3-credentials-ui.ts
+++ b/extensions/pi-sync/src/s3-credentials-ui.ts
@@ -1,0 +1,88 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { requiredInput } from "./manager-helpers.js";
+import { promptSecret } from "./secret-input.js";
+
+export interface ChosenS3Credentials {
+	profileFields: { accessKeyId?: string; secretAccessKey?: string };
+	summary: string;
+	ready: boolean;
+	replace?: boolean;
+}
+
+export async function chooseS3CredentialUpdate(
+	ctx: ExtensionCommandContext,
+	profile: Record<string, unknown>,
+) {
+	const hasStored =
+		typeof profile.accessKeyId === "string" && typeof profile.secretAccessKey === "string";
+	if (hasStored) {
+		const action = await ctx.ui.select("Credentials", [
+			"Keep current credentials",
+			"Change credential source",
+			"Cancel",
+		]);
+		if (!action || action === "Cancel") return undefined;
+		if (action === "Keep current credentials") {
+			return { profileFields: {}, summary: "Unchanged (values hidden)", ready: true };
+		}
+	}
+	const selected = await chooseS3Credentials(ctx);
+	return selected ? { ...selected, replace: true } : undefined;
+}
+
+export function applyS3CredentialUpdate(
+	profile: Record<string, unknown>,
+	credentials: ChosenS3Credentials,
+) {
+	const next = { ...profile };
+	if (credentials.replace) {
+		delete next.accessKeyId;
+		delete next.secretAccessKey;
+		delete next.sessionToken;
+	}
+	return { ...next, ...credentials.profileFields };
+}
+
+export async function chooseS3Credentials(
+	ctx: ExtensionCommandContext,
+): Promise<ChosenS3Credentials | undefined> {
+	const choice = await ctx.ui.select(
+		"Credentials\n\nStored secret values are masked during input and never shown afterward.",
+		[
+			"Use environment credentials",
+			"Store credentials privately",
+			"Create private settings template",
+			"Cancel",
+		],
+	);
+	if (!choice || choice === "Cancel") return undefined;
+	if (choice === "Use environment credentials") {
+		const ready = Boolean(
+			(process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID) &&
+				(process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY),
+		);
+		return {
+			profileFields: {},
+			summary: ready
+				? "Environment credentials detected"
+				: "Environment credentials are currently missing",
+			ready,
+		};
+	}
+	if (choice === "Create private settings template") {
+		return {
+			profileFields: {},
+			summary: "Credentials must be completed later in the private settings file",
+			ready: false,
+		};
+	}
+	const accessKeyId = await requiredInput(ctx, "Access key ID", "access-key-id");
+	if (!accessKeyId) return undefined;
+	const secretAccessKey = await promptSecret(ctx, "Secret access key");
+	if (secretAccessKey === undefined) return undefined;
+	return {
+		profileFields: { accessKeyId, secretAccessKey },
+		summary: "Stored privately (values hidden)",
+		ready: true,
+	};
+}

--- a/extensions/pi-sync/src/s3-credentials-ui.ts
+++ b/extensions/pi-sync/src/s3-credentials-ui.ts
@@ -11,21 +11,23 @@ export interface ChosenS3Credentials {
 export async function chooseS3CredentialUpdate(
 	ctx: ExtensionCommandContext,
 	profile: Record<string, unknown>,
+	signal?: AbortSignal,
 ) {
 	const hasStored =
 		typeof profile.accessKeyId === "string" && typeof profile.secretAccessKey === "string";
 	if (hasStored) {
-		const action = await ctx.ui.select("Credentials", [
-			"Keep current credentials",
-			"Change credential source",
-			"Cancel",
-		]);
+		const action = await ctx.ui.select(
+			"Credentials",
+			["Keep current credentials", "Change credential source", "Cancel"],
+			{ signal },
+		);
+		throwIfAborted(signal);
 		if (!action || action === "Cancel") return undefined;
 		if (action === "Keep current credentials") {
 			return { profileFields: {}, summary: "Unchanged (values hidden)", ready: true };
 		}
 	}
-	const selected = await chooseS3Credentials(ctx);
+	const selected = await chooseS3Credentials(ctx, signal);
 	return selected ? { ...selected, replace: true } : undefined;
 }
 
@@ -44,6 +46,7 @@ export function applyS3CredentialUpdate(
 
 export async function chooseS3Credentials(
 	ctx: ExtensionCommandContext,
+	signal?: AbortSignal,
 ): Promise<ChosenS3Credentials | undefined> {
 	const choice = await ctx.ui.select(
 		"Credentials\n\nStored secret values are masked during input and never shown afterward.",
@@ -53,7 +56,9 @@ export async function chooseS3Credentials(
 			"Create private settings template",
 			"Cancel",
 		],
+		{ signal },
 	);
+	throwIfAborted(signal);
 	if (!choice || choice === "Cancel") return undefined;
 	if (choice === "Use environment credentials") {
 		const ready = Boolean(
@@ -75,9 +80,10 @@ export async function chooseS3Credentials(
 			ready: false,
 		};
 	}
-	const accessKeyId = await requiredCredentialInput(ctx, "Access key ID", "access-key-id");
+	const accessKeyId = await requiredCredentialInput(ctx, "Access key ID", "access-key-id", signal);
 	if (!accessKeyId) return undefined;
-	const secretAccessKey = await promptSecret(ctx, "Secret access key");
+	const secretAccessKey = await promptSecret(ctx, "Secret access key", { signal });
+	throwIfAborted(signal);
 	if (secretAccessKey === undefined) return undefined;
 	return {
 		profileFields: { accessKeyId, secretAccessKey },
@@ -90,8 +96,10 @@ async function requiredCredentialInput(
 	ctx: ExtensionCommandContext,
 	title: string,
 	placeholder: string,
+	signal?: AbortSignal,
 ) {
-	const value = await ctx.ui.input(title, placeholder);
+	const value = await ctx.ui.input(title, placeholder, { signal });
+	throwIfAborted(signal);
 	if (value === undefined) return undefined;
 	const normalized = value.trim();
 	if (!normalized) {
@@ -99,4 +107,11 @@ async function requiredCredentialInput(
 		return undefined;
 	}
 	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("The operation was aborted", "AbortError");
 }

--- a/extensions/pi-sync/src/s3-credentials-ui.ts
+++ b/extensions/pi-sync/src/s3-credentials-ui.ts
@@ -1,5 +1,4 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { requiredInput } from "./manager-helpers.js";
 import { promptSecret } from "./secret-input.js";
 
 export interface ChosenS3Credentials {
@@ -76,7 +75,7 @@ export async function chooseS3Credentials(
 			ready: false,
 		};
 	}
-	const accessKeyId = await requiredInput(ctx, "Access key ID", "access-key-id");
+	const accessKeyId = await requiredCredentialInput(ctx, "Access key ID", "access-key-id");
 	if (!accessKeyId) return undefined;
 	const secretAccessKey = await promptSecret(ctx, "Secret access key");
 	if (secretAccessKey === undefined) return undefined;
@@ -85,4 +84,19 @@ export async function chooseS3Credentials(
 		summary: "Stored privately (values hidden)",
 		ready: true,
 	};
+}
+
+async function requiredCredentialInput(
+	ctx: ExtensionCommandContext,
+	title: string,
+	placeholder: string,
+) {
+	const value = await ctx.ui.input(title, placeholder);
+	if (value === undefined) return undefined;
+	const normalized = value.trim();
+	if (!normalized) {
+		ctx.ui.notify(`${title} is required.`, "warning");
+		return undefined;
+	}
+	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
 }

--- a/extensions/pi-sync/src/secret-input.ts
+++ b/extensions/pi-sync/src/secret-input.ts
@@ -1,0 +1,190 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+	CURSOR_MARKER,
+	decodeKittyPrintable,
+	type Focusable,
+	type KeybindingsManager,
+	Text,
+	truncateToWidth,
+} from "@earendil-works/pi-tui";
+
+const MASK = "•";
+
+export async function promptSecret(
+	ctx: ExtensionCommandContext,
+	title: string,
+	options: { required?: boolean } = { required: true },
+) {
+	if (ctx.mode !== "tui") return undefined;
+	const value = await ctx.ui.custom<string | undefined>((tui, theme, keybindings, done) => {
+		const heading = new Text("", 0, 0);
+		const hint = new Text("", 0, 0);
+		const applyTheme = () => {
+			heading.setText(theme.fg("accent", theme.bold(title)));
+			hint.setText(theme.fg("dim", "Enter save • Escape cancel • Input is hidden"));
+		};
+		applyTheme();
+		const input = new MaskedInput(keybindings);
+		const component: Focusable & {
+			render(width: number): string[];
+			invalidate(): void;
+			handleInput(data: string): void;
+			dispose(): void;
+		} = {
+			get focused() {
+				return input.focused;
+			},
+			set focused(focused: boolean) {
+				input.focused = focused;
+			},
+			render(width: number) {
+				const safeWidth = Math.max(1, width);
+				return [
+					...heading.render(safeWidth),
+					...input.render(safeWidth),
+					...hint.render(safeWidth),
+				].map((line) => truncateToWidth(line, safeWidth));
+			},
+			invalidate() {
+				applyTheme();
+				heading.invalidate();
+				input.invalidate();
+				hint.invalidate();
+			},
+			handleInput(data: string) {
+				if (keybindings.matches(data, "tui.select.cancel")) done(undefined);
+				else if (keybindings.matches(data, "tui.input.submit")) done(input.getValue());
+				else input.handleInput(data);
+				tui.requestRender();
+			},
+			dispose() {
+				input.clear();
+			},
+		};
+		return component;
+	});
+	if (value === undefined) return undefined;
+	if (options.required !== false && value.length === 0) {
+		ctx.ui.notify(`${title} is required.`, "warning");
+		return undefined;
+	}
+	return value;
+}
+
+class MaskedInput implements Focusable {
+	focused = false;
+	private value: string[] = [];
+	private cursor = 0;
+	private paste = "";
+	private pasting = false;
+
+	constructor(private readonly keybindings: KeybindingsManager) {}
+
+	getValue() {
+		return this.value.join("");
+	}
+
+	handleInput(data: string) {
+		if (data.includes("\u001b[200~")) {
+			this.pasting = true;
+			this.paste = "";
+			data = data.replace("\u001b[200~", "");
+		}
+		if (this.pasting) {
+			this.paste += data;
+			const end = this.paste.indexOf("\u001b[201~");
+			if (end < 0) return;
+			const pasted = this.paste
+				.slice(0, end)
+				.replace(/[\r\n]/gu, "")
+				.replace(/\t/gu, "    ");
+			this.insert(pasted);
+			const remaining = this.paste.slice(end + 6);
+			this.paste = "";
+			this.pasting = false;
+			if (remaining) this.handleInput(remaining);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteCharBackward")) {
+			if (this.cursor > 0) this.value.splice(--this.cursor, 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteCharForward")) {
+			if (this.cursor < this.value.length) this.value.splice(this.cursor, 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorLeft")) {
+			this.cursor = Math.max(0, this.cursor - 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorRight")) {
+			this.cursor = Math.min(this.value.length, this.cursor + 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorLineStart")) {
+			this.cursor = 0;
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorLineEnd")) {
+			this.cursor = this.value.length;
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteToLineStart")) {
+			this.value.splice(0, this.cursor);
+			this.cursor = 0;
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteToLineEnd")) {
+			this.value.splice(this.cursor);
+			return;
+		}
+		const printable = decodeKittyPrintable(data) ?? data;
+		if (!hasControlCharacter(printable)) this.insert(printable);
+	}
+
+	render(width: number) {
+		const prompt = "> ";
+		const available = width - prompt.length;
+		if (available <= 0) return [truncateToWidth(prompt, Math.max(1, width))];
+		const contentWidth = Math.max(0, available - 1);
+		let start = 0;
+		if (this.value.length > contentWidth) {
+			start = Math.max(
+				0,
+				Math.min(this.cursor - Math.floor(contentWidth / 2), this.value.length - contentWidth),
+			);
+		}
+		const end = Math.min(this.value.length, start + contentWidth);
+		const visibleCursor = Math.max(0, Math.min(this.cursor - start, end - start));
+		const masks = Array.from({ length: end - start }, () => MASK);
+		const before = masks.slice(0, visibleCursor).join("");
+		const atCursor = visibleCursor < masks.length ? MASK : " ";
+		const after = masks.slice(visibleCursor + (visibleCursor < masks.length ? 1 : 0)).join("");
+		const marker = this.focused ? CURSOR_MARKER : "";
+		const line = `${prompt}${before}${marker}\u001b[7m${atCursor}\u001b[27m${after}`;
+		return [truncateToWidth(line, width, "")];
+	}
+
+	invalidate() {}
+
+	clear() {
+		this.value.fill("");
+		this.value = [];
+		this.paste = "";
+		this.cursor = 0;
+		this.pasting = false;
+	}
+
+	private insert(value: string) {
+		const characters = Array.from(value);
+		this.value.splice(this.cursor, 0, ...characters);
+		this.cursor += characters.length;
+	}
+}
+
+function hasControlCharacter(value: string) {
+	return [...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+	});
+}

--- a/extensions/pi-sync/src/secret-input.ts
+++ b/extensions/pi-sync/src/secret-input.ts
@@ -13,9 +13,9 @@ const MASK = "•";
 export async function promptSecret(
 	ctx: ExtensionCommandContext,
 	title: string,
-	options: { required?: boolean } = { required: true },
+	options: { required?: boolean; signal?: AbortSignal } = { required: true },
 ) {
-	if (ctx.mode !== "tui") return undefined;
+	if (ctx.mode !== "tui" || options.signal?.aborted) return undefined;
 	const value = await ctx.ui.custom<string | undefined>((tui, theme, keybindings, done) => {
 		const heading = new Text("", 0, 0);
 		const hint = new Text("", 0, 0);
@@ -25,6 +25,14 @@ export async function promptSecret(
 		};
 		applyTheme();
 		const input = new MaskedInput(keybindings);
+		let settled = false;
+		const finish = (result: string | undefined) => {
+			if (settled) return;
+			settled = true;
+			done(result);
+		};
+		const onAbort = () => finish(undefined);
+		options.signal?.addEventListener("abort", onAbort, { once: true });
 		const component: Focusable & {
 			render(width: number): string[];
 			invalidate(): void;
@@ -52,12 +60,13 @@ export async function promptSecret(
 				hint.invalidate();
 			},
 			handleInput(data: string) {
-				if (keybindings.matches(data, "tui.select.cancel")) done(undefined);
-				else if (keybindings.matches(data, "tui.input.submit")) done(input.getValue());
+				if (keybindings.matches(data, "tui.select.cancel")) finish(undefined);
+				else if (keybindings.matches(data, "tui.input.submit")) finish(input.getValue());
 				else input.handleInput(data);
 				tui.requestRender();
 			},
 			dispose() {
+				options.signal?.removeEventListener("abort", onAbort);
 				input.clear();
 			},
 		};

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -16,7 +16,7 @@ import {
 	writeLocalConfigObject,
 } from "./config.js";
 import { withLock } from "./lock.js";
-import type { PartialConfig, S3StorageProfileSettings, S3SyncTargetSettings } from "./types.js";
+import type { PartialConfig, StorageProfileSettings, SyncTargetSettings } from "./types.js";
 
 let afterLegacySettingsReadHook: () => Promise<void> = async () => undefined;
 
@@ -116,8 +116,8 @@ export function legacySettingsAsV2(
 export async function saveNewV2Settings(input: {
 	targetName: string;
 	storageProfileName: string;
-	profile: S3StorageProfileSettings;
-	target: S3SyncTargetSettings;
+	profile: StorageProfileSettings;
+	target: SyncTargetSettings;
 }) {
 	validateName(input.targetName, "target");
 	validateName(input.storageProfileName, "storage profile");
@@ -137,7 +137,7 @@ export async function saveNewV2Settings(input: {
 	return settings;
 }
 
-export async function addStorageProfile(name: string, profile: S3StorageProfileSettings) {
+export async function addStorageProfile(name: string, profile: StorageProfileSettings) {
 	validateName(name, "storage profile");
 	await updateV2Settings((settings) => {
 		const profiles = requireObject(settings.profiles, "profiles");
@@ -160,7 +160,7 @@ export async function updateStorageProfile(
 	});
 }
 
-export async function addSyncTarget(name: string, target: S3SyncTargetSettings) {
+export async function addSyncTarget(name: string, target: SyncTargetSettings) {
 	validateName(name, "target");
 	await updateV2Settings((settings) => {
 		const targets = requireObject(settings.targets, "targets");
@@ -169,7 +169,7 @@ export async function addSyncTarget(name: string, target: S3SyncTargetSettings) 
 		if (!target.profile || !Object.hasOwn(profiles, target.profile)) {
 			throw new Error(`Storage profile not found: ${target.profile ?? "missing"}`);
 		}
-		assertUniqueRemoteIdentity(targets, name, target);
+		assertUniqueRemoteIdentity(targets, profiles, name, target);
 		return { ...settings, targets: { ...targets, [name]: { ...target } } };
 	});
 }
@@ -183,7 +183,12 @@ export async function updateSyncTarget(
 		const targets = requireObject(settings.targets, "targets");
 		const target = requireObject(targets[name], "target");
 		const nextTarget = update(target);
-		assertUniqueRemoteIdentity(targets, name, nextTarget);
+		assertUniqueRemoteIdentity(
+			targets,
+			requireObject(settings.profiles, "profiles"),
+			name,
+			nextTarget,
+		);
 		return { ...settings, targets: { ...targets, [name]: nextTarget } };
 	});
 }
@@ -274,14 +279,24 @@ async function adoptLegacyState(
 
 function assertUniqueRemoteIdentity(
 	targets: Record<string, unknown>,
+	profiles: Record<string, unknown>,
 	name: string,
-	target: S3SyncTargetSettings,
+	target: SyncTargetSettings,
 ) {
-	const identity = effectiveTargetRemoteIdentity(target as Record<string, unknown>, name);
+	const profileName = typeof target.profile === "string" ? target.profile : "";
+	const profile = requireObject(profiles[profileName], "storage profile");
+	const identity = effectiveTargetRemoteIdentity(target as Record<string, unknown>, name, profile);
 	for (const [otherName, value] of Object.entries(targets)) {
 		if (
 			otherName !== name &&
-			effectiveTargetRemoteIdentity(requireObject(value, "target"), otherName) === identity
+			effectiveTargetRemoteIdentity(
+				requireObject(value, "target"),
+				otherName,
+				requireObject(
+					profiles[String(requireObject(value, "target").profile ?? "")],
+					"storage profile",
+				),
+			) === identity
 		) {
 			throw new Error(`Target “${name}” duplicates the remote destination of “${otherName}”.`);
 		}

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -155,7 +155,7 @@ export async function updateStorageProfile(
 		const profiles = requireObject(settings.profiles, "profiles");
 		const profile = requireObject(profiles[name], "storage profile");
 		const nextProfiles = { ...profiles, [name]: update(profile) };
-		validateUniqueRemoteTargets(requireObject(settings.targets, "targets"));
+		validateUniqueRemoteTargets(requireObject(settings.targets, "targets"), nextProfiles);
 		return { ...settings, profiles: nextProfiles };
 	});
 }

--- a/extensions/pi-sync/src/settings-ui.ts
+++ b/extensions/pi-sync/src/settings-ui.ts
@@ -95,7 +95,11 @@ async function showSettingsList(
 			new Text(
 				theme.fg(
 					"muted",
-					`Target: ${safeTerminalText(partial.target ?? "default")} · ${storageDescription(partial.storageKind, partial.endpoint, partial.bucket)}`,
+					`Target: ${safeTerminalText(partial.target ?? "default")} · ${storageDescription(
+						partial.storageKind,
+						partial.storageKind === "webdav" ? partial.url : partial.endpoint,
+						partial.storageKind === "webdav" ? partial.path : partial.bucket,
+					)}`,
 				),
 				1,
 				0,
@@ -187,6 +191,15 @@ function storageDescription(
 	endpoint: string | undefined,
 	bucket: string | undefined,
 ) {
+	if (kind === "webdav") {
+		let host = "URL missing";
+		try {
+			host = endpoint ? new URL(endpoint).host : host;
+		} catch {
+			host = "invalid URL";
+		}
+		return `WebDAV · ${safeTerminalText(host)} · ${safeTerminalText(bucket ?? "path missing")}`;
+	}
 	const label =
 		kind === "r2" || isCloudflareR2Endpoint(endpoint) ? "Cloudflare R2" : "S3-compatible";
 	return `${label} · ${safeTerminalText(bucket ?? "bucket missing")}`;

--- a/extensions/pi-sync/src/storage-connections-ui.ts
+++ b/extensions/pi-sync/src/storage-connections-ui.ts
@@ -15,28 +15,28 @@ import { showAddWebDavStorageProfile, showEditWebDavStorageProfile } from "./web
 
 const BACK = "Back";
 
-export async function showStorageConnections(ctx: ExtensionCommandContext) {
+export async function showStorageConnections(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	const raw = await readLocalConfigObject();
 	if (raw?.version !== 2) {
 		ctx.ui.notify("Upgrade settings before managing saved connections.", "info");
 		return;
 	}
 	const profiles = ownRecord(raw.profiles) ?? {};
-	const selected = await ctx.ui.select("Saved connections", [
-		"Add saved connection",
-		...Object.keys(profiles).sort(),
-		BACK,
-	]);
+	const selected = await ctx.ui.select(
+		"Saved connections",
+		["Add saved connection", ...Object.keys(profiles).sort(), BACK],
+		{ signal },
+	);
 	if (!selected || selected === BACK) return;
 	if (selected === "Add saved connection") {
-		await showAddStorageConnection(ctx);
+		await showAddStorageConnection(ctx, signal);
 		return;
 	}
-	const action = await ctx.ui.select(`Saved connection “${safeTerminalText(selected)}”`, [
-		"Edit connection",
-		"Remove saved connection",
-		BACK,
-	]);
+	const action = await ctx.ui.select(
+		`Saved connection “${safeTerminalText(selected)}”`,
+		["Edit connection", "Remove saved connection", BACK],
+		{ signal },
+	);
 	if (!action || action === BACK) return;
 	if (action === "Remove saved connection") {
 		const confirmed = await ctx.ui.confirm(
@@ -51,7 +51,7 @@ export async function showStorageConnections(ctx: ExtensionCommandContext) {
 	const profile = ownRecord(profiles[selected]);
 	if (!profile) return;
 	if (profile.kind === "webdav") {
-		await showEditWebDavStorageProfile(ctx, selected, profile);
+		await showEditWebDavStorageProfile(ctx, selected, profile, signal);
 		return;
 	}
 	const endpoint = await requiredInput(
@@ -75,15 +75,14 @@ export async function showStorageConnections(ctx: ExtensionCommandContext) {
 	ctx.ui.notify(`Saved connection “${safeTerminalText(selected)}”.`, "info");
 }
 
-export async function showAddStorageConnection(ctx: ExtensionCommandContext) {
-	const preset = await ctx.ui.select("Storage type", [
-		"Cloudflare R2",
-		"Other S3-compatible storage",
-		"WebDAV",
-		"Cancel",
-	]);
+export async function showAddStorageConnection(ctx: ExtensionCommandContext, signal?: AbortSignal) {
+	const preset = await ctx.ui.select(
+		"Storage type",
+		["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Cancel"],
+		{ signal },
+	);
 	if (!preset || preset === "Cancel") return false;
-	if (preset === "WebDAV") return showAddWebDavStorageProfile(ctx);
+	if (preset === "WebDAV") return showAddWebDavStorageProfile(ctx, signal);
 	const name = await requiredInput(
 		ctx,
 		"Name this saved connection",

--- a/extensions/pi-sync/src/storage-connections-ui.ts
+++ b/extensions/pi-sync/src/storage-connections-ui.ts
@@ -1,0 +1,119 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { readLocalConfigObject } from "./config.js";
+import { ownRecord, requiredInput, safeTerminalText } from "./manager-helpers.js";
+import {
+	applyS3CredentialUpdate,
+	chooseS3Credentials,
+	chooseS3CredentialUpdate,
+} from "./s3-credentials-ui.js";
+import {
+	addStorageProfile,
+	removeStorageProfile,
+	updateStorageProfile,
+} from "./settings-management.js";
+import { showAddWebDavStorageProfile, showEditWebDavStorageProfile } from "./webdav-ui.js";
+
+const BACK = "Back";
+
+export async function showStorageConnections(ctx: ExtensionCommandContext) {
+	const raw = await readLocalConfigObject();
+	if (raw?.version !== 2) {
+		ctx.ui.notify("Upgrade settings before managing saved connections.", "info");
+		return;
+	}
+	const profiles = ownRecord(raw.profiles) ?? {};
+	const selected = await ctx.ui.select("Saved connections", [
+		"Add saved connection",
+		...Object.keys(profiles).sort(),
+		BACK,
+	]);
+	if (!selected || selected === BACK) return;
+	if (selected === "Add saved connection") {
+		await showAddStorageConnection(ctx);
+		return;
+	}
+	const action = await ctx.ui.select(`Saved connection “${safeTerminalText(selected)}”`, [
+		"Edit connection",
+		"Remove saved connection",
+		BACK,
+	]);
+	if (!action || action === BACK) return;
+	if (action === "Remove saved connection") {
+		const confirmed = await ctx.ui.confirm(
+			"Remove saved connection?",
+			`Remove saved connection “${safeTerminalText(selected)}”? Remote buckets and snapshots are not deleted.`,
+		);
+		if (!confirmed) return;
+		await removeStorageProfile(selected);
+		ctx.ui.notify(`Removed saved connection “${safeTerminalText(selected)}”.`, "info");
+		return;
+	}
+	const profile = ownRecord(profiles[selected]);
+	if (!profile) return;
+	if (profile.kind === "webdav") {
+		await showEditWebDavStorageProfile(ctx, selected, profile);
+		return;
+	}
+	const endpoint = await requiredInput(
+		ctx,
+		"Endpoint",
+		String(profile.endpoint ?? "https://s3.example.com"),
+	);
+	if (!endpoint) return;
+	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
+	if (!region) return;
+	const credentials = await chooseS3CredentialUpdate(ctx, profile);
+	if (!credentials) return;
+	const save = await ctx.ui.select(
+		`Review connection\n\nSaved connection: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
+		["Save profile", "Cancel"],
+	);
+	if (save !== "Save profile") return;
+	await updateStorageProfile(selected, (current) =>
+		applyS3CredentialUpdate({ ...current, endpoint, region }, credentials),
+	);
+	ctx.ui.notify(`Saved connection “${safeTerminalText(selected)}”.`, "info");
+}
+
+export async function showAddStorageConnection(ctx: ExtensionCommandContext) {
+	const preset = await ctx.ui.select("Storage type", [
+		"Cloudflare R2",
+		"Other S3-compatible storage",
+		"WebDAV",
+		"Cancel",
+	]);
+	if (!preset || preset === "Cancel") return false;
+	if (preset === "WebDAV") return showAddWebDavStorageProfile(ctx);
+	const name = await requiredInput(
+		ctx,
+		"Name this saved connection",
+		preset === "Cloudflare R2" ? "r2" : "s3",
+	);
+	if (!name) return false;
+	const endpoint = await requiredInput(
+		ctx,
+		"Endpoint",
+		preset === "Cloudflare R2"
+			? "https://<account-id>.r2.cloudflarestorage.com"
+			: "https://s3.example.com",
+	);
+	if (!endpoint) return false;
+	const region =
+		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
+	if (!region) return false;
+	const credentials = await chooseS3Credentials(ctx);
+	if (!credentials) return false;
+	const save = await ctx.ui.select(
+		`Review saved connection\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
+		["Add connection", "Cancel"],
+	);
+	if (save !== "Add connection") return false;
+	await addStorageProfile(name, {
+		kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
+		endpoint,
+		region,
+		...credentials.profileFields,
+	});
+	ctx.ui.notify(`Added saved connection “${safeTerminalText(name)}”.`, "info");
+	return true;
+}

--- a/extensions/pi-sync/src/storage-connections-ui.ts
+++ b/extensions/pi-sync/src/storage-connections-ui.ts
@@ -62,7 +62,7 @@ export async function showStorageConnections(ctx: ExtensionCommandContext, signa
 	if (!endpoint) return;
 	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
 	if (!region) return;
-	const credentials = await chooseS3CredentialUpdate(ctx, profile);
+	const credentials = await chooseS3CredentialUpdate(ctx, profile, signal);
 	if (!credentials) return;
 	const save = await ctx.ui.select(
 		`Review connection\n\nSaved connection: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
@@ -100,7 +100,7 @@ export async function showAddStorageConnection(ctx: ExtensionCommandContext, sig
 	const region =
 		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
 	if (!region) return false;
-	const credentials = await chooseS3Credentials(ctx);
+	const credentials = await chooseS3Credentials(ctx, signal);
 	if (!credentials) return false;
 	const save = await ctx.ui.select(
 		`Review saved connection\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,

--- a/extensions/pi-sync/src/sync-backend.ts
+++ b/extensions/pi-sync/src/sync-backend.ts
@@ -2,6 +2,7 @@ import type { Snapshot } from "./types.js";
 
 export type PublicationCapability =
 	| "read-check-write-verify"
+	| "conditional-required"
 	| "atomic-conditional"
 	| "lease-protected";
 

--- a/extensions/pi-sync/src/sync-format.ts
+++ b/extensions/pi-sync/src/sync-format.ts
@@ -1,7 +1,7 @@
 import { agentDir } from "./config.js";
 import type { RemoteHead } from "./sync-backend.js";
 import { fileHashMap } from "./sync-state.js";
-import type { Snapshot, SyncConfig } from "./types.js";
+import type { CommonSyncConfig, Snapshot } from "./types.js";
 
 export function formatDiff(local: Snapshot, remote: Snapshot) {
 	const localMap = fileHashMap(local);
@@ -36,7 +36,7 @@ export function formatSnapshotOnlyDiff(title: string, snapshot: Snapshot) {
 }
 
 export function formatPushSummary(
-	config: SyncConfig,
+	config: CommonSyncConfig,
 	destination: string,
 	upload: Snapshot,
 	head: RemoteHead | undefined,
@@ -66,7 +66,7 @@ export function formatApplyPreview(local: Snapshot, remote: Snapshot) {
 }
 
 export function formatPullSummary(
-	config: SyncConfig,
+	config: CommonSyncConfig,
 	destination: string,
 	local: Snapshot,
 	remote: Snapshot,
@@ -84,7 +84,7 @@ export function formatPullSummary(
 }
 
 export function formatRollbackSummary(
-	config: SyncConfig,
+	config: CommonSyncConfig,
 	destination: string,
 	local: Snapshot,
 	remote: Snapshot,

--- a/extensions/pi-sync/src/sync-operations.ts
+++ b/extensions/pi-sync/src/sync-operations.ts
@@ -54,7 +54,13 @@ import {
 	snapshotsMatch,
 	syncPolicyChanged,
 } from "./sync-state.js";
-import type { CommandOptions, Snapshot, SnapshotOptions, SyncConfig, SyncState } from "./types.js";
+import type {
+	AnySyncConfig,
+	CommandOptions,
+	Snapshot,
+	SnapshotOptions,
+	SyncState,
+} from "./types.js";
 
 const STATUS_KEY = "sync";
 const VERSION = 1;
@@ -90,13 +96,13 @@ export class RollbackPublicationError extends Error {
 }
 
 interface PushInput {
-	config: SyncConfig;
+	config: AnySyncConfig;
 	state: SyncState;
 	local: Snapshot;
 	backend?: SyncBackend;
 }
 
-function backendFor(config: SyncConfig, factory: SyncBackendFactory) {
+function backendFor(config: AnySyncConfig, factory: SyncBackendFactory) {
 	return factory(config);
 }
 
@@ -201,9 +207,9 @@ export async function doctor(
 		messages.push(
 			`config: ok (target ${config.target ?? "default"}; ${safeTerminalText(backend.destination)})`,
 		);
-		messages.push(`publication safety: ${backend.capability}`);
 		const diagnostics = await backend.diagnose(options.signal);
 		throwIfAborted(options.signal);
+		messages.push(`publication safety: ${backend.capability}`);
 		for (const diagnostic of diagnostics) {
 			messages.push(diagnostic.message);
 			if (diagnostic.level !== "info") level = "warning";
@@ -742,7 +748,7 @@ function protectedSessionPaths(ctx: ExtensionCommandContext | ExtensionContext) 
 
 function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
-	config: SyncConfig,
+	config: AnySyncConfig,
 ): SnapshotOptions {
 	return {
 		syncFiles: config.syncFiles,
@@ -782,7 +788,7 @@ async function maybeReload(ctx: ExtensionCommandContext | ExtensionContext, sign
 
 async function readRemoteSnapshotForUpload(
 	backend: SyncBackend,
-	config: SyncConfig,
+	config: AnySyncConfig,
 	head: RemoteHead | undefined,
 	state: SyncState,
 	signal?: AbortSignal,
@@ -800,7 +806,7 @@ async function readRemoteSnapshotForUpload(
 
 async function snapshotForUpload(
 	backend: SyncBackend,
-	config: SyncConfig,
+	config: AnySyncConfig,
 	local: Snapshot,
 	head: RemoteHead | undefined,
 	remote?: Snapshot,
@@ -820,7 +826,11 @@ async function snapshotForUpload(
 	return mergeRemotePreservedFiles(local, snapshot, config);
 }
 
-async function readRemoteSnapshot(backend: SyncBackend, config: SyncConfig, signal?: AbortSignal) {
+async function readRemoteSnapshot(
+	backend: SyncBackend,
+	config: AnySyncConfig,
+	signal?: AbortSignal,
+) {
 	const head = await backend.readHead(signal);
 	if (!head) return { head: undefined, snapshot: undefined };
 	const snapshot = await backend.readSnapshot(head.snapshotRef, signal);
@@ -835,7 +845,7 @@ async function readRemoteSnapshot(backend: SyncBackend, config: SyncConfig, sign
 async function confirmPush(
 	ctx: ExtensionCommandContext | ExtensionContext,
 	options: CommandOptions,
-	config: SyncConfig,
+	config: AnySyncConfig,
 	backend: SyncBackend,
 	local: Snapshot,
 	upload: Snapshot,

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -50,7 +50,7 @@ import {
 } from "./sync-operations.js";
 import { hasLocalChanges } from "./sync-state.js";
 import { TargetPullRequiresUiError, useSyncTarget } from "./target-switch.js";
-import type { CommandOptions, SnapshotOptions, SyncConfig } from "./types.js";
+import type { AnySyncConfig, CommandOptions, SnapshotOptions } from "./types.js";
 
 const STATUS_KEY = "sync";
 const DEFAULT_PROFILE = "default";
@@ -281,26 +281,39 @@ async function initConfig(ctx: ExtensionCommandContext) {
 
 async function showConfig(ctx: ExtensionCommandContext, options: CommandOptions) {
 	const partial = await loadPartialConfig(options.target);
+	const webdav = partial.storageKind === "webdav";
 	const syncSessions = isExplicitlyEnabled(partial.syncSessions);
 	const warnings = [
-		...deprecatedPiSyncEnvironmentWarnings(),
-		...sessionTokenWarnings(partial),
+		...(webdav ? [] : deprecatedPiSyncEnvironmentWarnings()),
+		...(webdav ? [] : sessionTokenWarnings(partial)),
 		...syncSessionsWarnings({ syncSessions }),
 	];
+	const storageLines = webdav
+		? [
+				`kind: webdav`,
+				`url: ${displayWebDavUrl(partial.url, partial.username)}`,
+				`username: ${partial.username ? "configured (value hidden)" : "missing"}`,
+				`password: ${partial.password ? "configured" : "missing"}`,
+				`path: ${partial.path ?? DEFAULT_PREFIX}`,
+				`namespace: ${partial.profile ?? DEFAULT_PROFILE}`,
+			]
+		: [
+				`endpoint: ${partial.endpoint ?? "missing"}`,
+				`bucket: ${partial.bucket ?? "missing"}`,
+				`region: ${partial.region ?? DEFAULT_REGION}`,
+				`accessKeyId: ${partial.accessKeyId ? redact(partial.accessKeyId) : "missing"}`,
+				`secretAccessKey: ${partial.secretAccessKey ? "configured" : "missing"}`,
+				`sessionToken: ${partial.sessionToken ? "configured" : "not configured"}`,
+				`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
+				`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
+			];
 	ctx.ui.notify(
 		[
 			"pi-sync config:",
 			`target: ${partial.target ?? "default"}`,
 			`storage profile: ${partial.storageProfile ?? "default"}`,
-			`endpoint: ${partial.endpoint ?? "missing"}`,
-			`bucket: ${partial.bucket ?? "missing"}`,
-			`region: ${partial.region ?? DEFAULT_REGION}`,
-			`accessKeyId: ${partial.accessKeyId ? redact(partial.accessKeyId) : "missing"}`,
-			`secretAccessKey: ${partial.secretAccessKey ? "configured" : "missing"}`,
-			`sessionToken: ${partial.sessionToken ? "configured" : "not configured"}`,
-			`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
-			`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
-			`autoSync: ${isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true) ? "enabled" : "disabled"}`,
+			...storageLines,
+			`autoSync: ${isEnabled(webdav ? partial.autoSync : (partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC), true) ? "enabled" : "disabled"}`,
 			`syncFiles: ${normalizeSyncFiles(partial.syncFiles).join(", ") || "none"}`,
 			`syncSessions: ${syncSessions ? "enabled" : "disabled"}`,
 			`extraFiles: ${normalizeExtraFiles(partial.extraFiles).join(", ") || "none"}`,
@@ -309,6 +322,21 @@ async function showConfig(ctx: ExtensionCommandContext, options: CommandOptions)
 		].join("\n"),
 		warnings.length > 0 ? "warning" : "info",
 	);
+}
+
+function displayWebDavUrl(value: string | undefined, username: string | undefined) {
+	if (!value) return "missing";
+	try {
+		const url = new URL(value);
+		url.username = "";
+		url.password = "";
+		url.search = "";
+		url.hash = "";
+		const pathname = username ? url.pathname.split(username).join("[redacted]") : url.pathname;
+		return `${url.origin}${pathname}`;
+	} catch {
+		return "invalid (value hidden)";
+	}
 }
 
 function throwIfAborted(signal: AbortSignal) {
@@ -324,7 +352,7 @@ function combineSignals(primary: AbortSignal, secondary?: AbortSignal) {
 
 function snapshotOptionsForContext(
 	ctx: ExtensionCommandContext | ExtensionContext,
-	config: SyncConfig,
+	config: AnySyncConfig,
 ): SnapshotOptions {
 	return {
 		syncFiles: config.syncFiles,

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -132,8 +132,11 @@ async function handleCommand(
 ) {
 	if (!rawArgs.trim()) {
 		try {
-			await showSyncManager(ctx, (route, signal, onCommit, target) =>
-				executeCommand(route, ctx, combineSignals(sessionSignal, signal), onCommit, target),
+			await showSyncManager(
+				ctx,
+				(route, signal, onCommit, target) =>
+					executeCommand(route, ctx, combineSignals(sessionSignal, signal), onCommit, target),
+				sessionSignal,
 			);
 		} catch (error) {
 			if (sessionSignal.aborted) return;
@@ -172,7 +175,7 @@ async function executeCommand(
 				);
 				return;
 			case "init":
-				await initConfig(ctx);
+				await initConfig(ctx, signal);
 				return;
 			case "config":
 				await showConfig(ctx, options);
@@ -221,7 +224,7 @@ async function autoSync(ctx: ExtensionContext, signal: AbortSignal) {
 	try {
 		const partial = await loadPartialConfig();
 		throwIfAborted(signal);
-		if (!isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true)) return;
+		if (!isEnabled(autoSyncSetting(partial), true)) return;
 		await ensureStateDir();
 		throwIfAborted(signal);
 		await loadConfig();
@@ -241,7 +244,7 @@ async function autoPushSessions(ctx: ExtensionContext, signal: AbortSignal) {
 	try {
 		const partial = await loadPartialConfig();
 		throwIfAborted(signal);
-		if (!isEnabled(partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC, true)) return;
+		if (!isEnabled(autoSyncSetting(partial), true)) return;
 		if (!isExplicitlyEnabled(partial.syncSessions)) return;
 		await ensureStateDir();
 		throwIfAborted(signal);
@@ -264,7 +267,7 @@ async function autoPushSessions(ctx: ExtensionContext, signal: AbortSignal) {
 	}
 }
 
-async function initConfig(ctx: ExtensionCommandContext) {
+async function initConfig(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	const configPath = localConfigPath();
 	if (await readLocalConfigObject()) {
 		ctx.ui.notify(`Config already exists: ${await activeLocalConfigPath()}`, "info");
@@ -272,7 +275,7 @@ async function initConfig(ctx: ExtensionCommandContext) {
 	}
 
 	if (ctx.mode === "tui") {
-		await showSetupWizard(ctx);
+		await showSetupWizard(ctx, signal);
 		return;
 	}
 	await writeLocalConfigObject(localConfigTemplate());
@@ -332,11 +335,16 @@ function displayWebDavUrl(value: string | undefined, username: string | undefine
 		url.password = "";
 		url.search = "";
 		url.hash = "";
-		const pathname = username ? url.pathname.split(username).join("[redacted]") : url.pathname;
-		return `${url.origin}${pathname}`;
+		return username ? `${url.origin}/…` : `${url.origin}${url.pathname}`;
 	} catch {
 		return "invalid (value hidden)";
 	}
+}
+
+function autoSyncSetting(partial: Awaited<ReturnType<typeof loadPartialConfig>>) {
+	return partial.storageKind === "webdav"
+		? partial.autoSync
+		: (partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC);
 }
 
 function throwIfAborted(signal: AbortSignal) {

--- a/extensions/pi-sync/src/types.ts
+++ b/extensions/pi-sync/src/types.ts
@@ -1,4 +1,4 @@
-export type StorageProfileKind = "r2" | "s3-compatible";
+export type StorageProfileKind = "r2" | "s3-compatible" | "webdav";
 export type TargetSwitchAction = "ask" | "pull" | "switch-only";
 
 export interface S3StorageProfileFields {
@@ -11,6 +11,15 @@ export interface S3StorageProfileFields {
 
 export type S3StorageProfileSettings = S3StorageProfileFields &
 	({ kind?: undefined } | { kind: "r2" } | { kind: "s3-compatible" });
+
+export interface WebDavStorageProfileSettings {
+	kind: "webdav";
+	url?: string;
+	username?: string;
+	password?: string;
+}
+
+export type StorageProfileSettings = S3StorageProfileSettings | WebDavStorageProfileSettings;
 
 export interface CommonSyncTargetSettings {
 	profile?: string;
@@ -26,17 +35,24 @@ export interface S3SyncTargetSettings extends CommonSyncTargetSettings {
 	namespace?: string;
 }
 
+export interface WebDavSyncTargetSettings extends CommonSyncTargetSettings {
+	path?: string;
+	namespace?: string;
+}
+
+export type SyncTargetSettings = S3SyncTargetSettings | WebDavSyncTargetSettings;
+
 export interface PiSyncSettingsV2 {
 	version: 2;
 	activeTarget?: string;
 	targetSwitchAction?: TargetSwitchAction;
-	profiles?: Record<string, S3StorageProfileSettings>;
-	targets?: Record<string, S3SyncTargetSettings>;
+	profiles?: Record<string, StorageProfileSettings>;
+	targets?: Record<string, SyncTargetSettings>;
 	[key: string]: unknown;
 }
 
 export interface ResolvedS3StorageProfile {
-	kind: StorageProfileKind;
+	kind: "r2" | "s3-compatible";
 	endpoint: string;
 	region: string;
 	accessKeyId: string;
@@ -56,6 +72,35 @@ export interface ResolvedS3Backend {
 	destination: ResolvedS3Destination;
 }
 
+export interface ResolvedWebDavStorageProfile {
+	kind: "webdav";
+	url: string;
+	username: string;
+	password: string;
+	/** S3-only compatibility properties remain absent at runtime. */
+	endpoint?: string;
+	region?: string;
+	accessKeyId?: string;
+	secretAccessKey?: string;
+	sessionToken?: string;
+}
+
+export interface ResolvedWebDavDestination {
+	path: string;
+	namespace: string;
+	/** S3-only compatibility properties remain absent at runtime. */
+	bucket?: string;
+	prefix?: string;
+}
+
+export interface ResolvedWebDavBackend {
+	type: "webdav";
+	profile: ResolvedWebDavStorageProfile;
+	destination: ResolvedWebDavDestination;
+}
+
+export type ResolvedSyncBackend = ResolvedS3Backend | ResolvedWebDavBackend;
+
 export interface CommonSyncConfig {
 	/** Remote namespace retained as `profile` for snapshot/wire compatibility. */
 	profile: string;
@@ -69,9 +114,12 @@ export interface CommonSyncConfig {
 }
 
 /** Discriminated union extended by each production backend. */
-export type SyncConfig = CommonSyncConfig & {
-	backend: ResolvedS3Backend;
-};
+export type SyncConfig<Backend extends ResolvedSyncBackend = ResolvedS3Backend> =
+	CommonSyncConfig & {
+		backend: Backend;
+	};
+
+export type AnySyncConfig = SyncConfig<ResolvedSyncBackend>;
 
 export interface PartialConfig {
 	target?: string;
@@ -79,7 +127,11 @@ export interface PartialConfig {
 	storageKind?: StorageProfileKind;
 	settingsVersion?: 1 | 2;
 	endpoint?: string;
+	url?: string;
+	username?: string;
+	password?: string;
 	bucket?: string;
+	path?: string;
 	region?: string;
 	accessKeyId?: string;
 	secretAccessKey?: string;

--- a/extensions/pi-sync/src/webdav-backend.ts
+++ b/extensions/pi-sync/src/webdav-backend.ts
@@ -1,0 +1,640 @@
+import { createHash, randomUUID } from "node:crypto";
+import { decodeSnapshot, encodeSnapshot } from "./snapshot-codec.js";
+import {
+	type BackendDiagnostic,
+	type ExpectedRemoteHead,
+	type PublishSnapshotOptions,
+	type PublishSnapshotResult,
+	type RemoteHead,
+	type RemoteHistoryEntry,
+	type SyncBackend,
+	SyncBackendConflictError,
+	SyncBackendPublicationOutcomeUnknownError,
+} from "./sync-backend.js";
+import type { LatestPointer, RemoteObject, ResolvedWebDavBackend, Snapshot } from "./types.js";
+import { WebDavClient, WebDavHttpError, WebDavPreconditionError } from "./webdav-client.js";
+
+const VERSION = 1;
+const POST_COMMIT_TIMEOUT_MS = 30_000;
+
+export class WebDavSyncBackend implements SyncBackend {
+	readonly identity: string;
+	readonly destination: string;
+	private conditionalVerified = false;
+	private readonly checksums = new Map<string, string>();
+	private capabilityCheck?: Promise<void>;
+
+	constructor(
+		private readonly config: ResolvedWebDavBackend,
+		private readonly postCommitTimeoutMs = POST_COMMIT_TIMEOUT_MS,
+	) {
+		assertSafeDestination(config);
+		this.identity = webDavBackendIdentity(config);
+		this.destination = webDavDestination(config);
+	}
+
+	get capability() {
+		return this.conditionalVerified
+			? ("atomic-conditional" as const)
+			: ("conditional-required" as const);
+	}
+
+	sameRevision(left: string, right: string) {
+		return left === right;
+	}
+
+	async readHead(signal?: AbortSignal): Promise<RemoteHead | undefined> {
+		const object = await new WebDavClient(this.config, signal).getJson<LatestPointer>(
+			latestPath(this.config),
+		);
+		throwIfAborted(signal);
+		if (object.missing) return undefined;
+		const pointer = requirePointer(object.value, this.config.destination.namespace);
+		this.registerChecksum(pointer.snapshot, pointer.sha256);
+		return remoteHead(pointer, this.identity, object.etag);
+	}
+
+	async readSnapshot(reference: string, signal?: AbortSignal): Promise<Snapshot> {
+		requireSnapshotReference(reference);
+		const expectedChecksum =
+			this.checksums.get(reference) ?? (await this.resolveChecksum(reference, signal));
+		const object = await new WebDavClient(this.config, signal).getBuffer(
+			snapshotPath(this.config, reference),
+		);
+		throwIfAborted(signal);
+		if (!object.value) throw new Error(`Snapshot not found: ${reference}`);
+		if (!expectedChecksum || sha256(object.value) !== expectedChecksum) {
+			throw new Error("Remote snapshot checksum mismatch.");
+		}
+		const snapshot = await decodeSnapshot(object.value, { signal });
+		if (snapshot.id !== reference || snapshot.profile !== this.config.destination.namespace) {
+			throw new Error("Remote snapshot identity mismatch.");
+		}
+		validateSnapshotBundle(snapshot);
+		return snapshot;
+	}
+
+	async publishSnapshot(
+		snapshot: Snapshot,
+		expected: ExpectedRemoteHead,
+		options: PublishSnapshotOptions = {},
+	): Promise<PublishSnapshotResult> {
+		throwIfAborted(options.signal);
+		assertSnapshotIdentity(snapshot, this.config.destination.namespace);
+		await this.ensureAtomicConditions(options.signal);
+		throwIfAborted(options.signal);
+		const client = new WebDavClient(this.config, options.signal);
+		await client.ensureCollection(snapshotsPath(this.config));
+		const encoded = await encodeSnapshot(snapshot);
+		throwIfAborted(options.signal);
+		const pointer = pointerFor(this.config, snapshot, sha256(encoded));
+		const stagedPath = snapshotPath(this.config, snapshot.id);
+		try {
+			await client.putBuffer(stagedPath, encoded, "application/gzip", { ifAbsent: true });
+		} catch (error) {
+			if (!(error instanceof WebDavPreconditionError)) throw error;
+			const existing = await client.getBuffer(stagedPath);
+			if (!existing.value || sha256(existing.value) !== pointer.sha256) {
+				throw new SyncBackendConflictError(
+					`Immutable snapshot id already exists with different content: ${snapshot.id}`,
+				);
+			}
+		}
+		const currentObject = await client.getJson<LatestPointer>(latestPath(this.config));
+		throwIfAborted(options.signal);
+		const current = currentObject.missing
+			? undefined
+			: remoteHead(
+					requirePointer(currentObject.value, this.config.destination.namespace),
+					this.identity,
+					currentObject.etag,
+				);
+		if (!matchesExpected(current, expected)) {
+			throw new SyncBackendConflictError(
+				"Remote changed while pushing. Run /sync pull first, then retry.",
+				{
+					currentHead: current,
+				},
+			);
+		}
+		const condition = publicationCondition(currentObject, expected, this.identity);
+		throwIfAborted(options.signal);
+		options.onCommit?.();
+		const commitClient = new WebDavClient(
+			this.config,
+			AbortSignal.timeout(this.postCommitTimeoutMs),
+			this.postCommitTimeoutMs,
+		);
+		try {
+			await commitClient.putJson(latestPath(this.config), pointer, condition);
+		} catch (error) {
+			if (error instanceof WebDavPreconditionError) {
+				const latest = await this.readHeadAfterCommit(commitClient).catch(() => undefined);
+				throw new SyncBackendConflictError("Remote changed while publishing the WebDAV pointer.", {
+					currentHead: latest,
+				});
+			}
+			throw new SyncBackendPublicationOutcomeUnknownError(
+				`Remote publication outcome is unknown: ${errorMessage(error)}`,
+				{ cause: error },
+			);
+		}
+		let verifiedObject: RemoteObject<LatestPointer>;
+		try {
+			verifiedObject = await commitClient.getJson<LatestPointer>(latestPath(this.config));
+		} catch (error) {
+			throw new SyncBackendPublicationOutcomeUnknownError(
+				`Remote snapshot may be active, but publication could not be verified: ${errorMessage(error)}`,
+				{ cause: error },
+			);
+		}
+		let verified: LatestPointer;
+		try {
+			verified = requirePointer(verifiedObject.value, this.config.destination.namespace);
+		} catch (error) {
+			throw new SyncBackendPublicationOutcomeUnknownError(
+				`Remote snapshot may be active, but publication verification was malformed: ${errorMessage(error)}`,
+				{ cause: error },
+			);
+		}
+		if (!samePointer(pointer, verified)) {
+			throw new SyncBackendConflictError(
+				"Remote latest changed immediately after push. Run /sync status before continuing.",
+				{
+					phase: "after-commit",
+					currentHead: remoteHead(verified, this.identity, verifiedObject.etag),
+					candidateMayHaveBeenActive: true,
+				},
+			);
+		}
+		if (!strongEtag(verifiedObject.etag)) {
+			throw new SyncBackendPublicationOutcomeUnknownError(
+				"Remote snapshot is active, but the WebDAV server returned no strong ETag.",
+			);
+		}
+		this.registerChecksum(verified.snapshot, verified.sha256);
+		const head = remoteHead(verified, this.identity, verifiedObject.etag);
+		const warning = await this.updateHistorySafely(commitClient, pointer);
+		return { head, warnings: warning ? [warning] : [] };
+	}
+
+	async listHistory(signal?: AbortSignal): Promise<RemoteHistoryEntry[]> {
+		const object = await new WebDavClient(this.config, signal).getJson<{
+			version: number;
+			snapshots: LatestPointer[];
+		}>(historyPath(this.config));
+		throwIfAborted(signal);
+		if (object.missing) return [];
+		const pointers = requireHistory(object.value, this.config.destination.namespace);
+		for (const pointer of pointers) this.registerChecksum(pointer.snapshot, pointer.sha256);
+		return pointers.map(remoteHistoryEntry);
+	}
+
+	async diagnose(signal?: AbortSignal): Promise<BackendDiagnostic[]> {
+		const diagnostics: BackendDiagnostic[] = [
+			{
+				key: "webdav-url",
+				level: "info",
+				message: `webdav URL/TLS/auth: configured (${webDavDestination(this.config)})`,
+			},
+		];
+		try {
+			await this.runCapabilityProbe(signal);
+			diagnostics.push(
+				{ key: "webdav-collection", level: "info", message: "webdav collection read/write: ok" },
+				{
+					key: "webdav-conditional",
+					level: "info",
+					message: "webdav conditional publication: atomic-conditional (verified)",
+				},
+				{ key: "webdav-cleanup", level: "info", message: "webdav probe cleanup: ok" },
+			);
+		} catch (error) {
+			this.capabilityCheck = undefined;
+			this.conditionalVerified = false;
+			if (error instanceof Error && error.name === "AbortError") throw error;
+			diagnostics.push({
+				key: "webdav-probe",
+				level: "error",
+				message: `webdav publication is read-only until diagnostics pass: ${errorMessage(error)}`,
+			});
+		}
+		return diagnostics;
+	}
+
+	private ensureAtomicConditions(signal?: AbortSignal) {
+		if (this.capabilityCheck) return this.capabilityCheck;
+		this.conditionalVerified = false;
+		const check = this.runCapabilityProbe(signal).finally(() => {
+			if (this.capabilityCheck === check) this.capabilityCheck = undefined;
+		});
+		this.capabilityCheck = check;
+		return check;
+	}
+
+	private async runCapabilityProbe(signal?: AbortSignal) {
+		throwIfAborted(signal);
+		const probeCollection = `${rootPath(this.config)}/.pi-sync-probes/${randomUUID()}`;
+		const probe = `${probeCollection}/conditional.txt`;
+		const client = new WebDavClient(this.config, signal);
+		let created = false;
+		let operationError: unknown;
+		try {
+			created = true;
+			await client.ensureCollection(probeCollection);
+			await client.listCollection(probeCollection);
+			await client.putBuffer(probe, Buffer.from("first"), "text/plain", { ifAbsent: true });
+			const read = await client.getBuffer(probe);
+			const etag = strongEtag(read.etag);
+			if (!read.value || !etag) {
+				throw new Error("WebDAV server did not return a strong ETag for the capability probe.");
+			}
+			await expectPrecondition(
+				client.putBuffer(probe, Buffer.from("replace"), "text/plain", { ifAbsent: true }),
+				"If-None-Match",
+			);
+			await expectPrecondition(
+				client.putBuffer(probe, Buffer.from("replace"), "text/plain", {
+					ifMatch: '"pi-sync-deliberately-stale"',
+				}),
+				"If-Match",
+			);
+			const unchanged = await client.getBuffer(probe);
+			if (!unchanged.value?.equals(Buffer.from("first"))) {
+				throw new Error("WebDAV server changed a probe despite a failed precondition.");
+			}
+			await client.putBuffer(probe, Buffer.from("second"), "text/plain", { ifMatch: etag });
+		} catch (error) {
+			operationError = error;
+		}
+		if (created) {
+			try {
+				await new WebDavClient(this.config, undefined).delete(probeCollection);
+			} catch (cleanupError) {
+				const operationDetail = operationError
+					? `WebDAV probe failed: ${errorMessage(operationError)}; `
+					: "";
+				throw new Error(
+					`${operationDetail}probe cleanup also failed; remove ${probeCollection}: ${errorMessage(cleanupError)}`,
+					{ cause: operationError ?? cleanupError },
+				);
+			}
+		}
+		if (operationError) throw operationError;
+		this.conditionalVerified = true;
+	}
+
+	private async resolveChecksum(reference: string, signal?: AbortSignal) {
+		await this.readHead(signal);
+		if (this.checksums.has(reference)) return this.checksums.get(reference);
+		await this.listHistory(signal);
+		return this.checksums.get(reference);
+	}
+
+	private registerChecksum(reference: string, checksum: string) {
+		const known = this.checksums.get(reference);
+		if (known && known !== checksum) {
+			throw new Error("Remote snapshot reference was rebound to a different checksum.");
+		}
+		this.checksums.set(reference, checksum);
+	}
+
+	private async readHeadAfterCommit(client: WebDavClient) {
+		const object = await client.getJson<LatestPointer>(latestPath(this.config));
+		if (object.missing) return undefined;
+		return remoteHead(
+			requirePointer(object.value, this.config.destination.namespace),
+			this.identity,
+			object.etag,
+		);
+	}
+
+	private async updateHistorySafely(client: WebDavClient, pointer: LatestPointer) {
+		try {
+			const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(
+				historyPath(this.config),
+			);
+			const snapshots = object.missing
+				? []
+				: requireHistory(object.value, this.config.destination.namespace);
+			const next = [
+				...snapshots.filter((entry) => entry.snapshot !== pointer.snapshot),
+				pointer,
+			].slice(-100);
+			const condition = object.missing
+				? { ifAbsent: true }
+				: { ifMatch: requireStrongEtag(object.etag, "history") };
+			await client.putJson(
+				historyPath(this.config),
+				{ version: VERSION, snapshots: next },
+				condition,
+			);
+			return undefined;
+		} catch (error) {
+			return `Remote snapshot is active, but history could not be updated: ${errorMessage(error)}. Run /sync doctor before relying on history.`;
+		}
+	}
+}
+
+export function rootPath(config: ResolvedWebDavBackend) {
+	return joinRemote(config.destination.path, "profiles", config.destination.namespace);
+}
+
+export function latestPath(config: ResolvedWebDavBackend) {
+	return joinRemote(rootPath(config), "latest.json");
+}
+
+export function historyPath(config: ResolvedWebDavBackend) {
+	return joinRemote(rootPath(config), "history.json");
+}
+
+export function snapshotsPath(config: ResolvedWebDavBackend) {
+	return joinRemote(rootPath(config), "snapshots");
+}
+
+export function snapshotPath(config: ResolvedWebDavBackend, reference: string) {
+	requireSnapshotReference(reference);
+	return joinRemote(snapshotsPath(config), `${reference}.json.gz`);
+}
+
+export function webDavBackendIdentity(config: ResolvedWebDavBackend) {
+	return `webdav:${sha256(
+		Buffer.from(
+			JSON.stringify([
+				secretFreeUrl(config.profile.url),
+				config.destination.path,
+				config.destination.namespace,
+			]),
+		),
+	)}`;
+}
+
+function webDavDestination(config: ResolvedWebDavBackend) {
+	const url = new URL(secretFreeUrl(config.profile.url));
+	return `${url.host} · ${rootPath(config)}`;
+}
+
+function pointerFor(
+	config: ResolvedWebDavBackend,
+	snapshot: Snapshot,
+	checksum: string,
+): LatestPointer {
+	return {
+		version: VERSION,
+		profile: config.destination.namespace,
+		snapshot: snapshot.id,
+		sha256: checksum,
+		createdAt: snapshot.createdAt,
+		machine: snapshot.machine,
+		syncSessions:
+			snapshot.syncSessions === true ||
+			snapshot.files.some((file) => file.path.startsWith("sessions/")),
+	};
+}
+
+function remoteHead(pointer: LatestPointer, identity: string, etag?: string): RemoteHead {
+	return {
+		snapshotRef: pointer.snapshot,
+		snapshotId: pointer.snapshot,
+		revision: encodeRevision(identity, etag, pointer),
+		createdAt: pointer.createdAt,
+		machine: pointer.machine,
+		syncSessions: pointer.syncSessions === true,
+	};
+}
+
+function encodeRevision(identity: string, etag: string | undefined, pointer: LatestPointer) {
+	return `webdav-v1:${Buffer.from(JSON.stringify({ identity, etag: etag ?? null, pointer: sha256(Buffer.from(canonicalJson(pointer))) })).toString("base64url")}`;
+}
+
+function decodeRevision(value: string, identity: string) {
+	try {
+		if (!value.startsWith("webdav-v1:")) return undefined;
+		const parsed = JSON.parse(Buffer.from(value.slice(10), "base64url").toString("utf8")) as {
+			identity?: unknown;
+			etag?: unknown;
+		};
+		if (parsed.identity !== identity || typeof parsed.etag !== "string") return undefined;
+		return strongEtag(parsed.etag);
+	} catch {
+		return undefined;
+	}
+}
+
+function publicationCondition(
+	current: RemoteObject<LatestPointer>,
+	expected: ExpectedRemoteHead,
+	identity: string,
+) {
+	if (expected.kind === "missing") return { ifAbsent: true };
+	const etag = decodeRevision(expected.revision, identity) ?? strongEtag(current.etag);
+	if (!etag) throw new SyncBackendConflictError("WebDAV head has no usable strong ETag.");
+	return { ifMatch: etag };
+}
+
+async function expectPrecondition(operation: Promise<unknown>, header: string) {
+	try {
+		await operation;
+	} catch (error) {
+		if (error instanceof WebDavPreconditionError) return;
+		throw error;
+	}
+	throw new Error(`WebDAV server ignored ${header}; publication is read-only for safety.`);
+}
+
+function requireStrongEtag(value: string | undefined, resource: string) {
+	const etag = strongEtag(value);
+	if (!etag) throw new Error(`WebDAV ${resource} has no strong ETag.`);
+	return etag;
+}
+
+function strongEtag(value: string | undefined) {
+	return value && !value.startsWith("W/") && /^"[^"\r\n]+"$/u.test(value) ? value : undefined;
+}
+
+function requirePointer(value: LatestPointer | undefined, expectedProfile: string) {
+	if (
+		!value ||
+		value.version !== VERSION ||
+		value.profile !== expectedProfile ||
+		!isSafeReference(value.snapshot) ||
+		!/^[0-9a-f]{64}$/u.test(value.sha256) ||
+		!isSafeMetadata(value.createdAt, 64) ||
+		!isSafeMetadata(value.machine, 256) ||
+		(value.syncSessions !== undefined && typeof value.syncSessions !== "boolean")
+	) {
+		throw new Error("Remote latest pointer is malformed.");
+	}
+	return value;
+}
+
+function requireHistory(
+	value: { version: number; snapshots: LatestPointer[] } | undefined,
+	expectedProfile: string,
+) {
+	if (!value || value.version !== VERSION || !Array.isArray(value.snapshots)) {
+		throw new Error("Remote history is malformed.");
+	}
+	const pointers = value.snapshots.map((item) => requirePointer(item, expectedProfile));
+	if (new Set(pointers.map((item) => item.snapshot)).size !== pointers.length) {
+		throw new Error("Remote history contains duplicate snapshot references.");
+	}
+	return pointers;
+}
+
+function remoteHistoryEntry(pointer: LatestPointer): RemoteHistoryEntry {
+	return {
+		snapshotRef: pointer.snapshot,
+		snapshotId: pointer.snapshot,
+		createdAt: pointer.createdAt,
+		machine: pointer.machine,
+		syncSessions: pointer.syncSessions === true,
+	};
+}
+
+function assertSnapshotIdentity(snapshot: Snapshot, namespace: string) {
+	if (
+		snapshot.version !== VERSION ||
+		snapshot.profile !== namespace ||
+		!isSafeReference(snapshot.id) ||
+		!isSafeMetadata(snapshot.createdAt, 64) ||
+		!isSafeMetadata(snapshot.machine, 256) ||
+		!Array.isArray(snapshot.files)
+	) {
+		throw new Error("Invalid snapshot identity for WebDAV publication.");
+	}
+}
+
+function validateSnapshotBundle(snapshot: Snapshot) {
+	const paths = new Set<string>();
+	for (const file of snapshot.files) {
+		if (
+			!file ||
+			!isSafeSnapshotPath(file.path) ||
+			paths.has(file.path) ||
+			typeof file.contentBase64 !== "string" ||
+			typeof file.sha256 !== "string"
+		) {
+			throw new Error("Remote snapshot bundle is malformed.");
+		}
+		const content = Buffer.from(file.contentBase64, "base64");
+		if (content.toString("base64") !== file.contentBase64 || sha256(content) !== file.sha256) {
+			throw new Error("Remote snapshot bundle is malformed.");
+		}
+		paths.add(file.path);
+	}
+}
+
+function isSafeSnapshotPath(value: unknown): value is string {
+	if (typeof value !== "string" || !value || value.length > 4096 || value.includes("\\")) {
+		return false;
+	}
+	if (
+		[...value].some((character) => {
+			const code = character.codePointAt(0) ?? 0;
+			return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+		})
+	) {
+		return false;
+	}
+	return value.split("/").every((segment) => segment && segment !== "." && segment !== "..");
+}
+
+function assertSafeDestination(config: ResolvedWebDavBackend) {
+	const url = new URL(config.profile.url);
+	if (url.username || url.password || url.search || url.hash)
+		throw new Error("Invalid WebDAV URL.");
+	for (const value of [config.destination.path, config.destination.namespace]) {
+		if (
+			!value ||
+			value.includes("\\") ||
+			[...value].some((character) => {
+				const code = character.codePointAt(0) ?? 0;
+				return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+			}) ||
+			value.split("/").some((part) => part === "." || part === "..")
+		) {
+			throw new Error("Invalid WebDAV destination.");
+		}
+	}
+}
+
+function isSafeMetadata(value: unknown, maxLength: number): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value.length <= maxLength &&
+		![...value].some((character) => {
+			const code = character.codePointAt(0) ?? 0;
+			return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+		})
+	);
+}
+
+function requireSnapshotReference(reference: string) {
+	if (!isSafeReference(reference)) throw new Error("Invalid WebDAV snapshot reference.");
+}
+
+function isSafeReference(value: string) {
+	return (
+		!!value &&
+		value.length <= 512 &&
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: Remote references cannot contain terminal controls.
+		!/[\\/\u0000-\u001f\u007f]/u.test(value) &&
+		value !== "." &&
+		value !== ".."
+	);
+}
+
+function matchesExpected(head: RemoteHead | undefined, expected: ExpectedRemoteHead) {
+	return expected.kind === "missing" ? head === undefined : head?.revision === expected.revision;
+}
+
+function samePointer(left: LatestPointer, right: LatestPointer) {
+	return canonicalJson(left) === canonicalJson(right);
+}
+
+function canonicalJson(value: unknown): string {
+	if (Array.isArray(value))
+		return JSON.stringify(value.map((item) => JSON.parse(canonicalJson(item))));
+	if (!value || typeof value !== "object") return JSON.stringify(value);
+	return JSON.stringify(
+		Object.fromEntries(
+			Object.keys(value)
+				.sort()
+				.map((key) => [key, JSON.parse(canonicalJson((value as Record<string, unknown>)[key]))]),
+		),
+	);
+}
+
+function joinRemote(...parts: string[]) {
+	return parts
+		.flatMap((part) => part.split("/"))
+		.filter(Boolean)
+		.join("/");
+}
+
+function secretFreeUrl(value: string) {
+	const url = new URL(value);
+	url.username = "";
+	url.password = "";
+	url.search = "";
+	url.hash = "";
+	return url.toString();
+}
+
+function sha256(value: Buffer) {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("The operation was aborted", "AbortError");
+}
+
+function errorMessage(error: unknown) {
+	if (error instanceof WebDavHttpError) return error.message;
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-sync/src/webdav-backend.ts
+++ b/extensions/pi-sync/src/webdav-backend.ts
@@ -218,6 +218,21 @@ export class WebDavSyncBackend implements SyncBackend {
 				level: "error",
 				message: `webdav publication is read-only until diagnostics pass: ${errorMessage(error)}`,
 			});
+			return diagnostics;
+		}
+		try {
+			diagnostics.push({
+				key: "webdav-history",
+				level: "info",
+				message: await this.reconcileActiveHistory(signal),
+			});
+		} catch (error) {
+			if (error instanceof Error && error.name === "AbortError") throw error;
+			diagnostics.push({
+				key: "webdav-history",
+				level: "error",
+				message: `webdav history repair failed: ${errorMessage(error)}`,
+			});
 		}
 		return diagnostics;
 	}
@@ -316,26 +331,48 @@ export class WebDavSyncBackend implements SyncBackend {
 		);
 	}
 
+	private async reconcileActiveHistory(signal?: AbortSignal) {
+		const client = new WebDavClient(this.config, signal);
+		const object = await client.getJson<LatestPointer>(latestPath(this.config));
+		throwIfAborted(signal);
+		if (object.missing) return "webdav history: no active snapshot";
+		const pointer = requirePointer(object.value, this.config.destination.namespace);
+		this.registerChecksum(pointer.snapshot, pointer.sha256);
+		const repaired = await this.ensureHistoryPointer(client, pointer);
+		return repaired
+			? "webdav history: repaired active snapshot entry"
+			: "webdav history: active snapshot entry present";
+	}
+
+	private async ensureHistoryPointer(client: WebDavClient, pointer: LatestPointer) {
+		const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(
+			historyPath(this.config),
+		);
+		const snapshots = object.missing
+			? []
+			: requireHistory(object.value, this.config.destination.namespace);
+		const existing = snapshots.find((entry) => entry.snapshot === pointer.snapshot);
+		if (existing) {
+			if (!samePointer(existing, pointer)) {
+				throw new Error("Remote history rebound an immutable snapshot reference.");
+			}
+			return false;
+		}
+		const next = [...snapshots, pointer].slice(-100);
+		const condition = object.missing
+			? { ifAbsent: true }
+			: { ifMatch: requireStrongEtag(object.etag, "history") };
+		await client.putJson(
+			historyPath(this.config),
+			{ version: VERSION, snapshots: next },
+			condition,
+		);
+		return true;
+	}
+
 	private async updateHistorySafely(client: WebDavClient, pointer: LatestPointer) {
 		try {
-			const object = await client.getJson<{ version: number; snapshots: LatestPointer[] }>(
-				historyPath(this.config),
-			);
-			const snapshots = object.missing
-				? []
-				: requireHistory(object.value, this.config.destination.namespace);
-			const next = [
-				...snapshots.filter((entry) => entry.snapshot !== pointer.snapshot),
-				pointer,
-			].slice(-100);
-			const condition = object.missing
-				? { ifAbsent: true }
-				: { ifMatch: requireStrongEtag(object.etag, "history") };
-			await client.putJson(
-				historyPath(this.config),
-				{ version: VERSION, snapshots: next },
-				condition,
-			);
+			await this.ensureHistoryPointer(client, pointer);
 			return undefined;
 		} catch (error) {
 			return `Remote snapshot is active, but history could not be updated: ${errorMessage(error)}. Run /sync doctor before relying on history.`;

--- a/extensions/pi-sync/src/webdav-backend.ts
+++ b/extensions/pi-sync/src/webdav-backend.ts
@@ -264,6 +264,13 @@ export class WebDavSyncBackend implements SyncBackend {
 				throw new Error("WebDAV server changed a probe despite a failed precondition.");
 			}
 			await client.putBuffer(probe, Buffer.from("second"), "text/plain", { ifMatch: etag });
+			const changed = await client.getBuffer(probe);
+			const changedEtag = strongEtag(changed.etag);
+			if (!changed.value?.equals(Buffer.from("second")) || !changedEtag || changedEtag === etag) {
+				throw new Error(
+					"WebDAV server did not rotate its strong ETag after changing the capability probe.",
+				);
+			}
 		} catch (error) {
 			operationError = error;
 		}
@@ -580,7 +587,7 @@ function isSafeReference(value: string) {
 		!!value &&
 		value.length <= 512 &&
 		// biome-ignore lint/suspicious/noControlCharactersInRegex: Remote references cannot contain terminal controls.
-		!/[\\/\u0000-\u001f\u007f]/u.test(value) &&
+		!/[\\/\u0000-\u001f\u007f-\u009f]/u.test(value) &&
 		value !== "." &&
 		value !== ".."
 	);

--- a/extensions/pi-sync/src/webdav-client.ts
+++ b/extensions/pi-sync/src/webdav-client.ts
@@ -1,0 +1,367 @@
+import { XMLParser } from "fast-xml-parser";
+import type { RemoteObject, ResolvedWebDavBackend } from "./types.js";
+
+const JSON_LIMIT = 1024 * 1024;
+const ERROR_LIMIT = 64 * 1024;
+const SNAPSHOT_LIMIT = 256 * 1024 * 1024;
+const XML_LIMIT = 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REDIRECTS = 3;
+
+export interface WebDavPutOptions {
+	ifAbsent?: boolean;
+	ifMatch?: string;
+}
+
+export interface WebDavEntry {
+	href: string;
+	etag?: string;
+	collection: boolean;
+}
+
+export class WebDavHttpError extends Error {
+	constructor(
+		message: string,
+		readonly status: number,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "WebDavHttpError";
+	}
+}
+
+export class WebDavPreconditionError extends WebDavHttpError {
+	constructor(message = "WebDAV precondition failed.") {
+		super(message, 412);
+		this.name = "WebDavPreconditionError";
+	}
+}
+
+export class WebDavClient {
+	private readonly baseUrl: URL;
+	private readonly authorization: string;
+
+	constructor(
+		private readonly config: ResolvedWebDavBackend,
+		private readonly signal?: AbortSignal,
+		private readonly timeoutMs = REQUEST_TIMEOUT_MS,
+	) {
+		this.baseUrl = new URL(config.profile.url);
+		assertSafeAuthenticatedUrl(this.baseUrl);
+		if (
+			!config.profile.username ||
+			!config.profile.password ||
+			config.profile.username.includes(":") ||
+			hasControlCharacter(config.profile.username) ||
+			hasControlCharacter(config.profile.password)
+		) {
+			throw new Error("Invalid WebDAV credentials.");
+		}
+		this.authorization = `Basic ${Buffer.from(`${config.profile.username}:${config.profile.password}`).toString("base64")}`;
+	}
+
+	async getBuffer(remotePath: string): Promise<RemoteObject<Buffer>> {
+		const response = await this.request(remotePath, { method: "GET" });
+		if (response.status === 404) return { missing: true };
+		await this.requireOk(response, "read");
+		return {
+			value: await readBounded(response, SNAPSHOT_LIMIT, "WebDAV response is too large"),
+			etag: response.headers.get("etag") ?? undefined,
+			missing: false,
+		};
+	}
+
+	async getJson<T>(remotePath: string): Promise<RemoteObject<T>> {
+		const response = await this.request(remotePath, { method: "GET" });
+		if (response.status === 404) return { missing: true };
+		await this.requireOk(response, "read");
+		const bytes = await readBounded(response, JSON_LIMIT, "WebDAV JSON response is too large");
+		try {
+			return {
+				value: JSON.parse(bytes.toString("utf8")) as T,
+				etag: response.headers.get("etag") ?? undefined,
+				missing: false,
+			};
+		} catch (error) {
+			throw new Error("WebDAV JSON response is malformed.", { cause: error });
+		}
+	}
+
+	async putBuffer(
+		remotePath: string,
+		body: Buffer,
+		contentType: string,
+		options: WebDavPutOptions = {},
+	) {
+		const headers: Record<string, string> = { "content-type": contentType };
+		if (options.ifAbsent) headers["if-none-match"] = "*";
+		if (options.ifMatch) headers["if-match"] = options.ifMatch;
+		const response = await this.request(remotePath, {
+			method: "PUT",
+			headers,
+			body: body as unknown as BodyInit,
+		});
+		if (response.status === 412) throw new WebDavPreconditionError();
+		await this.requireOk(response, "write");
+		await response.body?.cancel();
+		return response.headers.get("etag") ?? undefined;
+	}
+
+	async putJson(remotePath: string, value: unknown, options: WebDavPutOptions = {}) {
+		return this.putBuffer(
+			remotePath,
+			Buffer.from(JSON.stringify(value)),
+			"application/json",
+			options,
+		);
+	}
+
+	async makeCollection(remotePath: string) {
+		const response = await this.request(remotePath, { method: "MKCOL" });
+		if (response.status === 405) {
+			await response.body?.cancel();
+			return false;
+		}
+		await this.requireOk(response, "create collection");
+		await response.body?.cancel();
+		return true;
+	}
+
+	async ensureCollection(remotePath: string) {
+		const segments = safeSegments(remotePath);
+		for (let index = 1; index <= segments.length; index += 1) {
+			await this.makeCollection(segments.slice(0, index).join("/"));
+		}
+	}
+
+	async listCollection(remotePath: string): Promise<WebDavEntry[]> {
+		const response = await this.request(remotePath, {
+			method: "PROPFIND",
+			headers: { depth: "1", "content-type": "application/xml; charset=utf-8" },
+			body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:getetag/><d:resourcetype/></d:prop></d:propfind>',
+		});
+		if (response.status === 404) throw new WebDavHttpError("WebDAV collection is missing.", 404);
+		if (response.status !== 207) await this.requireOk(response, "list collection");
+		const xml = (
+			await readBounded(response, XML_LIMIT, "WebDAV directory response is too large")
+		).toString("utf8");
+		try {
+			const parsed = new XMLParser({
+				removeNSPrefix: true,
+				ignoreAttributes: false,
+				processEntities: false,
+			}).parse(xml) as {
+				multistatus?: { response?: unknown };
+			};
+			if (!parsed.multistatus || parsed.multistatus.response === undefined) {
+				throw new Error("Missing DAV multistatus response.");
+			}
+			const responses = asArray(parsed.multistatus.response);
+			return responses.map(parseEntry);
+		} catch (error) {
+			throw new Error("WebDAV directory response is malformed.", { cause: error });
+		}
+	}
+
+	async delete(remotePath: string) {
+		const response = await this.request(remotePath, { method: "DELETE" });
+		if (response.status === 404) {
+			await response.body?.cancel();
+			return;
+		}
+		await this.requireOk(response, "delete probe resource");
+		await response.body?.cancel();
+	}
+
+	private async request(remotePath: string, init: RequestInit) {
+		throwIfAborted(this.signal);
+		let url = appendRemotePath(this.baseUrl, remotePath);
+		for (let redirects = 0; ; redirects += 1) {
+			const timeout = AbortSignal.timeout(this.timeoutMs);
+			const signal = this.signal ? AbortSignal.any([this.signal, timeout]) : timeout;
+			let response: Response;
+			try {
+				response = await fetch(url, {
+					...init,
+					headers: {
+						accept: "*/*",
+						authorization: this.authorization,
+						...headersObject(init.headers),
+					},
+					redirect: "manual",
+					signal,
+				});
+			} catch (error) {
+				throwIfAborted(this.signal);
+				throw new Error(
+					`WebDAV ${String(init.method ?? "GET")} request failed for ${redactText(safeUrl(url), this.config)}.`,
+					{
+						cause: redactError(error, this.config),
+					},
+				);
+			}
+			if (![301, 302, 303, 307, 308].includes(response.status)) return response;
+			await response.body?.cancel();
+			const method = String(init.method ?? "GET").toUpperCase();
+			if ([301, 302, 303].includes(response.status) && method !== "GET" && method !== "HEAD") {
+				throw new Error(
+					`WebDAV refused an ambiguous HTTP ${response.status} redirect for ${method}; configure the canonical collection URL or require HTTP 307/308.`,
+				);
+			}
+			if (redirects >= MAX_REDIRECTS) throw new Error("WebDAV redirect limit exceeded.");
+			const location = response.headers.get("location");
+			if (!location) throw new Error("WebDAV redirect is missing Location.");
+			const next = new URL(location, url);
+			if (next.origin !== this.baseUrl.origin) {
+				throw new Error("WebDAV refused a cross-origin authenticated redirect.");
+			}
+			url = next;
+		}
+	}
+
+	private async requireOk(response: Response, action: string) {
+		if (response.ok) return;
+		const body = (await readBounded(response, ERROR_LIMIT, "WebDAV error body is too large"))
+			.toString("utf8")
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Remote error text is untrusted terminal input.
+			.replace(/[\u0000-\u001f\u007f-\u009f]/gu, " ")
+			.trim();
+		const detail = body ? `: ${redactText(body, this.config)}` : "";
+		throw new WebDavHttpError(
+			`WebDAV ${action} failed with HTTP ${response.status}${detail}`,
+			response.status,
+		);
+	}
+}
+
+function assertSafeAuthenticatedUrl(url: URL) {
+	const loopback =
+		url.hostname === "127.0.0.1" ||
+		url.hostname === "localhost" ||
+		url.hostname === "[::1]" ||
+		url.hostname === "::1";
+	if (
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash ||
+		(url.protocol !== "https:" && !(url.protocol === "http:" && loopback))
+	) {
+		throw new Error(
+			"Invalid WebDAV URL: HTTPS is required and embedded credentials, query, or fragment are not allowed.",
+		);
+	}
+}
+
+function hasControlCharacter(value: string) {
+	return [...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+	});
+}
+
+function appendRemotePath(base: URL, remotePath: string) {
+	const url = new URL(base);
+	const suffix = safeSegments(remotePath).map(encodeURIComponent).join("/");
+	url.pathname = `${base.pathname.replace(/\/+$/u, "")}/${suffix}`;
+	return url;
+}
+
+function safeSegments(value: string) {
+	const segments = value
+		.replace(/^\/+|\/+$/gu, "")
+		.split("/")
+		.filter(Boolean);
+	if (
+		segments.some(
+			(segment) =>
+				segment === "." ||
+				segment === ".." ||
+				// biome-ignore lint/suspicious/noControlCharactersInRegex: Remote path segments cannot contain controls.
+				/[\u0000-\u001f]/u.test(segment),
+		)
+	) {
+		throw new Error("Invalid WebDAV remote path.");
+	}
+	return segments;
+}
+
+async function readBounded(response: Response, limit: number, message: string) {
+	const length = Number(response.headers.get("content-length"));
+	if (Number.isFinite(length) && length > limit) {
+		await response.body?.cancel();
+		throw new Error(message);
+	}
+	if (!response.body) return Buffer.alloc(0);
+	const reader = response.body.getReader();
+	const chunks: Buffer[] = [];
+	let total = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			total += value.byteLength;
+			if (total > limit) throw new Error(message);
+			chunks.push(Buffer.from(value));
+		}
+	} catch (error) {
+		await reader.cancel().catch(() => undefined);
+		throw error;
+	}
+	return Buffer.concat(chunks, total);
+}
+
+function parseEntry(value: unknown): WebDavEntry {
+	if (!value || typeof value !== "object") throw new Error("Invalid WebDAV response entry.");
+	const record = value as Record<string, unknown>;
+	const href = typeof record.href === "string" ? record.href : undefined;
+	if (!href) throw new Error("Invalid WebDAV response href.");
+	const propstat = asArray(record.propstat).find((item) => {
+		if (!item || typeof item !== "object") return false;
+		return String((item as Record<string, unknown>).status ?? "").includes(" 200 ");
+	}) as Record<string, unknown> | undefined;
+	const prop = propstat?.prop as Record<string, unknown> | undefined;
+	return {
+		href,
+		etag: typeof prop?.getetag === "string" ? prop.getetag : undefined,
+		collection:
+			!!prop?.resourcetype &&
+			typeof prop.resourcetype === "object" &&
+			Object.hasOwn(prop.resourcetype, "collection"),
+	};
+}
+
+function asArray(value: unknown): unknown[] {
+	if (value === undefined) return [];
+	return Array.isArray(value) ? value : [value];
+}
+
+function headersObject(headers: HeadersInit | undefined) {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function safeUrl(url: URL) {
+	return `${url.protocol}//${url.host}${url.pathname}`;
+}
+
+function redactError(error: unknown, config: ResolvedWebDavBackend) {
+	const message = error instanceof Error ? error.message : String(error);
+	return new Error(redactText(message, config));
+}
+
+function redactText(value: string, config: ResolvedWebDavBackend) {
+	let result = value;
+	for (const secret of [config.profile.username, config.profile.password, config.profile.url]) {
+		if (secret) result = result.split(secret).join("[redacted]");
+	}
+	return result
+		.replace(/basic\s+[a-z0-9+/=]+/giu, "Basic [redacted]")
+		.replace(/\?[^\s]*/gu, "?[redacted]");
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("The operation was aborted", "AbortError");
+}

--- a/extensions/pi-sync/src/webdav-client.ts
+++ b/extensions/pi-sync/src/webdav-client.ts
@@ -368,11 +368,18 @@ function redactError(error: unknown, config: ResolvedWebDavBackend) {
 function redactText(value: string, config: ResolvedWebDavBackend) {
 	let result = value;
 	for (const secret of [config.profile.username, config.profile.password, config.profile.url]) {
-		if (secret) result = result.split(secret).join("[redacted]");
+		if (!secret) continue;
+		for (const variant of new Set([secret, encodeURIComponent(secret)])) {
+			result = result.replace(new RegExp(escapeRegExp(variant), "giu"), "[redacted]");
+		}
 	}
 	return result
 		.replace(/basic\s+[a-z0-9+/=]+/giu, "Basic [redacted]")
 		.replace(/\?[^\s]*/gu, "?[redacted]");
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/extensions/pi-sync/src/webdav-client.ts
+++ b/extensions/pi-sync/src/webdav-client.ts
@@ -62,7 +62,10 @@ export class WebDavClient {
 
 	async getBuffer(remotePath: string): Promise<RemoteObject<Buffer>> {
 		const response = await this.request(remotePath, { method: "GET" });
-		if (response.status === 404) return { missing: true };
+		if (response.status === 404) {
+			await response.body?.cancel();
+			return { missing: true };
+		}
 		await this.requireOk(response, "read");
 		return {
 			value: await readBounded(response, SNAPSHOT_LIMIT, "WebDAV response is too large"),
@@ -73,7 +76,10 @@ export class WebDavClient {
 
 	async getJson<T>(remotePath: string): Promise<RemoteObject<T>> {
 		const response = await this.request(remotePath, { method: "GET" });
-		if (response.status === 404) return { missing: true };
+		if (response.status === 404) {
+			await response.body?.cancel();
+			return { missing: true };
+		}
 		await this.requireOk(response, "read");
 		const bytes = await readBounded(response, JSON_LIMIT, "WebDAV JSON response is too large");
 		try {
@@ -101,7 +107,10 @@ export class WebDavClient {
 			headers,
 			body: body as unknown as BodyInit,
 		});
-		if (response.status === 412) throw new WebDavPreconditionError();
+		if (response.status === 412) {
+			await response.body?.cancel();
+			throw new WebDavPreconditionError();
+		}
 		await this.requireOk(response, "write");
 		await response.body?.cancel();
 		return response.headers.get("etag") ?? undefined;
@@ -140,7 +149,10 @@ export class WebDavClient {
 			headers: { depth: "1", "content-type": "application/xml; charset=utf-8" },
 			body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:getetag/><d:resourcetype/></d:prop></d:propfind>',
 		});
-		if (response.status === 404) throw new WebDavHttpError("WebDAV collection is missing.", 404);
+		if (response.status === 404) {
+			await response.body?.cancel();
+			throw new WebDavHttpError("WebDAV collection is missing.", 404);
+		}
 		if (response.status !== 207) await this.requireOk(response, "list collection");
 		const xml = (
 			await readBounded(response, XML_LIMIT, "WebDAV directory response is too large")
@@ -168,6 +180,10 @@ export class WebDavClient {
 		if (response.status === 404) {
 			await response.body?.cancel();
 			return;
+		}
+		if (response.status === 207) {
+			await response.body?.cancel();
+			throw new WebDavHttpError("WebDAV probe cleanup returned a partial response.", 207);
 		}
 		await this.requireOk(response, "delete probe resource");
 		await response.body?.cancel();

--- a/extensions/pi-sync/src/webdav-ui.ts
+++ b/extensions/pi-sync/src/webdav-ui.ts
@@ -35,6 +35,9 @@ export async function repairableWebDavDestinationName(signal?: AbortSignal) {
 			profile?.kind === "webdav" &&
 			(Object.hasOwn(target, "bucket") ||
 				Object.hasOwn(target, "prefix") ||
+				["endpoint", "region", "accessKeyId", "secretAccessKey", "sessionToken"].some((field) =>
+					Object.hasOwn(profile, field),
+				) ||
 				typeof profile.password !== "string" ||
 				profile.password.length === 0)
 		);

--- a/extensions/pi-sync/src/webdav-ui.ts
+++ b/extensions/pi-sync/src/webdav-ui.ts
@@ -1,0 +1,248 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+	localConfigPath,
+	normalizeWebDavPath,
+	normalizeWebDavUrl,
+	validateWebDavCredentials,
+	validateWebDavNamespace,
+} from "./config.js";
+import {
+	addStorageProfile,
+	addSyncTarget,
+	saveNewV2Settings,
+	updateStorageProfile,
+	updateSyncTarget,
+} from "./settings-management.js";
+import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
+import type { PartialConfig } from "./types.js";
+
+export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: string) {
+	const url = await requiredInput(
+		ctx,
+		"WebDAV collection URL",
+		"https://cloud.example.com/remote.php/dav/files/user",
+	);
+	if (!url) return false;
+	const username = await requiredInput(ctx, "WebDAV username", "user");
+	if (!username) return false;
+	const location = await chooseDestination(ctx, targetName);
+	if (!location) return false;
+	const connection = validateConnection(ctx, url, username);
+	const destination = validateDestination(ctx, location.path, location.namespace);
+	if (!connection || !destination) return false;
+	const content = await chooseContent(ctx);
+	if (!content) return false;
+	const automatic = await ctx.ui.select("Automatic sync for this target", [
+		"Enable automatic sync",
+		"Keep automatic sync off",
+		"Cancel",
+	]);
+	if (!automatic || automatic === "Cancel") return false;
+	const sessions = await chooseSessions(ctx);
+	if (sessions === undefined) return false;
+	const profileName = "webdav";
+	const review = await ctx.ui.select(
+		[
+			"Review WebDAV setup",
+			"",
+			`Target: ${safe(targetName)}`,
+			`Storage profile: ${profileName} (WebDAV)`,
+			`URL: ${displayUrl(connection.url)}`,
+			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
+			"Username: stored in the private settings file (value hidden)",
+			`Password: add it privately in ${safe(localConfigPath())}; pi-sync never requests secrets in an unmasked dialog.`,
+			`Conditional writes: /sync doctor verifies atomic If-Match and If-None-Match support before publication.`,
+			`Synced content: ${content.length} built-in groups · Sessions: ${sessions ? "On — privacy warning acknowledged" : "Off"}`,
+			`Auto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
+		].join("\n"),
+		["Save setup", "Cancel"],
+	);
+	if (review !== "Save setup") return false;
+	await saveNewV2Settings({
+		targetName,
+		storageProfileName: profileName,
+		profile: { kind: "webdav", ...connection },
+		target: {
+			profile: profileName,
+			path: destination.path,
+			namespace: destination.namespace,
+			autoSync: automatic === "Enable automatic sync",
+			syncFiles: content,
+			syncSessions: sessions,
+			extraFiles: [],
+		},
+	});
+	ctx.ui.notify(
+		`Saved target “${safe(targetName)}”; add the WebDAV password in ${safe(localConfigPath())} before syncing.`,
+		"info",
+	);
+	return true;
+}
+
+export async function showAddWebDavTarget(
+	ctx: ExtensionCommandContext,
+	name: string,
+	profile: string,
+) {
+	const location = await chooseDestination(ctx, name);
+	if (!location) return false;
+	const destination = validateDestination(ctx, location.path, location.namespace);
+	if (!destination) return false;
+	const content = await chooseContent(ctx);
+	if (!content) return false;
+	const review = await ctx.ui.select(
+		`Review WebDAV target\n\nTarget: ${safe(name)}\nStorage profile: ${safe(profile)}\nRemote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}\nSynced content: ${content.length} built-in groups · Sessions: Off\nSwitching later does not sync until its reviewed pull.`,
+		["Add target", "Cancel"],
+	);
+	if (review !== "Add target") return false;
+	await addSyncTarget(name, {
+		profile,
+		path: destination.path,
+		namespace: destination.namespace,
+		autoSync: true,
+		syncFiles: content,
+		syncSessions: false,
+		extraFiles: [],
+	});
+	ctx.ui.notify(`Added sync target “${safe(name)}”.`, "info");
+	return true;
+}
+
+export async function showEditWebDavTarget(ctx: ExtensionCommandContext, partial: PartialConfig) {
+	if (!partial.target) return false;
+	const remotePath = await requiredInput(ctx, "WebDAV remote path", partial.path ?? "pi-sync");
+	if (!remotePath) return false;
+	const namespace = await requiredInput(ctx, "Remote namespace", partial.profile ?? partial.target);
+	if (!namespace) return false;
+	const destination = validateDestination(ctx, remotePath, namespace);
+	if (!destination) return false;
+	const review = await ctx.ui.select(
+		`Review target “${safe(partial.target)}”\n\nPath: ${safe(partial.path ?? "pi-sync")} → ${safe(destination.path)}\nNamespace: ${safe(partial.profile ?? partial.target)} → ${safe(destination.namespace)}\nSaving changes future sync destination only; it does not move or delete remote data.`,
+		["Save target", "Cancel"],
+	);
+	if (review !== "Save target") return false;
+	await updateSyncTarget(partial.target, (target) => ({ ...target, ...destination }));
+	ctx.ui.notify(`Saved target “${safe(partial.target)}”.`, "info");
+	return true;
+}
+
+export async function showAddWebDavStorageProfile(ctx: ExtensionCommandContext) {
+	const name = await requiredInput(ctx, "Name the storage profile", "webdav");
+	if (!name) return false;
+	const url = await requiredInput(ctx, "WebDAV collection URL", "https://cloud.example.com/dav");
+	if (!url) return false;
+	const username = await requiredInput(ctx, "WebDAV username", "user");
+	if (!username) return false;
+	const connection = validateConnection(ctx, url, username);
+	if (!connection) return false;
+	const review = await ctx.ui.select(
+		`Review storage profile\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nAdd the password privately in ${safe(localConfigPath())}; it is never requested or displayed.`,
+		["Add profile", "Cancel"],
+	);
+	if (review !== "Add profile") return false;
+	await addStorageProfile(name, { kind: "webdav", ...connection });
+	ctx.ui.notify(`Added storage profile “${safe(name)}”.`, "info");
+	return true;
+}
+
+export async function showEditWebDavStorageProfile(
+	ctx: ExtensionCommandContext,
+	name: string,
+	profile: Record<string, unknown>,
+) {
+	const url = await requiredInput(
+		ctx,
+		"WebDAV collection URL",
+		String(profile.url ?? "https://cloud.example.com/dav"),
+	);
+	if (!url) return false;
+	const username = await requiredInput(ctx, "WebDAV username", String(profile.username ?? "user"));
+	if (!username) return false;
+	const connection = validateConnection(ctx, url, username);
+	if (!connection) return false;
+	const review = await ctx.ui.select(
+		`Review connection\n\nProfile: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword remains unchanged and is never shown.`,
+		["Save profile", "Cancel"],
+	);
+	if (review !== "Save profile") return false;
+	await updateStorageProfile(name, (current) => ({ ...current, ...connection }));
+	ctx.ui.notify(`Saved storage profile “${safe(name)}”.`, "info");
+	return true;
+}
+
+async function chooseDestination(ctx: ExtensionCommandContext, targetName: string) {
+	const remotePath = await requiredInput(ctx, "WebDAV remote path", "pi-sync");
+	if (!remotePath) return undefined;
+	const namespace = await requiredInput(ctx, "Remote namespace", targetName);
+	return namespace ? { path: remotePath, namespace } : undefined;
+}
+
+async function chooseContent(ctx: ExtensionCommandContext) {
+	const choice = await ctx.ui.select("Choose an initial sync preset", [
+		"Recommended Pi settings",
+		"Minimal settings",
+		"Cancel",
+	]);
+	if (!choice || choice === "Cancel") return undefined;
+	return choice === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
+}
+
+async function chooseSessions(ctx: ExtensionCommandContext) {
+	const choice = await ctx.ui.select(
+		"Session conversations\n\nSessions can contain prompts, tool output, paths, screenshots, and secrets.",
+		["Keep sessions off (recommended)", "Include session conversations", "Cancel"],
+	);
+	if (!choice || choice === "Cancel") return undefined;
+	if (choice !== "Include session conversations") return false;
+	return ctx.ui.confirm(
+		"Include session conversations?",
+		"I understand that session JSONL can contain prompts, tool output, paths, screenshots, and secrets.",
+	);
+}
+
+async function requiredInput(ctx: ExtensionCommandContext, title: string, placeholder: string) {
+	const value = await ctx.ui.input(title, placeholder);
+	if (value === undefined) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) {
+		ctx.ui.notify(`${title} is required.`, "warning");
+		return undefined;
+	}
+	return trimmed;
+}
+
+function validateConnection(ctx: ExtensionCommandContext, url: string, username: string) {
+	try {
+		const normalizedUrl = normalizeWebDavUrl(url);
+		if (!normalizedUrl) throw new Error("WebDAV URL is required.");
+		validateWebDavCredentials(username);
+		return { url: normalizedUrl, username: username.trim() };
+	} catch (error) {
+		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+		return undefined;
+	}
+}
+
+function validateDestination(ctx: ExtensionCommandContext, path: string, namespace: string) {
+	try {
+		const normalizedPath = normalizeWebDavPath(path);
+		validateWebDavNamespace(namespace.trim());
+		return { path: normalizedPath, namespace: namespace.trim() };
+	} catch (error) {
+		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+		return undefined;
+	}
+}
+
+function displayUrl(value: string) {
+	try {
+		return `${new URL(value).origin}/…`;
+	} catch {
+		return "invalid URL (value hidden)";
+	}
+}
+
+function safe(value: string) {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Settings values are untrusted terminal input.
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "�");
+}

--- a/extensions/pi-sync/src/webdav-ui.ts
+++ b/extensions/pi-sync/src/webdav-ui.ts
@@ -1,11 +1,14 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
-	localConfigPath,
 	normalizeWebDavPath,
 	normalizeWebDavUrl,
+	readActiveLocalConfigDocumentForRepair,
+	replaceLocalConfigDocument,
+	resolveV2PartialConfig,
 	validateWebDavCredentials,
 	validateWebDavNamespace,
 } from "./config.js";
+import { promptSecret } from "./secret-input.js";
 import {
 	addStorageProfile,
 	addSyncTarget,
@@ -16,6 +19,116 @@ import {
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
 import type { PartialConfig } from "./types.js";
 
+export async function repairableWebDavDestinationName() {
+	const document = await readActiveLocalConfigDocumentForRepair();
+	const settings = document?.parsed;
+	if (settings?.version !== 2) return undefined;
+	const profiles = record(settings.profiles);
+	const targets = record(settings.targets);
+	if (!profiles || !targets) return undefined;
+	const names = Object.keys(targets).filter((name) => {
+		const target = record(targets[name]);
+		if (!target) return false;
+		const profile =
+			typeof target.profile === "string" ? record(profiles[target.profile]) : undefined;
+		return (
+			profile?.kind === "webdav" &&
+			(Object.hasOwn(target, "bucket") ||
+				Object.hasOwn(target, "prefix") ||
+				typeof profile.password !== "string" ||
+				profile.password.length === 0)
+		);
+	});
+	const active = typeof settings.activeTarget === "string" ? settings.activeTarget : undefined;
+	return active && names.includes(active) ? active : names.length === 1 ? names[0] : undefined;
+}
+
+export async function showRepairableWebDavDestination(ctx: ExtensionCommandContext) {
+	const name = await repairableWebDavDestinationName();
+	return name ? showRepairWebDavDestination(ctx, name) : false;
+}
+
+export async function showRepairWebDavDestination(
+	ctx: ExtensionCommandContext,
+	targetName: string,
+) {
+	const document = await readActiveLocalConfigDocumentForRepair();
+	if (document?.parsed.version !== 2) return false;
+	const profiles = record(document.parsed.profiles);
+	const targets = record(document.parsed.targets);
+	const target = targets && record(targets[targetName]);
+	const profileName = target && typeof target.profile === "string" ? target.profile : undefined;
+	const profile = profileName && profiles ? record(profiles[profileName]) : undefined;
+	if (!target || !profileName || !profile || profile.kind !== "webdav") return false;
+	const url = typeof profile.url === "string" ? profile.url : "";
+	const username = typeof profile.username === "string" ? profile.username : "";
+	let password =
+		typeof profile.password === "string" && profile.password ? profile.password : undefined;
+	if (!password) {
+		password = await promptSecret(ctx, "WebDAV password");
+		if (password === undefined) return false;
+	}
+	const path = await requiredInput(
+		ctx,
+		"WebDAV remote path",
+		typeof target.path === "string"
+			? target.path
+			: typeof target.prefix === "string"
+				? target.prefix
+				: "pi-sync",
+	);
+	if (!path) return false;
+	const namespace = await requiredInput(
+		ctx,
+		"Remote namespace",
+		typeof target.namespace === "string" ? target.namespace : targetName,
+	);
+	if (!namespace) return false;
+	const connection = validateConnection(ctx, url, username, password);
+	const destination = validateDestination(ctx, path, namespace);
+	if (!connection || !destination) return false;
+	const removedTargetFields = ["bucket", "prefix"].filter((field) => Object.hasOwn(target, field));
+	const removedProfileFields = [
+		"endpoint",
+		"region",
+		"accessKeyId",
+		"secretAccessKey",
+		"sessionToken",
+	].filter((field) => Object.hasOwn(profile, field));
+	const review = await ctx.ui.select(
+		[
+			"Repair WebDAV destination",
+			"",
+			`Destination: ${safe(targetName)}`,
+			`Saved connection: ${safe(profileName)}`,
+			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
+			`Password: configured (value hidden)`,
+			...(removedTargetFields.length > 0
+				? [`Remove incompatible destination fields: ${removedTargetFields.join(", ")}`]
+				: []),
+			...(removedProfileFields.length > 0
+				? [`Remove incompatible connection fields: ${removedProfileFields.join(", ")}`]
+				: []),
+			"Unknown settings and every other destination remain unchanged.",
+		].join("\n"),
+		["Repair destination", "Cancel"],
+	);
+	if (review !== "Repair destination") return false;
+	const nextProfile: Record<string, unknown> = { ...profile, ...connection };
+	for (const field of removedProfileFields) delete nextProfile[field];
+	const nextTarget: Record<string, unknown> = { ...target, ...destination };
+	for (const field of removedTargetFields) delete nextTarget[field];
+	const next = {
+		...document.parsed,
+		profiles: { ...profiles, [profileName]: nextProfile },
+		targets: { ...targets, [targetName]: nextTarget },
+	};
+	resolveV2PartialConfig(next, targetName);
+	await replaceLocalConfigDocument(document, next);
+	ctx.ui.notify(`Repaired WebDAV destination “${safe(targetName)}”.`, "info");
+	return true;
+}
+
 export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: string) {
 	const url = await requiredInput(
 		ctx,
@@ -25,9 +138,11 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 	if (!url) return false;
 	const username = await requiredInput(ctx, "WebDAV username", "user");
 	if (!username) return false;
+	const password = await promptSecret(ctx, "WebDAV password");
+	if (password === undefined) return false;
 	const location = await chooseDestination(ctx, targetName);
 	if (!location) return false;
-	const connection = validateConnection(ctx, url, username);
+	const connection = validateConnection(ctx, url, username, password);
 	const destination = validateDestination(ctx, location.path, location.namespace);
 	if (!connection || !destination) return false;
 	const content = await chooseContent(ctx);
@@ -50,7 +165,7 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 			`URL: ${displayUrl(connection.url)}`,
 			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
 			"Username: stored in the private settings file (value hidden)",
-			`Password: add it privately in ${safe(localConfigPath())}; pi-sync never requests secrets in an unmasked dialog.`,
+			"Password: configured (value hidden)",
 			`Conditional writes: /sync doctor verifies atomic If-Match and If-None-Match support before publication.`,
 			`Synced content: ${content.length} built-in groups · Sessions: ${sessions ? "On — privacy warning acknowledged" : "Off"}`,
 			`Auto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
@@ -72,10 +187,7 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 			extraFiles: [],
 		},
 	});
-	ctx.ui.notify(
-		`Saved target “${safe(targetName)}”; add the WebDAV password in ${safe(localConfigPath())} before syncing.`,
-		"info",
-	);
+	ctx.ui.notify(`Destination “${safe(targetName)}” is ready. Use Sync now when ready.`, "info");
 	return true;
 }
 
@@ -133,10 +245,12 @@ export async function showAddWebDavStorageProfile(ctx: ExtensionCommandContext) 
 	if (!url) return false;
 	const username = await requiredInput(ctx, "WebDAV username", "user");
 	if (!username) return false;
-	const connection = validateConnection(ctx, url, username);
+	const password = await promptSecret(ctx, "WebDAV password");
+	if (password === undefined) return false;
+	const connection = validateConnection(ctx, url, username, password);
 	if (!connection) return false;
 	const review = await ctx.ui.select(
-		`Review storage profile\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nAdd the password privately in ${safe(localConfigPath())}; it is never requested or displayed.`,
+		`Review saved connection\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: configured (value hidden)`,
 		["Add profile", "Cancel"],
 	);
 	if (review !== "Add profile") return false;
@@ -158,14 +272,35 @@ export async function showEditWebDavStorageProfile(
 	if (!url) return false;
 	const username = await requiredInput(ctx, "WebDAV username", String(profile.username ?? "user"));
 	if (!username) return false;
-	const connection = validateConnection(ctx, url, username);
+	let password: string | undefined;
+	let replacePassword = false;
+	if (typeof profile.password === "string" && profile.password.length > 0) {
+		const passwordAction = await ctx.ui.select("WebDAV password", [
+			"Keep current password",
+			"Replace password",
+			"Cancel",
+		]);
+		if (!passwordAction || passwordAction === "Cancel") return false;
+		replacePassword = passwordAction === "Replace password";
+	} else {
+		replacePassword = true;
+	}
+	if (replacePassword) {
+		password = await promptSecret(ctx, "New WebDAV password");
+		if (password === undefined) return false;
+	}
+	const connection = validateConnection(ctx, url, username, password);
 	if (!connection) return false;
 	const review = await ctx.ui.select(
-		`Review connection\n\nProfile: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword remains unchanged and is never shown.`,
+		`Review connection\n\nSaved connection: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: ${replacePassword ? "will be replaced" : "unchanged"} (value hidden)`,
 		["Save profile", "Cancel"],
 	);
 	if (review !== "Save profile") return false;
-	await updateStorageProfile(name, (current) => ({ ...current, ...connection }));
+	await updateStorageProfile(name, (current) => ({
+		...current,
+		...connection,
+		...(replacePassword ? { password } : {}),
+	}));
 	ctx.ui.notify(`Saved storage profile “${safe(name)}”.`, "info");
 	return true;
 }
@@ -211,12 +346,21 @@ async function requiredInput(ctx: ExtensionCommandContext, title: string, placeh
 	return trimmed;
 }
 
-function validateConnection(ctx: ExtensionCommandContext, url: string, username: string) {
+function validateConnection(
+	ctx: ExtensionCommandContext,
+	url: string,
+	username: string,
+	password?: string,
+) {
 	try {
 		const normalizedUrl = normalizeWebDavUrl(url);
 		if (!normalizedUrl) throw new Error("WebDAV URL is required.");
-		validateWebDavCredentials(username);
-		return { url: normalizedUrl, username: username.trim() };
+		validateWebDavCredentials(username, password);
+		return {
+			url: normalizedUrl,
+			username: username.trim(),
+			...(password === undefined ? {} : { password }),
+		};
 	} catch (error) {
 		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 		return undefined;
@@ -240,6 +384,12 @@ function displayUrl(value: string) {
 	} catch {
 		return "invalid URL (value hidden)";
 	}
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
 }
 
 function safe(value: string) {

--- a/extensions/pi-sync/src/webdav-ui.ts
+++ b/extensions/pi-sync/src/webdav-ui.ts
@@ -19,8 +19,8 @@ import {
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
 import type { PartialConfig } from "./types.js";
 
-export async function repairableWebDavDestinationName() {
-	const document = await readActiveLocalConfigDocumentForRepair();
+export async function repairableWebDavDestinationName(signal?: AbortSignal) {
+	const document = await awaitActive(signal, readActiveLocalConfigDocumentForRepair());
 	const settings = document?.parsed;
 	if (settings?.version !== 2) return undefined;
 	const profiles = record(settings.profiles);
@@ -43,16 +43,20 @@ export async function repairableWebDavDestinationName() {
 	return active && names.includes(active) ? active : names.length === 1 ? names[0] : undefined;
 }
 
-export async function showRepairableWebDavDestination(ctx: ExtensionCommandContext) {
-	const name = await repairableWebDavDestinationName();
-	return name ? showRepairWebDavDestination(ctx, name) : false;
+export async function showRepairableWebDavDestination(
+	ctx: ExtensionCommandContext,
+	signal?: AbortSignal,
+) {
+	const name = await repairableWebDavDestinationName(signal);
+	return name ? showRepairWebDavDestination(ctx, name, signal) : false;
 }
 
 export async function showRepairWebDavDestination(
 	ctx: ExtensionCommandContext,
 	targetName: string,
+	signal?: AbortSignal,
 ) {
-	const document = await readActiveLocalConfigDocumentForRepair();
+	const document = await awaitActive(signal, readActiveLocalConfigDocumentForRepair());
 	if (document?.parsed.version !== 2) return false;
 	const profiles = record(document.parsed.profiles);
 	const targets = record(document.parsed.targets);
@@ -65,7 +69,7 @@ export async function showRepairWebDavDestination(
 	let password =
 		typeof profile.password === "string" && profile.password ? profile.password : undefined;
 	if (!password) {
-		password = await promptSecret(ctx, "WebDAV password");
+		password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 		if (password === undefined) return false;
 	}
 	const path = await requiredInput(
@@ -76,12 +80,14 @@ export async function showRepairWebDavDestination(
 			: typeof target.prefix === "string"
 				? target.prefix
 				: "pi-sync",
+		signal,
 	);
 	if (!path) return false;
 	const namespace = await requiredInput(
 		ctx,
 		"Remote namespace",
 		typeof target.namespace === "string" ? target.namespace : targetName,
+		signal,
 	);
 	if (!namespace) return false;
 	const connection = validateConnection(ctx, url, username, password);
@@ -95,7 +101,8 @@ export async function showRepairWebDavDestination(
 		"secretAccessKey",
 		"sessionToken",
 	].filter((field) => Object.hasOwn(profile, field));
-	const review = await ctx.ui.select(
+	const review = await select(
+		ctx,
 		[
 			"Repair WebDAV destination",
 			"",
@@ -112,6 +119,7 @@ export async function showRepairWebDavDestination(
 			"Unknown settings and every other destination remain unchanged.",
 		].join("\n"),
 		["Repair destination", "Cancel"],
+		signal,
 	);
 	if (review !== "Repair destination") return false;
 	const nextProfile: Record<string, unknown> = { ...profile, ...connection };
@@ -124,39 +132,47 @@ export async function showRepairWebDavDestination(
 		targets: { ...targets, [targetName]: nextTarget },
 	};
 	resolveV2PartialConfig(next, targetName);
-	await replaceLocalConfigDocument(document, next);
+	throwIfAborted(signal);
+	await awaitActive(signal, replaceLocalConfigDocument(document, next));
 	ctx.ui.notify(`Repaired WebDAV destination “${safe(targetName)}”.`, "info");
 	return true;
 }
 
-export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: string) {
+export async function showWebDavSetup(
+	ctx: ExtensionCommandContext,
+	targetName: string,
+	signal?: AbortSignal,
+) {
 	const url = await requiredInput(
 		ctx,
 		"WebDAV collection URL",
 		"https://cloud.example.com/remote.php/dav/files/user",
+		signal,
 	);
 	if (!url) return false;
-	const username = await requiredInput(ctx, "WebDAV username", "user");
+	const username = await requiredInput(ctx, "WebDAV username", "user", signal);
 	if (!username) return false;
-	const password = await promptSecret(ctx, "WebDAV password");
+	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
-	const location = await chooseDestination(ctx, targetName);
+	const location = await chooseDestination(ctx, targetName, signal);
 	if (!location) return false;
 	const connection = validateConnection(ctx, url, username, password);
 	const destination = validateDestination(ctx, location.path, location.namespace);
 	if (!connection || !destination) return false;
-	const content = await chooseContent(ctx);
+	const content = await chooseContent(ctx, signal);
 	if (!content) return false;
-	const automatic = await ctx.ui.select("Automatic sync for this target", [
-		"Enable automatic sync",
-		"Keep automatic sync off",
-		"Cancel",
-	]);
+	const automatic = await select(
+		ctx,
+		"Automatic sync for this target",
+		["Enable automatic sync", "Keep automatic sync off", "Cancel"],
+		signal,
+	);
 	if (!automatic || automatic === "Cancel") return false;
-	const sessions = await chooseSessions(ctx);
+	const sessions = await chooseSessions(ctx, signal);
 	if (sessions === undefined) return false;
 	const profileName = "webdav";
-	const review = await ctx.ui.select(
+	const review = await select(
+		ctx,
 		[
 			"Review WebDAV setup",
 			"",
@@ -171,22 +187,27 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 			`Auto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
 		].join("\n"),
 		["Save setup", "Cancel"],
+		signal,
 	);
 	if (review !== "Save setup") return false;
-	await saveNewV2Settings({
-		targetName,
-		storageProfileName: profileName,
-		profile: { kind: "webdav", ...connection },
-		target: {
-			profile: profileName,
-			path: destination.path,
-			namespace: destination.namespace,
-			autoSync: automatic === "Enable automatic sync",
-			syncFiles: content,
-			syncSessions: sessions,
-			extraFiles: [],
-		},
-	});
+	throwIfAborted(signal);
+	await awaitActive(
+		signal,
+		saveNewV2Settings({
+			targetName,
+			storageProfileName: profileName,
+			profile: { kind: "webdav", ...connection },
+			target: {
+				profile: profileName,
+				path: destination.path,
+				namespace: destination.namespace,
+				autoSync: automatic === "Enable automatic sync",
+				syncFiles: content,
+				syncSessions: sessions,
+				extraFiles: [],
+			},
+		}),
+	);
 	ctx.ui.notify(`Destination “${safe(targetName)}” is ready. Use Sync now when ready.`, "info");
 	return true;
 }
@@ -195,66 +216,104 @@ export async function showAddWebDavTarget(
 	ctx: ExtensionCommandContext,
 	name: string,
 	profile: string,
+	signal?: AbortSignal,
 ) {
-	const location = await chooseDestination(ctx, name);
+	const location = await chooseDestination(ctx, name, signal);
 	if (!location) return false;
 	const destination = validateDestination(ctx, location.path, location.namespace);
 	if (!destination) return false;
-	const content = await chooseContent(ctx);
+	const content = await chooseContent(ctx, signal);
 	if (!content) return false;
-	const review = await ctx.ui.select(
+	const review = await select(
+		ctx,
 		`Review WebDAV target\n\nTarget: ${safe(name)}\nStorage profile: ${safe(profile)}\nRemote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}\nSynced content: ${content.length} built-in groups · Sessions: Off\nSwitching later does not sync until its reviewed pull.`,
 		["Add target", "Cancel"],
+		signal,
 	);
 	if (review !== "Add target") return false;
-	await addSyncTarget(name, {
-		profile,
-		path: destination.path,
-		namespace: destination.namespace,
-		autoSync: true,
-		syncFiles: content,
-		syncSessions: false,
-		extraFiles: [],
-	});
+	throwIfAborted(signal);
+	await awaitActive(
+		signal,
+		addSyncTarget(name, {
+			profile,
+			path: destination.path,
+			namespace: destination.namespace,
+			autoSync: true,
+			syncFiles: content,
+			syncSessions: false,
+			extraFiles: [],
+		}),
+	);
 	ctx.ui.notify(`Added sync target “${safe(name)}”.`, "info");
 	return true;
 }
 
-export async function showEditWebDavTarget(ctx: ExtensionCommandContext, partial: PartialConfig) {
+export async function showEditWebDavTarget(
+	ctx: ExtensionCommandContext,
+	partial: PartialConfig,
+	signal?: AbortSignal,
+) {
 	if (!partial.target) return false;
-	const remotePath = await requiredInput(ctx, "WebDAV remote path", partial.path ?? "pi-sync");
+	const remotePath = await requiredInput(
+		ctx,
+		"WebDAV remote path",
+		partial.path ?? "pi-sync",
+		signal,
+	);
 	if (!remotePath) return false;
-	const namespace = await requiredInput(ctx, "Remote namespace", partial.profile ?? partial.target);
+	const namespace = await requiredInput(
+		ctx,
+		"Remote namespace",
+		partial.profile ?? partial.target,
+		signal,
+	);
 	if (!namespace) return false;
 	const destination = validateDestination(ctx, remotePath, namespace);
 	if (!destination) return false;
-	const review = await ctx.ui.select(
+	const review = await select(
+		ctx,
 		`Review target “${safe(partial.target)}”\n\nPath: ${safe(partial.path ?? "pi-sync")} → ${safe(destination.path)}\nNamespace: ${safe(partial.profile ?? partial.target)} → ${safe(destination.namespace)}\nSaving changes future sync destination only; it does not move or delete remote data.`,
 		["Save target", "Cancel"],
+		signal,
 	);
 	if (review !== "Save target") return false;
-	await updateSyncTarget(partial.target, (target) => ({ ...target, ...destination }));
+	throwIfAborted(signal);
+	await awaitActive(
+		signal,
+		updateSyncTarget(partial.target, (target) => ({ ...target, ...destination })),
+	);
 	ctx.ui.notify(`Saved target “${safe(partial.target)}”.`, "info");
 	return true;
 }
 
-export async function showAddWebDavStorageProfile(ctx: ExtensionCommandContext) {
-	const name = await requiredInput(ctx, "Name the storage profile", "webdav");
+export async function showAddWebDavStorageProfile(
+	ctx: ExtensionCommandContext,
+	signal?: AbortSignal,
+) {
+	const name = await requiredInput(ctx, "Name the storage profile", "webdav", signal);
 	if (!name) return false;
-	const url = await requiredInput(ctx, "WebDAV collection URL", "https://cloud.example.com/dav");
+	const url = await requiredInput(
+		ctx,
+		"WebDAV collection URL",
+		"https://cloud.example.com/dav",
+		signal,
+	);
 	if (!url) return false;
-	const username = await requiredInput(ctx, "WebDAV username", "user");
+	const username = await requiredInput(ctx, "WebDAV username", "user", signal);
 	if (!username) return false;
-	const password = await promptSecret(ctx, "WebDAV password");
+	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
 	const connection = validateConnection(ctx, url, username, password);
 	if (!connection) return false;
-	const review = await ctx.ui.select(
+	const review = await select(
+		ctx,
 		`Review saved connection\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: configured (value hidden)`,
 		["Add profile", "Cancel"],
+		signal,
 	);
 	if (review !== "Add profile") return false;
-	await addStorageProfile(name, { kind: "webdav", ...connection });
+	throwIfAborted(signal);
+	await awaitActive(signal, addStorageProfile(name, { kind: "webdav", ...connection }));
 	ctx.ui.notify(`Added storage profile “${safe(name)}”.`, "info");
 	return true;
 }
@@ -263,80 +322,108 @@ export async function showEditWebDavStorageProfile(
 	ctx: ExtensionCommandContext,
 	name: string,
 	profile: Record<string, unknown>,
+	signal?: AbortSignal,
 ) {
 	const url = await requiredInput(
 		ctx,
 		"WebDAV collection URL",
 		String(profile.url ?? "https://cloud.example.com/dav"),
+		signal,
 	);
 	if (!url) return false;
-	const username = await requiredInput(ctx, "WebDAV username", String(profile.username ?? "user"));
+	const username = await requiredInput(
+		ctx,
+		"WebDAV username",
+		String(profile.username ?? "user"),
+		signal,
+	);
 	if (!username) return false;
 	let password: string | undefined;
 	let replacePassword = false;
 	if (typeof profile.password === "string" && profile.password.length > 0) {
-		const passwordAction = await ctx.ui.select("WebDAV password", [
-			"Keep current password",
-			"Replace password",
-			"Cancel",
-		]);
+		const passwordAction = await select(
+			ctx,
+			"WebDAV password",
+			["Keep current password", "Replace password", "Cancel"],
+			signal,
+		);
 		if (!passwordAction || passwordAction === "Cancel") return false;
 		replacePassword = passwordAction === "Replace password";
 	} else {
 		replacePassword = true;
 	}
 	if (replacePassword) {
-		password = await promptSecret(ctx, "New WebDAV password");
+		password = await awaitActive(signal, promptSecret(ctx, "New WebDAV password", { signal }));
 		if (password === undefined) return false;
 	}
 	const connection = validateConnection(ctx, url, username, password);
 	if (!connection) return false;
-	const review = await ctx.ui.select(
+	const review = await select(
+		ctx,
 		`Review connection\n\nSaved connection: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: ${replacePassword ? "will be replaced" : "unchanged"} (value hidden)`,
 		["Save profile", "Cancel"],
+		signal,
 	);
 	if (review !== "Save profile") return false;
-	await updateStorageProfile(name, (current) => ({
-		...current,
-		...connection,
-		...(replacePassword ? { password } : {}),
-	}));
+	throwIfAborted(signal);
+	await awaitActive(
+		signal,
+		updateStorageProfile(name, (current) => ({
+			...current,
+			...connection,
+			...(replacePassword ? { password } : {}),
+		})),
+	);
 	ctx.ui.notify(`Saved storage profile “${safe(name)}”.`, "info");
 	return true;
 }
 
-async function chooseDestination(ctx: ExtensionCommandContext, targetName: string) {
-	const remotePath = await requiredInput(ctx, "WebDAV remote path", "pi-sync");
+async function chooseDestination(
+	ctx: ExtensionCommandContext,
+	targetName: string,
+	signal?: AbortSignal,
+) {
+	const remotePath = await requiredInput(ctx, "WebDAV remote path", "pi-sync", signal);
 	if (!remotePath) return undefined;
-	const namespace = await requiredInput(ctx, "Remote namespace", targetName);
+	const namespace = await requiredInput(ctx, "Remote namespace", targetName, signal);
 	return namespace ? { path: remotePath, namespace } : undefined;
 }
 
-async function chooseContent(ctx: ExtensionCommandContext) {
-	const choice = await ctx.ui.select("Choose an initial sync preset", [
-		"Recommended Pi settings",
-		"Minimal settings",
-		"Cancel",
-	]);
+async function chooseContent(ctx: ExtensionCommandContext, signal?: AbortSignal) {
+	const choice = await select(
+		ctx,
+		"Choose an initial sync preset",
+		["Recommended Pi settings", "Minimal settings", "Cancel"],
+		signal,
+	);
 	if (!choice || choice === "Cancel") return undefined;
 	return choice === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
 }
 
-async function chooseSessions(ctx: ExtensionCommandContext) {
-	const choice = await ctx.ui.select(
+async function chooseSessions(ctx: ExtensionCommandContext, signal?: AbortSignal) {
+	const choice = await select(
+		ctx,
 		"Session conversations\n\nSessions can contain prompts, tool output, paths, screenshots, and secrets.",
 		["Keep sessions off (recommended)", "Include session conversations", "Cancel"],
+		signal,
 	);
 	if (!choice || choice === "Cancel") return undefined;
 	if (choice !== "Include session conversations") return false;
-	return ctx.ui.confirm(
+	return confirm(
+		ctx,
 		"Include session conversations?",
 		"I understand that session JSONL can contain prompts, tool output, paths, screenshots, and secrets.",
+		signal,
 	);
 }
 
-async function requiredInput(ctx: ExtensionCommandContext, title: string, placeholder: string) {
-	const value = await ctx.ui.input(title, placeholder);
+async function requiredInput(
+	ctx: ExtensionCommandContext,
+	title: string,
+	placeholder: string,
+	signal?: AbortSignal,
+) {
+	const value = await awaitActive(signal, ctx.ui.input(title, placeholder, { signal }));
 	if (value === undefined) return undefined;
 	const trimmed = value.trim();
 	if (!trimmed) {
@@ -344,6 +431,37 @@ async function requiredInput(ctx: ExtensionCommandContext, title: string, placeh
 		return undefined;
 	}
 	return trimmed;
+}
+
+async function select(
+	ctx: ExtensionCommandContext,
+	title: string,
+	options: string[],
+	signal?: AbortSignal,
+) {
+	return awaitActive(signal, ctx.ui.select(title, options, { signal }));
+}
+
+async function confirm(
+	ctx: ExtensionCommandContext,
+	title: string,
+	message: string,
+	signal?: AbortSignal,
+) {
+	return awaitActive(signal, ctx.ui.confirm(title, message, { signal }));
+}
+
+async function awaitActive<T>(signal: AbortSignal | undefined, operation: Promise<T>) {
+	const result = await operation;
+	throwIfAborted(signal);
+	return result;
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("The operation was aborted", "AbortError");
 }
 
 function validateConnection(

--- a/extensions/pi-sync/test/backend-lifecycle.test.ts
+++ b/extensions/pi-sync/test/backend-lifecycle.test.ts
@@ -15,6 +15,52 @@ test("session shutdown aborts an in-flight backend operation", async () => {
 	await withPendingStatusOperation("session_shutdown");
 });
 
+test("WebDAV lifecycle ignores deprecated S3 auto-sync environment overrides", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "home",
+				profiles: {
+					dav: {
+						kind: "webdav",
+						url: "https://cloud.example.com/dav",
+						username: "user",
+						password: "pass",
+					},
+				},
+				targets: {
+					home: {
+						profile: "dav",
+						path: "pi-sync",
+						namespace: "home",
+						syncFiles: ["settings.json"],
+					},
+				},
+			}),
+		);
+		const originalFetch = globalThis.fetch;
+		let requests = 0;
+		globalThis.fetch = (async () => {
+			requests += 1;
+			return new Response("denied", { status: 401 });
+		}) as typeof globalThis.fetch;
+		process.env.PI_SYNC_AUTO_SYNC = "false";
+		try {
+			const mock = createMockPi();
+			sync(mock.pi);
+			const { ctx } = createMockContext({ hasUI: true });
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			assert.ok(requests > 0);
+		} finally {
+			delete process.env.PI_SYNC_AUTO_SYNC;
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
 test("session replacement aborts an in-flight WebDAV backend operation", async () => {
 	await withPendingStatusOperation("session_start", {
 		version: 2,

--- a/extensions/pi-sync/test/backend-lifecycle.test.ts
+++ b/extensions/pi-sync/test/backend-lifecycle.test.ts
@@ -15,6 +15,32 @@ test("session shutdown aborts an in-flight backend operation", async () => {
 	await withPendingStatusOperation("session_shutdown");
 });
 
+test("session replacement aborts an in-flight WebDAV backend operation", async () => {
+	await withPendingStatusOperation("session_start", {
+		version: 2,
+		activeTarget: "home",
+		profiles: {
+			dav: {
+				kind: "webdav",
+				url: "https://cloud.example.com/dav",
+				username: "user",
+				password: "pass",
+			},
+		},
+		targets: {
+			home: {
+				profile: "dav",
+				path: "pi-sync",
+				namespace: "home",
+				autoSync: false,
+				syncFiles: ["settings.json"],
+				syncSessions: false,
+				extraFiles: [],
+			},
+		},
+	});
+});
+
 test("session replacement cancels a still-preparing shutdown publication", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(path.join(agentDir, "sessions", "--project--"), { recursive: true });
@@ -119,13 +145,17 @@ test("session shutdown owns an opt-in session publication with a bounded signal"
 	});
 });
 
-async function withPendingStatusOperation(event: "session_start" | "session_shutdown") {
+async function withPendingStatusOperation(
+	event: "session_start" | "session_shutdown",
+	settings: Record<string, unknown> = {
+		...requiredConfig(),
+		autoSync: false,
+		syncFiles: ["settings.json"],
+	},
+) {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
-		writeFileSync(
-			localConfigPath(),
-			JSON.stringify({ ...requiredConfig(), autoSync: false, syncFiles: ["settings.json"] }),
-		);
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
 		let markStarted: (() => void) | undefined;
 		const started = new Promise<void>((resolve) => {
 			markStarted = resolve;

--- a/extensions/pi-sync/test/config-filename.test.ts
+++ b/extensions/pi-sync/test/config-filename.test.ts
@@ -165,7 +165,7 @@ test("targetless v2 legacy settings migrate and retain the recoverable manager f
 		});
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.deepEqual(options, ["Manage targets & storage", "Help"]);
+		assert.deepEqual(options, ["Manage destinations", "Help"]);
 	});
 });
 

--- a/extensions/pi-sync/test/mock-webdav-server.ts
+++ b/extensions/pi-sync/test/mock-webdav-server.ts
@@ -15,6 +15,7 @@ export interface MockWebDavOptions {
 	delayMs?: number;
 	redirectTo?: string;
 	failLatestPut?: boolean;
+	failHistoryPut?: boolean;
 	constantEtag?: boolean;
 }
 
@@ -122,6 +123,9 @@ export class MockWebDavServer {
 	private async put(path: string, request: IncomingMessage, response: ServerResponse) {
 		if (this.options.failLatestPut && path.endsWith("/latest.json")) {
 			return send(response, 500, "interrupted publication");
+		}
+		if (this.options.failHistoryPut && path.endsWith("/history.json")) {
+			return send(response, 500, "history update failed");
 		}
 		if (!this.collections.has(parent(path))) return send(response, 409, "parent missing");
 		const chunks: Buffer[] = [];

--- a/extensions/pi-sync/test/mock-webdav-server.ts
+++ b/extensions/pi-sync/test/mock-webdav-server.ts
@@ -10,10 +10,12 @@ export interface MockWebDavOptions {
 	etag?: "strong" | "weak" | "missing";
 	deny?: boolean;
 	cleanupFails?: boolean;
+	cleanupMultiStatus?: boolean;
 	malformedXml?: boolean;
 	delayMs?: number;
 	redirectTo?: string;
 	failLatestPut?: boolean;
+	constantEtag?: boolean;
 }
 
 export function webDavConfig(url: string): ResolvedWebDavBackend {
@@ -138,6 +140,9 @@ export class MockWebDavServer {
 	private delete(path: string, response: ServerResponse) {
 		if (this.options.cleanupFails && path.includes(".pi-sync-probes"))
 			return send(response, 500, "cleanup failed");
+		if (this.options.cleanupMultiStatus && path.includes(".pi-sync-probes")) {
+			return send(response, 207, "partial cleanup failed");
+		}
 		let found = this.collections.delete(path) || this.resources.delete(path);
 		for (const key of [...this.collections]) {
 			if (key.startsWith(`${path}/`)) {
@@ -155,7 +160,9 @@ export class MockWebDavServer {
 	}
 
 	private etag(body: Buffer) {
-		const value = `"${createHash("sha256").update(body).digest("hex").slice(0, 16)}"`;
+		const value = this.options.constantEtag
+			? '"constant"'
+			: `"${createHash("sha256").update(body).digest("hex").slice(0, 16)}"`;
 		return this.options.etag === "weak" ? `W/${value}` : value;
 	}
 

--- a/extensions/pi-sync/test/mock-webdav-server.ts
+++ b/extensions/pi-sync/test/mock-webdav-server.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { ResolvedWebDavBackend } from "../src/types.js";
+
+export interface MockWebDavOptions {
+	username?: string;
+	password?: string;
+	ignoreConditions?: boolean;
+	etag?: "strong" | "weak" | "missing";
+	deny?: boolean;
+	cleanupFails?: boolean;
+	malformedXml?: boolean;
+	delayMs?: number;
+	redirectTo?: string;
+	failLatestPut?: boolean;
+}
+
+export function webDavConfig(url: string): ResolvedWebDavBackend {
+	return {
+		type: "webdav",
+		profile: { kind: "webdav", url, username: "user", password: "pass" },
+		destination: { path: "pi-sync", namespace: "default" },
+	};
+}
+
+export interface RecordedWebDavRequest {
+	method: string;
+	path: string;
+	headers: IncomingMessage["headers"];
+}
+
+export class MockWebDavServer {
+	readonly requests: RecordedWebDavRequest[] = [];
+	readonly resources = new Map<string, Buffer>();
+	readonly collections = new Set<string>(["/dav"]);
+	private readonly server = createServer(
+		(request, response) => void this.handle(request, response),
+	);
+	private origin = "";
+
+	constructor(readonly options: MockWebDavOptions = {}) {}
+
+	get url() {
+		return `${this.origin}/dav/`;
+	}
+
+	async start() {
+		this.server.listen(0, "127.0.0.1");
+		await once(this.server, "listening");
+		const address = this.server.address();
+		if (!address || typeof address === "string")
+			throw new Error("Mock WebDAV server did not bind.");
+		this.origin = `http://127.0.0.1:${address.port}`;
+		return this;
+	}
+
+	async close() {
+		this.server.close();
+		await once(this.server, "close");
+	}
+
+	private async handle(request: IncomingMessage, response: ServerResponse) {
+		const method = request.method ?? "GET";
+		const path =
+			decodeURIComponent(new URL(request.url ?? "/", this.origin).pathname).replace(/\/+$/u, "") ||
+			"/";
+		this.requests.push({ method, path, headers: request.headers });
+		if (this.options.redirectTo) {
+			return send(response, 302, undefined, { location: this.options.redirectTo });
+		}
+		if (this.options.delayMs)
+			await new Promise((resolve) => setTimeout(resolve, this.options.delayMs));
+		const expectedAuth = `Basic ${Buffer.from(`${this.options.username ?? "user"}:${this.options.password ?? "pass"}`).toString("base64")}`;
+		if (request.headers.authorization !== expectedAuth)
+			return send(response, 401, "authentication required");
+		if (this.options.deny) return send(response, 403, "permission denied");
+		if (method === "MKCOL") return this.mkcol(path, response);
+		if (method === "PROPFIND") return this.propfind(path, response);
+		if (method === "GET") return this.get(path, response);
+		if (method === "PUT") return this.put(path, request, response);
+		if (method === "DELETE") return this.delete(path, response);
+		return send(response, 405, "method not allowed");
+	}
+
+	private mkcol(path: string, response: ServerResponse) {
+		if (this.collections.has(path)) return send(response, 405);
+		if (!this.collections.has(parent(path))) return send(response, 409, "parent missing");
+		this.collections.add(path);
+		return send(response, 201);
+	}
+
+	private propfind(path: string, response: ServerResponse) {
+		if (!this.collections.has(path)) return send(response, 404);
+		if (this.options.malformedXml)
+			return send(response, 207, "<broken", { "content-type": "application/xml" });
+		const children = [
+			entry(path, undefined, true),
+			...[...this.collections]
+				.filter((item) => parent(item) === path && item !== path)
+				.map((item) => entry(item, undefined, true)),
+			...[...this.resources]
+				.filter(([item]) => parent(item) === path)
+				.map(([item, body]) => entry(item, this.etag(body), false)),
+		].join("");
+		return send(
+			response,
+			207,
+			`<?xml version="1.0"?><d:multistatus xmlns:d="DAV:">${children}</d:multistatus>`,
+			{ "content-type": "application/xml" },
+		);
+	}
+
+	private get(path: string, response: ServerResponse) {
+		const body = this.resources.get(path);
+		if (!body) return send(response, 404);
+		return send(response, 200, body, this.etagHeader(body));
+	}
+
+	private async put(path: string, request: IncomingMessage, response: ServerResponse) {
+		if (this.options.failLatestPut && path.endsWith("/latest.json")) {
+			return send(response, 500, "interrupted publication");
+		}
+		if (!this.collections.has(parent(path))) return send(response, 409, "parent missing");
+		const chunks: Buffer[] = [];
+		for await (const chunk of request) chunks.push(Buffer.from(chunk));
+		const body = Buffer.concat(chunks);
+		const existing = this.resources.get(path);
+		if (!this.options.ignoreConditions) {
+			if (request.headers["if-none-match"] === "*" && existing) return send(response, 412);
+			const ifMatch = request.headers["if-match"];
+			if (ifMatch && (!existing || ifMatch !== this.etag(existing))) return send(response, 412);
+		}
+		this.resources.set(path, body);
+		return send(response, existing ? 204 : 201, undefined, this.etagHeader(body));
+	}
+
+	private delete(path: string, response: ServerResponse) {
+		if (this.options.cleanupFails && path.includes(".pi-sync-probes"))
+			return send(response, 500, "cleanup failed");
+		let found = this.collections.delete(path) || this.resources.delete(path);
+		for (const key of [...this.collections]) {
+			if (key.startsWith(`${path}/`)) {
+				this.collections.delete(key);
+				found = true;
+			}
+		}
+		for (const key of [...this.resources.keys()]) {
+			if (key.startsWith(`${path}/`)) {
+				this.resources.delete(key);
+				found = true;
+			}
+		}
+		return send(response, found ? 204 : 404);
+	}
+
+	private etag(body: Buffer) {
+		const value = `"${createHash("sha256").update(body).digest("hex").slice(0, 16)}"`;
+		return this.options.etag === "weak" ? `W/${value}` : value;
+	}
+
+	private etagHeader(body: Buffer): Record<string, string> {
+		return this.options.etag === "missing" ? {} : { etag: this.etag(body) };
+	}
+}
+
+function parent(value: string) {
+	const index = value.lastIndexOf("/");
+	return index <= 0 ? "/" : value.slice(0, index);
+}
+
+function entry(path: string, etag: string | undefined, collection: boolean) {
+	return `<d:response><d:href>${escapeXml(path)}</d:href><d:propstat><d:prop>${etag ? `<d:getetag>${etag}</d:getetag>` : ""}<d:resourcetype>${collection ? "<d:collection/>" : ""}</d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>`;
+}
+
+function escapeXml(value: string) {
+	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function send(
+	response: ServerResponse,
+	status: number,
+	body?: string | Buffer,
+	headers: Record<string, string> = {},
+) {
+	response.writeHead(status, headers);
+	response.end(body);
+}

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -223,7 +223,7 @@ test("main menu exposes shallow secondary navigation with Back", async () => {
 
 		assert.match(calls[1]?.title ?? "", /More options/);
 		assert.deepEqual(calls[1]?.options, [
-			"Manage targets & storage",
+			"Manage destinations",
 			"History & recovery",
 			"Help",
 			"Back",
@@ -1187,7 +1187,7 @@ test("first-time R2 setup recommends home/r2/pi-sync defaults without raw path q
 		assert.deepEqual(inputTitles, ["Cloudflare R2 endpoint"]);
 		assert.match(rendered.join("\n"), /Bucket must already exist/);
 		assert.match(rendered.join("\n"), /pi-sync\/profiles\/home/);
-		assert.match(notifications.at(-1)?.message ?? "", /Target “home” is ready/);
+		assert.match(notifications.at(-1)?.message ?? "", /Destination “home” is ready/);
 		assert.doesNotMatch(rendered.join("\n"), /setup-access-secret|setup-secret-value/);
 	});
 });
@@ -1231,6 +1231,50 @@ test("first-time S3 setup asks only for the existing bucket and derives work def
 		assert.equal(target?.prefix, "pi-sync");
 		assert.equal(target?.namespace, "work");
 		assert.deepEqual(inputTitles, ["S3-compatible endpoint", "Storage region", "Existing bucket"]);
+	});
+});
+
+test("first-time S3 setup can store masked credentials entirely through TUI", async () => {
+	await withTempSettings(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Set up sync",
+			"Other S3-compatible storage",
+			"Personal / Home",
+			"Use existing bucket with suggested path (recommended)",
+			"Store credentials privately",
+			"Minimal settings",
+			"Keep automatic sync off",
+			"Keep sessions off (recommended)",
+			"Save setup",
+			undefined,
+		];
+		const inputs = ["https://s3.example.com", "us-east-1", "personal-pi", "access-key-id"];
+		const rendered: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async () => inputs.shift(),
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 48);
+				rendered.push(harness.handleInput("secret-access-key").join("\n"));
+				harness.handleInput("tui.input.submit");
+				return harness.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		const profile = (saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.s3;
+		assert.equal(profile?.accessKeyId, "access-key-id");
+		assert.equal(profile?.secretAccessKey, "secret-access-key");
+		assert.doesNotMatch(rendered.join("\n"), /secret-access-key/);
 	});
 });
 
@@ -1308,8 +1352,8 @@ test("manage flow recommends the current profile bucket and derives a separate n
 		sync(mock.pi);
 		const selections = [
 			"More…",
-			"Manage targets & storage",
-			"Add sync target",
+			"Manage destinations",
+			"Add destination",
 			"r2",
 			"Same bucket as “home” (recommended)",
 			"Recommended Pi settings",

--- a/extensions/pi-sync/test/secret-input.test.ts
+++ b/extensions/pi-sync/test/secret-input.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { promptSecret } from "../src/secret-input.js";
+
+test("masked secret input never renders plaintext and submits pasted text", async () => {
+	const secret = "private-password";
+	let rendered: string[] = [];
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 24);
+			harness.setFocused(true);
+			rendered = harness.handleInput(`\u001b[200~${secret}\u001b[201~`);
+			assert.doesNotMatch(rendered.join("\n"), new RegExp(secret));
+			assert.match(rendered.join("\n"), /•+/u);
+			assert.equal(rendered.join("\n").includes(CURSOR_MARKER), true);
+			for (const line of rendered) assert.ok(visibleWidth(line) <= 24);
+			harness.handleInput("tui.input.submit");
+			return harness.result;
+		},
+	});
+
+	assert.equal(await promptSecret(ctx, "WebDAV password"), secret);
+});
+
+test("masked secret input cancellation returns without a secret", async () => {
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 12);
+			harness.handleInput("secret");
+			harness.handleInput("tui.select.cancel");
+			return harness.result;
+		},
+	});
+
+	assert.equal(await promptSecret(ctx, "Password"), undefined);
+});

--- a/extensions/pi-sync/test/secret-input.test.ts
+++ b/extensions/pi-sync/test/secret-input.test.ts
@@ -27,6 +27,35 @@ test("masked secret input never renders plaintext and submits pasted text", asyn
 	assert.equal(await promptSecret(ctx, "WebDAV password"), secret);
 });
 
+test("stored S3 credential setup aborts with its owning session", async () => {
+	const controller = new AbortController();
+	let resolveInput: ((value: string) => void) | undefined;
+	let customCalls = 0;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => "Store credentials privately",
+		input: async () =>
+			await new Promise<string>((resolve) => {
+				resolveInput = resolve;
+			}),
+		custom: async () => {
+			customCalls += 1;
+			return "secret";
+		},
+	});
+	const setup = chooseS3Credentials(ctx, controller.signal);
+	while (!resolveInput) await new Promise((resolve) => setImmediate(resolve));
+	controller.abort(new DOMException("Session replaced", "AbortError"));
+	resolveInput("access-key");
+
+	await assert.rejects(
+		setup,
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+	assert.equal(customCalls, 0);
+});
+
 test("stored S3 credentials reject a blank access key ID", async () => {
 	const { ctx, notifications } = createMockContext({
 		hasUI: true,

--- a/extensions/pi-sync/test/secret-input.test.ts
+++ b/extensions/pi-sync/test/secret-input.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { chooseS3Credentials } from "../src/s3-credentials-ui.js";
 import { promptSecret } from "../src/secret-input.js";
 
 test("masked secret input never renders plaintext and submits pasted text", async () => {
@@ -24,6 +25,18 @@ test("masked secret input never renders plaintext and submits pasted text", asyn
 	});
 
 	assert.equal(await promptSecret(ctx, "WebDAV password"), secret);
+});
+
+test("stored S3 credentials reject a blank access key ID", async () => {
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => "Store credentials privately",
+		input: async () => "",
+	});
+
+	assert.equal(await chooseS3Credentials(ctx), undefined);
+	assert.match(notifications.at(-1)?.message ?? "", /Access key ID is required/i);
 });
 
 test("masked secret input cancellation returns without a secret", async () => {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -743,6 +743,35 @@ test("sync config output reports session sync and privacy warning", async () => 
 	});
 });
 
+test("sync config output redacts percent-encoded WebDAV usernames from URLs", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "home",
+				profiles: {
+					dav: {
+						kind: "webdav",
+						url: "https://cloud.example.com/dav/files/alice%40example.com",
+						username: "alice@example.com",
+						password: "secret",
+					},
+				},
+				targets: { home: { profile: "dav", path: "pi-sync", namespace: "home" } },
+			}),
+		);
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext();
+		await mock.commands.get("sync")?.handler("config", ctx);
+		const output = notifications.at(-1)?.message ?? "";
+		assert.doesNotMatch(output, /alice(?:%40|@)example\.com/iu);
+		assert.match(output, /url: https:\/\/cloud\.example\.com\/…/u);
+	});
+});
+
 test("argument and option helpers parse quoted command lines", () => {
 	assert.deepEqual(splitArgs("push --yes 'snapshot one' \"two words\""), [
 		"push",

--- a/extensions/pi-sync/test/webdav-backend-contract.test.ts
+++ b/extensions/pi-sync/test/webdav-backend-contract.test.ts
@@ -1,0 +1,11 @@
+import { WebDavSyncBackend } from "../src/webdav-backend.js";
+import { registerSyncBackendContractSuite } from "./backend-contract-suite.js";
+import { MockWebDavServer, webDavConfig } from "./mock-webdav-server.js";
+
+registerSyncBackendContractSuite("webdav", async () => {
+	const server = await new MockWebDavServer().start();
+	return {
+		backend: new WebDavSyncBackend(webDavConfig(server.url)),
+		dispose: () => server.close(),
+	};
+});

--- a/extensions/pi-sync/test/webdav-backend.test.ts
+++ b/extensions/pi-sync/test/webdav-backend.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SyncBackendPublicationOutcomeUnknownError } from "../src/sync-backend.js";
+import { WebDavSyncBackend } from "../src/webdav-backend.js";
+import { snapshot } from "./helpers.js";
+import { MockWebDavServer, webDavConfig } from "./mock-webdav-server.js";
+
+test("WebDAV doctor verifies conditional publication and cleans its probe", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		const backend = new WebDavSyncBackend(webDavConfig(server.url));
+		assert.equal(backend.capability, "conditional-required");
+		const diagnostics = await backend.diagnose();
+		assert.equal(backend.capability, "atomic-conditional");
+		assert.ok(diagnostics.some((item) => item.message.includes("atomic-conditional (verified)")));
+		assert.ok(diagnostics.some((item) => item.message.includes("cleanup: ok")));
+		assert.equal(
+			[...server.resources.keys()].some((key) => key.includes(".pi-sync-probes")),
+			false,
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV diagnostics honor caller cancellation", async () => {
+	const controller = new AbortController();
+	controller.abort(new DOMException("cancelled", "AbortError"));
+	const backend = new WebDavSyncBackend(webDavConfig("http://127.0.0.1:1/dav/"));
+	await assert.rejects(
+		backend.diagnose(controller.signal),
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+});
+
+test("WebDAV cancellation before and after the commit boundary is classified correctly", async () => {
+	const delayedOptions: { delayMs?: number } = { delayMs: 30 };
+	const delayed = await new MockWebDavServer(delayedOptions).start();
+	try {
+		const controller = new AbortController();
+		const publication = new WebDavSyncBackend(webDavConfig(delayed.url)).publishSnapshot(
+			snapshot([]),
+			{ kind: "missing" },
+			{ signal: controller.signal },
+		);
+		while (delayed.requests.length === 0) await new Promise((resolve) => setImmediate(resolve));
+		controller.abort(new DOMException("cancelled", "AbortError"));
+		await assert.rejects(
+			publication,
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		assert.equal(delayed.resources.has("/dav/pi-sync/profiles/default/latest.json"), false);
+	} finally {
+		await delayed.close();
+	}
+
+	const server = await new MockWebDavServer().start();
+	try {
+		const controller = new AbortController();
+		const result = await new WebDavSyncBackend(webDavConfig(server.url)).publishSnapshot(
+			snapshot([]),
+			{ kind: "missing" },
+			{
+				signal: controller.signal,
+				onCommit: () => controller.abort(new DOMException("late cancel", "AbortError")),
+			},
+		);
+		assert.equal(result.head.snapshotId, "snap");
+		assert.equal(controller.signal.aborted, true);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV servers that ignore preconditions remain read-only", async () => {
+	const server = await new MockWebDavServer({ ignoreConditions: true }).start();
+	try {
+		const backend = new WebDavSyncBackend(webDavConfig(server.url));
+		await assert.rejects(
+			backend.publishSnapshot(snapshot([]), { kind: "missing" }),
+			/ignored If-None-Match|read-only/i,
+		);
+		assert.equal(server.resources.has("/dav/pi-sync/profiles/default/latest.json"), false);
+		assert.ok((await backend.diagnose()).some((item) => item.level === "error"));
+		assert.equal(backend.capability, "conditional-required");
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV rejects control-bearing remote pointer metadata", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		server.resources.set(
+			"/dav/pi-sync/profiles/default/latest.json",
+			Buffer.from(
+				JSON.stringify({
+					version: 1,
+					profile: "default",
+					snapshot: "snapshot",
+					sha256: "a".repeat(64),
+					createdAt: "2026-01-01T00:00:00.000Z",
+					machine: "unsafe\u001b[31m",
+				}),
+			),
+		);
+		await assert.rejects(new WebDavSyncBackend(webDavConfig(server.url)).readHead(), /malformed/);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV weak or missing ETags fail closed", async () => {
+	for (const etag of ["weak", "missing"] as const) {
+		const server = await new MockWebDavServer({ etag }).start();
+		try {
+			await assert.rejects(
+				new WebDavSyncBackend(webDavConfig(server.url)).publishSnapshot(snapshot([]), {
+					kind: "missing",
+				}),
+				/strong ETag/,
+			);
+		} finally {
+			await server.close();
+		}
+	}
+});
+
+test("WebDAV revalidates conditional support before every publication", async () => {
+	const options: { ignoreConditions?: boolean } = {};
+	const server = await new MockWebDavServer(options).start();
+	try {
+		const backend = new WebDavSyncBackend(webDavConfig(server.url));
+		const first = snapshot([]);
+		const head = (await backend.publishSnapshot(first, { kind: "missing" })).head;
+		options.ignoreConditions = true;
+		await assert.rejects(
+			backend.publishSnapshot(
+				{ ...first, id: "unsafe-second" },
+				{ kind: "revision", revision: head.revision },
+			),
+			/ignored If-None-Match|read-only/i,
+		);
+		assert.equal((await backend.readHead())?.snapshotId, first.id);
+		assert.equal(backend.capability, "conditional-required");
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV opaque revisions retain If-Match across backend instances", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		const config = webDavConfig(server.url);
+		const first = snapshot([]);
+		const firstHead = (
+			await new WebDavSyncBackend(config).publishSnapshot(first, { kind: "missing" })
+		).head;
+		const observed = await new WebDavSyncBackend(config).readHead();
+		assert.equal(observed?.revision, firstHead.revision);
+		const second = { ...first, id: "second", createdAt: "2026-01-02T00:00:00.000Z" };
+		const result = await new WebDavSyncBackend(config).publishSnapshot(second, {
+			kind: "revision",
+			revision: observed?.revision ?? "missing",
+		});
+		assert.equal(result.head.snapshotId, "second");
+		assert.ok(
+			server.requests.some(
+				(request) =>
+					request.path.endsWith("/latest.json") && typeof request.headers["if-match"] === "string",
+			),
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV active-head transport failures report an unknown publication outcome", async () => {
+	const server = await new MockWebDavServer({ failLatestPut: true }).start();
+	try {
+		await assert.rejects(
+			new WebDavSyncBackend(webDavConfig(server.url)).publishSnapshot(snapshot([]), {
+				kind: "missing",
+			}),
+			SyncBackendPublicationOutcomeUnknownError,
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV authentication and permission diagnostics remain actionable", async () => {
+	for (const setup of [
+		{ options: { username: "other", password: "other" }, expected: /HTTP 401/ },
+		{ options: { deny: true }, expected: /HTTP 403/ },
+	] as const) {
+		const server = await new MockWebDavServer(setup.options).start();
+		try {
+			const output = (await new WebDavSyncBackend(webDavConfig(server.url)).diagnose())
+				.map((item) => item.message)
+				.join("\n");
+			assert.match(output, setup.expected);
+			assert.match(output, /read-only/);
+			assert.doesNotMatch(output, /Basic [A-Za-z0-9+/=]+/);
+		} finally {
+			await server.close();
+		}
+	}
+});
+
+test("WebDAV probe cleanup failures are explicit without exposing credentials", async () => {
+	const server = await new MockWebDavServer({
+		cleanupFails: true,
+		username: "private-user",
+		password: "private-password",
+	}).start();
+	try {
+		const config = webDavConfig(server.url);
+		config.profile.username = "private-user";
+		config.profile.password = "private-password";
+		const diagnostics = await new WebDavSyncBackend(config).diagnose();
+		const output = diagnostics.map((item) => item.message).join("\n");
+		assert.match(output, /cleanup (also )?failed/);
+		assert.doesNotMatch(output, /private-user|private-password/);
+	} finally {
+		await server.close();
+	}
+});

--- a/extensions/pi-sync/test/webdav-backend.test.ts
+++ b/extensions/pi-sync/test/webdav-backend.test.ts
@@ -72,6 +72,20 @@ test("WebDAV cancellation before and after the commit boundary is classified cor
 	}
 });
 
+test("WebDAV servers with non-rotating strong ETags remain read-only", async () => {
+	const server = await new MockWebDavServer({ constantEtag: true }).start();
+	try {
+		const backend = new WebDavSyncBackend(webDavConfig(server.url));
+		await assert.rejects(
+			backend.publishSnapshot(snapshot([]), { kind: "missing" }),
+			/strong ETag|rotate|changed/i,
+		);
+		assert.equal(backend.capability, "conditional-required");
+	} finally {
+		await server.close();
+	}
+});
+
 test("WebDAV servers that ignore preconditions remain read-only", async () => {
 	const server = await new MockWebDavServer({ ignoreConditions: true }).start();
 	try {
@@ -88,25 +102,30 @@ test("WebDAV servers that ignore preconditions remain read-only", async () => {
 	}
 });
 
-test("WebDAV rejects control-bearing remote pointer metadata", async () => {
-	const server = await new MockWebDavServer().start();
-	try {
-		server.resources.set(
-			"/dav/pi-sync/profiles/default/latest.json",
-			Buffer.from(
-				JSON.stringify({
-					version: 1,
-					profile: "default",
-					snapshot: "snapshot",
-					sha256: "a".repeat(64),
-					createdAt: "2026-01-01T00:00:00.000Z",
-					machine: "unsafe\u001b[31m",
-				}),
-			),
-		);
-		await assert.rejects(new WebDavSyncBackend(webDavConfig(server.url)).readHead(), /malformed/);
-	} finally {
-		await server.close();
+test("WebDAV rejects control-bearing remote pointer metadata and references", async () => {
+	for (const unsafe of [
+		{ snapshot: "snapshot", machine: "unsafe\u001b[31m" },
+		{ snapshot: "unsafe\u009b31m", machine: "machine" },
+	]) {
+		const server = await new MockWebDavServer().start();
+		try {
+			server.resources.set(
+				"/dav/pi-sync/profiles/default/latest.json",
+				Buffer.from(
+					JSON.stringify({
+						version: 1,
+						profile: "default",
+						snapshot: unsafe.snapshot,
+						sha256: "a".repeat(64),
+						createdAt: "2026-01-01T00:00:00.000Z",
+						machine: unsafe.machine,
+					}),
+				),
+			);
+			await assert.rejects(new WebDavSyncBackend(webDavConfig(server.url)).readHead(), /malformed/);
+		} finally {
+			await server.close();
+		}
 	}
 });
 
@@ -209,20 +228,24 @@ test("WebDAV authentication and permission diagnostics remain actionable", async
 });
 
 test("WebDAV probe cleanup failures are explicit without exposing credentials", async () => {
-	const server = await new MockWebDavServer({
-		cleanupFails: true,
-		username: "private-user",
-		password: "private-password",
-	}).start();
-	try {
-		const config = webDavConfig(server.url);
-		config.profile.username = "private-user";
-		config.profile.password = "private-password";
-		const diagnostics = await new WebDavSyncBackend(config).diagnose();
-		const output = diagnostics.map((item) => item.message).join("\n");
-		assert.match(output, /cleanup (also )?failed/);
-		assert.doesNotMatch(output, /private-user|private-password/);
-	} finally {
-		await server.close();
+	for (const cleanupOptions of [{ cleanupFails: true }, { cleanupMultiStatus: true }]) {
+		const server = await new MockWebDavServer({
+			...cleanupOptions,
+			username: "private-user",
+			password: "private-password",
+		}).start();
+		try {
+			const config = webDavConfig(server.url);
+			config.profile.username = "private-user";
+			config.profile.password = "private-password";
+			const backend = new WebDavSyncBackend(config);
+			const diagnostics = await backend.diagnose();
+			const output = diagnostics.map((item) => item.message).join("\n");
+			assert.match(output, /cleanup (also )?failed/);
+			assert.doesNotMatch(output, /private-user|private-password/);
+			assert.equal(backend.capability, "conditional-required");
+		} finally {
+			await server.close();
+		}
 	}
 });

--- a/extensions/pi-sync/test/webdav-backend.test.ts
+++ b/extensions/pi-sync/test/webdav-backend.test.ts
@@ -194,6 +194,27 @@ test("WebDAV opaque revisions retain If-Match across backend instances", async (
 	}
 });
 
+test("WebDAV doctor repairs a missing active snapshot history entry", async () => {
+	const options: { failHistoryPut?: boolean } = { failHistoryPut: true };
+	const server = await new MockWebDavServer(options).start();
+	try {
+		const backend = new WebDavSyncBackend(webDavConfig(server.url));
+		const published = await backend.publishSnapshot(snapshot([]), { kind: "missing" });
+		assert.match(published.warnings.join("\n"), /history could not be updated/);
+		assert.deepEqual(await backend.listHistory(), []);
+
+		options.failHistoryPut = false;
+		const diagnostics = await backend.diagnose();
+		assert.ok(diagnostics.some((item) => /history.*repaired/i.test(item.message)));
+		assert.deepEqual(
+			(await backend.listHistory()).map((item) => item.snapshotId),
+			["snap"],
+		);
+	} finally {
+		await server.close();
+	}
+});
+
 test("WebDAV active-head transport failures report an unknown publication outcome", async () => {
 	const server = await new MockWebDavServer({ failLatestPut: true }).start();
 	try {

--- a/extensions/pi-sync/test/webdav-client.test.ts
+++ b/extensions/pi-sync/test/webdav-client.test.ts
@@ -61,6 +61,28 @@ test("WebDAV client reports authentication and malformed listing errors without 
 	}
 });
 
+test("WebDAV client redacts percent-encoded usernames from error bodies", async () => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (async () =>
+		new Response("principal alice%40example.com denied", {
+			status: 403,
+		})) as typeof globalThis.fetch;
+	try {
+		const config = webDavConfig("http://127.0.0.1:1/dav/");
+		config.profile.username = "alice@example.com";
+		await assert.rejects(
+			new WebDavClient(config).getBuffer("item"),
+			(error: unknown) =>
+				error instanceof Error &&
+				/HTTP 403/.test(error.message) &&
+				!error.message.includes("alice@example.com") &&
+				!error.message.includes("alice%40example.com"),
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test("WebDAV client cancels response bodies on early 404 and 412 exits", async () => {
 	const originalFetch = globalThis.fetch;
 	let cancelled = 0;

--- a/extensions/pi-sync/test/webdav-client.test.ts
+++ b/extensions/pi-sync/test/webdav-client.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WebDavClient } from "../src/webdav-client.js";
+import { MockWebDavServer, webDavConfig } from "./mock-webdav-server.js";
+
+test("WebDAV client rejects unsafe authenticated base URLs", () => {
+	const insecure = webDavConfig("http://example.com/dav/");
+	assert.throws(() => new WebDavClient(insecure), /HTTPS is required/);
+	const embedded = webDavConfig("https://user:password@example.com/dav/");
+	assert.throws(() => new WebDavClient(embedded), /embedded credentials/);
+});
+
+test("WebDAV client authenticates, encodes paths, creates collections, and lists them", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		const client = new WebDavClient(webDavConfig(server.url));
+		await client.ensureCollection("folder with space/child");
+		await client.putBuffer(
+			"folder with space/child/value.json",
+			Buffer.from("ok"),
+			"application/json",
+			{
+				ifAbsent: true,
+			},
+		);
+		assert.equal(
+			(await client.getBuffer("folder with space/child/value.json")).value?.toString(),
+			"ok",
+		);
+		assert.ok(
+			(await client.listCollection("folder with space/child")).some((entry) =>
+				entry.href.endsWith("value.json"),
+			),
+		);
+		assert.ok(
+			server.requests.every((request) => request.headers.authorization?.startsWith("Basic ")),
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV client reports authentication and malformed listing errors without secrets", async () => {
+	const server = await new MockWebDavServer({ malformedXml: true }).start();
+	try {
+		const config = webDavConfig(server.url);
+		const client = new WebDavClient(config);
+		await assert.rejects(client.listCollection("missing"), /collection is missing/);
+		await client.ensureCollection("list");
+		await assert.rejects(client.listCollection("list"), /malformed/);
+		config.profile.password = "wrong-private-password";
+		await assert.rejects(
+			new WebDavClient(config).getBuffer("item"),
+			(error: unknown) =>
+				error instanceof Error &&
+				/authentication|required|HTTP 401/i.test(error.message) &&
+				!error.message.includes("wrong-private-password"),
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV client refuses ambiguous redirects for mutating requests", async () => {
+	const options: { redirectTo?: string } = {};
+	const server = await new MockWebDavServer(options).start();
+	options.redirectTo = `${server.url}canonical`;
+	try {
+		await assert.rejects(
+			new WebDavClient(webDavConfig(server.url)).putBuffer(
+				"item",
+				Buffer.from("secret"),
+				"application/octet-stream",
+			),
+			/ambiguous HTTP 302 redirect for PUT/,
+		);
+		assert.equal(server.requests.length, 1);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV client rejects cross-origin authenticated redirects", async () => {
+	const server = await new MockWebDavServer({ redirectTo: "http://127.0.0.1:1/stolen" }).start();
+	try {
+		await assert.rejects(
+			new WebDavClient(webDavConfig(server.url)).getBuffer("item"),
+			/cross-origin authenticated redirect/,
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV client bounds JSON responses", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		server.resources.set("/dav/large.json", Buffer.alloc(1024 * 1024 + 1, 65));
+		await assert.rejects(
+			new WebDavClient(webDavConfig(server.url)).getJson("large.json"),
+			/too large/,
+		);
+	} finally {
+		await server.close();
+	}
+});
+
+test("WebDAV client honors caller cancellation and request timeout", async () => {
+	const server = await new MockWebDavServer({ delayMs: 100 }).start();
+	try {
+		const controller = new AbortController();
+		controller.abort(new DOMException("cancelled", "AbortError"));
+		await assert.rejects(
+			new WebDavClient(webDavConfig(server.url), controller.signal).getBuffer("item"),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		await assert.rejects(
+			new WebDavClient(webDavConfig(server.url), undefined, 10).getBuffer("item"),
+			/request failed/,
+		);
+	} finally {
+		await server.close();
+	}
+});

--- a/extensions/pi-sync/test/webdav-client.test.ts
+++ b/extensions/pi-sync/test/webdav-client.test.ts
@@ -61,6 +61,36 @@ test("WebDAV client reports authentication and malformed listing errors without 
 	}
 });
 
+test("WebDAV client cancels response bodies on early 404 and 412 exits", async () => {
+	const originalFetch = globalThis.fetch;
+	let cancelled = 0;
+	const responses = [404, 404, 404, 412];
+	globalThis.fetch = (async () => {
+		const status = responses.shift() ?? 500;
+		return new Response(
+			new ReadableStream({
+				cancel() {
+					cancelled += 1;
+				},
+			}),
+			{ status },
+		);
+	}) as typeof globalThis.fetch;
+	try {
+		const client = new WebDavClient(webDavConfig("http://127.0.0.1:1/dav/"));
+		assert.equal((await client.getBuffer("missing")).missing, true);
+		assert.equal((await client.getJson("missing")).missing, true);
+		await assert.rejects(client.listCollection("missing"), /missing/);
+		await assert.rejects(
+			client.putBuffer("item", Buffer.from("value"), "text/plain", { ifAbsent: true }),
+			/precondition/i,
+		);
+		assert.equal(cancelled, 4);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test("WebDAV client refuses ambiguous redirects for mutating requests", async () => {
 	const options: { redirectTo?: string } = {};
 	const server = await new MockWebDavServer(options).start();

--- a/extensions/pi-sync/test/webdav-config.test.ts
+++ b/extensions/pi-sync/test/webdav-config.test.ts
@@ -122,6 +122,28 @@ test("WebDAV settings reject aliased profiles that resolve to one remote destina
 	});
 });
 
+test("WebDAV settings allow separate authenticated users at one collection URL", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				...settings,
+				profiles: {
+					first: { ...settings.profiles.dav, username: "alice" },
+					second: { ...settings.profiles.dav, username: "bob" },
+				},
+				targets: {
+					home: { profile: "first", path: "pi-sync", namespace: "shared" },
+					work: { profile: "second", path: "pi-sync", namespace: "shared" },
+				},
+			}),
+		);
+
+		await assert.doesNotReject(loadConfig());
+	});
+});
+
 test("WebDAV profile edits reject newly duplicated remote destinations", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });

--- a/extensions/pi-sync/test/webdav-config.test.ts
+++ b/extensions/pi-sync/test/webdav-config.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.js";
+import { updateStorageProfile } from "../src/settings-management.js";
 import { withTempHome } from "./helpers.js";
 
 const settings = {
@@ -67,6 +68,33 @@ test("WebDAV settings reject aliased profiles that resolve to one remote destina
 			}),
 		);
 		await assert.rejects(loadConfig(), /same remote destination/);
+	});
+});
+
+test("WebDAV profile edits reject newly duplicated remote destinations", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				...settings,
+				profiles: {
+					first: settings.profiles.dav,
+					second: { ...settings.profiles.dav, url: "https://other.example.com/dav" },
+				},
+				targets: {
+					home: { profile: "first", path: "pi-sync", namespace: "shared" },
+					work: { profile: "second", path: "pi-sync", namespace: "shared" },
+				},
+			}),
+		);
+		await assert.rejects(
+			updateStorageProfile("second", (profile) => ({
+				...profile,
+				url: `${settings.profiles.dav.url}/`,
+			})),
+			/same remote destination/,
+		);
 	});
 });
 

--- a/extensions/pi-sync/test/webdav-config.test.ts
+++ b/extensions/pi-sync/test/webdav-config.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
-import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.js";
+import {
+	loadConfig,
+	localConfigPath,
+	readStateForConfig,
+	stateDir,
+	statePathForConfig,
+} from "../src/config.js";
 import { updateStorageProfile } from "../src/settings-management.js";
 import { withTempHome } from "./helpers.js";
 
@@ -47,6 +54,33 @@ test("version 2 resolves a WebDAV profile and destination without environment ov
 			delete process.env.PI_SYNC_AUTO_SYNC;
 			delete process.env.PI_SYNC_SESSIONS;
 		}
+	});
+});
+
+test("WebDAV targets do not adopt target-name-only legacy S3 state", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const config = await loadConfig();
+		const legacyPath = path.join(
+			stateDir(),
+			"targets",
+			`home-${createHash("sha256").update("home").digest("hex").slice(0, 10)}.state.json`,
+		);
+		mkdirSync(path.dirname(legacyPath), { recursive: true });
+		writeFileSync(
+			legacyPath,
+			JSON.stringify({
+				version: 1,
+				profile: "home",
+				lastAppliedSnapshot: "unrelated-s3-snapshot",
+				lastFileHashes: {},
+			}),
+		);
+
+		assert.equal((await readStateForConfig(config)).lastAppliedSnapshot, undefined);
+		assert.equal(existsSync(legacyPath), true);
+		assert.equal(existsSync(statePathForConfig(config)), false);
 	});
 });
 

--- a/extensions/pi-sync/test/webdav-config.test.ts
+++ b/extensions/pi-sync/test/webdav-config.test.ts
@@ -50,6 +50,23 @@ test("version 2 resolves a WebDAV profile and destination without environment ov
 	});
 });
 
+test("WebDAV state identity changes with the authenticated username", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		const first = await loadConfig();
+		if (first.backend.type !== "webdav") return;
+		const second = {
+			...first,
+			backend: {
+				...first.backend,
+				profile: { ...first.backend.profile, username: "other-user" },
+			},
+		};
+		assert.notEqual(statePathForConfig(first), statePathForConfig(second));
+	});
+});
+
 test("WebDAV settings reject aliased profiles that resolve to one remote destination", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });

--- a/extensions/pi-sync/test/webdav-config.test.ts
+++ b/extensions/pi-sync/test/webdav-config.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.js";
+import { withTempHome } from "./helpers.js";
+
+const settings = {
+	version: 2,
+	activeTarget: "home",
+	profiles: {
+		dav: {
+			kind: "webdav",
+			url: "https://cloud.example.com/remote.php/dav/files/user",
+			username: "user",
+			password: "secret",
+		},
+	},
+	targets: {
+		home: { profile: "dav", path: "pi-sync", namespace: "home", autoSync: true },
+	},
+};
+
+test("version 2 resolves a WebDAV profile and destination without environment overrides", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(settings));
+		process.env.PI_SYNC_ENDPOINT = "https://ignored.example.com";
+		process.env.PI_SYNC_AUTO_SYNC = "false";
+		process.env.PI_SYNC_SESSIONS = "true";
+		try {
+			const config = await loadConfig();
+			assert.equal(config.backend.type, "webdav");
+			if (config.backend.type !== "webdav") return;
+			assert.equal(
+				config.backend.profile.url,
+				"https://cloud.example.com/remote.php/dav/files/user/",
+			);
+			assert.equal(config.backend.profile.password, "secret");
+			assert.deepEqual(config.backend.destination, { path: "pi-sync", namespace: "home" });
+			assert.equal(config.autoSync, true);
+			assert.equal(config.syncSessions, false);
+			assert.match(statePathForConfig(config), new RegExp(`${path.sep}targets${path.sep}home-`));
+		} finally {
+			delete process.env.PI_SYNC_ENDPOINT;
+			delete process.env.PI_SYNC_AUTO_SYNC;
+			delete process.env.PI_SYNC_SESSIONS;
+		}
+	});
+});
+
+test("WebDAV settings reject aliased profiles that resolve to one remote destination", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				...settings,
+				profiles: {
+					first: settings.profiles.dav,
+					second: { ...settings.profiles.dav, url: `${settings.profiles.dav.url}/` },
+				},
+				targets: {
+					home: { profile: "first", path: "pi-sync", namespace: "shared" },
+					work: { profile: "second", path: "pi-sync", namespace: "shared" },
+				},
+			}),
+		);
+		await assert.rejects(loadConfig(), /same remote destination/);
+	});
+});
+
+test("WebDAV settings reject mixed backend fields and unsafe URLs", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				...settings,
+				profiles: { dav: { ...settings.profiles.dav, accessKeyId: "mixed" } },
+			}),
+		);
+		await assert.rejects(loadConfig(), /mixes backend fields/);
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				...settings,
+				profiles: { dav: { ...settings.profiles.dav, url: "http://cloud.example.com/dav" } },
+			}),
+		);
+		await assert.rejects(loadConfig(), /HTTPS is required/);
+	});
+});

--- a/extensions/pi-sync/test/webdav-routes.test.ts
+++ b/extensions/pi-sync/test/webdav-routes.test.ts
@@ -87,7 +87,7 @@ test("all backend-neutral sync routes operate against a WebDAV target", async ()
 			const configOutput = notifications.at(-1)?.message ?? "";
 			assert.match(configOutput, /kind: webdav/);
 			assert.match(configOutput, /password: configured/);
-			assert.match(configOutput, /url: http:\/\/127\.0\.0\.1:\d+\/dav\//);
+			assert.match(configOutput, /url: http:\/\/127\.0\.0\.1:\d+\/…/u);
 			assert.doesNotMatch(configOutput, /endpoint:|bucket:|password: pass/);
 			assert.match(notifications.map((item) => item.message).join("\n"), /WebDAV|webdav|snapshot/i);
 		});

--- a/extensions/pi-sync/test/webdav-routes.test.ts
+++ b/extensions/pi-sync/test/webdav-routes.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { localConfigPath } from "../src/config.js";
+import syncExtension from "../src/sync.js";
+import {
+	diff,
+	doctor,
+	history,
+	pull,
+	push,
+	rollback,
+	status,
+	syncBoth,
+} from "../src/sync-operations.js";
+import type { CommandOptions } from "../src/types.js";
+import { withTempHome } from "./helpers.js";
+import { MockWebDavServer } from "./mock-webdav-server.js";
+
+function options(args: string[] = []): CommandOptions {
+	return {
+		yes: true,
+		force: false,
+		stale: false,
+		silent: false,
+		reload: false,
+		auto: false,
+		args,
+	};
+}
+
+test("all backend-neutral sync routes operate against a WebDAV target", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			writeFileSync(path.join(agentDir, "settings.json"), '{"theme":"dark"}\n');
+			writeFileSync(
+				localConfigPath(),
+				JSON.stringify({
+					version: 2,
+					activeTarget: "home",
+					profiles: {
+						dav: {
+							kind: "webdav",
+							url: server.url,
+							username: "user",
+							password: "pass",
+						},
+					},
+					targets: {
+						home: {
+							profile: "dav",
+							path: "pi-sync",
+							namespace: "home",
+							autoSync: true,
+							syncFiles: ["settings.json"],
+							syncSessions: false,
+							extraFiles: [],
+						},
+					},
+				}),
+			);
+			const { ctx, notifications } = createMockContext({ hasUI: true });
+			await doctor(ctx, options());
+			await status(ctx, options());
+			await diff(ctx, options());
+			await push(ctx, options());
+			const pointer = JSON.parse(
+				server.resources.get("/dav/pi-sync/profiles/home/latest.json")?.toString("utf8") ?? "null",
+			) as { snapshot: string };
+			assert.ok(pointer.snapshot);
+			await history(ctx, options());
+			writeFileSync(path.join(agentDir, "settings.json"), '{"theme":"light"}\n');
+			await pull(ctx, options());
+			assert.equal(
+				readFileSync(path.join(agentDir, "settings.json"), "utf8"),
+				'{"theme":"dark"}\n',
+			);
+			await syncBoth(ctx, options());
+			await rollback(ctx, options([pointer.snapshot]));
+			const mock = createMockPi();
+			syncExtension(mock.pi);
+			await mock.commands.get("sync")?.handler("config", ctx);
+			const configOutput = notifications.at(-1)?.message ?? "";
+			assert.match(configOutput, /kind: webdav/);
+			assert.match(configOutput, /password: configured/);
+			assert.match(configOutput, /url: http:\/\/127\.0\.0\.1:\d+\/dav\//);
+			assert.doesNotMatch(configOutput, /endpoint:|bucket:|password: pass/);
+			assert.match(notifications.map((item) => item.message).join("\n"), /WebDAV|webdav|snapshot/i);
+		});
+	} finally {
+		await server.close();
+	}
+});

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -6,6 +6,7 @@ import {
 	createMockContext,
 	createMockPi,
 } from "../../../test/support.js";
+import { completeSyncArguments, setSyncTargetCompletions } from "../src/command.js";
 import { loadConfig, localConfigPath, readLocalConfigObject } from "../src/config.js";
 import sync from "../src/sync.js";
 import {
@@ -55,6 +56,7 @@ test("first-time WebDAV setup collects a masked password and stores a usable pro
 			custom: secretInput("app-password", rendered),
 		});
 
+		setSyncTargetCompletions([]);
 		await mock.commands.get("sync")?.handler("", ctx);
 
 		const saved = await readLocalConfigObject();
@@ -66,6 +68,7 @@ test("first-time WebDAV setup collects a masked password and stores a usable pro
 		assert.equal(profile.password, "app-password");
 		assert.equal(target.path, "pi-sync");
 		assert.equal(target.namespace, "home");
+		assert.ok(completeSyncArguments("use h")?.some((item) => item.value === "use home"));
 		assert.deepEqual(inputTitles, [
 			"WebDAV collection URL",
 			"WebDAV username",

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { localConfigPath, readLocalConfigObject } from "../src/config.js";
+import sync from "../src/sync.js";
+import {
+	showAddWebDavStorageProfile,
+	showAddWebDavTarget,
+	showEditWebDavStorageProfile,
+	showEditWebDavTarget,
+} from "../src/webdav-ui.js";
+import { withTempHome } from "./helpers.js";
+
+test("first-time WebDAV setup stores a discriminated profile without requesting a password", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Set up sync",
+			"WebDAV",
+			"Personal / Home",
+			"Recommended Pi settings",
+			"Enable automatic sync",
+			"Keep sessions off (recommended)",
+			"Save setup",
+			undefined,
+		];
+		const inputs = [
+			"https://cloud.example.com/remote.php/dav/files/user",
+			"user",
+			"pi-sync",
+			"home",
+		];
+		const inputTitles: string[] = [];
+		const rendered: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async (title: string) => {
+				inputTitles.push(title);
+				return inputs.shift();
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		const profile = (saved?.profiles as Record<string, Record<string, unknown>>)?.webdav;
+		const target = (saved?.targets as Record<string, Record<string, unknown>>)?.home;
+		assert.equal(profile.kind, "webdav");
+		assert.equal(profile.url, "https://cloud.example.com/remote.php/dav/files/user/");
+		assert.equal(profile.username, "user");
+		assert.equal(Object.hasOwn(profile, "password"), false);
+		assert.equal(target.path, "pi-sync");
+		assert.equal(target.namespace, "home");
+		assert.deepEqual(inputTitles, [
+			"WebDAV collection URL",
+			"WebDAV username",
+			"WebDAV remote path",
+			"Remote namespace",
+		]);
+		assert.match(rendered.join("\n"), /never requests secrets|add it privately/i);
+	});
+});
+
+test("WebDAV profile and target management preserve hidden credentials", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({ version: 2, profiles: {}, targets: {}, futureField: "preserved" }),
+		);
+		const selections = [
+			"Add profile",
+			"Recommended Pi settings",
+			"Add target",
+			"Save profile",
+			"Save target",
+		];
+		const inputs = [
+			"dav",
+			"https://cloud.example.com/remote.php/dav/files/user",
+			"private-user",
+			"pi-sync",
+			"home",
+			"https://cloud.example.com/remote.php/dav/files/private-user",
+			"new-private-user",
+			"new-path",
+			"new-space",
+		];
+		const rendered: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async () => inputs.shift(),
+		});
+		assert.equal(await showAddWebDavStorageProfile(ctx), true);
+		assert.equal(await showAddWebDavTarget(ctx, "home", "dav"), true);
+		let saved = await readLocalConfigObject();
+		const originalProfile = requireRecord(saved?.profiles).dav;
+		assert.equal(await showEditWebDavStorageProfile(ctx, "dav", originalProfile), true);
+		assert.equal(
+			await showEditWebDavTarget(ctx, {
+				settingsVersion: 2,
+				storageKind: "webdav",
+				target: "home",
+				path: "pi-sync",
+				profile: "home",
+			}),
+			true,
+		);
+		saved = await readLocalConfigObject();
+		const profile = requireRecord(saved?.profiles).dav;
+		const target = requireRecord(saved?.targets).home;
+		assert.equal(profile.username, "new-private-user");
+		assert.equal(target.path, "new-path");
+		assert.equal(target.namespace, "new-space");
+		assert.equal(saved?.futureField, "preserved");
+		const output = rendered.join("\n");
+		assert.doesNotMatch(output, /private-user|new-private-user|remote\.php/);
+		assert.match(output, /value hidden/);
+
+		const beforeInvalidEdit = readFileSync(localConfigPath());
+		const invalidInputs = ["http://cloud.example.com/dav", "private-user"];
+		const { ctx: invalidCtx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => invalidInputs.shift(),
+		});
+		assert.equal(await showEditWebDavStorageProfile(invalidCtx, "dav", profile), false);
+		assert.deepEqual(readFileSync(localConfigPath()), beforeInvalidEdit);
+	});
+});
+
+function requireRecord(value: unknown): Record<string, Record<string, unknown>> {
+	assert.ok(value && typeof value === "object" && !Array.isArray(value));
+	return value as Record<string, Record<string, unknown>>;
+}

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -76,6 +76,36 @@ test("first-time WebDAV setup collects a masked password and stores a usable pro
 	});
 });
 
+test("WebDAV setup cannot continue after its session is aborted", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify({ version: 2, profiles: {}, targets: {} }));
+		const controller = new AbortController();
+		let resolveInput: ((value: string) => void) | undefined;
+		let inputCalls = 0;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => {
+				inputCalls += 1;
+				return await new Promise<string>((resolve) => {
+					resolveInput = resolve;
+				});
+			},
+		});
+		const setup = showAddWebDavStorageProfile(ctx, controller.signal);
+		while (!resolveInput) await new Promise((resolve) => setImmediate(resolve));
+		controller.abort(new DOMException("Session replaced", "AbortError"));
+		resolveInput("dav");
+		await assert.rejects(
+			setup,
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		assert.equal(inputCalls, 1);
+		assert.deepEqual((await readLocalConfigObject())?.profiles, {});
+	});
+});
+
 test("WebDAV profile and target management preserve hidden credentials", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -9,6 +9,7 @@ import {
 import { loadConfig, localConfigPath, readLocalConfigObject } from "../src/config.js";
 import sync from "../src/sync.js";
 import {
+	repairableWebDavDestinationName,
 	showAddWebDavStorageProfile,
 	showAddWebDavTarget,
 	showEditWebDavStorageProfile,
@@ -241,6 +242,32 @@ test("Add destination can create a WebDAV connection without leaving the manager
 		assert.equal(requireRecord(saved?.targets).work.profile, "dav");
 		assert.equal(requireRecord(saved?.targets).work.path, "pi-sync");
 		assert.doesNotMatch(rendered.join("\n"), /app-password/);
+	});
+});
+
+test("WebDAV repair detection includes incompatible profile-only fields", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "webdav",
+				profiles: {
+					webdav: {
+						kind: "webdav",
+						url: "https://cloud.example.com/dav",
+						username: "user",
+						password: "secret",
+						accessKeyId: "incompatible",
+					},
+				},
+				targets: {
+					webdav: { profile: "webdav", path: "pi-sync", namespace: "webdav" },
+				},
+			}),
+		);
+		assert.equal(await repairableWebDavDestinationName(), "webdav");
 	});
 });
 

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -1,18 +1,23 @@
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import test from "node:test";
-import { createMockContext, createMockPi } from "../../../test/support.js";
-import { localConfigPath, readLocalConfigObject } from "../src/config.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import { loadConfig, localConfigPath, readLocalConfigObject } from "../src/config.js";
 import sync from "../src/sync.js";
 import {
 	showAddWebDavStorageProfile,
 	showAddWebDavTarget,
 	showEditWebDavStorageProfile,
 	showEditWebDavTarget,
+	showRepairWebDavDestination,
 } from "../src/webdav-ui.js";
 import { withTempHome } from "./helpers.js";
 
-test("first-time WebDAV setup stores a discriminated profile without requesting a password", async () => {
+test("first-time WebDAV setup collects a masked password and stores a usable profile", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		const mock = createMockPi();
@@ -46,6 +51,7 @@ test("first-time WebDAV setup stores a discriminated profile without requesting 
 				inputTitles.push(title);
 				return inputs.shift();
 			},
+			custom: secretInput("app-password", rendered),
 		});
 
 		await mock.commands.get("sync")?.handler("", ctx);
@@ -56,7 +62,7 @@ test("first-time WebDAV setup stores a discriminated profile without requesting 
 		assert.equal(profile.kind, "webdav");
 		assert.equal(profile.url, "https://cloud.example.com/remote.php/dav/files/user/");
 		assert.equal(profile.username, "user");
-		assert.equal(Object.hasOwn(profile, "password"), false);
+		assert.equal(profile.password, "app-password");
 		assert.equal(target.path, "pi-sync");
 		assert.equal(target.namespace, "home");
 		assert.deepEqual(inputTitles, [
@@ -65,7 +71,8 @@ test("first-time WebDAV setup stores a discriminated profile without requesting 
 			"WebDAV remote path",
 			"Remote namespace",
 		]);
-		assert.match(rendered.join("\n"), /never requests secrets|add it privately/i);
+		assert.doesNotMatch(rendered.join("\n"), /app-password/);
+		assert.match(rendered.join("\n"), /Password: configured/i);
 	});
 });
 
@@ -80,6 +87,7 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 			"Add profile",
 			"Recommended Pi settings",
 			"Add target",
+			"Keep current password",
 			"Save profile",
 			"Save target",
 		];
@@ -103,6 +111,7 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 				return selections.shift();
 			},
 			input: async () => inputs.shift(),
+			custom: secretInput("private-password", rendered),
 		});
 		assert.equal(await showAddWebDavStorageProfile(ctx), true);
 		assert.equal(await showAddWebDavTarget(ctx, "home", "dav"), true);
@@ -141,6 +150,133 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 		assert.deepEqual(readFileSync(localConfigPath()), beforeInvalidEdit);
 	});
 });
+
+test("Add destination can create a WebDAV connection without leaving the manager flow", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "home",
+				profiles: {
+					r2: {
+						kind: "r2",
+						endpoint: "https://account.r2.cloudflarestorage.com",
+						region: "auto",
+						accessKeyId: "access",
+						secretAccessKey: "secret",
+					},
+				},
+				targets: {
+					home: {
+						profile: "r2",
+						bucket: "pi-sync",
+						prefix: "pi-sync",
+						namespace: "home",
+					},
+				},
+			}),
+		);
+		const selections = [
+			"More…",
+			"Manage destinations",
+			"Add destination",
+			"Create a new saved connection…",
+			"WebDAV",
+			"Add profile",
+			"Recommended Pi settings",
+			"Add target",
+			undefined,
+		];
+		const inputs = ["work", "dav", "https://cloud.example.com/dav", "user", "pi-sync", "work"];
+		const rendered: string[] = [];
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async () => inputs.shift(),
+			custom: secretInput("app-password", rendered),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		assert.equal(requireRecord(saved?.profiles).dav.password, "app-password");
+		assert.equal(requireRecord(saved?.targets).work.profile, "dav");
+		assert.equal(requireRecord(saved?.targets).work.path, "pi-sync");
+		assert.doesNotMatch(rendered.join("\n"), /app-password/);
+	});
+});
+
+test("WebDAV repair removes incompatible fields and fills missing credentials through TUI", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "webdav",
+				futureField: { preserved: true },
+				profiles: {
+					webdav: {
+						kind: "webdav",
+						url: "https://cloud.example.com/dav",
+						username: "user",
+					},
+				},
+				targets: {
+					webdav: {
+						profile: "webdav",
+						bucket: "pi-sync",
+						prefix: "pi-sync",
+						namespace: "webdav",
+						futureTarget: "preserved",
+					},
+				},
+			}),
+		);
+		const inputs = ["pi-sync", "webdav"];
+		const reviews: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: secretInput("app-password", reviews),
+			input: async () => inputs.shift(),
+			select: async (title: string) => {
+				reviews.push(title);
+				return "Repair destination";
+			},
+		});
+
+		assert.equal(await showRepairWebDavDestination(ctx, "webdav"), true);
+		const saved = await readLocalConfigObject();
+		const profile = requireRecord(saved?.profiles).webdav;
+		const target = requireRecord(saved?.targets).webdav;
+		assert.equal(profile.password, "app-password");
+		assert.equal(target.path, "pi-sync");
+		assert.equal(Object.hasOwn(target, "bucket"), false);
+		assert.equal(Object.hasOwn(target, "prefix"), false);
+		assert.equal(target.futureTarget, "preserved");
+		assert.deepEqual(saved?.futureField, { preserved: true });
+		assert.equal((await loadConfig()).backend.type, "webdav");
+		assert.doesNotMatch(reviews.join("\n"), /app-password/);
+	});
+});
+
+function secretInput(secret: string, rendered: string[] = []) {
+	return async (factory: unknown) => {
+		const harness = createCustomSelectorHarness(factory, 50);
+		rendered.push(harness.handleInput(secret).join("\n"));
+		harness.handleInput("tui.input.submit");
+		return harness.result;
+	};
+}
 
 function requireRecord(value: unknown): Record<string, Record<string, unknown>> {
 	assert.ok(value && typeof value === "object" && !Array.isArray(value));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,6 +1875,7 @@
 			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
+				"fast-xml-parser": "^5.10.1",
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
@@ -6509,6 +6510,18 @@
 			"resolved": "extensions/pi-worktree",
 			"link": true
 		},
+		"node_modules/@nodable/entities": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+			"integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -8849,6 +8862,18 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/aria-hidden": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -9037,6 +9062,45 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+			"integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.6.2",
+				"xml-naming": "^0.3.0"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+			"integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^3.0.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^2.0.0",
+				"path-expression-matcher": "^1.6.2",
+				"strnum": "^2.4.1",
+				"xml-naming": "^0.3.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -9222,6 +9286,18 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/is-unsafe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+			"integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -9373,6 +9449,21 @@
 			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+			"integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/proper-lockfile": {
 			"version": "4.1.2",
@@ -9701,6 +9792,21 @@
 				"url": "https://github.com/sponsors/cyyynthia"
 			}
 		},
+		"node_modules/strnum": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
+		},
 		"node_modules/ts-algebra": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -9835,6 +9941,21 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+			"integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/yaml": {


### PR DESCRIPTION
## Summary

- add WebDAV profiles and targets to pi-sync without changing existing R2/S3 behavior
- implement bounded, authenticated WebDAV transport and immutable snapshot/history storage
- fail closed unless strong ETags and conditional writes are verified before every publication
- integrate WebDAV setup, management, diagnostics, status/config output, documentation, and packaging
- add a configurable account-free WebDAV fixture with contract, route, UI, security, and lifecycle coverage

## Safety

- credentials remain in the private local settings file and are never sourced from WebDAV-specific environment variables
- authenticated non-loopback HTTP, embedded URL credentials, cross-origin redirects, and ambiguous mutating redirects are rejected
- unsupported conditional publication remains readable but cannot publish
- request bodies, redirects, timeouts, cleanup, cancellation, and post-commit outcome classification are bounded and tested

## Verification

- `npm run check` — passed (Biome, boundaries, all workspace typechecks, 1,613 tests)
- `npm run pack:sync -- --json` — passed; 32 package entries inspected
- `npm audit --omit=dev --json` — zero production vulnerabilities
- `git diff --check` — passed

Live vendor-account testing was not performed; interoperability is covered by the required configurable local HTTP/WebDAV fixture and documented Nextcloud/ownCloud/Synology setup guidance.

Closes #271
