### PR TITLE
fix(file-context): replace Fuse with bounded search

### DIFF
--- a/docs/plans/archived/2026-07-31_pi-file-context-native-fuzzy-search-plan.md
+++ b/docs/plans/archived/2026-07-31_pi-file-context-native-fuzzy-search-plan.md
@@ -1,0 +1,32 @@
+# pi-file-context native fuzzy search plan
+
+## Goal
+
+Replace Fuse.js with a bounded package-owned file-path matcher that preserves relevance ranking, typo tolerance, abbreviation matching, and empty-query ordering without allowing long pasted queries to freeze Pi's TUI.
+
+## Architecture
+
+- Keep `ProjectFileSearch` as the explorer-facing boundary and precompute normalized path, basename, and path-part data once per picker.
+- Rank exact, prefix, substring, ordered-subsequence, and bounded typo matches with deterministic original-order tie breaking.
+- Reject overlong normalized queries before candidate scoring so work remains bounded independently of project size.
+- Remove Fuse.js from runtime metadata and the lockfile.
+
+## Risks
+
+- A custom scorer can overmatch short queries or reorder exact basename results; focused tests will pin representative ranking, abbreviations, typo tolerance, empty input, and no-match behavior.
+- Timing assertions are flaky; the regression test will prove that an overlong query returns before touching candidate-owned search data rather than asserting wall-clock duration.
+- Dependency removal can drift package metadata; regenerate with the repository-pinned npm and inspect a package dry run.
+
+## Plan
+
+- [x] Added focused failing tests for abbreviation matching and overlong-query rejection; the Fuse implementation returned no abbreviation matches, and the first native version still accepted an exact 257-character query.
+- [x] Replaced `experimental/pi-file-context/src/file-search.ts` with the bounded native matcher; focused exact-path, abbreviation, typo, transposition, tokenized typo, empty, no-match, and query-bound tests pass.
+- [x] Removed Fuse.js with npm 12.0.2; manifest and lockfile removal is bounded, package typecheck passes, and the dry run contains the expected eight files with no bundled dependency.
+- [x] Ran `npm run check` successfully with 1,884 tests and audited the diff against extension conventions and adjacent search-input boundaries.
+
+## Completion Checklist
+
+- [x] No source, manifest, or lockfile reference to Fuse.js remains.
+- [x] Exact basename, full path, typo, abbreviation, no-match, and empty-query contracts have deterministic tests.
+- [x] Overlong search work is bounded before per-file scoring; 10,000-character synthetic input now returns before candidate traversal.
+- [x] `npm run check`, package dry run, Pi `--list-models` load smoke, and `git diff --check` pass.

--- a/experimental/pi-file-context/README.md
+++ b/experimental/pi-file-context/README.md
@@ -78,6 +78,7 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 - File paths and symlink targets are checked against the real project root before reading.
 - Preview files are limited to 1 MB and NUL-containing files are treated as binary.
 - Discovery is limited to 5,000 files and skips symlinks.
+- File-search queries are limited to 256 characters before candidate scoring.
 - Terminal control characters are escaped before file names, Git refs, authors, summaries, or file contents are rendered.
 - Git is invoked read-only without a shell, pager, external diff, or text conversion; commands time out after 5 seconds and output is bounded to 1.1 MB.
 - Revision names are resolved to a commit before file loading. Historical files remain subject to the 1 MB and binary guards.
@@ -101,6 +102,7 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 src/index.ts                 Thin Pi entrypoint
 src/file-context.ts            Lifecycle, filesystem boundaries, quote injection
 src/file-context-explorer.ts   File list, Git detail views, and line-range TUI
+src/file-search.ts             Bounded native fuzzy matching and relevance ranking
 src/git-context.ts             Bounded read-only Git status, diff, blame, history, revisions
 
 test/file-context.test.ts      Filesystem, prompt, lifecycle, and TUI tests

--- a/experimental/pi-file-context/package.json
+++ b/experimental/pi-file-context/package.json
@@ -43,8 +43,5 @@
 		"type": "git",
 		"url": "https://github.com/narumiruna/pi-extensions",
 		"directory": "experimental/pi-file-context"
-	},
-	"dependencies": {
-		"fuse.js": "^7.5.0"
 	}
 }

--- a/experimental/pi-file-context/src/file-search.ts
+++ b/experimental/pi-file-context/src/file-search.ts
@@ -1,39 +1,274 @@
-import Fuse from "fuse.js/basic";
-
-const SEARCH_THRESHOLD = 0.2;
-const BASENAME_WEIGHT = 0.7;
-const PATH_WEIGHT = 0.3;
+const MAX_SEARCH_QUERY_LENGTH = 256;
+const MAX_SEARCH_QUERY_PARTS = 8;
+const PATH_SCORE_PENALTY = 50;
+const PREFIX_SCORE = 100;
+const SUBSTRING_SCORE = 200;
+const TYPO_SCORE = 300;
+const SUBSEQUENCE_SCORE = 400;
+const TOKENIZED_SCORE = 500;
+const NO_MATCH = Number.POSITIVE_INFINITY;
+const PATH_PART_SEPARATOR = /[/._\-\s]+/u;
 
 interface ProjectFileEntry {
 	path: string;
-	basename: string;
+	normalizedPath: string;
+	normalizedBasename: string;
+	basenameParts: readonly string[];
+	pathParts: readonly string[];
+	originalIndex: number;
 }
+
+interface RankedProjectFile {
+	path: string;
+	score: number;
+	originalIndex: number;
+}
+
+type TypoDistanceCache = Map<string, Map<string, number | undefined>>;
 
 export class ProjectFileSearch {
 	private readonly files: readonly string[];
-	private readonly index: Fuse<ProjectFileEntry>;
+	private readonly entries: readonly ProjectFileEntry[];
 
 	constructor(files: readonly string[]) {
 		this.files = [...files];
-		this.index = new Fuse(
-			this.files.map((path) => ({
+		this.entries = this.files.map((path, originalIndex) => {
+			const normalizedPath = path.toLowerCase();
+			const normalizedBasename = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
+			return {
 				path,
-				basename: path.slice(path.lastIndexOf("/") + 1),
-			})),
-			{
-				keys: [
-					{ name: "basename", weight: BASENAME_WEIGHT },
-					{ name: "path", weight: PATH_WEIGHT },
-				],
-				ignoreLocation: true,
-				threshold: SEARCH_THRESHOLD,
-			},
-		);
+				normalizedPath,
+				normalizedBasename,
+				basenameParts: splitPathParts(normalizedBasename),
+				pathParts: splitPathParts(normalizedPath),
+				originalIndex,
+			};
+		});
 	}
 
 	search(query: string): string[] {
-		const normalizedQuery = query.trim();
-		if (!normalizedQuery) return [...this.files];
-		return this.index.search(normalizedQuery).map((result) => result.item.path);
+		const trimmedQuery = query.trim();
+		if (!trimmedQuery) return [...this.files];
+		if (trimmedQuery.length > MAX_SEARCH_QUERY_LENGTH) return [];
+		const normalizedQuery = trimmedQuery.toLowerCase();
+		const queryParts = splitPathParts(normalizedQuery);
+		const typoDistanceCache: TypoDistanceCache = new Map();
+
+		return this.entries
+			.flatMap((entry): RankedProjectFile[] => {
+				const score = scoreEntry(normalizedQuery, queryParts, entry, typoDistanceCache);
+				return Number.isFinite(score)
+					? [{ path: entry.path, score, originalIndex: entry.originalIndex }]
+					: [];
+			})
+			.sort((left, right) => left.score - right.score || left.originalIndex - right.originalIndex)
+			.map((result) => result.path);
 	}
+}
+
+function scoreEntry(
+	query: string,
+	queryParts: readonly string[],
+	entry: ProjectFileEntry,
+	typoDistanceCache: TypoDistanceCache,
+): number {
+	const basenameScore = scoreField(
+		query,
+		queryParts,
+		entry.normalizedBasename,
+		entry.basenameParts,
+		typoDistanceCache,
+	);
+	const pathScore = scoreField(
+		query,
+		queryParts,
+		entry.normalizedPath,
+		entry.pathParts,
+		typoDistanceCache,
+	);
+	return Math.min(basenameScore, pathScore + PATH_SCORE_PENALTY);
+}
+
+function scoreField(
+	query: string,
+	queryParts: readonly string[],
+	text: string,
+	textParts: readonly string[],
+	typoDistanceCache: TypoDistanceCache,
+): number {
+	const directScore = scoreText(query, text);
+	if (directScore < TYPO_SCORE) return directScore;
+	const typoScore = scoreTypo(query, textParts, typoDistanceCache);
+	if (Number.isFinite(typoScore)) return Math.min(directScore, typoScore);
+	if (Number.isFinite(directScore)) return directScore;
+	return scoreTokenized(queryParts, textParts, typoDistanceCache);
+}
+
+function scoreTokenized(
+	queryParts: readonly string[],
+	candidateParts: readonly string[],
+	typoDistanceCache: TypoDistanceCache,
+): number {
+	if (queryParts.length < 2 || queryParts.length > MAX_SEARCH_QUERY_PARTS) return NO_MATCH;
+
+	let totalScore = TOKENIZED_SCORE;
+	for (const queryPart of queryParts) {
+		let bestDirectScore = NO_MATCH;
+		for (let index = 0; index < candidateParts.length; index += 1) {
+			bestDirectScore = Math.min(
+				bestDirectScore,
+				scoreText(queryPart, candidateParts[index] ?? "") + index * 2,
+			);
+		}
+		const bestPartScore =
+			bestDirectScore < TYPO_SCORE
+				? bestDirectScore
+				: Math.min(bestDirectScore, scoreTypo(queryPart, candidateParts, typoDistanceCache));
+		if (!Number.isFinite(bestPartScore)) return NO_MATCH;
+		totalScore += bestPartScore;
+	}
+	return totalScore;
+}
+
+function scoreText(query: string, text: string): number {
+	if (query === text) return 0;
+	if (text.startsWith(query)) return PREFIX_SCORE + lengthPenalty(query, text);
+
+	const substringIndex = text.indexOf(query);
+	if (substringIndex >= 0) {
+		return SUBSTRING_SCORE + substringIndex * 2 + lengthPenalty(query, text);
+	}
+
+	return scoreSubsequence(query, text);
+}
+
+function scoreSubsequence(query: string, text: string): number {
+	let queryIndex = 0;
+	let firstMatch = -1;
+	let previousMatch = -1;
+	let gaps = 0;
+	let boundaryMatches = 0;
+	let consecutiveMatches = 0;
+
+	for (let textIndex = 0; textIndex < text.length && queryIndex < query.length; textIndex += 1) {
+		if (text[textIndex] !== query[queryIndex]) continue;
+		if (firstMatch < 0) firstMatch = textIndex;
+		if (previousMatch >= 0) {
+			const gap = textIndex - previousMatch - 1;
+			gaps += gap;
+			if (gap === 0) consecutiveMatches += 1;
+		}
+		if (textIndex === 0 || PATH_PART_SEPARATOR.test(text[textIndex - 1] ?? "")) {
+			boundaryMatches += 1;
+		}
+		previousMatch = textIndex;
+		queryIndex += 1;
+	}
+
+	if (queryIndex !== query.length) return NO_MATCH;
+	return (
+		SUBSEQUENCE_SCORE +
+		gaps * 3 +
+		firstMatch * 2 +
+		lengthPenalty(query, text) -
+		boundaryMatches * 8 -
+		consecutiveMatches
+	);
+}
+
+function scoreTypo(
+	query: string,
+	parts: readonly string[],
+	typoDistanceCache: TypoDistanceCache,
+): number {
+	const maxDistance = allowedTypoDistance(query.length);
+	if (maxDistance === 0) return NO_MATCH;
+
+	let bestScore = NO_MATCH;
+	for (let index = 0; index < parts.length; index += 1) {
+		const part = parts[index] ?? "";
+		if (Math.abs(query.length - part.length) > maxDistance) continue;
+		const distance = cachedTypoDistance(query, part, maxDistance, typoDistanceCache);
+		if (distance === undefined || distance === 0) continue;
+		bestScore = Math.min(
+			bestScore,
+			TYPO_SCORE + distance * 20 + index * 2 + Math.abs(query.length - part.length),
+		);
+	}
+	return bestScore;
+}
+
+function cachedTypoDistance(
+	query: string,
+	part: string,
+	maxDistance: number,
+	cache: TypoDistanceCache,
+): number | undefined {
+	let queryCache = cache.get(query);
+	if (!queryCache) {
+		queryCache = new Map();
+		cache.set(query, queryCache);
+	}
+	if (queryCache.has(part)) return queryCache.get(part);
+	const distance = boundedDamerauLevenshtein(query, part, maxDistance);
+	queryCache.set(part, distance);
+	return distance;
+}
+
+function boundedDamerauLevenshtein(
+	left: string,
+	right: string,
+	maxDistance: number,
+): number | undefined {
+	if (Math.abs(left.length - right.length) > maxDistance) return undefined;
+
+	const unreachable = maxDistance + 1;
+	let previousPrevious = Array.from({ length: left.length + 1 }, () => unreachable);
+	let previous = Array.from({ length: left.length + 1 }, (_, index) =>
+		index <= maxDistance ? index : unreachable,
+	);
+
+	for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+		const current = Array.from({ length: left.length + 1 }, () => unreachable);
+		if (rightIndex <= maxDistance) current[0] = rightIndex;
+		const start = Math.max(1, rightIndex - maxDistance);
+		const end = Math.min(left.length, rightIndex + maxDistance);
+		for (let leftIndex = start; leftIndex <= end; leftIndex += 1) {
+			const substitutionCost = left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1;
+			current[leftIndex] = Math.min(
+				(previous[leftIndex] ?? unreachable) + 1,
+				(current[leftIndex - 1] ?? unreachable) + 1,
+				(previous[leftIndex - 1] ?? unreachable) + substitutionCost,
+			);
+			if (
+				leftIndex > 1 &&
+				rightIndex > 1 &&
+				left[leftIndex - 1] === right[rightIndex - 2] &&
+				left[leftIndex - 2] === right[rightIndex - 1]
+			) {
+				current[leftIndex] = Math.min(
+					current[leftIndex] ?? unreachable,
+					(previousPrevious[leftIndex - 2] ?? unreachable) + 1,
+				);
+			}
+		}
+		previousPrevious = previous;
+		previous = current;
+	}
+
+	const distance = previous[left.length] ?? unreachable;
+	return distance <= maxDistance ? distance : undefined;
+}
+
+function allowedTypoDistance(queryLength: number): number {
+	if (queryLength < 5) return 0;
+	return queryLength < 10 ? 1 : 2;
+}
+
+function splitPathParts(value: string): string[] {
+	return value.split(PATH_PART_SEPARATOR).filter(Boolean);
+}
+
+function lengthPenalty(query: string, text: string): number {
+	return Math.max(0, text.length - query.length) / 100;
 }

--- a/experimental/pi-file-context/test/file-context.test.ts
+++ b/experimental/pi-file-context/test/file-context.test.ts
@@ -100,9 +100,24 @@ test("ranks fuzzy file matches and tolerates typos", () => {
 		"file-context.ts-notes/README.md",
 	]);
 	assert.deepEqual(search.search("src/settings"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("fc"), ["src/file-context.ts", "file-context.ts-notes/README.md"]);
+	assert.deepEqual(search.search("stg"), ["src/settings.ts"]);
 	assert.deepEqual(search.search("setxings"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("settigns"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("file-contexx.ts"), [
+		"src/file-context.ts",
+		"file-context.ts-notes/README.md",
+	]);
 	assert.deepEqual(search.search("zzzzzz"), []);
 	assert.deepEqual(search.search("  "), files);
+});
+
+test("bounds fuzzy search before scoring overlong pasted queries", () => {
+	const maximumQuery = "a".repeat(256);
+	const overlongQuery = `${maximumQuery}a`;
+
+	assert.deepEqual(new ProjectFileSearch([maximumQuery]).search(maximumQuery), [maximumQuery]);
+	assert.deepEqual(new ProjectFileSearch([overlongQuery]).search(overlongQuery), []);
 });
 
 test("explorer previews a file, selects a range, and keeps rendered rows width-safe", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,6 @@
 			"name": "@narumitw/pi-file-context",
 			"version": "0.40.1",
 			"license": "MIT",
-			"dependencies": {
-				"fuse.js": "^7.5.0"
-			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
 				"@earendil-works/pi-coding-agent": "0.83.0",
@@ -5430,19 +5427,6 @@
 			},
 			"engines": {
 				"node": ">=12.20.0"
-			}
-		},
-		"node_modules/fuse.js": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
-			"integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/krisk"
 			}
 		},
 		"node_modules/gaxios": {


### PR DESCRIPTION
## Summary

- replace Fuse.js with a package-owned deterministic file-path matcher
- preserve exact, prefix, substring, abbreviation, tokenized, and typo-tolerant ranking
- reject search queries over 256 characters before candidate scoring to prevent TUI stalls
- remove the Fuse.js runtime dependency and document/test the new search boundary

## Verification

- `npm run check` (1,884 tests passed)
- `npm pack --workspace @narumitw/pi-file-context --dry-run --json`
- `pi --no-session -e ./experimental/pi-file-context --list-models`
- `git diff --check`
