### PR TITLE
feat(stamp): use declarative custom inputs

### DIFF
--- a/docs/plans/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
+++ b/docs/plans/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
@@ -156,23 +156,29 @@ behavior-preserving consumer migrations, then make an evidence-based go/no-go de
 
 ### 2. PR 2 — migrate `pi-stamp` custom values to declarative input
 
-- [ ] Add red-first menu/component tests in `extensions/pi-stamp/test/menu.test.ts` proving custom
+- [x] Add red-first menu/component tests in `extensions/pi-stamp/test/menu.test.ts` proving custom
   locale and time-zone rows transition to `input` projections, raw values reach domain validation,
   invalid submissions retain the TUI draft, valid values canonicalize and save once, Escape returns
-  to Settings, Ctrl+C closes, owner abort saves nothing, and RPC retries a rejected value.
-- [ ] Update `extensions/pi-stamp/package.json` and `package-lock.json` to the API-version-3-compatible
+  to Settings, Ctrl+C closes, owner abort saves nothing, and RPC retries a rejected value. Evidence:
+  the initial compile failed because the consumer still exposed only action screens; all seven final
+  tests pass, including a real component draft-retry flow and rejected-then-valid RPC flow.
+- [x] Update `extensions/pi-stamp/package.json` and `package-lock.json` to the API-version-3-compatible
   kit range; verify `pi-stamp` resolves the intended kit version in `npm ls` and packed metadata.
-- [ ] Refactor `createStampMenu()` so per-menu closure state switches the existing `locale` and
+  Evidence: both report the workspace 0.41.0 kit and no stamp-local 0.40 package remains.
+- [x] Refactor `createStampMenu()` so per-menu closure state switches the existing `locale` and
   `time-zone` screen ids between their choice and `input` projections; reset entry mode whenever the
-  corresponding chooser is opened so a cancelled input never reopens unexpectedly.
-- [ ] Split the custom-entry actions into navigation and submission actions. Keep
+  corresponding chooser is opened so a cancelled input never reopens unexpectedly. Evidence: screen
+  resolution and end-to-end navigation tests cover chooser, input, Back, and Close transitions.
+- [x] Split the custom-entry actions into navigation and submission actions. Keep
   `canonicalizeLocale()`, `canonicalizeTimeZone()`, warning copy, `savePatch()`, persistence ordering,
   rollback, and unknown-field behavior extension-owned; verify a rejected save retains the draft and
-  the previous effective setting.
-- [ ] Audit the final stamp diff against `docs/extension-settings.md`: no missing-file read creates a
+  the previous effective setting. Evidence: the same typed actions distinguish missing navigation
+  values from raw submissions, and focused tests prove canonical patch identity and rejection.
+- [x] Audit the final stamp diff against `docs/extension-settings.md`: no missing-file read creates a
   file, invalid files remain protected, updates stay serialized/atomic, unknown fields remain
   preserved, and every post-save continuation checks the action signal before notifying or
-  transitioning.
+  transitioning. Evidence: persistence code is unchanged; submissions still use `savePatch()`, which
+  checks the action signal before and after `runtime.update()`, and failures return `rejected`.
 - [ ] Run stamp focused tests, `npm run check --workspace @narumitw/pi-stamp`, `npm test`,
   `npm run check`, and `just pack-stamp`; inspect dependency and source contents and perform a
   deterministic RPC menu smoke for rejected-then-valid input.

--- a/extensions/pi-stamp/package.json
+++ b/extensions/pi-stamp/package.json
@@ -48,6 +48,6 @@
 		"directory": "extensions/pi-stamp"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.41.0"
 	}
 }

--- a/extensions/pi-stamp/src/menu.ts
+++ b/extensions/pi-stamp/src/menu.ts
@@ -34,6 +34,8 @@ export interface StampMenuOwner {
 }
 
 export function createStampMenu(runtime: StampSettingsRuntime) {
+	let localeEntry = false;
+	let timeZoneEntry = false;
 	return defineMenu<StampSettingsState, StampScreen, StampAction, ExtensionCommandContext>({
 		start: "main",
 		screens: {
@@ -125,58 +127,78 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 					},
 				],
 			}),
-			locale: ({ state }) => ({
-				kind: "actions",
-				title: "Stamp Locale",
-				lines: [`Current: ${localeLabel(state.settings.locale)}`],
-				items: [
-					{
-						id: "invariant",
-						label: "Invariant (default)",
-						description: "ISO date, Latin digits, and English AM/PM.",
-						action: "choose-invariant-locale",
-					},
-					{
-						id: "system",
-						label: "System locale",
-						description: "Use the operating system locale.",
-						action: "choose-system-locale",
-					},
-					{
-						id: "custom",
-						label: "Custom BCP 47 locale…",
-						description: "Examples: en-US, fr-FR, zh-TW.",
-						action: "choose-custom-locale",
-					},
-				],
-				hint: "back",
-			}),
-			"time-zone": ({ state }) => ({
-				kind: "actions",
-				title: "Stamp Time Zone",
-				lines: [`Current: ${timeZoneLabel(state.settings.timeZone)}`],
-				items: [
-					{
-						id: "local",
-						label: "Local (default)",
-						description: "Follow the operating system time zone.",
-						action: "choose-local-time-zone",
-					},
-					{
-						id: "UTC",
-						label: "UTC",
-						description: "Use Coordinated Universal Time.",
-						action: "choose-utc-time-zone",
-					},
-					{
-						id: "custom",
-						label: "Custom IANA time zone…",
-						description: "Examples: Asia/Taipei, America/New_York.",
-						action: "choose-custom-time-zone",
-					},
-				],
-				hint: "back",
-			}),
+			locale: ({ state }) =>
+				localeEntry
+					? {
+							kind: "input",
+							title: "Custom BCP 47 locale",
+							lines: [`Current: ${localeLabel(state.settings.locale)}`],
+							placeholder: "Examples: en-US, fr-FR, zh-TW",
+							action: "choose-custom-locale",
+							hint: "back",
+						}
+					: {
+							kind: "actions",
+							title: "Stamp Locale",
+							lines: [`Current: ${localeLabel(state.settings.locale)}`],
+							items: [
+								{
+									id: "invariant",
+									label: "Invariant (default)",
+									description: "ISO date, Latin digits, and English AM/PM.",
+									action: "choose-invariant-locale",
+								},
+								{
+									id: "system",
+									label: "System locale",
+									description: "Use the operating system locale.",
+									action: "choose-system-locale",
+								},
+								{
+									id: "custom",
+									label: "Custom BCP 47 locale…",
+									description: "Examples: en-US, fr-FR, zh-TW.",
+									action: "choose-custom-locale",
+								},
+							],
+							hint: "back",
+						},
+			"time-zone": ({ state }) =>
+				timeZoneEntry
+					? {
+							kind: "input",
+							title: "Custom IANA time zone",
+							lines: [`Current: ${timeZoneLabel(state.settings.timeZone)}`],
+							placeholder: "Examples: Asia/Taipei, America/New_York",
+							action: "choose-custom-time-zone",
+							hint: "back",
+						}
+					: {
+							kind: "actions",
+							title: "Stamp Time Zone",
+							lines: [`Current: ${timeZoneLabel(state.settings.timeZone)}`],
+							items: [
+								{
+									id: "local",
+									label: "Local (default)",
+									description: "Follow the operating system time zone.",
+									action: "choose-local-time-zone",
+								},
+								{
+									id: "UTC",
+									label: "UTC",
+									description: "Use Coordinated Universal Time.",
+									action: "choose-utc-time-zone",
+								},
+								{
+									id: "custom",
+									label: "Custom IANA time zone…",
+									description: "Examples: Asia/Taipei, America/New_York.",
+									action: "choose-custom-time-zone",
+								},
+							],
+							hint: "back",
+						},
 			status: ({ state }) => ({
 				kind: "detail",
 				title: "Stamp Status",
@@ -281,37 +303,63 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 			},
 			"set-tool-stamps": ({ ctx, value, signal }) =>
 				savePatch(runtime, ctx, signal, { toolStamps: value === "Show" }, `Tool stamps: ${value}.`),
-			"open-locale": async () => ({ kind: "to", screen: "locale" }),
+			"open-locale": async () => {
+				localeEntry = false;
+				return { kind: "to", screen: "locale" };
+			},
 			"choose-invariant-locale": ({ ctx, signal }) =>
 				savePatch(runtime, ctx, signal, { locale: "invariant" }, "Locale: Invariant.", "back"),
 			"choose-system-locale": ({ ctx, signal }) =>
 				savePatch(runtime, ctx, signal, { locale: "system" }, "Locale: System.", "back"),
-			"choose-custom-locale": async ({ ctx, signal }) => {
-				const raw = await ctx.ui.input("BCP 47 locale", "Examples: en-US, fr-FR, zh-TW");
-				if (signal.aborted) return { kind: "rejected" };
-				if (raw === undefined) return { kind: "back" };
-				const locale = canonicalizeLocale(raw.trim());
+			"choose-custom-locale": async ({ ctx, signal, value }) => {
+				if (value === undefined) {
+					localeEntry = true;
+					return { kind: "stay" };
+				}
+				const locale = canonicalizeLocale(value.trim());
 				if (!locale || locale === "invariant" || locale === "system") {
 					ctx.ui.notify("Enter one valid BCP 47 locale, such as en-US.", "warning");
 					return { kind: "rejected" };
 				}
-				return savePatch(runtime, ctx, signal, { locale }, `Locale: ${locale}.`, "back");
+				const result = await savePatch(
+					runtime,
+					ctx,
+					signal,
+					{ locale },
+					`Locale: ${locale}.`,
+					"back",
+				);
+				if (result.kind === "back") localeEntry = false;
+				return result;
 			},
-			"open-time-zone": async () => ({ kind: "to", screen: "time-zone" }),
+			"open-time-zone": async () => {
+				timeZoneEntry = false;
+				return { kind: "to", screen: "time-zone" };
+			},
 			"choose-local-time-zone": ({ ctx, signal }) =>
 				savePatch(runtime, ctx, signal, { timeZone: "local" }, "Time zone: Local.", "back"),
 			"choose-utc-time-zone": ({ ctx, signal }) =>
 				savePatch(runtime, ctx, signal, { timeZone: "UTC" }, "Time zone: UTC.", "back"),
-			"choose-custom-time-zone": async ({ ctx, signal }) => {
-				const raw = await ctx.ui.input("IANA time zone", "Examples: Asia/Taipei, America/New_York");
-				if (signal.aborted) return { kind: "rejected" };
-				if (raw === undefined) return { kind: "back" };
-				const timeZone = canonicalizeTimeZone(raw.trim());
+			"choose-custom-time-zone": async ({ ctx, signal, value }) => {
+				if (value === undefined) {
+					timeZoneEntry = true;
+					return { kind: "stay" };
+				}
+				const timeZone = canonicalizeTimeZone(value.trim());
 				if (!timeZone || timeZone === "local") {
 					ctx.ui.notify("Enter one valid IANA time zone, such as Asia/Taipei.", "warning");
 					return { kind: "rejected" };
 				}
-				return savePatch(runtime, ctx, signal, { timeZone }, `Time zone: ${timeZone}.`, "back");
+				const result = await savePatch(
+					runtime,
+					ctx,
+					signal,
+					{ timeZone },
+					`Time zone: ${timeZone}.`,
+					"back",
+				);
+				if (result.kind === "back") timeZoneEntry = false;
+				return result;
 			},
 		},
 	});

--- a/extensions/pi-stamp/test/menu.test.ts
+++ b/extensions/pi-stamp/test/menu.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
-import { createMockContext } from "../../../test/support.js";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
 import { DEFAULT_STAMP_SETTINGS } from "../src/format.js";
 import { createStampMenu, showStampMenu } from "../src/menu.js";
 import type {
@@ -152,39 +152,129 @@ test("bounded setting actions persist exact patches", async () => {
 	assert.equal(notifications.at(-1)?.level, "info");
 });
 
-test("custom locale and time-zone input validates, cancels without mutation, and saves canonical values", async () => {
+test("custom locale and time-zone screens validate and save canonical raw input", async () => {
 	const runtime = memorySettingsRuntime();
-	const values = [undefined, "not_a_locale", "EN-us", "Moon/Base", "utc"];
-	const { ctx, notifications } = createMockContext({
-		mode: "tui",
-		input: async () => values.shift(),
-	});
+	const { ctx, notifications } = createMockContext({ mode: "tui" });
 	const menu = createStampMenu(runtime);
-	const actionContext = () => ({
+	const actionContext = (value?: string) => ({
 		ctx,
 		state: runtime.get(),
 		signal: new AbortController().signal,
 		itemId: "custom",
+		value,
 	});
 
 	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext()), {
-		kind: "back",
+		kind: "stay",
 	});
-	assert.deepEqual(runtime.patches, []);
-	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext()), {
+	const localeInput = resolveMenuScreen(menu, "locale", runtime.get());
+	assert.equal(localeInput.kind, "input");
+	if (localeInput.kind !== "input") assert.fail("Expected locale input screen");
+	assert.equal(localeInput.action, "choose-custom-locale");
+	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext("not_a_locale")), {
 		kind: "rejected",
 	});
-	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext()), {
+	assert.deepEqual(await menu.actions["choose-custom-locale"](actionContext("EN-us")), {
 		kind: "back",
 	});
+
 	assert.deepEqual(await menu.actions["choose-custom-time-zone"](actionContext()), {
+		kind: "stay",
+	});
+	const timeZoneInput = resolveMenuScreen(menu, "time-zone", runtime.get());
+	assert.equal(timeZoneInput.kind, "input");
+	if (timeZoneInput.kind !== "input") assert.fail("Expected time-zone input screen");
+	assert.equal(timeZoneInput.action, "choose-custom-time-zone");
+	assert.deepEqual(await menu.actions["choose-custom-time-zone"](actionContext("Moon/Base")), {
 		kind: "rejected",
 	});
-	assert.deepEqual(await menu.actions["choose-custom-time-zone"](actionContext()), {
+	assert.deepEqual(await menu.actions["choose-custom-time-zone"](actionContext("utc")), {
 		kind: "back",
 	});
+
 	assert.deepEqual(runtime.patches, [{ locale: "en-US" }, { timeZone: "UTC" }]);
 	assert.ok(notifications.some((notice) => notice.level === "warning"));
+});
+
+test("TUI custom input retains a rejected draft and Ctrl+C closes the menu", async () => {
+	const runtime = memorySettingsRuntime();
+	let customCalls = 0;
+	let rejectedRender = "";
+	const { ctx } = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			customCalls += 1;
+			const harness = createCustomSelectorHarness(factory, 60);
+			if (customCalls === 1) harness.handleInput("tui.select.confirm");
+			else if (customCalls === 2) {
+				for (let index = 0; index < 3; index += 1) harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else if (customCalls === 3) {
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else if (customCalls === 4) {
+				harness.setFocused(true);
+				harness.handleInput("not_a_locale");
+				harness.handleInput("tui.input.submit");
+				await harness.waitForPending();
+				rejectedRender = harness.render().join("\n");
+				harness.handleInput("\u0015");
+				harness.handleInput("EN-us");
+				harness.handleInput("tui.input.submit");
+				await harness.waitForPending();
+			} else harness.handleInput("\u0003");
+			return harness.result ?? harness.resultPromise;
+		},
+	});
+	const result = await showStampMenu(ctx, runtime, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "closed");
+	assert.equal(customCalls, 5);
+	assert.match(rejectedRender, /not_a_locale/u);
+	assert.deepEqual(runtime.patches, [{ locale: "en-US" }]);
+});
+
+test("RPC custom input retries a rejected value before saving", async () => {
+	const runtime = memorySettingsRuntime();
+	let mainVisits = 0;
+	let settingsVisits = 0;
+	let inputCalls = 0;
+	const values = ["not_a_locale", "EN-us"];
+	const { ctx } = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		input: async () => {
+			inputCalls += 1;
+			return values.shift();
+		},
+		select: async (title: string, options: string[]) => {
+			if (title.startsWith("Stamp Settings")) {
+				settingsVisits += 1;
+				return settingsVisits === 1
+					? options.find((option) => option.startsWith("Locale"))
+					: undefined;
+			}
+			if (title.startsWith("Stamp Locale")) {
+				return options.find((option) => option.startsWith("Custom BCP 47"));
+			}
+			mainVisits += 1;
+			return mainVisits === 1 ? "Settings" : "Close";
+		},
+	});
+
+	const result = await showStampMenu(ctx, runtime, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "closed");
+	assert.equal(inputCalls, 2);
+	assert.deepEqual(runtime.patches, [{ locale: "en-US" }]);
 });
 
 test("save failure is rejected without changing effective settings", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -415,7 +415,7 @@
 			"version": "0.41.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.41.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -424,16 +424,6 @@
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
 			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"extensions/pi-stamp/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
-			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"


### PR DESCRIPTION
## Summary

- project Stamp's locale and time-zone chooser screens into declarative input screens for custom values
- retain extension-owned canonical validation, serialized persistence, rollback, and warning copy
- preserve TUI draft retry, Back/Ctrl+C behavior, owner cancellation, and RPC rejected-value retry
- require the API-version-3-compatible tui-kit range

## Verification

- focused pi-stamp tests: 7 passed
- `npm run check --workspace @narumitw/pi-stamp`
- `just pack-stamp`
- deterministic TUI component and RPC flows: passed
- LSP diagnostics: 0

This is PR 2 of the consumer migration stack and intentionally targets `refactor/pi-usage-run-task`; after PR #479 merges it can be retargeted to `main` without changing its own diff.
