### PR TITLE
fix: resolve code scanning findings

### DIFF
--- a/experimental/pi-webui/src/server.ts
+++ b/experimental/pi-webui/src/server.ts
@@ -449,16 +449,16 @@ export class WebUIServer {
 			}
 			throw new HttpError(404, "Not found");
 		} catch (error) {
-			const status =
+			const expectedError =
 				error instanceof HttpError ||
 				error instanceof AttachmentError ||
 				error instanceof DraftError ||
-				error instanceof SentImageError
-					? error.status
-					: 500;
+				error instanceof SentImageError;
+			const status = expectedError ? error.status : 500;
+			const message = expectedError ? error.message : "Internal server error";
 			if (error instanceof HttpError && error.closeConnection)
 				response.setHeader("Connection", "close");
-			this.json(response, status, { error: formatError(error) });
+			this.json(response, status, { error: message });
 			if (error instanceof HttpError && error.closeConnection) request.socket?.destroySoon?.();
 		}
 	}

--- a/experimental/pi-webui/test/server.test.ts
+++ b/experimental/pi-webui/test/server.test.ts
@@ -93,7 +93,9 @@ test("bootstrap links rotate and exchange once for isolated secure cookies", asy
 test("assets and APIs require auth and carry restrictive headers", async () => {
 	const { server } = await harness();
 	try {
-		assert.equal((await api(server, "/")).status, 401);
+		const unauthorized = await api(server, "/");
+		assert.equal(unauthorized.status, 401);
+		assert.deepEqual(await unauthorized.json(), { error: "Authentication required" });
 		const cookie = await authenticate(server);
 		const page = await api(server, "/", { cookie });
 		assert.equal(page.status, 200);
@@ -312,10 +314,9 @@ test("failed sends release their request id for an unchanged browser retry", asy
 			draftRevision: draft.revision,
 			delivery: "next",
 		});
-		assert.equal(
-			(await api(server, "/api/messages", { method: "POST", cookie, client, body })).status,
-			500,
-		);
+		const failed = await api(server, "/api/messages", { method: "POST", cookie, client, body });
+		assert.equal(failed.status, 500);
+		assert.deepEqual(await failed.json(), { error: "Internal server error" });
 		assert.equal(
 			(await api(server, "/api/messages", { method: "POST", cookie, client, body })).status,
 			202,

--- a/extensions/pi-btw/src/bring-to-main.ts
+++ b/extensions/pi-btw/src/bring-to-main.ts
@@ -853,7 +853,7 @@ function escapeBringToMainText(text: string): string {
 		.join("")
 		.replace(/<btw_context(?=[ \t\r\n>])/g, "&lt;btw_context")
 		.replace(/<\/btw_context[ \t\r\n]*>/g, (terminator) =>
-			terminator.replace("<", "&lt;").replace(">", "&gt;"),
+			terminator.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
 		);
 }
 

--- a/extensions/pi-starship/src/installed-packages.ts
+++ b/extensions/pi-starship/src/installed-packages.ts
@@ -75,7 +75,7 @@ function packageNameForSource(source: string, baseDirectory: string): string | u
 
 function npmPackageName(source: string): string {
 	const spec = source.slice("npm:".length);
-	if (spec.startsWith("@")) return spec.split("@").slice(0, 2).join("@").replace(/^@/u, "@");
+	if (spec.startsWith("@")) return spec.split("@").slice(0, 2).join("@");
 	return spec.split("@")[0] ?? spec;
 }
 

--- a/extensions/pi-starship/src/modules/extension-status.ts
+++ b/extensions/pi-starship/src/modules/extension-status.ts
@@ -179,6 +179,6 @@ export function buildExtensionStatusIconAliases(
 
 function npmPackageName(source: string): string {
 	const spec = source.slice("npm:".length);
-	if (spec.startsWith("@")) return spec.split("@").slice(0, 2).join("@").replace(/^@/u, "@");
+	if (spec.startsWith("@")) return spec.split("@").slice(0, 2).join("@");
 	return spec.split("@")[0] ?? spec;
 }

--- a/extensions/pi-starship/src/modules/git/runtime.ts
+++ b/extensions/pi-starship/src/modules/git/runtime.ts
@@ -198,12 +198,31 @@ export function parseGitStatusPorcelain(output: string): GitStatusSnapshot {
 }
 
 export function parseGitDiffShortstat(output: string): GitMetricsSnapshot {
-	const added = /(\d+) insertions?\(\+\)/u.exec(output)?.[1];
-	const deleted = /(\d+) deletions?\(-\)/u.exec(output)?.[1];
 	return {
-		added: added ? Number(added) : 0,
-		deleted: deleted ? Number(deleted) : 0,
+		added: parseShortstatMetric(output, "insertion(+)", "insertions(+)") ?? 0,
+		deleted: parseShortstatMetric(output, "deletion(-)", "deletions(-)") ?? 0,
 	};
+}
+
+function parseShortstatMetric(
+	output: string,
+	singularLabel: string,
+	pluralLabel: string,
+): number | undefined {
+	for (const field of output.split(",")) {
+		const trimmed = field.trim();
+		const separator = trimmed.indexOf(" ");
+		if (separator <= 0) continue;
+		const label = trimmed.slice(separator + 1).trimStart();
+		if (label !== singularLabel && label !== pluralLabel) continue;
+		const countText = trimmed.slice(0, separator);
+		for (const character of countText) {
+			if (character < "0" || character > "9") return undefined;
+		}
+		const count = Number(countText);
+		return Number.isSafeInteger(count) ? count : undefined;
+	}
+	return undefined;
 }
 
 export function parseGitState(gitDirectory: string): GitStateSnapshot | undefined {

--- a/extensions/pi-starship/test/git-runtime.test.ts
+++ b/extensions/pi-starship/test/git-runtime.test.ts
@@ -89,6 +89,11 @@ test("Git diff shortstat parser returns added and deleted line totals", () => {
 		deleted: 0,
 	});
 	assert.deepEqual(parseGitDiffShortstat(""), { added: 0, deleted: 0 });
+
+	const adversarial = `${"0".repeat(100_000)} insertionX(+)`;
+	const startedAt = performance.now();
+	assert.deepEqual(parseGitDiffShortstat(adversarial), { added: 0, deleted: 0 });
+	assert.ok(performance.now() - startedAt < 500, "malformed counts must be parsed linearly");
 });
 
 test("Git snapshot refresh collects optional commit tags and line metrics outside render", async () => {

--- a/extensions/pi-statusline/src/extension-status.ts
+++ b/extensions/pi-statusline/src/extension-status.ts
@@ -309,7 +309,7 @@ function packageNameForSource(source: string, baseDirectory: string): string | u
 
 export function npmPackageName(source: string): string {
 	const spec = source.slice("npm:".length);
-	if (spec.startsWith("@")) return spec.split("@").slice(0, 2).join("@").replace(/^@/, "@");
+	if (spec.startsWith("@")) return spec.split("@").slice(0, 2).join("@");
 	return spec.split("@")[0] ?? spec;
 }
 

--- a/extensions/pi-usage/src/format.ts
+++ b/extensions/pi-usage/src/format.ts
@@ -174,11 +174,13 @@ function normalizedModelKeys(model: UsageModel): Set<string> {
 }
 
 function normalizeKey(value: string | undefined): string | undefined {
-	const normalized = value
-		?.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "");
-	return normalized || undefined;
+	const separated = value?.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+	if (!separated) return undefined;
+	let start = 0;
+	let end = separated.length;
+	while (separated[start] === "-") start += 1;
+	while (end > start && separated[end - 1] === "-") end -= 1;
+	return separated.slice(start, end) || undefined;
 }
 
 function normalizedKeyHasToken(key: string, token: string): boolean {
@@ -192,9 +194,9 @@ function normalizedKeyHasToken(key: string, token: string): boolean {
 
 function compactLimitLabel(label: string): string {
 	const normalized = label.replace(/[_-]+/g, " ").trim();
-	return (normalized.match(/\bcodex\s+(.+)$/i)?.[1]?.trim() || normalized)
-		.toLowerCase()
-		.replace(/\s+/g, " ");
+	const codex = /\bcodex\s/iu.exec(normalized);
+	const suffix = codex ? normalized.slice(codex.index + codex[0].length).trim() : "";
+	return (suffix || normalized).toLowerCase().replace(/\s+/g, " ");
 }
 
 function formatPercentBucket(bucket: UsageBucket): string {

--- a/extensions/pi-usage/test/adapters.test.ts
+++ b/extensions/pi-usage/test/adapters.test.ts
@@ -176,4 +176,16 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 		}),
 		"codex spark 90% 5h",
 	);
+
+	const sparkBucket = report.buckets.find((bucket) => bucket.groupId === "gpt-5.3-codex-spark");
+	assert.ok(sparkBucket);
+	sparkBucket.groupLabel = `Codex${"\t".repeat(100_000)}Spark`;
+	assert.equal(
+		formatUsageStatusline(report, {
+			id: "gpt-5.3-codex-spark",
+			name: "-".repeat(100_000),
+			provider: "openai-codex",
+		}),
+		"codex spark 90% 5h",
+	);
 });


### PR DESCRIPTION
## Summary

- replace quadratic or analyzer-ambiguous parsing expressions with linear parsing
- remove no-op/incomplete replacements while preserving package and prompt-frame behavior
- return generic details for unexpected WebUI failures while retaining expected client errors
- add regressions for adversarial Git shortstat input, Codex labels, and HTTP error disclosure

## Code-scanning classification

Alerts 4, 6, 9, and 10 are false positives: the LSP launcher uses argument-array spawning for an intentionally configured local executable, the usage hash is a process-salted HMAC cache fingerprint rather than a password hash, and both loopback cookies carry random opaque in-memory session identifiers rather than stored credentials.

## Verification

- `npm run check` (1,646 tests passed)
