### PR TITLE
feat(tui-kit): add static choice screens

### DIFF
--- a/docs/plans/2026-07-30_pi-tui-kit-choice-screen-plan.md
+++ b/docs/plans/2026-07-30_pi-tui-kit-choice-screen-plan.md
@@ -1,0 +1,287 @@
+# Pi TUI Kit Phase 1–2 Choice Screen Plan
+
+## Goal
+
+Execute Phase 1 and, only if its admission gate passes, Phase 2 of
+`docs/roadmaps/pi-tui-kit-roadmap.md`: qualify a reusable static choice contract against two real
+consumer workflows, add it to `@narumitw/pi-tui-kit` without private Pi dependencies, and prove it
+through two behavior-preserving consumer migrations.
+
+## Context
+
+- The kit currently supports `actions`, `detail`, `settings`, and `multiSelect` screens through
+  `packages/pi-tui-kit/src/types.ts`, `model.ts`, `screen-components.ts`, and `runtime.ts`.
+- `PI_EXTENSION_MENU_API_VERSION` is `1`; adding a fifth `MenuScreen` variant would be the first new
+  declarative capability since that version was introduced.
+- Pi 0.82.1 root-exports `ThemeSelectorComponent`, `ThinkingSelectorComponent`,
+  `ModelSelectorComponent`, `SessionSelectorComponent`, `TreeSelectorComponent`,
+  `LoginDialogComponent`, `DynamicBorder`, and `BorderedLoader`. Those exports are public but mostly
+  domain-coupled; they must not be described as private or cloned as generic controls.
+- Pi does not root-export the settings selector's internal `SelectSubmenu`; the generic implementation
+  must still be composed from public `SelectList`, theme, keybinding, and width APIs rather than a
+  `dist/*` import.
+- `pi-statusline`'s information-profile picker is the strongest known static-choice candidate: it has
+  stable values, a current value, initial selection, per-item details, explicit apply, and no
+  cursor-movement side effect.
+- `pi-worktree`'s `selectWorktree()` is the second qualified consumer: it selects one static record,
+  maps a display-derived label back to a record by array position, and performs all mutation only
+  after selection. A choice screen can preserve its prompt while carrying the raw worktree path as
+  stable identity.
+- Known non-candidates for the static MVP are `pi-statusline`'s palette picker (live preview and
+  preview rollback), `pi-btw`'s editor-preserving standalone menus, `pi-starship`'s width-dependent
+  preview menus, `pi-image-drop`'s safety decision dialog, and `pi-file-context`'s searchable
+  multi-mode explorer.
+
+### Qualification matrix
+
+| Flow | Input and state | Details / side effects | Back, modes, lifecycle | Decision and evidence |
+| --- | --- | --- | --- | --- |
+| `pi-statusline` information profile | Stable profile names; `current` may be `custom`; initial cursor falls back to `balanced` | Selected segment names; save/apply/rollback only after confirmation | Escape closes its containing menu; no-argument command is TUI-only and owner signal/generation already wrap `runMenu()` | **Admit.** `extensions/pi-statusline/src/commands.ts`; 31 baseline command tests in `extensions/pi-statusline/test/commands.test.ts`. |
+| `pi-worktree` worktree selection | Static records; current worktree is excluded; first eligible row is initial | Existing formatted record label; switch/remove and identity revalidation happen after selection | Undefined means cancel in TUI/RPC; command context supplies an abort signal | **Admit.** `extensions/pi-worktree/src/command.ts`; 28 baseline command tests in `extensions/pi-worktree/test/command.test.ts`. |
+| `pi-statusline` palette | Stable presets and current value | Cursor movement performs live preview; cancel restores preview | TUI-only with save/apply rollback | **Reject for static choice.** Preview behavior is covered by `commands.test.ts`. |
+| `pi-btw` menus | Static strings and optional initial value | Some rows are decisions; helper captures concurrent editor state immediately before `done()` | Must distinguish Back/Close and preserve editor changes while custom UI is open | **Reject for static choice.** `extensions/pi-btw/src/btw.ts`; 65 baseline tests in `extensions/pi-btw/test/side-thread.test.ts`. |
+| `pi-starship` preview actions | Static actions | Body is computed from terminal width and can lead to edit/apply confirmation | TUI-only specialized review loop | **Reject.** `extensions/pi-starship/src/commands.ts`; 16 baseline tests in `extensions/pi-starship/test/commands.test.ts`. |
+| `pi-image-drop` confirmation | Confirm/Cancel decision | Safety copy and three-way confirmed/cancelled/close result | Explicit Escape versus Ctrl+C contract | **Defer to decision screen.** `extensions/pi-image-drop/src/menu.ts`; 5 baseline tests in `extensions/pi-image-drop/test/menu.test.ts`. |
+| `pi-file-context` explorer | Searchable files plus preview/history/revision/diff modes | Async loading, selection ranges, Git context | Focus forwarding, disposal, request generations | **Reject.** `experimental/pi-file-context/src/file-context-explorer.ts`; belongs to catalog/specialized UI. |
+
+### Touched-area rules
+
+- Library API, rendering, runtime, declarations, README, and package output must satisfy repository
+  package boundaries, root-exported Pi dependencies, width-safe rendering, injected keybindings,
+  terminal sanitization, deterministic tests, and `just pack-tui-kit` verification.
+- A consumer migration must keep `ctx.ui.custom()` TUI-only through `runMenu()`, preserve Back versus
+  Close, keep action cancellation and generation ownership, and test every claimed RPC/non-TUI path.
+- `pi-statusline` settings loading, validation, atomic persistence, unknown-field preservation,
+  serialized application, and rollback are out of scope for redesign but must remain covered because
+  its interactive settings command path is touched.
+- `pi-worktree` already depends on `@narumitw/pi-tui-kit`; its migration requires focused command
+  tests, `just pack-worktree`, and preservation of revalidation, switch/remove safety, cancellation,
+  and non-TUI rejection.
+
+## Architecture
+
+### Proposed static choice contract
+
+The Phase 1 gate should approve or revise this bounded shape before implementation:
+
+```ts
+interface MenuChoiceItem {
+  id: string;
+  label: string;
+  description?: string;
+  details?: readonly string[];
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+interface ChoiceScreen<ActionId extends string> {
+  kind: "choice";
+  title: string;
+  lines?: readonly string[];
+  items: readonly MenuChoiceItem[];
+  action: ActionId;
+  currentItemId?: string;
+  initialItemId?: string;
+  viewportSize?: number;
+  hint?: "back" | "close";
+}
+```
+
+- `currentItemId` controls only the textual current marker; it may be absent from the item list to
+  represent a custom or legacy value.
+- A valid remembered cursor wins, then `initialItemId`, then a matching `currentItemId`, then the
+  first row. Disabled rows remain focusable for explanation but cannot activate.
+- Moving the cursor only updates selected details and remembered selection. Confirmation invokes the
+  screen's one action with the raw `itemId`; rejected or thrown actions remain on the screen.
+- The screen owns no persistence, preview callback, rollback callback, TUI object, or arbitrary
+  renderer. Domain action handlers retain mutation and recovery.
+- TUI uses public `SelectList` plus a kit-owned frame/details adapter. RPC flattens rows into unique
+  labels while mapping the selected label back to raw identity and adding an explicit Back/Done row.
+- Existing menu definitions remain source compatible. If admitted, increment
+  `PI_EXTENSION_MENU_API_VERSION` to `2` because a v1 runtime cannot interpret the new screen kind;
+  do not change package versions manually.
+
+### Delivery boundaries
+
+- Land the kit contract and its two proof migrations in one focused rollout PR so the new public API
+  and its qualification evidence are reviewed atomically; keep each responsibility in a separate
+  commit when that improves reviewability.
+- Retain all statusline persistence and worktree switch/remove safety outside the kit.
+- Do not combine palette preview, searchable catalog, contextual decision, settings schema, or command
+  surface changes with the rollout.
+- This single-PR rollout supersedes the roadmap's default separate-migration preference for the first
+  admitted screen; future unrelated migrations remain separate.
+
+## Non-Goals
+
+- Add live preview or run actions when selection merely moves.
+- Replace Pi's exported theme, thinking, model, session, tree, or login selectors.
+- Add search, regex syntax, scope tabs, async refresh, free-form input, multi-step forms, or tree
+  navigation.
+- Change extension settings files, defaults, precedence, migration, or persistence protocols.
+- Remove specialized selectors that do not fit the approved static contract.
+- Publish packages, bump package versions, or merge PRs as part of implementation.
+
+## Assumptions
+
+- The two-consumer admission gate passes with `pi-statusline` information profiles and `pi-worktree`
+  worktree selection; neither requires a cursor-movement side effect or consumer-specific kit hook.
+- `currentItemId` and `initialItemId` remain separate because `pi-statusline` can report a `custom`
+  current profile while initially focusing `balanced`.
+- `pi-btw` remains specialized because preserving editor text at the exact pre-`done()` boundary is a
+  stronger contract than `runMenu()` exposes.
+
+## Risks
+
+- A choice screen may duplicate the existing `actions` screen without enough product difference.
+  Admission requires current-state marking, initial selection, selected details, and two migrations
+  that materially remove repeated standard behavior.
+- Adding a preview hook to qualify the palette picker would violate the static Phase 2 boundary and
+  create async rollback/lifecycle work; reject that expansion and defer the palette picker.
+- RPC labels can collide with duplicate display text or the exit row; preserve raw identity through
+  the existing unique-label adaptation and test collisions.
+- A missing or disabled current/initial item can produce unstable cursor behavior; define fallback
+  order once and cover reload, rejection, and item removal.
+- `screen-components.ts` is currently below 1,000 lines but will grow. Review line count and cohesion
+  before completion; split the choice adapter only if it creates a clearer responsibility boundary.
+
+## Rollback / Recovery
+
+- The library change is additive and has no persisted-data migration. If it regresses before consumer
+  adoption, revert the kit PR and restore API version `1` with its README declaration.
+- If a consumer migration regresses, revert that migration first; its prior specialized selector and
+  settings format remain available in Git and no stored data requires rollback.
+- A failed choice action must return or throw through the existing action protocol, report the error,
+  retain the last stable selection, and leave domain state recovery to the consumer.
+- Do not delete either specialized consumer implementation until its focused regression tests pass in
+  the migration PR.
+
+## Plan
+
+### Phase 1 — Foundation and qualification
+
+- [x] Audit Pi 0.82.1's root exports and relevant selector constructor types, then update the
+      `Current State` and `Decisions and Changes` sections of `docs/roadmaps/pi-tui-kit-roadmap.md` to
+      distinguish public domain-coupled composites from the non-exported `SelectSubmenu`. Evidence:
+      runtime export inspection and installed declarations show the domain selectors at the package
+      root, while `SelectSubmenu` is absent; package source has no planned `dist/*` import.
+- [x] Add a qualification matrix to this plan's `Context` for the candidate custom flows and worktree
+      selector, recording input, state, details, side effects, Back/Close, modes, lifecycle, migration
+      fit, and implementation/test evidence. Evidence: the matrix cites all seven inspected flows and
+      their owning source and regression suites.
+- [x] Run the existing statusline, BTW, Starship, image-drop, and worktree command/menu regression
+      suites to establish baseline behavior. Evidence: a fresh package build and test compilation pass;
+      absolute-path `node --test` runs pass 31, 65, 16, 5, and 28 tests respectively (145 total).
+- [x] Prove or reject `pi-btw` as the second consumer by tracing
+      `showBtwCustomPreservingEditor()`, `showBtwMenu()`, and their concurrent-editor tests. Evidence:
+      BTW is rejected because `runMenu()` cannot capture editor text at the required pre-`done()`
+      boundary without a consumer-specific hook; its 65 baseline tests remain unchanged.
+- [x] Apply the two-consumer admission gate and record the decision in this plan and the roadmap.
+      Evidence: `pi-statusline` information profiles and `pi-worktree` selection share confirmed static
+      selection with post-confirmation actions and stable raw IDs; preview, decision, and
+      editor-preserving flows remain excluded.
+- [x] Finalize the `ChoiceScreen` contract, fallback order, disabled behavior, TUI/RPC semantics,
+      consumers, and API version `2` decision in this plan. Evidence: neither admitted workflow needs
+      cursor-movement side effects, private Pi imports, arbitrary rendering hooks, or settings
+      persistence changes.
+
+### Phase 2 — Static choice library contract
+
+- [x] Add focused failing cases to `packages/pi-tui-kit/test/menu-model.test.ts` and compile-time usage
+      fixtures for valid choice definitions, blank/duplicate IDs, missing actions, invalid viewport,
+      missing current/initial IDs, disabled reasons, and unchanged four-kind definitions. Evidence:
+      test compilation failed on the absent `ChoiceScreen` export and `choice` union variant before
+      implementation.
+- [x] Add `MenuChoiceItem`, `ChoiceScreen`, and the `MenuScreen` union/export changes in
+      `packages/pi-tui-kit/src/types.ts` and `src/index.ts`, implement validation in `src/model.ts`, and
+      set `PI_EXTENSION_MENU_API_VERSION` to `2`. Evidence: the focused model suite passes 8 tests and
+      consumer-facing README usage compiles without casts.
+- [x] Add focused failing cases to `packages/pi-tui-kit/test/screen-components.test.ts` for current
+      marker, separate initial focus, selected details, viewport and page navigation, disabled focus
+      and rejection, duplicate labels, custom keybindings, Back/Close, narrow widths, terminal
+      controls, invalidation, disposal, and selection restoration. Evidence: four choice component
+      cases failed on the explicit unimplemented adapter before implementation.
+- [x] Implement the choice adapter in `packages/pi-tui-kit/src/screen-components.ts` from public
+      `SelectList`, `DynamicBorder`, and existing sanitization helpers, with no selection-change side
+      effect. Evidence: 27 component tests pass and choice output is bounded at widths 1, 20, 40, 80,
+      and 120.
+- [x] Add focused failing cases to `packages/pi-tui-kit/test/runtime.test.ts` for TUI confirmation,
+      raw item identity, remembered/initial/current fallback, rejection, item removal, RPC
+      duplicate/exit labels, disabled rows, owner abort, disposal, session replacement, and shutdown.
+      Evidence: three choice routing tests failed before runtime support; shared action tests continue
+      covering thrown-action recovery.
+- [x] Extend `packages/pi-tui-kit/src/runtime.ts` to route choice activation through the existing action
+      protocol and adapt choice rows in RPC mode, revalidating signal and `isCurrent()` after every
+      await. Evidence: 23 runtime tests pass, including current fallback, choice owner-abort draining,
+      and stale exit.
+- [x] Update `packages/pi-tui-kit/README.md` and `test/readme-usage.ts` with the choice contract,
+      API version `2`, current-versus-initial behavior, RPC flattening, and extension-owned preview and
+      persistence boundaries. Evidence: README examples compile and repository search finds no stale
+      four-screen or API version `1` statement in the package.
+- [x] Review `screen-components.ts` and `runtime.ts` line counts and responsibilities after the change.
+      Evidence: they remain cohesive at 851 and 678 lines respectively, below the 1,000-line review
+      threshold.
+- [x] Run the library and repository gates with
+      `npm run check --workspace @narumitw/pi-tui-kit`, the 58 focused compiled kit tests,
+      `npm run check`, and `just pack-tui-kit`; inspect the tarball. Evidence: all pass, the root gate
+      passes 1,824 tests, and the 15-file tarball contains built ESM/declarations, README, license, API
+      version `2`, and no private Pi import.
+
+### Phase 2 — Consumer proof
+
+- [x] Add failing regressions to `extensions/pi-statusline/test/commands.test.ts` and
+      `test/information-command.test.ts` for standard-screen ownership, custom-current/balanced-initial
+      presentation, selected details, confirm/apply, Escape, save/apply failure, rollback, and narrow
+      rendering. Evidence: the ownership test failed because the old information picker was not a kit
+      screen before migration.
+- [x] Replace only `showInformationProfilePicker()` and its information-profile call path in
+      `extensions/pi-statusline/src/commands.ts` with the admitted choice screen, retaining palette
+      preview, settings persistence, unknown fields, atomic save, runtime apply, rollback, and
+      non-TUI command behavior. Evidence: 35 focused command/information tests, the workspace check,
+      root gate, and `just pack-statusline` pass.
+- [x] Add a failing regression to `extensions/pi-worktree/test/command.test.ts` for standard-screen
+      ownership, raw path identity, duplicate sanitized labels, confirmation, and unchanged switch
+      revalidation. Evidence: the test failed with one custom screen instead of two while the old
+      display-label/index selector remained.
+- [x] Replace `selectWorktree()` in `extensions/pi-worktree/src/command.ts` with the admitted choice
+      screen without changing switch/remove domain behavior, and propagate the owning menu signal to
+      nested selection. Evidence: 28 focused command tests, the workspace check, root gate,
+      `just pack-worktree`, and boundary validation pass.
+- [x] Run a representative noninteractive Pi runtime smoke for a migrated consumer. Evidence:
+      `pi --mode rpc --no-session --no-extensions -e ./extensions/pi-worktree` loaded `/worktree`,
+      opened the main menu and nested choice dialog over the extension UI protocol, and returned
+      cleanly after cancellation. Interactive TUI rendering is covered by deterministic component and
+      command harnesses because agent commands may not open an interactive TUI.
+
+### Final audit and handoff
+
+- [x] Audit the final rollout diff against `docs/extension-conventions.md`,
+      `docs/extension-settings.md`, and the roadmap's Phase 1–2 success metrics. Evidence: package
+      boundaries, public Pi imports, width/theme/keybinding rules, TUI/RPC mode handling, owner-signal
+      cancellation, post-`await` stale handling, statusline atomic save/apply/rollback tests, worktree
+      revalidation/safety tests, root checks, and all pack contents pass review. Accepted deviations:
+      the first capability and proof migrations share one atomic rollout PR, and deterministic TUI
+      harnesses plus a real RPC smoke replace an interactive TUI command forbidden in this agent run.
+- [ ] Open one focused rollout PR containing qualification, the choice contract, both proof
+      migrations, tests, and documentation; verify CI and CodeQL pass and the PR remains mergeable.
+- [ ] Confirm every plan item and completion check has evidence, archive this completed plan under
+      `docs/plans/archived/2026-07-30_pi-tui-kit-choice-screen-plan.md`, and verify the active plan path
+      no longer exists and the archive did not overwrite another file.
+
+## Completion Checklist
+
+- [x] Phase 1 records accurate Pi export status, a complete compatibility matrix, 145 baseline tests,
+      and an explicit two-consumer admission decision.
+- [x] Not applicable: admission passed, so the failed-admission package-source condition does not
+      apply.
+- [x] The public contract remains declarative, uses no private Pi import, sets API version `2`, and
+      keeps existing four screen kinds source compatible.
+- [x] Choice model, TUI, and RPC tests cover validation, identity, current/initial selection, details,
+      disabled state, width, Unicode, sanitization, keybindings, navigation, failures, cancellation,
+      disposal, replacement, and shutdown.
+- [ ] The focused rollout PR passes package checks, root `npm run check`, all three pack dry runs,
+      CI/CodeQL, and the noninteractive RPC runtime smoke.
+- [x] Both migrations preserve domain state, settings persistence, rollback, editor state, preview
+      ownership, established commands, revalidation safety, and relevant non-TUI behavior.
+- [ ] The roadmap, package README, API version declaration, and archived plan agree on the delivered
+      Phase 1–2 outcome.

--- a/docs/plans/archived/2026-07-30_pi-tui-kit-choice-screen-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-choice-screen-plan.md
@@ -262,11 +262,14 @@ interface ChoiceScreen<ActionId extends string> {
       revalidation/safety tests, root checks, and all pack contents pass review. Accepted deviations:
       the first capability and proof migrations share one atomic rollout PR, and deterministic TUI
       harnesses plus a real RPC smoke replace an interactive TUI command forbidden in this agent run.
-- [ ] Open one focused rollout PR containing qualification, the choice contract, both proof
-      migrations, tests, and documentation; verify CI and CodeQL pass and the PR remains mergeable.
-- [ ] Confirm every plan item and completion check has evidence, archive this completed plan under
+- [x] Open one focused rollout PR containing qualification, the choice contract, both proof
+      migrations, tests, and documentation. Evidence: PR #463 is open and mergeable at commit
+      `838ed491ece0a944f844e9a382eea8d7f1d1cffb`; CI, both CodeQL analyses, and the aggregate CodeQL
+      check completed successfully.
+- [x] Confirm every plan item and completion check has evidence, archive this completed plan under
       `docs/plans/archived/2026-07-30_pi-tui-kit-choice-screen-plan.md`, and verify the active plan path
-      no longer exists and the archive did not overwrite another file.
+      no longer exists and the archive did not overwrite another file. Evidence: the destination was
+      absent before the move and the final repository check confirms only the archived path remains.
 
 ## Completion Checklist
 
@@ -279,9 +282,9 @@ interface ChoiceScreen<ActionId extends string> {
 - [x] Choice model, TUI, and RPC tests cover validation, identity, current/initial selection, details,
       disabled state, width, Unicode, sanitization, keybindings, navigation, failures, cancellation,
       disposal, replacement, and shutdown.
-- [ ] The focused rollout PR passes package checks, root `npm run check`, all three pack dry runs,
+- [x] The focused rollout PR passes package checks, root `npm run check`, all three pack dry runs,
       CI/CodeQL, and the noninteractive RPC runtime smoke.
 - [x] Both migrations preserve domain state, settings persistence, rollback, editor state, preview
       ownership, established commands, revalidation safety, and relevant non-TUI behavior.
-- [ ] The roadmap, package README, API version declaration, and archived plan agree on the delivered
+- [x] The roadmap, package README, API version declaration, and archived plan agree on the delivered
       Phase 1–2 outcome.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -26,10 +26,11 @@ RPC, cancellation, session replacement, and shutdown.
 
 ## Current State
 
-The kit currently provides four declarative screen kinds:
+The kit currently provides five declarative screen kinds:
 
 - `actions` for navigation and domain actions;
 - `detail` for read-only text;
+- `choice` for confirmed static alternatives with current/initial state and selected details;
 - `settings` for Pi-style searchable settings with serialized saves and rollback;
 - `multiSelect` for bounded optimistic toggles and bulk actions.
 
@@ -39,9 +40,10 @@ checks. Consumers retain domain state, transactional persistence, confirmations,
 session ownership.
 
 Pi publicly exports primitives that should be used directly: `SelectList`, `Input`, `SettingsList`,
-`DynamicBorder`, `BorderedLoader`, and `ctx.ui.input()`, `select()`, and `confirm()`. The patterns worth
-studying are private composites such as Pi's model, session, settings-submenu, trust, tree, and login
-selectors. Their `dist/*` locations are not public compatibility contracts and must not be imported.
+`DynamicBorder`, `BorderedLoader`, and `ctx.ui.input()`, `select()`, and `confirm()`. Pi also root-exports
+several domain-coupled composites, including its theme, thinking, model, session, tree, and login
+selectors; use those directly only when their domain contract fits. Generic patterns such as the
+settings selector's internal `SelectSubmenu` are not exported. Never deep-import a `dist/*` path.
 
 Current repository evidence includes:
 
@@ -50,6 +52,7 @@ Current repository evidence includes:
 - `pi-starship` framed action selection with width-dependent preview content;
 - `pi-image-drop` contextual input and decision dialogs;
 - `pi-file-context` experimental searchable file navigation;
+- `pi-worktree` worktree selection with display-derived identity mapping;
 - specialized UIs in `pi-sync`, `pi-btw`, and `pi-usage` that should remain local unless they share a
   proven contract with another consumer.
 
@@ -58,8 +61,8 @@ adds lifecycle complexity for a single extension.
 
 ## Guiding Principles
 
-- **Public Pi APIs only:** never import `@earendil-works/pi-coding-agent/dist/*` or copy a private
-  component wholesale.
+- **Public Pi APIs only:** import root-exported components directly when their domain contract fits;
+  never deep-import `@earendil-works/pi-coding-agent/dist/*` or copy an internal component wholesale.
 - **Two-consumer gate:** require two compatible workflows before adding an abstraction.
 - **Preserve capability:** migrations must retain preview, persistence, validation, failure recovery,
   safety, and non-TUI behavior.
@@ -73,7 +76,8 @@ adds lifecycle complexity for a single extension.
   shutdown independently for every async path.
 - **Safe display boundary:** sanitize labels, metadata, values, keybinding hints, pasted queries, and
   errors while preserving raw IDs and action payloads.
-- **Bounded delivery:** land one kit capability per focused PR and migrate consumers separately.
+- **Bounded delivery:** land one kit capability per focused rollout; keep unrelated consumer and
+  domain changes separate.
 
 ## Roadmap Themes
 
@@ -142,7 +146,7 @@ selectors without cursor-movement side effects.
   disposal, and stale sessions.
 - Document the screen and ownership boundary, build the package, run repository checks, and inspect
   the package dry run.
-- Migrate both qualified consumers in separate PRs without removing existing capability.
+- Migrate both qualified consumers in the focused rollout without removing existing capability.
 
 **Outcome:** A proven declarative choice screen with two behavior-preserving adopters and no
 consumer-specific preview hook.
@@ -259,9 +263,9 @@ and retires local abstractions when a stable public Pi replacement becomes avail
 | Date | Decision or change | Rationale |
 | --- | --- | --- |
 | 2026-07-30 | Store the roadmap under `docs/roadmaps/`. | Roadmaps describe long-term product direction; executable feature plans remain under `docs/plans/`. |
-| 2026-07-30 | Use private Pi composites only as interaction references. | Their implementation paths are not public compatibility contracts. |
+| 2026-07-30 | Reuse root-exported Pi composites only when their domain contract fits; use non-exported composites only as interaction references. | Deep implementation paths are not compatibility contracts, while public exports should not be copied. |
 | 2026-07-30 | Require two compatible consumers before adding a screen. | Prevents one-off hooks and unsupported abstraction growth. |
-| 2026-07-30 | Prioritize a static choice screen. | It is bounded, broadly recognizable, and can avoid live-preview lifecycle complexity. |
+| 2026-07-30 | Deliver the static choice screen with `pi-statusline` information profiles and `pi-worktree` selection in one focused rollout. | Both need confirmed static selection with raw identity and no cursor-movement side effect; an atomic proof rollout keeps preview, decision, and editor-preserving flows specialized. |
 | 2026-07-30 | Keep async catalogs, trees, login flows, and live previews deferred. | These patterns require stronger shared evidence or remain domain-specific. |
 
 ## Completion Checklist
@@ -276,5 +280,6 @@ and retires local abstractions when a stable public Pi replacement becomes avail
       disposal, replacement, and shutdown where applicable.
 - [ ] Each feature and migration passed focused tests, root checks, package dry runs, and a
       representative Pi runtime smoke with unverified paths recorded.
-- [ ] README ownership guidance distinguishes public Pi primitives to reuse, private composites used
-      only as references, kit-owned standard behavior, and extension-owned domain UI.
+- [ ] README ownership guidance distinguishes public Pi primitives and domain composites to reuse,
+      non-exported composites used only as references, kit-owned standard behavior, and
+      extension-owned domain UI.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -130,8 +130,11 @@ specialized or unsupported patterns explicitly deferred.
 
 ### Phase 2: Static Choice Screen
 
-The first candidate models the reusable core of Pi's private theme, thinking, and settings-submenu
-selectors without cursor-movement side effects.
+**Status:** implemented in [PR #463](https://github.com/narumiruna/pi-extensions/pull/463); see the
+[choice-screen plan](../plans/archived/2026-07-30_pi-tui-kit-choice-screen-plan.md).
+
+The first candidate models the reusable core of Pi's theme, thinking, and settings-submenu selectors
+without cursor-movement side effects.
 
 **Milestones:**
 

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -125,8 +125,8 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 		signal: fallbackController.signal,
 		isCurrent: () => !fallbackController.signal.aborted,
 	};
-	type Screen = "main" | "advanced";
-	type Action = "appearance" | "information" | "layout" | "edit" | "status" | "help" | "back";
+	type Screen = "main" | "advanced" | "information";
+	type Action = "appearance" | "setInformation" | "layout" | "edit" | "status" | "help" | "back";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 		start: "main",
 		screens: {
@@ -144,12 +144,30 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 						{
 							id: "information",
 							label: `Information (${inferInformationProfile(config.segments)})`,
-							action: "information",
+							to: "information",
 						},
 						{ id: "advanced", label: "Advanced", to: "advanced" },
 						{ id: "status", label: "Status", action: "status" },
 						{ id: "help", label: "Help", action: "help" },
 					],
+					hint: "close",
+				};
+			},
+			information: () => {
+				const current = inferInformationProfile(options.getLoaded().config.segments);
+				return {
+					kind: "choice",
+					title: "Information level",
+					lines: [`Current profile: ${current}`],
+					items: INFORMATION_PROFILE_NAMES.map((profile) => ({
+						id: profile,
+						label: `${profile[0]?.toUpperCase() ?? ""}${profile.slice(1)}`,
+						description: `${INFORMATION_PROFILES[profile].length} segments`,
+						details: [`Segments: ${INFORMATION_PROFILES[profile].join(" · ")}`],
+					})),
+					action: "setInformation",
+					currentItemId: current,
+					initialItemId: current === "custom" ? "balanced" : current,
 					hint: "close",
 				};
 			},
@@ -179,8 +197,10 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 				await choosePalettePreset(ctx, options);
 				return { kind: "close" };
 			},
-			information: async () => {
-				await chooseInformationProfile(ctx, options);
+			setInformation: async ({ itemId }) => {
+				const profile = INFORMATION_PROFILE_NAMES.find((candidate) => candidate === itemId);
+				if (!profile) return { kind: "rejected" };
+				applyInformationProfile(ctx, options, profile);
 				return { kind: "close" };
 			},
 			layout: async () => {
@@ -317,19 +337,12 @@ async function showPalettePresetPicker(
 	return result ?? undefined;
 }
 
-async function chooseInformationProfile(
+function applyInformationProfile(
 	ctx: ExtensionCommandContext,
 	options: StatuslineCommandOptions,
+	selection: InformationProfileName,
 ) {
-	if (ctx.mode !== "tui") {
-		if (ctx.hasUI) ctx.ui.notify(`Edit segments manually: ${options.settingsPath}`, "info");
-		return;
-	}
 	const current = options.getLoaded();
-	const currentProfile = inferInformationProfile(current.config.segments);
-	const selection = await showInformationProfilePicker(ctx, currentProfile);
-	if (selection === undefined) return;
-
 	try {
 		const change = informationProfileDocument(current, selection);
 		const loaded = applySegmentsDocumentChange(change, ctx, options);
@@ -340,69 +353,6 @@ async function chooseInformationProfile(
 	} catch (error) {
 		ctx.ui.notify(`Information level was not saved: ${formatError(error)}`, "error");
 	}
-}
-
-async function showInformationProfilePicker(
-	ctx: ExtensionCommandContext,
-	current: ReturnType<typeof inferInformationProfile>,
-): Promise<InformationProfileName | undefined> {
-	const items: SelectItem[] = INFORMATION_PROFILE_NAMES.map((profile) => ({
-		value: profile,
-		label: `${profile[0]?.toUpperCase() ?? ""}${profile.slice(1)}`,
-		description: `${INFORMATION_PROFILES[profile].length} segments${profile === current ? " • current" : ""}`,
-	}));
-	const initialProfile = current === "custom" ? "balanced" : current;
-	const selectedIndex = INFORMATION_PROFILE_NAMES.indexOf(initialProfile);
-	const result = await ctx.ui.custom<InformationProfileName | null>(
-		(tui, theme, _keybindings, done) => {
-			const container = new Container();
-			container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
-			const title = new Text("", 1, 0);
-			container.addChild(title);
-			const list = new SelectList(items, items.length, {
-				selectedPrefix: (text) => theme.fg("accent", text),
-				selectedText: (text) => theme.fg("accent", text),
-				description: (text) => theme.fg("muted", text),
-				scrollInfo: (text) => theme.fg("dim", text),
-				noMatch: (text) => theme.fg("warning", text),
-			});
-			list.setSelectedIndex(selectedIndex);
-			let selectedProfile = initialProfile;
-			const details = new Text("", 1, 0);
-			const hint = new Text("", 1, 0);
-			const updateThemedText = () => {
-				title.setText(theme.fg("accent", theme.bold(`Information level (current: ${current})`)));
-				details.setText(
-					theme.fg("muted", `Segments: ${INFORMATION_PROFILES[selectedProfile].join(" · ")}`),
-				);
-				hint.setText(theme.fg("dim", "↑↓ preview contents • enter apply • esc cancel"));
-			};
-			list.onSelectionChange = (item) => {
-				selectedProfile = item.value as InformationProfileName;
-				updateThemedText();
-			};
-			list.onSelect = (item) => done(item.value as InformationProfileName);
-			list.onCancel = () => done(null);
-			container.addChild(list);
-			container.addChild(details);
-			container.addChild(hint);
-			container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
-			updateThemedText();
-
-			return {
-				render: (width: number) => container.render(width),
-				invalidate() {
-					container.invalidate();
-					updateThemedText();
-				},
-				handleInput(data: string) {
-					list.handleInput(data);
-					tui.requestRender();
-				},
-			};
-		},
-	);
-	return result ?? undefined;
 }
 
 async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineCommandOptions) {

--- a/extensions/pi-statusline/test/commands.test.ts
+++ b/extensions/pi-statusline/test/commands.test.ts
@@ -7,7 +7,11 @@ import { join } from "node:path";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { getKeybindings, visibleWidth } from "@earendil-works/pi-tui";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import { registerStatuslineCommand } from "../src/commands.js";
 import {
 	DEFAULT_STATUSLINE_DOCUMENT,
@@ -33,6 +37,12 @@ function selectCustomLayout(title: string, choices: string[]): string | undefine
 	if (screenTitle(title) === "pi-statusline — Advanced") {
 		return choices.find((choice) => choice.startsWith("Custom layout ("));
 	}
+	return undefined;
+}
+
+function selectInformationProfile(title: string, choices: string[]): string | undefined {
+	if (screenTitle(title) === "pi-statusline") return choices[1];
+	if (title.includes("Information level")) return choices[0];
 	return undefined;
 }
 
@@ -104,6 +114,43 @@ test("/statusline keeps compatibility subcommands and an argument-free interacti
 	assert.match(context.notifications.at(-1)?.message ?? "", /unknown.*palette/iu);
 });
 
+test("information profiles use the standard choice screen with current state and details", async () => {
+	const mock = createMockPi();
+	registerStatuslineCommand(mock.pi, {
+		settingsPath: "/tmp/missing-pi-statusline-choice.json",
+		getLoaded: () => loadStatuslineSettings("/tmp/missing-pi-statusline-choice.json"),
+		apply() {},
+	});
+	let customCalls = 0;
+	let informationWasStandard = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const harness = createCustomSelectorHarness(factory, 80);
+			if (customCalls === 1) {
+				assert.equal(harness.isPiTuiKitScreen, true);
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else {
+				informationWasStandard = harness.isPiTuiKitScreen;
+				if (informationWasStandard) {
+					const rendered = harness.render().join("\n");
+					assert.match(rendered, /Balanced.*✓ current/);
+					assert.match(rendered, /Segments:/);
+				}
+				harness.handleInput("tui.select.cancel");
+			}
+			return harness.result;
+		},
+	});
+
+	await mock.commands.get("statusline")?.handler("", context.ctx);
+	assert.equal(customCalls, 2);
+	assert.equal(informationWasStandard, true);
+});
+
 test("fresh explicit statusline controls seed their first save without passive creation", async (t) => {
 	const scenarios = [
 		{
@@ -114,8 +161,7 @@ test("fresh explicit statusline controls seed their first save without passive c
 		},
 		{
 			name: "information",
-			select: (title: string, choices: string[]) =>
-				screenTitle(title) === "pi-statusline" ? choices[1] : undefined,
+			select: selectInformationProfile,
 			inputs: ["\r"],
 		},
 		{
@@ -180,8 +226,13 @@ test("failed first-run statusline application restores the missing file", async 
 				});
 				const context = createMockContext({
 					mode: "tui",
-					select: (title: string, choices: string[]) =>
-						screenTitle(title) === "pi-statusline" ? choices[scenario.menuIndex] : undefined,
+					select: (title: string, choices: string[]) => {
+						if (screenTitle(title) === "pi-statusline") return choices[scenario.menuIndex];
+						if (scenario.name === "information" && title.includes("Information level")) {
+							return choices[0];
+						}
+						return undefined;
+					},
 					custom: customPalettePicker(["\r"]),
 				});
 
@@ -248,8 +299,7 @@ test("failed updates from legacy statusline settings remove the new canonical fi
 		},
 		{
 			name: "information",
-			select: (title: string, choices: string[]) =>
-				screenTitle(title) === "pi-statusline" ? choices[1] : undefined,
+			select: selectInformationProfile,
 			inputs: ["\r"],
 		},
 		{

--- a/extensions/pi-statusline/test/information-command.test.ts
+++ b/extensions/pi-statusline/test/information-command.test.ts
@@ -3,43 +3,33 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { getKeybindings, visibleWidth } from "@earendil-works/pi-tui";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import { registerStatuslineCommand } from "../src/commands.js";
 import { loadStatuslineSettings, settingsFilePath } from "../src/settings.js";
 
-interface PickerComponent {
-	render?(width: number): string[];
-	handleInput?(data: string): void;
-}
-
-function profilePicker(
-	inputs: string[],
+function informationChoice(
+	getInputs: () => readonly string[],
 	inspect?: (lines: string[]) => void,
 	inspectNarrow?: (lines: string[]) => void,
 ) {
-	return async (factory: (...args: unknown[]) => unknown) => {
-		let result: unknown;
-		const component = factory(
-			{ requestRender() {} },
-			{
-				fg: (_color: string, text: string) => text,
-				bold: (text: string) => text,
-			},
-			getKeybindings(),
-			(value: unknown) => {
-				result = value;
-			},
-		) as PickerComponent;
-		if (inspect && component.render) inspect(component.render(100));
-		if (inspectNarrow && component.render) inspectNarrow(component.render(20));
-		for (const input of inputs) component.handleInput?.(input);
-		return result;
+	return async (factory: unknown) => {
+		const harness = createCustomSelectorHarness(factory, 100);
+		const lines = harness.render();
+		if (lines.join("\n").includes("Information level")) {
+			inspect?.(lines);
+			inspectNarrow?.(harness.render(20));
+			for (const input of getInputs()) harness.handleInput(input);
+		} else {
+			harness.handleInput("tui.select.down");
+			harness.handleInput("tui.select.confirm");
+		}
+		return harness.result;
 	};
-}
-
-function selectInformation(_title: string, choices: string[]): string | undefined {
-	return choices.find((choice) => choice.startsWith("Information ("));
 }
 
 test("information picker previews exact contents and atomically applies a curated profile", async () => {
@@ -62,9 +52,8 @@ test("information picker previews exact contents and atomically applies a curate
 		let narrowLines: string[] = [];
 		const context = createMockContext({
 			mode: "tui",
-			select: selectInformation,
-			custom: profilePicker(
-				["\r"],
+			custom: informationChoice(
+				() => ["tui.select.confirm"],
 				(lines) => {
 					pickerText = lines.join("\n");
 				},
@@ -76,7 +65,8 @@ test("information picker previews exact contents and atomically applies a curate
 
 		await mock.commands.get("statusline")?.handler("", context.ctx);
 
-		assert.match(pickerText, /Information level \(current: custom\)/u);
+		assert.match(pickerText, /Information level/u);
+		assert.match(pickerText, /Current profile: custom/u);
 		for (const label of ["Minimal", "Balanced", "Detailed"]) {
 			assert.match(pickerText, new RegExp(label, "u"));
 		}
@@ -115,7 +105,7 @@ test("information picker cancellation and save failure leave custom settings unc
 		const mock = createMockPi();
 		const loaded = loadStatuslineSettings(path);
 		let applied = 0;
-		let pickerInputs = ["\u001b"];
+		let pickerInputs = ["tui.select.cancel"];
 		registerStatuslineCommand(mock.pi, {
 			settingsPath: path,
 			getLoaded: () => loaded,
@@ -128,15 +118,14 @@ test("information picker cancellation and save failure leave custom settings unc
 		});
 		const context = createMockContext({
 			mode: "tui",
-			select: selectInformation,
-			custom: (factory: (...args: unknown[]) => unknown) => profilePicker(pickerInputs)(factory),
+			custom: informationChoice(() => pickerInputs),
 		});
 
 		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.equal(readFileSync(path, "utf8"), original);
 		assert.equal(applied, 0);
 
-		pickerInputs = ["\r"];
+		pickerInputs = ["tui.select.confirm"];
 		await mock.commands.get("statusline")?.handler("", context.ctx);
 		assert.equal(readFileSync(path, "utf8"), original);
 		assert.equal(applied, 0);

--- a/extensions/pi-worktree/src/command.ts
+++ b/extensions/pi-worktree/src/command.ts
@@ -115,8 +115,10 @@ export function registerWorktreeCommand(
 					},
 					actions: {
 						add: async () => runFlow(() => addFlow(pi, ctx, records, root.effectiveRoot)),
-						switch: async () => runFlow(() => switchFlow(pi, ctx, records, currentPath)),
-						remove: async () => runFlow(() => removeFlow(pi, ctx, records, currentPath)),
+						switch: async ({ signal }) =>
+							runFlow(() => switchFlow(pi, ctx, records, currentPath, signal)),
+						remove: async ({ signal }) =>
+							runFlow(() => removeFlow(pi, ctx, records, currentPath, signal)),
 						prune: async () => runFlow(() => pruneFlow(pi, ctx, records)),
 						configure: async () => runFlow(() => configureRootFlow(ctx, settings)),
 					},
@@ -273,6 +275,7 @@ async function switchFlow(
 	ctx: ExtensionCommandContext,
 	records: readonly WorktreeRecord[],
 	currentPath: string,
+	signal?: AbortSignal,
 ): Promise<void> {
 	const candidates = records.filter(
 		(record) =>
@@ -281,7 +284,7 @@ async function switchFlow(
 			existsSync(record.path) &&
 			!pathsEqual(record.path, currentPath),
 	);
-	const selected = await selectWorktree(ctx, "Switch to worktree", candidates, currentPath);
+	const selected = await selectWorktree(ctx, "Switch to worktree", candidates, currentPath, signal);
 	if (!selected) return;
 	const latest = await revalidateWorktreeIdentity(pi, ctx, selected);
 	if (
@@ -300,11 +303,18 @@ async function removeFlow(
 	ctx: ExtensionCommandContext,
 	records: readonly WorktreeRecord[],
 	currentPath: string,
+	signal?: AbortSignal,
 ): Promise<void> {
 	const candidates = records.filter(
 		(record) => !record.isMain && !record.bare && !pathsEqual(record.path, currentPath),
 	);
-	const selected = await selectWorktree(ctx, "Remove linked worktree", candidates, currentPath);
+	const selected = await selectWorktree(
+		ctx,
+		"Remove linked worktree",
+		candidates,
+		currentPath,
+		signal,
+	);
 	if (!selected) return;
 	if (selected.lockedReason !== undefined) {
 		throw new Error(
@@ -630,17 +640,40 @@ async function selectWorktree(
 	title: string,
 	records: readonly WorktreeRecord[],
 	currentPath: string,
+	signal?: AbortSignal,
 ): Promise<WorktreeRecord | undefined> {
 	if (records.length === 0) {
 		ctx.ui.notify("No eligible worktrees are available for this action.", "info");
 		return undefined;
 	}
-	const labels = records.map(
-		(record, index) => `${index + 1}. ${formatWorktree(record, currentPath)}`,
-	);
-	const selected = await ctx.ui.select(title, labels);
-	const index = selected === undefined ? -1 : labels.indexOf(selected);
-	return index < 0 ? undefined : records[index];
+	let selected: WorktreeRecord | undefined;
+	const menu = defineMenu<undefined, "worktrees", "choose", ExtensionCommandContext>({
+		start: "worktrees",
+		screens: {
+			worktrees: () => ({
+				kind: "choice",
+				title,
+				items: records.map((record, index) => ({
+					id: record.path,
+					label: `${index + 1}. ${formatWorktree(record, currentPath)}`,
+				})),
+				action: "choose",
+				hint: "close",
+			}),
+		},
+		actions: {
+			choose: async ({ itemId }) => {
+				selected = records.find((record) => record.path === itemId);
+				return selected ? { kind: "close" } : { kind: "rejected" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal,
+		isCurrent: () => !signal?.aborted,
+	});
+	return selected;
 }
 
 function safeNotify(

--- a/extensions/pi-worktree/test/command.test.ts
+++ b/extensions/pi-worktree/test/command.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { ExecResult } from "@earendil-works/pi-coding-agent";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import { createWorktreeSettingsRuntime, type WorktreeSettingsRuntime } from "../src/settings.js";
 import worktreeExtension from "../src/worktree.js";
 
@@ -927,15 +931,28 @@ test("switch choices use unique ordinals when sanitized worktree labels collide"
 		return result(`${main}\n`);
 	};
 	worktreeExtension(mock.pi);
-	let selectCount = 0;
+	let customCalls = 0;
 	let switchedCwd = "";
 	const context = createMockContext({
 		cwd: main,
 		hasUI: true,
 		mode: "tui",
 		sessionManager: { getSessionFile: () => undefined, getEntries: () => [] },
-		select: async (_title: string, items: string[]) =>
-			selectCount++ === 0 ? "Switch worktree" : items[1],
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const harness = createCustomSelectorHarness(factory, 80);
+			assert.equal(harness.isPiTuiKitScreen, true);
+			if (customCalls === 1) {
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else {
+				assert.match(harness.render().join("\n"), /1\..*wt-.*same/);
+				assert.match(harness.render().join("\n"), /2\..*wt-same/);
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			}
+			return harness.result;
+		},
 		switchSession: async (
 			path: string,
 			options: { withSession?: (ctx: unknown) => Promise<void> },
@@ -948,6 +965,7 @@ test("switch choices use unique ordinals when sanitized worktree labels collide"
 	});
 	try {
 		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(customCalls, 2);
 		assert.equal(switchedCwd, second);
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -96,11 +96,13 @@ remain pure projections of current extension state.
 
 ## 🖥️ Standard screens
 
-`defineMenu()` supports four standard screen kinds:
+`defineMenu()` supports five standard screen kinds:
 
 - **`actions`** — navigation targets, domain actions, close rows, and optional cancellable busy
   labels.
 - **`detail`** — read-only wrapped text with Back or Close behavior.
+- **`choice`** — one confirmed value from a static list, with separate current and initial items,
+  selected details, disabled explanations, and a bounded viewport.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
   serialized saves, and rollback when an action rejects.
 - **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback,
@@ -109,6 +111,43 @@ remain pure projections of current extension state.
 All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed
 content after invalidation, and bound rendered output to the supplied terminal width. Escape follows
 the screen's Back/Close hint; `Ctrl+C` closes the menu.
+
+Choice screens are for bounded static alternatives rather than actions that run while the cursor
+moves. `currentItemId` adds the textual current marker; `initialItemId` controls the first cursor when
+there is no remembered selection. They remain separate so a custom or legacy current value can focus
+a safe fallback. A confirmed row invokes the screen action with its raw `itemId`; moving the cursor
+only changes selected details. Rejected or thrown actions retain the selection. Disabled rows stay
+focusable for their explanation but never invoke the action. RPC flattens choice rows to unique dialog
+labels while preserving raw identity.
+
+```ts
+const profileScreen = {
+  kind: "choice" as const,
+  title: "Information profile",
+  lines: ["Current profile: custom"],
+  items: [
+    {
+      id: "minimal",
+      label: "Minimal",
+      description: "Four segments",
+      details: ["Segments: model · cwd · branch · context"],
+    },
+    {
+      id: "balanced",
+      label: "Balanced",
+      description: "Recommended",
+      details: ["Segments: model · thinking · cwd · branch · tools · context · time"],
+    },
+  ],
+  action: "setProfile" as const,
+  currentItemId: "custom", // May be absent from items; no false current marker is shown.
+  initialItemId: "balanced",
+  viewportSize: 8,
+};
+```
+
+Keep live previews, preview rollback, persistence, and confirmation policy in the consuming extension;
+a specialized UI remains appropriate when cursor movement itself has side effects.
 
 TUI settings screens retain the extension title and supporting context above Pi's familiar search
 field, aligned label/value columns, ten-row viewport, position indicator, selected-row description,
@@ -202,6 +241,11 @@ shutdown. The kit does not create lifecycle ownership for the extension.
 
 ## 🧩 Ownership boundary
 
+Reuse Pi primitives and domain components from their package root whenever their public contract fits.
+Use non-exported Pi composites only as interaction references; never deep-import Pi's `dist/*`
+implementation paths. The kit owns a composite only when public controls do not provide the complete
+cross-mode and lifecycle contract shared by multiple extensions.
+
 The library owns:
 
 - width-safe standard rendering and injected keybindings;
@@ -227,8 +271,8 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 - `runMenu()` — runs the definition in the current Pi mode.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
-- exported screen, action, transition, runtime option, and result types.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`1`).
+- exported screen, item, action, transition, runtime option, and result types.
+- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`2`).
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -4,10 +4,12 @@ export { type RunMenuOptions, type RunMenuResult, runMenu } from "./runtime.js";
 export type {
 	ActionMenuItem,
 	ActionsScreen,
+	ChoiceScreen,
 	DetailScreen,
 	MenuActionContext,
 	MenuActionHandler,
 	MenuActionResult,
+	MenuChoiceItem,
 	MenuContext,
 	MenuDefinition,
 	MenuMultiSelectItem,
@@ -20,4 +22,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 1;
+export const PI_EXTENSION_MENU_API_VERSION = 2;

--- a/packages/pi-tui-kit/src/model.ts
+++ b/packages/pi-tui-kit/src/model.ts
@@ -54,6 +54,16 @@ function validateScreen<
 		for (const item of screen.items) validateActionItem(definition, item);
 		return;
 	}
+	if (screen.kind === "choice") {
+		assertAction(definition, `choice screen ${screen.title}`, screen.action);
+		if (
+			screen.viewportSize !== undefined &&
+			(!Number.isInteger(screen.viewportSize) || screen.viewportSize <= 0)
+		) {
+			throw new Error("Menu choice viewport size must be a positive integer");
+		}
+		return;
+	}
 	if (screen.kind === "settings") {
 		for (const item of screen.items) {
 			assertAction(definition, item.id, item.action);

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -144,6 +144,22 @@ async function runTuiMenu<
 				navigator.apply(event.transition);
 				continue;
 			}
+			if (screen.kind === "choice") {
+				const item = screen.items.find((candidate) => candidate.id === event.itemId);
+				if (!item || item.disabled) continue;
+				navigator.rememberSelection(navigator.current, item.id);
+				const outcome = await invokeAction(
+					ctx,
+					definition.actions[screen.action],
+					state,
+					menuSignal,
+					item.id,
+					options,
+				);
+				if (outcome.stale) return { kind: "stale" };
+				navigator.apply(outcome.transition);
+				continue;
+			}
 			const actionItems =
 				screen.kind === "actions"
 					? screen.items
@@ -175,7 +191,12 @@ function selectableItemIds<ScreenId extends string, ActionId extends string>(
 	if (screen.kind === "multiSelect") {
 		return [...screen.items, ...(screen.actions ?? [])].map((item) => item.id);
 	}
-	return screen.items.map((item) => item.id);
+	const itemIds = screen.items.map((item) => item.id);
+	if (screen.kind !== "choice") return itemIds;
+	const preferred = [screen.initialItemId, screen.currentItemId].find(
+		(itemId): itemId is string => itemId !== undefined && itemIds.includes(itemId),
+	);
+	return preferred ? [preferred, ...itemIds.filter((itemId) => itemId !== preferred)] : itemIds;
 }
 
 async function showTuiScreen<
@@ -442,6 +463,21 @@ async function runDialogMenu<
 				navigator.apply(outcome.transition);
 				continue;
 			}
+			if (screen.kind === "choice") {
+				const item = screen.items[selectedRow.index];
+				if (!item || item.disabled) continue;
+				const outcome = await invokeAction(
+					ctx,
+					definition.actions[screen.action],
+					state,
+					menuSignal,
+					item.id,
+					options,
+				);
+				if (outcome.stale) return { kind: "stale" };
+				navigator.apply(outcome.transition);
+				continue;
+			}
 			if (selectedRow.kind === "action") {
 				const actionItem = screen.actions?.[selectedRow.index];
 				if (!actionItem || actionItem.disabled) continue;
@@ -518,6 +554,18 @@ function dialogRows<ScreenId extends string, ActionId extends string>(
 				index,
 				label: `${safeMenuText(item.label)} (${safeMenuText(item.currentValue)})`,
 			})),
+			{ kind: "exit", index: 0, label: dialogExitChoice(screen) },
+		];
+	} else if (screen.kind === "choice") {
+		rows = [
+			...screen.items.map((item, index) => {
+				const label = safeMenuText(item.label);
+				const current = item.id === screen.currentItemId ? " (current)" : "";
+				const unavailable = item.disabled
+					? `[-] ${label} (unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""})`
+					: `${label}${current}`;
+				return { kind: "item" as const, index, label: unavailable };
+			}),
 			{ kind: "exit", index: 0, label: dialogExitChoice(screen) },
 		];
 	} else {

--- a/packages/pi-tui-kit/src/screen-components.ts
+++ b/packages/pi-tui-kit/src/screen-components.ts
@@ -87,6 +87,9 @@ export function createMenuScreenComponent<ScreenId extends string, ActionId exte
 		case "detail":
 			component = createDetailComponent(options as DetailOptions<ScreenId, ActionId>);
 			break;
+		case "choice":
+			component = createChoiceComponent(options as ChoiceOptions<ScreenId, ActionId>);
+			break;
 		case "settings":
 			component = createSettingsComponent(options as SettingsOptions<ScreenId, ActionId>);
 			break;
@@ -109,6 +112,12 @@ type DetailOptions<ScreenId extends string, ActionId extends string> = MenuScree
 	ActionId
 > & {
 	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "detail" }>;
+};
+type ChoiceOptions<ScreenId extends string, ActionId extends string> = MenuScreenComponentOptions<
+	ScreenId,
+	ActionId
+> & {
+	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "choice" }>;
 };
 type SettingsOptions<ScreenId extends string, ActionId extends string> = MenuScreenComponentOptions<
 	ScreenId,
@@ -169,6 +178,124 @@ function createDetailComponent<ScreenId extends string, ActionId extends string>
 			else if (options.keybindings.matches(data, "tui.select.cancel")) {
 				options.onEvent({ kind: options.screen.hint ?? "back" });
 			}
+		},
+		async waitForPending() {},
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			options.onDispose?.();
+		},
+	};
+}
+
+function createChoiceComponent<ScreenId extends string, ActionId extends string>(
+	options: ChoiceOptions<ScreenId, ActionId>,
+): MenuScreenComponent {
+	const border = new DynamicBorder((text: string) => options.theme.fg("border", text));
+	const items: SelectItem[] = options.screen.items.map((item) => {
+		const current = item.id === options.screen.currentItemId ? " ✓ current" : "";
+		const unavailable = item.disabled
+			? `unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""}`
+			: undefined;
+		return {
+			value: item.id,
+			label: `${item.disabled ? "[-] " : ""}${safeMenuText(item.label)}${current}`,
+			description:
+				[unavailable, item.description ? safeMenuText(item.description) : undefined]
+					.filter((value): value is string => Boolean(value))
+					.join(" · ") || undefined,
+		};
+	});
+	const viewportSize = Math.min(items.length, options.screen.viewportSize ?? 10);
+	const list = new SelectList(items, viewportSize, selectTheme(options.theme));
+	const initialId = items.some((item) => item.value === options.selectedItemId)
+		? options.selectedItemId
+		: items[0]?.value;
+	let selectedItemId = initialId;
+	setInitialSelection(list, items, initialId);
+	const select = (index: number) => {
+		if (items.length === 0) return;
+		const selectedIndex = Math.max(0, Math.min(index, items.length - 1));
+		list.setSelectedIndex(selectedIndex);
+		selectedItemId = items[selectedIndex]?.value;
+		if (selectedItemId) options.onSelectionChange?.(selectedItemId);
+	};
+	const activate = (itemId: string | undefined) => {
+		if (!itemId) return;
+		const item = options.screen.items.find((candidate) => candidate.id === itemId);
+		if (!item?.disabled) options.onEvent({ kind: "activate", itemId });
+	};
+	list.onSelectionChange = (item) => {
+		selectedItemId = item.value;
+		options.onSelectionChange?.(item.value);
+	};
+	list.onSelect = (item) => activate(item.value);
+	list.onCancel = () => options.onEvent({ kind: options.screen.hint ?? "back" });
+	let disposed = false;
+	return {
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const selected = options.screen.items.find((item) => item.id === selectedItemId);
+			const details = [
+				...(selected?.disabledReason
+					? [`Unavailable: ${safeMenuText(selected.disabledReason)}`]
+					: []),
+				...(selected?.details ?? []).map(safeMenuText),
+			];
+			const content =
+				items.length === 0
+					? [options.theme.fg("dim", "  No choices available")]
+					: [
+							...list.render(safeWidth),
+							...(details.length > 0
+								? [
+										"",
+										...details.flatMap((line) =>
+											wrapTextWithAnsi(options.theme.fg("muted", line), safeWidth),
+										),
+									]
+								: []),
+						];
+			const result = [
+				...border.render(safeWidth),
+				...wrapTextWithAnsi(
+					options.theme.fg("accent", options.theme.bold(safeMenuText(options.screen.title))),
+					safeWidth,
+				),
+				...(options.screen.lines ?? []).flatMap((line) =>
+					wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
+				),
+				"",
+				...content,
+				...wrapTextWithAnsi(
+					options.theme.fg(
+						"dim",
+						menuHint(options.keybindings, options.screen.hint ?? "back", "select"),
+					),
+					safeWidth,
+				),
+				...border.render(safeWidth),
+			];
+			return result.map((line) => truncateToWidth(line, safeWidth, ""));
+		},
+		invalidate() {
+			border.invalidate();
+			list.invalidate();
+		},
+		handleInput(data) {
+			if (disposed) return;
+			if (matchesKey(data, Key.ctrl("c"))) options.onEvent({ kind: "close" });
+			else if (options.keybindings.matches(data, "tui.select.cancel")) {
+				options.onEvent({ kind: options.screen.hint ?? "back" });
+			} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+				const index = items.findIndex((item) => item.value === selectedItemId);
+				select(index - Math.max(1, viewportSize));
+			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+				const index = items.findIndex((item) => item.value === selectedItemId);
+				select(index + Math.max(1, viewportSize));
+			} else if (data === " ") activate(selectedItemId);
+			else list.handleInput(data);
+			options.tui.requestRender();
 		},
 		async waitForPending() {},
 		dispose() {

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -62,6 +62,23 @@ export interface DetailScreen {
 	hint?: "back" | "close";
 }
 
+export interface MenuChoiceItem extends MenuItemBase {
+	details?: readonly string[];
+	disabledReason?: string;
+}
+
+export interface ChoiceScreen<ActionId extends string> {
+	kind: "choice";
+	title: string;
+	lines?: readonly string[];
+	items: readonly MenuChoiceItem[];
+	action: ActionId;
+	currentItemId?: string;
+	initialItemId?: string;
+	viewportSize?: number;
+	hint?: "back" | "close";
+}
+
 export interface MenuSettingItem<ActionId extends string> extends MenuItemBase {
 	currentValue: string;
 	values?: readonly string[];
@@ -95,6 +112,7 @@ export interface MultiSelectScreen<ScreenId extends string, ActionId extends str
 export type MenuScreen<ScreenId extends string, ActionId extends string> =
 	| ActionsScreen<ScreenId, ActionId>
 	| DetailScreen
+	| ChoiceScreen<ActionId>
 	| SettingsScreen<ActionId>
 	| MultiSelectScreen<ScreenId, ActionId>;
 

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+	type ChoiceScreen,
 	createMenuNavigator,
 	defineMenu,
 	type MenuDefinition,
+	PI_EXTENSION_MENU_API_VERSION,
 	resolveMenuScreen,
 } from "../src/index.js";
 
@@ -35,6 +37,10 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 		},
 	});
 }
+
+test("the declarative API version includes choice screens", () => {
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 2);
+});
 
 test("menu definitions resolve dynamic screens and reject invalid references", () => {
 	const definition = testMenu();
@@ -119,6 +125,90 @@ test("multi-select viewports must be positive integers", () => {
 			/viewport.*positive integer/i,
 		);
 	}
+});
+
+test("choice screens accept stable items and optional missing current and initial ids", () => {
+	const screen: ChoiceScreen<"choose"> = {
+		kind: "choice",
+		title: "Profile",
+		items: [
+			{ id: "safe", label: "Safe", details: ["One", "Two"] },
+			{ id: "fast", label: "Fast", disabled: true, disabledReason: "Unavailable" },
+		],
+		action: "choose",
+		currentItemId: "custom",
+		initialItemId: "balanced",
+		viewportSize: 5,
+	};
+	const definition = defineMenu<undefined, "choice", "choose">({
+		start: "choice",
+		screens: { choice: () => screen },
+		actions: { choose: async () => ({ kind: "close" }) },
+	});
+	assert.equal(resolveMenuScreen(definition, "choice", undefined), screen);
+});
+
+test("choice screens require a known action and positive integer viewport", () => {
+	const definition = defineMenu<undefined, "choice", "choose">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Profile",
+				items: [{ id: "safe", label: "Safe" }],
+				action: "missing" as "choose",
+			}),
+		},
+		actions: { choose: async () => ({ kind: "close" }) },
+	});
+	assert.throws(
+		() => resolveMenuScreen(definition, "choice", undefined),
+		/choice.*unknown action.*missing/i,
+	);
+	for (const viewportSize of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+		assert.throws(
+			() =>
+				resolveMenuScreen(
+					{
+						...definition,
+						screens: {
+							choice: () => ({
+								kind: "choice" as const,
+								title: "Profile",
+								items: [{ id: "safe", label: "Safe" }],
+								action: "choose" as const,
+								viewportSize,
+							}),
+						},
+					},
+					"choice",
+					undefined,
+				),
+			/choice.*viewport.*positive integer/i,
+		);
+	}
+});
+
+test("choice screens reject blank and duplicate raw ids", () => {
+	const resolve = (ids: readonly string[]) =>
+		resolveMenuScreen(
+			defineMenu<undefined, "choice", "choose">({
+				start: "choice",
+				screens: {
+					choice: () => ({
+						kind: "choice",
+						title: "Profile",
+						items: ids.map((id) => ({ id, label: "Same" })),
+						action: "choose",
+					}),
+				},
+				actions: { choose: async () => ({ kind: "close" }) },
+			}),
+			"choice",
+			undefined,
+		);
+	assert.throws(() => resolve([" "]), /id must not be empty/i);
+	assert.throws(() => resolve(["same", "same"]), /id must be unique.*same/i);
 });
 
 test("navigator owns nested Back and Close transitions", () => {

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -1,14 +1,16 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "../src/index.js";
 
-type Screen = "main" | "settings";
-type Action = "refresh" | "setMode";
+type Screen = "main" | "profile" | "settings";
+type Action = "refresh" | "setMode" | "setProfile";
 interface State {
 	mode: "Safe" | "Fast";
+	profile: "Minimal" | "Balanced" | "Custom";
 }
 
 declare function refreshDomainState(signal: AbortSignal): Promise<void>;
 declare function saveMode(mode: State["mode"], signal: AbortSignal): Promise<void>;
+declare function saveProfile(profile: string, signal: AbortSignal): Promise<void>;
 declare function loadState(signal: AbortSignal): Promise<State>;
 declare function currentGeneration(): number;
 declare function currentSessionSignal(): AbortSignal;
@@ -23,10 +25,22 @@ const menu = defineMenu<State, Screen, Action>({
 			lines: [`Current mode: ${state.mode}`],
 			items: [
 				{ id: "refresh", label: "Refresh", action: "refresh", busyLabel: "Refreshing" },
+				{ id: "profile", label: "Profile", to: "profile" },
 				{ id: "settings", label: "Settings", to: "settings" },
 				{ id: "close", label: "Close", close: true },
 			],
 			hint: "close",
+		}),
+		profile: ({ state }) => ({
+			kind: "choice",
+			title: "Profile",
+			items: [
+				{ id: "minimal", label: "Minimal", details: ["Only essential information"] },
+				{ id: "balanced", label: "Balanced", details: ["Recommended information"] },
+			],
+			action: "setProfile",
+			currentItemId: state.profile.toLowerCase(),
+			initialItemId: state.profile === "Custom" ? "balanced" : state.profile.toLowerCase(),
 		}),
 		settings: ({ state }) => ({
 			kind: "settings",
@@ -50,6 +64,10 @@ const menu = defineMenu<State, Screen, Action>({
 		setMode: async ({ value, signal }) => {
 			await saveMode(value === "Fast" ? "Fast" : "Safe", signal);
 			return { kind: "stay" };
+		},
+		setProfile: async ({ itemId, signal }) => {
+			await saveProfile(itemId, signal);
+			return { kind: "back" };
 		},
 	},
 });

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -184,6 +184,240 @@ test("RPC uses dialog adaptation without custom TUI and print mode delegates uns
 	assert.equal(unsupportedMode, "tui");
 });
 
+test("choice TUI prefers initial over current and invokes the confirmed raw item id", async () => {
+	const invoked: string[] = [];
+	let customCalls = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			assert.equal(customCalls, 1);
+			const harness = createCustomSelectorHarness(factory, 80);
+			const rendered = harness.render().join("\n");
+			assert.match(rendered, /Safe.*✓ current/);
+			assert.match(rendered, /→ Balanced/);
+			harness.handleInput(" ");
+			return harness.result;
+		},
+	});
+	const definition = defineMenu<undefined, "profile", "choose">({
+		start: "profile",
+		screens: {
+			profile: () => ({
+				kind: "choice",
+				title: "Profile",
+				items: [
+					{ id: "safe", label: "Safe" },
+					{ id: "balanced", label: "Balanced", details: ["Recommended"] },
+				],
+				action: "choose",
+				currentItemId: "safe",
+				initialItemId: "balanced",
+			}),
+		},
+		actions: {
+			choose: async ({ itemId }) => {
+				invoked.push(itemId);
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(invoked, ["balanced"]);
+});
+
+test("choice TUI falls back from a missing initial id to the current item", async () => {
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 80);
+			assert.match(harness.render().join("\n"), /→ Safe.*✓ current/);
+			harness.handleInput("\u0003");
+			return harness.result;
+		},
+	});
+	const definition = defineMenu<undefined, "profile", "choose">({
+		start: "profile",
+		screens: {
+			profile: () => ({
+				kind: "choice",
+				title: "Profile",
+				items: [
+					{ id: "balanced", label: "Balanced" },
+					{ id: "safe", label: "Safe" },
+				],
+				action: "choose",
+				currentItemId: "safe",
+				initialItemId: "missing",
+			}),
+		},
+		actions: { choose: async () => ({ kind: "close" }) },
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+	});
+});
+
+test("choice rejection restores remembered selection and falls back when that item disappears", async () => {
+	let includeFast = true;
+	let customCalls = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const harness = createCustomSelectorHarness(factory, 80);
+			if (customCalls === 1) {
+				assert.match(harness.render().join("\n"), /→ Balanced/);
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else {
+				assert.match(harness.render().join("\n"), /→ Balanced/);
+				assert.doesNotMatch(harness.render().join("\n"), /Fast/);
+				harness.handleInput("\u0003");
+			}
+			return harness.result;
+		},
+	});
+	const definition = defineMenu<undefined, "profile", "choose">({
+		start: "profile",
+		screens: {
+			profile: () => ({
+				kind: "choice",
+				title: "Profile",
+				items: [
+					{ id: "safe", label: "Safe" },
+					{ id: "balanced", label: "Balanced" },
+					...(includeFast ? [{ id: "fast", label: "Fast" }] : []),
+				],
+				action: "choose",
+				currentItemId: "safe",
+				initialItemId: "balanced",
+			}),
+		},
+		actions: {
+			choose: async ({ itemId }) => {
+				assert.equal(itemId, "fast");
+				includeFast = false;
+				return { kind: "rejected" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.equal(customCalls, 2);
+});
+
+test("choice actions receive owner abort and drain before stale exit", async () => {
+	const owner = new AbortController();
+	let reportStarted: (() => void) | undefined;
+	let observedAbort = false;
+	const started = new Promise<void>((resolve) => {
+		reportStarted = resolve;
+	});
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) =>
+			driveCustomSelector(factory, ["tui.select.confirm"], 40).result,
+	});
+	const definition = defineMenu<undefined, "choice", "choose">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Choose",
+				items: [{ id: "safe", label: "Safe" }],
+				action: "choose",
+			}),
+		},
+		actions: {
+			choose: async ({ signal }) => {
+				reportStarted?.();
+				await new Promise<void>((resolve) => {
+					if (signal.aborted) resolve();
+					else {
+						signal.addEventListener(
+							"abort",
+							() => {
+								observedAbort = true;
+								resolve();
+							},
+							{ once: true },
+						);
+					}
+				});
+				return { kind: "stay" };
+			},
+		},
+	});
+	const running = runMenu(context.ctx, definition, {
+		getState: () => undefined,
+		signal: owner.signal,
+	});
+	await started;
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.equal(observedAbort, true);
+});
+
+test("choice RPC preserves duplicate-label identity and keeps disabled rows inert", async () => {
+	const invoked: string[] = [];
+	let selectCalls = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, choices: string[]) => {
+			selectCalls += 1;
+			assert.equal(new Set(choices).size, choices.length);
+			if (selectCalls === 1) return choices.find((choice) => choice.startsWith("[-]"));
+			return choices.find((choice) => choice === "Same [2]");
+		},
+	});
+	const definition = defineMenu<undefined, "choice", "choose">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Choose",
+				items: [
+					{ id: "raw-one", label: "Same" },
+					{ id: "raw-two", label: "Same" },
+					{
+						id: "disabled",
+						label: "Same",
+						disabled: true,
+						disabledReason: "Policy",
+					},
+				],
+				action: "choose",
+				hint: "close",
+			}),
+		},
+		actions: {
+			choose: async ({ itemId }) => {
+				invoked.push(itemId);
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(invoked, ["raw-two"]);
+	assert.equal(selectCalls, 2);
+});
+
 test("RPC choices preserve item identity across duplicate and exit labels", async () => {
 	let selectCalls = 0;
 	const invoked: string[] = [];

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -29,7 +29,7 @@ const testKeybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
 setKeybindings(testKeybindings);
 
 type ScreenId = "main" | "detail";
-type ActionId = "run" | "setting" | "toggle";
+type ActionId = "run" | "choose" | "setting" | "toggle";
 
 const actionScreen: MenuScreen<ScreenId, ActionId> = {
 	kind: "actions",
@@ -49,6 +49,39 @@ const detailScreen: MenuScreen<ScreenId, ActionId> = {
 	lines: [
 		"One very long detail line that must remain visible without crossing the terminal width.",
 	],
+	hint: "back",
+};
+
+const choiceScreen: MenuScreen<ScreenId, ActionId> = {
+	kind: "choice",
+	title: "Information profile",
+	lines: ["Current profile: Custom"],
+	items: [
+		{
+			id: "minimal",
+			label: "Minimal",
+			description: "Small output",
+			details: ["Segments: model · git"],
+		},
+		{
+			id: "balanced",
+			label: "Balanced",
+			description: "Recommended",
+			details: ["Segments: model · tokens · git"],
+		},
+		{
+			id: "verbose",
+			label: "Verbose\u001b]8;;unsafe\u0007",
+			description: "Everything",
+			details: ["Unsafe\u001b[31m detail", "Second detail"],
+			disabled: true,
+			disabledReason: "Unavailable\u0007 here",
+		},
+	],
+	action: "choose",
+	currentItemId: "minimal",
+	initialItemId: "balanced",
+	viewportSize: 2,
 	hint: "back",
 };
 
@@ -87,7 +120,13 @@ const multiSelectScreen: MenuScreen<ScreenId, ActionId> = {
 };
 
 test("standard screens remain bounded and sanitize terminal controls", () => {
-	for (const screen of [actionScreen, detailScreen, settingsScreen, multiSelectScreen]) {
+	for (const screen of [
+		actionScreen,
+		detailScreen,
+		choiceScreen,
+		settingsScreen,
+		multiSelectScreen,
+	]) {
 		for (const width of [20, 40, 80, 120]) {
 			const harness = componentHarness(screen);
 			const lines = harness.component.render(width);
@@ -114,6 +153,82 @@ test("action screens honor injected navigation and distinguish Back from Ctrl+C 
 	const close = componentHarness({ ...actionScreen, hint: "back" });
 	close.component.handleInput("\u0003");
 	assert.deepEqual(close.events, [{ kind: "close" }]);
+});
+
+test("choice screens render current state, initial selection, details, and disabled reasons", () => {
+	const harness = componentHarness(choiceScreen, {
+		plainTheme: true,
+		selectedItemId: "balanced",
+	});
+	const lines = plainRender(harness.component, 80);
+	assert.equal(lines[0], "─".repeat(80));
+	assert.equal(lines.at(-1), "─".repeat(80));
+	assert.match(lines.join("\n"), /Minimal.*✓ current/);
+	assert.match(lines.join("\n"), /→ Balanced/);
+	assert.match(lines.join("\n"), /Segments: model · tokens · git/);
+	assert.doesNotMatch(lines.join("\n"), /Unsafe.*detail/);
+	for (const width of [1, 20, 40, 80, 120]) {
+		assert.ok(harness.component.render(width).every((line) => visibleWidth(line) <= width));
+	}
+});
+
+test("choice screens use injected navigation, block disabled activation, and distinguish exits", () => {
+	const disabled = componentHarness(choiceScreen, { selectedItemId: "balanced" });
+	disabled.component.handleInput("j");
+	assert.match(
+		stripVTControlCharacters(disabled.component.render(80).join("\n")),
+		/Unavailable here/,
+	);
+	disabled.component.handleInput("l");
+	assert.deepEqual(disabled.events, []);
+	disabled.component.handleInput("q");
+	assert.deepEqual(disabled.events, [{ kind: "back" }]);
+
+	const selected = componentHarness(choiceScreen, { selectedItemId: "minimal" });
+	selected.component.handleInput("j");
+	selected.component.handleInput(" ");
+	assert.deepEqual(selected.events, [{ kind: "activate", itemId: "balanced" }]);
+
+	const closed = componentHarness(choiceScreen);
+	closed.component.handleInput("\u0003");
+	assert.deepEqual(closed.events, [{ kind: "close" }]);
+});
+
+test("disposed choice screens ignore later input and dispose once", () => {
+	const harness = componentHarness(choiceScreen, { selectedItemId: "balanced" });
+	harness.component.dispose?.();
+	harness.component.dispose?.();
+	harness.component.handleInput("l");
+	assert.deepEqual(harness.events, []);
+});
+
+test("choice screens page through a bounded viewport and sanitize all displayed text", () => {
+	const items = Array.from({ length: 12 }, (_, index) => ({
+		id: `choice-${index}`,
+		label:
+			index === 10 ? "詳細 🧭" : index === 11 ? "Unsafe\u001b]8;;label\u0007" : `Choice ${index}`,
+		details: index === 11 ? ["Unsafe\u001b[31m detail"] : [`Detail ${index}`],
+	}));
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "choice",
+		title: "Large choice",
+		items,
+		action: "choose",
+		viewportSize: 3,
+	};
+	const harness = componentHarness(screen, { selectedItemId: "choice-0", plainTheme: true });
+	harness.component.handleInput("d");
+	assert.deepEqual(harness.selectionChanges, ["choice-3"]);
+	const unicode = componentHarness(screen, { selectedItemId: "choice-10", plainTheme: true });
+	assert.ok(unicode.component.render(8).every((line) => visibleWidth(line) <= 8));
+	const unsafe = componentHarness(screen, { selectedItemId: "choice-11", plainTheme: true });
+	const raw = unsafe.component.render(24).join("\n");
+	const rendered = stripVTControlCharacters(raw);
+	assert.equal(raw.includes("\u001b]8;;label"), false);
+	assert.equal(raw.includes("\u001b[31m detail"), false);
+	assert.match(rendered, /Unsafe .*label/);
+	assert.match(rendered, /Unsafe .*detail/);
+	assert.ok(harness.component.render(24).every((line) => visibleWidth(line) <= 24));
 });
 
 test("theme invalidation rebuilds themed title content", () => {

--- a/test/support.ts
+++ b/test/support.ts
@@ -396,8 +396,8 @@ export function createCustomSelectorHarness(
 			component.handleInput(inputData[data] ?? data);
 			return component.render(width);
 		},
-		render() {
-			return component.render(width);
+		render(renderWidth = width) {
+			return component.render(renderWidth);
 		},
 		invalidate() {
 			(component as { invalidate?: () => void }).invalidate?.();


### PR DESCRIPTION
## Summary

- add a declarative `choice` screen with separate current/initial state, selected details, disabled explanations, bounded navigation, and API version 2
- preserve raw identity and action lifecycle across TUI and RPC, including cancellation, disposal, rejection, session replacement, and duplicate display labels
- prove the abstraction by migrating pi-statusline information profiles and pi-worktree selection while retaining palette preview, settings rollback, and worktree safety/revalidation
- update the pi-tui-kit roadmap and track the Phase 1–2 qualification evidence in the active implementation plan

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npm run check --workspace @narumitw/pi-statusline`
- `npm run check --workspace @narumitw/pi-worktree`
- focused compiled suites: 121 tests passed (58 kit, 35 statusline, 28 worktree)
- `npm run check` — 1,824 tests passed
- `just pack-tui-kit`
- `just pack-statusline`
- `just pack-worktree`
- Pi RPC smoke: loaded `/worktree`, opened the main menu and nested choice dialog, and cancelled cleanly

## Convention audit

Read `docs/extension-conventions.md` and `docs/extension-settings.md`. Audited package boundaries, public Pi imports, TUI width/theme/keybindings, TUI/RPC behavior, owner cancellation, stale continuations, statusline persistence/application rollback, worktree revalidation/safety, declarations, and packed contents.

Accepted rollout deviation: the first standard-screen capability and its two proof migrations are kept in one atomic PR; unrelated domain UI remains extension-owned. Interactive TUI execution was not opened from the noninteractive agent; deterministic component/command harnesses and a real RPC runtime smoke cover the path.
