### PR TITLE
feat(sync): add destination-focused credential setup

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -125,6 +125,7 @@
 
 ### General
 
+- Prefer destination-oriented pi-sync setup that completes credentials in a masked TUI; keep the profile/target split as an advanced persistence detail rather than a required user concept.
 - Prefer direct, user-owned context selection; avoid dedicated shortcuts or manual copy steps for routine quoting workflows.
 - Prefer reading GitHub issue and pull request links with `gh --json` first; use web tools only when `gh` cannot access the needed content.
 - Live provider smokes are acceptable when relevant, but stop after one clear external or entitlement failure; use deterministic tests instead of repeatedly retrying unless the user explicitly asks.

--- a/docs/plans/archived/2026-07-27_sync-destination-tui-plan.md
+++ b/docs/plans/archived/2026-07-27_sync-destination-tui-plan.md
@@ -1,0 +1,28 @@
+# Pi Sync destination TUI plan
+
+## Goal
+
+Make a new or existing pi-sync destination fully configurable from the TUI, including masked credentials, without requiring users to understand the internal profile/target split or manually edit JSON.
+
+## Architecture
+
+Keep the version 2 `profiles` and `targets` persistence schema unchanged. Present a destination-oriented manager that composes a reusable storage connection (profile) with a remote destination and sync policy (target). A package-owned masked input component handles secrets without ever rendering their plaintext. Existing atomic settings writers remain the only publication path.
+
+## Plan
+
+- [x] Add focused failing tests for masked secret entry, complete WebDAV setup, credential editing, cancellation, narrow rendering, and invalid WebDAV destination repair; the initial missing-module and missing-password failures established the red states.
+- [x] Add a focus-aware masked secret TUI component and credential helpers that honor callback keybindings, paste/edit safely, validate before returning, clear component-owned secret state on disposal, and never render plaintext; covered by `secret-input.test.ts`.
+- [x] Update WebDAV setup/profile editing to collect or replace passwords in TUI and save complete usable profiles atomically while preserving existing secrets and unknown fields; covered by WebDAV setup, edit, cancellation, and manager-flow tests.
+- [x] Replace profile-first management labels with destination-oriented primary flows, retain saved connections as advanced reuse, and add a reviewed WebDAV repair flow for S3-only target fields; covered by manager navigation and repair tests.
+- [x] Extend R2/S3 setup and connection editing with a private-settings credential option using masked secret input while preserving environment-credential behavior; covered by first-time S3 and existing environment-credential tests.
+- [x] Update `extensions/pi-sync/README.md` for the destination workflow, masked credential behavior, recovery, and unchanged settings schema.
+- [x] Run focused pi-sync tests, then `npm run check`, and audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md` touched-area checklists; `npm run check` passed with 1,618 tests and `just pack-sync` included all new runtime modules.
+
+## Completion Checklist
+
+- [x] A new WebDAV destination saved through TUI loads without manual JSON edits.
+- [x] Secret plaintext never appears in rendered lines, reviews, notifications, or errors.
+- [x] Cancellation and write failure retain the previous settings.
+- [x] Existing version 1/version 2 settings, unknown fields, and environment credentials remain compatible.
+- [x] The invalid local `webdav` target can be repaired through the TUI without changing unrelated destinations.
+- [x] Required tests and repository checks pass, and this completed plan is archived.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -73,7 +73,7 @@ For a first Cloudflare R2 target, the recommended location requires no raw path 
 
 The R2 bucket must already exist; pi-sync never creates buckets. Generic S3 setup asks for one existing, potentially globally unique bucket and derives storage profile `s3`, prefix `pi-sync`, and namespace `home` or `work`. **Customize remote location** retains direct control over profile name, bucket, prefix, and namespace.
 
-Pi's extension input API does not provide masked secret entry, so pi-sync never asks for a secret in an unmasked dialog. Use existing S3 environment credentials or add credentials manually to the private settings file. WebDAV credentials are settings-file only; there are no WebDAV environment-variable mirrors. Secret values are never shown in menus, status, warnings, or errors.
+The setup wizard can store WebDAV passwords and S3-compatible static credentials entirely through the TUI. Its package-owned masked input renders only bullets, and secret values are never shown in reviews, menus, status, notifications, warnings, or errors. S3 environment credentials and a manual private-settings template remain available; WebDAV has no environment-variable credential mirrors.
 
 ### WebDAV setup
 
@@ -124,7 +124,7 @@ Its primary actions are:
 - **Switch target** — preview the target change, then follow the configured pull behavior
 - **Status & changes** — perform a cancellable read-only remote check
 - **Settings** — control post-switch pulling, automatic sync, and synced content
-- **More…** — open one shallow level containing target/storage management, history/recovery, Help, and Back
+- **More…** — open one shallow level containing destination management, history/recovery, Help, and Back
 
 The menu does not query remote storage merely to open. It shows the last locally applied snapshot and marks remote changes as unchecked until an operation runs. When no synced content is selected, transfer actions are hidden and Settings becomes the first action. During an active or recoverable lock, mutation actions remain unavailable.
 
@@ -195,6 +195,8 @@ A version 2 example:
 ```
 
 ### Terminology
+
+The TUI presents each profile/target pair as a **destination**. **Add destination** is the primary flow; reusable **saved connections** are available as an advanced action. The version 2 JSON names remain unchanged for compatibility.
 
 - An S3/R2 **storage profile** owns `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`; a WebDAV profile owns `kind: "webdav"`, `url`, `username`, and `password`.
 - An S3/R2 **sync target** owns `bucket`, `prefix`, and `namespace`; a WebDAV target owns `path` and `namespace`. Every target also owns `autoSync` and its synced-content policy.

--- a/extensions/pi-sync/src/config-file.ts
+++ b/extensions/pi-sync/src/config-file.ts
@@ -114,6 +114,17 @@ export function consumeLocalConfigMigrationNotice() {
 	return notice;
 }
 
+export async function readActiveLocalConfigDocumentForRepair(): Promise<
+	LocalConfigDocument | undefined
+> {
+	return withLocalConfigFileLock(async () => {
+		const canonicalPath = localConfigPath();
+		const filePath = (await pathExists(canonicalPath)) ? canonicalPath : legacyLocalConfigPath();
+		const snapshot = await readConfigSnapshotIfExists(filePath);
+		return snapshot ? { path: filePath, ...snapshot } : undefined;
+	});
+}
+
 export async function readMigratingLocalConfigDocument(
 	validateForMigration: (settings: Record<string, unknown>) => void,
 ): Promise<LocalConfigDocument | undefined> {

--- a/extensions/pi-sync/src/config.ts
+++ b/extensions/pi-sync/src/config.ts
@@ -13,6 +13,7 @@ import {
 	legacyLocalConfigPath,
 	localConfigPath,
 	quarantineAndRemoveConfigIfMatches,
+	readActiveLocalConfigDocumentForRepair,
 	readMigratingLocalConfigDocument,
 	replaceLocalConfigDocument,
 	withLocalConfigFileLock,
@@ -42,6 +43,7 @@ export {
 	legacyLocalConfigPath,
 	localConfigPath,
 	quarantineAndRemoveConfigIfMatches,
+	readActiveLocalConfigDocumentForRepair,
 	replaceLocalConfigDocument,
 };
 

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -8,7 +8,6 @@ import {
 	loadConfig,
 	loadPartialConfig,
 	loadTargetSwitchAction,
-	localConfigPath,
 	normalizeSyncFiles,
 	readLocalConfigObject,
 	readStateForConfig,
@@ -23,25 +22,24 @@ import {
 	safeTerminalText,
 	storageDescription,
 } from "./manager-helpers.js";
+import { chooseS3Credentials } from "./s3-credentials-ui.js";
 import {
-	addStorageProfile,
 	addSyncTarget,
 	migrateLegacySettings,
-	removeStorageProfile,
 	removeSyncTarget,
 	saveNewV2Settings,
-	updateStorageProfile,
 	updateSyncTarget,
 } from "./settings-management.js";
 import { showSyncSettings } from "./settings-ui.js";
+import { showAddStorageConnection, showStorageConnections } from "./storage-connections-ui.js";
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
 import { type TargetPullOutcome, useSyncTarget } from "./target-switch.js";
 import type { AnySyncConfig } from "./types.js";
 import {
-	showAddWebDavStorageProfile,
+	repairableWebDavDestinationName,
 	showAddWebDavTarget,
-	showEditWebDavStorageProfile,
 	showEditWebDavTarget,
+	showRepairableWebDavDestination,
 	showWebDavSetup,
 } from "./webdav-ui.js";
 
@@ -54,17 +52,11 @@ export const MAIN_MENU_ACTIONS = [
 	"Settings",
 	"More…",
 ] as const;
-
-const MORE_MENU_ACTIONS = [
-	"Manage targets & storage",
-	"History & recovery",
-	"Help",
-	"Back",
-] as const;
+const MORE_MENU_ACTIONS = ["Manage destinations", "History & recovery", "Help", "Back"] as const;
 const BACK = "Back";
 
 type MainMenuAction = (typeof MAIN_MENU_ACTIONS)[number];
-type ContextualMenuAction = "Manage targets & storage" | "History & recovery" | "Help";
+type ContextualMenuAction = "Manage destinations" | "History & recovery" | "Help";
 type RunRoute = (
 	route: string,
 	signal?: AbortSignal,
@@ -85,7 +77,12 @@ export async function showSyncManager(
 		const selected = await ctx.ui.select(state.title, state.actions);
 		if (!selected) return;
 		switch (
-			selected as MainMenuAction | ContextualMenuAction | "Set up sync" | "Use existing settings"
+			selected as
+				| MainMenuAction
+				| ContextualMenuAction
+				| "Set up sync"
+				| "Use existing settings"
+				| "Repair WebDAV destination"
 		) {
 			case "Sync now (recommended)":
 				await runCancellableOperation(ctx, "Checking current target…", "sync", runRoute, true);
@@ -127,8 +124,11 @@ export async function showSyncManager(
 			case "More…":
 				if ((await showMoreMenu(ctx, runRoute)) === "exit") return;
 				break;
-			case "Manage targets & storage":
+			case "Manage destinations":
 				await showManageMenu(ctx, runRoute);
+				break;
+			case "Repair WebDAV destination":
+				await showRepairableWebDavDestination(ctx);
 				break;
 			case "History & recovery":
 				await showRecoveryMenu(ctx, runRoute);
@@ -147,7 +147,7 @@ export async function showSyncManager(
 async function showMoreMenu(ctx: ExtensionCommandContext, runRoute: RunRoute) {
 	const selected = await ctx.ui.select("More options", [...MORE_MENU_ACTIONS]);
 	if (!selected || selected === BACK) return;
-	if (selected === "Manage targets & storage") await showManageMenu(ctx, runRoute);
+	if (selected === "Manage destinations") await showManageMenu(ctx, runRoute);
 	else if (selected === "History & recovery") await showRecoveryMenu(ctx, runRoute);
 	else {
 		await runRoute("help");
@@ -215,6 +215,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 	try {
 		raw = await readLocalConfigObject();
 	} catch (error) {
+		const repairableWebDav = await repairableWebDavDestinationName().catch(() => undefined);
 		return {
 			title: [
 				"Pi Sync",
@@ -225,7 +226,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 				"",
 				"Repair the JSON file, then reopen /sync.",
 			].join("\n"),
-			actions: ["Help"],
+			actions: repairableWebDav ? ["Repair WebDAV destination", "Help"] : ["Help"],
 		};
 	}
 	if (!raw) {
@@ -245,7 +246,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 				"",
 				"What do you want to do?",
 			].join("\n"),
-			actions: ["Manage targets & storage", "Help"],
+			actions: ["Manage destinations", "Help"],
 		};
 	}
 	try {
@@ -326,7 +327,7 @@ async function describeManagerState(): Promise<{ title: string; actions: string[
 			].join("\n"),
 			actions: [
 				...(targets && Object.keys(targets).length > 1 ? ["Switch target"] : []),
-				"Manage targets & storage",
+				"Manage destinations",
 				"Help",
 			],
 		};
@@ -362,11 +363,8 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 	const location = await chooseInitialRemoteLocation(ctx, preset, targetName);
 	if (!location) return false;
 	const { profileName, bucket, prefix, namespace } = location;
-	const credentialChoice = await ctx.ui.select(
-		"Credentials\n\nSecret values are never shown in pi-sync screens.",
-		["Use environment credentials", "Create private settings template", "Cancel"],
-	);
-	if (!credentialChoice || credentialChoice === "Cancel") return false;
+	const credentials = await chooseS3Credentials(ctx);
+	if (!credentials) return false;
 	const contentChoice = await ctx.ui.select("Choose an initial sync preset", [
 		"Recommended Pi settings",
 		"Minimal settings",
@@ -397,16 +395,6 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 		return false;
 	}
 	const autoSync = automaticChoice === "Enable automatic sync";
-	const hasEnvironmentCredentials = Boolean(
-		(process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID) &&
-			(process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY),
-	);
-	const credentialSummary =
-		credentialChoice === "Use environment credentials"
-			? hasEnvironmentCredentials
-				? "Environment credentials detected"
-				: "Environment credentials are currently missing"
-			: `Complete accessKeyId and secretAccessKey in ${localConfigPath()}`;
 	const choice = await ctx.ui.select(
 		[
 			"Review setup",
@@ -419,7 +407,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 			"Bucket must already exist. pi-sync will not create it.",
 			`Synced content: ${syncFiles.length} built-in groups · Sessions: ${syncSessions ? "On — privacy warning acknowledged" : "Off"}`,
 			`Auto-sync: ${autoSync ? "On" : "Off"}`,
-			`Credentials: ${safeTerminalText(credentialSummary)}`,
+			`Credentials: ${safeTerminalText(credentials.summary)}`,
 		].join("\n"),
 		["Save setup", "Cancel"],
 	);
@@ -431,6 +419,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 			kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
 			endpoint,
 			region,
+			...credentials.profileFields,
 		},
 		target: {
 			bucket,
@@ -444,9 +433,9 @@ export async function showSetupWizard(ctx: ExtensionCommandContext) {
 	});
 	await refreshTargetCompletions();
 	ctx.ui.notify(
-		hasEnvironmentCredentials || credentialChoice !== "Use environment credentials"
-			? `Target “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
-			: `Saved target “${safeTerminalText(targetName)}”; add credentials before syncing.`,
+		credentials.ready
+			? `Destination “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
+			: `Saved destination “${safeTerminalText(targetName)}”; add credentials before syncing.`,
 		"info",
 	);
 	return true;
@@ -550,17 +539,17 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 }
 
 async function showManageMenu(ctx: ExtensionCommandContext, _runRoute: RunRoute) {
-	const selected = await ctx.ui.select("Manage targets & storage", [
-		"Add sync target",
-		"Edit current target",
-		"Manage storage profiles",
-		"Remove sync target",
+	const selected = await ctx.ui.select("Manage destinations", [
+		"Add destination",
+		"Edit current destination",
+		"Saved connections…",
+		"Remove destination",
 		BACK,
 	]);
 	if (!selected || selected === BACK) return;
-	if (selected === "Add sync target") await showAddTarget(ctx);
-	else if (selected === "Edit current target") await showEditCurrentTarget(ctx);
-	else if (selected === "Manage storage profiles") await showStorageProfiles(ctx);
+	if (selected === "Add destination") await showAddTarget(ctx);
+	else if (selected === "Edit current destination") await showEditCurrentTarget(ctx);
+	else if (selected === "Saved connections…") await showStorageConnections(ctx);
 	else await showRemoveTarget(ctx);
 }
 
@@ -590,18 +579,24 @@ async function showAddTarget(ctx: ExtensionCommandContext) {
 		);
 		raw = migration.settings;
 	}
-	const profiles = ownRecord(raw.profiles);
-	if (!profiles || Object.keys(profiles).length === 0) {
-		ctx.ui.notify("Add a storage profile before adding a sync target.", "warning");
-		return;
-	}
-	const name = await requiredInput(ctx, "Name the new sync target", "work");
+	let profiles = ownRecord(raw.profiles) ?? {};
+	const name = await requiredInput(ctx, "Name the new destination", "work");
 	if (!name) return;
-	const profile = await ctx.ui.select("Choose storage for this target", [
+	const createConnection = "Create a new saved connection…";
+	let profile = await ctx.ui.select("Choose a saved connection", [
 		...Object.keys(profiles).sort(),
+		createConnection,
 		"Cancel",
 	]);
 	if (!profile || profile === "Cancel") return;
+	if (profile === createConnection) {
+		const previousNames = new Set(Object.keys(profiles));
+		if (!(await showAddStorageConnection(ctx))) return;
+		raw = (await readLocalConfigObject()) ?? raw;
+		profiles = ownRecord(raw.profiles) ?? {};
+		profile = Object.keys(profiles).find((candidate) => !previousNames.has(candidate));
+		if (!profile) return;
+	}
 	if (ownRecord(profiles[profile])?.kind === "webdav") {
 		if (await showAddWebDavTarget(ctx, name, profile)) await refreshTargetCompletions();
 		return;
@@ -687,104 +682,6 @@ async function showEditCurrentTarget(ctx: ExtensionCommandContext) {
 	if (choice !== "Save target") return;
 	await updateSyncTarget(partial.target, (target) => ({ ...target, bucket, prefix, namespace }));
 	ctx.ui.notify(`Saved target “${safeTerminalText(partial.target)}”.`, "info");
-}
-
-async function showStorageProfiles(ctx: ExtensionCommandContext) {
-	const raw = await readLocalConfigObject();
-	if (raw?.version !== 2) {
-		ctx.ui.notify("Upgrade settings before managing storage profiles.", "info");
-		return;
-	}
-	const profiles = ownRecord(raw.profiles) ?? {};
-	const selected = await ctx.ui.select("Storage profiles", [
-		"Add storage profile",
-		...Object.keys(profiles).sort(),
-		BACK,
-	]);
-	if (!selected || selected === BACK) return;
-	if (selected === "Add storage profile") {
-		await showAddStorageProfile(ctx);
-		return;
-	}
-	const action = await ctx.ui.select(`Storage profile “${safeTerminalText(selected)}”`, [
-		"Edit connection",
-		"Remove storage profile",
-		BACK,
-	]);
-	if (!action || action === BACK) return;
-	if (action === "Remove storage profile") {
-		const confirmed = await ctx.ui.confirm(
-			"Remove storage profile?",
-			`Remove local profile “${safeTerminalText(selected)}”? Remote buckets and snapshots are not deleted.`,
-		);
-		if (!confirmed) return;
-		await removeStorageProfile(selected);
-		ctx.ui.notify(`Removed storage profile “${safeTerminalText(selected)}”.`, "info");
-		return;
-	}
-	const profile = ownRecord(profiles[selected]);
-	if (!profile) return;
-	if (profile.kind === "webdav") {
-		await showEditWebDavStorageProfile(ctx, selected, profile);
-		return;
-	}
-	const endpoint = await requiredInput(
-		ctx,
-		"Endpoint",
-		String(profile.endpoint ?? "https://s3.example.com"),
-	);
-	if (!endpoint) return;
-	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
-	if (!region) return;
-	const save = await ctx.ui.select(
-		`Review connection\n\nProfile: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials remain unchanged and are never shown.`,
-		["Save profile", "Cancel"],
-	);
-	if (save !== "Save profile") return;
-	await updateStorageProfile(selected, (current) => ({ ...current, endpoint, region }));
-	ctx.ui.notify(`Saved storage profile “${safeTerminalText(selected)}”.`, "info");
-}
-
-async function showAddStorageProfile(ctx: ExtensionCommandContext) {
-	const preset = await ctx.ui.select("Storage type", [
-		"Cloudflare R2",
-		"Other S3-compatible storage",
-		"WebDAV",
-		"Cancel",
-	]);
-	if (!preset || preset === "Cancel") return;
-	if (preset === "WebDAV") {
-		await showAddWebDavStorageProfile(ctx);
-		return;
-	}
-	const name = await requiredInput(
-		ctx,
-		"Name the storage profile",
-		preset === "Cloudflare R2" ? "r2" : "s3",
-	);
-	if (!name) return;
-	const endpoint = await requiredInput(
-		ctx,
-		"Endpoint",
-		preset === "Cloudflare R2"
-			? "https://<account-id>.r2.cloudflarestorage.com"
-			: "https://s3.example.com",
-	);
-	if (!endpoint) return;
-	const region =
-		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
-	if (!region) return;
-	const save = await ctx.ui.select(
-		`Review storage profile\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nAdd credentials privately in ${safeTerminalText(localConfigPath())} or use environment credentials.`,
-		["Add profile", "Cancel"],
-	);
-	if (save !== "Add profile") return;
-	await addStorageProfile(name, {
-		kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
-		endpoint,
-		region,
-	});
-	ctx.ui.notify(`Added storage profile “${safeTerminalText(name)}”.`, "info");
 }
 
 async function showRemoveTarget(ctx: ExtensionCommandContext) {

--- a/extensions/pi-sync/src/s3-credentials-ui.ts
+++ b/extensions/pi-sync/src/s3-credentials-ui.ts
@@ -1,0 +1,88 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { requiredInput } from "./manager-helpers.js";
+import { promptSecret } from "./secret-input.js";
+
+export interface ChosenS3Credentials {
+	profileFields: { accessKeyId?: string; secretAccessKey?: string };
+	summary: string;
+	ready: boolean;
+	replace?: boolean;
+}
+
+export async function chooseS3CredentialUpdate(
+	ctx: ExtensionCommandContext,
+	profile: Record<string, unknown>,
+) {
+	const hasStored =
+		typeof profile.accessKeyId === "string" && typeof profile.secretAccessKey === "string";
+	if (hasStored) {
+		const action = await ctx.ui.select("Credentials", [
+			"Keep current credentials",
+			"Change credential source",
+			"Cancel",
+		]);
+		if (!action || action === "Cancel") return undefined;
+		if (action === "Keep current credentials") {
+			return { profileFields: {}, summary: "Unchanged (values hidden)", ready: true };
+		}
+	}
+	const selected = await chooseS3Credentials(ctx);
+	return selected ? { ...selected, replace: true } : undefined;
+}
+
+export function applyS3CredentialUpdate(
+	profile: Record<string, unknown>,
+	credentials: ChosenS3Credentials,
+) {
+	const next = { ...profile };
+	if (credentials.replace) {
+		delete next.accessKeyId;
+		delete next.secretAccessKey;
+		delete next.sessionToken;
+	}
+	return { ...next, ...credentials.profileFields };
+}
+
+export async function chooseS3Credentials(
+	ctx: ExtensionCommandContext,
+): Promise<ChosenS3Credentials | undefined> {
+	const choice = await ctx.ui.select(
+		"Credentials\n\nStored secret values are masked during input and never shown afterward.",
+		[
+			"Use environment credentials",
+			"Store credentials privately",
+			"Create private settings template",
+			"Cancel",
+		],
+	);
+	if (!choice || choice === "Cancel") return undefined;
+	if (choice === "Use environment credentials") {
+		const ready = Boolean(
+			(process.env.PI_SYNC_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID) &&
+				(process.env.PI_SYNC_SECRET_ACCESS_KEY ?? process.env.AWS_SECRET_ACCESS_KEY),
+		);
+		return {
+			profileFields: {},
+			summary: ready
+				? "Environment credentials detected"
+				: "Environment credentials are currently missing",
+			ready,
+		};
+	}
+	if (choice === "Create private settings template") {
+		return {
+			profileFields: {},
+			summary: "Credentials must be completed later in the private settings file",
+			ready: false,
+		};
+	}
+	const accessKeyId = await requiredInput(ctx, "Access key ID", "access-key-id");
+	if (!accessKeyId) return undefined;
+	const secretAccessKey = await promptSecret(ctx, "Secret access key");
+	if (secretAccessKey === undefined) return undefined;
+	return {
+		profileFields: { accessKeyId, secretAccessKey },
+		summary: "Stored privately (values hidden)",
+		ready: true,
+	};
+}

--- a/extensions/pi-sync/src/secret-input.ts
+++ b/extensions/pi-sync/src/secret-input.ts
@@ -1,0 +1,190 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+	CURSOR_MARKER,
+	decodeKittyPrintable,
+	type Focusable,
+	type KeybindingsManager,
+	Text,
+	truncateToWidth,
+} from "@earendil-works/pi-tui";
+
+const MASK = "•";
+
+export async function promptSecret(
+	ctx: ExtensionCommandContext,
+	title: string,
+	options: { required?: boolean } = { required: true },
+) {
+	if (ctx.mode !== "tui") return undefined;
+	const value = await ctx.ui.custom<string | undefined>((tui, theme, keybindings, done) => {
+		const heading = new Text("", 0, 0);
+		const hint = new Text("", 0, 0);
+		const applyTheme = () => {
+			heading.setText(theme.fg("accent", theme.bold(title)));
+			hint.setText(theme.fg("dim", "Enter save • Escape cancel • Input is hidden"));
+		};
+		applyTheme();
+		const input = new MaskedInput(keybindings);
+		const component: Focusable & {
+			render(width: number): string[];
+			invalidate(): void;
+			handleInput(data: string): void;
+			dispose(): void;
+		} = {
+			get focused() {
+				return input.focused;
+			},
+			set focused(focused: boolean) {
+				input.focused = focused;
+			},
+			render(width: number) {
+				const safeWidth = Math.max(1, width);
+				return [
+					...heading.render(safeWidth),
+					...input.render(safeWidth),
+					...hint.render(safeWidth),
+				].map((line) => truncateToWidth(line, safeWidth));
+			},
+			invalidate() {
+				applyTheme();
+				heading.invalidate();
+				input.invalidate();
+				hint.invalidate();
+			},
+			handleInput(data: string) {
+				if (keybindings.matches(data, "tui.select.cancel")) done(undefined);
+				else if (keybindings.matches(data, "tui.input.submit")) done(input.getValue());
+				else input.handleInput(data);
+				tui.requestRender();
+			},
+			dispose() {
+				input.clear();
+			},
+		};
+		return component;
+	});
+	if (value === undefined) return undefined;
+	if (options.required !== false && value.length === 0) {
+		ctx.ui.notify(`${title} is required.`, "warning");
+		return undefined;
+	}
+	return value;
+}
+
+class MaskedInput implements Focusable {
+	focused = false;
+	private value: string[] = [];
+	private cursor = 0;
+	private paste = "";
+	private pasting = false;
+
+	constructor(private readonly keybindings: KeybindingsManager) {}
+
+	getValue() {
+		return this.value.join("");
+	}
+
+	handleInput(data: string) {
+		if (data.includes("\u001b[200~")) {
+			this.pasting = true;
+			this.paste = "";
+			data = data.replace("\u001b[200~", "");
+		}
+		if (this.pasting) {
+			this.paste += data;
+			const end = this.paste.indexOf("\u001b[201~");
+			if (end < 0) return;
+			const pasted = this.paste
+				.slice(0, end)
+				.replace(/[\r\n]/gu, "")
+				.replace(/\t/gu, "    ");
+			this.insert(pasted);
+			const remaining = this.paste.slice(end + 6);
+			this.paste = "";
+			this.pasting = false;
+			if (remaining) this.handleInput(remaining);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteCharBackward")) {
+			if (this.cursor > 0) this.value.splice(--this.cursor, 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteCharForward")) {
+			if (this.cursor < this.value.length) this.value.splice(this.cursor, 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorLeft")) {
+			this.cursor = Math.max(0, this.cursor - 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorRight")) {
+			this.cursor = Math.min(this.value.length, this.cursor + 1);
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorLineStart")) {
+			this.cursor = 0;
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.cursorLineEnd")) {
+			this.cursor = this.value.length;
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteToLineStart")) {
+			this.value.splice(0, this.cursor);
+			this.cursor = 0;
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.editor.deleteToLineEnd")) {
+			this.value.splice(this.cursor);
+			return;
+		}
+		const printable = decodeKittyPrintable(data) ?? data;
+		if (!hasControlCharacter(printable)) this.insert(printable);
+	}
+
+	render(width: number) {
+		const prompt = "> ";
+		const available = width - prompt.length;
+		if (available <= 0) return [truncateToWidth(prompt, Math.max(1, width))];
+		const contentWidth = Math.max(0, available - 1);
+		let start = 0;
+		if (this.value.length > contentWidth) {
+			start = Math.max(
+				0,
+				Math.min(this.cursor - Math.floor(contentWidth / 2), this.value.length - contentWidth),
+			);
+		}
+		const end = Math.min(this.value.length, start + contentWidth);
+		const visibleCursor = Math.max(0, Math.min(this.cursor - start, end - start));
+		const masks = Array.from({ length: end - start }, () => MASK);
+		const before = masks.slice(0, visibleCursor).join("");
+		const atCursor = visibleCursor < masks.length ? MASK : " ";
+		const after = masks.slice(visibleCursor + (visibleCursor < masks.length ? 1 : 0)).join("");
+		const marker = this.focused ? CURSOR_MARKER : "";
+		const line = `${prompt}${before}${marker}\u001b[7m${atCursor}\u001b[27m${after}`;
+		return [truncateToWidth(line, width, "")];
+	}
+
+	invalidate() {}
+
+	clear() {
+		this.value.fill("");
+		this.value = [];
+		this.paste = "";
+		this.cursor = 0;
+		this.pasting = false;
+	}
+
+	private insert(value: string) {
+		const characters = Array.from(value);
+		this.value.splice(this.cursor, 0, ...characters);
+		this.cursor += characters.length;
+	}
+}
+
+function hasControlCharacter(value: string) {
+	return [...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+	});
+}

--- a/extensions/pi-sync/src/storage-connections-ui.ts
+++ b/extensions/pi-sync/src/storage-connections-ui.ts
@@ -1,0 +1,119 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { readLocalConfigObject } from "./config.js";
+import { ownRecord, requiredInput, safeTerminalText } from "./manager-helpers.js";
+import {
+	applyS3CredentialUpdate,
+	chooseS3Credentials,
+	chooseS3CredentialUpdate,
+} from "./s3-credentials-ui.js";
+import {
+	addStorageProfile,
+	removeStorageProfile,
+	updateStorageProfile,
+} from "./settings-management.js";
+import { showAddWebDavStorageProfile, showEditWebDavStorageProfile } from "./webdav-ui.js";
+
+const BACK = "Back";
+
+export async function showStorageConnections(ctx: ExtensionCommandContext) {
+	const raw = await readLocalConfigObject();
+	if (raw?.version !== 2) {
+		ctx.ui.notify("Upgrade settings before managing saved connections.", "info");
+		return;
+	}
+	const profiles = ownRecord(raw.profiles) ?? {};
+	const selected = await ctx.ui.select("Saved connections", [
+		"Add saved connection",
+		...Object.keys(profiles).sort(),
+		BACK,
+	]);
+	if (!selected || selected === BACK) return;
+	if (selected === "Add saved connection") {
+		await showAddStorageConnection(ctx);
+		return;
+	}
+	const action = await ctx.ui.select(`Saved connection “${safeTerminalText(selected)}”`, [
+		"Edit connection",
+		"Remove saved connection",
+		BACK,
+	]);
+	if (!action || action === BACK) return;
+	if (action === "Remove saved connection") {
+		const confirmed = await ctx.ui.confirm(
+			"Remove saved connection?",
+			`Remove saved connection “${safeTerminalText(selected)}”? Remote buckets and snapshots are not deleted.`,
+		);
+		if (!confirmed) return;
+		await removeStorageProfile(selected);
+		ctx.ui.notify(`Removed saved connection “${safeTerminalText(selected)}”.`, "info");
+		return;
+	}
+	const profile = ownRecord(profiles[selected]);
+	if (!profile) return;
+	if (profile.kind === "webdav") {
+		await showEditWebDavStorageProfile(ctx, selected, profile);
+		return;
+	}
+	const endpoint = await requiredInput(
+		ctx,
+		"Endpoint",
+		String(profile.endpoint ?? "https://s3.example.com"),
+	);
+	if (!endpoint) return;
+	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
+	if (!region) return;
+	const credentials = await chooseS3CredentialUpdate(ctx, profile);
+	if (!credentials) return;
+	const save = await ctx.ui.select(
+		`Review connection\n\nSaved connection: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
+		["Save profile", "Cancel"],
+	);
+	if (save !== "Save profile") return;
+	await updateStorageProfile(selected, (current) =>
+		applyS3CredentialUpdate({ ...current, endpoint, region }, credentials),
+	);
+	ctx.ui.notify(`Saved connection “${safeTerminalText(selected)}”.`, "info");
+}
+
+export async function showAddStorageConnection(ctx: ExtensionCommandContext) {
+	const preset = await ctx.ui.select("Storage type", [
+		"Cloudflare R2",
+		"Other S3-compatible storage",
+		"WebDAV",
+		"Cancel",
+	]);
+	if (!preset || preset === "Cancel") return false;
+	if (preset === "WebDAV") return showAddWebDavStorageProfile(ctx);
+	const name = await requiredInput(
+		ctx,
+		"Name this saved connection",
+		preset === "Cloudflare R2" ? "r2" : "s3",
+	);
+	if (!name) return false;
+	const endpoint = await requiredInput(
+		ctx,
+		"Endpoint",
+		preset === "Cloudflare R2"
+			? "https://<account-id>.r2.cloudflarestorage.com"
+			: "https://s3.example.com",
+	);
+	if (!endpoint) return false;
+	const region =
+		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
+	if (!region) return false;
+	const credentials = await chooseS3Credentials(ctx);
+	if (!credentials) return false;
+	const save = await ctx.ui.select(
+		`Review saved connection\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
+		["Add connection", "Cancel"],
+	);
+	if (save !== "Add connection") return false;
+	await addStorageProfile(name, {
+		kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
+		endpoint,
+		region,
+		...credentials.profileFields,
+	});
+	ctx.ui.notify(`Added saved connection “${safeTerminalText(name)}”.`, "info");
+	return true;
+}

--- a/extensions/pi-sync/src/webdav-ui.ts
+++ b/extensions/pi-sync/src/webdav-ui.ts
@@ -1,11 +1,14 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
-	localConfigPath,
 	normalizeWebDavPath,
 	normalizeWebDavUrl,
+	readActiveLocalConfigDocumentForRepair,
+	replaceLocalConfigDocument,
+	resolveV2PartialConfig,
 	validateWebDavCredentials,
 	validateWebDavNamespace,
 } from "./config.js";
+import { promptSecret } from "./secret-input.js";
 import {
 	addStorageProfile,
 	addSyncTarget,
@@ -16,6 +19,116 @@ import {
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
 import type { PartialConfig } from "./types.js";
 
+export async function repairableWebDavDestinationName() {
+	const document = await readActiveLocalConfigDocumentForRepair();
+	const settings = document?.parsed;
+	if (settings?.version !== 2) return undefined;
+	const profiles = record(settings.profiles);
+	const targets = record(settings.targets);
+	if (!profiles || !targets) return undefined;
+	const names = Object.keys(targets).filter((name) => {
+		const target = record(targets[name]);
+		if (!target) return false;
+		const profile =
+			typeof target.profile === "string" ? record(profiles[target.profile]) : undefined;
+		return (
+			profile?.kind === "webdav" &&
+			(Object.hasOwn(target, "bucket") ||
+				Object.hasOwn(target, "prefix") ||
+				typeof profile.password !== "string" ||
+				profile.password.length === 0)
+		);
+	});
+	const active = typeof settings.activeTarget === "string" ? settings.activeTarget : undefined;
+	return active && names.includes(active) ? active : names.length === 1 ? names[0] : undefined;
+}
+
+export async function showRepairableWebDavDestination(ctx: ExtensionCommandContext) {
+	const name = await repairableWebDavDestinationName();
+	return name ? showRepairWebDavDestination(ctx, name) : false;
+}
+
+export async function showRepairWebDavDestination(
+	ctx: ExtensionCommandContext,
+	targetName: string,
+) {
+	const document = await readActiveLocalConfigDocumentForRepair();
+	if (document?.parsed.version !== 2) return false;
+	const profiles = record(document.parsed.profiles);
+	const targets = record(document.parsed.targets);
+	const target = targets && record(targets[targetName]);
+	const profileName = target && typeof target.profile === "string" ? target.profile : undefined;
+	const profile = profileName && profiles ? record(profiles[profileName]) : undefined;
+	if (!target || !profileName || !profile || profile.kind !== "webdav") return false;
+	const url = typeof profile.url === "string" ? profile.url : "";
+	const username = typeof profile.username === "string" ? profile.username : "";
+	let password =
+		typeof profile.password === "string" && profile.password ? profile.password : undefined;
+	if (!password) {
+		password = await promptSecret(ctx, "WebDAV password");
+		if (password === undefined) return false;
+	}
+	const path = await requiredInput(
+		ctx,
+		"WebDAV remote path",
+		typeof target.path === "string"
+			? target.path
+			: typeof target.prefix === "string"
+				? target.prefix
+				: "pi-sync",
+	);
+	if (!path) return false;
+	const namespace = await requiredInput(
+		ctx,
+		"Remote namespace",
+		typeof target.namespace === "string" ? target.namespace : targetName,
+	);
+	if (!namespace) return false;
+	const connection = validateConnection(ctx, url, username, password);
+	const destination = validateDestination(ctx, path, namespace);
+	if (!connection || !destination) return false;
+	const removedTargetFields = ["bucket", "prefix"].filter((field) => Object.hasOwn(target, field));
+	const removedProfileFields = [
+		"endpoint",
+		"region",
+		"accessKeyId",
+		"secretAccessKey",
+		"sessionToken",
+	].filter((field) => Object.hasOwn(profile, field));
+	const review = await ctx.ui.select(
+		[
+			"Repair WebDAV destination",
+			"",
+			`Destination: ${safe(targetName)}`,
+			`Saved connection: ${safe(profileName)}`,
+			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
+			`Password: configured (value hidden)`,
+			...(removedTargetFields.length > 0
+				? [`Remove incompatible destination fields: ${removedTargetFields.join(", ")}`]
+				: []),
+			...(removedProfileFields.length > 0
+				? [`Remove incompatible connection fields: ${removedProfileFields.join(", ")}`]
+				: []),
+			"Unknown settings and every other destination remain unchanged.",
+		].join("\n"),
+		["Repair destination", "Cancel"],
+	);
+	if (review !== "Repair destination") return false;
+	const nextProfile: Record<string, unknown> = { ...profile, ...connection };
+	for (const field of removedProfileFields) delete nextProfile[field];
+	const nextTarget: Record<string, unknown> = { ...target, ...destination };
+	for (const field of removedTargetFields) delete nextTarget[field];
+	const next = {
+		...document.parsed,
+		profiles: { ...profiles, [profileName]: nextProfile },
+		targets: { ...targets, [targetName]: nextTarget },
+	};
+	resolveV2PartialConfig(next, targetName);
+	await replaceLocalConfigDocument(document, next);
+	ctx.ui.notify(`Repaired WebDAV destination “${safe(targetName)}”.`, "info");
+	return true;
+}
+
 export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: string) {
 	const url = await requiredInput(
 		ctx,
@@ -25,9 +138,11 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 	if (!url) return false;
 	const username = await requiredInput(ctx, "WebDAV username", "user");
 	if (!username) return false;
+	const password = await promptSecret(ctx, "WebDAV password");
+	if (password === undefined) return false;
 	const location = await chooseDestination(ctx, targetName);
 	if (!location) return false;
-	const connection = validateConnection(ctx, url, username);
+	const connection = validateConnection(ctx, url, username, password);
 	const destination = validateDestination(ctx, location.path, location.namespace);
 	if (!connection || !destination) return false;
 	const content = await chooseContent(ctx);
@@ -50,7 +165,7 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 			`URL: ${displayUrl(connection.url)}`,
 			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
 			"Username: stored in the private settings file (value hidden)",
-			`Password: add it privately in ${safe(localConfigPath())}; pi-sync never requests secrets in an unmasked dialog.`,
+			"Password: configured (value hidden)",
 			`Conditional writes: /sync doctor verifies atomic If-Match and If-None-Match support before publication.`,
 			`Synced content: ${content.length} built-in groups · Sessions: ${sessions ? "On — privacy warning acknowledged" : "Off"}`,
 			`Auto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
@@ -72,10 +187,7 @@ export async function showWebDavSetup(ctx: ExtensionCommandContext, targetName: 
 			extraFiles: [],
 		},
 	});
-	ctx.ui.notify(
-		`Saved target “${safe(targetName)}”; add the WebDAV password in ${safe(localConfigPath())} before syncing.`,
-		"info",
-	);
+	ctx.ui.notify(`Destination “${safe(targetName)}” is ready. Use Sync now when ready.`, "info");
 	return true;
 }
 
@@ -133,10 +245,12 @@ export async function showAddWebDavStorageProfile(ctx: ExtensionCommandContext) 
 	if (!url) return false;
 	const username = await requiredInput(ctx, "WebDAV username", "user");
 	if (!username) return false;
-	const connection = validateConnection(ctx, url, username);
+	const password = await promptSecret(ctx, "WebDAV password");
+	if (password === undefined) return false;
+	const connection = validateConnection(ctx, url, username, password);
 	if (!connection) return false;
 	const review = await ctx.ui.select(
-		`Review storage profile\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nAdd the password privately in ${safe(localConfigPath())}; it is never requested or displayed.`,
+		`Review saved connection\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: configured (value hidden)`,
 		["Add profile", "Cancel"],
 	);
 	if (review !== "Add profile") return false;
@@ -158,14 +272,35 @@ export async function showEditWebDavStorageProfile(
 	if (!url) return false;
 	const username = await requiredInput(ctx, "WebDAV username", String(profile.username ?? "user"));
 	if (!username) return false;
-	const connection = validateConnection(ctx, url, username);
+	let password: string | undefined;
+	let replacePassword = false;
+	if (typeof profile.password === "string" && profile.password.length > 0) {
+		const passwordAction = await ctx.ui.select("WebDAV password", [
+			"Keep current password",
+			"Replace password",
+			"Cancel",
+		]);
+		if (!passwordAction || passwordAction === "Cancel") return false;
+		replacePassword = passwordAction === "Replace password";
+	} else {
+		replacePassword = true;
+	}
+	if (replacePassword) {
+		password = await promptSecret(ctx, "New WebDAV password");
+		if (password === undefined) return false;
+	}
+	const connection = validateConnection(ctx, url, username, password);
 	if (!connection) return false;
 	const review = await ctx.ui.select(
-		`Review connection\n\nProfile: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword remains unchanged and is never shown.`,
+		`Review connection\n\nSaved connection: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: ${replacePassword ? "will be replaced" : "unchanged"} (value hidden)`,
 		["Save profile", "Cancel"],
 	);
 	if (review !== "Save profile") return false;
-	await updateStorageProfile(name, (current) => ({ ...current, ...connection }));
+	await updateStorageProfile(name, (current) => ({
+		...current,
+		...connection,
+		...(replacePassword ? { password } : {}),
+	}));
 	ctx.ui.notify(`Saved storage profile “${safe(name)}”.`, "info");
 	return true;
 }
@@ -211,12 +346,21 @@ async function requiredInput(ctx: ExtensionCommandContext, title: string, placeh
 	return trimmed;
 }
 
-function validateConnection(ctx: ExtensionCommandContext, url: string, username: string) {
+function validateConnection(
+	ctx: ExtensionCommandContext,
+	url: string,
+	username: string,
+	password?: string,
+) {
 	try {
 		const normalizedUrl = normalizeWebDavUrl(url);
 		if (!normalizedUrl) throw new Error("WebDAV URL is required.");
-		validateWebDavCredentials(username);
-		return { url: normalizedUrl, username: username.trim() };
+		validateWebDavCredentials(username, password);
+		return {
+			url: normalizedUrl,
+			username: username.trim(),
+			...(password === undefined ? {} : { password }),
+		};
 	} catch (error) {
 		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 		return undefined;
@@ -240,6 +384,12 @@ function displayUrl(value: string) {
 	} catch {
 		return "invalid URL (value hidden)";
 	}
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
 }
 
 function safe(value: string) {

--- a/extensions/pi-sync/test/config-filename.test.ts
+++ b/extensions/pi-sync/test/config-filename.test.ts
@@ -165,7 +165,7 @@ test("targetless v2 legacy settings migrate and retain the recoverable manager f
 		});
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.deepEqual(options, ["Manage targets & storage", "Help"]);
+		assert.deepEqual(options, ["Manage destinations", "Help"]);
 	});
 });
 

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -223,7 +223,7 @@ test("main menu exposes shallow secondary navigation with Back", async () => {
 
 		assert.match(calls[1]?.title ?? "", /More options/);
 		assert.deepEqual(calls[1]?.options, [
-			"Manage targets & storage",
+			"Manage destinations",
 			"History & recovery",
 			"Help",
 			"Back",
@@ -1187,7 +1187,7 @@ test("first-time R2 setup recommends home/r2/pi-sync defaults without raw path q
 		assert.deepEqual(inputTitles, ["Cloudflare R2 endpoint"]);
 		assert.match(rendered.join("\n"), /Bucket must already exist/);
 		assert.match(rendered.join("\n"), /pi-sync\/profiles\/home/);
-		assert.match(notifications.at(-1)?.message ?? "", /Target “home” is ready/);
+		assert.match(notifications.at(-1)?.message ?? "", /Destination “home” is ready/);
 		assert.doesNotMatch(rendered.join("\n"), /setup-access-secret|setup-secret-value/);
 	});
 });
@@ -1231,6 +1231,50 @@ test("first-time S3 setup asks only for the existing bucket and derives work def
 		assert.equal(target?.prefix, "pi-sync");
 		assert.equal(target?.namespace, "work");
 		assert.deepEqual(inputTitles, ["S3-compatible endpoint", "Storage region", "Existing bucket"]);
+	});
+});
+
+test("first-time S3 setup can store masked credentials entirely through TUI", async () => {
+	await withTempSettings(async () => {
+		const mock = createMockPi();
+		sync(mock.pi);
+		const selections = [
+			"Set up sync",
+			"Other S3-compatible storage",
+			"Personal / Home",
+			"Use existing bucket with suggested path (recommended)",
+			"Store credentials privately",
+			"Minimal settings",
+			"Keep automatic sync off",
+			"Keep sessions off (recommended)",
+			"Save setup",
+			undefined,
+		];
+		const inputs = ["https://s3.example.com", "us-east-1", "personal-pi", "access-key-id"];
+		const rendered: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async () => inputs.shift(),
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 48);
+				rendered.push(harness.handleInput("secret-access-key").join("\n"));
+				harness.handleInput("tui.input.submit");
+				return harness.result;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		const profile = (saved?.profiles as Record<string, Record<string, unknown>> | undefined)?.s3;
+		assert.equal(profile?.accessKeyId, "access-key-id");
+		assert.equal(profile?.secretAccessKey, "secret-access-key");
+		assert.doesNotMatch(rendered.join("\n"), /secret-access-key/);
 	});
 });
 
@@ -1308,8 +1352,8 @@ test("manage flow recommends the current profile bucket and derives a separate n
 		sync(mock.pi);
 		const selections = [
 			"More…",
-			"Manage targets & storage",
-			"Add sync target",
+			"Manage destinations",
+			"Add destination",
 			"r2",
 			"Same bucket as “home” (recommended)",
 			"Recommended Pi settings",

--- a/extensions/pi-sync/test/secret-input.test.ts
+++ b/extensions/pi-sync/test/secret-input.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { promptSecret } from "../src/secret-input.js";
+
+test("masked secret input never renders plaintext and submits pasted text", async () => {
+	const secret = "private-password";
+	let rendered: string[] = [];
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 24);
+			harness.setFocused(true);
+			rendered = harness.handleInput(`\u001b[200~${secret}\u001b[201~`);
+			assert.doesNotMatch(rendered.join("\n"), new RegExp(secret));
+			assert.match(rendered.join("\n"), /•+/u);
+			assert.equal(rendered.join("\n").includes(CURSOR_MARKER), true);
+			for (const line of rendered) assert.ok(visibleWidth(line) <= 24);
+			harness.handleInput("tui.input.submit");
+			return harness.result;
+		},
+	});
+
+	assert.equal(await promptSecret(ctx, "WebDAV password"), secret);
+});
+
+test("masked secret input cancellation returns without a secret", async () => {
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 12);
+			harness.handleInput("secret");
+			harness.handleInput("tui.select.cancel");
+			return harness.result;
+		},
+	});
+
+	assert.equal(await promptSecret(ctx, "Password"), undefined);
+});

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -1,18 +1,23 @@
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import test from "node:test";
-import { createMockContext, createMockPi } from "../../../test/support.js";
-import { localConfigPath, readLocalConfigObject } from "../src/config.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import { loadConfig, localConfigPath, readLocalConfigObject } from "../src/config.js";
 import sync from "../src/sync.js";
 import {
 	showAddWebDavStorageProfile,
 	showAddWebDavTarget,
 	showEditWebDavStorageProfile,
 	showEditWebDavTarget,
+	showRepairWebDavDestination,
 } from "../src/webdav-ui.js";
 import { withTempHome } from "./helpers.js";
 
-test("first-time WebDAV setup stores a discriminated profile without requesting a password", async () => {
+test("first-time WebDAV setup collects a masked password and stores a usable profile", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		const mock = createMockPi();
@@ -46,6 +51,7 @@ test("first-time WebDAV setup stores a discriminated profile without requesting 
 				inputTitles.push(title);
 				return inputs.shift();
 			},
+			custom: secretInput("app-password", rendered),
 		});
 
 		await mock.commands.get("sync")?.handler("", ctx);
@@ -56,7 +62,7 @@ test("first-time WebDAV setup stores a discriminated profile without requesting 
 		assert.equal(profile.kind, "webdav");
 		assert.equal(profile.url, "https://cloud.example.com/remote.php/dav/files/user/");
 		assert.equal(profile.username, "user");
-		assert.equal(Object.hasOwn(profile, "password"), false);
+		assert.equal(profile.password, "app-password");
 		assert.equal(target.path, "pi-sync");
 		assert.equal(target.namespace, "home");
 		assert.deepEqual(inputTitles, [
@@ -65,7 +71,8 @@ test("first-time WebDAV setup stores a discriminated profile without requesting 
 			"WebDAV remote path",
 			"Remote namespace",
 		]);
-		assert.match(rendered.join("\n"), /never requests secrets|add it privately/i);
+		assert.doesNotMatch(rendered.join("\n"), /app-password/);
+		assert.match(rendered.join("\n"), /Password: configured/i);
 	});
 });
 
@@ -80,6 +87,7 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 			"Add profile",
 			"Recommended Pi settings",
 			"Add target",
+			"Keep current password",
 			"Save profile",
 			"Save target",
 		];
@@ -103,6 +111,7 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 				return selections.shift();
 			},
 			input: async () => inputs.shift(),
+			custom: secretInput("private-password", rendered),
 		});
 		assert.equal(await showAddWebDavStorageProfile(ctx), true);
 		assert.equal(await showAddWebDavTarget(ctx, "home", "dav"), true);
@@ -141,6 +150,133 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 		assert.deepEqual(readFileSync(localConfigPath()), beforeInvalidEdit);
 	});
 });
+
+test("Add destination can create a WebDAV connection without leaving the manager flow", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "home",
+				profiles: {
+					r2: {
+						kind: "r2",
+						endpoint: "https://account.r2.cloudflarestorage.com",
+						region: "auto",
+						accessKeyId: "access",
+						secretAccessKey: "secret",
+					},
+				},
+				targets: {
+					home: {
+						profile: "r2",
+						bucket: "pi-sync",
+						prefix: "pi-sync",
+						namespace: "home",
+					},
+				},
+			}),
+		);
+		const selections = [
+			"More…",
+			"Manage destinations",
+			"Add destination",
+			"Create a new saved connection…",
+			"WebDAV",
+			"Add profile",
+			"Recommended Pi settings",
+			"Add target",
+			undefined,
+		];
+		const inputs = ["work", "dav", "https://cloud.example.com/dav", "user", "pi-sync", "work"];
+		const rendered: string[] = [];
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				rendered.push(title);
+				return selections.shift();
+			},
+			input: async () => inputs.shift(),
+			custom: secretInput("app-password", rendered),
+		});
+
+		await mock.commands.get("sync")?.handler("", ctx);
+
+		const saved = await readLocalConfigObject();
+		assert.equal(requireRecord(saved?.profiles).dav.password, "app-password");
+		assert.equal(requireRecord(saved?.targets).work.profile, "dav");
+		assert.equal(requireRecord(saved?.targets).work.path, "pi-sync");
+		assert.doesNotMatch(rendered.join("\n"), /app-password/);
+	});
+});
+
+test("WebDAV repair removes incompatible fields and fills missing credentials through TUI", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 2,
+				activeTarget: "webdav",
+				futureField: { preserved: true },
+				profiles: {
+					webdav: {
+						kind: "webdav",
+						url: "https://cloud.example.com/dav",
+						username: "user",
+					},
+				},
+				targets: {
+					webdav: {
+						profile: "webdav",
+						bucket: "pi-sync",
+						prefix: "pi-sync",
+						namespace: "webdav",
+						futureTarget: "preserved",
+					},
+				},
+			}),
+		);
+		const inputs = ["pi-sync", "webdav"];
+		const reviews: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: secretInput("app-password", reviews),
+			input: async () => inputs.shift(),
+			select: async (title: string) => {
+				reviews.push(title);
+				return "Repair destination";
+			},
+		});
+
+		assert.equal(await showRepairWebDavDestination(ctx, "webdav"), true);
+		const saved = await readLocalConfigObject();
+		const profile = requireRecord(saved?.profiles).webdav;
+		const target = requireRecord(saved?.targets).webdav;
+		assert.equal(profile.password, "app-password");
+		assert.equal(target.path, "pi-sync");
+		assert.equal(Object.hasOwn(target, "bucket"), false);
+		assert.equal(Object.hasOwn(target, "prefix"), false);
+		assert.equal(target.futureTarget, "preserved");
+		assert.deepEqual(saved?.futureField, { preserved: true });
+		assert.equal((await loadConfig()).backend.type, "webdav");
+		assert.doesNotMatch(reviews.join("\n"), /app-password/);
+	});
+});
+
+function secretInput(secret: string, rendered: string[] = []) {
+	return async (factory: unknown) => {
+		const harness = createCustomSelectorHarness(factory, 50);
+		rendered.push(harness.handleInput(secret).join("\n"));
+		harness.handleInput("tui.input.submit");
+		return harness.result;
+	};
+}
 
 function requireRecord(value: unknown): Record<string, Record<string, unknown>> {
 	assert.ok(value && typeof value === "object" && !Array.isArray(value));


### PR DESCRIPTION
## Summary

- present pi-sync setup and management around destinations while keeping saved storage connections available for advanced reuse
- add a focus-aware masked secret input for WebDAV passwords and S3-compatible credentials
- support complete TUI credential setup, credential replacement, and repair of incompatible WebDAV destination fields
- preserve the version 2 profile/target schema, unknown settings, environment credential behavior, and atomic settings publication
- document the destination workflow and archive the completed implementation plan

## Safety

- secret plaintext is never rendered in input, review, notification, warning, or error output
- cancellation and failed writes retain existing settings
- WebDAV repair removes only incompatible known fields and preserves unrelated destinations and unknown fields

## Verification

- `npm run check` — passed (Biome, boundaries, workspace typechecks, 1,618 tests)
- `just pack-sync` — passed; 35 package entries inspected, including all new runtime modules
- `git diff --check` — passed

## Dependency

Stacked on #432, which introduces the WebDAV backend and configuration this change completes through the TUI.