### PR TITLE
refactor(tui-kit): group component modules

### DIFF
--- a/docs/plans/2026-07-30_pi-tui-kit-components-directory-plan.md
+++ b/docs/plans/2026-07-30_pi-tui-kit-components-directory-plan.md
@@ -1,0 +1,179 @@
+# Pi TUI Kit Components Directory Plan
+
+## Goal
+
+Move the existing internal Pi TUI component subsystem into
+`packages/pi-tui-kit/src/components/` so component contracts, rendering, and implementations have one
+clear home and one internal entrypoint, without changing the package's public API, screen behavior,
+consumer behavior, or declarative API version.
+
+## Context
+
+- The current component cluster consists of `screen-components.ts`,
+  `screen-component-contracts.ts`, `screen-component-rendering.ts`, and
+  `multi-select-component.ts`. Together they contain about 970 of the 1,994 authored lines under
+  `packages/pi-tui-kit/src/`.
+- Choice, settings, multi-select search, and the latest input hardening repeatedly changed this
+  cluster, while `model.ts`, `navigator.ts`, public `types.ts`, and most of `runtime.ts` have separate
+  responsibilities.
+- `runtime.ts` and the package's component tests are the only live callers of the internal component
+  entrypoint. Repository consumers import only `@narumitw/pi-tui-kit` through its root export.
+- `packages/pi-tui-kit/package.json` publishes only the `.` export, so the generated component module
+  paths are not supported package subpaths.
+- `tsconfig.build.json` already includes `src/**/*.ts`, and `scripts/build.mjs` removes `dist/` before
+  compilation. A nested source directory therefore needs no build-script or manifest expansion.
+- `docs/extension-conventions.md` applies to the reusable-library package boundary, TUI contract,
+  generated package contents, and verification. `docs/extension-settings.md` is not applicable because
+  this refactor does not change extension-owned settings state, persistence, precedence, or schema.
+
+## Architecture
+
+Use `components/index.ts` as the sole internal component facade:
+
+```text
+packages/pi-tui-kit/src/
+├── components/
+│   ├── index.ts          # screen dispatcher plus existing action/detail/choice/settings adapters
+│   ├── contracts.ts      # component host, event, change, and option contracts
+│   ├── rendering.ts      # frame, hints, safe text, and shared search-input handling
+│   └── multi-select.ts   # multi-select state, rendering, search, and pending queue
+├── index.ts              # unchanged npm public API
+├── model.ts
+├── navigator.ts
+├── runtime.ts
+└── types.ts
+```
+
+Map the existing files directly:
+
+- `src/screen-components.ts` → `src/components/index.ts`;
+- `src/screen-component-contracts.ts` → `src/components/contracts.ts`;
+- `src/screen-component-rendering.ts` → `src/components/rendering.ts`;
+- `src/multi-select-component.ts` → `src/components/multi-select.ts`.
+
+The dependency direction becomes:
+
+```text
+runtime.ts → components/index.ts → private component modules → ../types.ts
+```
+
+`components/index.ts` continues to expose only the internal symbols already needed by `runtime.ts`
+and component tests. Do not add package exports, a top-level compatibility shim, or a second component
+facade. Generated files move from top-level `dist/screen-component-*` and
+`dist/multi-select-component.*` paths to `dist/components/`; `dist/index.*` and its public declarations
+remain compatible.
+
+## Non-Goals
+
+- Change screen rendering, keybindings, width handling, search, pending queues, rollback, cancellation,
+  disposal, TUI/RPC adaptation, or lifecycle behavior.
+- Add, remove, or rename any public root export or public declarative type.
+- Change `PI_EXTENSION_MENU_API_VERSION`, package versions, dependencies, or package metadata.
+- Split every screen into one file. In particular, keep the small action/detail/choice adapters and the
+  existing settings adapter in `components/index.ts` during this bounded move.
+- Rewrite archived plans that accurately describe the file layout at the time they were executed.
+- Add an internal barrel or abstraction beyond the one existing component facade.
+
+## Risks
+
+- Incorrect NodeNext `.js` specifiers or `../types.js` paths could pass a source-only inspection but
+  fail the built ESM graph.
+- A stale generated top-level component file could hide a broken import unless the clean build and
+  tarball contents are inspected.
+- Mechanical edits inside component implementations could accidentally mix behavior changes into the
+  relocation and make review harder.
+- Current roadmap text names a top-level component file and will become stale unless updated, while
+  archived plans should remain historical.
+
+## Rollback / Recovery
+
+This is a source-layout-only refactor with no persisted data or public API migration. If verification
+fails, reverse the four moves and import-path updates as one change. Because the build removes `dist/`
+before emitting, rebuilding after rollback restores the original generated layout without manual file
+cleanup.
+
+## Plan
+
+### Baseline and boundary proof
+
+- [x] Run `npm run check --workspace @narumitw/pi-tui-kit`, remove
+      `node_modules/.cache/pi-extensions-test/`, run `npx tsc -p tsconfig.test.json`, and execute the
+      compiled kit model, component, and runtime tests; baseline evidence: the workspace check passed
+      and all 67 focused tests passed.
+- [x] Inspect `packages/pi-tui-kit/package.json`, `src/index.ts`, and repository imports with `rg` to
+      confirm only the root package export is public and no live consumer imports the four internal
+      module paths; evidence: the manifest exports only `.`, the root index names only public modules,
+      and the deep-import scan found no live consumer.
+
+### Component subsystem relocation
+
+- [x] Create `packages/pi-tui-kit/src/components/` and move the four existing component files to the
+      architecture mapping above with Git-aware renames; evidence: the directory contains exactly the
+      four mapped modules and no old top-level component source or compatibility shim remains.
+- [x] Update imports inside `components/index.ts`, `components/multi-select.ts`,
+      `components/rendering.ts`, and `components/contracts.ts` so sibling modules use `./*.js` and
+      public menu types use `../types.js`; evidence: the import scan shows the intended one-way paths
+      and `npm run typecheck --workspace @narumitw/pi-tui-kit` passed.
+- [x] Update `packages/pi-tui-kit/src/runtime.ts` and
+      `packages/pi-tui-kit/test/screen-components.test.ts` to import only
+      `components/index.js`; evidence: both callers use the facade and `rg` finds no former filenames
+      in live source, tests, README, or roadmap text.
+
+### Build, behavior, and documentation verification
+
+- [x] Run a clean `npm run build --workspace @narumitw/pi-tui-kit` and import
+      `packages/pi-tui-kit/dist/index.js` with Node; evidence: the ESM graph loaded with every expected
+      root export and API version 2, all four JS/declaration pairs exist under `dist/components/`, and
+      no former top-level generated component module remains.
+- [x] Recompile tests from a fresh `node_modules/.cache/pi-extensions-test/` and run the compiled kit
+      model, component, and runtime suites; evidence: all 67 tests passed, matching the baseline, and
+      the only test change is the internal import path.
+- [x] Update the `packages/pi-tui-kit/README.md` package-layout section and current architecture text in
+      `docs/roadmaps/pi-tui-kit-roadmap.md` to name `src/components/` and `multi-select.ts`; evidence:
+      both current documents name the new layout, their referenced source paths exist, and archived
+      plans remain unchanged.
+- [x] Review `git diff --find-renames` for the four moves and inspect `src/index.ts`, `types.ts`,
+      `model.ts`, `navigator.ts`, and the non-import portions of `runtime.ts`; evidence: Git reports
+      96–98% similarity for all four renames, the four core modules are byte-unchanged, and runtime's
+      only change is its component-facade import path.
+- [x] Run `npm run check --workspace @narumitw/pi-tui-kit` and `git diff --check`; evidence: Biome,
+      typechecking, the clean library build, and staged, unstaged, and untracked whitespace checks all
+      passed after Biome organized the relocated imports.
+- [x] Run `just pack-tui-kit` and inspect the dry-run tarball listing; evidence: the 21-file package
+      contains all four `dist/components/*` JS/declaration pairs, no former generated component paths,
+      and the expected root entrypoint, README, package metadata, and license.
+- [ ] Run root `npm run check`; verify the CI-equivalent build, Biome, boundaries, workspace
+      typechecks, and tests pass, leaving any unavailable or failing evidence open rather than
+      inferring success from focused checks.
+- [x] Audit the final diff against the package-layout, TUI, documentation, and verification MUST rules
+      in `docs/extension-conventions.md`; evidence: library boundaries, generated JS/declarations,
+      TUI contracts, source thresholds, current docs, and pack contents comply; no settings guide rule,
+      Pi runtime smoke, API-version change, migration, or accepted semantic deviation is applicable.
+- [ ] After every plan item and completion check has evidence, move this plan to
+      `docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md`; verify the active path is
+      gone, the archive exists, and no existing archived file was overwritten.
+
+## Verification Evidence
+
+- Pre-move and post-move focused baselines each passed the same 67 model, component, and runtime
+  tests.
+- The clean built ESM graph loaded all expected root exports at API version 2, and the package dry run
+  contained only the new generated component paths.
+- A local root `npm run check` attempt reached the complete touched kit suites successfully but timed
+  out after 600 seconds while unrelated timing-sensitive LSP, Subagents, and Statusline tests were
+  contending under the parallel runner. The root item remains open pending hosted CI evidence.
+
+## Completion Checklist
+
+- [ ] All four component subsystem files live under `packages/pi-tui-kit/src/components/`, and no
+      obsolete top-level source or generated component module remains.
+- [ ] `runtime.ts` and component tests use the single internal component facade; private component
+      modules preserve a one-way dependency on shared types and do not leak through package exports.
+- [ ] Public root exports, declarations, declarative API version, TUI/RPC behavior, lifecycle behavior,
+      and consumer contracts are unchanged.
+- [ ] README and current roadmap architecture text describe the new layout while archived plans remain
+      historical.
+- [ ] Focused tests, workspace checks, the clean-build module smoke, root `npm run check`, diff checks,
+      and the package dry run pass with inspectable evidence.
+- [ ] The completed plan is archived at
+      `docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md`.

--- a/docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md
@@ -142,16 +142,16 @@ cleanup.
 - [x] Run `just pack-tui-kit` and inspect the dry-run tarball listing; evidence: the 21-file package
       contains all four `dist/components/*` JS/declaration pairs, no former generated component paths,
       and the expected root entrypoint, README, package metadata, and license.
-- [ ] Run root `npm run check`; verify the CI-equivalent build, Biome, boundaries, workspace
-      typechecks, and tests pass, leaving any unavailable or failing evidence open rather than
-      inferring success from focused checks.
+- [x] Run root `npm run check`; evidence: the local parallel run reached all touched suites before an
+      unrelated timeout, and PR #468's hosted CI passed the complete build, Biome, boundaries,
+      workspace typechecks, and test gate.
 - [x] Audit the final diff against the package-layout, TUI, documentation, and verification MUST rules
       in `docs/extension-conventions.md`; evidence: library boundaries, generated JS/declarations,
       TUI contracts, source thresholds, current docs, and pack contents comply; no settings guide rule,
       Pi runtime smoke, API-version change, migration, or accepted semantic deviation is applicable.
-- [ ] After every plan item and completion check has evidence, move this plan to
-      `docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md`; verify the active path is
-      gone, the archive exists, and no existing archived file was overwritten.
+- [x] After every plan item and completion check has evidence, move this plan to
+      `docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md`; evidence: the active
+      path is gone, the archive exists, and no existing archived file was overwritten.
 
 ## Verification Evidence
 
@@ -161,19 +161,19 @@ cleanup.
   contained only the new generated component paths.
 - A local root `npm run check` attempt reached the complete touched kit suites successfully but timed
   out after 600 seconds while unrelated timing-sensitive LSP, Subagents, and Statusline tests were
-  contending under the parallel runner. The root item remains open pending hosted CI evidence.
+  contending under the parallel runner. PR #468's hosted CI then passed the complete root gate.
 
 ## Completion Checklist
 
-- [ ] All four component subsystem files live under `packages/pi-tui-kit/src/components/`, and no
+- [x] All four component subsystem files live under `packages/pi-tui-kit/src/components/`, and no
       obsolete top-level source or generated component module remains.
-- [ ] `runtime.ts` and component tests use the single internal component facade; private component
+- [x] `runtime.ts` and component tests use the single internal component facade; private component
       modules preserve a one-way dependency on shared types and do not leak through package exports.
-- [ ] Public root exports, declarations, declarative API version, TUI/RPC behavior, lifecycle behavior,
+- [x] Public root exports, declarations, declarative API version, TUI/RPC behavior, lifecycle behavior,
       and consumer contracts are unchanged.
-- [ ] README and current roadmap architecture text describe the new layout while archived plans remain
+- [x] README and current roadmap architecture text describe the new layout while archived plans remain
       historical.
-- [ ] Focused tests, workspace checks, the clean-build module smoke, root `npm run check`, diff checks,
-      and the package dry run pass with inspectable evidence.
-- [ ] The completed plan is archived at
+- [x] Focused tests, workspace checks, the clean-build module smoke, hosted root CI, diff checks, and
+      the package dry run pass with inspectable evidence.
+- [x] The completed plan is archived at
       `docs/plans/archived/2026-07-30_pi-tui-kit-components-directory-plan.md`.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -228,9 +228,9 @@ and retires local abstractions when a stable public Pi replacement becomes avail
 
 - Keep TypeScript strict, NodeNext-compatible, and built as published JavaScript plus declarations.
 - Keep authored source files below the repository's review threshold or split them along clear screen,
-  rendering, and runtime responsibilities when cohesion improves. Multi-select state/rendering now
-  lives in `multi-select-component.ts`, with shared contracts and rendering helpers separated from the
-  screen dispatcher.
+  rendering, and runtime responsibilities when cohesion improves. Internal TUI adapters now live
+  under `src/components/`; multi-select state/rendering is isolated in `multi-select.ts`, with shared
+  contracts and rendering helpers separated from the screen dispatcher.
 - Maintain deterministic model, component, runtime, and README usage tests for every public contract.
 - Run `npm run check --workspace @narumitw/pi-tui-kit`, the root `npm run check`, and
   `just pack-tui-kit` for each kit feature.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -291,7 +291,8 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 
 ## 🗂️ Package layout
 
-- `src/` — authored TypeScript
+- `src/` — authored TypeScript and the public package entrypoint
+- `src/components/` — internal TUI screen adapters, contracts, and rendering helpers
 - `dist/` — generated ESM and declarations included in the npm package
 - `test/` — contract, renderer, navigation, and lifecycle coverage
 

--- a/packages/pi-tui-kit/src/components/contracts.ts
+++ b/packages/pi-tui-kit/src/components/contracts.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { Component } from "@earendil-works/pi-tui";
-import type { MenuScreen, MenuTransition } from "./types.js";
+import type { MenuScreen, MenuTransition } from "../types.js";
 
 const MENU_BINDINGS = [
 	"tui.select.up",

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -11,21 +11,16 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { createMultiSelectComponent } from "./multi-select-component.js";
+import type { MenuScreen, MenuSettingItem } from "../types.js";
 import type {
 	MenuChangeResponse,
 	MenuKeybindings,
 	MenuScreenComponent,
 	MenuScreenComponentOptions,
 	MultiSelectOptions,
-} from "./screen-component-contracts.js";
-import {
-	handleSearchInput,
-	menuHint,
-	renderFrame,
-	safeMenuText,
-} from "./screen-component-rendering.js";
-import type { MenuScreen, MenuSettingItem } from "./types.js";
+} from "./contracts.js";
+import { createMultiSelectComponent } from "./multi-select.js";
+import { handleSearchInput, menuHint, renderFrame, safeMenuText } from "./rendering.js";
 
 export type {
 	MenuMultiSelectChange,
@@ -33,8 +28,8 @@ export type {
 	MenuScreenComponentOptions,
 	MenuScreenEvent,
 	MenuSettingChange,
-} from "./screen-component-contracts.js";
-export { safeMenuText } from "./screen-component-rendering.js";
+} from "./contracts.js";
+export { safeMenuText } from "./rendering.js";
 
 export function createMenuScreenComponent<ScreenId extends string, ActionId extends string>(
 	options: MenuScreenComponentOptions<ScreenId, ActionId>,

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -6,13 +6,9 @@ import {
 	matchesKey,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import type {
-	MenuChangeResponse,
-	MenuScreenComponent,
-	MultiSelectOptions,
-} from "./screen-component-contracts.js";
-import { handleSearchInput, renderFrame, safeMenuText } from "./screen-component-rendering.js";
-import type { ActionMenuItem, MenuMultiSelectItem } from "./types.js";
+import type { ActionMenuItem, MenuMultiSelectItem } from "../types.js";
+import type { MenuChangeResponse, MenuScreenComponent, MultiSelectOptions } from "./contracts.js";
+import { handleSearchInput, renderFrame, safeMenuText } from "./rendering.js";
 
 type ToggleRow = { kind: "toggle"; item: MenuMultiSelectItem };
 type ActionRow<ScreenId extends string, ActionId extends string> = {

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -1,9 +1,5 @@
 import { type Input, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
-import type {
-	MenuBinding,
-	MenuKeybindings,
-	MenuScreenComponentOptions,
-} from "./screen-component-contracts.js";
+import type { MenuBinding, MenuKeybindings, MenuScreenComponentOptions } from "./contracts.js";
 
 export function renderFrame<ScreenId extends string, ActionId extends string>(
 	title: string,

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -1,7 +1,5 @@
 import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey } from "@earendil-works/pi-tui";
-import { resolveMenuScreen } from "./model.js";
-import { createMenuNavigator } from "./navigator.js";
 import {
 	createMenuScreenComponent,
 	type MenuMultiSelectChange,
@@ -9,7 +7,9 @@ import {
 	type MenuScreenEvent,
 	type MenuSettingChange,
 	safeMenuText,
-} from "./screen-components.js";
+} from "./components/index.js";
+import { resolveMenuScreen } from "./model.js";
+import { createMenuNavigator } from "./navigator.js";
 import type {
 	ActionMenuItem,
 	MenuActionHandler,

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -14,7 +14,7 @@ import {
 	createMenuScreenComponent,
 	type MenuScreenComponent,
 	type MenuScreenEvent,
-} from "../src/screen-components.js";
+} from "../src/components/index.js";
 import type { MenuScreen, MenuTransition } from "../src/types.js";
 
 initTheme("dark", false);


### PR DESCRIPTION
## Summary

- move the four internal Pi TUI component modules under `packages/pi-tui-kit/src/components/`
- make `components/index.ts` the single internal facade used by the runtime and component tests
- keep public exports, screen behavior, declarative API version, and package metadata unchanged
- update current package and roadmap architecture documentation while preserving historical plans
- complete and archive the implementation plan with verification evidence

## Verification

- pre-move focused baseline: 67 passing kit model/component/runtime tests
- post-move focused baseline: 67 passing kit model/component/runtime tests
- `npm run check --workspace @narumitw/pi-tui-kit`
- clean built ESM import smoke with all expected root exports and API version 2
- `just pack-tui-kit` with all four JS/declaration pairs under `dist/components/` and no old generated component paths
- pre-commit Biome and workspace typechecks
- hosted CI and CodeQL: passing on both pushed commits

A local `npm run check` attempt reached and passed the complete touched kit suites but timed out after 600 seconds while unrelated timing-sensitive LSP, Subagents, and Statusline tests contended under the parallel runner. Hosted CI passed the complete root gate.

## Convention audit

Read and audited `docs/extension-conventions.md`. Touched areas are the reusable-library package boundary, internal custom-TUI module ownership, generated ESM/declarations, current architecture documentation, and package contents. No settings behavior, public API, lifecycle behavior, Pi runtime contract, dependency, package-version, or migration change is included.
