### PR TITLE
feat(pi-tui-kit): add adaptive review viewports

### DIFF
--- a/docs/plans/archived/2026-08-01_pi-tui-kit-adaptive-review-viewport-plan.md
+++ b/docs/plans/archived/2026-08-01_pi-tui-kit-adaptive-review-viewport-plan.md
@@ -1,0 +1,333 @@
+# Pi TUI Kit Adaptive Review Viewport Plan
+
+## Goal
+
+Add an opt-in terminal-adaptive viewport to `@narumitw/pi-tui-kit` review screens so TUI reviews use
+live terminal height without overflowing Pi's custom-UI region, while preserving existing fixed-size
+review rendering, deterministic RPC pagination, exact content formatting, navigation, confirmation,
+Back/Close, cancellation, disposal, and stale-owner behavior.
+
+The intended public contract is:
+
+```ts
+const review: ReviewScreen<Action> = {
+  kind: "review",
+  title: "Review changes",
+  content,
+  viewportSize: "adaptive",
+  confirm: { id: "apply", label: "Apply", action: "apply" },
+};
+```
+
+Repository source will raise `PI_EXTENSION_MENU_API_VERSION` from `4` to `5` because older runtimes
+reject the new viewport value. Package versioning and publication remain separate work.
+
+## Context
+
+- Repository source is menu API version 4 after PR #484; the roadmap records the latest published
+  `@narumitw/pi-tui-kit@0.41.0` as API version 3.
+- Review currently uses a 14-row TUI viewport by default, accepts explicit integer sizes from 1 to 50,
+  and caps RPC pages at 8 rows. Its formatting already sanitizes controls, preserves indentation,
+  hard-wraps by terminal cells, highlights code/diffs, clamps scroll offsets, and keeps confirmation
+  identity separate from labels.
+- The fixed 14-row viewport was the remaining Kit seam recorded by the `pi-btw` migration gate.
+  `BtwBringToMainPreview` already reads the public `tui.terminal.rows` getter and reserves three rows
+  for Pi-owned UI, demonstrating the current host-budget convention without a private `dist/*`
+  dependency.
+- Pi's public TUI contract supplies the live `TUI` instance to `ctx.ui.custom()`, exposes
+  `tui.terminal.rows`, rerenders on terminal resize, and requires every component line to remain within
+  the supplied width. RPC `custom()` remains unsupported, so review continues using signal-aware
+  `ctx.ui.select()` pages there.
+- Current planning baseline is clean: `npm run check --workspace @narumitw/pi-tui-kit` passes, and the
+  18 focused model/review tests pass on merged `main`. The repository regression baseline is 1,918
+  tests.
+- Guides read for this plan: `MEMORY.md`, `docs/extension-conventions.md`, Pi's complete
+  `docs/extensions.md`, `docs/tui.md`, and `docs/rpc.md`, plus the public TUI typings and relevant
+  preset/overlay examples. Applicable MUST areas are callback-provided TUI/theme/keybindings,
+  width-bounded rendering, render invalidation, TUI/RPC mode boundaries, cancellation/disposal and
+  stale-owner preservation, public package imports, deterministic tests, the root check, and package
+  dry-run inspection. `docs/extension-settings.md` is not applicable because this change neither
+  reads nor writes extension-owned settings.
+
+## Architecture
+
+### Public contract and compatibility
+
+Change only `ReviewScreen.viewportSize`:
+
+```ts
+viewportSize?: number | "adaptive";
+```
+
+- Omitted `viewportSize` remains the existing fixed 14-row TUI viewport.
+- Numeric values retain the existing integer range `1..50` and identical TUI/RPC behavior.
+- `"adaptive"` affects TUI presentation only. RPC uses the existing deterministic 8-row page size.
+- Any other string remains invalid at compile time and during runtime screen validation.
+- Existing API-version-4 menu definitions remain source-compatible. API version 5 identifies a
+  runtime that can interpret the new value; do not add another viewport property or a configurable
+  host-row reserve in this change.
+
+### TUI height budget
+
+Extend the internal component render host with read-only terminal rows from the callback-provided
+public `TUI`. Adaptive review reads that getter on every `render(width)` call, so Pi's normal resize
+render automatically recomputes the layout without listeners, timers, or retained terminal state.
+
+Use an internal available-row budget of:
+
+```ts
+Math.max(1, Math.floor(tui.terminal.rows) - 3)
+```
+
+The three reserved rows match the existing BTW custom-UI convention and remain an internal host
+policy, not a public consumer setting.
+
+Keep the fixed/default path on the existing `renderFrame()` behavior. For the adaptive path, use one
+pure row-budget helper owned by `components/review.ts` to compose the same sanitized/themed sections
+in the same reading order while never returning more rows than the budget:
+
+1. title and optional supporting `screen.lines`;
+2. an optional separator;
+3. at least one review-content row when content exists;
+4. a position row when content scrolls and at least four total rows are available; and
+5. the keyboard hint.
+
+Constrained-height degradation is explicit rather than accidental truncation:
+
+- one available row shows the primary review content;
+- two rows add a compact one-line title;
+- three rows add a compact critical hint that prioritizes confirmation, Back/Close, then navigation;
+- four or more rows include the position row when scrolling is required;
+- additional rows restore wrapped title/supporting context, the normal full hint, and the separator
+  before expanding the content viewport;
+- lower-priority supporting rows may be omitted only in the opt-in adaptive mode, and every visible
+  row remains width-safe.
+
+The effective content viewport is therefore at least one row, terminal-bounded rather than capped at
+50, and recalculated from fully wrapped frame chrome. Explicit numeric viewports keep the current
+50-row validation ceiling.
+
+### Scroll, resize, and rendering state
+
+Store the last rendered effective viewport size for Page Up/Page Down. Up/Down, Home/End, position
+feedback, raw confirmation identity, Back, and Ctrl+C retain their current behavior. On every render:
+
+- reformat content for the supplied width;
+- recompute the adaptive row budget from live terminal height;
+- recalculate maximum scroll;
+- clamp the existing display-line offset before slicing; and
+- produce position values from the effective viewport.
+
+This plan preserves current display-line offset semantics across width reflow; semantic source-line
+anchoring and follow-bottom behavior are not added.
+
+### RPC and lifecycle ownership
+
+Split fixed TUI sizing from RPC page sizing so `reviewDialogPages()` never reads terminal dimensions.
+For RPC, `"adaptive"` behaves like the omitted default and yields at most 8 lines per page; explicit
+numeric sizes keep `Math.min(viewportSize, 8)`.
+
+No asynchronous ownership changes are required. Existing runtime loops continue to own mode guards,
+combined owner signals, post-await stale checks, confirmation actions, error routing, and disposal.
+The implementation must audit those paths because the TUI host contract and review result matrix are
+touched, but it must not refactor runtime coordination.
+
+### Files and boundaries
+
+Expected implementation ownership:
+
+- `packages/pi-tui-kit/src/types.ts` — public viewport union;
+- `packages/pi-tui-kit/src/model.ts` — adaptive/numeric validation;
+- `packages/pi-tui-kit/src/components/contracts.ts` — internal live terminal-row host contract;
+- `packages/pi-tui-kit/src/components/review.ts` — adaptive layout, effective viewport, scrolling, and
+  unchanged RPC page policy;
+- `packages/pi-tui-kit/src/index.ts` — API version 5;
+- focused Pi TUI Kit tests and compile-time README/context examples;
+- `test/support.ts` — only the minimum mutable terminal-row field needed by deterministic custom-UI
+  tests; this is not a public testing package; and
+- package README, this execution plan, and the canonical roadmap after implementation evidence exists.
+
+Use only package-root Pi imports. Add no runtime dependency, settings, persistence, domain state, or
+consumer-owned policy.
+
+## Non-Goals
+
+- Do not create `@narumitw/pi-tui-kit/testing` or migrate consumer tests to a supported test entry
+  point; that remains the other open Phase 3 capability.
+- Do not migrate or otherwise modify `pi-btw`; its fresh review gate and any migration require a
+  separate plan after adaptive review and testability work are available.
+- Do not add adaptive sizing to action, choice, settings, input, detail, or multi-select screens.
+- Do not add semantic source-line anchoring, follow-bottom scrolling, horizontal scrolling, live
+  preview, editor support, standalone confirmation, deferred multi-select, or a general layout engine.
+- Do not refactor the TUI/RPC runtime into a shared interaction driver.
+- Do not change default/fixed review output, RPC dialog cadence, confirmation semantics, Back/Close
+  results, lifecycle ownership, package version, dependency ranges, or current consumers.
+- Do not publish the package, create a consumer migration PR, or combine unrelated dependency work.
+
+## Assumptions
+
+- The supported Pi version continues to expose live terminal rows through the callback-provided public
+  `TUI`, and Pi requests a render after resize.
+- Reserving three terminal rows remains sufficient for Pi-owned chrome in a non-overlay custom UI;
+  deterministic built-package smoke evidence must confirm the complete rendered review stays within
+  `terminal.rows - 3` for the supported Pi version.
+- Very small terminals cannot display every contextual row simultaneously. The explicit adaptive
+  priority above preserves the primary content and recovery actions before supporting prose.
+- Consumers that do not opt into `"adaptive"` must observe no rendering or pagination change.
+
+## Risks
+
+- **Circular row budgeting:** wrapped title, supporting lines, hints, and the conditional position row
+  all affect the content capacity. Mitigation: isolate a pure layout calculation and test the complete
+  rendered frame, not only its content slice.
+- **Critical hints lost at tiny heights:** naively slicing `renderFrame()` can hide confirmation or
+  exit paths. Mitigation: use the explicit constrained hierarchy and a critical one-line hint before
+  optional navigation/context rows.
+- **Resize drift:** a viewport change can leave `scrollOffset` beyond the new maximum or page by a
+  stale fixed size. Mitigation: clamp on every render and page by the last rendered effective size.
+- **RPC regression:** widening `viewportSize` can accidentally feed a string into numeric page math.
+  Mitigation: separate RPC sizing and compare default, fixed, and adaptive page fixtures.
+- **Compatibility ambiguity:** older runtimes reject `"adaptive"`. Mitigation: raise the declarative
+  API version to 5, document the requirement, and keep version-4 definitions valid.
+- **Testing-host scope creep:** adding generic orchestration to `test/support.ts` would pre-empt the
+  planned testing entry point. Mitigation: add only a mutable `terminal.rows` value and resize setter
+  needed to drive the existing callback; expose no component internals.
+- **Large terminals:** adaptive mode may render more than the fixed 50-row maximum. This is intentional
+  for host parity and remains bounded by live terminal height; content formatting is already complete
+  before slicing, so no new unbounded document traversal is introduced.
+
+## Rollback / Recovery
+
+There is no persisted data or migration. Before publication, revert the bounded adaptive-review PR to
+restore API version 4 and the numeric-only contract. If API version 5 has been published, retain the
+`"adaptive"` union and correct the sizing algorithm in a patch rather than removing an accepted public
+value; invalid or unavailable terminal dimensions may safely fall back to the existing fixed 14-row
+TUI viewport. Numeric/default behavior provides the unaffected fallback path throughout rollout.
+
+## Plan
+
+### 1. Lock the public and visual contracts with red tests
+
+- [x] Re-run `npm run check --workspace @narumitw/pi-tui-kit`, compile the repository test project,
+  and execute the focused model/review tests before edits; record the passing test counts and verify
+  `git status` remains clean so later failures are attributable to adaptive review.
+- [x] Extend `packages/pi-tui-kit/test/context-usage.ts`, `test/readme-usage.ts`, and
+  `test/menu-model.test.ts` with compile/runtime cases that accept `viewportSize: "adaptive"`, retain
+  numeric and omitted definitions, reject another string, and expect API version 5; verify the new
+  cases fail against the numeric-only API version 4 source.
+- [x] Add red-first component tests in `packages/pi-tui-kit/test/review-screen.test.ts` for complete
+  frame heights at constrained, typical, and large terminal rows; cover narrow wrapped headers,
+  supporting lines, critical/full hints, conditional position rows, a minimum content row, and the
+  invariant that every output line also stays within width; verify fixed/default renders remain
+  byte-for-byte unchanged.
+- [x] Add red-first resize and navigation cases that mutate live terminal rows and render widths,
+  scroll to the end, shrink and grow the viewport, and exercise Page Up/Page Down; verify the offset,
+  position text, visible range, and effective page step clamp to the latest render.
+- [x] Add red-first TUI/RPC runtime cases for an adaptive review: TUI must receive live rows through the
+  custom host, while RPC must emit the same bounded 8-row pages and dialog cadence as the omitted
+  default; verify failures are limited to the missing adaptive contract/terminal host.
+
+### 2. Implement adaptive review without changing fixed behavior
+
+- [x] Update `packages/pi-tui-kit/src/types.ts` and `src/model.ts` to accept exactly a numeric
+  `1..50` or `"adaptive"` review viewport and reject all other runtime values; make the focused public
+  type and validation tests pass without changing other screen unions.
+- [x] Extend the internal `RenderHost` in `src/components/contracts.ts` with public-TUI terminal rows,
+  and update the package and repository custom-component harnesses with a default mutable row count;
+  verify existing component/runtime tests compile and render unchanged before adaptive logic lands.
+- [x] Implement the pure adaptive row-budget/composition helper in
+  `packages/pi-tui-kit/src/components/review.ts`, entering it only for `"adaptive"`; prove the complete
+  frame respects `max(1, terminal.rows - 3)` and the constrained visibility hierarchy across the new
+  width/height matrix.
+- [x] Store and use the last rendered effective adaptive viewport for line/page movement, recompute and
+  clamp it after every height or width change, and make the focused resize/navigation tests pass while
+  retaining current fixed scroll behavior.
+- [x] Separate RPC page-size resolution from TUI viewport resolution so adaptive and omitted reviews
+  use 8-row RPC pages and numeric reviews keep the existing cap; make the focused TUI/RPC tests pass
+  without adding adapter-specific layout state.
+- [x] Run every Pi TUI Kit test after the focused green state and search exact fixed/default render and
+  pagination assertions for accidental reclassification; retain existing assertions unless they
+  explicitly opt into adaptive behavior.
+
+### 3. Finalize API version, documentation, and repository compatibility
+
+- [x] Raise `PI_EXTENSION_MENU_API_VERSION` to `5` in `packages/pi-tui-kit/src/index.ts`, update model
+  and compile-time tests to prove API-version-4 definitions still typecheck, and inspect generated
+  declarations for the exact `number | "adaptive"` contract.
+- [x] Update `packages/pi-tui-kit/README.md` and `test/readme-usage.ts` with opt-in adaptive behavior,
+  fixed/default compatibility, the three-row host reserve, constrained-height hierarchy, deterministic
+  RPC fallback, and API version 5; verify the mirrored examples compile through package typechecking.
+- [x] Inspect all production review consumers and exact review tests for assumptions about numeric
+  viewport types, fixed row counts, RPC pages, or API version; verify Image Drop remains unchanged and
+  no consumer source, manifest, lockfile, or dependency-range edit is required.
+- [x] Audit TUI versus RPC, callback TUI/theme/keybindings, resize/invalidation, Back/Close,
+  confirmation, owner abort, `isCurrent()` failure, disposal, pending-action draining, session
+  replacement, shutdown, errors, and unsupported modes against `docs/extension-conventions.md`; add a
+  focused regression for any path not already covered before marking the audit complete.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` after implementation evidence exists: record
+  repository API version 5, mark only the adaptive-review Phase 3 milestone complete/in progress,
+  update the regression metric and decision log, and leave the testing entry point, BTW gate/migration,
+  package release, and later phases open.
+
+### 4. Verify built and repository behavior
+
+- [x] Run LSP diagnostics on every touched TypeScript file and
+  `npm run check --workspace @narumitw/pi-tui-kit`; verify strict types, formatting, generated
+  JavaScript/declarations, public imports, and package-root API version 5 agree.
+- [x] Build the package and run a deterministic package-root TUI smoke through generated `dist/` that
+  renders adaptive review at constrained/typical/large heights, mutates rows and width, scrolls/pages,
+  confirms, returns Back, and closes with Ctrl+C; assert every complete frame fits
+  `terminal.rows - 3` without opening an interactive TUI.
+- [x] Run a real-Pi RPC smoke or deterministic protocol client through the built package for adaptive
+  review pagination, confirmation, cancellation, and owner abort; verify no custom-TUI request is
+  emitted and pages remain bounded/deterministic.
+- [x] Run `npm test` and then `npm run check` sequentially after the shared package build; verify every
+  repository test passes and no concurrent `dist/` rebuild race invalidates consumer results.
+- [x] Run `just pack-tui-kit` and inspect the dry-run tarball's JavaScript, declarations, README,
+  LICENSE, and package metadata; verify API version 5 and the adaptive union are present while package
+  version remains unchanged for the separate release workflow.
+- [x] Audit the final diff against this plan's boundaries; verify no testing entry point, BTW or other
+  consumer migration, generalized adaptive layout, runtime-driver refactor, package-version bump,
+  tracked generated artifact, dependency change, or unrelated roadmap work entered the change.
+
+## Execution Evidence
+
+- Baseline: `npm run check --workspace @narumitw/pi-tui-kit` passed; the repository test project
+  compiled and the pre-change model/review focus passed 18/18 tests.
+- Red contracts: package typechecking rejected `"adaptive"` at the numeric-only type boundary; after
+  the union/host seam landed, four focused adaptive frame/resize/runtime tests failed against the
+  fixed renderer for the intended reasons.
+- Focused green: model/review coverage passed 23/23 tests, and all Pi TUI Kit tests passed 99/99 after
+  package typechecking and build.
+- Public artifacts: generated `dist/types.d.ts` contains exactly `number | "adaptive"`, package-root
+  JavaScript/declarations report API version 5, and package version remains `0.41.0`.
+- Diagnostics and gates: LSP diagnostics reported zero findings across all 12 touched TypeScript
+  files; package check passed; `npm test` and the later `npm run check` each passed all 1,923 tests.
+- Built smokes: the generated package-root TUI smoke passed seven constrained/typical/large,
+  resize/reflow/navigation/confirmation/Back/Close frames; a real Pi 0.83 RPC client passed
+  confirmation, three deterministic 8-row pages, cancellation, and owner abort without custom TUI.
+- Packaging: `just pack-tui-kit` passed with 27 expected files (built JavaScript/declarations, README,
+  LICENSE, and metadata); dry-run version remained `0.41.0`.
+- Scope audit: Image Drop remains on omitted fixed review behavior; no consumer, BTW, manifest,
+  lockfile, dependency range, package version, testing entry point, generated artifact, or unrelated
+  source changed. Runtime mode guards, callback TUI/theme/keybindings, stale/abort/disposal/draining,
+  error, unsupported-mode, Back/Close, and confirmation paths remain covered by the 99-test Kit
+  matrix and the built smokes.
+
+## Completion Checklist
+
+- [x] `ReviewScreen.viewportSize` accepts only the existing numeric range or `"adaptive"`, existing
+  definitions remain valid, and repository menu API version is 5.
+- [x] Adaptive TUI review reads live terminal rows, keeps every complete frame within the host budget,
+  preserves width safety, and degrades constrained layouts according to the documented hierarchy.
+- [x] Resize, reflow, scrolling, paging, position feedback, confirmation, Back, and Close remain
+  deterministic, with fixed/default rendering unchanged.
+- [x] RPC adaptive review retains 8-row bounded pagination and existing cancellation, confirmation,
+  stale-owner, error, and unsupported-mode semantics.
+- [x] Current consumers typecheck and retain behavior without source, manifest, lockfile, package
+  version, or dependency-range changes; BTW remains specialized pending a separate gate.
+- [x] Source, declarations, package-root exports, README examples, packed contents, roadmap, and API
+  version agree on the implemented source/published-package boundary.
+- [x] Focused tests, all Pi TUI Kit tests, lifecycle regressions, LSP diagnostics, package check,
+  generated-dist TUI/RPC smokes, `npm test`, `npm run check`, and `just pack-tui-kit` pass with no
+  skipped or unverified required path.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -4,7 +4,7 @@
 - **Audience:** Pi TUI Kit maintainers and extension authors
 - **Planning horizon:** The next capability sequence after `@narumitw/pi-tui-kit@0.41.0`; no
   delivery dates are committed
-- **Repository source:** Menu API version 4 with distinct root Back and Close results
+- **Repository source:** Menu API version 5 with adaptive review and distinct root Back/Close results
 - **Latest published package:** `@narumitw/pi-tui-kit@0.41.0`, menu API version 3
 - **Migration evidence:** [archived consumer migration plan][consumer-migration-plan]
 
@@ -16,6 +16,8 @@
 [searchable-multi-select-plan]:
   ../plans/archived/2026-07-30_pi-tui-kit-searchable-multi-select-plan.md
 [agent-flows-plan]: ../plans/archived/2026-07-31_pi-tui-kit-agent-flows-plan.md
+[adaptive-review-plan]:
+  ../plans/archived/2026-08-01_pi-tui-kit-adaptive-review-viewport-plan.md
 
 ## Vision
 
@@ -53,9 +55,10 @@ The published `0.41.0` package exposes seven declarative screen kinds:
 
 The package also exposes `runTask()` for abort-aware work with a TUI loader and consistent completed,
 cancelled, stale, and error outcomes in other modes. Published menu API version 3 identifies runtimes
-that can interpret input and review screens. Repository source now uses API version 4 so ordinary
-`runMenu()` results distinguish root Back from explicit Close; package release remains a separate
-workflow.
+that can interpret input and review screens. Repository source now uses API version 5 so ordinary
+`runMenu()` results distinguish root Back from explicit Close and review screens can opt into a live
+terminal-height budget while fixed TUI sizing and deterministic RPC pagination remain compatible;
+package release remains a separate workflow.
 
 Eighteen extension or experimental packages depend on the kit, and 26 TypeScript source files import
 its API. Kit-dependent source still contains these literal direct Pi dialog calls:
@@ -82,9 +85,10 @@ The latest proof migrations established the following baseline:
 - all three migrations passed focused checks, package dry runs, CI, and the 1,914-test repository gate.
 
 The migrations exposed two concrete review gaps: root Back and Ctrl+C Close originally collapsed to
-one result, and `ReviewScreen` uses fixed rather than terminal-derived viewport sizing. Repository API
-version 4 now resolves the first gap. The `pi-btw` review migration remains deferred until adaptive
-sizing lands and its editor-preservation and restored-selection contracts pass a fresh gate.
+one result, and `ReviewScreen` used fixed rather than terminal-derived viewport sizing. Repository API
+versions 4 and 5 now resolve those Kit seams in sequence. The `pi-btw` review migration remains
+deferred until the separate supported testability milestone lands and its editor-preservation and
+restored-selection contracts pass a fresh gate.
 
 Consumer tests had to extend `test/support.ts` to drive real input focus, rejected retries, Ctrl+C,
 disposal, pending action draining, and RPC dialog cadence. That reusable lifecycle knowledge is not
@@ -182,18 +186,22 @@ three-way confirmation and preview composition.
 
 ### Phase 3: Adaptive Review and Supported Testability
 
+**Status:** Adaptive review complete in repository source through the
+[adaptive-review plan][adaptive-review-plan]; supported testability, the BTW gate, migration, and npm
+release remain open.
+
 **Milestones:**
 
-- Review accepts an opt-in terminal-adaptive viewport policy while existing fixed numeric sizing and
-  RPC pagination remain compatible.
-- Adaptive review stays within terminal row budgets at constrained, typical, and large heights,
+- [x] Review accepts an opt-in terminal-adaptive viewport policy while existing fixed numeric sizing
+  and RPC pagination remain compatible.
+- [x] Adaptive review stays within terminal row budgets at constrained, typical, and large heights,
   including wrapped headers, position indicators, resize, and scroll-offset clamping.
-- A separate `@narumitw/pi-tui-kit/testing` entry point drives real TUI components and RPC dialogs
+- [ ] A separate `@narumitw/pi-tui-kit/testing` entry point drives real TUI components and RPC dialogs
   through focus, text input, key events, rejected retries, pending actions, disposal, and owner abort.
-- Stamp and Image Drop consumer tests use the supported test host, allowing equivalent generic input
-  orchestration to leave repository-level `test/support.ts`.
-- The BTW review gate is rerun against close reasons and adaptive viewport; migration proceeds only if
-  editor-preservation and restored-selection invariants also remain explicit and testable.
+- [ ] Stamp and Image Drop consumer tests use the supported test host, allowing equivalent generic
+  input orchestration to leave repository-level `test/support.ts`.
+- [ ] The BTW review gate is rerun against close reasons and adaptive viewport; migration proceeds only
+  if editor-preservation and restored-selection invariants also remain explicit and testable.
 
 **Outcome:** Review behavior adapts to its host and consumer packages can verify kit lifecycle
 contracts without private component knowledge.
@@ -278,12 +286,12 @@ abstractions when Pi provides a better stable owner.
 | --- | --- | --- | --- |
 | Pi private `dist/*` imports in kit source | 0 | Remain 0 | Every phase; boundary check and source search |
 | Ordinary `runMenu()` close outcomes visible to callers | Published API 3 collapses Back and Close | Repository API 4 distinguishes root Back and explicit Close | Phase 2 complete in source; runtime TUI/RPC matrix |
-| Review TUI viewport policy | Fixed, default 14 rows | Opt-in adaptive policy stays within the terminal row budget | Phase 3; review component tests |
+| Review TUI viewport policy | Published API 3 is fixed, default 14 rows | Repository API 5 provides opt-in adaptive sizing within the live terminal budget | Adaptive source milestone complete; review component and built-package smokes |
 | Reusable consumer input-host logic | Generic behavior added to repository `test/support.ts` | Stamp and Image Drop use the supported testing entry point | Phase 3; consumer diffs and tests |
 | Proof for each new public flow | Two compatible consumers by default; exceptions require recorded evidence | Two completed proof migrations or an explicit no-go/deferral | Every expansion phase; archived plans and PRs |
 | Lifecycle verification | Existing deterministic package and consumer coverage | Every admitted contract covers TUI/RPC, cancellation, disposal, owner abort, stale state, and failure | Every phase; package and repository gates |
 | Runtime action/lifecycle ownership | TUI and RPC loops coordinate screen actions in separate branches | If the driver is admitted, one coordinator owns shared action and lifecycle policy | Phase 4; source diff plus behavior matrix |
-| Regression gate | 1,918 tests after menu termination reasons | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
+| Regression gate | 1,923 tests after adaptive review | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
 and adoption rather than calendar output.
@@ -324,3 +332,4 @@ and adoption rather than calendar output.
 | 2026-08-01 | Move the internal interaction driver, standalone confirmation, and deferred multi-select behind the near-term lifecycle work. | Behavior matrices and explicit terminal outcomes should precede broad runtime refactoring or new public flows. |
 | 2026-08-01 | Merge the next-architecture implementation note into this canonical roadmap. | Maintaining one Pi TUI Kit roadmap avoids conflicting priorities while preserving the migration evidence and prior decision history. |
 | 2026-08-01 | Implement mandatory `RunMenuResult.closed.reason` and raise repository menu API to version 4. | The navigator already owns root Back versus Close; exposing that reason removes a proven composition blocker while leaving domain completion values local. Publication remains a separate workflow. |
+| 2026-08-01 | Implement opt-in adaptive review and raise repository menu API to version 5. | Live public TUI rows now bound complete review frames while fixed/default TUI output and deterministic RPC pages remain unchanged; the testing entry point, BTW gate/migration, and package release remain separate work. |

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -139,8 +139,8 @@ does not hide an uncooperative task behind an arbitrary timeout.
   serialized saves, and rollback when an action rejects.
 - **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission,
   rejected-draft retention, and TUI/RPC adaptation.
-- **`review`** — bounded, scrollable exact text, code, or diff content with an optional primary
-  confirmation action and paginated RPC fallback.
+- **`review`** — fixed or terminal-adaptive scrollable exact text, code, or diff content with an
+  optional primary confirmation action and paginated RPC fallback.
 - **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback,
   selected-row descriptions, optional fuzzy search and bulk action rows, and a bounded TUI viewport.
 
@@ -218,14 +218,25 @@ const reviewScreen = {
   title: "Review configuration changes",
   content: unifiedDiff,
   format: { kind: "diff" as const, filePath: settingsPath },
-  viewportSize: 14,
+  viewportSize: "adaptive",
   confirm: { id: "apply", label: "Apply", action: "apply" as const },
 };
 ```
 
 Review formats are `{ kind: "text" }`, `{ kind: "code", language?, filePath? }`, and
-`{ kind: "diff", filePath? }`. The viewport maximum is 50 rows. A review without `confirm` is
-read-only. Escape follows Back/Close and `Ctrl+C` closes the whole menu.
+`{ kind: "diff", filePath? }`. Omitted `viewportSize` keeps the fixed 14-row TUI viewport, and
+numeric values remain fixed integers from 1 through 50. Set `viewportSize: "adaptive"` to recompute
+from the live terminal height on every TUI render. Adaptive review reserves three terminal rows for
+Pi-owned UI and keeps the complete frame within `max(1, floor(terminal rows) - 3)` rows; this mode is
+not capped at the numeric 50-row maximum.
+
+At constrained heights, adaptive review prioritizes one content row, then a compact title, then a
+compact confirmation/Back-or-Close/navigation hint. From four available rows it shows position when
+content scrolls; additional space restores wrapped title and supporting context, the full keyboard
+hint, and the separator before enlarging the content viewport. Fixed and omitted review rendering is
+unchanged. RPC does not read terminal dimensions: adaptive and omitted reviews use deterministic
+pages of at most eight rows, while numeric values retain the existing eight-row cap. A review without
+`confirm` is read-only. Escape follows Back/Close and `Ctrl+C` closes the whole menu.
 
 Action handlers return one of these results:
 
@@ -362,9 +373,9 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, `MenuCloseReason`, and result types.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`4`). Version 4 requires
-  `RunMenuResult` to report a reason when closed; version-3 screen definitions remain valid on the
-  version-4 runtime.
+- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`5`). Version 5 adds the
+  opt-in `ReviewScreen.viewportSize: "adaptive"` policy; version-4 definitions remain valid on the
+  version-5 runtime, including mandatory Back/Close reasons on closed menu results.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/src/components/contracts.ts
+++ b/packages/pi-tui-kit/src/components/contracts.ts
@@ -14,6 +14,7 @@ const MENU_BINDINGS = [
 export type MenuBinding = (typeof MENU_BINDINGS)[number];
 
 export interface RenderHost {
+	readonly terminal: { readonly rows: number };
 	requestRender(): void;
 }
 

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -1,13 +1,24 @@
 import { stripVTControlCharacters } from "node:util";
 import { getLanguageFromPath, highlightCode } from "@earendil-works/pi-coding-agent";
-import { Key, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	Key,
+	matchesKey,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import type { MenuScreen, ReviewScreen } from "../types.js";
-import type { MenuScreenComponent, MenuScreenComponentOptions } from "./contracts.js";
-import { renderFrame, safeMenuText } from "./rendering.js";
+import type {
+	MenuKeybindings,
+	MenuScreenComponent,
+	MenuScreenComponentOptions,
+} from "./contracts.js";
+import { menuHint, renderFrame, safeMenuText } from "./rendering.js";
 
 const DEFAULT_REVIEW_VIEWPORT_SIZE = 14;
 const RPC_REVIEW_VIEWPORT_SIZE = 8;
 const RPC_REVIEW_LINE_WIDTH = 120;
+const RESERVED_HOST_ROWS = 3;
 const TAB_SIZE = 4;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
@@ -23,6 +34,7 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 ): MenuScreenComponent {
 	let scrollOffset = 0;
 	let lastMaximumScroll = 0;
+	let lastViewportSize = reviewViewportSize(options.screen);
 	let disposed = false;
 
 	const moveTo = (offset: number) => {
@@ -34,9 +46,28 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 		render(width) {
 			const safeWidth = Math.max(1, width);
 			const allLines = formatReviewLines(options.screen, safeWidth, options.theme);
+			const terminalRows =
+				options.screen.viewportSize === "adaptive" ? options.tui.terminal.rows : undefined;
+			if (terminalRows !== undefined && Number.isFinite(terminalRows)) {
+				const frame = renderAdaptiveReviewFrame({
+					screen: options.screen,
+					allLines,
+					width: safeWidth,
+					terminalRows,
+					scrollOffset,
+					theme: options.theme,
+					keybindings: options.keybindings,
+				});
+				scrollOffset = frame.scrollOffset;
+				lastMaximumScroll = frame.maximumScroll;
+				lastViewportSize = frame.viewportSize;
+				return frame.lines;
+			}
+
 			const viewportSize = reviewViewportSize(options.screen);
 			lastMaximumScroll = Math.max(0, allLines.length - viewportSize);
 			scrollOffset = Math.max(0, Math.min(scrollOffset, lastMaximumScroll));
+			lastViewportSize = viewportSize;
 			const visible = allLines.slice(scrollOffset, scrollOffset + viewportSize);
 			const first = allLines.length === 0 ? 0 : scrollOffset + 1;
 			const last = Math.min(allLines.length, scrollOffset + viewportSize);
@@ -65,9 +96,9 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 			} else if (options.keybindings.matches(data, "tui.select.down")) {
 				moveTo(scrollOffset + 1);
 			} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
-				moveTo(scrollOffset - reviewViewportSize(options.screen));
+				moveTo(scrollOffset - lastViewportSize);
 			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
-				moveTo(scrollOffset + reviewViewportSize(options.screen));
+				moveTo(scrollOffset + lastViewportSize);
 			} else if (matchesKey(data, Key.home)) moveTo(0);
 			else if (matchesKey(data, Key.end)) moveTo(lastMaximumScroll);
 			else if (options.screen.confirm && options.keybindings.matches(data, "tui.select.confirm")) {
@@ -83,11 +114,179 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 	};
 }
 
+interface AdaptiveReviewFrameOptions<ActionId extends string> {
+	screen: ReviewScreen<ActionId>;
+	allLines: readonly string[];
+	width: number;
+	terminalRows: number;
+	scrollOffset: number;
+	theme: MenuScreenComponentOptions<string, ActionId>["theme"];
+	keybindings: MenuKeybindings;
+}
+
+interface AdaptiveReviewFrame {
+	lines: string[];
+	scrollOffset: number;
+	maximumScroll: number;
+	viewportSize: number;
+}
+
+interface AdaptiveReviewChrome {
+	header: string[];
+	separator: boolean;
+	hint: string[];
+	showPosition: boolean;
+	viewportSize: number;
+}
+
+function renderAdaptiveReviewFrame<ActionId extends string>(
+	options: AdaptiveReviewFrameOptions<ActionId>,
+): AdaptiveReviewFrame {
+	const availableRows = Math.max(1, Math.floor(options.terminalRows) - RESERVED_HOST_ROWS);
+	const destination = options.screen.hint ?? "back";
+	const confirmAction = options.screen.confirm ? safeMenuText(options.screen.confirm.label) : "";
+	const fullHeader = [
+		...wrapTextWithAnsi(
+			options.theme.fg("accent", options.theme.bold(safeMenuText(options.screen.title))),
+			options.width,
+		),
+		...(options.screen.lines ?? []).flatMap((line) =>
+			wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), options.width),
+		),
+	].map((line) => truncateToWidth(line, options.width, ""));
+	const fullHint = wrapTextWithAnsi(
+		options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
+		options.width,
+	).map((line) => truncateToWidth(line, options.width, ""));
+	const criticalHint = truncateToWidth(
+		options.theme.fg("dim", compactReviewHint(options.keybindings, destination, confirmAction)),
+		options.width,
+		"",
+	);
+
+	let chrome = allocateAdaptiveReviewChrome(
+		availableRows,
+		fullHeader,
+		fullHint,
+		criticalHint,
+		false,
+	);
+	if (availableRows >= 4 && options.allLines.length > chrome.viewportSize) {
+		chrome = allocateAdaptiveReviewChrome(availableRows, fullHeader, fullHint, criticalHint, true);
+	}
+
+	const maximumScroll = Math.max(0, options.allLines.length - chrome.viewportSize);
+	const scrollOffset = Math.max(0, Math.min(options.scrollOffset, maximumScroll));
+	const visible = options.allLines.slice(scrollOffset, scrollOffset + chrome.viewportSize);
+	const first = options.allLines.length === 0 ? 0 : scrollOffset + 1;
+	const last = Math.min(options.allLines.length, scrollOffset + chrome.viewportSize);
+	const position = chrome.showPosition
+		? [options.theme.fg("dim", `${first}-${last}/${options.allLines.length}`)]
+		: [];
+	const lines = [
+		...chrome.header,
+		...(chrome.separator ? [""] : []),
+		...visible,
+		...position,
+		...chrome.hint,
+	].map((line) => truncateToWidth(line, options.width, ""));
+
+	return { lines, scrollOffset, maximumScroll, viewportSize: chrome.viewportSize };
+}
+
+function allocateAdaptiveReviewChrome(
+	availableRows: number,
+	fullHeader: readonly string[],
+	fullHint: readonly string[],
+	criticalHint: string,
+	showPosition: boolean,
+): AdaptiveReviewChrome {
+	if (availableRows === 1) {
+		return { header: [], separator: false, hint: [], showPosition: false, viewportSize: 1 };
+	}
+	const compactHeader = [fullHeader[0] ?? ""];
+	if (availableRows === 2) {
+		return {
+			header: compactHeader,
+			separator: false,
+			hint: [],
+			showPosition: false,
+			viewportSize: 1,
+		};
+	}
+	if (availableRows === 3) {
+		return {
+			header: compactHeader,
+			separator: false,
+			hint: [criticalHint],
+			showPosition: false,
+			viewportSize: 1,
+		};
+	}
+
+	let remainingRows = availableRows - 3 - Number(showPosition);
+	const extraHeaderCount = Math.min(remainingRows, Math.max(0, fullHeader.length - 1));
+	const header = [...compactHeader, ...fullHeader.slice(1, 1 + extraHeaderCount)];
+	remainingRows -= extraHeaderCount;
+
+	let hint = [criticalHint];
+	const fullHintExtraRows = Math.max(0, fullHint.length - 1);
+	if (remainingRows > 0 && fullHint.length > 0 && fullHintExtraRows <= remainingRows) {
+		hint = [...fullHint];
+		remainingRows -= fullHintExtraRows;
+	}
+
+	const separator = remainingRows > 0;
+	if (separator) remainingRows -= 1;
+	return {
+		header,
+		separator,
+		hint,
+		showPosition,
+		viewportSize: 1 + remainingRows,
+	};
+}
+
+function compactReviewHint(
+	keybindings: MenuKeybindings,
+	destination: "back" | "close",
+	confirmAction: string,
+) {
+	const confirm = reviewBindingText(keybindings, "tui.select.confirm");
+	const cancel = reviewBindingText(keybindings, "tui.select.cancel", "ctrl+c");
+	const up = reviewBindingText(keybindings, "tui.select.up");
+	const down = reviewBindingText(keybindings, "tui.select.down");
+	return [
+		...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
+		...(cancel ? [`${cancel} ${destination}`] : []),
+		...(destination === "back" || !cancel ? ["ctrl+c close"] : []),
+		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
+	].join(" • ");
+}
+
+function reviewBindingText(
+	keybindings: MenuKeybindings,
+	binding: Parameters<MenuKeybindings["getKeys"]>[0],
+	excluded?: string,
+) {
+	return keybindings
+		.getKeys(binding)
+		.filter((key) => key !== excluded)
+		.map((key) => {
+			if (key === "up") return "↑";
+			if (key === "down") return "↓";
+			if (key === "escape") return "esc";
+			return safeMenuText(key);
+		})
+		.filter(Boolean)
+		.join("/");
+}
+
 export function reviewDialogPages<ActionId extends string>(
 	screen: ReviewScreen<ActionId>,
 ): string[][] {
 	const lines = plainReviewLines(screen.content, RPC_REVIEW_LINE_WIDTH);
-	const pageSize = Math.min(reviewViewportSize(screen), RPC_REVIEW_VIEWPORT_SIZE);
+	const pageSize = reviewDialogPageSize(screen);
 	const pages: string[][] = [];
 	for (let index = 0; index < lines.length; index += pageSize) {
 		pages.push(lines.slice(index, index + pageSize));
@@ -188,5 +387,13 @@ function hardWrapLine(line: string, width: number): string[] {
 }
 
 function reviewViewportSize<ActionId extends string>(screen: ReviewScreen<ActionId>) {
-	return screen.viewportSize ?? DEFAULT_REVIEW_VIEWPORT_SIZE;
+	return typeof screen.viewportSize === "number"
+		? screen.viewportSize
+		: DEFAULT_REVIEW_VIEWPORT_SIZE;
+}
+
+function reviewDialogPageSize<ActionId extends string>(screen: ReviewScreen<ActionId>) {
+	return typeof screen.viewportSize === "number"
+		? Math.min(screen.viewportSize, RPC_REVIEW_VIEWPORT_SIZE)
+		: RPC_REVIEW_VIEWPORT_SIZE;
 }

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -28,4 +28,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 4;
+export const PI_EXTENSION_MENU_API_VERSION = 5;

--- a/packages/pi-tui-kit/src/model.ts
+++ b/packages/pi-tui-kit/src/model.ts
@@ -89,12 +89,13 @@ function validateScreen<
 	if (screen.kind === "review") {
 		if (
 			screen.viewportSize !== undefined &&
+			screen.viewportSize !== "adaptive" &&
 			(!Number.isInteger(screen.viewportSize) ||
 				screen.viewportSize <= 0 ||
 				screen.viewportSize > MAX_REVIEW_VIEWPORT_SIZE)
 		) {
 			throw new Error(
-				`Menu review viewport size must be a positive integer no greater than ${MAX_REVIEW_VIEWPORT_SIZE}`,
+				`Menu review viewport size must be "adaptive" or a positive integer no greater than ${MAX_REVIEW_VIEWPORT_SIZE}`,
 			);
 		}
 		if (screen.confirm) {

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -122,7 +122,7 @@ export interface ReviewScreen<ActionId extends string> {
 	lines?: readonly string[];
 	content: string;
 	format?: ReviewFormat;
-	viewportSize?: number;
+	viewportSize?: number | "adaptive";
 	confirm?: ReviewConfirmation<ActionId>;
 	hint?: "back" | "close";
 }

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -60,8 +60,18 @@ const reviewScreen: ReviewScreen<Action> = {
 	content: "exact content",
 	confirm: { id: "apply", label: "Apply", action: "run" },
 };
+const numericReviewScreen: ReviewScreen<Action> = {
+	...reviewScreen,
+	viewportSize: 14,
+};
+const adaptiveReviewScreen: ReviewScreen<Action> = {
+	...reviewScreen,
+	viewportSize: "adaptive",
+};
 void inputScreen;
 void reviewScreen;
+void numericReviewScreen;
+void adaptiveReviewScreen;
 
 const invalidInputScreen: InputScreen<Action> = {
 	kind: "input",
@@ -76,8 +86,14 @@ const invalidReviewScreen: ReviewScreen<Action> = {
 	// @ts-expect-error Review confirmation actions stay within the menu action id union.
 	confirm: { id: "apply", label: "Apply", action: "missing" },
 };
+const invalidReviewViewport: ReviewScreen<Action> = {
+	...reviewScreen,
+	// @ts-expect-error Review viewports accept only a number or the adaptive policy.
+	viewportSize: "fluid",
+};
 void invalidInputScreen;
 void invalidReviewScreen;
+void invalidReviewViewport;
 
 declare const commandContext: ExtensionCommandContext;
 declare const lifecycleContext: ExtensionContext;

--- a/packages/pi-tui-kit/test/input-screen.test.ts
+++ b/packages/pi-tui-kit/test/input-screen.test.ts
@@ -252,7 +252,7 @@ function inputComponentHarness(
 	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
 	const component = createMenuScreenComponent<ScreenId, ActionId>({
 		screen: inputScreen,
-		tui: { requestRender() {} },
+		tui: { terminal: { rows: 24 }, requestRender() {} },
 		theme: {
 			fg: (_color: string, text: string) => text,
 			bold: (text: string) => text,

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -38,8 +38,8 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("mandatory menu termination reasons use declarative API version 4", () => {
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 4);
+test("adaptive review uses declarative API version 5", () => {
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 5);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 
@@ -231,6 +231,19 @@ test("input screens require a known action", () => {
 });
 
 test("review screens validate viewport and confirmation identity", () => {
+	const adaptiveScreen = {
+		kind: "review" as const,
+		title: "Adaptive review",
+		content: "diff",
+		viewportSize: "adaptive" as const,
+	};
+	const adaptiveDefinition = defineMenu<undefined, "review", "apply">({
+		start: "review",
+		screens: { review: () => adaptiveScreen },
+		actions: { apply: async () => ({ kind: "close" }) },
+	});
+	assert.equal(resolveMenuScreen(adaptiveDefinition, "review", undefined), adaptiveScreen);
+
 	const definition = defineMenu<undefined, "review", "apply">({
 		start: "review",
 		screens: {
@@ -248,7 +261,7 @@ test("review screens validate viewport and confirmation identity", () => {
 		() => resolveMenuScreen(definition, "review", undefined),
 		/review.*viewport.*positive integer/i,
 	);
-	for (const viewportSize of [-1, 1.5, 51, Number.NaN, Number.POSITIVE_INFINITY]) {
+	for (const viewportSize of [-1, 1.5, 51, Number.NaN, Number.POSITIVE_INFINITY, "fluid"]) {
 		assert.throws(
 			() =>
 				resolveMenuScreen(
@@ -259,7 +272,7 @@ test("review screens validate viewport and confirmation identity", () => {
 								kind: "review" as const,
 								title: "Review",
 								content: "diff",
-								viewportSize,
+								viewportSize: viewportSize as never,
 							}),
 						},
 					},

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -52,6 +52,7 @@ const reviewChangesScreen: ReviewScreen<Action> = {
 	title: "Review changes",
 	content: "+1 enabled=true",
 	format: { kind: "diff", filePath: "settings.json" },
+	viewportSize: "adaptive",
 	confirm: { id: "apply", label: "Apply", action: "refresh" },
 };
 void reviewChangesScreen;

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -42,6 +42,138 @@ test("review preserves whitespace, sanitizes controls, and bounds exact text at 
 	assert.match(rendered, /你🙂very-long-token/);
 });
 
+test("fixed and default review frames remain byte-for-byte compatible", () => {
+	const content = Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n");
+	const fixed = reviewComponentHarness({ ...reviewScreen, content });
+	assert.deepEqual(plainLines(fixed.component, 80), [
+		"Review changes",
+		"",
+		"row 1",
+		"row 2",
+		"row 3",
+		"1-3/20",
+		"k/j navigate • l Apply • q back • ctrl+c close",
+	]);
+
+	const defaultViewport = reviewComponentHarness({
+		...reviewScreen,
+		content,
+		viewportSize: undefined,
+	});
+	assert.deepEqual(plainLines(defaultViewport.component, 80), [
+		"Review changes",
+		"",
+		...Array.from({ length: 14 }, (_, index) => `row ${index + 1}`),
+		"1-14/20",
+		"k/j navigate • l Apply • q back • ctrl+c close",
+	]);
+});
+
+test("adaptive review degrades explicitly at constrained terminal heights", () => {
+	const content = Array.from({ length: 10 }, (_, index) => `row ${index + 1}`).join("\n");
+	const harness = reviewComponentHarness(
+		{ ...reviewScreen, content, viewportSize: "adaptive" },
+		false,
+		4,
+	);
+	assert.deepEqual(plainLines(harness.component, 80), ["row 1"]);
+
+	harness.setTerminalRows(5);
+	assert.deepEqual(plainLines(harness.component, 80), ["Review changes", "row 1"]);
+
+	harness.setTerminalRows(6);
+	assert.deepEqual(plainLines(harness.component, 80), [
+		"Review changes",
+		"row 1",
+		"l Apply • q back • ctrl+c close • k/j navigate",
+	]);
+
+	harness.setTerminalRows(7);
+	assert.deepEqual(plainLines(harness.component, 80), [
+		"Review changes",
+		"row 1",
+		"1-1/10",
+		"l Apply • q back • ctrl+c close • k/j navigate",
+	]);
+
+	harness.setTerminalRows(8);
+	assert.deepEqual(plainLines(harness.component, 80), [
+		"Review changes",
+		"",
+		"row 1",
+		"1-1/10",
+		"k/j navigate • l Apply • q back • ctrl+c close",
+	]);
+});
+
+test("adaptive review restores wrapped context and exceeds the numeric viewport ceiling safely", () => {
+	const content = Array.from({ length: 100 }, (_, index) => `row ${index + 1}`).join("\n");
+	const typical = reviewComponentHarness(
+		{
+			...reviewScreen,
+			title: "Review configuration changes",
+			lines: ["Supporting context that wraps at narrow widths"],
+			content,
+			viewportSize: "adaptive",
+		},
+		false,
+		30,
+	);
+	const typicalLines = plainLines(typical.component, 18);
+	assert.equal(typicalLines.length, 27);
+	assert.ok(typicalLines.some((line) => line.includes("Supporting")));
+	assert.ok(typicalLines.some((line) => /\d+-\d+\/100/u.test(line)));
+	assert.ok(typicalLines.every((line) => visibleWidth(line) <= 18));
+
+	const large = reviewComponentHarness(
+		{ ...reviewScreen, content, viewportSize: "adaptive" },
+		false,
+		80,
+	);
+	const largeLines = plainLines(large.component, 80);
+	assert.equal(largeLines.length, 77);
+	assert.ok(largeLines.includes("row 73"));
+	assert.ok(largeLines.every((line) => visibleWidth(line) <= 80));
+});
+
+test("adaptive review resizes, reflows, clamps, and pages by the latest rendered viewport", () => {
+	const content = Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n");
+	const harness = reviewComponentHarness(
+		{ ...reviewScreen, content, viewportSize: "adaptive" },
+		false,
+		12,
+	);
+	let rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /row 1[\s\S]*row 5/);
+	assert.match(rendered, /1-5\/20/);
+
+	harness.component.handleInput("\u001b[F");
+	rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /row 16[\s\S]*row 20/);
+	assert.match(rendered, /16-20\/20/);
+
+	harness.setTerminalRows(7);
+	rendered = plainRender(harness.component, 30);
+	assert.match(rendered, /row 16/);
+	assert.match(rendered, /16-16\/20/);
+
+	harness.setTerminalRows(14);
+	rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /row 14[\s\S]*row 20/);
+	assert.match(rendered, /14-20\/20/);
+	harness.component.handleInput("u");
+	rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /row 7[\s\S]*row 13/);
+
+	harness.setTerminalRows(9);
+	rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /row 7[\s\S]*row 8/);
+	harness.component.handleInput("d");
+	rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /row 9[\s\S]*row 10/);
+	assert.ok(harness.component.render(20).every((line) => visibleWidth(line) <= 20));
+});
+
 test("review scrolls by injected keys, pages, and clamps after resize", () => {
 	const harness = reviewComponentHarness({
 		...reviewScreen,
@@ -104,20 +236,30 @@ test("review formats code and diffs through theme-aware display paths", () => {
 	assert.match(rendered, /accent:@@ header/);
 });
 
-test("TUI review invokes its raw confirmation action", async () => {
+test("TUI adaptive review reads live host rows and invokes its raw confirmation action", async () => {
 	const invoked: string[] = [];
+	const frameHeights: number[] = [];
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
-			const harness = createCustomSelectorHarness(factory, 40);
+			const harness = createCustomSelectorHarness(factory, 80, undefined, 7);
+			frameHeights.push(harness.render().length);
+			harness.setTerminalRows(12);
+			frameHeights.push(harness.render().length);
 			harness.handleInput("tui.select.confirm");
 			return harness.result;
 		},
 	});
 	const menu = defineMenu<undefined, ScreenId, ActionId>({
 		start: "review",
-		screens: { review: () => reviewScreen },
+		screens: {
+			review: () => ({
+				...reviewScreen,
+				content: Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n"),
+				viewportSize: "adaptive",
+			}),
+		},
 		actions: {
 			apply: async ({ itemId }) => {
 				invoked.push(itemId);
@@ -130,6 +272,48 @@ test("TUI review invokes its raw confirmation action", async () => {
 		reason: "close",
 	});
 	assert.deepEqual(invoked, ["raw-apply"]);
+	assert.deepEqual(frameHeights, [4, 9]);
+});
+
+test("RPC adaptive review matches default bounded pagination without custom TUI", async () => {
+	async function collect(viewportSize: ReviewScreen<ActionId>["viewportSize"]) {
+		const titles: string[] = [];
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			select: async (title: string, choices: string[]) => {
+				titles.push(title);
+				return choices.find((choice) => choice.startsWith("Next")) ?? "Back";
+			},
+			custom: async () => {
+				throw new Error("RPC review must not open custom TUI");
+			},
+		});
+		const menu = defineMenu<undefined, ScreenId, ActionId>({
+			start: "review",
+			screens: {
+				review: () => ({
+					...reviewScreen,
+					content: Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n"),
+					viewportSize,
+					confirm: undefined,
+				}),
+			},
+			actions: { apply: async () => ({ kind: "close" }) },
+		});
+		assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+			kind: "closed",
+			reason: "back",
+		});
+		return titles;
+	}
+
+	const omitted = await collect(undefined);
+	const adaptive = await collect("adaptive");
+	assert.deepEqual(adaptive, omitted);
+	assert.equal(adaptive.length, 3);
+	assert.match(adaptive[0] ?? "", /row 1[\s\S]*row 8/);
+	assert.match(adaptive[2] ?? "", /row 17[\s\S]*row 20/);
 });
 
 test("RPC review paginates bounded content and preserves colliding confirmation identity", async () => {
@@ -181,7 +365,7 @@ test("RPC review paginates bounded content and preserves colliding confirmation 
 	assert.equal(new Set(choicesSeen[1]).size, choicesSeen[1]?.length);
 });
 
-test("owner abort dismisses an unanswered RPC review without invoking confirmation", async () => {
+test("owner abort dismisses an unanswered adaptive RPC review without invoking confirmation", async () => {
 	const owner = new AbortController();
 	let reportOpened: (() => void) | undefined;
 	const opened = new Promise<void>((resolve) => {
@@ -202,7 +386,9 @@ test("owner abort dismisses an unanswered RPC review without invoking confirmati
 	});
 	const menu = defineMenu<undefined, ScreenId, ActionId>({
 		start: "review",
-		screens: { review: () => reviewScreen },
+		screens: {
+			review: () => ({ ...reviewScreen, viewportSize: "adaptive" }),
+		},
 		actions: {
 			apply: async () => {
 				invoked = true;
@@ -220,11 +406,12 @@ test("owner abort dismisses an unanswered RPC review without invoking confirmati
 	assert.equal(invoked, false);
 });
 
-function reviewComponentHarness(screen: ReviewScreen<ActionId>, themed = false) {
+function reviewComponentHarness(screen: ReviewScreen<ActionId>, themed = false, terminalRows = 24) {
 	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
+	const terminal = { rows: terminalRows };
 	const component = createMenuScreenComponent<ScreenId, ActionId>({
 		screen,
-		tui: { requestRender() {} },
+		tui: { terminal, requestRender() {} },
 		theme: {
 			fg: (color: string, text: string) => (themed ? `${color}:${text}` : text),
 			bold: (text: string) => text,
@@ -255,9 +442,19 @@ function reviewComponentHarness(screen: ReviewScreen<ActionId>, themed = false) 
 		},
 		onEvent: (event) => events.push(event),
 	});
-	return { component, events };
+	return {
+		component,
+		events,
+		setTerminalRows(rows: number) {
+			terminal.rows = rows;
+		},
+	};
+}
+
+function plainLines(component: { render(width: number): string[] }, width: number) {
+	return component.render(width).map((line) => stripVTControlCharacters(line));
 }
 
 function plainRender(component: { render(width: number): string[] }, width: number) {
-	return stripVTControlCharacters(component.render(width).join("\n"));
+	return plainLines(component, width).join("\n");
 }

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -972,7 +972,7 @@ function componentHarness(
 	const component = createMenuScreenComponent({
 		screen,
 		selectedItemId: options.selectedItemId,
-		tui: { requestRender() {} },
+		tui: { terminal: { rows: 24 }, requestRender() {} },
 		theme: {
 			fg(color: string, text: string) {
 				if (options.plainTheme) return text;

--- a/test/support.ts
+++ b/test/support.ts
@@ -364,6 +364,7 @@ export function createCustomSelectorHarness(
 		matches(data: string, key: string): boolean;
 		getKeys(key: string): readonly string[];
 	},
+	terminalRows = 24,
 ) {
 	if (typeof factory !== "function") throw new Error("Expected a custom component factory");
 	let result: unknown;
@@ -371,13 +372,14 @@ export function createCustomSelectorHarness(
 	const resultPromise = new Promise<unknown>((resolve) => {
 		resolveResult = resolve;
 	});
+	const terminal = { rows: terminalRows };
 	const component = (
 		factory as (...args: unknown[]) => {
 			render(width: number): string[];
 			handleInput(data: string): void;
 		}
 	)(
-		{ requestRender() {} },
+		{ terminal, requestRender() {} },
 		{
 			fg(_color: string, text: string) {
 				return text;
@@ -432,6 +434,9 @@ export function createCustomSelectorHarness(
 		},
 		render(renderWidth = width) {
 			return component.render(renderWidth);
+		},
+		setTerminalRows(rows: number) {
+			terminal.rows = rows;
 		},
 		invalidate() {
 			(component as { invalidate?: () => void }).invalidate?.();


### PR DESCRIPTION
## Summary

- add the opt-in `ReviewScreen.viewportSize: "adaptive"` contract and raise repository menu API version to 5
- size adaptive TUI review frames from live terminal rows with constrained-height priorities, resize clamping, and latest-render page steps while preserving fixed/default rendering
- keep adaptive RPC pagination identical to the omitted 8-row default and document/archive the completed plan and roadmap milestone

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- all Pi TUI Kit tests: 99 passed
- generated package-root adaptive TUI smoke: 7 constrained/typical/large resize/navigation/confirmation/Back/Close frames
- real Pi 0.83 RPC smoke: confirmation, 3-page pagination, cancellation, and owner abort
- `npm test`: 1,923 passed
- `npm run check`: 1,923 passed
- `just pack-tui-kit`: 27 expected files, package version unchanged at `0.41.0`
- LSP diagnostics: 0 findings across 12 touched TypeScript files

## Convention audit

Read `MEMORY.md`, `docs/extension-conventions.md`, and Pi's complete `docs/extensions.md`, `docs/tui.md`, and `docs/rpc.md`, plus the public TUI typings and preset/BTW references. Audited the public package contract, callback-provided TUI/theme/keybindings, width and row bounds, render invalidation/resize behavior, TUI/RPC boundaries, confirmation, Back/Close, cancellation, disposal, stale ownership, error/unsupported-mode behavior, consumer compatibility, and package contents. Settings are not touched. No accepted deviations or unverified required paths.
