### PR TITLE
feat(stamp): add presentation controls

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -85,6 +85,7 @@
 - Treat session text rendered in custom TUI components as untrusted terminal input: escape C0/C1 controls before `wrapTextWithAnsi`, while retaining the raw value only for non-rendered payloads.
 - `wrapTextWithAnsi` performs word wrapping that trims whitespace at wrap boundaries; exact code/text previews need cell-aware hard wrapping or horizontal scrolling instead.
 - A Pi custom component that embeds an `Input` or `Editor` must implement `Focusable` and forward `focused` to the child. If the installed search-enabled `SettingsList` hides an `Input` without implementing `Focusable`, disable its search unless a public focus-forwarding path exists.
+- In `pi-tui-kit` RPC adaptation, selecting a settings row cycles directly to its next configured value and then re-renders the settings screen; clients should not wait for a separate value-choice dialog.
 - Tests that instantiate `BorderedLoader` must initialize Pi's theme first (for example, `initTheme("dark", false)`), because its keybinding hint reads the global theme during construction; dispose the loader-backed harness after `done()` so its animation timer cannot keep the test process alive.
 - Pi `ctx.ui.select()` returns `undefined` for both Escape and Ctrl+C; when back and close must differ, use a custom selector that handles Ctrl+C first and honors the injected named keybindings for navigation, confirmation, and cancellation.
 - Pi `Editor.getText()` retains large pastes as `[paste #…]` markers; use `getExpandedText()` whenever preserving or moving an editor draft outside that editor instance.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pi -e npm:@narumitw/pi-goal \
 | --- | --- | --- |
 | [`pi-github-pr`](./extensions/pi-github-pr) | Show current-branch pull request checks, reviews, and comment counts through the authenticated `gh` CLI. | `pi install npm:@narumitw/pi-github-pr` |
 | [`pi-langfuse`](./extensions/pi-langfuse) | Send agent runs, generations, token usage, costs, and tool activity to Langfuse. | `pi install npm:@narumitw/pi-langfuse` |
-| [`pi-stamp`](./extensions/pi-stamp) | Show quiet local timestamps after user and assistant messages in the TUI transcript. | `pi install npm:@narumitw/pi-stamp` |
+| [`pi-stamp`](./extensions/pi-stamp) | Show configurable timestamps and date context after user and assistant messages in the TUI transcript. | `pi install npm:@narumitw/pi-stamp` |
 | [`pi-starship`](./extensions/pi-starship) | Use a native Starship-style TOML footer with Pi-specific modules and no Starship binary dependency. | `pi install npm:@narumitw/pi-starship` |
 | [`pi-statusline`](./extensions/pi-statusline) | Show model, tools, Git state, context usage, tokens, cost, and time in a preset or JSON-configured footer. | `pi install npm:@narumitw/pi-statusline` |
 

--- a/docs/plans/archived/2026-07-29_pi-stamp-presentation-controls-plan.md
+++ b/docs/plans/archived/2026-07-29_pi-stamp-presentation-controls-plan.md
@@ -1,0 +1,276 @@
+# pi-stamp Presentation Controls Plan
+
+## Goal
+
+Implement Phase 2 of the
+[`pi-stamp` roadmap](../../roadmaps/pi-stamp-roadmap.md) by adding user-controlled absolute timestamp
+formatting and automatic date context while preserving the current dim, right-aligned, TUI-only
+transcript presentation.
+
+The public settings surface will be a partial JSON object at `<getAgentDir()>/pi-stamp.json`; omitted
+fields inherit these compatibility defaults:
+
+```json
+{
+  "hourCycle": "24h",
+  "showSeconds": true,
+  "dateContext": "day-change",
+  "locale": "invariant",
+  "timeZone": "local"
+}
+```
+
+Default same-day stamps remain `HH:mm:ss`. A newly recorded stamp that follows a stamp on another
+calendar day adds date context on the same row, for example `2026-07-30 · 00:01:02`.
+
+## Context
+
+- Phase 1 persists version-1 `pi-stamp` custom entries containing `role` and the owning message's
+  `timestamp`; Pi excludes those entries from LLM context.
+- The current renderer formats local `HH:mm:ss` once when Pi constructs the custom-entry component.
+  Settings must instead be read by mounted components during render so a successful menu change can
+  update existing visible stamps on the next TUI render.
+- A renderer receives one custom entry and cannot inspect adjacent transcript rows. Day-change
+  detection therefore needs enough relationship data in each newly persisted entry rather than
+  hidden renderer-global ordering.
+- This phase touches extension-owned settings, a command/menu, custom TUI rendering, session
+  lifecycle, persisted payload compatibility, package dependencies, and documentation. The
+  applicable MUST rules are the settings path and validation protocol, unknown-field preservation,
+  atomic publication, ordered reads/writes, TUI mode guards, menu cancellation/disposal, stale
+  session protection, width bounds, theme invalidation, canonical package boundaries, tests, pack
+  inspection, and a Pi runtime smoke.
+
+## Architecture
+
+### Formatting contract
+
+Add `extensions/pi-stamp/src/format.ts` to own presentation validation and pure formatting:
+
+- `hourCycle` accepts only `24h` or `12h`.
+- `showSeconds` controls whether seconds are present.
+- `dateContext` accepts `day-change`, `always`, or `never`.
+- `locale` accepts `invariant`, `system`, or one canonicalizable BCP 47 locale tag.
+- `timeZone` accepts `local` or an `Intl.DateTimeFormat`-supported IANA time-zone identifier,
+  including `UTC`.
+- `invariant` uses Gregorian dates, Latin digits, ISO `YYYY-MM-DD`, zero-padded 24-hour time, and
+  English `AM`/`PM` for 12-hour time. This keeps the Phase 1 default byte-for-byte compatible.
+- `system` and explicit locales use `Intl.DateTimeFormat` with an explicit Gregorian calendar,
+  selected hour cycle, seconds policy, and effective time zone. Date and time are formatted
+  separately and joined with ` · ` so locale punctuation cannot obscure their roles.
+- Day equality is computed from Gregorian year/month/day parts in the effective time zone, including
+  DST and date-line transitions; it is never inferred by dividing Unix milliseconds into 24-hour
+  periods.
+
+Keep absolute time as the only Phase 2 display mode. Relative labels are deferred because they age
+without new transcript events and would require an owned refresh timer plus disposal semantics for a
+cosmetic option.
+
+### Persisted stamp compatibility
+
+Continue rendering existing version-1 payloads and persist new entries as version 2:
+
+```ts
+interface MessageStampDataV2 {
+  version: 2;
+  role: "user" | "assistant";
+  timestamp: number;
+  previousTimestamp?: number;
+}
+```
+
+`previousTimestamp` is the previously appended valid `pi-stamp` timestamp on the active session
+branch. The lifecycle layer, not the renderer, assigns it in append order and updates the last-stamp
+cursor only after appending. On `session_start`, rebuild that cursor from valid version-1 and
+version-2 stamp entries in `ctx.sessionManager.getBranch()`.
+
+The renderer computes day changes from `previousTimestamp` using the current effective time-zone
+setting. This lets locale and time-zone changes reformat recorded version-2 stamps without rewriting
+session files. Version-1 entries remain time-format compatible; `dateContext: "always"` can show
+their own date, while `day-change` cannot infer a missing predecessor and therefore keeps them
+minimal. Do not migrate, backfill, or mutate existing session entries.
+
+### Settings ownership and persistence
+
+Add `extensions/pi-stamp/src/settings.ts` with one user-scoped protocol:
+
+```text
+built-in defaults -> <getAgentDir()>/pi-stamp.json
+```
+
+Project settings and extension-specific environment variables are intentionally unsupported: these
+controls are personal transcript preferences rather than repository policy. The loader and writer
+will:
+
+- treat a missing file as defaults without creating the agent directory, file, lock, or temporary;
+- require a JSON object, validate every recognized present field, canonicalize locale/time-zone
+  values for the effective runtime, and retain a structured invalid/unreadable issue;
+- preserve unknown top-level fields and omitted recognized fields on each field-level update;
+- reject every save while the latest file is malformed or invalid, leaving its exact bytes intact;
+- serialize reads and writes in one in-process queue, reread the latest valid document before each
+  mutation, and keep the queue usable after failure;
+- publish a complete temporary file in the destination directory with `0600` POSIX permissions,
+  rename it atomically without hard links, and remove abandoned temporaries;
+- keep the previous effective settings when publication fails, expose an explicit `flush()` boundary,
+  and make reload wait for earlier writes.
+
+The concurrency guarantee is deliberately in-process. Separate Pi processes may race and the last
+atomic writer can win; each process still rereads immediately before publication, but this phase does
+not add a cross-process lock for low-risk presentation preferences.
+
+### Runtime and menu
+
+Keep `src/stamp.ts` responsible for payload validation, entry rendering, and message ordering. Add a
+small session runtime that owns effective settings, the last-stamp cursor, one generation counter,
+and one `AbortController` for menu/session work.
+
+Register one argument-free `/stamp` command and implement its standard screens in
+`extensions/pi-stamp/src/menu.ts` with `@narumitw/pi-tui-kit`:
+
+- **Main:** Settings, Status, Help, and Close.
+- **Settings:** immediate rows for hour cycle, seconds, and date context; Locale and Time zone rows
+  open shallow choice screens with `ctx.ui.input()` only for custom BCP 47/IANA values.
+- **Status:** effective values, source (`Built-in` or `User`), canonical settings path, and any
+  read-only load issue. This is a menu detail, not a persistent statusline item.
+- **Help:** concise semantics for message creation time, date boundaries, persistence, and the lack of
+  relative-time refresh.
+
+Use `pi-tui-kit` serialization and rollback for displayed rows, while the extension-owned settings
+runtime remains authoritative for validation, persistence, and unknown-field preservation. Save
+before publishing a new effective runtime value; on failure, retain the prior formatter settings,
+let the kit restore the row, and report the sanitized error through `ctx.ui.notify()`.
+
+The custom stamp component reads current settings on every `render(width)`, formats the entry then,
+and right-aligns every wrapped line using ANSI-aware width. Pi rebuilds the renderer on theme
+invalidation; the component stores no themed render cache. A successful settings action requests a
+normal TUI render through the kit, so mounted stamps and new stamps use the same effective settings.
+
+`/stamp` supports TUI and the kit's RPC dialog adaptation. Print and JSON invocations reject through
+Pi's command error path before opening UI; unknown or trailing arguments are rejected in every mode.
+No command route writes ad hoc stdout. On session replacement/reload/shutdown, abort the old menu,
+drain any publication already past its cancellation boundary, guard every post-`await`
+continuation by generation, flush pending stamp entries, then clear session state.
+
+## Non-Goals
+
+- Relative labels, refresh timers, countdowns, or background work.
+- Response completion time, duration, first-token timing, model/provider data, usage, cost, or tool
+  stamps; those remain later roadmap phases.
+- Editing or monkey-patching Pi's built-in message rows.
+- Project settings, environment-variable overrides, cross-process locking, or a generic `/settings`
+  command.
+- Rewriting version-1 custom entries, backfilling unstamped history, or changing stamp data sent to
+  model context (there is none).
+- Arbitrary custom date/time patterns; Phase 2 exposes bounded semantic choices instead of a format
+  string language.
+
+## Assumptions
+
+- `dateContext: "day-change"` shows a date only when a version-2 stamp has a predecessor whose
+  Gregorian date differs in the effective time zone; the first known stamp stays time-only.
+- `dateContext: "always"` shows a date for both payload versions, while `never` always shows only
+  time.
+- Custom locale and time-zone inputs are canonicalized for display/runtime use but saves preserve
+  unrelated JSON and do not rewrite a valid file merely to normalize existing spelling.
+- Settings changes apply immediately to newly rendered and mounted stamp components after a
+  successful save; persisted session payloads remain presentation-neutral.
+- No settings-file migration exists because Phase 1 created no settings file.
+
+## Risks
+
+- A day can change at different instants after a time-zone change. Persisting the predecessor
+  timestamp rather than a precomputed boolean keeps the displayed boundary consistent with the
+  current setting.
+- `Intl` output varies by locale and ICU data. Exact snapshot assertions should cover only invariant
+  output; locale tests should assert canonical parts and representative supported locales without
+  coupling to incidental punctuation.
+- Longer localized date/time labels can wrap in narrow terminals. The right-alignment component must
+  preserve content and keep every rendered line within the supplied width.
+- A save may complete after its menu is cancelled. The operation must remain drainable and durable,
+  while generation checks prevent the stale continuation from mutating or notifying a replacement
+  session.
+- Supporting version 1 and version 2 can accidentally weaken validation. Keep separate exact guards
+  and test malformed optional predecessor values rather than coercing data.
+- Adding `/stamp` changes the Phase 1 no-command surface. Keep it menu-only, argument-free, and scoped
+  to presentation controls so the passive transcript behavior still requires no user action.
+
+## Plan
+
+- [x] Add red-first formatter specifications in `extensions/pi-stamp/test/format.test.ts` for the
+  compatibility `HH:mm:ss` default, 12/24-hour modes, seconds visibility, invariant/system/custom
+  locale handling, local/UTC/IANA zones, Gregorian day keys across DST/date-line boundaries,
+  `always`/`day-change`/`never` date context, invalid timestamps, and exact width-safe labels; root
+  `npm test` reached the intended TS2307 failure because `src/format.ts` did not exist.
+- [x] Implement `extensions/pi-stamp/src/format.ts` with exact setting-value validators, canonical
+  locale/time-zone resolution, invariant formatting, `Intl` formatting, and day-change comparison;
+  all six focused compiled formatter tests pass without reading files, current wall-clock time, or
+  global mutable locale/time-zone state.
+- [x] Add red-first settings specifications in `extensions/pi-stamp/test/settings.test.ts` for
+  side-effect-free missing loads, partial valid documents, every invalid recognized field,
+  malformed/unreadable/oversized/non-regular files, canonical path resolution, unknown-field
+  preservation, first save, `0600` temporary publication plus rename, failure rollback/cleanup,
+  ordered concurrent updates, reload-after-save, queue recovery, and explicit flush behavior; the
+  compiled test reached the intended TS2307 failure before `src/settings.ts` existed.
+- [x] Implement `extensions/pi-stamp/src/settings.ts` as the single queued read/update protocol;
+  all seven focused settings tests pass, including byte-identical invalid-file protection, failed
+  publication rollback, queue recovery, and user-only precedence.
+- [x] Extend `extensions/pi-stamp/test/stamp.test.ts` red-first for exact version-1/version-2 guards,
+  predecessor assignment in append order, active-branch cursor reconstruction on startup,
+  day-boundary rendering after reload/resume, dynamic re-render after a settings change, v1 fallback,
+  theme invalidation, ANSI-aware right alignment at narrow widths, lifecycle fallback deduplication,
+  and continued exclusion from `buildSessionContext()`; the focused suite first failed on the missing
+  renderer export and version-1 payloads.
+- [x] Refactor `extensions/pi-stamp/src/stamp.ts` to persist version-2 entries, rebuild and clear the
+  branch cursor at session boundaries, and render through a live settings getter while preserving
+  the existing timer-free user FIFO, assistant `turn_end`, non-TUI no-op behavior, and version-1
+  compatibility; all 14 focused renderer, persistence, ordering, replacement, shutdown, command,
+  and mode tests pass.
+- [x] Add `@narumitw/pi-tui-kit` `<1` to `extensions/pi-stamp/package.json` and the minimal workspace
+  lockfile edge, then add red-first command/menu tests covering the argument-free `/stamp` surface,
+  Main/Settings/Status/Help screens, all bounded choices, custom input validation/cancellation,
+  immediate application, serialized save rollback, invalid-file read-only behavior, RPC adaptation,
+  print/JSON rejection, unknown arguments, menu cancellation, session replacement, and shutdown
+  draining; compilation reached the intended missing-`menu.ts` failure and the extension boundary
+  check accepts the library dependency.
+- [x] Implement `extensions/pi-stamp/src/menu.ts` and session-owned settings/menu orchestration in
+  `src/stamp.ts` using `defineMenu()`/`runMenu()`, generation plus abort guards, sanitized
+  notifications, and a durability boundary; all five focused menu tests and the command/replacement/
+  shutdown lifecycle cases pass without stale-context notification or undrained publication.
+- [x] Update `extensions/pi-stamp/README.md` with `/stamp`, the settings table and examples, canonical
+  user path, defaults and precedence, locale/time-zone/date semantics, immediate application,
+  invalid-file recovery, in-process ordering and cross-process last-writer scope, RPC versus
+  print/JSON behavior, version-1 limitations, and the explicit relative-time deferral; the package
+  README, root catalog, and Phase 2 roadmap status now match the tested surface.
+- [x] Format touched package paths, run focused tests followed by `npm test` and `npm run check`, run
+  `just pack stamp` and inspect the dependency metadata plus every intended published source/document
+  file, then run a Pi 0.82.1 load smoke and TUI/RPC smokes covering settings save/rollback,
+  existing-stamp re-render, day-change display, `/reload`, resume, cancellation, and non-TUI protocol
+  safety; final `npm run check` passed all 1,793 tests, the eight-file pack is exact, Pi returned `OK`,
+  real TUI components passed day-change/live-reformat/invalidation width checks, RPC saved a setting,
+  publication rollback passed, and print/JSON rejection preserved their output contracts.
+- [x] Audit the final diff against `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, Pi's extension/package/TUI documentation, and the roadmap boundary;
+  package boundaries, user-only precedence, in-process last-writer scope, invalid-file protection,
+  atomic publication, menu cancellation/disposal, stale-session guards, shutdown draining, v1/v2
+  compatibility, width/theme behavior, non-TUI output, pack contents, and verification all pass with
+  no unrecorded deviation.
+
+## Completion Checklist
+
+- [x] The compatibility default remains dim, right-aligned local `HH:mm:ss` for ordinary same-day
+  user and assistant stamps.
+- [x] `hourCycle`, `showSeconds`, `dateContext`, `locale`, and `timeZone` are validated, documented,
+  persisted atomically, and applied through the exact documented precedence.
+- [x] New version-2 entries provide truthful date-boundary context in the selected time zone, while
+  existing version-1 entries remain readable and no session history is rewritten.
+- [x] `/stamp` exposes Settings, Status, and Help through `pi-tui-kit`; save failures roll back,
+  invalid files are read-only, custom-input cancellation is mutation-free, and unsupported modes are
+  observable without protocol corruption.
+- [x] Missing-file reads are side-effect free; unknown fields survive; malformed/invalid files are
+  never overwritten; ordered reads/writes, reload, replacement, and shutdown use one drainable
+  concurrency protocol.
+- [x] User cancellation, component disposal, session replacement, reload, and shutdown abort or drain
+  every owned operation and leave no stale-context continuation or background task.
+- [x] Renderer output remains callback-theme-aware, ANSI-width-safe, and outside LLM context at every
+  supported format and terminal width.
+- [x] Focused tests, root `npm test`, full `npm run check`, package dry run, Pi load smoke, and
+  representative TUI/RPC lifecycle smokes pass with no unrecorded deviation.

--- a/docs/roadmaps/pi-stamp-roadmap.md
+++ b/docs/roadmaps/pi-stamp-roadmap.md
@@ -52,10 +52,13 @@ historical backfill is not planned under the current API.
 
 ### Phase 2 — Presentation controls
 
+**Status:** implemented; see the archived
+[presentation-controls plan](../plans/archived/2026-07-29_pi-stamp-presentation-controls-plan.md)
+
 - Add date context when a conversation crosses a local day boundary.
-- Consider 12/24-hour display, seconds visibility, locale, and explicit time-zone selection.
-- Consider absolute versus relative labels such as `14:32:08` and `3m ago`; relative labels require
-  a bounded refresh strategy and lifecycle cleanup.
+- Support 12/24-hour display, seconds visibility, locale, and explicit time-zone selection.
+- Keep absolute labels such as `14:32:08`; relative labels such as `3m ago` remain deferred because
+  they require a bounded refresh strategy and lifecycle cleanup.
 - Keep the existing minimal format as the compatibility default.
 
 This phase introduces extension-owned settings and must follow `docs/extension-settings.md`,

--- a/extensions/pi-stamp/README.md
+++ b/extensions/pi-stamp/README.md
@@ -2,18 +2,17 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-stamp)](https://www.npmjs.com/package/@narumitw/pi-stamp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-stamp` is a passive [Pi coding agent](https://pi.dev) extension that adds a
-quiet local timestamp after each user and assistant message in the interactive transcript.
+`@narumitw/pi-stamp` is a quiet [Pi coding agent](https://pi.dev) extension that adds a
+right-aligned timestamp after each user and assistant message in the interactive transcript.
 
 ## ✨ Features
 
-- Shows local 24-hour time as `HH:mm:ss` on a dim, right-aligned transcript row.
-- Uses each user and assistant message's own persisted timestamp rather than the extension handler's
-  current time.
-- Stores stamps as versioned custom session entries that survive reload and resume.
+- Shows each message's recorded creation time on a dim, right-aligned transcript row.
+- Supports 12/24-hour clocks, optional seconds, automatic date context, locales, and time zones.
+- Stores versioned custom session entries that survive reload and resume.
 - Keeps stamp entries outside LLM context, so timestamp text is never sent to the model.
 - Uses Pi's current theme and remains width-safe in narrow terminals.
-- Performs no network requests and registers no command, tool, setting, status, or background task.
+- Performs no network requests and registers no tool, status item, timer, or background task.
 
 ## 📦 Install
 
@@ -37,9 +36,8 @@ pi -e ./extensions/pi-stamp
 
 ## 🚀 Quick start
 
-Load the extension and use Pi normally. There is no command to run or setting to configure.
-Each new user and assistant message receives a separate dim timestamp row aligned to the terminal's
-right edge:
+Load the extension and use Pi normally. Each new user and assistant message receives a separate dim
+stamp aligned to the terminal's right edge:
 
 ```text
 Your message
@@ -49,7 +47,73 @@ Assistant reply
                                  14:32:11
 ```
 
-The exact spacing adapts to the terminal width, and the foreground color follows the active Pi theme.
+Run `/stamp` to open the presentation menu:
+
+```text
+Stamp
+24-hour · seconds · Day changes · Invariant · Local
+
+Settings
+Status
+Help
+Close
+```
+
+Settings save immediately. Mounted stamps reformat on the next render, and future stamps use the
+same effective values.
+
+## ⚙️ Settings
+
+The `/stamp` Settings screen provides these controls:
+
+| Field | Accepted values | Default | Behavior |
+| --- | --- | --- | --- |
+| `hourCycle` | `"24h"`, `"12h"` | `"24h"` | Selects the clock style. |
+| `showSeconds` | boolean | `true` | Shows or hides seconds. |
+| `dateContext` | `"day-change"`, `"always"`, `"never"` | `"day-change"` | Adds a date at recorded day boundaries, every time, or never. |
+| `locale` | `"invariant"`, `"system"`, or one BCP 47 tag | `"invariant"` | Controls localized date/time presentation. |
+| `timeZone` | `"local"` or one supported IANA zone | `"local"` | Controls time and day-boundary interpretation; `UTC` is accepted. |
+
+The compatibility defaults produce local `HH:mm:ss` for ordinary same-day messages. `invariant`
+uses Gregorian ISO dates, Latin digits, and English `AM`/`PM`. `system` uses the operating system
+locale; examples of explicit locales are `en-US`, `fr-FR`, and `zh-TW`.
+
+The canonical user file is:
+
+```text
+~/.pi/agent/pi-stamp.json
+```
+
+Pi's configured agent directory replaces `~/.pi/agent` when applicable. The file is a partial JSON
+object, so this is enough to show 12-hour Taipei time without seconds:
+
+```json
+{
+  "hourCycle": "12h",
+  "showSeconds": false,
+  "timeZone": "Asia/Taipei"
+}
+```
+
+Settings precedence is intentionally:
+
+```text
+built-in defaults -> user pi-stamp.json
+```
+
+Presentation is a personal preference, so `pi-stamp` does not read project settings or
+extension-specific environment variables. Missing settings do not create a file or directory.
+Updates preserve unknown fields and publish through a private temporary file plus atomic rename.
+Malformed or invalid files become read-only and are never overwritten; fix the reported file and run
+`/reload`. A fresh process uses defaults while the file is invalid, and a running process retains its
+last valid settings.
+
+Reads and writes are serialized within one Pi process. Separate Pi processes do not share a lock, so
+concurrent saves are last-writer-wins even though each process rereads immediately before its atomic
+publication.
+
+`/stamp` supports TUI and RPC dialog modes. Print and JSON command invocations reject without writing
+ad hoc protocol output. Transcript stamps themselves are appended only in TUI mode.
 
 ## 🕰️ Timestamp semantics
 
@@ -58,16 +122,21 @@ The exact spacing adapts to the terminal width, and the foreground color follows
   not the response completion time.
 - If an assistant message invokes tools, its stamp appears after the complete tool block. Tool calls
   and results do not receive their own stamps.
-- Times use the machine's local time zone, always include seconds, and use a zero-padded 24-hour
-  clock.
+- `dateContext: "day-change"` compares each newly recorded stamp with its persisted predecessor in
+  the currently selected time zone. The first known stamp stays time-only.
+- Changing locale or time zone re-renders recorded version-2 stamps without rewriting session files.
 
-`pi-stamp` currently runs only in TUI mode. Print, JSON, and RPC sessions do not append stamp entries
-or emit extra protocol output.
+Relative labels such as `3m ago` are intentionally unavailable because they would require periodic
+background refresh and lifecycle cleanup.
 
 ## 🔒 Context and persistence
 
 Stamps use Pi custom session entries. Pi renders those entries in the interactive transcript but
 excludes them from model context. The extension does not modify user or assistant message content.
+
+Version-2 entries retain the previous recorded stamp timestamp so day changes can be recomputed for
+the active presentation settings. Existing version-1 entries remain readable. They can show their
+own date with `dateContext: "always"`, but `day-change` cannot infer a missing predecessor.
 
 Once recorded, a stamp survives `/reload` and session resume while the extension remains loaded.
 Messages created before `pi-stamp` recorded them are not backfilled because Pi's current public API
@@ -79,8 +148,8 @@ cannot insert a new custom entry into an older position in the session tree.
   separate transcript rows rather than inside the original message bubble.
 - Another extension can append transcript entries at the same lifecycle boundary, so strict visual
   adjacency between independently loaded extensions is not guaranteed.
-- There are no date, locale, time-zone, relative-time, duration, model, token, cost, or tool-timing
-  controls in the initial release.
+- There are no arbitrary format strings, relative labels, duration, model, token, cost, or
+  tool-timing controls.
 
 See the
 [pi-stamp roadmap](https://github.com/narumiruna/pi-extensions/blob/main/docs/roadmaps/pi-stamp-roadmap.md)
@@ -92,9 +161,15 @@ for possible future metadata stamps.
 extensions/pi-stamp/
 ├── src/
 │   ├── index.ts       # Thin Pi package entrypoint
-│   └── stamp.ts       # Formatter, renderer, and lifecycle hooks
+│   ├── format.ts      # Locale, time-zone, date, and clock formatting
+│   ├── menu.ts        # /stamp presentation menu
+│   ├── settings.ts    # Validation and atomic user settings
+│   └── stamp.ts       # Renderer, payload compatibility, and lifecycle hooks
 ├── test/
-│   └── stamp.test.ts  # Formatting, rendering, ordering, and lifecycle coverage
+│   ├── format.test.ts
+│   ├── menu.test.ts
+│   ├── settings.test.ts
+│   └── stamp.test.ts
 ├── README.md
 ├── LICENSE
 ├── package.json

--- a/extensions/pi-stamp/package.json
+++ b/extensions/pi-stamp/package.json
@@ -43,5 +43,8 @@
 		"type": "git",
 		"url": "https://github.com/narumiruna/pi-extensions",
 		"directory": "extensions/pi-stamp"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "<1"
 	}
 }

--- a/extensions/pi-stamp/src/format.ts
+++ b/extensions/pi-stamp/src/format.ts
@@ -1,0 +1,169 @@
+export const HOUR_CYCLES = ["24h", "12h"] as const;
+export const DATE_CONTEXTS = ["day-change", "always", "never"] as const;
+
+export type StampHourCycle = (typeof HOUR_CYCLES)[number];
+export type StampDateContext = (typeof DATE_CONTEXTS)[number];
+export type StampLocale = "invariant" | "system" | string;
+export type StampTimeZone = "local" | string;
+
+export interface StampSettings {
+	hourCycle: StampHourCycle;
+	showSeconds: boolean;
+	dateContext: StampDateContext;
+	locale: StampLocale;
+	timeZone: StampTimeZone;
+}
+
+export const DEFAULT_STAMP_SETTINGS: Readonly<StampSettings> = Object.freeze({
+	hourCycle: "24h",
+	showSeconds: true,
+	dateContext: "day-change",
+	locale: "invariant",
+	timeZone: "local",
+});
+
+export interface StampFormatEnvironment {
+	systemLocale?: string;
+	localTimeZone?: string;
+}
+
+interface ZonedParts {
+	year: string;
+	month: string;
+	day: string;
+	hour: number;
+	minute: string;
+	second: string;
+}
+
+export function canonicalizeLocale(value: string): string | undefined {
+	if (value === "invariant" || value === "system") return value;
+	try {
+		const locales = Intl.getCanonicalLocales(value);
+		return locales.length === 1 ? locales[0] : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function canonicalizeTimeZone(value: string): string | undefined {
+	if (value === "local") return value;
+	try {
+		return new Intl.DateTimeFormat("en-US", { timeZone: value }).resolvedOptions().timeZone;
+	} catch {
+		return undefined;
+	}
+}
+
+export function formatStampLabel(
+	timestamp: number,
+	previousTimestamp: number | undefined,
+	settings: Readonly<StampSettings>,
+	environment: StampFormatEnvironment = {},
+): string | undefined {
+	if (!isValidTimestamp(timestamp)) return undefined;
+	try {
+		const timeZone = settings.timeZone === "local" ? environment.localTimeZone : settings.timeZone;
+		const showDate = shouldShowDate(timestamp, previousTimestamp, settings.dateContext, timeZone);
+		if (settings.locale === "invariant") {
+			return formatInvariant(timestamp, showDate, settings, timeZone);
+		}
+		const locale = settings.locale === "system" ? environment.systemLocale : settings.locale;
+		return formatLocalized(timestamp, showDate, settings, locale, timeZone);
+	} catch {
+		return undefined;
+	}
+}
+
+function formatInvariant(
+	timestamp: number,
+	showDate: boolean,
+	settings: Readonly<StampSettings>,
+	timeZone: string | undefined,
+): string {
+	const parts = zonedParts(timestamp, timeZone);
+	const hour =
+		settings.hourCycle === "24h"
+			? String(parts.hour).padStart(2, "0")
+			: String(parts.hour % 12 || 12);
+	const seconds = settings.showSeconds ? `:${parts.second}` : "";
+	const period = settings.hourCycle === "12h" ? (parts.hour < 12 ? " AM" : " PM") : "";
+	const time = `${hour}:${parts.minute}${seconds}${period}`;
+	return showDate ? `${parts.year}-${parts.month}-${parts.day} · ${time}` : time;
+}
+
+function formatLocalized(
+	timestamp: number,
+	showDate: boolean,
+	settings: Readonly<StampSettings>,
+	locale: string | undefined,
+	timeZone: string | undefined,
+): string {
+	const date = new Date(timestamp);
+	const time = new Intl.DateTimeFormat(locale, {
+		calendar: "gregory",
+		timeZone,
+		hour: "2-digit",
+		minute: "2-digit",
+		...(settings.showSeconds ? { second: "2-digit" as const } : {}),
+		hourCycle: settings.hourCycle === "24h" ? "h23" : "h12",
+	}).format(date);
+	if (!showDate) return time;
+	const formattedDate = new Intl.DateTimeFormat(locale, {
+		calendar: "gregory",
+		timeZone,
+		dateStyle: "medium",
+	}).format(date);
+	return `${formattedDate} · ${time}`;
+}
+
+function shouldShowDate(
+	timestamp: number,
+	previousTimestamp: number | undefined,
+	dateContext: StampDateContext,
+	timeZone: string | undefined,
+): boolean {
+	if (dateContext === "always") return true;
+	if (dateContext === "never" || !isValidTimestamp(previousTimestamp)) return false;
+	return dateKey(timestamp, timeZone) !== dateKey(previousTimestamp, timeZone);
+}
+
+function dateKey(timestamp: number, timeZone: string | undefined): string {
+	const parts = zonedParts(timestamp, timeZone);
+	return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+function zonedParts(timestamp: number, timeZone: string | undefined): ZonedParts {
+	const values = new Map(
+		new Intl.DateTimeFormat("en-CA-u-ca-gregory-nu-latn", {
+			calendar: "gregory",
+			numberingSystem: "latn",
+			timeZone,
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+			hourCycle: "h23",
+		})
+			.formatToParts(new Date(timestamp))
+			.map((part) => [part.type, part.value]),
+	);
+	const year = values.get("year");
+	const month = values.get("month");
+	const day = values.get("day");
+	const hour = Number(values.get("hour"));
+	const minute = values.get("minute");
+	const second = values.get("second");
+	if (!year || !month || !day || !Number.isInteger(hour) || !minute || !second) {
+		throw new Error("Intl did not return complete Gregorian date/time parts.");
+	}
+	return { year, month, day, hour, minute, second };
+}
+
+function isValidTimestamp(value: number | undefined): value is number {
+	return (
+		typeof value === "number" && Number.isFinite(value) && !Number.isNaN(new Date(value).getTime())
+	);
+}

--- a/extensions/pi-stamp/src/menu.ts
+++ b/extensions/pi-stamp/src/menu.ts
@@ -1,0 +1,345 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	canonicalizeLocale,
+	canonicalizeTimeZone,
+	type StampDateContext,
+	type StampHourCycle,
+} from "./format.js";
+import type { StampSettingsPatch, StampSettingsRuntime, StampSettingsState } from "./settings.js";
+
+type StampScreen = "main" | "settings" | "locale" | "time-zone" | "status" | "help" | "invalid";
+type StampAction =
+	| "set-hour-cycle"
+	| "set-seconds"
+	| "set-date-context"
+	| "open-locale"
+	| "choose-invariant-locale"
+	| "choose-system-locale"
+	| "choose-custom-locale"
+	| "open-time-zone"
+	| "choose-local-time-zone"
+	| "choose-utc-time-zone"
+	| "choose-custom-time-zone";
+
+export interface StampMenuOwner {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export function createStampMenu(runtime: StampSettingsRuntime) {
+	return defineMenu<StampSettingsState, StampScreen, StampAction, ExtensionCommandContext>({
+		start: "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: "Stamp",
+				lines: [formatCompactStatus(state)],
+				items: [
+					state.issue
+						? {
+								id: "settings",
+								label: "Settings",
+								description: "Read-only until the invalid settings file is fixed.",
+								to: "invalid" as const,
+							}
+						: { id: "settings", label: "Settings", to: "settings" as const },
+					{ id: "status", label: "Status", to: "status" },
+					{ id: "help", label: "Help", to: "help" },
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+			settings: ({ state }) => ({
+				kind: "settings",
+				title: "Stamp Settings",
+				lines: [`User settings · ${safeTerminalText(runtime.getPath())}`],
+				items: [
+					{
+						id: "hourCycle",
+						label: "Hour cycle",
+						description: "Choose a 24-hour or 12-hour clock.",
+						currentValue: hourCycleLabel(state.settings.hourCycle),
+						values: ["24-hour", "12-hour"],
+						action: "set-hour-cycle",
+					},
+					{
+						id: "showSeconds",
+						label: "Seconds",
+						description: "Show or hide seconds in each stamp.",
+						currentValue: state.settings.showSeconds ? "Show" : "Hide",
+						values: ["Show", "Hide"],
+						action: "set-seconds",
+					},
+					{
+						id: "dateContext",
+						label: "Date context",
+						description: "Show dates at day changes, always, or never.",
+						currentValue: dateContextLabel(state.settings.dateContext),
+						values: ["Day changes", "Always", "Never"],
+						action: "set-date-context",
+					},
+					{
+						id: "locale",
+						label: "Locale",
+						description: "Use invariant, system, or an explicit BCP 47 locale.",
+						currentValue: localeLabel(state.settings.locale),
+						action: "open-locale",
+					},
+					{
+						id: "timeZone",
+						label: "Time zone",
+						description: "Use local time, UTC, or an explicit IANA time zone.",
+						currentValue: timeZoneLabel(state.settings.timeZone),
+						action: "open-time-zone",
+					},
+				],
+			}),
+			locale: ({ state }) => ({
+				kind: "actions",
+				title: "Stamp Locale",
+				lines: [`Current: ${localeLabel(state.settings.locale)}`],
+				items: [
+					{
+						id: "invariant",
+						label: "Invariant (default)",
+						description: "ISO date, Latin digits, and English AM/PM.",
+						action: "choose-invariant-locale",
+					},
+					{
+						id: "system",
+						label: "System locale",
+						description: "Use the operating system locale.",
+						action: "choose-system-locale",
+					},
+					{
+						id: "custom",
+						label: "Custom BCP 47 locale…",
+						description: "Examples: en-US, fr-FR, zh-TW.",
+						action: "choose-custom-locale",
+					},
+				],
+				hint: "back",
+			}),
+			"time-zone": ({ state }) => ({
+				kind: "actions",
+				title: "Stamp Time Zone",
+				lines: [`Current: ${timeZoneLabel(state.settings.timeZone)}`],
+				items: [
+					{
+						id: "local",
+						label: "Local (default)",
+						description: "Follow the operating system time zone.",
+						action: "choose-local-time-zone",
+					},
+					{
+						id: "UTC",
+						label: "UTC",
+						description: "Use Coordinated Universal Time.",
+						action: "choose-utc-time-zone",
+					},
+					{
+						id: "custom",
+						label: "Custom IANA time zone…",
+						description: "Examples: Asia/Taipei, America/New_York.",
+						action: "choose-custom-time-zone",
+					},
+				],
+				hint: "back",
+			}),
+			status: ({ state }) => ({
+				kind: "detail",
+				title: "Stamp Status",
+				lines: [
+					settingStatus("Hour cycle", hourCycleLabel(state.settings.hourCycle), state, "hourCycle"),
+					settingStatus(
+						"Seconds",
+						state.settings.showSeconds ? "Show" : "Hide",
+						state,
+						"showSeconds",
+					),
+					settingStatus(
+						"Date context",
+						dateContextLabel(state.settings.dateContext),
+						state,
+						"dateContext",
+					),
+					settingStatus("Locale", localeLabel(state.settings.locale), state, "locale"),
+					settingStatus("Time zone", timeZoneLabel(state.settings.timeZone), state, "timeZone"),
+					`Settings file: ${safeTerminalText(runtime.getPath())}`,
+					...(state.issue ? [`Issue: ${safeTerminalText(state.issue.message)}`] : []),
+				],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "Stamp Help",
+				lines: [
+					"Stamps show each message's recorded creation time, not assistant completion time.",
+					"Day changes compare the previous recorded stamp in the selected time zone.",
+					"Changes save immediately and reformat mounted and future stamps.",
+					"Relative labels are not available because they require background refresh work.",
+					"Stamp entries remain outside model context.",
+				],
+				hint: "back",
+			}),
+			invalid: ({ state }) => ({
+				kind: "detail",
+				title: "Stamp Settings · Read only",
+				lines: [
+					`Invalid settings file. Fix ${safeTerminalText(runtime.getPath())} and run /reload. The file will not be overwritten.`,
+					...(state.issue ? [`Issue: ${safeTerminalText(state.issue.message)}`] : []),
+					formatCompactStatus(state),
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			"set-hour-cycle": ({ ctx, value, signal }) =>
+				savePatch(
+					runtime,
+					ctx,
+					signal,
+					{ hourCycle: value === "12-hour" ? "12h" : "24h" },
+					`Hour cycle: ${value}.`,
+				),
+			"set-seconds": ({ ctx, value, signal }) =>
+				savePatch(runtime, ctx, signal, { showSeconds: value !== "Hide" }, `Seconds: ${value}.`),
+			"set-date-context": ({ ctx, value, signal }) => {
+				const dateContext: StampDateContext =
+					value === "Always" ? "always" : value === "Never" ? "never" : "day-change";
+				return savePatch(runtime, ctx, signal, { dateContext }, `Date context: ${value}.`);
+			},
+			"open-locale": async () => ({ kind: "to", screen: "locale" }),
+			"choose-invariant-locale": ({ ctx, signal }) =>
+				savePatch(runtime, ctx, signal, { locale: "invariant" }, "Locale: Invariant.", "back"),
+			"choose-system-locale": ({ ctx, signal }) =>
+				savePatch(runtime, ctx, signal, { locale: "system" }, "Locale: System.", "back"),
+			"choose-custom-locale": async ({ ctx, signal }) => {
+				const raw = await ctx.ui.input("BCP 47 locale", "Examples: en-US, fr-FR, zh-TW");
+				if (signal.aborted) return { kind: "rejected" };
+				if (raw === undefined) return { kind: "back" };
+				const locale = canonicalizeLocale(raw.trim());
+				if (!locale || locale === "invariant" || locale === "system") {
+					ctx.ui.notify("Enter one valid BCP 47 locale, such as en-US.", "warning");
+					return { kind: "rejected" };
+				}
+				return savePatch(runtime, ctx, signal, { locale }, `Locale: ${locale}.`, "back");
+			},
+			"open-time-zone": async () => ({ kind: "to", screen: "time-zone" }),
+			"choose-local-time-zone": ({ ctx, signal }) =>
+				savePatch(runtime, ctx, signal, { timeZone: "local" }, "Time zone: Local.", "back"),
+			"choose-utc-time-zone": ({ ctx, signal }) =>
+				savePatch(runtime, ctx, signal, { timeZone: "UTC" }, "Time zone: UTC.", "back"),
+			"choose-custom-time-zone": async ({ ctx, signal }) => {
+				const raw = await ctx.ui.input("IANA time zone", "Examples: Asia/Taipei, America/New_York");
+				if (signal.aborted) return { kind: "rejected" };
+				if (raw === undefined) return { kind: "back" };
+				const timeZone = canonicalizeTimeZone(raw.trim());
+				if (!timeZone || timeZone === "local") {
+					ctx.ui.notify("Enter one valid IANA time zone, such as Asia/Taipei.", "warning");
+					return { kind: "rejected" };
+				}
+				return savePatch(runtime, ctx, signal, { timeZone }, `Time zone: ${timeZone}.`, "back");
+			},
+		},
+	});
+}
+
+export function showStampMenu(
+	ctx: ExtensionCommandContext,
+	runtime: StampSettingsRuntime,
+	owner: StampMenuOwner,
+) {
+	return runMenu(ctx, createStampMenu(runtime), {
+		getState: () => runtime.get(),
+		signal: owner.signal,
+		isCurrent: owner.isCurrent,
+		onError: (errorCtx, error) => {
+			if (owner.isCurrent()) {
+				errorCtx.ui.notify(`Stamp menu failed: ${safeTerminalText(formatError(error))}`, "error");
+			}
+		},
+		onUnsupportedMode: (_unsupportedCtx, mode) => {
+			throw new Error(`/stamp is unavailable in ${mode} mode; use TUI or RPC mode.`);
+		},
+	});
+}
+
+async function savePatch(
+	runtime: StampSettingsRuntime,
+	ctx: ExtensionCommandContext,
+	signal: AbortSignal,
+	patch: StampSettingsPatch,
+	successMessage: string,
+	successTransition: "stay" | "back" = "stay",
+) {
+	if (signal.aborted) return { kind: "rejected" as const };
+	try {
+		await runtime.update(patch);
+		if (signal.aborted) return { kind: "rejected" as const };
+		ctx.ui.notify(successMessage, "info");
+		return { kind: successTransition } as const;
+	} catch (error) {
+		if (!signal.aborted) {
+			ctx.ui.notify(
+				`Could not save Stamp settings; the previous value remains: ${safeTerminalText(formatError(error))}`,
+				"error",
+			);
+		}
+		return { kind: "rejected" as const };
+	}
+}
+
+function settingStatus(
+	label: string,
+	value: string,
+	state: StampSettingsState,
+	field: keyof StampSettingsState["settings"],
+): string {
+	return `${label}: ${value} · ${state.sources[field] === "user" ? "User" : "Built-in"}`;
+}
+
+function formatCompactStatus(state: StampSettingsState): string {
+	return [
+		hourCycleLabel(state.settings.hourCycle),
+		state.settings.showSeconds ? "seconds" : "no seconds",
+		dateContextLabel(state.settings.dateContext),
+		localeLabel(state.settings.locale),
+		timeZoneLabel(state.settings.timeZone),
+	].join(" · ");
+}
+
+function hourCycleLabel(value: StampHourCycle): string {
+	return value === "24h" ? "24-hour" : "12-hour";
+}
+
+function dateContextLabel(value: StampDateContext): string {
+	if (value === "always") return "Always";
+	if (value === "never") return "Never";
+	return "Day changes";
+}
+
+function localeLabel(value: string): string {
+	if (value === "invariant") return "Invariant";
+	if (value === "system") return "System";
+	return safeTerminalText(value);
+}
+
+function timeZoneLabel(value: string): string {
+	return value === "local" ? "Local" : safeTerminalText(value);
+}
+
+function safeTerminalText(value: string): string {
+	return [...value]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+		})
+		.join("")
+		.trim();
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-stamp/src/settings.ts
+++ b/extensions/pi-stamp/src/settings.ts
@@ -1,0 +1,377 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	canonicalizeLocale,
+	canonicalizeTimeZone,
+	DATE_CONTEXTS,
+	DEFAULT_STAMP_SETTINGS,
+	HOUR_CYCLES,
+	type StampSettings,
+} from "./format.js";
+
+export const STAMP_SETTINGS_FILE = "pi-stamp.json";
+export const MAX_STAMP_SETTINGS_BYTES = 64 * 1024;
+
+export type StampSettingsField = keyof StampSettings;
+export type StampSettingsSource = "built-in" | "user";
+export type StampSettingsPatch = Partial<StampSettings>;
+
+export interface NormalizedStampSettings {
+	settings: StampSettings;
+	sources: Record<StampSettingsField, StampSettingsSource>;
+}
+
+export interface StampSettingsIssue {
+	kind: "invalid";
+	message: string;
+}
+
+export interface StampSettingsState extends NormalizedStampSettings {
+	issue?: StampSettingsIssue;
+	canSave: boolean;
+}
+
+export type StampSettingsLoadResult =
+	| (NormalizedStampSettings & {
+			kind: "missing";
+			path: string;
+			document: Record<string, unknown>;
+	  })
+	| (NormalizedStampSettings & {
+			kind: "loaded";
+			path: string;
+			document: Record<string, unknown>;
+	  })
+	| (NormalizedStampSettings & {
+			kind: "invalid";
+			path: string;
+			issue: StampSettingsIssue;
+	  });
+
+export interface StampSettingsOperations {
+	writeFile: typeof writeFile;
+	rename: typeof rename;
+}
+
+export interface StampSettingsRuntime {
+	get(): Readonly<StampSettingsState>;
+	getPath(): string;
+	reload(signal?: AbortSignal): Promise<Readonly<StampSettingsState>>;
+	update(patch: StampSettingsPatch): Promise<Readonly<StampSettingsState>>;
+	flush(): Promise<void>;
+}
+
+interface StampSettingsRuntimeOptions {
+	path?: string | (() => string);
+	operations?: Partial<StampSettingsOperations>;
+}
+
+const SETTING_FIELDS = [
+	"hourCycle",
+	"showSeconds",
+	"dateContext",
+	"locale",
+	"timeZone",
+] as const satisfies readonly StampSettingsField[];
+const SETTING_FIELD_SET = new Set<string>(SETTING_FIELDS);
+
+export function stampSettingsFilePath(): string {
+	return join(getAgentDir(), STAMP_SETTINGS_FILE);
+}
+
+export function normalizeStampSettingsDocument(
+	value: unknown,
+): NormalizedStampSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	const settings: StampSettings = { ...DEFAULT_STAMP_SETTINGS };
+	const sources = builtInSources();
+
+	if (Object.hasOwn(value, "hourCycle")) {
+		if (!HOUR_CYCLES.includes(value.hourCycle as StampSettings["hourCycle"])) return undefined;
+		settings.hourCycle = value.hourCycle as StampSettings["hourCycle"];
+		sources.hourCycle = "user";
+	}
+	if (Object.hasOwn(value, "showSeconds")) {
+		if (typeof value.showSeconds !== "boolean") return undefined;
+		settings.showSeconds = value.showSeconds;
+		sources.showSeconds = "user";
+	}
+	if (Object.hasOwn(value, "dateContext")) {
+		if (!DATE_CONTEXTS.includes(value.dateContext as StampSettings["dateContext"])) {
+			return undefined;
+		}
+		settings.dateContext = value.dateContext as StampSettings["dateContext"];
+		sources.dateContext = "user";
+	}
+	if (Object.hasOwn(value, "locale")) {
+		if (typeof value.locale !== "string") return undefined;
+		const locale = canonicalizeLocale(value.locale);
+		if (!locale) return undefined;
+		settings.locale = locale;
+		sources.locale = "user";
+	}
+	if (Object.hasOwn(value, "timeZone")) {
+		if (typeof value.timeZone !== "string") return undefined;
+		const timeZone = canonicalizeTimeZone(value.timeZone);
+		if (!timeZone) return undefined;
+		settings.timeZone = timeZone;
+		sources.timeZone = "user";
+	}
+	return { settings, sources };
+}
+
+export async function loadStampSettings(
+	path = stampSettingsFilePath(),
+	signal?: AbortSignal,
+): Promise<StampSettingsLoadResult> {
+	let text: string;
+	try {
+		text = await readSettingsDocument(path, signal);
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return {
+				kind: "missing",
+				path,
+				document: {},
+				settings: { ...DEFAULT_STAMP_SETTINGS },
+				sources: builtInSources(),
+			};
+		}
+		return invalidLoad(path, formatError(error));
+	}
+
+	try {
+		const document = JSON.parse(text) as unknown;
+		const normalized = normalizeStampSettingsDocument(document);
+		if (!normalized || !isRecord(document)) {
+			return invalidLoad(path, "the document is malformed or contains an invalid setting");
+		}
+		return { kind: "loaded", path, document, ...normalized };
+	} catch (error) {
+		return invalidLoad(path, formatError(error));
+	}
+}
+
+export function createStampSettingsRuntime(
+	options: StampSettingsRuntimeOptions = {},
+): StampSettingsRuntime {
+	let resolvedPath: string | undefined;
+	const getPath = () => {
+		resolvedPath ??=
+			typeof options.path === "function"
+				? options.path()
+				: (options.path ?? stampSettingsFilePath());
+		return resolvedPath;
+	};
+	const operations: StampSettingsOperations = {
+		writeFile,
+		rename,
+		...options.operations,
+	};
+	let state: StampSettingsState = {
+		settings: { ...DEFAULT_STAMP_SETTINGS },
+		sources: builtInSources(),
+		canSave: true,
+	};
+	let queue = Promise.resolve();
+
+	const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+		const result = queue.then(operation, operation);
+		queue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+
+	return {
+		get: () => freezeState(state),
+		getPath,
+		reload(signal) {
+			return enqueue(async () => {
+				const loaded = await loadStampSettings(getPath(), signal);
+				if (loaded.kind === "invalid") {
+					state = { ...state, issue: loaded.issue, canSave: false };
+					return freezeState(state);
+				}
+				state = { settings: loaded.settings, sources: loaded.sources, canSave: true };
+				return freezeState(state);
+			});
+		},
+		update(patch) {
+			return enqueue(async () => {
+				const canonicalPatch = normalizePatch(patch);
+				const latest = await loadStampSettings(getPath());
+				if (latest.kind === "invalid") {
+					state = { ...state, issue: latest.issue, canSave: false };
+					throw new Error(`Cannot update malformed or invalid settings: ${latest.issue.message}`);
+				}
+				const document = { ...latest.document, ...canonicalPatch };
+				const normalized = normalizeStampSettingsDocument(document);
+				if (!normalized) throw new Error("Refusing to publish invalid pi-stamp settings.");
+				await publishSettingsDocument(document, getPath(), operations);
+				state = { ...normalized, canSave: true };
+				return freezeState(state);
+			});
+		},
+		async flush() {
+			await queue;
+		},
+	};
+}
+
+function normalizePatch(patch: StampSettingsPatch): StampSettingsPatch {
+	if (!isRecord(patch) || Object.keys(patch).some((key) => !SETTING_FIELD_SET.has(key))) {
+		throw new Error("Refusing to update unknown pi-stamp settings.");
+	}
+	const normalized = normalizeStampSettingsDocument(patch);
+	if (!normalized) throw new Error("Refusing to update invalid pi-stamp settings.");
+	const canonical: StampSettingsPatch = {};
+	for (const field of SETTING_FIELDS) {
+		if (Object.hasOwn(patch, field)) {
+			assignSetting(canonical, field, normalized.settings[field]);
+		}
+	}
+	return canonical;
+}
+
+function assignSetting<K extends StampSettingsField>(
+	settings: StampSettingsPatch,
+	field: K,
+	value: StampSettings[K],
+): void {
+	settings[field] = value;
+}
+
+async function publishSettingsDocument(
+	document: Record<string, unknown>,
+	path: string,
+	operations: StampSettingsOperations,
+): Promise<void> {
+	const contents = `${JSON.stringify(document, null, "\t")}\n`;
+	if (Buffer.byteLength(contents, "utf8") > MAX_STAMP_SETTINGS_BYTES) {
+		throw new Error(`settings document exceeds ${MAX_STAMP_SETTINGS_BYTES} bytes`);
+	}
+	await mkdir(dirname(path), { recursive: true });
+	const temporaryPath = join(
+		dirname(path),
+		`.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+	);
+	try {
+		await operations.writeFile(temporaryPath, contents, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+		});
+		await operations.rename(temporaryPath, path);
+	} finally {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+}
+
+async function readSettingsDocument(path: string, signal?: AbortSignal): Promise<string> {
+	if (signal?.aborted) throw signal.reason;
+	const flags = constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0);
+	const opening = open(path, flags);
+	const handle = await abortable(opening, signal).catch((error) => {
+		if (signal?.aborted) void opening.then((opened) => opened.close()).catch(() => undefined);
+		throw error;
+	});
+	try {
+		const [descriptorStats, pathStats] = await Promise.all([
+			abortable(handle.stat(), signal),
+			abortable(lstat(path), signal),
+		]);
+		if (pathStats.isSymbolicLink()) throw new Error("symbolic links are not accepted");
+		if (!descriptorStats.isFile() || !pathStats.isFile()) {
+			throw new Error("settings path is not a regular file");
+		}
+		if (descriptorStats.dev !== pathStats.dev || descriptorStats.ino !== pathStats.ino) {
+			throw new Error("settings path changed while it was being opened");
+		}
+		if (descriptorStats.size > MAX_STAMP_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_STAMP_SETTINGS_BYTES} bytes`);
+		}
+		const buffer = Buffer.alloc(MAX_STAMP_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const result = await abortable(
+				handle.read(buffer, offset, buffer.length - offset, offset),
+				signal,
+			);
+			if (result.bytesRead === 0) break;
+			offset += result.bytesRead;
+		}
+		if (offset > MAX_STAMP_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_STAMP_SETTINGS_BYTES} bytes`);
+		}
+		return buffer.subarray(0, offset).toString("utf8");
+	} finally {
+		const closing = handle.close();
+		if (signal?.aborted) void closing.catch(() => undefined);
+		else await closing;
+	}
+}
+
+function abortable<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return operation;
+	if (signal.aborted) return Promise.reject(signal.reason);
+	return new Promise((resolve, reject) => {
+		const onAbort = () => reject(signal.reason);
+		signal.addEventListener("abort", onAbort, { once: true });
+		void operation.then(
+			(value) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
+function invalidLoad(path: string, reason: string): StampSettingsLoadResult {
+	return {
+		kind: "invalid",
+		path,
+		settings: { ...DEFAULT_STAMP_SETTINGS },
+		sources: builtInSources(),
+		issue: { kind: "invalid", message: `${STAMP_SETTINGS_FILE} ignored (${path}: ${reason})` },
+	};
+}
+
+function builtInSources(): Record<StampSettingsField, StampSettingsSource> {
+	return {
+		hourCycle: "built-in",
+		showSeconds: "built-in",
+		dateContext: "built-in",
+		locale: "built-in",
+		timeZone: "built-in",
+	};
+}
+
+function freezeState(state: StampSettingsState): Readonly<StampSettingsState> {
+	return Object.freeze({
+		...state,
+		settings: Object.freeze({ ...state.settings }),
+		sources: Object.freeze({ ...state.sources }),
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-stamp/src/stamp.ts
+++ b/extensions/pi-stamp/src/stamp.ts
@@ -1,38 +1,78 @@
 import type { EntryRenderer, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type Component, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { DEFAULT_STAMP_SETTINGS, formatStampLabel, type StampSettings } from "./format.js";
+import { showStampMenu } from "./menu.js";
+import { createStampSettingsRuntime, type StampSettingsRuntime } from "./settings.js";
 
 export const STAMP_ENTRY_TYPE = "pi-stamp";
 
-export interface MessageStampData {
+export interface MessageStampDataV1 {
 	version: 1;
 	role: "user" | "assistant";
 	timestamp: number;
 }
 
+export interface MessageStampDataV2 {
+	version: 2;
+	role: "user" | "assistant";
+	timestamp: number;
+	previousTimestamp?: number;
+}
+
+export type MessageStampData = MessageStampDataV1 | MessageStampDataV2;
+
+export interface StampExtensionOptions {
+	settingsRuntime?: StampSettingsRuntime;
+}
+
 export function formatStampTime(timestamp: number): string | undefined {
-	if (!Number.isFinite(timestamp)) return undefined;
-	const date = new Date(timestamp);
-	if (Number.isNaN(date.getTime())) return undefined;
-	return [date.getHours(), date.getMinutes(), date.getSeconds()]
-		.map((part) => String(part).padStart(2, "0"))
-		.join(":");
+	return formatStampLabel(timestamp, undefined, {
+		...DEFAULT_STAMP_SETTINGS,
+		dateContext: "never",
+	});
 }
 
 export function isMessageStampData(value: unknown): value is MessageStampData {
-	if (typeof value !== "object" || value === null) return false;
-	const candidate = value as Partial<MessageStampData>;
-	return (
-		candidate.version === 1 &&
-		(candidate.role === "user" || candidate.role === "assistant") &&
-		typeof candidate.timestamp === "number" &&
-		formatStampTime(candidate.timestamp) !== undefined
-	);
+	if (!isRecord(value) || !isStampRole(value.role) || !isValidTimestamp(value.timestamp)) {
+		return false;
+	}
+	if (value.version === 1) {
+		return hasOnlyKeys(value, ["version", "role", "timestamp"]);
+	}
+	if (
+		value.version !== 2 ||
+		!hasOnlyKeys(value, ["version", "role", "timestamp", "previousTimestamp"])
+	) {
+		return false;
+	}
+	return !Object.hasOwn(value, "previousTimestamp") || isValidTimestamp(value.previousTimestamp);
 }
 
-function rightAlignedText(text: string): Component {
+export function createStampEntryRenderer(
+	getSettings: () => Readonly<StampSettings>,
+): EntryRenderer<MessageStampData> {
+	return (entry, _options, theme) => {
+		if (!isMessageStampData(entry.data)) return undefined;
+		const data = entry.data;
+		return dynamicRightAlignedText(() => {
+			const label = formatStampLabel(
+				data.timestamp,
+				data.version === 2 ? data.previousTimestamp : undefined,
+				getSettings(),
+			);
+			return label ? theme.fg("dim", label) : undefined;
+		});
+	};
+}
+
+export const renderStampEntry = createStampEntryRenderer(() => DEFAULT_STAMP_SETTINGS);
+
+function dynamicRightAlignedText(getText: () => string | undefined): Component {
 	return {
 		render(width) {
 			if (width < 1) return [];
+			const text = getText();
+			if (!text) return [];
 			return wrapTextWithAnsi(text, width).map((line) => {
 				const leftPadding = " ".repeat(Math.max(0, width - visibleWidth(line)));
 				return `${leftPadding}${line}`;
@@ -42,21 +82,51 @@ function rightAlignedText(text: string): Component {
 	};
 }
 
-export const renderStampEntry: EntryRenderer<MessageStampData> = (entry, _options, theme) => {
-	if (!isMessageStampData(entry.data)) return undefined;
-	const time = formatStampTime(entry.data.timestamp);
-	if (!time) return undefined;
-	return rightAlignedText(theme.fg("dim", time));
-};
+export default function stampExtension(
+	pi: ExtensionAPI,
+	options: StampExtensionOptions = {},
+): void {
+	const settingsRuntime = options.settingsRuntime ?? createStampSettingsRuntime();
+	pi.registerEntryRenderer(
+		STAMP_ENTRY_TYPE,
+		createStampEntryRenderer(() => settingsRuntime.get().settings),
+	);
 
-export default function stampExtension(pi: ExtensionAPI): void {
-	pi.registerEntryRenderer(STAMP_ENTRY_TYPE, renderStampEntry);
-
+	let generation = 0;
+	let sessionController = new AbortController();
 	let tuiSessionActive = false;
-	const pendingUserStamps: MessageStampData[] = [];
+	let lastStampTimestamp: number | undefined;
+	const pendingUserStamps: Array<{ role: "user"; timestamp: number }> = [];
 
-	const appendStamp = (stamp: MessageStampData): void => {
-		pi.appendEntry<MessageStampData>(STAMP_ENTRY_TYPE, stamp);
+	pi.registerCommand("stamp", {
+		description: "Configure message timestamp presentation",
+		handler: async (args, ctx) => {
+			if (args.trim()) throw new Error("/stamp does not accept arguments.");
+			if (ctx.mode === "print" || ctx.mode === "json") {
+				throw new Error(`/stamp is unavailable in ${ctx.mode} mode; use TUI or RPC mode.`);
+			}
+			const commandGeneration = generation;
+			const commandController = sessionController;
+			await showStampMenu(ctx, settingsRuntime, {
+				signal: commandController.signal,
+				isCurrent: () =>
+					commandGeneration === generation &&
+					commandController === sessionController &&
+					!commandController.signal.aborted,
+			});
+		},
+	});
+
+	const appendStamp = (role: "user" | "assistant", timestamp: number): void => {
+		const stamp: MessageStampDataV2 = {
+			version: 2,
+			role,
+			timestamp,
+			...(lastStampTimestamp === undefined ? {} : { previousTimestamp: lastStampTimestamp }),
+		};
+		if (!isMessageStampData(stamp)) return;
+		pi.appendEntry<MessageStampDataV2>(STAMP_ENTRY_TYPE, stamp);
+		lastStampTimestamp = timestamp;
 	};
 
 	const flushPendingUsers = (): void => {
@@ -64,22 +134,49 @@ export default function stampExtension(pi: ExtensionAPI): void {
 			pendingUserStamps.length = 0;
 			return;
 		}
-		for (const stamp of pendingUserStamps.splice(0)) appendStamp(stamp);
+		while (pendingUserStamps.length > 0) {
+			const stamp = pendingUserStamps[0];
+			if (!stamp) break;
+			appendStamp(stamp.role, stamp.timestamp);
+			pendingUserStamps.shift();
+		}
 	};
 
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
+		sessionController.abort(new Error("pi-stamp session replaced"));
+		sessionController = new AbortController();
+		const controller = sessionController;
+		const currentGeneration = ++generation;
 		pendingUserStamps.length = 0;
 		tuiSessionActive = ctx.mode === "tui";
+		lastStampTimestamp = lastStampTimestampFromBranch(ctx.sessionManager.getBranch());
+		try {
+			const state = await settingsRuntime.reload(controller.signal);
+			if (
+				controller.signal.aborted ||
+				currentGeneration !== generation ||
+				controller !== sessionController
+			) {
+				return;
+			}
+			if (state.issue && ctx.hasUI) {
+				ctx.ui.notify(safeTerminalText(state.issue.message), "warning");
+			}
+		} catch (error) {
+			if (controller.signal.aborted) return;
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					`Could not load pi-stamp settings: ${safeTerminalText(formatError(error))}`,
+					"warning",
+				);
+			}
+		}
 	});
 
 	pi.on("message_end", (event) => {
 		if (!tuiSessionActive || event.message.role !== "user") return;
-		const stamp: MessageStampData = {
-			version: 1,
-			role: "user",
-			timestamp: event.message.timestamp,
-		};
-		if (isMessageStampData(stamp)) pendingUserStamps.push(stamp);
+		if (!isValidTimestamp(event.message.timestamp)) return;
+		pendingUserStamps.push({ role: "user", timestamp: event.message.timestamp });
 	});
 
 	pi.on("message_start", () => {
@@ -88,21 +185,68 @@ export default function stampExtension(pi: ExtensionAPI): void {
 
 	pi.on("turn_end", (event) => {
 		if (!tuiSessionActive || event.message.role !== "assistant") return;
-		const stamp: MessageStampData = {
-			version: 1,
-			role: "assistant",
-			timestamp: event.message.timestamp,
-		};
-		if (isMessageStampData(stamp)) appendStamp(stamp);
+		appendStamp("assistant", event.message.timestamp);
 	});
 
 	pi.on("agent_end", () => {
 		flushPendingUsers();
 	});
 
-	pi.on("session_shutdown", () => {
+	pi.on("session_shutdown", async () => {
+		sessionController.abort(new Error("pi-stamp session shut down"));
+		generation += 1;
 		flushPendingUsers();
 		pendingUserStamps.length = 0;
 		tuiSessionActive = false;
+		lastStampTimestamp = undefined;
+		await settingsRuntime.flush();
 	});
+}
+
+function lastStampTimestampFromBranch(entries: readonly unknown[]): number | undefined {
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (
+			isRecord(entry) &&
+			entry.type === "custom" &&
+			entry.customType === STAMP_ENTRY_TYPE &&
+			isMessageStampData(entry.data)
+		) {
+			return entry.data.timestamp;
+		}
+	}
+	return undefined;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+	const allowedKeys = new Set(allowed);
+	return Object.keys(value).every((key) => allowedKeys.has(key));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStampRole(value: unknown): value is MessageStampData["role"] {
+	return value === "user" || value === "assistant";
+}
+
+function isValidTimestamp(value: unknown): value is number {
+	return (
+		typeof value === "number" && Number.isFinite(value) && !Number.isNaN(new Date(value).getTime())
+	);
+}
+
+function safeTerminalText(value: string): string {
+	return [...value]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+		})
+		.join("")
+		.trim();
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/extensions/pi-stamp/test/format.test.ts
+++ b/extensions/pi-stamp/test/format.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	canonicalizeLocale,
+	canonicalizeTimeZone,
+	DEFAULT_STAMP_SETTINGS,
+	formatStampLabel,
+} from "../src/format.js";
+
+const BEFORE_MIDNIGHT_UTC = Date.UTC(2026, 6, 29, 23, 59, 58);
+const AFTER_MIDNIGHT_UTC = Date.UTC(2026, 6, 30, 0, 1, 2);
+const UTC_ENV = { localTimeZone: "UTC" } as const;
+
+test("formatStampLabel preserves the invariant Phase 1 default", () => {
+	assert.equal(
+		formatStampLabel(AFTER_MIDNIGHT_UTC, undefined, DEFAULT_STAMP_SETTINGS, UTC_ENV),
+		"00:01:02",
+	);
+	assert.equal(
+		formatStampLabel(AFTER_MIDNIGHT_UTC, BEFORE_MIDNIGHT_UTC, DEFAULT_STAMP_SETTINGS, UTC_ENV),
+		"2026-07-30 · 00:01:02",
+	);
+});
+
+test("formatStampLabel supports hour cycle, seconds, and date context", () => {
+	assert.equal(
+		formatStampLabel(
+			AFTER_MIDNIGHT_UTC,
+			undefined,
+			{
+				...DEFAULT_STAMP_SETTINGS,
+				hourCycle: "12h",
+				showSeconds: false,
+			},
+			UTC_ENV,
+		),
+		"12:01 AM",
+	);
+	assert.equal(
+		formatStampLabel(
+			AFTER_MIDNIGHT_UTC,
+			undefined,
+			{
+				...DEFAULT_STAMP_SETTINGS,
+				dateContext: "always",
+			},
+			UTC_ENV,
+		),
+		"2026-07-30 · 00:01:02",
+	);
+	assert.equal(
+		formatStampLabel(
+			AFTER_MIDNIGHT_UTC,
+			BEFORE_MIDNIGHT_UTC,
+			{
+				...DEFAULT_STAMP_SETTINGS,
+				dateContext: "never",
+			},
+			UTC_ENV,
+		),
+		"00:01:02",
+	);
+});
+
+test("day changes use the selected time zone rather than elapsed duration", () => {
+	const taipei = { ...DEFAULT_STAMP_SETTINGS, timeZone: "Asia/Taipei" } as const;
+	assert.equal(formatStampLabel(AFTER_MIDNIGHT_UTC, BEFORE_MIDNIGHT_UTC, taipei), "08:01:02");
+
+	const losAngeles = { ...DEFAULT_STAMP_SETTINGS, timeZone: "America/Los_Angeles" } as const;
+	assert.equal(formatStampLabel(AFTER_MIDNIGHT_UTC, BEFORE_MIDNIGHT_UTC, losAngeles), "17:01:02");
+
+	const dateLineBefore = Date.UTC(2026, 6, 29, 9, 59, 58);
+	const dateLineAfter = Date.UTC(2026, 6, 29, 10, 0, 2);
+	const kiritimati = { ...DEFAULT_STAMP_SETTINGS, timeZone: "Pacific/Kiritimati" } as const;
+	assert.equal(
+		formatStampLabel(dateLineAfter, dateLineBefore, kiritimati),
+		"2026-07-30 · 00:00:02",
+	);
+});
+
+test("system and explicit locales use Intl formatting with bounded semantic options", () => {
+	const settings = {
+		...DEFAULT_STAMP_SETTINGS,
+		hourCycle: "12h" as const,
+		locale: "system",
+		timeZone: "UTC",
+	};
+	assert.equal(
+		formatStampLabel(AFTER_MIDNIGHT_UTC, undefined, settings, { systemLocale: "en-US" }),
+		"12:01:02 AM",
+	);
+	const localized = formatStampLabel(
+		AFTER_MIDNIGHT_UTC,
+		undefined,
+		{ ...settings, locale: "fr-FR", dateContext: "always" },
+		{ systemLocale: "en-US" },
+	);
+	assert.ok(localized);
+	assert.match(localized, /2026.*12:01:02\sAM/u);
+});
+
+test("locale and time-zone values canonicalize or reject exactly", () => {
+	assert.equal(canonicalizeLocale("invariant"), "invariant");
+	assert.equal(canonicalizeLocale("system"), "system");
+	assert.equal(canonicalizeLocale("EN-us"), "en-US");
+	assert.equal(canonicalizeLocale("not_a_locale"), undefined);
+	assert.equal(canonicalizeTimeZone("local"), "local");
+	assert.equal(canonicalizeTimeZone("utc"), "UTC");
+	assert.equal(canonicalizeTimeZone("Asia/Taipei"), "Asia/Taipei");
+	assert.equal(canonicalizeTimeZone("Moon/Base"), undefined);
+});
+
+test("formatStampLabel rejects invalid timestamps", () => {
+	assert.equal(formatStampLabel(Number.NaN, undefined, DEFAULT_STAMP_SETTINGS, UTC_ENV), undefined);
+	assert.equal(
+		formatStampLabel(Number.POSITIVE_INFINITY, undefined, DEFAULT_STAMP_SETTINGS, UTC_ENV),
+		undefined,
+	);
+	assert.equal(formatStampLabel(10 ** 20, undefined, DEFAULT_STAMP_SETTINGS, UTC_ENV), undefined);
+});

--- a/extensions/pi-stamp/test/menu.test.ts
+++ b/extensions/pi-stamp/test/menu.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
+import { createMockContext } from "../../../test/support.js";
+import { DEFAULT_STAMP_SETTINGS } from "../src/format.js";
+import { createStampMenu, showStampMenu } from "../src/menu.js";
+import type {
+	StampSettingsPatch,
+	StampSettingsRuntime,
+	StampSettingsState,
+} from "../src/settings.js";
+
+test("stamp menu exposes Main, Settings, Status, Help, and read-only invalid state", () => {
+	const runtime = memorySettingsRuntime();
+	const menu = createStampMenu(runtime);
+	const state = runtime.get();
+	const main = resolveMenuScreen(menu, "main", state);
+	assert.equal(main.kind, "actions");
+	if (main.kind !== "actions") assert.fail("Expected actions screen");
+	assert.deepEqual(
+		main.items.map((item) => item.label),
+		["Settings", "Status", "Help", "Close"],
+	);
+
+	const settings = resolveMenuScreen(menu, "settings", state);
+	assert.equal(settings.kind, "settings");
+	if (settings.kind !== "settings") assert.fail("Expected settings screen");
+	assert.deepEqual(
+		settings.items.map((item) => [item.id, item.currentValue]),
+		[
+			["hourCycle", "24-hour"],
+			["showSeconds", "Show"],
+			["dateContext", "Day changes"],
+			["locale", "Invariant"],
+			["timeZone", "Local"],
+		],
+	);
+
+	const status = resolveMenuScreen(menu, "status", state);
+	assert.equal(status.kind, "detail");
+	if (status.kind !== "detail") assert.fail("Expected detail screen");
+	assert.match(status.lines.join("\n"), /24-hour.*Built-in/u);
+	assert.match(status.lines.join("\n"), /\/tmp\/pi-stamp\.json/u);
+
+	const invalidState = {
+		...state,
+		issue: { kind: "invalid" as const, message: "bad settings" },
+		canSave: false,
+	};
+	const invalidMain = resolveMenuScreen(menu, "main", invalidState);
+	assert.equal(invalidMain.kind, "actions");
+	if (invalidMain.kind !== "actions") assert.fail("Expected actions screen");
+	const invalidSettingsItem = invalidMain.items[0];
+	assert.ok(invalidSettingsItem);
+	assert.equal("to" in invalidSettingsItem ? invalidSettingsItem.to : undefined, "invalid");
+	const invalid = resolveMenuScreen(menu, "invalid", invalidState);
+	assert.equal(invalid.kind, "detail");
+	if (invalid.kind !== "detail") assert.fail("Expected detail screen");
+	assert.match(invalid.lines.join("\n"), /will not be overwritten/u);
+});
+
+test("bounded setting actions persist exact patches", async () => {
+	const runtime = memorySettingsRuntime();
+	const menu = createStampMenu(runtime);
+	const { ctx, notifications } = createMockContext({ mode: "tui" });
+
+	assert.deepEqual(
+		await menu.actions["set-hour-cycle"]({
+			ctx,
+			state: runtime.get(),
+			signal: new AbortController().signal,
+			itemId: "hourCycle",
+			value: "12-hour",
+		}),
+		{ kind: "stay" },
+	);
+	await menu.actions["set-seconds"]({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "showSeconds",
+		value: "Hide",
+	});
+	await menu.actions["set-date-context"]({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "dateContext",
+		value: "Always",
+	});
+	assert.deepEqual(runtime.patches, [
+		{ hourCycle: "12h" },
+		{ showSeconds: false },
+		{ dateContext: "always" },
+	]);
+	assert.equal(notifications.at(-1)?.level, "info");
+});
+
+test("custom locale and time-zone input validates, cancels without mutation, and saves canonical values", async () => {
+	const runtime = memorySettingsRuntime();
+	const values = [undefined, "not_a_locale", "EN-us", "Moon/Base", "utc"];
+	const { ctx, notifications } = createMockContext({
+		mode: "tui",
+		input: async () => values.shift(),
+	});
+	const menu = createStampMenu(runtime);
+	const actionContext = () => ({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "custom",
+	});
+
+	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext()), {
+		kind: "back",
+	});
+	assert.deepEqual(runtime.patches, []);
+	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext()), {
+		kind: "rejected",
+	});
+	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext()), {
+		kind: "back",
+	});
+	assert.deepEqual(await menu.actions["choose-custom-time-zone"](actionContext()), {
+		kind: "rejected",
+	});
+	assert.deepEqual(await menu.actions["choose-custom-time-zone"](actionContext()), {
+		kind: "back",
+	});
+	assert.deepEqual(runtime.patches, [{ locale: "en-US" }, { timeZone: "UTC" }]);
+	assert.ok(notifications.some((notice) => notice.level === "warning"));
+});
+
+test("save failure is rejected without changing effective settings", async () => {
+	const runtime = memorySettingsRuntime({ rejectUpdate: new Error("save\u001b[31m rejected") });
+	const menu = createStampMenu(runtime);
+	const { ctx, notifications } = createMockContext({ mode: "tui" });
+	const result = await menu.actions["set-seconds"]({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "showSeconds",
+		value: "Hide",
+	});
+	assert.deepEqual(result, { kind: "rejected" });
+	assert.equal(runtime.get().settings.showSeconds, true);
+	assert.equal((notifications.at(-1)?.message ?? "").includes("\u001b"), false);
+});
+
+test("RPC adapts the standard menu and an aborted owner closes stale work", async () => {
+	const runtime = memorySettingsRuntime();
+	const choices: string[][] = [];
+	const { ctx } = createMockContext({
+		mode: "rpc",
+		select: async (_title: string, options: string[]) => {
+			choices.push(options);
+			return "Close";
+		},
+	});
+	const controller = new AbortController();
+	const result = await showStampMenu(ctx, runtime, {
+		signal: controller.signal,
+		isCurrent: () => true,
+	});
+	assert.equal(result.kind, "closed");
+	assert.deepEqual(choices[0], ["Settings", "Status", "Help", "Close"]);
+
+	controller.abort();
+	assert.equal(
+		(
+			await showStampMenu(ctx, runtime, {
+				signal: controller.signal,
+				isCurrent: () => false,
+			})
+		).kind,
+		"stale",
+	);
+});
+
+function memorySettingsRuntime(
+	options: { rejectUpdate?: Error } = {},
+): StampSettingsRuntime & { patches: StampSettingsPatch[] } {
+	let state: StampSettingsState = {
+		settings: { ...DEFAULT_STAMP_SETTINGS },
+		sources: {
+			hourCycle: "built-in",
+			showSeconds: "built-in",
+			dateContext: "built-in",
+			locale: "built-in",
+			timeZone: "built-in",
+		},
+		canSave: true,
+	};
+	const patches: StampSettingsPatch[] = [];
+	return {
+		patches,
+		get: () => state,
+		getPath: () => "/tmp/pi-stamp.json",
+		reload: async () => state,
+		update: async (patch) => {
+			if (options.rejectUpdate) throw options.rejectUpdate;
+			patches.push(patch);
+			state = {
+				...state,
+				settings: { ...state.settings, ...patch },
+				sources: {
+					...state.sources,
+					...Object.fromEntries(Object.keys(patch).map((key) => [key, "user"])),
+				},
+			};
+			return state;
+		},
+		flush: async () => undefined,
+	};
+}

--- a/extensions/pi-stamp/test/settings.test.ts
+++ b/extensions/pi-stamp/test/settings.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { DEFAULT_STAMP_SETTINGS } from "../src/format.js";
+import {
+	createStampSettingsRuntime,
+	loadStampSettings,
+	normalizeStampSettingsDocument,
+} from "../src/settings.js";
+
+function temporarySettings(t: TestContext) {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-stamp-settings-"));
+	t.after(() => rmSync(directory, { recursive: true, force: true }));
+	return { directory, settingsPath: path.join(directory, "agent", "pi-stamp.json") };
+}
+
+test("missing settings load defaults without materializing the parent", async (t) => {
+	const { directory, settingsPath } = temporarySettings(t);
+	const loaded = await loadStampSettings(settingsPath);
+	assert.equal(loaded.kind, "missing");
+	assert.deepEqual(loaded.settings, DEFAULT_STAMP_SETTINGS);
+	assert.equal(statExists(path.join(directory, "agent")), false);
+});
+
+test("normalization accepts partial settings, canonicalizes locale and zone, and rejects fields", () => {
+	assert.deepEqual(
+		normalizeStampSettingsDocument({
+			hourCycle: "12h",
+			locale: "EN-us",
+			timeZone: "utc",
+			future: { retained: true },
+		}),
+		{
+			settings: {
+				...DEFAULT_STAMP_SETTINGS,
+				hourCycle: "12h",
+				locale: "en-US",
+				timeZone: "UTC",
+			},
+			sources: {
+				hourCycle: "user",
+				showSeconds: "built-in",
+				dateContext: "built-in",
+				locale: "user",
+				timeZone: "user",
+			},
+		},
+	);
+	for (const value of [
+		null,
+		[],
+		{ hourCycle: "wide" },
+		{ showSeconds: "yes" },
+		{ dateContext: "sometimes" },
+		{ locale: "not_a_locale" },
+		{ timeZone: "Moon/Base" },
+	]) {
+		assert.equal(normalizeStampSettingsDocument(value), undefined);
+	}
+});
+
+test("updates preserve unknown and omitted fields and publish private JSON atomically", async (t) => {
+	const { settingsPath } = temporarySettings(t);
+	mkdirSync(path.dirname(settingsPath), { recursive: true });
+	writeFileSync(
+		settingsPath,
+		`${JSON.stringify({ showSeconds: false, future: { retained: true } }, null, 2)}\n`,
+	);
+	const runtime = createStampSettingsRuntime({ path: settingsPath });
+	await runtime.reload();
+	await runtime.update({ hourCycle: "12h" });
+
+	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+		showSeconds: false,
+		future: { retained: true },
+		hourCycle: "12h",
+	});
+	assert.deepEqual(runtime.get().settings, {
+		...DEFAULT_STAMP_SETTINGS,
+		showSeconds: false,
+		hourCycle: "12h",
+	});
+	if (process.platform !== "win32") {
+		assert.equal(statSync(settingsPath).mode & 0o777, 0o600);
+	}
+	assert.deepEqual(listTemporaryFiles(settingsPath), []);
+});
+
+test("malformed and invalid files stay byte-for-byte unchanged and block updates", async (t) => {
+	for (const contents of ["{bad json\n", '{"showSeconds":"yes"}\n']) {
+		const { settingsPath } = temporarySettings(t);
+		mkdirSync(path.dirname(settingsPath), { recursive: true });
+		writeFileSync(settingsPath, contents);
+		const runtime = createStampSettingsRuntime({ path: settingsPath });
+		const state = await runtime.reload();
+		assert.ok(state.issue);
+		await assert.rejects(runtime.update({ showSeconds: false }), /invalid|malformed/u);
+		assert.equal(readFileSync(settingsPath, "utf8"), contents);
+		assert.deepEqual(runtime.get().settings, DEFAULT_STAMP_SETTINGS);
+	}
+});
+
+test("publication failure retains effective state, cleans temporary files, and queue recovers", async (t) => {
+	const { settingsPath } = temporarySettings(t);
+	let rejectRename = true;
+	const runtime = createStampSettingsRuntime({
+		path: settingsPath,
+		operations: {
+			rename: async (
+				source: Parameters<typeof rename>[0],
+				destination: Parameters<typeof rename>[1],
+			) => {
+				if (rejectRename) throw new Error("rename rejected");
+				await rename(source, destination);
+			},
+		},
+	});
+	await runtime.reload();
+	await assert.rejects(runtime.update({ showSeconds: false }), /rename rejected/u);
+	assert.deepEqual(runtime.get().settings, DEFAULT_STAMP_SETTINGS);
+	assert.deepEqual(listTemporaryFiles(settingsPath), []);
+
+	rejectRename = false;
+	await runtime.update({ showSeconds: false });
+	assert.equal(runtime.get().settings.showSeconds, false);
+});
+
+test("concurrent updates serialize in call order and reload waits for pending publication", async (t) => {
+	const { settingsPath } = temporarySettings(t);
+	let releaseFirst!: () => void;
+	const firstWrite = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	let writes = 0;
+	const runtime = createStampSettingsRuntime({
+		path: settingsPath,
+		operations: {
+			writeFile: async (
+				file: Parameters<typeof writeFile>[0],
+				data: Parameters<typeof writeFile>[1],
+				options: Parameters<typeof writeFile>[2],
+			) => {
+				writes += 1;
+				if (writes === 1) await firstWrite;
+				await writeFile(file, data, options);
+			},
+		},
+	});
+	await runtime.reload();
+	const first = runtime.update({ hourCycle: "12h" });
+	const second = runtime.update({ showSeconds: false });
+	const reloadPromise = runtime.reload();
+	await Promise.resolve();
+	assert.equal(runtime.get().settings.hourCycle, "24h");
+	releaseFirst();
+	await Promise.all([first, second, reloadPromise, runtime.flush()]);
+	assert.deepEqual(runtime.get().settings, {
+		...DEFAULT_STAMP_SETTINGS,
+		hourCycle: "12h",
+		showSeconds: false,
+	});
+});
+
+test("oversized, directory, and symlink settings paths are invalid", async (t) => {
+	const { directory, settingsPath } = temporarySettings(t);
+	mkdirSync(path.dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, " ".repeat(64 * 1024 + 1));
+	assert.equal((await loadStampSettings(settingsPath)).kind, "invalid");
+
+	const directoryPath = path.join(directory, "settings-dir");
+	mkdirSync(directoryPath);
+	assert.equal((await loadStampSettings(directoryPath)).kind, "invalid");
+
+	if (process.platform !== "win32") {
+		const target = path.join(directory, "target.json");
+		writeFileSync(target, "{}\n");
+		const symlink = path.join(directory, "settings-link.json");
+		symlinkSync(target, symlink);
+		assert.equal((await loadStampSettings(symlink)).kind, "invalid");
+	}
+});
+
+function statExists(target: string) {
+	try {
+		statSync(target);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function listTemporaryFiles(settingsPath: string) {
+	try {
+		return readdirSync(path.dirname(settingsPath)).filter((name) => name.endsWith(".tmp"));
+	} catch {
+		return [];
+	}
+}

--- a/extensions/pi-stamp/test/stamp.test.ts
+++ b/extensions/pi-stamp/test/stamp.test.ts
@@ -5,17 +5,24 @@ import test from "node:test";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import stamp, { formatStampTime, isMessageStampData, STAMP_ENTRY_TYPE } from "../src/stamp.js";
+import { DEFAULT_STAMP_SETTINGS, type StampSettings } from "../src/format.js";
+import type { StampSettingsRuntime, StampSettingsState } from "../src/settings.js";
+import stamp, {
+	createStampEntryRenderer,
+	formatStampTime,
+	isMessageStampData,
+	STAMP_ENTRY_TYPE,
+} from "../src/stamp.js";
 
 const USER_TIMESTAMP = new Date(2026, 0, 2, 5, 6, 7, 123).getTime();
 const ASSISTANT_TIMESTAMP = new Date(2026, 0, 2, 5, 6, 9, 456).getTime();
 
-test("stamp registers one entry renderer and only passive lifecycle handlers", () => {
+test("stamp registers one entry renderer, one menu command, and no tools", () => {
 	const mock = createMockPi();
 	stamp(mock.pi);
 
 	assert.deepEqual([...mock.entryRenderers.keys()], [STAMP_ENTRY_TYPE]);
-	assert.equal(mock.commands.size, 0);
+	assert.deepEqual([...mock.commands.keys()], ["stamp"]);
 	assert.equal(mock.tools.length, 0);
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"agent_end",
@@ -34,13 +41,39 @@ test("formatStampTime uses zero-padded local 24-hour time and rejects invalid va
 	assert.equal(formatStampTime(10 ** 20), undefined);
 });
 
-test("isMessageStampData accepts only the current finite persisted schema", () => {
+test("isMessageStampData accepts exact finite version 1 and version 2 schemas", () => {
 	assert.equal(isMessageStampData({ version: 1, role: "user", timestamp: USER_TIMESTAMP }), true);
 	assert.equal(
-		isMessageStampData({ version: 1, role: "assistant", timestamp: ASSISTANT_TIMESTAMP }),
+		isMessageStampData({ version: 2, role: "assistant", timestamp: ASSISTANT_TIMESTAMP }),
 		true,
 	);
-	assert.equal(isMessageStampData({ version: 2, role: "user", timestamp: USER_TIMESTAMP }), false);
+	assert.equal(
+		isMessageStampData({
+			version: 2,
+			role: "user",
+			timestamp: USER_TIMESTAMP,
+			previousTimestamp: USER_TIMESTAMP - 1_000,
+		}),
+		true,
+	);
+	assert.equal(
+		isMessageStampData({
+			version: 1,
+			role: "user",
+			timestamp: USER_TIMESTAMP,
+			previousTimestamp: USER_TIMESTAMP - 1_000,
+		}),
+		false,
+	);
+	assert.equal(
+		isMessageStampData({
+			version: 2,
+			role: "user",
+			timestamp: USER_TIMESTAMP,
+			previousTimestamp: NaN,
+		}),
+		false,
+	);
 	assert.equal(
 		isMessageStampData({ version: 1, role: "toolResult", timestamp: USER_TIMESTAMP }),
 		false,
@@ -49,30 +82,33 @@ test("isMessageStampData accepts only the current finite persisted schema", () =
 	assert.equal(isMessageStampData(null), false);
 });
 
-test("entry renderer uses the callback theme, right-aligns, and stays width-safe", () => {
-	const mock = createMockPi();
-	stamp(mock.pi);
-	const renderer = mock.entryRenderers.get(STAMP_ENTRY_TYPE);
-	assert.ok(renderer);
-
+test("entry renderer reads live settings, uses the callback theme, and stays width-safe", () => {
+	let settings: StampSettings = { ...DEFAULT_STAMP_SETTINGS, timeZone: "UTC" };
+	const renderer = createStampEntryRenderer(() => settings);
 	const colors: string[] = [];
 	const component = renderer(
 		{
-			data: { version: 1, role: "user", timestamp: USER_TIMESTAMP },
-		},
+			data: {
+				version: 2,
+				role: "user",
+				timestamp: Date.UTC(2026, 6, 30, 0, 1, 2),
+				previousTimestamp: Date.UTC(2026, 6, 29, 23, 59, 58),
+			},
+		} as never,
 		{ expanded: false },
 		{
 			fg(color: string, text: string) {
 				colors.push(color);
 				return text;
 			},
-		},
-	) as { render(width: number): string[] } | undefined;
+		} as never,
+	);
 
 	assert.ok(component);
-	assert.deepEqual(colors, ["dim"]);
-	assert.equal(component.render(12).join("\n"), "    05:06:07");
-	assert.equal(component.render(8).join("\n"), "05:06:07");
+	assert.equal(component.render(30).join("\n"), "         2026-07-30 · 00:01:02");
+	settings = { ...settings, showSeconds: false, dateContext: "never" };
+	assert.equal(component.render(12).join("\n"), "       00:01");
+	assert.deepEqual(colors, ["dim", "dim"]);
 	for (const width of [1, 4, 8, 10]) {
 		for (const line of component.render(width)) {
 			assert.ok(visibleWidth(line) <= width, `${JSON.stringify(line)} exceeded width ${width}`);
@@ -80,7 +116,7 @@ test("entry renderer uses the callback theme, right-aligns, and stays width-safe
 	}
 
 	assert.equal(
-		renderer({ data: { version: 99 } }, { expanded: false }, { fg: () => "" }),
+		renderer({ data: { version: 99 } } as never, { expanded: false }, { fg: () => "" } as never),
 		undefined,
 	);
 });
@@ -89,7 +125,12 @@ test("Pi persists stamp entries across reopen without adding them to model conte
 	const sessionDir = mkdtempSync(`${os.tmpdir()}/pi-stamp-session-`);
 	t.after(() => rmSync(sessionDir, { recursive: true, force: true }));
 	const session = SessionManager.create(process.cwd(), sessionDir);
-	const stampData = { version: 1, role: "user", timestamp: USER_TIMESTAMP } as const;
+	const stampData = {
+		version: 2,
+		role: "user",
+		timestamp: USER_TIMESTAMP,
+		previousTimestamp: USER_TIMESTAMP - 1_000,
+	} as const;
 
 	session.appendMessage(userMessage(USER_TIMESTAMP));
 	session.appendCustomEntry(STAMP_ENTRY_TYPE, stampData);
@@ -132,7 +173,7 @@ test("TUI lifecycle appends one user stamp before the assistant and one assistan
 	await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
 	assert.deepEqual(mock.entries, [
 		stampEntry("user", USER_TIMESTAMP),
-		stampEntry("assistant", ASSISTANT_TIMESTAMP),
+		stampEntry("assistant", ASSISTANT_TIMESTAMP, USER_TIMESTAMP),
 	]);
 
 	await emit(mock, "agent_end", { messages: [user, assistant] }, ctx);
@@ -158,7 +199,7 @@ test("successive user messages flush in source order at the following message bo
 
 	assert.deepEqual(mock.entries, [
 		stampEntry("user", USER_TIMESTAMP),
-		stampEntry("user", USER_TIMESTAMP + 1_000),
+		stampEntry("user", USER_TIMESTAMP + 1_000, USER_TIMESTAMP),
 	]);
 });
 
@@ -190,8 +231,81 @@ test("assistant tool and error turns receive one stamp without stamping tool res
 
 	assert.deepEqual(mock.entries, [
 		stampEntry("assistant", ASSISTANT_TIMESTAMP),
-		stampEntry("assistant", ASSISTANT_TIMESTAMP + 2_000),
+		stampEntry("assistant", ASSISTANT_TIMESTAMP + 2_000, ASSISTANT_TIMESTAMP),
 	]);
+});
+
+test("session start rebuilds the predecessor cursor from the active branch", async () => {
+	const mock = createMockPi();
+	stamp(mock.pi);
+	const previous = USER_TIMESTAMP - 60_000;
+	const { ctx } = createMockContext({
+		mode: "tui",
+		sessionManager: {
+			getSessionId: () => "test-session",
+			getSessionName: () => undefined,
+			getEntries: () => [],
+			getBranch: () => [
+				{
+					type: "custom",
+					customType: STAMP_ENTRY_TYPE,
+					data: { version: 1, role: "user", timestamp: previous },
+				},
+			],
+		},
+	});
+
+	await emit(mock, "session_start", { reason: "resume" }, ctx);
+	const assistant = assistantMessage(ASSISTANT_TIMESTAMP);
+	await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
+	assert.deepEqual(mock.entries, [stampEntry("assistant", ASSISTANT_TIMESTAMP, previous)]);
+});
+
+test("a delayed settings reload cannot notify through a replaced session", async () => {
+	const mock = createMockPi();
+	const delayed = deferred<Readonly<StampSettingsState>>();
+	const activeState = defaultSettingsState();
+	let reloads = 0;
+	const runtime = testSettingsRuntime({
+		reload: async () => {
+			reloads += 1;
+			return reloads === 1 ? delayed.promise : activeState;
+		},
+	});
+	stamp(mock.pi, { settingsRuntime: runtime });
+	const first = createMockContext({ mode: "tui" });
+	const second = createMockContext({ mode: "tui" });
+
+	const firstStart = emit(mock, "session_start", { reason: "startup" }, first.ctx);
+	await Promise.resolve();
+	await emit(mock, "session_start", { reason: "switch" }, second.ctx);
+	delayed.resolve({
+		...activeState,
+		issue: { kind: "invalid", message: "stale issue" },
+		canSave: false,
+	});
+	await firstStart;
+
+	assert.deepEqual(first.notifications, []);
+	assert.deepEqual(second.notifications, []);
+});
+
+test("session shutdown waits for an in-flight settings durability boundary", async () => {
+	const mock = createMockPi();
+	const flushing = deferred<void>();
+	const runtime = testSettingsRuntime({ flush: () => flushing.promise });
+	stamp(mock.pi, { settingsRuntime: runtime });
+	const { ctx } = createMockContext({ mode: "tui" });
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	let settled = false;
+	const shutdown = emit(mock, "session_shutdown", { reason: "quit" }, ctx).then(() => {
+		settled = true;
+	});
+	await Promise.resolve();
+	assert.equal(settled, false);
+	flushing.resolve();
+	await shutdown;
+	assert.equal(settled, true);
 });
 
 test("agent end and shutdown flush a pending user at most once and reload resets state", async () => {
@@ -217,6 +331,24 @@ test("agent end and shutdown flush a pending user at most once and reload resets
 	]);
 });
 
+test("/stamp is argument-free, supports TUI, and rejects print and JSON observably", async () => {
+	const mock = createMockPi();
+	stamp(mock.pi);
+	const command = mock.commands.get("stamp");
+	assert.ok(command);
+	const tui = createMockContext({
+		mode: "tui",
+		select: async (_title: string, options: string[]) =>
+			options.find((option) => option === "Close"),
+	});
+	await command.handler("", tui.ctx);
+	await assert.rejects(async () => command.handler("extra", tui.ctx), /does not accept arguments/u);
+	for (const mode of ["print", "json"] as const) {
+		const { ctx } = createMockContext({ mode });
+		await assert.rejects(async () => command.handler("", ctx), new RegExp(`${mode} mode`, "u"));
+	}
+});
+
 test("print, JSON, and RPC sessions never append stamp entries", async () => {
 	for (const mode of ["print", "json", "rpc"] as const) {
 		const mock = createMockPi();
@@ -235,10 +367,15 @@ test("print, JSON, and RPC sessions never append stamp entries", async () => {
 	}
 });
 
-function stampEntry(role: "user" | "assistant", timestamp: number) {
+function stampEntry(role: "user" | "assistant", timestamp: number, previousTimestamp?: number) {
 	return {
 		customType: STAMP_ENTRY_TYPE,
-		data: { version: 1, role, timestamp },
+		data: {
+			version: 2,
+			role,
+			timestamp,
+			...(previousTimestamp === undefined ? {} : { previousTimestamp }),
+		},
 	};
 }
 
@@ -275,4 +412,40 @@ async function emit(
 	for (const handler of mock.events.get(name) ?? []) {
 		await handler(event, ctx);
 	}
+}
+
+function defaultSettingsState(): Readonly<StampSettingsState> {
+	return {
+		settings: { ...DEFAULT_STAMP_SETTINGS },
+		sources: {
+			hourCycle: "built-in",
+			showSeconds: "built-in",
+			dateContext: "built-in",
+			locale: "built-in",
+			timeZone: "built-in",
+		},
+		canSave: true,
+	};
+}
+
+function testSettingsRuntime(overrides: Partial<StampSettingsRuntime> = {}): StampSettingsRuntime {
+	const state = defaultSettingsState();
+	return {
+		get: () => state,
+		getPath: () => "/tmp/pi-stamp.json",
+		reload: async () => state,
+		update: async () => state,
+		flush: async () => undefined,
+		...overrides,
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,6 +1721,9 @@
 			"name": "@narumitw/pi-stamp",
 			"version": "0.38.0",
 			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "<1"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.5",
 				"@earendil-works/pi-coding-agent": "0.82.1",


### PR DESCRIPTION
## Summary

- add `/stamp` Settings, Status, and Help screens through `@narumitw/pi-tui-kit` for 12/24-hour clocks, seconds, date context, locale, and time zone
- persist new version-2 stamp entries with predecessor timestamps so day boundaries re-render truthfully while preserving version-1 sessions and LLM-context exclusion
- add user-only `pi-stamp.json` settings with validation, unknown-field preservation, ordered reads/writes, invalid-file protection, atomic publication, rollback, and lifecycle draining
- document the settings contract, archive the completed Phase 2 plan, and mark presentation controls implemented on the roadmap

Relative timestamps remain deferred because they require background refresh work. The compatibility default remains dim, right-aligned local `HH:mm:ss` for ordinary same-day messages.

## Verification

- `npm run check` — Biome, package boundaries, workspace typechecks, and all 1,793 tests passed
- `npm run check --workspace @narumitw/pi-stamp`
- `just pack stamp` — eight intended publish files and the `<1` TUI Kit dependency inspected
- Pi 0.82.1 print-mode load returned `OK`
- real Pi TUI components — day-change rendering, live mounted reformat, theme invalidation, and 40/20/8-column width bounds passed
- RPC smokes — `/stamp` exposed Settings/Status/Help and atomically saved 12-hour mode in an isolated agent directory
- settings smoke — atomic save, mounted reformat, and rejected-publication rollback passed
- print/JSON command smokes — unsupported-mode errors remained observable without corrupting JSON stdout
