### PR TITLE
fix(goal): harden managed run lifecycle boundaries

### DIFF
--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -249,6 +249,8 @@ A successful start produces canonical state on `pi-goal:v1:event:${runId}`:
 
 Subsequent state events use `active`, `complete`, `blocked`, `paused`, `usage_limited`, `budget_limited`, or `cleared`. `complete` is the only successful terminal outcome. A matching completion may include `summary`; other terminal outcomes may include `reason`. Events come only from canonical Goal persistence and only for the matching managed run. Manual and restored Goals are not adopted or broadcast, unchanged persistence does not duplicate a status, and each run emits at most one terminal event.
 
+Terminal events are dispatched after the underlying Goal transition settles, so a listener can start the next managed run directly after `complete` without re-entering completion cleanup. Other terminal statuses leave a stopped Goal that must be resolved or cleared first. If a manual edit, replacement, skip, or priority transition rotates the Goal id, the prior managed run ends as `cleared` with a superseded reason; the replacement remains outside that run.
+
 To cancel before or after activation, emit the same `runId`:
 
 ```ts

--- a/extensions/pi-goal/src/run-protocol.ts
+++ b/extensions/pi-goal/src/run-protocol.ts
@@ -67,10 +67,32 @@ export function goalRunEventChannel(runId: string) {
 	return `pi-goal:v1:event:${runId}`;
 }
 
+function isPayloadRecord(data: unknown): data is object {
+	if (!data || typeof data !== "object") return false;
+	try {
+		return !Array.isArray(data);
+	} catch {
+		return false;
+	}
+}
+
+function readPayloadProperty(
+	data: object,
+	key: "runId" | "objective" | "tokenBudget" | "reason",
+): { ok: true; value: unknown } | { ok: false } {
+	try {
+		return { ok: true, value: Reflect.get(data, key) };
+	} catch {
+		return { ok: false };
+	}
+}
+
 function parseRunId(data: unknown): string | undefined {
-	if (!data || typeof data !== "object" || Array.isArray(data)) return undefined;
-	const runId = Reflect.get(data, "runId");
-	return typeof runId === "string" && RUN_ID_PATTERN.test(runId) ? runId : undefined;
+	if (!isPayloadRecord(data)) return undefined;
+	const runId = readPayloadProperty(data, "runId");
+	return runId.ok && typeof runId.value === "string" && RUN_ID_PATTERN.test(runId.value)
+		? runId.value
+		: undefined;
 }
 
 function currentActiveGoal(runtime: GoalRuntime) {
@@ -78,35 +100,39 @@ function currentActiveGoal(runtime: GoalRuntime) {
 }
 
 function parseStartPayload(data: unknown): string | Omit<GoalRunStartPayload, "runId"> {
-	if (!data || typeof data !== "object" || Array.isArray(data)) {
-		return "start payload must be an object";
+	if (!isPayloadRecord(data)) return "start payload must be an object";
+	const objectiveValue = readPayloadProperty(data, "objective");
+	if (!objectiveValue.ok || typeof objectiveValue.value !== "string") {
+		return "objective must be a string";
 	}
-	const objectiveValue = Reflect.get(data, "objective");
-	if (typeof objectiveValue !== "string") return "objective must be a string";
-	const objective = objectiveValue.trim();
+	const objective = objectiveValue.value.trim();
 	const objectiveError = validateObjective(objective);
 	if (objectiveError) return objectiveError;
-	const tokenBudgetValue = Reflect.get(data, "tokenBudget");
+	const tokenBudgetValue = readPayloadProperty(data, "tokenBudget");
 	if (
-		tokenBudgetValue !== undefined &&
-		(typeof tokenBudgetValue !== "number" ||
-			!Number.isFinite(tokenBudgetValue) ||
-			!Number.isSafeInteger(tokenBudgetValue) ||
-			tokenBudgetValue <= 0)
+		!tokenBudgetValue.ok ||
+		(tokenBudgetValue.value !== undefined &&
+			(typeof tokenBudgetValue.value !== "number" ||
+				!Number.isFinite(tokenBudgetValue.value) ||
+				!Number.isSafeInteger(tokenBudgetValue.value) ||
+				tokenBudgetValue.value <= 0))
 	) {
 		return "tokenBudget must be a positive integer";
 	}
-	return { objective, tokenBudget: tokenBudgetValue as number | undefined };
+	return { objective, tokenBudget: tokenBudgetValue.value as number | undefined };
 }
 
 function parseCancelReason(data: unknown): string | undefined | { error: string } {
-	if (!data || typeof data !== "object" || Array.isArray(data)) {
-		return { error: "cancel payload must be an object" };
+	if (!isPayloadRecord(data)) return { error: "cancel payload must be an object" };
+	const reasonValue = readPayloadProperty(data, "reason");
+	if (
+		!reasonValue.ok ||
+		(reasonValue.value !== undefined && typeof reasonValue.value !== "string")
+	) {
+		return { error: "reason must be a string" };
 	}
-	const reasonValue = Reflect.get(data, "reason");
-	if (reasonValue === undefined) return undefined;
-	if (typeof reasonValue !== "string") return { error: "reason must be a string" };
-	const reason = reasonValue.trim();
+	if (reasonValue.value === undefined) return undefined;
+	const reason = reasonValue.value.trim();
 	if (reason.length > MAX_CANCEL_REASON_LENGTH) {
 		return { error: `reason must be at most ${MAX_CANCEL_REASON_LENGTH} characters` };
 	}
@@ -128,9 +154,7 @@ export class GoalRunController {
 	}
 
 	register(pi: ExtensionAPI) {
-		pi.events.on(GOAL_RUN_START_CHANNEL, (data) => {
-			void this.handleStart(data);
-		});
+		pi.events.on(GOAL_RUN_START_CHANNEL, (data) => this.handleStart(data));
 		pi.events.on(GOAL_RUN_CANCEL_CHANNEL, (data) => {
 			this.handleCancel(data);
 		});
@@ -169,6 +193,19 @@ export class GoalRunController {
 		const parsed = parseStartPayload(data);
 		if (typeof parsed === "string") {
 			this.emitError(runId, "start", "INVALID_REQUEST", parsed);
+			return;
+		}
+		if (this.session !== session || this.generation !== session.generation) {
+			this.emitError(
+				runId,
+				"start",
+				"SUPERSEDED",
+				"The pi-goal session changed while validating the request.",
+			);
+			return;
+		}
+		if (this.usedRunIds.has(runId)) {
+			this.emitError(runId, "start", "RUN_ID_IN_USE", "runId was already used in this session.");
 			return;
 		}
 		if (this.runtime.activeGoal || (this.run && !this.run.closed)) {
@@ -267,9 +304,26 @@ export class GoalRunController {
 
 	private handleGoalState(snapshot: GoalStateSnapshot) {
 		const run = this.run;
-		if (!run || run.closed || !run.goalId || run.goalId !== snapshot.goalId) return;
+		if (!run || run.closed || !run.goalId) return;
+		if (run.goalId !== snapshot.goalId) {
+			if (currentActiveGoal(this.runtime)?.id !== snapshot.goalId) return;
+			this.publishStateEvent(run, {
+				goalId: run.goalId,
+				status: "cleared",
+				reason: "managed Goal superseded by another Goal",
+			});
+			return;
+		}
 		if (snapshot.status === "queued" || run.lastStatus === snapshot.status) return;
+		this.publishStateEvent(run, snapshot);
+	}
+
+	private publishStateEvent(
+		run: ManagedRun,
+		snapshot: Pick<GoalStateSnapshot, "goalId" | "status" | "summary" | "reason">,
+	) {
 		const status = snapshot.status;
+		if (status === "queued") return;
 		run.lastStatus = status;
 		const event: GoalRunEvent = {
 			type: "state",
@@ -279,11 +333,21 @@ export class GoalRunController {
 			...(snapshot.summary ? { summary: snapshot.summary } : {}),
 			...(snapshot.reason ? { reason: snapshot.reason } : {}),
 		};
-		if (isTerminalGoalStatus(status)) {
-			run.closed = true;
-			this.run = undefined;
+		if (!isTerminalGoalStatus(status)) {
+			this.runtime.pi.events.emit(goalRunEventChannel(run.runId), event);
+			return;
 		}
-		this.runtime.pi.events.emit(goalRunEventChannel(run.runId), event);
+
+		run.closed = true;
+		this.run = undefined;
+		const generation = run.generation;
+		// Active stays synchronous so a listener can cancel before kickoff. Terminal
+		// publication waits until the transition finishes, preventing listener work
+		// from being overwritten by the old transition's remaining UI or cleanup.
+		queueMicrotask(() => {
+			if (this.generation !== generation) return;
+			this.runtime.pi.events.emit(goalRunEventChannel(run.runId), event);
+		});
 	}
 
 	private emitError(

--- a/extensions/pi-goal/test/goal-run-protocol.test.ts
+++ b/extensions/pi-goal/test/goal-run-protocol.test.ts
@@ -238,6 +238,76 @@ test("valid run ids receive structured request validation errors", async () => {
 	}
 });
 
+test("payload access failures are contained as invalid requests", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	registerGoal(mock);
+	bindSession(mock);
+	const startEvents = observeRun(mock, "throwing-start");
+	const throwingStart = {
+		runId: "throwing-start",
+		get objective(): string {
+			throw new Error("objective accessor failed");
+		},
+	};
+
+	mock.eventBus.emit(START_CHANNEL, throwingStart);
+	await flush();
+
+	assert.deepEqual(
+		errors(startEvents).map((event) => event.error.code),
+		["INVALID_REQUEST"],
+	);
+	assert.equal(lastPersistedGoal(mock), undefined);
+
+	const revoked = Proxy.revocable({}, {});
+	revoked.revoke();
+	mock.eventBus.emit(START_CHANNEL, revoked.proxy);
+	await flush();
+	assert.equal(lastPersistedGoal(mock), undefined);
+
+	const cancelEvents = observeRun(mock, "throwing-cancel");
+	startRun(mock, "throwing-cancel");
+	await flush();
+	const throwingCancel = {
+		runId: "throwing-cancel",
+		get reason(): string {
+			throw new Error("reason accessor failed");
+		},
+	};
+	mock.eventBus.emit(CANCEL_CHANNEL, throwingCancel);
+	await flush();
+
+	assert.deepEqual(
+		errors(cancelEvents).map((event) => event.error.code),
+		["INVALID_REQUEST"],
+	);
+	assert.equal(lastPersistedGoal(mock)?.status, "active");
+});
+
+test("payload evaluation cannot revive a replaced session", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	registerGoal(mock);
+	const context = bindSession(mock);
+	const events = observeRun(mock, "session-changing-payload");
+	const payload = {
+		runId: "session-changing-payload",
+		get objective() {
+			mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+			return "must not start after shutdown";
+		},
+	};
+
+	mock.eventBus.emit(START_CHANNEL, payload);
+	await flush();
+
+	assert.deepEqual(
+		errors(events).map((event) => event.error.code),
+		["SUPERSEDED"],
+	);
+	assert.equal(lastPersistedGoal(mock), undefined);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
 test("start rejects a pre-existing manual goal without replacement confirmation", async () => {
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	registerGoal(mock);
@@ -371,6 +441,28 @@ test("cancel rejects malformed reasons without mutating the run", async () => {
 	}
 });
 
+test("manual edits terminate the prior managed run as superseded", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	registerGoal(mock);
+	const context = bindSession(mock);
+	const events = observeRun(mock, "edited-run");
+	startRun(mock, "edited-run", { objective: "managed objective" });
+	await flush();
+	const managedGoalId = states(events)[0]?.goalId;
+	assert.ok(managedGoalId);
+
+	await mock.commands.get("goal")?.handler("edit manually revised objective", context.ctx);
+	await flush();
+
+	assert.deepEqual(
+		states(events).map((event) => event.status),
+		["active", "cleared"],
+	);
+	assert.match(states(events).at(-1)?.reason ?? "", /superseded/i);
+	assert.notEqual(lastPersistedGoal(mock)?.id, managedGoalId);
+	assert.equal(lastPersistedGoal(mock)?.text, "manually revised objective");
+});
+
 test("completion emits one terminal event with summary and suppresses clear duplication", async () => {
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	registerGoal(mock);
@@ -401,6 +493,81 @@ test("completion emits one terminal event with summary and suppresses clear dupl
 	assert.deepEqual(
 		errors(events).map((event) => event.error.code),
 		["RUN_ID_IN_USE"],
+	);
+});
+
+test("a completion listener can start the next managed run", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	registerGoal(mock);
+	const context = bindSession(mock);
+	const firstEvents = observeRun(mock, "chained-first");
+	const secondEvents = observeRun(mock, "chained-second");
+	mock.eventBus.on(runEventChannel("chained-first"), (data) => {
+		const event = data as RunEvent;
+		if (event.type === "state" && event.status === "complete") {
+			startRun(mock, "chained-second", { objective: "second managed objective" });
+		}
+	});
+	startRun(mock, "chained-first", { objective: "first managed objective" });
+	await flush();
+	const goalId = states(firstEvents)[0]?.goalId;
+	assert.ok(goalId);
+
+	await requireGoalTool(mock, "goal_complete").execute(
+		"complete-chained-first",
+		{ goal_id: goalId, summary: "First run verified." },
+		new AbortController().signal,
+		() => undefined,
+		context.ctx,
+	);
+	await flush();
+
+	assert.deepEqual(
+		states(firstEvents).map((event) => event.status),
+		["active", "complete"],
+	);
+	assert.deepEqual(
+		states(secondEvents).map((event) => event.status),
+		["active"],
+	);
+	assert.deepEqual(errors(secondEvents), []);
+	assert.equal(lastPersistedGoal(mock)?.text, "second managed objective");
+	assert.equal(lastPersistedGoal(mock)?.status, "active");
+});
+
+test("terminal listeners cannot make stale pause work mutate a replacement", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	registerGoal(mock);
+	const context = bindSession(mock);
+	const firstEvents = observeRun(mock, "pause-first");
+	const secondEvents = observeRun(mock, "pause-second");
+	mock.eventBus.on(runEventChannel("pause-first"), (data) => {
+		const event = data as RunEvent;
+		if (event.type === "state" && event.status === "paused") {
+			void mock.commands.get("goal")?.handler("clear", context.ctx);
+			startRun(mock, "pause-second", { objective: "replacement after pause" });
+		}
+	});
+	startRun(mock, "pause-first", { objective: "cancelled managed objective" });
+	await flush();
+
+	cancelRun(mock, "pause-first", { reason: "advance to replacement" });
+	await flush();
+
+	assert.deepEqual(
+		states(firstEvents).map((event) => event.status),
+		["active", "paused"],
+	);
+	assert.deepEqual(
+		states(secondEvents).map((event) => event.status),
+		["active"],
+	);
+	assert.equal(lastPersistedGoal(mock)?.text, "replacement after pause");
+	assert.equal(
+		context.notifications.some(
+			(notification) => notification.message === "Goal paused: replacement after pause",
+		),
+		false,
 	);
 });
 
@@ -446,6 +613,7 @@ test("blocked and usage-limited transitions preserve terminal reasons", async ()
 		},
 		usageContext.ctx,
 	);
+	await flush();
 	assert.equal(states(usageEvents).at(-1)?.status, "usage_limited");
 	assert.match(states(usageEvents).at(-1)?.reason ?? "", /usage limit/i);
 });
@@ -602,6 +770,25 @@ test("disabling RPC rejects new starts while the accepted run can drain", async 
 		["active", "paused"],
 	);
 	assert.equal(states(acceptedEvents).at(-1)?.reason, "drained after disable");
+});
+
+test("shutdown cancels a queued terminal publication from the old session", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	registerGoal(mock);
+	const context = bindSession(mock);
+	const events = observeRun(mock, "shutdown-terminal");
+	startRun(mock, "shutdown-terminal");
+	await flush();
+
+	cancelRun(mock, "shutdown-terminal");
+	mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	await flush();
+
+	assert.deepEqual(
+		states(events).map((event) => event.status),
+		["active"],
+	);
+	assert.equal(lastPersistedGoal(mock)?.status, "paused");
 });
 
 test("shutdown invalidates a start continuation still awaiting kickoff delivery", async () => {


### PR DESCRIPTION
## Summary

- contain throwing accessors, revoked proxies, and malformed managed-run payloads at the protocol boundary, while revalidating session ownership after payload evaluation
- close a managed run as `cleared` with a superseded reason when a manual edit, replacement, skip, or priority transition rotates the active Goal id
- defer terminal event publication until the canonical Goal transition settles, preventing terminal listeners from re-entering and corrupting the old transition's remaining UI or cleanup
- retain synchronous `active` publication so cancellation from the first active event still suppresses kickoff delivery; generation guards drop queued terminal publication after session replacement or shutdown

## Confirmed failures fixed

The new regressions fail against #475 before this patch:

- throwing payload access produced no structured response and could escape the detached start handler
- a manual edit left the previous managed run open forever
- a completion listener could not start the next managed run
- a paused terminal listener could make stale pause work act on the replacement Goal

## Verification

- managed-run protocol suite — 28/28 passed
- `npm run check --workspace @narumitw/pi-goal`
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `npm run check` — 1,881/1,881 tests passed
- `just pack-goal` — dry-run package includes the hardened `src/run-protocol.ts`
- `git diff --check`
- Biome LSP diagnostics — 0 diagnostics

Stacked on #475; this PR intentionally targets `feat/pi-goal-managed-run-rpc` and contains only the hardening delta.
