### PR TITLE
feat(tui-kit): match Pi settings presentation

### DIFF
--- a/docs/plans/archived/2026-07-30_pi-tui-kit-native-settings-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-native-settings-plan.md
@@ -1,0 +1,126 @@
+# Pi TUI Kit Native Settings Presentation Plan
+
+## Goal
+
+Make `@narumitw/pi-tui-kit` TUI settings screens follow Pi's built-in `/settings` visual and
+keyboard pattern while preserving the kit's declarative API, stable row identity, disabled-row
+behavior, serialized immediate saves, rollback, navigation, RPC adaptation, and lifecycle safety.
+
+## Context
+
+- `packages/pi-tui-kit/src/screen-components.ts` currently renders settings with a package-owned
+  selector because Pi's public `SettingsList` cannot initialize a restored cursor, enforce disabled
+  rows, or expose its search input for focus forwarding.
+- The current selector lacks the built-in search row, aligned label/value columns, ten-row viewport,
+  native-style hint, and dynamic borders shown by Pi's `/settings` screen.
+- Existing consumers use `SettingsScreen.title` and `SettingsScreen.lines` for extension identity,
+  effective scope, settings paths, and failure notices; those capabilities must remain visible.
+- Applicable guidance: `docs/extension-conventions.md`, `docs/extension-settings.md`, Pi's complete
+  `docs/tui.md`, and the `designing-user-interfaces` skill. The relevant MUST audits are width-safe
+  rendering, callback-provided theme/keybindings, render requests after state changes, IME focus
+  forwarding, cancellation/disposal, stale async continuation safety, deterministic tests, root
+  `npm run check`, and package-content verification.
+
+## Architecture
+
+- Keep `SettingsScreen`, `MenuSettingItem`, `runMenu()`, RPC behavior, and
+  `PI_EXTENSION_MENU_API_VERSION` unchanged; this is a TUI-only presentation and interaction update,
+  not a public schema change.
+- Retain a package-owned settings adapter rather than importing Pi's private
+  `SettingsSelectorComponent` or delegating state to public `SettingsList`. Use only public
+  primitives: `Input`, `fuzzyFilter`, width utilities, `Focusable`, and `DynamicBorder` with an
+  explicit callback-provided color function.
+- Preserve the existing title and supporting lines as a visible header, then render a Pi-style search
+  field, aligned settings rows, bounded viewport and position indicator, selected-row description,
+  keyboard hint, and closing border. Disabled state remains textual as well as themed so color is not
+  its only signal.
+- Keep raw item IDs and values separate from sanitized display/search projections. Filtering and
+  cursor movement operate on stable item identities; action callbacks continue receiving unchanged
+  raw values.
+- Make the settings component implement `Focusable` and forward `focused` to its embedded `Input` so
+  IME candidate placement remains correct. Menu keys are handled before search input, preserving
+  injected navigation/confirm/cancel bindings and `Ctrl+C` close behavior.
+- Keep the existing promise queue, committed/displayed value maps, rejection rollback, transition
+  draining, and disposal guards as the sole owner of asynchronous setting changes.
+
+## Non-Goals
+
+- Do not restyle action, detail, multi-select, RPC, print, or JSON screens.
+- Do not change extension-owned persistence, validation, precedence, or settings files.
+- Do not add free-form setting values, submenus, or new public settings-screen options.
+- Do not depend on Pi private modules or copy Pi's complete settings implementation.
+
+## Assumptions
+
+- All kit settings screens should expose search, including short lists, to match the requested Pi
+  presentation without adding a new opt-in API.
+- The selector body should match Pi, but extension-owned titles and supporting lines remain visible
+  because removing them would hide scope, path, and recovery information used by current consumers.
+- Escape remains Back within a menu and `Ctrl+C` remains Close. The hint should use Pi-like wording
+  without claiming that Escape rolls back changes that were already saved.
+
+## Risks
+
+- Search can desynchronize filtered indexes from stable rows; tests must activate, restore, and roll
+  back by item ID rather than display index.
+- A hidden or unforwarded `Input` focus would regress CJK IME positioning; test the structural
+  `Focusable` contract directly.
+- Native-looking alignment can exceed narrow terminal widths or mishandle ANSI/wide characters;
+  calculate columns with `visibleWidth()` and bound every line with `truncateToWidth()` or
+  `wrapTextWithAnsi()`.
+- Pi may change its built-in styling later. Keep parity expressed through public theme tokens and
+  focused behavioral tests rather than importing private source.
+
+## Plan
+
+- [x] Add focused red tests in `packages/pi-tui-kit/test/screen-components.test.ts` for the Pi-style
+      search row, aligned label/value columns, ten-row viewport and `(n/total)` indicator,
+      selected-row description, native-style hint, explicit borders, empty/no-match states, and
+      narrow/wide-character width safety; verified the focused run failed on the absent border and
+      no-match presentation before implementation.
+- [x] Add focused interaction tests in `packages/pi-tui-kit/test/screen-components.test.ts` proving
+      fuzzy search uses sanitized labels, filtered activation retains raw IDs/values, initial and
+      moved selections remain stable by ID, disabled rows cannot activate, custom keybindings and
+      `Ctrl+C` retain Back/Close semantics, and `focused` is forwarded to the search `Input`; verified
+      the focused run failed because filtering and the `Focusable` contract were absent.
+- [x] Refactor only the settings adapter in
+      `packages/pi-tui-kit/src/screen-components.ts` to compose the visible header, explicitly themed
+      `DynamicBorder`, focus-forwarded `Input`, fuzzy-filtered stable row model, native column layout,
+      ten-row viewport, description, and keybinding-aware hint while preserving existing async queue,
+      rollback, transition, disposal, and render-request behavior; the focused component suite passes
+      all 20 tests.
+- [x] Extend `packages/pi-tui-kit/test/runtime.test.ts` only where component-level coverage cannot
+      prove runtime integration, specifically cursor restoration after a filtered/changed row and
+      draining of pending saves when search is present; `npm test` passes all 1,807 tests, including
+      existing TUI, RPC, stale-session, cancellation, and disposal coverage.
+- [x] Update `packages/pi-tui-kit/README.md` to document that settings screens use Pi-style search,
+      aligned rows, immediate changes, Back/Close behavior, and IME-safe focus while retaining the
+      package-owned adapter rationale and ownership boundary; package typechecking includes and passes
+      the README usage fixture.
+- [x] Rebuild ignored publication output in `packages/pi-tui-kit/dist/` with
+      `npm run build --workspace @narumitw/pi-tui-kit`, inspect generated JavaScript/declarations for
+      source parity and absence of unrelated output, and verify `npm run check --workspace
+      @narumitw/pi-tui-kit` passes; the package check and generated-output inspection passed.
+- [x] Audit the final diff against the TUI and settings touched-area rules—width bounds, theme
+      invalidation, render requests, focus forwarding, stable raw payloads, disabled rows, user
+      cancellation, component disposal, session replacement, shutdown, and every post-`await`
+      continuation; focused and runtime tests cover each applicable path, and the retained custom
+      adapter deviation is documented beside the implementation and in the README.
+- [x] Run the CI-equivalent `npm run check`, then run `just pack-tui-kit` and inspect the tarball list
+      for the expected README, license, built JavaScript, and declarations only; `npm run check` passed
+      all 1,807 tests and the dry run contained the expected 15 files with no tarball artifact left.
+
+## Completion Checklist
+
+- [x] A representative kit settings screen visibly matches Pi's settings-list pattern at normal
+      terminal widths while retaining its extension title and supporting context; a generated-output
+      smoke rendered the border, search field, aligned rows, viewport indicator, description, and hint.
+- [x] Search, navigation, activation, Back, Close, disabled rows, rejection rollback, rapid serialized
+      updates, and cursor restoration are covered by deterministic passing tests.
+- [x] The embedded search input satisfies the `Focusable`/IME contract, and every rendered line stays
+      within its supplied width, including widths from one column and CJK content.
+- [x] Public menu types, API version, RPC behavior, and consumer-owned persistence semantics remain
+      unchanged.
+- [x] `packages/pi-tui-kit/README.md` and generated `packages/pi-tui-kit/dist/` match the implementation.
+- [x] `npm run check` and `just pack-tui-kit` pass, the semantic convention audit is complete, and no
+      known required work remains.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -101,13 +101,22 @@ remain pure projections of current extension state.
 - **`actions`** — navigation targets, domain actions, close rows, and optional cancellable busy
   labels.
 - **`detail`** — read-only wrapped text with Back or Close behavior.
-- **`settings`** — immediate value changes with serialized saves and rollback when an action rejects.
+- **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
+  serialized saves, and rollback when an action rejects.
 - **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback,
   selected-row descriptions, optional bulk action rows, and a bounded TUI viewport.
 
 All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed
 content after invalidation, and bound rendered output to the supplied terminal width. Escape follows
 the screen's Back/Close hint; `Ctrl+C` closes the menu.
+
+TUI settings screens retain the extension title and supporting context above Pi's familiar search
+field, aligned label/value columns, ten-row viewport, position indicator, selected-row description,
+and keyboard hint. Typing fuzzy-filters labels, arrows navigate, and Enter or Space changes the
+selected value. Changes save immediately, so Back or Close never implies rollback. The embedded
+search input forwards focus for IME positioning. The kit owns this adapter because Pi's public
+`SettingsList` does not currently expose restored-cursor, disabled-row, async rollback, and search
+focus behavior together.
 
 Action handlers return one of these results:
 

--- a/packages/pi-tui-kit/src/screen-components.ts
+++ b/packages/pi-tui-kit/src/screen-components.ts
@@ -320,6 +320,8 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 				const searchData = data.replaceAll(" ", "");
 				if (searchData) {
 					searchInput.handleInput(searchData);
+					const query = replaceTerminalControls(searchInput.getValue());
+					if (query !== searchInput.getValue()) searchInput.setValue(query);
 					applyFilter();
 				}
 			}
@@ -364,8 +366,8 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 		const selected = index === selectedIndex;
 		const prefix = selected ? options.theme.fg("accent", "→ ") : "  ";
 		const labelPadded = label + " ".repeat(Math.max(0, maxLabelWidth - visibleWidth(label)));
-		const unavailable = item.disabled ? " (unavailable)" : "";
-		const value = `${safeMenuText(displayed.get(item.id) ?? item.currentValue)}${unavailable}`;
+		const currentValue = safeMenuText(displayed.get(item.id) ?? item.currentValue);
+		const value = item.disabled ? `(unavailable) ${currentValue}` : currentValue;
 		const valueWidth = Math.max(0, width - visibleWidth(prefix) - maxLabelWidth - 2);
 		let labelText = labelPadded;
 		let valueText = truncateToWidth(value, valueWidth, "");
@@ -410,7 +412,7 @@ function settingsHint(keybindings: MenuKeybindings) {
 }
 
 function uniqueHintKeys(keys: readonly string[]) {
-	return [...new Set(keys.map(displayHintKey))].join("/");
+	return [...new Set(keys.map(displayHintKey).filter(Boolean))].join("/");
 }
 
 function displayHintKey(key: string) {
@@ -420,7 +422,7 @@ function displayHintKey(key: string) {
 	if (key === "ctrl+c") return "Ctrl+C";
 	if (key === "up") return "↑";
 	if (key === "down") return "↓";
-	return key;
+	return safeMenuText(key);
 }
 
 function createMultiSelectComponent<ScreenId extends string, ActionId extends string>(
@@ -681,8 +683,9 @@ function bindingText(keybindings: MenuKeybindings, binding: MenuBinding, exclude
 			if (key === "up") return "↑";
 			if (key === "down") return "↓";
 			if (key === "escape") return "esc";
-			return key;
+			return safeMenuText(key);
 		})
+		.filter(Boolean)
 		.join("/");
 }
 
@@ -703,13 +706,14 @@ function setInitialSelection(list: SelectList, items: readonly SelectItem[], sel
 }
 
 export function safeMenuText(value: unknown) {
+	return replaceTerminalControls(value).replace(/\s+/gu, " ").trim();
+}
+
+function replaceTerminalControls(value: unknown) {
 	return Array.from(String(value), (character) => {
 		const codePoint = character.codePointAt(0) ?? 0;
 		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
-	})
-		.join("")
-		.replace(/\s+/gu, " ")
-		.trim();
+	}).join("");
 }
 
 export function settingForAction<ActionId extends string>(

--- a/packages/pi-tui-kit/src/screen-components.ts
+++ b/packages/pi-tui-kit/src/screen-components.ts
@@ -1,11 +1,15 @@
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
+	type Focusable,
+	fuzzyFilter,
+	Input,
 	Key,
 	matchesKey,
 	type SelectItem,
 	SelectList,
 	truncateToWidth,
+	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import type { MenuScreen, MenuSettingItem, MenuTransition } from "./types.js";
@@ -175,21 +179,29 @@ function createDetailComponent<ScreenId extends string, ActionId extends string>
 	};
 }
 
-// Pi's current SettingsList cannot initialize its cursor, enforce disabled rows, or expose search
-// focus. Keep this adapter local until those behaviors are available through its public API.
+// Pi's current SettingsList cannot initialize its cursor, enforce disabled rows, expose search
+// focus, or await rejected saves. Keep this adapter local while matching its public presentation.
 function createSettingsComponent<ScreenId extends string, ActionId extends string>(
 	options: SettingsOptions<ScreenId, ActionId>,
 ): MenuScreenComponent {
+	const searchInput = new Input();
+	const border = new DynamicBorder((text: string) => options.theme.fg("border", text));
+	const searchableItems = options.screen.items.map((item) => ({
+		item,
+		label: safeMenuText(item.label),
+	}));
+	let filteredItems = searchableItems;
 	const committed = new Map(options.screen.items.map((item) => [item.id, item.currentValue]));
 	const displayed = new Map(committed);
 	const latestRequested = new Map<string, string>();
 	let selectedIndex = Math.max(
 		0,
-		options.screen.items.findIndex((item) => item.id === options.selectedItemId),
+		filteredItems.findIndex(({ item }) => item.id === options.selectedItemId),
 	);
 	let pending = Promise.resolve();
 	let disposed = false;
 	let closing = false;
+	const selectedItem = () => filteredItems[selectedIndex]?.item;
 	const closeAfterPending = (kind: "back" | "close") => {
 		if (closing || disposed) return;
 		closing = true;
@@ -198,13 +210,23 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 		});
 	};
 	const select = (index: number) => {
-		if (options.screen.items.length === 0) return;
-		selectedIndex = (index + options.screen.items.length) % options.screen.items.length;
-		const item = options.screen.items[selectedIndex];
+		if (filteredItems.length === 0) return;
+		selectedIndex = (index + filteredItems.length) % filteredItems.length;
+		const item = selectedItem();
+		if (item) options.onSelectionChange?.(item.id);
+	};
+	const applyFilter = () => {
+		filteredItems = fuzzyFilter(
+			searchableItems,
+			searchInput.getValue(),
+			(candidate) => candidate.label,
+		);
+		selectedIndex = 0;
+		const item = selectedItem();
 		if (item) options.onSelectionChange?.(item.id);
 	};
 	const activate = () => {
-		const item = options.screen.items[selectedIndex];
+		const item = selectedItem();
 		if (!item || item.disabled || closing || disposed) return;
 		const values = item.values ?? [item.currentValue];
 		if (values.length === 0) return;
@@ -241,51 +263,45 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 		});
 		pending = operation.catch(() => undefined);
 	};
-	return {
-		render(width) {
-			const maxVisible = Math.min(options.screen.items.length, 13);
-			const startIndex = Math.max(
-				0,
-				Math.min(
-					selectedIndex - Math.floor(maxVisible / 2),
-					options.screen.items.length - maxVisible,
-				),
-			);
-			const visibleItems = options.screen.items.slice(startIndex, startIndex + maxVisible);
-			const content = visibleItems.map((item, offset) => {
-				const selected = startIndex + offset === selectedIndex;
-				const label = safeMenuText(item.label);
-				const value = safeMenuText(displayed.get(item.id) ?? item.currentValue);
-				const unavailable = item.disabled ? " (unavailable)" : "";
-				const text = `${selected ? "→ " : "  "}${label}  ${value}${unavailable}`;
-				return selected ? options.theme.fg("accent", text) : text;
-			});
-			if (maxVisible < options.screen.items.length) {
-				content.push(
-					options.theme.fg("dim", `  (${selectedIndex + 1}/${options.screen.items.length})`),
-				);
-			}
-			const selectedItem = options.screen.items[selectedIndex];
-			if (selectedItem?.description) {
-				content.push(
-					"",
-					...wrapTextWithAnsi(
-						options.theme.fg("dim", `  ${safeMenuText(selectedItem.description)}`),
-						Math.max(1, width),
-					),
-				);
-			}
-			return renderFrame(
-				options.screen.title,
-				options.screen.lines ?? [],
-				content,
-				"back",
-				width,
-				options,
-				"change",
-			);
+	const component: MenuScreenComponent & Focusable = {
+		get focused() {
+			return searchInput.focused;
 		},
-		invalidate() {},
+		set focused(value: boolean) {
+			searchInput.focused = value;
+		},
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const result = [
+				...border.render(safeWidth),
+				...wrapTextWithAnsi(
+					options.theme.fg("accent", options.theme.bold(safeMenuText(options.screen.title))),
+					safeWidth,
+				),
+				...(options.screen.lines ?? []).flatMap((line) =>
+					wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
+				),
+				"",
+				...searchInput.render(safeWidth),
+				"",
+				...renderSettingsRows(
+					filteredItems,
+					searchableItems,
+					selectedIndex,
+					displayed,
+					safeWidth,
+					options,
+				),
+				"",
+				...wrapTextWithAnsi(options.theme.fg("dim", settingsHint(options.keybindings)), safeWidth),
+				...border.render(safeWidth),
+			];
+			return result.map((line) => truncateToWidth(line, safeWidth, ""));
+		},
+		invalidate() {
+			border.invalidate();
+			searchInput.invalidate();
+		},
 		handleInput(data) {
 			if (disposed || closing) return;
 			if (matchesKey(data, Key.ctrl("c"))) closeAfterPending("close");
@@ -297,9 +313,15 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 				select(selectedIndex + 1);
 			} else if (options.keybindings.matches(data, "tui.select.pageUp")) select(0);
 			else if (options.keybindings.matches(data, "tui.select.pageDown")) {
-				select(options.screen.items.length - 1);
+				select(filteredItems.length - 1);
 			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
 				activate();
+			} else {
+				const searchData = data.replaceAll(" ", "");
+				if (searchData) {
+					searchInput.handleInput(searchData);
+					applyFilter();
+				}
 			}
 			options.tui.requestRender();
 		},
@@ -310,6 +332,95 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 			options.onDispose?.();
 		},
 	};
+	return component;
+}
+
+function renderSettingsRows<ScreenId extends string, ActionId extends string>(
+	filteredItems: readonly { item: MenuSettingItem<ActionId>; label: string }[],
+	allItems: readonly { item: MenuSettingItem<ActionId>; label: string }[],
+	selectedIndex: number,
+	displayed: ReadonlyMap<string, string>,
+	width: number,
+	options: SettingsOptions<ScreenId, ActionId>,
+): string[] {
+	if (allItems.length === 0) return [options.theme.fg("dim", "  No settings available")];
+	if (filteredItems.length === 0) return [options.theme.fg("dim", "  No matching settings")];
+
+	const maxVisible = Math.min(filteredItems.length, 10);
+	const startIndex = Math.max(
+		0,
+		Math.min(selectedIndex - Math.floor(maxVisible / 2), filteredItems.length - maxVisible),
+	);
+	const endIndex = Math.min(startIndex + maxVisible, filteredItems.length);
+	const maxLabelWidth = Math.min(
+		30,
+		Math.max(...allItems.map((candidate) => visibleWidth(candidate.label))),
+	);
+	const lines: string[] = [];
+	for (let index = startIndex; index < endIndex; index += 1) {
+		const candidate = filteredItems[index];
+		if (!candidate) continue;
+		const { item, label } = candidate;
+		const selected = index === selectedIndex;
+		const prefix = selected ? options.theme.fg("accent", "→ ") : "  ";
+		const labelPadded = label + " ".repeat(Math.max(0, maxLabelWidth - visibleWidth(label)));
+		const unavailable = item.disabled ? " (unavailable)" : "";
+		const value = `${safeMenuText(displayed.get(item.id) ?? item.currentValue)}${unavailable}`;
+		const valueWidth = Math.max(0, width - visibleWidth(prefix) - maxLabelWidth - 2);
+		let labelText = labelPadded;
+		let valueText = truncateToWidth(value, valueWidth, "");
+		if (selected) {
+			labelText = options.theme.fg("accent", labelText);
+			valueText = options.theme.fg("accent", valueText);
+		} else if (item.disabled) {
+			labelText = options.theme.fg("dim", labelText);
+			valueText = options.theme.fg("dim", valueText);
+		} else {
+			valueText = options.theme.fg("muted", valueText);
+		}
+		lines.push(truncateToWidth(`${prefix}${labelText}  ${valueText}`, width, ""));
+	}
+	if (startIndex > 0 || endIndex < filteredItems.length) {
+		lines.push(options.theme.fg("dim", `  (${selectedIndex + 1}/${filteredItems.length})`));
+	}
+	const selected = filteredItems[selectedIndex]?.item;
+	if (selected?.description) {
+		lines.push("");
+		for (const line of wrapTextWithAnsi(
+			safeMenuText(selected.description),
+			Math.max(1, width - 4),
+		)) {
+			lines.push(options.theme.fg("dim", `  ${line}`));
+		}
+	}
+	return lines;
+}
+
+function settingsHint(keybindings: MenuKeybindings) {
+	const confirmKeys = uniqueHintKeys([...keybindings.getKeys("tui.select.confirm"), "space"]);
+	const cancelKeys = uniqueHintKeys(
+		keybindings.getKeys("tui.select.cancel").filter((key) => key !== "ctrl+c"),
+	);
+	return [
+		"Type to search",
+		...(confirmKeys ? [`${confirmKeys} to change`] : []),
+		...(cancelKeys ? [`${cancelKeys} to go back`] : []),
+		"Ctrl+C to close",
+	].join(" · ");
+}
+
+function uniqueHintKeys(keys: readonly string[]) {
+	return [...new Set(keys.map(displayHintKey))].join("/");
+}
+
+function displayHintKey(key: string) {
+	if (key === "enter") return "Enter";
+	if (key === "space") return "Space";
+	if (key === "escape") return "Esc";
+	if (key === "ctrl+c") return "Ctrl+C";
+	if (key === "up") return "↑";
+	if (key === "down") return "↓";
+	return key;
 }
 
 function createMultiSelectComponent<ScreenId extends string, ActionId extends string>(

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -679,6 +679,7 @@ test("component disposal aborts and drains pending setting work before returning
 		hasUI: true,
 		custom: async (factory: unknown) => {
 			const harness = createCustomSelectorHarness(factory, 80);
+			harness.handleInput("m");
 			harness.handleInput("tui.select.confirm");
 			await actionStarted;
 			harness.dispose();
@@ -738,7 +739,8 @@ test("settings refreshes preserve the changed row cursor", async () => {
 			customCalls += 1;
 			const harness = createCustomSelectorHarness(factory, 80);
 			if (customCalls === 1) {
-				harness.handleInput("tui.select.down");
+				for (const input of ["m", "a", "n"]) harness.handleInput(input);
+				assert.doesNotMatch(harness.render().join("\n"), /Automatic mode/);
 				harness.handleInput("tui.select.confirm");
 			} else {
 				assert.match(harness.render().join("\n"), /→ .*Manual mode/);

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import {
+	CURSOR_MARKER,
+	type Focusable,
 	KeybindingsManager,
 	setKeybindings,
 	TUI_KEYBINDINGS,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import { createMenuScreenComponent, type MenuScreenEvent } from "../src/screen-components.js";
+import {
+	createMenuScreenComponent,
+	type MenuScreenComponent,
+	type MenuScreenEvent,
+} from "../src/screen-components.js";
 import type { MenuScreen, MenuTransition } from "../src/types.js";
 
 initTheme("dark", false);
@@ -123,6 +130,159 @@ test("theme invalidation rebuilds themed title content", () => {
 test("settings restore a selected row when the screen is reopened", () => {
 	const harness = componentHarness(settingsScreen, { selectedItemId: "manual" });
 	assert.match(harness.component.render(80).join("\n"), /→ .*Manual mode/);
+});
+
+test("settings use Pi's searchable, aligned, bounded presentation", () => {
+	const harness = componentHarness(largeSettingsScreen(), {
+		plainTheme: true,
+		selectedItemId: "setting-0",
+	});
+	const lines = plainRender(harness.component, 60);
+
+	assert.equal(lines[0], "─".repeat(60));
+	assert.equal(lines.at(-1), "─".repeat(60));
+	assert.ok(lines.includes("Large settings"));
+	assert.ok(lines.includes("Changes save immediately."));
+	assert.ok(lines.some((line) => line.startsWith("> ")));
+	const firstRow = lines.find((line) => line.includes("Setting 0"));
+	const secondRow = lines.find((line) => line.includes("Longer setting 1"));
+	assert.ok(firstRow);
+	assert.ok(secondRow);
+	assert.equal(firstRow.indexOf("Off"), secondRow.indexOf("On"));
+	assert.ok(lines.some((line) => line.includes("Setting 9")));
+	assert.equal(
+		lines.some((line) => line.includes("Setting 10")),
+		false,
+	);
+	assert.ok(lines.some((line) => line.includes("(1/12)")));
+	assert.ok(lines.some((line) => line.includes("Description for setting 0")));
+	const rendered = lines.join("\n");
+	for (const hint of ["Type to search", "change", "back", "close"]) {
+		assert.ok(rendered.includes(hint));
+	}
+});
+
+test("settings search reports no matches and all presentation remains width-safe", () => {
+	const harness = componentHarness(
+		{
+			kind: "settings",
+			title: "介面設定",
+			lines: ["搜尋並立即儲存設定。"],
+			items: [
+				{
+					id: "display",
+					label: "介面顯示設定",
+					description: "選取項目的詳細說明",
+					currentValue: "開啟",
+					values: ["開啟", "關閉"],
+					action: "setting",
+				},
+			],
+		},
+		{ plainTheme: true },
+	);
+
+	harness.component.handleInput("z");
+	assert.ok(
+		plainRender(harness.component, 40).some((line) => line.includes("No matching settings")),
+	);
+	harness.component.handleInput("\u007f");
+	assert.ok(plainRender(harness.component, 40).some((line) => line.includes("介面顯示設定")));
+
+	const empty = componentHarness(
+		{ kind: "settings", title: "Empty settings", items: [] },
+		{ plainTheme: true },
+	);
+	assert.ok(
+		plainRender(empty.component, 40).some((line) => line.includes("No settings available")),
+	);
+	for (const width of [1, 2, 8, 20, 40]) {
+		assert.ok(
+			harness.component.render(width).every((line) => visibleWidth(line) <= width),
+			`settings search at ${width}`,
+		);
+	}
+});
+
+test("settings fuzzy search activates stable raw rows and values", async () => {
+	const rawValue = "On\u0007raw";
+	const requests: Array<{ itemId: string; value: string; previousValue: string }> = [];
+	const harness = componentHarness(
+		{
+			kind: "settings",
+			title: "Settings",
+			items: [
+				{
+					id: "automatic",
+					label: "Automatic mode",
+					currentValue: "Off",
+					values: ["Off", "On"],
+					action: "setting",
+				},
+				{
+					id: "manual-raw",
+					label: "Manual\u0007 mode",
+					currentValue: "Off",
+					values: ["Off", rawValue],
+					action: "setting",
+				},
+			],
+		},
+		{
+			plainTheme: true,
+			onSettingChange: async (request) => {
+				requests.push(request);
+				return true;
+			},
+		},
+	);
+
+	for (const input of ["m", "a", "n"]) harness.component.handleInput(input);
+	const filtered = plainRender(harness.component, 60).join("\n");
+	assert.match(filtered, /Manual mode/);
+	assert.doesNotMatch(filtered, /Automatic mode/);
+	harness.component.handleInput("l");
+	await harness.component.waitForPending();
+	assert.deepEqual(requests, [{ itemId: "manual-raw", value: rawValue, previousValue: "Off" }]);
+	assert.equal(harness.selectionChanges.at(-1), "manual-raw");
+});
+
+test("settings search keeps disabled rows inert and distinguishes Back from Close", async () => {
+	let changes = 0;
+	const disabled = settingsScreen.items[1];
+	assert.ok(disabled);
+	const automatic = settingsScreen.items[0];
+	assert.ok(automatic);
+	const back = componentHarness(
+		{ ...settingsScreen, items: [automatic, { ...disabled, disabled: true }] },
+		{
+			onSettingChange: async () => {
+				changes += 1;
+				return true;
+			},
+		},
+	);
+	for (const input of ["m", "a", "n"]) back.component.handleInput(input);
+	back.component.handleInput("l");
+	await back.component.waitForPending();
+	assert.equal(changes, 0);
+	back.component.handleInput("q");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(back.events, [{ kind: "back" }]);
+
+	const close = componentHarness(settingsScreen);
+	close.component.handleInput("\u0003");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(close.events, [{ kind: "close" }]);
+});
+
+test("settings forward component focus to the search input for IME", () => {
+	const harness = componentHarness(settingsScreen, { plainTheme: true });
+	const focusable = harness.component as MenuScreenComponent & Focusable;
+	assert.equal("focused" in focusable, true);
+	assert.equal(focusable.focused, false);
+	focusable.focused = true;
+	assert.equal(harness.component.render(80).join("\n").includes(CURSOR_MARKER), true);
 });
 
 test("disabled settings cannot invoke their action", async () => {
@@ -390,11 +550,32 @@ function largeMultiSelectScreen(): MenuScreen<ScreenId, ActionId> {
 	};
 }
 
+function largeSettingsScreen(): MenuScreen<ScreenId, ActionId> {
+	return {
+		kind: "settings",
+		title: "Large settings",
+		lines: ["Changes save immediately."],
+		items: Array.from({ length: 12 }, (_, index) => ({
+			id: `setting-${index}`,
+			label: index === 1 ? "Longer setting 1" : `Setting ${index}`,
+			description: `Description for setting ${index}`,
+			currentValue: index % 2 === 0 ? "Off" : "On",
+			values: ["Off", "On"],
+			action: "setting" as const,
+		})),
+	};
+}
+
+function plainRender(component: MenuScreenComponent, width: number) {
+	return component.render(width).map((line) => stripVTControlCharacters(line));
+}
+
 function componentHarness(
 	screen: MenuScreen<ScreenId, ActionId>,
 	options: {
 		selectedItemId?: string;
 		themePrefix?: () => string;
+		plainTheme?: boolean;
 		onSettingChange?: (request: {
 			itemId: string;
 			value: string;
@@ -409,6 +590,7 @@ function componentHarness(
 ) {
 	const events: MenuScreenEvent[] = [];
 	const transitions: MenuTransition<ScreenId>[] = [];
+	const selectionChanges: string[] = [];
 	const themePrefix = options.themePrefix ?? (() => "accent");
 	const component = createMenuScreenComponent({
 		screen,
@@ -416,6 +598,7 @@ function componentHarness(
 		tui: { requestRender() {} },
 		theme: {
 			fg(color: string, text: string) {
+				if (options.plainTheme) return text;
 				return color === "accent" ? `${themePrefix()}:${text}` : text;
 			},
 			bold(text: string) {
@@ -424,9 +607,10 @@ function componentHarness(
 		},
 		keybindings: testKeybindings,
 		onEvent: (event) => events.push(event),
+		onSelectionChange: (itemId) => selectionChanges.push(itemId),
 		onSettingChange: options.onSettingChange,
 		onMultiSelectChange: options.onMultiSelectChange,
 		onTransition: (transition) => transitions.push(transition),
 	});
-	return { component, events, transitions };
+	return { component, events, transitions, selectionChanges };
 }

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -285,6 +285,44 @@ test("settings forward component focus to the search input for IME", () => {
 	assert.equal(harness.component.render(80).join("\n").includes(CURSOR_MARKER), true);
 });
 
+test("settings sanitize terminal controls from bracketed search paste", () => {
+	const harness = componentHarness(settingsScreen, { plainTheme: true });
+	const pasted =
+		"\u001b[200~man\u001b]8;;https://unsafe.example\u0007ual\u009dtitle\u009c\u001b[201~";
+	harness.component.handleInput(pasted);
+	const rendered = harness.component.render(80).join("\n");
+	assert.equal(rendered.includes("\u001b]8;;https://unsafe.example"), false);
+	assert.equal(rendered.includes("\u0007"), false);
+	assert.equal(rendered.includes("\u009d"), false);
+	assert.equal(rendered.includes("\u009c"), false);
+});
+
+test("menu hints sanitize configured keybinding labels", () => {
+	const unsafeKey = "\u001b]8;;https://unsafe.example\u0007enter";
+	const keybindings = {
+		matches: () => false,
+		getKeys: (binding: string) => (binding === "tui.select.confirm" ? [unsafeKey] : []),
+	};
+	for (const screen of [actionScreen, settingsScreen]) {
+		const harness = componentHarness(screen, { keybindings, plainTheme: true });
+		const rendered = harness.component.render(80).join("\n");
+		assert.equal(rendered.includes("\u001b]8;;https://unsafe.example"), false);
+	}
+});
+
+test("disabled settings keep their unavailable marker when long values truncate", () => {
+	const setting = settingsScreen.items[0];
+	assert.ok(setting);
+	const harness = componentHarness(
+		{
+			...settingsScreen,
+			items: [{ ...setting, currentValue: "x".repeat(100), disabled: true }],
+		},
+		{ plainTheme: true },
+	);
+	assert.ok(plainRender(harness.component, 50).some((line) => line.includes("unavailable")));
+});
+
 test("disabled settings cannot invoke their action", async () => {
 	let changes = 0;
 	const firstSetting = settingsScreen.items[0];
@@ -576,6 +614,10 @@ function componentHarness(
 		selectedItemId?: string;
 		themePrefix?: () => string;
 		plainTheme?: boolean;
+		keybindings?: {
+			matches(data: string, binding: string): boolean;
+			getKeys(binding: string): readonly string[];
+		};
 		onSettingChange?: (request: {
 			itemId: string;
 			value: string;
@@ -605,7 +647,7 @@ function componentHarness(
 				return text;
 			},
 		},
-		keybindings: testKeybindings,
+		keybindings: options.keybindings ?? testKeybindings,
 		onEvent: (event) => events.push(event),
 		onSelectionChange: (itemId) => selectionChanges.push(itemId),
 		onSettingChange: options.onSettingChange,


### PR DESCRIPTION
## Summary

- render TUI settings with Pi-style borders, search, aligned values, a ten-row viewport, descriptions, and keybinding-aware hints while retaining extension context
- fuzzy-filter by sanitized labels while preserving stable raw IDs/values, disabled rows, serialized saves, rollback, and cursor restoration
- sanitize bracketed search paste and configured keybinding labels at the display boundary, and keep disabled-state text visible when long values truncate
- forward search focus for IME positioning and document the package-owned adapter and completed implementation plan

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- focused settings component suite (23 tests)
- `npm run check` (CI-equivalent; 1,810 tests)
- `just pack-tui-kit` (15 expected files)
- generated-output render smoke at 72 columns

## Convention audit

Read `docs/extension-conventions.md`, `docs/extension-settings.md`, and Pi's complete TUI documentation. Audited width bounds, callback theme/keybindings, invalidation, render requests, IME focus forwarding, stable payload identity, disabled rows, cancellation, disposal, session replacement/shutdown, and post-`await` continuation guards.

The intentional deviation from directly using Pi's public `SettingsList` remains documented beside the implementation and in the README: the public component does not expose restored cursor, disabled-row, async rollback, and search-focus behavior together. No public menu API, RPC behavior, or persistence semantics changed.
