### PR TITLE
feat(statusline): show time in balanced profile

### DIFF
--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -8,12 +8,12 @@ without setup and keeps useful context visible as the terminal narrows.
 A representative uncolored layout:
 
 ```text
-░▒▓ 🤖 sonnet-4 🧠 high 📁 pi-extensions 🌿 main ~2 🪟 ctx 42% 💸 $0.184
+░▒▓ 🤖 sonnet-4 🧠 high 📁 pi-extensions 🌿 main ~2 🪟 ctx 42% 🕒 16:42
 ```
 
 ## ✨ Features
 
-- **Zero-config default:** model, thinking, workspace, Git/PR state, context use, and cost.
+- **Zero-config default:** model, thinking, workspace, Git/PR state, context use, and local time.
 - **Responsive:** removes lower-priority segments before important information gets clipped.
 - **Quiet when idle:** activity appears only while Pi is streaming or running tools.
 - **Easy choices:** three information levels and seven previewable color presets.
@@ -73,7 +73,7 @@ preserved.
 | Level | Included segments |
 | --- | --- |
 | **Minimal** | `model cwd branch context` |
-| **Balanced** (default) | `model thinking cwd branch tools context cost` |
+| **Balanced** (default) | `model thinking cwd branch tools context time` |
 | **Detailed** | `provider model thinking cwd branch tools context tokens cost time` |
 | **Custom** | Any other segment order, including explicit line breaks |
 

--- a/extensions/pi-statusline/src/information-profiles.ts
+++ b/extensions/pi-statusline/src/information-profiles.ts
@@ -8,7 +8,7 @@ export const INFORMATION_PROFILES: Readonly<
 	Record<InformationProfileName, readonly SegmentName[]>
 > = {
 	minimal: ["model", "cwd", "branch", "context"],
-	balanced: ["model", "thinking", "cwd", "branch", "tools", "context", "cost"],
+	balanced: ["model", "thinking", "cwd", "branch", "tools", "context", "time"],
 	detailed: [
 		"provider",
 		"model",

--- a/extensions/pi-statusline/test/information-command.test.ts
+++ b/extensions/pi-statusline/test/information-command.test.ts
@@ -80,7 +80,7 @@ test("information picker previews exact contents and atomically applies a curate
 		for (const label of ["Minimal", "Balanced", "Detailed"]) {
 			assert.match(pickerText, new RegExp(label, "u"));
 		}
-		assert.match(pickerText, /Segments: model · thinking · cwd · branch · tools · context · cost/u);
+		assert.match(pickerText, /Segments: model · thinking · cwd · branch · tools · context · time/u);
 		assert.ok(narrowLines.length > 0);
 		assert.ok(narrowLines.every((line) => visibleWidth(line) <= 20));
 		assert.deepEqual(loaded.config.segments, [
@@ -90,10 +90,10 @@ test("information picker previews exact contents and atomically applies a curate
 			"branch",
 			"tools",
 			"context",
-			"cost",
+			"time",
 		]);
 		assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
-			segments: ["model", "thinking", "cwd", "branch", "tools", "context", "cost"],
+			segments: ["model", "thinking", "cwd", "branch", "tools", "context", "time"],
 			future: true,
 		});
 		assert.equal(applied, 1);

--- a/extensions/pi-statusline/test/information-profiles.test.ts
+++ b/extensions/pi-statusline/test/information-profiles.test.ts
@@ -11,7 +11,7 @@ test("information profiles expose curated segment sets in deterministic order", 
 		"branch",
 		"tools",
 		"context",
-		"cost",
+		"time",
 	]);
 	assert.deepEqual(INFORMATION_PROFILES.detailed, [
 		"provider",

--- a/extensions/pi-statusline/test/responsive-statusline.test.ts
+++ b/extensions/pi-statusline/test/responsive-statusline.test.ts
@@ -70,7 +70,8 @@ test("balanced footer fits common widths and keeps context visible at narrow wid
 		assert.match(wide, /sonnet-4/u);
 		assert.match(wide, /pi-extensions/u);
 		assert.match(wide, /main/u);
-		assert.match(wide, /💸/u);
+		assert.match(wide, /🕒/u);
+		assert.doesNotMatch(wide, /💸/u);
 		assert.doesNotMatch(wide, /💤|✅/u);
 	} finally {
 		footer.dispose();

--- a/extensions/pi-statusline/test/settings.test.ts
+++ b/extensions/pi-statusline/test/settings.test.ts
@@ -35,7 +35,7 @@ test("initial JSON exposes active defaults without materializing an inactive pal
 		"branch",
 		"tools",
 		"context",
-		"cost",
+		"time",
 	]);
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.provider.prefix, "🔌 ");
 	assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.turn.prefix, "🔁 #");
@@ -51,7 +51,7 @@ test("initial JSON exposes active defaults without materializing an inactive pal
 		palettePreset: "tokyo-night",
 		density: "compact",
 		separator: "none",
-		segments: ["model", "thinking", "cwd", "branch", "tools", "context", "cost"],
+		segments: ["model", "thinking", "cwd", "branch", "tools", "context", "time"],
 		segmentText: DEFAULT_STATUSLINE_CONFIG.segmentText,
 		extensionStatusIcons: {
 			accounts: "👤",


### PR DESCRIPTION
## Summary

- replace the Balanced information profile's cost segment with local time
- make the zero-config default follow the updated Balanced profile
- update the profile picker, footer coverage, settings expectations, and README

## Testing

- `npm run check --workspace @narumitw/pi-statusline`
- focused pi-statusline tests: 26 passed
- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run check` *(pi-statusline passed; the repository gate still fails in the unrelated `pi-github-pr` test `branch changes abort an in-flight periodic refresh`)*
