### PR TITLE
feat(stamp): add response timing

### DIFF
--- a/docs/plans/archived/2026-07-29_pi-stamp-response-timing-plan.md
+++ b/docs/plans/archived/2026-07-29_pi-stamp-response-timing-plan.md
@@ -1,0 +1,278 @@
+# pi-stamp Response Timing Plan
+
+## Goal
+
+Implement Phase 3 of the
+[`pi-stamp` roadmap](../roadmaps/pi-stamp-roadmap.md) by recording extension-observed assistant
+completion and first-content times, deriving truthful per-response elapsed labels, and keeping the
+existing timestamp-only transcript as the compatibility default.
+
+Add one opt-in setting:
+
+```json
+{
+  "responseTiming": "off"
+}
+```
+
+Accepted values are `"off"`, `"duration"`, and `"detailed"`. Assistant stamps render as follows
+when timing data is available:
+
+```text
+Off:       14:32:08
+Duration:  14:32:08 · 3.2s
+Detailed:  14:32:08 · first 0.8s · total 3.2s
+```
+
+User stamps never show response timing. `detailed` renders `first n/a` when Pi finalized a newly
+recorded assistant response without emitting a meaningful streaming update; it does not substitute
+message start, response headers, or completion time for first content.
+
+## Context
+
+- Assistant `message.timestamp` is created by Pi's provider stream near request/message creation; it
+  is not completion time. This phase defines total response elapsed as the extension-observed
+  `message_end` time minus that persisted timestamp.
+- Pi emits assistant `message_end` before persisting the message. The extension must capture timing
+  there but continue appending the stamp at `turn_end`, after the assistant and any tool results are
+  persisted.
+- `message_update` exposes text, thinking, and tool-call stream events. Provider granularity varies,
+  so the UI must call the optional metric **first content**, not first token or network latency.
+- Phase 2 already owns a queued, atomic user-settings protocol and a live renderer settings getter.
+  Adding a recognized field must preserve its malformed-file protection, unknown-field retention,
+  ordered publication, rollback, and reload/shutdown durability behavior.
+- This phase touches persisted custom-entry compatibility, message/turn lifecycle, settings,
+  standard menu screens, custom transcript rendering, and documentation. Applicable MUST rules are
+  exact runtime validation, TUI-only entry creation, width/theme-safe rendering, no stale session
+  state, settings ordering and atomic publication, menu cancellation/disposal, deterministic tests,
+  the root CI-equivalent check, pack inspection, and a Pi runtime smoke.
+
+## Architecture
+
+### Measurement contract
+
+Use an injectable wall-clock function, defaulting to `Date.now`, only at Pi event boundaries:
+
+- **Response start:** the finalized assistant message's existing `timestamp`.
+- **First content:** the first extension-observed assistant `message_update` that carries a non-empty
+  text/thinking/tool-call delta, a non-empty completed text/thinking block when no delta was observed,
+  or a completed tool call. Empty deltas and block-start events do not count.
+- **Completion:** the extension-observed wall-clock time in assistant `message_end`.
+- **Total elapsed:** `completedAt - message.timestamp`.
+- **First-content elapsed:** `firstContentAt - message.timestamp`.
+
+These are local Pi observations, not provider-server timestamps. A tool-using response completes at
+assistant `message_end`; tool execution time is deliberately excluded even though the assistant stamp
+continues to appear after the complete tool block. Error and aborted assistant messages use the same
+finalization boundary.
+
+Retain only the first qualifying update. Require finite, valid Unix-millisecond values and ordered
+boundaries. If completion precedes message creation because the wall clock moved backwards or a
+provider supplied an inconsistent timestamp, persist the assistant stamp without timing. If only the
+first-content boundary is inconsistent, retain valid completion timing and omit first content.
+
+Format elapsed values as locale-independent ASCII seconds rounded to one decimal. Render `0.0s` for
+an exact zero and `<0.1s` for a positive elapsed value below one tenth of a second. Reject negative or
+non-finite durations instead of clamping or estimating them. Existing ANSI-aware wrapping and
+right-alignment remain responsible for narrow widths.
+
+### Persisted compatibility
+
+Continue reading exact version-1 and version-2 payloads. Keep new user stamps at version 2 and add an
+exact assistant-only version 3 payload:
+
+```ts
+interface AssistantMessageStampDataV3 {
+  version: 3;
+  role: "assistant";
+  timestamp: number;
+  previousTimestamp?: number;
+  completedAt: number;
+  firstContentAt?: number;
+}
+```
+
+Persist absolute observed boundaries, not preformatted labels or redundant durations. The renderer
+recomputes elapsed labels and date/time presentation from the payload and current settings. Version 3
+validation accepts no unknown keys, enforces `timestamp <= completedAt`, and, when present, enforces
+`timestamp <= firstContentAt <= completedAt`.
+
+Version-1/version-2 assistant entries remain timestamp-only in every timing mode because they do not
+contain the required observations. Do not backfill, migrate, or rewrite session history. Include
+version 3 in predecessor-cursor reconstruction so date context remains continuous across mixed
+payload versions.
+
+### Lifecycle and state
+
+Keep timing state bounded to the one sequential assistant stream owned by the active Pi turn:
+
+1. `session_start` clears timing state, advances existing session ownership, reloads settings, and
+   rebuilds only the persisted predecessor cursor.
+2. Assistant `message_start` initializes one in-memory observation from the message timestamp; it
+   does not append an entry.
+3. Assistant `message_update` records the first qualifying content boundary once.
+4. Assistant `message_end` captures completion and finalizes a pending timing observation without
+   appending before Pi persistence.
+5. `turn_end` consumes only the finalized observation for that assistant message and appends a
+   version-3 stamp; if no valid observation matches, it appends the existing version-2 fallback.
+6. A new turn, agent end, session replacement, reload, and shutdown clear unmatched timing state so
+   it cannot leak into another response. Existing pending-user FIFO and settings flush behavior stay
+   unchanged.
+
+No timer, refresh loop, process, watcher, network request, or captured `ExtensionContext` is added.
+Every timing event handler remains synchronous; session cancellation and disposal still apply to the
+existing menu/settings flow only.
+
+### Settings and presentation
+
+Extend `StampSettings` with:
+
+```ts
+responseTiming: "off" | "duration" | "detailed";
+```
+
+`off` is the built-in default so ordinary same-day output remains byte-for-byte compatible. The
+existing user-only precedence remains:
+
+```text
+built-in defaults -> <getAgentDir()>/pi-stamp.json
+```
+
+Add one **Response timing** row to `/stamp` Settings and include its effective value/source in Main
+and Status. The row cycles through Off, Duration, and Detailed using the existing `pi-tui-kit`
+settings action and queued persistence path. No command route, project setting, environment variable,
+or new file is introduced.
+
+The renderer adds timing only for valid version-3 assistant entries:
+
+- `duration`: append the unlabeled compact total, matching `14:32:08 · 3.2s`.
+- `detailed`: append `first <elapsed> · total <elapsed>`; use `first n/a` only for a version-3 entry
+  whose first-content observation is absent.
+- Legacy assistant entries and every user entry: retain their existing timestamp/date label.
+
+Mounted version-3 stamps respond to successful setting changes through the existing live settings
+getter without rewriting persisted data.
+
+## Non-Goals
+
+- Provider-server latency, HTTP-response timing, token-level timestamps, or a claim that first content
+  is time-to-first-token.
+- Including tool execution, retries outside the individual assistant message, queued follow-ups, or
+  full agent settlement in response elapsed time.
+- Absolute completion-clock display, relative labels, periodic refresh, thresholds, color coding, or
+  timing aggregates.
+- Phase 4 provider/model/usage/cost fields or Phase 5 tool stamps.
+- Editing built-in message rows, altering message content, adding model context, or backfilling old
+  sessions.
+- New commands, project settings, environment variables, dependencies, package metadata, or network
+  access.
+
+## Assumptions
+
+- Phase 3 timing is opt-in because the roadmap's minimal-default principle says the default
+  transcript shows only a dim timestamp.
+- `responseTiming: "duration"` is the compact mode shown in the roadmap; `"detailed"` is the explicit
+  diagnostic mode needed to label first-content and total measurements without ambiguity.
+- Pi processes one assistant stream at a time within a model turn. Tool results may occur between its
+  `message_end` and `turn_end`, but another assistant stream does not start before that turn ends.
+- A completed tool call is meaningful assistant content, while a block-start event with no payload is
+  not.
+- Version-3 entries with no first-content field distinguish a measured non-streaming/no-update
+  response from legacy entries that contain no timing observations at all.
+
+## Risks
+
+- Provider adapters may emit streaming updates at different granularities. Define and test the exact
+  qualifying event set, label it first content, and expose `n/a` rather than substituting another
+  lifecycle boundary.
+- Wall-clock adjustment or malformed provider timestamps can make elapsed values negative. Validate
+  ordering before persistence and fall back to timestamp-only data rather than clamping.
+- Assistant completion occurs before tools, while the stamp renders after tools. Documentation and a
+  tool-use test must prove that the displayed total excludes tool runtime.
+- A stale finalized observation could be attached to a later turn after malformed or interrupted
+  event ordering. Match the pending observation to the assistant timestamp, consume it once, and
+  clear it at every turn/session terminal boundary.
+- Adding a recognized setting can make a previously ignored unknown `responseTiming` value invalid.
+  Preserve the exact invalid file and previous effective runtime settings under the existing
+  settings protocol.
+- Longer detailed labels can wrap in narrow terminals. Keep timing formatting independent from ANSI
+  alignment and rerun width checks at one-column and representative narrow widths.
+
+## Plan
+
+- [x] Add red-first pure formatting specifications in
+  `extensions/pi-stamp/test/format.test.ts` for Off/Duration/Detailed assistant labels, exact-zero,
+  positive sub-tenth, one-decimal rounding, missing first content, legacy/no-timing omission,
+  negative/non-finite rejection, and date-context composition; root `npm test` reached the intended
+  TS2724/TS2305 failures for the absent timing-format exports before implementation.
+- [x] Extend `extensions/pi-stamp/src/format.ts` with the response-timing enum/type, compatibility
+  default, elapsed validation/formatting, and stamp-suffix composition while preserving existing
+  locale/time-zone behavior; root `npm test` passed all 1,796 tests, including deterministic timing
+  composition and elapsed-boundary cases with no clock or mutable global dependency.
+- [x] Add red-first settings specifications in `extensions/pi-stamp/test/settings.test.ts` for the
+  missing-file default, every accepted `responseTiming` value, invalid type/value protection,
+  unknown-field preservation, source reporting, ordered updates, save rollback, reload, and flush;
+  root `npm test` reached two intended failures: the field remained built-in instead of `detailed`,
+  and updates rejected it as unknown.
+- [x] Extend `extensions/pi-stamp/src/settings.ts` so `responseTiming` participates in exact
+  normalization, patch validation, sources, queued reread/update, atomic publication, and frozen
+  runtime state; root `npm test` passed all 1,796 tests, including accepted values, invalid fields,
+  source reporting, unknown-field retention, atomic publication, rollback, queue, reload, and flush.
+- [x] Add red-first lifecycle and persistence specifications in
+  `extensions/pi-stamp/test/stamp.test.ts` for exact version-3 validation, persisted reload/context
+  exclusion, text/thinking/tool-call first content, ignored starts/empty updates, no-update `n/a`,
+  completion capture at `message_end`, append ordering at `turn_end`, tool-runtime exclusion,
+  stop/error/abort responses, one-shot consumption, timestamp mismatch, clock reversal, mixed-version
+  predecessor recovery, replacement/reload/shutdown clearing, default rendering compatibility,
+  duration/detailed width safety, and injected-clock determinism; root `npm test` reached the intended
+  TS2353 failures because the timing clock/lifecycle option did not exist.
+- [x] Refactor `extensions/pi-stamp/src/stamp.ts` to own one generation-bounded assistant observation,
+  persist validated version-3 assistant data, retain version-2 user/fallback entries, and render live
+  timing settings while preserving the existing pending-user FIFO and TUI-only behavior; root
+  `npm test` passed all 1,801 tests, including first-content variants, no-update/tool/error/abort,
+  mismatch, clock reversal, replacement, persistence/context exclusion, and width-safe rendering.
+- [x] Add red-first menu specifications in `extensions/pi-stamp/test/menu.test.ts` for the Response
+  timing row, all three cycles, Main/Status source labels, immediate application, invalid-file
+  read-only behavior, save rollback, cancellation, and RPC adaptation; root `npm test` reached the
+  intended TS7053 failures because `set-response-timing` was absent from the menu contract.
+- [x] Update `extensions/pi-stamp/src/menu.ts` to expose and persist Response timing through the
+  existing `pi-tui-kit` flow and revise Help with creation/completion, first-content, tool-exclusion,
+  legacy, and `n/a` semantics; root `npm test` passed all 1,801 tests, including all timing cycles,
+  Main/Status labels, rollback, cancellation/disposal, RPC adaptation, and shutdown draining.
+- [x] Update `extensions/pi-stamp/README.md` and the Phase 3 status in
+  `docs/roadmaps/pi-stamp-roadmap.md` with the opt-in setting, exact compact/detailed examples,
+  observer-clock semantics, provider dependence, tool-runtime exclusion, old-entry behavior,
+  privacy/no-context guarantee, and limitations; a 10-claim documentation assertion audit passed,
+  and the roadmap points to this plan's final archived path.
+- [x] Format only the touched `pi-stamp` paths, run focused tests followed by root `npm test` and
+  `npm run check`, run `just pack stamp` and inspect the intended source/docs, then run a
+  non-interactive Pi load and programmatic TUI lifecycle/render smoke covering default, duration,
+  detailed/no-update, tool-use, reload, and resume; final tests/check passed all 1,802 tests, the
+  eight-file pack is exact, offline Pi package loading returned OK, and the programmatic smoke passed.
+- [x] Audit the final diff against `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, Pi's extension/session-format/TUI/package documentation, and the
+  roadmap boundary; settings concurrency, malformed-file protection, custom-entry validation,
+  message/turn ordering, cancellation, component disposal, replacement/shutdown, width/theme,
+  non-TUI safety, resource/network absence, package contents, and every touched-area MUST passed with
+  no finding or deviation.
+
+## Completion Checklist
+
+- [x] The built-in default and legacy entries remain dim, right-aligned timestamp-only rows with
+  unchanged date, locale, time-zone, width, and theme behavior.
+- [x] New assistant stamps persist exact completion observations and optional first-content
+  observations as validated version-3 custom entries outside LLM context; user stamps remain version
+  2 and all older payloads remain readable.
+- [x] `duration` shows creation-to-`message_end` elapsed time, while `detailed` labels first content
+  and total distinctly and uses `first n/a` without substituting another measurement.
+- [x] Tool execution time, full-agent retries/settlement, provider-server clocks, and legacy history
+  are never presented as response timing.
+- [x] Invalid or out-of-order observations degrade to timestamp-only data without negative, clamped,
+  fabricated, duplicate, or cross-turn values.
+- [x] `responseTiming` is validated, documented, source-labeled, persisted atomically, applied live,
+  and protected by the existing ordered settings/menu lifecycle in TUI and RPC modes.
+- [x] User cancellation, component disposal, agent end, turn replacement, session replacement,
+  reload, and shutdown clear or drain every owned state/operation with no stale continuation or
+  background task.
+- [x] Focused tests, root `npm test`, full `npm run check`, package dry run, Pi load smoke, and
+  representative programmatic TUI lifecycle/render smokes pass with no unrecorded deviation.

--- a/docs/roadmaps/pi-stamp-roadmap.md
+++ b/docs/roadmaps/pi-stamp-roadmap.md
@@ -67,6 +67,9 @@ publication.
 
 ### Phase 3 — Response timing
 
+**Status:** implemented; see the archived
+[response-timing plan](../plans/archived/2026-07-29_pi-stamp-response-timing-plan.md)
+
 - Record assistant completion time at `message_end` separately from `message.timestamp`.
 - Derive response duration from request/message creation to completion.
 - Evaluate time-to-first-content using the first meaningful assistant `message_update`.

--- a/extensions/pi-stamp/README.md
+++ b/extensions/pi-stamp/README.md
@@ -9,6 +9,7 @@ right-aligned timestamp after each user and assistant message in the interactive
 
 - Shows each message's recorded creation time on a dim, right-aligned transcript row.
 - Supports 12/24-hour clocks, optional seconds, automatic date context, locales, and time zones.
+- Optionally shows assistant response duration and detailed first-content/total timing.
 - Stores versioned custom session entries that survive reload and resume.
 - Keeps stamp entries outside LLM context, so timestamp text is never sent to the model.
 - Uses Pi's current theme and remains width-safe in narrow terminals.
@@ -51,7 +52,7 @@ Run `/stamp` to open the presentation menu:
 
 ```text
 Stamp
-24-hour · seconds · Day changes · Invariant · Local
+24-hour · seconds · Day changes · Invariant · Local · Timing off
 
 Settings
 Status
@@ -73,6 +74,7 @@ The `/stamp` Settings screen provides these controls:
 | `dateContext` | `"day-change"`, `"always"`, `"never"` | `"day-change"` | Adds a date at recorded day boundaries, every time, or never. |
 | `locale` | `"invariant"`, `"system"`, or one BCP 47 tag | `"invariant"` | Controls localized date/time presentation. |
 | `timeZone` | `"local"` or one supported IANA zone | `"local"` | Controls time and day-boundary interpretation; `UTC` is accepted. |
+| `responseTiming` | `"off"`, `"duration"`, `"detailed"` | `"off"` | Keeps timestamps minimal, adds total assistant duration, or labels first-content and total timing. |
 
 The compatibility defaults produce local `HH:mm:ss` for ordinary same-day messages. `invariant`
 uses Gregorian ISO dates, Latin digits, and English `AM`/`PM`. `system` uses the operating system
@@ -91,7 +93,8 @@ object, so this is enough to show 12-hour Taipei time without seconds:
 {
   "hourCycle": "12h",
   "showSeconds": false,
-  "timeZone": "Asia/Taipei"
+  "timeZone": "Asia/Taipei",
+  "responseTiming": "duration"
 }
 ```
 
@@ -115,19 +118,40 @@ publication.
 `/stamp` supports TUI and RPC dialog modes. Print and JSON command invocations reject without writing
 ad hoc protocol output. Transcript stamps themselves are appended only in TUI mode.
 
-## 🕰️ Timestamp semantics
+## 🕰️ Timestamp and response-timing semantics
 
 - A **user** stamp is the timestamp recorded when Pi creates the submitted user message.
-- An **assistant** stamp is the timestamp recorded when Pi creates the response stream/message. It is
-  not the response completion time.
-- If an assistant message invokes tools, its stamp appears after the complete tool block. Tool calls
-  and results do not receive their own stamps.
+- An **assistant** clock is the timestamp recorded when Pi creates the response stream/message.
+- New assistant entries separately record when this extension observes Pi's final `message_end`.
+  `responseTiming: "duration"` shows creation-to-completion elapsed time:
+
+  ```text
+  14:32:08 · 3.2s
+  ```
+
+- `responseTiming: "detailed"` distinguishes the first meaningful streamed content observed by Pi
+  from total completion:
+
+  ```text
+  14:32:08 · first 0.8s · total 3.2s
+  ```
+
+  First content is the first non-empty text, thinking, or tool-call update—not a provider-server
+  timestamp or guaranteed time-to-first-token. `first n/a` means Pi finalized the response without
+  such an update; completion time is never substituted.
+- If an assistant message invokes tools, its stamp appears after the complete tool block, but total
+  response timing ends at the assistant's `message_end` and excludes tool execution. Tool calls and
+  results do not receive their own stamps.
+- Error and aborted assistant messages use the same local completion boundary. Invalid or backwards
+  clock observations degrade to timestamp-only data rather than showing a negative or clamped value.
 - `dateContext: "day-change"` compares each newly recorded stamp with its persisted predecessor in
   the currently selected time zone. The first known stamp stays time-only.
-- Changing locale or time zone re-renders recorded version-2 stamps without rewriting session files.
+- Changing presentation settings re-renders compatible recorded stamps without rewriting session
+  files.
 
-Relative labels such as `3m ago` are intentionally unavailable because they would require periodic
-background refresh and lifecycle cleanup.
+Timing labels are local Pi lifecycle observations, not provider latency telemetry. They require no
+network request or refresh task. Relative labels such as `3m ago` remain unavailable because they
+would require periodic background refresh and lifecycle cleanup.
 
 ## 🔒 Context and persistence
 
@@ -135,8 +159,11 @@ Stamps use Pi custom session entries. Pi renders those entries in the interactiv
 excludes them from model context. The extension does not modify user or assistant message content.
 
 Version-2 entries retain the previous recorded stamp timestamp so day changes can be recomputed for
-the active presentation settings. Existing version-1 entries remain readable. They can show their
-own date with `dateContext: "always"`, but `day-change` cannot infer a missing predecessor.
+the active presentation settings. Version-3 assistant entries add absolute extension-observed
+completion and optional first-content boundaries; elapsed labels are derived during rendering.
+Existing version-1 and version-2 entries remain readable and timestamp-only because they contain no
+timing observations. Version-1 entries can show their own date with `dateContext: "always"`, but
+`day-change` cannot infer a missing predecessor.
 
 Once recorded, a stamp survives `/reload` and session resume while the extension remains loaded.
 Messages created before `pi-stamp` recorded them are not backfilled because Pi's current public API
@@ -148,8 +175,8 @@ cannot insert a new custom entry into an older position in the session tree.
   separate transcript rows rather than inside the original message bubble.
 - Another extension can append transcript entries at the same lifecycle boundary, so strict visual
   adjacency between independently loaded extensions is not guaranteed.
-- There are no arbitrary format strings, relative labels, duration, model, token, cost, or
-  tool-timing controls.
+- There are no arbitrary format strings, relative labels, provider-server latency, model, token,
+  cost, timing aggregates, or tool-timing controls.
 
 See the
 [pi-stamp roadmap](https://github.com/narumiruna/pi-extensions/blob/main/docs/roadmaps/pi-stamp-roadmap.md)
@@ -161,10 +188,10 @@ for possible future metadata stamps.
 extensions/pi-stamp/
 ├── src/
 │   ├── index.ts       # Thin Pi package entrypoint
-│   ├── format.ts      # Locale, time-zone, date, and clock formatting
+│   ├── format.ts      # Date, clock, and response-elapsed formatting
 │   ├── menu.ts        # /stamp presentation menu
 │   ├── settings.ts    # Validation and atomic user settings
-│   └── stamp.ts       # Renderer, payload compatibility, and lifecycle hooks
+│   └── stamp.ts       # Renderer, payload compatibility, and timing lifecycle
 ├── test/
 │   ├── format.test.ts
 │   ├── menu.test.ts

--- a/extensions/pi-stamp/src/format.ts
+++ b/extensions/pi-stamp/src/format.ts
@@ -1,8 +1,10 @@
 export const HOUR_CYCLES = ["24h", "12h"] as const;
 export const DATE_CONTEXTS = ["day-change", "always", "never"] as const;
+export const RESPONSE_TIMING_MODES = ["off", "duration", "detailed"] as const;
 
 export type StampHourCycle = (typeof HOUR_CYCLES)[number];
 export type StampDateContext = (typeof DATE_CONTEXTS)[number];
+export type StampResponseTimingMode = (typeof RESPONSE_TIMING_MODES)[number];
 export type StampLocale = "invariant" | "system" | string;
 export type StampTimeZone = "local" | string;
 
@@ -12,6 +14,7 @@ export interface StampSettings {
 	dateContext: StampDateContext;
 	locale: StampLocale;
 	timeZone: StampTimeZone;
+	responseTiming: StampResponseTimingMode;
 }
 
 export const DEFAULT_STAMP_SETTINGS: Readonly<StampSettings> = Object.freeze({
@@ -20,11 +23,19 @@ export const DEFAULT_STAMP_SETTINGS: Readonly<StampSettings> = Object.freeze({
 	dateContext: "day-change",
 	locale: "invariant",
 	timeZone: "local",
+	responseTiming: "off",
 });
 
 export interface StampFormatEnvironment {
 	systemLocale?: string;
 	localTimeZone?: string;
+}
+
+export interface MessageStampFormatInput {
+	timestamp: number;
+	previousTimestamp?: number;
+	completedAt?: number;
+	firstContentAt?: number;
 }
 
 interface ZonedParts {
@@ -73,6 +84,33 @@ export function formatStampLabel(
 	} catch {
 		return undefined;
 	}
+}
+
+export function formatMessageStampLabel(
+	input: Readonly<MessageStampFormatInput>,
+	settings: Readonly<StampSettings>,
+	environment: StampFormatEnvironment = {},
+): string | undefined {
+	const label = formatStampLabel(input.timestamp, input.previousTimestamp, settings, environment);
+	if (!label || settings.responseTiming === "off") return label;
+	if (!isValidTimestamp(input.completedAt) || input.completedAt < input.timestamp) return label;
+	const total = formatResponseElapsed(input.completedAt - input.timestamp);
+	if (!total) return label;
+	if (settings.responseTiming === "duration") return `${label} · ${total}`;
+	const first =
+		isValidTimestamp(input.firstContentAt) &&
+		input.firstContentAt >= input.timestamp &&
+		input.firstContentAt <= input.completedAt
+			? formatResponseElapsed(input.firstContentAt - input.timestamp)
+			: undefined;
+	return `${label} · first ${first ?? "n/a"} · total ${total}`;
+}
+
+export function formatResponseElapsed(elapsedMilliseconds: number): string | undefined {
+	if (!Number.isFinite(elapsedMilliseconds) || elapsedMilliseconds < 0) return undefined;
+	if (elapsedMilliseconds > 0 && elapsedMilliseconds < 100) return "<0.1s";
+	const tenths = Math.round(elapsedMilliseconds / 100);
+	return `${(tenths / 10).toFixed(1)}s`;
 }
 
 function formatInvariant(

--- a/extensions/pi-stamp/src/menu.ts
+++ b/extensions/pi-stamp/src/menu.ts
@@ -5,6 +5,7 @@ import {
 	canonicalizeTimeZone,
 	type StampDateContext,
 	type StampHourCycle,
+	type StampResponseTimingMode,
 } from "./format.js";
 import type { StampSettingsPatch, StampSettingsRuntime, StampSettingsState } from "./settings.js";
 
@@ -13,6 +14,7 @@ type StampAction =
 	| "set-hour-cycle"
 	| "set-seconds"
 	| "set-date-context"
+	| "set-response-timing"
 	| "open-locale"
 	| "choose-invariant-locale"
 	| "choose-system-locale"
@@ -93,6 +95,14 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 						currentValue: timeZoneLabel(state.settings.timeZone),
 						action: "open-time-zone",
 					},
+					{
+						id: "responseTiming",
+						label: "Response timing",
+						description: "Show no timing, total duration, or detailed first/total timing.",
+						currentValue: responseTimingLabel(state.settings.responseTiming),
+						values: ["Off", "Duration", "Detailed"],
+						action: "set-response-timing",
+					},
 				],
 			}),
 			locale: ({ state }) => ({
@@ -166,6 +176,12 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 					),
 					settingStatus("Locale", localeLabel(state.settings.locale), state, "locale"),
 					settingStatus("Time zone", timeZoneLabel(state.settings.timeZone), state, "timeZone"),
+					settingStatus(
+						"Response timing",
+						responseTimingLabel(state.settings.responseTiming),
+						state,
+						"responseTiming",
+					),
 					`Settings file: ${safeTerminalText(runtime.getPath())}`,
 					...(state.issue ? [`Issue: ${safeTerminalText(state.issue.message)}`] : []),
 				],
@@ -175,11 +191,13 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 				kind: "detail",
 				title: "Stamp Help",
 				lines: [
-					"Stamps show each message's recorded creation time, not assistant completion time.",
+					"The clock shows message creation; response timing ends at assistant message completion.",
+					"First content is Pi's first non-empty text, thinking, or tool-call stream update.",
+					"First n/a means no meaningful update was observed; no other boundary is substituted.",
+					"Assistant timing excludes tool execution and is unavailable on legacy stamp entries.",
 					"Day changes compare the previous recorded stamp in the selected time zone.",
 					"Changes save immediately and reformat mounted and future stamps.",
-					"Relative labels are not available because they require background refresh work.",
-					"Stamp entries remain outside model context.",
+					"Stamp entries remain outside model context and never use a refresh timer.",
 				],
 				hint: "back",
 			}),
@@ -209,6 +227,11 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 				const dateContext: StampDateContext =
 					value === "Always" ? "always" : value === "Never" ? "never" : "day-change";
 				return savePatch(runtime, ctx, signal, { dateContext }, `Date context: ${value}.`);
+			},
+			"set-response-timing": ({ ctx, value, signal }) => {
+				const responseTiming: StampResponseTimingMode =
+					value === "Detailed" ? "detailed" : value === "Duration" ? "duration" : "off";
+				return savePatch(runtime, ctx, signal, { responseTiming }, `Response timing: ${value}.`);
 			},
 			"open-locale": async () => ({ kind: "to", screen: "locale" }),
 			"choose-invariant-locale": ({ ctx, signal }) =>
@@ -307,6 +330,7 @@ function formatCompactStatus(state: StampSettingsState): string {
 		dateContextLabel(state.settings.dateContext),
 		localeLabel(state.settings.locale),
 		timeZoneLabel(state.settings.timeZone),
+		`Timing ${responseTimingLabel(state.settings.responseTiming).toLowerCase()}`,
 	].join(" · ");
 }
 
@@ -328,6 +352,12 @@ function localeLabel(value: string): string {
 
 function timeZoneLabel(value: string): string {
 	return value === "local" ? "Local" : safeTerminalText(value);
+}
+
+function responseTimingLabel(value: StampResponseTimingMode): string {
+	if (value === "duration") return "Duration";
+	if (value === "detailed") return "Detailed";
+	return "Off";
 }
 
 function safeTerminalText(value: string): string {

--- a/extensions/pi-stamp/src/settings.ts
+++ b/extensions/pi-stamp/src/settings.ts
@@ -9,6 +9,7 @@ import {
 	DATE_CONTEXTS,
 	DEFAULT_STAMP_SETTINGS,
 	HOUR_CYCLES,
+	RESPONSE_TIMING_MODES,
 	type StampSettings,
 } from "./format.js";
 
@@ -75,6 +76,7 @@ const SETTING_FIELDS = [
 	"dateContext",
 	"locale",
 	"timeZone",
+	"responseTiming",
 ] as const satisfies readonly StampSettingsField[];
 const SETTING_FIELD_SET = new Set<string>(SETTING_FIELDS);
 
@@ -119,6 +121,13 @@ export function normalizeStampSettingsDocument(
 		if (!timeZone) return undefined;
 		settings.timeZone = timeZone;
 		sources.timeZone = "user";
+	}
+	if (Object.hasOwn(value, "responseTiming")) {
+		if (!RESPONSE_TIMING_MODES.includes(value.responseTiming as StampSettings["responseTiming"])) {
+			return undefined;
+		}
+		settings.responseTiming = value.responseTiming as StampSettings["responseTiming"];
+		sources.responseTiming = "user";
 	}
 	return { settings, sources };
 }
@@ -353,6 +362,7 @@ function builtInSources(): Record<StampSettingsField, StampSettingsSource> {
 		dateContext: "built-in",
 		locale: "built-in",
 		timeZone: "built-in",
+		responseTiming: "built-in",
 	};
 }
 

--- a/extensions/pi-stamp/src/stamp.ts
+++ b/extensions/pi-stamp/src/stamp.ts
@@ -1,6 +1,11 @@
 import type { EntryRenderer, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type Component, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
-import { DEFAULT_STAMP_SETTINGS, formatStampLabel, type StampSettings } from "./format.js";
+import {
+	DEFAULT_STAMP_SETTINGS,
+	formatMessageStampLabel,
+	formatStampLabel,
+	type StampSettings,
+} from "./format.js";
 import { showStampMenu } from "./menu.js";
 import { createStampSettingsRuntime, type StampSettingsRuntime } from "./settings.js";
 
@@ -19,10 +24,32 @@ export interface MessageStampDataV2 {
 	previousTimestamp?: number;
 }
 
-export type MessageStampData = MessageStampDataV1 | MessageStampDataV2;
+export interface AssistantMessageStampDataV3 {
+	version: 3;
+	role: "assistant";
+	timestamp: number;
+	previousTimestamp?: number;
+	completedAt: number;
+	firstContentAt?: number;
+}
+
+export type MessageStampData =
+	| MessageStampDataV1
+	| MessageStampDataV2
+	| AssistantMessageStampDataV3;
 
 export interface StampExtensionOptions {
 	settingsRuntime?: StampSettingsRuntime;
+	now?: () => number;
+}
+
+interface AssistantTimingObservation {
+	timestamp: number;
+	firstContentAt?: number;
+}
+
+interface FinalizedAssistantTiming extends AssistantTimingObservation {
+	completedAt: number;
 }
 
 export function formatStampTime(timestamp: number): string | undefined {
@@ -39,13 +66,35 @@ export function isMessageStampData(value: unknown): value is MessageStampData {
 	if (value.version === 1) {
 		return hasOnlyKeys(value, ["version", "role", "timestamp"]);
 	}
+	if (value.version === 2) {
+		return (
+			hasOnlyKeys(value, ["version", "role", "timestamp", "previousTimestamp"]) &&
+			(!Object.hasOwn(value, "previousTimestamp") || isValidTimestamp(value.previousTimestamp))
+		);
+	}
 	if (
-		value.version !== 2 ||
-		!hasOnlyKeys(value, ["version", "role", "timestamp", "previousTimestamp"])
+		value.version !== 3 ||
+		value.role !== "assistant" ||
+		!hasOnlyKeys(value, [
+			"version",
+			"role",
+			"timestamp",
+			"previousTimestamp",
+			"completedAt",
+			"firstContentAt",
+		]) ||
+		!isValidTimestamp(value.completedAt) ||
+		value.completedAt < value.timestamp ||
+		(Object.hasOwn(value, "previousTimestamp") && !isValidTimestamp(value.previousTimestamp))
 	) {
 		return false;
 	}
-	return !Object.hasOwn(value, "previousTimestamp") || isValidTimestamp(value.previousTimestamp);
+	return (
+		!Object.hasOwn(value, "firstContentAt") ||
+		(isValidTimestamp(value.firstContentAt) &&
+			value.firstContentAt >= value.timestamp &&
+			value.firstContentAt <= value.completedAt)
+	);
 }
 
 export function createStampEntryRenderer(
@@ -55,9 +104,17 @@ export function createStampEntryRenderer(
 		if (!isMessageStampData(entry.data)) return undefined;
 		const data = entry.data;
 		return dynamicRightAlignedText(() => {
-			const label = formatStampLabel(
-				data.timestamp,
-				data.version === 2 ? data.previousTimestamp : undefined,
+			const label = formatMessageStampLabel(
+				{
+					timestamp: data.timestamp,
+					...(data.version === 1 ? {} : { previousTimestamp: data.previousTimestamp }),
+					...(data.version === 3
+						? {
+								completedAt: data.completedAt,
+								firstContentAt: data.firstContentAt,
+							}
+						: {}),
+				},
 				getSettings(),
 			);
 			return label ? theme.fg("dim", label) : undefined;
@@ -87,6 +144,7 @@ export default function stampExtension(
 	options: StampExtensionOptions = {},
 ): void {
 	const settingsRuntime = options.settingsRuntime ?? createStampSettingsRuntime();
+	const now = options.now ?? Date.now;
 	pi.registerEntryRenderer(
 		STAMP_ENTRY_TYPE,
 		createStampEntryRenderer(() => settingsRuntime.get().settings),
@@ -96,6 +154,8 @@ export default function stampExtension(
 	let sessionController = new AbortController();
 	let tuiSessionActive = false;
 	let lastStampTimestamp: number | undefined;
+	let activeAssistantTiming: AssistantTimingObservation | undefined;
+	let finalizedAssistantTiming: FinalizedAssistantTiming | undefined;
 	const pendingUserStamps: Array<{ role: "user"; timestamp: number }> = [];
 
 	pi.registerCommand("stamp", {
@@ -117,7 +177,7 @@ export default function stampExtension(
 		},
 	});
 
-	const appendStamp = (role: "user" | "assistant", timestamp: number): void => {
+	const appendVersion2Stamp = (role: "user" | "assistant", timestamp: number): void => {
 		const stamp: MessageStampDataV2 = {
 			version: 2,
 			role,
@@ -129,6 +189,30 @@ export default function stampExtension(
 		lastStampTimestamp = timestamp;
 	};
 
+	const appendAssistantStamp = (
+		timestamp: number,
+		timing: FinalizedAssistantTiming | undefined,
+	): void => {
+		if (!timing || timing.timestamp !== timestamp) {
+			appendVersion2Stamp("assistant", timestamp);
+			return;
+		}
+		const stamp: AssistantMessageStampDataV3 = {
+			version: 3,
+			role: "assistant",
+			timestamp,
+			...(lastStampTimestamp === undefined ? {} : { previousTimestamp: lastStampTimestamp }),
+			completedAt: timing.completedAt,
+			...(timing.firstContentAt === undefined ? {} : { firstContentAt: timing.firstContentAt }),
+		};
+		if (!isMessageStampData(stamp)) {
+			appendVersion2Stamp("assistant", timestamp);
+			return;
+		}
+		pi.appendEntry<AssistantMessageStampDataV3>(STAMP_ENTRY_TYPE, stamp);
+		lastStampTimestamp = timestamp;
+	};
+
 	const flushPendingUsers = (): void => {
 		if (!tuiSessionActive) {
 			pendingUserStamps.length = 0;
@@ -137,7 +221,7 @@ export default function stampExtension(
 		while (pendingUserStamps.length > 0) {
 			const stamp = pendingUserStamps[0];
 			if (!stamp) break;
-			appendStamp(stamp.role, stamp.timestamp);
+			appendVersion2Stamp(stamp.role, stamp.timestamp);
 			pendingUserStamps.shift();
 		}
 	};
@@ -148,6 +232,8 @@ export default function stampExtension(
 		const controller = sessionController;
 		const currentGeneration = ++generation;
 		pendingUserStamps.length = 0;
+		activeAssistantTiming = undefined;
+		finalizedAssistantTiming = undefined;
 		tuiSessionActive = ctx.mode === "tui";
 		lastStampTimestamp = lastStampTimestampFromBranch(ctx.sessionManager.getBranch());
 		try {
@@ -173,23 +259,79 @@ export default function stampExtension(
 		}
 	});
 
-	pi.on("message_end", (event) => {
-		if (!tuiSessionActive || event.message.role !== "user") return;
-		if (!isValidTimestamp(event.message.timestamp)) return;
-		pendingUserStamps.push({ role: "user", timestamp: event.message.timestamp });
+	pi.on("turn_start", () => {
+		activeAssistantTiming = undefined;
+		finalizedAssistantTiming = undefined;
 	});
 
-	pi.on("message_start", () => {
+	pi.on("message_start", (event) => {
 		flushPendingUsers();
+		if (
+			!tuiSessionActive ||
+			event.message.role !== "assistant" ||
+			!isValidTimestamp(event.message.timestamp)
+		) {
+			return;
+		}
+		activeAssistantTiming = { timestamp: event.message.timestamp };
+		finalizedAssistantTiming = undefined;
+	});
+
+	pi.on("message_update", (event) => {
+		if (
+			!tuiSessionActive ||
+			event.message.role !== "assistant" ||
+			!activeAssistantTiming ||
+			activeAssistantTiming.timestamp !== event.message.timestamp ||
+			activeAssistantTiming.firstContentAt !== undefined ||
+			!isMeaningfulAssistantUpdate(event.assistantMessageEvent)
+		) {
+			return;
+		}
+		const firstContentAt = now();
+		if (isValidTimestamp(firstContentAt)) activeAssistantTiming.firstContentAt = firstContentAt;
+	});
+
+	pi.on("message_end", (event) => {
+		if (!tuiSessionActive || !isValidTimestamp(event.message.timestamp)) return;
+		if (event.message.role === "user") {
+			pendingUserStamps.push({ role: "user", timestamp: event.message.timestamp });
+			return;
+		}
+		if (event.message.role !== "assistant") return;
+		const completedAt = now();
+		if (!isValidTimestamp(completedAt) || completedAt < event.message.timestamp) {
+			activeAssistantTiming = undefined;
+			finalizedAssistantTiming = undefined;
+			return;
+		}
+		const firstContentAt =
+			activeAssistantTiming?.timestamp === event.message.timestamp &&
+			isValidTimestamp(activeAssistantTiming.firstContentAt) &&
+			activeAssistantTiming.firstContentAt >= event.message.timestamp &&
+			activeAssistantTiming.firstContentAt <= completedAt
+				? activeAssistantTiming.firstContentAt
+				: undefined;
+		finalizedAssistantTiming = {
+			timestamp: event.message.timestamp,
+			completedAt,
+			...(firstContentAt === undefined ? {} : { firstContentAt }),
+		};
+		activeAssistantTiming = undefined;
 	});
 
 	pi.on("turn_end", (event) => {
 		if (!tuiSessionActive || event.message.role !== "assistant") return;
-		appendStamp("assistant", event.message.timestamp);
+		const timing = finalizedAssistantTiming;
+		activeAssistantTiming = undefined;
+		finalizedAssistantTiming = undefined;
+		appendAssistantStamp(event.message.timestamp, timing);
 	});
 
 	pi.on("agent_end", () => {
 		flushPendingUsers();
+		activeAssistantTiming = undefined;
+		finalizedAssistantTiming = undefined;
 	});
 
 	pi.on("session_shutdown", async () => {
@@ -197,6 +339,8 @@ export default function stampExtension(
 		generation += 1;
 		flushPendingUsers();
 		pendingUserStamps.length = 0;
+		activeAssistantTiming = undefined;
+		finalizedAssistantTiming = undefined;
 		tuiSessionActive = false;
 		lastStampTimestamp = undefined;
 		await settingsRuntime.flush();
@@ -216,6 +360,21 @@ function lastStampTimestampFromBranch(entries: readonly unknown[]): number | und
 		}
 	}
 	return undefined;
+}
+
+function isMeaningfulAssistantUpdate(value: unknown): boolean {
+	if (!isRecord(value) || typeof value.type !== "string") return false;
+	if (
+		value.type === "text_delta" ||
+		value.type === "thinking_delta" ||
+		value.type === "toolcall_delta"
+	) {
+		return typeof value.delta === "string" && value.delta.length > 0;
+	}
+	if (value.type === "text_end" || value.type === "thinking_end") {
+		return typeof value.content === "string" && value.content.length > 0;
+	}
+	return value.type === "toolcall_end" && isRecord(value.toolCall);
 }
 
 function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {

--- a/extensions/pi-stamp/test/format.test.ts
+++ b/extensions/pi-stamp/test/format.test.ts
@@ -4,7 +4,10 @@ import {
 	canonicalizeLocale,
 	canonicalizeTimeZone,
 	DEFAULT_STAMP_SETTINGS,
+	formatMessageStampLabel,
+	formatResponseElapsed,
 	formatStampLabel,
+	RESPONSE_TIMING_MODES,
 } from "../src/format.js";
 
 const BEFORE_MIDNIGHT_UTC = Date.UTC(2026, 6, 29, 23, 59, 58);
@@ -117,4 +120,74 @@ test("formatStampLabel rejects invalid timestamps", () => {
 		undefined,
 	);
 	assert.equal(formatStampLabel(10 ** 20, undefined, DEFAULT_STAMP_SETTINGS, UTC_ENV), undefined);
+});
+
+test("response timing modes preserve the default and compose with date context", () => {
+	assert.deepEqual(RESPONSE_TIMING_MODES, ["off", "duration", "detailed"]);
+	const input = {
+		timestamp: AFTER_MIDNIGHT_UTC,
+		previousTimestamp: BEFORE_MIDNIGHT_UTC,
+		completedAt: AFTER_MIDNIGHT_UTC + 3_200,
+		firstContentAt: AFTER_MIDNIGHT_UTC + 800,
+	};
+	assert.equal(
+		formatMessageStampLabel(input, DEFAULT_STAMP_SETTINGS, UTC_ENV),
+		"2026-07-30 · 00:01:02",
+	);
+	assert.equal(
+		formatMessageStampLabel(
+			input,
+			{ ...DEFAULT_STAMP_SETTINGS, responseTiming: "duration" },
+			UTC_ENV,
+		),
+		"2026-07-30 · 00:01:02 · 3.2s",
+	);
+	assert.equal(
+		formatMessageStampLabel(
+			input,
+			{ ...DEFAULT_STAMP_SETTINGS, responseTiming: "detailed" },
+			UTC_ENV,
+		),
+		"2026-07-30 · 00:01:02 · first 0.8s · total 3.2s",
+	);
+});
+
+test("response timing labels unavailable first content without fabricating legacy timing", () => {
+	const detailed = { ...DEFAULT_STAMP_SETTINGS, responseTiming: "detailed" } as const;
+	assert.equal(
+		formatMessageStampLabel(
+			{ timestamp: AFTER_MIDNIGHT_UTC, completedAt: AFTER_MIDNIGHT_UTC + 1_500 },
+			detailed,
+			UTC_ENV,
+		),
+		"00:01:02 · first n/a · total 1.5s",
+	);
+	assert.equal(
+		formatMessageStampLabel({ timestamp: AFTER_MIDNIGHT_UTC }, detailed, UTC_ENV),
+		"00:01:02",
+	);
+	assert.equal(
+		formatMessageStampLabel(
+			{
+				timestamp: AFTER_MIDNIGHT_UTC,
+				completedAt: AFTER_MIDNIGHT_UTC + 1_500,
+				firstContentAt: AFTER_MIDNIGHT_UTC - 1,
+			},
+			detailed,
+			UTC_ENV,
+		),
+		"00:01:02 · first n/a · total 1.5s",
+	);
+});
+
+test("response elapsed formatting is exact at boundaries and rejects invalid values", () => {
+	assert.equal(formatResponseElapsed(0), "0.0s");
+	assert.equal(formatResponseElapsed(1), "<0.1s");
+	assert.equal(formatResponseElapsed(99), "<0.1s");
+	assert.equal(formatResponseElapsed(100), "0.1s");
+	assert.equal(formatResponseElapsed(3_249), "3.2s");
+	assert.equal(formatResponseElapsed(3_250), "3.3s");
+	assert.equal(formatResponseElapsed(-1), undefined);
+	assert.equal(formatResponseElapsed(Number.NaN), undefined);
+	assert.equal(formatResponseElapsed(Number.POSITIVE_INFINITY), undefined);
 });

--- a/extensions/pi-stamp/test/menu.test.ts
+++ b/extensions/pi-stamp/test/menu.test.ts
@@ -33,13 +33,16 @@ test("stamp menu exposes Main, Settings, Status, Help, and read-only invalid sta
 			["dateContext", "Day changes"],
 			["locale", "Invariant"],
 			["timeZone", "Local"],
+			["responseTiming", "Off"],
 		],
 	);
+	assert.match((main.lines ?? []).join("\n"), /Timing off/u);
 
 	const status = resolveMenuScreen(menu, "status", state);
 	assert.equal(status.kind, "detail");
 	if (status.kind !== "detail") assert.fail("Expected detail screen");
 	assert.match(status.lines.join("\n"), /24-hour.*Built-in/u);
+	assert.match(status.lines.join("\n"), /Response timing: Off · Built-in/u);
 	assert.match(status.lines.join("\n"), /\/tmp\/pi-stamp\.json/u);
 
 	const invalidState = {
@@ -88,10 +91,34 @@ test("bounded setting actions persist exact patches", async () => {
 		itemId: "dateContext",
 		value: "Always",
 	});
+	await menu.actions["set-response-timing"]({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "responseTiming",
+		value: "Duration",
+	});
+	await menu.actions["set-response-timing"]({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "responseTiming",
+		value: "Detailed",
+	});
+	await menu.actions["set-response-timing"]({
+		ctx,
+		state: runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "responseTiming",
+		value: "Off",
+	});
 	assert.deepEqual(runtime.patches, [
 		{ hourCycle: "12h" },
 		{ showSeconds: false },
 		{ dateContext: "always" },
+		{ responseTiming: "duration" },
+		{ responseTiming: "detailed" },
+		{ responseTiming: "off" },
 	]);
 	assert.equal(notifications.at(-1)?.level, "info");
 });
@@ -188,6 +215,7 @@ function memorySettingsRuntime(
 			dateContext: "built-in",
 			locale: "built-in",
 			timeZone: "built-in",
+			responseTiming: "built-in",
 		},
 		canSave: true,
 	};

--- a/extensions/pi-stamp/test/settings.test.ts
+++ b/extensions/pi-stamp/test/settings.test.ts
@@ -40,6 +40,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 			hourCycle: "12h",
 			locale: "EN-us",
 			timeZone: "utc",
+			responseTiming: "detailed",
 			future: { retained: true },
 		}),
 		{
@@ -48,6 +49,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 				hourCycle: "12h",
 				locale: "en-US",
 				timeZone: "UTC",
+				responseTiming: "detailed",
 			},
 			sources: {
 				hourCycle: "user",
@@ -55,6 +57,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 				dateContext: "built-in",
 				locale: "user",
 				timeZone: "user",
+				responseTiming: "user",
 			},
 		},
 	);
@@ -66,8 +69,16 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 		{ dateContext: "sometimes" },
 		{ locale: "not_a_locale" },
 		{ timeZone: "Moon/Base" },
+		{ responseTiming: "sometimes" },
+		{ responseTiming: false },
 	]) {
 		assert.equal(normalizeStampSettingsDocument(value), undefined);
+	}
+	for (const responseTiming of ["off", "duration", "detailed"] as const) {
+		assert.equal(
+			normalizeStampSettingsDocument({ responseTiming })?.settings.responseTiming,
+			responseTiming,
+		);
 	}
 });
 
@@ -81,17 +92,21 @@ test("updates preserve unknown and omitted fields and publish private JSON atomi
 	const runtime = createStampSettingsRuntime({ path: settingsPath });
 	await runtime.reload();
 	await runtime.update({ hourCycle: "12h" });
+	await runtime.update({ responseTiming: "duration" });
 
 	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
 		showSeconds: false,
 		future: { retained: true },
 		hourCycle: "12h",
+		responseTiming: "duration",
 	});
 	assert.deepEqual(runtime.get().settings, {
 		...DEFAULT_STAMP_SETTINGS,
 		showSeconds: false,
 		hourCycle: "12h",
+		responseTiming: "duration",
 	});
+	assert.equal(runtime.get().sources.responseTiming, "user");
 	if (process.platform !== "win32") {
 		assert.equal(statSync(settingsPath).mode & 0o777, 0o600);
 	}

--- a/extensions/pi-stamp/test/stamp.test.ts
+++ b/extensions/pi-stamp/test/stamp.test.ts
@@ -28,9 +28,11 @@ test("stamp registers one entry renderer, one menu command, and no tools", () =>
 		"agent_end",
 		"message_end",
 		"message_start",
+		"message_update",
 		"session_shutdown",
 		"session_start",
 		"turn_end",
+		"turn_start",
 	]);
 });
 
@@ -41,7 +43,7 @@ test("formatStampTime uses zero-padded local 24-hour time and rejects invalid va
 	assert.equal(formatStampTime(10 ** 20), undefined);
 });
 
-test("isMessageStampData accepts exact finite version 1 and version 2 schemas", () => {
+test("isMessageStampData accepts exact finite version 1, version 2, and assistant version 3 schemas", () => {
 	assert.equal(isMessageStampData({ version: 1, role: "user", timestamp: USER_TIMESTAMP }), true);
 	assert.equal(
 		isMessageStampData({ version: 2, role: "assistant", timestamp: ASSISTANT_TIMESTAMP }),
@@ -74,6 +76,48 @@ test("isMessageStampData accepts exact finite version 1 and version 2 schemas", 
 		}),
 		false,
 	);
+	assert.equal(
+		isMessageStampData({
+			version: 3,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			previousTimestamp: USER_TIMESTAMP - 1_000,
+			completedAt: USER_TIMESTAMP + 3_200,
+			firstContentAt: USER_TIMESTAMP + 800,
+		}),
+		true,
+	);
+	for (const value of [
+		{
+			version: 3,
+			role: "user",
+			timestamp: USER_TIMESTAMP,
+			completedAt: USER_TIMESTAMP + 1_000,
+		},
+		{ version: 3, role: "assistant", timestamp: USER_TIMESTAMP },
+		{
+			version: 3,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			completedAt: USER_TIMESTAMP - 1,
+		},
+		{
+			version: 3,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			completedAt: USER_TIMESTAMP + 1_000,
+			firstContentAt: USER_TIMESTAMP + 2_000,
+		},
+		{
+			version: 3,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			completedAt: USER_TIMESTAMP + 1_000,
+			future: true,
+		},
+	]) {
+		assert.equal(isMessageStampData(value), false);
+	}
 	assert.equal(
 		isMessageStampData({ version: 1, role: "toolResult", timestamp: USER_TIMESTAMP }),
 		false,
@@ -108,10 +152,34 @@ test("entry renderer reads live settings, uses the callback theme, and stays wid
 	assert.equal(component.render(30).join("\n"), "         2026-07-30 · 00:01:02");
 	settings = { ...settings, showSeconds: false, dateContext: "never" };
 	assert.equal(component.render(12).join("\n"), "       00:01");
+	settings = { ...settings, showSeconds: true, responseTiming: "duration" };
+	const timedComponent = renderer(
+		{
+			data: {
+				version: 3,
+				role: "assistant",
+				timestamp: Date.UTC(2026, 6, 30, 0, 1, 2),
+				completedAt: Date.UTC(2026, 6, 30, 0, 1, 5, 200),
+				firstContentAt: Date.UTC(2026, 6, 30, 0, 1, 2, 800),
+			},
+		} as never,
+		{ expanded: false },
+		{ fg: (_color: string, text: string) => text } as never,
+	);
+	assert.ok(timedComponent);
+	assert.equal(timedComponent.render(50).join("\n").trim(), "00:01:02 · 3.2s");
+	settings = { ...settings, responseTiming: "detailed" };
+	assert.equal(
+		timedComponent.render(50).join("\n"),
+		"                00:01:02 · first 0.8s · total 3.2s",
+	);
 	assert.deepEqual(colors, ["dim", "dim"]);
+	const renderedComponents = [component, timedComponent];
 	for (const width of [1, 4, 8, 10]) {
-		for (const line of component.render(width)) {
-			assert.ok(visibleWidth(line) <= width, `${JSON.stringify(line)} exceeded width ${width}`);
+		for (const renderedComponent of renderedComponents) {
+			for (const line of renderedComponent.render(width)) {
+				assert.ok(visibleWidth(line) <= width, `${JSON.stringify(line)} exceeded width ${width}`);
+			}
 		}
 	}
 
@@ -126,10 +194,12 @@ test("Pi persists stamp entries across reopen without adding them to model conte
 	t.after(() => rmSync(sessionDir, { recursive: true, force: true }));
 	const session = SessionManager.create(process.cwd(), sessionDir);
 	const stampData = {
-		version: 2,
-		role: "user",
+		version: 3,
+		role: "assistant",
 		timestamp: USER_TIMESTAMP,
 		previousTimestamp: USER_TIMESTAMP - 1_000,
+		completedAt: USER_TIMESTAMP + 3_200,
+		firstContentAt: USER_TIMESTAMP + 800,
 	} as const;
 
 	session.appendMessage(userMessage(USER_TIMESTAMP));
@@ -154,9 +224,10 @@ test("Pi persists stamp entries across reopen without adding them to model conte
 	);
 });
 
-test("TUI lifecycle appends one user stamp before the assistant and one assistant stamp at turn end", async () => {
+test("TUI lifecycle appends one user stamp before the assistant and measured assistant timing at turn end", async () => {
 	const mock = createMockPi();
-	stamp(mock.pi);
+	const times = [ASSISTANT_TIMESTAMP + 800, ASSISTANT_TIMESTAMP + 3_200];
+	stamp(mock.pi, { now: () => times.shift() ?? assert.fail("Unexpected clock read") });
 	const { ctx } = createMockContext({ mode: "tui" });
 	const user = userMessage(USER_TIMESTAMP);
 	const assistant = assistantMessage(ASSISTANT_TIMESTAMP);
@@ -168,12 +239,32 @@ test("TUI lifecycle appends one user stamp before the assistant and one assistan
 
 	await emit(mock, "message_start", { message: assistant }, ctx);
 	assert.deepEqual(mock.entries, [stampEntry("user", USER_TIMESTAMP)]);
-
+	await emit(
+		mock,
+		"message_update",
+		{ message: assistant, assistantMessageEvent: { type: "text_start", contentIndex: 0 } },
+		ctx,
+	);
+	await emit(
+		mock,
+		"message_update",
+		{ message: assistant, assistantMessageEvent: { type: "text_delta", delta: "" } },
+		ctx,
+	);
+	await emit(
+		mock,
+		"message_update",
+		{ message: assistant, assistantMessageEvent: { type: "text_delta", delta: "hello" } },
+		ctx,
+	);
 	await emit(mock, "message_end", { message: assistant }, ctx);
 	await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
 	assert.deepEqual(mock.entries, [
 		stampEntry("user", USER_TIMESTAMP),
-		stampEntry("assistant", ASSISTANT_TIMESTAMP, USER_TIMESTAMP),
+		timedAssistantStamp(ASSISTANT_TIMESTAMP, ASSISTANT_TIMESTAMP + 3_200, {
+			previousTimestamp: USER_TIMESTAMP,
+			firstContentAt: ASSISTANT_TIMESTAMP + 800,
+		}),
 	]);
 
 	await emit(mock, "agent_end", { messages: [user, assistant] }, ctx);
@@ -181,6 +272,75 @@ test("TUI lifecycle appends one user stamp before the assistant and one assistan
 	assert.equal(mock.entries.length, 2);
 	assert.deepEqual(mock.sentMessages, []);
 	assert.deepEqual(mock.sentUserMessages, []);
+});
+
+test("thinking, completed blocks, and tool calls can be the first meaningful assistant content", async () => {
+	const events = [
+		{ type: "thinking_delta", delta: "reasoning" },
+		{ type: "text_end", content: "complete" },
+		{ type: "toolcall_end", toolCall: { id: "call-1", name: "read", arguments: {} } },
+	] as const;
+	for (const [index, assistantMessageEvent] of events.entries()) {
+		const mock = createMockPi();
+		const timestamp = ASSISTANT_TIMESTAMP + index * 10_000;
+		let now = timestamp + 700;
+		stamp(mock.pi, { now: () => now });
+		const { ctx } = createMockContext({ mode: "tui" });
+		const assistant = assistantMessage(timestamp);
+		await emit(mock, "session_start", { reason: "startup" }, ctx);
+		await emit(mock, "turn_start", { turnIndex: 0, timestamp: timestamp - 10 }, ctx);
+		await emit(mock, "message_start", { message: assistant }, ctx);
+		await emit(mock, "message_update", { message: assistant, assistantMessageEvent }, ctx);
+		now = timestamp + 2_000;
+		await emit(mock, "message_end", { message: assistant }, ctx);
+		now = timestamp + 20_000;
+		await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
+		assert.deepEqual(
+			mock.entries,
+			[timedAssistantStamp(timestamp, timestamp + 2_000, { firstContentAt: timestamp + 700 })],
+			assistantMessageEvent.type,
+		);
+	}
+});
+
+test("missing first content stays unavailable and tool execution does not extend completion", async () => {
+	const mock = createMockPi();
+	let now = ASSISTANT_TIMESTAMP + 3_200;
+	stamp(mock.pi, { now: () => now });
+	const { ctx } = createMockContext({ mode: "tui" });
+	const assistant = assistantMessage(ASSISTANT_TIMESTAMP, "toolUse");
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await emit(mock, "message_start", { message: assistant }, ctx);
+	await emit(mock, "message_end", { message: assistant }, ctx);
+	now = ASSISTANT_TIMESTAMP + 30_000;
+	await emit(
+		mock,
+		"message_end",
+		{
+			message: {
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read",
+				content: [],
+				isError: false,
+				timestamp: now,
+			},
+		},
+		ctx,
+	);
+	await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
+	assert.deepEqual(mock.entries, [
+		timedAssistantStamp(ASSISTANT_TIMESTAMP, ASSISTANT_TIMESTAMP + 3_200),
+	]);
+	const renderer = createStampEntryRenderer(() => ({
+		...DEFAULT_STAMP_SETTINGS,
+		responseTiming: "detailed",
+	}));
+	const component = renderer({ data: mock.entries[0]?.data } as never, { expanded: false }, {
+		fg: (_color: string, text: string) => text,
+	} as never);
+	assert.ok(component);
+	assert.match(component.render(80).join("\n"), /first n\/a · total 3\.2s$/u);
 });
 
 test("successive user messages flush in source order at the following message boundaries", async () => {
@@ -201,6 +361,89 @@ test("successive user messages flush in source order at the following message bo
 		stampEntry("user", USER_TIMESTAMP),
 		stampEntry("user", USER_TIMESTAMP + 1_000, USER_TIMESTAMP),
 	]);
+});
+
+test("error and aborted assistant messages retain completion timing", async () => {
+	for (const [index, stopReason] of ["error", "aborted"].entries()) {
+		const mock = createMockPi();
+		const timestamp = ASSISTANT_TIMESTAMP + index * 10_000;
+		stamp(mock.pi, { now: () => timestamp + 1_500 });
+		const { ctx } = createMockContext({ mode: "tui" });
+		const assistant = assistantMessage(timestamp, stopReason as "error" | "aborted");
+		await emit(mock, "session_start", { reason: "startup" }, ctx);
+		await emit(mock, "message_start", { message: assistant }, ctx);
+		await emit(mock, "message_end", { message: assistant }, ctx);
+		await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
+		assert.deepEqual(mock.entries, [timedAssistantStamp(timestamp, timestamp + 1_500)]);
+	}
+});
+
+test("mismatched and reversed timing degrades without leaking into a later response", async () => {
+	const mock = createMockPi();
+	let now = ASSISTANT_TIMESTAMP + 500;
+	stamp(mock.pi, { now: () => now });
+	const { ctx } = createMockContext({ mode: "tui" });
+	const first = assistantMessage(ASSISTANT_TIMESTAMP);
+	const mismatch = assistantMessage(ASSISTANT_TIMESTAMP + 1_000);
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await emit(mock, "message_start", { message: first }, ctx);
+	await emit(
+		mock,
+		"message_update",
+		{ message: first, assistantMessageEvent: { type: "text_delta", delta: "x" } },
+		ctx,
+	);
+	now = ASSISTANT_TIMESTAMP + 900;
+	await emit(mock, "message_end", { message: first }, ctx);
+	await emit(mock, "turn_end", { message: mismatch, toolResults: [], turnIndex: 0 }, ctx);
+
+	const reversed = assistantMessage(ASSISTANT_TIMESTAMP + 2_000);
+	await emit(mock, "turn_start", { turnIndex: 1, timestamp: ASSISTANT_TIMESTAMP + 1_500 }, ctx);
+	await emit(mock, "message_start", { message: reversed }, ctx);
+	now = reversed.timestamp - 1;
+	await emit(mock, "message_end", { message: reversed }, ctx);
+	await emit(mock, "turn_end", { message: reversed, toolResults: [], turnIndex: 1 }, ctx);
+
+	assert.deepEqual(mock.entries, [
+		stampEntry("assistant", mismatch.timestamp),
+		stampEntry("assistant", reversed.timestamp, mismatch.timestamp),
+	]);
+});
+
+test("an out-of-order first-content clock is omitted while valid completion remains", async () => {
+	const mock = createMockPi();
+	let now = ASSISTANT_TIMESTAMP - 1;
+	stamp(mock.pi, { now: () => now });
+	const { ctx } = createMockContext({ mode: "tui" });
+	const assistant = assistantMessage(ASSISTANT_TIMESTAMP);
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await emit(mock, "message_start", { message: assistant }, ctx);
+	await emit(
+		mock,
+		"message_update",
+		{ message: assistant, assistantMessageEvent: { type: "text_delta", delta: "x" } },
+		ctx,
+	);
+	now = ASSISTANT_TIMESTAMP + 1_000;
+	await emit(mock, "message_end", { message: assistant }, ctx);
+	await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, ctx);
+	assert.deepEqual(mock.entries, [
+		timedAssistantStamp(ASSISTANT_TIMESTAMP, ASSISTANT_TIMESTAMP + 1_000),
+	]);
+});
+
+test("session replacement clears finalized timing owned by the prior session", async () => {
+	const mock = createMockPi();
+	stamp(mock.pi, { now: () => ASSISTANT_TIMESTAMP + 2_000 });
+	const first = createMockContext({ mode: "tui" });
+	const second = createMockContext({ mode: "tui" });
+	const assistant = assistantMessage(ASSISTANT_TIMESTAMP);
+	await emit(mock, "session_start", { reason: "startup" }, first.ctx);
+	await emit(mock, "message_start", { message: assistant }, first.ctx);
+	await emit(mock, "message_end", { message: assistant }, first.ctx);
+	await emit(mock, "session_start", { reason: "resume" }, second.ctx);
+	await emit(mock, "turn_end", { message: assistant, toolResults: [], turnIndex: 0 }, second.ctx);
+	assert.deepEqual(mock.entries, [stampEntry("assistant", ASSISTANT_TIMESTAMP)]);
 });
 
 test("assistant tool and error turns receive one stamp without stamping tool results", async () => {
@@ -249,7 +492,17 @@ test("session start rebuilds the predecessor cursor from the active branch", asy
 				{
 					type: "custom",
 					customType: STAMP_ENTRY_TYPE,
-					data: { version: 1, role: "user", timestamp: previous },
+					data: { version: 1, role: "user", timestamp: previous - 60_000 },
+				},
+				{
+					type: "custom",
+					customType: STAMP_ENTRY_TYPE,
+					data: {
+						version: 3,
+						role: "assistant",
+						timestamp: previous,
+						completedAt: previous + 2_000,
+					},
 				},
 			],
 		},
@@ -379,11 +632,34 @@ function stampEntry(role: "user" | "assistant", timestamp: number, previousTimes
 	};
 }
 
+function timedAssistantStamp(
+	timestamp: number,
+	completedAt: number,
+	options: { previousTimestamp?: number; firstContentAt?: number } = {},
+) {
+	return {
+		customType: STAMP_ENTRY_TYPE,
+		data: {
+			version: 3,
+			role: "assistant",
+			timestamp,
+			...(options.previousTimestamp === undefined
+				? {}
+				: { previousTimestamp: options.previousTimestamp }),
+			completedAt,
+			...(options.firstContentAt === undefined ? {} : { firstContentAt: options.firstContentAt }),
+		},
+	};
+}
+
 function userMessage(timestamp: number) {
 	return { role: "user" as const, content: "hello", timestamp };
 }
 
-function assistantMessage(timestamp: number, stopReason: "stop" | "toolUse" | "error" = "stop") {
+function assistantMessage(
+	timestamp: number,
+	stopReason: "stop" | "toolUse" | "error" | "aborted" = "stop",
+) {
 	return {
 		role: "assistant" as const,
 		content: [{ type: "text" as const, text: "hello" }],
@@ -423,6 +699,7 @@ function defaultSettingsState(): Readonly<StampSettingsState> {
 			dateContext: "built-in",
 			locale: "built-in",
 			timeZone: "built-in",
+			responseTiming: "built-in",
 		},
 		canSave: true,
 	};


### PR DESCRIPTION
## Summary

- persist version-3 assistant stamps with extension-observed completion and optional first-content times
- add opt-in `responseTiming` modes for compact duration or labeled first/total timing while preserving the timestamp-only default
- extend `/stamp`, settings validation/persistence, documentation, and the Phase 3 roadmap status

## Verification

- `npm test` — 1,802 tests passed
- `npm run check`
- `npm run check --workspace @narumitw/pi-stamp`
- `just pack stamp` — inspected the exact eight-file package
- offline Pi package load via `pi -e ./extensions/pi-stamp --list-models`
- programmatic TUI lifecycle/render smoke covering default, duration, detailed/no-update, tool-use exclusion, reload, and resume

## Semantic audit

Reviewed against `docs/extension-conventions.md`, `docs/extension-settings.md`, and Pi's extension, session-format, TUI, and package documentation. Settings ordering/rollback, malformed-file protection, cancellation/disposal, session replacement, shutdown, persisted compatibility, width/theme behavior, non-TUI safety, and package contents pass with no accepted deviation.
