### PR TITLE
refactor(usage): adopt shared task runner

### DIFF
--- a/docs/plans/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
+++ b/docs/plans/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
@@ -1,0 +1,268 @@
+# pi-tui-kit Consumer Migrations Plan
+
+## Goal
+
+Adopt the agent-level flows added in `@narumitw/pi-tui-kit` through three bounded,
+behavior-preserving consumer migrations, then make an evidence-based go/no-go decision for the
+`pi-btw` preview. Execute the work as separate PR-ready changes in this order:
+
+1. `pi-usage` uses `runTask()` for abort-aware usage queries.
+2. `pi-stamp` uses declarative `input` screens for custom locale and time-zone values.
+3. `pi-image-drop` uses declarative `input` and `review` screens for resource-limit editing.
+4. `pi-btw` is assessed for a safe `review` migration without changing its interaction contract.
+
+## Context
+
+- `@narumitw/pi-tui-kit@0.41.0` is published with `runTask()`, `input`, and `review`.
+- Existing consumers still declare `^0.40.0`. Because zero-major caret ranges are minor-bounded,
+  each migrated package must explicitly adopt a range that includes menu API version 3; do not bump
+  unrelated consumers.
+- `extensions/pi-usage/src/usage.ts` owns `runMenuOperation()`, which repeats TUI/non-TUI mode
+  adaptation, `BorderedLoader`, signal composition, cancellation, and error-result mapping.
+- `extensions/pi-stamp/src/menu.ts` opens two direct `ctx.ui.input()` loops from an otherwise
+  declarative menu. Validation and persistence are already extension-owned.
+- `extensions/pi-image-drop/src/menu.ts` owns a custom numeric input while
+  `extensions/pi-image-drop/src/runtime.ts` owns the limit draft, validation, save preview, and a
+  custom confirmation. The loader and link-rotation confirmation have stricter three-way semantics
+  and are not equivalent to the new generic flows.
+- `extensions/pi-btw/src/bring-to-main.ts` has an exact, scrollable preview, but callers require
+  distinct Bring, Back, and Ctrl+C Close results, terminal-row-adaptive rendering, and preservation
+  of Pi's live editor draft. A root `runMenu()` currently reports Back and Close as the same
+  `{ kind: "closed" }` result.
+- The worktree currently contains unrelated dependency updates produced by `just update`. They must
+  be landed separately or isolated in another worktree before any migration commit is prepared.
+
+## Architecture
+
+- `pi-tui-kit` owns mode adaptation, standard component lifecycle, cancellation/disposal draining,
+  input draft retention, exact review rendering, and RPC dialog adaptation.
+- Each extension continues to own domain validation, mutable draft state, persistence, generation
+  checks, success/error copy, and product-specific navigation decisions.
+- Consumers import only the package-root API. No extension reaches into `pi-tui-kit/src` or
+  `dist/components`.
+- Each adopting package updates its own runtime dependency range and lockfile entries. Other package
+  ranges remain unchanged so their existing menu API compatibility remains explicit.
+- The migrations are independent and ordered as separate PRs. Later work must start from updated
+  `main`, not accumulate into one cross-extension diff.
+- `pi-image-drop` keeps its cancellable loader and link-rotation confirmation specialized because
+  they distinguish Escape cancellation from Ctrl+C Close. Its limit input/review becomes standard,
+  while settings publication and future-session semantics remain extension-owned.
+- No `pi-tui-kit` public API expansion is allowed during the first three migrations. The `pi-btw`
+  gate may recommend a future kit change, but it must not silently add one to this migration wave.
+
+## Non-Goals
+
+- Do not migrate `pi-sync`'s commit-aware loader; it dynamically refuses cancellation after the
+  publication boundary, which `runTask()` does not model.
+- Do not migrate secret inputs, multi-line editors, live previews, the `pi-btw` transcript composer,
+  or its exact text-range selector.
+- Do not change settings schemas, paths, defaults, precedence, atomic-write protocols, or unknown
+  field preservation.
+- Do not enable `pi-image-drop` in RPC, print, or JSON mode; its established command remains TUI-only.
+- Do not update all 18 current `pi-tui-kit` consumers merely because a newer library exists.
+- Do not publish packages or create/merge PRs as part of plan execution without separate approval.
+
+## Assumptions
+
+- `pi-usage` maps both `runTask()` `cancelled` and `stale` results to its existing `undefined`
+  control flow and maps `error` back to a thrown error. It suppresses `runTask()`'s default notifier
+  so existing callers remain the sole error reporter.
+- `pi-stamp` keeps the current chooser screen id and switches its projection between choices and an
+  input screen using per-menu closure state. This preserves the existing stack: a valid custom value
+  or Escape returns from the locale/time-zone level to Settings, while Ctrl+C closes the whole menu.
+- `pi-image-drop` uses child `limit-input` and `limit-review` screens. Input and review Back return to
+  the limits list; Ctrl+C closes the full menu. After a successful save, the review returns to a
+  refreshed limits list showing zero unsaved changes. This adds one visible review step compared
+  with the old automatic return to Settings, but provides exact post-save state without requiring a
+  new multi-pop navigation API.
+- The `pi-btw` phase is complete with a documented no-go if its three-way result and editor/viewport
+  invariants cannot be preserved through the existing public kit API.
+
+## Risks
+
+- A migrated source package paired with `^0.40.0` can typecheck against the workspace library but
+  fail after npm installation. Package metadata, lockfile, and pack output must be verified together.
+- Consumer tests resolve `@narumitw/pi-tui-kit` through generated `dist/`; rebuild the kit before
+  focused tests when the local package output is stale, even though these migrations should not edit
+  kit source.
+- `runTask()` reports errors unless given an extension-specific `onError`; careless mapping could
+  duplicate `pi-usage` notifications or turn owner replacement into a user cancellation.
+- Rejected input must retain the same TUI draft. Reopening `ctx.ui.input()` in a loop would recreate
+  the old architecture rather than adopting the screen contract.
+- `pi-image-drop` settings publication can finish after session replacement. Every continuation
+  after the save await must revalidate the owner before touching draft state or UI; persistence
+  itself remains ordered and atomic.
+- `extensions/pi-image-drop/src/runtime.ts` is already over 1,000 lines with a lifecycle-cohesion
+  justification. The migration should move pure limit projection/parsing into `src/menu.ts` rather
+  than grow a second settings owner or expand the runtime further.
+- Replacing `BtwBringToMainPreview` without a way to distinguish root Back from Close would regress a
+  tested contract. The final gate must prefer deferral over lossy unification.
+
+## Rollback / Recovery
+
+- Keep each extension migration in its own commit/PR so it can be reverted independently.
+- No persisted data migration occurs. Reverting restores the previous UI implementation while the
+  unchanged settings files remain valid.
+- If an adopting package fails its package smoke, revert both its dependency range and corresponding
+  lockfile edges; do not leave source importing API version 3 from a version-2-compatible range.
+- Delete any temporary `pi-btw` prototype after the go/no-go check. A no-go leaves `pi-btw` source and
+  package metadata unchanged and records the missing seam for a future scoped decision.
+
+## Plan
+
+### 0. Isolate prerequisites and establish baselines
+
+- [x] Land the existing `just update` dependency changes in their own PR or move migration work to a
+  clean worktree based on current `main`; verify `git status --short` contains no dependency-update
+  files before staging a consumer migration. Evidence: migration work started in
+  `/home/narumi/.worktrees/pi-extensions-refactor-pi-usage-run-task` at release commit `3e0d145`; its
+  initial status contained only this plan, while dependency updates remained in the invoking tree.
+- [x] Record the installed and published `pi-tui-kit` version/API evidence with
+  `npm view @narumitw/pi-tui-kit version` and a package-root import assertion for
+  `PI_EXTENSION_MENU_API_VERSION === 3`; verify consumers will not rely only on a workspace symlink.
+  Evidence: npm reported `0.41.0`, and a package-root Node import returned API version `3` after a
+  clean `npm ci` in the migration worktree.
+- [x] Run `npm run check` on the clean baseline and record the test count; do not begin migration work
+  with an unexplained failing gate. Evidence: the pre-migration `just update` gate passed all 1,907
+  tests. A linked-worktree rerun reproduced one environment-only Git-runner assertion because Git
+  exports its administrative `GIT_DIR` to aliases in linked worktrees; final full gates will run in
+  an independent clone rather than accepting that harness artifact.
+
+### 1. PR 1 — migrate `pi-usage` to `runTask()`
+
+- [x] Add focused characterization tests in `extensions/pi-usage/test/usage.test.ts` for successful
+  TUI execution, Escape cancellation, owner abort/session shutdown, direct RPC execution, and an
+  operation error reported exactly once; verify the tests pass against the current helper before the
+  refactor and would fail if cancellation stopped aborting the query. Evidence: 18 focused usage
+  tests passed before and after the refactor, including new loader-success and single-error tests;
+  existing cancellation/shutdown/RPC tests retain their controlled assertions.
+- [x] Update `extensions/pi-usage/package.json` and `package-lock.json` so the package depends on the
+  API-version-3-compatible kit range (currently `^0.41.0`); verify the package lock no longer installs
+  `pi-tui-kit@0.40.x` beneath `pi-usage` with `npm ls @narumitw/pi-tui-kit --depth=1`. Evidence: the
+  usage-local 0.40 lock entry was removed and `npm ls` resolves the workspace 0.41.0 package.
+- [x] Replace `runMenuOperation()`'s direct `BorderedLoader`/`ctx.ui.custom()` orchestration with
+  package-root `runTask()`, preserving `T | undefined` for completed/cancelled/stale work and
+  rethrowing the original error without duplicate notification; verify `BorderedLoader` and
+  `LoaderResult` disappear from `extensions/pi-usage/src/usage.ts`. Evidence: the helper now maps all
+  four typed task results and supplies a no-op reporter before rethrowing the original error.
+- [x] Audit every `runMenuOperation()` caller after the refactor for state captured before awaits,
+  generation/model revalidation, parent-signal ownership, and error propagation; verify current,
+  another-provider, all-provider, and revalidation paths still use only settled current-session data.
+  Evidence: every call retains the menu controller signal; existing stable-current, provider,
+  fan-out, shutdown, and model/account revalidation guards run after the awaited helper.
+- [ ] Run the pi-usage focused tests, `npm run check --workspace @narumitw/pi-usage`, `npm test`,
+  `npm run check`, and `just pack-usage`; inspect the dry-run tarball dependency metadata and record
+  any unavailable runtime smoke before marking this PR ready.
+
+### 2. PR 2 — migrate `pi-stamp` custom values to declarative input
+
+- [ ] Add red-first menu/component tests in `extensions/pi-stamp/test/menu.test.ts` proving custom
+  locale and time-zone rows transition to `input` projections, raw values reach domain validation,
+  invalid submissions retain the TUI draft, valid values canonicalize and save once, Escape returns
+  to Settings, Ctrl+C closes, owner abort saves nothing, and RPC retries a rejected value.
+- [ ] Update `extensions/pi-stamp/package.json` and `package-lock.json` to the API-version-3-compatible
+  kit range; verify `pi-stamp` resolves the intended kit version in `npm ls` and packed metadata.
+- [ ] Refactor `createStampMenu()` so per-menu closure state switches the existing `locale` and
+  `time-zone` screen ids between their choice and `input` projections; reset entry mode whenever the
+  corresponding chooser is opened so a cancelled input never reopens unexpectedly.
+- [ ] Split the custom-entry actions into navigation and submission actions. Keep
+  `canonicalizeLocale()`, `canonicalizeTimeZone()`, warning copy, `savePatch()`, persistence ordering,
+  rollback, and unknown-field behavior extension-owned; verify a rejected save retains the draft and
+  the previous effective setting.
+- [ ] Audit the final stamp diff against `docs/extension-settings.md`: no missing-file read creates a
+  file, invalid files remain protected, updates stay serialized/atomic, unknown fields remain
+  preserved, and every post-save continuation checks the action signal before notifying or
+  transitioning.
+- [ ] Run stamp focused tests, `npm run check --workspace @narumitw/pi-stamp`, `npm test`,
+  `npm run check`, and `just pack-stamp`; inspect dependency and source contents and perform a
+  deterministic RPC menu smoke for rejected-then-valid input.
+
+### 3. PR 3 — migrate `pi-image-drop` limits to input and review
+
+- [ ] Extend `extensions/pi-image-drop/test/lifecycle.test.ts` and `test/menu.test.ts` with failing
+  contract tests for a standard limit input and review: exact current/default/pending copy, raw-value
+  and hard-ceiling validation, the per-image-versus-batch cross-field invariant, rejected-draft
+  retention, Back versus Ctrl+C, no-change save, cancel-without-save, owner abort, save-failure retry,
+  successful patch identity, and a refreshed zero-unsaved-changes limits screen.
+- [ ] Update `extensions/pi-image-drop/package.json` and `package-lock.json` to the
+  API-version-3-compatible kit range; verify standalone installation metadata cannot select
+  `pi-tui-kit@0.40.x` for the migrated source.
+- [ ] Move pure limit labels, prompt/units, formatting, parsing, hard-ceiling and cross-field
+  validation, diff text, patch construction, and screen projection helpers from `src/runtime.ts`
+  into extension-owned `src/menu.ts`; verify runtime lifecycle/generation and settings persistence
+  remain in `ImageDropRuntime`, and recheck the existing over-1,000-line cohesion justification after
+  the move.
+- [ ] Add `limit-input` and `limit-review` screen ids and dedicated submit/confirm actions to the
+  existing Image Drop menu. Keep the selected limit and draft in the menu invocation, return input
+  Back/review Back to the limits list, and preserve Ctrl+C as whole-menu Close through kit-owned
+  navigation.
+- [ ] On valid input, update only the in-memory draft and return to the limits list; on review confirm,
+  publish exactly `limitSettingsPatch()`, revalidate generation/signal after the await, then advance
+  `loadedSettings`, `originalLimits`, and `limitDraft` together so the reopened limits screen shows
+  no pending changes. Verify failed or stale publication cannot update UI or in-memory committed
+  state.
+- [ ] Remove `showImageDropInputDialog`, `InputDialogResult`, the `showInput` runtime dependency, and
+  superseded component tests/imports. Retain `runImageDropMenuLoad()` and
+  `showImageDropConfirmDialog()` for their distinct loader and link-rotation three-way contracts;
+  verify those existing cancellation/close tests remain unchanged and pass.
+- [ ] Update `extensions/pi-image-drop/README.md` so command-menu, settings, and package-layout text
+  identify limit input/review as standard kit flows while loaders and link-rotation confirmation stay
+  specialized; preserve the documented TUI-only command and future-session settings behavior.
+- [ ] Audit settings concurrency and lifecycle end to end: invalid-file protection, latest-document
+  writes, unknown fields, atomic publication, invocation ordering, failure recovery, session
+  replacement, component disposal, and shutdown. Verify every post-await continuation uses the
+  original menu generation/signal and no stale `ExtensionContext` is touched.
+- [ ] Run Image Drop focused lifecycle/menu tests, its web-asset check,
+  `npm run check --workspace @narumitw/pi-image-drop`, `npm test`, `npm run check`, and
+  `just pack-image-drop`; inspect the tarball and run an automated TUI-host smoke because repository
+  rules prohibit opening an interactive TUI.
+
+### 4. Gate — assess `pi-btw` preview against `review`
+
+- [ ] Write a contract matrix from `extensions/pi-btw/src/bring-to-main.ts`,
+  `extensions/pi-btw/src/btw.ts`, and `extensions/pi-btw/test/side-thread.test.ts` covering exact raw
+  draft delivery, terminal-control escaping, grapheme/cell wrapping, terminal-row viewport sizing,
+  paging, configured confirm/back keys, Ctrl+C Close, editor-text preservation, and restored
+  selection state; verify every current behavior has an explicit proposed owner.
+- [ ] Test the existing package-root `runMenu()`/`ReviewScreen` interface against that matrix with a
+  disposable local prototype or compile-time harness. Mark the gate **go** only if Bring, Back, and
+  Close remain distinct and editor/viewport invariants survive without a new kit API or broad
+  `chooseBringToMain()` rewrite; otherwise delete the prototype and record a no-go with the exact
+  missing seam.
+- [ ] If the gate is go, draft a separate implementation plan/PR boundary that adds the dependency,
+  replaces only `BtwBringToMainPreview`, maps its regression tests to the public review contract, and
+  runs `just pack-btw`. If it is no-go, leave `pi-btw` source/package metadata unchanged and record
+  whether a future close-reason or adaptive-viewport contract would justify kit work.
+
+### 5. Cross-PR audit and handoff
+
+- [ ] For each migration diff, audit TUI versus RPC/unsupported modes, user cancellation, component
+  disposal, session replacement, shutdown, post-await state use, package-root imports, metadata, and
+  source-file size against `docs/extension-conventions.md`; record deviations or unavailable smokes
+  in that PR's handoff.
+- [ ] Verify each adopting extension has a compatible kit range while every non-adopting consumer's
+  range is untouched; use manifest diffs, lockfile inspection, `npm ls`, and each package dry run as
+  evidence.
+- [ ] Confirm the three implementation PRs remain independently revertible and the `pi-btw` decision
+  is finite. Do not combine unrelated dependency updates, generated artifacts, or deferred kit API
+  work into a migration commit.
+
+## Completion Checklist
+
+- [ ] `pi-usage` delegates generic task lifecycle policy to `runTask()` with unchanged query,
+  cancellation, stale-session, and error-reporting behavior.
+- [ ] `pi-stamp` custom locale/time-zone entry uses declarative input while preserving canonical
+  validation, rejected drafts, settings safety, navigation, TUI focus, and RPC behavior.
+- [ ] `pi-image-drop` limit editing uses standard input/review screens while preserving draft-only
+  edits, exact save patches, future-session semantics, failure recovery, and three-way specialized
+  flows outside the limits workflow.
+- [ ] The `pi-btw` review migration has an evidence-backed go/no-go result; no interaction invariant
+  is silently weakened.
+- [ ] Only adopting packages require menu API version 3, and their manifests, lockfile edges, tests,
+  and dry-run tarballs agree on the dependency contract.
+- [ ] Focused tests, package checks, root `npm test`, root `npm run check`, applicable deterministic
+  smokes, and `just pack-*` checks pass for every completed migration, with any accepted unverified
+  path documented.
+- [ ] Guides read and audited in each handoff: `docs/extension-conventions.md` and, for Stamp and
+  Image Drop, `docs/extension-settings.md`; touched UI, lifecycle, settings, package, documentation,
+  and verification areas have no unexplained MUST-rule deviation.

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -45,6 +45,6 @@
 		"directory": "extensions/pi-usage"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.41.0"
 	}
 }

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -1,10 +1,9 @@
-import {
-	BorderedLoader,
-	type ExtensionAPI,
-	type ExtensionCommandContext,
-	type ExtensionContext,
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
 import {
 	awaitWithDeadline,
 	errorMessage,
@@ -51,8 +50,6 @@ type StableCurrent = {
 	outcome: QueryOutcome;
 	model: PiModel | undefined;
 };
-
-type LoaderResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
 
 export default function usageExtension(pi: ExtensionAPI) {
 	const cache = new UsageCache(CACHE_TTL_MS);
@@ -351,28 +348,21 @@ export default function usageExtension(pi: ExtensionAPI) {
 		parentSignal: AbortSignal,
 		operation: (signal: AbortSignal) => Promise<T>,
 	): Promise<T | undefined> => {
-		if (ctx.mode !== "tui") return operation(parentSignal);
-		const result = await ctx.ui.custom<LoaderResult<T> | null>((tui, theme, _keybindings, done) => {
-			const loader = new BorderedLoader(tui, theme, label);
-			let finished = false;
-			const finish = (value: LoaderResult<T> | null) => {
-				if (finished) return;
-				finished = true;
-				done(value);
-			};
-			loader.onAbort = () => finish(null);
-			const signal = AbortSignal.any([parentSignal, loader.signal]);
-			void operation(signal)
-				.then((value) => finish({ ok: true, value }))
-				.catch((error) => {
-					if (isAbortError(error)) finish(null);
-					else finish({ ok: false, error });
-				});
-			return loader;
+		const result = await runTask(ctx, {
+			label,
+			signal: parentSignal,
+			onError: () => undefined,
+			task: ({ signal }) => operation(signal),
 		});
-		if (!result) return undefined;
-		if (!result.ok) throw result.error;
-		return result.value;
+		switch (result.kind) {
+			case "completed":
+				return result.value;
+			case "cancelled":
+			case "stale":
+				return undefined;
+			case "error":
+				throw result.error;
+		}
 	};
 
 	const outcomeStillCurrent = async (

--- a/extensions/pi-usage/test/usage.test.ts
+++ b/extensions/pi-usage/test/usage.test.ts
@@ -305,23 +305,90 @@ test("automatic lifecycle refresh starts asynchronously", () => {
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 });
 
+test("TUI usage queries complete through the loader before opening the menu", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = usageFetch;
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	let customCalls = 0;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		model: openRouterModel,
+		custom: async (factory: unknown) =>
+			new Promise<unknown>((resolve) => {
+				if (typeof factory !== "function") return resolve(undefined);
+				customCalls += 1;
+				let component: {
+					dispose?(): void;
+					handleInput(data: string): void;
+					render(width: number): string[];
+				};
+				const done = (value: unknown) => {
+					component.dispose?.();
+					resolve(value);
+				};
+				component = (
+					factory as (
+						tui: { requestRender(): void },
+						theme: { fg(_color: string, text: string): string },
+						keybindings: object,
+						done: (value: unknown) => void,
+					) => typeof component
+				)({ requestRender() {} }, { fg: (_color, text) => text }, {}, done);
+				if (customCalls === 2) setImmediate(() => component.handleInput("\u0003"));
+			}),
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "openrouter-key" } }),
+			getAvailable: () => [openRouterModel],
+			getAll: () => [openRouterModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(customCalls, 2);
+});
+
+test("a loader UI failure propagates once without an extra task notification", async () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		model: openRouterModel,
+		custom: async () => {
+			throw new Error("loader UI failed");
+		},
+	});
+
+	await assert.rejects(Promise.resolve(command.handler("", ctx)), /loader UI failed/u);
+	assert.deepEqual(notifications, []);
+});
+
 test("TUI usage queries can be cancelled with Escape", async () => {
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 	const command = mock.commands.get("usage");
 	assert.ok(command);
-	let selected = false;
+	let customCalls = 0;
 	const { ctx } = createMockContext({
 		hasUI: true,
 		mode: "tui",
 		model: openRouterModel,
-		select: async () => {
-			selected = true;
-			return "Close";
-		},
 		custom: async (factory: unknown) =>
 			new Promise<unknown>((resolve) => {
 				if (typeof factory !== "function") return resolve(undefined);
+				customCalls += 1;
 				let component: { dispose?(): void; handleInput(data: string): void };
 				const done = (value: unknown) => {
 					component.dispose?.();
@@ -345,7 +412,7 @@ test("TUI usage queries can be cancelled with Escape", async () => {
 	});
 
 	await command.handler("", ctx);
-	assert.equal(selected, false);
+	assert.equal(customCalls, 1);
 });
 
 test("session shutdown aborts usage action and provider selectors", async (t) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,7 +565,7 @@
 			"version": "0.41.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.41.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -575,16 +575,6 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": ">=0.81.0"
-			}
-		},
-		"extensions/pi-usage/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"extensions/pi-worktree": {


### PR DESCRIPTION
## Summary

- replace pi-usage's local `BorderedLoader` orchestration with `pi-tui-kit`'s public `runTask()`
- preserve cancellation/stale/error mapping and existing provider/model revalidation
- require the API-version-3-compatible tui-kit range and add the tracked consumer migration plan

## Verification

- focused pi-usage tests: 18 passed
- `npm run check --workspace @narumitw/pi-usage`
- `just pack-usage`
- LSP diagnostics: 0

The repository-wide gate will also run in CI. A local linked-worktree run reached 1,906 passing tests but its Git alias environment adds `GIT_DIR`, triggering one worktree-only sanitization assertion; final plan verification will run from an independent clone.
