### PR TITLE
feat(pi-tui-kit): add supported testing entrypoint

### DIFF
--- a/docs/plans/archived/2026-08-01_pi-tui-kit-supported-testing-entrypoint-plan.md
+++ b/docs/plans/archived/2026-08-01_pi-tui-kit-supported-testing-entrypoint-plan.md
@@ -1,0 +1,427 @@
+# Pi TUI Kit Supported Testing Entrypoint Plan
+
+## Goal
+
+Add a supported `@narumitw/pi-tui-kit/testing` subpath to the existing
+`@narumitw/pi-tui-kit` npm package so extension tests can drive Kit-owned TUI components and RPC
+adapters without importing repository-private helpers or receiving raw component instances.
+
+This is one package with two import boundaries, not a second npm package:
+
+```ts
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+```
+
+The package PR will add and verify the testing boundary only. Stamp and Image Drop adoption,
+repository-level test-support cleanup, the fresh BTW migration gate, package versioning, and npm
+publication remain separate follow-ups.
+
+## Context
+
+- Merged `main` is clean at PR #486's merge commit `a8b8926`. Repository source exposes menu API
+  version 5; npm still publishes `@narumitw/pi-tui-kit@0.41.0` with menu API version 3.
+- The package currently exports only `"."` from `packages/pi-tui-kit/package.json`. Its existing
+  TypeScript build already compiles every `src/**/*.ts` file into JavaScript and declarations under
+  `dist/`, and its `files` list already publishes the complete `dist/` tree.
+- `test/support.ts` currently knows how to invoke a public `ctx.ui.custom()` factory, provide TUI,
+  theme, and keybindings, render at controlled dimensions, send keys/text, forward focus, wait for
+  pending Kit actions, dispose components, capture results, and adapt `select`/`input` callbacks to
+  standard Kit screens.
+- Stamp and Image Drop tests repeat or depend on that repository-private knowledge. Their demonstrated
+  needs are the admission evidence for a supported test seam: input focus, rejected-draft retry,
+  key-driven Back/Close, pending-action draining, disposal, owner abort, deterministic review/dialog
+  cadence, and terminal resize.
+- Pi's public `ctx.ui.custom()` contract passes `TUI`, `Theme`, `KeybindingsManager`, and an exactly-once
+  `done` callback to a component factory. Its RPC UI methods expose signal-aware `input()` and
+  `select()` calls. The testing entrypoint must model those public boundaries rather than private Pi
+  `dist/*` implementation details.
+- The canonical roadmap explicitly requires semantic driving and stable render/dialog observations
+  through a separate testing entrypoint, and explicitly forbids exposing Pi TUI component instances.
+- Guides read for this plan: `MEMORY.md`, `docs/extension-conventions.md`, Pi's complete
+  `docs/extensions.md`, `docs/tui.md`, `docs/rpc.md`, and `docs/packages.md`, the installed public Pi
+  typings, the current package build/manifest, Kit component/runtime contracts, repository test
+  support, and the relevant Stamp/Image Drop tests. Applicable MUST areas are public package roots,
+  callback-provided TUI/theme/keybindings, focus, cancellation/disposal and task draining, reusable
+  library output, deterministic tests, the root check, and package dry-run inspection.
+  `docs/extension-settings.md` is not applicable because this change does not read, write, validate,
+  or migrate extension settings.
+
+## Architecture
+
+### npm and source boundaries
+
+Keep one workspace and one npm package. Add one conditional subpath export:
+
+```json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
+    }
+  }
+}
+```
+
+Use this source layout:
+
+```text
+packages/pi-tui-kit/src/testing/
+├── index.ts
+├── types.ts
+├── tui-harness.ts
+└── rpc-harness.ts
+```
+
+`src/testing/index.ts` is the only testing export surface. The production `src/index.ts` must not
+re-export testing helpers, and `PI_EXTENSION_MENU_API_VERSION` remains 5 because the menu definition
+protocol does not change. The existing build should emit the mirrored `dist/testing/` tree without a
+second `package.json`, workspace, dependency, or build pipeline.
+
+All implementation imports use package-root Pi exports. Testing code may depend on package-internal
+component contracts behind its own boundary, but generated declarations must not expose internal
+source paths, private component types, or raw instances.
+
+### TUI harness
+
+`createTuiHarness()` owns a composable implementation of the public `ctx.ui.custom()` callback. A
+consumer combines `harness.custom` with its own context fixture; the Kit must not publish a general
+mock of `ExtensionContext`, session state, notifications, persistence, or domain services.
+
+The intended usage shape is:
+
+```ts
+const tui = createTuiHarness({ width: 80, rows: 24 });
+const ctx = {
+  ...consumerContext,
+  mode: "tui" as const,
+  hasUI: true,
+  ui: { ...consumerContext.ui, custom: tui.custom },
+};
+
+const running = runMenu(ctx, menu, options);
+await tui.waitForOpen();
+const frame = tui.render();
+tui.press("tui.select.confirm");
+tui.type("raw input");
+tui.resize({ width: 60, rows: 12 });
+await tui.waitForPending();
+tui.dispose();
+await running;
+```
+
+Lock final names and parameter ordering with compile-time tests before implementation. The public
+harness must provide only semantic operations and immutable observations needed by demonstrated
+consumers:
+
+- wait for the current custom component to open, including a factory that returns a promise;
+- render at the configured or supplied width and observe render-request count without rewriting output;
+- send supported Kit binding events, Ctrl+C/Home/End, and explicit raw input; type text separately so
+  tests do not confuse text with named keys;
+- forward and inspect focus without returning the component;
+- resize live terminal rows and width;
+- invalidate themed content;
+- wait for optional pending Kit work;
+- settle `done` exactly once and expose the custom call's result promise;
+- dispose exactly once, resolve externally closed custom UI as `undefined`, and ignore later input;
+  and
+- support sequential screen openings without allowing an obsolete component or promise to become the
+  current target.
+
+Default theme and keybinding adapters cover only the public behavior Kit components consume. Allow
+explicit callback-compatible overrides for theme/keybinding tests rather than exposing global Pi
+state. The harness may recognize package-internal pending/focus/disposal capabilities internally, but
+those details must stop at `@narumitw/pi-tui-kit/testing`.
+
+### RPC harness
+
+`createRpcHarness()` owns a strict scripted adapter for the UI methods the current Kit runtime uses in
+RPC: `input()`, `select()`, and a `custom()` trap that fails if RPC incorrectly requests TUI. It exposes
+those handlers for composition into a consumer-owned context instead of constructing a broad Pi
+context mock.
+
+The intended usage shape is:
+
+```ts
+const rpc = createRpcHarness([
+  { kind: "input", response: "not-a-number" },
+  { kind: "input", response: "12" },
+  { kind: "select", response: "Apply" },
+]);
+
+const ctx = {
+  ...consumerContext,
+  mode: "rpc" as const,
+  hasUI: true,
+  ui: { ...consumerContext.ui, ...rpc.ui },
+};
+
+const result = await runMenu(ctx, menu, options);
+rpc.assertConsumed();
+```
+
+The script and observations must:
+
+- distinguish input and select steps and fail immediately on unexpected kind/order or exhausted steps;
+- record raw, unmodified titles, placeholders, choices, call order, and whether the supplied signal
+  was already aborted;
+- return exact scripted strings or `undefined` cancellation without fuzzy matching or label inference;
+- support a pending step that settles from caller abort so owner-abort tests cannot hang;
+- remove abort listeners after every settlement and reject duplicate settlement;
+- expose immutable dialog records and a finite `assertConsumed()` check; and
+- reject `custom()` deterministically so tests prove RPC never crossed into TUI.
+
+Do not add `confirm()`, editor, notification, session, model, settings, filesystem, timer, or network
+mocks until a Kit-owned production path and compatible consumers require them. In particular, this
+entrypoint does not become a general Pi SDK test framework.
+
+### Ownership and migration boundary
+
+The testing entrypoint owns only translation between Pi's public UI callback/dialog seams and
+repeatable semantic test controls. Consumer tests continue to own:
+
+- their `ExtensionContext` fixture and domain methods;
+- session generation and owner `AbortController` instances;
+- action results, validation, persistence, and error assertions; and
+- decisions about which frame/dialog content is product-significant.
+
+Package tests prove the harness itself and a representative `runMenu()` integration. Follow-up Stamp
+and Image Drop PRs must prove that this smaller interface actually deletes their private orchestration
+before equivalent logic is removed from `test/support.ts`.
+
+## Non-Goals
+
+- Do not create another npm package, workspace, package manifest, package version, release tag, or npm
+  page such as `@narumitw/pi-tui-kit-testing`.
+- Do not change production menu types, screen behavior, runtime branching, menu API version, result
+  objects, rendering, RPC cadence, or task semantics.
+- Do not migrate Stamp, Image Drop, BTW, or any other consumer in the package PR.
+- Do not remove or broadly refactor `test/support.ts`; consumer-owned deletion belongs to follow-up
+  migrations after the supported API is merged.
+- Do not export raw Pi or Kit components, internal component factories, mutable current-component
+  state, private source paths, or testing helpers from the production `"."` entrypoint.
+- Do not publish a complete `ExtensionContext` mock, assertion library, snapshot framework, fake
+  clock, filesystem, settings store, session manager, model registry, editor host, overlay host, or
+  generic Pi-extension runner.
+- Do not add a standalone confirmation harness before the Kit owns a compatible production
+  confirmation flow.
+- Do not add dependencies, change peer ranges, edit the lockfile without generated metadata evidence,
+  bump the package version, publish npm artifacts, or combine the work with the BTW gate or runtime
+  interaction-driver refactor.
+
+## Assumptions
+
+- Pi 0.83's installed public `ctx.ui.custom()`, `input()`, and `select()` signatures remain the tested
+  compatibility target for this source milestone.
+- Kit TUI factories are serial within one `runMenu()` loop. The harness still guards obsolete or
+  concurrently opened sessions so a test failure is finite and actionable.
+- Consumer tests can compose UI handlers into their existing context fixtures; they do not require the
+  Kit to own notifications, editor state, session managers, or domain callbacks.
+- The existing `src/**/*.ts` build include and `files: ["dist", "README.md", "LICENSE"]` publication
+  boundary can carry `dist/testing/` without build-script or dependency changes.
+- Testing helpers are a supported public API and therefore require compatibility discipline after
+  publication even though applications normally import them only from test files.
+
+## Risks
+
+- **Internal coupling leaks outward:** declarations could expose `MenuScreenComponent`, private marker
+  fields, or source-relative types. Mitigation: keep raw values private, define structural public
+  testing types in `testing/types.ts`, and inspect declaration imports plus packed consumer
+  compilation.
+- **A fake host diverges from Pi:** invented key, focus, disposal, or dialog behavior could make tests
+  pass incorrectly. Mitigation: invoke the real public custom factory signature, send real key data,
+  compare one built-package TUI flow and one RPC transcript with Pi 0.83, and avoid emulating APIs the
+  Kit does not use.
+- **Lifecycle hangs:** unresolved `done`, pending work, async factories, owner abort, or disposal could
+  strand tests. Mitigation: exactly-once per-open settlement, explicit pending/abort steps, listener
+  cleanup, obsolete-session guards, and deterministic timeout-bounded smokes.
+- **Testing API sprawl:** moving all of `test/support.ts` would replace one broad mock with a public
+  broad mock. Mitigation: apply the deletion test; admit only policy repeated by Kit tests and the
+  two named consumers, while leaving context/domain fixtures local.
+- **Subpath packaging drift:** source tests can pass while Node or TypeScript cannot resolve
+  `@narumitw/pi-tui-kit/testing` from the package. Mitigation: test generated JavaScript/declarations,
+  package-root imports, a temporary packed consumer, and exact tarball contents.
+- **Premature cleanup:** changing consumers or root support in the same PR would make rollback and API
+  review difficult. Mitigation: keep this plan package-only and require separate migration evidence
+  before deletion.
+
+## Rollback / Recovery
+
+No persisted data or production runtime contract changes. Before npm publication, revert the bounded
+package PR to remove the `./testing` export and `src/testing/` implementation. Existing consumers
+continue using repository-local support throughout this PR, so rollback does not strand them.
+
+After publication, treat the testing subpath as public: retain `@narumitw/pi-tui-kit/testing` and fix
+behavior or declaration defects in a patch rather than removing the export. If consumer migration
+finds a missing contract, leave consumer tests on existing local support until a separately reviewed
+additive patch is available; do not widen the harness opportunistically inside a migration.
+
+## Plan
+
+### 1. Establish baseline and lock the public boundary with red tests
+
+- [x] Run `npm run check --workspace @narumitw/pi-tui-kit`, compile the repository test project, and
+  execute all current Pi TUI Kit tests on clean `main`; record package/test counts and verify no stale
+  `dist/` or worktree change exists before adding the entrypoint. Evidence: package check/build and
+  repository test compilation passed at merge commit `a8b8926`; all 99 Kit tests passed, and the only
+  initial worktree path was this plan before branching.
+- [x] Inventory the exact TUI/RPC orchestration used by Kit, Stamp, and Image Drop tests and map every
+  admitted operation to `createTuiHarness()` or `createRpcHarness()`; record any operation outside the
+  Architecture section as deferred rather than silently widening the API. Evidence: TUI admission is
+  limited to controlled width/rows, render requests, named/raw keys and text, focus, invalidate,
+  pending drain, result, sequential open, disposal, and owner abort; RPC admission is exact
+  input/select sequencing, records, cancellation, pending abort, and a custom trap. General context,
+  Pi API, notifications/status, editor/confirm, overlay, fuzzy row inference, domain, settings, and
+  specialized non-Kit component mocks remain local/deferred.
+- [x] Add `packages/pi-tui-kit/test/testing-context-usage.ts` with positive imports from
+  `../src/testing/index.js`, negative production-root import assertions, composable consumer-context
+  examples, immutable public types, and no raw component access; verify package typechecking fails
+  only because the new testing entrypoint is absent. Evidence: package typechecking reports the
+  missing `../src/testing/index.js`; downstream unused-directive diagnostics are consequences of that
+  absent contextual type, while production-root negative assertions remain active.
+- [x] Add red-first `packages/pi-tui-kit/test/testing-tui.test.ts` cases for async/sync open, render and
+  requestRender observation, named/raw keys, text, focus, resize, invalidation, exactly-once result,
+  sequential screens, pending work, disposal, and ignored stale input; verify focused tests fail at
+  the missing TUI harness rather than against unrelated runtime behavior. Evidence: compilation fails
+  at the missing testing module and its absent contextual callback types before any production source
+  changes.
+- [x] Add red-first `packages/pi-tui-kit/test/testing-rpc.test.ts` cases for strict input/select
+  scripts, exact records, cancellation, unexpected/exhausted steps, pending owner abort, listener
+  cleanup, complete-script assertion, and the custom-TUI trap; verify focused tests fail at the missing
+  RPC harness. Evidence: compilation fails at the missing testing module; the pre-change 99-test Kit
+  baseline remains green.
+
+### 2. Implement the TUI testing seam without exposing components
+
+- [x] Add `packages/pi-tui-kit/src/testing/types.ts` and a thin `src/testing/index.ts` containing only
+  the contract fixed by compile-time tests; verify emitted public types use package-root Pi types and
+  do not name component internals or repository test support. Evidence: package typechecking/build
+  pass; generated `dist/testing/types.d.ts` references only public coding-agent types and structural
+  testing contracts, while `index.d.ts` exposes only the two factories and documented types.
+- [x] Implement `src/testing/tui-harness.ts` around the public custom-factory callback with inert
+  callback-compatible theme/keybinding defaults, configurable width/live rows, render-request
+  observation, and semantic/raw input translation; make the focused synchronous render/key/text/focus/
+  resize/invalidation tests pass. Evidence: the focused TUI suite passes actual terminal sequences,
+  raw text, focus, 20x9 to 12x6 resize, invalidation, and render-request assertions.
+- [x] Add per-open generation and exactly-once settlement inside the TUI harness so async factories,
+  sequential screens, `done`, external disposal, and late input cannot target obsolete state; make the
+  focused result/disposal/stale-session tests pass without returning the component. Evidence: focused
+  tests pass sync/async opens, reject overlap/factory failure, dispose a late async component, advance
+  two sequential owners, settle once, and ignore post-close input; compile-time coverage rejects raw
+  component access.
+- [x] Implement optional pending-work draining and result/open promises with abort-listener cleanup;
+  integrate a representative `runMenu()` input flow that rejects once, retains the draft, accepts a
+  correction, then proves owner abort and component disposal settle without later action or UI use.
+  Evidence: focused tests drain a controlled pending promise, retain `bad` before accepting `12`,
+  return stale for owner abort, and distinguish external disposal as a finite Close.
+
+### 3. Implement strict RPC scripts at the current Kit boundary
+
+- [x] Implement `src/testing/rpc-harness.ts` with composable `input`, `select`, and rejecting `custom`
+  handlers, exact typed script steps, immutable dialog records, and strict call-order/exhaustion
+  errors; make the focused immediate-response and cancellation tests pass. Evidence: focused tests
+  pass exact expected input/select calls, frozen records/choice lists, undefined cancellation, and
+  actionable unexpected-kind, exhausted, invalid-response, incomplete-script, and custom errors.
+- [x] Add one-owner pending RPC steps that observe pre-abort and later abort, settle only once, remove
+  listeners, and leave finite script state; make focused owner-abort and duplicate-settlement tests
+  pass without timers or unresolved promises. Evidence: focused tests pass pre-abort and later abort,
+  duplicate abort is inert, and instrumented signal methods observe one listener addition/removal.
+- [x] Integrate the RPC harness with representative `runMenu()` input rejection/retry and adaptive
+  review pagination flows; verify exact raw responses, deterministic page records, confirmation
+  identity, Back/Close mapping, owner abort, and zero custom-TUI calls. Evidence: focused integration
+  passes `bad`/`12` retry, exact two-page 8-row adaptive review records, raw `raw-apply` confirmation,
+  Close, stale owner abort, and a rejecting custom trap.
+- [x] Run every Pi TUI Kit test after TUI/RPC focused green and audit existing runtime/component tests
+  for duplicated helper knowledge; keep behavior assertions, and defer broad test rewrites unless a
+  small package-owned case can directly exercise the new public entrypoint. Evidence: all 113 Kit
+  tests pass in the final root gate; the new package-owned integration cases exercise the public
+  harnesses directly, while
+  existing low-level component/runtime characterizations and consumer/root helper migrations remain
+  unchanged for independent follow-ups.
+
+### 4. Publish the subpath in package artifacts and documentation
+
+- [x] Add the exact `"./testing"` export to `packages/pi-tui-kit/package.json` while retaining
+  `main`, `types`, the production `"."` export, peer dependencies, `files`, package version `0.41.0`,
+  and menu API version 5; verify no lockfile change is generated or required. Evidence: manifest
+  inspection shows both exact exports, unchanged `dist`/README/LICENSE files, Pi `*` peers, version
+  `0.41.0`, and source API 5; `package-lock.json` has no diff.
+- [x] Update `packages/pi-tui-kit/README.md` with same-package installation, production versus testing
+  imports, TUI and RPC composition examples, supported operations, lifecycle semantics, strict script
+  behavior, and explicit non-goals; mirror the examples in compile-time usage coverage. Evidence: the
+  English README documents both composable harnesses and boundaries; `test/readme-usage.ts` mirrors
+  both examples and package typechecking passes.
+- [x] Build the package and inspect `dist/testing/index.{js,d.ts}`, subordinate JavaScript/declarations,
+  and the unchanged production entry; verify no declaration imports `src/`, `test/support.ts`, private
+  Pi `dist/*`, or a raw component type. Evidence: the build emits four testing JavaScript/declaration
+  pairs; searches find only public coding-agent types and structural testing contracts, and no
+  forbidden source/private/component reference.
+- [x] Add a package-root Node/TypeScript resolution smoke that imports both
+  `@narumitw/pi-tui-kit` and `@narumitw/pi-tui-kit/testing` after a clean build; verify production
+  exports do not contain testing names and the testing subpath exposes only its documented surface.
+  Evidence: `testing-exports.test.ts` dynamically imports both built package roots, confirms source
+  API 5 and exactly two testing runtime exports, and compiles a disposable NodeNext consumer; it
+  passes.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` only after implementation evidence exists: mark the
+  supported testing-entrypoint milestone complete, keep Stamp/Image Drop adoption, root-support
+  cleanup, BTW gate/migration, and npm release open, and update the decision log and regression count.
+  Evidence: the roadmap records the same-package testing subpath as source-complete, retains every
+  named follow-up, adds the bounded testing decision, and records the verified 1,937-test gate.
+
+### 5. Verify conformance, package contents, and bounded scope
+
+- [x] Run LSP diagnostics on every touched TypeScript file and
+  `npm run check --workspace @narumitw/pi-tui-kit`; verify formatting, strict NodeNext types, generated
+  output, source boundaries, and examples agree. Evidence: Biome LSP reports zero findings across all
+  nine touched TypeScript paths, and the 32-file package check/typecheck/build passes.
+- [x] Run a timeout-bounded generated-package TUI smoke using production `runMenu()` from `dist/index.js`
+  and `createTuiHarness()` from `dist/testing/index.js`; exercise render, focus, rejected input retry,
+  resize, pending action, disposal, Back/Close, and owner abort without opening an interactive TUI.
+  Evidence: the package-root generated smoke passes all named paths, including width checks after
+  resize and requestRender observation, without launching interactive Pi.
+- [x] Run a real-Pi 0.83 RPC conformance smoke for one input retry and one paginated review, then run
+  the same menu through the generated `createRpcHarness()` and compare dialog kinds/order, exact
+  titles/options, cancellation, and abort outcomes; record any intentional Pi limitation rather than
+  relaxing strict scripts. Evidence: four real-Pi/package-root comparisons pass exact retry, two-page
+  review, cancellation, and owner-abort transcripts/results with no custom TUI request.
+- [x] Run `npm test` and then `npm run check` sequentially after the shared package build; verify every
+  repository test passes and consumer tests retain existing behavior without source or harness
+  migration. Evidence: both sequential commands pass all 1,937 tests with zero failures, cancellations,
+  skips, or todos; consumer source and private test support remain unchanged.
+- [x] Run `just pack-tui-kit`, inspect the dry-run file list, and install a generated tarball into a
+  disposable non-workspace fixture; verify Node and TypeScript resolve both exports, only expected
+  `dist/`, README, LICENSE, and metadata ship, peer dependencies remain external, and the package
+  version is unchanged. Evidence: the dry run contains 35 expected files; an actual tarball installed
+  under `/tmp` passes Node and strict NodeNext TypeScript imports for both roots, contains no source,
+  tests, or bundled dependencies, resolves Pi 0.83 peers externally, and remains version `0.41.0`.
+- [x] Audit the final diff against this plan, `docs/extension-conventions.md`, and the roadmap deletion
+  test; verify no second package, production-root re-export, raw component exposure, general Pi mock,
+  consumer/root-support migration, runtime behavior change, menu API/package version bump, dependency,
+  lockfile, tracked build artifact, private Pi import, or unrelated roadmap work entered the PR.
+  Evidence: the 13-path diff is limited to the package testing subpath/tests/docs/manifest, this plan,
+  and its canonical roadmap milestone. Automated scope assertions confirm every forbidden path/class
+  is absent, production has no testing runtime export, testing has exactly two, declarations expose no
+  internal component/source path, and the deletion test concentrates demonstrated host policy behind
+  composable UI adapters while leaving broad context/domain mocks local.
+
+## Completion Checklist
+
+- [x] `@narumitw/pi-tui-kit/testing` resolves as a subpath of the existing package in source,
+  generated declarations/JavaScript, package-root imports, and a disposable packed consumer.
+- [x] `createTuiHarness()` drives real Kit custom factories through render, keys/text, focus, resize,
+  invalidation, rejected retries, pending work, sequential screens, disposal, results, and owner abort
+  without exposing raw components.
+- [x] `createRpcHarness()` provides strict deterministic input/select scripts, immutable observations,
+  cancellation and owner-abort settlement, complete-script checks, and a failing custom-TUI trap.
+- [x] Production `@narumitw/pi-tui-kit` exports, menu API version 5, screen/runtime behavior, package
+  version, peer dependencies, and current consumers remain unchanged.
+- [x] README, compile-time examples, source ownership, declarations, tarball contents, and roadmap
+  agree that testing is a supported but bounded API and consumer migrations remain follow-up work.
+- [x] Focused TDD evidence, all Kit tests, lifecycle integrations, LSP diagnostics, package check,
+  generated-package TUI smoke, real-Pi RPC conformance, root `npm test`, root `npm run check`, and
+  `just pack-tui-kit` pass with no unrecorded skipped path or convention deviation.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -4,7 +4,8 @@
 - **Audience:** Pi TUI Kit maintainers and extension authors
 - **Planning horizon:** The next capability sequence after `@narumitw/pi-tui-kit@0.41.0`; no
   delivery dates are committed
-- **Repository source:** Menu API version 5 with adaptive review and distinct root Back/Close results
+- **Repository source:** Menu API version 5 with adaptive review, distinct root Back/Close results,
+  and a supported `/testing` subpath
 - **Latest published package:** `@narumitw/pi-tui-kit@0.41.0`, menu API version 3
 - **Migration evidence:** [archived consumer migration plan][consumer-migration-plan]
 
@@ -18,6 +19,8 @@
 [agent-flows-plan]: ../plans/archived/2026-07-31_pi-tui-kit-agent-flows-plan.md
 [adaptive-review-plan]:
   ../plans/archived/2026-08-01_pi-tui-kit-adaptive-review-viewport-plan.md
+[supported-testing-plan]:
+  ../plans/archived/2026-08-01_pi-tui-kit-supported-testing-entrypoint-plan.md
 
 ## Vision
 
@@ -57,8 +60,10 @@ The package also exposes `runTask()` for abort-aware work with a TUI loader and 
 cancelled, stale, and error outcomes in other modes. Published menu API version 3 identifies runtimes
 that can interpret input and review screens. Repository source now uses API version 5 so ordinary
 `runMenu()` results distinguish root Back from explicit Close and review screens can opt into a live
-terminal-height budget while fixed TUI sizing and deterministic RPC pagination remain compatible;
-package release remains a separate workflow.
+terminal-height budget while fixed TUI sizing and deterministic RPC pagination remain compatible.
+The same source package also exposes a separate supported `/testing` subpath for semantic TUI driving
+and strict RPC scripts without exporting raw components; consumer adoption and package release remain
+separate workflows.
 
 Eighteen extension or experimental packages depend on the kit, and 26 TypeScript source files import
 its API. Kit-dependent source still contains these literal direct Pi dialog calls:
@@ -91,8 +96,9 @@ deferred until the separate supported testability milestone lands and its editor
 restored-selection contracts pass a fresh gate.
 
 Consumer tests had to extend `test/support.ts` to drive real input focus, rejected retries, Ctrl+C,
-disposal, pending action draining, and RPC dialog cadence. That reusable lifecycle knowledge is not
-yet provided by the package.
+disposal, pending action draining, and RPC dialog cadence. Repository source now provides that
+reusable lifecycle knowledge through `@narumitw/pi-tui-kit/testing`; Stamp and Image Drop still need
+separate migrations before equivalent generic orchestration can leave repository test support.
 
 The main maintainability hotspot is `packages/pi-tui-kit/src/runtime.ts`, currently 767 lines. It owns
 both TUI and RPC loops, state loading, action dispatch, navigation, signal composition, stale checks,
@@ -186,8 +192,8 @@ three-way confirmation and preview composition.
 
 ### Phase 3: Adaptive Review and Supported Testability
 
-**Status:** Adaptive review complete in repository source through the
-[adaptive-review plan][adaptive-review-plan]; supported testability, the BTW gate, migration, and npm
+**Status:** Adaptive review and the [supported testing entrypoint][supported-testing-plan] are
+complete in repository source; Stamp/Image Drop test-host adoption, the BTW gate/migration, and npm
 release remain open.
 
 **Milestones:**
@@ -196,7 +202,7 @@ release remain open.
   and RPC pagination remain compatible.
 - [x] Adaptive review stays within terminal row budgets at constrained, typical, and large heights,
   including wrapped headers, position indicators, resize, and scroll-offset clamping.
-- [ ] A separate `@narumitw/pi-tui-kit/testing` entry point drives real TUI components and RPC dialogs
+- [x] A separate `@narumitw/pi-tui-kit/testing` entry point drives real TUI components and RPC dialogs
   through focus, text input, key events, rejected retries, pending actions, disposal, and owner abort.
 - [ ] Stamp and Image Drop consumer tests use the supported test host, allowing equivalent generic
   input orchestration to leave repository-level `test/support.ts`.
@@ -287,11 +293,11 @@ abstractions when Pi provides a better stable owner.
 | Pi private `dist/*` imports in kit source | 0 | Remain 0 | Every phase; boundary check and source search |
 | Ordinary `runMenu()` close outcomes visible to callers | Published API 3 collapses Back and Close | Repository API 4 distinguishes root Back and explicit Close | Phase 2 complete in source; runtime TUI/RPC matrix |
 | Review TUI viewport policy | Published API 3 is fixed, default 14 rows | Repository API 5 provides opt-in adaptive sizing within the live terminal budget | Adaptive source milestone complete; review component and built-package smokes |
-| Reusable consumer input-host logic | Generic behavior added to repository `test/support.ts` | Stamp and Image Drop use the supported testing entry point | Phase 3; consumer diffs and tests |
+| Reusable consumer input-host logic | Generic behavior added to repository `test/support.ts` | Supported `/testing` source is complete; Stamp and Image Drop adoption remains | Phase 3; package and consumer diffs/tests |
 | Proof for each new public flow | Two compatible consumers by default; exceptions require recorded evidence | Two completed proof migrations or an explicit no-go/deferral | Every expansion phase; archived plans and PRs |
 | Lifecycle verification | Existing deterministic package and consumer coverage | Every admitted contract covers TUI/RPC, cancellation, disposal, owner abort, stale state, and failure | Every phase; package and repository gates |
 | Runtime action/lifecycle ownership | TUI and RPC loops coordinate screen actions in separate branches | If the driver is admitted, one coordinator owns shared action and lifecycle policy | Phase 4; source diff plus behavior matrix |
-| Regression gate | 1,923 tests after adaptive review | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
+| Regression gate | 1,937 tests after the supported testing entrypoint | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
 and adoption rather than calendar output.
@@ -333,3 +339,4 @@ and adoption rather than calendar output.
 | 2026-08-01 | Merge the next-architecture implementation note into this canonical roadmap. | Maintaining one Pi TUI Kit roadmap avoids conflicting priorities while preserving the migration evidence and prior decision history. |
 | 2026-08-01 | Implement mandatory `RunMenuResult.closed.reason` and raise repository menu API to version 4. | The navigator already owns root Back versus Close; exposing that reason removes a proven composition blocker while leaving domain completion values local. Publication remains a separate workflow. |
 | 2026-08-01 | Implement opt-in adaptive review and raise repository menu API to version 5. | Live public TUI rows now bound complete review frames while fixed/default TUI output and deterministic RPC pages remain unchanged; the testing entry point, BTW gate/migration, and package release remain separate work. |
+| 2026-08-01 | Add the supported `@narumitw/pi-tui-kit/testing` subpath without changing production exports or menu API version. | Semantic TUI driving and strict input/select RPC scripts concentrate demonstrated test-host policy without exposing components or absorbing consumer context/domain mocks; adoption and release remain separate. |

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -365,6 +365,73 @@ The consuming extension still owns:
 
 Keep specialized UI local rather than adding package hooks that expose Pi TUI internals.
 
+## 🧪 Supported testing entrypoint
+
+The same npm package exposes test-only drivers from `@narumitw/pi-tui-kit/testing`; there is no
+second package to install. Keep production imports on the main entrypoint and import harnesses only
+from test code. The testing entrypoint drives Kit behavior through Pi's public custom-factory and RPC
+dialog boundaries without returning a raw component or creating a general `ExtensionContext` mock.
+
+Compose `createTuiHarness()` with the consumer's own context fixture:
+
+```ts
+import { runMenu } from "@narumitw/pi-tui-kit";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+
+const tui = createTuiHarness({ width: 80, rows: 24 });
+const ctx = {
+  ...consumerContext,
+  mode: "tui" as const,
+  hasUI: true,
+  ui: { ...consumerContext.ui, custom: tui.custom },
+};
+
+const running = runMenu(ctx, menu, options);
+await tui.waitForOpen();
+tui.setFocused(true);
+tui.type("12");
+tui.press("tui.input.submit");
+await tui.waitForPending();
+tui.resize({ width: 60, rows: 12 });
+const frame = tui.render();
+const result = await running;
+```
+
+The TUI harness supports semantic Kit bindings, explicit raw input, Ctrl+C/Home/End, focus,
+invalidation, live width/row changes, render-request observations, pending-action draining,
+sequential screens, result observation, and external disposal. `done`, disposal, factory failure,
+and obsolete async openings settle exactly once; input after closure is inert. Supply optional
+callback-compatible theme/keybinding overrides only when a test needs them.
+
+Use strict scripts for RPC:
+
+```ts
+import { createRpcHarness } from "@narumitw/pi-tui-kit/testing";
+
+const rpc = createRpcHarness([
+  { kind: "input", title: "Value", placeholder: "", response: "not-a-number" },
+  { kind: "input", title: "Value", placeholder: "", response: "12" },
+  { kind: "select", options: ["Apply", "Back"], response: "Apply" },
+]);
+const rpcCtx = {
+  ...consumerContext,
+  mode: "rpc" as const,
+  hasUI: true,
+  ui: { ...consumerContext.ui, ...rpc.ui },
+};
+
+await runMenu(rpcCtx, menu, options);
+rpc.assertConsumed();
+```
+
+RPC steps match call kind and optional exact title, placeholder, or choices. Responses are exact raw
+strings or `undefined` cancellation; the harness never fuzzy-matches labels. A `waitForAbort: true`
+step supports owner-abort tests without a timer. Dialog records are immutable, unexpected or leftover
+steps fail observably, and any RPC request for custom TUI throws. The current Kit runtime uses only
+signal-aware `input()` and `select()` in RPC, so the testing entrypoint deliberately does not mock
+confirmations, editors, notifications, sessions, models, settings, filesystems, clocks, or networks.
+Consumer fixtures continue to own domain state, persistence, generation checks, and owner signals.
+
 ## 📚 Public API
 
 - `defineMenu()` — validates and returns a typed menu definition.
@@ -373,6 +440,8 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, `MenuCloseReason`, and result types.
+- `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
+  strict scripts, and their public testing types; it is not re-exported from the production root.
 - `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`5`). Version 5 adds the
   opt-in `ReviewScreen.viewportSize: "adaptive"` policy; version-4 definitions remain valid on the
   version-5 runtime, including mandatory Back/Close reasons on closed menu results.
@@ -381,9 +450,10 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 
 - `src/` — authored TypeScript and the public package entrypoint
 - `src/components/` — internal TUI input, review, list, settings, and rendering adapters
+- `src/testing/` — supported TUI/RPC test drivers exported only through the `/testing` subpath
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `dist/` — generated ESM and declarations included in the npm package
-- `test/` — contract, renderer, navigation, and lifecycle coverage
+- `test/` — contract, renderer, navigation, lifecycle, and public testing-entrypoint coverage
 
 ## 📄 License
 

--- a/packages/pi-tui-kit/package.json
+++ b/packages/pi-tui-kit/package.json
@@ -24,6 +24,10 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
+		},
+		"./testing": {
+			"types": "./dist/testing/index.d.ts",
+			"import": "./dist/testing/index.js"
 		}
 	},
 	"scripts": {

--- a/packages/pi-tui-kit/src/testing/index.ts
+++ b/packages/pi-tui-kit/src/testing/index.ts
@@ -1,0 +1,11 @@
+export { createRpcHarness } from "./rpc-harness.js";
+export { createTuiHarness } from "./tui-harness.js";
+export type {
+	RpcDialogRecord,
+	RpcHarness,
+	RpcHarnessStep,
+	TuiHarness,
+	TuiHarnessKey,
+	TuiHarnessOptions,
+	TuiHarnessResize,
+} from "./types.js";

--- a/packages/pi-tui-kit/src/testing/rpc-harness.ts
+++ b/packages/pi-tui-kit/src/testing/rpc-harness.ts
@@ -1,0 +1,160 @@
+import type { ExtensionContext, ExtensionUIDialogOptions } from "@earendil-works/pi-coding-agent";
+import type { RpcDialogRecord, RpcHarness, RpcHarnessStep } from "./types.js";
+
+interface CallWaiter {
+	resolve(record: RpcDialogRecord): void;
+}
+
+export function createRpcHarness(steps: readonly RpcHarnessStep[]): RpcHarness {
+	const script = steps.map(copyStep);
+	const records: RpcDialogRecord[] = [];
+	const waiters: CallWaiter[] = [];
+	let scriptIndex = 0;
+	let waitIndex = 0;
+	let pendingCalls = 0;
+
+	const input: ExtensionContext["ui"]["input"] = async (title, placeholder, options) => {
+		const step = consumeStep("input", { title, placeholder }, options);
+		if (options?.signal?.aborted) return undefined;
+		if (step.waitForAbort) return waitForAbort(options?.signal, "input");
+		return step.response;
+	};
+	const select: ExtensionContext["ui"]["select"] = async (title, options, dialogOptions) => {
+		const step = consumeStep("select", { title, options }, dialogOptions);
+		if (dialogOptions?.signal?.aborted) return undefined;
+		if (step.waitForAbort) return waitForAbort(dialogOptions?.signal, "select");
+		if (step.response !== undefined && !options.includes(step.response)) {
+			throw new Error(
+				`Scripted select response ${JSON.stringify(step.response)} is not one of the offered options`,
+			);
+		}
+		return step.response;
+	};
+	const custom: ExtensionContext["ui"]["custom"] = async () => {
+		throw new Error("RPC harness does not support custom TUI");
+	};
+	const ui = Object.freeze({ input, select, custom });
+
+	function consumeStep(
+		kind: "input",
+		actual: { title: string; placeholder?: string },
+		options?: ExtensionUIDialogOptions,
+	): Extract<RpcHarnessStep, { kind: "input" }>;
+	function consumeStep(
+		kind: "select",
+		actual: { title: string; options: readonly string[] },
+		options?: ExtensionUIDialogOptions,
+	): Extract<RpcHarnessStep, { kind: "select" }>;
+	function consumeStep(
+		kind: "input" | "select",
+		actual: { title: string; placeholder?: string; options?: readonly string[] },
+		options?: ExtensionUIDialogOptions,
+	): RpcHarnessStep {
+		const step = script[scriptIndex];
+		if (!step) throw new Error(`Unexpected ${kind} RPC call: script is exhausted`);
+		if (step.kind !== kind) {
+			throw new Error(`Expected ${step.kind} RPC call but received ${kind}`);
+		}
+		if (step.title !== undefined && step.title !== actual.title) {
+			throw new Error(
+				`Expected ${kind} title ${JSON.stringify(step.title)} but received ${JSON.stringify(actual.title)}`,
+			);
+		}
+		if (kind === "input" && step.kind === "input") {
+			if (step.placeholder !== undefined && step.placeholder !== actual.placeholder) {
+				throw new Error(
+					`Expected input placeholder ${JSON.stringify(step.placeholder)} but received ${JSON.stringify(actual.placeholder)}`,
+				);
+			}
+		} else if (kind === "select" && step.kind === "select" && step.options !== undefined) {
+			if (!sameStrings(step.options, actual.options ?? [])) {
+				throw new Error(
+					`Expected select options ${JSON.stringify(step.options)} but received ${JSON.stringify(actual.options ?? [])}`,
+				);
+			}
+		}
+
+		scriptIndex += 1;
+		const record = Object.freeze({
+			kind,
+			title: actual.title,
+			...(kind === "input" ? { placeholder: actual.placeholder } : {}),
+			...(kind === "select" ? { options: Object.freeze([...(actual.options ?? [])]) } : {}),
+			signalWasAborted: options?.signal?.aborted ?? false,
+		}) satisfies RpcDialogRecord;
+		recordCall(record);
+		return step;
+	}
+
+	function recordCall(record: RpcDialogRecord) {
+		records.push(record);
+		const waiter = waiters.shift();
+		if (waiter) {
+			waitIndex += 1;
+			waiter.resolve(record);
+		}
+	}
+
+	async function waitForAbort(signal: AbortSignal | undefined, kind: "input" | "select") {
+		if (!signal) throw new Error(`Pending ${kind} RPC step requires an AbortSignal`);
+		if (signal.aborted) return undefined;
+		pendingCalls += 1;
+		let onAbort: (() => void) | undefined;
+		try {
+			await new Promise<void>((resolve) => {
+				let settled = false;
+				onAbort = () => {
+					if (settled) return;
+					settled = true;
+					resolve();
+				};
+				signal.addEventListener("abort", onAbort, { once: true });
+				if (signal.aborted) onAbort();
+			});
+			return undefined;
+		} finally {
+			if (onAbort) signal.removeEventListener("abort", onAbort);
+			pendingCalls -= 1;
+		}
+	}
+
+	return {
+		ui,
+		get dialogs() {
+			return Object.freeze([...records]);
+		},
+		get remainingSteps() {
+			return script.length - scriptIndex;
+		},
+		waitForCall() {
+			const existing = records[waitIndex];
+			if (existing) {
+				waitIndex += 1;
+				return Promise.resolve(existing);
+			}
+			return new Promise<RpcDialogRecord>((resolve) => waiters.push({ resolve }));
+		},
+		assertConsumed() {
+			const remaining = script.length - scriptIndex;
+			if (remaining > 0) {
+				throw new Error(
+					`${remaining} scripted RPC step${remaining === 1 ? " remains" : "s remain"}`,
+				);
+			}
+			if (pendingCalls > 0) throw new Error(`${pendingCalls} scripted RPC call is still pending`);
+		},
+	};
+}
+
+function copyStep(step: RpcHarnessStep): RpcHarnessStep {
+	return Object.freeze({
+		...step,
+		...(step.kind === "select" && step.options
+			? { options: Object.freeze([...step.options]) }
+			: {}),
+	});
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]) {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
+}

--- a/packages/pi-tui-kit/src/testing/tui-harness.ts
+++ b/packages/pi-tui-kit/src/testing/tui-harness.ts
@@ -1,0 +1,367 @@
+import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import { type Component, isFocusable, Key, matchesKey, type TUI } from "@earendil-works/pi-tui";
+import type { TuiHarness, TuiHarnessKey, TuiHarnessOptions, TuiHarnessResize } from "./types.js";
+
+interface HarnessComponent extends Component {
+	waitForPending?(): Promise<void>;
+	dispose?(): void;
+}
+
+type CustomFactory<Value> = (
+	tui: TUI,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (result: Value) => void,
+) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>;
+type HarnessKeybindings = NonNullable<TuiHarnessOptions["keybindings"]>;
+
+interface Deferred<Value> {
+	promise: Promise<Value>;
+	resolve(value: Value): void;
+	reject(error: unknown): void;
+}
+
+interface OpenWaiter {
+	resolve(openCount: number): void;
+	reject(error: unknown): void;
+}
+
+interface HarnessSession {
+	generation: number;
+	component?: HarnessComponent;
+	open: boolean;
+	opened: boolean;
+	openError?: unknown;
+	settled: boolean;
+	disposed: boolean;
+	result: unknown;
+	resultDeferred: Deferred<unknown>;
+}
+
+const DEFAULT_WIDTH = 100;
+const DEFAULT_ROWS = 24;
+
+export function createTuiHarness(options: TuiHarnessOptions = {}): TuiHarness {
+	let width = validDimension(options.width ?? DEFAULT_WIDTH, "width");
+	let rows = validDimension(options.rows ?? DEFAULT_ROWS, "rows");
+	let openCount = 0;
+	let nextGeneration = 0;
+	let requestRenderCount = 0;
+	let active: HarnessSession | undefined;
+	let latest: HarnessSession | undefined;
+	let lastFrame: readonly string[] = Object.freeze([]);
+	const openWaiters: OpenWaiter[] = [];
+	const terminal = {
+		get columns() {
+			return width;
+		},
+		get rows() {
+			return rows;
+		},
+	};
+	const tui = {
+		terminal,
+		requestRender() {
+			requestRenderCount += 1;
+		},
+	} as unknown as TUI;
+	const theme = testingTheme(options.theme);
+	const keybindings = testingKeybindings(options.keybindings);
+
+	const custom = (async <Value>(
+		factory: CustomFactory<Value>,
+		customOptions?: unknown,
+	): Promise<Value> => {
+		if (customOptions !== undefined) {
+			throw new Error("TUI harness does not support custom UI options or overlays");
+		}
+		if (active && !active.settled) {
+			throw new Error("TUI harness already has an active custom component");
+		}
+		const session: HarnessSession = {
+			generation: ++nextGeneration,
+			open: false,
+			opened: false,
+			settled: false,
+			disposed: false,
+			result: undefined,
+			resultDeferred: deferred<unknown>(),
+		};
+		active = session;
+		latest = session;
+		const done = (value: Value) => settle(session, value);
+		void Promise.resolve()
+			.then(() => factory(tui, theme, keybindings, done))
+			.then(
+				(component) => {
+					session.component = component as HarnessComponent;
+					if (session.settled) {
+						disposeComponent(session);
+						return;
+					}
+					if (active !== session) {
+						failSession(
+							session,
+							new Error(
+								`TUI custom generation ${session.generation} became obsolete before opening`,
+							),
+						);
+						disposeComponent(session);
+						return;
+					}
+					session.open = true;
+					session.opened = true;
+					openCount += 1;
+					resolveOpenWaiters(openCount);
+				},
+				(error) => failSession(session, error),
+			)
+			.catch((error) => failSession(session, error));
+		try {
+			return (await session.resultDeferred.promise) as Value;
+		} finally {
+			if (active === session) active = undefined;
+		}
+	}) as ExtensionContext["ui"]["custom"];
+
+	function failSession(session: HarnessSession, error: unknown) {
+		if (session.settled) return;
+		session.settled = true;
+		session.open = false;
+		session.openError = error;
+		session.resultDeferred.reject(error);
+		rejectOpenWaiters(error);
+	}
+
+	function settle<Value>(session: HarnessSession, value: Value | undefined) {
+		if (session.settled) return;
+		const settledBeforeOpen = !session.open && !session.component;
+		session.settled = true;
+		session.open = false;
+		session.result = value;
+		session.resultDeferred.resolve(session.result);
+		disposeComponent(session);
+		if (settledBeforeOpen) {
+			const error = new Error("TUI custom component settled before opening");
+			session.openError = error;
+			rejectOpenWaiters(error);
+		}
+	}
+
+	function disposeComponent(session: HarnessSession) {
+		if (session.disposed || !session.component) return;
+		session.disposed = true;
+		try {
+			session.component.dispose?.();
+		} catch {
+			// Match Pi's custom host: disposal failures do not replace the component result.
+		}
+	}
+
+	function resolveOpenWaiters(count: number) {
+		for (const waiter of openWaiters.splice(0)) waiter.resolve(count);
+	}
+
+	function rejectOpenWaiters(error: unknown) {
+		for (const waiter of openWaiters.splice(0)) waiter.reject(error);
+	}
+
+	function currentOpen() {
+		return active?.open ? active : undefined;
+	}
+
+	function render(renderWidth = width): readonly string[] {
+		const session = currentOpen();
+		if (!session?.component) throw new Error("TUI harness has no open custom component");
+		width = validDimension(renderWidth, "width");
+		lastFrame = Object.freeze([...session.component.render(width)]);
+		return lastFrame;
+	}
+
+	function send(data: string): readonly string[] {
+		const session = currentOpen();
+		if (!session?.component) return lastFrame;
+		session.component.handleInput?.(data);
+		return session.open ? render() : lastFrame;
+	}
+
+	return {
+		custom,
+		get openCount() {
+			return openCount;
+		},
+		get requestRenderCount() {
+			return requestRenderCount;
+		},
+		get isOpen() {
+			return currentOpen() !== undefined;
+		},
+		get isFocusable() {
+			return isFocusable(currentOpen()?.component ?? null);
+		},
+		get focused() {
+			const component = currentOpen()?.component ?? null;
+			return isFocusable(component) ? component.focused : false;
+		},
+		get result() {
+			return latest?.result;
+		},
+		get resultPromise() {
+			if (!latest) throw new Error("TUI harness has not opened a custom component");
+			return latest.resultDeferred.promise;
+		},
+		waitForOpen() {
+			if (currentOpen()) return Promise.resolve(openCount);
+			const session = active ?? latest;
+			if (session?.settled && !session.opened && session.openError !== undefined) {
+				return Promise.reject(session.openError);
+			}
+			return new Promise<number>((resolve, reject) => openWaiters.push({ resolve, reject }));
+		},
+		render,
+		press(key: TuiHarnessKey) {
+			return send(keyData(key));
+		},
+		send,
+		type(text: string) {
+			return send(text);
+		},
+		resize(size: TuiHarnessResize) {
+			const nextWidth = size.width === undefined ? width : validDimension(size.width, "width");
+			const nextRows = size.rows === undefined ? rows : validDimension(size.rows, "rows");
+			width = nextWidth;
+			rows = nextRows;
+			return render();
+		},
+		invalidate() {
+			currentOpen()?.component?.invalidate();
+		},
+		setFocused(focused: boolean) {
+			const component = currentOpen()?.component ?? null;
+			if (isFocusable(component)) component.focused = focused;
+		},
+		async waitForPending() {
+			await latest?.component?.waitForPending?.();
+		},
+		dispose() {
+			const session = active;
+			if (!session || session.settled) return;
+			settle(session, undefined);
+		},
+	};
+}
+
+function deferred<Value>(): Deferred<Value> {
+	let resolve!: (value: Value) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	void promise.catch(() => undefined);
+	return { promise, resolve, reject };
+}
+
+function validDimension(value: number, name: string) {
+	if (!Number.isInteger(value) || value <= 0) {
+		throw new Error(`TUI harness ${name} must be a positive integer`);
+	}
+	return value;
+}
+
+function keyData(key: TuiHarnessKey) {
+	switch (key) {
+		case "tui.select.up":
+			return "\u001b[A";
+		case "tui.select.down":
+			return "\u001b[B";
+		case "tui.select.pageUp":
+			return "\u001b[5~";
+		case "tui.select.pageDown":
+			return "\u001b[6~";
+		case "tui.select.confirm":
+		case "tui.input.submit":
+			return "\r";
+		case "tui.select.cancel":
+			return "\u001b";
+		case "ctrl+c":
+			return "\u0003";
+		case "home":
+			return "\u001b[H";
+		case "end":
+			return "\u001b[F";
+	}
+}
+
+function testingTheme(override?: TuiHarnessOptions["theme"]) {
+	const identity = (text: string) => text;
+	return {
+		fg: (color: Parameters<Theme["fg"]>[0], text: string) => override?.fg(color, text) ?? text,
+		bg: (_color: Parameters<Theme["bg"]>[0], text: string) => text,
+		bold: (text: string) => override?.bold(text) ?? text,
+		italic: identity,
+		underline: identity,
+		inverse: identity,
+		strikethrough: identity,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor" as const,
+		getThinkingBorderColor: () => identity,
+		getBashModeBorderColor: () => identity,
+	} as unknown as Theme;
+}
+
+function testingKeybindings(override?: TuiHarnessOptions["keybindings"]) {
+	const matches = override?.matches.bind(override);
+	const getKeys = override?.getKeys.bind(override);
+	return {
+		matches(data: string, binding: string) {
+			if (matches) return matches(data, binding as Parameters<HarnessKeybindings["matches"]>[1]);
+			const expected = bindingKey(binding);
+			return (
+				(expected !== undefined && matchesKey(data, expected)) ||
+				(binding === "tui.select.cancel" && matchesKey(data, Key.ctrl("c")))
+			);
+		},
+		getKeys(binding: string): readonly string[] {
+			if (getKeys) return getKeys(binding as Parameters<HarnessKeybindings["getKeys"]>[0]);
+			switch (binding) {
+				case "tui.select.up":
+					return ["up"];
+				case "tui.select.down":
+					return ["down"];
+				case "tui.select.pageUp":
+					return ["pageup"];
+				case "tui.select.pageDown":
+					return ["pagedown"];
+				case "tui.select.confirm":
+				case "tui.input.submit":
+					return ["enter"];
+				case "tui.select.cancel":
+					return ["escape", "ctrl+c"];
+				default:
+					return [];
+			}
+		},
+	} as unknown as KeybindingsManager;
+}
+
+function bindingKey(binding: string) {
+	switch (binding) {
+		case "tui.select.up":
+			return Key.up;
+		case "tui.select.down":
+			return Key.down;
+		case "tui.select.pageUp":
+			return Key.pageUp;
+		case "tui.select.pageDown":
+			return Key.pageDown;
+		case "tui.select.confirm":
+		case "tui.input.submit":
+			return Key.enter;
+		case "tui.select.cancel":
+			return Key.escape;
+		default:
+			return undefined;
+	}
+}

--- a/packages/pi-tui-kit/src/testing/types.ts
+++ b/packages/pi-tui-kit/src/testing/types.ts
@@ -1,0 +1,94 @@
+import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+
+export type TuiHarnessKey =
+	| "tui.select.up"
+	| "tui.select.down"
+	| "tui.select.pageUp"
+	| "tui.select.pageDown"
+	| "tui.select.confirm"
+	| "tui.select.cancel"
+	| "tui.input.submit"
+	| "ctrl+c"
+	| "home"
+	| "end";
+
+export interface TuiHarnessOptions {
+	width?: number;
+	rows?: number;
+	theme?: Pick<Theme, "fg" | "bold">;
+	keybindings?: Pick<KeybindingsManager, "matches" | "getKeys">;
+}
+
+export interface TuiHarnessResize {
+	width?: number;
+	rows?: number;
+}
+
+export interface TuiHarness {
+	readonly custom: ExtensionContext["ui"]["custom"];
+	readonly openCount: number;
+	readonly requestRenderCount: number;
+	readonly isOpen: boolean;
+	readonly isFocusable: boolean;
+	readonly focused: boolean;
+	readonly result: unknown;
+	readonly resultPromise: Promise<unknown>;
+	waitForOpen(): Promise<number>;
+	render(width?: number): readonly string[];
+	press(key: TuiHarnessKey): readonly string[];
+	send(data: string): readonly string[];
+	type(text: string): readonly string[];
+	resize(size: TuiHarnessResize): readonly string[];
+	invalidate(): void;
+	setFocused(focused: boolean): void;
+	waitForPending(): Promise<void>;
+	dispose(): void;
+}
+
+interface RpcExpectedInput {
+	title?: string;
+	placeholder?: string;
+}
+
+interface RpcExpectedSelect {
+	title?: string;
+	options?: readonly string[];
+}
+
+export type RpcHarnessStep =
+	| ({
+			kind: "input";
+			response: string | undefined;
+			waitForAbort?: never;
+	  } & RpcExpectedInput)
+	| ({
+			kind: "input";
+			waitForAbort: true;
+			response?: never;
+	  } & RpcExpectedInput)
+	| ({
+			kind: "select";
+			response: string | undefined;
+			waitForAbort?: never;
+	  } & RpcExpectedSelect)
+	| ({
+			kind: "select";
+			waitForAbort: true;
+			response?: never;
+	  } & RpcExpectedSelect);
+
+export interface RpcDialogRecord {
+	readonly kind: "input" | "select";
+	readonly title: string;
+	readonly placeholder?: string;
+	readonly options?: readonly string[];
+	readonly signalWasAborted: boolean;
+}
+
+export interface RpcHarness {
+	readonly ui: Pick<ExtensionContext["ui"], "input" | "select" | "custom">;
+	readonly dialogs: readonly RpcDialogRecord[];
+	readonly remainingSteps: number;
+	waitForCall(): Promise<RpcDialogRecord>;
+	assertConsumed(): void;
+}

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -7,6 +7,7 @@ import {
 	type ReviewScreen,
 	runMenu,
 } from "../src/index.js";
+import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
 
 type Screen = "main" | "profile" | "settings";
 type Action = "refresh" | "setMode" | "setProfile";
@@ -127,5 +128,50 @@ export async function showMenu(ctx: ExtensionCommandContext, generation: number)
 		const reason: MenuCloseReason = result.reason;
 		if (reason === "back") ctx.ui.notify("Returned from the root menu", "info");
 	}
+	return result;
+}
+
+declare const consumerContext: ExtensionCommandContext;
+
+export async function driveMenuWithSupportedTuiHarness() {
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const ctx = {
+		...consumerContext,
+		mode: "tui" as const,
+		hasUI: true,
+		ui: { ...consumerContext.ui, custom: tui.custom },
+	};
+	const running = runMenu(ctx, menu, {
+		getState: ({ signal }) => loadState(signal),
+		signal: currentSessionSignal(),
+	});
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("12");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	tui.resize({ width: 60, rows: 12 });
+	const frame = tui.render();
+	const result = await running;
+	return { frame, result };
+}
+
+export async function driveMenuWithSupportedRpcHarness() {
+	const rpc = createRpcHarness([
+		{ kind: "input", title: "Value", placeholder: "", response: "not-a-number" },
+		{ kind: "input", title: "Value", placeholder: "", response: "12" },
+		{ kind: "select", options: ["Apply", "Back"], response: "Apply" },
+	]);
+	const ctx = {
+		...consumerContext,
+		mode: "rpc" as const,
+		hasUI: true,
+		ui: { ...consumerContext.ui, ...rpc.ui },
+	};
+	const result = await runMenu(ctx, menu, {
+		getState: ({ signal }) => loadState(signal),
+		signal: currentSessionSignal(),
+	});
+	rpc.assertConsumed();
 	return result;
 }

--- a/packages/pi-tui-kit/test/testing-context-usage.ts
+++ b/packages/pi-tui-kit/test/testing-context-usage.ts
@@ -1,0 +1,40 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import * as production from "../src/index.js";
+import {
+	createRpcHarness,
+	createTuiHarness,
+	type RpcDialogRecord,
+	type RpcHarness,
+	type RpcHarnessStep,
+	type TuiHarness,
+	type TuiHarnessKey,
+	type TuiHarnessOptions,
+} from "../src/testing/index.js";
+
+const tuiOptions: TuiHarnessOptions = { width: 80, rows: 24 };
+const tui: TuiHarness = createTuiHarness(tuiOptions);
+const custom: ExtensionContext["ui"]["custom"] = tui.custom;
+const key: TuiHarnessKey = "tui.select.confirm";
+void custom;
+void key;
+
+const steps: readonly RpcHarnessStep[] = [
+	{ kind: "input", title: "Value", response: "12" },
+	{ kind: "select", title: "Apply?", options: ["Apply", "Back"], response: "Apply" },
+];
+const rpc: RpcHarness = createRpcHarness(steps);
+const rpcUi: Pick<ExtensionContext["ui"], "input" | "select" | "custom"> = rpc.ui;
+const dialogs: readonly RpcDialogRecord[] = rpc.dialogs;
+void rpcUi;
+void dialogs;
+
+// @ts-expect-error Testing helpers stay off the production entrypoint.
+production.createTuiHarness;
+// @ts-expect-error Testing helpers stay off the production entrypoint.
+production.createRpcHarness;
+// @ts-expect-error The TUI harness never exposes its raw component.
+tui.component;
+// @ts-expect-error Dialog observations are immutable.
+rpc.dialogs.push({ kind: "input", title: "bad", signalWasAborted: false });
+// @ts-expect-error Script observations cannot be mutated through their readonly choice list.
+rpc.dialogs[0]?.options?.push("bad");

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const packageRoot = path.resolve("packages/pi-tui-kit");
+
+test("built package roots resolve separate production and testing exports", async (t) => {
+	const productionSpecifier = "@narumitw/pi-tui-kit";
+	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
+	const production = await import(productionSpecifier);
+	const testing = await import(testingSpecifier);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 5);
+	assert.equal("createTuiHarness" in production, false);
+	assert.equal("createRpcHarness" in production, false);
+	assert.deepEqual(Object.keys(testing).sort(), ["createRpcHarness", "createTuiHarness"]);
+
+	const cacheRoot = path.resolve("node_modules/.cache");
+	mkdirSync(cacheRoot, { recursive: true });
+	const fixture = mkdtempSync(path.join(cacheRoot, "pi-tui-kit-testing-export-"));
+	t.after(() => rmSync(fixture, { recursive: true, force: true }));
+	writeFileSync(
+		path.join(fixture, "usage.ts"),
+		`import { PI_EXTENSION_MENU_API_VERSION } from "@narumitw/pi-tui-kit";\n` +
+			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
+			`const version: 5 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`void version;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
+	);
+	writeFileSync(
+		path.join(fixture, "tsconfig.json"),
+		JSON.stringify({
+			compilerOptions: {
+				target: "ES2022",
+				module: "NodeNext",
+				moduleResolution: "NodeNext",
+				strict: true,
+				noEmit: true,
+				skipLibCheck: true,
+			},
+			include: ["usage.ts"],
+		}),
+	);
+	const tsc = path.resolve("node_modules/.bin/tsc");
+	execFileSync(tsc, ["-p", path.join(fixture, "tsconfig.json")], {
+		cwd: packageRoot,
+		stdio: "pipe",
+	});
+});

--- a/packages/pi-tui-kit/test/testing-rpc.test.ts
+++ b/packages/pi-tui-kit/test/testing-rpc.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createRpcHarness } from "../src/testing/index.js";
+
+test("RPC harness scripts exact input/select calls and exposes immutable records", async () => {
+	const rpc = createRpcHarness([
+		{ kind: "input", title: "Value", placeholder: "Positive integer", response: "12" },
+		{
+			kind: "select",
+			title: "Apply?",
+			options: ["Apply", "Back"],
+			response: "Apply",
+		},
+	]);
+	assert.equal(await rpc.ui.input("Value", "Positive integer"), "12");
+	assert.equal(await rpc.ui.select("Apply?", ["Apply", "Back"]), "Apply");
+	rpc.assertConsumed();
+	assert.equal(rpc.remainingSteps, 0);
+	assert.deepEqual(rpc.dialogs, [
+		{
+			kind: "input",
+			title: "Value",
+			placeholder: "Positive integer",
+			signalWasAborted: false,
+		},
+		{
+			kind: "select",
+			title: "Apply?",
+			options: ["Apply", "Back"],
+			signalWasAborted: false,
+		},
+	]);
+	assert.equal(Object.isFrozen(rpc.dialogs), true);
+	assert.equal(Object.isFrozen(rpc.dialogs[1]?.options), true);
+});
+
+test("RPC harness fails on unexpected, exhausted, invalid, and incomplete scripts", async () => {
+	const unexpected = createRpcHarness([{ kind: "select", response: "Back" }]);
+	await assert.rejects(unexpected.ui.input("Value"), /expected select.*received input/i);
+
+	const exhausted = createRpcHarness([]);
+	await assert.rejects(
+		exhausted.ui.select("Menu", ["Back"]),
+		/unexpected select.*script is exhausted/i,
+	);
+
+	const invalidChoice = createRpcHarness([{ kind: "select", response: "Missing" }]);
+	await assert.rejects(
+		invalidChoice.ui.select("Menu", ["Apply", "Back"]),
+		/scripted select response.*not one of the offered options/i,
+	);
+
+	const expectedTitle = createRpcHarness([{ kind: "input", title: "Expected", response: "ok" }]);
+	await assert.rejects(expectedTitle.ui.input("Wrong"), /expected input title.*received/i);
+	assert.equal(expectedTitle.remainingSteps, 1);
+	assert.equal(await expectedTitle.ui.input("Expected"), "ok");
+
+	const incomplete = createRpcHarness([{ kind: "input", response: undefined }]);
+	assert.throws(() => incomplete.assertConsumed(), /1 scripted RPC step remains/i);
+	const missingSignal = createRpcHarness([{ kind: "input", waitForAbort: true }]);
+	await assert.rejects(missingSignal.ui.input("Value"), /requires an AbortSignal/i);
+
+	const custom = createRpcHarness([]);
+	await assert.rejects(
+		custom.ui.custom(() => ({ render: () => [], invalidate() {} })),
+		/RPC harness does not support custom TUI/i,
+	);
+});
+
+test("RPC harness models cancellation, pre-abort, and a pending owner abort finitely", async () => {
+	const cancelled = createRpcHarness([{ kind: "input", response: undefined }]);
+	assert.equal(await cancelled.ui.input("Value"), undefined);
+	cancelled.assertConsumed();
+
+	const preAbortedController = new AbortController();
+	preAbortedController.abort(new DOMException("Already stale", "AbortError"));
+	const preAborted = createRpcHarness([{ kind: "select", response: "Apply" }]);
+	assert.equal(
+		await preAborted.ui.select("Menu", ["Apply"], { signal: preAbortedController.signal }),
+		undefined,
+	);
+	assert.equal(preAborted.dialogs[0]?.signalWasAborted, true);
+	preAborted.assertConsumed();
+
+	const owner = new AbortController();
+	let addedListeners = 0;
+	let removedListeners = 0;
+	const addEventListener = owner.signal.addEventListener.bind(owner.signal);
+	const removeEventListener = owner.signal.removeEventListener.bind(owner.signal);
+	Object.defineProperties(owner.signal, {
+		addEventListener: {
+			value: (...args: Parameters<AbortSignal["addEventListener"]>) => {
+				addedListeners += 1;
+				return addEventListener(...args);
+			},
+		},
+		removeEventListener: {
+			value: (...args: Parameters<AbortSignal["removeEventListener"]>) => {
+				removedListeners += 1;
+				return removeEventListener(...args);
+			},
+		},
+	});
+	const pending = createRpcHarness([{ kind: "input", waitForAbort: true }]);
+	const response = pending.ui.input("Value", "", { signal: owner.signal });
+	const record = await pending.waitForCall();
+	assert.equal(record.kind, "input");
+	assert.equal(record.signalWasAborted, false);
+	assert.throws(() => pending.assertConsumed(), /1 scripted RPC call is still pending/i);
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	owner.abort();
+	assert.equal(await response, undefined);
+	assert.equal(addedListeners, 1);
+	assert.equal(removedListeners, 1);
+	pending.assertConsumed();
+});
+
+test("RPC harness drives rejected input retry and review pagination by exact identity", async () => {
+	const inputRpc = createRpcHarness([
+		{ kind: "input", title: "Value", placeholder: "", response: "bad" },
+		{ kind: "input", title: "Value", placeholder: "", response: "12" },
+	]);
+	const inputContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		input: inputRpc.ui.input,
+		select: inputRpc.ui.select,
+		custom: inputRpc.ui.custom,
+	});
+	const values: string[] = [];
+	const inputMenu = defineMenu<undefined, "input", "submit">({
+		start: "input",
+		screens: { input: () => ({ kind: "input", title: "Value", action: "submit" }) },
+		actions: {
+			submit: async ({ value }) => {
+				values.push(value ?? "");
+				return value === "12" ? { kind: "close" } : { kind: "rejected" };
+			},
+		},
+	});
+	assert.deepEqual(await runMenu(inputContext.ctx, inputMenu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "close",
+	});
+	assert.deepEqual(values, ["bad", "12"]);
+	inputRpc.assertConsumed();
+
+	const reviewRpc = createRpcHarness([
+		{ kind: "select", options: ["Next", "Apply", "Back"], response: "Next" },
+		{ kind: "select", options: ["Previous", "Apply", "Back"], response: "Apply" },
+	]);
+	const reviewContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		input: reviewRpc.ui.input,
+		select: reviewRpc.ui.select,
+		custom: reviewRpc.ui.custom,
+	});
+	let confirmedId = "";
+	const reviewMenu = defineMenu<undefined, "review", "apply">({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Review",
+				content: Array.from({ length: 10 }, (_, index) => `row ${index + 1}`).join("\n"),
+				viewportSize: "adaptive",
+				confirm: { id: "raw-apply", label: "Apply", action: "apply" },
+			}),
+		},
+		actions: {
+			apply: async ({ itemId }) => {
+				confirmedId = itemId;
+				return { kind: "close" };
+			},
+		},
+	});
+	assert.deepEqual(await runMenu(reviewContext.ctx, reviewMenu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "close",
+	});
+	assert.equal(confirmedId, "raw-apply");
+	assert.match(reviewRpc.dialogs[0]?.title ?? "", /row 1[\s\S]*row 8[\s\S]*Page 1\/2/u);
+	assert.match(reviewRpc.dialogs[1]?.title ?? "", /row 9[\s\S]*row 10[\s\S]*Page 2\/2/u);
+	reviewRpc.assertConsumed();
+});
+
+test("RPC harness pending dialog settles runMenu as stale on owner abort", async () => {
+	const rpc = createRpcHarness([{ kind: "input", waitForAbort: true }]);
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		input: rpc.ui.input,
+		select: rpc.ui.select,
+		custom: rpc.ui.custom,
+	});
+	const owner = new AbortController();
+	const menu = defineMenu<undefined, "input", "submit">({
+		start: "input",
+		screens: { input: () => ({ kind: "input", title: "Value", action: "submit" }) },
+		actions: { submit: async () => ({ kind: "close" }) },
+	});
+	const running = runMenu(context.ctx, menu, {
+		getState: () => undefined,
+		signal: owner.signal,
+	});
+	await rpc.waitForCall();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await running, { kind: "stale" });
+	rpc.assertConsumed();
+});

--- a/packages/pi-tui-kit/test/testing-tui.test.ts
+++ b/packages/pi-tui-kit/test/testing-tui.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+test("TUI harness drives an async public factory without exposing its component", async () => {
+	const inputs: string[] = [];
+	let invalidations = 0;
+	let disposals = 0;
+	const harness = createTuiHarness({ width: 20, rows: 9 });
+	const running = harness.custom<string>(async (tui, theme, keybindings, done) => {
+		await Promise.resolve();
+		return {
+			focused: false,
+			render(width: number) {
+				return [theme.bold(`width=${width} rows=${tui.terminal.rows}`)];
+			},
+			invalidate() {
+				invalidations += 1;
+			},
+			handleInput(data: string) {
+				inputs.push(data);
+				tui.requestRender();
+				if (keybindings.matches(data, "tui.select.confirm")) done("accepted");
+			},
+			dispose() {
+				disposals += 1;
+			},
+		};
+	});
+
+	assert.equal(await harness.waitForOpen(), 1);
+	assert.equal(harness.openCount, 1);
+	assert.equal(harness.isOpen, true);
+	assert.equal(harness.isFocusable, true);
+	assert.equal(harness.focused, false);
+	assert.deepEqual(harness.render(), ["width=20 rows=9"]);
+	assert.throws(() => harness.resize({ width: 10, rows: 0 }), /rows must be a positive integer/i);
+	assert.deepEqual(harness.render(), ["width=20 rows=9"]);
+
+	harness.setFocused(true);
+	assert.equal(harness.focused, true);
+	harness.press("tui.select.down");
+	harness.press("home");
+	harness.send("\u0015");
+	harness.type("raw input");
+	assert.deepEqual(inputs, ["\u001b[B", "\u001b[H", "\u0015", "raw input"]);
+	assert.equal(harness.requestRenderCount, 4);
+
+	assert.deepEqual(harness.resize({ width: 12, rows: 6 }), ["width=12 rows=6"]);
+	harness.invalidate();
+	assert.equal(invalidations, 1);
+
+	const observedResult = harness.resultPromise;
+	harness.press("tui.select.confirm");
+	assert.equal(await observedResult, "accepted");
+	assert.equal(await running, "accepted");
+	assert.equal(harness.result, "accepted");
+	assert.equal(harness.isOpen, false);
+	assert.equal(disposals, 1);
+
+	const inputCount = inputs.length;
+	harness.type("ignored after close");
+	harness.press("ctrl+c");
+	assert.equal(inputs.length, inputCount);
+});
+
+test("TUI harness applies callback overrides and validates terminal dimensions", async () => {
+	assert.throws(() => createTuiHarness({ width: 0 }), /width must be a positive integer/i);
+	assert.throws(() => createTuiHarness({ rows: 1.5 }), /rows must be a positive integer/i);
+	const unsupportedOptions = createTuiHarness();
+	await assert.rejects(
+		unsupportedOptions.custom(() => ({ render: () => [], invalidate() {} }), { overlay: true }),
+		/does not support custom UI options or overlays/i,
+	);
+	const harness = createTuiHarness({
+		theme: {
+			fg: (color, text) => `${color}:${text}`,
+			bold: (text) => `bold:${text}`,
+		},
+		keybindings: {
+			matches: (data, binding) => data === "x" && binding === "tui.select.confirm",
+			getKeys: (binding) => (binding === "tui.select.confirm" ? ["x"] : []),
+		},
+	});
+	const running = harness.custom<string>((_tui, theme, keybindings, done) => ({
+		render: () => [
+			theme.fg("accent", theme.bold(keybindings.getKeys("tui.select.confirm")[0] ?? "")),
+		],
+		invalidate() {},
+		handleInput(data) {
+			if (keybindings.matches(data, "tui.select.confirm")) done("custom-key");
+		},
+	}));
+	await harness.waitForOpen();
+	assert.deepEqual(harness.render(), ["accent:bold:x"]);
+	assert.throws(() => harness.resize({ rows: 0 }), /rows must be a positive integer/i);
+	harness.send("x");
+	assert.equal(await running, "custom-key");
+});
+
+test("TUI harness rejects overlapping factories and advances sequential screen ownership", async () => {
+	const harness = createTuiHarness();
+	const first = harness.custom<string>((_tui, _theme, keybindings, done) => ({
+		render: () => ["first"],
+		invalidate() {},
+		handleInput(data: string) {
+			if (keybindings.matches(data, "tui.select.cancel")) done("first-result");
+		},
+	}));
+	assert.equal(await harness.waitForOpen(), 1);
+	assert.deepEqual(harness.render(), ["first"]);
+
+	await assert.rejects(
+		harness.custom(async () => ({ render: () => ["overlap"], invalidate() {} })),
+		/already has an active custom component/i,
+	);
+
+	harness.press("tui.select.cancel");
+	assert.equal(await first, "first-result");
+	const second = harness.custom<string>(async (_tui, _theme, _keybindings, done) => {
+		await Promise.resolve();
+		return {
+			render: () => ["second"],
+			invalidate() {},
+			handleInput() {
+				done("second-result");
+			},
+		};
+	});
+	assert.equal(await harness.waitForOpen(), 2);
+	assert.deepEqual(harness.render(), ["second"]);
+	harness.send("finish");
+	assert.equal(await second, "second-result");
+	assert.equal(harness.result, "second-result");
+	assert.equal(harness.openCount, 2);
+});
+
+test("TUI harness rejects failed or disposed asynchronous opens without stale ownership", async () => {
+	const factoryError = new Error("factory failed");
+	const failed = createTuiHarness();
+	const failedOpen = failed.waitForOpen();
+	const failedCustom = failed.custom(async () => {
+		throw factoryError;
+	});
+	await assert.rejects(failedCustom, (error) => error === factoryError);
+	await assert.rejects(failedOpen, (error) => error === factoryError);
+	await assert.rejects(failed.waitForOpen(), (error) => error === factoryError);
+
+	let releaseFactory: () => void = () => undefined;
+	const factoryGate = new Promise<void>((resolve) => {
+		releaseFactory = resolve;
+	});
+	let disposals = 0;
+	const disposed = createTuiHarness();
+	const disposedCustom = disposed.custom(async () => {
+		await factoryGate;
+		return {
+			render: () => ["late"],
+			invalidate() {},
+			dispose() {
+				disposals += 1;
+			},
+		};
+	});
+	const disposedOpen = disposed.waitForOpen();
+	let customSettled = false;
+	void disposedCustom.then(() => {
+		customSettled = true;
+	});
+	disposed.dispose();
+	await assert.rejects(disposedOpen, /settled before opening/i);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(customSettled, true);
+	await assert.rejects(disposed.waitForOpen(), /settled before opening/i);
+	releaseFactory();
+	assert.equal(await disposedCustom, undefined);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(disposals, 1);
+	assert.equal(disposed.isOpen, false);
+});
+
+test("TUI harness drains pending work and external disposal settles once", async () => {
+	let releasePending: () => void = () => undefined;
+	const pending = new Promise<void>((resolve) => {
+		releasePending = resolve;
+	});
+	let disposals = 0;
+	let inputCalls = 0;
+	const harness = createTuiHarness();
+	const running = harness.custom(() => ({
+		render: () => ["pending"],
+		invalidate() {},
+		handleInput() {
+			inputCalls += 1;
+		},
+		waitForPending: () => pending,
+		dispose() {
+			disposals += 1;
+		},
+	}));
+	await harness.waitForOpen();
+	harness.send("start");
+	const draining = harness.waitForPending();
+	let drained = false;
+	void draining.then(() => {
+		drained = true;
+	});
+	await Promise.resolve();
+	assert.equal(drained, false);
+	releasePending();
+	await draining;
+	assert.equal(drained, true);
+
+	harness.dispose();
+	harness.dispose();
+	assert.equal(await running, undefined);
+	assert.equal(disposals, 1);
+	harness.send("late");
+	assert.equal(inputCalls, 1);
+});
+
+test("TUI harness external disposal wins over a racing component result", async () => {
+	const harness = createTuiHarness();
+	let doneOnDispose: (() => void) | undefined;
+	const running = harness.custom<string>((_tui, _theme, _keybindings, done) => {
+		doneOnDispose = () => done("late-component-result");
+		return {
+			render: () => ["open"],
+			invalidate() {},
+			dispose() {
+				doneOnDispose?.();
+			},
+		};
+	});
+	await harness.waitForOpen();
+	harness.dispose();
+	assert.equal(await running, undefined);
+	assert.equal(harness.result, undefined);
+});
+
+test("TUI harness preserves a rejected input draft before accepted completion", async () => {
+	const values: string[] = [];
+	const tui = createTuiHarness({ width: 40, rows: 12 });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+	});
+	const menu = defineMenu<undefined, "input", "submit">({
+		start: "input",
+		screens: {
+			input: () => ({ kind: "input", title: "Value", action: "submit" }),
+		},
+		actions: {
+			submit: async ({ value }) => {
+				values.push(value ?? "");
+				return value === "12" ? { kind: "close" } : { kind: "rejected" };
+			},
+		},
+	});
+
+	const running = runMenu(context.ctx, menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("bad");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	assert.match(tui.render().join("\n"), /bad/u);
+	tui.send("\u0015");
+	tui.type("12");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+	assert.deepEqual(values, ["bad", "12"]);
+});
+
+test("TUI harness owner abort and external disposal remain distinct finite exits", async () => {
+	function idleMenu() {
+		return defineMenu<undefined, "main", "unused">({
+			start: "main",
+			screens: { main: () => ({ kind: "detail", title: "Idle", lines: ["waiting"] }) },
+			actions: { unused: async () => ({ kind: "close" }) },
+		});
+	}
+
+	const owner = new AbortController();
+	const abortedTui = createTuiHarness();
+	const abortedContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: abortedTui.custom,
+	});
+	const aborted = runMenu(abortedContext.ctx, idleMenu(), {
+		getState: () => undefined,
+		signal: owner.signal,
+	});
+	await abortedTui.waitForOpen();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await aborted, { kind: "stale" });
+	assert.equal(abortedTui.isOpen, false);
+
+	const disposedTui = createTuiHarness();
+	const disposedContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: disposedTui.custom,
+	});
+	const disposed = runMenu(disposedContext.ctx, idleMenu(), { getState: () => undefined });
+	await disposedTui.waitForOpen();
+	disposedTui.dispose();
+	assert.deepEqual(await disposed, { kind: "closed", reason: "close" });
+	assert.equal(disposedTui.isOpen, false);
+});


### PR DESCRIPTION
## Summary

- add the supported `@narumitw/pi-tui-kit/testing` subpath to the existing npm package without changing production exports, menu API version, package version, dependencies, or consumers
- provide a composable semantic TUI harness for real public custom factories, including focus, keys/text, resize, invalidation, pending drains, sequential ownership, results, disposal, factory failure, and owner abort without exposing components
- provide strict scripted RPC input/select adapters with immutable transcripts, exact expectations/responses, cancellation, pending abort, listener cleanup, complete-script checks, and a custom-TUI trap
- document the bounded testing API, verify built/packed subpath resolution, update the roadmap, and archive the completed plan

## Verification

- red-first package typecheck failed on the absent testing entrypoint before implementation
- focused testing-entrypoint tests: 14 passed
- all Pi TUI Kit tests: 113 passed
- LSP diagnostics: 0 findings across 9 touched TypeScript files
- `npm run check --workspace @narumitw/pi-tui-kit`
- generated package-root TUI smoke: render, focus, rejected retry, resize, pending action, disposal, Back/Close, and owner abort
- real Pi 0.83 versus generated RPC harness conformance: exact input retry, paginated review, cancellation, and owner-abort transcripts/results
- `npm test`: 1,937 passed
- `npm run check`: 1,937 passed
- `just pack-tui-kit`: 35 expected files
- actual tarball installed into a disposable non-workspace fixture; Node and strict NodeNext TypeScript resolved both roots, with Pi peers external and no source/tests/bundled dependencies

## Convention audit

Read `MEMORY.md`, `docs/extension-conventions.md`, and Pi's complete extension, TUI, RPC, and package guides. Audited public package roots, callback-provided TUI/theme/keybindings, focus, key data, atomic resize validation, async factory generation replacement, exactly-once settlement, pending drains, disposal/result races, owner abort, RPC sequence/exhaustion, abort-listener cleanup, declaration boundaries, packed contents, and the deletion test. Settings are not touched. Stamp/Image Drop adoption, root test-support cleanup, BTW migration, versioning, and publication remain separate follow-ups. No accepted deviation or unverified required path.
