### PR TITLE
fix(deps): require compatible pi-tui-kit versions

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -130,6 +130,7 @@
 - Symptom: the subagent disposable-worktree test reports that a nested cwd is outside its freshly initialized repository on macOS. Cause: temp paths may use `/var/...` while Git canonicalizes the same path to `/private/var/...`; lexical containment fails. Fix: compare canonical realpaths.
 - Kit settings and multi-select actions settle asynchronously; test adapters that drive `ctx.ui.custom()` must drain `waitForPending()`, observe an accepted transition, and close a rejected screen instead of returning before the callback settles.
 - Consumer tests load `@narumitw/pi-tui-kit` from its built `dist/`; rebuild the kit after source changes or consumer behavior tests can exercise stale UI code.
+- Symptom: a newer extension screen can make Pi focus `undefined` and crash. Cause: a broad zero-major helper range lets Pi's npm lock retain an older `pi-tui-kit` without that screen kind. Fix: use a bounded caret minor range and keep shared version bumps from rewriting consumer-owned compatibility ranges.
 - Searchable TUI wrappers should reserve only a standalone Space key for activation; stripping spaces from whole input chunks corrupts bracketed-paste token queries.
 
 ## TASTE
@@ -150,3 +151,5 @@
 - Keep package versions out of long-lived guidance and memory; derive current versions from manifests, lockfiles, or workflows, while retaining versions in historical evidence and compatibility documentation when they are part of the fact being recorded.
 - Keep `just` install recipes resilient by verifying registry visibility and falling back only when it solves the current install path.
 - Earendil Works acquired the Pi tooling from mariozechner; prefer `@earendil-works/*` Pi packages because `@mariozechner/pi-*` packages are deprecated and should not be used for new extension work.
+
+## CONVENTIONS

--- a/docs/plans/archived/2026-07-31_narrow-pi-tui-kit-ranges-plan.md
+++ b/docs/plans/archived/2026-07-31_narrow-pi-tui-kit-ranges-plan.md
@@ -1,0 +1,29 @@
+# Narrow pi-tui-kit dependency ranges plan
+
+## Goal
+
+Prevent extensions that use `@narumitw/pi-tui-kit` from resolving an older incompatible minor by replacing the broad `<1` dependency with the tested `^0.40.0` minor range and preserving explicit compatibility ranges during shared version bumps.
+
+## Context
+
+`@narumitw/pi-worktree@0.39.0` resolved `@narumitw/pi-tui-kit@0.36.0` from an existing Pi package lock even though its `choice` screen requires the newer menu API. The old kit returned no component for that screen, and Pi crashed while focusing `undefined`. All current kit consumers are tested with the repository's `0.40.x` kit; for a zero-major package, `^0.40.0` accepts only `>=0.40.0 <0.41.0`.
+
+## Non-Goals
+
+- Changing extension commands, menus, settings, or lifecycle behavior.
+- Updating the user's `~/.pi/agent/npm` installation as part of the repository change.
+- Changing publication selection or package versions.
+
+## Plan
+
+- [x] Add focused repository-script tests that require every active or experimental kit consumer to use a bounded `^0.minor.patch` range at least `0.40.0` and require shared version bumps to preserve explicit internal compatibility ranges; red evidence: both tests failed against `<1` and the bump script rewrote `^0.40.0` to `<2`.
+- [x] Update every active and experimental extension manifest that depends on `@narumitw/pi-tui-kit`, regenerate `package-lock.json` with pinned npm `12.0.2`, and change the shared bump script to leave consumer-owned internal ranges unchanged; evidence: 18 manifests and 18 lockfile entries use `^0.40.0`, with focused tests passing.
+- [x] Run the repository CI-equivalent check and dry-pack every changed extension workspace, confirming each tarball retains `^0.40.0` and expected package contents. Evidence: all 18 dry-packs, Biome, boundaries, typechecks, focused tests, and dependency-tree validation pass; the full Node 24 Linux/modern-Git container gate passes all 1,873 tests. The host macOS gate exposed three platform-sensitive baseline failures outside this diff, all covered successfully by the Linux gate or focused reruns.
+- [x] Audit package/release-tooling changes against `docs/extension-conventions.md`, confirm no command, settings, lifecycle, or custom-TUI behavior changed, and archive this completed plan. Audit covered package metadata, dependency ownership, publication ordering, lockfile alignment, and dry-pack contents.
+
+## Completion Checklist
+
+- [x] No active or experimental extension declares a broad `<1` range for `@narumitw/pi-tui-kit`.
+- [x] Future shared patch/minor bumps cannot silently widen the explicit kit range.
+- [x] `package-lock.json`, tests, checks, and all affected package dry-runs pass in the CI-equivalent Linux environment.
+- [x] No unrelated production behavior is changed.

--- a/experimental/pi-jupyter/package.json
+++ b/experimental/pi-jupyter/package.json
@@ -44,6 +44,6 @@
 		"directory": "experimental/pi-jupyter"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/experimental/pi-webui/package.json
+++ b/experimental/pi-webui/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "npm run check:web && tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"@radix-ui/colors": "^3.0.0",
 		"@radix-ui/react-icons": "^1.3.2",
 		"@radix-ui/themes": "^3.3.0",

--- a/extensions/pi-accounts/package.json
+++ b/extensions/pi-accounts/package.json
@@ -32,7 +32,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"proper-lockfile": "^4.1.2"
 	},
 	"peerDependencies": {

--- a/extensions/pi-caffeinate/package.json
+++ b/extensions/pi-caffeinate/package.json
@@ -40,6 +40,6 @@
 		"directory": "extensions/pi-caffeinate"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"typebox": "^1.3.8"
 	},
 	"devDependencies": {

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"typebox": "^1.3.8"
 	},
 	"devDependencies": {

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -30,7 +30,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"typebox": "^1.3.8"
 	},
 	"peerDependencies": {

--- a/extensions/pi-google-genai/package.json
+++ b/extensions/pi-google-genai/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"typebox": "^1.3.8"
 	},
 	"devDependencies": {

--- a/extensions/pi-image-drop/package.json
+++ b/extensions/pi-image-drop/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "npm run check:web && tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"@radix-ui/colors": "3.0.0",
 		"@radix-ui/react-icons": "1.3.2",
 		"@radix-ui/themes": "3.3.0",

--- a/extensions/pi-langfuse/package.json
+++ b/extensions/pi-langfuse/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@langfuse/otel": "^5.9.1",
 		"@langfuse/tracing": "^5.9.1",
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
 		"@opentelemetry/sdk-trace-base": "^2.10.0",

--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -43,6 +43,6 @@
 		"directory": "extensions/pi-plan-mode"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/extensions/pi-stamp/package.json
+++ b/extensions/pi-stamp/package.json
@@ -48,6 +48,6 @@
 		"directory": "extensions/pi-stamp"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/extensions/pi-starship/package.json
+++ b/extensions/pi-starship/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"smol-toml": "^1.7.1",
 		"yaml": "^2.9.0"
 	},

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -40,6 +40,6 @@
 		"directory": "extensions/pi-statusline"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"proper-lockfile": "^4.1.2",
 		"typebox": "^1.3.8"
 	},

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -36,7 +36,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1",
+		"@narumitw/pi-tui-kit": "^0.40.0",
 		"fast-xml-parser": "^5.10.1",
 		"proper-lockfile": "^4.1.2"
 	},

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -45,6 +45,6 @@
 		"directory": "extensions/pi-usage"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/extensions/pi-worktree/package.json
+++ b/extensions/pi-worktree/package.json
@@ -43,6 +43,6 @@
 		"directory": "extensions/pi-worktree"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "<1"
+		"@narumitw/pi-tui-kit": "^0.40.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -64,7 +64,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"@radix-ui/colors": "^3.0.0",
 				"@radix-ui/react-icons": "^1.3.2",
 				"@radix-ui/themes": "^3.3.0",
@@ -95,7 +95,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
@@ -127,7 +127,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -141,7 +141,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"typebox": "^1.3.8"
 			},
 			"devDependencies": {
@@ -155,7 +155,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"typebox": "^1.3.8"
 			},
 			"devDependencies": {
@@ -180,7 +180,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"typebox": "^1.3.8"
 			},
 			"devDependencies": {
@@ -200,7 +200,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"typebox": "^1.3.8"
 			},
 			"devDependencies": {
@@ -215,7 +215,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"@radix-ui/colors": "3.0.0",
 				"@radix-ui/react-icons": "1.3.2",
 				"@radix-ui/themes": "3.3.0",
@@ -249,7 +249,7 @@
 			"dependencies": {
 				"@langfuse/otel": "^5.9.1",
 				"@langfuse/tracing": "^5.9.1",
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
 				"@opentelemetry/sdk-trace-base": "^2.10.0",
@@ -290,7 +290,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -308,7 +308,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -327,7 +327,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"smol-toml": "^1.7.1",
 				"yaml": "^2.9.0"
 			},
@@ -348,7 +348,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -363,7 +363,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"proper-lockfile": "^4.1.2",
 				"typebox": "^1.3.8"
 			},
@@ -387,7 +387,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1",
+				"@narumitw/pi-tui-kit": "^0.40.0",
 				"fast-xml-parser": "^5.10.1",
 				"proper-lockfile": "^4.1.2"
 			},
@@ -408,7 +408,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -425,7 +425,7 @@
 			"version": "0.40.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "<1"
+				"@narumitw/pi-tui-kit": "^0.40.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",

--- a/scripts/bump-shared-version.mjs
+++ b/scripts/bump-shared-version.mjs
@@ -50,16 +50,9 @@ const currentVersion = packages
 
 const newVersionParts = bumpVersion(currentVersion, bump);
 const newVersion = newVersionParts.join(".");
-const internalPackageNames = new Set(
-	packages
-		.map(({ packageJson }) => packageJson.name)
-		.filter((name) => typeof name === "string" && name.length > 0),
-);
-const internalDependencyRange = `<${newVersionParts[0] + 1}`;
 
 for (const { packagePath, packageJson } of packages) {
 	packageJson.version = newVersion;
-	updateInternalDependencyRanges(packageJson, internalPackageNames, internalDependencyRange);
 	fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, "\t")}\n`);
 }
 
@@ -71,21 +64,6 @@ console.log(newVersion);
 
 function readPackage(packagePath) {
 	return JSON.parse(fs.readFileSync(packagePath, "utf8"));
-}
-
-function updateInternalDependencyRanges(packageJson, internalPackageNames, range) {
-	for (const field of [
-		"dependencies",
-		"devDependencies",
-		"optionalDependencies",
-		"peerDependencies",
-	]) {
-		const dependencies = packageJson[field];
-		if (!dependencies) continue;
-		for (const dependencyName of Object.keys(dependencies)) {
-			if (internalPackageNames.has(dependencyName)) dependencies[dependencyName] = range;
-		}
-	}
 }
 
 function parseVersion(version) {

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -50,23 +58,23 @@ test("shared-version discovery includes publishable library and extension worksp
 	}
 });
 
-test("shared major bumps advance internal workspace dependency ranges", () => {
+test("shared bumps preserve consumer-owned internal compatibility ranges", () => {
 	const fixture = mkdtempSync(path.join(tmpdir(), "pi-workspace-ranges-"));
 	try {
 		writeJson(path.join(fixture, "package.json"), {
 			name: "fixture-root",
 			private: true,
-			version: "0.35.0",
+			version: "0.40.0",
 			workspaces: ["packages/*", "extensions/*"],
 		});
 		writeJson(path.join(fixture, "packages/menu/package.json"), {
 			name: "@fixture/menu",
-			version: "0.35.0",
+			version: "0.40.0",
 		});
 		writeJson(path.join(fixture, "extensions/consumer/package.json"), {
 			name: "@fixture/consumer",
-			version: "0.35.0",
-			dependencies: { "@fixture/menu": "<1" },
+			version: "0.40.0",
+			dependencies: { "@fixture/menu": "^0.40.0" },
 		});
 		const fixtureScript = path.join(fixture, "scripts/bump-shared-version.mjs");
 		mkdirSync(path.dirname(fixtureScript), { recursive: true });
@@ -83,10 +91,31 @@ test("shared major bumps advance internal workspace dependency ranges", () => {
 			readFileSync(path.join(fixture, "extensions/consumer/package.json"), "utf8"),
 		);
 		assert.equal(consumer.version, "1.0.0");
-		assert.equal(consumer.dependencies["@fixture/menu"], "<2");
+		assert.equal(consumer.dependencies["@fixture/menu"], "^0.40.0");
 	} finally {
 		rmSync(fixture, { recursive: true, force: true });
 	}
+});
+
+test("pi-tui-kit consumers use a bounded compatible zero-major range", () => {
+	const consumers: string[] = [];
+	for (const packageRoot of ["extensions", "experimental"]) {
+		for (const entry of readdirSync(path.join(repositoryRoot, packageRoot), {
+			withFileTypes: true,
+		})) {
+			if (!entry.isDirectory()) continue;
+			const manifestPath = path.join(repositoryRoot, packageRoot, entry.name, "package.json");
+			if (!existsSync(manifestPath)) continue;
+			const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+			const range = manifest.dependencies?.["@narumitw/pi-tui-kit"];
+			if (range === undefined) continue;
+			consumers.push(manifest.name);
+			const match = /^\^0\.(\d+)\.(\d+)$/.exec(range);
+			assert.ok(match, `${manifest.name} must use a bounded ^0.minor.patch pi-tui-kit range`);
+			assert.ok(Number(match[1]) >= 40, `${manifest.name} must require pi-tui-kit 0.40 or newer`);
+		}
+	}
+	assert.ok(consumers.length > 0, "expected at least one pi-tui-kit consumer");
 });
 
 test("shared-version discovery skips workspace roots that are not present", () => {


### PR DESCRIPTION
## Summary

- require `@narumitw/pi-tui-kit` `^0.40.0` across all 18 active and experimental consumers
- preserve consumer-owned internal compatibility ranges during shared version bumps
- add repository regressions for bounded kit ranges and bump-script behavior

## Verification

- `npm run check` in Node 24 Alpine with modern Git: 1,873/1,873 tests passed
- `npm run biome:check`
- `npm run check:boundaries`
- `PI_EXTENSIONS_BUILD_READY=1 npm run typecheck`
- `node --test test/repository-scripts.test.ts`: 12/12 passed
- dry-packed all 18 affected consumer workspaces
