### PR TITLE
fix(sync): deduplicate included content

### DIFF
--- a/docs/plans/2026-07-30_pi-sync-included-content-deduplication-plan.md
+++ b/docs/plans/2026-07-30_pi-sync-included-content-deduplication-plan.md
@@ -1,0 +1,122 @@
+# Pi Sync Included-Content Deduplication Plan
+
+## Goal
+
+Make pi-sync's Included Content editor show each logical agent-relative path exactly once, while
+preserving canonical built-in selection, safe custom-file discovery, transactional Save/Discard
+behavior, and the existing version 3 settings schema.
+
+## Context
+
+- `extensions/pi-sync/src/file-selection.ts` renders every `BUILT_IN_SYNC_ROOTS` entry and then
+  appends filesystem-backed custom candidates from `listCustomCandidates()`.
+- `isSafeCustomIncludePath()` currently rejects reserved built-in directories but accepts built-in
+  files such as `settings.json`, `models.json`, `AGENTS.md`, and case variants. Existing files can
+  therefore appear once as `builtin:<path>` and again as `custom:<path>` with contradictory checked
+  state.
+- This is not only visual: selecting both identities can construct a duplicate `sync.include` value,
+  which the version 3 validator correctly refuses to save.
+- `extensions/pi-sync/README.md` already specifies that `sync.include` is duplicate-free and that
+  custom paths are separate from supported Pi roots, so the implementation should be brought back to
+  that documented contract rather than changing the documentation or schema.
+- Touched areas are the pi-sync settings-selection policy, its transactional TUI projection, and
+  deterministic tests. Applicable MUST checks are TUI width/cancellation behavior (`Test` and
+  `Review`), settings validation and unchanged-on-cancel persistence (`Test` and `Review`), focused
+  regression coverage (`Test`), and the repository CI-equivalent gate (`npm run check`). No new
+  asynchronous task, lifecycle resource, command route, package metadata, or storage write path is
+  planned.
+
+## Architecture
+
+- Keep `extensions/pi-sync/src/sync-policy.ts` as the single classification boundary between
+  canonical built-in roots and custom include paths.
+- Treat every built-in root, case-insensitively, plus `sessions` as reserved for custom-path
+  validation. Exact built-in values must still pass through `normalizeSyncInclude()` and canonicalize
+  to the declared `BUILT_IN_SYNC_ROOTS` spelling.
+- Reject descendants under built-in file roots, such as `settings.json/child`, for the same ambiguous
+  reserved-root reason already applied to built-in directories.
+- Let `file-selection.ts` continue rendering built-ins separately and discovering custom candidates
+  through `isSafeCustomIncludePath()`. Do not add label-only deduplication in the UI, because that
+  would leave two underlying identities and inconsistent policy semantics.
+
+## Non-Goals
+
+- Redesign, reorder, or add search to the Included Content menu.
+- Change defaults, `sync.include` persistence, backend behavior, migration, or concurrency handling.
+- Change `@narumitw/pi-tui-kit` or introduce a new dependency.
+- Bump versions, publish packages, or release the fix as part of plan execution.
+
+## Risks
+
+- An over-broad reserved-name check could reject canonical built-ins; cover normalization separately
+  from custom-path classification.
+- Case-insensitive matching could accidentally reject near names such as `settings.json.backup`; keep
+  matching at the complete top-level path segment.
+- A rendering-only test could miss the invalid duplicate state; cover both policy classification and
+  the real TUI candidate projection.
+
+## Implementation Record
+
+- Branch: `fix/pi-sync-included-content-deduplication`.
+- Red evidence: the focused policy test failed because `settings.json` was accepted as custom, and
+  the TUI test stopped at the second `AGENTS.md` identity before reaching `custom.json` or `sessions`.
+- The implementation expands the shared reserved-root set to every case-normalized built-in root;
+  exact built-ins still canonicalize before custom validation, while nested built-in paths now fail
+  the existing canonical-root rule.
+- No command, package, dependency, schema, async task, settings writer, or lifecycle path changed.
+- Local root `npm test` and `npm run check` were both attempted with canonical `TMPDIR` and Git commit
+  signing disabled. All 27 focused pi-sync tests and all non-test gates pass, but unrelated existing
+  tests in pi-github-pr and pi-worktree fail consistently on this macOS checkout; one concurrent root
+  run also timed out an experimental pi-jupyter FIFO test. The same `origin/main` commit has a passing
+  hosted CI run, so the pull request's hosted CI is the remaining authoritative root-gate evidence.
+
+## Plan
+
+- [x] Add a focused failing policy regression in
+      `extensions/pi-sync/test/v3-schema.test.ts` proving that every `BUILT_IN_SYNC_ROOTS` value, its
+      representative case variant, and descendants under built-in roots are not safe custom paths,
+      while canonical built-ins still normalize successfully and near/custom names remain valid;
+      verify the compiled `v3-schema.test.js` fails on the current policy for built-in files.
+- [x] Add a focused failing TUI regression in `extensions/pi-sync/test/sync.test.ts` that creates real
+      built-in files/directories plus one ordinary custom entry in a temporary agent directory, walks
+      the pi-tui-kit multi-select rows by stable navigation, and asserts each built-in label and the
+      custom label appear exactly once; cancel the editor and verify `pi-sync.json` remains byte-for-byte
+      unchanged. Confirm the current implementation fails because built-in files are projected twice.
+- [x] Tighten the shared reserved-root classification in
+      `extensions/pi-sync/src/sync-policy.ts` so `isSafeCustomIncludePath()` excludes exact and
+      case-equivalent built-in roots and their descendants, while `normalizeSyncInclude()` continues
+      canonicalizing exact built-ins before custom validation; verify both focused regressions pass
+      without adding a second deduplication layer to `file-selection.ts`.
+- [x] Perform a bounded same-pattern audit across `normalizeSyncInclude()`,
+      `includeFromSelectionConfig()`, `normalizeExtraFiles()`, and `listCustomCandidates()` for exact
+      names, case variants, nested paths, safe near names, configured custom entries, and empty or
+      missing agent directories; add only regression cases that expose the same built-in/custom
+      identity bug, and verify existing duplicate/overlap/denied-path tests remain green.
+- [x] Re-run the existing Included Content UI tests for narrow/wide rendering, concurrent settings
+      changes, cancellation/disposal, Save/Discard review, and custom-entry selection; verify no row
+      exceeds its supplied width, cancellation and session replacement remain read-only, and a saved
+      include contains one canonical identity per path.
+- [ ] Run the focused compiled pi-sync tests, `npm run check --workspace @narumitw/pi-sync`, root
+      `npm test`, root `npm run check`, and `git diff --check`; leave any unavailable or failing gate
+      open and report it rather than inferring success. A pack dry run or Pi load smoke is not required
+      unless implementation unexpectedly changes package metadata, dependencies, exports, or runtime
+      loading.
+- [x] Audit the final diff against `docs/extension-conventions.md` and
+      `docs/extension-settings.md`, explicitly rechecking user cancellation, component disposal,
+      session replacement, shutdown applicability, post-`await` state use, settings ordering/failure
+      recovery, invalid-file protection, unknown-field preservation, and atomic publication; record
+      that unchanged paths were reviewed rather than claiming tests alone cover them.
+
+## Completion Checklist
+
+- [x] `settings.json`, `models.json`, and every other built-in root render once even when physically
+      present in the agent directory or encountered with a case variant.
+- [x] Safe custom top-level files and directories still render once and can be selected.
+- [x] Canonical built-in `sync.include` values remain accepted; duplicate, overlapping, denied, and
+      nested reserved-root values remain or become correctly rejected.
+- [x] Save, Discard, Escape, cancellation/disposal, concurrent-change detection, and settings bytes
+      retain their existing behavior.
+- [ ] Focused tests, pi-sync workspace checks, root tests, root `npm run check`, and `git diff --check`
+      pass, with any exception documented.
+- [x] No unrelated source, package metadata, README contract, version, or generated dependency output
+      changes are included.

--- a/docs/plans/2026-07-30_pi-sync-included-content-deduplication-plan.md
+++ b/docs/plans/2026-07-30_pi-sync-included-content-deduplication-plan.md
@@ -69,6 +69,8 @@ behavior, and the existing version 3 settings schema.
   tests in pi-github-pr and pi-worktree fail consistently on this macOS checkout; one concurrent root
   run also timed out an experimental pi-jupyter FIFO test. The same `origin/main` commit has a passing
   hosted CI run, so the pull request's hosted CI is the remaining authoritative root-gate evidence.
+- Pull request: https://github.com/narumiruna/pi-extensions/pull/470. Its initial CodeQL checks pass;
+  the repository CI check is still pending dispatch.
 
 ## Plan
 

--- a/docs/plans/archived/2026-07-30_pi-sync-included-content-deduplication-plan.md
+++ b/docs/plans/archived/2026-07-30_pi-sync-included-content-deduplication-plan.md
@@ -68,9 +68,9 @@ behavior, and the existing version 3 settings schema.
   signing disabled. All 27 focused pi-sync tests and all non-test gates pass, but unrelated existing
   tests in pi-github-pr and pi-worktree fail consistently on this macOS checkout; one concurrent root
   run also timed out an experimental pi-jupyter FIFO test. The same `origin/main` commit has a passing
-  hosted CI run, so the pull request's hosted CI is the remaining authoritative root-gate evidence.
-- Pull request: https://github.com/narumiruna/pi-extensions/pull/470. Its initial CodeQL checks pass;
-  the repository CI check is still pending dispatch.
+  hosted CI run, so the pull request's hosted CI provides the authoritative root-gate evidence.
+- Pull request: https://github.com/narumiruna/pi-extensions/pull/470. CodeQL and hosted CI pass;
+  CI run 30523865002 completed the repository root gate successfully.
 
 ## Plan
 
@@ -98,7 +98,7 @@ behavior, and the existing version 3 settings schema.
       changes, cancellation/disposal, Save/Discard review, and custom-entry selection; verify no row
       exceeds its supplied width, cancellation and session replacement remain read-only, and a saved
       include contains one canonical identity per path.
-- [ ] Run the focused compiled pi-sync tests, `npm run check --workspace @narumitw/pi-sync`, root
+- [x] Run the focused compiled pi-sync tests, `npm run check --workspace @narumitw/pi-sync`, root
       `npm test`, root `npm run check`, and `git diff --check`; leave any unavailable or failing gate
       open and report it rather than inferring success. A pack dry run or Pi load smoke is not required
       unless implementation unexpectedly changes package metadata, dependencies, exports, or runtime
@@ -109,6 +109,21 @@ behavior, and the existing version 3 settings schema.
       recovery, invalid-file protection, unknown-field preservation, and atomic publication; record
       that unchanged paths were reviewed rather than claiming tests alone cover them.
 
+## Verification Evidence
+
+- Red-first focused run: 2 expected failures for built-in/custom classification and duplicate TUI
+  projection.
+- Final focused run: 27 passing tests across `sync.test.js` and `v3-schema.test.js`.
+- `npm run check --workspace @narumitw/pi-sync`: passed Biome and TypeScript checks.
+- `git diff --check`: passed before each commit.
+- Local root `npm test` and `npm run check`: attempted; touched tests and non-test gates passed, with
+  unrelated macOS-local failures recorded above.
+- Hosted PR checks: CI, CodeQL actions analysis, CodeQL JavaScript/TypeScript analysis, and CodeQL all
+  passed on the committed branch.
+- Pack and Pi runtime smokes were not applicable because package metadata, dependencies, exports, and
+  runtime loading were unchanged; deterministic policy and component-harness tests exercise the
+  changed behavior directly.
+
 ## Completion Checklist
 
 - [x] `settings.json`, `models.json`, and every other built-in root render once even when physically
@@ -118,7 +133,7 @@ behavior, and the existing version 3 settings schema.
       nested reserved-root values remain or become correctly rejected.
 - [x] Save, Discard, Escape, cancellation/disposal, concurrent-change detection, and settings bytes
       retain their existing behavior.
-- [ ] Focused tests, pi-sync workspace checks, root tests, root `npm run check`, and `git diff --check`
+- [x] Focused tests, pi-sync workspace checks, root tests, root `npm run check`, and `git diff --check`
       pass, with any exception documented.
 - [x] No unrelated source, package metadata, README contract, version, or generated dependency output
       changes are included.

--- a/extensions/pi-sync/src/sync-policy.ts
+++ b/extensions/pi-sync/src/sync-policy.ts
@@ -28,7 +28,7 @@ const TOP_LEVEL_FILE_PATHS = new Map<string, string>(
 const TOP_LEVEL_DIRS = new Set<string>(
 	BUILT_IN_SYNC_ROOTS.filter((fileName) => !fileName.includes(".")),
 );
-const RESERVED_TOP_LEVEL_NAMES = new Set<string>([...TOP_LEVEL_DIRS, "sessions"]);
+const RESERVED_TOP_LEVEL_NAMES = new Set<string>([...BUILT_IN_BY_LOWER.keys(), "sessions"]);
 
 export function normalizeSyncInclude(value: unknown): string[] {
 	if (!Array.isArray(value)) {

--- a/extensions/pi-sync/test/sync.test.ts
+++ b/extensions/pi-sync/test/sync.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -20,9 +21,19 @@ import { localConfigPath, readLocalConfigObject, updateLocalConfig } from "../sr
 import { showFileSelection } from "../src/file-selection.js";
 import sync from "../src/sync.js";
 import { syncBoth } from "../src/sync-operations.js";
+import { BUILT_IN_SYNC_ROOTS } from "../src/sync-policy.js";
 import { v3S3Settings, withTempHome } from "./helpers.js";
 
 initTheme("dark", false);
+
+function selectedMultiSelectLabel(lines: readonly string[]) {
+	const line = lines.find((candidate) => candidate.startsWith("→ ") || candidate.startsWith("› "));
+	return line
+		?.slice(2)
+		.replace(/^\[(?:x| |-)\]\s+/u, "")
+		.split(/\s{2,}/u)[0]
+		?.trim();
+}
 
 test("sync command catalog and usage document setup-addressing routes", () => {
 	assert.ok(SYNC_COMMANDS.some((command) => command.name === "use"));
@@ -140,6 +151,80 @@ test("included-content TUI renders textual state at narrow and wide widths", asy
 			assert.ok(lines.every((line) => visibleWidth(line) <= width));
 			assert.match(lines.join("\n"), /Included Content|included|excluded/u);
 		}
+	});
+});
+
+test("included-content TUI lists built-in and custom paths exactly once", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		for (const root of BUILT_IN_SYNC_ROOTS) {
+			const target = path.join(agentDir, root);
+			if (root.includes(".")) writeFileSync(target, "{}\n");
+			else mkdirSync(target);
+		}
+		writeFileSync(path.join(agentDir, "custom.json"), "{}\n");
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		let customCalls = 0;
+		const labels: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				customCalls += 1;
+				const harness = createCustomSelectorHarness(factory, 100);
+				for (let index = 0; index < 32; index += 1) {
+					const label = selectedMultiSelectLabel(harness.render());
+					if (!label || labels.includes(label)) break;
+					labels.push(label);
+					harness.handleInput("tui.select.down");
+				}
+				harness.handleInput("tui.select.cancel");
+				return harness.result;
+			},
+		});
+		await showFileSelection(ctx, "home");
+		assert.equal(customCalls, 1);
+		assert.deepEqual(labels, [...BUILT_IN_SYNC_ROOTS, "custom.json", "sessions"]);
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+	});
+});
+
+test("included-content TUI saves a discovered custom path once", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), "{}\n");
+		writeFileSync(path.join(agentDir, "custom.json"), "{}\n");
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		let screen = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				screen += 1;
+				const harness = createCustomSelectorHarness(factory, 100);
+				if (screen === 1) {
+					for (let index = 0; index < BUILT_IN_SYNC_ROOTS.length; index += 1) {
+						harness.handleInput("tui.select.down");
+					}
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+					await Promise.resolve();
+				} else if (screen === 2) {
+					harness.handleInput("tui.select.cancel");
+				} else {
+					harness.handleInput("tui.select.confirm");
+				}
+				return harness.result;
+			},
+		});
+		await showFileSelection(ctx, "home");
+		assert.equal(screen, 3);
+		assert.deepEqual((await readLocalConfigObject())?.syncSetups.home.sync.include, [
+			"settings.json",
+			"custom.json",
+		]);
+		assert.match(notifications.at(-1)?.message ?? "", /Saved included content/u);
 	});
 });
 

--- a/extensions/pi-sync/test/v3-schema.test.ts
+++ b/extensions/pi-sync/test/v3-schema.test.ts
@@ -11,6 +11,7 @@ import {
 	readLocalConfigObject,
 	validateSettingsDocument,
 } from "../src/config.js";
+import { BUILT_IN_SYNC_ROOTS, isSafeCustomIncludePath } from "../src/sync-policy.js";
 import { withTempHome } from "./helpers.js";
 
 function connection(type: "s3" | "git" | "webdav") {
@@ -118,6 +119,20 @@ test("version 3 rejects missing references and backend-field mixing", async () =
 		await writeSettings(agentDir, mixed);
 		await assert.rejects(loadConfig(), /Git sync setup.*mixes backend fields/u);
 	});
+});
+
+test("built-in sync roots stay canonical and cannot become custom paths", () => {
+	for (const root of BUILT_IN_SYNC_ROOTS) {
+		const caseVariant = root.toUpperCase();
+		assert.deepEqual(normalizeSyncInclude([caseVariant]), [root]);
+		assert.equal(isSafeCustomIncludePath(root), false, root);
+		assert.equal(isSafeCustomIncludePath(caseVariant), false, caseVariant);
+		assert.equal(isSafeCustomIncludePath(`${root}/child`), false, `${root}/child`);
+		assert.throws(() => normalizeSyncInclude([`${root}/child`]), /canonical .* root/u);
+		assert.equal(isSafeCustomIncludePath(`${root}.backup`), true, `${root}.backup`);
+	}
+	assert.equal(isSafeCustomIncludePath("custom.json"), true);
+	assert.equal(isSafeCustomIncludePath("custom"), true);
 });
 
 test("version 3 rejects reserved names, duplicate remotes, and invalid include values", async () => {


### PR DESCRIPTION
## Summary

- reserve every canonical built-in sync root from custom-path discovery
- prevent duplicate built-in/custom identities in the Included Content editor
- cover case variants, nested reserved roots, cancellation, and custom-path saves

## Verification

- focused compiled pi-sync tests: 27 passed
- `npm run check --workspace @narumitw/pi-sync`
- `git diff --check`
- local `npm test` / `npm run check` attempted; touched tests and non-test gates pass, while unrelated macOS-local pi-github-pr, pi-worktree, and one concurrent pi-jupyter test failed (the base commit's hosted CI is green; this PR's hosted CI is the authoritative root gate)
