### PR TITLE
feat(tui-kit): add agent interaction flows

### DIFF
--- a/docs/plans/archived/2026-07-31_pi-tui-kit-agent-flows-plan.md
+++ b/docs/plans/archived/2026-07-31_pi-tui-kit-agent-flows-plan.md
@@ -1,0 +1,316 @@
+# Pi TUI Kit Agent-Level Flows Plan
+
+## Goal
+
+Extend `@narumitw/pi-tui-kit` with three reusable composites that Pi coding-agent already
+assembles above the raw `pi-tui` primitives:
+
+1. a standalone, cancellable `runTask()` flow;
+2. a declarative single-line `input` menu screen; and
+3. a bounded, scrollable `review` menu screen for exact text, code, and diffs.
+
+The change must preserve existing menu behavior, keep domain state and persistence in consuming
+extensions, and enforce TUI/RPC/lifecycle behavior once inside the kit instead of repeating it in
+callers.
+
+## Context
+
+- `packages/pi-tui-kit/src/runtime.ts` already embeds `BorderedLoader` for `busyLabel`, but no public
+  task helper exists. Similar cancellation/result wrappers are repeated in
+  `extensions/pi-image-drop/src/menu.ts`, `extensions/pi-usage/src/usage.ts`,
+  `extensions/pi-sync/src/manager-ui.ts`, `extensions/pi-btw/src/btw.ts`, and
+  `experimental/pi-jupyter/src/jupyter-preview.ts`.
+- Pi exposes `ExtensionInputComponent`, `ExtensionEditorComponent`, `ctx.ui.input()`, and
+  `ctx.ui.editor()`, while the kit cannot currently place text entry inside its screen stack.
+  `extensions/pi-image-drop/src/menu.ts` consequently owns a custom input component to distinguish
+  Back from Close and retain menu semantics.
+- The existing `detail` screen word-wraps prose. It is unsuitable for code and diffs because exact
+  whitespace can be lost and there is no viewport. Scroll/review behavior is independently owned by
+  `extensions/pi-btw/src/bring-to-main.ts`, `extensions/pi-btw/src/transcript-pager.ts`,
+  `experimental/pi-file-context/src/file-context-explorer.ts`, and
+  `experimental/pi-jupyter/src/notebook-panel.ts`.
+- Pi coding-agent publicly provides relevant higher-level behavior such as `BorderedLoader`,
+  `renderDiff()`, `highlightCode()`, `getLanguageFromPath()`, keybinding hints, and visual truncation;
+  raw `pi-tui` provides the lower-level components, key matching, width utilities, and focus model.
+- Guides read for this plan: `docs/extension-conventions.md`, Pi's `docs/extensions.md`, `docs/tui.md`,
+  `docs/rpc.md`, and `docs/keybindings.md`. Applicable MUST areas are TUI/non-interactive mode
+  guards, width-bounded rendering, callback theme/keybindings, IME focus forwarding, cancellation and
+  disposal, stale-context protection, reusable-library boundaries, deterministic tests, the root
+  check, and package dry-run inspection. `docs/extension-settings.md` is not applicable because the
+  kit will not load, validate, or persist extension settings.
+
+## Architecture
+
+### Public contracts
+
+#### `runTask()`
+
+Add a public helper with a generic context and typed terminal result. Final naming and parameter
+ordering should be locked by type tests before implementation, with this intended shape:
+
+```ts
+const result = await runTask(ctx, {
+  label: "Loading usage…",
+  signal: sessionSignal,
+  isCurrent: () => generation === currentGeneration(),
+  task: ({ signal }) => loadUsage(signal),
+  onError: (_ctx, error) => reportError(error),
+});
+```
+
+```ts
+type RunTaskResult<T> =
+  | { kind: "completed"; value: T }
+  | { kind: "cancelled" }
+  | { kind: "stale" }
+  | { kind: "error"; error: unknown };
+```
+
+The result meanings are part of the public contract:
+
+- `completed`: the task settled successfully while its owner was current;
+- `cancelled`: the user cancelled the task through the task UI;
+- `stale`: the owner signal aborted, `isCurrent()` failed, or Pi externally disposed the task UI;
+- `error`: a non-cancellation failure occurred while the owner was still current.
+
+The kit owns signal composition, exactly-once settlement, stale checks after every await, error
+reporting fallback, component disposal, and draining the task before returning. The supplied task
+must honor its signal so cancellation can finish; the kit will not hide an uncooperative task behind
+an arbitrary timeout.
+
+`runMenu()` busy actions must use the same internal task flow so standalone tasks and `busyLabel`
+actions cannot drift in cancellation or disposal behavior.
+
+#### `input` screen
+
+Add a screen whose submitted raw value is delivered through the existing action context `value`:
+
+```ts
+{
+  kind: "input",
+  title: "Maximum image count",
+  lines: ["Current: 20"],
+  placeholder: "Enter a positive integer",
+  action: "setMaximum",
+  hint: "back",
+}
+```
+
+The kit owns the draft, focus forwarding, submit/pending state, Back/Close distinction, action
+serialization, rejected-action recovery, and mode adaptation. The consuming action owns validation,
+normalization, persistence, and product-specific errors. A rejected or thrown action keeps the same
+TUI draft available for correction; an accepted transition follows the normal navigator semantics.
+
+TUI uses an injected-theme/keybinding component built from public `pi-tui` controls rather than
+instantiating Pi's globally themed extension input component. RPC uses `ctx.ui.input()` with the
+combined owner signal and reopens the dialog after a rejected action. Print and JSON retain the
+existing unsupported-menu contract.
+
+Version one will not add secret masking, an initial editable value, or multi-field forms because Pi's
+cross-mode input protocol does not provide those contracts consistently.
+
+#### `review` screen
+
+Add a read-only screen with raw content, an explicit rendering format, a bounded viewport, and at
+most one primary confirmation action:
+
+```ts
+{
+  kind: "review",
+  title: "Review configuration changes",
+  content: unifiedDiff,
+  format: { kind: "diff", filePath: settingsPath },
+  viewportSize: 14,
+  confirm: { id: "apply", label: "Apply", action: "apply" },
+  hint: "back",
+}
+```
+
+The intended format union is exact text, code with an optional language/file path, and unified diff.
+The final discriminated type must be fixed by public type tests. The kit owns terminal-control
+sanitization, cell-aware hard wrapping that preserves whitespace, themed rendering, scroll clamping,
+Page Up/Page Down behavior, position feedback, width bounds, confirmation dispatch, and Back/Close.
+The consumer owns the content, consequences, confirmation wording, and mutation.
+
+TUI renders a fixed-size viewport so it does not need undocumented terminal-height access. RPC
+presents bounded pages through signal-aware `ctx.ui.select()` dialogs with Previous/Next, the primary
+action when present, and Back/Close. It must never send the full unbounded document as one RPC title.
+Print and JSON retain the existing unsupported-menu contract.
+
+Use only package-root Pi imports. Prefer Pi's public highlighting/diff helpers when deterministic tests
+prove they sanitize input, rebuild correctly after theme invalidation, and preserve width; otherwise
+implement the smallest callback-themed adapter in the kit rather than deep-importing Pi internals.
+
+### Internal ownership and layout
+
+- Add `packages/pi-tui-kit/src/task.ts` for standalone task orchestration and the reusable internal
+  task runner used by menu busy actions.
+- Add `packages/pi-tui-kit/src/components/input.ts` for the input component and its pending/draft
+  state.
+- Add `packages/pi-tui-kit/src/components/review.ts` for review formatting, viewport state, and input
+  handling; extract an exact-wrap helper beside it if tests show the responsibility is independently
+  reusable.
+- Keep `packages/pi-tui-kit/src/components/index.ts` as dispatch/composition rather than adding both
+  implementations inline.
+- Extend `packages/pi-tui-kit/src/types.ts`, `src/model.ts`, `src/runtime.ts`, and `src/index.ts` only
+  with the public unions, validation, mode adapters, and exports they own.
+- Raise `PI_EXTENSION_MENU_API_VERSION` from `2` to `3` because older runtimes cannot interpret the
+  new screen discriminants. Do not hand-edit the npm package version; release versioning remains a
+  separate repository workflow.
+
+### Lifecycle and mode requirements
+
+Audit these paths independently for each asynchronous flow:
+
+- user cancellation;
+- component disposal;
+- owner/session signal abort;
+- `isCurrent()` becoming false after an await;
+- TUI replacement by another custom component;
+- action/task success and failure racing with cancellation; and
+- shutdown/session replacement while RPC waits for a response.
+
+After any owner becomes stale, no continuation may report success, invoke another action, reopen a
+screen, or use the captured context. Pending work must be aborted and drained before the public
+promise resolves.
+
+## Non-Goals
+
+- Do not add the multi-line `editor` screen in this change. Pi's `ctx.ui.editor()` currently lacks an
+  `AbortSignal` option, so it cannot satisfy the same RPC/session-replacement contract.
+- Do not wrap `ModelSelectorComponent`, `SessionSelectorComponent`, `TreeSelectorComponent`, or other
+  Pi-domain selectors; they remain coupled to Pi's model/session managers.
+- Do not re-export shallow aliases for `DynamicBorder`, `keyHint()`, `Text`, `Box`, or other directly
+  importable primitives.
+- Do not add settings schemas, persistence, migrations, domain validation, live cursor-driven
+  previews, external-editor launching, horizontal scrolling, or consumer-specific confirmations.
+- Do not migrate existing extension call sites in the initial package change. The existing
+  `busyLabel` path is the first in-package consumer; extension migrations should be separate bounded
+  follow-ups after the public contract ships.
+- Do not add runtime dependencies; the existing Pi peer packages must provide all required behavior.
+
+## Assumptions
+
+- Existing action, detail, choice, settings, and multi-select definitions remain source-compatible and
+  behavior-compatible.
+- RPC clients can display multiline `select` titles, as documented by Pi's extension UI protocol;
+  review pages will nevertheless be bounded to limit protocol/UI burden.
+- `input` action rejection is observable through the existing `onError`/notification path, while the
+  draft remains in the active TUI component.
+- Exact review content is untrusted terminal input and must be sanitized before any highlighting or
+  wrapping.
+
+## Risks
+
+- Refactoring busy actions onto `runTask()` can subtly change whether Escape returns to the menu or
+  exits stale. Preserve the existing `runtime.test.ts` behavior before migrating the path.
+- Pi's public `renderDiff()` reads Pi's active theme internally rather than accepting the callback
+  theme. Theme-switch and invalidation tests must decide whether it is safe to reuse.
+- ANSI-aware hard wrapping can corrupt style resets, split wide graphemes, or lose indentation.
+  Exercise narrow widths, CJK/emoji, tabs, long unbroken tokens, ANSI styles, and terminal controls.
+- RPC review pagination can create label collisions or navigation loops. Keep raw action identity
+  separate from display labels and test cancellation at every page.
+- New screen kinds expand a public discriminated union. API version `3`, declaration output, README
+  examples, and the packed tarball must agree.
+
+## Plan
+
+### 1. Establish the task contract and shared runner
+
+- [x] Add red-first public type and behavior coverage in
+  `packages/pi-tui-kit/test/task.test.ts` and `test/context-usage.ts` for `runTask()` completion,
+  user cancellation, owner abort, stale generation, external disposal, task draining, real errors,
+  rejecting error reporters, and TUI versus non-TUI execution. Evidence: package typechecking failed
+  on the missing `runTask` export and task callback types before implementation.
+- [x] Implement `packages/pi-tui-kit/src/task.ts` and export its function/result/options types from
+  `src/index.ts`, yielding exactly one typed terminal result while combining cancellation and stale
+  ownership. Evidence: package typechecking and all seven focused task tests pass.
+- [x] Refactor the `busyLabel` branch in `packages/pi-tui-kit/src/runtime.ts` to use the shared task
+  runner without changing menu outcomes. Evidence: all 25 focused runtime regressions and all six
+  task tests pass together.
+
+### 2. Add the declarative input screen
+
+- [x] Add red-first type, validation, component, and runtime cases in
+  `packages/pi-tui-kit/test/menu-model.test.ts`, a new `test/input-screen.test.ts`, and
+  `test/readme-usage.ts` for the intended `InputScreen` contract. Evidence: package typechecking
+  failed only on the missing screen type, component callback, and screen union before implementation.
+- [x] Implement `InputScreen` validation and the focused TUI component in
+  `packages/pi-tui-kit/src/types.ts`, `src/model.ts`, and `src/components/input.ts`, preserving raw
+  submitted values while sanitizing display text, keeping rejected drafts, serializing submission,
+  bounding every width, rebuilding themed content, and aborting/draining on disposal. Evidence: all
+  focused input component and model tests pass across widths 1–120.
+- [x] Integrate input dispatch and action handling into `src/components/index.ts` and
+  `src/runtime.ts`, using `ctx.ui.input(..., { signal })` in RPC and preserving TUI Back versus
+  Ctrl+C Close semantics. Evidence: seven focused input runtime/component tests cover RPC retry and
+  cancellation, TUI draft retention, action disposal, owner abort, raw values, and no RPC custom UI.
+
+### 3. Add the bounded review screen
+
+- [x] Add red-first type, validation, formatting, viewport, and RPC pagination cases in
+  `packages/pi-tui-kit/test/menu-model.test.ts`, a new `test/review-screen.test.ts`, and
+  `test/readme-usage.ts` for exact text, code, diff, optional confirmation, viewport bounds, and
+  invalid configurations. Evidence: package typechecking failed only on the unsupported review
+  discriminant and missing public type before implementation.
+- [x] Implement review sanitization, exact cell-aware wrapping, theme-aware text/code/diff formatting,
+  and viewport state in `packages/pi-tui-kit/src/components/review.ts`, keeping every rendered line
+  within widths `1`, `2`, `8`, `20`, `40`, `80`, and `120`. Evidence: focused tests pass for
+  CJK/emoji, tabs, indentation, long tokens, control bytes, resize clamping, and line/page scrolling.
+- [x] Integrate review confirmation and exits into `src/components/index.ts`, `src/model.ts`, and
+  `src/runtime.ts`, and implement bounded signal-aware RPC pages with collision-free labels. Evidence:
+  focused TUI/RPC tests prove raw confirmation identity, bounded pagination, label collision handling,
+  owner abort, Back/Close, read-only behavior, and no RPC custom TUI.
+
+### 4. Finalize the public API and documentation
+
+- [x] Raise `PI_EXTENSION_MENU_API_VERSION` to `3`, export the new task and screen types from
+  `packages/pi-tui-kit/src/index.ts`, and extend `test/context-usage.ts` with positive and negative
+  compile-time examples. Evidence: existing screen definitions remain unchanged, invalid action ids
+  are compile-time errors, and package typechecking passes.
+- [x] Update `packages/pi-tui-kit/README.md` with `runTask()`, input, and review examples, the complete
+  mode/cancellation behavior, API version `3`, ownership boundaries, editor deferral, and package
+  layout while preserving the existing English title, badges, and standard sections. Evidence:
+  `test/readme-usage.ts` mirrors and typechecks every new public shape.
+- [x] Rebuild `packages/pi-tui-kit/dist/` using the package build script and inspect declarations and
+  JavaScript exports for source parity. Evidence: generated declarations expose `runTask`, input,
+  review, and API version `3`; `npm run check --workspace @narumitw/pi-tui-kit` passes cleanly.
+
+### 5. Verify runtime and publication behavior
+
+- [x] Run a temporary built-package TUI-host smoke that exercises successful and cancelled
+  `runTask()`, input rejection with draft correction, review scrolling/resizing, confirmation, Back,
+  and Ctrl+C Close. Evidence: `node node_modules/.cache/pi-tui-kit-consumer-smoke.mjs` passed against
+  package-root imports from generated `dist/`. Accepted deviation: repository instructions prohibit
+  launching an interactive TUI, so the smoke used Pi's real components with an automated custom-UI
+  host rather than opening an interactive Pi process; deterministic TUI tests cover the same inputs.
+- [x] Run an RPC smoke or deterministic protocol harness for task execution, signal-cancelled input,
+  rejected input retry, review pagination, confirmation, and cancellation. Evidence:
+  `node node_modules/.cache/pi-tui-kit-rpc-client.mjs` passed against a real `pi --mode rpc` process;
+  focused owner-abort tests cover signal cancellation, no custom request was emitted, and every
+  observed review title was bounded below 2,000 characters.
+- [x] Run `npm test`, `npm run check`, and `just pack-tui-kit`, inspect the tarball for `dist/`,
+  declarations, README, and LICENSE only. Evidence: 1,907 root tests pass, the CI-equivalent root
+  check exits successfully, and the 27-file dry-run tarball contains package metadata, LICENSE,
+  README, generated JavaScript, and declarations with no source or tests.
+- [x] Audit the final diff against the TUI/non-interactive, lifecycle, package-boundary,
+  documentation, and verification MUST rules in `docs/extension-conventions.md`. Evidence: all new
+  custom UI is TUI-guarded and width-tested; RPC uses signal-aware dialogs; tasks/actions abort and
+  drain on cancellation, disposal, and replacement; imports use Pi package roots; no persistence or
+  dependency moved into the kit; the largest changed source file is 767 lines; LSP reports zero
+  diagnostics; and the automated-host TUI smoke deviation is documented above.
+
+## Completion Checklist
+
+- [x] `runTask()` has one public contract shared by standalone callers and menu busy actions, proven
+  by task and regression tests.
+- [x] Input screens preserve raw payload identity, rejected drafts, IME focus, width safety,
+  cancellation, disposal, stale ownership, and TUI/RPC adaptation.
+- [x] Review screens preserve exact safe content, remain width/viewport bounded, scroll predictably,
+  dispatch optional confirmation by raw id, and paginate safely in RPC.
+- [x] Existing menu definitions and behavior remain compatible; the new screen capability is marked
+  by `PI_EXTENSION_MENU_API_VERSION === 3`.
+- [x] Source, declarations, generated `dist/`, README examples, and packed contents expose the same
+  API.
+- [x] Focused tests, `npm test`, `npm run check`, automated-host TUI and real-Pi RPC smokes, and
+  `just pack-tui-kit` all pass; the prohibited interactive-TUI path is explicitly covered by the
+  documented automated-host deviation.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -7,7 +7,8 @@ Reusable navigation helpers and typed, declarative interaction flows for indepen
 [Pi](https://pi.dev) extensions, built on
 [`@earendil-works/pi-tui`](https://www.npmjs.com/package/@earendil-works/pi-tui). The initial
 high-level API lets extensions describe menu screens and domain actions while this package owns
-standard rendering, navigation, mode adaptation, cancellation, and lifecycle behavior.
+standard rendering, navigation, mode adaptation, cancellation, and lifecycle behavior. It also
+provides a standalone task runner for abort-aware work that needs Pi's cancellable TUI loader.
 
 ## 📦 Install
 
@@ -94,9 +95,30 @@ export async function showMenu(ctx: ExtensionCommandContext, generation: number)
 The state loader runs again whenever a screen is entered or refreshed, so screen factories can
 remain pure projections of current extension state.
 
+For abort-aware work outside a menu, use `runTask()`. TUI mode shows Pi's cancellable bordered
+loader; RPC, print, and JSON execute the same task directly. User cancellation, owner replacement,
+external component disposal, errors, and successful completion remain distinct typed results.
+
+```ts
+import { runTask } from "@narumitw/pi-tui-kit";
+
+const result = await runTask(ctx, {
+  label: "Refreshing domain state…",
+  signal: currentSessionSignal(),
+  isCurrent: () => generation === currentGeneration(),
+  task: ({ signal }) => refreshDomainState(signal),
+  onError: (_ctx, error) => ctx.ui.notify(formatError(error), "error"),
+});
+
+if (result.kind === "completed") ctx.ui.notify("Refreshed", "info");
+```
+
+A task must honor its supplied signal. The runner aborts and drains owned work before returning; it
+does not hide an uncooperative task behind an arbitrary timeout.
+
 ## 🖥️ Standard screens
 
-`defineMenu()` supports five standard screen kinds:
+`defineMenu()` supports seven standard screen kinds:
 
 - **`actions`** — navigation targets, domain actions, close rows, and optional cancellable busy
   labels.
@@ -105,6 +127,10 @@ remain pure projections of current extension state.
   selected details, disabled explanations, and a bounded viewport.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
   serialized saves, and rollback when an action rejects.
+- **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission,
+  rejected-draft retention, and TUI/RPC adaptation.
+- **`review`** — bounded, scrollable exact text, code, or diff content with an optional primary
+  confirmation action and paginated RPC fallback.
 - **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback,
   selected-row descriptions, optional fuzzy search and bulk action rows, and a bounded TUI viewport.
 
@@ -156,6 +182,40 @@ selected value. Changes save immediately, so Back or Close never implies rollbac
 search input forwards focus for IME positioning. The kit owns this adapter because Pi's public
 `SettingsList` does not currently expose restored-cursor, disabled-row, async rollback, and search
 focus behavior together.
+
+Input screens submit through the existing action `value`. Validation, normalization, persistence,
+and product copy remain extension-owned. Rejection keeps the TUI draft available for correction;
+RPC reopens its signal-aware input dialog.
+
+```ts
+const inputScreen = {
+  kind: "input" as const,
+  title: "Maximum image count",
+  lines: ["Current: 20"],
+  placeholder: "Enter a positive integer",
+  action: "setMaximum" as const,
+};
+```
+
+Review screens preserve indentation and hard-wrap by terminal cells rather than prose words. Their
+viewport supports Up, Down, Page Up, Page Down, Home, and End. RPC sends bounded pages instead of one
+unbounded dialog title. Treat `content` as untrusted display input; the kit strips terminal controls
+before formatting it.
+
+```ts
+const reviewScreen = {
+  kind: "review" as const,
+  title: "Review configuration changes",
+  content: unifiedDiff,
+  format: { kind: "diff" as const, filePath: settingsPath },
+  viewportSize: 14,
+  confirm: { id: "apply", label: "Apply", action: "apply" as const },
+};
+```
+
+Review formats are `{ kind: "text" }`, `{ kind: "code", language?, filePath? }`, and
+`{ kind: "diff", filePath? }`. The viewport maximum is 50 rows. A review without `confirm` is
+read-only. Escape follows Back/Close and `Ctrl+C` closes the whole menu.
 
 Action handlers return one of these results:
 
@@ -250,7 +310,9 @@ pi.on("agent_settled", async (_event, ctx) => {
 
 The consumer must own and abort the session signal, check its generation or equivalent identity after
 every await, and never retain or use an `ExtensionContext` after session replacement, reload, or
-shutdown. The kit does not create lifecycle ownership for the extension.
+shutdown. The kit does not create lifecycle ownership for the extension. `input` uses a signal-aware
+RPC dialog; a multi-line `editor` screen is intentionally deferred because Pi's current RPC editor
+contract does not accept an `AbortSignal`.
 
 ## 🧩 Ownership boundary
 
@@ -261,11 +323,13 @@ cross-mode and lifecycle contract shared by multiple extensions.
 
 The library owns:
 
+- standalone task-mode adaptation, cancellation, stale checks, error routing, and draining;
 - width-safe standard rendering and injected keybindings;
 - screen-stack navigation, Back/Close semantics, and per-screen cursor memory;
 - serial settings and multi-select updates, optimistic rollback, and pending-update draining;
 - menu, screen, and busy-action cancellation;
 - stale-continuation checks around asynchronous work;
+- input draft/pending behavior and exact review formatting, scrolling, and RPC pagination;
 - TUI/RPC adaptation and unsupported-mode routing.
 
 The consuming extension still owns:
@@ -274,7 +338,8 @@ The consuming extension still owns:
 - transactional persistence and preservation of unknown settings fields;
 - confirmations and product-specific copy;
 - session generation and shutdown policy supplied through `isCurrent()`;
-- specialized editors, previews, forms, or other custom TUI.
+- multi-line editors, secret inputs, live side-effecting previews, multi-field forms, or other
+  specialized custom TUI.
 
 Keep specialized UI local rather than adding package hooks that expose Pi TUI internals.
 
@@ -282,17 +347,18 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 
 - `defineMenu()` — validates and returns a typed menu definition.
 - `runMenu()` — runs the definition in the current Pi mode.
+- `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, and result types.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`2`). Optional multi-select
-  search is additive: version-2 runtimes that do not implement it safely retain the full unfiltered
-  multi-select rather than rejecting an otherwise compatible screen.
+- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`3`). Version 3 adds `input`
+  and `review` screen discriminants; existing version-2 menu definitions remain source-compatible.
 
 ## 🗂️ Package layout
 
 - `src/` — authored TypeScript and the public package entrypoint
-- `src/components/` — internal TUI screen adapters, contracts, and rendering helpers
+- `src/components/` — internal TUI input, review, list, settings, and rendering adapters
+- `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `dist/` — generated ESM and declarations included in the npm package
 - `test/` — contract, renderer, navigation, and lifecycle coverage
 

--- a/packages/pi-tui-kit/src/components/contracts.ts
+++ b/packages/pi-tui-kit/src/components/contracts.ts
@@ -9,6 +9,7 @@ const MENU_BINDINGS = [
 	"tui.select.pageDown",
 	"tui.select.confirm",
 	"tui.select.cancel",
+	"tui.input.submit",
 ] as const;
 export type MenuBinding = (typeof MENU_BINDINGS)[number];
 
@@ -38,6 +39,10 @@ export interface MenuMultiSelectChange {
 	previousSelected: boolean;
 }
 
+export interface MenuInputSubmit {
+	value: string;
+}
+
 export interface MenuScreenComponent extends Component {
 	readonly __piTuiKitScreen?: true;
 	handleInput(data: string): void;
@@ -59,6 +64,7 @@ export interface MenuScreenComponentOptions<ScreenId extends string, ActionId ex
 	onSelectionChange?(itemId: string): void;
 	onSettingChange?(change: MenuSettingChange): Promise<MenuChangeResponse<ScreenId>>;
 	onMultiSelectChange?(change: MenuMultiSelectChange): Promise<MenuChangeResponse<ScreenId>>;
+	onInputSubmit?(change: MenuInputSubmit): Promise<MenuChangeResponse<ScreenId>>;
 	onTransition?(transition: MenuTransition<ScreenId>): void;
 	onError?(error: unknown): void;
 	onDispose?(): void;

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -19,10 +19,13 @@ import type {
 	MenuScreenComponentOptions,
 	MultiSelectOptions,
 } from "./contracts.js";
+import { createInputComponent, type InputOptions } from "./input.js";
 import { createMultiSelectComponent } from "./multi-select.js";
 import { handleSearchInput, menuHint, renderFrame, safeMenuText } from "./rendering.js";
+import { createReviewComponent, type ReviewOptions } from "./review.js";
 
 export type {
+	MenuInputSubmit,
 	MenuMultiSelectChange,
 	MenuScreenComponent,
 	MenuScreenComponentOptions,
@@ -30,6 +33,7 @@ export type {
 	MenuSettingChange,
 } from "./contracts.js";
 export { safeMenuText } from "./rendering.js";
+export { reviewDialogPages } from "./review.js";
 
 export function createMenuScreenComponent<ScreenId extends string, ActionId extends string>(
 	options: MenuScreenComponentOptions<ScreenId, ActionId>,
@@ -47,6 +51,12 @@ export function createMenuScreenComponent<ScreenId extends string, ActionId exte
 			break;
 		case "settings":
 			component = createSettingsComponent(options as SettingsOptions<ScreenId, ActionId>);
+			break;
+		case "input":
+			component = createInputComponent(options as InputOptions<ScreenId, ActionId>);
+			break;
+		case "review":
+			component = createReviewComponent(options as ReviewOptions<ScreenId, ActionId>);
 			break;
 		case "multiSelect":
 			component = createMultiSelectComponent(options as MultiSelectOptions<ScreenId, ActionId>);

--- a/packages/pi-tui-kit/src/components/input.ts
+++ b/packages/pi-tui-kit/src/components/input.ts
@@ -1,0 +1,112 @@
+import { type Focusable, Input, Key, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { MenuScreen } from "../types.js";
+import type {
+	MenuChangeResponse,
+	MenuScreenComponent,
+	MenuScreenComponentOptions,
+} from "./contracts.js";
+import { handleSearchInput, renderFrame, safeMenuText } from "./rendering.js";
+
+export type InputOptions<
+	ScreenId extends string,
+	ActionId extends string,
+> = MenuScreenComponentOptions<ScreenId, ActionId> & {
+	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "input" }>;
+};
+
+export function createInputComponent<ScreenId extends string, ActionId extends string>(
+	options: InputOptions<ScreenId, ActionId>,
+): MenuScreenComponent {
+	const input = new Input();
+	let pending = Promise.resolve();
+	let submitting = false;
+	let closing = false;
+	let disposed = false;
+
+	const closeAfterPending = (kind: "back" | "close") => {
+		if (closing || disposed) return;
+		closing = true;
+		void pending.then(() => {
+			if (!disposed) options.onEvent({ kind });
+		});
+	};
+	const submit = () => {
+		if (submitting || closing || disposed) return;
+		submitting = true;
+		const value = input.getValue();
+		const operation = Promise.resolve()
+			.then(async () => {
+				let response: MenuChangeResponse<ScreenId> = false;
+				try {
+					response = (await options.onInputSubmit?.({ value })) ?? false;
+				} catch (error) {
+					options.onError?.(error);
+				}
+				if (disposed) return;
+				submitting = false;
+				const accepted = typeof response === "boolean" ? response : response.accepted;
+				if (accepted && typeof response !== "boolean") {
+					closing = true;
+					options.onTransition?.(response.transition);
+				}
+				options.tui.requestRender();
+			})
+			.catch(() => {
+				if (!disposed) {
+					submitting = false;
+					options.tui.requestRender();
+				}
+			});
+		pending = operation;
+	};
+
+	const component: MenuScreenComponent & Focusable = {
+		get focused() {
+			return input.focused;
+		},
+		set focused(value: boolean) {
+			input.focused = value;
+		},
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const content = [
+				...input.render(safeWidth),
+				...(input.getValue().length === 0 && options.screen.placeholder
+					? wrapTextWithAnsi(
+							options.theme.fg("dim", safeMenuText(options.screen.placeholder)),
+							safeWidth,
+						)
+					: []),
+				...(submitting ? [options.theme.fg("dim", "Saving…")] : []),
+			];
+			return renderFrame(
+				options.screen.title,
+				options.screen.lines ?? [],
+				content,
+				options.screen.hint ?? "back",
+				safeWidth,
+				options,
+				"submit",
+			);
+		},
+		invalidate() {
+			input.invalidate();
+		},
+		handleInput(data) {
+			if (disposed || closing) return;
+			if (matchesKey(data, Key.ctrl("c"))) closeAfterPending("close");
+			else if (options.keybindings.matches(data, "tui.select.cancel")) {
+				closeAfterPending(options.screen.hint ?? "back");
+			} else if (options.keybindings.matches(data, "tui.input.submit")) submit();
+			else if (!submitting) handleSearchInput(input, data);
+			options.tui.requestRender();
+		},
+		waitForPending: () => pending,
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			options.onDispose?.();
+		},
+	};
+	return component;
+}

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -39,7 +39,7 @@ export function menuHint(
 	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
 	return [
 		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
-		...(confirm ? [`${confirm} ${confirmAction}`] : []),
+		...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
 		...(cancel ? [`${cancel} ${destination}`] : []),
 		...(destination === "back" ? ["ctrl+c close"] : []),
 	].join(" • ");

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -1,0 +1,192 @@
+import { stripVTControlCharacters } from "node:util";
+import { getLanguageFromPath, highlightCode } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
+import type { MenuScreen, ReviewScreen } from "../types.js";
+import type { MenuScreenComponent, MenuScreenComponentOptions } from "./contracts.js";
+import { renderFrame, safeMenuText } from "./rendering.js";
+
+const DEFAULT_REVIEW_VIEWPORT_SIZE = 14;
+const RPC_REVIEW_VIEWPORT_SIZE = 8;
+const RPC_REVIEW_LINE_WIDTH = 120;
+const TAB_SIZE = 4;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export type ReviewOptions<
+	ScreenId extends string,
+	ActionId extends string,
+> = MenuScreenComponentOptions<ScreenId, ActionId> & {
+	screen: Extract<MenuScreen<ScreenId, ActionId>, { kind: "review" }>;
+};
+
+export function createReviewComponent<ScreenId extends string, ActionId extends string>(
+	options: ReviewOptions<ScreenId, ActionId>,
+): MenuScreenComponent {
+	let scrollOffset = 0;
+	let lastMaximumScroll = 0;
+	let disposed = false;
+
+	const moveTo = (offset: number) => {
+		scrollOffset = Math.max(0, Math.min(offset, lastMaximumScroll));
+		options.tui.requestRender();
+	};
+
+	return {
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const allLines = formatReviewLines(options.screen, safeWidth, options.theme);
+			const viewportSize = reviewViewportSize(options.screen);
+			lastMaximumScroll = Math.max(0, allLines.length - viewportSize);
+			scrollOffset = Math.max(0, Math.min(scrollOffset, lastMaximumScroll));
+			const visible = allLines.slice(scrollOffset, scrollOffset + viewportSize);
+			const first = allLines.length === 0 ? 0 : scrollOffset + 1;
+			const last = Math.min(allLines.length, scrollOffset + viewportSize);
+			const position =
+				allLines.length > viewportSize
+					? [options.theme.fg("dim", `${first}-${last}/${allLines.length}`)]
+					: [];
+			return renderFrame(
+				options.screen.title,
+				options.screen.lines ?? [],
+				[...visible, ...position],
+				options.screen.hint ?? "back",
+				safeWidth,
+				options,
+				options.screen.confirm ? safeMenuText(options.screen.confirm.label) : "",
+			);
+		},
+		invalidate() {},
+		handleInput(data) {
+			if (disposed) return;
+			if (matchesKey(data, Key.ctrl("c"))) options.onEvent({ kind: "close" });
+			else if (options.keybindings.matches(data, "tui.select.cancel")) {
+				options.onEvent({ kind: options.screen.hint ?? "back" });
+			} else if (options.keybindings.matches(data, "tui.select.up")) {
+				moveTo(scrollOffset - 1);
+			} else if (options.keybindings.matches(data, "tui.select.down")) {
+				moveTo(scrollOffset + 1);
+			} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+				moveTo(scrollOffset - reviewViewportSize(options.screen));
+			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+				moveTo(scrollOffset + reviewViewportSize(options.screen));
+			} else if (matchesKey(data, Key.home)) moveTo(0);
+			else if (matchesKey(data, Key.end)) moveTo(lastMaximumScroll);
+			else if (options.screen.confirm && options.keybindings.matches(data, "tui.select.confirm")) {
+				options.onEvent({ kind: "activate", itemId: options.screen.confirm.id });
+			}
+		},
+		async waitForPending() {},
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			options.onDispose?.();
+		},
+	};
+}
+
+export function reviewDialogPages<ActionId extends string>(
+	screen: ReviewScreen<ActionId>,
+): string[][] {
+	const lines = plainReviewLines(screen.content, RPC_REVIEW_LINE_WIDTH);
+	const pageSize = Math.min(reviewViewportSize(screen), RPC_REVIEW_VIEWPORT_SIZE);
+	const pages: string[][] = [];
+	for (let index = 0; index < lines.length; index += pageSize) {
+		pages.push(lines.slice(index, index + pageSize));
+	}
+	return pages.length > 0 ? pages : [[""]];
+}
+
+function formatReviewLines<ActionId extends string>(
+	screen: ReviewScreen<ActionId>,
+	width: number,
+	theme: MenuScreenComponentOptions<string, ActionId>["theme"],
+): string[] {
+	const segments = reviewSegments(screen.content, width);
+	const format = screen.format ?? { kind: "text" as const };
+	if (format.kind === "code") {
+		const language =
+			format.language ?? (format.filePath ? getLanguageFromPath(format.filePath) : undefined);
+		return segments.map(({ text }) =>
+			theme.fg("mdCodeBlock", highlightCode(text, language)[0] ?? text),
+		);
+	}
+	if (format.kind === "diff") {
+		return segments.map(({ source, text }) => {
+			if (source.startsWith("@@")) return theme.fg("accent", text);
+			if (source.startsWith("+") && !source.startsWith("+++")) {
+				return theme.fg("toolDiffAdded", text);
+			}
+			if (source.startsWith("-") && !source.startsWith("---")) {
+				return theme.fg("toolDiffRemoved", text);
+			}
+			return theme.fg("toolDiffContext", text);
+		});
+	}
+	return segments.map(({ text }) => theme.fg("text", text));
+}
+
+function plainReviewLines(content: string, width: number): string[] {
+	return reviewSegments(content, width).map(({ text }) => text);
+}
+
+function reviewSegments(content: string, width: number) {
+	const safe = sanitizeDocumentText(content);
+	return safe.split("\n").flatMap((line) => {
+		const source = expandTabs(line);
+		return hardWrapLine(source, width).map((text) => ({ source, text }));
+	});
+}
+
+export function sanitizeDocumentText(value: unknown): string {
+	const stripped = stripVTControlCharacters(String(value)).replace(/\r\n?/gu, "\n");
+	return Array.from(stripped, (character) => {
+		if (character === "\n" || character === "\t") return character;
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
+}
+
+function expandTabs(line: string): string {
+	let column = 0;
+	let result = "";
+	for (const { segment } of graphemeSegmenter.segment(line)) {
+		if (segment === "\t") {
+			const count = TAB_SIZE - (column % TAB_SIZE);
+			result += " ".repeat(count);
+			column += count;
+			continue;
+		}
+		result += segment;
+		column += visibleWidth(segment);
+	}
+	return result;
+}
+
+function hardWrapLine(line: string, width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	if (line.length === 0) return [""];
+	const lines: string[] = [];
+	let current = "";
+	let currentWidth = 0;
+	const flush = () => {
+		lines.push(current);
+		current = "";
+		currentWidth = 0;
+	};
+	for (const { segment } of graphemeSegmenter.segment(line)) {
+		const segmentWidth = visibleWidth(segment);
+		if (segmentWidth > safeWidth) {
+			if (current.length > 0) flush();
+			lines.push("?".repeat(safeWidth));
+			continue;
+		}
+		if (currentWidth + segmentWidth > safeWidth && current.length > 0) flush();
+		current += segment;
+		currentWidth += segmentWidth;
+	}
+	if (current.length > 0 || lines.length === 0) lines.push(current);
+	return lines;
+}
+
+function reviewViewportSize<ActionId extends string>(screen: ReviewScreen<ActionId>) {
+	return screen.viewportSize ?? DEFAULT_REVIEW_VIEWPORT_SIZE;
+}

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -1,11 +1,13 @@
 export { defineMenu, resolveMenuScreen } from "./model.js";
 export { createMenuNavigator, type MenuNavigator } from "./navigator.js";
 export { type RunMenuOptions, type RunMenuResult, runMenu } from "./runtime.js";
+export { type RunTaskOptions, type RunTaskResult, runTask } from "./task.js";
 export type {
 	ActionMenuItem,
 	ActionsScreen,
 	ChoiceScreen,
 	DetailScreen,
+	InputScreen,
 	MenuActionContext,
 	MenuActionHandler,
 	MenuActionResult,
@@ -19,7 +21,10 @@ export type {
 	MenuSettingItem,
 	MenuTransition,
 	MultiSelectScreen,
+	ReviewConfirmation,
+	ReviewFormat,
+	ReviewScreen,
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 2;
+export const PI_EXTENSION_MENU_API_VERSION = 3;

--- a/packages/pi-tui-kit/src/model.ts
+++ b/packages/pi-tui-kit/src/model.ts
@@ -1,5 +1,11 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import type { ActionMenuItem, MenuContext, MenuDefinition, MenuScreen } from "./types.js";
+import {
+	type ActionMenuItem,
+	MAX_REVIEW_VIEWPORT_SIZE,
+	type MenuContext,
+	type MenuDefinition,
+	type MenuScreen,
+} from "./types.js";
 
 export function defineMenu<
 	State,
@@ -73,6 +79,32 @@ function validateScreen<
 			if (item.values && !item.values.includes(item.currentValue)) {
 				throw new Error(`Menu setting ${item.id} values must include its current value`);
 			}
+		}
+		return;
+	}
+	if (screen.kind === "input") {
+		assertAction(definition, `input screen ${screen.title}`, screen.action);
+		return;
+	}
+	if (screen.kind === "review") {
+		if (
+			screen.viewportSize !== undefined &&
+			(!Number.isInteger(screen.viewportSize) ||
+				screen.viewportSize <= 0 ||
+				screen.viewportSize > MAX_REVIEW_VIEWPORT_SIZE)
+		) {
+			throw new Error(
+				`Menu review viewport size must be a positive integer no greater than ${MAX_REVIEW_VIEWPORT_SIZE}`,
+			);
+		}
+		if (screen.confirm) {
+			if (!screen.confirm.id.trim()) {
+				throw new Error("Menu review confirmation id must not be empty");
+			}
+			if (!screen.confirm.label.trim()) {
+				throw new Error("Menu review confirmation label must not be empty");
+			}
+			assertAction(definition, `review screen ${screen.title}`, screen.confirm.action);
 		}
 		return;
 	}

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -1,15 +1,17 @@
-import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { Key, matchesKey } from "@earendil-works/pi-tui";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
 	createMenuScreenComponent,
+	type MenuInputSubmit,
 	type MenuMultiSelectChange,
 	type MenuScreenComponent,
 	type MenuScreenEvent,
 	type MenuSettingChange,
+	reviewDialogPages,
 	safeMenuText,
 } from "./components/index.js";
 import { resolveMenuScreen } from "./model.js";
 import { createMenuNavigator } from "./navigator.js";
+import { runTask } from "./task.js";
 import type {
 	ActionMenuItem,
 	MenuActionHandler,
@@ -127,6 +129,23 @@ async function runTuiMenu<
 						if (invocation.stale) staleAction = true;
 						return invocation;
 					},
+					onInputSubmit: async (change, signal) => {
+						if (screen.kind !== "input") return rejected();
+						const invocation = await invokeAction(
+							ctx,
+							definition.actions[screen.action],
+							state,
+							AbortSignal.any([menuSignal, signal]),
+							"input",
+							options,
+							{ value: change.value },
+						);
+						if (invocation.stale) {
+							staleAction = true;
+							return accepted({ kind: "close" });
+						}
+						return invocation;
+					},
 				},
 			);
 			if (staleAction || !isCurrent(options) || menuSignal.aborted) {
@@ -154,6 +173,20 @@ async function runTuiMenu<
 					state,
 					menuSignal,
 					item.id,
+					options,
+				);
+				if (outcome.stale) return { kind: "stale" };
+				navigator.apply(outcome.transition);
+				continue;
+			}
+			if (screen.kind === "review") {
+				if (!screen.confirm || screen.confirm.id !== event.itemId) continue;
+				const outcome = await invokeAction(
+					ctx,
+					definition.actions[screen.confirm.action],
+					state,
+					menuSignal,
+					screen.confirm.id,
 					options,
 				);
 				if (outcome.stale) return { kind: "stale" };
@@ -218,6 +251,10 @@ async function showTuiScreen<
 			change: MenuMultiSelectChange,
 			signal: AbortSignal,
 		): Promise<ActionInvocation<ScreenId>>;
+		onInputSubmit(
+			change: MenuInputSubmit,
+			signal: AbortSignal,
+		): Promise<ActionInvocation<ScreenId>>;
 	},
 ): Promise<InternalScreenEvent<ScreenId> | undefined> {
 	let component: MenuScreenComponent | undefined;
@@ -250,6 +287,7 @@ async function showTuiScreen<
 					onSettingChange: (change) => callbacks.onSettingChange(change, screenController.signal),
 					onMultiSelectChange: (change) =>
 						callbacks.onMultiSelectChange(change, screenController.signal),
+					onInputSubmit: (change) => callbacks.onInputSubmit(change, screenController.signal),
 					onTransition: (transition) => finish({ kind: "transition", transition }),
 					onDispose: () => {
 						removeAbortListener();
@@ -297,60 +335,23 @@ async function invokeBusyAction<State, ScreenId extends string, Context extends 
 	menuSignal: AbortSignal,
 	options: RunMenuOptions<State, Context>,
 ): Promise<ActionInvocation<ScreenId>> {
-	let actionTask: Promise<ActionInvocation<ScreenId>> | undefined;
-	let customFailed = false;
-	let customError: unknown;
-	let externallyDisposed = false;
-	let result: ActionInvocation<ScreenId> | undefined;
-	try {
-		result = await uiFor(ctx).custom<ActionInvocation<ScreenId> | undefined>(
-			(tui, theme, _keybindings, done) => {
-				const actionController = new AbortController();
-				const signal = AbortSignal.any([menuSignal, actionController.signal]);
-				const loader = new BorderedLoader(tui, theme, safeMenuText(label), { cancellable: true });
-				let cancelRequested = false;
-				let completed = false;
-				let disposed = false;
-				const cancelAction = () => {
-					cancelRequested = true;
-					actionController.abort(new DOMException("Menu action cancelled", "AbortError"));
-				};
-				loader.onAbort = cancelAction;
-				actionTask = invokeAction(ctx, handler, state, signal, itemId, options, {}, false);
-				void actionTask.then(
-					(outcome) => {
-						completed = true;
-						if (!disposed) done(outcome);
-					},
-					() => {
-						completed = true;
-						if (!disposed) done(rejected());
-					},
-				);
-				return {
-					render: (width: number) => loader.render(width),
-					invalidate: () => loader.invalidate(),
-					handleInput(data: string) {
-						if (matchesKey(data, Key.ctrl("c"))) cancelAction();
-						loader.handleInput(data);
-					},
-					dispose() {
-						disposed = true;
-						if (!completed && !cancelRequested && !menuSignal.aborted) externallyDisposed = true;
-						actionController.abort(new DOMException("Menu action disposed", "AbortError"));
-						loader.dispose();
-					},
-				};
-			},
-		);
-	} catch (error) {
-		customFailed = true;
-		customError = error;
+	const result = await runTask(ctx, {
+		label,
+		signal: menuSignal,
+		isCurrent: options.isCurrent,
+		onError: () => undefined,
+		task: ({ signal }) => invokeAction(ctx, handler, state, signal, itemId, options, {}, false),
+	});
+	switch (result.kind) {
+		case "completed":
+			return result.value;
+		case "cancelled":
+			return rejected();
+		case "stale":
+			return { ...rejected<ScreenId>(), stale: true };
+		case "error":
+			throw result.error;
 	}
-	const actionOutcome = await actionTask;
-	if (customFailed) throw customError;
-	if (externallyDisposed) return { ...rejected<ScreenId>(), stale: true };
-	return result ?? actionOutcome ?? rejected();
 }
 
 async function invokeAction<State, ScreenId extends string, Context extends MenuContext>(
@@ -418,6 +419,81 @@ async function runDialogMenu<
 			if (loaded.kind !== "loaded") return loaded.result;
 			const state = loaded.state;
 			const screen = resolveMenuScreen(definition, navigator.current, state);
+			if (screen.kind === "input") {
+				const value = await uiFor(ctx).input(
+					dialogTitle(screen),
+					safeMenuText(screen.placeholder ?? ""),
+					{ signal: menuSignal },
+				);
+				if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+				if (value === undefined) {
+					navigator.apply({ kind: screen.hint ?? "back" });
+					continue;
+				}
+				const outcome = await invokeAction(
+					ctx,
+					definition.actions[screen.action],
+					state,
+					menuSignal,
+					"input",
+					options,
+					{ value },
+				);
+				if (outcome.stale) return { kind: "stale" };
+				navigator.apply(outcome.transition);
+				continue;
+			}
+			if (screen.kind === "review") {
+				const pages = reviewDialogPages(screen);
+				let pageIndex = 0;
+				let finished = false;
+				while (!finished) {
+					const choices = uniqueReviewChoices([
+						...(pageIndex > 0 ? [{ kind: "previous" as const, label: "Previous" }] : []),
+						...(pageIndex < pages.length - 1 ? [{ kind: "next" as const, label: "Next" }] : []),
+						...(screen.confirm
+							? [{ kind: "confirm" as const, label: safeMenuText(screen.confirm.label) }]
+							: []),
+						{ kind: "exit" as const, label: dialogExitChoice(screen) },
+					]);
+					const pageTitle = [
+						dialogTitle(screen),
+						pages[pageIndex]?.join("\n") ?? "",
+						...(pages.length > 1 ? [`Page ${pageIndex + 1}/${pages.length}`] : []),
+					]
+						.filter(Boolean)
+						.join("\n");
+					const choice = await uiFor(ctx).select(
+						pageTitle,
+						choices.map((row) => row.label),
+						{ signal: menuSignal },
+					);
+					if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+					const selected = choices.find((row) => row.label === choice);
+					if (!selected || selected.kind === "exit") {
+						navigator.apply({ kind: screen.hint ?? "back" });
+						finished = true;
+					} else if (selected.kind === "previous") pageIndex = Math.max(0, pageIndex - 1);
+					else if (selected.kind === "next") {
+						pageIndex = Math.min(pages.length - 1, pageIndex + 1);
+					} else if (screen.confirm) {
+						const outcome = await invokeAction(
+							ctx,
+							definition.actions[screen.confirm.action],
+							state,
+							menuSignal,
+							screen.confirm.id,
+							options,
+						);
+						if (outcome.stale) return { kind: "stale" };
+						if (outcome.accepted) {
+							navigator.apply(outcome.transition);
+							finished = true;
+						}
+					}
+				}
+				continue;
+			}
 			const rows = dialogRows(screen);
 			const choice = await uiFor(ctx).select(
 				dialogTitle(screen),
@@ -535,6 +611,11 @@ interface DialogRow {
 	label: string;
 }
 
+interface ReviewDialogChoice {
+	kind: "previous" | "next" | "confirm" | "exit";
+	label: string;
+}
+
 function dialogRows<ScreenId extends string, ActionId extends string>(
 	screen: MenuScreen<ScreenId, ActionId>,
 ): DialogRow[] {
@@ -556,6 +637,8 @@ function dialogRows<ScreenId extends string, ActionId extends string>(
 			})),
 			{ kind: "exit", index: 0, label: dialogExitChoice(screen) },
 		];
+	} else if (screen.kind === "input" || screen.kind === "review") {
+		rows = [];
 	} else if (screen.kind === "choice") {
 		rows = [
 			...screen.items.map((item, index) => {
@@ -588,19 +671,25 @@ function dialogRows<ScreenId extends string, ActionId extends string>(
 	return uniqueDialogRows(rows);
 }
 
+function uniqueReviewChoices(rows: readonly ReviewDialogChoice[]): ReviewDialogChoice[] {
+	const used = new Set<string>();
+	return rows.map((row) => ({ ...row, label: uniqueDialogLabel(row.label, used) }));
+}
+
 function uniqueDialogRows(rows: readonly DialogRow[]): DialogRow[] {
 	const used = new Set<string>();
-	return rows.map((row) => {
-		const base = row.label;
-		let label = base;
-		let suffix = 2;
-		while (used.has(label)) {
-			label = `${base} [${suffix}]`;
-			suffix += 1;
-		}
-		used.add(label);
-		return { ...row, label };
-	});
+	return rows.map((row) => ({ ...row, label: uniqueDialogLabel(row.label, used) }));
+}
+
+function uniqueDialogLabel(base: string, used: Set<string>) {
+	let label = base;
+	let suffix = 2;
+	while (used.has(label)) {
+		label = `${base} [${suffix}]`;
+		suffix += 1;
+	}
+	used.add(label);
+	return label;
 }
 
 function dialogExitChoice<ScreenId extends string, ActionId extends string>(

--- a/packages/pi-tui-kit/src/task.ts
+++ b/packages/pi-tui-kit/src/task.ts
@@ -1,0 +1,195 @@
+import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { safeMenuText } from "./components/rendering.js";
+import type { MenuContext } from "./types.js";
+
+export type RunTaskResult<Value> =
+	| { kind: "completed"; value: Value }
+	| { kind: "cancelled" }
+	| { kind: "stale" }
+	| { kind: "error"; error: unknown };
+
+export interface RunTaskOptions<Value, Context extends MenuContext = ExtensionCommandContext> {
+	label: string;
+	task(context: { ctx: Context; signal: AbortSignal }): Value | Promise<Value>;
+	signal?: AbortSignal;
+	isCurrent?(): boolean;
+	cancellable?: boolean;
+	onError?(ctx: Context, error: unknown): void | Promise<void>;
+}
+
+interface TaskOwnership {
+	userCancelled: boolean;
+	externallyDisposed: boolean;
+}
+
+/**
+ * Run abort-aware work with Pi's cancellable loader in TUI mode and the same
+ * typed lifecycle result in every other mode.
+ */
+export async function runTask<Value, Context extends MenuContext = ExtensionCommandContext>(
+	ctx: Context,
+	options: RunTaskOptions<Value, Context>,
+): Promise<RunTaskResult<Value>> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	if (ctx.mode !== "tui" || !ctx.hasUI) {
+		const controller = new AbortController();
+		const signal = options.signal
+			? AbortSignal.any([controller.signal, options.signal])
+			: controller.signal;
+		return executeTask(ctx, options, signal, {
+			userCancelled: false,
+			externallyDisposed: false,
+		});
+	}
+	return runTuiTask(ctx, options);
+}
+
+async function runTuiTask<Value, Context extends MenuContext>(
+	ctx: Context,
+	options: RunTaskOptions<Value, Context>,
+): Promise<RunTaskResult<Value>> {
+	const controller = new AbortController();
+	const signal = options.signal
+		? AbortSignal.any([controller.signal, options.signal])
+		: controller.signal;
+	const ownership: TaskOwnership = { userCancelled: false, externallyDisposed: false };
+	let taskPromise: Promise<RunTaskResult<Value>> | undefined;
+	let taskSettled = false;
+	let componentDisposed = false;
+	let customResult: RunTaskResult<Value> | undefined;
+	let customError: unknown;
+
+	try {
+		customResult = await uiFor(ctx).custom<RunTaskResult<Value> | undefined>(
+			(tui, theme, _keybindings, done) => {
+				const loader = new BorderedLoader(tui, theme, safeMenuText(options.label), {
+					cancellable: options.cancellable ?? true,
+				});
+				let loaderDisposed = false;
+				const disposeLoader = () => {
+					if (loaderDisposed) return;
+					loaderDisposed = true;
+					loader.dispose();
+				};
+				loader.onAbort = () => {
+					if (taskSettled || ownership.userCancelled) return;
+					ownership.userCancelled = true;
+					controller.abort(new DOMException("Task cancelled", "AbortError"));
+				};
+				taskPromise = executeTask(ctx, options, signal, ownership);
+				void taskPromise.then((result) => {
+					taskSettled = true;
+					disposeLoader();
+					if (!componentDisposed) done(result);
+				});
+				return {
+					render: (width: number) => loader.render(width),
+					invalidate: () => loader.invalidate(),
+					handleInput: (data: string) => loader.handleInput(data),
+					dispose() {
+						if (componentDisposed) return;
+						componentDisposed = true;
+						if (!taskSettled && !ownership.userCancelled && !options.signal?.aborted) {
+							ownership.externallyDisposed = true;
+						}
+						controller.abort(new DOMException("Task UI disposed", "AbortError"));
+						disposeLoader();
+					},
+				};
+			},
+		);
+	} catch (error) {
+		customError = error;
+		controller.abort(new DOMException("Task UI failed", "AbortError"));
+	}
+	if (
+		customError === undefined &&
+		customResult === undefined &&
+		!ownership.userCancelled &&
+		!options.signal?.aborted
+	) {
+		ownership.externallyDisposed = true;
+		controller.abort(new DOMException("Task UI closed", "AbortError"));
+	}
+
+	const taskResult = taskPromise ? await taskPromise : undefined;
+	if (ownership.externallyDisposed || !isCurrent(options) || options.signal?.aborted) {
+		return { kind: "stale" };
+	}
+	if (customError !== undefined) {
+		await reportTaskError(ctx, options, customError);
+		if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+		return { kind: "error", error: customError };
+	}
+	return customResult ?? taskResult ?? { kind: "stale" };
+}
+
+async function executeTask<Value, Context extends MenuContext>(
+	ctx: Context,
+	options: RunTaskOptions<Value, Context>,
+	signal: AbortSignal,
+	ownership: TaskOwnership,
+): Promise<RunTaskResult<Value>> {
+	if (!isCurrent(options) || options.signal?.aborted || ownership.externallyDisposed) {
+		return { kind: "stale" };
+	}
+	if (ownership.userCancelled || signal.aborted) return abortResult(options, ownership);
+	try {
+		const value = await options.task({ ctx, signal });
+		if (!isCurrent(options) || options.signal?.aborted || ownership.externallyDisposed) {
+			return { kind: "stale" };
+		}
+		if (ownership.userCancelled || signal.aborted) return abortResult(options, ownership);
+		return { kind: "completed", value };
+	} catch (error) {
+		if (!isCurrent(options) || options.signal?.aborted || ownership.externallyDisposed) {
+			return { kind: "stale" };
+		}
+		if (ownership.userCancelled || signal.aborted) return abortResult(options, ownership);
+		await reportTaskError(ctx, options, error);
+		if (!isCurrent(options) || options.signal?.aborted || ownership.externallyDisposed) {
+			return { kind: "stale" };
+		}
+		if (ownership.userCancelled || signal.aborted) return abortResult(options, ownership);
+		return { kind: "error", error };
+	}
+}
+
+function abortResult<Value, Context extends MenuContext>(
+	options: RunTaskOptions<Value, Context>,
+	ownership: TaskOwnership,
+): RunTaskResult<Value> {
+	return ownership.userCancelled && !options.signal?.aborted
+		? { kind: "cancelled" }
+		: { kind: "stale" };
+}
+
+async function reportTaskError<Value, Context extends MenuContext>(
+	ctx: Context,
+	options: RunTaskOptions<Value, Context>,
+	error: unknown,
+) {
+	if (options.onError) {
+		try {
+			await options.onError(ctx, error);
+			return;
+		} catch {
+			// Fall through to Pi's notifier when the custom reporter is unavailable.
+		}
+	}
+	if (!ctx.hasUI) return;
+	const message = error instanceof Error ? error.message : String(error);
+	try {
+		uiFor(ctx).notify(`Task failed: ${safeMenuText(message)}`, "error");
+	} catch {
+		// Error reporting must not change the typed task result.
+	}
+}
+
+function isCurrent<Value, Context extends MenuContext>(options: RunTaskOptions<Value, Context>) {
+	return options.isCurrent?.() ?? true;
+}
+
+function uiFor(ctx: MenuContext): ExtensionCommandContext["ui"] {
+	return ctx.ui as ExtensionCommandContext["ui"];
+}

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -92,6 +92,39 @@ export interface SettingsScreen<ActionId extends string> {
 	items: readonly MenuSettingItem<ActionId>[];
 }
 
+export interface InputScreen<ActionId extends string> {
+	kind: "input";
+	title: string;
+	lines?: readonly string[];
+	placeholder?: string;
+	action: ActionId;
+	hint?: "back" | "close";
+}
+
+export const MAX_REVIEW_VIEWPORT_SIZE = 50;
+
+export type ReviewFormat =
+	| { kind: "text" }
+	| { kind: "code"; language?: string; filePath?: string }
+	| { kind: "diff"; filePath?: string };
+
+export interface ReviewConfirmation<ActionId extends string> {
+	id: string;
+	label: string;
+	action: ActionId;
+}
+
+export interface ReviewScreen<ActionId extends string> {
+	kind: "review";
+	title: string;
+	lines?: readonly string[];
+	content: string;
+	format?: ReviewFormat;
+	viewportSize?: number;
+	confirm?: ReviewConfirmation<ActionId>;
+	hint?: "back" | "close";
+}
+
 export interface MenuMultiSelectItem extends MenuItemBase {
 	selected: boolean;
 	disabledReason?: string;
@@ -118,6 +151,8 @@ export type MenuScreen<ScreenId extends string, ActionId extends string> =
 	| DetailScreen
 	| ChoiceScreen<ActionId>
 	| SettingsScreen<ActionId>
+	| InputScreen<ActionId>
+	| ReviewScreen<ActionId>
 	| MultiSelectScreen<ScreenId, ActionId>;
 
 export interface MenuScreenContext<State> {

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -1,5 +1,12 @@
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "../src/index.js";
+import {
+	defineMenu,
+	type InputScreen,
+	type ReviewScreen,
+	type RunTaskResult,
+	runMenu,
+	runTask,
+} from "../src/index.js";
 
 type Screen = "main";
 type Action = "run";
@@ -40,11 +47,60 @@ const lifecycleMenu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 	},
 });
 
+const inputScreen: InputScreen<Action> = {
+	kind: "input",
+	title: "Value",
+	action: "run",
+};
+const reviewScreen: ReviewScreen<Action> = {
+	kind: "review",
+	title: "Review",
+	content: "exact content",
+	confirm: { id: "apply", label: "Apply", action: "run" },
+};
+void inputScreen;
+void reviewScreen;
+
+const invalidInputScreen: InputScreen<Action> = {
+	kind: "input",
+	title: "Invalid",
+	// @ts-expect-error Input actions stay within the menu action id union.
+	action: "missing",
+};
+const invalidReviewScreen: ReviewScreen<Action> = {
+	kind: "review",
+	title: "Invalid",
+	content: "content",
+	// @ts-expect-error Review confirmation actions stay within the menu action id union.
+	confirm: { id: "apply", label: "Apply", action: "missing" },
+};
+void invalidInputScreen;
+void invalidReviewScreen;
+
 declare const commandContext: ExtensionCommandContext;
 declare const lifecycleContext: ExtensionContext;
 
 void runMenu(commandContext, commandMenu, { getState: () => undefined });
 void runMenu(lifecycleContext, lifecycleMenu, { getState: () => undefined });
+
+const commandTask: Promise<RunTaskResult<number>> = runTask(commandContext, {
+	label: "Command task",
+	task: async ({ ctx, signal }) => {
+		await ctx.waitForIdle();
+		if (signal.aborted) return 0;
+		return 1;
+	},
+});
+void commandTask;
+
+void runTask(lifecycleContext, {
+	label: "Lifecycle task",
+	task: async ({ ctx }) => {
+		ctx.isIdle();
+		// @ts-expect-error Lifecycle tasks must not gain command-only session methods.
+		await ctx.waitForIdle();
+	},
+});
 
 // @ts-expect-error A command-only menu cannot run with a lifecycle context.
 void runMenu(lifecycleContext, commandMenu, { getState: () => undefined });

--- a/packages/pi-tui-kit/test/input-screen.test.ts
+++ b/packages/pi-tui-kit/test/input-screen.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { CURSOR_MARKER, type Focusable, visibleWidth } from "@earendil-works/pi-tui";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { createMenuScreenComponent } from "../src/components/index.js";
+import { defineMenu, type InputScreen, type MenuTransition, runMenu } from "../src/index.js";
+
+initTheme("dark", false);
+
+type ScreenId = "input";
+type ActionId = "submit";
+
+const inputScreen: InputScreen<ActionId> = {
+	kind: "input",
+	title: "Maximum image count",
+	lines: ["Current: 20"],
+	placeholder: "Enter a positive integer",
+	action: "submit",
+	hint: "back",
+};
+
+test("input screen is width-safe, forwards focus, and sanitizes pasted controls", () => {
+	const harness = inputComponentHarness();
+	const focusable = harness.component as typeof harness.component & Focusable;
+	assert.equal("focused" in focusable, true);
+	focusable.focused = true;
+	assert.equal(harness.component.render(40).join("\n").includes(CURSOR_MARKER), true);
+
+	harness.component.handleInput(
+		"\u001b[200~  raw\u001b]8;;https://unsafe.example\u0007 value  \u001b[201~",
+	);
+	const raw = harness.component.render(40).join("\n");
+	assert.equal(raw.includes("\u001b]8;;https://unsafe.example"), false);
+	assert.match(stripVTControlCharacters(raw), /value/);
+	for (const width of [1, 2, 8, 20, 40, 80, 120]) {
+		assert.ok(harness.component.render(width).every((line) => visibleWidth(line) <= width));
+	}
+});
+
+test("input rejection preserves the draft and accepted submit transitions", async () => {
+	const submissions: string[] = [];
+	const transitions: MenuTransition<ScreenId>[] = [];
+	const harness = inputComponentHarness({
+		onInputSubmit: async ({ value }) => {
+			submissions.push(value);
+			if (submissions.length === 1) return false;
+			return { accepted: true, transition: { kind: "close" } };
+		},
+		onTransition: (transition) => transitions.push(transition),
+	});
+
+	for (const input of [" ", " ", "4", "2", " ", " "]) harness.component.handleInput(input);
+	harness.component.handleInput("\r");
+	await harness.component.waitForPending();
+	assert.deepEqual(submissions, ["  42  "]);
+	assert.deepEqual(transitions, []);
+	assert.match(stripVTControlCharacters(harness.component.render(40).join("\n")), /42/);
+
+	harness.component.handleInput("\r");
+	await harness.component.waitForPending();
+	assert.deepEqual(submissions, ["  42  ", "  42  "]);
+	assert.deepEqual(transitions, [{ kind: "close" }]);
+});
+
+test("input screen drains a pending submit before Back and distinguishes Ctrl+C Close", async () => {
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const back = inputComponentHarness({
+		onInputSubmit: async () => {
+			await gate;
+			return false;
+		},
+	});
+	back.component.handleInput("x");
+	back.component.handleInput("\r");
+	back.component.handleInput("\u001b");
+	assert.deepEqual(back.events, []);
+	release?.();
+	await back.component.waitForPending();
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(back.events, [{ kind: "back" }]);
+
+	const close = inputComponentHarness();
+	close.component.handleInput("\u0003");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(close.events, [{ kind: "close" }]);
+});
+
+test("RPC input retries a rejected value, preserves raw payload, and never opens custom TUI", async () => {
+	const responses = [" bad ", " 42 "];
+	const values: string[] = [];
+	let customCalls = 0;
+	let inputCalls = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		input: async (_title: string, _placeholder: string, options?: { signal?: AbortSignal }) => {
+			inputCalls += 1;
+			assert.equal(options?.signal?.aborted, false);
+			return responses.shift();
+		},
+		custom: async () => {
+			customCalls += 1;
+		},
+	});
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "input",
+		screens: { input: () => inputScreen },
+		actions: {
+			submit: async ({ value }) => {
+				values.push(value ?? "");
+				return value?.trim() === "42" ? { kind: "close" } : { kind: "rejected" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(values, [" bad ", " 42 "]);
+	assert.equal(inputCalls, 2);
+	assert.equal(customCalls, 0);
+});
+
+test("TUI input rejection retains the same draft before a later accepted transition", async () => {
+	const values: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			for (const input of [" ", "x", " "]) harness.handleInput(input);
+			harness.handleInput("tui.input.submit");
+			await harness.waitForPending();
+			assert.match(stripVTControlCharacters(harness.render().join("\n")), /> {2}x/);
+			harness.handleInput("tui.input.submit");
+			await harness.waitForPending();
+			return harness.resultPromise;
+		},
+	});
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "input",
+		screens: { input: () => inputScreen },
+		actions: {
+			submit: async ({ value }) => {
+				values.push(value ?? "");
+				return values.length === 1 ? { kind: "rejected" } : { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(values, [" x ", " x "]);
+});
+
+test("disposing a TUI input aborts and drains its in-flight action", async () => {
+	let reportStarted: (() => void) | undefined;
+	const started = new Promise<void>((resolve) => {
+		reportStarted = resolve;
+	});
+	let observedAbort = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			harness.handleInput("x");
+			harness.handleInput("tui.input.submit");
+			await started;
+			harness.dispose();
+			return undefined;
+		},
+	});
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "input",
+		screens: { input: () => inputScreen },
+		actions: {
+			submit: async ({ signal }) => {
+				reportStarted?.();
+				await new Promise<void>((resolve) => {
+					if (signal.aborted) resolve();
+					else {
+						signal.addEventListener(
+							"abort",
+							() => {
+								observedAbort = true;
+								resolve();
+							},
+							{ once: true },
+						);
+					}
+				});
+				return { kind: "stay" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "stale",
+	});
+	assert.equal(observedAbort, true);
+});
+
+test("owner abort dismisses an unanswered RPC input and returns stale", async () => {
+	const owner = new AbortController();
+	let reportOpened: (() => void) | undefined;
+	const opened = new Promise<void>((resolve) => {
+		reportOpened = resolve;
+	});
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		input: async (_title: string, _placeholder: string, options?: { signal?: AbortSignal }) => {
+			reportOpened?.();
+			await new Promise<void>((resolve) => {
+				if (options?.signal?.aborted) resolve();
+				else options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+			return undefined;
+		},
+	});
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "input",
+		screens: { input: () => inputScreen },
+		actions: { submit: async () => ({ kind: "close" }) },
+	});
+	const running = runMenu(context.ctx, menu, {
+		getState: () => undefined,
+		signal: owner.signal,
+	});
+	await opened;
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await running, { kind: "stale" });
+});
+
+function inputComponentHarness(
+	overrides: {
+		onInputSubmit?: (change: {
+			value: string;
+		}) => Promise<boolean | { accepted: boolean; transition: MenuTransition<ScreenId> }>;
+		onTransition?: (transition: MenuTransition<ScreenId>) => void;
+	} = {},
+) {
+	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
+	const component = createMenuScreenComponent<ScreenId, ActionId>({
+		screen: inputScreen,
+		tui: { requestRender() {} },
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		},
+		keybindings: {
+			matches(data: string, binding: string) {
+				if (binding === "tui.select.cancel") return data === "\u001b" || data === "\u0003";
+				if (binding === "tui.input.submit") return data === "\r";
+				return false;
+			},
+			getKeys(binding: string) {
+				if (binding === "tui.select.cancel") return ["escape", "ctrl+c"];
+				if (binding === "tui.input.submit") return ["enter"];
+				return [];
+			},
+		},
+		onEvent: (event) => events.push(event),
+		onInputSubmit: overrides.onInputSubmit,
+		onTransition: overrides.onTransition,
+	});
+	return { component, events };
+}

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -38,8 +38,8 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("additive multi-select search remains compatible with declarative API version 2", () => {
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 2);
+test("agent-level input and review screens use declarative API version 3", () => {
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 3);
 });
 
 test("menu definitions resolve dynamic screens and reject invalid references", () => {
@@ -209,6 +209,122 @@ test("choice screens reject blank and duplicate raw ids", () => {
 		);
 	assert.throws(() => resolve([" "]), /id must not be empty/i);
 	assert.throws(() => resolve(["same", "same"]), /id must be unique.*same/i);
+});
+
+test("input screens require a known action", () => {
+	const definition = defineMenu<undefined, "input", "submit">({
+		start: "input",
+		screens: {
+			input: () => ({
+				kind: "input",
+				title: "Value",
+				action: "missing" as "submit",
+			}),
+		},
+		actions: { submit: async () => ({ kind: "close" }) },
+	});
+	assert.throws(
+		() => resolveMenuScreen(definition, "input", undefined),
+		/input.*unknown action.*missing/i,
+	);
+});
+
+test("review screens validate viewport and confirmation identity", () => {
+	const definition = defineMenu<undefined, "review", "apply">({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Review",
+				content: "diff",
+				viewportSize: 0,
+				confirm: { id: " ", label: "Apply", action: "missing" as "apply" },
+			}),
+		},
+		actions: { apply: async () => ({ kind: "close" }) },
+	});
+	assert.throws(
+		() => resolveMenuScreen(definition, "review", undefined),
+		/review.*viewport.*positive integer/i,
+	);
+	for (const viewportSize of [-1, 1.5, 51, Number.NaN, Number.POSITIVE_INFINITY]) {
+		assert.throws(
+			() =>
+				resolveMenuScreen(
+					{
+						...definition,
+						screens: {
+							review: () => ({
+								kind: "review" as const,
+								title: "Review",
+								content: "diff",
+								viewportSize,
+							}),
+						},
+					},
+					"review",
+					undefined,
+				),
+			/review.*viewport.*positive integer/i,
+		);
+	}
+	const withViewport = {
+		...definition,
+		screens: {
+			review: () => ({
+				kind: "review" as const,
+				title: "Review",
+				content: "diff",
+				confirm: { id: " ", label: "Apply", action: "apply" as const },
+			}),
+		},
+	};
+	assert.throws(
+		() => resolveMenuScreen(withViewport, "review", undefined),
+		/review.*confirmation id.*empty/i,
+	);
+	assert.throws(
+		() =>
+			resolveMenuScreen(
+				{
+					...withViewport,
+					screens: {
+						review: () => ({
+							kind: "review" as const,
+							title: "Review",
+							content: "diff",
+							confirm: { id: "apply", label: " ", action: "apply" as const },
+						}),
+					},
+				},
+				"review",
+				undefined,
+			),
+		/review.*confirmation label.*empty/i,
+	);
+	assert.throws(
+		() =>
+			resolveMenuScreen(
+				{
+					...withViewport,
+					screens: {
+						review: () => ({
+							kind: "review" as const,
+							title: "Review",
+							content: "diff",
+							confirm: {
+								id: "apply",
+								label: "Apply",
+								action: "missing" as "apply",
+							},
+						}),
+					},
+				},
+				"review",
+				undefined,
+			),
+		/review.*unknown action.*missing/i,
+	);
 });
 
 test("navigator owns nested Back and Close transitions", () => {

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -1,5 +1,11 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, type MultiSelectScreen, runMenu } from "../src/index.js";
+import {
+	defineMenu,
+	type InputScreen,
+	type MultiSelectScreen,
+	type ReviewScreen,
+	runMenu,
+} from "../src/index.js";
 
 type Screen = "main" | "profile" | "settings";
 type Action = "refresh" | "setMode" | "setProfile";
@@ -31,6 +37,23 @@ const searchableToolsScreen: MultiSelectScreen<Screen, Action> = {
 	action: "refresh",
 };
 void searchableToolsScreen;
+
+const boundedInputScreen: InputScreen<Action> = {
+	kind: "input",
+	title: "Refresh label",
+	placeholder: "Label",
+	action: "refresh",
+};
+void boundedInputScreen;
+
+const reviewChangesScreen: ReviewScreen<Action> = {
+	kind: "review",
+	title: "Review changes",
+	content: "+1 enabled=true",
+	format: { kind: "diff", filePath: "settings.json" },
+	confirm: { id: "apply", label: "Apply", action: "refresh" },
+};
+void reviewChangesScreen;
 
 const menu = defineMenu<State, Screen, Action>({
 	start: "main",

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { createMenuScreenComponent } from "../src/components/index.js";
+import { defineMenu, type ReviewScreen, runMenu } from "../src/index.js";
+
+initTheme("dark", false);
+
+type ScreenId = "review";
+type ActionId = "apply";
+
+const reviewScreen: ReviewScreen<ActionId> = {
+	kind: "review",
+	title: "Review changes",
+	content: "line 1\nline 2\nline 3\nline 4\nline 5",
+	format: { kind: "text" },
+	viewportSize: 3,
+	confirm: { id: "raw-apply", label: "Apply", action: "apply" },
+	hint: "back",
+};
+
+test("review preserves whitespace, sanitizes controls, and bounds exact text at every width", () => {
+	const harness = reviewComponentHarness({
+		...reviewScreen,
+		content:
+			"  indented\tvalue\n你🙂very-long-token\nunsafe\u001b]8;;https://unsafe.example\u0007text",
+		viewportSize: 20,
+	});
+	for (const width of [1, 2, 8, 20, 40, 80, 120]) {
+		const lines = harness.component.render(width);
+		assert.ok(
+			lines.every((line) => visibleWidth(line) <= width),
+			`width ${width}`,
+		);
+		assert.equal(lines.join("\n").includes("\u001b]8;;https://unsafe.example"), false);
+	}
+	const rendered = stripVTControlCharacters(harness.component.render(80).join("\n"));
+	assert.match(rendered, / {2}indented {2,}value/);
+	assert.match(rendered, /你🙂very-long-token/);
+});
+
+test("review scrolls by injected keys, pages, and clamps after resize", () => {
+	const harness = reviewComponentHarness({
+		...reviewScreen,
+		content: Array.from({ length: 10 }, (_, index) => `row ${index + 1}`).join("\n"),
+	});
+	let rendered = plainRender(harness.component, 40);
+	assert.match(rendered, /row 1[\s\S]*row 3/);
+	assert.doesNotMatch(rendered, /row 4/);
+
+	harness.component.handleInput("j");
+	rendered = plainRender(harness.component, 40);
+	assert.match(rendered, /row 2[\s\S]*row 4/);
+	harness.component.handleInput("d");
+	rendered = plainRender(harness.component, 40);
+	assert.match(rendered, /row 5[\s\S]*row 7/);
+	harness.component.handleInput("\u001b[F");
+	rendered = plainRender(harness.component, 40);
+	assert.match(rendered, /row 8[\s\S]*row 10/);
+	assert.match(rendered, /8-10\/10/);
+	assert.ok(harness.component.render(8).every((line) => visibleWidth(line) <= 8));
+});
+
+test("review confirmation dispatches raw identity and exits remain Back versus Close", () => {
+	const confirm = reviewComponentHarness(reviewScreen);
+	confirm.component.handleInput("l");
+	assert.deepEqual(confirm.events, [{ kind: "activate", itemId: "raw-apply" }]);
+
+	const readOnly = reviewComponentHarness({ ...reviewScreen, confirm: undefined });
+	readOnly.component.handleInput("l");
+	assert.deepEqual(readOnly.events, []);
+	readOnly.component.handleInput("q");
+	assert.deepEqual(readOnly.events, [{ kind: "back" }]);
+
+	const close = reviewComponentHarness(reviewScreen);
+	close.component.handleInput("\u0003");
+	assert.deepEqual(close.events, [{ kind: "close" }]);
+});
+
+test("review formats code and diffs through theme-aware display paths", () => {
+	const code = reviewComponentHarness({
+		...reviewScreen,
+		content: "const answer = 42;",
+		format: { kind: "code", language: "typescript" },
+		confirm: undefined,
+	});
+	assert.match(stripVTControlCharacters(code.component.render(80).join("\n")), /const answer = 42/);
+
+	const diff = reviewComponentHarness(
+		{
+			...reviewScreen,
+			content: "@@ header\n-old\n+new\n same",
+			format: { kind: "diff", filePath: "settings.json" },
+			confirm: undefined,
+		},
+		true,
+	);
+	const rendered = diff.component.render(80).join("\n");
+	assert.match(rendered, /toolDiffRemoved:-old/);
+	assert.match(rendered, /toolDiffAdded:\+new/);
+	assert.match(rendered, /accent:@@ header/);
+});
+
+test("TUI review invokes its raw confirmation action", async () => {
+	const invoked: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			harness.handleInput("tui.select.confirm");
+			return harness.result;
+		},
+	});
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "review",
+		screens: { review: () => reviewScreen },
+		actions: {
+			apply: async ({ itemId }) => {
+				invoked.push(itemId);
+				return { kind: "close" };
+			},
+		},
+	});
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.deepEqual(invoked, ["raw-apply"]);
+});
+
+test("RPC review paginates bounded content and preserves colliding confirmation identity", async () => {
+	const titles: string[] = [];
+	const choicesSeen: string[][] = [];
+	let call = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[], options?: { signal?: AbortSignal }) => {
+			call += 1;
+			titles.push(title);
+			choicesSeen.push(choices);
+			assert.equal(options?.signal?.aborted, false);
+			assert.ok(title.length < 2000);
+			if (call === 1) return choices.find((choice) => choice.startsWith("Next"));
+			return choices.find((choice) => choice.startsWith("Next") && choice !== "Next");
+		},
+		custom: async () => {
+			throw new Error("RPC review must not open custom TUI");
+		},
+	});
+	const content = Array.from({ length: 30 }, (_, index) => `row ${index + 1}`).join("\n");
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "review",
+		screens: {
+			review: () => ({
+				...reviewScreen,
+				content,
+				confirm: { id: "confirm-next", label: "Next", action: "apply" },
+			}),
+		},
+		actions: {
+			apply: async ({ itemId }) => {
+				assert.equal(itemId, "confirm-next");
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+	});
+	assert.equal(call, 2);
+	assert.match(titles[0] ?? "", /row 1/);
+	assert.doesNotMatch(titles[0] ?? "", /row 30/);
+	assert.match(titles[1] ?? "", /row 4/);
+	assert.equal(new Set(choicesSeen[1]).size, choicesSeen[1]?.length);
+});
+
+test("owner abort dismisses an unanswered RPC review without invoking confirmation", async () => {
+	const owner = new AbortController();
+	let reportOpened: (() => void) | undefined;
+	const opened = new Promise<void>((resolve) => {
+		reportOpened = resolve;
+	});
+	let invoked = false;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, _choices: string[], options?: { signal?: AbortSignal }) => {
+			reportOpened?.();
+			await new Promise<void>((resolve) => {
+				if (options?.signal?.aborted) resolve();
+				else options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+			return undefined;
+		},
+	});
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "review",
+		screens: { review: () => reviewScreen },
+		actions: {
+			apply: async () => {
+				invoked = true;
+				return { kind: "close" };
+			},
+		},
+	});
+	const running = runMenu(context.ctx, menu, {
+		getState: () => undefined,
+		signal: owner.signal,
+	});
+	await opened;
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.equal(invoked, false);
+});
+
+function reviewComponentHarness(screen: ReviewScreen<ActionId>, themed = false) {
+	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
+	const component = createMenuScreenComponent<ScreenId, ActionId>({
+		screen,
+		tui: { requestRender() {} },
+		theme: {
+			fg: (color: string, text: string) => (themed ? `${color}:${text}` : text),
+			bold: (text: string) => text,
+		},
+		keybindings: {
+			matches(data: string, binding: string) {
+				const values: Record<string, string> = {
+					"tui.select.up": "k",
+					"tui.select.down": "j",
+					"tui.select.pageUp": "u",
+					"tui.select.pageDown": "d",
+					"tui.select.confirm": "l",
+					"tui.select.cancel": "q",
+				};
+				return data === values[binding];
+			},
+			getKeys(binding: string) {
+				const values: Record<string, readonly string[]> = {
+					"tui.select.up": ["k"],
+					"tui.select.down": ["j"],
+					"tui.select.pageUp": ["u"],
+					"tui.select.pageDown": ["d"],
+					"tui.select.confirm": ["l"],
+					"tui.select.cancel": ["q", "ctrl+c"],
+				};
+				return values[binding] ?? [];
+			},
+		},
+		onEvent: (event) => events.push(event),
+	});
+	return { component, events };
+}
+
+function plainRender(component: { render(width: number): string[] }, width: number) {
+	return stripVTControlCharacters(component.render(width).join("\n"));
+}

--- a/packages/pi-tui-kit/test/task.test.ts
+++ b/packages/pi-tui-kit/test/task.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { runTask } from "../src/index.js";
+
+initTheme("dark", false);
+
+test("runTask executes directly outside TUI without opening custom UI", async () => {
+	let customCalls = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		custom: async () => {
+			customCalls += 1;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async ({ signal }) => {
+			assert.equal(signal.aborted, false);
+			return 42;
+		},
+	});
+
+	assert.deepEqual(result, { kind: "completed", value: 42 });
+	assert.equal(customCalls, 0);
+});
+
+test("runTask user cancellation aborts and drains the task before returning", async () => {
+	let observedAbort = false;
+	let settled = false;
+	let releaseDrain: (() => void) | undefined;
+	const drain = new Promise<void>((resolve) => {
+		releaseDrain = resolve;
+	});
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			harness.handleInput("tui.select.cancel");
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			assert.equal(observedAbort, true);
+			assert.equal(harness.result, undefined);
+			releaseDrain?.();
+			return harness.resultPromise;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async ({ signal }) => {
+			await new Promise<void>((resolve) => {
+				if (signal.aborted) {
+					observedAbort = true;
+					resolve();
+					return;
+				}
+				signal.addEventListener(
+					"abort",
+					() => {
+						observedAbort = true;
+						resolve();
+					},
+					{ once: true },
+				);
+			});
+			await drain;
+			settled = true;
+			return "late";
+		},
+	});
+
+	assert.deepEqual(result, { kind: "cancelled" });
+	assert.equal(settled, true);
+});
+
+test("runTask owner abort is stale and drains before closing TUI", async () => {
+	const owner = new AbortController();
+	let reportStarted: (() => void) | undefined;
+	const started = new Promise<void>((resolve) => {
+		reportStarted = resolve;
+	});
+	let taskSettled = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			await started;
+			owner.abort(new DOMException("Session replaced", "AbortError"));
+			const result = await harness.resultPromise;
+			assert.equal(taskSettled, true);
+			return result;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		signal: owner.signal,
+		task: async ({ signal }) => {
+			reportStarted?.();
+			await new Promise<void>((resolve) => {
+				if (signal.aborted) resolve();
+				else signal.addEventListener("abort", () => resolve(), { once: true });
+			});
+			taskSettled = true;
+			return "late";
+		},
+	});
+
+	assert.deepEqual(result, { kind: "stale" });
+});
+
+test("runTask treats a custom UI that closes without disposal as stale", async () => {
+	let observedAbort = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			createCustomSelectorHarness(factory, 40);
+			return undefined;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async ({ signal }) => {
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			observedAbort = signal.aborted;
+			return "late";
+		},
+	});
+
+	assert.deepEqual(result, { kind: "stale" });
+	assert.equal(observedAbort, true);
+});
+
+test("runTask treats external component disposal as stale", async () => {
+	let reportStarted: (() => void) | undefined;
+	const started = new Promise<void>((resolve) => {
+		reportStarted = resolve;
+	});
+	let observedAbort = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			await started;
+			harness.dispose();
+			return undefined;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async ({ signal }) => {
+			reportStarted?.();
+			await new Promise<void>((resolve) => {
+				if (signal.aborted) resolve();
+				else {
+					signal.addEventListener(
+						"abort",
+						() => {
+							observedAbort = true;
+							resolve();
+						},
+						{ once: true },
+					);
+				}
+			});
+			return "late";
+		},
+	});
+
+	assert.deepEqual(result, { kind: "stale" });
+	assert.equal(observedAbort, true);
+});
+
+test("runTask returns the original error when a custom reporter rejects", async () => {
+	const failure = new Error("Task failed");
+	let reporterCalls = 0;
+	const context = createMockContext({ mode: "print", hasUI: false });
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async () => {
+			throw failure;
+		},
+		onError: async () => {
+			reporterCalls += 1;
+			throw new Error("Reporter failed");
+		},
+	});
+
+	assert.deepEqual(result, { kind: "error", error: failure });
+	assert.equal(reporterCalls, 1);
+});
+
+test("runTask suppresses errors after the owner becomes stale", async () => {
+	let current = true;
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let reporterCalls = 0;
+	const context = createMockContext({ mode: "print", hasUI: false });
+	const running = runTask(context.ctx, {
+		label: "Loading",
+		isCurrent: () => current,
+		task: async () => {
+			await gate;
+			throw new Error("Late failure");
+		},
+		onError: () => {
+			reporterCalls += 1;
+		},
+	});
+
+	current = false;
+	release?.();
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.equal(reporterCalls, 0);
+});


### PR DESCRIPTION
## Summary

- add public `runTask()` lifecycle orchestration and reuse it for menu `busyLabel` actions
- add declarative single-line `input` and scrollable text/code/diff `review` screens with TUI and RPC adapters
- raise `PI_EXTENSION_MENU_API_VERSION` to 3 and update public types, documentation, declarations, and focused coverage

## Lifecycle and compatibility

- distinguishes completed, cancelled, stale, and error task outcomes while aborting and draining owned work
- preserves rejected input drafts, raw submitted values, IME focus, Back/Close behavior, and stale-session guards
- sanitizes and cell-wraps review content, bounds TUI viewports and RPC pages, and keeps confirmation identity collision-safe
- retains existing menu behavior and leaves persistence, domain validation, confirmations, and session ownership with consumers

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npm test` — 1,907 passed
- `npm run check`
- `just pack-tui-kit` — expected 27-file dry-run tarball
- LSP diagnostics — 0 diagnostics across package source and tests
- built-package automated TUI-host smoke — passed successful/cancelled tasks, rejected-input correction, review navigation/resize/confirmation, Back, and Close
- real `pi --mode rpc` smoke — passed task execution, input retry, bounded review pagination/confirmation/cancellation, and emitted no unsupported custom-UI request

## Audit notes

Read and audited against `docs/extension-conventions.md` plus Pi's extension, TUI, keybinding, and RPC documentation. Touched areas included public API, TUI/non-interactive adaptation, asynchronous lifecycle ownership, rendering bounds, package boundaries, declarations, documentation, and packaging. No extension persistence or new dependency moved into the kit, and no deep Pi import was added.

Repository instructions prohibit launching an interactive TUI, so the TUI smoke used Pi's real components through an automated custom-UI host; deterministic component/runtime tests cover the same inputs. The completed plan is archived at `docs/plans/archived/2026-07-31_pi-tui-kit-agent-flows-plan.md`.
