### PR TITLE
feat(usage): add resilient GitHub Copilot quotas

### DIFF
--- a/docs/plans/2026-07-29_pi-usage-copilot-quota-hardening-plan.md
+++ b/docs/plans/2026-07-29_pi-usage-copilot-quota-hardening-plan.md
@@ -1,0 +1,40 @@
+# Pi Usage Copilot Quota Hardening Plan
+
+## Goal
+
+Supersede PR #451 with GitHub Copilot usage support that preserves current AI-credit semantics,
+legacy premium-request semantics, free-tier quota responses, and valid overage states without
+weakening runtime-account credential checks.
+
+## Context
+
+The reviewed adapter handles the legacy paid `quota_snapshots.premium_interactions` shape, but it
+labels token-based billing as premium requests, rejects negative overage balances, and rejects the
+observed Copilot Free `limited_user_quotas`/`monthly_quotas` shape.
+
+## Plan
+
+- [x] Add focused adapter and formatter regressions for token-based AI credits, overage, and the
+      Copilot Free response shape; verified four focused failures against the reviewed code.
+- [x] Normalize the supported Copilot response variants in
+      `extensions/pi-usage/src/providers/github-copilot.ts`, preserving distinct quota labels and
+      representing overage without a query failure; 38 focused package tests pass.
+- [x] Update Copilot report/status formatting and `extensions/pi-usage/README.md` so labels match the
+      normalized billing mode; legacy status output remains compatible and package checks pass.
+- [x] Audit adjacent malformed, unlimited, reset-date, numeric-boundary, auth-origin, cancellation,
+      and secret-redaction paths; added AI-credit unlimited and derived-overage coverage while retaining
+      the existing auth-origin, cancellation, and redaction regressions.
+- [x] Run the package check, focused tests, root CI-equivalent check, package dry run, and local Pi
+      load smoke; package checks, 38 focused tests, pack, and load smoke pass. The root gate reached
+      1,767 passing tests but failed two unrelated `pi-github-pr` branch-watch tests; a focused rerun
+      passed one and reproduced the other without touching that package.
+- [ ] Archive this completed plan, commit only the intended paths, push the new branch, and open a
+      pull request to `main` that supersedes PR #451.
+
+## Completion Checklist
+
+- [x] AI-credit, legacy request, free-tier, unlimited, and overage payloads have deterministic tests.
+- [x] User-visible detail and statusline text use the correct quota unit.
+- [x] Runtime credential matching and official-origin fail-closed behavior remain intact.
+- [x] Required checks and package/runtime smokes pass or have an explicit unrelated-failure record.
+- [ ] The worktree is clean after the focused commit and the new pull request is open.

--- a/docs/plans/archived/2026-07-29_pi-usage-copilot-quota-hardening-plan.md
+++ b/docs/plans/archived/2026-07-29_pi-usage-copilot-quota-hardening-plan.md
@@ -28,8 +28,8 @@ observed Copilot Free `limited_user_quotas`/`monthly_quotas` shape.
       load smoke; package checks, 38 focused tests, pack, and load smoke pass. The root gate reached
       1,767 passing tests but failed two unrelated `pi-github-pr` branch-watch tests; a focused rerun
       passed one and reproduced the other without touching that package.
-- [ ] Archive this completed plan, commit only the intended paths, push the new branch, and open a
-      pull request to `main` that supersedes PR #451.
+- [x] Archive this completed plan, commit only the intended paths, push the new branch, and open
+      replacement PR #453 to `main`, superseding PR #451.
 
 ## Completion Checklist
 
@@ -37,4 +37,4 @@ observed Copilot Free `limited_user_quotas`/`monthly_quotas` shape.
 - [x] User-visible detail and statusline text use the correct quota unit.
 - [x] Runtime credential matching and official-origin fail-closed behavior remain intact.
 - [x] Required checks and package/runtime smokes pass or have an explicit unrelated-failure record.
-- [ ] The worktree is clean after the focused commit and the new pull request is open.
+- [x] The worktree is clean after the focused commits and replacement PR #453 is open.

--- a/extensions/pi-usage/README.md
+++ b/extensions/pi-usage/README.md
@@ -2,20 +2,21 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds one interactive `/usage` command for reading usage from the account Pi is actually using. It supports OpenAI Codex ChatGPT subscription windows and OpenRouter API-key spend limits without pretending those limits have the same semantics.
+`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds one interactive `/usage` command for reading usage from the account Pi is actually using. It supports OpenAI Codex ChatGPT subscription windows, GitHub Copilot premium request quota, and OpenRouter API-key spend limits without pretending those limits have the same semantics.
 
 ## ✨ Features
 
 - Opens one interactive `/usage` menu with current state and next actions.
 - Automatically queries the selected model provider and active runtime account.
 - Supports OpenAI Codex subscription windows, resets, credits, and model-specific buckets.
+- Supports GitHub Copilot premium request entitlement, remaining requests, percentage, and reset time.
 - Supports OpenRouter per-key credit limits plus daily, weekly, monthly, and all-time spend.
 - Provides explicit refresh, another-provider, and all-configured-provider actions.
 - Runs manually requested all-provider queries with concurrency limited to two and preserves partial results.
 - Labels only the selected model provider as `Current`; other results are `Configured`.
 - Keeps the compact statusline scoped to the current provider and runtime account.
 - Isolates its five-minute in-memory cache by provider and a process-salted credential fingerprint.
-- Resolves credentials through Pi and never reads Pi, account-extension, Codex CLI, or provider auth files.
+- Resolves runtime credentials through Pi; for Copilot only, reads Pi's stored OAuth credential through Pi's public credential API and verifies that it matches the active runtime account.
 
 ## 📦 Install
 
@@ -68,6 +69,16 @@ There are intentionally no `/usage --refresh`, `/usage <provider>`, or `/usage -
 
 The statusline selects a returned bucket that matches the current Codex model when one is available. Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
 
+### GitHub Copilot
+
+- Provider ID: `github-copilot`
+- Semantics: GitHub Copilot consumer subscription quota
+- Source: GitHub's undocumented `GET /copilot_internal/user` endpoint
+- Displayed data: premium request entitlement, remaining requests, percentage, reset time, and plan
+- Statusline example: `copilot 245/300 82%`
+
+GitHub's quota endpoint requires the original GitHub OAuth token rather than the short-lived Copilot inference token exposed by runtime auth. `pi-usage` therefore supports Copilot accounts created through Pi's `/login` flow, reads that stored credential through Pi's public API, and uses it only when its short-lived access token matches the active runtime credential. API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed.
+
 ### OpenRouter
 
 - Provider ID: `openrouter`
@@ -110,7 +121,8 @@ Behavior changes:
 
 ## 🚧 Limitations
 
-- Only providers with a stable, meaningful usage source and Pi-resolvable runtime auth are supported.
+- Only providers with a meaningful usage source and verifiable Pi runtime auth are supported.
+- GitHub Copilot quota uses an undocumented GitHub endpoint that may change without notice.
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
@@ -127,7 +139,7 @@ extensions/pi-usage/
 │   ├── query.ts       # Runtime auth resolution and provider queries
 │   ├── format.ts      # Provider-aware notifications and statusline text
 │   ├── core.ts        # Cache, concurrency, fingerprint, and redaction helpers
-│   ├── providers/     # Codex and OpenRouter normalization adapters
+│   ├── providers/     # Codex, GitHub Copilot, and OpenRouter normalization adapters
 │   └── types.ts       # Common presentation and adapter contracts
 ├── test/
 ├── README.md
@@ -140,7 +152,7 @@ extensions/pi-usage/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscription limits, OpenRouter credits, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscription limits, GitHub Copilot premium requests, OpenRouter credits, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/extensions/pi-usage/README.md
+++ b/extensions/pi-usage/README.md
@@ -2,14 +2,14 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds one interactive `/usage` command for reading usage from the account Pi is actually using. It supports OpenAI Codex ChatGPT subscription windows, GitHub Copilot premium request quota, and OpenRouter API-key spend limits without pretending those limits have the same semantics.
+`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds one interactive `/usage` command for reading usage from the account Pi is actually using. It supports OpenAI Codex ChatGPT subscription windows, GitHub Copilot allowances, and OpenRouter API-key spend limits without pretending those limits have the same semantics.
 
 ## ✨ Features
 
 - Opens one interactive `/usage` menu with current state and next actions.
 - Automatically queries the selected model provider and active runtime account.
 - Supports OpenAI Codex subscription windows, resets, credits, and model-specific buckets.
-- Supports GitHub Copilot premium request entitlement, remaining requests, percentage, and reset time.
+- Supports GitHub Copilot AI Credits, legacy premium requests, Free chat quota, additional usage, percentage, and reset time.
 - Supports OpenRouter per-key credit limits plus daily, weekly, monthly, and all-time spend.
 - Provides explicit refresh, another-provider, and all-configured-provider actions.
 - Runs manually requested all-provider queries with concurrency limited to two and preserves partial results.
@@ -72,12 +72,12 @@ The statusline selects a returned bucket that matches the current Codex model wh
 ### GitHub Copilot
 
 - Provider ID: `github-copilot`
-- Semantics: GitHub Copilot consumer subscription quota
+- Semantics: the allowance reported for the active Copilot plan—AI credits for current usage-based billing, premium requests for legacy annual billing, or chat requests for Copilot Free's limited response shape
 - Source: GitHub's undocumented `GET /copilot_internal/user` endpoint
-- Displayed data: premium request entitlement, remaining requests, percentage, reset time, and plan
-- Statusline example: `copilot 245/300 82%`
+- Displayed data: entitlement, remaining allowance, percentage, reset time, plan, and any additional usage beyond the included allowance
+- Statusline examples: `copilot credits 1200/1500 80%`, `copilot 245/300 82%`, or `copilot chat 40/50 80%`
 
-GitHub's quota endpoint requires the original GitHub OAuth token rather than the short-lived Copilot inference token exposed by runtime auth. `pi-usage` therefore supports Copilot accounts created through Pi's `/login` flow, reads that stored credential through Pi's public API, and uses it only when its short-lived access token matches the active runtime credential. API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed.
+GitHub's quota endpoint requires the original GitHub OAuth token rather than the short-lived Copilot inference token exposed by runtime auth. `pi-usage` therefore supports Copilot accounts created through Pi's `/login` flow, reads that stored credential through Pi's public API, and uses it only when its short-lived access token matches the active runtime credential. API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed. The detailed report follows the endpoint's `token_based_billing` marker so AI credits are not mislabeled as legacy premium requests, and it reports overage without treating a negative included balance as a malformed response.
 
 ### OpenRouter
 
@@ -152,7 +152,7 @@ extensions/pi-usage/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscription limits, GitHub Copilot premium requests, OpenRouter credits, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscription limits, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-usage",
 	"version": "0.37.0",
-	"description": "Pi extension that shows current-account usage for Codex, GitHub Copilot, and OpenRouter."
+	"description": "Pi extension that shows current-account usage for Codex, GitHub Copilot, and OpenRouter.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-usage",
 	"version": "0.37.0",
-	"description": "Pi extension that shows current-account usage across supported model providers.",
+	"description": "Pi extension that shows current-account usage for Codex, GitHub Copilot, and OpenRouter."
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -12,6 +12,7 @@
 		"usage",
 		"quota",
 		"codex",
+		"copilot",
 		"openrouter"
 	],
 	"files": [

--- a/extensions/pi-usage/src/format.ts
+++ b/extensions/pi-usage/src/format.ts
@@ -78,24 +78,44 @@ function formatCodexReport(lines: string[], report: UsageReport): void {
 }
 
 function formatGitHubCopilotReport(lines: string[], report: UsageReport): void {
-	const premium = report.buckets.find((bucket) => bucket.id === "premium-requests");
-	if (!premium || premium.limit === undefined || premium.remaining === undefined) {
-		lines.push(`${"Premium requests:".padEnd(VALUE_COLUMN)}unlimited`);
+	const quota = findGitHubCopilotQuota(report);
+	if (!quota || quota.limit === undefined || quota.remaining === undefined) {
+		lines.push(`${`${quota?.label ?? "Copilot quota"}:`.padEnd(VALUE_COLUMN)}unlimited`);
 		return;
 	}
-	const percent = percentRemaining(premium);
-	const reset = premium.resetsAt ? ` (resets ${formatReset(premium.resetsAt)})` : "";
+	const percent = percentRemaining(quota);
+	const reset = quota.resetsAt ? ` (resets ${formatReset(quota.resetsAt)})` : "";
 	lines.push(
-		`${"Premium requests:".padEnd(VALUE_COLUMN)}${premium.remaining} of ${premium.limit} left · ${percent}%${reset}`,
+		`${`${quota.label}:`.padEnd(VALUE_COLUMN)}${quota.remaining} of ${quota.limit} left · ${percent}%${reset}`,
 	);
+	const overage = report.metrics.find((metric) => metric.id === "overage-used");
+	if (typeof overage?.value === "number" && overage.value > 0) {
+		lines.push(`${"Additional usage:".padEnd(VALUE_COLUMN)}${overage.value} ${quota.label}`);
+	}
 }
 
 function formatGitHubCopilotStatusline(report: UsageReport): string {
-	const premium = report.buckets.find((bucket) => bucket.id === "premium-requests");
-	if (!premium || premium.limit === undefined || premium.remaining === undefined) {
-		return "copilot premium unlimited";
+	const quota = findGitHubCopilotQuota(report);
+	const kind = compactGitHubCopilotQuotaKind(quota);
+	if (!quota || quota.limit === undefined || quota.remaining === undefined) {
+		return `copilot ${kind} unlimited`;
 	}
-	return `copilot ${premium.remaining}/${premium.limit} ${percentRemaining(premium)}%`;
+	const overage = report.metrics.find((metric) => metric.id === "overage-used");
+	const overageSuffix =
+		typeof overage?.value === "number" && overage.value > 0 ? ` +${overage.value} over` : "";
+	return `copilot ${kind === "premium" ? "" : `${kind} `}${quota.remaining}/${quota.limit} ${percentRemaining(quota)}%${overageSuffix}`;
+}
+
+function findGitHubCopilotQuota(report: UsageReport): UsageBucket | undefined {
+	return report.buckets.find((bucket) =>
+		["ai-credits", "premium-requests", "chat-requests"].includes(bucket.id),
+	);
+}
+
+function compactGitHubCopilotQuotaKind(bucket: UsageBucket | undefined): string {
+	if (bucket?.id === "ai-credits") return "credits";
+	if (bucket?.id === "chat-requests") return "chat";
+	return "premium";
 }
 
 function percentRemaining(bucket: UsageBucket): number {

--- a/extensions/pi-usage/src/format.ts
+++ b/extensions/pi-usage/src/format.ts
@@ -16,6 +16,7 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 	lines.push(`Semantics: ${report.semantics.label}`, "");
 
 	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
+	else if (report.providerId === "github-copilot") formatGitHubCopilotReport(lines, report);
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
 	else formatGenericReport(lines, report);
 
@@ -27,6 +28,7 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 
 export function formatUsageStatusline(report: UsageReport, model?: UsageModel): string | undefined {
 	if (report.providerId === "openai-codex") return formatCodexStatusline(report, model);
+	if (report.providerId === "github-copilot") return formatGitHubCopilotStatusline(report);
 	if (report.providerId === "openrouter") {
 		const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
 		if (limit?.remaining !== undefined) return `openrouter ${formatUsd(limit.remaining)} left`;
@@ -73,6 +75,32 @@ function formatCodexReport(lines: string[], report: UsageReport): void {
 			);
 		}
 	}
+}
+
+function formatGitHubCopilotReport(lines: string[], report: UsageReport): void {
+	const premium = report.buckets.find((bucket) => bucket.id === "premium-requests");
+	if (!premium || premium.limit === undefined || premium.remaining === undefined) {
+		lines.push(`${"Premium requests:".padEnd(VALUE_COLUMN)}unlimited`);
+		return;
+	}
+	const percent = percentRemaining(premium);
+	const reset = premium.resetsAt ? ` (resets ${formatReset(premium.resetsAt)})` : "";
+	lines.push(
+		`${"Premium requests:".padEnd(VALUE_COLUMN)}${premium.remaining} of ${premium.limit} left · ${percent}%${reset}`,
+	);
+}
+
+function formatGitHubCopilotStatusline(report: UsageReport): string {
+	const premium = report.buckets.find((bucket) => bucket.id === "premium-requests");
+	if (!premium || premium.limit === undefined || premium.remaining === undefined) {
+		return "copilot premium unlimited";
+	}
+	return `copilot ${premium.remaining}/${premium.limit} ${percentRemaining(premium)}%`;
+}
+
+function percentRemaining(bucket: UsageBucket): number {
+	if (!bucket.limit || bucket.remaining === undefined) return 0;
+	return Math.round(clampPercent((bucket.remaining / bucket.limit) * 100));
 }
 
 function formatOpenRouterReport(lines: string[], report: UsageReport): void {

--- a/extensions/pi-usage/src/index.ts
+++ b/extensions/pi-usage/src/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./core.js";
 export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
+export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 export { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 export {
 	adapterForProvider,

--- a/extensions/pi-usage/src/providers/github-copilot.ts
+++ b/extensions/pi-usage/src/providers/github-copilot.ts
@@ -7,31 +7,69 @@ export function normalizeGitHubCopilotUsagePayload(
 ): UsageReport {
 	const snapshots = asObject(payload.quota_snapshots);
 	const premium = asObject(snapshots?.premium_interactions);
-	if (!premium) {
-		throw new Error("GitHub Copilot usage response contained no premium request quota.");
-	}
+	const metrics: UsageReport["metrics"] = [];
+	let semanticsLabel: string;
+	let bucket: UsageBucket;
 
-	const unlimited = premium.unlimited === true;
-	const entitlement = asNonnegativeNumber(premium.entitlement);
-	const remaining =
-		asNonnegativeNumber(premium.remaining) ?? asNonnegativeNumber(premium.quota_remaining);
-	const buckets: UsageBucket[] = [];
-	if (unlimited) {
-		buckets.push({ id: "premium-requests", label: "Premium requests", unit: "count" });
-	} else {
-		if (entitlement === undefined || remaining === undefined) {
-			throw new Error("GitHub Copilot premium request quota was incomplete.");
+	if (premium) {
+		const tokenBasedBilling = premium.token_based_billing === true;
+		const id = tokenBasedBilling ? "ai-credits" : "premium-requests";
+		const label = tokenBasedBilling ? "AI credits" : "Premium requests";
+		semanticsLabel = tokenBasedBilling
+			? "GitHub Copilot AI Credits allowance"
+			: "GitHub Copilot premium request quota";
+
+		if (premium.unlimited === true) {
+			bucket = { id, label, unit: "count" };
+		} else {
+			const entitlement = asNonnegativeNumber(premium.entitlement);
+			const rawRemaining =
+				asFiniteNumber(premium.remaining) ?? asFiniteNumber(premium.quota_remaining);
+			if (entitlement === undefined || rawRemaining === undefined) {
+				throw new Error(`GitHub Copilot ${label.toLowerCase()} quota was incomplete.`);
+			}
+			const overageUsed = Math.max(
+				asNonnegativeNumber(premium.overage_count) ?? 0,
+				Math.max(0, -rawRemaining),
+			);
+			if (overageUsed > 0) {
+				metrics.push({
+					id: "overage-used",
+					label: "Additional usage",
+					value: overageUsed,
+					unit: "count",
+				});
+			}
+			bucket = {
+				id,
+				label,
+				used: asNonnegativeNumber(premium.credits_used) ?? Math.max(0, entitlement - rawRemaining),
+				remaining: Math.max(0, rawRemaining),
+				limit: entitlement,
+				unit: "count",
+				period: "monthly",
+				...resetTimestamp(payload),
+			};
 		}
-		buckets.push({
-			id: "premium-requests",
-			label: "Premium requests",
+	} else {
+		const limited = asObject(payload.limited_user_quotas);
+		const monthly = asObject(payload.monthly_quotas);
+		const remaining = asNonnegativeNumber(limited?.chat);
+		const entitlement = asNonnegativeNumber(monthly?.chat);
+		if (remaining === undefined || entitlement === undefined) {
+			throw new Error("GitHub Copilot usage response contained no supported quota.");
+		}
+		semanticsLabel = "GitHub Copilot Free chat quota";
+		bucket = {
+			id: "chat-requests",
+			label: "Chat requests",
 			used: Math.max(0, entitlement - remaining),
 			remaining,
 			limit: entitlement,
 			unit: "count",
 			period: "monthly",
 			...resetTimestamp(payload),
-		});
+		};
 	}
 
 	const notes: string[] = [];
@@ -43,19 +81,19 @@ export function normalizeGitHubCopilotUsagePayload(
 		providerName: "GitHub Copilot",
 		capturedAt,
 		source: "github-copilot-user",
-		semantics: {
-			kind: "consumer-subscription",
-			label: "GitHub Copilot premium request quota",
-		},
+		semantics: { kind: "consumer-subscription", label: semanticsLabel },
 		accountLabel: asString(payload.login),
-		buckets,
-		metrics: [],
+		buckets: [bucket],
+		metrics,
 		...(notes.length > 0 ? { notes } : {}),
 	};
 }
 
 function resetTimestamp(payload: GitHubCopilotUsagePayload): { resetsAt?: number } {
-	const raw = asString(payload.quota_reset_date_utc) ?? asString(payload.quota_reset_date);
+	const raw =
+		asString(payload.quota_reset_date_utc) ??
+		asString(payload.quota_reset_date) ??
+		asString(payload.limited_user_reset_date);
 	if (!raw) return {};
 	const milliseconds = Date.parse(raw);
 	return Number.isNaN(milliseconds) ? {} : { resetsAt: Math.floor(milliseconds / 1000) };
@@ -71,7 +109,12 @@ function asString(value: unknown): string | undefined {
 	return sanitizeDisplayText(value, 80) || undefined;
 }
 
-function asNonnegativeNumber(value: unknown): number | undefined {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+function asFiniteNumber(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
 	return value;
+}
+
+function asNonnegativeNumber(value: unknown): number | undefined {
+	const number = asFiniteNumber(value);
+	return number === undefined || number < 0 ? undefined : number;
 }

--- a/extensions/pi-usage/src/providers/github-copilot.ts
+++ b/extensions/pi-usage/src/providers/github-copilot.ts
@@ -1,0 +1,77 @@
+import { sanitizeDisplayText } from "../core.js";
+import type { GitHubCopilotUsagePayload, UsageBucket, UsageReport } from "../types.js";
+
+export function normalizeGitHubCopilotUsagePayload(
+	payload: GitHubCopilotUsagePayload,
+	capturedAt: number,
+): UsageReport {
+	const snapshots = asObject(payload.quota_snapshots);
+	const premium = asObject(snapshots?.premium_interactions);
+	if (!premium) {
+		throw new Error("GitHub Copilot usage response contained no premium request quota.");
+	}
+
+	const unlimited = premium.unlimited === true;
+	const entitlement = asNonnegativeNumber(premium.entitlement);
+	const remaining =
+		asNonnegativeNumber(premium.remaining) ?? asNonnegativeNumber(premium.quota_remaining);
+	const buckets: UsageBucket[] = [];
+	if (unlimited) {
+		buckets.push({ id: "premium-requests", label: "Premium requests", unit: "count" });
+	} else {
+		if (entitlement === undefined || remaining === undefined) {
+			throw new Error("GitHub Copilot premium request quota was incomplete.");
+		}
+		buckets.push({
+			id: "premium-requests",
+			label: "Premium requests",
+			used: Math.max(0, entitlement - remaining),
+			remaining,
+			limit: entitlement,
+			unit: "count",
+			period: "monthly",
+			...resetTimestamp(payload),
+		});
+	}
+
+	const notes: string[] = [];
+	const plan = asString(payload.copilot_plan) ?? asString(payload.access_type_sku);
+	if (plan) notes.push(`Plan: ${plan}`);
+
+	return {
+		providerId: "github-copilot",
+		providerName: "GitHub Copilot",
+		capturedAt,
+		source: "github-copilot-user",
+		semantics: {
+			kind: "consumer-subscription",
+			label: "GitHub Copilot premium request quota",
+		},
+		accountLabel: asString(payload.login),
+		buckets,
+		metrics: [],
+		...(notes.length > 0 ? { notes } : {}),
+	};
+}
+
+function resetTimestamp(payload: GitHubCopilotUsagePayload): { resetsAt?: number } {
+	const raw = asString(payload.quota_reset_date_utc) ?? asString(payload.quota_reset_date);
+	if (!raw) return {};
+	const milliseconds = Date.parse(raw);
+	return Number.isNaN(milliseconds) ? {} : { resetsAt: Math.floor(milliseconds / 1000) };
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return sanitizeDisplayText(value, 80) || undefined;
+}
+
+function asNonnegativeNumber(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+	return value;
+}

--- a/extensions/pi-usage/src/query.ts
+++ b/extensions/pi-usage/src/query.ts
@@ -1,10 +1,12 @@
 import { randomBytes } from "node:crypto";
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { type ExtensionContext, readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
+import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 import type {
 	CodexBackendPayload,
+	GitHubCopilotUsagePayload,
 	OpenRouterKeyPayload,
 	PiModel,
 	ResolvedUsageAuth,
@@ -13,6 +15,7 @@ import type {
 } from "./types.js";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const MAX_SUCCESS_BODY_BYTES = 64 * 1024;
 const MAX_ERROR_BODY_BYTES = 4 * 1024;
@@ -36,6 +39,24 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				"Codex usage endpoint",
 			);
 			return normalizeCodexBackendPayload(payload as CodexBackendPayload, Date.now());
+		},
+	},
+	{
+		id: "github-copilot",
+		displayName: "GitHub Copilot",
+		semantics: {
+			kind: "consumer-subscription",
+			label: "GitHub Copilot premium request quota",
+		},
+		async query(auth, signal, timeoutMs) {
+			const payload = await fetchProviderJson(
+				GITHUB_COPILOT_USAGE_URL,
+				auth,
+				signal,
+				timeoutMs,
+				"GitHub Copilot usage endpoint",
+			);
+			return normalizeGitHubCopilotUsagePayload(payload as GitHubCopilotUsagePayload, Date.now());
 		},
 	},
 	{
@@ -72,6 +93,7 @@ export async function resolveUsageAuth(
 	ctx: ExtensionContext,
 	adapter: UsageProviderAdapter,
 	salt: Uint8Array = AUTH_FINGERPRINT_SALT,
+	credentialReader: StoredCredentialReader = readStoredCredential,
 ): Promise<ResolvedUsageAuth | undefined> {
 	if (ctx.model?.provider === adapter.id && !hasOfficialOrigin(ctx.model, adapter.id)) {
 		throw new Error(
@@ -104,6 +126,9 @@ export async function resolveUsageAuth(
 	}
 	const auth = modelAuth ?? providerResult?.auth;
 	if (!auth) return undefined;
+	if (adapter.id === "github-copilot") {
+		return resolveGitHubCopilotUsageAuth(auth, model, salt, credentialReader);
+	}
 	const authorization = authorizationFrom(auth);
 	if (!authorization) return undefined;
 	const headers = { Authorization: authorization };
@@ -262,6 +287,8 @@ type RequestAuth = {
 	headers?: Record<string, string | null>;
 };
 
+type StoredCredentialReader = (providerId: string) => unknown;
+
 type UsageAuthRegistry = {
 	getApiKeyAndHeaders?(
 		model: PiModel,
@@ -274,6 +301,51 @@ type UsageAuthRegistry = {
 	>;
 };
 
+function resolveGitHubCopilotUsageAuth(
+	auth: RequestAuth,
+	model: PiModel,
+	salt: Uint8Array,
+	credentialReader: StoredCredentialReader,
+): ResolvedUsageAuth {
+	const credential = asObject(credentialReader("github-copilot"));
+	if (credential?.type !== "oauth") {
+		throw new Error(
+			"GitHub Copilot usage requires the OAuth account configured through Pi /login.",
+		);
+	}
+	if (
+		typeof credential.enterpriseUrl === "string" &&
+		credential.enterpriseUrl &&
+		!isPublicGitHubDomain(credential.enterpriseUrl)
+	) {
+		throw new Error("GitHub Copilot usage does not yet support GitHub Enterprise accounts.");
+	}
+	const refresh = typeof credential.refresh === "string" ? credential.refresh : undefined;
+	const storedAccess = typeof credential.access === "string" ? credential.access : undefined;
+	const resolvedAccess = bearerToken(headerValue(auth.headers, "Authorization")) ?? auth.apiKey;
+	if (!refresh || !storedAccess || !resolvedAccess) {
+		throw new Error("GitHub Copilot OAuth credentials were incomplete.");
+	}
+	if (storedAccess !== resolvedAccess) {
+		throw new Error(
+			"The active GitHub Copilot runtime account does not match Pi's stored OAuth account.",
+		);
+	}
+
+	const authorization = `Bearer ${refresh}`;
+	const headers = {
+		Authorization: authorization,
+		"X-GitHub-Api-Version": "2025-05-01",
+	};
+	return {
+		apiKey: refresh,
+		headers,
+		fingerprint: fingerprintResolvedAuth({ headers }, salt),
+		secrets: [refresh, storedAccess, resolvedAccess, authorization],
+		model,
+	};
+}
+
 function authorizationFrom(auth: RequestAuth): string | undefined {
 	return (
 		headerValue(auth.headers, "Authorization") ??
@@ -281,14 +353,40 @@ function authorizationFrom(auth: RequestAuth): string | undefined {
 	);
 }
 
+function bearerToken(authorization: string | undefined): string | undefined {
+	const match = /^Bearer\s+(.+)$/iu.exec(authorization ?? "");
+	return match?.[1];
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function isPublicGitHubDomain(value: string): boolean {
+	try {
+		const url = new URL(value.includes("://") ? value : `https://${value}`);
+		return url.hostname.toLowerCase() === "github.com";
+	} catch {
+		return false;
+	}
+}
+
 function hasOfficialOrigin(model: PiModel, providerId: string): boolean {
 	return hasOfficialUrlOrigin(model.baseUrl, providerId);
 }
 
 function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
-	const expected = providerId === "openai-codex" ? "https://chatgpt.com" : "https://openrouter.ai";
 	try {
-		return new URL(value).origin === expected;
+		const url = new URL(value);
+		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
+		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
+		if (providerId === "github-copilot") {
+			return (
+				url.protocol === "https:" && /^api\.[a-z0-9-]+\.githubcopilot\.com$/u.test(url.hostname)
+			);
+		}
+		return false;
 	} catch {
 		return false;
 	}

--- a/extensions/pi-usage/src/query.ts
+++ b/extensions/pi-usage/src/query.ts
@@ -46,7 +46,7 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 		displayName: "GitHub Copilot",
 		semantics: {
 			kind: "consumer-subscription",
-			label: "GitHub Copilot premium request quota",
+			label: "GitHub Copilot account allowance",
 		},
 		async query(auth, signal, timeoutMs) {
 			const payload = await fetchProviderJson(

--- a/extensions/pi-usage/src/types.ts
+++ b/extensions/pi-usage/src/types.ts
@@ -81,6 +81,9 @@ export type GitHubCopilotUsagePayload = {
 	login?: unknown;
 	copilot_plan?: unknown;
 	access_type_sku?: unknown;
+	limited_user_quotas?: unknown;
+	limited_user_reset_date?: unknown;
+	monthly_quotas?: unknown;
 	quota_reset_date?: unknown;
 	quota_reset_date_utc?: unknown;
 	quota_snapshots?: unknown;

--- a/extensions/pi-usage/src/types.ts
+++ b/extensions/pi-usage/src/types.ts
@@ -77,6 +77,15 @@ export type ProviderUsageState =
 			message: string;
 	  };
 
+export type GitHubCopilotUsagePayload = {
+	login?: unknown;
+	copilot_plan?: unknown;
+	access_type_sku?: unknown;
+	quota_reset_date?: unknown;
+	quota_reset_date_utc?: unknown;
+	quota_snapshots?: unknown;
+};
+
 export type OpenRouterKeyPayload = {
 	data?: unknown;
 };

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -526,10 +526,11 @@ export default function usageExtension(pi: ExtensionAPI) {
 					if (!revalidated) continue;
 					stableCurrent = revalidated;
 					current = revalidated.outcome;
-					visibleStates =
+					visibleStates = [
 						outcome.state.providerId === current.state.providerId
-							? [current.state]
-							: [current.state, { ...outcome.state, displayState: "configured" }];
+							? current.state
+							: { ...outcome.state, displayState: "configured" },
+					];
 					continue;
 				}
 				if (action === VIEW_ALL) {

--- a/extensions/pi-usage/test/adapters.test.ts
+++ b/extensions/pi-usage/test/adapters.test.ts
@@ -8,7 +8,7 @@ import {
 	normalizeOpenRouterKeyPayload,
 } from "../src/index.js";
 
-test("GitHub Copilot adapter normalizes premium request quota", () => {
+test("GitHub Copilot adapter normalizes legacy premium request quota", () => {
 	const report = normalizeGitHubCopilotUsagePayload(
 		{
 			login: "octocat",
@@ -19,6 +19,7 @@ test("GitHub Copilot adapter normalizes premium request quota", () => {
 					entitlement: 300,
 					remaining: 245,
 					percent_remaining: 81.7,
+					token_based_billing: false,
 					unlimited: false,
 				},
 			},
@@ -28,6 +29,10 @@ test("GitHub Copilot adapter normalizes premium request quota", () => {
 
 	assert.equal(report.providerId, "github-copilot");
 	assert.equal(report.accountLabel, "octocat");
+	assert.deepEqual(report.semantics, {
+		kind: "consumer-subscription",
+		label: "GitHub Copilot premium request quota",
+	});
 	assert.deepEqual(report.buckets[0], {
 		id: "premium-requests",
 		label: "Premium requests",
@@ -42,6 +47,96 @@ test("GitHub Copilot adapter normalizes premium request quota", () => {
 	assert.equal(formatUsageStatusline(report), "copilot 245/300 82%");
 });
 
+test("GitHub Copilot adapter preserves AI-credit billing semantics", () => {
+	const report = normalizeGitHubCopilotUsagePayload(
+		{
+			quota_reset_date_utc: "2026-08-01T00:00:00Z",
+			quota_snapshots: {
+				premium_interactions: {
+					credits_used: 300,
+					entitlement: 1_500,
+					remaining: 1_200,
+					token_based_billing: true,
+					unlimited: false,
+				},
+			},
+		},
+		550,
+	);
+
+	assert.deepEqual(report.semantics, {
+		kind: "consumer-subscription",
+		label: "GitHub Copilot AI Credits allowance",
+	});
+	assert.deepEqual(report.buckets[0], {
+		id: "ai-credits",
+		label: "AI credits",
+		used: 300,
+		remaining: 1_200,
+		limit: 1_500,
+		unit: "count",
+		period: "monthly",
+		resetsAt: 1_785_542_400,
+	});
+	assert.match(formatUsageReport(report, "current"), /AI credits:\s+1200 of 1500 left · 80%/);
+	assert.equal(formatUsageStatusline(report), "copilot credits 1200/1500 80%");
+});
+
+test("GitHub Copilot adapter represents overage without rejecting negative remaining quota", () => {
+	const report = normalizeGitHubCopilotUsagePayload(
+		{
+			quota_snapshots: {
+				premium_interactions: {
+					entitlement: 1_500,
+					overage_count: 100,
+					overage_permitted: true,
+					remaining: -100,
+					token_based_billing: true,
+					unlimited: false,
+				},
+			},
+		},
+		575,
+	);
+
+	assert.equal(report.buckets[0]?.remaining, 0);
+	assert.equal(report.buckets[0]?.used, 1_600);
+	assert.deepEqual(report.metrics, [
+		{ id: "overage-used", label: "Additional usage", value: 100, unit: "count" },
+	]);
+	assert.match(formatUsageReport(report, "current"), /Additional usage:\s+100 AI credits/);
+	assert.equal(formatUsageStatusline(report), "copilot credits 0/1500 0% +100 over");
+});
+
+test("GitHub Copilot adapter normalizes the free-tier quota shape", () => {
+	const report = normalizeGitHubCopilotUsagePayload(
+		{
+			access_type_sku: "free_limited_copilot",
+			limited_user_quotas: { chat: 40, completions: 1_900 },
+			limited_user_reset_date: "2026-08-01T00:00:00Z",
+			monthly_quotas: { chat: 50, completions: 2_000 },
+		},
+		590,
+	);
+
+	assert.deepEqual(report.semantics, {
+		kind: "consumer-subscription",
+		label: "GitHub Copilot Free chat quota",
+	});
+	assert.deepEqual(report.buckets[0], {
+		id: "chat-requests",
+		label: "Chat requests",
+		used: 10,
+		remaining: 40,
+		limit: 50,
+		unit: "count",
+		period: "monthly",
+		resetsAt: 1_785_542_400,
+	});
+	assert.match(formatUsageReport(report, "current"), /Chat requests:\s+40 of 50 left · 80%/);
+	assert.equal(formatUsageStatusline(report), "copilot chat 40/50 80%");
+});
+
 test("GitHub Copilot adapter handles unlimited quota and rejects incomplete responses", () => {
 	const unlimited = normalizeGitHubCopilotUsagePayload(
 		{
@@ -52,7 +147,33 @@ test("GitHub Copilot adapter handles unlimited quota and rejects incomplete resp
 	assert.match(formatUsageReport(unlimited, "configured"), /Premium requests:\s+unlimited/);
 	assert.equal(formatUsageStatusline(unlimited), "copilot premium unlimited");
 
-	assert.throws(() => normalizeGitHubCopilotUsagePayload({}, 0), /premium request quota/iu);
+	const unlimitedCredits = normalizeGitHubCopilotUsagePayload(
+		{
+			quota_snapshots: {
+				premium_interactions: { token_based_billing: true, unlimited: true },
+			},
+		},
+		650,
+	);
+	assert.match(formatUsageReport(unlimitedCredits, "current"), /AI credits:\s+unlimited/);
+	assert.equal(formatUsageStatusline(unlimitedCredits), "copilot credits unlimited");
+
+	const derivedOverage = normalizeGitHubCopilotUsagePayload(
+		{
+			quota_snapshots: {
+				premium_interactions: {
+					entitlement: 300,
+					quota_remaining: -20,
+					unlimited: false,
+				},
+			},
+		},
+		675,
+	);
+	assert.equal(derivedOverage.metrics[0]?.value, 20);
+	assert.equal(formatUsageStatusline(derivedOverage), "copilot 0/300 0% +20 over");
+
+	assert.throws(() => normalizeGitHubCopilotUsagePayload({}, 0), /supported quota/iu);
 	assert.throws(
 		() =>
 			normalizeGitHubCopilotUsagePayload(

--- a/extensions/pi-usage/test/adapters.test.ts
+++ b/extensions/pi-usage/test/adapters.test.ts
@@ -4,8 +4,64 @@ import {
 	formatUsageReport,
 	formatUsageStatusline,
 	normalizeCodexBackendPayload,
+	normalizeGitHubCopilotUsagePayload,
 	normalizeOpenRouterKeyPayload,
 } from "../src/index.js";
+
+test("GitHub Copilot adapter normalizes premium request quota", () => {
+	const report = normalizeGitHubCopilotUsagePayload(
+		{
+			login: "octocat",
+			copilot_plan: "individual",
+			quota_reset_date_utc: "2026-08-01T00:00:00Z",
+			quota_snapshots: {
+				premium_interactions: {
+					entitlement: 300,
+					remaining: 245,
+					percent_remaining: 81.7,
+					unlimited: false,
+				},
+			},
+		},
+		500,
+	);
+
+	assert.equal(report.providerId, "github-copilot");
+	assert.equal(report.accountLabel, "octocat");
+	assert.deepEqual(report.buckets[0], {
+		id: "premium-requests",
+		label: "Premium requests",
+		used: 55,
+		remaining: 245,
+		limit: 300,
+		unit: "count",
+		period: "monthly",
+		resetsAt: 1_785_542_400,
+	});
+	assert.match(formatUsageReport(report, "current"), /245 of 300 left · 82%/);
+	assert.equal(formatUsageStatusline(report), "copilot 245/300 82%");
+});
+
+test("GitHub Copilot adapter handles unlimited quota and rejects incomplete responses", () => {
+	const unlimited = normalizeGitHubCopilotUsagePayload(
+		{
+			quota_snapshots: { premium_interactions: { unlimited: true } },
+		},
+		600,
+	);
+	assert.match(formatUsageReport(unlimited, "configured"), /Premium requests:\s+unlimited/);
+	assert.equal(formatUsageStatusline(unlimited), "copilot premium unlimited");
+
+	assert.throws(() => normalizeGitHubCopilotUsagePayload({}, 0), /premium request quota/iu);
+	assert.throws(
+		() =>
+			normalizeGitHubCopilotUsagePayload(
+				{ quota_snapshots: { premium_interactions: { entitlement: 300 } } },
+				0,
+			),
+		/incomplete/iu,
+	);
+});
 
 test("OpenRouter adapter normalizes documented per-key spend limits without claiming subscription quota", () => {
 	const report = normalizeOpenRouterKeyPayload(

--- a/extensions/pi-usage/test/core.test.ts
+++ b/extensions/pi-usage/test/core.test.ts
@@ -204,6 +204,76 @@ test("runtime auth rejects proxy origins and forwards only adapter-approved head
 	assert.deepEqual(modelKeyAuth?.headers, { Authorization: "Bearer current-model-key" });
 });
 
+test("GitHub Copilot usage uses the matching Pi OAuth refresh token", async () => {
+	const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "github-copilot");
+	assert.ok(adapter);
+	const model = {
+		id: "gpt-5.4",
+		name: "GPT-5.4",
+		provider: "github-copilot",
+		baseUrl: "https://api.individual.githubcopilot.com",
+	};
+	const { ctx } = createMockContext({
+		model,
+		modelRegistry: {
+			getProviderAuth: async () => ({
+				auth: { apiKey: "copilot-session-token", baseUrl: model.baseUrl },
+			}),
+			getAvailable: () => [model],
+			getAll: () => [model],
+		},
+	});
+	const credentialReader = () => ({
+		type: "oauth",
+		access: "copilot-session-token",
+		refresh: "github-oauth-token",
+		expires: Date.now() + 60_000,
+		enterpriseUrl: "github.com",
+	});
+
+	const auth = await resolveUsageAuth(ctx, adapter, new Uint8Array(32), credentialReader);
+	assert.deepEqual(auth?.headers, {
+		Authorization: "Bearer github-oauth-token",
+		"X-GitHub-Api-Version": "2025-05-01",
+	});
+	assert.ok(auth?.secrets.includes("copilot-session-token"));
+	assert.ok(auth?.secrets.includes("github-oauth-token"));
+
+	await assert.rejects(
+		() =>
+			resolveUsageAuth(ctx, adapter, new Uint8Array(32), () => ({
+				...credentialReader(),
+				access: "another-session-token",
+			})),
+		/does not match/iu,
+	);
+	const { ctx: conflictingHeaderContext } = createMockContext({
+		model,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				apiKey: "copilot-session-token",
+				headers: { Authorization: "Bearer another-session-token" },
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "copilot-session-token" } }),
+			getAvailable: () => [model],
+			getAll: () => [model],
+		},
+	});
+	await assert.rejects(
+		() => resolveUsageAuth(conflictingHeaderContext, adapter, new Uint8Array(32), credentialReader),
+		/does not match/iu,
+	);
+	await assert.rejects(
+		() =>
+			resolveUsageAuth(ctx, adapter, new Uint8Array(32), () => ({
+				...credentialReader(),
+				enterpriseUrl: "company.ghe.com",
+			})),
+		/Enterprise/iu,
+	);
+});
+
 test("provider cancellation preserves AbortError identity", async () => {
 	const abort = Object.assign(new Error("cancelled"), { name: "AbortError" });
 	const adapter = {

--- a/extensions/pi-usage/test/usage.test.ts
+++ b/extensions/pi-usage/test/usage.test.ts
@@ -179,7 +179,7 @@ test("explicit all-provider query labels current/configured and retains provider
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 });
 
-test("another-provider queries remain configured and never replace current status", async (t) => {
+test("another-provider queries show only the selected provider and preserve current status", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.after(() => {
 		globalThis.fetch = originalFetch;
@@ -211,6 +211,7 @@ test("another-provider queries remain configured and never replace current statu
 	await command.handler("", ctx);
 
 	assert.match(titles.at(-1) ?? "", /OpenAI Codex Usage · Configured/);
+	assert.doesNotMatch(titles.at(-1) ?? "", /OpenRouter Usage · Current/);
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 });
 


### PR DESCRIPTION
## Summary

- add GitHub Copilot usage through Pi's stored OAuth credential while preserving active-runtime-account and official-origin checks
- distinguish current AI Credits, legacy premium requests, and Copilot Free chat quotas
- preserve valid negative balances as explicit additional usage instead of rejecting overage responses
- update detailed and statusline formatting, package documentation, and deterministic adapter coverage

Supersedes #451 and includes its original contributor commit.

## Verification

- `npm run check --workspace @narumitw/pi-usage`
- focused compiled `pi-usage` tests: 38 passed
- `just pack-usage` (12 expected files)
- `pi -e ./extensions/pi-usage --list-models`
- root `npm run check`: all validators completed and 1,767 tests passed; two unrelated `pi-github-pr` branch-watch tests failed locally, with a focused rerun passing one and reproducing the other

## Review scope

Read and audited `docs/extension-conventions.md` plus Pi's extension and package documentation. Touched areas are provider response normalization, authentication integration, report/status formatting, package documentation, and tests; no settings behavior changed.

Closes #451 
