### PR TITLE
fix(lsp): gate project config on trust

### DIFF
--- a/docs/plans/archived/2026-07-28_01-pi-lsp-project-trust-plan.md
+++ b/docs/plans/archived/2026-07-28_01-pi-lsp-project-trust-plan.md
@@ -1,0 +1,31 @@
+# PR 01 — pi-lsp project settings trust
+
+## Goal
+
+Prevent pi-lsp from reading or executing project-local LSP configuration unless Pi trusts the current project, while preserving explicit environment configuration, user settings, defaults, and documented precedence.
+
+## Architecture
+
+- `extensions/pi-lsp/src/adapters.ts` remains the configuration parser, but configuration lookup receives the session project root and an explicit trust decision instead of inferring that every requested tool root is trusted.
+- Command, lifecycle, and tool handlers pass `ctx.cwd` plus `ctx.isProjectTrusted()` for configuration selection. Tool parameters may still select files beneath another operation root, but they do not implicitly grant that root permission to supply executable configuration.
+- Trusted project paths use Pi's `CONFIG_DIR_NAME`; untrusted projects skip canonical and legacy project files and continue with explicit `PI_LSP_CONFIG`, user settings, or built-in defaults.
+
+## Non-Goals
+
+- Do not change LSP server schemas, tool behavior, environment-variable compatibility, or legacy-file publication; hard-link removal belongs to PR 02.
+- Do not add a new trust prompt or trust store outside Pi's existing API.
+
+## Plan
+
+- [x] Add focused tests in `extensions/pi-lsp/test/lsp.test.ts` proving an untrusted project's canonical and legacy config cannot alter the selected command, while a trusted project can; the focused red test selected `project` instead of `user` before implementation.
+- [x] Refactor `loadRuntime()` and `loadConfig()` in `extensions/pi-lsp/src/adapters.ts` to accept an explicit project root and trust state, use `CONFIG_DIR_NAME`, and preserve precedence `PI_LSP_CONFIG -> trusted project -> user -> built-in`; the focused configuration tests pass.
+- [x] Update `extensions/pi-lsp/src/pi-lsp.ts` so session, command, diagnostics, and fix paths use the active session's trust decision and never treat a tool-supplied root as trusted configuration authority; the command and diagnostics-tool test resolves only the user server without spawning the untrusted command.
+- [x] Update `extensions/pi-lsp/README.md` to document project trust, precedence, and the distinction between configuration root and operation root; the documented four-level order agrees with the tested implementation.
+- [x] Run `npm run typecheck --workspace @narumitw/pi-lsp`, `./node_modules/.bin/tsc -p tsconfig.test.json`, `node --test "$(realpath node_modules/.cache/pi-extensions-test/extensions/pi-lsp/test/lsp.test.js)"`, and `npm run check`; all focused tests and all 1,654 repository tests passed, while no external LSP server was needed for the deterministic trust path.
+
+## Completion Checklist
+
+- [x] No untrusted `.pi/pi-lsp.json` or `.pi/lsp.json` value can reach an adapter or spawned command.
+- [x] Trusted project, user, environment, and built-in configuration retain deterministic documented precedence.
+- [x] All configuration entrypoints use the same trust-aware lookup contract.
+- [x] Documentation, focused tests, typecheck, deterministic tool smoke, and `npm run check` pass.

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -78,15 +78,16 @@ go install golang.org/x/tools/gopls@latest
 
 Ensure the Go install directory (`$GOBIN` or `$(go env GOPATH)/bin`) is also on `PATH`.
 
-Custom config can be supplied in one of these locations:
+Custom config is resolved in this order:
 
 1. `PI_LSP_CONFIG` as inline JSON or a path to a JSON file
-2. `<workspace>/.pi/pi-lsp.json`
+2. `<workspace>/.pi/pi-lsp.json`, only when Pi trusts the current project
 3. `~/.pi/agent/pi-lsp.json`
+4. the built-in server catalog
 
-`PI_LSP_CONFIG` only accepts JSON or a JSON file path; JavaScript and TypeScript config files are not evaluated.
+`PI_LSP_CONFIG` only accepts JSON or a JSON file path; JavaScript and TypeScript config files are not evaluated. An untrusted project's canonical and legacy files are ignored. A `root` passed to an LSP tool selects files and the server working directory; it does not grant that directory authority to provide project settings. Project settings always come from the trusted Pi session workspace.
 
-Compatibility: a user-scoped legacy `lsp.json` is migrated automatically. A project-scoped legacy `.pi/lsp.json` remains readable with a warning but is not renamed automatically, so the extension never modifies a repository working tree. New paths take precedence when both names exist.
+Compatibility: a user-scoped legacy `lsp.json` is migrated automatically. A trusted project-scoped legacy `.pi/lsp.json` remains readable with a warning but is not renamed automatically, so the extension never modifies a repository working tree. New paths take precedence when both names exist.
 
 Providing custom config replaces the default server map. The following `pi-lsp.json` example intentionally keeps five selected servers:
 

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -12,7 +12,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { InternalLspServer, LspConfig, LspServerAdapter } from "./types.js";
 
 const COMMON_SKIP_DIRECTORIES = new Set([
@@ -231,16 +231,20 @@ export const DEFAULT_SERVER_CONFIGS: InternalLspServer[] = [
 	},
 ];
 
-export function loadRuntime(cwd = process.cwd()) {
-	const config = loadConfig(cwd);
+export interface LspConfigLoadOptions {
+	projectTrusted?: boolean;
+}
+
+export function loadRuntime(cwd = process.cwd(), options: LspConfigLoadOptions = {}) {
+	const config = loadConfig(cwd, options);
 	return {
 		adapters: config.servers.map(configToAdapter),
 		timeoutMs: config.timeout ?? 20_000,
 	};
 }
 
-export function loadConfig(cwd = process.cwd()): LspConfig {
-	const configured = loadConfiguredConfig(cwd);
+export function loadConfig(cwd = process.cwd(), options: LspConfigLoadOptions = {}): LspConfig {
+	const configured = loadConfiguredConfig(cwd, options.projectTrusted === true);
 	return (
 		configured ?? {
 			servers: DEFAULT_SERVER_CONFIGS.map((server) => ({ ...server, isDefault: true })),
@@ -250,23 +254,24 @@ export function loadConfig(cwd = process.cwd()): LspConfig {
 
 let pendingConfigNotice: string | undefined;
 
-function loadConfiguredConfig(cwd: string): LspConfig | undefined {
+function loadConfiguredConfig(cwd: string, projectTrusted: boolean): LspConfig | undefined {
 	pendingConfigNotice = undefined;
 	const rawConfig = process.env.PI_LSP_CONFIG?.trim();
 	if (rawConfig) return parseConfigSource(rawConfig, cwd, "PI_LSP_CONFIG");
 
-	const projectConfig = path.join(cwd, ".pi", "pi-lsp.json");
-	const legacyProjectConfig = path.join(cwd, ".pi", "lsp.json");
-	if (existsSync(projectConfig)) {
-		if (existsSync(legacyProjectConfig)) {
-			pendingConfigNotice = ".pi/lsp.json ignored because .pi/pi-lsp.json takes precedence.";
+	if (projectTrusted) {
+		const projectConfig = path.join(cwd, CONFIG_DIR_NAME, "pi-lsp.json");
+		const legacyProjectConfig = path.join(cwd, CONFIG_DIR_NAME, "lsp.json");
+		if (existsSync(projectConfig)) {
+			if (existsSync(legacyProjectConfig)) {
+				pendingConfigNotice = `${CONFIG_DIR_NAME}/lsp.json ignored because ${CONFIG_DIR_NAME}/pi-lsp.json takes precedence.`;
+			}
+			return parseConfigFile(projectConfig);
 		}
-		return parseConfigFile(projectConfig);
-	}
-	if (existsSync(legacyProjectConfig)) {
-		pendingConfigNotice =
-			"Using legacy .pi/lsp.json. Rename it to .pi/pi-lsp.json; the repository file was not modified automatically.";
-		return parseConfigFile(legacyProjectConfig);
+		if (existsSync(legacyProjectConfig)) {
+			pendingConfigNotice = `Using legacy ${CONFIG_DIR_NAME}/lsp.json. Rename it to ${CONFIG_DIR_NAME}/pi-lsp.json; the repository file was not modified automatically.`;
+			return parseConfigFile(legacyProjectConfig);
+		}
 	}
 
 	const userConfig = path.join(getAgentDir(), "pi-lsp.json");

--- a/extensions/pi-lsp/src/pi-lsp.ts
+++ b/extensions/pi-lsp/src/pi-lsp.ts
@@ -59,7 +59,9 @@ const lspDiagnosticsTool = defineTool({
 	parameters: DiagnosticsParameters,
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const requestedRoot = resolveRoot(params.root);
-		const { adapters, timeoutMs } = loadRuntime(requestedRoot);
+		const { adapters, timeoutMs } = loadRuntime(ctx.cwd, {
+			projectTrusted: ctx.isProjectTrusted(),
+		});
 		const { root, routes, skipped } = selectDiagnosticRoutes(
 			adapters,
 			{ ...params, root: requestedRoot },
@@ -125,7 +127,9 @@ const lspFixTool = defineTool({
 	}),
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 		const requestedRoot = resolveRoot(params.root);
-		const { adapters, timeoutMs } = loadRuntime(requestedRoot);
+		const { adapters, timeoutMs } = loadRuntime(ctx.cwd, {
+			projectTrusted: ctx.isProjectTrusted(),
+		});
 		const { root, route } = selectFixRoute(adapters, { ...params, root: requestedRoot });
 		return runFix(
 			route.adapter,
@@ -146,7 +150,9 @@ export default function lsp(pi: ExtensionAPI) {
 		description: "Show shared LSP extension configuration",
 		handler: async (_args, ctx) => {
 			try {
-				const { adapters } = loadRuntime(ctx.cwd);
+				const { adapters } = loadRuntime(ctx.cwd, {
+					projectTrusted: ctx.isProjectTrusted(),
+				});
 				const notice = consumeLspConfigNotice();
 				if (notice) ctx.ui.notify(notice, "warning");
 				ctx.ui.notify(buildStatusMessage(adapters, ctx.cwd), statusLevel(adapters, ctx.cwd));
@@ -159,7 +165,7 @@ export default function lsp(pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx) => {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		try {
-			loadRuntime(ctx.cwd);
+			loadRuntime(ctx.cwd, { projectTrusted: ctx.isProjectTrusted() });
 			const notice = consumeLspConfigNotice();
 			if (notice) ctx.ui.notify(notice, "warning");
 		} catch (error) {

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -14,7 +14,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
 	consumeLspConfigNotice,
 	DEFAULT_SERVER_CONFIGS,
@@ -445,27 +445,28 @@ test("LSP config uses canonical paths while preserving project legacy files", ()
 	const config = (name: string) => ({
 		servers: { [name]: { command: [name], extensions: [`.${name}`] } },
 	});
+	const loadTrustedConfig = () => loadConfig(project, { projectTrusted: true });
 	try {
 		const userLegacy = path.join(agentDir, "lsp.json");
 		writeFileSync(userLegacy, JSON.stringify(config("user")));
 		chmodSync(userLegacy, 0o600);
-		assert.equal(loadConfig(project).servers[0]?.name, "user");
+		assert.equal(loadTrustedConfig().servers[0]?.name, "user");
 		assert.equal(existsSync(path.join(agentDir, "pi-lsp.json")), true);
 		assert.equal(statSync(path.join(agentDir, "pi-lsp.json")).mode & 0o777, 0o600);
 		assert.equal(existsSync(userLegacy), false);
 
 		const projectLegacy = path.join(project, ".pi", "lsp.json");
 		writeFileSync(projectLegacy, JSON.stringify(config("legacy-project")));
-		assert.equal(loadConfig(project).servers[0]?.name, "legacy-project");
+		assert.equal(loadTrustedConfig().servers[0]?.name, "legacy-project");
 		assert.equal(existsSync(projectLegacy), true);
 		assert.equal(existsSync(path.join(project, ".pi", "pi-lsp.json")), false);
 
 		const projectCanonical = path.join(project, ".pi", "pi-lsp.json");
 		writeFileSync(projectCanonical, JSON.stringify(config("project")));
-		assert.equal(loadConfig(project).servers[0]?.name, "project");
+		assert.equal(loadTrustedConfig().servers[0]?.name, "project");
 
 		writeFileSync(projectCanonical, "invalid");
-		assert.throws(() => loadConfig(project));
+		assert.throws(loadTrustedConfig);
 		assert.equal(existsSync(projectLegacy), true);
 		unlinkSync(projectCanonical);
 		unlinkSync(projectLegacy);
@@ -473,14 +474,64 @@ test("LSP config uses canonical paths while preserving project legacy files", ()
 		writeFileSync(userLegacy, JSON.stringify(config("fallback")));
 		unlinkSync(path.join(agentDir, "pi-lsp.json"));
 		symlinkSync("missing-target", path.join(agentDir, "pi-lsp.json"));
-		assert.equal(loadConfig(project).servers[0]?.name, "fallback");
+		assert.equal(loadTrustedConfig().servers[0]?.name, "fallback");
 		assert.equal(existsSync(userLegacy), true);
 
 		process.env.PI_LSP_CONFIG = JSON.stringify(config("explicit"));
-		assert.equal(loadConfig(project).servers[0]?.name, "explicit");
+		assert.equal(loadTrustedConfig().servers[0]?.name, "explicit");
 		assert.equal(consumeLspConfigNotice(), undefined);
 	} finally {
 		delete process.env.PI_LSP_CONFIG;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LSP project config requires trust across loaders and command handlers", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-trust-"));
+	const agentDir = path.join(root, "agent");
+	const project = path.join(root, "project");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(path.join(project, ".pi"), { recursive: true });
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousConfig = process.env.PI_LSP_CONFIG;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env.PI_LSP_CONFIG;
+	const config = (name: string) => ({
+		servers: { [name]: { command: [name], extensions: [`.${name}`] } },
+	});
+	writeFileSync(path.join(agentDir, "pi-lsp.json"), JSON.stringify(config("user")));
+	writeFileSync(path.join(project, ".pi", "lsp.json"), JSON.stringify(config("legacy-project")));
+	writeFileSync(path.join(project, ".pi", "pi-lsp.json"), JSON.stringify(config("project")));
+	try {
+		assert.equal(loadConfig(project, { projectTrusted: false }).servers[0]?.name, "user");
+		assert.equal(loadConfig(project, { projectTrusted: true }).servers[0]?.name, "project");
+		unlinkSync(path.join(project, ".pi", "pi-lsp.json"));
+		assert.equal(loadConfig(project, { projectTrusted: true }).servers[0]?.name, "legacy-project");
+		assert.equal(loadConfig(project, { projectTrusted: false }).servers[0]?.name, "user");
+
+		process.env.PI_LSP_CONFIG = JSON.stringify(config("explicit"));
+		assert.equal(loadConfig(project, { projectTrusted: false }).servers[0]?.name, "explicit");
+		delete process.env.PI_LSP_CONFIG;
+
+		const mock = createMockPi();
+		lsp(mock.pi);
+		const context = createMockContext({ cwd: project, isProjectTrusted: () => false });
+		await mock.commands.get("lsp")?.handler("", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /user LSP command/u);
+		assert.doesNotMatch(context.notifications.at(-1)?.message ?? "", /legacy-project/u);
+
+		const diagnostics = mock.tools.find((tool) => tool.name === "lsp_diagnostics");
+		assert.ok(diagnostics);
+		const executeDiagnostics = diagnostics.execute as (...args: unknown[]) => Promise<unknown>;
+		await assert.rejects(
+			executeDiagnostics("trust-test", { server: "missing" }, undefined, undefined, context.ctx),
+			/Configured LSP servers: user/u,
+		);
+	} finally {
+		delete process.env.PI_LSP_CONFIG;
+		if (previousConfig !== undefined) process.env.PI_LSP_CONFIG = previousConfig;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- ignore canonical and legacy project LSP configuration unless the active Pi session trusts the workspace
- separate tool operation roots from configuration authority so a tool-supplied root cannot introduce executable settings
- preserve explicit environment, trusted project, user, and built-in precedence
- document and test trust behavior across commands, lifecycle, and tools

## Verification

- focused pi-lsp test suite (12 tests)
- `npm run typecheck --workspace @narumitw/pi-lsp`
- `npm run check` (1,654 tests)

## Plan

Completed and archived at `docs/plans/archived/2026-07-28_01-pi-lsp-project-trust-plan.md`.