### PR TITLE
feat(sync): redesign manager around sync setups

### DIFF
--- a/docs/plans/2026-07-27_pi-sync-v3-schema-plan.md
+++ b/docs/plans/2026-07-27_pi-sync-v3-schema-plan.md
@@ -1,0 +1,293 @@
+# Pi Sync v3 settings schema plan
+
+## Goal
+
+First make pi-sync's current user-facing wording and management flows consistently use **storage
+connections** and **sync setups**, without changing the version 2 settings schema or sync behavior in
+that milestone. After explicit wording approval, replace the profile/target settings model with a
+version 3 schema using the same concepts. Keep the schema small under YAGNI, support S3-compatible
+storage (including the Cloudflare R2 preset), Git, and WebDAV, and make every invalid reference or
+backend-field combination fail closed without exposing secrets or damaging the settings file.
+
+## Context
+
+- The current settings file uses `version: 2`, `profiles`, `targets`, `activeTarget`, backend-specific
+  target location fields, and separate `syncFiles`, `syncSessions`, and `extraFiles` fields.
+- Current menus mix `destination`, `saved connection`, `storage profile`, and `sync target` wording.
+- The approved vocabulary is **storage connection** for reusable access configuration and **sync
+  setup** for a named, switchable combination of remote storage, included content, and automatic-sync
+  behavior.
+- Delivery is intentionally staged: milestone 1 changes wording, menu hierarchy, command descriptions,
+  and user-facing errors while preserving version 2 storage and behavior; milestone 2 starts only
+  after explicit review of that wording in a Pi runtime smoke.
+- The version 3 milestone is an explicitly approved breaking redesign. Migration cost is out of scope:
+  version 1 and 2 settings must not be rewritten or partially interpreted as version 3.
+- Applicable guides read before planning: `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, Pi `docs/extensions.md`, and Pi `docs/tui.md`. Touched areas are
+  settings loading/validation/persistence, settings and manager UI, command wording/completions,
+  backend configuration, remote identity, documentation, tests, and package/runtime verification.
+
+## Architecture
+
+### Canonical version 3 shape
+
+```json
+{
+  "version": 3,
+  "activeSyncSetup": "home",
+  "onSwitch": "ask-before-pull",
+  "storageConnections": {
+    "r2": {
+      "type": "s3",
+      "endpoint": "https://example.r2.cloudflarestorage.com",
+      "region": "auto",
+      "credentials": {
+        "accessKeyId": "...",
+        "secretAccessKey": "..."
+      }
+    },
+    "github": {
+      "type": "git",
+      "remote": "git@github.com:user/pi-sync.git"
+    },
+    "nextcloud": {
+      "type": "webdav",
+      "url": "https://cloud.example.com/remote.php/dav/files/user",
+      "credentials": {
+        "username": "user",
+        "password": "..."
+      }
+    }
+  },
+  "syncSetups": {
+    "home": {
+      "storage": {
+        "connection": "r2",
+        "bucket": "personal-pi",
+        "path": "pi-sync/home"
+      },
+      "sync": {
+        "include": ["settings.json", "AGENTS.md", "skills", "prompts", "themes"],
+        "automatic": true
+      }
+    },
+    "git-backup": {
+      "storage": {
+        "connection": "github",
+        "branch": "pi-sync/home",
+        "path": "pi-sync/home"
+      },
+      "sync": {
+        "include": ["settings.json", "AGENTS.md"],
+        "automatic": false
+      }
+    },
+    "webdav-backup": {
+      "storage": {
+        "connection": "nextcloud",
+        "path": "pi-sync/home"
+      },
+      "sync": {
+        "include": ["settings.json", "sessions"],
+        "automatic": false
+      }
+    }
+  }
+}
+```
+
+### Ownership and validation
+
+- `storageConnections` is the only reusable resource catalog. Each own-property key names one
+  discriminated connection: `s3`, `git`, or `webdav`. Cloudflare R2 is an S3 setup preset, not a
+  fourth persisted type.
+- S3 connections own `endpoint`, `region`, and credentials; Git connections own `remote` and rely on
+  the user's Git credential/SSH configuration; WebDAV connections own `url` and credentials.
+- `syncSetups` owns each setup's backend-relative storage coordinates and sync policy. There is no
+  independent storage-location object, id, catalog, command, or menu.
+- A setup's referenced connection type selects its accepted `storage` shape: S3 requires `bucket` and
+  `path` and rejects `branch`; Git requires `branch` and `path` and rejects `bucket`; WebDAV requires
+  `path` and rejects `bucket` and `branch`.
+- `storage.path` is the complete user-facing path beneath the backend-specific container. The
+  normalization boundary splits or maps it into the backend contract's base path and namespace as
+  needed; the setup name is a local id and must not silently change the remote location when renamed.
+- `sync.include` is one ordered, duplicate-free list of supported Pi roots and safe agent-relative
+  paths. The reserved `sessions` entry triggers the existing privacy acknowledgement and live-session
+  safeguards. Empty `include` is valid and disables useful transfer without being reported as up to
+  date.
+- `sync.automatic` is explicit for every setup. `onSwitch` accepts `ask-before-pull`,
+  `pull-after-switch`, or `switch-only`.
+- `activeSyncSetup` must reference an own-property setup whenever setups are non-empty and must be
+  absent when setups are empty. A referenced storage connection cannot be removed. Two setups cannot
+  resolve to the same normalized remote identity.
+- Parsed maps must be own-property dictionaries; reserved prototype names, controls, empty names,
+  invalid paths, mixed backend fields, missing references, malformed credentials, and secret-bearing
+  Git URLs fail closed.
+
+### Loading and persistence
+
+- Parse and validate the complete version 3 document before replacing the last-known effective
+  settings. A malformed or invalid file pauses automatic sync and remains byte-for-byte untouched.
+- Version 1, version 2, and unversioned non-empty documents receive an actionable unsupported-version
+  error; pi-sync does not migrate, reinterpret, or overwrite them.
+- UI mutations use the existing cross-process settings lock and atomic private-file publication,
+  preserve unknown fields at every retained object boundary, serialize reads and writes, and restore
+  prior displayed/effective state after failure.
+- Credentials remain in the canonical private `pi-sync.json` file, use POSIX `0600`, and are redacted
+  from menus, reviews, notifications, errors, logs, command output, snapshots, and tests.
+
+### UI and commands
+
+- The manager consistently uses `Current sync setup`, `Switch sync setup`, `Sync setups`, and
+  `Storage connections`; it removes `target`, `profile`, `destination`, and `saved connection` when
+  referring to these two managed resources.
+- `Sync setups` and `Storage connections` use symmetric list/detail flows: add, select, edit, remove,
+  and Back. A setup detail additionally offers `Make current` when applicable.
+- Existing direct command routes remain available, but target-addressing syntax becomes setup
+  addressing (`--setup <name>` and `/sync use <name>` unless the implementation review finds a
+  clearer non-breaking command name). Known setup names receive completions and unknown/trailing
+  arguments remain rejected.
+- TUI-only screens remain guarded by `ctx.mode === "tui"`; RPC uses supported dialogs/notifications,
+  and print/JSON paths never rely on no-op UI output.
+
+## Non-Goals
+
+- Migrating version 1 or version 2 settings, local state, or remote data.
+- Creating an independently reusable or manageable storage-location resource.
+- Adding another backend, project-scoped settings, a generic credential provider, encryption, or new
+  environment-variable mirrors.
+- Automatically syncing multiple setups into the same local agent directory.
+- Deleting remote data when a local setup or connection is removed.
+
+## Assumptions
+
+- The breaking version 3 reset and lack of migration are approved product decisions.
+- S3, Git, and WebDAV are the complete backend set for this work.
+- Storage connections must remain reusable by multiple sync setups; exact remote locations must not.
+- Existing safety behavior—locking, atomic settings writes, duplicate-remote rejection, secret
+  scanning, pull backups, transactional apply, live-session protection, and reviewed publication—
+  remains required even though old settings compatibility does not.
+
+## Risks
+
+- A connection reference makes backend-shape validation cross-object; centralizing resolution before
+  any backend construction is required to prevent mixed fields from reaching runtime code.
+- Collapsing built-in groups, sessions, and extra paths into `sync.include` can introduce ambiguous
+  names unless canonical reserved roots and relative-path rules are specified and tested first.
+- Reinterpreting `storage.path` inconsistently across S3, Git, and WebDAV can redirect publication;
+  backend-specific normalization and identity fixtures must prove the exact resulting location.
+- Removing version 1/2 support can strand existing local settings. The unsupported-version error and
+  release documentation must be explicit, and no automatic write may occur after that error.
+- Broad terminology changes can leave stale strings in errors, tests, README examples, completion
+  descriptions, and state paths; review must audit the complete pi-sync package, not only menus.
+
+## Rollback / Recovery
+
+- Before release, rollback is a code revert because no version 3 settings should be published by an
+  unapproved build.
+- After release, rollback requires restoring the prior package and the user's separately retained
+  version 1/2 settings; version 3 files must not be silently downgraded.
+- Settings write failures retain the previous bytes and effective runtime state. Invalid or
+  unsupported documents remain untouched for manual recovery.
+- Remote publication and local apply retain their existing immutable staging, concurrency checks,
+  backups, journals, and recovery boundaries; the settings redesign must not weaken them.
+
+## Plan
+
+### Milestone 1 — wording and symmetric management
+
+- [ ] Inventory every user-visible pi-sync occurrence of `target`, `profile`, `destination`, saved
+      connection, and connection across `extensions/pi-sync/src/`, tests, and `README.md`; record the
+      intended replacement or justified technical-only retention in this plan so the wording pass is
+      complete rather than limited to the main menu.
+- [ ] Add focused failing menu and wording tests for `Manage sync`, symmetric `Sync setups` and
+      `Storage connections` list/detail flows, current markers, Make current, add/edit/remove, Back and
+      Escape, notifications, errors, command descriptions, and completion labels while keeping version
+      2 fixture bytes unchanged; verify the intended red state with a focused compiled Node test run.
+- [ ] Refactor `extensions/pi-sync/src/manager-ui.ts`, `storage-connections-ui.ts`, backend setup UIs,
+      and settings UI so the current version 2 data is presented only as sync setups and storage
+      connections, with symmetric add/select/edit/remove navigation and no behavior or persistence
+      change; verify main, empty, invalid, partial, cancellation, disposal, session replacement,
+      shutdown, narrow-width, and RPC fallback tests.
+- [ ] Update command descriptions, completion labels, status/help text, validation errors, and
+      notifications to use sync setup and storage connection consistently; introduce `--setup` as the
+      documented spelling while retaining `--target` as a tested compatibility alias until the
+      version 3 milestone, and verify TUI/RPC/print/JSON argument and mode tests.
+- [ ] Update the workflow portions of `extensions/pi-sync/README.md` to use the approved vocabulary
+      while labeling `profiles` and `targets` only as temporary version 2 JSON field names; verify links,
+      documented commands, and JSON examples without changing the stored schema examples yet.
+- [ ] Run the focused pi-sync tests and `npm run check`, then exercise `/sync` with an isolated
+      temporary agent directory and record the main, sync-setup, and storage-connection menu wording;
+      obtain explicit user approval of this milestone before starting version 3 work.
+
+### Milestone 2 — version 3 schema
+
+- [ ] Add focused version 3 schema fixtures and failing tests in `extensions/pi-sync/test/` for all
+      three connection/setup shapes, empty settings, every required field, mixed backend fields,
+      missing references, prototype names, duplicate remote identities, normalized paths, complete
+      `sync.include` semantics, and redaction; verify the intended red state with a focused compiled
+      Node test run.
+- [ ] Replace the persisted settings and normalized domain types in `extensions/pi-sync/src/types.ts`
+      with exhaustive version 3 storage-connection and sync-setup unions; verify TypeScript rejects
+      impossible backend combinations with `npm run typecheck`.
+- [ ] Refactor `extensions/pi-sync/src/config.ts` and backend-specific config modules to parse only
+      `version: 3`, resolve a setup through its referenced connection, normalize `storage.path`, map
+      `sync.include`, and reject unsupported/invalid documents before updating effective state;
+      verify with the focused schema and backend-config tests.
+- [ ] Update remote identity and state-path derivation to use normalized version 3 connection and
+      setup coordinates without treating the setup name as an implicit remote path; verify distinct,
+      equivalent, renamed, and duplicated S3/Git/WebDAV fixtures in backend identity/state tests.
+- [ ] Replace profile/target mutation helpers in `extensions/pi-sync/src/settings-management.ts` with
+      symmetric storage-connection and sync-setup CRUD that preserves unknown fields, rejects removal
+      of referenced connections/current setups, and atomically publishes one valid document; verify
+      add/edit/remove, concurrent mutation, invalid-file, write-failure, permissions, and
+      last-known-state tests.
+- [ ] Refactor sync policy and file-selection boundaries to consume `sync.include`, recognize the
+      reserved `sessions` entry, validate safe relative paths, preserve privacy confirmation and
+      live-session exclusion, and treat an empty list as no selected content; verify focused policy,
+      snapshot, cancellation, symlink/path, and session tests.
+- [ ] Update S3/R2, Git, and WebDAV setup/edit flows to write the exact version 3 connection and setup
+      shapes with complete reviewed storage paths and masked credentials while preserving the approved
+      milestone 1 navigation and wording; verify each backend's first setup, connection reuse, edit,
+      cancellation, invalid credentials/path, narrow rendering, and secret-redaction tests.
+- [ ] Update `extensions/pi-sync/src/command.ts` and route handling to make `--setup` canonical for
+      version 3, remove the temporary version 2 `--target` alias under the approved breaking reset,
+      retain every other approved direct workflow, complete known values, and reject unsupported modes
+      and trailing input observably; verify the full command catalog, completion chaining,
+      TUI/RPC/print/JSON behavior, and safety confirmation tests.
+- [ ] Remove version 1/2 migration and compatibility code only after version 3 loading, UI, and command
+      tests pass; verify unsupported old/unversioned files remain byte-for-byte unchanged and produce
+      actionable, secret-free errors rather than migration prompts or writes.
+- [ ] Update `extensions/pi-sync/README.md` with the version 3 schema, S3/R2/Git/WebDAV examples,
+      storage connection/sync setup terminology, defaults, path meaning, settings permissions,
+      unsupported old-version behavior, direct commands, and recovery guidance; verify every JSON
+      example parses and every documented route has deterministic coverage.
+- [ ] Audit the complete pi-sync diff against `docs/extension-conventions.md` and
+      `docs/extension-settings.md`, including async cancellation/disposal/session/shutdown, settings
+      concurrency and failure recovery, unknown-field preservation, secret handling, mode behavior,
+      and established-route policy; record any approved deviation in this plan before completion.
+- [ ] Run `npm run check`, then `just pack-sync` and inspect the tarball, then load the extension in an
+      isolated temporary agent directory with `pi -e ./extensions/pi-sync`; record passing commands,
+      package contents, and any unverified external backend smoke.
+
+## Completion Checklist
+
+- [ ] Milestone 1 passes focused tests and `npm run check`, preserves version 2 settings bytes and sync
+      behavior, and has explicit user approval of the runtime menu wording before milestone 2 begins.
+- [ ] `pi-sync.json` accepts exactly the documented version 3 shapes for S3-compatible/R2, Git, and
+      WebDAV storage connections and sync setups.
+- [ ] Loading, empty, valid, malformed, unsupported-version, missing-reference, mixed-backend,
+      duplicate-remote, no-content, secret-bearing, and partial states are deterministic and tested.
+- [ ] Storage connection and sync setup CRUD are symmetric, atomic, concurrency-safe, private,
+      unknown-field preserving, and cancellation-safe.
+- [ ] UI, commands, completions, errors, tests, and README consistently use storage connection and sync
+      setup terminology with no managed-resource `profile`, `target`, `destination`, or saved
+      connection wording left.
+- [ ] S3/R2, Git, and WebDAV resolve the exact reviewed remote location and retain publication,
+      conflict, backup, recovery, and session-privacy safeguards.
+- [ ] Version 1/2 and unversioned non-empty settings are never migrated or overwritten and receive
+      documented recovery guidance.
+- [ ] `npm run check`, `just pack-sync`, and the isolated Pi runtime smoke pass, with any unavailable
+      live backend validation explicitly recorded.
+- [ ] The final semantic audit names the guides read, touched areas checked, accepted deviations, and
+      any genuinely unverified path before the completed plan is archived.

--- a/docs/plans/archived/2026-07-27_pi-sync-menu-wording-plan.md
+++ b/docs/plans/archived/2026-07-27_pi-sync-menu-wording-plan.md
@@ -1,0 +1,492 @@
+# Pi Sync menu experience plan
+
+## Goal
+
+Redesign pi-sync's interactive menu around the jobs users are trying to complete—understand current
+sync state, sync safely, switch context, adjust scope, and recover—while consistently naming the two
+managed concepts **sync setups** and **storage connections**. Keep frequent actions shallow, move
+explicit/risky operations behind predictable disclosure, preserve every existing capability and
+version 2 setting, and make previews, cancellation, failure recovery, responsive behavior, and
+keyboard operation explicit before implementation.
+
+The user approved implementation by explicitly requesting execution of this plan. The implementation
+evidence and accepted deviations are recorded below.
+
+## Context
+
+### Evidence inspected
+
+- Current interaction and state logic in `extensions/pi-sync/src/manager-ui.ts`,
+  `storage-connections-ui.ts`, `settings-ui.ts`, `git-ui.ts`, and `webdav-ui.ts`.
+- Current user-facing behavior and version 2 schema in `extensions/pi-sync/README.md`.
+- Current menu, lock, empty-content, switching, cancellation, settings, S3/R2, Git, and WebDAV tests
+  under `extensions/pi-sync/test/`.
+- Repository requirements in `docs/extension-conventions.md` and `docs/extension-settings.md`.
+- Pi extension and TUI constraints in the installed `docs/extensions.md` and `docs/tui.md`.
+- `manager-ui.ts` is currently 945 lines, so adding setup list/detail and richer selection behavior in
+  that file would cross the repository's 1,000-line review boundary.
+
+### Current experience
+
+- The main screen shows current target, backend storage, consistency mechanism, selected-content
+  counts, automatic sync, last applied snapshot id, and unchecked remote state.
+- Seven main actions give equal visual weight to smart sync, explicit pull, explicit push, switching,
+  status, settings, and More.
+- More opens destination management, history/recovery, and Help. Destination management then exposes
+  add/edit/remove target actions and a differently structured Saved connections submenu.
+- Switching already shows from/to, storage, content scope, automatic sync, sessions, and configured
+  post-switch behavior before confirmation.
+- Setup already offers Cloudflare R2, generic S3, WebDAV, and Git; recommended/minimal content presets;
+  automatic-sync choice; session privacy acknowledgement; and a final reviewed save.
+- Read-only remote checks use a cancellable loader. Once publication/apply begins, cancellation is
+  intentionally disabled. Settings writes are private, atomic, serialized, and unknown-field
+  preserving.
+
+### Primary user groups and goals
+
+1. **Single-setup user** — evidenced by first-time setup and default automatic sync. They need to know
+   whether sync is healthy, run safe Sync now, and adjust included content without learning the
+   connection/setup data model.
+2. **Multi-context user** — evidenced by named `home`/`work` targets and current-target behavior. They
+   need to see which setup is current, compare another setup, switch deliberately, and understand any
+   pull that follows.
+3. **Privacy-sensitive user** — evidenced by opt-in session syncing and explicit warnings. They need
+   session inclusion visible wherever a setup is reviewed, switched, or edited.
+4. **Recovery user** — evidenced by history, rollback, diagnostics, stale-lock recovery, backups, and
+   conflict handling. They need an actionable route when normal mutation is blocked.
+5. **Expert/automation user** — evidenced by documented direct commands, target flags, environment
+   overrides, and manual JSON editing. They need compatibility and precise errors, but these controls
+   need not dominate the interactive menu.
+
+Frequency assumptions are inferred from current defaults and workflows; pi-sync has no usage
+telemetry. They require maintainer/user validation in the approval smoke.
+
+## Capability classification
+
+| Capability | Classification | Presentation |
+| --- | --- | --- |
+| Current sync setup and attention state | Primary safety/status | Always visible on the main screen |
+| Sync now | Primary | First main action |
+| Switch sync setup | Primary only when multiple setups exist | Main action when applicable |
+| Status & changes | Supporting | Main action; read-only and cancellable |
+| Automatic sync and included content | Supporting settings | Settings for the current setup |
+| Explicit pull / push | Advanced and potentially consequential | More, plus contextual recovery guidance |
+| Add/edit/remove sync setups | Secondary management | More → Sync setups |
+| Add/edit/remove storage connections | Advanced management | More → Storage connections |
+| History / rollback / diagnostics / stale lock | Advanced or destructive recovery | More → History & recovery; surfaced sooner when blocked |
+| Session inclusion | Safety/status | Visible in setup summaries and reviewed before enablement |
+| Force routes, `--target`, environment overrides, manual JSON | Compatibility-only expert surface | Direct commands/docs, not primary menus |
+| Remove setup / connection | Destructive local configuration | Item detail with exact confirmation |
+
+## Flow evaluation
+
+| Flow | Expected frequency | Importance | Complexity | Risk | Reversibility |
+| --- | --- | --- | --- | --- | --- |
+| Open `/sync` and understand state | High | High | Low | None | N/A |
+| Sync now | Medium/high | High | Medium | Direction-dependent | Pull backed up; remote publication guarded |
+| Switch setup | Medium for multi-context users | High | Medium | May lead to reviewed pull | Switchable back; pull separately reviewed |
+| Status & changes | Medium | High | Medium | None | Fully cancellable before completion |
+| Change settings/content | Low/medium | High | Medium | Changes future sync scope | Atomic save; draft can be discarded |
+| Explicit pull/push | Low | Critical when needed | Medium | High | Pull backed up; push can supersede remote state |
+| Add/edit setup | Low | High | High | Can redirect future sync | Atomic config save; remote data untouched |
+| Edit shared connection | Rare | Critical | High | Can redirect several setups | Atomic config save; must preview dependents |
+| Remove setup/connection | Rare | Medium | Low | Local configuration loss | Remote data retained; local recovery manual |
+| History/recovery | Rare | Critical | High | Rollback/unlock can be destructive | Existing backups/liveness guards |
+
+## Usability findings in the current plan
+
+1. **It optimizes for symmetric CRUD before user goals.** Symmetric setup/connection management is
+   useful, but it should stay secondary; the main experience should remain about syncing safely.
+2. **It adds an unnecessary `Manage sync` level.** Main → More → Manage sync → resource list → detail
+   is deeper than needed. More can link directly to Sync setups and Storage connections.
+3. **It leaves explicit Pull and Push in the primary menu.** They compete with Sync now despite being
+   less common and more consequential. Capability should remain under More and direct commands.
+4. **It does not define what belongs in the main status summary.** The current `Consistency` line is
+   implementation language, snapshot ids are noisy, and the connection name is not shown even though
+   it matters when choosing a setup.
+5. **It specifies labels but not complete goal flows.** First setup, add setup using an existing/new
+   connection, switching with post-switch pull, shared-connection edits, and blocked recovery need
+   explicit steps and consequences.
+6. **It misses connection-edit blast radius.** Changing a reusable endpoint, URL, remote, or
+   credentials can affect several setups; the review must list those setup names before saving.
+7. **It overpromises menu semantics that Pi's basic selector does not provide.** `ctx.ui.select()`
+   returns the same result for Escape and Ctrl+C and has no disabled rows or rich descriptions. The
+   design must either accept those semantics or use a tested richer component with RPC fallback.
+8. **Responsive and accessibility requirements are too generic.** Long Unicode names, hosts, paths,
+   multiple dependents, privacy warnings, 32-column terminals, focus restoration, non-color cues, and
+   exact full-value access need concrete criteria.
+9. **State behavior is incomplete.** Loading, empty, invalid active setup, partially invalid setup
+   collections, live/recoverable locks, no selected content, save failure, and stale reads need defined
+   actions and feedback.
+10. **Compatibility boundaries are ambiguous.** Interactive wording may change while version 2 JSON,
+    direct `--target`, and technical storage errors retain compatibility terms; the document must say
+    exactly where old terms remain and why.
+
+## Architecture
+
+### Revised information architecture
+
+The main menu contains at most five goal-oriented actions:
+
+```text
+Pi Sync
+
+Current sync setup: home
+Storage: Cloudflare R2 · r2 · personal-pi
+Included: 9 groups · Sessions off
+Automatic sync: On
+Last applied: Never synced
+Remote status: Not checked
+
+What do you want to do?
+
+Sync now (recommended)
+Switch sync setup
+Status & changes
+Settings
+More…
+```
+
+Rules:
+
+- Omit `Switch sync setup` when fewer than two valid setups exist.
+- Replace the technical `Consistency` line with status/recovery detail shown by Status & changes or
+  Help; keep a short warning on the main screen only when consistency is degraded or unavailable.
+- Use `Storage` to show backend type, storage connection name, and a concise destination discriminator
+  such as bucket, branch, or path. Full endpoint/path remains available in setup detail.
+- Keep `Remote status: Not checked`; opening the menu must not perform network I/O.
+- Use text (`current`, `invalid`, `sessions included`, `automatic sync off`) rather than color alone.
+
+More provides one shallow disclosure level:
+
+```text
+More options
+├─ Pull from remote…
+├─ Push to remote…
+├─ Sync setups…
+├─ Storage connections…
+├─ History & recovery…
+├─ Help
+└─ Back
+```
+
+The ellipsis indicates that Pull and Push always lead to a check/preview rather than immediate
+mutation. There is no intermediate `Manage sync` screen.
+
+### Sync setup list and detail
+
+In TUI mode, use a bounded `SelectList`-based screen when richer descriptions/search are needed; use
+`ctx.ui.select()` as the RPC fallback. Rows show a short name and textual current/invalid marker, with
+connection/storage and privacy summaries as descriptions. Never concatenate every detail into one
+unbounded selector string.
+
+```text
+Sync setups
+├─ Add sync setup
+├─ home (current) — R2 · r2 · Sessions off
+├─ work — S3 · company · Sessions off
+├─ archive (invalid) — Missing connection “old-s3”
+└─ Back
+```
+
+Selecting a valid setup opens one detail screen:
+
+```text
+Sync setup “work”
+
+Status: Not current
+Storage connection: company
+Storage location: S3 · company-pi/developers/work
+Included content: 3 groups · 0 extra files
+Sessions: Off
+Automatic sync: On
+
+Make current…
+Edit sync setup…
+Remove sync setup…
+Back
+```
+
+- The current setup shows `Status: Current` and omits Make current.
+- Invalid setups remain visible and open repair-oriented detail; Make current and sync are unavailable
+  with a textual reason.
+- Edit and remove always carry the selected setup explicitly. They never fall back to `activeTarget`.
+- Removing the current setup is unavailable while another setup exists, with `Switch first` guidance.
+- Remove confirmation states that local configuration is removed and remote data/history remain.
+
+### Storage connection list and detail
+
+```text
+Storage connections
+├─ Add storage connection
+├─ r2 — Cloudflare R2 · Used by 2 setups
+├─ github — Git · Used by 1 setup
+└─ Back
+```
+
+```text
+Storage connection “r2”
+
+Type: Cloudflare R2
+Endpoint: example.r2.cloudflarestorage.com
+Credentials: Settings file
+Used by: home, archive
+
+Edit storage connection…
+Remove storage connection (unavailable while in use)
+Back
+```
+
+- Credentials display presence/source only, never values.
+- If removal is unavailable, show the reason in text rather than silently hiding the capability.
+- Editing endpoint, URL, remote, region, username, or credential source previews every affected setup
+  and the old/new non-secret values before one atomic save.
+- Adding a connection alone performs no remote probe or sync. A later Check setup remains explicit.
+
+### Primary interaction flows
+
+#### First setup
+
+1. `Set up sync` asks where Pi settings will be stored: R2, S3-compatible, WebDAV, or Git.
+2. Suggest `home`/`work`/custom setup purpose and a connection name; do not require users to understand
+   the version 2 profile/target split.
+3. Collect connection details and masked credentials, then propose backend-specific storage defaults.
+4. Offer Recommended Pi settings and Minimal settings presets; expert content customization stays
+   available after setup.
+5. Keep sessions off by default and require the existing privacy acknowledgement before enabling.
+6. Ask whether automatic sync is enabled.
+7. Preview setup name, connection, exact storage location, included-content summary, sessions,
+   automatic sync, credential presence/source, and external prerequisites.
+8. `Save sync setup` publishes one complete valid configuration atomically. Cancel writes nothing.
+9. Success says the setup is ready and returns to the refreshed main menu; it does not automatically
+   publish remote content.
+
+#### Add another sync setup
+
+1. Start from Sync setups → Add sync setup.
+2. Name/purpose the setup.
+3. Choose an existing storage connection or Add storage connection without abandoning the draft.
+4. Offer safe backend-specific location defaults based on the selected connection, with Customize as
+   progressive disclosure.
+5. Choose content preset, sessions, and automatic sync.
+6. Preview overlap warnings, exact remote location, and the fact that only the current setup runs
+   automatically.
+7. Save atomically; cancellation at any step retains byte-for-byte settings.
+
+#### Make current / switch
+
+1. Show From, To, connection, exact storage location, content summary, sessions, and automatic sync.
+2. State the configured post-switch behavior in plain language.
+3. Confirm `Switch to <name>`; cancel changes nothing.
+4. Atomically change the current setup.
+5. If policy asks, separately ask whether to check/review a pull. If policy starts a pull review,
+   retain the exact preview and apply confirmation. Declining/failing the pull leaves the new setup
+   current and clearly states that local files were not changed.
+
+#### Explicit pull / push
+
+1. Open from More or a documented direct route.
+2. Show a cancellable read-only loader while collecting local/remote state.
+3. Show exact target setup, storage location, changed paths/counts, session impact, backup/publication
+   effect, and any conflict.
+4. Use action-specific confirmation (`Apply 3 remote changes`, `Publish 4 local changes`).
+5. Once apply/publication begins, remove misleading cancellation and label the committed phase.
+6. Success identifies setup, direction, count, and snapshot/backup where useful; failure says whether
+   local/remote state changed and gives the next safe action.
+
+#### Edit/remove
+
+- Editing a setup previews storage changes and warns that saving changes future sync location only;
+  it never moves or deletes old remote data.
+- Editing a shared connection lists every affected setup before saving.
+- Removal confirmations identify exactly the local object removed and explicitly state that remote
+  data/history remain.
+- Every confirmed settings mutation is one locked atomic write; cancellation and failed validation
+  leave previous bytes/effective state unchanged.
+
+### Navigation and cancellation
+
+- Main Escape or Ctrl+C exits pi-sync without side effects.
+- On Pi's basic selector, Escape and Ctrl+C are indistinguishable; in submenus both return one level.
+  Back is always visible. Do not claim a distinct close behavior without a custom tested selector.
+- Maximum routine depth is main → More → resource list → item detail/editor. Add/edit wizards may add a
+  focused review step but always provide Cancel.
+- SettingsList changes that save immediately remain labeled as immediate. The synced-content editor
+  retains Save, Discard, and Continue editing for its transactional draft.
+- After success or recoverable failure, return to the owning list/detail with refreshed state rather
+  than exiting the entire manager, except when a completed pull requires session reload/replacement.
+
+### State behavior
+
+| State | Visible message/state | Available actions |
+| --- | --- | --- |
+| Loading/checking | Dedicated cancellable loader; no stale action list underneath | Cancel before commit |
+| No settings | `Not set up` | Set up sync, Help |
+| Connections but no setups | `No sync setups configured` | Add sync setup, Storage connections, Help |
+| Valid configured | Current setup, storage, scope, sessions, automatic sync, last applied, unchecked remote | Primary five-action menu |
+| No included content | Explicit warning; do not call it up to date | Settings, Switch when applicable, Status, More |
+| Invalid current setup | Automatic sync paused; exact secret-free reason | Switch to valid setup, Sync setups, Help |
+| Some invalid non-current setups | Current valid setup continues; invalid rows remain visible | Normal actions plus repair through Sync setups |
+| Live lock | Operation and pid visible; mutation actions unavailable | Status, History & recovery, Help |
+| Stale/unreadable lock | Recovery required | Status, Recover stale operation, Help |
+| Remote unavailable | Local navigation remains usable; never label remote empty | Retry check, Back, Help |
+| Save success | Concrete verb/object feedback and refreshed state | Return to owning screen |
+| Save failure | Previous value/bytes retained; actionable error names object and retry path | Retry/Edit, Back |
+| Cancel | No success wording and no mutation | Return to previous screen |
+
+## Responsive and accessibility behavior
+
+- Cover widths 32, 60, and 100 columns with long Unicode setup/connection names, hosts, paths,
+  warnings, and dependent lists. No rendered line may exceed the supplied width.
+- Keep selector rows short; full critical values appear in detail/review screens with ANSI-safe
+  wrapping, never ambiguous ellipsis as the only access to a value.
+- Use Pi's callback theme and text labels; current, invalid, unavailable, warning, saved, cancelled,
+  and applied states must not depend on color or symbols alone.
+- Use injected keybindings. TUI list tests cover arrows, Enter, Escape, Ctrl+C/basic cancel semantics,
+  paging/search when enabled, and focus restoration to Pi after closing.
+- Any custom component with Input/Editor must implement `Focusable` and forward focus. Dispose must
+  cancel every owned asynchronous task as well as user cancellation.
+- Pi exposes no ARIA/semantic terminal tree. Accessibility acceptance therefore covers logical reading
+  order, plain-text meaning, keyboard-only operation, focus/IME behavior, non-color cues, contrast via
+  theme roles, and a recorded conditional terminal/screen-reader smoke without claiming unsupported
+  semantics.
+- Async transitions use a dedicated loader followed by a complete result; avoid inserting/removing
+  lines repeatedly in a way that causes harmful layout shifts.
+
+## Compatibility and boundaries
+
+- Preserve version 2 `profiles`, `targets`, `activeTarget`, unknown fields, private permissions,
+  migration behavior, environment precedence, direct routes, `--target`, remote layout, snapshots,
+  state, and backend contracts.
+- Interactive UI, menu-owned errors, and workflow documentation use sync setup/storage connection.
+  The settings reference explicitly calls `profiles` and `targets` version 2 JSON compatibility names;
+  code identifiers and wire fields may retain technical terms in this phase.
+- Do not remove Pull, Push, management, recovery, Help, or direct automation capability; only change
+  interactive hierarchy and labels.
+- No settings save or remote operation occurs merely from opening, listing, backing out, or cancelling
+  a menu.
+
+## Design decisions and trade-offs
+
+1. **Five primary actions instead of seven.** This makes Sync now dominant and moves explicit Pull/Push
+   behind More without removing them. Unknown telemetry is the validation risk.
+2. **No Manage sync intermediary.** Direct More links preserve shallow navigation while keeping
+   management secondary.
+3. **Goal flow before symmetric CRUD.** Setup/connection lists are symmetric where useful, but first
+   setup and Add setup remain destination-oriented wizards so users need not construct internal
+   objects in dependency order.
+4. **Connection impact is visible.** Shared connection edits receive stronger preview because one save
+   can affect several setups.
+5. **Rich TUI lists, RPC fallback.** SelectList descriptions improve recognition and overflow behavior;
+   RPC retains supported plain selectors because `custom()` is unavailable there.
+6. **Compatibility terms remain in the JSON reference.** Total textual elimination would make version
+   2 documentation inaccurate; the boundary is user concept versus stored compatibility field.
+7. **No independent storage-location manager.** Location remains descriptive setup data under YAGNI.
+
+## Non-Goals
+
+- Changing `pi-sync.json`, its version, profile/target storage fields, migrations, remote identities,
+  backend layout, snapshot/state formats, or environment precedence.
+- Renaming direct command flags or internal TypeScript identifiers solely for wording consistency.
+- Adding a storage-location resource, a new backend, project-scoped settings, telemetry, or remote
+  probes on menu open.
+- Redesigning the concrete diff viewer, rollback engine, file-selection component, or backend safety
+  protocols beyond the menu handoffs described here.
+
+## Risks
+
+- Moving Pull/Push can reduce discoverability for users who rely on the menu; More labels, Help, direct
+  route compatibility, and runtime approval must validate the trade-off.
+- Editing a non-current setup can accidentally fall back to implicit `activeTarget`; selected identity
+  must be explicit and revalidated after every await.
+- A richer TUI selector introduces cancellation/disposal/focus responsibility and needs an RPC
+  fallback; reusing Pi components does not remove lifecycle review.
+- Connection edits can redirect multiple setups after a stale read; review and write must participate
+  in one settings concurrency protocol and revalidate dependents before publication.
+- `manager-ui.ts` is already 945 lines; adding flows there would violate the repository source-size
+  boundary and worsen ownership.
+
+## Approved terminology mapping
+
+| Previous interactive wording | Approved interactive wording | Compatibility boundary |
+| --- | --- | --- |
+| Current target / Switch target | Current sync setup / Switch sync setup | `activeTarget`, `/sync use`, and `--target` remain unchanged |
+| Destination / sync destination | Sync setup when naming the managed configuration; storage location when naming backend coordinates | Backend `destination` properties and version 2 `targets` remain unchanged |
+| Saved connection / storage profile | Storage connection | Version 2 `profiles` and internal typed profile symbols remain unchanged |
+| Synced content / manages files | Included content / includes files | Version 2 `syncFiles`, `syncSessions`, and `extraFiles` remain unchanged |
+| Auto-sync / target switch behavior | Automatic sync / After switching setup | Version 2 `autoSync` and `targetSwitchAction` remain unchanged |
+| Manage destinations | Direct Sync setups / Storage connections links | Removed from interactive navigation |
+
+## Plan
+
+- [x] Present this revised information architecture, primary-action reduction, direct More links,
+      setup/connection detail content, and state behavior for explicit user approval; approval was the
+      user's explicit request to implement this plan.
+- [x] Inventory every interactive label and path in `manager-ui.ts`, `storage-connections-ui.ts`,
+      `settings-ui.ts`, `git-ui.ts`, `webdav-ui.ts`, tests, and the README; the approved mapping above
+      documents why version 2 field names and direct `--target` syntax remain.
+- [x] Add focused failing tests for the five-action main menu, conditional Switch visibility, direct
+      More disclosure, empty/invalid/partial/lock/no-content states, and Pull/Push discoverability;
+      the compiled harness first failed on the old seven-action menu and then passed the updated
+      focused and full suites.
+- [x] Extract setup management into `extensions/pi-sync/src/sync-setups-ui.ts` and connection
+      management into `storage-connections-ui.ts`; both reuse Pi's bounded selector rather than adding
+      a custom shared list, and `manager-ui.ts` remains below 1,000 lines (974 after implementation).
+- [x] Implement the main/More hierarchy and concise state summary in `manager-ui.ts` without remote I/O
+      on open; compiled manager tests cover current/error/lock/no-content state, Back/cancellation, and
+      Pi selector behavior shared by TUI and RPC.
+- [x] Implement Sync setup list/detail/add/edit/remove/Make current flows with explicit selected setup
+      identity, invalid/current/unavailable text states, reviewed switching, and no implicit fallback;
+      focused tests cover non-current edits, invalid visibility, current removal guards, concurrent
+      switch-policy changes, cancellation, and existing lifecycle/post-switch suites.
+- [x] Implement Storage connection list/detail/add/edit/remove flows with credential source/presence,
+      dependent setup summaries, unavailable removal explanation, and shared-edit impact preview;
+      focused stale-dependent tests and the existing backend, atomic-save, unknown-field, redaction,
+      and reference-guard suites pass.
+- [x] Update setup/edit/review/settings wording and goal flows to use sync setup, storage connection,
+      storage location, `After switching setup`, and action-specific Save/Apply/Remove labels while
+      preserving existing presets and privacy confirmation; first/add/edit/discard/confirmation tests
+      pass across S3/R2, Git, and WebDAV.
+- [x] Verify responsive/accessibility behavior: the existing extension-owned custom content screen
+      passes deterministic 32/60/100-column tests; the new menus intentionally use Pi-owned selectors,
+      so width, keyboard, focus/IME, theme, search/paging, and disposal remain platform behavior rather
+      than duplicated custom code. New tests verify textual state and terminal-control escaping for
+      stored setup/connection names; the README documents the honest terminal accessibility smoke.
+- [x] Update the interactive workflow and terminology sections of `extensions/pi-sync/README.md`, keep
+      version 2 field names explicit in the settings reference, and verify documented labels/routes
+      against menu constants and deterministic tests.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`:
+      owned tasks keep existing abort/disposal ownership, continuations recheck signals, selected
+      identities and shared dependents are revalidated, writes retain serialized atomic publication,
+      malformed/symlink protection and unknown fields remain intact, secrets stay redacted, and basic
+      selectors provide the supported TUI/RPC fallback. Accepted deviation: no custom shared list was
+      added because Pi's selector already owns the required bounded interaction behavior.
+- [x] Run focused pi-sync tests and `npm run check`, then smoke the published extension entrypoint in
+      isolated RPC mode. Deterministic harnesses capture main, More, setup/connection detail, lock, and
+      failure states; `npm run check` passed 1,699 tests and the isolated smoke exited 0 with
+      protocol-safe JSON and no stderr. Representative width rendering is covered by the custom-screen
+      test and Pi owns rendering for the new basic selectors.
+
+## Acceptance criteria
+
+- [x] Main shows current setup, connection/storage, included-content/session state, automatic sync,
+      last applied state, and honest remote freshness without network I/O or implementation jargon.
+- [x] Main has at most five actions; Sync now is first, Switch appears only when useful, and explicit
+      Pull/Push remain discoverable under More and through existing direct commands.
+- [x] No Manage sync intermediary exists; routine management depth does not exceed main → More → list
+      → detail/editor, and every screen has Back/Cancel or defined Escape behavior.
+- [x] Setup and connection lists/details expose current, invalid, unavailable, privacy, and dependency
+      state in text, with full critical values available without ambiguous truncation.
+- [x] Switching, setup edits, shared-connection edits, Pull, Push, and removals preview concrete effects
+      and use action-specific confirmation before one atomic mutation/publication.
+- [x] Cancellation before commit has no side effects; commit phases do not present misleading cancel;
+      failures retain previous valid settings/state and give an actionable next step.
+- [x] Loading, empty, success, error, disabled, and partial states behave as specified in TUI and have
+      safe supported RPC/non-TUI fallbacks.
+- [x] Keyboard-only navigation, focus restoration/IME forwarding, non-color meaning, theme contrast,
+      terminal sanitization, and 32/60/100-column rendering are covered by Pi-owned selectors plus
+      deterministic extension tests; unsupported screen-reader semantics are documented honestly.
+- [x] Version 2 settings bytes/schema, unknown fields, direct commands/flags, migration/environment
+      behavior, remote data/layout, snapshots/state, privacy, and safety protocols remain compatible.
+- [x] Focused tests and `npm run check` pass, and the isolated Pi runtime smoke is accepted for this
+      implementation request; the separate version 3 schema plan remains unimplemented.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -2,26 +2,26 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-sync` syncs selected Pi configuration through Git, WebDAV, Cloudflare R2, or other S3-compatible storage. Named sync targets such as `home` and `work` can reuse saved connections such as `github`, `webdav`, `r2`, and `s3`.
+`@narumitw/pi-sync` syncs selected Pi configuration through Git, WebDAV, Cloudflare R2, or other S3-compatible storage. Named sync setups such as `home` and `work` can reuse storage connections such as `github`, `webdav`, `r2`, and `s3`.
 
-The extension uses immutable snapshots, local locking, secret scanning, pre-apply backups, and recoverable local apply transactions. S3/WebDAV publish compressed bundles through a managed `latest.json` pointer; Git stores one strict manifest plus reusable raw Git blobs per commit on a pi-sync-owned branch. Remote persistence is isolated behind a backend-neutral contract, and normalized runtime config pairs each discriminated storage profile with its matching destination. Git, WebDAV, and S3/R2 are production backends in this release. Conversation/session syncing remains opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets.
+The extension uses immutable snapshots, local locking, secret scanning, pre-apply backups, and recoverable local apply transactions. S3/WebDAV publish compressed bundles through a managed `latest.json` pointer; Git stores one strict manifest plus reusable raw Git blobs per commit on a pi-sync-owned branch. Remote persistence is isolated behind a backend-neutral contract, and normalized runtime config pairs each storage connection with its matching storage location. Git, WebDAV, and S3/R2 are production backends in this release. Conversation/session syncing remains opt-in because session JSONL can contain prompts, tool output, paths, screenshots, and secrets.
 
 ## ✨ Features
 
-- Opens a goal-oriented `/sync` manager showing the current target, storage, auto-sync, session scope, and relevant next actions.
-- Supports multiple named **sync targets** and reusable Git/WebDAV/R2/S3 **storage profiles**.
+- Opens a goal-oriented `/sync` manager showing the current sync setup, storage, automatic sync, session scope, and relevant next actions.
+- Supports multiple named **sync setups** and reusable Git/WebDAV/R2/S3 **storage connections**.
 - Publishes Git snapshots as one commit with an exact expected-ref lease, preserving native first-parent history without unconditional force pushes.
 - Uses verified `ETag`, `If-Match`, and `If-None-Match` preconditions for atomic WebDAV publication and fails closed when a server ignores them.
-- Asks to review a pull after switching targets by default, with settings to start that review automatically or switch only.
+- Asks to review a pull after switching sync setups by default, with settings to start that review automatically or switch only.
 - Previews concrete local or remote file changes before push, pull, force resolution, or rollback.
-- Uses transactional synced-content drafts with explicit Save, Discard, and Continue editing choices.
+- Uses transactional included-content drafts with explicit Save, Discard, and Continue editing choices.
 - Keeps direct `help`, `use`, `init`, `config`, `files`, `status`, `diff`, `doctor`, `push`, `pull`, `sync`, `history`, `rollback`, and `unlock` routes for compatibility and automation.
 - Syncs allowlisted Pi configuration from the Pi agent directory:
   - `settings.json`, `keybindings.json`, `models.json`, `AGENTS.md`, and `APPEND_SYSTEM.md`
   - recursive `skills/`, `prompts/`, `themes/`, and `extensions/` groups
   - safe top-level files selected through `extraFiles`
   - optionally denylist-filtered `sessions/**/*.jsonl`
-- Preserves files outside the addressed target's selection locally and in remote uploads.
+- Preserves files outside the addressed setup's selection locally and in remote uploads.
 - Creates backups before pull/rollback and journals multi-file applies so failures roll back; interrupted transactions recover before the next sync.
 - Refuses common secret patterns, unsafe paths, symlink escapes, live-lock removal, and unreviewed conflict overwrites.
 
@@ -54,14 +54,14 @@ Run the manager:
 When pi-sync is not configured, choose **Set up sync**. The TUI guides you through:
 
 1. Git, WebDAV, Cloudflare R2, or another S3-compatible service
-2. `Personal / Home`, `Work`, or a custom target purpose
+2. `Personal / Home`, `Work`, or a custom setup purpose
 3. an endpoint and, for S3, the existing bucket name
 4. a recommended remote location or advanced customization
 5. existing Git/SSH authentication, masked WebDAV credentials, S3 environment credentials, or a private settings-file template
-6. a synced-content preset
+6. an included-content preset
 7. an exact setup preview and **Save setup** confirmation
 
-For a first Cloudflare R2 target, the recommended location requires no raw path questions:
+For a first Cloudflare R2 setup, the recommended location requires no raw path questions:
 
 ```json
 {
@@ -72,13 +72,13 @@ For a first Cloudflare R2 target, the recommended location requires no raw path 
 }
 ```
 
-The R2 bucket must already exist; pi-sync never creates buckets. Generic S3 setup asks for one existing, potentially globally unique bucket and derives storage profile `s3`, prefix `pi-sync`, and namespace `home` or `work`. **Customize remote location** retains direct control over profile name, bucket, prefix, and namespace.
+The R2 bucket must already exist; pi-sync never creates buckets. Generic S3 setup asks for one existing, potentially globally unique bucket and derives storage connection `s3`, prefix `pi-sync`, and namespace `home` or `work`. **Customize storage location** retains direct control over the connection name, bucket, prefix, and namespace.
 
 The setup wizard can store WebDAV passwords and S3-compatible static credentials entirely through the TUI. Its package-owned masked input renders only bullets, and secret values are never shown in reviews, menus, status, notifications, warnings, or errors. S3 environment credentials and a manual private-settings template remain available; WebDAV has no environment-variable credential mirrors.
 
 ### Git setup
 
-Git profiles contain only a remote URL; credentials remain in your existing Git credential helper, SSH agent, or SSH configuration. Targets select a pi-sync-owned branch, repository directory, and namespace:
+Git storage connections contain only a remote URL; credentials remain in your existing Git credential helper, SSH agent, or SSH configuration. Sync setups select a pi-sync-owned branch, repository directory, and namespace:
 
 ```json
 {
@@ -99,7 +99,7 @@ Git profiles contain only a remote URL; credentials remain in your existing Git 
 }
 ```
 
-The remote repository must already exist; the owned branch may be absent and is created on first push with an exact missing-ref lease. Setup asks whether automatic sync should be enabled and shows that choice before saving. Each effective repository/branch pair belongs to exactly one pi-sync target; equivalent scp-like and `ssh://` spellings are treated as the same remote, and another namespace or target must use a distinct branch. Existing non-empty repositories are safe because pi-sync reads and updates only the configured branch. If that branch already exists, its complete tip tree must contain only the valid pi-sync manifest and its exact declared regular files; pi-sync rejects rather than deletes any other branch content.
+The remote repository must already exist; the owned branch may be absent and is created on first push with an exact missing-ref lease. Setup asks whether automatic sync should be enabled and shows that choice before saving. Each effective repository/branch pair belongs to exactly one pi-sync setup; equivalent scp-like and `ssh://` spellings are treated as the same remote, and another namespace or setup must use a distinct branch. Existing non-empty repositories are safe because pi-sync reads and updates only the configured branch. If that branch already exists, its complete tip tree must contain only the valid pi-sync manifest and its exact declared regular files; pi-sync rejects rather than deletes any other branch content.
 
 Supported production remotes are HTTPS without embedded credentials, `ssh://` URLs, and conservative scp-like SSH remotes such as `git@github.com:owner/repo.git`. Local paths and `file`, `git`, `ext`, and arbitrary remote-helper transports are rejected. Automatic commands disable repository hooks, editors, pagers, terminal prompts, and askpass interaction. User-configured credential helpers, SSH agents/configuration, and SSH `ProxyCommand` remain trusted external authentication mechanisms; pi-sync does not sandbox or store them.
 
@@ -107,7 +107,7 @@ Git 2.30 or newer and a SHA-1-format remote repository are currently required; S
 
 ### WebDAV setup
 
-Generic WebDAV profiles use the authenticated collection URL, a username, and a password. Targets add a relative `path` and `namespace`:
+Generic WebDAV storage connections use the authenticated collection URL, a username, and a password. Sync setups add a relative `path` and `namespace`:
 
 ```json
 {
@@ -135,28 +135,28 @@ Generic WebDAV profiles use the authenticated collection URL, a username, and a 
 
 Run `/sync doctor` after setup. It creates an unpredictable temporary probe, verifies collection listing/read/write/cleanup plus strong ETags and stale conditional writes, and removes the probe. A server without working strong `If-Match` and `If-None-Match` remains readable but publication is rejected before `latest.json` changes; pi-sync never silently degrades WebDAV automatic sync to an unsafe overwrite.
 
-A configured manager shows:
+A configured manager shows locally available state without contacting remote storage:
 
 ```text
-Current target: home
-Storage: Cloudflare R2 · personal-pi
-Synced content: 9 built-in groups · 0 extra files · Sessions: Off
-Auto-sync: On
-Last applied snapshot: snapshot-id (or Never synced)
-Remote changes: Not checked
+Current sync setup: home
+Storage: Cloudflare R2 · r2 · personal-pi
+Included: 9 built-in groups · 0 extra files · Sessions off
+Automatic sync: On
+Last applied: snapshot-id (or Never synced)
+Remote status: Not checked
 ```
 
 Its primary actions are:
 
 - **Sync now (recommended)** — conservatively decide whether to push, pull, or do nothing
-- **Pull from remote** — check the remote snapshot, preview exact local writes/deletes, then confirm
-- **Push to remote** — scan and preview exact remote publication changes, then confirm
-- **Switch target** — preview the target change, then follow the configured pull behavior
+- **Switch sync setup** — shown when multiple setups exist; preview the change and configured pull behavior
 - **Status & changes** — perform a cancellable read-only remote check
-- **Settings** — control post-switch pulling, automatic sync, and synced content
-- **More…** — open one shallow level containing destination management, history/recovery, Help, and Back
+- **Settings** — control post-switch pulling, automatic sync, and included content
+- **More…** — open explicit Pull/Push, Sync setups, Storage connections, history/recovery, Help, and Back
 
-The menu does not query remote storage merely to open. It shows the last locally applied snapshot and marks remote changes as unchecked until an operation runs. When no synced content is selected, transfer actions are hidden and Settings becomes the first action. During an active or recoverable lock, mutation actions remain unavailable.
+Explicit **Pull from remote…** and **Push to remote…** remain available under More and through their documented direct commands. The ellipsis indicates that each action checks and previews concrete effects before confirmation.
+
+The menu does not query remote storage merely to open. It shows the last locally applied snapshot and marks remote changes as unchecked until an operation runs. When no included content is selected, transfer actions are hidden and Settings becomes the first action. During an active or recoverable lock, mutation actions remain unavailable.
 
 Push and pull keep their existing concrete previews and confirmation prompts. Pull creates a local backup before applying; push scans locally managed content for likely secrets before publication. Escape cancels a pre-commit check without changing local or remote files. Once publication or apply begins, cancellation is disabled. Conflicts never force automatically; inspect **Status & changes** and use an explicit direct route only after reviewing the conflict.
 
@@ -240,29 +240,29 @@ A version 2 example:
 
 ### Terminology
 
-The TUI presents each profile/target pair as a **destination**. **Add destination** is the primary flow; reusable **saved connections** are available as an advanced action. The version 2 JSON names remain unchanged for compatibility.
+The interactive UI has two managed concepts:
 
-- A Git **storage profile** owns `kind: "git"` and a credential-free `remote`; a WebDAV profile owns `kind: "webdav"`, `url`, `username`, and `password`; an S3/R2 profile owns `kind`, `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`.
-- A Git **sync target** owns `branch`, `directory`, and `namespace`; a WebDAV target owns `path` and `namespace`; an S3/R2 target owns `bucket`, `prefix`, and `namespace`. Every target also owns `autoSync` and its synced-content policy.
-- `activeTarget` is used by bare commands and automatic sync.
-- `targetSwitchAction` controls what happens after a target switch: `ask` (default), `pull`, or `switch-only`.
-- `namespace` is the old flat `profile` concept. The remote layout and snapshot wire field remain named `profiles`/`profile` for compatibility.
+- A **storage connection** is reusable access configuration. Git connections own a credential-free `remote`; WebDAV connections own `url`, `username`, and `password`; S3/R2 connections own `endpoint`, `region`, `accessKeyId`, `secretAccessKey`, and optional `sessionToken`.
+- A **sync setup** is a named, switchable combination of one storage connection, its storage location, included content, session choice, and automatic-sync behavior.
+- A **storage location** is descriptive setup data such as bucket/prefix/namespace, branch/directory/namespace, or WebDAV path/namespace. It is not independently managed.
 
-When adding another target with the same storage profile, pi-sync recommends reusing the current target's bucket and prefix while deriving a separate namespace from the new target name. For example, `home` and `work` may both use profile `r2`, bucket `pi-sync`, and prefix `pi-sync`, producing `pi-sync/profiles/home/` and `pi-sync/profiles/work/`.
+Version 2 JSON retains compatibility field names: `profiles` stores storage connections, `targets` stores sync setups, `activeTarget` names the current setup, and `targetSwitchAction` controls behavior after switching. The remote layout and snapshot wire field also retain `profiles`/`profile`; these stored names are not interactive menu terminology.
 
-Two targets may intentionally overlap local files, but only one is automatic. pi-sync rejects duplicate effective target remote identities—including deprecated bucket/prefix/namespace environment overrides—to prevent independent local states from controlling the same remote pointer. Removing a target/profile removes local configuration only; it never deletes buckets or snapshots. A referenced profile cannot be removed, and users must switch away before removing one of several current targets.
+When adding another sync setup with the same storage connection, pi-sync recommends reusing the current setup's bucket and prefix while deriving a separate namespace from the new setup name. For example, `home` and `work` may both use connection `r2`, bucket `pi-sync`, and prefix `pi-sync`, producing `pi-sync/profiles/home/` and `pi-sync/profiles/work/`.
 
-### Target switching
+Two setups may intentionally overlap local files, but only one is automatic. pi-sync rejects duplicate effective storage locations—including deprecated bucket/prefix/namespace environment overrides—to prevent independent local states from controlling the same remote pointer. Removing a setup/connection removes local configuration only; it never deletes buckets or snapshots. A referenced connection cannot be removed, and users must switch away before removing one of several current setups.
 
-The default `targetSwitchAction: "ask"` changes `activeTarget` atomically, then asks in TUI mode whether to review a pull for that target. Choosing not to review leaves local files unchanged. Accepting starts the normal pull flow, which fetches the remote snapshot and shows the exact writes and deletions before apply. In print, JSON, or RPC mode, `ask` switches without pulling and directs interactive users to `/sync pull` where notifications are available.
+### Sync setup switching
 
-Set `targetSwitchAction` to `"pull"` to start that reviewed pull automatically after a confirmed target switch. The exact pull summary and apply confirmation remain enabled, conflict detection still stops unsafe merges, a local backup is created before apply, and pi-sync never adds `--force`; Pi may separately ask whether to reload changed resources after a successful pull. Because that confirmation requires observable UI, `/sync use` rejects `"pull"` in print and JSON modes before changing `activeTarget`; use TUI or RPC mode instead. Set it to `"switch-only"` to retain the previous no-pull behavior. Selecting an already-current target is a no-op. If a pull fails or its concrete review is declined, the new target remains active and pi-sync reports that synced files were not changed before `/sync pull` is retried.
+The default `targetSwitchAction: "ask"` changes `activeTarget` atomically, then asks in TUI mode whether to review a pull for that setup. Choosing not to review leaves local files unchanged. Accepting starts the normal pull flow, which fetches the remote snapshot and shows the exact writes and deletions before apply. In print, JSON, or RPC mode, `ask` switches without pulling and directs interactive users to `/sync pull` where notifications are available.
 
-### Synced content
+Set `targetSwitchAction` to `"pull"` to start that reviewed pull automatically after a confirmed sync setup switch. The exact pull summary and apply confirmation remain enabled, conflict detection still stops unsafe merges, a local backup is created before apply, and pi-sync never adds `--force`; Pi may separately ask whether to reload changed resources after a successful pull. Because that confirmation requires observable UI, `/sync use` rejects `"pull"` in print and JSON modes before changing `activeTarget`; use TUI or RPC mode instead. Set it to `"switch-only"` to retain the previous no-pull behavior. Selecting the current setup is a no-op. If a pull fails or its concrete review is declined, the new setup remains current and pi-sync reports that synced files were not changed before `/sync pull` is retried.
 
-The **Settings → Choose synced content** screen edits a draft. Arrow keys navigate, Enter or Space toggles, and Escape opens the Save/Discard/Continue decision. A single Save atomically updates the target while preserving unknown fields and POSIX `0600` permissions. Saving settings never starts network sync.
+### Included content
 
-Omitting `syncFiles` preserves the legacy default of every built-in item. An empty array is valid and means the target manages nothing; **Sync now** reports that state instead of publishing an empty sync. Unknown built-in names fail validation.
+The **Settings → Choose included content** screen edits a draft. Arrow keys navigate, Enter or Space toggles, and Escape opens the Save/Discard/Continue decision. A single Save atomically updates the setup while preserving unknown fields and POSIX `0600` permissions. Saving settings never starts network sync.
+
+Omitting `syncFiles` preserves the legacy default of every built-in item. An empty array is valid and means the setup includes nothing; **Sync now** reports that state instead of publishing an empty sync. Unknown built-in names fail validation.
 
 Unselected items are unmanaged: pi-sync does not compare, pull, overwrite, or delete their local content, and pushes preserve their existing remote content.
 
@@ -270,7 +270,7 @@ Unselected items are unmanaged: pi-sync does not compare, pull, overwrite, or de
 
 The existing `PI_SYNC_*` family still works in this release with its existing highest precedence, but it is deprecated and will be removed in a future major version. pi-sync shows variable names—not values—and migration guidance when any are active.
 
-Move these fields into a storage profile:
+Move these fields into a storage connection (`profiles` in version 2 JSON):
 
 - `PI_SYNC_ENDPOINT`
 - `PI_SYNC_REGION`
@@ -278,7 +278,7 @@ Move these fields into a storage profile:
 - `PI_SYNC_SECRET_ACCESS_KEY`
 - `PI_SYNC_SESSION_TOKEN`
 
-Move these fields into a sync target:
+Move these fields into a sync setup (`targets` in version 2 JSON):
 
 - `PI_SYNC_BUCKET`
 - `PI_SYNC_PROFILE` → `namespace`
@@ -286,7 +286,7 @@ Move these fields into a sync target:
 - `PI_SYNC_AUTO_SYNC`
 - `PI_SYNC_SESSIONS`
 
-`PI_SYNC_PROFILE` continues to mean only the remote namespace during the deprecation period; it never selects a storage profile or current target.
+`PI_SYNC_PROFILE` continues to mean only the remote namespace during the deprecation period; it never selects a storage connection or current setup.
 
 Standard compatibility aliases remain below `PI_SYNC_*` precedence:
 
@@ -297,17 +297,17 @@ Environment-overridden fields are read-only in interactive settings. Cloudflare 
 
 ### Legacy flat settings
 
-Existing flat settings continue to work unchanged as a synthetic `default` target/profile, including settings migrated from the legacy `pi-sync.local.json` filename. The old flat `profile` remains the remote namespace.
+Existing flat settings continue to work unchanged as a synthetic `default` setup/connection, including settings migrated from the legacy `pi-sync.local.json` filename. The old flat `profile` remains the remote namespace.
 
-Adding a second target offers an explicit migration preview. On confirmation pi-sync:
+Adding a second sync setup offers an explicit migration preview. On confirmation pi-sync:
 
 1. takes an exact private backup of the original JSON bytes;
 2. preserves unknown top-level fields;
-3. maps existing connection and policy fields without changing the remote destination;
-4. adopts the existing local sync state for the migrated target;
+3. maps existing connection and policy fields without changing the storage location;
+4. adopts the existing local sync state for the migrated setup;
 5. publishes the version 2 file atomically.
 
-Malformed, invalid, symlinked, or concurrently changed settings are never overwritten automatically. Version 2 settings require the multi-target pi-sync release or newer. For a manual downgrade, restore the exact `.legacy-<timestamp>.bak` flat-config backup; no remote migration or rollback is needed.
+Malformed, invalid, symlinked, or concurrently changed settings are never overwritten automatically. Version 2 settings require the multi-setup pi-sync release or newer. For a manual downgrade, restore the exact `.legacy-<timestamp>.bak` flat-config backup; no remote migration or rollback is needed.
 
 ## 💬 Commands
 
@@ -315,7 +315,7 @@ The menu is the preferred interactive workflow. Existing deterministic routes re
 
 ```text
 /sync help
-/sync use <target>
+/sync use <setup>
 /sync init
 /sync config [--target <name>]
 /sync files [--target <name>]
@@ -332,12 +332,12 @@ The menu is the preferred interactive workflow. Existing deterministic routes re
 
 Flags:
 
-- `--target <name>` addresses a target without switching it.
+- `--target <name>` addresses a sync setup without switching it.
 - `--yes` / `-y` skips an explicit direct command's confirmation.
 - `--force` resolves a reviewed conflict for push/pull/sync.
 - `--stale` requests guarded stale-lock recovery.
 
-Unknown flags, unexpected values, and missing target/snapshot values are rejected. Argument completion includes configured target names after session start.
+Unknown flags, unexpected values, and missing setup/snapshot values are rejected. Argument completion includes configured setup names after session start.
 
 TUI mode provides the full manager and custom settings components. RPC uses Pi's dialog/notification protocol and does not call TUI-only components. Print/JSON modes cannot display extension UI; use explicit direct routes for compatible automation and do not expect notification-only status output.
 
@@ -349,21 +349,21 @@ TUI mode provides the full manager and custom settings components. RPC uses Pi's
 | WebDAV | Verified strong `If-Match`/`If-None-Match` (`atomic-conditional`) | Private settings-file username/app password over HTTPS | Managed snapshot history; rollback publishes a new pointer | No extra executable; conditional-capability probe | Suitable only on a trusted server; server retention still applies |
 | R2/S3 | Read-check-write-verify; an unobserved simultaneous race remains possible | Private settings or existing compatibility environment variables | Managed snapshot history; rollback publishes a new pointer | No extra executable | Suitable only on trusted storage with an explicit retention policy |
 
-`--force` has the same meaning on every backend: accept reviewed content divergence, re-read the destination, and retain the backend's concurrency protection. It never authorizes an unconditional Git force push or pointer overwrite.
+`--force` has the same meaning on every backend: accept reviewed content divergence, re-read the storage location, and retain the backend's concurrency protection. It never authorizes an unconditional Git force push or pointer overwrite.
 
 To migrate between backends manually:
 
-1. Disable automatic sync for the source target.
+1. Disable automatic sync for the source setup.
 2. Run source diagnostics, inspect status, pull the intended current state, and retain the local backup.
-3. Add a separate destination/saved connection for the new backend and run `/sync doctor --target <destination>`.
-4. Switch deliberately, review the exact destination push, and publish only after confirming that an empty destination or its existing content is expected.
-5. Verify destination status and history before removing any local source configuration.
+3. Add a separate sync setup and storage connection for the new backend, then run `/sync doctor --target <setup>`.
+4. Switch deliberately, review the exact storage-location push, and publish only after confirming that an empty location or its existing content is expected.
+5. Verify storage-location status and history before removing any local source configuration.
 
-Do not run source and destination automatic sync simultaneously over overlapping local files. Cancelling before destination publication leaves it unchanged; after publication begins, an ambiguous transport result requires `/sync status` before retrying. Migration publishes only the current selected snapshot—it does not copy S3/WebDAV managed history or Git native commit history. Removing a local target/profile never deletes remote data.
+Do not run source and new-setup automatic sync simultaneously over overlapping local files. Cancelling before publication leaves the new storage location unchanged; after publication begins, an ambiguous transport result requires `/sync status` before retrying. Migration publishes only the current selected snapshot—it does not copy S3/WebDAV managed history or Git native commit history. Removing a local setup/connection never deletes remote data.
 
 ## 🔄 Sync and recovery model
 
-For the current target, startup auto-sync uses conservative decisions:
+For the current sync setup, startup automatic sync uses conservative decisions:
 
 - local changed or remote empty → preview/confirm manually, or push in the existing quiet automatic path
 - identical first sync → initialize local state
@@ -371,7 +371,7 @@ For the current target, startup auto-sync uses conservative decisions:
 - first-sync mismatch or both changed → stop and require review
 - no selected content → report/skip
 
-Switching targets first changes `activeTarget`, then follows `targetSwitchAction`: ask before reviewing a pull in TUI by default, start a reviewed pull automatically when configured, or stop after switching. Pulls remain pinned to the selected target and retain exact summaries, locking, backups, and conflict safeguards. The next startup uses the new target's `autoSync` regardless of the switch action.
+Switching sync setups first changes `activeTarget`, then follows `targetSwitchAction`: ask before reviewing a pull in TUI by default, start a reviewed pull automatically when configured, or stop after switching. Pulls remain pinned to the selected setup and retain exact summaries, locking, backups, and conflict safeguards. The next startup uses the new setup's `autoSync` regardless of the switch action.
 
 S3/WebDAV remote layout remains compatible:
 
@@ -416,11 +416,11 @@ R2/S3 is explicitly reported as `read-check-write-verify`, not atomic compare-an
 
 Only JSONL session files are included. Denylisted names and paths such as `.env*`, `.pisync`, `node_modules`, `token`, and `secret` are ignored. The currently open session file is protected during pull; restart Pi or resume a pulled session to use newly synced conversations.
 
-Sessions can contain prompts, model output, tool results, file paths, images, and secrets. Use only storage you trust. Git is especially persistent: disabling session sync, deleting a cache/target, or publishing a later snapshot does not remove session content from old commits; removal requires an explicit repository history-retention or rewrite procedure outside pi-sync.
+Sessions can contain prompts, model output, tool results, file paths, images, and secrets. Use only storage you trust. Git is especially persistent: disabling session sync, deleting a cache/setup, or publishing a later snapshot does not remove session content from old commits; removal requires an explicit repository history-retention or rewrite procedure outside pi-sync.
 
 ## 🛡️ Safety notes
 
-- Credentials stay local; canonical, legacy, temporary, and migration-recovery settings files are always excluded from snapshots. Git remote URLs with embedded HTTPS credentials are rejected, and rendered Git destinations contain only host, owned branch, directory, and namespace.
+- Credentials stay local; canonical, legacy, temporary, and migration-recovery settings files are always excluded from snapshots. Git remote URLs with embedded HTTPS credentials are rejected, and rendered Git storage locations contain only host, owned branch, directory, and namespace.
 - Push refuses common secret patterns in locally managed files.
 - Pull/rollback reject unsafe paths, duplicate paths, checksum mismatches, symlink parents, and file/directory replacement hazards before mutation. Git additionally rejects missing/extra/non-regular tree entries, file/directory path collisions, payloads above 100 MiB, and aggregate content above 512 MiB. Remote JSON and WebDAV XML responses are limited to 1 MiB, error bodies to 64 KiB, compressed S3/WebDAV snapshot downloads to 256 MiB, and decompressed bundles to 512 MiB.
 - Unmanaged local/remote files remain preserved.
@@ -433,7 +433,7 @@ Sessions can contain prompts, model output, tool results, file paths, images, an
 Pi exposes terminal components rather than a semantic/ARIA tree, so automated tests verify textual state, keyboard paths, control-character escaping, and 32/60/100-column fitting rather than claiming semantic announcements. When validating a release in a supported environment:
 
 1. open `/sync` using only the keyboard and verify arrows, Enter, Space, search typing, paging where available, Back, and Escape;
-2. enter a Unicode target/profile name with an IME and confirm focus returns to Pi after closing;
+2. enter a Unicode sync-setup/storage-connection name with an IME and confirm focus returns to Pi after closing;
 3. check the main, warning, preview, saved, cancelled, and invalid states with the terminal screen reader in use;
 4. repeat under a light and dark Pi theme and at 32, 60, and 100 columns.
 
@@ -453,18 +453,18 @@ extensions/pi-sync/
 │   ├── s3-client.ts             # Bounded, signed S3 transport
 │   ├── webdav-backend.ts        # Conditional WebDAV publication and diagnostics
 │   ├── webdav-client.ts         # Bounded authenticated WebDAV transport
-│   ├── webdav-ui.ts             # WebDAV setup and profile/target management
+│   ├── webdav-ui.ts             # WebDAV setup and connection/setup management
 │   ├── git-backend.ts           # Lease-protected Git commits, history, cache, and diagnostics
 │   ├── git-storage.ts           # Strict Git manifest, tree, blob, and size validation
 │   ├── git-runner.ts            # Bounded non-interactive Git subprocess lifecycle
-│   ├── git-ui.ts                # Git setup and profile/target management
+│   ├── git-ui.ts                # Git setup and connection/setup management
 │   ├── snapshot-codec.ts        # S3/WebDAV immutable snapshot bundle codec
 │   ├── manager-ui.ts            # Goal-oriented menus and setup/management flows
 │   ├── file-selection.ts        # Transactional synced-content editor
 │   ├── config-file.ts           # Private settings I/O and legacy filename migration
-│   ├── settings-management.ts   # Profiles, targets, migration, and atomic saves
+│   ├── settings-management.ts   # Connections, setups, migration, and atomic saves
 │   ├── settings-ui.ts           # SettingsList interaction and serialized saves
-│   ├── target-switch.ts         # Post-switch prompt, policy, and target handoff
+│   ├── target-switch.ts         # Post-switch prompt, policy, and setup handoff
 │   ├── snapshot-transaction.ts  # Local apply journal, rollback, and recovery
 │   └── *.ts                     # Config, policy, snapshot, S3, lock, and format modules
 ├── test/
@@ -476,7 +476,7 @@ extensions/pi-sync/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, settings sync, Git, GitHub, GitLab, Forgejo, WebDAV, Nextcloud, ownCloud, Synology, Cloudflare R2, S3-compatible storage, multi-profile sync, sync targets, snapshot sync, dotfiles sync.
+Pi extension, Pi coding agent, settings sync, Git, GitHub, GitLab, Forgejo, WebDAV, Nextcloud, ownCloud, Synology, Cloudflare R2, S3-compatible storage, storage connections, sync setups, snapshot sync, dotfiles sync.
 
 ## 📄 License
 

--- a/extensions/pi-sync/src/command.ts
+++ b/extensions/pi-sync/src/command.ts
@@ -7,10 +7,10 @@ const YES_FLAG_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 ];
 export const SYNC_COMMANDS = [
 	{ name: "help", description: "Show command usage" },
-	{ name: "use", description: "Switch the current sync target", usageSuffix: " <target>" },
+	{ name: "use", description: "Switch the current sync setup", usageSuffix: " <setup>" },
 	{ name: "init", description: "Create local config template" },
 	{ name: "config", description: "Show resolved configuration" },
-	{ name: "files", description: "Choose synced files" },
+	{ name: "files", description: "Choose included content" },
 	{ name: "status", description: "Show sync status" },
 	{ name: "diff", description: "Show local/remote diff" },
 	{ name: "doctor", description: "Check config, secrets, and lock state" },
@@ -35,7 +35,7 @@ export function setSyncTargetCompletions(names: readonly string[]) {
 const TARGET_FLAG_COMPLETION = {
 	value: "--target",
 	label: "--target",
-	description: "Address a target without switching",
+	description: "Address a sync setup without switching",
 } as const;
 const SYNC_FLAG_COMPLETIONS: Record<string, readonly CommandArgumentCompletion[]> = {
 	config: [TARGET_FLAG_COMPLETION],
@@ -83,7 +83,7 @@ export function parseOptions(args: string[]): CommandOptions {
 		else if (arg === "--stale") stale = true;
 		else if (arg === "--target") {
 			const name = args[index + 1];
-			if (!name || name.startsWith("-")) throw new Error("--target requires a target name.");
+			if (!name || name.startsWith("-")) throw new Error("--target requires a sync setup name.");
 			if (target !== undefined) throw new Error("--target may be provided only once.");
 			target = name;
 			index += 1;
@@ -129,7 +129,7 @@ export function validateCommandOptions(command: string, options: CommandOptions)
 	if (options.args.length !== expectedValues) {
 		if (command === "rollback")
 			throw new Error("Usage: /sync rollback <snapshot-id> [--yes] [--target <name>]");
-		if (command === "use") throw new Error("Usage: /sync use <target>");
+		if (command === "use") throw new Error("Usage: /sync use <setup>");
 		throw new Error(`Unexpected argument for /sync ${command}: ${options.args.join(" ")}`);
 	}
 }
@@ -189,7 +189,7 @@ function completeTargetValue(prefix: string, current: string) {
 		? matches.map((name) => ({
 				value: `${completionPrefix}${name}`,
 				label: name,
-				description: "Sync target",
+				description: "Sync setup",
 			}))
 		: null;
 }
@@ -230,6 +230,6 @@ export function usage() {
 	return [
 		"Usage: /sync <command>",
 		`Commands: ${commands}`,
-		"Settings: use /sync init or edit profiles and targets in ~/.pi/agent/pi-sync.json (or $PI_CODING_AGENT_DIR/pi-sync.json). Existing S3-only PI_SYNC_* overrides still work but are deprecated for future major-version removal.",
+		"Settings: use /sync init or edit storage connections (`profiles`) and sync setups (`targets`) in ~/.pi/agent/pi-sync.json (or $PI_CODING_AGENT_DIR/pi-sync.json). Existing S3-only PI_SYNC_* overrides still work but are deprecated for future major-version removal.",
 	].join("\n");
 }

--- a/extensions/pi-sync/src/file-selection.ts
+++ b/extensions/pi-sync/src/file-selection.ts
@@ -44,7 +44,7 @@ export async function showFileSelection(ctx: ExtensionCommandContext, targetName
 	if (ctx.mode !== "tui") {
 		ctx.ui.notify(
 			[
-				`pi-sync selected files for target ${safeTerminalText(partial.target ?? "default")}:`,
+				`pi-sync included content for sync setup ${safeTerminalText(partial.target ?? "default")}:`,
 				`built-ins: ${[...draft.builtIns].join(", ") || "none"}`,
 				`sessions: ${draft.sessions ? INCLUDED : EXCLUDED}${sessionEnvironmentOverride ? " (PI_SYNC_SESSIONS, deprecated)" : ""}`,
 				`extra files: ${[...draft.extras].map(safeTerminalText).join(", ") || "none"}`,
@@ -78,7 +78,7 @@ export async function showFileSelection(ctx: ExtensionCommandContext, targetName
 		try {
 			await persistSelectionDraft(draft, targetName, sessionEnvironmentOverride);
 			ctx.ui.notify(
-				`Saved synced content for target “${safeTerminalText(partial.target ?? "default")}”. It applies to the next manual or automatic sync.`,
+				`Saved included content for sync setup “${safeTerminalText(partial.target ?? "default")}”. It applies to the next manual or automatic sync.`,
 				"info",
 			);
 		} catch (error) {
@@ -109,7 +109,7 @@ async function showDraftEditor(
 			id: SESSIONS_ID,
 			label: "sessions",
 			description: sessionEnvironmentOverride
-				? "Read-only because deprecated PI_SYNC_SESSIONS currently overrides this target. Move it into target settings before the future major removal."
+				? "Read-only because deprecated PI_SYNC_SESSIONS currently overrides this setup. Move it into sync setup settings before the future major removal."
 				: "Session JSONL may contain prompts, tool output, paths, images, and secrets. Sync only to storage you trust.",
 			currentValue: sessionEnvironmentOverride
 				? `${draft.sessions ? INCLUDED : EXCLUDED} (environment, deprecated)`
@@ -134,7 +134,7 @@ async function showDraftEditor(
 		const hint = new Text("", 1, 0);
 		const updateChrome = () => {
 			title.setText(
-				theme.fg("accent", theme.bold(`Synced Content · ${safeTerminalText(targetName)}`)),
+				theme.fg("accent", theme.bold(`Included Content · ${safeTerminalText(targetName)}`)),
 			);
 			hint.setText(theme.fg("dim", "Draft only · Esc reviews Save, Discard, or Continue editing."));
 		};
@@ -200,9 +200,9 @@ async function persistSelectionDraft(
 		const targets = asObject(current.targets);
 		const selectedTarget =
 			targetName ?? (typeof current.activeTarget === "string" ? current.activeTarget : undefined);
-		if (!targets || !selectedTarget) throw new Error("Current sync target is not configured.");
+		if (!targets || !selectedTarget) throw new Error("Current sync setup is not configured.");
 		const target = asObject(targets[selectedTarget]);
-		if (!target) throw new Error(`Sync target not found: ${selectedTarget}`);
+		if (!target) throw new Error(`Sync setup not found: ${selectedTarget}`);
 		return {
 			...current,
 			targets: { ...targets, [selectedTarget]: { ...target, ...selection } },

--- a/extensions/pi-sync/src/git-ui.ts
+++ b/extensions/pi-sync/src/git-ui.ts
@@ -21,7 +21,7 @@ export async function showGitSetup(
 	targetName: string,
 	signal?: AbortSignal,
 ) {
-	const profileName = await requiredInput(ctx, "Name this saved Git connection", "git", signal);
+	const profileName = await requiredInput(ctx, "Name this Git storage connection", "git", signal);
 	if (!profileName) return false;
 	const remoteInput = await requiredInput(
 		ctx,
@@ -33,7 +33,7 @@ export async function showGitSetup(
 	const destination = await promptGitDestination(ctx, targetName, signal);
 	if (!destination) return false;
 	const automatic = await ctx.ui.select(
-		"Automatic sync for this target",
+		"Automatic sync for this setup",
 		["Enable automatic sync", "Keep automatic sync off", "Cancel"],
 		{ signal },
 	);
@@ -49,15 +49,15 @@ export async function showGitSetup(
 	if (!remote) return false;
 	const choice = await ctx.ui.select(
 		[
-			"Review Git setup",
+			"Review Git sync setup",
 			"",
-			`Target: ${safeTerminalText(targetName)}`,
-			`Saved connection: ${safeTerminalText(profileName)} (Git)`,
+			`Sync setup: ${safeTerminalText(targetName)}`,
+			`Storage connection: ${safeTerminalText(profileName)} (Git)`,
 			`Remote: ${safeGitRemote(remote)}`,
 			`Owned branch: ${safeTerminalText(destination.branch)}`,
-			`Remote directory: ${safeTerminalText(`${destination.directory}/profiles/${destination.namespace}/`)}`,
-			`Synced content: ${DEFAULT_SYNC_FILES.length} built-in groups · Sessions: Off`,
-			`Auto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
+			`Storage location: ${safeTerminalText(`${destination.directory}/profiles/${destination.namespace}/`)}`,
+			`Included content: ${DEFAULT_SYNC_FILES.length} built-in groups · Sessions: Off`,
+			`Automatic sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
 			"Authentication: existing non-interactive Git/SSH credentials; no credentials are stored by pi-sync.",
 			"The remote repository must already exist. The owned branch may be created on first push.",
 		].join("\n"),
@@ -80,14 +80,14 @@ export async function showGitSetup(
 	});
 	if (signal?.aborted) return true;
 	ctx.ui.notify(
-		`Saved Git destination “${safeTerminalText(targetName)}”. Run /sync doctor.`,
+		`Saved Git sync setup “${safeTerminalText(targetName)}”. Run /sync doctor.`,
 		"info",
 	);
 	return true;
 }
 
 export async function showAddGitStorageProfile(ctx: ExtensionCommandContext, signal?: AbortSignal) {
-	const name = await requiredInput(ctx, "Name this saved Git connection", "git", signal);
+	const name = await requiredInput(ctx, "Name this Git storage connection", "git", signal);
 	if (!name) return false;
 	const remoteInput = await requiredInput(
 		ctx,
@@ -105,15 +105,15 @@ export async function showAddGitStorageProfile(ctx: ExtensionCommandContext, sig
 	}
 	if (!remote) return false;
 	const choice = await ctx.ui.select(
-		`Review saved connection\n\nName: ${safeTerminalText(name)}\nType: Git\nRemote: ${safeGitRemote(remote)}\nCredentials: existing Git/SSH authentication (not stored)`,
-		["Add connection", "Cancel"],
+		`Review storage connection\n\nName: ${safeTerminalText(name)}\nType: Git\nRemote: ${safeGitRemote(remote)}\nCredentials: existing Git/SSH authentication (not stored)\nAdding a connection does not contact the remote or start syncing.`,
+		["Add storage connection", "Cancel"],
 		{ signal },
 	);
 	throwIfAborted(signal);
-	if (choice !== "Add connection") return false;
+	if (choice !== "Add storage connection") return false;
 	await addStorageProfile(name, { kind: "git", remote });
 	if (signal?.aborted) return true;
-	ctx.ui.notify(`Added saved connection “${safeTerminalText(name)}”.`, "info");
+	ctx.ui.notify(`Added storage connection “${safeTerminalText(name)}”.`, "info");
 	return true;
 }
 
@@ -122,6 +122,7 @@ export async function showEditGitStorageProfile(
 	name: string,
 	profile: Record<string, unknown>,
 	signal?: AbortSignal,
+	affectedSetups?: string[],
 ) {
 	const remoteInput = await requiredInput(
 		ctx,
@@ -141,15 +142,19 @@ export async function showEditGitStorageProfile(
 	}
 	if (!remote) return false;
 	const choice = await ctx.ui.select(
-		`Review connection\n\nSaved connection: ${safeTerminalText(name)}\nRemote: ${safeGitRemote(remote)}\nChanging it does not move or delete remote history.`,
-		["Save profile", "Cancel"],
+		`Review storage connection\n\nStorage connection: ${safeTerminalText(name)}\nRemote: ${safeGitRemote(String(profile.remote ?? "missing"))} → ${safeGitRemote(remote)}\nAffected sync setups: ${affectedSetups && affectedSetups.length > 0 ? affectedSetups.map(safeTerminalText).join(", ") : "None"}\nSaving changes future storage access for every affected setup; it does not move or delete remote history.`,
+		["Save storage connection", "Cancel"],
 		{ signal },
 	);
 	throwIfAborted(signal);
-	if (choice !== "Save profile") return false;
-	await updateStorageProfile(name, (current) => ({ ...current, kind: "git", remote }));
+	if (choice !== "Save storage connection") return false;
+	await updateStorageProfile(
+		name,
+		(current) => ({ ...current, kind: "git", remote }),
+		affectedSetups,
+	);
 	if (signal?.aborted) return true;
-	ctx.ui.notify(`Saved connection “${safeTerminalText(name)}”.`, "info");
+	ctx.ui.notify(`Saved storage connection “${safeTerminalText(name)}”.`, "info");
 	return true;
 }
 
@@ -162,7 +167,7 @@ export async function showAddGitTarget(
 	const destination = await promptGitDestination(ctx, name, signal);
 	if (!destination) return false;
 	const preset = await ctx.ui.select(
-		"Choose synced content",
+		"Choose included content",
 		["Recommended Pi settings", "Minimal settings", "Cancel"],
 		{ signal },
 	);
@@ -171,19 +176,19 @@ export async function showAddGitTarget(
 	const syncFiles =
 		preset === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
 	const automatic = await ctx.ui.select(
-		"Automatic sync for this target",
+		"Automatic sync for this setup",
 		["Enable automatic sync", "Keep automatic sync off", "Cancel"],
 		{ signal },
 	);
 	throwIfAborted(signal);
 	if (!automatic || automatic === "Cancel") return false;
 	const choice = await ctx.ui.select(
-		`Review Git target\n\nTarget: ${safeTerminalText(name)}\nSaved connection: ${safeTerminalText(profile)}\nOwned branch: ${safeTerminalText(destination.branch)}\nRemote directory: ${safeTerminalText(`${destination.directory}/profiles/${destination.namespace}/`)}\nSynced content: ${syncFiles.length} built-in groups · Sessions: Off\nAuto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
-		["Add target", "Cancel"],
+		`Review Git sync setup\n\nSync setup: ${safeTerminalText(name)}\nStorage connection: ${safeTerminalText(profile)}\nOwned branch: ${safeTerminalText(destination.branch)}\nStorage location: ${safeTerminalText(`${destination.directory}/profiles/${destination.namespace}/`)}\nIncluded content: ${syncFiles.length} built-in groups · Sessions: Off\nAutomatic sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
+		["Add sync setup", "Cancel"],
 		{ signal },
 	);
 	throwIfAborted(signal);
-	if (choice !== "Add target") return false;
+	if (choice !== "Add sync setup") return false;
 	await addSyncTarget(name, {
 		profile,
 		...destination,
@@ -193,7 +198,7 @@ export async function showAddGitTarget(
 		extraFiles: [],
 	});
 	if (signal?.aborted) return true;
-	ctx.ui.notify(`Added sync target “${safeTerminalText(name)}”.`, "info");
+	ctx.ui.notify(`Added sync setup “${safeTerminalText(name)}”.`, "info");
 	return true;
 }
 
@@ -202,7 +207,7 @@ export async function showEditGitTarget(
 	partial: PartialConfig,
 	signal?: AbortSignal,
 ) {
-	if (!partial.target) throw new Error("Git target is not configured.");
+	if (!partial.target) throw new Error("Git sync setup is not configured.");
 	const targetName = partial.target;
 	const destination = await promptGitDestination(ctx, targetName, signal, partial);
 	if (!destination) return false;
@@ -219,15 +224,15 @@ export async function showEditGitTarget(
 		return false;
 	}
 	const choice = await ctx.ui.select(
-		`Review target “${safeTerminalText(targetName)}”\n\nBranch: ${safeTerminalText(partial.branch ?? "pi-sync")} → ${safeTerminalText(destination.branch)}\nDirectory: ${safeTerminalText(partial.directory ?? "pi-sync")} → ${safeTerminalText(destination.directory)}\nNamespace: ${safeTerminalText(partial.profile ?? targetName)} → ${safeTerminalText(destination.namespace)}\nSaving changes future sync destination only; it does not move or delete remote history.`,
-		["Save target", "Cancel"],
+		`Review sync setup “${safeTerminalText(targetName)}”\n\nBranch: ${safeTerminalText(partial.branch ?? "pi-sync")} → ${safeTerminalText(destination.branch)}\nDirectory: ${safeTerminalText(partial.directory ?? "pi-sync")} → ${safeTerminalText(destination.directory)}\nNamespace: ${safeTerminalText(partial.profile ?? targetName)} → ${safeTerminalText(destination.namespace)}\nSaving changes the future storage location only; it does not move or delete remote history.`,
+		["Save sync setup", "Cancel"],
 		{ signal },
 	);
 	throwIfAborted(signal);
-	if (choice !== "Save target") return false;
+	if (choice !== "Save sync setup") return false;
 	await updateSyncTarget(targetName, (target) => ({ ...target, ...destination }));
 	if (signal?.aborted) return true;
-	ctx.ui.notify(`Saved target “${safeTerminalText(targetName)}”.`, "info");
+	ctx.ui.notify(`Saved sync setup “${safeTerminalText(targetName)}”.`, "info");
 	return true;
 }
 

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -21,7 +21,6 @@ import {
 	requiredExistingBucket,
 	requiredInput,
 	safeTerminalText,
-	storageDescription,
 } from "./manager-helpers.js";
 import { chooseS3Credentials } from "./s3-credentials-ui.js";
 import {
@@ -34,6 +33,7 @@ import {
 import { showSyncSettings } from "./settings-ui.js";
 import { showAddStorageConnection, showStorageConnections } from "./storage-connections-ui.js";
 import { DEFAULT_SYNC_FILES } from "./sync-policy.js";
+import { countValidSyncSetups, showSyncSetups } from "./sync-setups-ui.js";
 import { type TargetPullOutcome, useSyncTarget } from "./target-switch.js";
 import type { AnySyncConfig } from "./types.js";
 import {
@@ -46,18 +46,23 @@ import {
 
 export const MAIN_MENU_ACTIONS = [
 	"Sync now (recommended)",
-	"Pull from remote",
-	"Push to remote",
-	"Switch target",
+	"Switch sync setup",
 	"Status & changes",
 	"Settings",
 	"More…",
 ] as const;
-const MORE_MENU_ACTIONS = ["Manage destinations", "History & recovery", "Help", "Back"] as const;
+const MORE_MENU_ACTIONS = [
+	"Pull from remote…",
+	"Push to remote…",
+	"Sync setups…",
+	"Storage connections…",
+	"History & recovery…",
+	"Help",
+	"Back",
+] as const;
 const BACK = "Back";
 
 type MainMenuAction = (typeof MAIN_MENU_ACTIONS)[number];
-type ContextualMenuAction = "Manage destinations" | "History & recovery" | "Help";
 type RunRoute = (
 	route: string,
 	signal?: AbortSignal,
@@ -83,44 +88,25 @@ export async function showSyncManager(
 		switch (
 			selected as
 				| MainMenuAction
-				| ContextualMenuAction
+				| "Sync setups…"
+				| "Storage connections…"
+				| "History & recovery…"
+				| "Help"
 				| "Set up sync"
 				| "Use existing settings"
-				| "Repair WebDAV destination"
+				| "Repair WebDAV storage location"
 		) {
 			case "Sync now (recommended)":
-				await runCancellableOperation(ctx, "Checking current target…", "sync", runRoute, true);
+				await runCancellableOperation(ctx, "Checking current sync setup…", "sync", runRoute, true);
 				break;
-			case "Pull from remote": {
-				const result = await runCancellableOperation(
-					ctx,
-					"Checking remote changes…",
-					"pull",
-					runRoute,
-					true,
-					"Pull check cancelled; no local files were changed.",
-				);
-				if (result === "applied") return;
-				break;
-			}
-			case "Push to remote":
-				await runCancellableOperation(
-					ctx,
-					"Preparing push preview…",
-					"push",
-					runRoute,
-					true,
-					"Push preparation cancelled; no remote files were changed.",
-				);
-				break;
-			case "Switch target": {
+			case "Switch sync setup": {
 				const result = await showTargetSwitcher(ctx, runRoute);
 				if (result === "pull-attempted") return;
 				if (result === "switched") continue;
 				break;
 			}
 			case "Status & changes":
-				await runCancellableOperation(ctx, "Checking current target…", "diff", runRoute);
+				await runCancellableOperation(ctx, "Checking current sync setup…", "diff", runRoute);
 				break;
 			case "Settings":
 				await showSyncSettings(ctx, runRoute);
@@ -128,13 +114,16 @@ export async function showSyncManager(
 			case "More…":
 				if ((await showMoreMenu(ctx, runRoute, sessionSignal)) === "exit") return;
 				break;
-			case "Manage destinations":
-				await showManageMenu(ctx, runRoute, sessionSignal);
+			case "Sync setups…":
+				if ((await showSyncSetupManager(ctx, runRoute, sessionSignal)) === "exit") return;
 				break;
-			case "Repair WebDAV destination":
+			case "Storage connections…":
+				await showStorageConnections(ctx, sessionSignal);
+				break;
+			case "Repair WebDAV storage location":
 				await showRepairableWebDavDestination(ctx, sessionSignal);
 				break;
-			case "History & recovery":
+			case "History & recovery…":
 				await showRecoveryMenu(ctx, runRoute);
 				break;
 			case "Help":
@@ -155,8 +144,32 @@ async function showMoreMenu(
 ) {
 	const selected = await ctx.ui.select("More options", [...MORE_MENU_ACTIONS], { signal });
 	if (!selected || selected === BACK) return;
-	if (selected === "Manage destinations") await showManageMenu(ctx, runRoute, signal);
-	else if (selected === "History & recovery") await showRecoveryMenu(ctx, runRoute);
+	if (selected === "Pull from remote…") {
+		const result = await runCancellableOperation(
+			ctx,
+			"Checking remote changes…",
+			"pull",
+			runRoute,
+			true,
+			"Pull check cancelled; no local files were changed.",
+		);
+		if (result === "applied") return "exit" as const;
+		return;
+	}
+	if (selected === "Push to remote…") {
+		await runCancellableOperation(
+			ctx,
+			"Preparing push preview…",
+			"push",
+			runRoute,
+			true,
+			"Push preparation cancelled; no remote files were changed.",
+		);
+		return;
+	}
+	if (selected === "Sync setups…") return showSyncSetupManager(ctx, runRoute, signal);
+	else if (selected === "Storage connections…") await showStorageConnections(ctx, signal);
+	else if (selected === "History & recovery…") await showRecoveryMenu(ctx, runRoute);
 	else {
 		await runRoute("help");
 		return "exit" as const;
@@ -236,7 +249,7 @@ async function describeManagerState(
 				"",
 				"Repair the JSON file, then reopen /sync.",
 			].join("\n"),
-			actions: repairableWebDav ? ["Repair WebDAV destination", "Help"] : ["Help"],
+			actions: repairableWebDav ? ["Repair WebDAV storage location", "Help"] : ["Help"],
 		};
 	}
 	if (!raw) {
@@ -251,12 +264,12 @@ async function describeManagerState(
 			title: [
 				"Pi Sync",
 				"",
-				"No sync targets are configured.",
-				"Add a target using an existing storage profile.",
+				"No sync setups are configured.",
+				"Add a sync setup using an existing storage connection.",
 				"",
 				"What do you want to do?",
 			].join("\n"),
-			actions: ["Manage destinations", "Help"],
+			actions: ["Sync setups…", "Storage connections…", "Help"],
 		};
 	}
 	try {
@@ -282,20 +295,26 @@ async function describeManagerState(
 				: syncState
 					? "Never synced"
 					: "Unavailable";
+		const canSwitch = (await countValidSyncSetups(configuredTargets, signal)) > 1;
+		const mainActions = MAIN_MENU_ACTIONS.filter(
+			(action) => action !== "Switch sync setup" || canSwitch,
+		);
 		return {
 			title: [
 				"Pi Sync",
 				"",
-				`Current target: ${safeTerminalText(target)}`,
+				`Current sync setup: ${safeTerminalText(target)}`,
 				`Storage: ${storage}`,
-				`Consistency: ${backendConsistencyDescription(config)}`,
-				`Synced content: ${builtInCount} built-in group${builtInCount === 1 ? "" : "s"} · ${extraFileCount} extra file${extraFileCount === 1 ? "" : "s"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
-				`Auto-sync: ${config.autoSync ? "On" : "Off"}`,
-				`Last applied snapshot: ${lastAppliedSnapshot}`,
-				"Remote changes: Not checked",
+				`Included: ${builtInCount} built-in group${builtInCount === 1 ? "" : "s"} · ${extraFileCount} extra file${extraFileCount === 1 ? "" : "s"} · Sessions ${config.syncSessions ? "on" : "off"}`,
+				`Automatic sync: ${config.autoSync ? "On" : "Off"}`,
+				`Last applied: ${lastAppliedSnapshot}`,
+				"Remote status: Not checked",
 				...warnings.map((warning) => `Warning: ${safeTerminalText(warning)}`),
 				...(noSyncedContent
-					? ["", "No synced content is selected. Choose synced content in Settings before syncing."]
+					? [
+							"",
+							"No included content is selected. Choose included content in Settings before syncing.",
+						]
 					: []),
 				...(liveLock
 					? [
@@ -311,56 +330,44 @@ async function describeManagerState(
 			].join("\n"),
 			actions:
 				liveLock || recoverableLock
-					? ["Status & changes", "History & recovery", "Help"]
+					? ["Status & changes", "History & recovery…", "Help"]
 					: noSyncedContent
-						? ["Settings", "Switch target", "Status & changes", "More…"]
-						: [...MAIN_MENU_ACTIONS],
+						? ["Settings", ...(canSwitch ? ["Switch sync setup"] : []), "Status & changes", "More…"]
+						: mainActions,
 		};
 	} catch (error) {
-		const targets = ownRecord(raw.targets);
+		if (signal?.aborted) throw error;
 		return {
 			title: [
 				"Pi Sync",
 				"",
 				"Settings need attention. Automatic sync is paused.",
-				`Current target: ${safeTerminalText(typeof raw.activeTarget === "string" ? raw.activeTarget : "default")}`,
+				`Current sync setup: ${safeTerminalText(typeof raw.activeTarget === "string" ? raw.activeTarget : "default")}`,
 				`Error: ${safeTerminalText(errorMessage(error))}`,
 				`File: ${safeTerminalText(await activeLocalConfigPath())}`,
 				"",
 				"What do you want to do?",
 			].join("\n"),
-			actions: [
-				...(targets && Object.keys(targets).length > 1 ? ["Switch target"] : []),
-				"Manage destinations",
-				"Help",
-			],
+			actions: ["Sync setups…", "Storage connections…", "History & recovery…", "Help"],
 		};
 	}
 }
 
-function backendConsistencyDescription(config: AnySyncConfig) {
-	switch (config.backend.type) {
-		case "git":
-			return "Exact expected-branch lease";
-		case "webdav":
-			return "Verified atomic conditional update required";
-		case "s3":
-			return "Read, check, write, and verify; simultaneous unseen races remain possible";
-	}
-}
-
 function backendStorageDescription(config: AnySyncConfig) {
+	const connection = safeTerminalText(config.storageProfile ?? "default");
 	switch (config.backend.type) {
-		case "s3":
-			return storageDescription(
-				config.backend.profile.kind,
-				config.backend.profile.endpoint,
-				config.backend.destination.bucket,
-			);
+		case "s3": {
+			const type =
+				config.backend.profile.kind === "r2" ||
+				isCloudflareR2Endpoint(config.backend.profile.endpoint)
+					? "Cloudflare R2"
+					: "S3-compatible";
+			return `${type} · ${connection} · ${safeTerminalText(config.backend.destination.bucket)}`;
+		}
 		case "webdav":
-			return `WebDAV · ${safeTerminalText(config.backend.destination.path)}`;
+			return `WebDAV · ${connection} · ${safeTerminalText(config.backend.destination.path)}`;
 		case "git":
-			return `Git · ${safeTerminalText(config.backend.destination.branch)}`;
+			return `Git · ${connection} · ${safeTerminalText(config.backend.destination.branch)}`;
 	}
 }
 
@@ -376,11 +383,13 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	if (!targetName) return false;
 	if (preset === "WebDAV") {
 		const saved = await showWebDavSetup(ctx, targetName, signal);
+		if (signal?.aborted) return false;
 		if (saved) await refreshTargetCompletions();
 		return saved;
 	}
 	if (preset === "Git") {
 		const saved = await showGitSetup(ctx, targetName, signal);
+		if (signal?.aborted) return false;
 		if (saved) await refreshTargetCompletions();
 		return saved;
 	}
@@ -412,7 +421,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	const syncFiles =
 		contentChoice === "Minimal settings" ? ["settings.json", "AGENTS.md"] : [...DEFAULT_SYNC_FILES];
 	const automaticChoice = await ctx.ui.select(
-		"Automatic sync for this target",
+		"Automatic sync for this setup",
 		["Enable automatic sync", "Keep automatic sync off", "Cancel"],
 		{ signal },
 	);
@@ -437,22 +446,22 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	const autoSync = automaticChoice === "Enable automatic sync";
 	const choice = await ctx.ui.select(
 		[
-			"Review setup",
+			"Review sync setup",
 			"",
-			`Target: ${safeTerminalText(targetName)}`,
-			`Storage profile: ${safeTerminalText(profileName)} (${preset})`,
+			`Sync setup: ${safeTerminalText(targetName)}`,
+			`Storage connection: ${safeTerminalText(profileName)} (${preset})`,
 			`Endpoint: ${safeTerminalText(endpoint)}`,
 			`Bucket: ${safeTerminalText(bucket)}`,
-			`Remote path: ${formatRemotePath(prefix, namespace)}`,
+			`Storage location: ${formatRemotePath(prefix, namespace)}`,
 			"Bucket must already exist. pi-sync will not create it.",
-			`Synced content: ${syncFiles.length} built-in groups · Sessions: ${syncSessions ? "On — privacy warning acknowledged" : "Off"}`,
-			`Auto-sync: ${autoSync ? "On" : "Off"}`,
+			`Included content: ${syncFiles.length} built-in groups · Sessions: ${syncSessions ? "On — privacy warning acknowledged" : "Off"}`,
+			`Automatic sync: ${autoSync ? "On" : "Off"}`,
 			`Credentials: ${safeTerminalText(credentials.summary)}`,
 		].join("\n"),
-		["Save setup", "Cancel"],
+		["Save sync setup", "Cancel"],
 		{ signal },
 	);
-	if (signal?.aborted || choice !== "Save setup") return false;
+	if (signal?.aborted || choice !== "Save sync setup") return false;
 	await saveNewV2Settings({
 		targetName,
 		storageProfileName: profileName,
@@ -476,56 +485,63 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	await refreshTargetCompletions();
 	ctx.ui.notify(
 		credentials.ready
-			? `Destination “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
-			: `Saved destination “${safeTerminalText(targetName)}”; add credentials before syncing.`,
+			? `Sync setup “${safeTerminalText(targetName)}” is ready. Use Sync now when ready.`
+			: `Saved sync setup “${safeTerminalText(targetName)}”; add credentials before syncing.`,
 		"info",
 	);
 	return true;
 }
 
-async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRoute) {
+async function showTargetSwitcher(
+	ctx: ExtensionCommandContext,
+	runRoute: RunRoute,
+	selectedName?: string,
+) {
 	const raw = await readLocalConfigObject();
 	if (raw?.version !== 2) {
-		ctx.ui.notify("Add a second sync target before switching targets.", "info");
+		ctx.ui.notify("Add a second sync setup before switching setups.", "info");
 		return false;
 	}
 	const targets = ownRecord(raw.targets);
 	if (!targets) {
-		ctx.ui.notify("No sync targets are configured.", "warning");
+		ctx.ui.notify("No sync setups are configured.", "warning");
 		return false;
 	}
 	const active = typeof raw.activeTarget === "string" ? raw.activeTarget : undefined;
-	const profiles = ownRecord(raw.profiles);
-	const names = Object.keys(targets).sort((left, right) => left.localeCompare(right));
-	const labels = new Map<string, string>();
-	for (const name of names) {
-		const target = ownRecord(targets[name]);
-		const profileName = typeof target?.profile === "string" ? target.profile : undefined;
-		const profile = profileName && profiles ? ownRecord(profiles[profileName]) : undefined;
-		const label = [
-			`${safeTerminalText(name)}${name === active ? " (current)" : ""}`,
-			profile
-				? `${safeTerminalText(profileName ?? "unknown")} · ${safeTerminalText(
-						profile.kind === "webdav"
-							? String(target?.path ?? "pi-sync")
-							: profile.kind === "git"
-								? String(target?.branch ?? "pi-sync")
-								: String(target?.bucket ?? "missing bucket"),
-					)}`
-				: `Invalid: missing storage profile ${safeTerminalText(profileName ?? "reference")}`,
-			`${normalizeSyncFiles(target?.syncFiles as string[] | undefined).length} groups · Sessions: ${target?.syncSessions === true ? "On" : "Off"}`,
-		].join(" · ");
-		labels.set(label, name);
+	let name = selectedName;
+	if (!name) {
+		const profiles = ownRecord(raw.profiles);
+		const labels = new Map<string, string>();
+		for (const candidate of Object.keys(targets).sort((left, right) => left.localeCompare(right))) {
+			const target = ownRecord(targets[candidate]);
+			const profileName = typeof target?.profile === "string" ? target.profile : undefined;
+			const profile = profileName && profiles ? ownRecord(profiles[profileName]) : undefined;
+			const location = profile
+				? profile.kind === "webdav"
+					? String(target?.path ?? "pi-sync")
+					: profile.kind === "git"
+						? String(target?.branch ?? "pi-sync")
+						: String(target?.bucket ?? "missing bucket")
+				: `invalid: missing connection ${profileName ?? "reference"}`;
+			const label = `${safeTerminalText(candidate)}${candidate === active ? " (current)" : ""} · ${safeTerminalText(profileName ?? "unknown")} · ${safeTerminalText(location)}`;
+			labels.set(label, candidate);
+		}
+		const selected = await ctx.ui.select(
+			`Switch sync setup\n\nCurrent sync setup: ${safeTerminalText(active ?? "none")}`,
+			[...labels.keys(), BACK],
+		);
+		if (!selected || selected === BACK) return false;
+		name = labels.get(selected);
 	}
-	const options = [...labels.keys(), BACK];
-	const selected = await ctx.ui.select(
-		`Switch target\n\nCurrent target: ${safeTerminalText(active ?? "none")}`,
-		options,
-	);
-	if (!selected || selected === BACK) return false;
-	const name = labels.get(selected) ?? selected.replace(/ \(current\)$/u, "");
+	if (!name || !Object.hasOwn(targets, name)) {
+		ctx.ui.notify(
+			`Sync setup “${safeTerminalText(name ?? "unknown")}” no longer exists.`,
+			"warning",
+		);
+		return false;
+	}
 	if (name === active) {
-		ctx.ui.notify(`Target “${safeTerminalText(name)}” is already current.`, "info");
+		ctx.ui.notify(`Sync setup “${safeTerminalText(name)}” is already current.`, "info");
 		return false;
 	}
 	let config: AnySyncConfig;
@@ -533,7 +549,7 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 		config = await loadConfig(name);
 	} catch (error) {
 		ctx.ui.notify(
-			`Cannot use target “${safeTerminalText(name)}”: ${safeTerminalText(errorMessage(error))}`,
+			`Cannot use sync setup “${safeTerminalText(name)}”: ${safeTerminalText(errorMessage(error))}`,
 			"error",
 		);
 		return false;
@@ -541,80 +557,98 @@ async function showTargetSwitcher(ctx: ExtensionCommandContext, runRoute: RunRou
 	const targetSwitchAction = await loadTargetSwitchAction();
 	const switchEffect =
 		targetSwitchAction === "ask"
-			? "After switching, pi-sync will ask whether to review a pull for the target."
+			? "After switching, pi-sync will ask whether to review a pull for this setup."
 			: targetSwitchAction === "pull"
-				? "After switching, pi-sync will check the target and show exact changes before applying them."
+				? "After switching, pi-sync will check this setup and show exact changes before applying them."
 				: "After switching, pi-sync will not pull or modify synced files.";
 	const choice = await ctx.ui.select(
 		[
-			"Switch target",
+			"Switch sync setup",
 			"",
 			`From: ${safeTerminalText(active ?? "none")}`,
 			`To: ${safeTerminalText(name)}`,
 			`Storage: ${backendStorageDescription(config)}`,
-			`Synced content: ${normalizeSyncFiles(config.syncFiles).length} built-in groups · ${config.extraFiles.length} extra files`,
-			`Auto-sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
+			`Included content: ${normalizeSyncFiles(config.syncFiles).length} built-in groups · ${config.extraFiles.length} extra files`,
+			`Automatic sync: ${config.autoSync ? "On" : "Off"} · Sessions: ${config.syncSessions ? "On" : "Off"}`,
 			"",
 			switchEffect,
 		].join("\n"),
 		[`Switch to ${safeTerminalText(name)}`, "Cancel"],
 	);
 	if (choice !== `Switch to ${safeTerminalText(name)}`) return false;
-	const result = await useSyncTarget(ctx, name, (selectedTarget) =>
-		runCancellableOperation(
+	try {
+		const result = await useSyncTarget(
 			ctx,
-			`Pulling target “${safeTerminalText(name)}”…`,
-			"pull",
-			runRoute,
-			true,
-			null,
-			selectedTarget,
-		),
-	);
-	return result.pullApplied ? "pull-attempted" : "switched";
+			name,
+			(selectedTarget) =>
+				runCancellableOperation(
+					ctx,
+					`Pulling sync setup “${safeTerminalText(name)}”…`,
+					"pull",
+					runRoute,
+					true,
+					null,
+					selectedTarget,
+				),
+			targetSwitchAction,
+		);
+		return result.pullApplied ? "pull-attempted" : "switched";
+	} catch (error) {
+		ctx.ui.notify(
+			`Sync setup “${safeTerminalText(name)}” was not switched: ${safeTerminalText(errorMessage(error))}`,
+			"error",
+		);
+		return false;
+	}
 }
 
-async function showManageMenu(
+async function showSyncSetupManager(
 	ctx: ExtensionCommandContext,
-	_runRoute: RunRoute,
+	runRoute: RunRoute,
 	signal?: AbortSignal,
 ) {
-	const selected = await ctx.ui.select(
-		"Manage destinations",
-		[
-			"Add destination",
-			"Edit current destination",
-			"Saved connections…",
-			"Remove destination",
-			BACK,
-		],
-		{ signal },
+	return showSyncSetups(
+		ctx,
+		{
+			add: async (setupSignal) => {
+				await showAddTarget(ctx, setupSignal);
+			},
+			edit: async (name, setupSignal) => {
+				await showEditTarget(ctx, name, setupSignal);
+			},
+			makeCurrent: async (name) => {
+				const result = await showTargetSwitcher(ctx, runRoute, name);
+				return result === "pull-attempted" ? "exit" : undefined;
+			},
+			remove: async (name) => {
+				await showRemoveTarget(ctx, name);
+			},
+		},
+		signal,
 	);
-	if (!selected || selected === BACK) return;
-	if (selected === "Add destination") await showAddTarget(ctx, signal);
-	else if (selected === "Edit current destination") await showEditCurrentTarget(ctx, signal);
-	else if (selected === "Saved connections…") await showStorageConnections(ctx, signal);
-	else await showRemoveTarget(ctx);
 }
 
 async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	let raw = await readLocalConfigObject();
-	if (!raw)
-		return void ctx.ui.notify("Set up the first sync target before adding another.", "info");
+	if (!raw) return void ctx.ui.notify("Set up the first sync setup before adding another.", "info");
 	if (raw.version !== 2) {
 		const choice = await ctx.ui.select(
 			[
-				"Upgrade settings for multiple targets",
+				"Upgrade settings for multiple sync setups",
 				"",
-				"The existing destination, unknown fields, and local sync state will be preserved.",
+				"The existing storage location, unknown fields, and local sync state will be preserved.",
 				"An exact private backup is created before the atomic conversion.",
 			].join("\n"),
 			["Upgrade settings", "Cancel"],
 		);
 		if (choice !== "Upgrade settings") return;
-		const currentTarget = await requiredInput(ctx, "Name the existing sync target", "default");
+		const currentTarget = await requiredInput(ctx, "Name the existing sync setup", "default");
 		if (!currentTarget) return;
-		const currentProfile = await requiredInput(ctx, "Name the existing storage profile", "default");
+		const currentProfile = await requiredInput(
+			ctx,
+			"Name the existing storage connection",
+			"default",
+		);
 		if (!currentProfile) return;
 		const migration = await migrateLegacySettings(currentTarget, currentProfile);
 		ctx.ui.notify(
@@ -624,10 +658,10 @@ async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal)
 		raw = migration.settings;
 	}
 	let profiles = ownRecord(raw.profiles) ?? {};
-	const name = await requiredInput(ctx, "Name the new destination", "work");
+	const name = await requiredInput(ctx, "Name the new sync setup", "work");
 	if (!name) return;
-	const createConnection = "Create a new saved connection…";
-	let profile = await ctx.ui.select("Choose a saved connection", [
+	const createConnection = "Add a new storage connection…";
+	let profile = await ctx.ui.select("Choose a storage connection", [
 		...Object.keys(profiles).sort(),
 		createConnection,
 		"Cancel",
@@ -636,6 +670,7 @@ async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal)
 	if (profile === createConnection) {
 		const previousNames = new Set(Object.keys(profiles));
 		if (!(await showAddStorageConnection(ctx, signal))) return;
+		if (signal?.aborted) return;
 		raw = (await readLocalConfigObject()) ?? raw;
 		profiles = ownRecord(raw.profiles) ?? {};
 		profile = Object.keys(profiles).find((candidate) => !previousNames.has(candidate));
@@ -643,17 +678,21 @@ async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal)
 	}
 	const storageKind = ownRecord(profiles[profile])?.kind;
 	if (storageKind === "webdav") {
-		if (await showAddWebDavTarget(ctx, name, profile, signal)) await refreshTargetCompletions();
+		const saved = await showAddWebDavTarget(ctx, name, profile, signal);
+		if (signal?.aborted) return;
+		if (saved) await refreshTargetCompletions();
 		return;
 	}
 	if (storageKind === "git") {
-		if (await showAddGitTarget(ctx, name, profile, signal)) await refreshTargetCompletions();
+		const saved = await showAddGitTarget(ctx, name, profile, signal);
+		if (signal?.aborted) return;
+		if (saved) await refreshTargetCompletions();
 		return;
 	}
 	const location = await chooseAdditionalRemoteLocation(ctx, raw, profile, name);
 	if (!location) return;
 	const { bucket, prefix, namespace } = location;
-	const preset = await ctx.ui.select("Choose synced content", [
+	const preset = await ctx.ui.select("Choose included content", [
 		"Recommended Pi settings",
 		"Minimal settings",
 		"Cancel",
@@ -669,24 +708,24 @@ async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal)
 	});
 	const choice = await ctx.ui.select(
 		[
-			"Review new sync target",
+			"Review new sync setup",
 			"",
-			`Target: ${safeTerminalText(name)}`,
-			`Storage profile: ${safeTerminalText(profile)}`,
+			`Sync setup: ${safeTerminalText(name)}`,
+			`Storage connection: ${safeTerminalText(profile)}`,
 			`Bucket: ${safeTerminalText(bucket)}`,
-			`Remote path: ${formatRemotePath(prefix, namespace)}`,
+			`Storage location: ${formatRemotePath(prefix, namespace)}`,
 			"Bucket must already exist. pi-sync will not create it.",
-			`Synced content: ${syncFiles.length} built-in groups · Sessions: Off`,
+			`Included content: ${syncFiles.length} built-in groups · Sessions: Off`,
 			...(overlapsExistingTarget
 				? [
-						"Warning: this target shares local content with another target; only the current target auto-syncs.",
+						"Warning: this setup shares local content with another setup; only the current setup syncs automatically.",
 					]
 				: []),
-			"Switching to this target later will not sync automatically.",
+			"Adding this setup does not sync or modify remote data.",
 		].join("\n"),
-		["Add target", "Cancel"],
+		["Add sync setup", "Cancel"],
 	);
-	if (choice !== "Add target") return;
+	if (choice !== "Add sync setup") return;
 	await addSyncTarget(name, {
 		profile,
 		bucket,
@@ -697,14 +736,15 @@ async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal)
 		syncSessions: false,
 		extraFiles: [],
 	});
+	if (signal?.aborted) return;
 	await refreshTargetCompletions();
-	ctx.ui.notify(`Added sync target “${safeTerminalText(name)}”.`, "info");
+	ctx.ui.notify(`Added sync setup “${safeTerminalText(name)}”.`, "info");
 }
 
-async function showEditCurrentTarget(ctx: ExtensionCommandContext, signal?: AbortSignal) {
-	const partial = await loadPartialConfig();
+async function showEditTarget(ctx: ExtensionCommandContext, name: string, signal?: AbortSignal) {
+	const partial = await loadPartialConfig(name);
 	if (partial.settingsVersion !== 2 || !partial.target) {
-		ctx.ui.notify("Upgrade settings before editing a named target.", "info");
+		ctx.ui.notify("Upgrade settings before editing a named sync setup.", "info");
 		return;
 	}
 	if (partial.storageKind === "webdav") {
@@ -723,41 +763,30 @@ async function showEditCurrentTarget(ctx: ExtensionCommandContext, signal?: Abor
 	if (!namespace) return;
 	const choice = await ctx.ui.select(
 		[
-			`Review target “${safeTerminalText(partial.target)}”`,
+			`Review sync setup “${safeTerminalText(partial.target)}”`,
 			"",
 			`Bucket: ${safeTerminalText(partial.bucket ?? "missing")} → ${safeTerminalText(bucket)}`,
 			`Prefix: ${safeTerminalText(partial.prefix ?? "pi-sync")} → ${safeTerminalText(prefix)}`,
 			`Namespace: ${safeTerminalText(partial.profile ?? partial.target)} → ${safeTerminalText(namespace)}`,
-			"Saving changes future sync destination only; it does not move or delete remote data.",
+			"Saving changes the future storage location only; it does not move or delete remote data.",
 		].join("\n"),
-		["Save target", "Cancel"],
+		["Save sync setup", "Cancel"],
 	);
-	if (choice !== "Save target") return;
+	if (choice !== "Save sync setup") return;
 	await updateSyncTarget(partial.target, (target) => ({ ...target, bucket, prefix, namespace }));
-	ctx.ui.notify(`Saved target “${safeTerminalText(partial.target)}”.`, "info");
+	ctx.ui.notify(`Saved sync setup “${safeTerminalText(partial.target)}”.`, "info");
 }
 
-async function showRemoveTarget(ctx: ExtensionCommandContext) {
-	const raw = await readLocalConfigObject();
-	const targets = ownRecord(raw?.targets);
-	if (raw?.version !== 2 || !targets || Object.keys(targets).length === 0) {
-		ctx.ui.notify("No named sync targets are available to remove.", "info");
-		return;
-	}
-	const selected = await ctx.ui.select("Remove sync target", [
-		...Object.keys(targets).sort(),
-		"Cancel",
-	]);
-	if (!selected || selected === "Cancel") return;
+async function showRemoveTarget(ctx: ExtensionCommandContext, name: string) {
 	const confirmed = await ctx.ui.confirm(
-		"Remove sync target?",
-		`Remove local target “${safeTerminalText(selected)}”? Remote data and history are not deleted.`,
+		"Remove sync setup?",
+		`Remove local sync setup “${safeTerminalText(name)}”? Remote data and history are not deleted.`,
 	);
 	if (!confirmed) return;
-	await removeSyncTarget(selected);
+	await removeSyncTarget(name);
 	await refreshTargetCompletions();
 	ctx.ui.notify(
-		`Removed sync target “${safeTerminalText(selected)}”; remote data was not deleted.`,
+		`Removed sync setup “${safeTerminalText(name)}”; remote data was not deleted.`,
 		"info",
 	);
 }
@@ -790,7 +819,7 @@ interface ChosenRemoteLocation {
 }
 
 async function chooseInitialTargetName(ctx: ExtensionCommandContext) {
-	const purpose = await ctx.ui.select("What will this target be used for?", [
+	const purpose = await ctx.ui.select("What will this sync setup be used for?", [
 		"Personal / Home",
 		"Work",
 		"Custom",
@@ -799,7 +828,7 @@ async function chooseInitialTargetName(ctx: ExtensionCommandContext) {
 	if (!purpose || purpose === "Cancel") return undefined;
 	if (purpose === "Personal / Home") return "home";
 	if (purpose === "Work") return "work";
-	return requiredInput(ctx, "Name this sync target", "default");
+	return requiredInput(ctx, "Name this sync setup", "default");
 }
 
 async function chooseInitialRemoteLocation(
@@ -817,9 +846,9 @@ async function chooseInitialRemoteLocation(
 	if (preset === "Cloudflare R2") {
 		const choice = await ctx.ui.select(
 			[
-				"Choose remote location",
+				"Choose storage location",
 				"",
-				`Suggested storage profile: ${profileName}`,
+				`Suggested storage connection: ${profileName}`,
 				`Suggested bucket: ${suggested.bucket}`,
 				`Remote path: ${formatRemotePath(suggested.prefix, suggested.namespace)}`,
 				"Bucket must already exist. pi-sync will not create it.",
@@ -833,9 +862,9 @@ async function chooseInitialRemoteLocation(
 
 	const choice = await ctx.ui.select(
 		[
-			"Choose remote location",
+			"Choose storage location",
 			"",
-			`Suggested storage profile: ${profileName}`,
+			`Suggested storage connection: ${profileName}`,
 			`Suggested path: ${formatRemotePath("pi-sync", targetName)}`,
 			"S3 bucket names may need to be globally unique and the bucket must already exist.",
 		].join("\n"),
@@ -877,7 +906,7 @@ async function chooseAdditionalRemoteLocation(
 		const sameBucketLabel = `Same bucket as “${safeTerminalText(source.name)}” (recommended)`;
 		const choice = await ctx.ui.select(
 			[
-				`Remote location for “${safeTerminalText(targetName)}”`,
+				`Storage location for “${safeTerminalText(targetName)}”`,
 				"",
 				`Recommended bucket: ${safeTerminalText(String(source.target.bucket))}`,
 				`Remote path: ${formatRemotePath(sourcePrefix, targetName)}`,
@@ -911,7 +940,7 @@ async function chooseAdditionalRemoteLocation(
 		? "Use suggested location (recommended)"
 		: "Use existing bucket with suggested path (recommended)";
 	const choice = await ctx.ui.select(
-		`Remote location for “${safeTerminalText(targetName)}”\n\nSuggested path: ${formatRemotePath("pi-sync", targetName)}`,
+		`Storage location for “${safeTerminalText(targetName)}”\n\nSuggested path: ${formatRemotePath("pi-sync", targetName)}`,
 		[suggestedLabel, "Customize remote location", "Cancel"],
 	);
 	if (!choice || choice === "Cancel") return undefined;
@@ -933,7 +962,7 @@ async function chooseCustomRemoteLocation(
 	customizeProfileName: boolean,
 ): Promise<ChosenRemoteLocation | undefined> {
 	const profileName = customizeProfileName
-		? await requiredInput(ctx, "Storage profile name", initialProfileName)
+		? await requiredInput(ctx, "Storage connection name", initialProfileName)
 		: initialProfileName;
 	if (!profileName) return undefined;
 	const bucket = await requiredExistingBucket(ctx, "pi-sync");

--- a/extensions/pi-sync/src/settings-management.ts
+++ b/extensions/pi-sync/src/settings-management.ts
@@ -64,7 +64,7 @@ export async function migrateLegacySettings(
 		if (!document) throw new Error("No legacy pi-sync settings are available to migrate.");
 		const { bytes: originalBytes, parsed: current } = document;
 		if (current.version === 2) {
-			throw new Error("pi-sync settings already use profiles and targets.");
+			throw new Error("pi-sync settings already use storage connections and sync setups.");
 		}
 		await afterLegacySettingsReadHook();
 		const next = legacySettingsAsV2(current, targetName, storageProfileName);
@@ -141,7 +141,8 @@ export async function addStorageProfile(name: string, profile: StorageProfileSet
 	validateName(name, "storage profile");
 	await updateV2Settings((settings) => {
 		const profiles = requireObject(settings.profiles, "profiles");
-		if (Object.hasOwn(profiles, name)) throw new Error(`Storage profile already exists: ${name}`);
+		if (Object.hasOwn(profiles, name))
+			throw new Error(`Storage connection already exists: ${name}`);
 		return { ...settings, profiles: { ...profiles, [name]: { ...profile } } };
 	});
 }
@@ -149,13 +150,26 @@ export async function addStorageProfile(name: string, profile: StorageProfileSet
 export async function updateStorageProfile(
 	name: string,
 	update: (profile: Record<string, unknown>) => Record<string, unknown>,
+	expectedSetups?: readonly string[],
 ) {
 	validateName(name, "storage profile");
 	await updateV2Settings((settings) => {
 		const profiles = requireObject(settings.profiles, "profiles");
+		const targets = requireObject(settings.targets, "targets");
+		if (expectedSetups) {
+			const currentSetups = referencingTargetNames(targets, name);
+			if (
+				currentSetups.length !== expectedSetups.length ||
+				currentSetups.some((setup, index) => setup !== expectedSetups[index])
+			) {
+				throw new Error(
+					`Storage connection “${name}” usage changed while it was open; reopen it and review the affected sync setups.`,
+				);
+			}
+		}
 		const profile = requireObject(profiles[name], "storage profile");
 		const nextProfiles = { ...profiles, [name]: update(profile) };
-		validateUniqueRemoteTargets(requireObject(settings.targets, "targets"), nextProfiles);
+		validateUniqueRemoteTargets(targets, nextProfiles);
 		return { ...settings, profiles: nextProfiles };
 	});
 }
@@ -165,9 +179,9 @@ export async function addSyncTarget(name: string, target: SyncTargetSettings) {
 	await updateV2Settings((settings) => {
 		const targets = requireObject(settings.targets, "targets");
 		const profiles = requireObject(settings.profiles, "profiles");
-		if (Object.hasOwn(targets, name)) throw new Error(`Sync target already exists: ${name}`);
+		if (Object.hasOwn(targets, name)) throw new Error(`Sync setup already exists: ${name}`);
 		if (!target.profile || !Object.hasOwn(profiles, target.profile)) {
-			throw new Error(`Storage profile not found: ${target.profile ?? "missing"}`);
+			throw new Error(`Storage connection not found: ${target.profile ?? "missing"}`);
 		}
 		assertUniqueRemoteIdentity(targets, profiles, name, target);
 		return { ...settings, targets: { ...targets, [name]: { ...target } } };
@@ -197,9 +211,9 @@ export async function removeSyncTarget(name: string) {
 	validateName(name, "target");
 	await updateV2Settings((settings) => {
 		const targets = requireObject(settings.targets, "targets");
-		if (!Object.hasOwn(targets, name)) throw new Error(`Sync target not found: ${name}`);
+		if (!Object.hasOwn(targets, name)) throw new Error(`Sync setup not found: ${name}`);
 		if (settings.activeTarget === name && Object.keys(targets).length > 1) {
-			throw new Error("Switch to another target before removing the current target.");
+			throw new Error("Switch to another sync setup before removing the current setup.");
 		}
 		const nextTargets = { ...targets };
 		delete nextTargets[name];
@@ -220,8 +234,9 @@ export async function removeStorageProfile(name: string) {
 		const referenced = Object.entries(targets).find(
 			([, target]) => requireObject(target, "target").profile === name,
 		)?.[0];
-		if (referenced) throw new Error(`Storage profile “${name}” is used by target “${referenced}”.`);
-		if (!Object.hasOwn(profiles, name)) throw new Error(`Storage profile not found: ${name}`);
+		if (referenced)
+			throw new Error(`Storage connection “${name}” is used by sync setup “${referenced}”.`);
+		if (!Object.hasOwn(profiles, name)) throw new Error(`Storage connection not found: ${name}`);
 		const nextProfiles = { ...profiles };
 		delete nextProfiles[name];
 		return { ...settings, profiles: nextProfiles };
@@ -234,7 +249,7 @@ async function updateV2Settings(
 	return withLock("settings", async () => {
 		const current = await readLocalConfigObject();
 		if (current?.version !== 2) {
-			throw new Error("Profiles and targets require version 2 pi-sync settings.");
+			throw new Error("Storage connections and sync setups require version 2 pi-sync settings.");
 		}
 		const next = update(current);
 		await writeLocalConfigObject(next);
@@ -277,6 +292,13 @@ async function adoptLegacyState(
 	}
 }
 
+function referencingTargetNames(targets: Record<string, unknown>, profileName: string) {
+	return Object.entries(targets)
+		.filter(([, value]) => requireObject(value, "target").profile === profileName)
+		.map(([name]) => name)
+		.sort((left, right) => left.localeCompare(right));
+}
+
 function assertUniqueRemoteIdentity(
 	targets: Record<string, unknown>,
 	profiles: Record<string, unknown>,
@@ -298,7 +320,7 @@ function assertUniqueRemoteIdentity(
 				),
 			) === identity
 		) {
-			throw new Error(`Target “${name}” duplicates the remote destination of “${otherName}”.`);
+			throw new Error(`Sync setup “${name}” duplicates the storage location of “${otherName}”.`);
 		}
 	}
 }
@@ -330,6 +352,12 @@ function validateName(value: string, label: string) {
 		// biome-ignore lint/suspicious/noControlCharactersInRegex: Stored identifiers cannot contain controls.
 		/[\u0000-\u001f\u007f-\u009f]/u.test(value)
 	) {
-		throw new Error(`Invalid ${label} name.`);
+		const displayLabel =
+			label === "target"
+				? "sync setup"
+				: label === "storage profile"
+					? "storage connection"
+					: label;
+		throw new Error(`Invalid ${displayLabel} name.`);
 	}
 }

--- a/extensions/pi-sync/src/settings-ui.ts
+++ b/extensions/pi-sync/src/settings-ui.ts
@@ -65,7 +65,7 @@ async function showSettingsList(
 				id: "automaticSync",
 				label: automaticSyncOverridden ? "Automatic sync (environment override)" : "Automatic sync",
 				description: automaticSyncOverridden
-					? "Read-only while deprecated PI_SYNC_AUTO_SYNC overrides this target. Move the value into target settings before the future major removal."
+					? "Read-only while deprecated PI_SYNC_AUTO_SYNC overrides this sync setup. Move the value into setup settings before the future major removal."
 					: "Run conservative synchronization automatically at session startup and shutdown.",
 				currentValue: automaticSyncValue,
 				...(automaticSyncOverridden ? {} : { values: ["On", "Off"] }),
@@ -74,7 +74,7 @@ async function showSettingsList(
 				? [
 						{
 							id: "targetSwitchAction",
-							label: "After target switch",
+							label: "After switching setup",
 							description:
 								"Ask before starting a pull, start a pull review automatically, or switch without checking remote files. Every pull still shows exact changes before apply.",
 							currentValue: targetSwitchValue,
@@ -84,7 +84,7 @@ async function showSettingsList(
 				: []),
 			{
 				id: "syncFiles",
-				label: "Synced content",
+				label: "Included content",
 				description: `${normalizeSyncFiles(partial.syncFiles).length} built-in groups and ${normalizeExtraFiles(partial.extraFiles).length} extra files. Opens the reviewed content-selection draft.`,
 				currentValue: "Open editor",
 				values: ["Open editor"],
@@ -96,7 +96,7 @@ async function showSettingsList(
 			new Text(
 				theme.fg(
 					"muted",
-					`Target: ${safeTerminalText(partial.target ?? "default")} · ${storageDescription(
+					`Sync setup: ${safeTerminalText(partial.target ?? "default")} · ${storageDescription(
 						partial.storageKind,
 						partial.storageKind === "webdav"
 							? partial.url
@@ -151,9 +151,9 @@ async function showSettingsList(
 							const latest = await loadTargetSwitchAction();
 							previousValue = targetSwitchActionLabel(latest);
 							const action = targetSwitchActionFromLabel(newValue);
-							if (!action) throw new Error(`Invalid target-switch action: ${newValue}`);
+							if (!action) throw new Error(`Invalid setup-switch action: ${newValue}`);
 							await saveTargetSwitchAction(action);
-							ctx.ui.notify(`After target switch: ${newValue}.`, "info");
+							ctx.ui.notify(`After switching setup: ${newValue}.`, "info");
 						}
 					} catch (error) {
 						if (latestRequested.get(id) === newValue) {
@@ -188,9 +188,9 @@ async function updateSettingsTarget(
 		const targets = ownRecord(current.targets);
 		const selected =
 			targetName ?? (typeof current.activeTarget === "string" ? current.activeTarget : undefined);
-		if (!targets || !selected) throw new Error("Settings target is not configured.");
+		if (!targets || !selected) throw new Error("Settings sync setup is not configured.");
 		const target = ownRecord(targets[selected]);
-		if (!target) throw new Error(`Settings target “${selected}” is invalid.`);
+		if (!target) throw new Error(`Settings sync setup “${selected}” is invalid.`);
 		return { ...current, targets: { ...targets, [selected]: update(target) } };
 	});
 }

--- a/extensions/pi-sync/src/storage-connections-ui.ts
+++ b/extensions/pi-sync/src/storage-connections-ui.ts
@@ -1,7 +1,7 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { readLocalConfigObject } from "./config.js";
 import { showAddGitStorageProfile, showEditGitStorageProfile } from "./git-ui.js";
-import { ownRecord, requiredInput, safeTerminalText } from "./manager-helpers.js";
+import { errorMessage, ownRecord, requiredInput, safeTerminalText } from "./manager-helpers.js";
 import {
 	applyS3CredentialUpdate,
 	chooseS3Credentials,
@@ -17,46 +17,109 @@ import { showAddWebDavStorageProfile, showEditWebDavStorageProfile } from "./web
 const BACK = "Back";
 
 export async function showStorageConnections(ctx: ExtensionCommandContext, signal?: AbortSignal) {
-	const raw = await readLocalConfigObject();
-	if (raw?.version !== 2) {
-		ctx.ui.notify("Upgrade settings before managing saved connections.", "info");
-		return;
-	}
-	const profiles = ownRecord(raw.profiles) ?? {};
-	const selected = await ctx.ui.select(
-		"Saved connections",
-		["Add saved connection", ...Object.keys(profiles).sort(), BACK],
-		{ signal },
-	);
-	if (!selected || selected === BACK) return;
-	if (selected === "Add saved connection") {
-		await showAddStorageConnection(ctx, signal);
-		return;
-	}
-	const action = await ctx.ui.select(
-		`Saved connection “${safeTerminalText(selected)}”`,
-		["Edit connection", "Remove saved connection", BACK],
-		{ signal },
-	);
-	if (!action || action === BACK) return;
-	if (action === "Remove saved connection") {
-		const confirmed = await ctx.ui.confirm(
-			"Remove saved connection?",
-			`Remove saved connection “${safeTerminalText(selected)}”? Remote data and history are not deleted.`,
+	while (!signal?.aborted) {
+		const raw = await readLocalConfigObject();
+		if (raw?.version !== 2) {
+			ctx.ui.notify("Upgrade settings before managing storage connections.", "info");
+			return;
+		}
+		const profiles = ownRecord(raw.profiles) ?? {};
+		const labels = new Map(
+			Object.keys(profiles)
+				.sort((left, right) => left.localeCompare(right))
+				.map((name) => [safeTerminalText(name), name]),
 		);
-		if (!confirmed) return;
-		await removeStorageProfile(selected);
-		ctx.ui.notify(`Removed saved connection “${safeTerminalText(selected)}”.`, "info");
-		return;
+		const selected = await ctx.ui.select(
+			"Storage connections",
+			["Add storage connection", ...labels.keys(), BACK],
+			{ signal },
+		);
+		if (signal?.aborted || !selected || selected === BACK) return;
+		if (selected === "Add storage connection") {
+			try {
+				await showAddStorageConnection(ctx, signal);
+			} catch (error) {
+				ctx.ui.notify(
+					`Storage connection was not added: ${safeTerminalText(errorMessage(error))} Retry from Add storage connection.`,
+					"error",
+				);
+			}
+			continue;
+		}
+		const name = labels.get(selected);
+		if (name) await showStorageConnectionDetail(ctx, name, signal);
 	}
-	const profile = ownRecord(profiles[selected]);
-	if (!profile) return;
+}
+
+async function showStorageConnectionDetail(
+	ctx: ExtensionCommandContext,
+	name: string,
+	signal?: AbortSignal,
+) {
+	while (!signal?.aborted) {
+		const raw = await readLocalConfigObject();
+		const profiles = ownRecord(raw?.profiles) ?? {};
+		const profile = ownRecord(profiles[name]);
+		if (!profile) {
+			ctx.ui.notify(`Storage connection “${safeTerminalText(name)}” no longer exists.`, "warning");
+			return;
+		}
+		const usedBy = referencingSetups(raw, name);
+		const selected = await ctx.ui.select(
+			[
+				`Storage connection “${safeTerminalText(name)}”`,
+				"",
+				`Type: ${connectionType(profile)}`,
+				`Endpoint: ${connectionEndpoint(profile)}`,
+				`Credentials: ${credentialSource(profile)}`,
+				`Used by: ${usedBy.length > 0 ? usedBy.map(safeTerminalText).join(", ") : "No sync setups"}`,
+				...(usedBy.length > 0
+					? ["Remove unavailable: edit or remove the listed sync setups first."]
+					: []),
+			].join("\n"),
+			[
+				"Edit storage connection…",
+				...(usedBy.length === 0 ? ["Remove storage connection…"] : []),
+				BACK,
+			],
+			{ signal },
+		);
+		if (signal?.aborted || !selected || selected === BACK) return;
+		try {
+			if (selected === "Remove storage connection…") {
+				const confirmed = await ctx.ui.confirm(
+					"Remove storage connection?",
+					`Remove local storage connection “${safeTerminalText(name)}”? Remote data and history are not deleted.`,
+					{ signal },
+				);
+				if (!confirmed || signal?.aborted) continue;
+				await removeStorageProfile(name);
+				ctx.ui.notify(`Removed storage connection “${safeTerminalText(name)}”.`, "info");
+				return;
+			}
+			await editStorageConnection(ctx, name, profile, usedBy, signal);
+		} catch (error) {
+			ctx.ui.notify(
+				`Storage connection “${safeTerminalText(name)}” was not changed: ${safeTerminalText(errorMessage(error))} Reopen it and retry.`,
+				"error",
+			);
+		}
+	}
+}
+
+async function editStorageConnection(
+	ctx: ExtensionCommandContext,
+	name: string,
+	profile: Record<string, unknown>,
+	usedBy: string[],
+	signal?: AbortSignal,
+) {
 	if (profile.kind === "webdav") {
-		await showEditWebDavStorageProfile(ctx, selected, profile, signal);
+		await showEditWebDavStorageProfile(ctx, name, profile, signal, usedBy);
 		return;
 	}
 	if (profile.kind === "git") {
-		await showEditGitStorageProfile(ctx, selected, profile, signal);
+		await showEditGitStorageProfile(ctx, name, profile, signal, usedBy);
 		return;
 	}
 	const endpoint = await requiredInput(
@@ -64,20 +127,33 @@ export async function showStorageConnections(ctx: ExtensionCommandContext, signa
 		"Endpoint",
 		String(profile.endpoint ?? "https://s3.example.com"),
 	);
-	if (!endpoint) return;
+	if (!endpoint || signal?.aborted) return;
 	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"));
-	if (!region) return;
+	if (!region || signal?.aborted) return;
 	const credentials = await chooseS3CredentialUpdate(ctx, profile, signal);
-	if (!credentials) return;
+	if (!credentials || signal?.aborted) return;
 	const save = await ctx.ui.select(
-		`Review connection\n\nSaved connection: ${safeTerminalText(selected)}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
-		["Save profile", "Cancel"],
+		[
+			"Review storage connection",
+			"",
+			`Storage connection: ${safeTerminalText(name)}`,
+			`Endpoint: ${safeTerminalText(String(profile.endpoint ?? "missing"))} → ${safeTerminalText(endpoint)}`,
+			`Region: ${safeTerminalText(String(profile.region ?? "auto"))} → ${safeTerminalText(region)}`,
+			`Credentials: ${safeTerminalText(credentials.summary)}`,
+			`Affected sync setups: ${usedBy.length > 0 ? usedBy.map(safeTerminalText).join(", ") : "None"}`,
+			"Saving changes future storage access for every affected setup; it does not move remote data.",
+		].join("\n"),
+		["Save storage connection", "Cancel"],
+		{ signal },
 	);
-	if (save !== "Save profile") return;
-	await updateStorageProfile(selected, (current) =>
-		applyS3CredentialUpdate({ ...current, endpoint, region }, credentials),
+	if (save !== "Save storage connection" || signal?.aborted) return;
+	await updateStorageProfile(
+		name,
+		(current) => applyS3CredentialUpdate({ ...current, endpoint, region }, credentials),
+		usedBy,
 	);
-	ctx.ui.notify(`Saved connection “${safeTerminalText(selected)}”.`, "info");
+	if (signal?.aborted) return;
+	ctx.ui.notify(`Saved storage connection “${safeTerminalText(name)}”.`, "info");
 }
 
 export async function showAddStorageConnection(ctx: ExtensionCommandContext, signal?: AbortSignal) {
@@ -86,15 +162,15 @@ export async function showAddStorageConnection(ctx: ExtensionCommandContext, sig
 		["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Git", "Cancel"],
 		{ signal },
 	);
-	if (!preset || preset === "Cancel") return false;
+	if (signal?.aborted || !preset || preset === "Cancel") return false;
 	if (preset === "WebDAV") return showAddWebDavStorageProfile(ctx, signal);
 	if (preset === "Git") return showAddGitStorageProfile(ctx, signal);
 	const name = await requiredInput(
 		ctx,
-		"Name this saved connection",
+		"Name this storage connection",
 		preset === "Cloudflare R2" ? "r2" : "s3",
 	);
-	if (!name) return false;
+	if (!name || signal?.aborted) return false;
 	const endpoint = await requiredInput(
 		ctx,
 		"Endpoint",
@@ -102,23 +178,71 @@ export async function showAddStorageConnection(ctx: ExtensionCommandContext, sig
 			? "https://<account-id>.r2.cloudflarestorage.com"
 			: "https://s3.example.com",
 	);
-	if (!endpoint) return false;
+	if (!endpoint || signal?.aborted) return false;
 	const region =
 		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1");
-	if (!region) return false;
+	if (!region || signal?.aborted) return false;
 	const credentials = await chooseS3Credentials(ctx, signal);
-	if (!credentials) return false;
+	if (!credentials || signal?.aborted) return false;
 	const save = await ctx.ui.select(
-		`Review saved connection\n\nName: ${safeTerminalText(name)}\nType: ${preset}\nEndpoint: ${safeTerminalText(endpoint)}\nRegion: ${safeTerminalText(region)}\nCredentials: ${safeTerminalText(credentials.summary)}`,
-		["Add connection", "Cancel"],
+		[
+			"Review storage connection",
+			"",
+			`Name: ${safeTerminalText(name)}`,
+			`Type: ${preset}`,
+			`Endpoint: ${safeTerminalText(endpoint)}`,
+			`Region: ${safeTerminalText(region)}`,
+			`Credentials: ${safeTerminalText(credentials.summary)}`,
+			"Adding a connection does not contact remote storage or start syncing.",
+		].join("\n"),
+		["Add storage connection", "Cancel"],
+		{ signal },
 	);
-	if (save !== "Add connection") return false;
+	if (save !== "Add storage connection" || signal?.aborted) return false;
 	await addStorageProfile(name, {
 		kind: preset === "Cloudflare R2" ? "r2" : "s3-compatible",
 		endpoint,
 		region,
 		...credentials.profileFields,
 	});
-	ctx.ui.notify(`Added saved connection “${safeTerminalText(name)}”.`, "info");
+	if (signal?.aborted) return true;
+	ctx.ui.notify(`Added storage connection “${safeTerminalText(name)}”.`, "info");
 	return true;
+}
+
+function referencingSetups(raw: Record<string, unknown> | undefined, connection: string) {
+	return Object.entries(ownRecord(raw?.targets) ?? {})
+		.filter(([, value]) => ownRecord(value)?.profile === connection)
+		.map(([name]) => name)
+		.sort((left, right) => left.localeCompare(right));
+}
+
+function connectionType(profile: Record<string, unknown>) {
+	if (profile.kind === "git") return "Git";
+	if (profile.kind === "webdav") return "WebDAV";
+	if (profile.kind === "r2") return "Cloudflare R2";
+	return "S3-compatible";
+}
+
+function connectionEndpoint(profile: Record<string, unknown>) {
+	const value =
+		profile.kind === "git"
+			? profile.remote
+			: profile.kind === "webdav"
+				? profile.url
+				: profile.endpoint;
+	if (typeof value !== "string" || value.length === 0) return "Missing";
+	if (profile.kind === "git") return safeTerminalText(value);
+	try {
+		return safeTerminalText(new URL(value).host);
+	} catch {
+		return "Invalid";
+	}
+}
+
+function credentialSource(profile: Record<string, unknown>) {
+	if (profile.kind === "git") return "Git credential helper or SSH configuration";
+	if (profile.kind === "webdav") return profile.password ? "Settings file" : "Missing";
+	if (profile.accessKeyId && profile.secretAccessKey) return "Settings file";
+	return "Environment or missing";
 }

--- a/extensions/pi-sync/src/sync-format.ts
+++ b/extensions/pi-sync/src/sync-format.ts
@@ -44,8 +44,8 @@ export function formatPushSummary(
 	remote?: Snapshot,
 ) {
 	return [
-		`Target: ${safeTerminalText(config.target ?? "default")}`,
-		`Destination: ${safeTerminalText(destination)}`,
+		`Sync setup: ${safeTerminalText(config.target ?? "default")}`,
+		`Storage location: ${safeTerminalText(destination)}`,
 		`Upload ${upload.files.length} files from ${safeTerminalText(agentDir())}.`,
 		`Sessions: ${upload.syncSessions ? "included — may contain private conversations" : "not included"}`,
 		head ? `Remote latest: ${head.snapshotId}` : "Remote latest: empty",
@@ -73,8 +73,8 @@ export function formatPullSummary(
 	protectedSessionCount: number,
 ) {
 	return [
-		`Target: ${safeTerminalText(config.target ?? "default")}`,
-		`Destination: ${safeTerminalText(destination)}`,
+		`Sync setup: ${safeTerminalText(config.target ?? "default")}`,
+		`Storage location: ${safeTerminalText(destination)}`,
 		`Snapshot: ${safeTerminalText(remote.id)}`,
 		`Sessions: ${remote.syncSessions ? "included — may contain private conversations" : "not included"}`,
 		`Protected live sessions: ${protectedSessionCount || "none"}`,
@@ -92,8 +92,8 @@ export function formatRollbackSummary(
 	protectedSessionCount: number,
 ) {
 	return [
-		`Target: ${safeTerminalText(config.target ?? "default")}`,
-		`Destination: ${safeTerminalText(destination)}`,
+		`Sync setup: ${safeTerminalText(config.target ?? "default")}`,
+		`Storage location: ${safeTerminalText(destination)}`,
 		`Snapshot: ${safeTerminalText(requestedSnapshot)}`,
 		`Sessions: ${remote.syncSessions ? "included — may contain private conversations" : "not included"}`,
 		`Protected live sessions: ${protectedSessionCount || "none"}`,

--- a/extensions/pi-sync/src/sync-operations.ts
+++ b/extensions/pi-sync/src/sync-operations.ts
@@ -137,9 +137,9 @@ export async function status(
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	ctx.ui.notify(
 		[
-			`target: ${config.target ?? "default"}`,
-			`storage profile: ${config.storageProfile ?? "default"}`,
-			`destination: ${safeTerminalText(backend.destination)}`,
+			`sync setup: ${config.target ?? "default"}`,
+			`storage connection: ${config.storageProfile ?? "default"}`,
+			`storage location: ${safeTerminalText(backend.destination)}`,
 			`publication safety: ${publicationCapabilityDescription(backend.capability)}`,
 			`remote namespace: ${config.profile}`,
 			`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
@@ -175,9 +175,9 @@ export async function diff(
 		...syncSessionsWarnings(config),
 	];
 	const header = [
-		`target: ${config.target ?? "default"}`,
-		`storage profile: ${config.storageProfile ?? "default"}`,
-		`destination: ${safeTerminalText(backend.destination)}`,
+		`sync setup: ${config.target ?? "default"}`,
+		`storage connection: ${config.storageProfile ?? "default"}`,
+		`storage location: ${safeTerminalText(backend.destination)}`,
 		`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
 		`extra files: ${config.extraFiles.join(", ") || "none"}`,
 		`sessions: ${config.syncSessions ? "included" : "excluded"}`,
@@ -214,13 +214,13 @@ export async function doctor(
 		profile = config.profile;
 		snapshotOptions = snapshotOptionsForContext(ctx, config);
 		messages.push(
-			`config: ok (target ${config.target ?? "default"})`,
+			`config: ok (sync setup ${config.target ?? "default"})`,
 			`sync files: ${normalizeSyncFiles(config.syncFiles).join(", ") || "none"}`,
 			`extra files: ${config.extraFiles.join(", ") || "none"}`,
 			`sessions: ${config.syncSessions ? "included" : "excluded"}`,
 		);
 		backendSummary = [
-			`destination: ${safeTerminalText(backend.destination)}`,
+			`storage location: ${safeTerminalText(backend.destination)}`,
 			`publication safety: ${publicationCapabilityDescription(backend.capability)}`,
 		];
 		const warnings = [
@@ -397,7 +397,7 @@ export async function push(
 	if (!options.silent) {
 		ctx.ui.notify(
 			[
-				`Pushed ${upload.files.length} files from target “${config.target ?? "default"}” as ${result.head.snapshotId}.`,
+				`Pushed ${upload.files.length} files from sync setup “${config.target ?? "default"}” as ${result.head.snapshotId}.`,
 				...result.warnings,
 			]
 				.filter(Boolean)
@@ -510,7 +510,7 @@ export async function syncBoth(
 	) {
 		if (!options.silent) {
 			ctx.ui.notify(
-				`Target “${config.target ?? "default"}” manages no files. Choose synced content in /sync Settings before syncing.`,
+				`Sync setup “${config.target ?? "default"}” includes no files. Choose included content in /sync Settings before syncing.`,
 				"warning",
 			);
 		}
@@ -621,7 +621,7 @@ export async function history(
 				`${index + 1}. ${item.createdAt} · ${safeTerminalText(item.machine)} · ${item.snapshotId}${item.snapshotId === currentSnapshot ? " (current)" : ""}${item.syncSessions ? " · sessions" : ""}`,
 		);
 		const selected = await ctx.ui.select(
-			`History for target “${safeTerminalText(config.target ?? "default")}”\n\nChoose a snapshot to preview rollback.`,
+			`History for sync setup “${safeTerminalText(config.target ?? "default")}”\n\nChoose a snapshot to preview rollback.`,
 			[...labels, "Back"],
 		);
 		if (!selected || selected === "Back") return;
@@ -663,7 +663,7 @@ export async function rollback(
 			config.target !== expectedSelection.target)
 	) {
 		throw new Error(
-			"Sync target or destination changed while history was open; reopen history and retry.",
+			"Sync setup or storage location changed while history was open; reopen history and retry.",
 		);
 	}
 	const decoded = await backend.readSnapshot(target, options.signal);
@@ -745,7 +745,7 @@ export async function rollback(
 	if (options.signal?.aborted) return;
 	ctx.ui.notify(
 		[
-			`Rolled back target “${config.target ?? "default"}” to ${target}; latest: ${result.head.snapshotId}. Backup: ${backup}`,
+			`Rolled back sync setup “${config.target ?? "default"}” to ${target}; latest: ${result.head.snapshotId}. Backup: ${backup}`,
 			...result.warnings,
 		]
 			.filter(Boolean)

--- a/extensions/pi-sync/src/sync-setups-ui.ts
+++ b/extensions/pi-sync/src/sync-setups-ui.ts
@@ -1,0 +1,186 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+	loadConfig,
+	normalizeExtraFiles,
+	normalizeSyncFiles,
+	readLocalConfigObject,
+} from "./config.js";
+import { errorMessage, ownRecord, safeTerminalText } from "./manager-helpers.js";
+
+const BACK = "Back";
+
+export async function countValidSyncSetups(
+	setups: Record<string, unknown> | undefined,
+	signal?: AbortSignal,
+) {
+	let count = 0;
+	for (const name of Object.keys(setups ?? {})) {
+		throwIfAborted(signal);
+		let valid = false;
+		try {
+			await loadConfig(name);
+			valid = true;
+		} catch {
+			// Invalid setups stay visible in management but are not switchable.
+		}
+		throwIfAborted(signal);
+		if (valid) count += 1;
+	}
+	return count;
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("The operation was aborted", "AbortError");
+}
+
+type SyncSetupActions = {
+	add(signal?: AbortSignal): Promise<void>;
+	edit(name: string, signal?: AbortSignal): Promise<void>;
+	makeCurrent(name: string): Promise<"exit" | undefined>;
+	remove(name: string): Promise<void>;
+};
+
+export async function showSyncSetups(
+	ctx: ExtensionCommandContext,
+	actions: SyncSetupActions,
+	signal?: AbortSignal,
+): Promise<"exit" | undefined> {
+	while (!signal?.aborted) {
+		const raw = await readLocalConfigObject();
+		const setups = ownRecord(raw?.targets) ?? {};
+		const active = typeof raw?.activeTarget === "string" ? raw.activeTarget : undefined;
+		const labels = new Map<string, string>();
+		for (const name of Object.keys(setups).sort((left, right) => left.localeCompare(right))) {
+			const label = `${safeTerminalText(name)}${name === active ? " (current)" : ""}`;
+			labels.set(label, name);
+		}
+		const selected = await ctx.ui.select(
+			"Sync setups",
+			["Add sync setup", ...labels.keys(), BACK],
+			{ signal },
+		);
+		if (signal?.aborted || !selected || selected === BACK) return;
+		if (selected === "Add sync setup") {
+			try {
+				await actions.add(signal);
+			} catch (error) {
+				ctx.ui.notify(
+					`Sync setup was not added: ${menuErrorMessage(error)} Retry from Add sync setup.`,
+					"error",
+				);
+			}
+			continue;
+		}
+		const name = labels.get(selected);
+		if (!name) continue;
+		const result = await showSyncSetupDetail(ctx, name, actions, signal);
+		if (result === "exit") return "exit";
+	}
+}
+
+async function showSyncSetupDetail(
+	ctx: ExtensionCommandContext,
+	name: string,
+	actions: SyncSetupActions,
+	signal?: AbortSignal,
+): Promise<"exit" | undefined> {
+	while (!signal?.aborted) {
+		const raw = await readLocalConfigObject();
+		const setups = ownRecord(raw?.targets) ?? {};
+		const setup = ownRecord(setups[name]);
+		if (!setup) {
+			ctx.ui.notify(`Sync setup “${safeTerminalText(name)}” no longer exists.`, "warning");
+			return;
+		}
+		const active = typeof raw?.activeTarget === "string" ? raw.activeTarget : undefined;
+		const setupCount = Object.keys(setups).length;
+		const isCurrent = name === active;
+		let detail: string[];
+		let valid = true;
+		try {
+			const config = await loadConfig(name);
+			detail = [
+				`Status: ${isCurrent ? "Current" : "Not current"}`,
+				`Storage connection: ${safeTerminalText(config.storageProfile ?? "default")}`,
+				`Endpoint: ${storageEndpoint(config)}`,
+				`Storage location: ${storageLocation(config)}`,
+				`Included content: ${normalizeSyncFiles(config.syncFiles).length} built-in groups · ${normalizeExtraFiles(config.extraFiles).length} extra files`,
+				`Sessions: ${config.syncSessions ? "On — privacy-sensitive" : "Off"}`,
+				`Automatic sync: ${config.autoSync ? "On" : "Off"}`,
+			];
+		} catch (error) {
+			valid = false;
+			detail = [
+				`Status: Invalid${isCurrent ? " current setup" : ""}`,
+				`Reason: ${menuErrorMessage(error)}`,
+				"Make current and sync are unavailable until this setup is repaired.",
+			];
+		}
+		const removeUnavailable = isCurrent && setupCount > 1;
+		if (removeUnavailable) detail.push("Remove unavailable: switch to another setup first.");
+		const selected = await ctx.ui.select(
+			[`Sync setup “${safeTerminalText(name)}”`, "", ...detail].join("\n"),
+			[
+				...(!isCurrent && valid ? ["Make current…"] : []),
+				"Edit sync setup…",
+				...(removeUnavailable ? [] : ["Remove sync setup…"]),
+				BACK,
+			],
+			{ signal },
+		);
+		if (signal?.aborted || !selected || selected === BACK) return;
+		try {
+			if (selected === "Make current…") return actions.makeCurrent(name);
+			if (selected === "Edit sync setup…") await actions.edit(name, signal);
+			else if (selected === "Remove sync setup…") {
+				await actions.remove(name);
+				return;
+			}
+		} catch (error) {
+			ctx.ui.notify(
+				`Sync setup “${safeTerminalText(name)}” was not changed: ${menuErrorMessage(error)} Reopen it and retry.`,
+				"error",
+			);
+		}
+	}
+}
+
+function menuErrorMessage(error: unknown) {
+	return safeTerminalText(errorMessage(error))
+		.replace(/storage profile/giu, "storage connection")
+		.replace(/missing profile/giu, "missing storage connection")
+		.replace(/\btargets\b/giu, "sync setups")
+		.replace(/\btarget\b/giu, "sync setup")
+		.replace(/remote destination/giu, "storage location");
+}
+
+function storageEndpoint(config: Awaited<ReturnType<typeof loadConfig>>) {
+	switch (config.backend.type) {
+		case "s3":
+			return safeTerminalText(config.backend.profile.endpoint);
+		case "git":
+			return safeTerminalText(config.backend.profile.remote);
+		case "webdav":
+			return safeTerminalText(config.backend.profile.url);
+	}
+}
+
+function storageLocation(config: Awaited<ReturnType<typeof loadConfig>>) {
+	switch (config.backend.type) {
+		case "s3":
+			return safeTerminalText(
+				`${config.backend.destination.bucket}/${config.backend.destination.prefix}/profiles/${config.backend.destination.namespace}`,
+			);
+		case "git":
+			return safeTerminalText(
+				`Git · ${config.backend.destination.branch}/${config.backend.destination.directory}/profiles/${config.backend.destination.namespace}`,
+			);
+		case "webdav":
+			return safeTerminalText(
+				`WebDAV · ${config.backend.destination.path}/profiles/${config.backend.destination.namespace}`,
+			);
+	}
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -298,14 +298,14 @@ async function showConfig(ctx: ExtensionCommandContext, options: CommandOptions)
 	ctx.ui.notify(
 		[
 			"pi-sync config:",
-			`target: ${partial.target ?? "default"}`,
-			`storage profile: ${partial.storageProfile ?? "default"}`,
+			`sync setup: ${partial.target ?? "default"}`,
+			`storage connection: ${partial.storageProfile ?? "default"}`,
 			...storageLines,
-			`autoSync: ${isEnabled(s3 ? (partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC) : partial.autoSync, true) ? "enabled" : "disabled"}`,
-			`syncFiles: ${normalizeSyncFiles(partial.syncFiles).join(", ") || "none"}`,
-			`syncSessions: ${syncSessions ? "enabled" : "disabled"}`,
-			`extraFiles: ${normalizeExtraFiles(partial.extraFiles).join(", ") || "none"}`,
-			`local config: ${localConfigPath()}`,
+			`automatic sync: ${isEnabled(s3 ? (partial.autoSync ?? process.env.PI_SYNC_AUTO_SYNC) : partial.autoSync, true) ? "enabled" : "disabled"}`,
+			`included built-ins: ${normalizeSyncFiles(partial.syncFiles).join(", ") || "none"}`,
+			`sessions: ${syncSessions ? "included" : "not included"}`,
+			`extra included files: ${normalizeExtraFiles(partial.extraFiles).join(", ") || "none"}`,
+			`settings file: ${localConfigPath()}`,
 			...warnings,
 		].join("\n"),
 		warnings.length > 0 ? "warning" : "info",
@@ -340,7 +340,7 @@ function configStorageLines(partial: Awaited<ReturnType<typeof loadPartialConfig
 				`accessKeyId: ${partial.accessKeyId ? redact(partial.accessKeyId) : "missing"}`,
 				`secretAccessKey: ${partial.secretAccessKey ? "configured" : "missing"}`,
 				`sessionToken: ${partial.sessionToken ? "configured" : "not configured"}`,
-				`profile: ${partial.profile ?? DEFAULT_PROFILE}`,
+				`namespace: ${partial.profile ?? DEFAULT_PROFILE}`,
 				`prefix: ${partial.prefix ?? DEFAULT_PREFIX}`,
 			];
 	}

--- a/extensions/pi-sync/src/target-switch.ts
+++ b/extensions/pi-sync/src/target-switch.ts
@@ -3,8 +3,7 @@ import { setSyncTargetCompletions } from "./command.js";
 import {
 	configuredTargetNames,
 	loadConfig,
-	loadTargetSwitchAction,
-	readLocalConfigObject,
+	normalizeTargetSwitchAction,
 	updateLocalConfig,
 } from "./config.js";
 import { safeTerminalText } from "./sync-format.js";
@@ -30,7 +29,7 @@ export function targetSwitchActionFromLabel(label: string): TargetSwitchAction |
 export async function saveTargetSwitchAction(action: TargetSwitchAction) {
 	await updateLocalConfig((settings) => {
 		if (settings.version !== 2) {
-			throw new Error("Target-switch settings require version 2 settings.");
+			throw new Error("Setup-switch settings require version 2 settings.");
 		}
 		return { ...settings, targetSwitchAction: action };
 	});
@@ -48,48 +47,59 @@ export async function useSyncTarget(
 	ctx: ExtensionCommandContext,
 	name: string,
 	pullCurrentTarget?: (target: string) => Promise<TargetPullOutcome | undefined>,
+	expectedAction?: TargetSwitchAction,
 ): Promise<TargetSwitchResult> {
 	const normalized = name.trim();
-	if (!normalized) throw new Error("Usage: /sync use <target>");
+	if (!normalized) throw new Error("Usage: /sync use <setup>");
 	await loadConfig(normalized);
-	const before = await readLocalConfigObject();
-	if (before?.version === 2 && before.activeTarget === normalized) {
-		ctx.ui.notify(`Target “${safeTerminalText(normalized)}” is already current.`, "info");
-		return { pullApplied: false };
-	}
-	const action = await loadTargetSwitchAction();
-	if (action === "pull" && !ctx.hasUI) {
-		throw new TargetPullRequiresUiError(
-			`Automatic target pulls require interactive confirmation; target “${safeTerminalText(normalized)}” was not switched. Use TUI or RPC mode.`,
-		);
-	}
-	let switched = false;
+	const switchResult: { action: TargetSwitchAction; switched: boolean } = {
+		action: "ask",
+		switched: false,
+	};
 	await updateLocalConfig((current) => {
-		if (current.version !== 2) throw new Error("Target switching requires version 2 settings.");
+		if (current.version !== 2) throw new Error("Sync setup switching requires version 2 settings.");
+		const targets = current.targets;
+		if (!targets || typeof targets !== "object" || Array.isArray(targets)) {
+			throw new Error("No sync setups are configured.");
+		}
+		if (!Object.hasOwn(targets, normalized)) {
+			throw new Error(`Sync setup “${safeTerminalText(normalized)}” no longer exists.`);
+		}
+		switchResult.action = normalizeTargetSwitchAction(current.targetSwitchAction);
+		if (expectedAction !== undefined && switchResult.action !== expectedAction) {
+			throw new Error(
+				"Setup-switch behavior changed while the preview was open; reopen it and retry.",
+			);
+		}
+		if (switchResult.action === "pull" && !ctx.hasUI) {
+			throw new TargetPullRequiresUiError(
+				`Automatic setup pulls require interactive confirmation; sync setup “${safeTerminalText(normalized)}” was not switched. Use TUI or RPC mode.`,
+			);
+		}
 		if (current.activeTarget === normalized) return current;
-		switched = true;
+		switchResult.switched = true;
 		return { ...current, activeTarget: normalized };
 	});
-	if (!switched) {
-		ctx.ui.notify(`Target “${safeTerminalText(normalized)}” is already current.`, "info");
+	if (!switchResult.switched) {
+		ctx.ui.notify(`Sync setup “${safeTerminalText(normalized)}” is already current.`, "info");
 		return { pullApplied: false };
 	}
 	setSyncTargetCompletions(await configuredTargetNames());
 
-	if (action === "switch-only") {
+	if (switchResult.action === "switch-only") {
 		ctx.ui.notify(`Switched to “${safeTerminalText(normalized)}”. No files were pulled.`, "info");
 		return { pullApplied: false };
 	}
-	if (action === "ask") {
+	if (switchResult.action === "ask") {
 		if (ctx.mode !== "tui") {
 			ctx.ui.notify(
-				`Switched to “${safeTerminalText(normalized)}”. No files were pulled because confirmation requires TUI mode; run /sync pull to apply the target.`,
+				`Switched to “${safeTerminalText(normalized)}”. No files were pulled because confirmation requires TUI mode; run /sync pull to apply this setup.`,
 				"info",
 			);
 			return { pullApplied: false };
 		}
 		const confirmed = await ctx.ui.confirm(
-			`Review a pull for target “${safeTerminalText(normalized)}” now?`,
+			`Review a pull for sync setup “${safeTerminalText(normalized)}” now?`,
 			"pi-sync will check the remote snapshot and show the exact local writes and deletions before applying anything.",
 		);
 		if (!confirmed) {
@@ -111,7 +121,7 @@ export async function useSyncTarget(
 	const pullOutcome = await pullCurrentTarget(normalized);
 	if (pullOutcome === "cancelled") {
 		ctx.ui.notify(
-			`Pull cancelled; target “${safeTerminalText(normalized)}” remains active and synced files were not changed.`,
+			`Pull cancelled; sync setup “${safeTerminalText(normalized)}” remains current and synced files were not changed.`,
 			"info",
 		);
 	}

--- a/extensions/pi-sync/src/webdav-ui.ts
+++ b/extensions/pi-sync/src/webdav-ui.ts
@@ -109,24 +109,24 @@ export async function showRepairWebDavDestination(
 	const review = await select(
 		ctx,
 		[
-			"Repair WebDAV destination",
+			"Repair WebDAV storage location",
 			"",
-			`Destination: ${safe(targetName)}`,
-			`Saved connection: ${safe(profileName)}`,
-			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
+			`Sync setup: ${safe(targetName)}`,
+			`Storage connection: ${safe(profileName)}`,
+			`Storage location: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
 			`Password: configured (value hidden)`,
 			...(removedTargetFields.length > 0
-				? [`Remove incompatible destination fields: ${removedTargetFields.join(", ")}`]
+				? [`Remove incompatible storage-location fields: ${removedTargetFields.join(", ")}`]
 				: []),
 			...(removedProfileFields.length > 0
 				? [`Remove incompatible connection fields: ${removedProfileFields.join(", ")}`]
 				: []),
-			"Unknown settings and every other destination remain unchanged.",
+			"Unknown settings and every other sync setup remain unchanged.",
 		].join("\n"),
-		["Repair destination", "Cancel"],
+		["Repair storage location", "Cancel"],
 		signal,
 	);
-	if (review !== "Repair destination") return false;
+	if (review !== "Repair storage location") return false;
 	const nextProfile: Record<string, unknown> = { ...profile, ...connection };
 	for (const field of removedProfileFields) delete nextProfile[field];
 	const nextTarget: Record<string, unknown> = { ...target, ...destination };
@@ -139,7 +139,7 @@ export async function showRepairWebDavDestination(
 	resolveV2PartialConfig(next, targetName);
 	throwIfAborted(signal);
 	await awaitActive(signal, replaceLocalConfigDocument(document, next));
-	ctx.ui.notify(`Repaired WebDAV destination “${safe(targetName)}”.`, "info");
+	ctx.ui.notify(`Repaired WebDAV storage location for sync setup “${safe(targetName)}”.`, "info");
 	return true;
 }
 
@@ -168,7 +168,7 @@ export async function showWebDavSetup(
 	if (!content) return false;
 	const automatic = await select(
 		ctx,
-		"Automatic sync for this target",
+		"Automatic sync for this setup",
 		["Enable automatic sync", "Keep automatic sync off", "Cancel"],
 		signal,
 	);
@@ -181,15 +181,15 @@ export async function showWebDavSetup(
 		[
 			"Review WebDAV setup",
 			"",
-			`Target: ${safe(targetName)}`,
-			`Storage profile: ${profileName} (WebDAV)`,
+			`Sync setup: ${safe(targetName)}`,
+			`Storage connection: ${profileName} (WebDAV)`,
 			`URL: ${displayUrl(connection.url)}`,
-			`Remote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
+			`Storage location: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}`,
 			"Username: stored in the private settings file (value hidden)",
 			"Password: configured (value hidden)",
 			`Conditional writes: /sync doctor verifies atomic If-Match and If-None-Match support before publication.`,
-			`Synced content: ${content.length} built-in groups · Sessions: ${sessions ? "On — privacy warning acknowledged" : "Off"}`,
-			`Auto-sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
+			`Included content: ${content.length} built-in groups · Sessions: ${sessions ? "On — privacy warning acknowledged" : "Off"}`,
+			`Automatic sync: ${automatic === "Enable automatic sync" ? "On" : "Off"}`,
 		].join("\n"),
 		["Save setup", "Cancel"],
 		signal,
@@ -213,7 +213,7 @@ export async function showWebDavSetup(
 			},
 		}),
 	);
-	ctx.ui.notify(`Destination “${safe(targetName)}” is ready. Use Sync now when ready.`, "info");
+	ctx.ui.notify(`Sync setup “${safe(targetName)}” is ready. Use Sync now when ready.`, "info");
 	return true;
 }
 
@@ -231,11 +231,11 @@ export async function showAddWebDavTarget(
 	if (!content) return false;
 	const review = await select(
 		ctx,
-		`Review WebDAV target\n\nTarget: ${safe(name)}\nStorage profile: ${safe(profile)}\nRemote path: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}\nSynced content: ${content.length} built-in groups · Sessions: Off\nSwitching later does not sync until its reviewed pull.`,
-		["Add target", "Cancel"],
+		`Review WebDAV sync setup\n\nSync setup: ${safe(name)}\nStorage connection: ${safe(profile)}\nStorage location: ${safe(`${destination.path}/profiles/${destination.namespace}/`)}\nIncluded content: ${content.length} built-in groups · Sessions: Off\nAdding this setup does not sync or modify remote data.`,
+		["Add sync setup", "Cancel"],
 		signal,
 	);
-	if (review !== "Add target") return false;
+	if (review !== "Add sync setup") return false;
 	throwIfAborted(signal);
 	await awaitActive(
 		signal,
@@ -249,7 +249,7 @@ export async function showAddWebDavTarget(
 			extraFiles: [],
 		}),
 	);
-	ctx.ui.notify(`Added sync target “${safe(name)}”.`, "info");
+	ctx.ui.notify(`Added sync setup “${safe(name)}”.`, "info");
 	return true;
 }
 
@@ -277,17 +277,17 @@ export async function showEditWebDavTarget(
 	if (!destination) return false;
 	const review = await select(
 		ctx,
-		`Review target “${safe(partial.target)}”\n\nPath: ${safe(partial.path ?? "pi-sync")} → ${safe(destination.path)}\nNamespace: ${safe(partial.profile ?? partial.target)} → ${safe(destination.namespace)}\nSaving changes future sync destination only; it does not move or delete remote data.`,
-		["Save target", "Cancel"],
+		`Review sync setup “${safe(partial.target)}”\n\nPath: ${safe(partial.path ?? "pi-sync")} → ${safe(destination.path)}\nNamespace: ${safe(partial.profile ?? partial.target)} → ${safe(destination.namespace)}\nSaving changes the future storage location only; it does not move or delete remote data.`,
+		["Save sync setup", "Cancel"],
 		signal,
 	);
-	if (review !== "Save target") return false;
+	if (review !== "Save sync setup") return false;
 	throwIfAborted(signal);
 	await awaitActive(
 		signal,
 		updateSyncTarget(partial.target, (target) => ({ ...target, ...destination })),
 	);
-	ctx.ui.notify(`Saved target “${safe(partial.target)}”.`, "info");
+	ctx.ui.notify(`Saved sync setup “${safe(partial.target)}”.`, "info");
 	return true;
 }
 
@@ -295,7 +295,7 @@ export async function showAddWebDavStorageProfile(
 	ctx: ExtensionCommandContext,
 	signal?: AbortSignal,
 ) {
-	const name = await requiredInput(ctx, "Name the storage profile", "webdav", signal);
+	const name = await requiredInput(ctx, "Name this storage connection", "webdav", signal);
 	if (!name) return false;
 	const url = await requiredInput(
 		ctx,
@@ -312,14 +312,14 @@ export async function showAddWebDavStorageProfile(
 	if (!connection) return false;
 	const review = await select(
 		ctx,
-		`Review saved connection\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: configured (value hidden)`,
-		["Add profile", "Cancel"],
+		`Review storage connection\n\nName: ${safe(name)}\nType: WebDAV\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: configured (value hidden)\nAdding a connection does not contact the server or start syncing.`,
+		["Add storage connection", "Cancel"],
 		signal,
 	);
-	if (review !== "Add profile") return false;
+	if (review !== "Add storage connection") return false;
 	throwIfAborted(signal);
 	await awaitActive(signal, addStorageProfile(name, { kind: "webdav", ...connection }));
-	ctx.ui.notify(`Added storage profile “${safe(name)}”.`, "info");
+	ctx.ui.notify(`Added storage connection “${safe(name)}”.`, "info");
 	return true;
 }
 
@@ -328,6 +328,7 @@ export async function showEditWebDavStorageProfile(
 	name: string,
 	profile: Record<string, unknown>,
 	signal?: AbortSignal,
+	affectedSetups?: string[],
 ) {
 	const url = await requiredInput(
 		ctx,
@@ -365,21 +366,25 @@ export async function showEditWebDavStorageProfile(
 	if (!connection) return false;
 	const review = await select(
 		ctx,
-		`Review connection\n\nSaved connection: ${safe(name)}\nURL: ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: ${replacePassword ? "will be replaced" : "unchanged"} (value hidden)`,
-		["Save profile", "Cancel"],
+		`Review storage connection\n\nStorage connection: ${safe(name)}\nURL: ${displayUrl(String(profile.url ?? "https://invalid.invalid"))} → ${displayUrl(connection.url)}\nUsername: stored privately (value hidden)\nPassword: ${replacePassword ? "will be replaced" : "unchanged"} (value hidden)\nAffected sync setups: ${affectedSetups && affectedSetups.length > 0 ? affectedSetups.map(safe).join(", ") : "None"}\nSaving changes future storage access for every affected setup; it does not move remote data.`,
+		["Save storage connection", "Cancel"],
 		signal,
 	);
-	if (review !== "Save profile") return false;
+	if (review !== "Save storage connection") return false;
 	throwIfAborted(signal);
 	await awaitActive(
 		signal,
-		updateStorageProfile(name, (current) => ({
-			...current,
-			...connection,
-			...(replacePassword ? { password } : {}),
-		})),
+		updateStorageProfile(
+			name,
+			(current) => ({
+				...current,
+				...connection,
+				...(replacePassword ? { password } : {}),
+			}),
+			affectedSetups,
+		),
 	);
-	ctx.ui.notify(`Saved storage profile “${safe(name)}”.`, "info");
+	ctx.ui.notify(`Saved storage connection “${safe(name)}”.`, "info");
 	return true;
 }
 

--- a/extensions/pi-sync/test/backend-orchestration.test.ts
+++ b/extensions/pi-sync/test/backend-orchestration.test.ts
@@ -109,7 +109,7 @@ test("history rollback aborts if the selected backend destination changes", asyn
 			},
 		});
 
-		await assert.rejects(history(ctx, commandOptions(), factory), /destination changed/i);
+		await assert.rejects(history(ctx, commandOptions(), factory), /storage location changed/i);
 		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"current":true}\n');
 		assert.equal((await first.readHead())?.snapshotId, current.id);
 		assert.equal(await second.readHead(), undefined);
@@ -242,7 +242,7 @@ test("fake backend exercises status, diff, sync, and backend diagnostics", async
 		assert.match(output, /publication safety: atomic-conditional \(verified atomic precondition\)/);
 		assert.match(output, /memory backend: ok/);
 		const doctorOutput = notifications.at(-1)?.message ?? "";
-		assert.ok(doctorOutput.indexOf("secret scan:") < doctorOutput.indexOf("destination:"));
+		assert.ok(doctorOutput.indexOf("secret scan:") < doctorOutput.indexOf("storage location:"));
 		assert.ok(doctorOutput.indexOf("lock:") < doctorOutput.indexOf("publication safety:"));
 	});
 });

--- a/extensions/pi-sync/test/config-filename.test.ts
+++ b/extensions/pi-sync/test/config-filename.test.ts
@@ -165,7 +165,7 @@ test("targetless v2 legacy settings migrate and retain the recoverable manager f
 		});
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.deepEqual(options, ["Manage destinations", "Help"]);
+		assert.deepEqual(options, ["Sync setups…", "Storage connections…", "Help"]);
 	});
 });
 

--- a/extensions/pi-sync/test/git-ui.test.ts
+++ b/extensions/pi-sync/test/git-ui.test.ts
@@ -39,9 +39,7 @@ test("Git setup stores a backend-specific destination without credentials", asyn
 			input: async () => inputs.shift(),
 			select: async (title: string) => {
 				reviews.push(title);
-				return title === "Automatic sync for this target"
-					? "Keep automatic sync off"
-					: "Save setup";
+				return title === "Automatic sync for this setup" ? "Keep automatic sync off" : "Save setup";
 			},
 		});
 		assert.equal(await showGitSetup(ctx, "home"), true);
@@ -55,7 +53,7 @@ test("Git setup stores a backend-specific destination without credentials", asyn
 			namespace: "home",
 		});
 		assert.equal(config.autoSync, false);
-		assert.match(reviews.join("\n"), /Auto-sync: Off/);
+		assert.match(reviews.join("\n"), /Automatic sync: Off/);
 		assert.doesNotMatch(reviews.join("\n"), /token|password/i);
 		assert.match(reviews.join("\n"), /existing non-interactive Git\/SSH credentials/i);
 	});
@@ -78,7 +76,7 @@ test("Git setup review preserves a credential-free custom SSH port", async () =>
 			input: async () => inputs.shift(),
 			select: async (title: string) => {
 				reviews.push(title);
-				return title === "Automatic sync for this target" ? "Keep automatic sync off" : "Cancel";
+				return title === "Automatic sync for this setup" ? "Keep automatic sync off" : "Cancel";
 			},
 		});
 		assert.equal(await showGitSetup(ctx, "home"), false);
@@ -103,7 +101,7 @@ test("Git settings ignore deprecated S3 automatic-sync environment overrides", a
 				mode: "tui",
 				input: async () => setupInputs.shift(),
 				select: async (title: string) =>
-					title === "Automatic sync for this target" ? "Enable automatic sync" : "Save setup",
+					title === "Automatic sync for this setup" ? "Enable automatic sync" : "Save setup",
 			});
 			assert.equal(await showGitSetup(setup.ctx, "home"), true);
 			let rendered = "";
@@ -190,11 +188,12 @@ test("Git is available through the existing setup manager and config route", asy
 		assert.match(output, /kind: git/i);
 		assert.match(output, /branch: pi-sync\/home/i);
 		assert.doesNotMatch(output, /accessKeyId|secretAccessKey|password:/i);
-		assert.match(rendered.join("\n"), /Consistency: Exact expected-branch lease/);
+		assert.doesNotMatch(rendered.join("\n"), /Consistency:/);
+		assert.match(rendered.join("\n"), /Storage: Git · github · pi-sync\/home/);
 	});
 });
 
-test("Git saved connections and targets add and edit through one destination model", async () => {
+test("Git storage connections and sync setups add and edit through one model", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		const setupInputs = [
@@ -217,12 +216,12 @@ test("Git saved connections and targets add and edit through one destination mod
 			hasUI: true,
 			mode: "tui",
 			input: async () => addProfileInputs.shift(),
-			select: async () => "Add connection",
+			select: async () => "Add storage connection",
 		});
 		assert.equal(await showAddGitStorageProfile(addProfile.ctx), true);
 
 		const addTargetInputs = ["pi-sync/work", "settings", "work"];
-		const targetSelections = ["Minimal settings", "Keep automatic sync off", "Add target"];
+		const targetSelections = ["Minimal settings", "Keep automatic sync off", "Add sync setup"];
 		const addTarget = createMockContext({
 			hasUI: true,
 			mode: "tui",
@@ -244,7 +243,7 @@ test("Git saved connections and targets add and edit through one destination mod
 			hasUI: true,
 			mode: "tui",
 			input: async () => invalidTargetInputs.shift(),
-			select: async () => "Save target",
+			select: async () => "Save sync setup",
 		});
 		assert.equal(
 			await showEditGitTarget(invalidTarget.ctx, {
@@ -266,7 +265,7 @@ test("Git saved connections and targets add and edit through one destination mod
 			hasUI: true,
 			mode: "tui",
 			input: async () => editProfileInputs.shift(),
-			select: async () => "Save profile",
+			select: async () => "Save storage connection",
 		});
 		await showEditGitStorageProfile(editProfile.ctx, "backup", {
 			kind: "git",
@@ -278,7 +277,7 @@ test("Git saved connections and targets add and edit through one destination mod
 			hasUI: true,
 			mode: "tui",
 			input: async () => editTargetInputs.shift(),
-			select: async () => "Save target",
+			select: async () => "Save sync setup",
 		});
 		await showEditGitTarget(editTarget.ctx, {
 			settingsVersion: 2,

--- a/extensions/pi-sync/test/menu-wording.test.ts
+++ b/extensions/pi-sync/test/menu-wording.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { localConfigPath, readLocalConfigObject } from "../src/config.js";
+import { showSyncManager } from "../src/manager-ui.js";
+import { updateStorageProfile } from "../src/settings-management.js";
+import { withTempHome } from "./helpers.js";
+
+function settings() {
+	return {
+		version: 2,
+		activeTarget: "home",
+		profiles: {
+			r2: {
+				kind: "r2",
+				endpoint: "https://account.r2.cloudflarestorage.com",
+				region: "auto",
+				accessKeyId: "access",
+				secretAccessKey: "secret",
+			},
+		},
+		targets: {
+			home: {
+				profile: "r2",
+				bucket: "home-bucket",
+				prefix: "pi-sync",
+				namespace: "home",
+				autoSync: true,
+				syncFiles: ["settings.json"],
+				syncSessions: false,
+				extraFiles: [],
+			},
+			work: {
+				profile: "r2",
+				bucket: "work-bucket",
+				prefix: "pi-sync",
+				namespace: "work",
+				autoSync: false,
+				syncFiles: ["AGENTS.md"],
+				syncSessions: true,
+				extraFiles: [],
+			},
+		},
+	};
+}
+
+test("main shows Switch sync setup only when multiple setups are useful", async () => {
+	await withSettings(settings(), async () => {
+		let options: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (_title: string, nextOptions: string[]) => {
+				options = nextOptions;
+				return undefined;
+			},
+		});
+		await showSyncManager(ctx, async () => undefined);
+		assert.deepEqual(options, [
+			"Sync now (recommended)",
+			"Switch sync setup",
+			"Status & changes",
+			"Settings",
+			"More…",
+		]);
+	});
+});
+
+test("switch preview rejects a concurrent post-switch behavior change", async () => {
+	const value = { ...settings(), targetSwitchAction: "ask" as const };
+	await withSettings(value, async () => {
+		const choices = ["Switch sync setup", "work · r2 · work-bucket", "Switch to work"];
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				const choice = choices.shift();
+				if (choice === "Switch to work") {
+					writeFileSync(
+						localConfigPath(),
+						`${JSON.stringify({ ...value, targetSwitchAction: "pull" }, null, "\t")}\n`,
+					);
+				}
+				assert.ok(title.length > 0);
+				return choice;
+			},
+		});
+		await showSyncManager(ctx, async () => undefined);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/setup-switch behavior changed.*reopen it and retry/i,
+		);
+		assert.equal((await readLocalConfigObject())?.activeTarget, "home");
+	});
+});
+
+test("editing a non-current setup never mutates the current setup", async () => {
+	await withSettings(settings(), async () => {
+		const choices = [
+			"More…",
+			"Sync setups…",
+			"work",
+			"Edit sync setup…",
+			"Save sync setup",
+			"Back",
+			"Back",
+			undefined,
+		];
+		const inputs = ["updated-work", "work-prefix", "work-space"];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => choices.shift(),
+			input: async () => inputs.shift(),
+		});
+		await showSyncManager(ctx, async () => undefined);
+		const saved = (await readLocalConfigObject()) as ReturnType<typeof settings>;
+		assert.equal(saved.targets.home.bucket, "home-bucket");
+		assert.equal(saved.targets.work.bucket, "updated-work");
+		assert.equal(saved.targets.work.prefix, "work-prefix");
+		assert.equal(saved.targets.work.namespace, "work-space");
+	});
+});
+
+test("invalid non-current setups stay visible with repair-oriented detail", async () => {
+	const value = settings();
+	value.targets.work.profile = "missing";
+	await withSettings(value, async () => {
+		const choices = ["More…", "Sync setups…", "work", "Back", "Back", undefined];
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return choices.shift();
+			},
+		});
+		await showSyncManager(ctx, async () => undefined);
+		assert.doesNotMatch(calls[0]?.options.join("\n") ?? "", /Switch sync setup/);
+		assert.deepEqual(calls[2]?.options, ["Add sync setup", "home (current)", "work", "Back"]);
+		assert.match(calls[3]?.title ?? "", /Status: Invalid/);
+		assert.match(calls[3]?.title ?? "", /missing storage connection "missing"/);
+		assert.doesNotMatch(calls[3]?.options.join("\n") ?? "", /Make current/);
+		assert.deepEqual(calls[3]?.options, ["Edit sync setup…", "Remove sync setup…", "Back"]);
+	});
+});
+
+test("current setup detail explains why removal is unavailable", async () => {
+	await withSettings(settings(), async () => {
+		const choices = ["More…", "Sync setups…", "home (current)", "Back", "Back", undefined];
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return choices.shift();
+			},
+		});
+		await showSyncManager(ctx, async () => undefined);
+		assert.match(calls[3]?.title ?? "", /Endpoint: https:\/\/account\.r2\.cloudflarestorage\.com/);
+		assert.match(calls[3]?.title ?? "", /Storage location: home-bucket\/pi-sync\/profiles\/home/);
+		assert.match(calls[3]?.title ?? "", /Remove unavailable: switch to another setup first/);
+		assert.deepEqual(calls[3]?.options, ["Edit sync setup…", "Back"]);
+	});
+});
+
+test("setup and connection lists escape terminal controls in stored names", async () => {
+	const value = settings();
+	const profiles = value.profiles as Record<string, typeof value.profiles.r2>;
+	const targets = value.targets as Record<string, typeof value.targets.work>;
+	profiles["unsafe\u001b[31m"] = { ...value.profiles.r2 };
+	targets["unsafe\u0007setup"] = {
+		...value.targets.work,
+		profile: "unsafe\u001b[31m",
+		bucket: "other-bucket",
+	};
+	await withSettings(value, async () => {
+		const choices = [
+			"More…",
+			"Sync setups…",
+			"Back",
+			"More…",
+			"Storage connections…",
+			"Back",
+			undefined,
+		];
+		const rendered: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				rendered.push(title, ...options);
+				return choices.shift();
+			},
+		});
+		await showSyncManager(ctx, async () => undefined);
+		const output = rendered.join("\n");
+		assert.equal(output.includes("\u001b"), false);
+		assert.equal(output.includes("\u0007"), false);
+		assert.match(output, /unsafe\?\[31m/);
+		assert.match(output, /unsafe\?setup/);
+	});
+});
+
+test("shared storage connection edits reject stale dependent previews", async () => {
+	await withSettings(settings(), async () => {
+		const before = JSON.stringify(await readLocalConfigObject());
+		await assert.rejects(
+			updateStorageProfile("r2", (profile) => ({ ...profile, region: "other" }), ["home"]),
+			/usage changed.*review the affected sync setups/i,
+		);
+		assert.equal(JSON.stringify(await readLocalConfigObject()), before);
+	});
+});
+
+test("shared storage connection edits preview every affected setup", async () => {
+	await withSettings(settings(), async () => {
+		const choices = [
+			"More…",
+			"Storage connections…",
+			"r2",
+			"Edit storage connection…",
+			"Keep current credentials",
+			"Save storage connection",
+			"Back",
+			"Back",
+			undefined,
+		];
+		const inputs = ["https://new.example.com", "us-east-1"];
+		const titles: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string) => {
+				titles.push(title);
+				return choices.shift();
+			},
+			input: async () => inputs.shift(),
+		});
+		await showSyncManager(ctx, async () => undefined);
+		const review = titles.find((title) => title.includes("Review storage connection")) ?? "";
+		assert.match(review, /Affected sync setups: home, work/);
+		assert.match(review, /account\.r2\.cloudflarestorage\.com.*new\.example\.com/s);
+		const saved = (await readLocalConfigObject()) as ReturnType<typeof settings>;
+		assert.equal(saved.profiles.r2.endpoint, "https://new.example.com");
+	});
+});
+
+async function withSettings(value: unknown, run: () => Promise<void>) {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), `${JSON.stringify(value, null, "\t")}\n`);
+		await run();
+	});
+}

--- a/extensions/pi-sync/test/multi-profile.test.ts
+++ b/extensions/pi-sync/test/multi-profile.test.ts
@@ -185,17 +185,14 @@ test("bare sync menu shows current state and goal-oriented actions", async () =>
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.match(calls[0]?.title ?? "", /Current target: home/);
-		assert.match(calls[0]?.title ?? "", /Cloudflare R2.*personal-pi/);
-		assert.match(calls[0]?.title ?? "", /Synced content: 1 built-in group.*Sessions: Off/);
-		assert.match(calls[0]?.title ?? "", /Auto-sync: On/);
-		assert.match(calls[0]?.title ?? "", /Last applied snapshot: snapshot-home-123/);
-		assert.match(calls[0]?.title ?? "", /Remote changes: Not checked/);
+		assert.match(calls[0]?.title ?? "", /Current sync setup: home/);
+		assert.match(calls[0]?.title ?? "", /Storage: Cloudflare R2.*r2.*personal-pi/);
+		assert.match(calls[0]?.title ?? "", /Included: 1 built-in group.*Sessions off/);
+		assert.match(calls[0]?.title ?? "", /Automatic sync: On/);
+		assert.match(calls[0]?.title ?? "", /Last applied: snapshot-home-123/);
+		assert.match(calls[0]?.title ?? "", /Remote status: Not checked/);
 		assert.deepEqual(calls[0]?.options, [
 			"Sync now (recommended)",
-			"Pull from remote",
-			"Push to remote",
-			"Switch target",
 			"Status & changes",
 			"Settings",
 			"More…",
@@ -223,19 +220,73 @@ test("main menu exposes shallow secondary navigation with Back", async () => {
 
 		assert.match(calls[1]?.title ?? "", /More options/);
 		assert.deepEqual(calls[1]?.options, [
-			"Manage destinations",
-			"History & recovery",
+			"Pull from remote…",
+			"Push to remote…",
+			"Sync setups…",
+			"Storage connections…",
+			"History & recovery…",
 			"Help",
 			"Back",
 		]);
-		assert.match(calls[2]?.title ?? "", /Current target: home/);
+		assert.match(calls[2]?.title ?? "", /Current sync setup: home/);
 	});
 });
 
-test("main menu dispatches explicit pull and push routes", async () => {
+test("Sync setups expose current state and symmetric detail actions", async () => {
 	await withTempSettings(async () => {
 		writeSettings(v2Settings());
-		const choices = ["Pull from remote", "Push to remote", undefined];
+		const choices = ["More…", "Sync setups…", "home (current)", "Back", "Back", undefined];
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return choices.shift();
+			},
+		});
+
+		await showSyncManager(ctx, async () => undefined);
+
+		assert.equal(calls[2]?.title, "Sync setups");
+		assert.deepEqual(calls[2]?.options, ["Add sync setup", "home (current)", "Back"]);
+		assert.match(calls[3]?.title ?? "", /Sync setup “home”/);
+		assert.match(calls[3]?.title ?? "", /Status: Current/);
+		assert.match(calls[3]?.title ?? "", /Storage connection: r2/);
+		assert.deepEqual(calls[3]?.options, ["Edit sync setup…", "Remove sync setup…", "Back"]);
+	});
+});
+
+test("Storage connections show type, credential source, dependents, and unavailable removal", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const choices = ["More…", "Storage connections…", "r2", "Back", "Back", undefined];
+		const calls: Array<{ title: string; options: string[] }> = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				calls.push({ title, options });
+				return choices.shift();
+			},
+		});
+
+		await showSyncManager(ctx, async () => undefined);
+
+		assert.equal(calls[2]?.title, "Storage connections");
+		assert.deepEqual(calls[2]?.options, ["Add storage connection", "r2", "Back"]);
+		assert.match(calls[3]?.title ?? "", /Storage connection “r2”/);
+		assert.match(calls[3]?.title ?? "", /Credentials: Settings file/);
+		assert.match(calls[3]?.title ?? "", /Used by: home/);
+		assert.match(calls[3]?.title ?? "", /Remove unavailable/);
+		assert.deepEqual(calls[3]?.options, ["Edit storage connection…", "Back"]);
+	});
+});
+
+test("More dispatches explicit pull and push routes", async () => {
+	await withTempSettings(async () => {
+		writeSettings(v2Settings());
+		const choices = ["More…", "Pull from remote…", "More…", "Push to remote…", undefined];
 		const routes: string[] = [];
 		const titles: string[] = [];
 		const { ctx } = createMockContext({
@@ -260,27 +311,28 @@ test("main menu dispatches explicit pull and push routes", async () => {
 		});
 
 		assert.deepEqual(routes, ["pull", "push"]);
-		assert.match(titles[1] ?? "", /Last applied snapshot: after-pull/);
-		assert.match(titles[2] ?? "", /Last applied snapshot: after-push/);
+		assert.match(titles[2] ?? "", /Last applied: after-pull/);
+		assert.match(titles[4] ?? "", /Last applied: after-push/);
 	});
 });
 
 test("main menu exits the stale continuation after an applied pull", async () => {
 	await withTempSettings(async () => {
 		writeSettings(v2Settings());
+		const choices = ["More…", "Pull from remote…"];
 		let selectCalls = 0;
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "rpc",
 			select: async () => {
 				selectCalls += 1;
-				return "Pull from remote";
+				return choices.shift();
 			},
 		});
 
 		await showSyncManager(ctx, async () => "applied");
 
-		assert.equal(selectCalls, 1);
+		assert.equal(selectCalls, 2);
 	});
 });
 
@@ -338,12 +390,12 @@ test("bare sync disables mutations and exposes recovery while a live lock is hel
 		await mock.commands.get("sync")?.handler("", ctx);
 
 		assert.match(title, /Operation in progress: pull/);
-		assert.doesNotMatch(options.join("\n"), /Sync now|Pull|Push|Settings|Switch target/);
-		assert.deepEqual(options, ["Status & changes", "History & recovery", "Help"]);
+		assert.doesNotMatch(options.join("\n"), /Sync now|Pull|Push|Settings|Switch sync setup/);
+		assert.deepEqual(options, ["Status & changes", "History & recovery…", "Help"]);
 	});
 });
 
-test("menu hides transfer actions when no synced content is selected", async () => {
+test("menu hides transfer actions when no included content is selected", async () => {
 	await withTempSettings(async () => {
 		const settings = v2Settings();
 		settings.targets.home.syncFiles = [];
@@ -365,21 +417,21 @@ test("menu hides transfer actions when no synced content is selected", async () 
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.match(title, /No synced content is selected/);
-		assert.deepEqual(options, ["Settings", "Switch target", "Status & changes", "More…"]);
+		assert.match(title, /No included content is selected/);
+		assert.deepEqual(options, ["Settings", "Status & changes", "More…"]);
 	});
 });
 
 test("menu pull and push checks cancel before commit with distinct feedback", async () => {
 	for (const scenario of [
 		{
-			label: "Pull from remote",
+			label: "Pull from remote…",
 			route: "pull",
 			loading: /Checking remote changes/,
 			cancelled: /Pull check cancelled; no local files were changed/,
 		},
 		{
-			label: "Push to remote",
+			label: "Push to remote…",
 			route: "push",
 			loading: /Preparing push preview/,
 			cancelled: /Push preparation cancelled; no remote files were changed/,
@@ -387,7 +439,7 @@ test("menu pull and push checks cancel before commit with distinct feedback", as
 	] as const) {
 		await withTempSettings(async () => {
 			writeSettings(v2Settings());
-			const choices = [scenario.label, undefined];
+			const choices = ["More…", scenario.label, undefined];
 			let requestedRoute = "";
 			let signalAborted = false;
 			let commitStarted = false;
@@ -446,7 +498,7 @@ test("menu push and pull preview concrete effects and cancellation is read-only"
 			return new Response(null, { status: 404 });
 		}) as typeof globalThis.fetch;
 		try {
-			const choices = ["Push to remote", undefined];
+			const choices = ["More…", "Push to remote…", undefined];
 			let confirmTitle = "";
 			let confirmMessage = "";
 			const mock = createMockPi();
@@ -499,7 +551,7 @@ test("menu push and pull preview concrete effects and cancellation is read-only"
 			throw new Error(`Unexpected request: ${url.pathname}`);
 		}) as typeof globalThis.fetch;
 		try {
-			const choices = ["Pull from remote", undefined];
+			const choices = ["More…", "Pull from remote…", undefined];
 			let confirmTitle = "";
 			let confirmMessage = "";
 			const mock = createMockPi();
@@ -538,7 +590,7 @@ test("menu pull failure preserves local files and suggests the next action", asy
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = (async () => new Response(null, { status: 404 })) as typeof globalThis.fetch;
 		try {
-			const choices = ["Pull from remote", undefined];
+			const choices = ["More…", "Pull from remote…", undefined];
 			const mock = createMockPi();
 			sync(mock.pi);
 			const { ctx, notifications } = createMockContext({
@@ -597,7 +649,7 @@ test("Sync now read-only check stops before transport when Escape wins command r
 	});
 });
 
-test("switch target asks to pull by default and declining leaves local files unchanged", async () => {
+test("switch sync setup asks to pull by default and declining leaves local files unchanged", async () => {
 	await withTempSettings(async () => {
 		const settings = v2Settings();
 		settings.profiles.s3 = {
@@ -619,7 +671,7 @@ test("switch target asks to pull by default and declining leaves local files unc
 		writeSettings(settings);
 		const mock = createMockPi();
 		sync(mock.pi);
-		const selections = ["Switch target", "work", "Switch to work", undefined];
+		const selections = ["Switch sync setup", "work · s3 · company-pi", "Switch to work", undefined];
 		const calls: Array<{ title: string; options: string[] }> = [];
 		let pullPrompt = "";
 		const { ctx, notifications } = createMockContext({
@@ -637,16 +689,16 @@ test("switch target asks to pull by default and declining leaves local files unc
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.match(calls[1]?.title ?? "", /Current target: home/);
+		assert.match(calls[1]?.title ?? "", /Current sync setup: home/);
 		assert.deepEqual(calls[1]?.options, [
-			"home (current) · r2 · personal-pi · 1 groups · Sessions: Off",
-			"work · s3 · company-pi · 1 groups · Sessions: Off",
+			"home (current) · r2 · personal-pi",
+			"work · s3 · company-pi",
 			"Back",
 		]);
 		assert.match(calls[2]?.title ?? "", /From: home/);
 		assert.match(calls[2]?.title ?? "", /To: work/);
 		assert.match(calls[2]?.title ?? "", /ask whether to review a pull/i);
-		assert.match(pullPrompt, /Review a pull for target “work” now\?/);
+		assert.match(pullPrompt, /Review a pull for sync setup “work” now\?/);
 		assert.match(pullPrompt, /exact local writes and deletions/i);
 		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
 		assert.match(notifications.at(-1)?.message ?? "", /Switched to “work”.*not pulled/i);
@@ -676,7 +728,7 @@ test("accepting the default post-switch prompt starts a pull", async () => {
 			return "applied";
 		});
 
-		assert.match(promptTitle, /Review a pull for target “work” now\?/);
+		assert.match(promptTitle, /Review a pull for sync setup “work” now\?/);
 		assert.equal(pullCalls, 1);
 		assert.equal(pulledTarget, "work");
 		assert.equal(result.pullApplied, true);
@@ -720,7 +772,7 @@ test("automatic post-switch pulls reject no-UI modes before changing the active 
 			try {
 				await assert.rejects(
 					async () => await mock.commands.get("sync")?.handler("use work", ctx),
-					/automatic target pulls require interactive confirmation/i,
+					/automatic setup pulls require interactive confirmation/i,
 				);
 			} finally {
 				globalThis.fetch = originalFetch;
@@ -838,7 +890,7 @@ test("declining a post-switch pull review reports that the selected target remai
 			assert.equal(readFileSync(settingsPath, "utf8"), '{"local":true}\n');
 			assert.match(
 				notifications.at(-1)?.message ?? "",
-				/Pull cancelled; target “work” remains active and synced files were not changed/,
+				/Pull cancelled; sync setup “work” remains current and synced files were not changed/,
 			);
 		} finally {
 			globalThis.fetch = originalFetch;
@@ -860,7 +912,7 @@ test("post-switch pulls stay pinned to the selected target across concurrent act
 				return new Response(null, { status: 404 });
 			}) as typeof globalThis.fetch;
 			try {
-				const selections = ["Switch target", "work", "Switch to work"];
+				const selections = ["Switch sync setup", "work · r2 · personal-pi", "Switch to work"];
 				const mock = createMockPi();
 				sync(mock.pi);
 				const { ctx } = createMockContext({
@@ -940,7 +992,7 @@ test("cancelling an automatic post-switch pull reports that the target remains s
 			throw new Error("Transport must not start after cancellation");
 		}) as typeof globalThis.fetch;
 		try {
-			const selections = ["Switch target", "work", "Switch to work"];
+			const selections = ["Switch sync setup", "work · r2 · personal-pi", "Switch to work"];
 			const mock = createMockPi();
 			sync(mock.pi);
 			const { ctx, notifications } = createMockContext({
@@ -961,7 +1013,7 @@ test("cancelling an automatic post-switch pull reports that the target remains s
 			assert.equal((await readLocalConfigObject())?.activeTarget, "work");
 			assert.match(
 				notifications.at(-1)?.message ?? "",
-				/Pull cancelled; target “work” remains active and synced files were not changed/,
+				/Pull cancelled; sync setup “work” remains current and synced files were not changed/,
 			);
 		} finally {
 			globalThis.fetch = originalFetch;
@@ -1028,7 +1080,7 @@ test("settings menu uses SettingsList and persists target-switch choices in plac
 
 		assert.match(initialRender, /Pi Sync Settings/);
 		assert.match(initialRender, /Automatic sync/);
-		assert.match(initialRender, /After target switch/);
+		assert.match(initialRender, /After switching setup/);
 		assert.doesNotMatch(initialRender, /Type to search/);
 		const saved = await readLocalConfigObject();
 		assert.equal(saved?.targetSwitchAction, "pull");
@@ -1073,7 +1125,7 @@ test("settings list restores the displayed value when an atomic save is rejected
 
 		await mock.commands.get("sync")?.handler("", ctx);
 
-		assert.match(afterFailure, /After target switch/);
+		assert.match(afterFailure, /After switching setup/);
 		assert.match(afterFailure, /Ask before pull/);
 		assert.doesNotMatch(afterFailure, /Start pull/);
 		assert.match(notifications.at(-1)?.message ?? "", /settings save failed/i);
@@ -1113,11 +1165,11 @@ test("legacy settings screen omits the unavailable target-switch setting", async
 		await mock.commands.get("sync")?.handler("", ctx);
 
 		assert.match(rendered, /Automatic sync/);
-		assert.doesNotMatch(rendered, /After target switch/);
+		assert.doesNotMatch(rendered, /After switching setup/);
 	});
 });
 
-test("cancelling a target switch leaves settings byte-for-byte unchanged", async () => {
+test("cancelling a sync setup switch leaves settings byte-for-byte unchanged", async () => {
 	await withTempSettings(async () => {
 		const settings = v2Settings();
 		settings.targets.work = { ...settings.targets.home, namespace: "work" };
@@ -1125,7 +1177,7 @@ test("cancelling a target switch leaves settings byte-for-byte unchanged", async
 		const before = JSON.stringify(await readLocalConfigObject());
 		const mock = createMockPi();
 		sync(mock.pi);
-		const selections = ["Switch target", "work", "Cancel", undefined];
+		const selections = ["Switch sync setup", "work · r2 · personal-pi", "Cancel", undefined];
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
@@ -1153,7 +1205,7 @@ test("first-time R2 setup recommends home/r2/pi-sync defaults without raw path q
 			"Recommended Pi settings",
 			"Enable automatic sync",
 			"Keep sessions off (recommended)",
-			"Save setup",
+			"Save sync setup",
 			undefined,
 		];
 		const inputs = ["https://account.r2.cloudflarestorage.com"];
@@ -1187,7 +1239,7 @@ test("first-time R2 setup recommends home/r2/pi-sync defaults without raw path q
 		assert.deepEqual(inputTitles, ["Cloudflare R2 endpoint"]);
 		assert.match(rendered.join("\n"), /Bucket must already exist/);
 		assert.match(rendered.join("\n"), /pi-sync\/profiles\/home/);
-		assert.match(notifications.at(-1)?.message ?? "", /Destination “home” is ready/);
+		assert.match(notifications.at(-1)?.message ?? "", /Sync setup “home” is ready/);
 		assert.doesNotMatch(rendered.join("\n"), /setup-access-secret|setup-secret-value/);
 	});
 });
@@ -1205,7 +1257,7 @@ test("first-time S3 setup asks only for the existing bucket and derives work def
 			"Minimal settings",
 			"Keep automatic sync off",
 			"Keep sessions off (recommended)",
-			"Save setup",
+			"Save sync setup",
 			undefined,
 		];
 		const inputs = ["https://s3.example.com", "ap-northeast-1", "company-pi"];
@@ -1247,7 +1299,7 @@ test("first-time S3 setup can store masked credentials entirely through TUI", as
 			"Minimal settings",
 			"Keep automatic sync off",
 			"Keep sessions off (recommended)",
-			"Save setup",
+			"Save sync setup",
 			undefined,
 		];
 		const inputs = ["https://s3.example.com", "us-east-1", "personal-pi", "access-key-id"];
@@ -1291,7 +1343,7 @@ test("first-time setup keeps advanced profile and remote-location customization"
 			"Minimal settings",
 			"Keep automatic sync off",
 			"Keep sessions off (recommended)",
-			"Save setup",
+			"Save sync setup",
 			undefined,
 		];
 		const inputs = [
@@ -1345,19 +1397,19 @@ test("cancelling first-time setup creates no settings or state", async () => {
 	});
 });
 
-test("manage flow recommends the current profile bucket and derives a separate namespace", async () => {
+test("add sync setup recommends the current connection bucket and derives a separate namespace", async () => {
 	await withTempSettings(async () => {
 		writeSettings(v2Settings());
 		const mock = createMockPi();
 		sync(mock.pi);
 		const selections = [
 			"More…",
-			"Manage destinations",
-			"Add destination",
+			"Sync setups…",
+			"Add sync setup",
 			"r2",
 			"Same bucket as “home” (recommended)",
 			"Recommended Pi settings",
-			"Add target",
+			"Add sync setup",
 			undefined,
 		];
 		const inputs = ["work"];
@@ -1382,11 +1434,11 @@ test("manage flow recommends the current profile bucket and derives a separate n
 		assert.equal(work?.prefix, "pi-sync");
 		assert.equal(work?.namespace, "work");
 		assert.match(rendered.join("\n"), /personal-pi.*pi-sync\/profiles\/work/s);
-		assert.match(notifications.at(-1)?.message ?? "", /Added sync target “work”/);
+		assert.match(notifications.at(-1)?.message ?? "", /Added sync setup “work”/);
 	});
 });
 
-test("synced-content UI fits narrow and wide terminal widths with textual state", async () => {
+test("included-content UI fits narrow and wide terminal widths with textual state", async () => {
 	await withTempSettings(async () => {
 		const settings = v2Settings();
 		settings.activeTarget = "家庭與工作設定";
@@ -1475,7 +1527,7 @@ test("TUI history selects a snapshot, previews concrete rollback, and cancellati
 
 			await mock.commands.get("sync")?.handler("history", ctx);
 
-			assert.match(historyTitle, /History for target “home”/);
+			assert.match(historyTitle, /History for sync setup “home”/);
 			assert.match(confirmMessage, /Snapshot: remote-snapshot/);
 			assert.match(confirmMessage, /Update locally: settings\.json/);
 			assert.equal(putCalls, 0);
@@ -1506,7 +1558,7 @@ test("Sync now reports nothing selected without network or state mutation", asyn
 			await mock.commands.get("sync")?.handler("sync", ctx);
 
 			assert.equal(requests, 0);
-			assert.match(notifications.at(-1)?.message ?? "", /manages no files/);
+			assert.match(notifications.at(-1)?.message ?? "", /includes no files/);
 			assert.equal(existsSync(path.join(stateDir(), "targets")), false);
 		} finally {
 			globalThis.fetch = originalFetch;
@@ -1554,7 +1606,7 @@ test("direct use switches targets and target options parse exactly", async () =>
 		assert.equal((await readLocalConfigObject())?.activeTarget, "work");
 		assert.match(notifications.at(-1)?.message ?? "", /confirmation requires TUI mode/);
 		assert.equal(parseOptions(["--target", "home"]).target, "home");
-		assert.throws(() => parseOptions(["--target"]), /requires a target name/);
+		assert.throws(() => parseOptions(["--target"]), /requires a sync setup name/);
 		assert.throws(() => parseOptions(["--unknown"]), /Unknown sync option/);
 	});
 });

--- a/extensions/pi-sync/test/review-feedback.test.ts
+++ b/extensions/pi-sync/test/review-feedback.test.ts
@@ -64,7 +64,7 @@ test("duplicate destination validation uses normalized S3 key segments", async (
 
 		await assert.rejects(
 			addSyncTarget("work", duplicate),
-			/duplicates the remote destination of “home”/,
+			/duplicates the storage location of “home”/,
 		);
 
 		settings.targets.work = duplicate;
@@ -81,7 +81,7 @@ test("recovery menu passes explicit stale confirmation for unreadable lock metad
 		writeFileSync(lockPath(), "");
 		const mock = createMockPi();
 		sync(mock.pi);
-		const selections = ["History & recovery", "Recover stale operation", undefined];
+		const selections = ["History & recovery…", "Recover stale operation", undefined];
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
 			mode: "tui",

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -67,10 +67,10 @@ test("sync command help and errors use the public command name", async () => {
 
 const expectedSyncMenuOptions = [
 	"help — Show command usage",
-	"use — Switch the current sync target",
+	"use — Switch the current sync setup",
 	"init — Create local config template",
 	"config — Show resolved configuration",
-	"files — Choose synced files",
+	"files — Choose included content",
 	"status — Show sync status",
 	"diff — Show local/remote diff",
 	"doctor — Check config, secrets, and lock state",
@@ -301,7 +301,10 @@ test("sync files has a protocol-safe non-TUI summary", async () => {
 
 		await mock.commands.get("sync")?.handler("files", ctx);
 		assert.equal(customCalls, 0);
-		assert.match(notifications.at(-1)?.message ?? "", /selected files.*syncFiles.*pi-sync\.json/is);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/included content.*syncFiles.*pi-sync\.json/is,
+		);
 	});
 });
 
@@ -738,7 +741,7 @@ test("sync config output reports session sync and privacy warning", async () => 
 			await mock.commands.get("sync")?.handler("config", ctx);
 		});
 
-		assert.match(notifications[0]?.message ?? "", /syncSessions: enabled/);
+		assert.match(notifications[0]?.message ?? "", /sessions: included/);
 		assert.match(notifications[0]?.message ?? "", /session JSONL can contain/);
 	});
 });

--- a/extensions/pi-sync/test/webdav-ui.test.ts
+++ b/extensions/pi-sync/test/webdav-ui.test.ts
@@ -110,7 +110,7 @@ test("WebDAV setup cannot continue after its session is aborted", async () => {
 	});
 });
 
-test("WebDAV profile and target management preserve hidden credentials", async () => {
+test("WebDAV storage connection and sync setup management preserve hidden credentials", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(
@@ -118,12 +118,12 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 			JSON.stringify({ version: 2, profiles: {}, targets: {}, futureField: "preserved" }),
 		);
 		const selections = [
-			"Add profile",
+			"Add storage connection",
 			"Recommended Pi settings",
-			"Add target",
+			"Add sync setup",
 			"Keep current password",
-			"Save profile",
-			"Save target",
+			"Save storage connection",
+			"Save sync setup",
 		];
 		const inputs = [
 			"dav",
@@ -185,7 +185,7 @@ test("WebDAV profile and target management preserve hidden credentials", async (
 	});
 });
 
-test("Add destination can create a WebDAV connection without leaving the manager flow", async () => {
+test("Add sync setup can create a WebDAV connection without leaving the manager flow", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(
@@ -214,13 +214,13 @@ test("Add destination can create a WebDAV connection without leaving the manager
 		);
 		const selections = [
 			"More…",
-			"Manage destinations",
-			"Add destination",
-			"Create a new saved connection…",
+			"Sync setups…",
+			"Add sync setup",
+			"Add a new storage connection…",
 			"WebDAV",
-			"Add profile",
+			"Add storage connection",
 			"Recommended Pi settings",
-			"Add target",
+			"Add sync setup",
 			undefined,
 		];
 		const inputs = ["work", "dav", "https://cloud.example.com/dav", "user", "pi-sync", "work"];
@@ -310,7 +310,7 @@ test("WebDAV repair removes incompatible fields and fills missing credentials th
 			input: async () => inputs.shift(),
 			select: async (title: string) => {
 				reviews.push(title);
-				return "Repair destination";
+				return "Repair storage location";
 			},
 		});
 


### PR DESCRIPTION
## Summary

- redesign the `/sync` manager around current state and common workflows, with conditional setup switching and explicit pull/push actions under `More…`
- add symmetric sync-setup and storage-connection management with dependency previews, invalid-state visibility, stale-read protection, and consistent user-facing terminology
- preserve the version 2 schema and compatibility routes, archive the completed menu plan, and document the separate version 3 schema proposal without implementing it

## Verification

- `npm run check` (1,699 tests)
- `just pack-sync` (43 files inspected)
- isolated `pi --mode rpc --no-session -e ./extensions/pi-sync` smoke (exit 0, protocol-safe JSON, no stderr)
- `git diff --check`
