### PR TITLE
docs: add pi-goal cross-extension supervision roadmap

### DIFF
--- a/docs/plans/2026-07-30_pi-goal-blocked-proposal-review-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-blocked-proposal-review-plan.md
@@ -1,0 +1,142 @@
+# pi-goal Blocked-Proposal Review Plan
+
+## Goal
+
+Conditionally deliver Phase 5 of
+`docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md`: allow one admitted, explicitly
+enabled supervisor to review a fully validated `goal_blocked` proposal before it becomes durable,
+without weakening the blocker audit or making terminal progress depend indefinitely on a listener.
+
+## Context
+
+- This plan is not admitted for execution until Phase 4 records **Admit** for blocked-proposal review
+  and identifies the validating consumer and protocol constraints.
+- `goal_blocked` currently validates run ownership, pending skip, exact Goal ID, active status, bounded
+  reason/evidence, and `repeated_turns >= 3`, then immediately cancels continuation/recovery work,
+  blocks stale tools, persists `blocked`, and returns a terminating result.
+- Pi's `EventBus.emit()` is synchronous only for listener invocation; listener callbacks are wrapped
+  asynchronously, their promises are not awaited by `emit()`, failures are isolated, and the API has
+  no listener-count method. No-listener behavior therefore requires an explicit immediate claim
+  handshake rather than an unconditional review timeout.
+- Phase 1–3 settings, provenance, and supervisor access must already be complete.
+
+## Architecture
+
+The Phase 4 admission record must finalize channel names and bounds. The expected protocol has three
+steps:
+
+1. `pi-goal` emits a JSON proposal with a unique `proposalId`, exact `goalId`, validated reason,
+   evidence, recurrence count, and a request-scoped claim channel.
+2. A listener that is already registered claims synchronously before the proposal emission returns.
+   The first valid claim owns the proposal; no claim means the current `blocked` transition proceeds
+   immediately with no timer or visible delay.
+3. A claimed reviewer sends one bounded decision on a proposal-scoped reply channel before timeout:
+   allow the original block, or defer it once with bounded guidance under the admitted policy.
+
+The event bus is not an authorization system. User settings grant `pi-goal` permission to offer a
+proposal only when access is `supervisor` and `blockedProposalReview` is enabled. The coordinator
+owns proposal IDs, first-claim arbitration, timeout, cancellation, session generation, policy
+revocation, and waiter cleanup. `goal.ts` remains the owner of blocker validation and final tool
+result; `GoalRuntime` remains the only state writer.
+
+A review occurs only after every existing `goal_blocked` validation succeeds. Invalid blocker calls
+never emit proposals. Timeout, malformed decision, listener failure, policy downgrade, replacement,
+shutdown, or exceeded deferral allowance resolves to the original durable `blocked` transition.
+
+A defer decision must have one explicit run-boundary behavior chosen in Phase 4: either return a
+non-terminating tool result with guidance or terminate the current run and schedule one owned
+continuation. It must not permit an immediate same-run proposal loop. The exact maximum deferrals,
+timeout, and guidance length come from the admission decision rather than being invented here.
+
+## Non-Goals
+
+- Review ordinary clarification, terminal provider errors, retry exhaustion, usage limits, budgets,
+  or invalid `goal_blocked` calls.
+- Lower the three-turn recurrence requirement or stale Goal-ID guard.
+- Let multiple supervisors vote, race policy decisions, or retain a proposal after its session ends.
+- Persist pending review ownership across reload.
+- Add continuation hold/release as part of blocker review.
+- Allow a reviewer to mark a Goal complete or mutate its objective, budget, queue, or settings.
+
+## Unknowns
+
+The Phase 4 admission record must resolve these before implementation:
+
+- exact request, claim, and reply channels plus payload versioning;
+- timeout, guidance length, and maximum deferral count;
+- first-claim identity and duplicate-claim response semantics;
+- defer tool-result termination and next-run behavior;
+- whether deferral count persists with the Goal safety epoch and how resume/edit resets it.
+
+## Risks
+
+- Awaiting every proposal would add latency when no supervisor is installed. Require an immediate
+  synchronous claim and prove no-listener equivalence.
+- A reviewer can create unbounded token use by repeatedly vetoing a valid blocker. Enforce the admitted
+  deferral bound in canonical Goal state or an equally durable safety epoch.
+- State can change while a claimed review is pending. Revalidate session, Goal ID, status, run
+  ownership, pending skip, policy, and cancellation after the wait.
+- Returning a non-terminating tool result can let the model call `goal_blocked` again in the same run.
+  The admitted run-boundary design must prevent that loop.
+- Event-listener failures are logged by Pi and cannot be awaited directly. The proposal coordinator
+  must own timeout and fallback rather than relying on listener exceptions.
+
+## Rollback / Recovery
+
+- The setting and event channels are additive and default off. Reverting the phase restores immediate
+  blocking; optional retained deferral counters must be ignored safely by older versions.
+- Disabling review, downgrading access, replacing the session, or shutting down resolves every owned
+  proposal to the original block and releases its timer and waiter exactly once.
+- A failed settings save restores the prior effective permission. Runtime policy changes occur only
+  after durable save through the existing settings transaction.
+
+## Plan
+
+- [ ] Verify Phase 4 recorded **Admit** for blocked-proposal review and copy the consumer reference,
+      exact channel schema, timeout, guidance, deferral, claimant, and run-boundary decisions into this
+      plan; if the gate did not pass, mark every remaining item not applicable with the roadmap
+      decision as evidence and do not change production code.
+- [ ] Add a real-`createEventBus()` characterization suite proving synchronous listener invocation,
+      asynchronous handler non-awaiting, isolated listener failure, first-claim ordering, unsubscribe,
+      and no listener-count API; verify the selected claim handshake works without delaying an
+      unclaimed proposal.
+- [ ] Add failing settings and UI cases for `blockedProposalReview`, its default-off value,
+      `supervisor` dependency, trusted-extension warning, immediate policy downgrade, save rollback,
+      invalid file, and unknown-field preservation; verify the cases fail before changing the schema.
+- [ ] Extend `settings.ts` and `settings-ui.ts` with the admitted permission while preserving one-level
+      settings discoverability and existing transaction semantics; verify lower access cannot leave
+      the permission effective and no active Goal changes merely because the setting toggles.
+- [ ] Add failing protocol tests for absent listener, first/duplicate claims, allow, defer, timeout,
+      invalid payload, listener throw, policy revocation, cancellation, replacement, shutdown, stale
+      Goal, pending skip, and maximum deferrals; verify unclaimed and failure cases expect the exact
+      current `blocked` state and terminating result.
+- [ ] Implement a focused session-owned blocked-review coordinator with unique proposal IDs,
+      first-claim ownership, bounded wait, abortable timer, generation checks, and idempotent cleanup;
+      verify its unit tests pass without adding proposal state to `goal.ts` or a second Goal writer.
+- [ ] Insert the coordinator after all current `goal_blocked` validation and before terminal mutation,
+      then implement the admitted allow/defer run-boundary behavior with full post-wait revalidation;
+      verify invalid blocker calls emit no proposal and no stale decision can mutate a replaced Goal.
+- [ ] Add integration regressions for blocker-audit preservation, deferral epoch/reset semantics,
+      stale-tool blocking, usage accounting, queue skip, parallel tool batches, settings downgrade,
+      reload, and no-listener behavioral equivalence; verify no path creates an unbounded same-run or
+      cross-run blocker loop.
+- [ ] Update `extensions/pi-goal/README.md` with opt-in settings, JSON channels, bounds, first-claim
+      rule, no-listener behavior, timeout/failure fallback, and security limitations; verify examples
+      match the admitted consumer and deterministic tests.
+- [ ] Audit cancellation, proposal disposal, replacement, shutdown, every post-`await` state use,
+      settings mutation ordering, and public contract compatibility; run focused tests, the pi-goal
+      workspace check and runtime smoke, root `npm test`, root `npm run check`, `just pack-goal`, the
+      admitted consumer smoke/dry run, and `git diff --check` before handoff.
+
+## Completion Checklist
+
+- [ ] Phase 4 evidence explicitly admits this capability and supplies every required bound and
+      ownership decision, or the plan is completed as an evidence-backed deferral without code.
+- [ ] Only fully valid `goal_blocked` calls can produce a proposal, and the existing audit remains
+      unchanged.
+- [ ] No listener, timeout, failure, invalid response, revocation, replacement, or shutdown preserves
+      the current durable blocked outcome without a leaked waiter or timer.
+- [ ] Deferral is bounded and cannot create an immediate or indefinite blocker-proposal loop.
+- [ ] One supervisor owns one proposal, and stale or duplicate claims and decisions are inert.
+- [ ] Settings, README, consumer contract, deterministic lifecycle tests, runtime smokes, package dry
+      runs, and repository gates agree on the final admitted behavior.

--- a/docs/plans/2026-07-30_pi-goal-continuation-lease-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-continuation-lease-plan.md
@@ -1,0 +1,161 @@
+# pi-goal Continuation Lease Plan
+
+## Goal
+
+Conditionally deliver Phase 6 of
+`docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md`: let one admitted, explicitly enabled
+supervisor hold one automatic Goal continuation for bounded lifecycle preparation and release it back
+through the normal settled dispatcher without compromising single-flight delivery or Goal liveness.
+
+## Context
+
+- This plan is not admitted for execution until Phase 4 records **Admit** for continuation control
+  and identifies the validating consumer and workflow.
+- `GoalRuntime` currently models one `continuationIntent` and one `continuationDelivery`.
+  `agent_end` records intent; `agent_settled` calls `dispatchContinuationIfSettled()` after recovery
+  and queue actions drain.
+- Dispatch already verifies active Goal identity, terminal-tool availability, automatic/no-progress
+  limits, idle state, and pending messages. New work, stop/clear/replace, compaction, and stale prompt
+  markers cancel or supersede continuation ownership.
+- Internal continuation markers already contain Goal ID, iteration, and a random UUID. A public hold
+  must retain equally exact ticket identity rather than releasing by Goal ID alone.
+- Pi's event bus does not await listeners or expose listener count. No-listener behavior requires an
+  immediate claim handshake; a claimed hold needs an extension-owned lease timer and later release
+  event.
+
+## Architecture
+
+The Phase 4 admission record must finalize channels, lease bounds, claimant semantics, and the
+validated consumer flow. The expected lifecycle is:
+
+```text
+continuation intent
+  -> settled dispatcher offers unique ticket
+  -> optional synchronous first claim
+  -> no claim: normal delivery
+  -> claim: held ticket with bounded lease
+  -> release or expiry
+  -> normal settled dispatcher revalidates and delivers or remains pending
+```
+
+Add a focused continuation-lease coordinator owned by `GoalRuntime` or a narrow runtime collaborator.
+It owns ticket/claim identity, at-most-one holder, expiry, release correlation, policy generation, and
+cleanup. It does not send prompts directly. Release and expiry restore an eligible ticket to
+`dispatchContinuationIfSettled()`, which remains the single delivery authority.
+
+A public ticket contains an opaque `continuationId`, exact `goalId`, and only the bounded metadata the
+consumer needs. Do not expose the prompt or allow the holder to alter it. The first synchronous valid
+claim wins; no claim returns immediately to current dispatch with no timer. A release must match the
+same continuation and claimant identity if the admitted protocol includes one.
+
+The lease is session-owned and never persisted across reload. Pause, clear, replace, edit, resume,
+newer user/extension work, queue supersession, safety/budget stop, tool loss, settings revocation,
+session replacement, and shutdown invalidate it. Expiry does not send directly from a stale timer;
+it reacquires the current session generation and runs the normal idle/pending checks.
+
+When the user disables continuation hold or downgrades access, the setting transaction invalidates
+the hold and schedules ordinary redispatch at the next safe settled/idle boundary. It does not abort
+unrelated work or immediately inject a prompt from the settings callback.
+
+## Non-Goals
+
+- Hold user prompts, steering messages, queue transitions, retries, overflow compaction retries, or
+  budget wrap-up messages.
+- Let a holder edit, replace, inspect, or directly deliver the continuation prompt.
+- Persist leases across reload or recover a supervisor process after session shutdown.
+- Allow multiple holders, votes, lease transfer, or unbounded renewal in the first contract.
+- Trigger compaction inside `pi-goal`; the supervisor owns its admitted preparation workflow.
+- Add blocked-proposal review as part of continuation control.
+
+## Unknowns
+
+The Phase 4 admission record must resolve these before implementation:
+
+- exact offer, claim, release, and optional rejection channels plus payload versioning;
+- lease-duration source and whether one bounded renewal is needed;
+- claimant identity and duplicate claim/release reply semantics;
+- how release requests receive observable acknowledgement;
+- how an expiry or release wakes the dispatcher when no new Pi lifecycle event will occur;
+- whether manual compaction completion requires any additional scheduling beyond the existing
+  `session_compact` idle fallback.
+
+## Risks
+
+- A missing release can strand Goal work. Every claim requires an expiring lease and idempotent
+  cleanup.
+- Releasing by Goal ID can collide with a later continuation for the same Goal. Require the unique
+  ticket ID and invalidate it on every superseding transition.
+- A timer that captures an old `ExtensionContext` can crash or deliver into a replacement session.
+  Capture plain identity data and reacquire/revalidate the bound session generation.
+- Direct send on release can bypass tools, limits, queue, pending-message, and idle checks. Route every
+  release through the existing dispatcher.
+- The continuation subsystem has a long history of race-condition fixes. Adding state across
+  `runtime.ts`, `goal.ts`, settings snapshots, and queue paths without one coordinator can regress
+  ownership locality.
+
+## Rollback / Recovery
+
+- The setting and protocol are additive and default off. Reverting the phase returns to immediate
+  settled dispatch; no persisted lease requires migration.
+- Policy downgrade, pause, clear, replacement, reload, or shutdown cancels the timer, unregisters
+  request ownership, and leaves at most the valid continuation intent available to normal dispatch.
+- A failed settings save restores both the prior permission and exact held/intent/delivery snapshot
+  through the settings transaction; a rollback must not duplicate or lose the ticket.
+- If the admitted runtime cannot prove safe wake-up after lease expiry, defer the capability rather
+  than ship a hold that can require manual user input to recover.
+
+## Plan
+
+- [ ] Verify Phase 4 recorded **Admit** for continuation control and copy the consumer reference,
+      exact channels, lease, claimant, acknowledgement, renewal, wake-up, and compaction decisions
+      into this plan; if the gate did not pass, mark every remaining item not applicable with the
+      roadmap decision as evidence and do not change production code.
+- [ ] Add a real-`createEventBus()` characterization suite for immediate offer/claim ordering,
+      first-claim arbitration, async listener isolation, unsubscribe, duplicate events, and no-listener
+      behavior; verify the selected handshake can claim synchronously without delaying an unclaimed
+      continuation.
+- [ ] Add failing settings and UI cases for `continuationHold`, default off, `supervisor` dependency,
+      warning text, live revocation, save rollback, invalid file, and unknown-field preservation;
+      verify lower access cannot leave lease permission effective.
+- [ ] Add failing coordinator tests for unique tickets, one holder, duplicate/stale claims, valid and
+      invalid release, expiry, optional renewal, policy generation, replacement, shutdown, and exact
+      cleanup; verify fake timers or an injected clock make every lease path deterministic.
+- [ ] Implement the focused lease coordinator and include held state in runtime settings snapshots,
+      cancellation, replacement, and shutdown cleanup; verify deleting the coordinator would disperse
+      real ticket, timer, and generation policy rather than leave a pass-through abstraction.
+- [ ] Add failing dispatcher integration cases for no listener, claim, release, expiry, pending user
+      or extension messages, new work, pause, clear, replace, edit, resume, queue action, safety/budget
+      stop, tool loss, compaction, settings revocation, and repeated `agent_settled`; verify current
+      behavior is the expected baseline in every unclaimed case.
+- [ ] Integrate ticket offering at the existing settled single-flight boundary and route release or
+      expiry back through `dispatchContinuationIfSettled()` with current session/context
+      revalidation; verify no protocol handler or timer calls `sendUserMessage()` directly and one
+      ticket can produce at most one delivery.
+- [ ] Add the admitted consumer's planned lifecycle or compaction workflow tests and a disposable
+      two-extension runtime smoke; verify held work prevents only its exact continuation, newer user
+      work still wins, and release/expiry leaves no timer, listener, status, or stale ticket.
+- [ ] Update `extensions/pi-goal/README.md` with opt-in settings, JSON protocol, unique ticket and
+      first-holder rules, lease/expiry behavior, invalidation matrix, acknowledgements, no-listener
+      behavior, and security limitations; verify examples match consumer and provider tests.
+- [ ] Review `runtime.ts` and `goal.ts` responsibility and line growth, splitting only where the
+      coordinator establishes a clear ownership boundary; audit cancellation, disposal, session
+      replacement, shutdown, settings rollback, and every timer/event continuation against both
+      extension guides.
+- [ ] Run focused deterministic tests, the pi-goal workspace check and runtime smoke, root `npm test`,
+      root `npm run check`, `just pack-goal`, the admitted consumer check/dry run and runtime smoke,
+      plus `git diff --check`; record lease cleanup and no-listener equivalence evidence before
+      handoff.
+
+## Completion Checklist
+
+- [ ] Phase 4 evidence explicitly admits this capability and supplies every lease and ownership
+      decision, or the plan is completed as an evidence-backed deferral without code.
+- [ ] No listener preserves current settled dispatch without delay or behavioral change.
+- [ ] One unique ticket has at most one holder and at most one eventual delivery; stale Goal-only
+      releases cannot affect newer work.
+- [ ] Release, expiry, revocation, replacement, shutdown, and every superseding Goal transition leave
+      no retained timer, listener, waiter, status, or stale ticket.
+- [ ] Every released or expired ticket re-enters the normal dispatcher and rechecks current Goal,
+      tools, limits, queue, idle, and pending-message state.
+- [ ] Settings, README, admitted consumer, deterministic lifecycle tests, runtime smokes, package dry
+      runs, source-boundary review, and repository gates agree on the final behavior.

--- a/docs/plans/2026-07-30_pi-goal-cross-extension-access-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-cross-extension-access-plan.md
@@ -1,0 +1,130 @@
+# pi-goal Cross-Extension Access Plan
+
+## Goal
+
+Deliver Phase 1 of `docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md`: give users a
+backward-compatible settings boundary for disabling the existing cross-extension contract,
+observing Goal state without control, or retaining the current RPC-owned start/pause behavior.
+
+## Context
+
+- `extensions/pi-goal/src/rpc.ts` always registers `pi-goal:rpc:start` and
+  `pi-goal:rpc:pause`; session binding currently determines whether a request can act.
+- `extensions/pi-goal/src/runtime.ts` emits `pi-goal:state` whenever canonical Goal state is
+  persisted or cleared.
+- `extensions/pi-goal/src/settings.ts` owns the user-scoped `pi-goal.json` schema, defaults,
+  validation, unknown-field-preserving save, and atomic publication.
+- `extensions/pi-goal/src/settings-ui.ts` presents four current settings through
+  `@narumitw/pi-tui-kit` and applies successful changes immediately with rollback on failure.
+- Existing RPC behavior is public and tested in `extensions/pi-goal/test/goal-rpc.test.ts`; an
+  omitted new setting must preserve it.
+
+## Architecture
+
+Add one user-scoped setting:
+
+```json
+{
+  "crossExtension": {
+    "access": "rpc-owned"
+  }
+}
+```
+
+The accepted access levels and effective policy are:
+
+| Access | Emit `pi-goal:state` | Accept `rpc:start` | Accept correlated `rpc:pause` |
+| --- | --- | --- | --- |
+| `off` | No | No | No |
+| `observe` | Yes | No | No |
+| `rpc-owned` | Yes | Yes | Yes |
+
+`rpc-owned` is the compatibility default. The settings parser and writer remain in `settings.ts`.
+A small policy helper should answer observation and control questions so `rpc.ts` and Goal-state
+publication do not duplicate string comparisons.
+
+The event handlers remain registered at factory load because Pi's shared event bus is process-wide
+and supports only subscribe/unsubscribe, not dynamic listener discovery. They consult the current
+runtime policy on each request. A valid start request rejected by policy receives a request-scoped
+failure reply; pause remains a safe no-op because the established pause channel has no reply
+contract.
+
+A request that passes policy validation is considered accepted at that boundary and may complete if
+the setting changes while its existing transition is in flight. The access downgrade blocks later
+requests and state broadcasts but does not roll back, pause, or clear the current Goal. Replies for
+already accepted requests are still delivered so callers are not stranded.
+
+The existing Goal Settings screen gains one direct **Cross-extension access** row. Five total rows
+remain below the repository threshold for introducing another submenu. Non-TUI Settings behavior
+continues to report the manual settings path.
+
+## Non-Goals
+
+- Add Resume RPC, state-transition provenance, terminal review, or continuation hold.
+- Add project-scoped settings or environment-variable overrides.
+- Turn the access setting into an extension security sandbox.
+- Change the established start or pause payloads, ownership rules, or reply channel.
+- Clear or pause a Goal merely because access is downgraded.
+
+## Risks
+
+- Suppressing state events while allowing a request reply can surprise a caller that changes policy
+  concurrently; document request acceptance and current-policy event publication separately.
+- A listener may interpret `off` as protection from malicious installed code. UI and README wording
+  must state that installed extensions remain fully privileged.
+- Adding a recognized nested object can accidentally discard unknown sibling fields. Save tests must
+  cover unknown top-level and `crossExtension` fields.
+- Settings changes occur while RPC work can be pending. Tests must establish the accepted-request
+  linearization rule instead of relying on timing.
+
+## Rollback / Recovery
+
+- The setting is additive and has no Goal-state migration. Reverting the feature makes its retained
+  JSON object unknown to older versions, which the existing writer must preserve.
+- A save or runtime-application failure restores the previous file bytes, runtime setting, RPC
+  policy, and displayed value through the existing settings rollback protocol.
+- Invalid existing settings remain read-only and byte-for-byte unchanged; built-in defaults remain
+  effective until the user repairs the file and reloads.
+
+## Plan
+
+- [ ] Add failing cases to `extensions/pi-goal/test/settings.test.ts` for the omitted
+      `rpc-owned` default, all three access values, invalid values and container shapes, and
+      preservation of unknown top-level and nested fields; verify the intended failures with the
+      focused compiled settings test before changing `settings.ts`.
+- [ ] Extend `extensions/pi-goal/src/settings.ts` with the access enum, normalized default, nested
+      read/write behavior, and unknown-field-preserving publication; verify the new settings cases
+      and existing malformed-file, missing-file, and atomic-save tests pass.
+- [ ] Add failing policy-matrix and concurrency cases to
+      `extensions/pi-goal/test/goal-rpc.test.ts` for state emission, start replies, correlated pause,
+      unbound sessions, live downgrades, and an accepted start completing after downgrade; verify
+      failures show the current always-enabled behavior before adding policy checks.
+- [ ] Add one cross-extension policy helper and apply it in
+      `extensions/pi-goal/src/rpc.ts` plus `GoalRuntime.persistGoal()` and clear-event publication so
+      each access level matches the documented matrix without changing request ownership; verify the
+      focused RPC suite passes, including listener-error isolation and session bind/unbind cases.
+- [ ] Add failing settings-menu cases to `extensions/pi-goal/test/settings-ui.test.ts` for the fifth
+      row, effective value labels, immediate application, save rollback, invalid-file read-only
+      output, and non-TUI fallback; then update `extensions/pi-goal/src/settings-ui.ts` to use the
+      existing declarative settings flow and verify those cases pass at supported widths and keyboard
+      paths.
+- [ ] Update `extensions/pi-goal/README.md` with the JSON schema, compatibility default, access
+      matrix, trusted-extension warning, live-change semantics, and non-TUI editing path; verify every
+      documented value and channel is covered by settings or RPC tests.
+- [ ] Audit request acceptance, state suppression, settings ordering, failure rollback, session
+      replacement, and shutdown against `docs/extension-conventions.md` and
+      `docs/extension-settings.md`; run `npm run check --workspace @narumitw/pi-goal`,
+      `npm run test:runtime --workspace @narumitw/pi-goal`, root `npm test`, root `npm run check`,
+      `just pack-goal`, and `git diff --check`, recording any unverified runtime path before handoff.
+
+## Completion Checklist
+
+- [ ] Missing or omitted `crossExtension` settings preserve current state, start, and RPC-owned pause
+      behavior.
+- [ ] `off`, `observe`, and `rpc-owned` accept and reject exactly the operations in the policy matrix.
+- [ ] Downgrading access does not clear, pause, replace, or otherwise mutate the current Goal.
+- [ ] Settings UI, JSON persistence, reload, invalid-file protection, unknown-field preservation,
+      immediate application, and rollback agree with the README.
+- [ ] No Resume RPC, provenance, terminal review, or continuation-hold behavior entered this phase.
+- [ ] Focused tests, runtime smoke, root test/check gates, package dry run, and final semantic audits
+      pass with any accepted deviation documented.

--- a/docs/plans/2026-07-30_pi-goal-supervision-validation-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-supervision-validation-plan.md
@@ -1,0 +1,136 @@
+# pi-goal Supervisor Contract Validation Plan
+
+## Goal
+
+Execute Phase 4 of `docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md`: validate the
+Phase 1–3 public contract against at least one inspectable supervisor consumer and record an explicit
+admission or deferral decision for blocked-proposal review and continuation hold.
+
+## Context
+
+- The repository currently contains `pi-goal` provider-side tests but no sibling extension that
+  consumes its start, pause, state, or proposed resume channels.
+- Issue #455 states that an external local prototype exists, but no inspectable branch, package, or
+  fixture was supplied with the issue.
+- Phases 5 and 6 deliberately add authority at the most sensitive terminal-decision and continuation
+  boundaries. They are not justified by provider-side tests alone.
+- This phase is an evidence and contract-validation gate. A defensible deferral is a successful
+  outcome when no real consumer or recurring workflow can be demonstrated.
+
+## Architecture
+
+The admitted consumer must be an actual sibling extension or an inspectable prototype with the same
+session-local `pi.events` constraints as production. A provider-only unit-test emitter is useful for
+regression coverage but does not satisfy the roadmap's real-consumer gate by itself.
+
+Validate the full public flow:
+
+```text
+consumer registration
+  -> state observation
+  -> optional RPC start and correlated pause
+  -> stopped-state classification
+  -> exact Resume RPC request
+  -> rotated Goal-ID adoption
+  -> reload/shutdown cleanup
+```
+
+The consumer must not import `pi-goal` runtime code, mutate its session entries, emulate TUI input, or
+open a second Pi session. It may share JSON-shaped TypeScript test fixtures locally, but the shipped
+extensions remain dependency-free.
+
+For each proposed Phase 2 hook, collect concrete workflow evidence, required timing, cancellation,
+ownership, timeout, and failure behavior. Record one of three decisions in the roadmap:
+
+- **Admit:** the workflow recurs, lower-level APIs cannot solve it safely, and a bounded protocol is
+  demonstrated.
+- **Revise:** the need is real but the proposed hook or boundary must change before planning.
+- **Defer:** evidence is absent, one-off, or safely handled by Phase 3.
+
+No Phase 5 or 6 implementation begins until its own decision is **Admit**.
+
+## Non-Goals
+
+- Implement blocked-proposal review or continuation hold as part of validation.
+- Treat a synthetic provider-side test as proof of product demand.
+- Add an extension-to-extension runtime dependency or a shared mutable Goal store.
+- Publish, merge, or release the consumer or `pi-goal` automatically.
+- Require both proposed capabilities to receive the same admission decision.
+
+## Unknowns
+
+- Which inspectable consumer will satisfy the gate is currently unknown. The issue author's prototype
+  is preferred if it can be supplied; otherwise a repository-owned consumer must have an independent
+  product reason to exist.
+- No baseline frequency exists for false blocked proposals or planned continuation holds. The phase
+  must report the evidence gap rather than invent a target.
+- Pi's event bus is fire-and-forget and has no listener-count API. A consumer must demonstrate any
+  proposed registration or claim handshake before a Phase 2 design is admitted.
+
+## Risks
+
+- Building a new supervisor solely to satisfy the gate can manufacture demand. Require a concrete
+  user workflow and keep test fixtures distinct from product evidence.
+- A happy-path demo can hide lost replies, stale Goal IDs, session replacement, and listener cleanup.
+  Exercise the failure matrix before admitting more authority.
+- The external prototype may depend on behavior not present in the public contract. Record the gap
+  and revise the roadmap rather than adding private coupling.
+- Validation can drift into implementation. Stop after evidence and admission decisions are
+  documented.
+
+## Rollback / Recovery
+
+- Validation should not change persisted Goal formats or production transitions. Consumer fixtures
+  and documentation can be reverted without data migration.
+- A live smoke must use a disposable session and settings directory. Shutdown must leave no retained
+  listener, timer, session file, or active Goal outside the fixture's declared cleanup.
+- If the consumer cannot be inspected or made deterministic, record both Phase 2 capabilities as
+  deferred and complete this plan without speculative implementation.
+
+## Plan
+
+- [ ] Obtain or identify one inspectable supervisor consumer, record its repository path or immutable
+      review reference plus concrete user workflow in this plan, and verify it uses the public
+      session-local event contract without importing `pi-goal` internals; if none exists, record the
+      evidence gap and move both Phase 2 decisions to **Defer**.
+- [ ] Create a consumer/provider compatibility matrix covering request and reply channels, state
+      provenance, rotated Goal-ID tracking, registration lifetime, settings access, cancellation,
+      reload, shutdown, duplicate/lost request behavior, and every consumer assumption; verify each
+      row cites source and a deterministic test or an explicitly unverified live path.
+- [ ] Add or run cross-extension contract tests that load both factories against the same real
+      `createEventBus()` semantics and exercise observe, start, correlated pause, stop classification,
+      Resume RPC, duplicate/lost reply handling, settings downgrade, reload, session replacement, and
+      shutdown; verify no second writer, command emulation, or stale session context appears.
+- [ ] Run a disposable Pi runtime smoke with the admitted consumer and `pi-goal`, capturing the exact
+      setup, settings, state transitions, rotated IDs, cancellation, and cleanup result; verify the
+      process exits without a retained Goal-owned task or listener and record any path that cannot be
+      automated.
+- [ ] Evaluate blocked-proposal review against observed cases, documenting recurrence, why Phase 3
+      cannot solve them, required claim timing, maximum wait/deferral behavior, multi-listener rule,
+      and failure fallback; record **Admit**, **Revise**, or **Defer** with evidence in the roadmap's
+      Decisions and Changes section.
+- [ ] Evaluate continuation hold against observed planned-compaction or lifecycle cases, documenting
+      why existing settled/pending-message ordering is insufficient, required lease duration source,
+      single-holder rule, stale-ticket behavior, and failure fallback; record an independent
+      **Admit**, **Revise**, or **Defer** decision with evidence in the roadmap.
+- [ ] Reconcile the conditional Phase 5 and Phase 6 plan artifacts with the admission decisions:
+      update admitted plans with verified consumer constraints, or mark their gate and remaining work
+      deferred without pretending implementation is authorized; verify roadmap, plans, and consumer
+      evidence do not contradict one another.
+- [ ] Run affected consumer and `pi-goal` focused tests, root `npm test`, root `npm run check`, relevant
+      package dry runs, and `git diff --check`; verify the final diff contains only validation fixtures,
+      documentation, and explicit decision records unless a separately approved consumer change was
+      required.
+
+## Completion Checklist
+
+- [ ] One inspectable real consumer is validated, or the absence of one is recorded as the reason both
+      Phase 2 capabilities remain deferred.
+- [ ] The Phase 1–3 contract is exercised across success, stale, duplicate/lost, reload, replacement,
+      settings downgrade, and shutdown paths using real event-bus semantics.
+- [ ] Blocked review and continuation hold each have an independent evidence-backed Admit, Revise, or
+      Defer decision.
+- [ ] No Phase 5 or 6 production protocol was implemented during this validation phase.
+- [ ] Roadmap decisions, conditional plans, tests, smoke evidence, and known gaps are mutually
+      consistent.
+- [ ] All applicable focused checks, root gates, dry runs, and cleanup verification pass.

--- a/docs/plans/2026-07-30_pi-goal-supervisor-resume-rpc-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-supervisor-resume-rpc-plan.md
@@ -1,0 +1,143 @@
+# pi-goal Supervisor Resume RPC Plan
+
+## Goal
+
+Deliver Phase 3 of `docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md`: add an explicit
+supervisor access level and a request-scoped Resume RPC that reuses `/goal resume`, rotates the stale
+Goal ID, preserves operator intent, and rolls back safely when activation cannot be delivered.
+
+## Context
+
+- `GoalCommandController.resumeGoal()` currently owns resumable-status and budget checks, terminal-tool
+  activation, continuation/recovery cleanup, stale-ID rotation, safety reset, owned prompt delivery,
+  rollback, status updates, and user notifications.
+- `GoalRpcController` already provides a start request/reply handshake, correlated pause ownership,
+  session bind/unbind, and stale-start protection.
+- The Phase 1 plan provides `off`, `observe`, and `rpc-owned` policy levels. The Phase 2 plan provides
+  durable stopped-transition provenance, including explicit operator and conservative legacy-unknown
+  stops.
+- Pi's shared event bus returns from `emit()` without awaiting async listeners, so request completion
+  must continue to use a request-scoped reply channel rather than a returned event value.
+
+## Architecture
+
+Extend `crossExtension.access` with `supervisor`. It includes state observation and the existing
+RPC-owned start/pause operations, then adds Resume RPC for an exact current stopped foreground Goal.
+It does not grant direct state mutation or permission to resume an explicit operator pause.
+
+Use these proposed channels, finalized by the first plan item:
+
+```text
+request: pi-goal:rpc:resume
+reply:   pi-goal:rpc:resume:reply:${requestId}
+```
+
+The request carries `requestId` and the exact current stopped `goalId`. The success reply carries the
+newly rotated `goalId`, resulting authoritative status, and optionally the prior ID for correlation.
+Every syntactically valid request ID receives exactly one success or failure reply, including policy,
+session, stale-ID, eligibility, budget, tool-availability, supersession, and delivery failures.
+
+Refactor the existing resume path behind one structured operation result. The slash-command adapter
+owns user-facing notifications; the RPC adapter owns JSON replies. Both use the same validation,
+transition, prompt ownership, and rollback implementation. Do not invoke a slash command through
+text input or infer success from notifications.
+
+A supervisor request can resume only provenance classes explicitly admitted by a table-driven policy.
+`operator/explicit_pause` and `legacy_unknown` are denied server-side. Resume remains status- and
+budget-gated exactly as the command is today. Successful resume rotates the Goal ID before prompt
+delivery, so the reply and subsequent state event must expose the new ID.
+
+Session binding gains a monotonically changing generation or equivalent exact-context token. After
+owned prompt delivery awaits, the continuation revalidates session generation, request ownership,
+old/new Goal identity, and current status before reporting success or restoring prior state.
+
+Optional `reason` is diagnostic request metadata and is not injected into the model prompt. Optional
+repair guidance is deferred unless the first plan item admits a bounded schema, trust-boundary
+wording, and tests without widening the objective. Deferral does not block the core Resume RPC.
+
+## Non-Goals
+
+- Resume explicit operator pauses or legacy stops whose origin cannot be proven safe.
+- Add terminal proposal review, continuation hold, multi-supervisor arbitration, or a second writer.
+- Change the current token-budget eligibility rule or silently increase a budget.
+- Replace the existing `/goal resume` user workflow or its notifications.
+- Guarantee durable cross-process request deduplication; the contract remains session-local.
+
+## Unknowns
+
+- Whether duplicate `requestId` values return a cached result or a deterministic duplicate/stale
+  failure must be decided before the public schema is documented. In either case, a duplicate cannot
+  reactivate Goal work twice.
+- The exact resumable provenance allowlist requires the completed Phase 2 taxonomy.
+- Repair guidance remains optional in issue #455. It must be explicitly admitted or deferred before
+  implementation rather than appearing as an unbounded string.
+
+## Risks
+
+- Calling the current UI-oriented method directly from RPC can duplicate notifications or make the
+  reply depend on side effects. Use a structured shared operation and thin adapters.
+- A successful transition rotates the Goal ID before an async send. A stale completion can otherwise
+  report success for a replaced session or roll back a newer Goal.
+- Metadata alone does not protect operator intent. Enforce denied provenance inside `pi-goal`, not
+  only in the supervisor consumer.
+- Request retries after a lost success reply can look stale because the ID already rotated. The public
+  duplicate rule must be explicit and deterministic.
+
+## Rollback / Recovery
+
+- The RPC channel is additive and carries no persisted request state. Reverting to a Phase 1 build
+  requires changing an explicit `supervisor` setting back to `rpc-owned` before that older validator
+  can load the file; document this rollback instead of claiming forward enum compatibility.
+- A failed resume restores the exact prior stopped Goal ID, status, provenance, safety counters,
+  safety cause, continuation/recovery state, stale-tool block, status text, and tool-visibility
+  snapshot only if that request still owns the current transition.
+- Session replacement or shutdown invalidates all pending resume ownership and prevents replies from
+  claiming a new session's Goal.
+
+## Plan
+
+- [ ] Finalize and record the Resume RPC request, success/failure reply, error codes, duplicate
+      behavior, admitted provenance allowlist, and repair-guidance decision in this plan and README
+      draft; verify each public field has one deterministic validation or lifecycle test before
+      production implementation begins.
+- [ ] Add failing settings and UI cases in `settings.test.ts` and `settings-ui.test.ts` for the
+      `supervisor` access value, compatibility default, immediate downgrade, save rollback, and
+      trusted-extension/operator-pause wording; verify the failures precede schema and menu changes.
+- [ ] Extend `settings.ts` and the existing Cross-extension access row in `settings-ui.ts` with
+      `supervisor`, preserving the current settings transaction and no-project-override boundary;
+      verify settings normalization, persistence, UI, invalid-file, and non-TUI tests pass.
+- [ ] Add failing command-level characterization tests for every current `/goal resume` success and
+      rejection result, then refactor `GoalCommandController` to return a tagged resume result used by
+      both command and future RPC adapters without changing command-visible behavior; verify the
+      existing resume, budget, tool-visibility, prompt-delivery rollback, and queue tests remain green.
+- [ ] Add failing `goal-rpc.test.ts` cases for malformed payloads, no session, insufficient access,
+      exact stopped ID, denied operator and legacy provenance, each admitted stopped class, exhausted
+      budget, unavailable tools, rotated success ID, duplicate requests, clear/replace races, session
+      replacement, shutdown, and send failure; verify they fail because no resume channel exists.
+- [ ] Implement the request/reply handler and session-generation ownership in `rpc.ts`, call the shared
+      resume operation, and emit exactly one correlated reply without command emulation; verify the
+      focused RPC suite proves stale continuations cannot report or roll back across a newer Goal or
+      session.
+- [ ] Add integration regressions showing successful Resume RPC resets the safety epoch, clears the
+      stale-tool block, rotates blocker audit ownership, emits active state for the new Goal ID, and
+      preserves denied operator state byte-for-byte; verify these invariants through canonical session
+      entries rather than notifications alone.
+- [ ] Update `extensions/pi-goal/README.md` with supervisor opt-in, exact payloads and channels,
+      provenance eligibility, operator-pause denial, duplicate/lost-reply semantics, new Goal-ID
+      tracking, settings behavior, and any explicit guidance deferral; verify examples match tests.
+- [ ] Audit user cancellation, prompt disposal, session replacement, shutdown, post-`await` state,
+      settings downgrade, and tool-visibility rollback against both extension guides; run the
+      workspace check and runtime smoke, root `npm test`, root `npm run check`, `just pack-goal`, and
+      `git diff --check`, recording any live supervisor path that remains unverified for Phase 4.
+
+## Completion Checklist
+
+- [ ] `supervisor` is explicit opt-in and lower access levels cannot invoke Resume RPC.
+- [ ] Slash-command and RPC resume use one transition implementation with unchanged command behavior.
+- [ ] Every valid request ID receives one documented reply, and success returns the rotated Goal ID.
+- [ ] Operator, legacy-unknown, stale, replaced-session, ineligible, budget-exhausted, and failed-send
+      cases cannot leave unauthorized Goal work active.
+- [ ] Successful resume preserves existing safety reset, blocker-audit reset, stale-tool, tool-policy,
+      usage, queue, and persistence invariants.
+- [ ] Public schema, settings UI, README, deterministic tests, runtime smoke, package dry run, and root
+      gates agree on the delivered Phase 3 contract.

--- a/docs/plans/2026-07-30_pi-goal-transition-provenance-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-transition-provenance-plan.md
@@ -1,0 +1,141 @@
+# pi-goal Stopped-Transition Provenance Plan
+
+## Goal
+
+Deliver Phase 2 of `docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md`: make the source
+and cause of every stopped Goal state authoritative, machine-readable, and durable across reload so
+integrations can distinguish operator intent from recoverable or system-originated stops.
+
+## Context
+
+- `GoalStateEventPayload` currently contains `goalId`, `status`, `summary?`, and `reason?` in
+  `extensions/pi-goal/src/runtime.ts`.
+- Human-readable terminal details are held outside `ActiveGoal` and deliberately cleared across
+  session bindings; `goal-rpc.test.ts` verifies an old reason does not leak into a restored Goal.
+- `ActiveGoal.safetyPauseCause` persists only `continuation_limit` or `no_progress` and cannot explain
+  command pause, RPC pause, interruption, unavailable tools, provider limits, blocked reports,
+  terminal errors, budgets, clears, or failed activation rollback.
+- Stopped transitions are initiated from `commands.ts`, `runtime.ts`, and `goal.ts`. Adding metadata
+  independently at each event emission would allow state and provenance to diverge.
+- This plan depends on the access policy delivered by the Phase 1 plan. Provenance remains canonical
+  internally even when state observation is disabled.
+
+## Architecture
+
+Add a JSON-safe discriminated transition-provenance type owned by Goal persistence. The final source
+and cause names must be frozen by the first plan item, but the taxonomy must cover at least:
+
+- explicit operator pause and RPC-owned pause;
+- agent interruption;
+- automatic-response and no-progress safety pauses;
+- unavailable terminal tools;
+- provider usage exhaustion and token-budget exhaustion;
+- model-proposed `goal_blocked` and terminal agent-error blocking;
+- explicit clear and activation rollback.
+
+Persist provenance only when it describes the current stopped Goal instance. Active, queued, and
+completed states do not retain stale stopped provenance. Clear and failed-activation events have no
+remaining `ActiveGoal`, so their event builder receives an exact transition value at the clear
+boundary rather than storing orphan state.
+
+Legacy stopped entries without provenance remain loadable. A legacy safety pause may be derived from
+`safetyPauseCause`; every other unclassified legacy stop receives an explicit conservative
+`legacy_unknown` classification that is never eligible for automatic supervisor resume. Existing
+human-readable `reason` and completion `summary` semantics remain separate from the stable machine
+classification.
+
+Introduce one transition helper or narrow runtime operation that requires provenance whenever a Goal
+enters a stopped status. Do not turn the helper into a second persistence layer: the runtime remains
+responsible for persistence and state-event publication, and existing command/tool owners retain
+their domain validation.
+
+The additive state-event shape should use one optional nested field, for example
+`transition: { source, cause }`, so future compatible details can grow without adding unrelated
+root-level fields. The exact public field and enum names are fixed and documented before production
+code changes.
+
+## Non-Goals
+
+- Add Resume RPC or decide which new stopped states a supervisor may resume.
+- Persist free-form provider errors, blocker evidence, or operator guidance as provenance.
+- Rewrite historical session entries or backfill information that cannot be derived safely.
+- Remove `safetyPauseCause` before all internal UI and migration consumers have a proven replacement.
+- Change Goal status names, blocker validation, queue semantics, or state-event channels.
+
+## Unknowns
+
+- Whether a stopped Goal edited without reactivation should preserve its prior stop provenance or
+  record a distinct stopped-edit cause must be resolved in the transition matrix.
+- Whether unavailable tools discovered during session restore should be classified as a restore
+  source or the same Goal-safety source as a live loss must be decided before enum names become
+  public.
+- Completion is terminal but not stopped. This phase must decide whether completion receives
+  provenance now or remains represented only by `summary`; the decision must not widen the Resume
+  safety scope.
+
+## Risks
+
+- An incomplete transition matrix can silently emit stale or missing provenance on rare rollback,
+  queue, retry, or settings-driven paths.
+- Spreading provenance updates across callers can leave persisted state, emitted state, and UI status
+  inconsistent. Enforce the stopped-state invariant in one helper and test every caller.
+- Strict validation of a new optional field could reject legacy or forward-compatible entries. Keep
+  absence valid, reject malformed recognized provenance conservatively, and preserve unknown fields.
+- Reusing human-facing `reason` values as enum names would make wording changes break integrations.
+  Keep stable codes and display text separate.
+
+## Rollback / Recovery
+
+- The persisted field is optional. An older version should ignore and preserve it through object
+  spreading; reverting this phase must not make existing Goal entries unreadable.
+- If provenance validation fails on one entry, preserve the last known safe Goal behavior and surface
+  the existing invalid-state handling rather than inventing a resumable classification.
+- A failed settings or runtime operation that restores a Goal snapshot must restore its matching
+  provenance atomically with status, Goal ID, safety counters, and continuation ownership.
+
+## Plan
+
+- [ ] Build a stopped-transition matrix in this plan and corresponding table-driven fixtures in
+      `extensions/pi-goal/test/goal-rpc.test.ts`, naming every current source path, resulting status,
+      source/cause code, persistence expectation, edit/rotation behavior, and legacy fallback; resolve
+      the three listed unknowns and verify repository search finds no unclassified stopped transition.
+- [ ] Add failing persistence cases to `extensions/pi-goal/test/persistence.test.ts` for valid
+      provenance, malformed recognized values, legacy absence, `safetyPauseCause` derivation,
+      `legacy_unknown`, queues, and unknown-field compatibility; verify the failures precede changes
+      to `persistence.ts`.
+- [ ] Extend `extensions/pi-goal/src/persistence.ts` with the finalized JSON-safe provenance type,
+      validation, normalization, and legacy derivation while preserving current session shapes; verify
+      persistence and existing queue/session restore tests pass.
+- [ ] Add a provenance-aware stopped-transition helper in `extensions/pi-goal/src/runtime.ts` and
+      migrate command pause, RPC pause, safety pause, unavailable tools, budget limit, blocker tool,
+      interruption, retry exhaustion, clear, and activation rollback callers in `commands.ts`,
+      `runtime.ts`, and `goal.ts`; verify a typecheck or exhaustive test fails if a new stopped call
+      omits provenance.
+- [ ] Extend `buildGoalStateEvent()` and clear-event publication with the additive nested transition
+      field, gated only by the Phase 1 observation policy; verify table-driven event tests prove active
+      state has no stale transition and rotated, replaced, queued, completed, and cleared Goals cannot
+      inherit unrelated provenance.
+- [ ] Add reload, fork/branch, session replacement, stopped edit, resume, and failed-delivery rollback
+      regressions to `goal-rpc.test.ts`, `goal.test.ts`, and `goal-queue.test.ts` as applicable; verify
+      canonical provenance follows the active branch and exact Goal instance while free-form terminal
+      details retain their existing non-leak behavior.
+- [ ] Update `extensions/pi-goal/README.md` with the public event shape, complete source/cause table,
+      legacy `legacy_unknown` semantics, and the rule that consumers never parse `reason`; verify the
+      documentation examples match exported TypeScript types and deterministic tests.
+- [ ] Audit every stopped-state writer, post-`await` rollback, session reload, queue transition, and
+      settings snapshot against the roadmap and extension conventions; run the pi-goal workspace
+      check and runtime smoke, root `npm test`, root `npm run check`, `just pack-goal`, and
+      `git diff --check`, recording the transition-matrix evidence in the completed plan.
+
+## Completion Checklist
+
+- [ ] Every documented current stopped transition has one stable source/cause classification and a
+      deterministic test.
+- [ ] Provenance survives reload and branch reconstruction only with its matching Goal instance.
+- [ ] Legacy stopped Goals remain loadable and default conservatively when provenance is unavailable.
+- [ ] Active, queued, completed, rotated, replaced, and cleared state cannot expose stale stopped
+      provenance.
+- [ ] Existing summary/reason behavior, statuses, blocker audit, queue behavior, and access policy
+      remain compatible.
+- [ ] README, persisted schema, event payload types, focused tests, runtime smoke, package contents,
+      and repository gates agree on the delivered contract.

--- a/docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md
+++ b/docs/roadmaps/pi-goal-cross-extension-supervision-roadmap.md
@@ -1,0 +1,303 @@
+# pi-goal Cross-Extension Supervision Roadmap
+
+## Vision
+
+`@narumitw/pi-goal` should let users choose how trusted sibling extensions may observe or
+supervise Goal work while keeping Goal transitions, persistence, stale-turn protection, and
+lifecycle safety under one authoritative `pi-goal` state machine.
+
+## Objectives
+
+- Give users an explicit, backward-compatible boundary for disabling cross-extension integration,
+  observing state, or controlling only RPC-owned goals.
+- Make the source and cause of every stopped Goal transition machine-readable and durable across
+  session reloads.
+- Support supervised recovery of eligible stopped foreground Goals without allowing stale requests
+  or automatic reversal of an explicit operator pause.
+- Admit terminal review and continuation control only after a real supervisor integration validates
+  their need and protocol assumptions.
+- Preserve current standalone behavior, completion and blocker audits, and lifecycle safety when no
+  supervisor participates.
+
+## Current State
+
+This roadmap is for `pi-goal` maintainers, contributors, and sibling-extension authors. It sequences
+cross-extension supervision work without committing to delivery dates, release versions, or owners.
+No implementation phase in this document is an approved commitment yet.
+
+The current package provides a session-local JSON event contract over `pi.events`:
+
+- `pi-goal:rpc:start` starts a new Goal only when no Goal already exists;
+- `pi-goal:rpc:pause` pauses only the Goal owned by the correlated RPC start request; and
+- `pi-goal:state` broadcasts canonical `goalId` and `status`, with a terminal `summary` or `reason`
+  when available.
+
+The existing `/goal resume` path already validates resumable state and token budget, rotates the
+stale-turn guard, resets the safety epoch, delivers an owned prompt, and restores the prior stopped
+state if delivery fails. There is no cross-extension resume request.
+
+State events do not carry structured transition provenance. A human-readable terminal reason is
+held in runtime state and intentionally does not leak into a different restored session. Internal
+Goal persistence carries a limited `safetyPauseCause`, but it cannot distinguish the full set of
+operator, RPC, interruption, safety, provider, agent, and rollback transitions required by a
+supervisor.
+
+The user settings file currently controls tool visibility, the experimental ordered-goal queue, and
+continuation limits. It has no cross-extension access policy. Settings already use defaults for an
+absent file, reject malformed content, preserve unknown fields, publish explicit saves atomically,
+and apply menu changes with rollback on failure.
+
+No repository extension currently consumes the `pi-goal` RPC channels. Issue #455 reports an
+external local prototype and deterministic tests, but that implementation is not available in this
+repository for validation. Terminal proposal review and continuation hold/release therefore remain
+proposed capabilities rather than demonstrated repository requirements.
+
+## Guiding Principles
+
+- **Preserve the compatibility default:** an omitted new setting retains the current state, start,
+  and RPC-owned pause contract.
+- **Increase authority explicitly:** observing state, controlling RPC-owned Goals, and supervising a
+  foreground Goal are distinct permission levels.
+- **Keep operator intent authoritative:** an explicit operator pause remains resumable only through
+  a user-owned path unless a later decision introduces an equally explicit user authorization.
+- **Keep one Goal writer:** sibling extensions request, review, claim, or release; only `pi-goal`
+  validates and commits state transitions.
+- **Fail back to current behavior:** an absent, invalid, failed, timed-out, or replaced supervisor
+  must not strand or silently advance a Goal.
+- **Revalidate after every boundary:** continuations that cross an await, event response, lease, or
+  session change must recheck session generation, Goal identity, status, policy, and ownership.
+- **Earn lifecycle complexity with evidence:** Phase 2 intervention proceeds only after a real
+  consumer demonstrates the workflow and its failure semantics.
+- **Treat settings as cooperation policy, not a sandbox:** installed Pi extensions are fully
+  privileged; these settings govern only whether `pi-goal` honors its own integration contract.
+
+## Roadmap Themes
+
+### User-controlled interoperability
+
+Expose a small access model that communicates how far sibling extensions may reach and keeps risky
+capabilities behind explicit, user-owned choices.
+
+### Authoritative transition provenance
+
+Represent why a Goal stopped as canonical state rather than requiring integrations to parse optional
+human-readable error text.
+
+### Safe supervised recovery
+
+Complete the current start/pause/observe contract with a guarded recovery path that reuses the same
+transition as `/goal resume`.
+
+### Bounded lifecycle intervention
+
+Allow external review or preparation only through single-owner, expiring decisions that preserve
+Goal liveness and reject stale work.
+
+## Phases and Milestones
+
+### Phase 1: Establish a user-controlled integration boundary
+
+**Plan:** [Cross-extension access](../plans/2026-07-30_pi-goal-cross-extension-access-plan.md)
+
+**Milestones:**
+
+- User settings expose `off`, `observe`, and `rpc-owned` access levels with `rpc-owned` as the
+  compatibility default.
+- `off` accepts no new `pi-goal` RPC work and emits no subsequent state events; `observe` emits state
+  without accepting control requests; `rpc-owned` preserves the current start and correlated pause
+  behavior.
+- The Goal settings experience shows the effective access level, explains that only trusted
+  installed extensions should participate, and applies changes with the existing persistence and
+  rollback guarantees.
+- Downgrading access leaves the current Goal intact and has documented semantics for requests already
+  accepted at the policy boundary.
+- Deterministic settings, lifecycle, and RPC coverage proves each access level and the unchanged
+  default behavior.
+
+**Outcome:** Users can restrict the existing integration contract before any foreground-supervision
+capability is introduced.
+
+### Phase 2: Make stopped-transition provenance authoritative
+
+**Plan:** [Stopped-transition provenance](../plans/2026-07-30_pi-goal-transition-provenance-plan.md)
+
+**Milestones:**
+
+- A documented transition source-and-cause taxonomy distinguishes explicit operator and RPC pauses,
+  interruption, Goal safety, unavailable terminal tools, provider usage limits, token budgets,
+  agent-proposed blocking, terminal agent errors, clear, and activation rollback.
+- Provenance is stored with the matching canonical stopped Goal and survives reload without attaching
+  old details to a rotated, replaced, queued, or cleared Goal.
+- State events expose the provenance through an additive JSON shape whenever observation is allowed;
+  integrations never need to infer policy from `reason` text.
+- Every documented stopped-transition path has deterministic event and restore coverage.
+- Provenance remains internal when cross-extension access is off and is not exposed as an independent
+  setting that could create an unsafe control-without-context combination.
+
+**Outcome:** Integrations can reliably distinguish intentional operator stops from recoverable or
+system-originated stops, establishing the safety prerequisite for Resume RPC.
+
+### Phase 3: Enable safe supervised recovery
+
+**Plan:** [Supervisor Resume RPC](../plans/2026-07-30_pi-goal-supervisor-resume-rpc-plan.md)
+
+**Milestones:**
+
+- A new `supervisor` access level adds request-scoped Resume RPC to the lower access-level
+  capabilities.
+- Slash-command and RPC callers share one authoritative resume operation rather than duplicating
+  transition, budget, tool-visibility, safety-reset, prompt-ownership, or rollback policy.
+- A resume request validates the exact current stopped Goal and active session; success returns the
+  newly rotated Goal ID rather than leaving the caller with the stale request ID.
+- Explicit operator pauses, ineligible statuses, exhausted budgets, replaced sessions, replaced or
+  cleared Goals, and stale requests cannot reactivate Goal work.
+- Failed owned-prompt delivery restores the original stopped state only when that request still owns
+  the current Goal.
+- Optional repair guidance is either admitted with a documented length limit and prompt trust
+  boundary or explicitly deferred without weakening the core recovery contract.
+
+**Outcome:** The first part of issue #455 is complete: an opted-in supervisor can recover an eligible
+foreground Goal without bypassing existing Goal invariants.
+
+### Phase 4: Validate the supervision contract with a real consumer
+
+**Plan:** [Supervisor contract validation](../plans/2026-07-30_pi-goal-supervision-validation-plan.md)
+
+**Milestones:**
+
+- At least one supervisor integration exercises observe, start, owned pause, stopped-state
+  classification, and resume through the documented public contract.
+- The integration demonstrates deterministic behavior for duplicate or lost requests, reload,
+  shutdown, session replacement, and stale Goal IDs without a second writer or Pi session.
+- Evidence identifies whether blocked-proposal review and continuation hold solve recurring workflows
+  that cannot be handled safely through Phase 3.
+- Before further expansion, maintainers record an admission or deferral decision for each proposed
+  Phase 2 capability, including multi-listener ownership and timeout semantics.
+
+**Outcome:** Further lifecycle authority is based on observed integration needs and validated failure
+modes rather than the uninspected prototype alone.
+
+### Phase 5: Admit bounded blocked-proposal review
+
+**Plan:** [Blocked-proposal review](../plans/2026-07-30_pi-goal-blocked-proposal-review-plan.md)
+
+**Milestones:**
+
+- This phase proceeds only after Phase 4 admits the capability and the user explicitly enables
+  blocked-proposal review under `supervisor` access.
+- A supervisor can review only after the existing `goal_blocked` Goal-ID, ownership, evidence, and
+  three-turn recurrence audit succeeds and before `blocked` becomes durable.
+- No listener preserves the current transition without visible delay; timeout, invalid output,
+  listener failure, policy revocation, or session loss falls back to the original `blocked`
+  transition.
+- Review ownership, guidance size, response time, and the number of allowed deferrals are bounded so
+  a supervisor cannot veto terminal state indefinitely.
+- A returned decision revalidates the session, Goal instance, active status, pending queue action,
+  tool-call ownership, and cancellation state before it can affect the Goal.
+
+**Outcome:** An opted-in supervisor can correct a validated but recoverable blocker assessment
+without weakening the blocker audit or creating unbounded autonomous work.
+
+### Phase 6: Admit leased continuation control
+
+**Plan:** [Continuation lease](../plans/2026-07-30_pi-goal-continuation-lease-plan.md)
+
+**Milestones:**
+
+- This phase proceeds only after Phase 4 admits the capability and the user explicitly enables
+  continuation hold under `supervisor` access.
+- Each claim targets one unique continuation ticket, not only a Goal ID, and at most one holder can
+  own that ticket.
+- Every hold has a bounded lease; missing release, listener failure, policy revocation, reload, or
+  shutdown returns control to the normal dispatcher rather than stranding the Goal.
+- Release re-enters the existing settled dispatcher and rechecks Goal identity, status, idle state,
+  pending messages, tools, budget, queue actions, and safety limits instead of sending directly.
+- Pause, clear, replace, edit, resume, newer user or extension work, and session replacement
+  invalidate stale tickets so an old release cannot start a newer continuation.
+
+**Outcome:** An opted-in supervisor can perform planned compaction or lifecycle preparation between
+Goal turns while preserving single-flight delivery and Goal liveness.
+
+## Technical Health
+
+- Keep protocol parsing, request/reply correlation, and access checks in a focused cross-extension
+  boundary while the Goal runtime remains the owner of state and lifecycle invariants.
+- Introduce one structured transition-provenance owner instead of adding source/cause fields at each
+  caller independently.
+- Return structured results from the shared resume operation so command and RPC adapters do not infer
+  outcomes from UI notifications.
+- Review `runtime.ts` and `goal.ts`, both already above the repository's 1,000-line threshold, before
+  adding Phase 2 coordination. Extract a focused coordinator only when it owns real claim, lease,
+  timeout, and generation policy rather than acting as a pass-through wrapper.
+- Preserve side-effect-free missing-file reads, invalid-file protection, unknown-field preservation,
+  atomic publication, ordered application, rollback, and reload semantics for every settings phase.
+- Keep session-owned claims, timers, and waiters cancellable from user cancellation, session
+  replacement, settings revocation, and shutdown independently.
+- Keep the public contract JSON-shaped and dependency-free; do not introduce extension-to-extension
+  package dependencies.
+- Require focused deterministic tests, the root `npm run check` gate, and a representative Pi runtime
+  smoke for every delivered phase.
+
+## Risks and Dependencies
+
+- **False security boundary:** users may interpret access settings as extension sandboxing.
+  Documentation and UI must state that installed extensions remain fully privileged and that the
+  setting controls only `pi-goal` cooperation.
+- **Compatibility regression:** changing the omitted-setting default could break current external
+  consumers. Preserve `rpc-owned` as the default unless an explicitly approved breaking migration
+  provides contrary evidence.
+- **Incomplete provenance:** event-only metadata would disappear after reload and could allow an
+  operator pause to be misclassified. Persist provenance with the stopped Goal and test restoration.
+- **Unverified consumer demand:** no repository consumer currently proves the supervision workflow.
+  Phase 4 is a dependency for either lifecycle-intervention phase.
+- **Multiple supervisors:** a broadcast bus can produce conflicting reviewers or holders. Phase 4
+  must choose a deterministic single-owner arbitration rule before Phase 5 or 6 proceeds.
+- **Review-induced nontermination:** repeated vetoes can increase token use indefinitely. Bound review
+  time and deferral count, and preserve the original terminal fallback.
+- **Lease-induced deadlock:** a lost release can stop automatic work indefinitely. Require expiry and
+  route fallback through the normal settled dispatcher.
+- **Stale release collision:** Goal ID alone cannot distinguish successive continuations. Require a
+  unique continuation ticket and invalidate it on every superseding transition.
+- **Platform event limitations:** Pi's shared event bus may not supply request ownership, cancellation,
+  listener discovery, or asynchronous arbitration directly. Validate the proposed handshake against
+  the installed public API before admitting either Phase 2 protocol.
+
+## Success Metrics
+
+| Objective | Baseline | Target and horizon | Measurement source |
+| --- | --- | --- | --- |
+| Preserve current integration behavior | Start, RPC-owned pause, and state events are documented and tested without an access setting. | The default path remains behaviorally equivalent when Phase 1 ships. | Existing and extended `goal-rpc` tests plus a Pi runtime smoke. |
+| Give users an effective access boundary | No current setting gates the integration contract. | Every documented access level accepts and rejects exactly its declared operations by the end of Phase 1. | Settings, UI, RPC, session-start, reload, and shutdown tests. |
+| Make stopped state machine-readable | State events have no structured transition provenance. | Every documented stopped path emits and restores the matching source/cause by the end of Phase 2. | Transition matrix tests over command, tool, safety, provider, budget, clear, and rollback paths. |
+| Recover eligible foreground Goals safely | Resume exists only as a user command. | All accepted resumes rotate the guard and all stale, operator-paused, replaced-session, and failed-delivery cases leave unauthorized work inactive by the end of Phase 3. | Focused Resume RPC tests and end-to-end supervisor smoke. |
+| Justify lifecycle intervention | No repository consumer demonstrates terminal review or continuation hold. | At least one real consumer validates the need and failure contract before either Phase 5 or Phase 6 is admitted. | Phase 4 integration evidence and recorded admission decision. |
+| Preserve liveness under Phase 2 | No external reviewer or holder can currently delay Goal work. | No admitted listener failure, timeout, revocation, replacement, or shutdown path leaves a permanent review or hold. | Deterministic fault, timeout, stale-ticket, and lifecycle tests plus runtime smoke. |
+
+## Non-Goals
+
+- Building an extension security sandbox, authentication system, or protection from malicious
+  installed code.
+- Letting project-controlled settings grant foreground-supervision authority.
+- Adding a second Goal writer, persistence implementation, Pi session, or TUI-input emulation path.
+- Allowing a supervisor to automatically reverse an explicit operator pause.
+- Weakening `goal_blocked` recurrence, evidence, or stale-ID validation.
+- Delivering settings, Resume RPC, terminal review, and continuation leases in one change.
+- Redesigning the Goal queue, token accounting, tool visibility, or the general `/goal` manager as
+  part of this roadmap.
+- Committing to Phase 5 or 6 before the Phase 4 evidence gate passes.
+- Assigning delivery dates, releases, owners, or capacity without separate planning evidence.
+
+## Decisions and Changes
+
+No prior roadmap or approved decision record for cross-extension supervision was supplied. The
+following entries record the proposed direction of this initial draft, not implementation
+commitments.
+
+| Record | Status | Decision or change | Rationale and impact |
+| --- | --- | --- | --- |
+| Initial draft | Proposed | Split issue #455 and integration settings into six outcome phases. | Establishes reversible checkpoints instead of one lifecycle-heavy rollout. |
+| Initial draft | Proposed | Preserve current behavior through a default `rpc-owned` access level. | Avoids silently breaking the documented start, pause, and state contract. |
+| Initial draft | Proposed | Deliver durable transition provenance before Resume RPC. | Prevents a supervisor from inferring operator intent from incomplete status or reason text. |
+| Initial draft | Proposed | Keep explicit operator pause outside automatic supervisor recovery. | Preserves direct user agency at the highest-priority stop boundary. |
+| Initial draft | Proposed | Require a real consumer and admission decision before either Phase 2 hook. | Prevents speculative async ownership and liveness complexity from entering the core Goal state machine. |
+| Initial draft | Proposed | Separate blocked review from continuation leases. | Their terminal-decision and delivery-liveness risks require independent contracts and verification. |


### PR DESCRIPTION
## Summary

- add a six-phase roadmap for the `pi-goal` cross-extension supervision proposal in #455
- add executable plans for access controls, stopped-state provenance, Resume RPC, real-consumer validation, blocked-proposal review, and continuation leases
- gate blocked review and continuation control on evidence from an inspectable supervisor consumer

## Compatibility

- preserve current behavior by default with `crossExtension.access: "rpc-owned"`
- keep existing state observation, RPC start, and owner-correlated pause behavior without requiring a settings migration
- require explicit opt-in for supervisor Resume RPC, blocked-proposal review, and continuation hold
- treat stopped-state provenance as an additive event-payload field; exact byte-for-byte legacy payload shape is not a configurable mode

## Scope

Documentation and planning only. This PR does not implement any roadmap phase.

## Verification

- `npm run check` — 1,824 tests passed
- pre-commit `npm biome check`
- pre-commit `npm typecheck`
- `git diff --cached --check`

Relates to #455.
