### PR TITLE
chore(deps): update npm dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.40.0",
-		"typebox": "^1.3.8"
+		"typebox": "^1.3.9"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.40.0",
-		"typebox": "^1.3.8"
+		"typebox": "^1.3.9"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.40.0",
-		"typebox": "^1.3.8"
+		"typebox": "^1.3.9"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",

--- a/extensions/pi-google-genai/package.json
+++ b/extensions/pi-google-genai/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.40.0",
-		"typebox": "^1.3.8"
+		"typebox": "^1.3.9"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",

--- a/extensions/pi-image-drop/package.json
+++ b/extensions/pi-image-drop/package.json
@@ -52,8 +52,8 @@
 		"@earendil-works/pi-ai": "0.83.0",
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
-		"@types/react": "19.2.17",
-		"@types/react-dom": "19.2.3",
+		"@types/react": "19.2.18",
+		"@types/react-dom": "19.2.4",
 		"esbuild": "0.28.1",
 		"typescript": "7.0.2"
 	},

--- a/extensions/pi-langfuse/package.json
+++ b/extensions/pi-langfuse/package.json
@@ -29,8 +29,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@langfuse/otel": "^5.9.1",
-		"@langfuse/tracing": "^5.9.1",
+		"@langfuse/otel": "^5.10.0",
+		"@langfuse/tracing": "^5.10.0",
 		"@narumitw/pi-tui-kit": "^0.40.0",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",

--- a/extensions/pi-lsp/package.json
+++ b/extensions/pi-lsp/package.json
@@ -32,7 +32,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typebox": "^1.3.8"
+		"typebox": "^1.3.9"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.40.0",
 		"proper-lockfile": "^4.1.2",
-		"typebox": "^1.3.8"
+		"typebox": "^1.3.9"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-agent-core": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
-				"typebox": "^1.3.8",
+				"typebox": "^1.3.9",
 				"typescript": "^7.0.2"
 			}
 		},
@@ -179,7 +179,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.40.0",
-				"typebox": "^1.3.8"
+				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -203,7 +203,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.40.0",
-				"typebox": "^1.3.8"
+				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -238,7 +238,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.40.0",
-				"typebox": "^1.3.8"
+				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -268,7 +268,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.40.0",
-				"typebox": "^1.3.8"
+				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -308,8 +308,8 @@
 				"@earendil-works/pi-ai": "0.83.0",
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
-				"@types/react": "19.2.17",
-				"@types/react-dom": "19.2.3",
+				"@types/react": "19.2.18",
+				"@types/react-dom": "19.2.4",
 				"esbuild": "0.28.1",
 				"typescript": "7.0.2"
 			},
@@ -324,8 +324,8 @@
 			"version": "0.41.0",
 			"license": "MIT",
 			"dependencies": {
-				"@langfuse/otel": "^5.9.1",
-				"@langfuse/tracing": "^5.9.1",
+				"@langfuse/otel": "^5.10.0",
+				"@langfuse/tracing": "^5.10.0",
 				"@narumitw/pi-tui-kit": "^0.40.0",
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
@@ -363,7 +363,7 @@
 			"version": "0.41.0",
 			"license": "MIT",
 			"dependencies": {
-				"typebox": "^1.3.8"
+				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -482,7 +482,7 @@
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.40.0",
 				"proper-lockfile": "^4.1.2",
-				"typebox": "^1.3.8"
+				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -2709,21 +2709,21 @@
 			}
 		},
 		"node_modules/@langfuse/core": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.9.1.tgz",
-			"integrity": "sha512-KvyAskAO+2ixJwr9wy148ttR/Zn3oapvOJ2Br4Xcp6zhDpjSIIGB4jW/jkp53/KU9MyEHj0RSFPK/yKoxLC4KA==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.10.0.tgz",
+			"integrity": "sha512-XXz1DBEwGMpNXz8DZHFsixqo+3vBkfYpat3oLLldRMuT8ur6OWQ81Kgh5Obh0CZ31adaR4FrLTHh4N9eBXo64A==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.9.0"
 			}
 		},
 		"node_modules/@langfuse/otel": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.9.1.tgz",
-			"integrity": "sha512-viM5Qq/AIPZPXfO7YdSmDHxEDSrNU/MyGzuE9zKA6hGBII1iLowU+qL99O+TjnXqxoADqlNibhY2pg1/WTIPcw==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.10.0.tgz",
+			"integrity": "sha512-q1expgCm3QwjWII0PeCJJSyEV5o96FQ4VNzL5hgziWGmCPCd9TrrWxWxHdSY7cpZWddEJCp71zdh1nq0xISOpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@langfuse/core": "^5.9.1"
+				"@langfuse/core": "^5.10.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -2736,12 +2736,12 @@
 			}
 		},
 		"node_modules/@langfuse/tracing": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.9.1.tgz",
-			"integrity": "sha512-tJRyVAv1JkuOPh4Uz5eWUNH8U4jcJVtK2F5QNy5cZUzXCSrXobCSHusPbxY6VFZcLcFgtpDtSaxL7ev1tV2JNQ==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.10.0.tgz",
+			"integrity": "sha512-//S9dcZszmEk2yx+h7eg10mEMswyU7MYLkGIJlO6gUfrXA+3Y5pvNiZNZU3cfDus94OAr16dHQpg3nNFiziZjg==",
 			"license": "MIT",
 			"dependencies": {
-				"@langfuse/core": "^5.9.1"
+				"@langfuse/core": "^5.10.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -4819,9 +4819,9 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.17",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-			"integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+			"version": "19.2.18",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+			"integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4829,9 +4829,9 @@
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "19.2.3",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+			"integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
 			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -6127,9 +6127,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/typebox": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.8.tgz",
-			"integrity": "sha512-xYaJgF0KMvBViKWRaKTAtfR6sDt/yH6xAjGAHXYJxKxUF4pVyPXZZhIlwOg6cDIE81N7L0pyIHs136RHBm6rLQ==",
+			"version": "1.3.9",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.9.tgz",
+			"integrity": "sha512-erh7xzupOex0jkMRU72du2Bq7w1aL8625CJuFEiE7dM4YoJqaxKZqwZw00rsrohS78uDICG3h7FhQ9iJQRDRqg==",
 			"license": "MIT"
 		},
 		"node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
-		"typebox": "^1.3.8",
+		"typebox": "^1.3.9",
 		"typescript": "^7.0.2"
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary

- update TypeBox to 1.3.9 across workspace consumers
- update Langfuse packages to 5.10.0 and React type packages to their latest patch releases
- refresh the npm lockfile and align the Biome schema with version 2.5.6

## Testing

- `just update` (1,914 tests passed)
- `npx --no-install biome check biome.json`
- pre-commit Biome and TypeScript checks