### PR TITLE
fix(goal): defer settings creation until save

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -118,6 +118,7 @@
 - Credential-file path and permission checks must run on every locked read, not only startup migration; reject symlinks and repair `0600` through the opened descriptor.
 - Credential filename migrations cannot safely delete a legacy path while uncoordinated older writers may still replace it; install the canonical file exclusively, retain a private legacy recovery copy, and deny canonical, legacy, temporary, and recovery names from sync/export paths.
 - Pi-sync settings read-modify-write must hold one cross-process lock across the read, complete v3 validation, and atomic replacement; separate read/write lock windows only detect stale edits and can still reject otherwise serializable concurrent saves.
+- Symptom: first-run settings publication fails in Android/Termux despite a writable directory. Cause: SELinux forbids hard links for `untrusted_app`. Fix: keep missing-file loads side-effect free and publish explicit saves with same-directory temporary files plus rename.
 
 ## TASTE
 

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -186,8 +186,9 @@ than an arbitrary row boundary.
 
 ### Settings
 
-[`docs/extension-settings.md`](extension-settings.md) owns settings names, paths, precedence, project
-trust, validation, persistence, migration, secrets, interactive UI, and settings-specific tests.
+[`docs/extension-settings.md`](extension-settings.md) owns alignment with Pi core plus settings names,
+paths, precedence, project trust, validation, persistence, migration, secrets, interactive UI, and
+settings-specific tests.
 
 - **MUST:** Read and follow that guide when adding or changing extension-owned settings, including
   their commands or UI. **Verification:** `Review` against its applicable sections and verification

--- a/docs/extension-settings.md
+++ b/docs/extension-settings.md
@@ -3,6 +3,29 @@
 Use these conventions when an extension owns user-facing configuration. Keep packages independently
 installable: each package owns its loader, validator, persistence, UI, tests, and migration code.
 
+## Alignment with Pi core
+
+Pi core's
+[settings documentation](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/settings.md)
+and
+[SDK settings contract](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/sdk.md#settings-management)
+provide the behavioral reference for extension settings:
+
+- An absent file means no explicit overrides. Defaults stay in code, and a read does not create the
+  settings file or its parent directory.
+- In-memory getters and setters are synchronous from the caller's perspective. Persistence may be
+  queued, but writes stay ordered; callers await an explicit durability boundary before shutdown,
+  reload, or tests that inspect disk state.
+- Storage errors remain data until the application layer reports them. A storage helper must not
+  print directly or corrupt JSON, RPC, or TUI output.
+- A write starts from the latest valid document and changes only owned fields, preserving unrelated
+  settings. A malformed existing file blocks the write instead of being replaced with defaults.
+
+Adopt those semantics, not Pi core's private storage implementation. Extension-owned fields belong in
+an extension-owned file rather than Pi's `settings.json`. For extension files, this repository also
+requires temporary-file-plus-rename publication below, even if Pi core currently uses a different
+internal write mechanism.
+
 ## File names and locations
 
 Name the active user JSON file after the unscoped package name and use the same basename for project
@@ -153,15 +176,23 @@ defaults -> user settings -> trusted project overrides -> explicit runtime overr
 
 ## Loading, validation, and persistence
 
-- Treat a missing file as defaults, not an error.
+- Treat a missing file as defaults, not an error. Loading settings must be side-effect free: do not
+  create the settings file, its parent directory, a lock, or a temporary file merely to materialize
+  defaults. Create the file only after an explicit user save or setup action.
 - Require a JSON object at the top level and validate values at runtime.
 - Warn when invalid settings are ignored; do not silently overwrite an invalid file.
 - Preserve unknown fields during UI saves and migrations so older versions do not erase
   forward-compatible data.
-- Write atomically through a temporary file in the destination directory followed by rename.
+- Write atomically through a temporary file in the destination directory followed by rename. Do not
+  use a hard link as the publication step: Android SELinux denies hard-link creation to Termux's
+  `untrusted_app` domain even when ordinary directory writes and renames are allowed.
 - Keep the previous file and effective runtime settings when a write fails.
 - Coordinate reads with pending writes to the same path so reload or session replacement cannot load
-  a pre-write snapshot. Ensure a failed write does not poison subsequent reads or writes.
+  a pre-write snapshot. Keep queued writes in request order, await their durability boundary before a
+  dependent reload or shutdown completes, and ensure a failed write does not poison subsequent reads
+  or writes.
+- Return or retain storage errors for the command, lifecycle, or UI layer to report through a
+  mode-appropriate channel; do not print from the persistence helper.
 - Reload settings on `session_start`, including starts caused by `/reload` and session replacement.
 - Document defaults, precedence, paths, reload behavior, and accepted values in the package README.
 
@@ -195,7 +226,8 @@ README and any supported Status or Help route.
 
 Tests for a configurable extension should cover the behavior it implements, including:
 
-- missing, valid, malformed, and invalid settings;
+- side-effect-free missing-file loads, first explicit-save creation, valid, malformed, and invalid
+  settings;
 - defaults and user/project precedence;
 - project trust gating;
 - unknown-field preservation and atomic-write failure;

--- a/docs/plans/archived/2026-07-28_pi-goal-core-settings-convention-plan.md
+++ b/docs/plans/archived/2026-07-28_pi-goal-core-settings-convention-plan.md
@@ -1,0 +1,32 @@
+# pi-goal core settings convention
+
+## Goal
+
+Align pi-goal startup with Pi core's settings behavior: a missing settings file uses built-in defaults without creating files, while the first explicit user save creates the extension file. Document the applicable Pi core semantics and the repository's stronger atomic-write requirement.
+
+## Architecture
+
+- `extensions/pi-goal/src/settings.ts` remains the package-owned parser and atomic writer.
+- `extensions/pi-goal/src/goal.ts` performs a side-effect-free settings read on every `session_start`; only malformed or unreadable existing files become load issues.
+- Pi core's public settings semantics are the behavioral reference. Extension-owned files remain separate from Pi's `settings.json` and continue using temporary-file-plus-rename publication required by this repository.
+
+## Assumptions
+
+- “Pi core convention” means missing files represent defaults and reads do not materialize configuration; it does not mean copying Pi core's private `proper-lockfile`/direct-write implementation.
+- Automatic creation added in `2cc1bce` may be removed as an intentional behavior change; existing valid and invalid files remain untouched.
+
+## Plan
+
+- [x] Update pi-goal settings and lifecycle tests to require side-effect-free missing-file loads and explicit-save creation; focused red test failed because startup created the missing parent (`true !== false`), while explicit-save creation passed.
+- [x] Remove pi-goal's startup creation and hard-link publication paths while preserving validation, unknown-field preservation, atomic saves, and invalid-file protection; 173 focused settings, lifecycle, and settings-UI tests passed.
+- [x] Update `docs/extension-settings.md` with the relevant Pi core load, in-memory, persistence-order, durability, and error-reporting semantics plus the repository-specific atomic-write distinction; update `docs/extension-conventions.md` and `extensions/pi-goal/README.md` to match the new startup/save behavior.
+- [x] Audit settings loading, invalid-file protection, unknown-field preservation, atomic saves, ordered UI persistence, and repeated `session_start` behavior against both guides; pi-goal typecheck and runtime smoke passed, and `npm run check` passed all 1,653 tests.
+- [x] Record the reusable Termux hard-link compatibility gotcha in `MEMORY.md`, archive this completed plan under `docs/plans/archived/`, and verify only the intended settings, documentation, tests, memory, and plan paths changed.
+
+## Completion Checklist
+
+- [x] A missing `pi-goal.json` remains absent across startup, reload, and session replacement while defaults are effective and no warning is emitted.
+- [x] The first successful Goal Settings save creates a valid complete file atomically; existing malformed settings remain protected.
+- [x] Repository guidance names the applicable Pi core semantics without prescribing core-private storage mechanics to extensions.
+- [x] pi-goal README, tests, and implementation agree on load, save, reload, and failure behavior.
+- [x] Focused tests, pi-goal runtime/type checks, and `npm run check` pass.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -54,8 +54,8 @@ pi -e ./extensions/pi-goal
 
 ## ⚙️ Configuration
 
-On the first session start, pi-goal automatically creates `~/.pi/agent/pi-goal.json`
-with the complete current defaults:
+Settings are optional. When `~/.pi/agent/pi-goal.json` is absent, pi-goal uses these
+built-in defaults without creating the file:
 
 ```json
 {
@@ -70,7 +70,7 @@ with the complete current defaults:
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to edit these values interactively, or edit the generated file directly. The screen keeps all four controls on one level in task order:
+Use `/goal` → **Settings…** in the TUI to create or update the file interactively, or create and edit it directly. The screen keeps all four controls on one level in task order:
 
 - **Automatic work** shows **Unlimited** or an exact **≤_N_** response cap. Choose **Unlimited** directly, or choose **Set a maximum…** and enter a safe whole number greater than zero.
 - **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
@@ -91,10 +91,9 @@ Custom number inputs reject zero, negative numbers, decimals, text, and unsafe i
 - `automaticTurns` accepts a positive safe integer or `null` and defaults to `null` (unlimited). When configured, it counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field to `null` to remove the authoritative hard bound.
 - `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
 
-Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file is created during any of those session starts, while an existing file is read without being rewritten. Initialization publishes the generated file atomically and never overwrites a file
-created concurrently by another process.
+Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file remains absent and uses the built-in defaults. The first successful settings change creates the file atomically; later saves preserve unknown fields.
 
-Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults. In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and directs the user to fix it and run `/reload`. If the default file cannot be created, pi-goal warns, continues with the built-in defaults, and retries when a setting is saved or on the next session start. Reload Pi after changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"`
+Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults. In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and directs the user to fix it and run `/reload`. Reload Pi after changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"`
 restores only the exact tools that pi-goal previously hid, while switching to
 `"after-first-goal"` locks a runtime that has no unfinished goal.
 

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -31,7 +31,7 @@ import {
 	truncateNotification,
 } from "./runtime.js";
 import { hasAssistantToolCall } from "./safety.js";
-import { DEFAULT_GOAL_SETTINGS, loadOrCreateGoalSettings } from "./settings.js";
+import { DEFAULT_GOAL_SETTINGS, readGoalSettings } from "./settings.js";
 import { showGoalSettings } from "./settings-ui.js";
 
 // goal.ts remains the Pi-facing composition root despite its size because tool contracts and
@@ -54,7 +54,6 @@ interface GoalBlockedDetails {
 
 interface GoalOptions {
 	settingsPath?: string;
-	settingsFileSystem?: Parameters<typeof loadOrCreateGoalSettings>[1];
 }
 
 const EXPERIMENTAL_GOALS_WARNING =
@@ -487,21 +486,13 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 		runtime.clearTerminalDetails();
 		rpc.bindSession(ctx);
 		const previousToolVisibility = runtime.settings.toolVisibility;
-		const settingsResult = loadOrCreateGoalSettings(
-			options.settingsPath,
-			options.settingsFileSystem,
-		);
+		const settingsResult = readGoalSettings(options.settingsPath);
 		runtime.settings =
 			settingsResult.kind === "loaded" ? settingsResult.settings : DEFAULT_GOAL_SETTINGS;
-		runtime.settingsLoadIssue = settingsResult.kind === "loaded" ? undefined : settingsResult;
+		runtime.settingsLoadIssue = settingsResult.kind === "invalid" ? settingsResult : undefined;
 		if (settingsResult.kind === "invalid") {
 			ctx.ui.notify(
 				`pi-goal settings ignored: ${settingsResult.reason}. Using default settings.`,
-				"warning",
-			);
-		} else if (settingsResult.kind === "create-failed") {
-			ctx.ui.notify(
-				`Could not create pi-goal settings: ${settingsResult.reason}. Using default settings.`,
 				"warning",
 			);
 		}

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -149,7 +149,6 @@ export function applyGoalSettings(
 		const abortOwnedRun = activeGoalId !== undefined && runtime.agentRunGoalId === activeGoalId;
 		const pausedByAutomaticLimit = runtime.enforceAutomaticTurnLimit(ctx, abortOwnedRun);
 		if (!pausedByAutomaticLimit) runtime.enforceNoProgressLimit(ctx, abortOwnedRun);
-		if (fileSaved) runtime.settingsLoadIssue = undefined;
 	} catch (error) {
 		const rollbackErrors: unknown[] = [];
 		try {
@@ -216,21 +215,13 @@ async function showSettingsScreen(
 				theme.fg("muted", text),
 			),
 		);
-		if (runtime.settingsLoadIssue?.kind === "create-failed") {
-			container.addChild(
-				dynamicText(
-					() => settingsIssueBanner(runtime),
-					(text) => theme.fg("warning", text),
-				),
-			);
-		}
 		let closing = false;
 		const closeAfterSaves = (result: SettingsScreenResult) => {
 			if (closing) return;
 			closing = true;
 			void saveQueue.then(() => done(result));
 		};
-		const updateIssueText = () => tui.requestRender();
+		const requestRender = () => tui.requestRender();
 		const previewGoalIds = new Map<LimitField, string | null>();
 		const styles: LimitChoiceStyles = {
 			title: (text) => theme.fg("accent", theme.bold(text)),
@@ -315,7 +306,7 @@ async function showSettingsScreen(
 						applyGoalSettings(runtime, next, ctx, {
 							save: (value) => (options.save ?? saveGoalSettings)(value, settingsPath),
 						});
-						updateIssueText();
+						requestRender();
 						ctx.ui.notify(`Goal tools: ${newValue}.`, "info");
 					} catch (error) {
 						if (latestRequested.get(id) === newValue) {
@@ -716,12 +707,6 @@ function retainedGoalCount(runtime: GoalRuntime) {
 		runtime.queuedGoals.length +
 		(runtime.pendingQueueAction?.kind === "prioritize" ? 1 : 0)
 	);
-}
-
-function settingsIssueBanner(runtime: GoalRuntime) {
-	return runtime.settingsLoadIssue?.kind === "create-failed"
-		? "Built-in defaults are active because the settings file could not be created. Saving a change will retry."
-		: "";
 }
 
 function notifySettingsFailure(ctx: ExtensionCommandContext, settingsPath: string, error: unknown) {

--- a/extensions/pi-goal/src/settings.ts
+++ b/extensions/pi-goal/src/settings.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { linkSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
@@ -26,25 +26,12 @@ export const DEFAULT_GOAL_SETTINGS: GoalSettings = {
 	continuationLimits: { automaticTurns: null, noProgressTurns: 3 },
 };
 
-export const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`;
-
 export type GoalSettingsLoadResult =
 	| { kind: "missing" }
 	| { kind: "invalid"; reason: string }
 	| { kind: "loaded"; settings: GoalSettings };
 
-export type GoalSettingsInitializationResult =
-	| Exclude<GoalSettingsLoadResult, { kind: "missing" }>
-	| { kind: "create-failed"; reason: string };
-
-export type GoalSettingsLoadIssue = Exclude<GoalSettingsInitializationResult, { kind: "loaded" }>;
-
-interface GoalSettingsInitializationFileSystem {
-	mkdirSync: typeof mkdirSync;
-	writeFileSync: typeof writeFileSync;
-	linkSync: typeof linkSync;
-	rmSync: typeof rmSync;
-}
+export type GoalSettingsLoadIssue = Extract<GoalSettingsLoadResult, { kind: "invalid" }>;
 
 interface GoalSettingsSaveFileSystem {
 	mkdirSync: typeof mkdirSync;
@@ -116,51 +103,6 @@ function normalizeContinuationLimit(
 	if (value === undefined) return fallback;
 	if (value === null) return null;
 	return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
-
-export function loadOrCreateGoalSettings(
-	settingsPath = join(getAgentDir(), GOAL_SETTINGS_FILE),
-	overrides: Partial<GoalSettingsInitializationFileSystem> = {},
-): GoalSettingsInitializationResult {
-	const loaded = readGoalSettings(settingsPath);
-	if (loaded.kind !== "missing") return loaded;
-
-	const fs = { mkdirSync, writeFileSync, linkSync, rmSync, ...overrides };
-	const temporaryPath = join(
-		dirname(settingsPath),
-		`.${basename(settingsPath)}.${randomUUID()}.tmp`,
-	);
-	try {
-		fs.mkdirSync(dirname(settingsPath), { recursive: true });
-		fs.writeFileSync(temporaryPath, DEFAULT_GOAL_SETTINGS_DOCUMENT, {
-			encoding: "utf8",
-			flag: "wx",
-		});
-		try {
-			fs.linkSync(temporaryPath, settingsPath);
-		} catch (error) {
-			if (!isAlreadyExistsError(error)) throw error;
-		}
-
-		const published = readGoalSettings(settingsPath);
-		return published.kind === "missing"
-			? {
-					kind: "create-failed",
-					reason: `${settingsPath}: settings file disappeared during initialization`,
-				}
-			: published;
-	} catch (error) {
-		return {
-			kind: "create-failed",
-			reason: `${settingsPath}: ${formatError(error)}`,
-		};
-	} finally {
-		try {
-			fs.rmSync(temporaryPath, { force: true });
-		} catch {
-			// Best-effort cleanup must not replace the initialization result.
-		}
-	}
 }
 
 export function saveGoalSettings(
@@ -248,10 +190,6 @@ function ownRecord(value: unknown): Record<string, unknown> | undefined {
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
 	return error instanceof Error && "code" in error;
-}
-
-function isAlreadyExistsError(error: unknown): boolean {
-	return isNodeError(error) && error.code === "EEXIST";
 }
 
 function formatError(error: unknown) {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
@@ -30,7 +30,6 @@ import {
 	nextToolFreeRepeatState,
 	normalizeVisibleAssistantOutput,
 } from "../src/safety.js";
-import { DEFAULT_GOAL_SETTINGS_DOCUMENT } from "../src/settings.js";
 
 // This suite stays in one file because it exercises one module-scoped extension
 // state machine across commands, lifecycle hooks, tools, persistence, prompts,
@@ -190,8 +189,9 @@ test("bare goal is menu-first in TUI, observable in RPC, and rejects headless mo
 	);
 });
 
-test("session start creates complete default settings when the file is missing", () => {
-	const settingsPath = join(GOAL_SETTINGS_DIRECTORY, "session-created.json");
+test("session start uses defaults without materializing missing settings", () => {
+	const parent = join(GOAL_SETTINGS_DIRECTORY, "session-missing");
+	const settingsPath = join(parent, "pi-goal.json");
 	const mock = createMockPi({
 		activeTools: ["read", "bash", "goal_complete", "goal_blocked"],
 	});
@@ -199,39 +199,11 @@ test("session start creates complete default settings when the file is missing",
 	const context = createMockContext();
 
 	mock.events.get("session_start")?.[0]?.({}, context.ctx);
-
-	assert.equal(readFileSync(settingsPath, "utf8"), DEFAULT_GOAL_SETTINGS_DOCUMENT);
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "goal_complete", "goal_blocked"]);
-	assert.equal(context.notifications.length, 0);
-});
-
-test("session start warns and keeps defaults when settings creation fails", () => {
-	const settingsPath = join(GOAL_SETTINGS_DIRECTORY, "create-failed.json");
-	const mock = createMockPi({
-		activeTools: ["read", "bash", "goal_complete", "goal_blocked"],
-	});
-	mock.rawPi.setActiveTools([
-		...new Set([...mock.rawPi.getActiveTools(), "goal_complete", "goal_blocked"]),
-	]);
-	goal(mock.pi, {
-		settingsPath,
-		settingsFileSystem: {
-			linkSync() {
-				throw new Error("publish failed");
-			},
-		},
-	});
-	const context = createMockContext();
-
 	mock.events.get("session_start")?.[0]?.({}, context.ctx);
 
-	assert.equal(existsSync(settingsPath), false);
-	assert.equal(
-		readdirSync(GOAL_SETTINGS_DIRECTORY).some((name) => name.includes("create-failed.json")),
-		false,
-	);
+	assert.equal(existsSync(parent), false);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "goal_complete", "goal_blocked"]);
-	assert.match(context.notifications[0]?.message ?? "", /could not create.*publish failed/i);
+	assert.equal(context.notifications.length, 0);
 });
 
 test("missing and invalid settings fall back to always-visible tools", () => {

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -716,41 +716,6 @@ test("invalid settings render read-only defaults and cannot overwrite the file",
 	assert.match(render, /Automatic work.*Unlimited/is);
 });
 
-test("a create-failed fallback clears after a successful settings save", async () => {
-	const state = runtime() as GoalRuntime & {
-		settingsLoadIssue?: { kind: "create-failed"; reason: string };
-	};
-	state.settingsLoadIssue = { kind: "create-failed", reason: "publish failed" };
-	let screens = 0;
-	const context = createMockContext({
-		mode: "tui",
-		hasUI: true,
-		input: async () => "25",
-		custom: async (factory: unknown) => {
-			const selector = createCustomSelectorHarness(factory, 80);
-			if (screens++ === 0) {
-				assert.match(selector.render().join("\n"), /Built-in defaults.*retry/is);
-				selector.handleInput("\r");
-				selector.handleInput("\u001b[B");
-				selector.handleInput("\r");
-			} else {
-				assert.doesNotMatch(selector.render().join("\n"), /Built-in defaults/i);
-				selector.handleInput("\u001b");
-			}
-			await new Promise((resolve) => setImmediate(resolve));
-			return selector.result;
-		},
-	});
-
-	await showGoalSettings(state, context.ctx, {
-		settingsPath: "/tmp/pi-goal.json",
-		save() {},
-	});
-
-	assert.equal(state.settingsLoadIssue, undefined);
-	assert.equal(state.settings.continuationLimits.automaticTurns, 25);
-});
-
 test("a failed safety-setting save keeps the previous state and gives actionable feedback", async () => {
 	const state = runtime();
 	let screens = 0;

--- a/extensions/pi-goal/test/settings.test.ts
+++ b/extensions/pi-goal/test/settings.test.ts
@@ -6,12 +6,12 @@ import { join } from "node:path";
 import test from "node:test";
 import {
 	DEFAULT_GOAL_SETTINGS,
-	DEFAULT_GOAL_SETTINGS_DOCUMENT,
-	loadOrCreateGoalSettings,
 	normalizeGoalSettings,
 	readGoalSettings,
 	saveGoalSettings,
 } from "../src/settings.js";
+
+const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`;
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
 	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns, null);
@@ -70,106 +70,22 @@ test("normalizeGoalSettings applies defaults and accepts bounded continuation li
 	}
 });
 
-test("loadOrCreateGoalSettings creates a readable complete default document", async (t) => {
+test("saveGoalSettings creates a complete document only on explicit save", async (t) => {
 	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-create-"));
 	t.after(() => rm(directory, { recursive: true, force: true }));
-	const settingsPath = join(directory, "nested", "pi-goal.json");
+	const parent = join(directory, "nested");
+	const settingsPath = join(parent, "pi-goal.json");
 
-	assert.deepEqual(loadOrCreateGoalSettings(settingsPath), {
-		kind: "loaded",
-		settings: DEFAULT_GOAL_SETTINGS,
-	});
-	assert.equal(readFileSync(settingsPath, "utf8"), DEFAULT_GOAL_SETTINGS_DOCUMENT);
+	assert.deepEqual(readGoalSettings(settingsPath), { kind: "missing" });
+	assert.equal(existsSync(parent), false);
+
+	saveGoalSettings(DEFAULT_GOAL_SETTINGS, settingsPath);
+
 	assert.equal(
-		DEFAULT_GOAL_SETTINGS_DOCUMENT,
+		readFileSync(settingsPath, "utf8"),
 		`${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`,
 	);
-});
-
-test("loadOrCreateGoalSettings never overwrites existing valid or invalid settings", async (t) => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-existing-"));
-	t.after(() => rm(directory, { recursive: true, force: true }));
-	const settingsPath = join(directory, "pi-goal.json");
-	const validDocument = '{"toolVisibility":"after-first-goal"}\n';
-	writeFileSync(settingsPath, validDocument);
-
-	assert.deepEqual(loadOrCreateGoalSettings(settingsPath), {
-		kind: "loaded",
-		settings: {
-			...DEFAULT_GOAL_SETTINGS,
-			toolVisibility: "after-first-goal",
-		},
-	});
-	assert.equal(readFileSync(settingsPath, "utf8"), validDocument);
-
-	const invalidDocument = "{invalid";
-	writeFileSync(settingsPath, invalidDocument);
-	assert.equal(loadOrCreateGoalSettings(settingsPath).kind, "invalid");
-	assert.equal(readFileSync(settingsPath, "utf8"), invalidDocument);
-});
-
-test("loadOrCreateGoalSettings reports creation failures and removes temporary files", async (t) => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-failure-"));
-	t.after(() => rm(directory, { recursive: true, force: true }));
-
-	for (const [name, overrides] of [
-		[
-			"directory",
-			{
-				mkdirSync() {
-					throw new Error("mkdir failed");
-				},
-			},
-		],
-		[
-			"temporary file",
-			{
-				writeFileSync() {
-					throw new Error("write failed");
-				},
-			},
-		],
-		[
-			"publish",
-			{
-				linkSync() {
-					throw new Error("publish failed");
-				},
-			},
-		],
-	] as const) {
-		const parent = join(directory, name);
-		const settingsPath = join(parent, "pi-goal.json");
-		const result = loadOrCreateGoalSettings(settingsPath, overrides);
-		assert.equal(result.kind, "create-failed");
-		assert.match(result.kind === "create-failed" ? result.reason : "", /failed/);
-		assert.equal(existsSync(settingsPath), false);
-		assert.deepEqual(existsSync(parent) ? readdirSync(parent) : [], []);
-	}
-});
-
-test("loadOrCreateGoalSettings adopts a concurrent winner without overwriting it", async (t) => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-goal-settings-race-"));
-	t.after(() => rm(directory, { recursive: true, force: true }));
-	const settingsPath = join(directory, "pi-goal.json");
-	const winnerDocument = '{"experimental":{"goals":true}}\n';
-
-	const result = loadOrCreateGoalSettings(settingsPath, {
-		linkSync(_temporaryPath, targetPath) {
-			writeFileSync(targetPath, winnerDocument);
-			throw Object.assign(new Error("already exists"), { code: "EEXIST" });
-		},
-	});
-
-	assert.deepEqual(result, {
-		kind: "loaded",
-		settings: {
-			...DEFAULT_GOAL_SETTINGS,
-			experimental: { goals: true },
-		},
-	});
-	assert.equal(readFileSync(settingsPath, "utf8"), winnerDocument);
-	assert.deepEqual(readdirSync(directory), ["pi-goal.json"]);
+	assert.deepEqual(readdirSync(parent), ["pi-goal.json"]);
 });
 
 test("saveGoalSettings atomically preserves unknown top-level and nested fields", async (t) => {


### PR DESCRIPTION
## Summary

- treat a missing `pi-goal.json` as built-in defaults without creating files during `session_start`
- remove hard-link publication and create the settings file only after an explicit atomic save
- document the applicable Pi core settings semantics and the repository's temp-file-plus-rename requirement
- update pi-goal documentation and archive the completed implementation plan

## Verification

- 173 focused pi-goal settings, lifecycle, and settings UI tests
- `npm run typecheck --workspace @narumitw/pi-goal`
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `npm run check` (1,653 tests)

A physical Android/Termux smoke was not available locally; the affected hard-link path is removed and deterministic tests cover side-effect-free startup plus explicit-save creation.

Closes #439