### PR TITLE
feat: add searchable multi-select menus

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -128,6 +128,7 @@
 - Symptom: the subagent disposable-worktree test reports that a nested cwd is outside its freshly initialized repository on macOS. Cause: temp paths may use `/var/...` while Git canonicalizes the same path to `/private/var/...`; lexical containment fails. Fix: compare canonical realpaths.
 - Kit settings and multi-select actions settle asynchronously; test adapters that drive `ctx.ui.custom()` must drain `waitForPending()`, observe an accepted transition, and close a rejected screen instead of returning before the callback settles.
 - Consumer tests load `@narumitw/pi-tui-kit` from its built `dist/`; rebuild the kit after source changes or consumer behavior tests can exercise stale UI code.
+- Searchable TUI wrappers should reserve only a standalone Space key for activation; stripping spaces from whole input chunks corrupts bracketed-paste token queries.
 
 ## TASTE
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -127,6 +127,7 @@
 - To preserve mutating command invocation order, enqueue the whole mutation before prerequisite awaits; queuing only the eventual persistence step lets asynchronous settings loads reorder rapid commands.
 - Symptom: the subagent disposable-worktree test reports that a nested cwd is outside its freshly initialized repository on macOS. Cause: temp paths may use `/var/...` while Git canonicalizes the same path to `/private/var/...`; lexical containment fails. Fix: compare canonical realpaths.
 - Kit settings and multi-select actions settle asynchronously; test adapters that drive `ctx.ui.custom()` must drain `waitForPending()`, observe an accepted transition, and close a rejected screen instead of returning before the callback settles.
+- Consumer tests load `@narumitw/pi-tui-kit` from its built `dist/`; rebuild the kit after source changes or consumer behavior tests can exercise stale UI code.
 
 ## TASTE
 

--- a/docs/plans/archived/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md
@@ -197,10 +197,9 @@ preview callbacks for Starship would violate the declarative boundary.
 - Kit, Plan-mode, and Subagents workspace checks passed, as did all three package dry runs and the
   Plan-mode RPC smoke.
 - Root `npm run check` was executed repeatedly. Its build, Biome, boundaries, typechecks, and all
-  touched tests passed, but unrelated pre-existing timing/path tests varied under the parallel root
-  runner. A full sequential run passed 1,847 of 1,848 tests; the remaining `pi-github-pr` periodic
-  refresh test passes when focused and is outside this diff. This unavailable clean root-run evidence
-  is reported rather than inferred.
+  touched tests passed, but unrelated timing/path tests varied under the local parallel runner. A full
+  sequential run passed 1,847 of 1,848 tests and the remaining `pi-github-pr` periodic-refresh test
+  passed when focused. PR #467's hosted CI subsequently passed the complete root gate.
 
 ## Completion Checklist
 

--- a/docs/plans/archived/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md
@@ -1,0 +1,216 @@
+# Pi TUI Kit Next-Capabilities Qualification Plan
+
+## Goal
+
+Qualify the next bounded `@narumitw/pi-tui-kit` capabilities against current repository consumers,
+record an explicit admit/defer/reject decision for searchable multi-select, searchable catalog, and
+contextual decision patterns, and update the roadmap without adding speculative public API.
+
+## Context
+
+- The kit currently exposes five screen kinds: `actions`, `detail`, `choice`, `settings`, and
+  `multiSelect`; the static `choice` rollout and its two proof migrations were completed in PR #463.
+- The roadmap requires two compatible consumers before admitting a reusable interaction contract and
+  keeps searchable catalog and contextual decision independent.
+- Search pressure is now visible in dynamic tool and resource lists:
+  - `extensions/pi-plan-mode/src/plan-mode.ts` projects every currently selectable Pi tool into a
+    bounded `multiSelect` screen;
+  - `extensions/pi-subagents/src/config-ui.ts` projects every configured/current tool into a
+    draft-based `multiSelect` screen with pinned Save and Discard actions;
+  - `experimental/pi-jupyter/src/jupyter-preview.ts` lists discovered notebooks before opening a
+    specialized preview;
+  - `extensions/pi-sync/src/sync-setups-ui.ts` and `storage-connections-ui.ts` list user-owned
+    resources before a detail screen.
+- `experimental/pi-file-context/src/file-context-explorer.ts` combines search with two activation
+  gestures, asynchronous preview, history, revision, diff, and range selection. Its whole workflow is
+  not evidence for a simple catalog contract.
+- `extensions/pi-image-drop/src/menu.ts` has an explicit confirmed/cancelled/close result, while
+  `extensions/pi-starship/src/commands.ts` owns width-dependent preview and `pi-sync` already expresses
+  contextual reviews with public `ctx.ui.select()` and `ctx.ui.confirm()`.
+- Pi 0.83.0 publicly exposes `Input`, `SelectList`, `SettingsList`, `fuzzyFilter`, `DynamicBorder`,
+  `BorderedLoader`, and RPC dialog methods. `ctx.ui.custom()` remains TUI-only; RPC adaptation must use
+  dialog methods.
+
+## Architecture
+
+Qualification will use one compatibility matrix with these fields for every candidate flow:
+
+- package and source/test evidence;
+- item source and maximum/expected cardinality;
+- snapshot versus asynchronous refresh behavior;
+- stable raw identity, display labels, descriptions, disabled/current state, and search corpus;
+- activation gestures and whether selection itself has side effects;
+- extension-owned persistence, validation, confirmation, preview, and rollback;
+- TUI, RPC, print, and JSON behavior;
+- cancellation, disposal, session replacement, and shutdown ownership;
+- exact capability that a shared contract would remove without consumer-specific hooks.
+
+Evaluate three distinct contracts rather than one generic list:
+
+1. **Searchable multi-select enhancement:** optional TUI filtering over labels plus declarative search
+   text, with stable raw IDs, pinned action rows, unchanged serialized toggle/rollback behavior, and a
+   flat unfiltered RPC dialog.
+2. **Searchable catalog screen:** a static snapshot of selectable items with stable IDs, declared
+   search text, metadata/current/disabled state, one confirmation action, bounded viewport, and no
+   asynchronous refresh, tabs, custom sort, secondary activation gesture, or preview callback.
+3. **Contextual decision screen:** only admissible if two workflows cannot preserve required context,
+   Back/Close semantics, and safe defaults with public `ctx.ui.select()` or `ctx.ui.confirm()`.
+
+An admitted capability receives its own focused implementation plan and rollout. A deferred or
+rejected capability records the missing shared requirement instead of widening this qualification
+plan into implementation.
+
+## Non-Goals
+
+- Implement or publish a kit capability.
+- Migrate a consumer or change extension settings, commands, persistence, or runtime behavior.
+- Turn `actions`, `choice`, `multiSelect`, and catalog into one configurable universal list.
+- Admit async catalogs, file trees, live preview, editors, secret input, or multi-step wizards.
+- Treat two screens in one package as sufficient proof when the roadmap requires two repository
+  consumers.
+
+## Unknowns
+
+- Whether searchable multi-select has two behaviorally compatible consumers once pinned action rows,
+  draft save semantics, and session-persisted immediate toggles are compared precisely.
+- Whether any two catalog candidates need search strongly enough and share one-gesture static
+  selection without requiring auxiliary renderer or refresh hooks.
+- Whether image-drop has a second compatible decision consumer after excluding flows already served
+  by Pi's public dialogs.
+- Whether an optional enhancement to an existing screen changes
+  `PI_EXTENSION_MENU_API_VERSION`, even though existing version-2 runtimes can safely ignore unknown
+  optional fields.
+
+## Risks
+
+- Counting merely similar-looking lists can admit an abstraction without shared lifecycle or product
+  semantics.
+- Using `pi-file-context` as proof could pull dual activation, preview, and async request generations
+  into a generic catalog.
+- Search added to multi-select can conflict with pinned action rows or documented single-key actions;
+  qualification must compare exact current behavior before approving the contract.
+- A rich TUI contract can flatten poorly in RPC; every decision must define whether RPC remains a
+  full unfiltered list or needs a separate public behavior.
+- Roadmap status can drift if qualification evidence remains only in an implementation plan; the
+  final decision must be linked from the roadmap.
+
+## Qualification Evidence
+
+### Public Pi and compatibility baseline
+
+- Installed Pi 0.83.0 root exports were imported directly and verified for `Input`, `SelectList`,
+  `SettingsList`, `fuzzyFilter`, `DynamicBorder`, and `BorderedLoader`.
+- Repository searches found no private Pi `dist/*` import in the kit or either proof consumer.
+- The focused pre-change baseline passed 106 tests across kit model/component/runtime, Plan-mode tool
+  selection and role policy, and Subagents configuration.
+- Search is an optional enhancement to an existing screen kind. `PI_EXTENSION_MENU_API_VERSION`
+  remains `2`: an older version-2 runtime ignores the optional fields and keeps a valid full
+  multi-select instead of rejecting the definition.
+
+### Searchable multi-select matrix
+
+| Consumer | Shared contract | Owned behavior retained | Decision |
+| --- | --- | --- | --- |
+| `pi-plan-mode` `/plan tools` | Snapshot of installed tools, stable raw IDs, labels plus policy/source/description search text, disabled policy rows | Immediate active-tool application, required tools, session persistence/restore, replacement and shutdown signal | Proof migration |
+| `pi-subagents` agent-tool draft | Snapshot of available and preserved-unavailable tools, stable names, pinned Save/Discard, availability search text | One-save draft, malformed-file refusal, unknown fields, mutation lock, atomic publication, reload wording | Proof migration |
+| `pi-sync` included-content draft | Snapshot of built-in/custom paths and stable IDs with a later review step | Sensitive-session confirmation, review loop, setup concurrency, atomic settings update | Compatible future adopter; excluded from the first focused rollout |
+
+**Decision:** admit optional `enableSearch` and item `searchText` on `multiSelect`. TUI filters toggle
+rows and pins action rows; empty/no-match, stable cursor restoration, hidden pending rollback, focus,
+paste sanitization, width, and custom keybindings stay kit-owned. RPC remains a complete unfiltered
+flat dialog. No matcher, renderer, persistence, or lifecycle hook is public.
+
+### Searchable catalog matrix
+
+| Candidate | Reusable portion | Incompatible or missing requirement |
+| --- | --- | --- |
+| `pi-jupyter` notebook picker | Stable discovered paths, current marker, useful filename/path search | Manual path entry, asynchronous load/cancel, outside-workspace confirmation, and TUI-only preview ownership |
+| `pi-subagents` agent picker | Static stable agent names, source/tool summaries, one confirmed transition | Compatible bounded shape, but no second proven large-list workflow currently shares it |
+| `pi-sync` setup and storage lists | Stable user-owned names and current state | Add/edit/remove actions and state refresh belong to a live manager rather than one static confirmation |
+| `pi-accounts` account lists | Stable provider/account IDs and current/disabled state | Credential login, switching, removal confirmation, and refreshed storage state are mutation workflows |
+| `pi-file-context` explorer | Fuzzy path search and stable file identity | Dual activation, async preview, history, revision input, diff, range selection, and request generations |
+
+**Decision:** defer searchable catalog. Subagents is a plausible first consumer, but no second
+consumer has both demonstrated large-list search pressure and the proposed static one-confirmation
+contract. The missing gate is shared product behavior, not a rendering primitive.
+
+### Contextual decision matrix
+
+| Candidate | Required context | Qualification result |
+| --- | --- | --- |
+| `pi-image-drop` | Message plus distinct Confirm, Escape cancellation, and `Ctrl+C` Close | One clear consumer |
+| `pi-starship` | Width-dependent live preview, Continue/Edit/Cancel, then a separate exact confirmation | Incompatible with a static decision contract |
+| `pi-sync` and `pi-accounts` confirmations | Exact consequence text and safe cancellation | Public `ctx.ui.confirm()`/`select()` already preserves the required behavior |
+
+**Decision:** defer contextual decision. Image Drop lacks a second compatible consumer, and adding
+preview callbacks for Starship would violate the declarative boundary.
+
+## Plan
+
+- [x] Capture the installed Pi 0.83.0 public exports and relevant `Input`, `fuzzyFilter`, `SelectList`,
+      and RPC dialog contracts in this plan's evidence notes; verify with root-package import/type
+      inspection and repository searches showing zero proposed `dist/*` dependency.
+- [x] Build a compatibility matrix for searchable multi-select candidates in `pi-plan-mode`,
+      `pi-subagents`, and `pi-sync`; verify each row against its source, README, and focused regression
+      tests for stable IDs, toggle timing, pinned actions, persistence, cancellation, and mode behavior.
+- [x] Run the existing kit, Plan-mode tool-selection, and Subagents configuration regressions before
+      deciding searchable multi-select compatibility; verify with a fresh build/test compilation and
+      absolute-path `node --test` runs under `node_modules/.cache/pi-extensions-test/` for
+      `packages/pi-tui-kit/test/{menu-model,screen-components,runtime}.test.js`,
+      `extensions/pi-plan-mode/test/{default-tools,subagent-allowlist}.test.js`, and
+      `extensions/pi-subagents/test/subagents.test.js`.
+- [x] Apply the two-consumer gate to searchable multi-select and record an admit or defer decision,
+      including the exact query, cursor, pinned-action, pending-toggle, RPC, API-version, and consumer
+      migration contract as acceptance evidence.
+- [x] Build a compatibility matrix for catalog candidates in `pi-jupyter`, `pi-subagents`, `pi-sync`,
+      and `pi-accounts`, explicitly compare `pi-file-context` as a rejection case, and verify every row
+      against source plus existing menu/lifecycle tests.
+- [x] Apply the two-consumer gate to searchable catalog and record either two named proof migrations
+      with one bounded contract or the missing shared requirement that keeps the screen deferred.
+- [x] Build a compatibility matrix for decision candidates in `pi-image-drop`, `pi-starship`,
+      `pi-sync`, and other direct `ctx.ui.confirm()` owners; verify whether public Pi dialogs already
+      preserve each workflow's context, safe default, cancellation, and non-mutation behavior.
+- [x] Apply the two-consumer gate to contextual decision and record either two named proof migrations
+      that cannot use public dialogs or an explicit deferral with the incompatible requirements.
+- [x] Decide `PI_EXTENSION_MENU_API_VERSION` treatment separately for each admitted additive field or
+      screen kind; verify the decision against version-2 source compatibility, runtime behavior, and
+      README wording without manually changing package versions.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` with Phase 1–2 completion evidence, the three
+      qualification decisions, named consumers, missing gates, and links to any focused implementation
+      plans; verify the roadmap does not claim implementation that has not shipped.
+- [x] Create or reconcile one focused `docs/plans/YYYY-MM-DD_<capability>-plan.md` for each admitted
+      capability, and mark any conditional pre-draft deferred when its gate fails; verify each
+      executable plan names one bounded rollout, two proof consumers, TUI/RPC behavior, lifecycle
+      checks, package dry runs, and rollback.
+- [x] Run `npm run check` after the documentation changes and inspect `git diff --check`; record any
+      unavailable baseline or runtime path instead of marking its qualification evidence complete.
+- [x] Audit the final qualification diff against `docs/extension-conventions.md`,
+      `docs/extension-settings.md`, Pi's `tui.md`, `extensions.md`, `rpc.md`, and the roadmap's
+      two-consumer/public-API rules; report touched areas, admitted/deferred capabilities, checks, and
+      accepted deviations in the handoff.
+
+## Verification Evidence
+
+- Public Pi root imports and private-import searches passed.
+- The pre-change focused baseline passed 106 tests; the final focused kit and consumer selection passed
+  115 tests.
+- Kit, Plan-mode, and Subagents workspace checks passed, as did all three package dry runs and the
+  Plan-mode RPC smoke.
+- Root `npm run check` was executed repeatedly. Its build, Biome, boundaries, typechecks, and all
+  touched tests passed, but unrelated pre-existing timing/path tests varied under the parallel root
+  runner. A full sequential run passed 1,847 of 1,848 tests; the remaining `pi-github-pr` periodic
+  refresh test passes when focused and is outside this diff. This unavailable clean root-run evidence
+  is reported rather than inferred.
+
+## Completion Checklist
+
+- [x] Every candidate has source, test, mode, lifecycle, side-effect, and ownership evidence in one
+      compatibility matrix.
+- [x] Every admitted capability names two compatible consumers and one bounded contract; every
+      deferred/rejected capability names the missing or incompatible requirement.
+- [x] Public Pi primitives and RPC behavior are verified without private imports or TUI-object API.
+- [x] API-version decisions are explicit and existing five-screen definitions remain source
+      compatible.
+- [x] The roadmap and any focused implementation plans agree on status and scope.
+- [x] Baseline regressions, `npm run check`, and `git diff --check` pass, or unavailable evidence
+      remains unchecked and is reported.

--- a/docs/plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md
@@ -295,10 +295,10 @@ The extraction is behavior-preserving and must stay green before the first searc
   option list, cancelled it, and exited without extension errors. Deterministic custom-component tests
   substitute for a non-automatable interactive TUI smoke and cover focus, keys, width, paste, filtering,
   pending work, and disposal semantics.
-- Root `npm run check` was attempted repeatedly. All touched tests and non-test gates pass, but the
-  parallel root test runner exposed unrelated pre-existing timing/path flakes. A full sequential run
-  passed 1,847 of 1,848 tests; the sole remaining `pi-github-pr` periodic-refresh failure passes when
-  focused and is outside this diff. The root-pass completion item remains explicitly unchecked.
+- Root `npm run check` was attempted repeatedly. All touched tests and non-test gates passed, but the
+  local parallel runner exposed unrelated timing/path flakes. A full sequential run passed 1,847 of
+  1,848 tests and the remaining `pi-github-pr` periodic-refresh test passed when focused. PR #467's
+  hosted CI subsequently passed the complete root gate.
 
 ## Completion Checklist
 
@@ -311,8 +311,7 @@ The extraction is behavior-preserving and must stay green before the first searc
       non-TUI behavior.
 - [x] Subagents preserves draft-only mutation, Save/Discard/Escape, unavailable names, malformed-file
       protection, unknown fields, locking, atomic publication, and reload behavior.
-- [ ] Focused suites and workspace checks pass, as do all three pack dry runs and the recorded Pi
-      runtime smoke; root `npm run check` remains open because unrelated parallel-run flakes are
-      recorded above.
+- [x] Focused suites, workspace checks, hosted root CI, all three pack dry runs, and the recorded Pi
+      runtime smoke pass.
 - [x] Roadmap, README, generated declarations, API-version declaration, and archived plan agree on the
       delivered behavior.

--- a/docs/plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md
@@ -1,0 +1,318 @@
+# Pi TUI Kit Searchable Multi-Select Plan
+
+## Goal
+
+After the two-consumer qualification gate passes, add an optional searchable mode to
+`@narumitw/pi-tui-kit`'s existing `multiSelect` screen and prove it through behavior-preserving
+migrations of Plan-mode tool selection and Subagents agent-tool configuration.
+
+## Context
+
+- `MultiSelectScreen` currently provides bounded optimistic toggles, pinned action rows, serialized
+  action execution, rollback, cursor restoration, disabled explanations, paging, Back/Close, and
+  TUI/RPC adaptation.
+- `extensions/pi-plan-mode/src/plan-mode.ts` can project every installed Pi tool into `/plan tools`.
+  Toggling applies immediately to session-owned Plan-mode state and persists the selected names in the
+  active Pi session.
+- `extensions/pi-subagents/src/config-ui.ts` can project every available or previously configured tool
+  into an agent-specific draft. It must not write `pi-subagents.json` until **Save changes**, and
+  Escape/Discard must leave the settings document unchanged.
+- The two consumers intentionally have different persistence timing. The shared contract is limited
+  to filtering and stable row identity; immediate application, draft ownership, validation,
+  persistence, and rollback remain consumer- or runtime-owned.
+- Pi 0.83.0 publicly exports `Input` and `fuzzyFilter`. A component containing `Input` must implement
+  `Focusable`, forward focus for IME positioning, sanitize pasted controls before filtering/rendering,
+  and stay within the supplied width.
+- RPC `select` requests expose a flat option array and no server-side incremental query event. The
+  searchable option therefore affects TUI presentation only; RPC continues to expose every row with
+  stable identity and disabled semantics.
+- `packages/pi-tui-kit/src/screen-components.ts` is 851 authored lines. Search state and rendering
+  would create a clear multi-select responsibility boundary and likely push the file through the
+  repository's 1,000-line review threshold.
+
+## Architecture
+
+### Public contract
+
+Subject to the qualification/API-version decision, use this bounded additive shape:
+
+```ts
+interface MenuMultiSelectItem {
+  id: string;
+  label: string;
+  description?: string;
+  selected: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+  searchText?: string;
+}
+
+interface MultiSelectScreen<ScreenId extends string, ActionId extends string> {
+  kind: "multiSelect";
+  // Existing fields remain unchanged.
+  enableSearch?: boolean;
+}
+```
+
+- `enableSearch` defaults to `false`, preserving existing rendering, key handling, and source
+  compatibility.
+- Search matches the sanitized display label plus optional declarative `searchText`. It does not use
+  raw IDs or renderer callbacks and never renders `searchText`.
+- The query is screen-instance state and resets when the screen is recreated. The selected raw ID is
+  retained when still visible; filtering away the selected row moves to the first visible toggle or
+  pinned action, and clearing the query restores a valid remembered row deterministically.
+- Toggle rows are filtered; `screen.actions` remain visible and keep their declared order so Save,
+  Discard, bulk actions, and Done routes do not disappear behind a query.
+- Empty source and no-match states are distinct. A no-match screen can still activate pinned actions.
+- Filtering never changes `selected`, `committedSelected`, revisions, or pending action order. A
+  queued toggle settles against its raw item ID even if the query later hides that row; Back/Close
+  still waits for owned pending work.
+- Navigation and paging operate over the currently visible toggle rows plus pinned action rows.
+  Enter/Space continues toggling or activating the selected row; other input is forwarded to the
+  search `Input` only when search is enabled.
+- TUI search forwards `Focusable.focused`, rebuilds themed content on invalidation, sanitizes pasted
+  C0/C1 controls, and bounds every rendered line. RPC ignores the visual filter and presents the full
+  unique row list.
+
+### Internal boundaries
+
+Before adding search behavior, extract the multi-select adapter from the growing component module:
+
+- keep `createMenuScreenComponent()` and existing import compatibility in
+  `src/screen-components.ts`;
+- move shared internal component contracts, frame/hint rendering, and terminal-safe helpers to a
+  cohesive internal module while re-exporting the symbols currently imported by `runtime.ts` and
+  tests;
+- move multi-select state, rendering, pending-queue, and search behavior to a dedicated internal
+  module;
+- keep public exports unchanged except for the admitted optional fields.
+
+The extraction is behavior-preserving and must stay green before the first search behavior is added.
+
+### Consumer ownership
+
+- Plan mode continues owning tool policy, active-tool application, session state, lifecycle restore,
+  and required tool membership.
+- Subagents continues owning agent discovery, one-save drafts, unknown-field preservation,
+  malformed-file protection, mutation locking, atomic publication, and notifications.
+- Neither consumer passes callbacks, TUI instances, custom matchers, persistence functions, or
+  lifecycle state through the declarative screen model.
+
+## Non-Goals
+
+- Add a new `catalog` screen or make `actions`/`choice` searchable.
+- Add regex syntax, asynchronous refresh, remote search, scope tabs, sorting callbacks, or custom
+  renderers.
+- Filter RPC options server-side or add a new RPC protocol.
+- Change Plan-mode settings schema, default tool policy, command routes, or implementation handoff.
+- Change Subagents settings schema, workflow tools, agent discovery, save timing, lock protocol, or
+  reload behavior.
+- Add search to every existing multi-select consumer in the same rollout.
+- Publish packages, bump versions manually, merge a pull request, or release as part of execution.
+
+## Assumptions
+
+- `docs/plans/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md` admits searchable
+  multi-select with `pi-plan-mode` and `pi-subagents` as compatible consumers before implementation
+  starts.
+- Search over installed tool names and declared descriptions/source text is useful at realistic tool
+  counts and does not require asynchronous discovery inside the screen.
+- Pinned action rows remain available during filtering, which preserves the Subagents draft workflow
+  without adding a keyboard shortcut API.
+
+## Risks
+
+- Printable search input competes with Space-as-toggle and any consumer documentation that implies a
+  single-letter action shortcut. Establish the exact baseline first and update only inaccurate touched
+  UI guidance rather than adding an undocumented shortcut contract.
+- Rebuilding a filtered row array can lose cursor identity or route an activation to the wrong raw
+  item. Derive actions from stable IDs and test duplicate labels plus changing filters.
+- A pending optimistic toggle can settle after its row is filtered out. Keep revision and committed
+  state keyed by raw ID independently of visible rows.
+- Pinned Save/Discard rows can become unreachable or unexpectedly selected after no-match filtering.
+  Define and test visible-row navigation and no-match fallback before implementation.
+- Reusing the settings search implementation mechanically could inherit its different immediate-save
+  and row-layout assumptions. Share only safe primitives, not settings state semantics.
+- A source split can obscure behavior changes. Land or verify the behavior-preserving extraction while
+  all focused tests are green, then start red/green search increments.
+
+## Rollback / Recovery
+
+- The public change is optional and has no persisted-data migration. Reverting `enableSearch` and
+  `searchText` restores the previous UI while all raw tool selections remain readable.
+- Revert either consumer's opt-in independently if its interaction regresses; the library remains
+  backward compatible with non-searchable multi-select definitions.
+- A failed toggle or save follows the existing rollback path. Search state must never become a source
+  of truth for committed selection.
+- If the qualification gate fails, mark implementation and migration items not applicable, record the
+  deferral in the roadmap, and archive the completed qualification-only plan without changing package
+  source.
+
+## Implementation Record
+
+- Qualification admitted Plan mode and Subagents. Catalog and contextual decision remained deferred
+  because neither passed an independent two-consumer gate.
+- `PI_EXTENSION_MENU_API_VERSION` remains `2`; `enableSearch` and `searchText` are optional and older
+  version-2 runtimes degrade to the existing full unfiltered screen.
+- The behavior-preserving extraction reduced `screen-components.ts` from 851 to 572 lines and placed
+  multi-select behavior in a 259-line internal module, with separate shared contracts and rendering
+  helpers.
+- TDD red evidence:
+  - the README/type fixture first failed with TS2353 for missing `searchText`;
+  - four focused component tests failed because filtering, no-match, focus, and hidden rollback did
+    not exist;
+  - the Plan-mode proof initially retained `custom` because metadata search was absent;
+  - the Subagents proof stopped on the unfiltered tool screen before Save/Discard assertions.
+- The final contract uses public Pi `Input` and `fuzzyFilter`, filters toggle rows only, pins action
+  rows, preserves stable raw IDs and pending maps, forwards focus, sanitizes pasted controls, and
+  leaves RPC unfiltered.
+- Plan mode retains immediate session-owned activation and restore behavior. Subagents retains its
+  one-save draft, malformed-file protection, unavailable names, unknown fields, mutation lock, and
+  atomic publication; Save, Discard, and Escape are covered independently.
+
+## Plan
+
+### Qualification and baseline
+
+- [x] Complete `docs/plans/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md` and record
+      that Plan-mode and Subagents satisfy the two-consumer gate for the bounded contract above;
+      verify the roadmap names both consumers and no consumer-specific hook.
+- [x] Audit the current `/plan tools` and Subagents agent-tool flows against their README and tests,
+      including query-key conflicts, pinned Save/Discard rows, immediate versus draft persistence,
+      Escape/Ctrl+C, TUI/RPC fallback, session replacement, and shutdown; record any pre-existing
+      documentation mismatch before changing behavior.
+- [x] Establish a green baseline by building test output and running the absolute compiled tests under
+      `node_modules/.cache/pi-extensions-test/` for
+      `packages/pi-tui-kit/test/{menu-model,screen-components,runtime}.test.js` plus the compiled
+      `packages/pi-tui-kit/test/readme-usage.js` fixture,
+      `extensions/pi-plan-mode/test/{default-tools,subagent-allowlist}.test.js`, and
+      `extensions/pi-subagents/test/subagents.test.js`; record test counts and commands as evidence.
+- [x] Inspect Pi 0.83.0 root exports and declarations for `Input`, `Focusable`, and `fuzzyFilter`, then
+      decide whether optional search fields change `PI_EXTENSION_MENU_API_VERSION`; verify the plan and
+      roadmap record the decision and package source needs no private `dist/*` import.
+
+### Internal extraction
+
+- [x] Extract shared internal component contracts/rendering helpers and the multi-select adapter from
+      `packages/pi-tui-kit/src/screen-components.ts` without changing public exports or behavior;
+      verify the pre-existing kit component/runtime tests pass before adding search cases and every
+      authored source file remains below the review threshold.
+- [x] Run `npm run check --workspace @narumitw/pi-tui-kit` after the extraction and inspect the built
+      `dist/` diff; verify it contains only equivalent generated structure and no search API yet.
+
+### Search contract and kit behavior
+
+- [x] Add focused failing type/model and README-usage fixtures for `enableSearch`, item `searchText`,
+      default-off compatibility, duplicate display labels with unique raw IDs, and unchanged existing
+      definitions; verify the red state fails because the optional contract is absent.
+- [x] Add the admitted optional fields to `packages/pi-tui-kit/src/types.ts`, exports/declarations as
+      applicable, and model validation only where runtime-invalid values exist; verify the focused
+      model and compile-time usage fixtures pass without casts.
+- [x] Add focused failing component tests for label/searchText fuzzy matching, CJK/emoji, bracketed
+      paste and C0/C1 sanitization, IME focus forwarding, empty/no-match states, width/resize,
+      duplicate labels, disabled rows, selected-ID restoration, clearing a query, paging, custom
+      keybindings, and default-off output; verify each red case fails for missing search behavior.
+- [x] Add focused failing component tests for pinned action visibility and ordering, no-match action
+      activation, optimistic toggles hidden during pending work, rejection rollback, serialized rapid
+      toggles, Back/Close waiting, disposal, and stale transition suppression; verify the red state
+      isolates filtering from existing queue semantics.
+- [x] Implement searchable multi-select in the extracted adapter using public `Input` and
+      `fuzzyFilter`, stable-ID state maps, pinned action rows, focus forwarding, final-boundary display
+      sanitization, and visible-row navigation; verify all focused component tests pass at narrow and
+      representative widths.
+- [x] Add runtime tests proving TUI passes raw IDs after filtering and remains stale-safe across owner
+      abort/disposal/session replacement, while RPC exposes the full unique unfiltered list with
+      disabled rows and unchanged toggle semantics; verify the focused runtime suite passes.
+- [x] Update `packages/pi-tui-kit/README.md` and `test/readme-usage.ts` with the optional search
+      contract, search corpus, pinned-action behavior, TUI/RPC difference, API-version decision, and
+      ownership boundary; verify examples compile and no text claims search for screens that do not
+      support it.
+
+### Proof migration: Plan mode
+
+- [x] Add failing Plan-mode regressions in `extensions/pi-plan-mode/test/default-tools.test.ts` for
+      searching by tool name and declared metadata, toggling the intended raw tool, clearing the
+      query, blocked rows, cursor stability, Escape, and session-state persistence; verify the red
+      state shows `/plan tools` is not yet searchable.
+- [x] Enable the admitted search contract only on the Plan-mode tool screen in
+      `extensions/pi-plan-mode/src/plan-mode.ts`, retaining tool policy, required tools, active-tool
+      restoration, session persistence, and non-TUI routes; verify the focused Plan-mode tests and
+      workspace check pass.
+- [x] Update `extensions/pi-plan-mode/README.md` to describe search without changing documented tool
+      risk or settings precedence; verify the README still distinguishes session selections from
+      `defaultPlanTools` and matches tested behavior.
+
+### Proof migration: Subagents
+
+- [x] Add failing Subagents regressions in `extensions/pi-subagents/test/subagents.test.ts` for
+      searching available and preserved-unavailable tools, toggling by raw name, pinned Save/Discard,
+      no-match behavior, Escape/Discard read-only behavior, and Save-after-filter unknown-field
+      preservation; verify the red state shows the agent-tool draft is not yet searchable.
+- [x] Enable the admitted search contract only on the Subagents `tool-draft` screen in
+      `extensions/pi-subagents/src/config-ui.ts`, retaining one-save draft state, unavailable tool
+      preservation, malformed-file refusal, mutation locking, atomic save, and reload semantics;
+      verify focused Subagents tests and the workspace check pass.
+- [x] Update `extensions/pi-subagents/README.md` so agent-tool instructions accurately describe search,
+      Save/Discard navigation, and Escape behavior; verify no documentation implies a shortcut the
+      tested component does not implement.
+
+### Verification and handoff
+
+- [x] Run the compiled focused kit and consumer suites after a fresh build, then run
+      `npm run check --workspace @narumitw/pi-tui-kit`,
+      `npm run check --workspace @narumitw/pi-plan-mode`, and
+      `npm run check --workspace @narumitw/pi-subagents`; record commands, test counts, and results.
+- [x] Run root `npm run check` and `git diff --check`; leave any unavailable check open rather than
+      inferring success from focused tests.
+- [x] Run `just pack-tui-kit`, `just pack-plan-mode`, and `just pack-subagents`, inspect each tarball's
+      files and generated declarations, and verify no private Pi import, source-only dependency, or
+      unintended package content.
+- [x] Run a representative local Pi smoke for Plan mode or Subagents plus an RPC smoke that exercises
+      the full unfiltered multi-select dialog; record why deterministic component tests substitute for
+      any interactive TUI path that cannot be automated.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` with the shipped searchable multi-select capability,
+      two proof migrations, API-version decision, checks, and retained catalog/decision status;
+      verify the roadmap and package/consumer READMEs agree.
+- [x] Audit the final diff against `docs/extension-conventions.md`, `docs/extension-settings.md`, Pi's
+      `tui.md`, `extensions.md`, `rpc.md`, and the roadmap touched-area checklist, separately checking
+      user cancellation, component disposal, session replacement, shutdown, post-`await` state,
+      settings ordering/failure recovery, and unknown-field protection; report deviations and
+      unverified paths in the handoff.
+- [x] Confirm every plan item and completion check has evidence, then move this completed plan to
+      `docs/plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md`; verify the active
+      path is gone and the archive does not overwrite an existing file.
+
+## Verification Evidence
+
+- Focused final suite: 115 passing tests across kit model/components/runtime, Plan-mode tool selection
+  and role policy, and the complete Subagents integration test file.
+- Workspace checks passed for `@narumitw/pi-tui-kit`, `@narumitw/pi-plan-mode`, and
+  `@narumitw/pi-subagents`.
+- `just pack-tui-kit`, `just pack-plan-mode`, and `just pack-subagents` passed; the kit tarball contains
+  built JavaScript/declarations for the extracted modules, and `dist/types.d.ts` contains both optional
+  fields.
+- A real Pi 0.83.0 RPC smoke loaded local Plan mode, invoked `/plan tools`, verified the complete flat
+  option list, cancelled it, and exited without extension errors. Deterministic custom-component tests
+  substitute for a non-automatable interactive TUI smoke and cover focus, keys, width, paste, filtering,
+  pending work, and disposal semantics.
+- Root `npm run check` was attempted repeatedly. All touched tests and non-test gates pass, but the
+  parallel root test runner exposed unrelated pre-existing timing/path flakes. A full sequential run
+  passed 1,847 of 1,848 tests; the sole remaining `pi-github-pr` periodic-refresh failure passes when
+  focused and is outside this diff. The root-pass completion item remains explicitly unchecked.
+
+## Completion Checklist
+
+- [x] The two-consumer gate passes with Plan mode and Subagents, and the public contract has no
+      consumer-specific callback, renderer, persistence, or lifecycle hook.
+- [x] Existing multi-select definitions retain their prior behavior when search is omitted.
+- [x] Search tests cover identity, filtering, pinned actions, pending/rejected toggles, width, Unicode,
+      terminal safety, IME focus, keybindings, Back/Close, disposal, replacement, shutdown, and RPC.
+- [x] Plan mode preserves tool policy, required tools, session persistence, lifecycle restore, and
+      non-TUI behavior.
+- [x] Subagents preserves draft-only mutation, Save/Discard/Escape, unavailable names, malformed-file
+      protection, unknown fields, locking, atomic publication, and reload behavior.
+- [ ] Focused suites and workspace checks pass, as do all three pack dry runs and the recorded Pi
+      runtime smoke; root `npm run check` remains open because unrelated parallel-run flakes are
+      recorded above.
+- [x] Roadmap, README, generated declarations, API-version declaration, and archived plan agree on the
+      delivered behavior.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -32,7 +32,7 @@ The kit currently provides five declarative screen kinds:
 - `detail` for read-only text;
 - `choice` for confirmed static alternatives with current/initial state and selected details;
 - `settings` for Pi-style searchable settings with serialized saves and rollback;
-- `multiSelect` for bounded optimistic toggles and bulk actions.
+- `multiSelect` for bounded optimistic toggles, optional TUI fuzzy search, and pinned bulk actions.
 
 The runtime already owns screen-stack navigation, per-screen cursor memory, TUI/RPC adaptation,
 Back/Close semantics, cancellable busy actions, terminal-safe rendering, and stale-continuation
@@ -52,6 +52,8 @@ Current repository evidence includes:
 - `pi-starship` framed action selection with width-dependent preview content;
 - `pi-image-drop` contextual input and decision dialogs;
 - `pi-file-context` experimental searchable file navigation;
+- `pi-plan-mode` searchable installed-tool selection with immediate session-owned activation;
+- `pi-subagents` searchable agent-tool drafts with explicit Save and Discard actions;
 - `pi-worktree` worktree selection with display-derived identity mapping;
 - specialized UIs in `pi-sync`, `pi-btw`, and `pi-usage` that should remain local unless they share a
   proven contract with another consumer.
@@ -158,7 +160,19 @@ consumer-specific preview hook.
 
 ### Phase 3: Searchable Catalog and Contextual Decision
 
-These screens proceed independently; either may be deferred if it lacks two compatible consumers.
+**Qualification status:** completed. Searchable catalog and contextual decision remain deferred; see
+[the next-capabilities qualification plan](../plans/archived/2026-07-30_pi-tui-kit-next-capabilities-qualification-plan.md).
+The qualification found a smaller already-proven prerequisite: optional search on the existing
+`multiSelect` screen. It passed the two-consumer gate and shipped through Plan mode and Subagents; see
+[the searchable multi-select plan](../plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md).
+Because the change adds optional fields rather than a screen kind, `PI_EXTENSION_MENU_API_VERSION`
+remains `2`; older version-2 runtimes retain a valid unfiltered multi-select.
+
+**Searchable catalog status:** deferred. Jupyter's notebook picker needs a manual-path route,
+asynchronous loading, outside-workspace confirmation, and TUI-only preview ownership. Subagents has a
+compatible static agent picker but not a second proven large-list workflow. Sync setup/resource lists
+mix creation and refreshed manager state, Accounts owns credential mutations, and `pi-file-context`
+requires dual activation, asynchronous preview, history, revision, diff, and range selection.
 
 **Searchable catalog milestones:**
 
@@ -169,6 +183,11 @@ These screens proceed independently; either may be deferred if it lacks two comp
 - Keep regex grammar, asynchronous refresh, scope tabs, and domain sorting out of the first contract.
 - Migrate two qualified catalog consumers while retaining specialized sorting, previews, and actions
   outside the kit.
+
+**Contextual decision status:** deferred. Image Drop has the only compatible need to distinguish
+Confirm, Escape cancellation, and `Ctrl+C` Close. Starship requires width-dependent live preview plus
+multiple actions, while Sync and Accounts retain their required context and safe defaults with public
+`ctx.ui.confirm()` or `ctx.ui.select()`.
 
 **Contextual decision milestones:**
 
@@ -209,7 +228,9 @@ and retires local abstractions when a stable public Pi replacement becomes avail
 
 - Keep TypeScript strict, NodeNext-compatible, and built as published JavaScript plus declarations.
 - Keep authored source files below the repository's review threshold or split them along clear screen,
-  rendering, and runtime responsibilities when cohesion improves.
+  rendering, and runtime responsibilities when cohesion improves. Multi-select state/rendering now
+  lives in `multi-select-component.ts`, with shared contracts and rendering helpers separated from the
+  screen dispatcher.
 - Maintain deterministic model, component, runtime, and README usage tests for every public contract.
 - Run `npm run check --workspace @narumitw/pi-tui-kit`, the root `npm run check`, and
   `just pack-tui-kit` for each kit feature.
@@ -270,19 +291,23 @@ and retires local abstractions when a stable public Pi replacement becomes avail
 | 2026-07-30 | Require two compatible consumers before adding a screen. | Prevents one-off hooks and unsupported abstraction growth. |
 | 2026-07-30 | Deliver the static choice screen with `pi-statusline` information profiles and `pi-worktree` selection in one focused rollout. | Both need confirmed static selection with raw identity and no cursor-movement side effect; an atomic proof rollout keeps preview, decision, and editor-preserving flows specialized. |
 | 2026-07-30 | Keep async catalogs, trees, login flows, and live previews deferred. | These patterns require stronger shared evidence or remain domain-specific. |
+| 2026-07-30 | Admit optional searchable multi-select with Plan mode and Subagents as proof consumers; keep API version 2. | Both share stable tool IDs and filtering while retaining different persistence ownership; optional fields degrade safely to the existing unfiltered screen. |
+| 2026-07-30 | Defer searchable catalog. | Jupyter is specialized and only Subagents currently fits the bounded static contract without proving a second large-list need. |
+| 2026-07-30 | Defer contextual decision. | Image Drop has no second compatible consumer; Starship preview and existing public confirmation flows require different contracts. |
 
 ## Completion Checklist
 
-- [ ] Every shipped composite passed the two-consumer qualification gate and completed two
+- [x] Every shipped composite passed the two-consumer qualification gate and completed two
       behavior-preserving migrations, or its phase is explicitly deferred with evidence.
-- [ ] Package source contains no Pi private `dist/*` imports or public contracts exposing TUI objects.
-- [ ] Existing action, detail, settings, and multi-select consumers remain source compatible unless an
+- [x] Package source contains no Pi private `dist/*` imports or public contracts exposing TUI objects.
+- [x] Existing action, detail, settings, and multi-select consumers remain source compatible unless an
       approved API-version change documents migration.
-- [ ] Every admitted screen has deterministic TUI and RPC coverage for identity, width, Unicode,
+- [x] Every admitted screen has deterministic TUI and RPC coverage for identity, width, Unicode,
       terminal sanitization, keybindings, Back/Close, disabled state, failures, cancellation,
       disposal, replacement, and shutdown where applicable.
 - [ ] Each feature and migration passed focused tests, root checks, package dry runs, and a
-      representative Pi runtime smoke with unverified paths recorded.
-- [ ] README ownership guidance distinguishes public Pi primitives and domain composites to reuse,
+      representative Pi runtime smoke with unverified paths recorded. The searchable multi-select
+      plan records unrelated parallel root-run flakes while its full focused gates pass.
+- [x] README ownership guidance distinguishes public Pi primitives and domain composites to reuse,
       non-exported composites used only as references, kit-owned standard behavior, and
       extension-owned domain UI.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -305,9 +305,8 @@ and retires local abstractions when a stable public Pi replacement becomes avail
 - [x] Every admitted screen has deterministic TUI and RPC coverage for identity, width, Unicode,
       terminal sanitization, keybindings, Back/Close, disabled state, failures, cancellation,
       disposal, replacement, and shutdown where applicable.
-- [ ] Each feature and migration passed focused tests, root checks, package dry runs, and a
-      representative Pi runtime smoke with unverified paths recorded. The searchable multi-select
-      plan records unrelated parallel root-run flakes while its full focused gates pass.
+- [x] Each feature and migration passed focused tests, root checks, package dry runs, and a
+      representative Pi runtime smoke with unverified paths recorded.
 - [x] README ownership guidance distinguishes public Pi primitives and domain composites to reuse,
       non-exported composites used only as references, kit-owned standard behavior, and
       extension-owned domain UI.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -57,7 +57,9 @@ Use `/plan` to enter Plan mode before writing your planning prompt. Use `/plan <
 Plan mode and immediately submit `<prompt>` as the first Plan-mode user message. Use `/plan tools`
 to choose which tools are active while Plan mode is enabled; the standard bounded multi-select shows
 10 rows at a time, supports viewport paging, descriptions, and explicit unavailable rows for blocked
-tools. The `plan_mode_question` tool keeps its one-off question/choice dialog because it is a
+tools. In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; clear
+the query to restore the stable tool cursor. RPC keeps the complete unfiltered tool list. The
+`plan_mode_question` tool keeps its one-off question/choice dialog because it is a
 model-requested planning interaction, not command-menu navigation. `/plan show` displays the stored
 plan without starting a model turn, `/plan finalize`
 explicitly asks the agent to complete the plan or ask one remaining material question, and

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -647,6 +647,7 @@ export default function planMode(pi: ExtensionAPI) {
 						kind: "multiSelect",
 						title: "Plan-mode tools",
 						lines: ["Non-built-in tools run at user risk."],
+						enableSearch: true,
 						viewportSize: TOOL_SELECTOR_VIEWPORT_SIZE,
 						items: tools.map((tool, index) => {
 							const selectable = canSelectToolInPlanMode(tool);
@@ -654,6 +655,7 @@ export default function planMode(pi: ExtensionAPI) {
 								id: `${index}:${tool.name}`,
 								label: tool.name,
 								description: `${toolPolicyLabel(tool)} · ${tool.description}`,
+								searchText: [toolPolicyLabel(tool), tool.description].filter(Boolean).join(" "),
 								selected: selectedNames.has(tool.name),
 								disabled: !selectable,
 								disabledReason: selectable ? undefined : "Blocked by Plan-mode policy",

--- a/extensions/pi-plan-mode/test/default-tools.test.ts
+++ b/extensions/pi-plan-mode/test/default-tools.test.ts
@@ -3,8 +3,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
 import {
 	builtinTool,
+	createCustomSelectorHarness,
 	createMockContext,
 	createMockPi,
 	driveCustomSelector,
@@ -301,6 +303,50 @@ test("the Plan-mode tool selector keeps the cursor on the toggled row", async ()
 			"custom",
 			...REQUIRED_PLAN_TOOLS,
 		]);
+	});
+});
+
+test("the Plan-mode tool selector searches metadata and toggles the stable tool name", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({ defaultPlanTools: ["bash", "custom"] }),
+		);
+		const allTools = [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("write"),
+			{ ...extensionTool("custom"), description: "Remote inspection helper" },
+		];
+		const mock = createMockPi({ activeTools: ["write"], allTools });
+		planMode(mock.pi);
+		let customCalled = false;
+		const context = createMockContext({
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				customCalled = true;
+				const harness = createCustomSelectorHarness(factory, 60);
+				for (const input of ["r", "e", "m", "o", "t", "e"]) harness.handleInput(input);
+				const filtered = stripVTControlCharacters(harness.render().join("\n"));
+				assert.match(filtered, /custom/);
+				assert.doesNotMatch(filtered, /› .*bash|› .*read|› .*write/);
+				harness.handleInput("tui.select.confirm");
+				for (let index = 0; index < 6; index += 1) harness.handleInput("\u007f");
+				assert.match(stripVTControlCharacters(harness.render().join("\n")), /› \[ \] custom/);
+				harness.handleInput("tui.select.cancel");
+				await harness.waitForPending();
+				return harness.result;
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("tools", context.ctx);
+
+		assert.equal(customCalled, true);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", ...REQUIRED_PLAN_TOOLS]);
+		const persisted = mock.entries.at(-1)?.data as { selectedToolNames?: string[] } | undefined;
+		assert.deepEqual(persisted?.selectedToolNames, ["bash"]);
 	});
 });
 

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -390,13 +390,16 @@ Built-in agents inherit the active/default Pi model instead of forcing a provide
 
 Open `/subagents`, choose **Advanced settings**, then **Agent tool permissions** in an interactive
 Pi session to edit the tools each subagent may use. The standard bounded multi-select keeps a
-one-save draft: toggles do not write until **Save changes**, Escape discards the draft, and unavailable
-configured tool names remain visible and preserved. These are user settings stored in `~/.pi/agent/pi-subagents.json` and affect future sessions.
+one-save draft: toggles do not write until **Save changes**, Escape leaves the draft without writing,
+and unavailable configured tool names remain visible and preserved. In TUI mode, type to fuzzy-search
+tool names and availability metadata; Save and Discard remain pinned below the matches. These are user
+settings stored in `~/.pi/agent/pi-subagents.json` and affect future sessions.
 
 Compatibility: a valid legacy `pi-subagents-config.json` remains readable with a warning and is never modified automatically; rename it to `pi-subagents.json`. The first subsequent settings save writes the canonical file. If both files exist, the new filename takes precedence.
 
 - Select an agent, then press Enter or Space to toggle tools.
-- Press `S` to save, or Esc to cancel and return to agent selection.
+- Choose **Save changes** to write the draft, choose **Discard draft** to abandon it, or press Esc to
+  return to agent selection without writing.
 - Save the default selection to remove a custom override and use the agent defaults again.
 - Deselect every tool and save to run that agent with no tools.
 

--- a/extensions/pi-subagents/src/config-ui.ts
+++ b/extensions/pi-subagents/src/config-ui.ts
@@ -297,6 +297,7 @@ async function showSubagentManager(
 			"tool-draft": () => ({
 				kind: "multiSelect",
 				title: toolDraft ? `${safeTerminalText(toolDraft.agentName)} tools` : "Agent tools",
+				enableSearch: true,
 				lines: toolDraft
 					? [
 							`Source: ${safeTerminalText(toolDraft.agentSource)}`,
@@ -311,6 +312,7 @@ async function showSubagentManager(
 							id: name,
 							label: safeTerminalText(name),
 							description: available ? "Available tool" : "Configured tool is not currently loaded",
+							searchText: available ? "available tool" : "configured unavailable preserved",
 							selected: toolDraft?.selected.has(name) ?? false,
 							disabled: !available,
 							disabledReason: available

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -16,9 +16,17 @@ import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
+import {
+	builtinTool,
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+	driveCustomSelector,
+	extensionTool,
+} from "../../../test/support.js";
 import { discoverAgents, formatAgentList } from "../src/agents.js";
 import { registerSubagentConfigCommand, type SubagentSettingsRuntime } from "../src/config-ui.js";
 import { hasUsableAggregator } from "../src/params.js";
@@ -271,6 +279,157 @@ test("bare subagents opens a current-session manager and keeps direct routes pre
 		for (const handler of mock.events.get("session_shutdown") ?? []) {
 			await handler({}, managerContext.ctx);
 		}
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("agent tool drafts preserve settings across searchable save, discard, and Escape", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-search-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				future: { kept: true },
+				agents: { scout: { tools: ["read", "missing-tool"] } },
+			}),
+		);
+		const mock = createMockPi({
+			allTools: [builtinTool("read"), builtinTool("bash"), extensionTool("remote-tool")],
+		});
+		const runtime: SubagentSettingsRuntime = {
+			getBlockingEnabled: () => true,
+			getCompletionDelivery: () => "next-turn",
+			setCompletionDelivery: () => undefined,
+			getRuntimeStatus: () => ({
+				enabled: true,
+				initialized: true,
+				transport: "subprocess",
+				completionDelivery: "next-turn",
+				activeAgents: 0,
+				retainedAgents: 0,
+			}),
+			listAgents: () => [],
+			clearAgents: async () => 0,
+		};
+		registerSubagentConfigCommand(mock.pi, runtime);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let call = 0;
+		const openedScreens: string[] = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 70);
+				openedScreens.push(stripVTControlCharacters(harness.render().join("\n")));
+				if (call === 0) {
+					for (let index = 0; index < 3; index += 1) {
+						harness.handleInput("tui.select.down");
+					}
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 1 || call === 2) {
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 3) {
+					assert.match(stripVTControlCharacters(harness.render().join("\n")), /missing-tool/);
+					for (const input of ["r", "e", "m", "o", "t", "e"]) harness.handleInput(input);
+					const filtered = stripVTControlCharacters(harness.render().join("\n"));
+					assert.match(filtered, /remote-tool/);
+					assert.doesNotMatch(filtered, /\bread\b|\bbash\b|missing-tool/);
+					assert.match(filtered, /Save changes/);
+					assert.match(filtered, /Discard draft/);
+					harness.handleInput("tui.select.confirm");
+					for (let index = 0; index < 6; index += 1) harness.handleInput("\u007f");
+					const cleared = stripVTControlCharacters(harness.render().join("\n"));
+					assert.match(cleared, /› \[x\] remote-tool/);
+					assert.match(cleared, /missing-tool.*unavailable/);
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+					await new Promise<void>((resolve) => setImmediate(resolve));
+				} else {
+					harness.handleInput("\u0003");
+				}
+				call += 1;
+				return harness.result;
+			},
+		});
+
+		await command.handler("", context.ctx);
+		assert.equal(call, 5, openedScreens.join("\n---\n"));
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			future: { kept: true },
+			agents: { scout: { tools: ["read", "missing-tool", "remote-tool"] } },
+		});
+		const savedDocument = readFileSync(settingsPath, "utf8");
+
+		let discardCall = 0;
+		const discardContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 70);
+				if (discardCall === 0) {
+					for (let index = 0; index < 3; index += 1) {
+						harness.handleInput("tui.select.down");
+					}
+					harness.handleInput("tui.select.confirm");
+				} else if (discardCall === 1 || discardCall === 2) {
+					harness.handleInput("tui.select.confirm");
+				} else if (discardCall === 3) {
+					for (const input of ["b", "a", "s", "h"]) harness.handleInput(input);
+					harness.handleInput("tui.select.confirm");
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.down");
+					assert.match(stripVTControlCharacters(harness.render().join("\n")), /› Discard draft/);
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+					await new Promise<void>((resolve) => setImmediate(resolve));
+				} else {
+					harness.handleInput("\u0003");
+				}
+				discardCall += 1;
+				return harness.result;
+			},
+		});
+		await command.handler("", discardContext.ctx);
+		assert.equal(discardCall, 5);
+		assert.equal(readFileSync(settingsPath, "utf8"), savedDocument);
+
+		let escapeCall = 0;
+		const escapeContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 70);
+				if (escapeCall === 0) {
+					for (let index = 0; index < 3; index += 1) {
+						harness.handleInput("tui.select.down");
+					}
+					harness.handleInput("tui.select.confirm");
+				} else if (escapeCall === 1 || escapeCall === 2) {
+					harness.handleInput("tui.select.confirm");
+				} else if (escapeCall === 3) {
+					for (const input of ["b", "a", "s", "h"]) harness.handleInput(input);
+					harness.handleInput("tui.select.confirm");
+					harness.handleInput("tui.select.cancel");
+					await harness.waitForPending();
+					await new Promise<void>((resolve) => setImmediate(resolve));
+				} else {
+					harness.handleInput("\u0003");
+				}
+				escapeCall += 1;
+				return harness.result;
+			},
+		});
+		await command.handler("", escapeContext.ctx);
+		assert.equal(escapeCall, 5);
+		assert.equal(readFileSync(settingsPath, "utf8"), savedDocument);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -106,7 +106,7 @@ remain pure projections of current extension state.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
   serialized saves, and rollback when an action rejects.
 - **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback,
-  selected-row descriptions, optional bulk action rows, and a bounded TUI viewport.
+  selected-row descriptions, optional fuzzy search and bulk action rows, and a bounded TUI viewport.
 
 All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed
 content after invalidation, and bound rendered output to the supplied terminal width. Escape follows
@@ -170,20 +170,33 @@ Action handlers return one of these results:
 A rejected settings or multi-select action restores the last accepted value. Throwing has the same
 recovery behavior and is routed through `onError`.
 
-For a large catalog, set `viewportSize` to the maximum number of toggle and action rows rendered at
-once. Up and Down wrap; Page Up and Page Down move by one viewport and clamp at the first or last row.
-The viewport applies only to TUI rendering—RPC keeps one flat list of unique dialog choices.
-Descriptions for the selected row appear below the viewport.
+For a large multi-select, set `viewportSize` to the maximum number of toggle and action rows rendered
+at once. Up and Down wrap; Page Up and Page Down move by one viewport and clamp at the first or last
+row. Descriptions for the selected row appear below the viewport.
+
+Set `enableSearch: true` when toggle rows can become difficult to scan. TUI typing fuzzy-filters each
+sanitized label plus optional non-rendered `searchText`; use that field for source, policy, aliases, or
+other useful metadata without parsing display labels or raw IDs. The query is local to the current
+screen instance. Rows in `actions` remain pinned below the matches, including when there are no
+matching toggle rows, so Save, Discard, and bulk workflows stay reachable. Clearing the query restores
+a valid stable-ID selection. The embedded public Pi `Input` forwards focus for IME positioning and
+sanitizes pasted terminal controls before filtering.
+
+Search and the viewport affect TUI presentation only. RPC deliberately keeps one flat, unfiltered
+list of unique dialog choices, preserving raw identity, disabled rows, toggle semantics, and action
+rows without introducing a second query protocol.
 
 ```ts
 const tools = {
   kind: "multiSelect" as const,
   title: "Tool permissions",
+  enableSearch: true,
   viewportSize: 9,
   items: allTools.map((tool) => ({
     id: tool.name, // raw stable identity; never recover it from the display label
     label: tool.name,
     description: tool.description,
+    searchText: `${tool.source} ${tool.description}`,
     selected: enabledTools.has(tool.name),
     disabled: blockedTools.has(tool.name),
     disabledReason: blockedTools.has(tool.name) ? "Blocked by the active policy" : undefined,
@@ -272,7 +285,9 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, and result types.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`2`).
+- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`2`). Optional multi-select
+  search is additive: version-2 runtimes that do not implement it safely retain the full unfiltered
+  multi-select rather than rejecting an otherwise compatible screen.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/src/multi-select-component.ts
+++ b/packages/pi-tui-kit/src/multi-select-component.ts
@@ -1,0 +1,259 @@
+import {
+	type Focusable,
+	fuzzyFilter,
+	Input,
+	Key,
+	matchesKey,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import type {
+	MenuChangeResponse,
+	MenuScreenComponent,
+	MultiSelectOptions,
+} from "./screen-component-contracts.js";
+import {
+	renderFrame,
+	replaceTerminalControls,
+	safeMenuText,
+} from "./screen-component-rendering.js";
+import type { ActionMenuItem, MenuMultiSelectItem } from "./types.js";
+
+type ToggleRow = { kind: "toggle"; item: MenuMultiSelectItem };
+type ActionRow<ScreenId extends string, ActionId extends string> = {
+	kind: "action";
+	item: ActionMenuItem<ScreenId, ActionId>;
+};
+type MultiSelectRow<ScreenId extends string, ActionId extends string> =
+	| ToggleRow
+	| ActionRow<ScreenId, ActionId>;
+
+export function createMultiSelectComponent<ScreenId extends string, ActionId extends string>(
+	options: MultiSelectOptions<ScreenId, ActionId>,
+): MenuScreenComponent {
+	const searchInput = new Input();
+	const toggleRows: ToggleRow[] = options.screen.items.map((item) => ({ kind: "toggle", item }));
+	const actionRows: ActionRow<ScreenId, ActionId>[] = (options.screen.actions ?? []).map(
+		(item) => ({ kind: "action", item }),
+	);
+	const searchableRows = toggleRows.map((row) => ({
+		row,
+		text: [safeMenuText(row.item.label), safeMenuText(row.item.searchText ?? "")]
+			.filter(Boolean)
+			.join(" "),
+	}));
+	let rows: MultiSelectRow<ScreenId, ActionId>[] = [...toggleRows, ...actionRows];
+	const selected = new Map(options.screen.items.map((item) => [item.id, item.selected]));
+	const committedSelected = new Map(selected);
+	const revisions = new Map<string, number>();
+	let selectedIndex = Math.max(
+		0,
+		rows.findIndex(({ item }) => item.id === options.selectedItemId),
+	);
+	let restoreItemId: string | undefined;
+	let pending = Promise.resolve();
+	let closing = false;
+	let disposed = false;
+	const selectedRow = () => rows[selectedIndex];
+	const closeAfterPending = (kind: "back" | "close") => {
+		if (closing || disposed) return;
+		closing = true;
+		void pending.then(() => {
+			if (!disposed) options.onEvent({ kind });
+		});
+	};
+	const setSelectedIndex = (index: number, rememberUserSelection: boolean) => {
+		if (rows.length === 0) {
+			selectedIndex = 0;
+			return;
+		}
+		selectedIndex = Math.max(0, Math.min(index, rows.length - 1));
+		const row = selectedRow();
+		if (!row) return;
+		if (rememberUserSelection) restoreItemId = undefined;
+		options.onSelectionChange?.(row.item.id);
+	};
+	const selectIndex = (index: number) => setSelectedIndex(index, true);
+	const move = (delta: number) => {
+		if (rows.length === 0) return;
+		selectIndex((selectedIndex + delta + rows.length) % rows.length);
+	};
+	const applyFilter = () => {
+		if (!options.screen.enableSearch) return;
+		const previouslySelectedId = selectedRow()?.item.id;
+		const filteredRows = fuzzyFilter(
+			searchableRows,
+			searchInput.getValue(),
+			(candidate) => candidate.text,
+		).map((candidate) => candidate.row);
+		rows = [...filteredRows, ...actionRows];
+		if (rows.length === 0) {
+			if (previouslySelectedId) restoreItemId ??= previouslySelectedId;
+			selectedIndex = 0;
+			return;
+		}
+		const previousIndex = rows.findIndex((row) => row.item.id === previouslySelectedId);
+		if (previousIndex < 0 && previouslySelectedId) restoreItemId ??= previouslySelectedId;
+		const restoreIndex = rows.findIndex((row) => row.item.id === restoreItemId);
+		const nextIndex = restoreIndex >= 0 ? restoreIndex : previousIndex >= 0 ? previousIndex : 0;
+		if (restoreIndex >= 0) restoreItemId = undefined;
+		setSelectedIndex(nextIndex, false);
+	};
+	const activate = () => {
+		const row = selectedRow();
+		if (!row || row.item.disabled) return;
+		restoreItemId = undefined;
+		if (row.kind === "action") {
+			if (closing || disposed) return;
+			closing = true;
+			void pending.then(() => {
+				if (!disposed) options.onEvent({ kind: "activate", itemId: row.item.id });
+			});
+			return;
+		}
+		const item = row.item;
+		const previousSelected = selected.get(item.id) ?? false;
+		const nextSelected = !previousSelected;
+		selected.set(item.id, nextSelected);
+		const revision = (revisions.get(item.id) ?? 0) + 1;
+		revisions.set(item.id, revision);
+		const operation = pending.then(async () => {
+			if (disposed) return;
+			let response: MenuChangeResponse<ScreenId> = false;
+			try {
+				response =
+					(await options.onMultiSelectChange?.({
+						itemId: item.id,
+						selected: nextSelected,
+						previousSelected,
+					})) ?? false;
+			} catch (error) {
+				options.onError?.(error);
+			}
+			if (disposed) return;
+			const accepted = typeof response === "boolean" ? response : response.accepted;
+			if (accepted) committedSelected.set(item.id, nextSelected);
+			else if (revisions.get(item.id) === revision) {
+				selected.set(item.id, committedSelected.get(item.id) ?? false);
+			}
+			options.tui.requestRender();
+			if (accepted && typeof response !== "boolean") {
+				closing = true;
+				void pending.then(() => {
+					if (!disposed) options.onTransition?.(response.transition);
+				});
+			}
+		});
+		pending = operation.catch(() => undefined);
+	};
+	const component: MenuScreenComponent & Partial<Focusable> = {
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const requestedViewport = options.screen.viewportSize ?? 13;
+			const viewportSize = Math.min(requestedViewport, rows.length);
+			const viewportStart = Math.max(
+				0,
+				Math.min(selectedIndex - Math.floor(viewportSize / 2), rows.length - viewportSize),
+			);
+			const visibleRows = rows.slice(viewportStart, viewportStart + viewportSize);
+			const rowContent = visibleRows.map((row, offset) => {
+				const index = viewportStart + offset;
+				const isSelected = index === selectedIndex;
+				const prefix = isSelected ? "› " : "  ";
+				const marker =
+					row.kind === "toggle"
+						? `${row.item.disabled ? "[-]" : selected.get(row.item.id) ? "[x]" : "[ ]"} `
+						: "";
+				const unavailable = row.item.disabled ? " (unavailable)" : "";
+				const label = `${prefix}${marker}${safeMenuText(row.item.label)}${unavailable}`;
+				if (isSelected) return options.theme.fg("accent", label);
+				return row.item.disabled ? options.theme.fg("dim", label) : label;
+			});
+			if (viewportSize < rows.length) {
+				rowContent.push(options.theme.fg("dim", `  (${selectedIndex + 1}/${rows.length})`));
+			}
+			const row = selectedRow();
+			const descriptions = row
+				? [
+						row.item.description,
+						row.kind === "toggle" && row.item.disabled
+							? row.item.disabledReason
+								? `Unavailable: ${row.item.disabledReason}`
+								: "Unavailable"
+							: undefined,
+					].filter((value): value is string => Boolean(value))
+				: [];
+			if (descriptions.length > 0) {
+				rowContent.push(
+					"",
+					...descriptions.flatMap((description) =>
+						wrapTextWithAnsi(options.theme.fg("dim", `  ${safeMenuText(description)}`), safeWidth),
+					),
+				);
+			}
+			const content = options.screen.enableSearch
+				? [
+						...searchInput.render(safeWidth),
+						"",
+						...(options.screen.items.length === 0
+							? [options.theme.fg("dim", "  No items available")]
+							: rows.every((candidate) => candidate.kind === "action")
+								? [options.theme.fg("dim", "  No matching items")]
+								: []),
+						...rowContent,
+						options.theme.fg("dim", "Type to search"),
+					]
+				: rowContent;
+			return renderFrame(
+				options.screen.title,
+				options.screen.lines ?? [],
+				content,
+				options.screen.hint ?? "back",
+				width,
+				options,
+				row?.kind === "action" ? "select" : "toggle",
+			);
+		},
+		invalidate() {
+			if (options.screen.enableSearch) searchInput.invalidate();
+		},
+		handleInput(data) {
+			if (disposed || closing) return;
+			if (matchesKey(data, Key.ctrl("c"))) closeAfterPending("close");
+			else if (options.keybindings.matches(data, "tui.select.cancel")) {
+				closeAfterPending(options.screen.hint ?? "back");
+			} else if (options.keybindings.matches(data, "tui.select.up")) move(-1);
+			else if (options.keybindings.matches(data, "tui.select.down")) move(1);
+			else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+				selectIndex(selectedIndex - (options.screen.viewportSize ?? 13));
+			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+				selectIndex(selectedIndex + (options.screen.viewportSize ?? 13));
+			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
+				activate();
+			} else if (options.screen.enableSearch) {
+				const searchData = data.replaceAll(" ", "");
+				if (searchData) {
+					searchInput.handleInput(searchData);
+					const query = replaceTerminalControls(searchInput.getValue());
+					if (query !== searchInput.getValue()) searchInput.setValue(query);
+					applyFilter();
+				}
+			}
+			options.tui.requestRender();
+		},
+		waitForPending: () => pending,
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			options.onDispose?.();
+		},
+	};
+	if (options.screen.enableSearch) {
+		Object.defineProperty(component, "focused", {
+			get: () => searchInput.focused,
+			set: (value: boolean) => {
+				searchInput.focused = value;
+			},
+		});
+	}
+	return component;
+}

--- a/packages/pi-tui-kit/src/multi-select-component.ts
+++ b/packages/pi-tui-kit/src/multi-select-component.ts
@@ -11,11 +11,7 @@ import type {
 	MenuScreenComponent,
 	MultiSelectOptions,
 } from "./screen-component-contracts.js";
-import {
-	renderFrame,
-	replaceTerminalControls,
-	safeMenuText,
-} from "./screen-component-rendering.js";
+import { handleSearchInput, renderFrame, safeMenuText } from "./screen-component-rendering.js";
 import type { ActionMenuItem, MenuMultiSelectItem } from "./types.js";
 
 type ToggleRow = { kind: "toggle"; item: MenuMultiSelectItem };
@@ -230,13 +226,8 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
 				activate();
 			} else if (options.screen.enableSearch) {
-				const searchData = data.replaceAll(" ", "");
-				if (searchData) {
-					searchInput.handleInput(searchData);
-					const query = replaceTerminalControls(searchInput.getValue());
-					if (query !== searchInput.getValue()) searchInput.setValue(query);
-					applyFilter();
-				}
+				handleSearchInput(searchInput, data);
+				applyFilter();
 			}
 			options.tui.requestRender();
 		},

--- a/packages/pi-tui-kit/src/screen-component-contracts.ts
+++ b/packages/pi-tui-kit/src/screen-component-contracts.ts
@@ -1,0 +1,72 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import type { MenuScreen, MenuTransition } from "./types.js";
+
+const MENU_BINDINGS = [
+	"tui.select.up",
+	"tui.select.down",
+	"tui.select.pageUp",
+	"tui.select.pageDown",
+	"tui.select.confirm",
+	"tui.select.cancel",
+] as const;
+export type MenuBinding = (typeof MENU_BINDINGS)[number];
+
+export interface RenderHost {
+	requestRender(): void;
+}
+
+export interface MenuKeybindings {
+	matches(data: string, binding: MenuBinding): boolean;
+	getKeys(binding: MenuBinding): readonly string[];
+}
+
+export type MenuScreenEvent =
+	| { kind: "activate"; itemId: string }
+	| { kind: "back" }
+	| { kind: "close" };
+
+export interface MenuSettingChange {
+	itemId: string;
+	value: string;
+	previousValue: string;
+}
+
+export interface MenuMultiSelectChange {
+	itemId: string;
+	selected: boolean;
+	previousSelected: boolean;
+}
+
+export interface MenuScreenComponent extends Component {
+	readonly __piTuiKitScreen?: true;
+	handleInput(data: string): void;
+	waitForPending(): Promise<void>;
+	dispose?(): void;
+}
+
+export type MenuChangeResponse<ScreenId extends string> =
+	| boolean
+	| { accepted: boolean; transition: MenuTransition<ScreenId> };
+
+export interface MenuScreenComponentOptions<ScreenId extends string, ActionId extends string> {
+	screen: MenuScreen<ScreenId, ActionId>;
+	selectedItemId?: string;
+	tui: RenderHost;
+	theme: Pick<Theme, "fg" | "bold">;
+	keybindings: MenuKeybindings;
+	onEvent(event: MenuScreenEvent): void;
+	onSelectionChange?(itemId: string): void;
+	onSettingChange?(change: MenuSettingChange): Promise<MenuChangeResponse<ScreenId>>;
+	onMultiSelectChange?(change: MenuMultiSelectChange): Promise<MenuChangeResponse<ScreenId>>;
+	onTransition?(transition: MenuTransition<ScreenId>): void;
+	onError?(error: unknown): void;
+	onDispose?(): void;
+}
+
+export type MultiSelectOptions<
+	ScreenId extends string,
+	ActionId extends string,
+> = MenuScreenComponentOptions<ScreenId, ActionId> & {
+	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "multiSelect" }>;
+};

--- a/packages/pi-tui-kit/src/screen-component-rendering.ts
+++ b/packages/pi-tui-kit/src/screen-component-rendering.ts
@@ -1,0 +1,75 @@
+import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type {
+	MenuBinding,
+	MenuKeybindings,
+	MenuScreenComponentOptions,
+} from "./screen-component-contracts.js";
+
+export function renderFrame<ScreenId extends string, ActionId extends string>(
+	title: string,
+	lines: readonly string[],
+	content: readonly string[],
+	destination: "back" | "close",
+	width: number,
+	options: MenuScreenComponentOptions<ScreenId, ActionId>,
+	confirmAction = "select",
+): string[] {
+	const safeWidth = Math.max(1, width);
+	const result = [
+		...wrapTextWithAnsi(
+			options.theme.fg("accent", options.theme.bold(safeMenuText(title))),
+			safeWidth,
+		),
+		...lines.flatMap((line) =>
+			wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
+		),
+		...(content.length > 0 ? ["", ...content] : []),
+		...wrapTextWithAnsi(
+			options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
+			safeWidth,
+		),
+	];
+	return result.map((line) => truncateToWidth(line, safeWidth, ""));
+}
+
+export function menuHint(
+	keybindings: MenuKeybindings,
+	destination: "back" | "close",
+	confirmAction: string,
+) {
+	const up = bindingText(keybindings, "tui.select.up");
+	const down = bindingText(keybindings, "tui.select.down");
+	const confirm = bindingText(keybindings, "tui.select.confirm");
+	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
+	return [
+		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
+		...(confirm ? [`${confirm} ${confirmAction}`] : []),
+		...(cancel ? [`${cancel} ${destination}`] : []),
+		...(destination === "back" ? ["ctrl+c close"] : []),
+	].join(" • ");
+}
+
+function bindingText(keybindings: MenuKeybindings, binding: MenuBinding, excluded?: string) {
+	return keybindings
+		.getKeys(binding)
+		.filter((key) => key !== excluded)
+		.map((key) => {
+			if (key === "up") return "↑";
+			if (key === "down") return "↓";
+			if (key === "escape") return "esc";
+			return safeMenuText(key);
+		})
+		.filter(Boolean)
+		.join("/");
+}
+
+export function safeMenuText(value: unknown) {
+	return replaceTerminalControls(value).replace(/\s+/gu, " ").trim();
+}
+
+export function replaceTerminalControls(value: unknown) {
+	return Array.from(String(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
+}

--- a/packages/pi-tui-kit/src/screen-component-rendering.ts
+++ b/packages/pi-tui-kit/src/screen-component-rendering.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { type Input, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type {
 	MenuBinding,
 	MenuKeybindings,
@@ -65,6 +65,12 @@ function bindingText(keybindings: MenuKeybindings, binding: MenuBinding, exclude
 
 export function safeMenuText(value: unknown) {
 	return replaceTerminalControls(value).replace(/\s+/gu, " ").trim();
+}
+
+export function handleSearchInput(input: Input, data: string) {
+	input.handleInput(data);
+	const value = replaceTerminalControls(input.getValue());
+	if (value !== input.getValue()) input.setValue(value);
 }
 
 export function replaceTerminalControls(value: unknown) {

--- a/packages/pi-tui-kit/src/screen-components.ts
+++ b/packages/pi-tui-kit/src/screen-components.ts
@@ -1,6 +1,5 @@
 import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
 import {
-	type Component,
 	type Focusable,
 	fuzzyFilter,
 	Input,
@@ -12,69 +11,30 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import type { MenuScreen, MenuSettingItem, MenuTransition } from "./types.js";
+import { createMultiSelectComponent } from "./multi-select-component.js";
+import type {
+	MenuChangeResponse,
+	MenuKeybindings,
+	MenuScreenComponent,
+	MenuScreenComponentOptions,
+	MultiSelectOptions,
+} from "./screen-component-contracts.js";
+import {
+	menuHint,
+	renderFrame,
+	replaceTerminalControls,
+	safeMenuText,
+} from "./screen-component-rendering.js";
+import type { MenuScreen, MenuSettingItem } from "./types.js";
 
-const MENU_BINDINGS = [
-	"tui.select.up",
-	"tui.select.down",
-	"tui.select.pageUp",
-	"tui.select.pageDown",
-	"tui.select.confirm",
-	"tui.select.cancel",
-] as const;
-type MenuBinding = (typeof MENU_BINDINGS)[number];
-
-interface RenderHost {
-	requestRender(): void;
-}
-
-interface MenuKeybindings {
-	matches(data: string, binding: MenuBinding): boolean;
-	getKeys(binding: MenuBinding): readonly string[];
-}
-
-export type MenuScreenEvent =
-	| { kind: "activate"; itemId: string }
-	| { kind: "back" }
-	| { kind: "close" };
-
-export interface MenuSettingChange {
-	itemId: string;
-	value: string;
-	previousValue: string;
-}
-
-export interface MenuMultiSelectChange {
-	itemId: string;
-	selected: boolean;
-	previousSelected: boolean;
-}
-
-export interface MenuScreenComponent extends Component {
-	readonly __piTuiKitScreen?: true;
-	handleInput(data: string): void;
-	waitForPending(): Promise<void>;
-	dispose?(): void;
-}
-
-type MenuChangeResponse<ScreenId extends string> =
-	| boolean
-	| { accepted: boolean; transition: MenuTransition<ScreenId> };
-
-export interface MenuScreenComponentOptions<ScreenId extends string, ActionId extends string> {
-	screen: MenuScreen<ScreenId, ActionId>;
-	selectedItemId?: string;
-	tui: RenderHost;
-	theme: Pick<Theme, "fg" | "bold">;
-	keybindings: MenuKeybindings;
-	onEvent(event: MenuScreenEvent): void;
-	onSelectionChange?(itemId: string): void;
-	onSettingChange?(change: MenuSettingChange): Promise<MenuChangeResponse<ScreenId>>;
-	onMultiSelectChange?(change: MenuMultiSelectChange): Promise<MenuChangeResponse<ScreenId>>;
-	onTransition?(transition: MenuTransition<ScreenId>): void;
-	onError?(error: unknown): void;
-	onDispose?(): void;
-}
+export type {
+	MenuMultiSelectChange,
+	MenuScreenComponent,
+	MenuScreenComponentOptions,
+	MenuScreenEvent,
+	MenuSettingChange,
+} from "./screen-component-contracts.js";
+export { safeMenuText } from "./screen-component-rendering.js";
 
 export function createMenuScreenComponent<ScreenId extends string, ActionId extends string>(
 	options: MenuScreenComponentOptions<ScreenId, ActionId>,
@@ -125,13 +85,6 @@ type SettingsOptions<ScreenId extends string, ActionId extends string> = MenuScr
 > & {
 	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "settings" }>;
 };
-type MultiSelectOptions<
-	ScreenId extends string,
-	ActionId extends string,
-> = MenuScreenComponentOptions<ScreenId, ActionId> & {
-	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "multiSelect" }>;
-};
-
 function createActionsComponent<ScreenId extends string, ActionId extends string>(
 	options: ActionsOptions<ScreenId, ActionId>,
 ): MenuScreenComponent {
@@ -552,169 +505,6 @@ function displayHintKey(key: string) {
 	return safeMenuText(key);
 }
 
-function createMultiSelectComponent<ScreenId extends string, ActionId extends string>(
-	options: MultiSelectOptions<ScreenId, ActionId>,
-): MenuScreenComponent {
-	const rows = [
-		...options.screen.items.map((item) => ({ kind: "toggle" as const, item })),
-		...(options.screen.actions ?? []).map((item) => ({ kind: "action" as const, item })),
-	];
-	const selected = new Map(options.screen.items.map((item) => [item.id, item.selected]));
-	const committedSelected = new Map(selected);
-	const revisions = new Map<string, number>();
-	let selectedIndex = Math.max(
-		0,
-		rows.findIndex(({ item }) => item.id === options.selectedItemId),
-	);
-	let pending = Promise.resolve();
-	let closing = false;
-	let disposed = false;
-	const closeAfterPending = (kind: "back" | "close") => {
-		if (closing || disposed) return;
-		closing = true;
-		void pending.then(() => {
-			if (!disposed) options.onEvent({ kind });
-		});
-	};
-	const selectIndex = (index: number) => {
-		if (rows.length === 0) return;
-		selectedIndex = Math.max(0, Math.min(index, rows.length - 1));
-		const row = rows[selectedIndex];
-		if (row) options.onSelectionChange?.(row.item.id);
-	};
-	const move = (delta: number) => {
-		if (rows.length === 0) return;
-		selectIndex((selectedIndex + delta + rows.length) % rows.length);
-	};
-	const activate = () => {
-		const row = rows[selectedIndex];
-		if (!row || row.item.disabled) return;
-		if (row.kind === "action") {
-			if (closing || disposed) return;
-			closing = true;
-			void pending.then(() => {
-				if (!disposed) options.onEvent({ kind: "activate", itemId: row.item.id });
-			});
-			return;
-		}
-		const item = row.item;
-		const previousSelected = selected.get(item.id) ?? false;
-		const nextSelected = !previousSelected;
-		selected.set(item.id, nextSelected);
-		const revision = (revisions.get(item.id) ?? 0) + 1;
-		revisions.set(item.id, revision);
-		const operation = pending.then(async () => {
-			if (disposed) return;
-			let response: MenuChangeResponse<ScreenId> = false;
-			try {
-				response =
-					(await options.onMultiSelectChange?.({
-						itemId: item.id,
-						selected: nextSelected,
-						previousSelected,
-					})) ?? false;
-			} catch (error) {
-				options.onError?.(error);
-			}
-			if (disposed) return;
-			const accepted = typeof response === "boolean" ? response : response.accepted;
-			if (accepted) committedSelected.set(item.id, nextSelected);
-			else if (revisions.get(item.id) === revision) {
-				selected.set(item.id, committedSelected.get(item.id) ?? false);
-			}
-			options.tui.requestRender();
-			if (accepted && typeof response !== "boolean") {
-				closing = true;
-				void pending.then(() => {
-					if (!disposed) options.onTransition?.(response.transition);
-				});
-			}
-		});
-		pending = operation.catch(() => undefined);
-	};
-	return {
-		render(width) {
-			const requestedViewport = options.screen.viewportSize ?? 13;
-			const viewportSize = Math.min(requestedViewport, rows.length);
-			const viewportStart = Math.max(
-				0,
-				Math.min(selectedIndex - Math.floor(viewportSize / 2), rows.length - viewportSize),
-			);
-			const visibleRows = rows.slice(viewportStart, viewportStart + viewportSize);
-			const content = visibleRows.map((row, offset) => {
-				const index = viewportStart + offset;
-				const isSelected = index === selectedIndex;
-				const prefix = isSelected ? "› " : "  ";
-				const marker =
-					row.kind === "toggle"
-						? `${row.item.disabled ? "[-]" : selected.get(row.item.id) ? "[x]" : "[ ]"} `
-						: "";
-				const unavailable = row.item.disabled ? " (unavailable)" : "";
-				const label = `${prefix}${marker}${safeMenuText(row.item.label)}${unavailable}`;
-				if (isSelected) return options.theme.fg("accent", label);
-				return row.item.disabled ? options.theme.fg("dim", label) : label;
-			});
-			if (viewportSize < rows.length) {
-				content.push(options.theme.fg("dim", `  (${selectedIndex + 1}/${rows.length})`));
-			}
-			const selectedRow = rows[selectedIndex];
-			const descriptions = selectedRow
-				? [
-						selectedRow.item.description,
-						selectedRow.kind === "toggle" && selectedRow.item.disabled
-							? selectedRow.item.disabledReason
-								? `Unavailable: ${selectedRow.item.disabledReason}`
-								: "Unavailable"
-							: undefined,
-					].filter((value): value is string => Boolean(value))
-				: [];
-			if (descriptions.length > 0) {
-				content.push(
-					"",
-					...descriptions.flatMap((description) =>
-						wrapTextWithAnsi(
-							options.theme.fg("dim", `  ${safeMenuText(description)}`),
-							Math.max(1, width),
-						),
-					),
-				);
-			}
-			return renderFrame(
-				options.screen.title,
-				options.screen.lines ?? [],
-				content,
-				options.screen.hint ?? "back",
-				width,
-				options,
-				rows[selectedIndex]?.kind === "action" ? "select" : "toggle",
-			);
-		},
-		invalidate() {},
-		handleInput(data) {
-			if (disposed || closing) return;
-			if (matchesKey(data, Key.ctrl("c"))) closeAfterPending("close");
-			else if (options.keybindings.matches(data, "tui.select.cancel")) {
-				closeAfterPending(options.screen.hint ?? "back");
-			} else if (options.keybindings.matches(data, "tui.select.up")) move(-1);
-			else if (options.keybindings.matches(data, "tui.select.down")) move(1);
-			else if (options.keybindings.matches(data, "tui.select.pageUp")) {
-				selectIndex(selectedIndex - (options.screen.viewportSize ?? 13));
-			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
-				selectIndex(selectedIndex + (options.screen.viewportSize ?? 13));
-			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
-				activate();
-			}
-			options.tui.requestRender();
-		},
-		waitForPending: () => pending,
-		dispose() {
-			if (disposed) return;
-			disposed = true;
-			options.onDispose?.();
-		},
-	};
-}
-
 function commonListComponent<ScreenId extends string, ActionId extends string>(
 	options: MenuScreenComponentOptions<ScreenId, ActionId>,
 	list: SelectList,
@@ -758,64 +548,6 @@ function commonListComponent<ScreenId extends string, ActionId extends string>(
 	};
 }
 
-function renderFrame<ScreenId extends string, ActionId extends string>(
-	title: string,
-	lines: readonly string[],
-	content: readonly string[],
-	destination: "back" | "close",
-	width: number,
-	options: MenuScreenComponentOptions<ScreenId, ActionId>,
-	confirmAction = "select",
-): string[] {
-	const safeWidth = Math.max(1, width);
-	const result = [
-		...wrapTextWithAnsi(
-			options.theme.fg("accent", options.theme.bold(safeMenuText(title))),
-			safeWidth,
-		),
-		...lines.flatMap((line) =>
-			wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
-		),
-		...(content.length > 0 ? ["", ...content] : []),
-		...wrapTextWithAnsi(
-			options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
-			safeWidth,
-		),
-	];
-	return result.map((line) => truncateToWidth(line, safeWidth, ""));
-}
-
-function menuHint(
-	keybindings: MenuKeybindings,
-	destination: "back" | "close",
-	confirmAction: string,
-) {
-	const up = bindingText(keybindings, "tui.select.up");
-	const down = bindingText(keybindings, "tui.select.down");
-	const confirm = bindingText(keybindings, "tui.select.confirm");
-	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
-	return [
-		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
-		...(confirm ? [`${confirm} ${confirmAction}`] : []),
-		...(cancel ? [`${cancel} ${destination}`] : []),
-		...(destination === "back" ? ["ctrl+c close"] : []),
-	].join(" • ");
-}
-
-function bindingText(keybindings: MenuKeybindings, binding: MenuBinding, excluded?: string) {
-	return keybindings
-		.getKeys(binding)
-		.filter((key) => key !== excluded)
-		.map((key) => {
-			if (key === "up") return "↑";
-			if (key === "down") return "↓";
-			if (key === "escape") return "esc";
-			return safeMenuText(key);
-		})
-		.filter(Boolean)
-		.join("/");
-}
-
 function selectTheme(theme: Pick<Theme, "fg">) {
 	return {
 		selectedPrefix: (text: string) => theme.fg("accent", text),
@@ -830,17 +562,6 @@ function setInitialSelection(list: SelectList, items: readonly SelectItem[], sel
 	if (!selectedId) return;
 	const index = items.findIndex((item) => item.value === selectedId);
 	if (index >= 0) list.setSelectedIndex(index);
-}
-
-export function safeMenuText(value: unknown) {
-	return replaceTerminalControls(value).replace(/\s+/gu, " ").trim();
-}
-
-function replaceTerminalControls(value: unknown) {
-	return Array.from(String(value), (character) => {
-		const codePoint = character.codePointAt(0) ?? 0;
-		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
-	}).join("");
 }
 
 export function settingForAction<ActionId extends string>(

--- a/packages/pi-tui-kit/src/screen-components.ts
+++ b/packages/pi-tui-kit/src/screen-components.ts
@@ -20,9 +20,9 @@ import type {
 	MultiSelectOptions,
 } from "./screen-component-contracts.js";
 import {
+	handleSearchInput,
 	menuHint,
 	renderFrame,
-	replaceTerminalControls,
 	safeMenuText,
 } from "./screen-component-rendering.js";
 import type { MenuScreen, MenuSettingItem } from "./types.js";
@@ -397,13 +397,8 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
 				activate();
 			} else {
-				const searchData = data.replaceAll(" ", "");
-				if (searchData) {
-					searchInput.handleInput(searchData);
-					const query = replaceTerminalControls(searchInput.getValue());
-					if (query !== searchInput.getValue()) searchInput.setValue(query);
-					applyFilter();
-				}
+				handleSearchInput(searchInput, data);
+				applyFilter();
 			}
 			options.tui.requestRender();
 		},

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -95,6 +95,8 @@ export interface SettingsScreen<ActionId extends string> {
 export interface MenuMultiSelectItem extends MenuItemBase {
 	selected: boolean;
 	disabledReason?: string;
+	/** Additional non-rendered text used by optional TUI fuzzy search. */
+	searchText?: string;
 }
 
 export interface MultiSelectScreen<ScreenId extends string, ActionId extends string> {
@@ -103,6 +105,8 @@ export interface MultiSelectScreen<ScreenId extends string, ActionId extends str
 	lines?: readonly string[];
 	items: readonly MenuMultiSelectItem[];
 	action: ActionId;
+	/** Enables TUI-only fuzzy filtering over labels and item search text. */
+	enableSearch?: boolean;
 	viewportSize?: number;
 	actions?: readonly ActionMenuItem<ScreenId, ActionId>[];
 	hint?: "back" | "close";

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -38,7 +38,7 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("the declarative API version includes choice screens", () => {
+test("additive multi-select search remains compatible with declarative API version 2", () => {
 	assert.equal(PI_EXTENSION_MENU_API_VERSION, 2);
 });
 

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "../src/index.js";
+import { defineMenu, type MultiSelectScreen, runMenu } from "../src/index.js";
 
 type Screen = "main" | "profile" | "settings";
 type Action = "refresh" | "setMode" | "setProfile";
@@ -15,6 +15,22 @@ declare function loadState(signal: AbortSignal): Promise<State>;
 declare function currentGeneration(): number;
 declare function currentSessionSignal(): AbortSignal;
 declare function formatError(error: unknown): string;
+
+const searchableToolsScreen: MultiSelectScreen<Screen, Action> = {
+	kind: "multiSelect",
+	title: "Tool permissions",
+	enableSearch: true,
+	items: [
+		{
+			id: "read",
+			label: "read",
+			searchText: "built-in filesystem inspection",
+			selected: true,
+		},
+	],
+	action: "refresh",
+};
+void searchableToolsScreen;
 
 const menu = defineMenu<State, Screen, Action>({
 	start: "main",

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -418,6 +418,93 @@ test("choice RPC preserves duplicate-label identity and keeps disabled rows iner
 	assert.equal(selectCalls, 2);
 });
 
+test("searchable multi-select TUI dispatches the filtered raw item id", async () => {
+	const invoked: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 60);
+			harness.handleInput("f");
+			harness.handleInput("s");
+			harness.handleInput("tui.select.confirm");
+			await harness.waitForPending();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			return harness.result;
+		},
+	});
+	const definition = defineMenu<undefined, "tools", "toggle">({
+		start: "tools",
+		screens: {
+			tools: () => ({
+				kind: "multiSelect",
+				title: "Tools",
+				enableSearch: true,
+				items: [
+					{ id: "raw-one", label: "Same", searchText: "alpha", selected: false },
+					{ id: "raw-two", label: "Same", searchText: "filesystem", selected: false },
+				],
+				action: "toggle",
+			}),
+		},
+		actions: {
+			toggle: async ({ itemId }) => {
+				invoked.push(itemId);
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(invoked, ["raw-two"]);
+});
+
+test("searchable multi-select RPC keeps the full unfiltered unique row list", async () => {
+	const invoked: string[] = [];
+	let choicesSeen: string[] = [];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, choices: string[]) => {
+			choicesSeen = choices;
+			return choices[1];
+		},
+	});
+	const definition = defineMenu<undefined, "tools", "toggle">({
+		start: "tools",
+		screens: {
+			tools: () => ({
+				kind: "multiSelect",
+				title: "Tools",
+				enableSearch: true,
+				items: [
+					{ id: "raw-one", label: "Same", searchText: "alpha", selected: false },
+					{ id: "raw-two", label: "Same", searchText: "filesystem", selected: false },
+				],
+				action: "toggle",
+				hint: "close",
+			}),
+		},
+		actions: {
+			toggle: async ({ itemId }) => {
+				invoked.push(itemId);
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(invoked, ["raw-two"]);
+	assert.equal(new Set(choicesSeen).size, choicesSeen.length);
+	assert.match(choicesSeen[0] ?? "", /Same/);
+	assert.match(choicesSeen[1] ?? "", /Same/);
+	assert.doesNotMatch(choicesSeen.join("\n"), /alpha|filesystem/);
+});
+
 test("RPC choices preserve item identity across duplicate and exit labels", async () => {
 	let selectCalls = 0;
 	const invoked: string[] = [];

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -28,6 +28,31 @@ const testKeybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
 });
 setKeybindings(testKeybindings);
 
+const inputFriendlyKeybindings = {
+	matches(data: string, binding: string) {
+		const inputs: Record<string, string> = {
+			"tui.select.up": "\u001b[A",
+			"tui.select.down": "\u001b[B",
+			"tui.select.pageUp": "\u001b[5~",
+			"tui.select.pageDown": "\u001b[6~",
+			"tui.select.confirm": "\r",
+			"tui.select.cancel": "\u001b",
+		};
+		return data === inputs[binding];
+	},
+	getKeys(binding: string) {
+		const keys: Record<string, readonly string[]> = {
+			"tui.select.up": ["up"],
+			"tui.select.down": ["down"],
+			"tui.select.pageUp": ["pageup"],
+			"tui.select.pageDown": ["pagedown"],
+			"tui.select.confirm": ["enter"],
+			"tui.select.cancel": ["escape", "ctrl+c"],
+		};
+		return keys[binding] ?? [];
+	},
+};
+
 type ScreenId = "main" | "detail";
 type ActionId = "run" | "choose" | "setting" | "toggle";
 
@@ -685,6 +710,156 @@ test("disabled multi-select rows are focusable, explained, sanitized, and never 
 	harness.component.handleInput(" ");
 	await harness.component.waitForPending();
 	assert.equal(toggles, 0);
+});
+
+test("searchable multi-select filters label and declared search text by stable raw id", async () => {
+	const requests: Array<{ itemId: string; selected: boolean; previousSelected: boolean }> = [];
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "multiSelect",
+		title: "Searchable tools",
+		enableSearch: true,
+		items: [
+			{
+				id: "read\u0007raw",
+				label: "讀取 📖",
+				searchText: "filesystem inspect\u001b]8;;unsafe\u0007 built-in",
+				selected: false,
+			},
+			{ id: "write", label: "Write", searchText: "mutation", selected: true },
+		],
+		action: "toggle",
+		actions: [{ id: "save", label: "Save changes", action: "run" }],
+	};
+	const harness = componentHarness(screen, {
+		plainTheme: true,
+		selectedItemId: "write",
+		keybindings: inputFriendlyKeybindings,
+		onMultiSelectChange: async (request) => {
+			requests.push(request);
+			return true;
+		},
+	});
+
+	for (const input of ["f", "s"]) harness.component.handleInput(input);
+	const filtered = plainRender(harness.component, 60).join("\n");
+	assert.match(filtered, /讀取 📖/);
+	assert.doesNotMatch(filtered, /Write/);
+	assert.match(filtered, /Save changes/);
+	harness.component.handleInput("\r");
+	await harness.component.waitForPending();
+	assert.deepEqual(requests, [
+		{ itemId: "read\u0007raw", selected: true, previousSelected: false },
+	]);
+
+	for (const input of ["\u007f", "\u007f"]) harness.component.handleInput(input);
+	assert.match(plainRender(harness.component, 60).join("\n"), /› \[x\] 讀取 📖/);
+});
+
+test("searchable multi-select keeps actions available for no matches and distinguishes empty", async () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "multiSelect",
+		title: "Searchable tools",
+		enableSearch: true,
+		items: [{ id: "read", label: "Read", selected: false }],
+		action: "toggle",
+		actions: [{ id: "save", label: "Save changes", action: "run" }],
+	};
+	const noMatch = componentHarness(screen, {
+		plainTheme: true,
+		keybindings: inputFriendlyKeybindings,
+	});
+	for (const input of ["z", "z", "z"]) noMatch.component.handleInput(input);
+	const rendered = plainRender(noMatch.component, 60).join("\n");
+	assert.match(rendered, /No matching items/);
+	assert.match(rendered, /› Save changes/);
+	noMatch.component.handleInput("\r");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(noMatch.events, [{ kind: "activate", itemId: "save" }]);
+
+	const empty = componentHarness(
+		{ ...screen, items: [] },
+		{ plainTheme: true, keybindings: inputFriendlyKeybindings },
+	);
+	assert.match(plainRender(empty.component, 60).join("\n"), /No items available/);
+	assert.doesNotMatch(plainRender(empty.component, 60).join("\n"), /No matching items/);
+});
+
+test("searchable multi-select forwards focus and sanitizes bracketed paste", () => {
+	const harness = componentHarness(
+		{
+			kind: "multiSelect",
+			title: "Searchable tools",
+			enableSearch: true,
+			items: [
+				{ id: "read", label: "讀取 📖", searchText: "filesystem", selected: false },
+				{ id: "write", label: "Write", selected: false },
+			],
+			action: "toggle",
+		},
+		{ plainTheme: true, keybindings: inputFriendlyKeybindings },
+	);
+	const focusable = harness.component as MenuScreenComponent & Focusable;
+	assert.equal("focused" in focusable, true);
+	focusable.focused = true;
+	assert.equal(harness.component.render(80).join("\n").includes(CURSOR_MARKER), true);
+	focusable.focused = false;
+
+	harness.component.handleInput("\u001b[200~📖\u0007\u009d\u009c\u001b[201~");
+	const rendered = harness.component.render(80).join("\n");
+	assert.match(stripVTControlCharacters(rendered), /讀取 📖/);
+	assert.doesNotMatch(stripVTControlCharacters(rendered), /Write/);
+	assert.equal(rendered.includes("\u001b[200~"), false);
+	assert.equal(rendered.includes("\u0007"), false);
+	assert.equal(rendered.includes("\u009d"), false);
+	assert.equal(rendered.includes("\u009c"), false);
+	for (const width of [1, 2, 8, 20, 40, 80]) {
+		assert.ok(harness.component.render(width).every((line) => visibleWidth(line) <= width));
+	}
+});
+
+test("searchable multi-select rollback remains keyed by hidden item id", async () => {
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const harness = componentHarness(
+		{
+			kind: "multiSelect",
+			title: "Searchable tools",
+			enableSearch: true,
+			items: [
+				{ id: "read", label: "Read", searchText: "filesystem", selected: false },
+				{ id: "write", label: "Write", searchText: "mutation", selected: false },
+			],
+			action: "toggle",
+		},
+		{
+			plainTheme: true,
+			keybindings: inputFriendlyKeybindings,
+			onMultiSelectChange: async () => {
+				await gate;
+				return false;
+			},
+		},
+	);
+	for (const input of ["f", "s", "\r", "z"]) harness.component.handleInput(input);
+	assert.match(plainRender(harness.component, 60).join("\n"), /No matching items/);
+	release?.();
+	await harness.component.waitForPending();
+	for (const input of ["\u007f", "\u007f", "\u007f"]) harness.component.handleInput(input);
+	assert.match(plainRender(harness.component, 60).join("\n"), /› \[ \] Read/);
+});
+
+test("multi-select search is opt-in and default rendering remains unchanged", () => {
+	const harness = componentHarness(multiSelectScreen, {
+		plainTheme: true,
+		keybindings: inputFriendlyKeybindings,
+	});
+	const before = harness.component.render(80);
+	assert.equal("focused" in harness.component, false);
+	harness.component.handleInput("f");
+	assert.deepEqual(harness.component.render(80), before);
+	assert.doesNotMatch(before.join("\n"), /Type to search/);
 });
 
 function largeMultiSelectScreen(): MenuScreen<ScreenId, ActionId> {

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -437,6 +437,25 @@ test("settings sanitize terminal controls from bracketed search paste", () => {
 	assert.equal(rendered.includes("\u009c"), false);
 });
 
+test("settings preserve pasted query spaces without stealing Space activation", async () => {
+	let changedItemId: string | undefined;
+	const harness = componentHarness(settingsScreen, {
+		plainTheme: true,
+		keybindings: inputFriendlyKeybindings,
+		onSettingChange: async ({ itemId }) => {
+			changedItemId = itemId;
+			return true;
+		},
+	});
+	harness.component.handleInput("\u001b[200~mode manual\u001b[201~");
+	const rendered = plainRender(harness.component, 80).join("\n");
+	assert.match(rendered, /Manual mode/);
+	assert.doesNotMatch(rendered, /Automatic start/);
+	harness.component.handleInput(" ");
+	await harness.component.waitForPending();
+	assert.equal(changedItemId, "manual");
+});
+
 test("menu hints sanitize configured keybinding labels", () => {
 	const unsafeKey = "\u001b]8;;https://unsafe.example\u0007enter";
 	const keybindings = {
@@ -815,6 +834,32 @@ test("searchable multi-select forwards focus and sanitizes bracketed paste", () 
 	for (const width of [1, 2, 8, 20, 40, 80]) {
 		assert.ok(harness.component.render(width).every((line) => visibleWidth(line) <= width));
 	}
+});
+
+test("searchable multi-select preserves pasted query spaces without stealing Space", async () => {
+	let toggledItemId: string | undefined;
+	const harness = componentHarness(
+		{
+			kind: "multiSelect",
+			title: "Searchable tools",
+			enableSearch: true,
+			items: [{ id: "target", label: "bar foo", selected: false }],
+			action: "toggle",
+		},
+		{
+			plainTheme: true,
+			keybindings: inputFriendlyKeybindings,
+			onMultiSelectChange: async ({ itemId }) => {
+				toggledItemId = itemId;
+				return true;
+			},
+		},
+	);
+	harness.component.handleInput("\u001b[200~foo bar\u001b[201~");
+	assert.match(plainRender(harness.component, 80).join("\n"), /bar foo/);
+	harness.component.handleInput(" ");
+	await harness.component.waitForPending();
+	assert.equal(toggledItemId, "target");
 });
 
 test("searchable multi-select rollback remains keyed by hidden item id", async () => {


### PR DESCRIPTION
## Summary

- add optional TUI fuzzy search to `pi-tui-kit` multi-select screens with stable raw IDs, pinned action rows, IME focus forwarding, paste sanitization, pending rollback safety, and an unchanged full RPC list
- split the growing screen component module into shared contracts/rendering and a focused multi-select adapter
- migrate Plan-mode tool selection and Subagents agent-tool drafts while preserving their distinct session and settings ownership
- harden shared searchable inputs so bracketed-paste whitespace remains available to fuzzy token matching while a standalone Space still activates the selected row
- record qualification evidence, defer catalog/contextual decision screens, update the roadmap, and archive both completed plans

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npm run check --workspace @narumitw/pi-plan-mode`
- `npm run check --workspace @narumitw/pi-subagents`
- focused compiled kit/consumer suites: 117 passing tests
- root build, Biome, boundary checks, and all workspace typechecks
- `just pack-tui-kit`
- `just pack-plan-mode`
- `just pack-subagents`
- local Pi 0.83.0 RPC smoke for `/plan tools`
- hosted CI and CodeQL: passing

Local `npm run check` attempts exposed unrelated existing timing/path flakes in `pi-github-pr`, `pi-lsp`, `pi-subagents`, and `pi-worktree`; their canonical-path/focused reruns passed. The hosted root CI gate passed on every pushed commit, including the hardening follow-up.

## Convention audit

Read and audited `docs/extension-conventions.md`, `docs/extension-settings.md`, and Pi's TUI, extension, RPC, and package documentation. Touched areas: public library API, custom TUI rendering/focus, RPC adaptation, lifecycle/pending actions, Plan-mode session state, Subagents transactional settings UI, package contents, tests, and documentation. No private Pi imports, settings schema changes, package-version changes, or consumer-specific public hooks were added.
