### PR TITLE
feat(image-drop): adopt declarative limit flows

### DIFF
--- a/docs/plans/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
+++ b/docs/plans/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
@@ -108,6 +108,25 @@ behavior-preserving consumer migrations, then make an evidence-based go/no-go de
 - Delete any temporary `pi-btw` prototype after the go/no-go check. A no-go leaves `pi-btw` source and
   package metadata unchanged and records the missing seam for a future scoped decision.
 
+## pi-btw Gate Result
+
+| Contract | Current owner/evidence | Public `review` fit |
+| --- | --- | --- |
+| Exact raw draft delivery | `formatBtwBringToMain()` and caller-owned `choice.draft` | Fits; the review action can retain the raw id/content boundary. |
+| Terminal-control safety and cell wrapping | `BtwBringToMainPreview`; focused C0/C1, Unicode, and narrow-width tests | Fits through kit sanitization and grapheme/cell hard wrapping. |
+| Terminal-row viewport | `BtwBringToMainPreview` derives rows from `tui.terminal.rows` | **Missing:** kit review uses a fixed/default `viewportSize` and never reads terminal rows. |
+| Paging and configured keys | Preview tests cover page keys plus configured Bring/Back | Fits for paging and injected confirm/cancel keys. |
+| Bring vs Back vs Ctrl+C Close | `BtwBringToMainPreviewAction` has three distinct variants | **Missing:** a root `runMenu()` returns `{ kind: "closed" }` for both Back and Close. |
+| Main-editor preservation | `showBtwCustomPreservingEditor()` snapshots/restores around custom UI | Could remain extension-owned, but requires a new wrapper around `runMenu()`. |
+| Exact-selector restoration | Caller restores `selectionState` only after preview Back | Blocked by the missing Back/Close result distinction. |
+
+**Decision: no-go for this migration wave.** A disposable package-root harness drove Escape and
+Ctrl+C through the same `ReviewScreen`; both returned the identical `{ kind: "closed" }` result.
+Source inspection also confirmed `reviewViewportSize()` is fixed and does not observe terminal rows.
+Migrating now would weaken tested behavior or require a new kit close-reason/adaptive-viewport API,
+which is outside this plan. The disposable harness was deleted after the check, and `pi-btw`
+source/package metadata is unchanged.
+
 ## Plan
 
 ### 0. Isolate prerequisites and establish baselines
@@ -185,39 +204,48 @@ behavior-preserving consumer migrations, then make an evidence-based go/no-go de
 
 ### 3. PR 3 — migrate `pi-image-drop` limits to input and review
 
-- [ ] Extend `extensions/pi-image-drop/test/lifecycle.test.ts` and `test/menu.test.ts` with failing
+- [x] Extend `extensions/pi-image-drop/test/lifecycle.test.ts` and `test/menu.test.ts` with failing
   contract tests for a standard limit input and review: exact current/default/pending copy, raw-value
   and hard-ceiling validation, the per-image-versus-batch cross-field invariant, rejected-draft
   retention, Back versus Ctrl+C, no-change save, cancel-without-save, owner abort, save-failure retry,
-  successful patch identity, and a refreshed zero-unsaved-changes limits screen.
-- [ ] Update `extensions/pi-image-drop/package.json` and `package-lock.json` to the
+  successful patch identity, and a refreshed zero-unsaved-changes limits screen. Evidence: the first
+  compile failed on the missing projection/validation exports; 42 final focused lifecycle/menu tests
+  pass, including rejected-draft inspection, no-op save, stale-save, and refreshed-state assertions.
+- [x] Update `extensions/pi-image-drop/package.json` and `package-lock.json` to the
   API-version-3-compatible kit range; verify standalone installation metadata cannot select
-  `pi-tui-kit@0.40.x` for the migrated source.
-- [ ] Move pure limit labels, prompt/units, formatting, parsing, hard-ceiling and cross-field
+  `pi-tui-kit@0.40.x` for the migrated source. Evidence: the image-local 0.40 lock entry was removed,
+  `npm ci` followed by `npm ls` resolves workspace 0.41.0, and the dry-run package has the new range.
+- [x] Move pure limit labels, prompt/units, formatting, parsing, hard-ceiling and cross-field
   validation, diff text, patch construction, and screen projection helpers from `src/runtime.ts`
   into extension-owned `src/menu.ts`; verify runtime lifecycle/generation and settings persistence
   remain in `ImageDropRuntime`, and recheck the existing over-1,000-line cohesion justification after
-  the move.
-- [ ] Add `limit-input` and `limit-review` screen ids and dedicated submit/confirm actions to the
+  the move. Evidence: runtime is now 972 lines, menu projection is 367 lines, and no persistence or
+  lifecycle owner moved out of `ImageDropRuntime`.
+- [x] Add `limit-input` and `limit-review` screen ids and dedicated submit/confirm actions to the
   existing Image Drop menu. Keep the selected limit and draft in the menu invocation, return input
   Back/review Back to the limits list, and preserve Ctrl+C as whole-menu Close through kit-owned
-  navigation.
-- [ ] On valid input, update only the in-memory draft and return to the limits list; on review confirm,
+  navigation. Evidence: lifecycle tests drive standard kit components through all transitions.
+- [x] On valid input, update only the in-memory draft and return to the limits list; on review confirm,
   publish exactly `limitSettingsPatch()`, revalidate generation/signal after the await, then advance
   `loadedSettings`, `originalLimits`, and `limitDraft` together so the reopened limits screen shows
   no pending changes. Verify failed or stale publication cannot update UI or in-memory committed
-  state.
-- [ ] Remove `showImageDropInputDialog`, `InputDialogResult`, the `showInput` runtime dependency, and
+  state. Evidence: focused tests assert exact patches, zero unsaved state after success, retry after
+  failure, and no stale state/UI publication after replacement during a pending save.
+- [x] Remove `showImageDropInputDialog`, `InputDialogResult`, the `showInput` runtime dependency, and
   superseded component tests/imports. Retain `runImageDropMenuLoad()` and
   `showImageDropConfirmDialog()` for their distinct loader and link-rotation three-way contracts;
-  verify those existing cancellation/close tests remain unchanged and pass.
-- [ ] Update `extensions/pi-image-drop/README.md` so command-menu, settings, and package-layout text
+  verify those existing cancellation/close tests remain unchanged and pass. Evidence: repository
+  search finds no removed symbol, while all specialized loader/confirmation tests pass.
+- [x] Update `extensions/pi-image-drop/README.md` so command-menu, settings, and package-layout text
   identify limit input/review as standard kit flows while loaders and link-rotation confirmation stay
   specialized; preserve the documented TUI-only command and future-session settings behavior.
-- [ ] Audit settings concurrency and lifecycle end to end: invalid-file protection, latest-document
+  Evidence: the command-menu and package-layout sections now state that ownership split explicitly.
+- [x] Audit settings concurrency and lifecycle end to end: invalid-file protection, latest-document
   writes, unknown fields, atomic publication, invocation ordering, failure recovery, session
   replacement, component disposal, and shutdown. Verify every post-await continuation uses the
-  original menu generation/signal and no stale `ExtensionContext` is touched.
+  original menu generation/signal and no stale `ExtensionContext` is touched. Evidence: settings
+  storage code is unchanged; both automatic-start and limit-save continuations now check their action
+  signal and captured generation before state/UI, and the replacement-during-save test passes.
 - [ ] Run Image Drop focused lifecycle/menu tests, its web-asset check,
   `npm run check --workspace @narumitw/pi-image-drop`, `npm test`, `npm run check`, and
   `just pack-image-drop`; inspect the tarball and run an automated TUI-host smoke because repository
@@ -225,20 +253,25 @@ behavior-preserving consumer migrations, then make an evidence-based go/no-go de
 
 ### 4. Gate — assess `pi-btw` preview against `review`
 
-- [ ] Write a contract matrix from `extensions/pi-btw/src/bring-to-main.ts`,
+- [x] Write a contract matrix from `extensions/pi-btw/src/bring-to-main.ts`,
   `extensions/pi-btw/src/btw.ts`, and `extensions/pi-btw/test/side-thread.test.ts` covering exact raw
   draft delivery, terminal-control escaping, grapheme/cell wrapping, terminal-row viewport sizing,
   paging, configured confirm/back keys, Ctrl+C Close, editor-text preservation, and restored
-  selection state; verify every current behavior has an explicit proposed owner.
-- [ ] Test the existing package-root `runMenu()`/`ReviewScreen` interface against that matrix with a
+  selection state; verify every current behavior has an explicit proposed owner. Evidence: the
+  matrix above maps all eight contracts and identifies the two missing public-kit seams.
+- [x] Test the existing package-root `runMenu()`/`ReviewScreen` interface against that matrix with a
   disposable local prototype or compile-time harness. Mark the gate **go** only if Bring, Back, and
   Close remain distinct and editor/viewport invariants survive without a new kit API or broad
   `chooseBringToMain()` rewrite; otherwise delete the prototype and record a no-go with the exact
-  missing seam.
-- [ ] If the gate is go, draft a separate implementation plan/PR boundary that adds the dependency,
+  missing seam. Evidence: `node node_modules/.cache/pi-btw-review-gate.mjs` passed an assertion that
+  root Escape and Ctrl+C both return `{ kind: "closed" }`; source inspection proves fixed viewport
+  sizing, so the gate is no-go.
+- [x] If the gate is go, draft a separate implementation plan/PR boundary that adds the dependency,
   replaces only `BtwBringToMainPreview`, maps its regression tests to the public review contract, and
   runs `just pack-btw`. If it is no-go, leave `pi-btw` source/package metadata unchanged and record
-  whether a future close-reason or adaptive-viewport contract would justify kit work.
+  whether a future close-reason or adaptive-viewport contract would justify kit work. Evidence:
+  `pi-btw` has no diff or new dependency; a future plan must first decide whether kit should expose a
+  close reason and terminal-adaptive viewport.
 
 ### 5. Cross-PR audit and handoff
 

--- a/docs/plans/archived/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
+++ b/docs/plans/archived/2026-07-31_pi-tui-kit-consumer-migrations-plan.md
@@ -169,9 +169,11 @@ source/package metadata is unchanged.
   another-provider, all-provider, and revalidation paths still use only settled current-session data.
   Evidence: every call retains the menu controller signal; existing stable-current, provider,
   fan-out, shutdown, and model/account revalidation guards run after the awaited helper.
-- [ ] Run the pi-usage focused tests, `npm run check --workspace @narumitw/pi-usage`, `npm test`,
+- [x] Run the pi-usage focused tests, `npm run check --workspace @narumitw/pi-usage`, `npm test`,
   `npm run check`, and `just pack-usage`; inspect the dry-run tarball dependency metadata and record
-  any unavailable runtime smoke before marking this PR ready.
+  any unavailable runtime smoke before marking this PR ready. Evidence: 18 focused tests and the
+  package check passed; the final independent-clone root gates passed 1,914 tests; the 12-file pack
+  includes the compatible dependency; PR #479 CI/CodeQL passed and the PR merged.
 
 ### 2. PR 2 — migrate `pi-stamp` custom values to declarative input
 
@@ -198,9 +200,11 @@ source/package metadata is unchanged.
   preserved, and every post-save continuation checks the action signal before notifying or
   transitioning. Evidence: persistence code is unchanged; submissions still use `savePatch()`, which
   checks the action signal before and after `runtime.update()`, and failures return `rejected`.
-- [ ] Run stamp focused tests, `npm run check --workspace @narumitw/pi-stamp`, `npm test`,
+- [x] Run stamp focused tests, `npm run check --workspace @narumitw/pi-stamp`, `npm test`,
   `npm run check`, and `just pack-stamp`; inspect dependency and source contents and perform a
-  deterministic RPC menu smoke for rejected-then-valid input.
+  deterministic RPC menu smoke for rejected-then-valid input. Evidence: seven focused tests, package
+  check, final 1,914-test root gates, 9-file pack, TUI draft retry, and RPC retry all passed; PR #481
+  CI and CodeQL are green.
 
 ### 3. PR 3 — migrate `pi-image-drop` limits to input and review
 
@@ -246,10 +250,12 @@ source/package metadata is unchanged.
   original menu generation/signal and no stale `ExtensionContext` is touched. Evidence: settings
   storage code is unchanged; both automatic-start and limit-save continuations now check their action
   signal and captured generation before state/UI, and the replacement-during-save test passes.
-- [ ] Run Image Drop focused lifecycle/menu tests, its web-asset check,
+- [x] Run Image Drop focused lifecycle/menu tests, its web-asset check,
   `npm run check --workspace @narumitw/pi-image-drop`, `npm test`, `npm run check`, and
   `just pack-image-drop`; inspect the tarball and run an automated TUI-host smoke because repository
-  rules prohibit opening an interactive TUI.
+  rules prohibit opening an interactive TUI. Evidence: 42 focused tests, fresh browser assets,
+  package check, independent-clone 1,914-test root gates, and the 23-file pack passed; lifecycle tests
+  drive the real kit input/review components as the automated TUI-host smoke.
 
 ### 4. Gate — assess `pi-btw` preview against `review`
 
@@ -275,33 +281,38 @@ source/package metadata is unchanged.
 
 ### 5. Cross-PR audit and handoff
 
-- [ ] For each migration diff, audit TUI versus RPC/unsupported modes, user cancellation, component
+- [x] For each migration diff, audit TUI versus RPC/unsupported modes, user cancellation, component
   disposal, session replacement, shutdown, post-await state use, package-root imports, metadata, and
   source-file size against `docs/extension-conventions.md`; record deviations or unavailable smokes
-  in that PR's handoff.
-- [ ] Verify each adopting extension has a compatible kit range while every non-adopting consumer's
+  in that PR's handoff. Evidence: all custom UI remains TUI-guarded; Usage/Stamp retain RPC behavior;
+  Image Drop stays TUI-only; cancellation/replacement tests pass; only package-root imports remain;
+  LSP reports zero diagnostics; and Image Drop runtime fell from 1,085 to 972 lines.
+- [x] Verify each adopting extension has a compatible kit range while every non-adopting consumer's
   range is untouched; use manifest diffs, lockfile inspection, `npm ls`, and each package dry run as
-  evidence.
-- [ ] Confirm the three implementation PRs remain independently revertible and the `pi-btw` decision
+  evidence. Evidence: only Usage, Stamp, and Image Drop changed to `^0.41.0`; all other 15 consumers
+  remain `^0.40.0`, all three local 0.40 lock entries were removed, and all packs passed.
+- [x] Confirm the three implementation PRs remain independently revertible and the `pi-btw` decision
   is finite. Do not combine unrelated dependency updates, generated artifacts, or deferred kit API
-  work into a migration commit.
+  work into a migration commit. Evidence: commits/PRs #479, #481, and #482 each expose one extension
+  diff; #482 is temporarily stacked on #481 and can retarget main unchanged; dependency updates stayed
+  in the invoking tree; the Btw gate is recorded as no-go with no Btw or kit diff.
 
 ## Completion Checklist
 
-- [ ] `pi-usage` delegates generic task lifecycle policy to `runTask()` with unchanged query,
+- [x] `pi-usage` delegates generic task lifecycle policy to `runTask()` with unchanged query,
   cancellation, stale-session, and error-reporting behavior.
-- [ ] `pi-stamp` custom locale/time-zone entry uses declarative input while preserving canonical
+- [x] `pi-stamp` custom locale/time-zone entry uses declarative input while preserving canonical
   validation, rejected drafts, settings safety, navigation, TUI focus, and RPC behavior.
-- [ ] `pi-image-drop` limit editing uses standard input/review screens while preserving draft-only
+- [x] `pi-image-drop` limit editing uses standard input/review screens while preserving draft-only
   edits, exact save patches, future-session semantics, failure recovery, and three-way specialized
   flows outside the limits workflow.
-- [ ] The `pi-btw` review migration has an evidence-backed go/no-go result; no interaction invariant
+- [x] The `pi-btw` review migration has an evidence-backed go/no-go result; no interaction invariant
   is silently weakened.
-- [ ] Only adopting packages require menu API version 3, and their manifests, lockfile edges, tests,
+- [x] Only adopting packages require menu API version 3, and their manifests, lockfile edges, tests,
   and dry-run tarballs agree on the dependency contract.
-- [ ] Focused tests, package checks, root `npm test`, root `npm run check`, applicable deterministic
-  smokes, and `just pack-*` checks pass for every completed migration, with any accepted unverified
-  path documented.
-- [ ] Guides read and audited in each handoff: `docs/extension-conventions.md` and, for Stamp and
+- [x] Focused tests, package checks, root `npm test`, root `npm run check`, applicable deterministic
+  smokes, and `just pack-*` checks pass for every completed migration. Accepted path: interactive TUI
+  launch is prohibited, so deterministic automated hosts exercised the real TUI components.
+- [x] Guides read and audited in each handoff: `docs/extension-conventions.md` and, for Stamp and
   Image Drop, `docs/extension-settings.md`; touched UI, lifecycle, settings, package, documentation,
   and verification areas have no unexplained MUST-rule deviation.

--- a/extensions/pi-image-drop/README.md
+++ b/extensions/pi-image-drop/README.md
@@ -60,8 +60,9 @@ service state, then offers:
 
 Use the configured navigation and confirmation keys. Escape returns from a standard subview or closes
 the main menu; Ctrl+C closes from any menu level. Status, settings, limits, and help share one
-lifecycle-owned navigation flow. Exact three-way confirmations, numeric inputs, and cancellable
-loaders remain specialized. `/image-drop` accepts no arguments. The interactive menu is unavailable
+lifecycle-owned navigation flow. Resource-limit entry and save review use standard declarative
+screens with rejected-draft retention and exact bounded content; cancellable loaders and link-rotation
+three-way confirmation remain specialized. `/image-drop` accepts no arguments. The interactive menu is unavailable
 in RPC, JSON, and print modes and rejects those invocations before starting the service; manual
 settings remain available through the JSON file below.
 
@@ -164,7 +165,7 @@ Then open the unchanged `http://127.0.0.1:45678/...` link locally. Image Drop do
 src/index.ts            Pi package entrypoint
 src/image-drop.ts       extension registration and command orchestration
 src/runtime.ts          Pi lifecycle, command menu, and message orchestration
-src/menu.ts             specialized loaders, confirmations, inputs, and menu-state helpers
+src/menu.ts             limit input/review projections, menu-state helpers, loader, and confirmation
 src/batch.ts            in-memory draft and sent-history state machine
 src/images.ts           bounded image processing
 src/server.ts           authenticated loopback HTTP/SSE server

--- a/extensions/pi-image-drop/package.json
+++ b/extensions/pi-image-drop/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "npm run check:web && tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.41.0",
 		"@radix-ui/colors": "3.0.0",
 		"@radix-ui/react-icons": "1.3.2",
 		"@radix-ui/themes": "3.3.0",

--- a/extensions/pi-image-drop/src/menu.ts
+++ b/extensions/pi-image-drop/src/menu.ts
@@ -4,16 +4,14 @@ import {
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import {
-	type Focusable,
-	Input,
 	Key,
 	matchesKey,
 	SelectList,
-	Text,
 	truncateToWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import type { PublicBatchState, PublicHistoryState } from "./batch.js";
+import { DEFAULT_SETTINGS, HARD_LIMITS, type ImageDropSettings } from "./settings.js";
 
 export type LimitSettingAction =
 	| "maxImages"
@@ -44,6 +42,202 @@ export interface ImageDropMenuState {
 	batch: PublicBatchState;
 	history: PublicHistoryState;
 	serverRunning: boolean;
+}
+
+const MIB = 1024 * 1024;
+export const LIMIT_SETTING_ACTIONS = [
+	"maxImages",
+	"maxImageBytes",
+	"maxBatchBytes",
+	"maxImagePixels",
+	"maxRetainedImages",
+	"maxRetainedBytes",
+] as const satisfies readonly LimitSettingAction[];
+
+export function isLimitSettingAction(value: string): value is LimitSettingAction {
+	return (LIMIT_SETTING_ACTIONS as readonly string[]).includes(value);
+}
+
+export function createLimitInputScreen(
+	key: LimitSettingAction,
+	draft: ImageDropSettings,
+	original: ImageDropSettings,
+) {
+	return {
+		kind: "input" as const,
+		title: limitPrompt(key),
+		lines: [
+			`Current: ${formatLimit(key, draft[key])} · Saved: ${formatLimit(key, original[key])} · Default: ${formatLimit(key, DEFAULT_SETTINGS[key])}`,
+			`Allowed: ${limitRange(key)}.`,
+		],
+		placeholder: limitInputValue(key, draft),
+		action: "submit-limit" as const,
+		hint: "back" as const,
+	};
+}
+
+export function createLimitReviewScreen(original: ImageDropSettings, draft: ImageDropSettings) {
+	return {
+		kind: "review" as const,
+		title: "Review resource-limit changes",
+		content: [
+			...limitChanges(original, draft),
+			"",
+			"These limits apply when the next Pi session starts.",
+			"Higher limits may increase memory use or provider failures.",
+		].join("\n"),
+		format: { kind: "text" as const },
+		confirm: {
+			id: "save",
+			label: "Save resource limits",
+			action: "save-limits" as const,
+		},
+		hint: "back" as const,
+	};
+}
+
+export type LimitInputValidation =
+	| { kind: "valid"; value: number }
+	| { kind: "invalid"; message: string };
+
+export function validateLimitInput(
+	key: LimitSettingAction,
+	input: string,
+	draft: ImageDropSettings,
+): LimitInputValidation {
+	const value = parseLimitInput(key, input);
+	if (value === undefined || value > HARD_LIMITS[key]) {
+		return { kind: "invalid", message: `Enter ${limitRange(key)}.` };
+	}
+	const next = { ...draft, [key]: value };
+	if (next.maxImageBytes > next.maxBatchBytes) {
+		return {
+			kind: "invalid",
+			message: "Size per image cannot exceed the combined draft size.",
+		};
+	}
+	return { kind: "valid", value };
+}
+
+export function limitMenuDescription(
+	value: ImageDropLimitsMenuState["values"][LimitSettingAction],
+): string {
+	return value.pending === undefined
+		? `Current: ${value.current} · Default: ${value.defaultValue}`
+		: `Pending: ${value.pending} · Current: ${value.current} · Default: ${value.defaultValue}`;
+}
+
+export function usesSafeLimits(settings: ImageDropSettings): boolean {
+	return LIMIT_SETTING_ACTIONS.every((key) => settings[key] === DEFAULT_SETTINGS[key]);
+}
+
+export function limitMenuState(
+	draft: ImageDropSettings,
+	original: ImageDropSettings,
+): ImageDropLimitsMenuState {
+	const value = (key: LimitSettingAction) => ({
+		current: formatLimitValue(key, original[key]),
+		defaultValue: formatLimitValue(key, DEFAULT_SETTINGS[key]),
+		...(draft[key] === original[key] ? {} : { pending: formatLimitValue(key, draft[key]) }),
+	});
+	return {
+		unsavedChanges: limitChanges(original, draft).length,
+		values: {
+			maxImages: value("maxImages"),
+			maxImageBytes: value("maxImageBytes"),
+			maxBatchBytes: value("maxBatchBytes"),
+			maxImagePixels: value("maxImagePixels"),
+			maxRetainedImages: value("maxRetainedImages"),
+			maxRetainedBytes: value("maxRetainedBytes"),
+		},
+	};
+}
+
+export function limitChanges(original: ImageDropSettings, draft: ImageDropSettings): string[] {
+	return LIMIT_SETTING_ACTIONS.filter((key) => original[key] !== draft[key]).map(
+		(key) =>
+			`${limitLabel(key)}: ${formatLimit(key, original[key])} → ${formatLimit(key, draft[key])}`,
+	);
+}
+
+export function limitSettingsPatch(
+	original: ImageDropSettings,
+	draft: ImageDropSettings,
+): Partial<ImageDropSettings> {
+	const patch: Partial<ImageDropSettings> = {};
+	for (const key of LIMIT_SETTING_ACTIONS) {
+		if (original[key] !== draft[key]) patch[key] = draft[key];
+	}
+	return patch;
+}
+
+function formatLimitValue(key: LimitSettingAction, value: number): string {
+	if (key === "maxImageBytes" || key === "maxBatchBytes" || key === "maxRetainedBytes") {
+		return formatBytes(value);
+	}
+	if (key === "maxImagePixels" && value % 1_000_000 === 0) {
+		return `${value / 1_000_000} MP`;
+	}
+	return formatCount(value);
+}
+
+function limitPrompt(key: LimitSettingAction): string {
+	const unit = byteLimit(key) ? "MiB" : key === "maxImagePixels" ? "megapixels" : "images";
+	return `${limitLabel(key)} (${unit})`;
+}
+
+function limitInputValue(key: LimitSettingAction, settings: ImageDropSettings): string {
+	const value = settings[key];
+	if (byteLimit(key)) return String(value / MIB);
+	if (key === "maxImagePixels") return String(value / 1_000_000);
+	return String(value);
+}
+
+function parseLimitInput(key: LimitSettingAction, input: string): number | undefined {
+	const value = Number(input.trim());
+	if (!Number.isFinite(value) || value <= 0) return undefined;
+	const scaled = byteLimit(key)
+		? value * MIB
+		: key === "maxImagePixels"
+			? value * 1_000_000
+			: value;
+	return Number.isSafeInteger(scaled) ? scaled : undefined;
+}
+
+function limitRange(key: LimitSettingAction): string {
+	return `a positive value no greater than ${formatLimit(key, HARD_LIMITS[key])}`;
+}
+
+function limitLabel(key: LimitSettingAction): string {
+	return {
+		maxImages: "Images for next message",
+		maxImageBytes: "Per-image upload size",
+		maxBatchBytes: "Total upload size",
+		maxImagePixels: "Maximum image resolution",
+		maxRetainedImages: "Staged + sent image count",
+		maxRetainedBytes: "Staged + sent image memory",
+	}[key];
+}
+
+function formatLimit(key: LimitSettingAction, value: number): string {
+	if (byteLimit(key)) return formatBytes(value);
+	return key === "maxImagePixels" ? formatCount(value) : String(value);
+}
+
+function byteLimit(key: LimitSettingAction): boolean {
+	return key === "maxImageBytes" || key === "maxBatchBytes" || key === "maxRetainedBytes";
+}
+
+export function formatBytes(value: number): string {
+	if (value < 1024) return `${value} B`;
+	if (value < MIB) return `${Math.round(value / 1024)} KiB`;
+	return `${Number((value / MIB).toFixed(1))} MiB`;
+}
+
+function formatCount(value: number): string {
+	return value >= 1_000_000
+		? `${Number((value / 1_000_000).toFixed(1))} megapixels`
+		: String(value);
 }
 
 export function runImageDropMenuLoad<T>(
@@ -89,10 +283,6 @@ export function runImageDropMenuLoad<T>(
 }
 
 export type ConfirmDialogResult = "confirmed" | "cancelled" | "close";
-export type InputDialogResult =
-	| { kind: "submitted"; value: string }
-	| { kind: "cancelled" }
-	| { kind: "closed" };
 
 /** Specialized three-way confirmation retained to distinguish Escape from Ctrl+C. */
 export function showImageDropConfirmDialog(
@@ -101,63 +291,6 @@ export function showImageDropConfirmDialog(
 	message: string,
 ): Promise<ConfirmDialogResult> {
 	return showConfirmScreen(ctx, title, message.split(/\r?\n/));
-}
-
-/** Specialized numeric input retained because standard kit screens do not own text editing. */
-export function showImageDropInputDialog(
-	ctx: ExtensionContext,
-	title: string,
-	initialValue: string,
-): Promise<InputDialogResult> {
-	return ctx.ui.custom<InputDialogResult>((tui, theme, keybindings, done) => {
-		const input = new Input();
-		const heading = new Text("", 0, 0);
-		const current = new Text("", 0, 0);
-		const hint = new Text("", 0, 0);
-		const applyTheme = () => {
-			heading.setText(theme.fg("accent", theme.bold(safeMenuText(title))));
-			current.setText(theme.fg("muted", `Current: ${safeMenuText(initialValue)}`));
-			hint.setText(theme.fg("dim", "enter save • esc back • ctrl+c close"));
-		};
-		applyTheme();
-		const component: Focusable & {
-			render(width: number): string[];
-			invalidate(): void;
-			handleInput(data: string): void;
-		} = {
-			get focused() {
-				return input.focused;
-			},
-			set focused(value: boolean) {
-				input.focused = value;
-			},
-			render(width: number) {
-				const safeWidth = Math.max(1, width);
-				return [
-					...heading.render(safeWidth),
-					...current.render(safeWidth),
-					...input.render(safeWidth),
-					...hint.render(safeWidth),
-				].map((line) => truncateToWidth(line, safeWidth));
-			},
-			invalidate() {
-				applyTheme();
-				heading.invalidate();
-				current.invalidate();
-				input.invalidate();
-				hint.invalidate();
-			},
-			handleInput(data: string) {
-				if (matchesKey(data, Key.ctrl("c"))) done({ kind: "closed" });
-				else if (keybindings.matches(data, "tui.select.cancel")) done({ kind: "cancelled" });
-				else if (keybindings.matches(data, "tui.input.submit")) {
-					done({ kind: "submitted", value: input.getValue() });
-				} else input.handleInput(data);
-				tui.requestRender();
-			},
-		};
-		return component;
-	});
 }
 
 function showConfirmScreen(

--- a/extensions/pi-image-drop/src/runtime.ts
+++ b/extensions/pi-image-drop/src/runtime.ts
@@ -12,20 +12,27 @@ import { BatchError, BatchStore, digestImages, type ProcessedImage } from "./bat
 import { ImageProcessor } from "./images.js";
 import {
 	type ConfirmDialogResult,
+	createLimitInputScreen,
+	createLimitReviewScreen,
+	formatBytes,
 	type ImageDropLimitsMenuState,
-	type InputDialogResult,
+	isLimitSettingAction,
 	type LimitSettingAction,
+	limitChanges,
+	limitMenuDescription,
+	limitMenuState,
+	limitSettingsPatch,
 	type MenuLoadResult,
 	menuSummary,
 	runImageDropMenuLoad,
 	showImageDropConfirmDialog,
-	showImageDropInputDialog,
+	usesSafeLimits,
+	validateLimitInput,
 } from "./menu.js";
 import { readEffectivePiImageSettings } from "./pi-settings.js";
 import { ImageDropServer, type ImageDropServerOptions } from "./server.js";
 import {
 	DEFAULT_SETTINGS,
-	HARD_LIMITS,
 	type ImageDropSettings,
 	loadSettings,
 	settingsFilePath,
@@ -57,7 +64,6 @@ export interface RuntimeDependencies {
 		task: (signal: AbortSignal) => Promise<T>,
 	): Promise<MenuLoadResult<T>>;
 	showConfirm(ctx: ExtensionContext, title: string, message: string): Promise<ConfirmDialogResult>;
-	showInput(ctx: ExtensionContext, title: string, initialValue: string): Promise<InputDialogResult>;
 	updateSettings: typeof updateSettings;
 	settingsFilePath: typeof settingsFilePath;
 }
@@ -69,7 +75,6 @@ const DEFAULT_DEPENDENCIES: RuntimeDependencies = {
 	createProcessor: () => new ImageProcessor(2),
 	loadStatus: runImageDropMenuLoad,
 	showConfirm: showImageDropConfirmDialog,
-	showInput: showImageDropInputDialog,
 	updateSettings,
 	settingsFilePath,
 };
@@ -327,8 +332,17 @@ export class ImageDropRuntime {
 		let loadedSettings: ImageDropSettings | undefined;
 		let originalLimits: ImageDropSettings | undefined;
 		let limitDraft: ImageDropSettings | undefined;
+		let selectedLimit: LimitSettingAction | undefined;
 		let settingsLines: string[] = [];
-		type Screen = "main" | "status" | "settings" | "limits" | "help" | "invalid-settings";
+		type Screen =
+			| "main"
+			| "status"
+			| "settings"
+			| "limits"
+			| "limit-input"
+			| "limit-review"
+			| "help"
+			| "invalid-settings";
 		type Action =
 			| "open"
 			| "load-status"
@@ -338,6 +352,8 @@ export class ImageDropRuntime {
 			| "set-start"
 			| "to-limits"
 			| "limit"
+			| "submit-limit"
+			| "save-limits"
 			| "back";
 		const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 			start: "main",
@@ -464,6 +480,28 @@ export class ImageDropRuntime {
 						hint: "back",
 					};
 				},
+				"limit-input": () => {
+					if (!selectedLimit || !limitDraft || !originalLimits) {
+						return {
+							kind: "detail",
+							title: "Image limit unavailable",
+							lines: ["Return to Image limits and choose a value again."],
+							hint: "back",
+						};
+					}
+					return createLimitInputScreen(selectedLimit, limitDraft, originalLimits);
+				},
+				"limit-review": () => {
+					if (!limitDraft || !originalLimits) {
+						return {
+							kind: "detail",
+							title: "Resource-limit review unavailable",
+							lines: ["Return to Image limits and reload settings."],
+							hint: "back",
+						};
+					}
+					return createLimitReviewScreen(originalLimits, limitDraft);
+				},
 				help: () => ({
 					kind: "detail",
 					title: "How Image Drop works",
@@ -507,12 +545,12 @@ export class ImageDropRuntime {
 					settingsLines = outcome.lines;
 					return { kind: "to", screen: outcome.invalid ? "invalid-settings" : "settings" };
 				},
-				"set-start": async ({ value }) => {
-					if (!loadedSettings) return { kind: "rejected" };
+				"set-start": async ({ value, signal }) => {
+					if (signal.aborted || !loadedSettings) return { kind: "rejected" };
 					const enabled = value === "On";
 					try {
 						await this.dependencies.updateSettings({ startOnSessionStart: enabled });
-						if (!this.isCurrentMenu(generation)) return { kind: "rejected" };
+						if (signal.aborted || !this.isCurrentMenu(generation)) return { kind: "rejected" };
 						loadedSettings = { ...loadedSettings, startOnSessionStart: enabled };
 						if (originalLimits) originalLimits.startOnSessionStart = enabled;
 						if (limitDraft) limitDraft.startOnSessionStart = enabled;
@@ -522,7 +560,7 @@ export class ImageDropRuntime {
 						);
 						return { kind: "stay" };
 					} catch (error) {
-						if (this.isCurrentMenu(generation)) {
+						if (!signal.aborted && this.isCurrentMenu(generation)) {
 							ctx.ui.notify(
 								`Image Drop settings were not saved; the previous settings remain active: ${formatError(error)}`,
 								"error",
@@ -532,14 +570,69 @@ export class ImageDropRuntime {
 					}
 				},
 				"to-limits": async () => ({ kind: "to", screen: "limits" }),
-				limit: async ({ itemId }) =>
-					this.applyLimitMenuAction(ctx, generation, itemId, () => ({
-						original: originalLimits,
-						draft: limitDraft,
-						setDraft: (next) => {
-							limitDraft = next;
-						},
-					})),
+				limit: async ({ itemId }) => {
+					if (!originalLimits || !limitDraft) return { kind: "rejected" };
+					if (itemId === "defaults") {
+						limitDraft = {
+							...limitDraft,
+							...DEFAULT_SETTINGS,
+							startOnSessionStart: originalLimits.startOnSessionStart,
+						};
+						return { kind: "stay" };
+					}
+					if (itemId === "save") {
+						if (limitChanges(originalLimits, limitDraft).length === 0) {
+							ctx.ui.notify("No resource-limit changes to save.", "info");
+							return { kind: "stay" };
+						}
+						return { kind: "to", screen: "limit-review" };
+					}
+					if (!isLimitSettingAction(itemId)) return { kind: "rejected" };
+					selectedLimit = itemId;
+					return { kind: "to", screen: "limit-input" };
+				},
+				"submit-limit": async ({ value, signal }) => {
+					if (signal.aborted || !selectedLimit || !limitDraft || value === undefined) {
+						return { kind: "rejected" };
+					}
+					const validation = validateLimitInput(selectedLimit, value, limitDraft);
+					if (validation.kind === "invalid") {
+						ctx.ui.notify(validation.message, "warning");
+						return { kind: "rejected" };
+					}
+					limitDraft = { ...limitDraft, [selectedLimit]: validation.value };
+					return { kind: "back" };
+				},
+				"save-limits": async ({ signal }) => {
+					if (signal.aborted || !loadedSettings || !originalLimits || !limitDraft) {
+						return { kind: "rejected" };
+					}
+					const patch = limitSettingsPatch(originalLimits, limitDraft);
+					if (Object.keys(patch).length === 0) {
+						ctx.ui.notify("No resource-limit changes to save.", "info");
+						return { kind: "back" };
+					}
+					const committed = { ...limitDraft };
+					try {
+						await this.dependencies.updateSettings(patch);
+						if (signal.aborted || !this.isCurrentMenu(generation)) {
+							return { kind: "rejected" };
+						}
+						loadedSettings = { ...loadedSettings, ...patch };
+						originalLimits = committed;
+						limitDraft = { ...committed };
+						ctx.ui.notify("Resource limits saved for future Pi sessions.", "info");
+						return { kind: "back" };
+					} catch (error) {
+						if (!signal.aborted && this.isCurrentMenu(generation)) {
+							ctx.ui.notify(
+								`Resource limits were not saved; the previous settings remain active: ${formatError(error)}`,
+								"error",
+							);
+						}
+						return { kind: "rejected" };
+					}
+				},
 				back: async () => ({ kind: "back" }),
 			},
 		});
@@ -662,76 +755,6 @@ export class ImageDropRuntime {
 					]
 				: [`Settings file: ${result.kind === "missing" ? "Defaults (not created)" : path}`],
 		};
-	}
-
-	private async applyLimitMenuAction(
-		ctx: ExtensionCommandContext,
-		generation: number,
-		itemId: string,
-		state: () => {
-			original: ImageDropSettings | undefined;
-			draft: ImageDropSettings | undefined;
-			setDraft(next: ImageDropSettings): void;
-		},
-	): Promise<MenuActionResult<"main" | "settings" | "limits">> {
-		const current = state();
-		if (!current.original || !current.draft) return { kind: "rejected" };
-		if (itemId === "defaults") {
-			current.setDraft({
-				...current.draft,
-				...DEFAULT_SETTINGS,
-				startOnSessionStart: current.original.startOnSessionStart,
-			});
-			return { kind: "stay" };
-		}
-		if (itemId === "save") {
-			const changes = limitChanges(current.original, current.draft);
-			if (changes.length === 0) {
-				ctx.ui.notify("No resource-limit changes to save.", "info");
-				return { kind: "stay" };
-			}
-			const confirmation = await this.dependencies.showConfirm(
-				ctx,
-				"Save resource limits for future sessions?",
-				`${changes.join("\n")}\n\nThese limits apply when the next Pi session starts. Higher limits may increase memory use or provider failures.`,
-			);
-			if (!this.isCurrentMenu(generation) || confirmation === "close") return { kind: "close" };
-			if (confirmation !== "confirmed") return { kind: "stay" };
-			try {
-				await this.dependencies.updateSettings(limitSettingsPatch(current.original, current.draft));
-				if (!this.isCurrentMenu(generation)) return { kind: "close" };
-				ctx.ui.notify("Resource limits saved for future Pi sessions.", "info");
-				return { kind: "back" };
-			} catch (error) {
-				if (this.isCurrentMenu(generation)) {
-					ctx.ui.notify(
-						`Resource limits were not saved; the previous settings remain active: ${formatError(error)}`,
-						"error",
-					);
-				}
-				return { kind: "stay" };
-			}
-		}
-		if (!isLimitSettingAction(itemId)) return { kind: "rejected" };
-		const input = await this.dependencies.showInput(
-			ctx,
-			limitPrompt(itemId),
-			limitInputValue(itemId, current.draft),
-		);
-		if (!this.isCurrentMenu(generation) || input.kind === "closed") return { kind: "close" };
-		if (input.kind === "cancelled") return { kind: "stay" };
-		const parsed = parseLimitInput(itemId, input.value);
-		if (parsed === undefined || parsed > HARD_LIMITS[itemId]) {
-			ctx.ui.notify(`Enter ${limitRange(itemId)}.`, "warning");
-			return { kind: "stay" };
-		}
-		const next = { ...current.draft, [itemId]: parsed };
-		if (next.maxImageBytes > next.maxBatchBytes) {
-			ctx.ui.notify("Size per image cannot exceed the combined draft size.", "warning");
-			return { kind: "stay" };
-		}
-		current.setDraft(next);
-		return { kind: "stay" };
 	}
 
 	private batchStatusLine(state: ReturnType<BatchStore["publicState"]>): string {
@@ -910,142 +933,6 @@ export class ImageDropRuntime {
 			? "Resolve or delete failed images before sending."
 			: "Wait for every image to finish uploading before sending.";
 	}
-}
-
-const MIB = 1024 * 1024;
-const LIMIT_KEYS = [
-	"maxImages",
-	"maxImageBytes",
-	"maxBatchBytes",
-	"maxImagePixels",
-	"maxRetainedImages",
-	"maxRetainedBytes",
-] as const;
-type LimitKey = (typeof LIMIT_KEYS)[number];
-
-function isLimitSettingAction(value: string): value is LimitSettingAction {
-	return (LIMIT_KEYS as readonly string[]).includes(value);
-}
-
-function limitMenuDescription(
-	value: ImageDropLimitsMenuState["values"][LimitSettingAction],
-): string {
-	return value.pending === undefined
-		? `Current: ${value.current} · Default: ${value.defaultValue}`
-		: `Pending: ${value.pending} · Current: ${value.current} · Default: ${value.defaultValue}`;
-}
-
-function usesSafeLimits(settings: ImageDropSettings): boolean {
-	return LIMIT_KEYS.every((key) => settings[key] === DEFAULT_SETTINGS[key]);
-}
-
-function limitMenuState(
-	draft: ImageDropSettings,
-	original: ImageDropSettings,
-): ImageDropLimitsMenuState {
-	const value = (key: LimitSettingAction) => ({
-		current: formatLimitValue(key, original[key]),
-		defaultValue: formatLimitValue(key, DEFAULT_SETTINGS[key]),
-		...(draft[key] === original[key] ? {} : { pending: formatLimitValue(key, draft[key]) }),
-	});
-	return {
-		unsavedChanges: limitChanges(original, draft).length,
-		values: {
-			maxImages: value("maxImages"),
-			maxImageBytes: value("maxImageBytes"),
-			maxBatchBytes: value("maxBatchBytes"),
-			maxImagePixels: value("maxImagePixels"),
-			maxRetainedImages: value("maxRetainedImages"),
-			maxRetainedBytes: value("maxRetainedBytes"),
-		},
-	};
-}
-
-function formatLimitValue(key: LimitSettingAction, value: number): string {
-	if (key === "maxImageBytes" || key === "maxBatchBytes" || key === "maxRetainedBytes") {
-		return formatBytes(value);
-	}
-	if (key === "maxImagePixels" && value % 1_000_000 === 0) {
-		return `${value / 1_000_000} MP`;
-	}
-	return formatCount(value);
-}
-
-function limitChanges(original: ImageDropSettings, draft: ImageDropSettings): string[] {
-	return LIMIT_KEYS.filter((key) => original[key] !== draft[key]).map(
-		(key) =>
-			`${limitLabel(key)}: ${formatLimit(key, original[key])} → ${formatLimit(key, draft[key])}`,
-	);
-}
-
-function limitSettingsPatch(
-	original: ImageDropSettings,
-	draft: ImageDropSettings,
-): Partial<Record<LimitKey, number>> {
-	const patch: Partial<Record<LimitKey, number>> = {};
-	for (const key of LIMIT_KEYS) {
-		if (original[key] !== draft[key]) patch[key] = draft[key];
-	}
-	return patch;
-}
-
-function limitPrompt(key: LimitKey): string {
-	const unit = byteLimit(key) ? "MiB" : key === "maxImagePixels" ? "megapixels" : "images";
-	return `${limitLabel(key)} (${unit})`;
-}
-
-function limitInputValue(key: LimitKey, settings: ImageDropSettings): string {
-	const value = settings[key];
-	if (byteLimit(key)) return String(value / MIB);
-	if (key === "maxImagePixels") return String(value / 1_000_000);
-	return String(value);
-}
-
-function parseLimitInput(key: LimitKey, input: string): number | undefined {
-	const value = Number(input.trim());
-	if (!Number.isFinite(value) || value <= 0) return undefined;
-	const scaled = byteLimit(key)
-		? value * MIB
-		: key === "maxImagePixels"
-			? value * 1_000_000
-			: value;
-	return Number.isSafeInteger(scaled) ? scaled : undefined;
-}
-
-function limitRange(key: LimitKey): string {
-	return `a positive value no greater than ${formatLimit(key, HARD_LIMITS[key])}`;
-}
-
-function limitLabel(key: LimitKey): string {
-	return {
-		maxImages: "Images for next message",
-		maxImageBytes: "Per-image upload size",
-		maxBatchBytes: "Total upload size",
-		maxImagePixels: "Maximum image resolution",
-		maxRetainedImages: "Staged + sent image count",
-		maxRetainedBytes: "Staged + sent image memory",
-	}[key];
-}
-
-function formatLimit(key: LimitKey, value: number): string {
-	if (byteLimit(key)) return formatBytes(value);
-	return key === "maxImagePixels" ? formatCount(value) : String(value);
-}
-
-function byteLimit(key: LimitKey): boolean {
-	return key === "maxImageBytes" || key === "maxBatchBytes" || key === "maxRetainedBytes";
-}
-
-function formatBytes(value: number): string {
-	if (value < 1024) return `${value} B`;
-	if (value < MIB) return `${Math.round(value / 1024)} KiB`;
-	return `${Number((value / MIB).toFixed(1))} MiB`;
-}
-
-function formatCount(value: number): string {
-	return value >= 1_000_000
-		? `${Number((value / 1_000_000).toFixed(1))} megapixels`
-		: String(value);
 }
 
 function supportsImages(ctx: ExtensionContext): boolean {

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -4,11 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { digestImages, type ProcessedImage } from "../src/batch.js";
-import type {
-	ConfirmDialogResult,
-	ImageDropLimitsMenuState,
-	InputDialogResult,
-} from "../src/menu.js";
+import type { ConfirmDialogResult, ImageDropLimitsMenuState } from "../src/menu.js";
 import { ImageDropRuntime } from "../src/runtime.js";
 import type { ImageDropServerOptions } from "../src/server.js";
 import { DEFAULT_SETTINGS, type ImageDropSettings } from "../src/settings.js";
@@ -59,9 +55,11 @@ function createHarness(
 			| "close"
 		>;
 		confirm?: () => Promise<boolean>;
-		input?: () => Promise<string | undefined>;
+		input?: (render?: string) => Promise<string | undefined>;
 		confirmDialog?: () => Promise<ConfirmDialogResult>;
-		inputDialog?: () => Promise<InputDialogResult>;
+		inputDialog?: () => Promise<
+			{ kind: "submitted"; value: string } | { kind: "cancelled" } | { kind: "closed" }
+		>;
 		onConfirm?: (title: string, message: string) => void;
 		onStatus?: (lines: readonly string[]) => void;
 		onLimits?: (state: ImageDropLimitsMenuState) => void;
@@ -123,12 +121,6 @@ function createHarness(
 			if (options.confirmDialog) return options.confirmDialog();
 			return ((await options.confirm?.()) ?? true) ? "confirmed" : "cancelled";
 		},
-		showInput:
-			options.inputDialog ??
-			(async () => {
-				const value = await options.input?.();
-				return value === undefined ? { kind: "cancelled" } : { kind: "submitted", value };
-			}),
 		updateSettings: options.onSave ?? (async () => undefined),
 		settingsFilePath: () => "/agent/pi-image-drop.json",
 	});
@@ -138,7 +130,7 @@ function createHarness(
 		mode: "tui",
 		hasUI: true,
 		confirm: options.confirm,
-		input: options.input,
+		input: options.inputDialog ?? options.input,
 		select: async (title: string) => {
 			if (/Image Drop Status/u.test(title)) {
 				options.onStatus?.(title.split("\n").slice(1));
@@ -155,6 +147,19 @@ function createHarness(
 					? "Start with each Pi session"
 					: action === "limits"
 						? "Image limits"
+						: undefined;
+			}
+			if (/Review resource-limit changes/u.test(title)) {
+				options.onConfirm?.("Review resource-limit changes", title);
+				const result = options.confirmDialog
+					? await options.confirmDialog()
+					: ((await options.confirm?.()) ?? true)
+						? "confirmed"
+						: "cancelled";
+				return result === "close"
+					? "\u0003"
+					: result === "confirmed"
+						? "Save resource limits"
 						: undefined;
 			}
 			if (/Image limits/u.test(title)) {
@@ -539,9 +544,58 @@ test("Settings preview and save future limits without changing current-session l
 		current: "128",
 		defaultValue: "128",
 	});
+	assert.equal(menuStates.at(-1)?.unsavedChanges, 0);
+	assert.deepEqual(menuStates.at(-1)?.values.maxRetainedImages, {
+		current: "120",
+		defaultValue: "128",
+	});
 	assert.equal(harness.runtime.getBatchForTesting()?.publicHistoryState().maxImages, 128);
 	assert.match(confirmation, /Staged \+ sent image count/);
 	assert.match(harness.context.notifications.at(-1)?.message ?? "", /future Pi sessions/i);
+});
+
+test("limit input retains a rejected draft before saving the corrected value", async () => {
+	let inputCalls = 0;
+	let rejectedRender = "";
+	let saved: Partial<ImageDropSettings> | undefined;
+	const harness = createHarness({
+		menuActions: ["settings", "close"],
+		settingsActions: ["limits", "back"],
+		limitActions: ["maxImages", "save"],
+		input: async (render) => {
+			inputCalls += 1;
+			if (inputCalls === 2) rejectedRender = render ?? "";
+			return inputCalls === 1 ? "not-a-number" : "12";
+		},
+		confirm: async () => true,
+		onSave: async (patch) => {
+			saved = patch;
+		},
+	});
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+
+	assert.equal(inputCalls, 2);
+	assert.match(rejectedRender, /not-a-number/u);
+	assert.deepEqual(saved, { maxImages: 12 });
+	assert.ok(harness.context.notifications.some((notice) => /positive value/u.test(notice.message)));
+});
+
+test("saving unchanged limits stays in the list without publishing", async () => {
+	let saves = 0;
+	const harness = createHarness({
+		menuActions: ["settings", "close"],
+		settingsActions: ["limits", "back"],
+		limitActions: ["save", "back"],
+		onSave: async () => {
+			saves += 1;
+		},
+	});
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+
+	assert.equal(saves, 0);
+	assert.match(harness.context.notifications.at(-1)?.message ?? "", /no resource-limit changes/iu);
 });
 
 test("automatic-start updates patch only the toggled setting", async () => {
@@ -587,6 +641,53 @@ test("cancelled and failed settings changes preserve the previous valid state", 
 	assert.match(
 		failed.context.notifications.at(-1)?.message ?? "",
 		/previous settings remain active.*disk full/i,
+	);
+});
+
+test("session replacement during a limit save suppresses stale state and UI publication", async () => {
+	let releaseSave: () => void = () => undefined;
+	let saveStarted: () => void = () => undefined;
+	const started = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	const pendingSave = new Promise<void>((resolve) => {
+		releaseSave = resolve;
+	});
+	let saved: Partial<ImageDropSettings> | undefined;
+	const menuStates: ImageDropLimitsMenuState[] = [];
+	const harness = createHarness({
+		menuActions: ["settings"],
+		settingsActions: ["limits"],
+		limitActions: ["maxImages", "save"],
+		input: async () => "12",
+		confirm: async () => true,
+		onLimits: (state) => menuStates.push(state),
+		onSave: async (patch) => {
+			saved = patch;
+			saveStarted();
+			await pendingSave;
+		},
+	});
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	const command = Promise.resolve(
+		harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx),
+	);
+	await started;
+	const replacement = createMockContext({
+		cwd: "/workspace/image-drop",
+		mode: "tui",
+		hasUI: true,
+		model: { id: "vision", provider: "test", input: ["text", "image"] },
+	});
+	const replacing = Promise.resolve(emit(harness.mock, "session_start", {}, replacement.ctx));
+	releaseSave();
+	await Promise.all([command, replacing]);
+
+	assert.deepEqual(saved, { maxImages: 12 });
+	assert.equal(menuStates.at(-1)?.unsavedChanges, 1);
+	assert.equal(
+		harness.context.notifications.some((notice) => /resource limits saved/iu.test(notice.message)),
+		false,
 	);
 });
 

--- a/extensions/pi-image-drop/test/menu.test.ts
+++ b/extensions/pi-image-drop/test/menu.test.ts
@@ -1,16 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
-import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
 import {
+	createLimitInputScreen,
+	createLimitReviewScreen,
 	type ImageDropMenuState,
 	menuSummary,
 	runImageDropMenuLoad,
 	safeMenuText,
 	showImageDropConfirmDialog,
-	showImageDropInputDialog,
+	validateLimitInput,
 } from "../src/menu.js";
+import { DEFAULT_SETTINGS } from "../src/settings.js";
 
 initTheme("dark", false);
 
@@ -41,6 +43,42 @@ test("menu summaries expose empty, partial, and queued state without relying on 
 		/queued/,
 	);
 	assert.equal(safeMenuText("unsafe\u001b]8;;bad\u0007 value"), "unsafe ]8;;bad value");
+});
+
+test("limit input and review projections preserve exact domain values", () => {
+	const original = { ...DEFAULT_SETTINGS };
+	const draft = { ...original, maxRetainedImages: 120 };
+	const input = createLimitInputScreen("maxRetainedImages", draft, original);
+	assert.equal(input.kind, "input");
+	assert.equal(input.action, "submit-limit");
+	assert.match((input.lines ?? []).join("\n"), /Current: 120.*Default: 128/u);
+
+	assert.deepEqual(validateLimitInput("maxImages", "0", draft), {
+		kind: "invalid",
+		message: "Enter a positive value no greater than 32.",
+	});
+	assert.deepEqual(validateLimitInput("maxImages", "33", draft), {
+		kind: "invalid",
+		message: "Enter a positive value no greater than 32.",
+	});
+	assert.deepEqual(validateLimitInput("maxImageBytes", "41", draft), {
+		kind: "invalid",
+		message: "Size per image cannot exceed the combined draft size.",
+	});
+	assert.deepEqual(validateLimitInput("maxImageBytes", "5", draft), {
+		kind: "valid",
+		value: 5 * 1024 * 1024,
+	});
+
+	const review = createLimitReviewScreen(original, draft);
+	assert.equal(review.kind, "review");
+	assert.match(review.content, /Staged \+ sent image count: 128 → 120/u);
+	assert.match(review.content, /next Pi session/u);
+	assert.deepEqual(review.confirm, {
+		id: "save",
+		label: "Save resource limits",
+		action: "save-limits",
+	});
 });
 
 test("status loading distinguishes Escape back from Ctrl+C close", async () => {
@@ -111,26 +149,4 @@ test("specialized confirmation distinguishes cancellation from closing Image Dro
 	}
 	assert.equal(await drive("\u0003"), "close");
 	assert.equal(await drive("\u001b"), "cancelled");
-});
-
-test("specialized numeric input submits, closes, and remains width safe", async () => {
-	let focusedRender = "";
-	const context = createMockContext({
-		mode: "tui",
-		custom: async (factory: unknown) => {
-			const harness = createCustomSelectorHarness(factory, 20);
-			harness.setFocused(true);
-			harness.handleInput("1");
-			harness.handleInput("2");
-			focusedRender = harness.render().join("\n");
-			harness.handleInput("tui.input.submit");
-			return harness.result;
-		},
-	});
-	assert.deepEqual(await showImageDropInputDialog(context.ctx, "Limit", "4"), {
-		kind: "submitted",
-		value: "12",
-	});
-	assert.equal(focusedRender.includes(CURSOR_MARKER), true);
-	for (const line of focusedRender.split("\n")) assert.ok(visibleWidth(line) <= 20);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,7 +292,7 @@
 			"version": "0.41.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.41.0",
 				"@radix-ui/colors": "3.0.0",
 				"@radix-ui/react-icons": "1.3.2",
 				"@radix-ui/themes": "3.3.0",
@@ -315,16 +315,6 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-ai": "*",
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"extensions/pi-image-drop/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
-			"license": "MIT",
-			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
 			}

--- a/test/support.ts
+++ b/test/support.ts
@@ -198,6 +198,9 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 	const selectOverride = overrides.select as
 		| ((title: string, options: string[]) => Promise<string | undefined>)
 		| undefined;
+	const inputOverride = overrides.input as
+		| ((title: string, placeholder?: string) => Promise<unknown>)
+		| undefined;
 	const defaultCustom = async (factory: unknown) => {
 		if (!selectOverride) return undefined;
 		const harness = createCustomSelectorHarness(factory, 100);
@@ -211,7 +214,34 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 		for (let index = 0; index < options.length; index += 1) {
 			harness.handleInput("tui.select.up");
 		}
+		if (options.length === 0 && harness.isFocusable && inputOverride) {
+			for (let attempt = 0; attempt < 20; attempt += 1) {
+				const response = await inputOverride(harness.render().join("\n"), "");
+				if (isRecord(response) && response.kind === "closed") {
+					harness.handleInput("\u0003");
+					return harness.result;
+				}
+				if (response === undefined || (isRecord(response) && response.kind === "cancelled")) {
+					harness.handleInput("tui.select.cancel");
+					return harness.result;
+				}
+				const value =
+					isRecord(response) && response.kind === "submitted" ? response.value : response;
+				if (typeof value !== "string") throw new Error("Mock input must return a string or exit");
+				harness.setFocused(true);
+				if (attempt > 0) harness.handleInput("\u0015");
+				harness.handleInput(value);
+				harness.handleInput("tui.input.submit");
+				await harness.waitForPending();
+				if (harness.result !== undefined) return harness.result;
+			}
+			throw new Error("Mock input exceeded its retry limit");
+		}
 		const selected = await selectOverride(harness.render().join("\n"), options);
+		if (selected === "\u0003") {
+			harness.handleInput("\u0003");
+			return harness.result;
+		}
 		if (selected === undefined) {
 			harness.handleInput("tui.select.cancel");
 			return harness.result;
@@ -311,6 +341,10 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 			return editorText;
 		},
 	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function selectedKitRow(lines: readonly string[]): string | undefined {
@@ -414,6 +448,9 @@ export function createCustomSelectorHarness(
 		resultPromise,
 		get isPiTuiKitScreen() {
 			return (component as { __piTuiKitScreen?: true }).__piTuiKitScreen === true;
+		},
+		get isFocusable() {
+			return "focused" in component;
 		},
 		get result() {
 			return result;


### PR DESCRIPTION
## Summary

- replace Image Drop's custom resource-limit input and save confirmation with declarative input/review screens
- move pure limit projection, parsing, validation, formatting, and patch construction into the extension menu module
- retain extension-owned draft/persistence policy, specialized loader/link confirmation, and TUI-only command behavior
- revalidate owner state after saves and refresh committed menu state only after successful publication
- record a no-go for pi-btw review migration because root Back/Close and terminal-adaptive viewport contracts are missing

## Verification

- focused Image Drop lifecycle/menu tests: 42 passed
- `npm run check --workspace @narumitw/pi-image-drop`
- browser asset freshness check: passed
- independent-clone `npm test`: 1,914 passed
- independent-clone `npm run check`: passed, 1,914 tests
- `just pack-usage`, `just pack-stamp`, and `just pack-image-drop`
- LSP diagnostics: 0 across touched source/tests
- automated TUI-host limit input/review smoke through lifecycle tests

This is PR 3 of the consumer migration stack and intentionally targets `feat/pi-stamp-declarative-input`; after PR #481 merges it can be retargeted to `main` without changing its own diff.
