### PR TITLE
feat(goal): redesign safety settings

### DIFF
--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -179,7 +179,10 @@ menu-only:
 
 Use `ctx.ui.select()` for a small action menu. Use `SelectList` for richer selection and
 `SettingsList` for editable settings; do not repeatedly reopen `ctx.ui.select()` after each toggle,
-because that resets navigation state.
+because that resets navigation state. Keep related settings or actions on one level when the list has
+seven or fewer items; do not add an **Advanced** submenu merely to shorten such a list. Only consider
+splitting by item count after the list exceeds seven, and then split along a coherent user task rather
+than an arbitrary row boundary.
 
 ### Settings
 

--- a/docs/plans/archived/2026-07-27_pi-goal-settings-ux-plan.md
+++ b/docs/plans/archived/2026-07-27_pi-goal-settings-ux-plan.md
@@ -2,19 +2,21 @@
 
 ## Goal
 
-Make Goal safety settings understandable from `/goal` without magic input values: show the active automatic-response policy in the Goal menu, offer explicit Unlimited/Off choices, accept only positive whole numbers in custom limit inputs, and move internal or experimental controls behind a shallow Advanced screen while preserving settings safety and compatibility.
+Make Goal settings understandable from `/goal` without magic input values or unnecessary navigation: show the active automatic-response policy in the Goal menu, offer explicit Unlimited/Off choices, accept only positive whole numbers in custom limit inputs, and keep Goal tools and the ordered queue directly below the two safety controls while preserving settings safety and compatibility.
 
 ## Plan
 
 - [x] Add focused menu and settings-UI tests for visible Unlimited/capped state, explicit safety choices, positive-integer validation, cancellation, reached-limit confirmation, stale-goal protection, advanced navigation, load/save failure recovery, keyboard behavior, and 40/80/120-column rendering; focused menu/settings run failed in 10 intended behavior assertions before implementation.
-- [x] Update `extensions/pi-goal/src/menu.ts`, `src/settings-ui.ts`, and the minimal runtime settings-load state needed to implement the approved information architecture and interaction flows without changing the persisted `number | null` schema; 281 compiled pi-goal tests pass.
-- [x] Update `extensions/pi-goal/README.md` to document the final menu, explicit Unlimited/Off choices, positive-number-only custom input, Advanced screen, persistence, and error behavior.
-- [x] Run the focused compiled pi-goal tests, pi-goal runtime smoke, `git diff --check`, and the repository `npm run check`; 281 focused tests, the runtime smoke, and the 1,657-test repository gate pass, with final settings/TUI review against `docs/extension-conventions.md` and `docs/extension-settings.md`.
+- [x] Update `extensions/pi-goal/src/menu.ts`, `src/settings-ui.ts`, and the minimal runtime settings-load state needed to implement the approved information architecture and interaction flows without changing the persisted `number | null` schema; 282 compiled pi-goal tests pass.
+- [x] Update `extensions/pi-goal/README.md` to document the explicit Unlimited/Off choices, positive-number-only custom input, persistence, and error behavior.
+- [x] Move Goal tools and Ordered goal queue from Advanced onto the main Goal Settings screen below Automatic work and No-progress guard; three focused assertions first failed because the controls and queue action still required Advanced.
+- [x] Update the README and responsive-width/keyboard tests for the final four-row Goal Settings screen, including direct tool/queue operation and exact safe-integer display at 40/80/120 columns.
+- [x] Run the focused compiled pi-goal tests, pi-goal runtime smoke, `git diff --check`, and the repository `npm run check`; 282 focused tests, the runtime smoke, and the 1,658-test repository gate pass, with final settings/TUI review against `docs/extension-conventions.md` and `docs/extension-settings.md`.
 
 ## Completion Checklist
 
 - [x] `/goal` displays `Unlimited` or `used/limit` automatic-response state for an active goal.
-- [x] Goal Settings prioritizes Automatic work and the No-progress guard, with Goal tools and the experimental queue under Advanced.
+- [x] Goal Settings presents Automatic work, No-progress guard, Goal tools, and Ordered goal queue in that order on one screen.
 - [x] Unlimited and Off are explicit choices; custom inputs accept only safe whole numbers greater than zero and reject every other value without saving.
 - [x] Consequential reached-limit changes preview their immediate pause effect; cancellation and stale-goal changes have no side effects.
 - [x] Successful changes save atomically and apply immediately; failures retain the prior valid state and show actionable feedback; invalid files remain untouched.

--- a/docs/plans/archived/2026-07-27_pi-goal-settings-ux-plan.md
+++ b/docs/plans/archived/2026-07-27_pi-goal-settings-ux-plan.md
@@ -1,0 +1,22 @@
+# pi-goal settings UX redesign plan
+
+## Goal
+
+Make Goal safety settings understandable from `/goal` without magic input values: show the active automatic-response policy in the Goal menu, offer explicit Unlimited/Off choices, accept only positive whole numbers in custom limit inputs, and move internal or experimental controls behind a shallow Advanced screen while preserving settings safety and compatibility.
+
+## Plan
+
+- [x] Add focused menu and settings-UI tests for visible Unlimited/capped state, explicit safety choices, positive-integer validation, cancellation, reached-limit confirmation, stale-goal protection, advanced navigation, load/save failure recovery, keyboard behavior, and 40/80/120-column rendering; focused menu/settings run failed in 10 intended behavior assertions before implementation.
+- [x] Update `extensions/pi-goal/src/menu.ts`, `src/settings-ui.ts`, and the minimal runtime settings-load state needed to implement the approved information architecture and interaction flows without changing the persisted `number | null` schema; 281 compiled pi-goal tests pass.
+- [x] Update `extensions/pi-goal/README.md` to document the final menu, explicit Unlimited/Off choices, positive-number-only custom input, Advanced screen, persistence, and error behavior.
+- [x] Run the focused compiled pi-goal tests, pi-goal runtime smoke, `git diff --check`, and the repository `npm run check`; 281 focused tests, the runtime smoke, and the 1,657-test repository gate pass, with final settings/TUI review against `docs/extension-conventions.md` and `docs/extension-settings.md`.
+
+## Completion Checklist
+
+- [x] `/goal` displays `Unlimited` or `used/limit` automatic-response state for an active goal.
+- [x] Goal Settings prioritizes Automatic work and the No-progress guard, with Goal tools and the experimental queue under Advanced.
+- [x] Unlimited and Off are explicit choices; custom inputs accept only safe whole numbers greater than zero and reject every other value without saving.
+- [x] Consequential reached-limit changes preview their immediate pause effect; cancellation and stale-goal changes have no side effects.
+- [x] Successful changes save atomically and apply immediately; failures retain the prior valid state and show actionable feedback; invalid files remain untouched.
+- [x] Existing numeric/null settings, unknown fields, non-TUI fallback, queue/tool behavior, theme/keybindings, and supported terminal widths remain compatible.
+- [x] README and deterministic tests match the final behavior, all required checks pass, and this completed plan is archived here.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -70,11 +70,12 @@ with the complete current defaults:
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. The primary screen keeps the two Goal safety policies visible:
+Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. The screen keeps all four controls on one level in task order:
 
 - **Automatic work** shows **Unlimited** or an exact **≤_N_** response cap. Choose **Unlimited** directly, or choose **Set a maximum…** and enter a safe whole number greater than zero.
 - **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
-- **Advanced…** contains Goal tool visibility and the experimental ordered queue.
+- **Goal tools** controls whether terminal Goal tools are always visible or appear after the first goal.
+- **Ordered goal queue** controls the experimental ordered-goal workflows.
 
 Custom number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. A successful change updates the visible state immediately. A failed save restores the prior value and reports the settings path so it can be retried. Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles. Escape returns to the previous screen without reverting changes that were already saved.
 

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -13,7 +13,7 @@ Goal mode uses Codex-like persistence instructions and sends guarded continuatio
 - Keeps direct goal management available through `/goal` subcommands: `status`, `pause`, `resume`, `clear`, and `edit`.
 - Exposes only one top-level command: `/goal`, including when ordered goals are enabled.
 - Optionally adds ordered-goal operations through `/goal add`, `prioritize`, `drop-last`, and `skip`, while accepting `push`, `unshift`, `pop`, and `shift` as hidden compatibility aliases.
-- Bounds automatic work by default to 25 normal model responses, including responses inside automatic tool loops and Pi-owned retry/compaction recovery; set `continuationLimits.automaticTurns` explicitly to `null` only when unbounded automatic work is intended.
+- Leaves automatic response count unlimited by default; set `continuationLimits.automaticTurns` to a positive whole number when an authoritative response cap is wanted.
 - Pauses after three consecutive empty or normalized-identical tool-free automatic runs, while distinct short output and tool activity reset the repeat detector.
 - Supports optional token budgets such as `/goal --tokens 100k <goal>`, using provider-reported total-token accounting with a cache-inclusive compatibility fallback.
 - Tracks distinct `active`, `paused`, `blocked`, `usage_limited`, `budget_limited`, and `complete` states.
@@ -64,13 +64,19 @@ with the complete current defaults:
     "goals": false
   },
   "continuationLimits": {
-    "automaticTurns": 25,
+    "automaticTurns": null,
     "noProgressTurns": 3
   }
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles. Escape closes the settings screen without reverting changes that were already saved.
+Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. The primary screen keeps the two Goal safety policies visible:
+
+- **Automatic work** shows **Unlimited** or an exact **≤_N_** response cap. Choose **Unlimited** directly, or choose **Set a maximum…** and enter a safe whole number greater than zero.
+- **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
+- **Advanced…** contains Goal tool visibility and the experimental ordered queue.
+
+Custom number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. A successful change updates the visible state immediately. A failed save restores the prior value and reports the settings path so it can be retried. Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles. Escape returns to the previous screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
 
@@ -79,18 +85,15 @@ Use `/goal` → **Settings…** in the TUI to edit these values interactively, o
 
 `experimental.goals` accepts a boolean and defaults to `false`. Set it to `true` to enable the ordered-goal subcommands and automatic queue advancement described below. Enabled sessions show one warning because command behavior and persisted queue state remain experimental.
 
-`continuationLimits` controls the default-on runaway guards:
+`continuationLimits` controls the runaway guards:
 
-- `automaticTurns` is a positive safe integer and defaults to `25`. It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field to `null` to remove the authoritative hard bound.
+- `automaticTurns` accepts a positive safe integer or `null` and defaults to `null` (unlimited). When configured, it counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field to `null` to remove the authoritative hard bound.
 - `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
 
 Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file is created during any of those session starts, while an existing file is read without being rewritten. Initialization publishes the generated file atomically and never overwrites a file
 created concurrently by another process.
 
-Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten;
-they produce a warning and fall back to all defaults. If the default file cannot be created, pi-goal
-warns, continues with the built-in defaults, and retries on the next session start. Reload Pi after
-changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"`
+Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults. In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and directs the user to fix it and run `/reload`. If the default file cannot be created, pi-goal warns, continues with the built-in defaults, and retries when a setting is saved or on the next session start. Reload Pi after changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"`
 restores only the exact tools that pi-goal previously hid, while switching to
 `"after-first-goal"` locks a runtime that has no unfinished goal.
 
@@ -115,7 +118,7 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 /goal skip
 ```
 
-- In the TUI, `/goal` opens a state-aware manager. Its first action follows the current state: start when empty, pause when active, resume when stopped, or increase the budget when exhausted. Status, Settings, Help, queue management, Clear, and Close remain shallow, labeled routes. Arrow keys navigate, Enter selects, and Escape cancels or closes without changing state.
+- In the TUI, `/goal` opens a state-aware manager. Its first action follows the current state: start when empty, pause when active, resume when stopped, or increase the budget when exhausted. An active goal shows automatic-response state as **_used_ automatic responses · Unlimited** or **_used_/_limit_ automatic responses**. Status, Settings, Help, queue management, Clear, and Close remain shallow, labeled routes. Arrow keys navigate, Enter selects, and Escape cancels or returns without changing state.
 - In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI. Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
 - Menu-driven Replace, Clear, Prioritize, Skip, and Drop last actions preview the exact affected goals and require confirmation. Existing direct routes remain immediate for compatibility and automation.
 - `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters. Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
@@ -167,7 +170,7 @@ For each persisted assistant message, `pi-goal` uses finite, non-negative `usage
 
 Provider usage becomes authoritative only when an assistant message finishes, so a budget can overshoot by one model call. When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, and queues one bounded custom wrap-up instruction before the next model call. The instruction permits only a concise progress/results/blockers summary; a substantive tool attempt is blocked and aborts the remaining wrap-up. A rejected `goal_complete` also terminates the wrap-up, while accepted completion still requires existing evidence that proves every requirement—budget exhaustion itself never means completion. If exhaustion is first visible at `agent_end` and no turn remains, the extension stops without creating another model turn.
 
-The automatic-response cap is a call-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the 25th response is still retained. No default token budget is imposed. For stricter spend control, combine the default circuit breakers with `/goal --tokens`.
+When configured, the automatic-response cap is a call-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained. No default automatic-response cap or token budget is imposed. For stricter spend control, configure `automaticTurns` and/or use `/goal --tokens`.
 
 Elapsed time is accumulated only while status is `active`. Pause, blocked, usage-limited, budget-limited, shutdown, and offline periods do not increase it. Legacy session entries are migrated by preserving their accumulated seconds and starting a fresh active clock when loaded.
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -493,6 +493,7 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		);
 		runtime.settings =
 			settingsResult.kind === "loaded" ? settingsResult.settings : DEFAULT_GOAL_SETTINGS;
+		runtime.settingsLoadIssue = settingsResult.kind === "loaded" ? undefined : settingsResult;
 		if (settingsResult.kind === "invalid") {
 			ctx.ui.notify(
 				`pi-goal settings ignored: ${settingsResult.reason}. Using default settings.`,

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -56,12 +56,17 @@ export function buildGoalMenuState(runtime: GoalMenuRuntimeView): GoalMenuState 
 		: runtime.pendingQueueAction
 			? "Waiting for Pi to settle"
 			: displayStatus(goal?.status);
+	const automaticTurnLimit = runtime.settings.continuationLimits.automaticTurns;
+	const automaticResponses =
+		automaticTurnLimit === null
+			? `${goal?.automaticModelTurns ?? 0} automatic responses · Unlimited`
+			: `${goal?.automaticModelTurns ?? 0}/${automaticTurnLimit} automatic responses`;
 	const details = goal
 		? [
 				goal.tokenBudget === undefined
 					? formatDuration(goal.timeUsedSeconds)
 					: `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`,
-				`${goal.automaticModelTurns} automatic responses`,
+				automaticResponses,
 				...(queueCount > 0 ? [`${queueCount} queued`] : []),
 			].join(" · ")
 		: "No goal is currently set";

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -24,7 +24,11 @@ import { nextToolFreeRepeatState, resetGoalSafetyEpoch } from "./safety.js";
 
 export { queueGoalSafetyReset, resetGoalSafetyEpoch } from "./safety.js";
 
-import { DEFAULT_GOAL_SETTINGS, type GoalSettings } from "./settings.js";
+import {
+	DEFAULT_GOAL_SETTINGS,
+	type GoalSettings,
+	type GoalSettingsLoadIssue,
+} from "./settings.js";
 
 export interface ContinuationTicket {
 	goalId: string;
@@ -167,6 +171,7 @@ const CONTRADICTORY_COMPLETION_PATTERNS = [
 // budget, safety, and tool-policy transitions share ordering-sensitive invariants.
 export class GoalRuntime {
 	settings: GoalSettings = DEFAULT_GOAL_SETTINGS;
+	settingsLoadIssue?: GoalSettingsLoadIssue;
 	activeGoal?: ActiveGoal;
 	/** Terminal details captured for the matching cross-extension state event. */
 	private terminalDetails?: GoalTerminalDetails;

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -2,12 +2,27 @@ import { join } from "node:path";
 import {
 	type ExtensionCommandContext,
 	getAgentDir,
+	getSelectListTheme,
 	getSettingsListTheme,
 } from "@earendil-works/pi-coding-agent";
-import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	Container,
+	matchesKey,
+	type SelectItem,
+	SelectList,
+	type SettingItem,
+	SettingsList,
+	Text,
+} from "@earendil-works/pi-tui";
 import { checkpointGoalActiveTime } from "./accounting.js";
 import { abortCurrentTurn, type GoalRuntime, STATUS_KEY } from "./runtime.js";
-import { GOAL_SETTINGS_FILE, type GoalSettings, saveGoalSettings } from "./settings.js";
+import {
+	DEFAULT_GOAL_SETTINGS,
+	GOAL_SETTINGS_FILE,
+	type GoalSettings,
+	saveGoalSettings,
+} from "./settings.js";
 
 interface GoalSettingsUiOptions {
 	settingsPath?: string;
@@ -20,10 +35,23 @@ interface GoalSettingsApplyOptions {
 }
 
 type LimitField = "automaticTurns" | "noProgressTurns";
+type LimitSelection = "unlimited" | "default" | "custom" | "off";
 type SettingsScreenResult =
-	| { kind: "limit"; field: LimitField }
+	| {
+			kind: "limit";
+			field: LimitField;
+			selection: LimitSelection;
+			activeGoalId: string | null;
+	  }
 	| { kind: "queue"; enabled: boolean }
 	| undefined;
+
+interface LimitChoiceStyles {
+	title: (text: string) => string;
+	muted: (text: string) => string;
+}
+
+type EnqueueSettingsChange = (operation: () => void | Promise<void>) => Promise<void>;
 
 export async function showGoalSettings(
 	runtime: GoalRuntime,
@@ -41,7 +69,7 @@ export async function showGoalSettings(
 		if (!result) return;
 		if (result.kind === "queue") {
 			const next = await nextQueueSettings(runtime, ctx, result.enabled);
-			if (!next) return;
+			if (!next) continue;
 			const wasFrozen = runtime.queueFrozen;
 			try {
 				applyGoalSettings(runtime, next, ctx, {
@@ -52,27 +80,33 @@ export async function showGoalSettings(
 						await options.onQueueUnfrozen?.(ctx);
 					} catch (error) {
 						ctx.ui.notify(
-							`Goal queue enabled, but automatic resume failed: ${formatError(error)}. Reopen /goal to retry.`,
+							`Goal queue enabled, but automatic resume failed: ${safeTerminalText(formatError(error))}. Reopen /goal to retry.`,
 							"warning",
 						);
 					}
 				}
 				ctx.ui.notify(`Ordered goal queue: ${result.enabled ? "Experimental" : "Off"}.`, "info");
 			} catch (error) {
-				ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
+				notifySettingsFailure(ctx, settingsPath, error);
 			}
 			return;
 		}
 
+		if ((runtime.activeGoal?.id ?? null) !== result.activeGoalId) {
+			ctx.ui.notify(
+				"The active goal changed while the safety setting was open. No settings were changed.",
+				"warning",
+			);
+			continue;
+		}
 		const previous = runtime.settings.continuationLimits[result.field];
-		const raw = await ctx.ui.input(
-			result.field === "automaticTurns" ? "Automatic response limit" : "No-progress run limit",
-			formatGoalLimit(previous),
-		);
-		if (raw === undefined) continue;
-		const limit = parseGoalLimit(raw);
-		if (limit === undefined) {
-			ctx.ui.notify("Enter a positive whole number or Unlimited.", "warning");
+		const limit = await resolveLimitSelection(result, previous, ctx);
+		if (limit === undefined || limit === previous) continue;
+		if ((runtime.activeGoal?.id ?? null) !== result.activeGoalId) {
+			ctx.ui.notify(
+				"The active goal changed while editing the safety setting. No settings were changed.",
+				"warning",
+			);
 			continue;
 		}
 		const confirmation = await confirmLowerActiveLimit(runtime, ctx, result.field, limit);
@@ -89,12 +123,9 @@ export async function showGoalSettings(
 			applyGoalSettings(runtime, next, ctx, {
 				save: (settings) => (options.save ?? saveGoalSettings)(settings, settingsPath),
 			});
-			ctx.ui.notify(
-				`${result.field === "automaticTurns" ? "Automatic response" : "No-progress"} limit: ${formatGoalLimit(limit)}.`,
-				"info",
-			);
+			ctx.ui.notify(formatLimitSuccess(result.field, limit), "info");
 		} catch (error) {
-			ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
+			notifySettingsFailure(ctx, settingsPath, error);
 		}
 	}
 }
@@ -117,6 +148,7 @@ export function applyGoalSettings(
 		const abortOwnedRun = activeGoalId !== undefined && runtime.agentRunGoalId === activeGoalId;
 		const pausedByAutomaticLimit = runtime.enforceAutomaticTurnLimit(ctx, abortOwnedRun);
 		if (!pausedByAutomaticLimit) runtime.enforceNoProgressLimit(ctx, abortOwnedRun);
+		if (fileSaved) runtime.settingsLoadIssue = undefined;
 	} catch (error) {
 		const rollbackErrors: unknown[] = [];
 		try {
@@ -146,9 +178,8 @@ export function applyGoalSettings(
 	}
 }
 
-export function parseGoalLimit(value: string): number | null | undefined {
-	const normalized = value.trim().toLowerCase();
-	if (normalized === "unlimited" || normalized === "off") return null;
+export function parseGoalLimit(value: string): number | undefined {
+	const normalized = value.trim();
 	if (!/^\d+$/u.test(normalized)) return undefined;
 	const parsed = Number(normalized);
 	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
@@ -164,94 +195,104 @@ async function showSettingsScreen(
 	settingsPath: string,
 	options: GoalSettingsUiOptions,
 ): Promise<SettingsScreenResult> {
+	if (runtime.settingsLoadIssue?.kind === "invalid") {
+		return showReadOnlySettingsScreen(runtime, ctx, settingsPath);
+	}
+
 	let saveQueue = Promise.resolve();
-	const latestRequested = new Map<string, string>();
+	const enqueueSettingsChange: EnqueueSettingsChange = (operation) => {
+		const queued = saveQueue.then(operation);
+		saveQueue = queued.catch(() => undefined);
+		return queued;
+	};
 	return ctx.ui.custom<SettingsScreenResult>((tui, theme, _keybindings, done) => {
-		const settings = runtime.settings;
-		const items: SettingItem[] = [
-			{
-				id: "toolVisibility",
-				label: "Goal tools",
-				description: "Keep terminal Goal tools visible, or reveal them after the first goal.",
-				currentValue: visibilityLabel(settings.toolVisibility),
-				values: ["Always", "After first goal"],
-			},
-			{
-				id: "experimentalGoals",
-				label: "Ordered goal queue",
-				description: "Enable experimental add, prioritize, skip, and drop-last workflows.",
-				currentValue: settings.experimental.goals ? "Experimental" : "Off",
-				values: ["Off", "Experimental"],
-			},
-			limitItem(
-				"automaticTurns",
-				"Automatic response limit",
-				"Pause after this many Goal-owned automatic model responses.",
-				settings.continuationLimits.automaticTurns,
-			),
-			limitItem(
-				"noProgressTurns",
-				"No-progress limit",
-				"Pause after this many repeated or empty tool-free automatic runs.",
-				settings.continuationLimits.noProgressTurns,
-			),
-		];
 		const container = new Container();
-		container.addChild(new Text(theme.fg("accent", theme.bold("Pi Goal Settings")), 1, 0));
 		container.addChild(
-			new Text(theme.fg("muted", `User settings · ${safeTerminalText(settingsPath)}`), 1, 0),
+			dynamicText("Pi Goal Settings", (text) => theme.fg("accent", theme.bold(text))),
 		);
-		let settingsList: SettingsList;
+		container.addChild(
+			dynamicText(`User settings · ${safeTerminalText(settingsPath)}`, (text) =>
+				theme.fg("muted", text),
+			),
+		);
+		if (runtime.settingsLoadIssue?.kind === "create-failed") {
+			container.addChild(
+				dynamicText(
+					() => settingsIssueBanner(runtime),
+					(text) => theme.fg("warning", text),
+				),
+			);
+		}
 		let closing = false;
 		const closeAfterSaves = (result: SettingsScreenResult) => {
 			if (closing) return;
 			closing = true;
 			void saveQueue.then(() => done(result));
 		};
-		settingsList = new SettingsList(
+		const updateIssueText = () => tui.requestRender();
+		const previewGoalIds = new Map<LimitField, string | null>();
+		const styles: LimitChoiceStyles = {
+			title: (text) => theme.fg("accent", theme.bold(text)),
+			muted: (text) => theme.fg("muted", text),
+		};
+		const items: SettingItem[] = [
+			limitItem(
+				"automaticTurns",
+				"Automatic work",
+				"Choose whether Goal can continue without a response-count cap.",
+				runtime.settings.continuationLimits.automaticTurns,
+				(doneSelection) => {
+					previewGoalIds.set("automaticTurns", runtime.activeGoal?.id ?? null);
+					return createLimitChoiceComponent(runtime, "automaticTurns", styles, doneSelection);
+				},
+			),
+			limitItem(
+				"noProgressTurns",
+				"No-progress guard",
+				"Pause after repeated or empty tool-free automatic runs.",
+				runtime.settings.continuationLimits.noProgressTurns,
+				(doneSelection) => {
+					previewGoalIds.set("noProgressTurns", runtime.activeGoal?.id ?? null);
+					return createLimitChoiceComponent(runtime, "noProgressTurns", styles, doneSelection);
+				},
+			),
+			{
+				id: "advanced",
+				label: "Advanced…",
+				description: "Configure Goal tools and the experimental ordered queue.",
+				currentValue: "Open…",
+				submenu: (_currentValue, back) =>
+					createAdvancedSettingsComponent({
+						runtime,
+						ctx,
+						settingsPath,
+						options,
+						enqueueSettingsChange,
+						closeAfterSaves,
+						onApplied: updateIssueText,
+						onBack: () => back(),
+						title: (text) => theme.fg("accent", theme.bold(text)),
+					}),
+			},
+		];
+		const settingsList = new SettingsList(
 			items,
 			Math.min(items.length + 2, 15),
-			getSettingsListTheme(),
+			goalSettingsListTheme("Goal menu"),
 			(id, newValue) => {
-				if (closing) return;
-				if ((id === "automaticTurns" || id === "noProgressTurns") && newValue === "Edit…") {
-					closeAfterSaves({ kind: "limit", field: id });
-					return;
-				}
-				if (id === "experimentalGoals") {
-					closeAfterSaves({ kind: "queue", enabled: newValue === "Experimental" });
-					return;
-				}
-				if (id !== "toolVisibility") return;
-				latestRequested.set(id, newValue);
-				const operation = saveQueue.then(async () => {
-					const previousValue = visibilityLabel(runtime.settings.toolVisibility);
-					try {
-						const next = {
-							...structuredClone(runtime.settings),
-							toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
-						} satisfies GoalSettings;
-						applyGoalSettings(runtime, next, ctx, {
-							save: (value) => (options.save ?? saveGoalSettings)(value, settingsPath),
-						});
-						ctx.ui.notify(`Goal tools: ${newValue}.`, "info");
-					} catch (error) {
-						if (latestRequested.get(id) === newValue) {
-							settingsList.updateValue(id, previousValue);
-						}
-						ctx.ui.notify(`pi-goal settings save failed: ${formatError(error)}`, "error");
-						tui.requestRender();
-					}
+				if (closing || (id !== "automaticTurns" && id !== "noProgressTurns")) return;
+				if (!isLimitSelection(newValue)) return;
+				closeAfterSaves({
+					kind: "limit",
+					field: id,
+					selection: newValue,
+					activeGoalId: previewGoalIds.get(id) ?? null,
 				});
-				saveQueue = operation.catch(() => undefined);
 			},
 			() => closeAfterSaves(undefined),
 			{ enableSearch: false },
 		);
 		container.addChild(settingsList);
-		container.addChild(
-			new Text(theme.fg("dim", "↑↓ navigate · enter/space change · esc close"), 1, 0),
-		);
 		return {
 			render: (width: number) => container.render(width),
 			invalidate: () => container.invalidate(),
@@ -262,6 +303,260 @@ async function showSettingsScreen(
 			},
 		};
 	});
+}
+
+function showReadOnlySettingsScreen(
+	runtime: GoalRuntime,
+	ctx: ExtensionCommandContext,
+	settingsPath: string,
+): Promise<SettingsScreenResult> {
+	return ctx.ui.custom<SettingsScreenResult>((_tui, theme, keybindings, done) => {
+		const container = new Container();
+		container.addChild(
+			dynamicText("Pi Goal Settings · Read only", (text) => theme.fg("accent", theme.bold(text))),
+		);
+		container.addChild(
+			dynamicText(
+				`Invalid settings file. Pi-goal is using built-in defaults. Fix ${safeTerminalText(settingsPath)} and run /reload. The file will not be overwritten.`,
+				(text) => theme.fg("warning", text),
+			),
+		);
+		container.addChild(
+			dynamicText(() =>
+				[
+					`Automatic work: ${formatAutomaticWork(runtime.settings.continuationLimits.automaticTurns)}`,
+					`No-progress guard: ${formatNoProgressProtection(runtime.settings.continuationLimits.noProgressTurns)}`,
+					`Goal tools: ${visibilityLabel(runtime.settings.toolVisibility)}`,
+					`Ordered goal queue: ${runtime.settings.experimental.goals ? "Experimental" : "Off"}`,
+				].join("\n"),
+			),
+		);
+		container.addChild(dynamicText("Esc back to Goal menu", (text) => theme.fg("dim", text)));
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput(data: string) {
+				if (
+					keybindings.matches(data, "tui.select.cancel") ||
+					matchesKey(data, "escape") ||
+					matchesKey(data, "ctrl+c")
+				) {
+					done(undefined);
+				}
+			},
+		};
+	});
+}
+
+function createLimitChoiceComponent(
+	runtime: GoalRuntime,
+	field: LimitField,
+	styles: LimitChoiceStyles,
+	done: (selectedValue?: string) => void,
+): Component {
+	const value = runtime.settings.continuationLimits[field];
+	const goal = runtime.activeGoal;
+	const items = limitChoices(field, value, goal?.automaticModelTurns);
+	const selectionItems = items.map(({ value: itemValue, label }) => ({
+		value: itemValue,
+		label,
+	}));
+	const descriptions = new Map(items.map((item) => [item.value, item.description ?? ""]));
+	const container = new Container();
+	container.addChild(
+		dynamicText(field === "automaticTurns" ? "Automatic work" : "No-progress guard", styles.title),
+	);
+	container.addChild(
+		dynamicText(
+			field === "automaticTurns"
+				? `Current: ${formatAutomaticWork(value)}`
+				: `Current: ${formatNoProgressProtection(value)}`,
+			styles.muted,
+		),
+	);
+	if (goal) {
+		container.addChild(
+			dynamicText(
+				field === "automaticTurns"
+					? `Active goal: ${goal.automaticModelTurns} automatic responses used`
+					: `Active goal: ${goal.toolFreeRepeatCount} repeated or empty runs detected`,
+				styles.muted,
+			),
+		);
+	}
+	const selectedIndex = selectedLimitChoiceIndex(field, value);
+	const selectList = new SelectList(
+		selectionItems,
+		Math.min(selectionItems.length, 8),
+		getSelectListTheme(),
+	);
+	selectList.setSelectedIndex(selectedIndex);
+	let selectedDescription = descriptions.get(selectionItems[selectedIndex]?.value ?? "") ?? "";
+	const description = dynamicText(() => selectedDescription, styles.muted);
+	selectList.onSelectionChange = (item) => {
+		selectedDescription = descriptions.get(item.value) ?? "";
+	};
+	selectList.onSelect = (item) => done(item.value);
+	selectList.onCancel = () => done();
+	container.addChild(selectList);
+	container.addChild(description);
+	container.addChild(dynamicText("↑↓ navigate · Enter select · Esc back", styles.muted));
+	return {
+		render: (width: number) => container.render(width),
+		invalidate: () => container.invalidate(),
+		handleInput(data: string) {
+			selectList.handleInput(data);
+		},
+	};
+}
+
+function limitChoices(
+	field: LimitField,
+	value: number | null,
+	automaticTurnsUsed: number | undefined,
+): SelectItem[] {
+	if (field === "automaticTurns") {
+		const unlimitedDescription =
+			value === null
+				? "No response-count cap. Completion, manual pause, blockers, provider limits, and other configured guards still apply."
+				: automaticTurnsUsed === undefined
+					? `Remove the current ${value}-response cap. Goal work will have no response-count cap; other configured stop conditions remain.`
+					: `Remove the current ${value}-response cap. The active goal has used ${automaticTurnsUsed} responses; other configured stop conditions remain.`;
+		return [
+			{ value: "unlimited", label: "Unlimited (default)", description: unlimitedDescription },
+			{
+				value: "custom",
+				label: "Set a maximum…",
+				description: "Pause after a whole number of Goal-owned automatic responses.",
+			},
+		];
+	}
+	const defaultLimit = DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns;
+	return [
+		{
+			value: "default",
+			label: `After ${defaultLimit} repeated runs (default)`,
+			description: "Pause after the default number of repeated or empty tool-free runs.",
+		},
+		{
+			value: "custom",
+			label: "Set threshold…",
+			description: "Choose a whole number of repeated or empty runs before pausing.",
+		},
+		{
+			value: "off",
+			label: "Off",
+			description: "Do not pause based on repeated or empty tool-free runs.",
+		},
+	];
+}
+
+function selectedLimitChoiceIndex(field: LimitField, value: number | null) {
+	if (field === "automaticTurns") return value === null ? 0 : 1;
+	if (value === null) return 2;
+	return value === DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns ? 0 : 1;
+}
+
+function createAdvancedSettingsComponent(options: {
+	runtime: GoalRuntime;
+	ctx: ExtensionCommandContext;
+	settingsPath: string;
+	options: GoalSettingsUiOptions;
+	enqueueSettingsChange: EnqueueSettingsChange;
+	closeAfterSaves: (result: SettingsScreenResult) => void;
+	onApplied: () => void;
+	onBack: () => void;
+	title: (text: string) => string;
+}): Component {
+	const { runtime, ctx, settingsPath } = options;
+	const container = new Container();
+	container.addChild(dynamicText("Advanced Goal Settings", options.title));
+	const items: SettingItem[] = [
+		{
+			id: "toolVisibility",
+			label: "Goal tools",
+			description: "Keep terminal Goal tools visible, or reveal them after the first goal.",
+			currentValue: visibilityLabel(runtime.settings.toolVisibility),
+			values: ["Always", "After first goal"],
+		},
+		{
+			id: "experimentalGoals",
+			label: "Ordered goal queue",
+			description: "Enable experimental add, prioritize, skip, and drop-last workflows.",
+			currentValue: runtime.settings.experimental.goals ? "Experimental" : "Off",
+			values: ["Off", "Experimental"],
+		},
+	];
+	const latestRequested = new Map<string, string>();
+	let settingsList: SettingsList;
+	settingsList = new SettingsList(
+		items,
+		Math.min(items.length + 2, 15),
+		goalSettingsListTheme("Goal Settings"),
+		(id, newValue) => {
+			if (id === "experimentalGoals") {
+				options.closeAfterSaves({ kind: "queue", enabled: newValue === "Experimental" });
+				return;
+			}
+			if (id !== "toolVisibility") return;
+			latestRequested.set(id, newValue);
+			void options.enqueueSettingsChange(async () => {
+				const previousValue = visibilityLabel(runtime.settings.toolVisibility);
+				try {
+					const next = {
+						...structuredClone(runtime.settings),
+						toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
+					} satisfies GoalSettings;
+					applyGoalSettings(runtime, next, ctx, {
+						save: (value) => (options.options.save ?? saveGoalSettings)(value, settingsPath),
+					});
+					options.onApplied();
+					ctx.ui.notify(`Goal tools: ${newValue}.`, "info");
+				} catch (error) {
+					if (latestRequested.get(id) === newValue) {
+						settingsList.updateValue(id, previousValue);
+					}
+					notifySettingsFailure(ctx, settingsPath, error);
+				}
+			});
+		},
+		options.onBack,
+		{ enableSearch: false },
+	);
+	container.addChild(settingsList);
+	return {
+		render: (width: number) => container.render(width),
+		invalidate: () => container.invalidate(),
+		handleInput(data: string) {
+			settingsList.handleInput?.(data);
+		},
+	};
+}
+
+async function resolveLimitSelection(
+	result: Extract<SettingsScreenResult, { kind: "limit" }>,
+	previous: number | null,
+	ctx: ExtensionCommandContext,
+): Promise<number | null | undefined> {
+	if (result.selection === "unlimited" || result.selection === "off") return null;
+	if (result.selection === "default") {
+		return DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns;
+	}
+	while (true) {
+		const raw = await ctx.ui.input(
+			result.field === "automaticTurns"
+				? "Maximum automatic responses (whole number greater than 0)"
+				: "Repeated-run threshold (whole number greater than 0)",
+			previous === null ? "Positive whole number" : String(previous),
+		);
+		if (raw === undefined) return undefined;
+		const parsed = parseGoalLimit(raw);
+		if (parsed !== undefined) return parsed;
+		ctx.ui.notify(
+			`Enter a whole number greater than 0. Choose ${result.field === "automaticTurns" ? "Unlimited" : "Off"} from the previous screen if you do not want a limit.`,
+			"warning",
+		);
+	}
 }
 
 async function nextQueueSettings(
@@ -378,7 +673,7 @@ async function confirmLowerActiveLimit(
 	if (used < limit) return { apply: true };
 	return {
 		apply: await ctx.ui.confirm(
-			"Apply reached safety limit?",
+			"Apply limit and pause now?",
 			`The active goal has already used ${used}. Setting this limit to ${limit} will pause it immediately without deleting progress.`,
 		),
 		goalId: goal.id,
@@ -392,15 +687,63 @@ function withLimit(settings: GoalSettings, field: LimitField, value: number | nu
 	};
 }
 
-function limitItem(id: LimitField, label: string, description: string, value: number | null) {
-	const currentValue = formatGoalLimit(value);
+function limitItem(
+	id: LimitField,
+	label: string,
+	description: string,
+	value: number | null,
+	submenu: (done: (selectedValue?: string) => void) => Component,
+): SettingItem {
 	return {
 		id,
 		label,
 		description,
-		currentValue,
-		values: [currentValue, "Edit…"],
-	} satisfies SettingItem;
+		currentValue:
+			id === "automaticTurns"
+				? formatAutomaticSettingValue(value)
+				: formatNoProgressSettingValue(value),
+		submenu: (_currentValue, done) => submenu(done),
+	};
+}
+
+function formatAutomaticSettingValue(value: number | null) {
+	return value === null ? "Unlimited" : `≤${value}`;
+}
+
+function formatNoProgressSettingValue(value: number | null) {
+	if (value === null) return "Off";
+	return `${value} ${value === 1 ? "run" : "runs"}`;
+}
+
+function formatAutomaticWork(value: number | null) {
+	return value === null ? "Unlimited" : `Up to ${value} responses`;
+}
+
+function formatNoProgressProtection(value: number | null) {
+	if (value === null) return "Off";
+	return `After ${value} repeated ${value === 1 ? "run" : "runs"}`;
+}
+
+function formatLimitSuccess(field: LimitField, value: number | null) {
+	return field === "automaticTurns"
+		? `Automatic work: ${formatAutomaticWork(value)}.`
+		: `No-progress guard: ${formatNoProgressProtection(value)}.`;
+}
+
+function goalSettingsListTheme(backTarget: string) {
+	const theme = getSettingsListTheme();
+	return {
+		...theme,
+		hint(text: string) {
+			return text.includes("Enter/Space to change")
+				? theme.hint(`  Enter/Space to select · Esc back to ${backTarget}`)
+				: theme.hint(text);
+		},
+	};
+}
+
+function isLimitSelection(value: string): value is LimitSelection {
+	return value === "unlimited" || value === "default" || value === "custom" || value === "off";
 }
 
 function visibilityLabel(value: GoalSettings["toolVisibility"]) {
@@ -413,6 +756,36 @@ function retainedGoalCount(runtime: GoalRuntime) {
 		runtime.queuedGoals.length +
 		(runtime.pendingQueueAction?.kind === "prioritize" ? 1 : 0)
 	);
+}
+
+function settingsIssueBanner(runtime: GoalRuntime) {
+	return runtime.settingsLoadIssue?.kind === "create-failed"
+		? "Built-in defaults are active because the settings file could not be created. Saving a change will retry."
+		: "";
+}
+
+function notifySettingsFailure(ctx: ExtensionCommandContext, settingsPath: string, error: unknown) {
+	const path = safeTerminalText(settingsPath);
+	const detail = safeTerminalText(formatError(error));
+	ctx.ui.notify(
+		error instanceof AggregateError
+			? `Could not apply Goal settings, and rollback was incomplete. Check ${path}, run /reload, and verify the effective settings before retrying: ${detail}`
+			: `Could not save Goal settings; the previous value remains. Check ${path} and retry: ${detail}`,
+		"error",
+	);
+}
+
+function dynamicText(
+	content: string | (() => string),
+	style: (text: string) => string = (text) => text,
+): Component {
+	return {
+		render(width: number) {
+			const value = typeof content === "function" ? content() : content;
+			return new Text(style(value), 1, 0).render(width);
+		},
+		invalidate() {},
+	};
 }
 
 function safeTerminalText(value: string) {

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -14,6 +14,7 @@ import {
 	type SettingItem,
 	SettingsList,
 	Text,
+	truncateToWidth,
 } from "@earendil-works/pi-tui";
 import { checkpointGoalActiveTime } from "./accounting.js";
 import { abortCurrentTurn, type GoalRuntime, STATUS_KEY } from "./runtime.js";
@@ -235,6 +236,7 @@ async function showSettingsScreen(
 			title: (text) => theme.fg("accent", theme.bold(text)),
 			muted: (text) => theme.fg("muted", text),
 		};
+		let limitChoiceOpen = false;
 		const items: SettingItem[] = [
 			limitItem(
 				"automaticTurns",
@@ -243,7 +245,11 @@ async function showSettingsScreen(
 				runtime.settings.continuationLimits.automaticTurns,
 				(doneSelection) => {
 					previewGoalIds.set("automaticTurns", runtime.activeGoal?.id ?? null);
-					return createLimitChoiceComponent(runtime, "automaticTurns", styles, doneSelection);
+					limitChoiceOpen = true;
+					return createLimitChoiceComponent(runtime, "automaticTurns", styles, (selection) => {
+						limitChoiceOpen = false;
+						doneSelection(selection);
+					});
 				},
 			),
 			limitItem(
@@ -253,46 +259,76 @@ async function showSettingsScreen(
 				runtime.settings.continuationLimits.noProgressTurns,
 				(doneSelection) => {
 					previewGoalIds.set("noProgressTurns", runtime.activeGoal?.id ?? null);
-					return createLimitChoiceComponent(runtime, "noProgressTurns", styles, doneSelection);
+					limitChoiceOpen = true;
+					return createLimitChoiceComponent(runtime, "noProgressTurns", styles, (selection) => {
+						limitChoiceOpen = false;
+						doneSelection(selection);
+					});
 				},
 			),
 			{
-				id: "advanced",
-				label: "Advanced…",
-				description: "Configure Goal tools and the experimental ordered queue.",
-				currentValue: "Open…",
-				submenu: (_currentValue, back) =>
-					createAdvancedSettingsComponent({
-						runtime,
-						ctx,
-						settingsPath,
-						options,
-						enqueueSettingsChange,
-						closeAfterSaves,
-						onApplied: updateIssueText,
-						onBack: () => back(),
-						title: (text) => theme.fg("accent", theme.bold(text)),
-					}),
+				id: "toolVisibility",
+				label: "Goal tools",
+				description: "Keep terminal Goal tools visible, or reveal them after the first goal.",
+				currentValue: visibilityLabel(runtime.settings.toolVisibility),
+				values: ["Always", "After first goal"],
+			},
+			{
+				id: "experimentalGoals",
+				label: "Ordered goal queue",
+				description: "Enable experimental add, prioritize, skip, and drop-last workflows.",
+				currentValue: runtime.settings.experimental.goals ? "Experimental" : "Off",
+				values: ["Off", "Experimental"],
 			},
 		];
-		const settingsList = new SettingsList(
+		const latestRequested = new Map<string, string>();
+		let settingsList: SettingsList;
+		settingsList = new SettingsList(
 			items,
 			Math.min(items.length + 2, 15),
 			goalSettingsListTheme("Goal menu"),
 			(id, newValue) => {
-				if (closing || (id !== "automaticTurns" && id !== "noProgressTurns")) return;
-				if (!isLimitSelection(newValue)) return;
-				closeAfterSaves({
-					kind: "limit",
-					field: id,
-					selection: newValue,
-					activeGoalId: previewGoalIds.get(id) ?? null,
+				if (closing) return;
+				if (id === "automaticTurns" || id === "noProgressTurns") {
+					if (!isLimitSelection(newValue)) return;
+					closeAfterSaves({
+						kind: "limit",
+						field: id,
+						selection: newValue,
+						activeGoalId: previewGoalIds.get(id) ?? null,
+					});
+					return;
+				}
+				if (id === "experimentalGoals") {
+					closeAfterSaves({ kind: "queue", enabled: newValue === "Experimental" });
+					return;
+				}
+				if (id !== "toolVisibility") return;
+				latestRequested.set(id, newValue);
+				void enqueueSettingsChange(async () => {
+					const previousValue = visibilityLabel(runtime.settings.toolVisibility);
+					try {
+						const next = {
+							...structuredClone(runtime.settings),
+							toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
+						} satisfies GoalSettings;
+						applyGoalSettings(runtime, next, ctx, {
+							save: (value) => (options.save ?? saveGoalSettings)(value, settingsPath),
+						});
+						updateIssueText();
+						ctx.ui.notify(`Goal tools: ${newValue}.`, "info");
+					} catch (error) {
+						if (latestRequested.get(id) === newValue) {
+							settingsList.updateValue(id, previousValue);
+						}
+						notifySettingsFailure(ctx, settingsPath, error);
+					}
 				});
 			},
 			() => closeAfterSaves(undefined),
 			{ enableSearch: false },
 		);
-		container.addChild(settingsList);
+		container.addChild(goalSettingsListComponent(settingsList, () => limitChoiceOpen));
 		return {
 			render: (width: number) => container.render(width),
 			invalidate: () => container.invalidate(),
@@ -455,82 +491,6 @@ function selectedLimitChoiceIndex(field: LimitField, value: number | null) {
 	if (field === "automaticTurns") return value === null ? 0 : 1;
 	if (value === null) return 2;
 	return value === DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns ? 0 : 1;
-}
-
-function createAdvancedSettingsComponent(options: {
-	runtime: GoalRuntime;
-	ctx: ExtensionCommandContext;
-	settingsPath: string;
-	options: GoalSettingsUiOptions;
-	enqueueSettingsChange: EnqueueSettingsChange;
-	closeAfterSaves: (result: SettingsScreenResult) => void;
-	onApplied: () => void;
-	onBack: () => void;
-	title: (text: string) => string;
-}): Component {
-	const { runtime, ctx, settingsPath } = options;
-	const container = new Container();
-	container.addChild(dynamicText("Advanced Goal Settings", options.title));
-	const items: SettingItem[] = [
-		{
-			id: "toolVisibility",
-			label: "Goal tools",
-			description: "Keep terminal Goal tools visible, or reveal them after the first goal.",
-			currentValue: visibilityLabel(runtime.settings.toolVisibility),
-			values: ["Always", "After first goal"],
-		},
-		{
-			id: "experimentalGoals",
-			label: "Ordered goal queue",
-			description: "Enable experimental add, prioritize, skip, and drop-last workflows.",
-			currentValue: runtime.settings.experimental.goals ? "Experimental" : "Off",
-			values: ["Off", "Experimental"],
-		},
-	];
-	const latestRequested = new Map<string, string>();
-	let settingsList: SettingsList;
-	settingsList = new SettingsList(
-		items,
-		Math.min(items.length + 2, 15),
-		goalSettingsListTheme("Goal Settings"),
-		(id, newValue) => {
-			if (id === "experimentalGoals") {
-				options.closeAfterSaves({ kind: "queue", enabled: newValue === "Experimental" });
-				return;
-			}
-			if (id !== "toolVisibility") return;
-			latestRequested.set(id, newValue);
-			void options.enqueueSettingsChange(async () => {
-				const previousValue = visibilityLabel(runtime.settings.toolVisibility);
-				try {
-					const next = {
-						...structuredClone(runtime.settings),
-						toolVisibility: newValue === "Always" ? "always" : "after-first-goal",
-					} satisfies GoalSettings;
-					applyGoalSettings(runtime, next, ctx, {
-						save: (value) => (options.options.save ?? saveGoalSettings)(value, settingsPath),
-					});
-					options.onApplied();
-					ctx.ui.notify(`Goal tools: ${newValue}.`, "info");
-				} catch (error) {
-					if (latestRequested.get(id) === newValue) {
-						settingsList.updateValue(id, previousValue);
-					}
-					notifySettingsFailure(ctx, settingsPath, error);
-				}
-			});
-		},
-		options.onBack,
-		{ enableSearch: false },
-	);
-	container.addChild(settingsList);
-	return {
-		render: (width: number) => container.render(width),
-		invalidate: () => container.invalidate(),
-		handleInput(data: string) {
-			settingsList.handleInput?.(data);
-		},
-	};
 }
 
 async function resolveLimitSelection(
@@ -773,6 +733,20 @@ function notifySettingsFailure(ctx: ExtensionCommandContext, settingsPath: strin
 			: `Could not save Goal settings; the previous value remains. Check ${path} and retry: ${detail}`,
 		"error",
 	);
+}
+
+function goalSettingsListComponent(
+	settingsList: SettingsList,
+	isLimitChoiceOpen: () => boolean,
+): Component {
+	return {
+		render(width: number) {
+			// Reclaim one of SettingsList's two trailing cells so a safe 16-digit cap stays exact at 40 columns.
+			const renderWidth = isLimitChoiceOpen() ? width : width + 1;
+			return settingsList.render(renderWidth).map((line) => truncateToWidth(line, width, ""));
+		},
+		invalidate: () => settingsList.invalidate(),
+	};
 }
 
 function dynamicText(

--- a/extensions/pi-goal/src/settings.ts
+++ b/extensions/pi-goal/src/settings.ts
@@ -23,7 +23,7 @@ export interface GoalSettings {
 export const DEFAULT_GOAL_SETTINGS: GoalSettings = {
 	toolVisibility: "always",
 	experimental: { goals: false },
-	continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+	continuationLimits: { automaticTurns: null, noProgressTurns: 3 },
 };
 
 export const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`;
@@ -36,6 +36,8 @@ export type GoalSettingsLoadResult =
 export type GoalSettingsInitializationResult =
 	| Exclude<GoalSettingsLoadResult, { kind: "missing" }>
 	| { kind: "create-failed"; reason: string };
+
+export type GoalSettingsLoadIssue = Exclude<GoalSettingsInitializationResult, { kind: "loaded" }>;
 
 interface GoalSettingsInitializationFileSystem {
 	mkdirSync: typeof mkdirSync;

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -3,7 +3,11 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import goal, {
 	assistantUsageTokens,
 	buildGoalSystemPrompt,
@@ -253,6 +257,32 @@ test("missing and invalid settings fall back to always-visible tools", () => {
 			expectsWarning,
 		);
 	}
+});
+
+test("invalid settings remain read-only in the Goal settings UI", async () => {
+	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked"] });
+	registerGoalWithSettingsPath(mock.pi, INVALID_SETTINGS_PATH);
+	const selections = ["Settings…", "Close"];
+	let settingsRender = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => selections.shift(),
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			settingsRender = selector.render().join("\n");
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+	mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	await mock.commands.get("goal")?.handler("", context.ctx);
+
+	assert.match(settingsRender, /Read only/i);
+	assert.match(settingsRender, /invalid settings file/i);
+	assert.match(settingsRender, /using built-in defaults/i);
+	assert.equal(readFileSync(INVALID_SETTINGS_PATH, "utf8"), '{"toolVisibility":"sometimes"}\n');
 });
 
 test("after-first-goal hides tools until activation, then keeps them visible", async () => {

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -55,8 +55,15 @@ test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget,
 
 	const active = createGoal("ship the release", 100, 0);
 	active.tokensUsed = 20;
-	assert.equal(buildGoalMenuState(runtime(active)).actions[0], GOAL_MENU_ACTIONS.pause);
-	assert.match(buildGoalMenuState(runtime(active)).title, /Active.*20\/100/is);
+	active.automaticModelTurns = 12;
+	const unlimited = runtime(active);
+	assert.equal(buildGoalMenuState(unlimited).actions[0], GOAL_MENU_ACTIONS.pause);
+	assert.match(buildGoalMenuState(unlimited).title, /Active.*20\/100/is);
+	assert.match(buildGoalMenuState(unlimited).title, /12 automatic responses.*Unlimited/is);
+
+	const capped = runtime(active);
+	capped.settings.continuationLimits.automaticTurns = 25;
+	assert.match(buildGoalMenuState(capped).title, /12\/25 automatic responses/is);
 
 	for (const status of ["paused", "blocked", "usage_limited"] as const) {
 		const stopped = runtime(transitionGoal(active, status));

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -33,11 +33,19 @@ function runtime() {
 	return state;
 }
 
-test("goal setting limit parsing preserves arbitrary positive integers and unlimited", () => {
+test("goal setting custom limits accept only safe whole numbers greater than zero", () => {
 	assert.equal(parseGoalLimit("40"), 40);
-	assert.equal(parseGoalLimit("unlimited"), null);
-	assert.equal(parseGoalLimit("off"), null);
-	for (const invalid of ["", "0", "-1", "1.5", "many"]) {
+	assert.equal(parseGoalLimit(" 25 "), 25);
+	for (const invalid of [
+		"",
+		"0",
+		"-1",
+		"1.5",
+		"Unlimited",
+		"off",
+		"many",
+		String(Number.MAX_SAFE_INTEGER + 1),
+	]) {
 		assert.equal(parseGoalLimit(invalid), undefined);
 	}
 	assert.equal(formatGoalLimit(25), "25");
@@ -415,37 +423,339 @@ test("unfreezing a pending priority dispatches it at the idle boundary", async (
 	assert.equal(mock.sentUserMessages.length, 1);
 });
 
-test("settings screen saves changes in place and Escape waits for the save queue", async () => {
+test("settings screen prioritizes safety state and keeps internal controls under Advanced", async () => {
 	const state = runtime();
-	const saved: GoalSettings[] = [];
 	let initialRender = "";
+	let advancedRender = "";
+	let screens = 0;
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
-			const selector = createCustomSelectorHarness(factory, 40);
+			if (screens++ > 0) throw new Error("Navigation unexpectedly reopened settings.");
+			const selector = createCustomSelectorHarness(factory, 80);
 			initialRender = selector.render().join("\n");
-			selector.handleInput("\r");
+			selector.handleInput("\u001b[B");
+			selector.handleInput("\u001b[B");
+			advancedRender = selector.handleInput("\r").join("\n");
+			const mainAgain = selector.handleInput("\u001b").join("\n");
+			assert.match(mainAgain, /Automatic work/);
 			selector.handleInput("\u001b");
-			selector.handleInput("\r");
 			await new Promise((resolve) => setImmediate(resolve));
 			return selector.result;
 		},
 	});
 
-	await showGoalSettings(state as never, context.ctx, {
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("Navigation must not save.");
+		},
+	});
+
+	assert.match(initialRender, /Pi Goal Settings/);
+	assert.match(initialRender, /Automatic work.*Unlimited/is);
+	assert.match(initialRender, /No-progress guard.*3 runs/is);
+	assert.match(initialRender, /Advanced.*Open/is);
+	assert.match(initialRender, /Esc back to Goal menu/);
+	assert.doesNotMatch(initialRender, /Goal tools/);
+	assert.doesNotMatch(initialRender, /Type to search/);
+	assert.match(advancedRender, /Advanced Goal Settings/);
+	assert.match(advancedRender, /Goal tools/);
+	assert.match(advancedRender, /Ordered goal queue/);
+	assert.match(advancedRender, /Esc back to Goal Settings/);
+});
+
+test("Automatic work offers an explicit Unlimited choice with concrete active-goal state", async () => {
+	const state = runtime();
+	state.settings.continuationLimits.automaticTurns = 25;
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.activeGoal.automaticModelTurns = 12;
+	const saved: GoalSettings[] = [];
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		confirm: async () => {
+			throw new Error("Choosing Unlimited must not add a redundant confirmation.");
+		},
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				const choices = selector.handleInput("\r").join("\n");
+				assert.match(choices, /Current: Up to 25 responses/i);
+				assert.match(choices, /12 automatic responses used/i);
+				assert.match(choices, /Unlimited \(default\)/i);
+				assert.match(choices, /Set a maximum/i);
+				selector.handleInput("\u001b[A");
+				selector.handleInput("\r");
+			} else {
+				assert.match(selector.render().join("\n"), /Automatic work.*Unlimited/is);
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
 		settingsPath: "/tmp/pi-goal.json",
 		save(settings) {
 			saved.push(structuredClone(settings));
 		},
 	});
 
-	assert.match(initialRender, /Pi Goal Settings/);
-	assert.match(initialRender, /Goal tools/);
-	assert.doesNotMatch(initialRender, /Type to search/);
 	assert.equal(saved.length, 1);
-	assert.equal(saved[0]?.toolVisibility, "after-first-goal");
-	assert.equal(state.settings.toolVisibility, "after-first-goal");
+	assert.equal(saved[0]?.continuationLimits.automaticTurns, null);
+	assert.equal(state.settings.continuationLimits.automaticTurns, null);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Automatic work: Unlimited/i);
+});
+
+test("Unlimited preview does not invent active-goal usage when no goal exists", async () => {
+	const state = runtime();
+	state.settings.continuationLimits.automaticTurns = 25;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			selector.handleInput("\r");
+			const choices = selector.handleInput("\u001b[A").join("\n");
+			assert.match(choices, /Goal work will have no response-count cap/i);
+			assert.doesNotMatch(choices, /Active goal:/i);
+			selector.handleInput("\u001b");
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("Preview cancellation must not save.");
+		},
+	});
+});
+
+test("custom automatic limits reject invalid values in place and save one positive integer", async () => {
+	const state = runtime();
+	const inputs = ["0", "-1", "Unlimited", "off", "1.5", "25"];
+	const inputTitles: string[] = [];
+	const saved: GoalSettings[] = [];
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		input: async (title: string) => {
+			inputTitles.push(title);
+			return inputs.shift();
+		},
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				selector.handleInput("\r");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save(settings) {
+			saved.push(structuredClone(settings));
+		},
+	});
+
+	assert.equal(inputs.length, 0);
+	assert.ok(inputTitles.every((title) => /> 0|greater than 0/i.test(title)));
+	assert.equal(
+		context.notifications.filter((notice) => /whole number greater than 0/i.test(notice.message))
+			.length,
+		5,
+	);
+	assert.equal(saved.length, 1);
+	assert.equal(saved[0]?.continuationLimits.automaticTurns, 25);
+	assert.equal(state.settings.continuationLimits.automaticTurns, 25);
+});
+
+test("No-progress guard exposes default, custom, and Off as explicit choices", async () => {
+	const state = runtime();
+	const saved: GoalSettings[] = [];
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				selector.handleInput("\u001b[B");
+				const choices = selector.handleInput("\r").join("\n");
+				assert.match(choices, /After 3 repeated runs \(default\)/i);
+				assert.match(choices, /Set threshold/i);
+				assert.match(choices, /Off/i);
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				assert.match(selector.render().join("\n"), /No-progress guard.*Off/is);
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save(settings) {
+			saved.push(structuredClone(settings));
+		},
+	});
+
+	assert.equal(saved.length, 1);
+	assert.equal(saved[0]?.continuationLimits.noProgressTurns, null);
+	assert.equal(state.settings.continuationLimits.noProgressTurns, null);
+	assert.match(context.notifications.at(-1)?.message ?? "", /No-progress guard: Off/i);
+});
+
+test("cancelling a custom limit input leaves settings untouched", async () => {
+	const state = runtime();
+	let saves = 0;
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		input: async () => undefined,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				selector.handleInput("\r");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			saves++;
+		},
+	});
+
+	assert.equal(saves, 0);
+	assert.deepEqual(state.settings, DEFAULT_GOAL_SETTINGS);
+});
+
+test("invalid settings render read-only defaults and cannot overwrite the file", async () => {
+	const state = runtime() as GoalRuntime & {
+		settingsLoadIssue?: { kind: "invalid"; reason: string };
+	};
+	state.settingsLoadIssue = { kind: "invalid", reason: "invalid settings shape" };
+	let render = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 40);
+			render = selector.render().join("\n");
+			selector.handleInput("\r");
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("Invalid settings must remain untouched.");
+		},
+	});
+
+	assert.match(render, /Read only/i);
+	assert.match(render, /invalid settings file/i);
+	assert.match(render, /using built-in defaults/i);
+	assert.match(render, /fix .*pi-goal\.json.*\/reload/is);
+	assert.match(render, /Automatic work.*Unlimited/is);
+});
+
+test("a create-failed fallback clears after a successful settings save", async () => {
+	const state = runtime() as GoalRuntime & {
+		settingsLoadIssue?: { kind: "create-failed"; reason: string };
+	};
+	state.settingsLoadIssue = { kind: "create-failed", reason: "publish failed" };
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		input: async () => "25",
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				assert.match(selector.render().join("\n"), /Built-in defaults.*retry/is);
+				selector.handleInput("\r");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				assert.doesNotMatch(selector.render().join("\n"), /Built-in defaults/i);
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {},
+	});
+
+	assert.equal(state.settingsLoadIssue, undefined);
+	assert.equal(state.settings.continuationLimits.automaticTurns, 25);
+});
+
+test("a failed safety-setting save keeps the previous state and gives actionable feedback", async () => {
+	const state = runtime();
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		input: async () => "25",
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				selector.handleInput("\r");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				assert.match(selector.render().join("\n"), /Automatic work.*Unlimited/is);
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("disk full");
+		},
+	});
+
+	assert.equal(state.settings.continuationLimits.automaticTurns, null);
+	assert.match(context.notifications.at(-1)?.message ?? "", /previous value remains/i);
+	assert.match(context.notifications.at(-1)?.message ?? "", /\/tmp\/pi-goal\.json/i);
+	assert.match(context.notifications.at(-1)?.message ?? "", /disk full/i);
 });
 
 test("lowered limit confirmation cannot apply to a replacement goal", async () => {
@@ -461,14 +771,17 @@ test("lowered limit confirmation cannot apply to a replacement goal", async () =
 		mode: "tui",
 		hasUI: true,
 		input: async () => "3",
-		confirm: async () => {
+		confirm: async (title: string, message: string) => {
+			assert.equal(title, "Apply limit and pause now?");
+			assert.match(message, /already used 5/i);
+			assert.match(message, /pause it immediately without deleting progress/i);
 			state.activeGoal = replacement;
 			return true;
 		},
 		custom: async (factory: unknown) => {
 			const selector = createCustomSelectorHarness(factory, 80);
 			if (screens++ === 0) {
-				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
 				selector.handleInput("\u001b[B");
 				selector.handleInput("\r");
 			} else {
@@ -494,6 +807,44 @@ test("lowered limit confirmation cannot apply to a replacement goal", async () =
 	assert.equal(state.activeGoal?.id, replacement.id);
 	assert.equal(state.activeGoal?.status, "active");
 	assert.match(context.notifications.at(-1)?.message ?? "", /goal changed/i);
+});
+
+test("confirming an already-reached automatic limit pauses the owned run", async () => {
+	const state = runtime();
+	state.activeGoal = createGoal("current objective", undefined, 0);
+	state.activeGoal.automaticModelTurns = 5;
+	state.beginAgentRun(state.activeGoal.id, "automatic");
+	let aborts = 0;
+	let screens = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		abort: () => aborts++,
+		input: async () => "3",
+		confirm: async () => true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			if (screens++ === 0) {
+				selector.handleInput("\r");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+			} else {
+				selector.handleInput("\u001b");
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {},
+	});
+
+	assert.equal(aborts, 1);
+	assert.equal(state.settings.continuationLimits.automaticTurns, 3);
+	assert.equal(state.activeGoal?.status, "paused");
+	assert.equal(state.activeGoal?.safetyPauseCause, "continuation_limit");
 });
 
 test("full goal status includes a pending priority objective", () => {
@@ -541,6 +892,9 @@ test("queue confirmations open only after the custom settings screen closes", as
 				const selector = createCustomSelectorHarness(factory, 80);
 				if (screens++ === 0) {
 					selector.handleInput("\u001b[B");
+					selector.handleInput("\u001b[B");
+					selector.handleInput("\r");
+					selector.handleInput("\u001b[B");
 					selector.handleInput("\r");
 				} else {
 					selector.handleInput("\u001b");
@@ -577,6 +931,9 @@ test("settings screen resumes retained work after enabling the queue", async () 
 			const selector = createCustomSelectorHarness(factory, 80);
 			if (screens++ === 0) {
 				selector.handleInput("\u001b[B");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\r");
+				selector.handleInput("\u001b[B");
 				selector.handleInput("\r");
 			} else {
 				selector.handleInput("\u001b");
@@ -600,7 +957,33 @@ test("settings screen resumes retained work after enabling the queue", async () 
 	assert.equal(screens, 1);
 });
 
-test("settings screen fits narrow, normal, and wide terminal widths", async () => {
+test("narrow settings preserve an exact maximum safe automatic-response cap", async () => {
+	const state = runtime();
+	state.settings.continuationLimits.automaticTurns = Number.MAX_SAFE_INTEGER;
+	let render = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 40);
+			render = selector.render().join("\n");
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("Rendering must not save.");
+		},
+	});
+
+	assert.match(render, new RegExp(`≤${Number.MAX_SAFE_INTEGER}`));
+	assert.doesNotMatch(render, /900719925474099(?!1)/);
+});
+
+test("settings, safety choices, and Advanced fit narrow, normal, and wide terminals", async () => {
 	for (const width of [40, 80, 120]) {
 		const state = runtime();
 		const context = createMockContext({
@@ -608,17 +991,24 @@ test("settings screen fits narrow, normal, and wide terminal widths", async () =
 			hasUI: true,
 			custom: async (factory: unknown) => {
 				const selector = createCustomSelectorHarness(factory, width);
-				const lines = selector.render();
-				assert.ok(lines.every((line) => visibleWidth(line) <= width));
+				for (const lines of [selector.render(), selector.handleInput("\r")]) {
+					assert.ok(lines.every((line) => visibleWidth(line) <= width));
+				}
+				selector.handleInput("\u001b");
+				selector.handleInput("\u001b[B");
+				selector.handleInput("\u001b[B");
+				const advanced = selector.handleInput("\r");
+				assert.ok(advanced.every((line) => visibleWidth(line) <= width));
+				selector.handleInput("\u001b");
 				selector.handleInput("\u001b");
 				await new Promise((resolve) => setImmediate(resolve));
 				return selector.result;
 			},
 		});
-		await showGoalSettings(state as never, context.ctx, {
+		await showGoalSettings(state, context.ctx, {
 			settingsPath: "/tmp/pi-goal.json",
 			save() {
-				throw new Error("Escape must not save.");
+				throw new Error("Navigation must not save.");
 			},
 		});
 	}

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -423,23 +423,19 @@ test("unfreezing a pending priority dispatches it at the idle boundary", async (
 	assert.equal(mock.sentUserMessages.length, 1);
 });
 
-test("settings screen prioritizes safety state and keeps internal controls under Advanced", async () => {
+test("settings screen keeps all four settings in task order on one level", async () => {
 	const state = runtime();
 	let initialRender = "";
-	let advancedRender = "";
-	let screens = 0;
+	let selectedQueueRender = "";
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
-			if (screens++ > 0) throw new Error("Navigation unexpectedly reopened settings.");
 			const selector = createCustomSelectorHarness(factory, 80);
 			initialRender = selector.render().join("\n");
 			selector.handleInput("\u001b[B");
 			selector.handleInput("\u001b[B");
-			advancedRender = selector.handleInput("\r").join("\n");
-			const mainAgain = selector.handleInput("\u001b").join("\n");
-			assert.match(mainAgain, /Automatic work/);
+			selectedQueueRender = selector.handleInput("\u001b[B").join("\n");
 			selector.handleInput("\u001b");
 			await new Promise((resolve) => setImmediate(resolve));
 			return selector.result;
@@ -456,14 +452,46 @@ test("settings screen prioritizes safety state and keeps internal controls under
 	assert.match(initialRender, /Pi Goal Settings/);
 	assert.match(initialRender, /Automatic work.*Unlimited/is);
 	assert.match(initialRender, /No-progress guard.*3 runs/is);
-	assert.match(initialRender, /Advanced.*Open/is);
+	assert.match(initialRender, /Goal tools.*Always/is);
+	assert.match(initialRender, /Ordered goal queue.*Off/is);
+	assert.ok(initialRender.indexOf("Automatic work") < initialRender.indexOf("No-progress guard"));
+	assert.ok(initialRender.indexOf("No-progress guard") < initialRender.indexOf("Goal tools"));
+	assert.ok(initialRender.indexOf("Goal tools") < initialRender.indexOf("Ordered goal queue"));
 	assert.match(initialRender, /Esc back to Goal menu/);
-	assert.doesNotMatch(initialRender, /Goal tools/);
+	assert.doesNotMatch(initialRender, /Advanced/);
 	assert.doesNotMatch(initialRender, /Type to search/);
-	assert.match(advancedRender, /Advanced Goal Settings/);
-	assert.match(advancedRender, /Goal tools/);
-	assert.match(advancedRender, /Ordered goal queue/);
-	assert.match(advancedRender, /Esc back to Goal Settings/);
+	assert.match(selectedQueueRender, /→ .*Ordered goal queue/s);
+});
+
+test("Goal tools changes directly from the main settings screen", async () => {
+	const state = runtime();
+	const saved: GoalSettings[] = [];
+	let changedRender = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const selector = createCustomSelectorHarness(factory, 80);
+			selector.handleInput("\u001b[B");
+			selector.handleInput("\u001b[B");
+			changedRender = selector.handleInput("\r").join("\n");
+			await new Promise((resolve) => setImmediate(resolve));
+			selector.handleInput("\u001b");
+			return selector.result;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save(settings) {
+			saved.push(structuredClone(settings));
+		},
+	});
+
+	assert.match(changedRender, /Goal tools.*After first goal/is);
+	assert.equal(state.settings.toolVisibility, "after-first-goal");
+	assert.equal(saved.length, 1);
+	assert.match(context.notifications.at(-1)?.message ?? "", /Goal tools: After first goal/i);
 });
 
 test("Automatic work offers an explicit Unlimited choice with concrete active-goal state", async () => {
@@ -893,7 +921,6 @@ test("queue confirmations open only after the custom settings screen closes", as
 				if (screens++ === 0) {
 					selector.handleInput("\u001b[B");
 					selector.handleInput("\u001b[B");
-					selector.handleInput("\r");
 					selector.handleInput("\u001b[B");
 					selector.handleInput("\r");
 				} else {
@@ -932,7 +959,6 @@ test("settings screen resumes retained work after enabling the queue", async () 
 			if (screens++ === 0) {
 				selector.handleInput("\u001b[B");
 				selector.handleInput("\u001b[B");
-				selector.handleInput("\r");
 				selector.handleInput("\u001b[B");
 				selector.handleInput("\r");
 			} else {
@@ -983,7 +1009,7 @@ test("narrow settings preserve an exact maximum safe automatic-response cap", as
 	assert.doesNotMatch(render, /900719925474099(?!1)/);
 });
 
-test("settings, safety choices, and Advanced fit narrow, normal, and wide terminals", async () => {
+test("settings and safety choices fit narrow, normal, and wide terminals", async () => {
 	for (const width of [40, 80, 120]) {
 		const state = runtime();
 		const context = createMockContext({
@@ -997,9 +1023,8 @@ test("settings, safety choices, and Advanced fit narrow, normal, and wide termin
 				selector.handleInput("\u001b");
 				selector.handleInput("\u001b[B");
 				selector.handleInput("\u001b[B");
-				const advanced = selector.handleInput("\r");
-				assert.ok(advanced.every((line) => visibleWidth(line) <= width));
-				selector.handleInput("\u001b");
+				const queueSelected = selector.handleInput("\u001b[B");
+				assert.ok(queueSelected.every((line) => visibleWidth(line) <= width));
 				selector.handleInput("\u001b");
 				await new Promise((resolve) => setImmediate(resolve));
 				return selector.result;

--- a/extensions/pi-goal/test/settings.test.ts
+++ b/extensions/pi-goal/test/settings.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/settings.js";
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
+	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns, null);
 	assert.deepEqual(normalizeGoalSettings({}), DEFAULT_GOAL_SETTINGS);
 	assert.deepEqual(normalizeGoalSettings({ futureOption: true }), DEFAULT_GOAL_SETTINGS);
 	assert.deepEqual(normalizeGoalSettings({ toolVisibility: "always" }), {
@@ -38,7 +39,7 @@ test("normalizeGoalSettings applies defaults and accepts bounded continuation li
 	});
 	assert.deepEqual(normalizeGoalSettings({ continuationLimits: { noProgressTurns: 2 } }), {
 		...DEFAULT_GOAL_SETTINGS,
-		continuationLimits: { automaticTurns: 25, noProgressTurns: 2 },
+		continuationLimits: { automaticTurns: null, noProgressTurns: 2 },
 	});
 	assert.deepEqual(
 		normalizeGoalSettings({
@@ -242,7 +243,7 @@ test("readGoalSettings distinguishes missing, loaded, malformed, and unreadable 
 		settings: {
 			toolVisibility: "after-first-goal",
 			experimental: { goals: true },
-			continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+			continuationLimits: { automaticTurns: null, noProgressTurns: 3 },
 		},
 	});
 


### PR DESCRIPTION
## Summary

- make automatic response limits unlimited by default and show used/limit or Unlimited state in the Goal manager
- keep Automatic work, No-progress guard, Goal tools, and Ordered goal queue together on the main Goal Settings screen, with explicit Unlimited/Off choices
- validate custom limits as positive safe integers, confirm changes that immediately pause an active goal, and preserve prior runtime/persisted state on load or save failures
- document the seven-item threshold for considering extra menu depth and add deterministic keyboard, responsive-width, cancellation, stale-state, and failure-path coverage

## Testing

- `npm run check` (1,658 tests)
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `npm run check --workspace @narumitw/pi-goal`
- `git diff --check`
