### PR TITLE
test(pi-stamp): adopt TUI Kit testing harnesses

### DIFF
--- a/docs/plans/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
+++ b/docs/plans/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
@@ -1,0 +1,364 @@
+# Pi TUI Kit Testing Adoption and Release Plan
+
+## Goal
+
+Complete the next Pi TUI Kit delivery sequence without publishing an unproven testing contract:
+
+1. migrate Stamp and Image Drop test orchestration to the supported
+   `@narumitw/pi-tui-kit/testing` subpath in separate PRs;
+2. remove only repository test-support logic that is proven unused, while retaining domain and
+   specialized-component fixtures;
+3. publish the repository's accumulated Pi TUI Kit API 5 work in a shared minor release; and
+4. rerun the BTW migration gate against the published API, migrating and publishing BTW only if
+   editor preservation, Back/Close, adaptive review, and selection-restoration invariants all pass.
+
+The intended order is therefore **consumer test adoption → Kit release → BTW production gate**.
+Stamp and Image Drop test migrations do not need a prior npm release because repository tests resolve
+and build the local workspace package.
+
+## Context
+
+- Clean `main` is synchronized at merge commit `9f2c9dc`, which includes PR #487 and the supported
+  testing subpath. PR #487 passed CI and CodeQL before merge.
+- Repository `@narumitw/pi-tui-kit` remains version `0.41.0` but exposes menu API version 5, adaptive
+  review, distinct root Back/Close results, and `@narumitw/pi-tui-kit/testing`. npm currently exposes
+  `@narumitw/pi-tui-kit@0.41.0` with menu API version 3.
+- Stamp and Image Drop already depend on `@narumitw/pi-tui-kit` through `^0.41.0`. Their tests ship
+  neither test files nor the testing import, so adopting `/testing` does not change either extension's
+  production dependency boundary.
+- Stamp's `test/menu.test.ts` directly owns one ad hoc TUI factory driver and one callback-scripted RPC
+  flow. Image Drop's `test/menu.test.ts` directly owns loader and confirmation drivers, while
+  `test/lifecycle.test.ts` uses broad callback automation for representative declarative input/review
+  settings flows.
+- `test/support.ts#createCustomSelectorHarness()` is not deletable after only these two migrations:
+  current Kit, production-extension, experimental, and deprecated tests still use it. The supported
+  entrypoint replaces repeated Kit-host policy, not every specialized component fixture or the broad
+  consumer-owned `createMockContext()`.
+- Since tag `v0.41.0`, the currently changed publish roots include Pi TUI Kit, Stamp, Image Drop, and
+  several unrelated packages, while `extensions/pi-btw` is unchanged. A canonical shared minor bump
+  should therefore bump BTW's source manifest but omit BTW from tag-triggered publication. Recheck
+  this immediately before release because concurrent merges can change the package selection.
+- BTW currently owns `BtwMenuSelector`, `BtwBringToMainPreview`, and `BtwTextRangeSelector` plus
+  `showBtwCustomPreservingEditor()`. Only the standard menu and preview are migration candidates;
+  exact text-range selection remains specialized.
+- Guides read for this plan: `MEMORY.md`, `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, the supported-testing archived plan, the canonical Kit roadmap,
+  package manifests, release workflows/scripts, root test support, and relevant Stamp, Image Drop,
+  and BTW source/tests. Applicable MUST areas are deterministic tests, public package roots,
+  callback-provided TUI/keybindings, cancellation/disposal, settings UI behavior preservation,
+  extension dependency metadata, pack inspection, and the root CI-equivalent gate. No settings
+  loading, validation, persistence, precedence, or file format will change.
+
+## Architecture
+
+### Test-adoption boundary
+
+Consumer tests compose only the supported UI adapters into their existing fixtures:
+
+```ts
+const tui = createTuiHarness({ width: 80, rows: 24 });
+const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+const running = showMenu(context.ctx, runtime, options);
+await tui.waitForOpen();
+tui.press("tui.select.confirm");
+await tui.waitForPending();
+await running;
+```
+
+RPC tests use exact scripts and finish with `assertConsumed()`. Consumer fixtures continue to own Pi
+context fields, notifications, session generations, persistence, domain state, and specialized UI.
+Do not add those concerns to Pi TUI Kit testing.
+
+Each migration is a separate behavior-preserving PR:
+
+1. Stamp testing adoption;
+2. Image Drop testing adoption;
+3. bounded root-support/roadmap cleanup if the post-migration usage audit permits a real deletion.
+
+If a consumer proves a missing harness capability, stop that migration. Add the smallest generally
+valid capability in a separate Pi TUI Kit PR with package-owned tests and rerun package conformance
+before continuing. Do not widen `/testing` inside a consumer PR.
+
+### Release boundary
+
+Use the canonical GitHub shared-version workflow, not a hand-edited version commit. A minor bump is
+selected because the unpublished delta includes new public production behavior, menu API versions 4
+and 5, adaptive review, and a supported testing subpath. Starting from the current highest workspace
+version, the expected release is `0.42.0`; derive and verify the actual version at execution time.
+
+Before dispatch, derive the exact changed-package set from the previous release tag, inspect every
+selected tarball, and obtain explicit approval for the version and package list. The workflow must
+produce one canonical `chore(release): v<version>` commit and matching tag; the tag-triggered publish
+workflow must publish Pi TUI Kit before selected dependents.
+
+### BTW gate after Kit publication
+
+Gate BTW after the Kit release so a successful migration can declare a real bounded dependency on the
+published API 5 minor. Admission requires all of the following:
+
+- standard menu choices preserve initial/restored selection and raw identity;
+- root Back and Ctrl+C Close remain distinct through nested flows;
+- review uses the adaptive viewport without hiding exact content;
+- the main editor draft is preserved across every menu/review result and revalidated after awaits;
+- returning from preview restores question or text-range selection state; and
+- exact character/line selection remains in `BtwTextRangeSelector` with no capability loss.
+
+A no-go is a valid finite result. Record the failed invariant and retain the existing specialized
+components rather than approximating behavior.
+
+## Non-Goals
+
+- Do not publish before Stamp and Image Drop prove the supported testing seam.
+- Do not migrate every repository use of `createCustomSelectorHarness()` or delete
+  `createMockContext()` merely to reduce helper counts.
+- Do not change Stamp or Image Drop production source, settings behavior, package ranges, commands,
+  lifecycle semantics, or shipped files in their test-adoption PRs.
+- Do not expose components, add fuzzy dialog matching, or add context/session/settings/filesystem
+  mocks to `@narumitw/pi-tui-kit/testing`.
+- Do not combine Stamp, Image Drop, release, and BTW changes into one PR.
+- Do not force BTW onto Kit if editor preservation, restored selection, exact text selection, or
+  Back/Close semantics regress.
+- Do not publish a version manually when the canonical tag workflow is healthy. Manual publication is
+  recovery-only, except for a successfully migrated BTW version intentionally omitted from the prior
+  canonical release selection.
+- Do not start Phase 4 interaction-driver, standalone-confirmation, or deferred-multi-select work.
+
+## Assumptions
+
+- Repository tests continue to build Pi TUI Kit before consumers, so source adoption can import
+  `@narumitw/pi-tui-kit/testing` before npm publication.
+- The shared minor workflow remains the version authority and preserves consumer-owned dependency
+  ranges unless a migration explicitly requires a newer Kit API.
+- GitHub Actions retains trusted npm provenance credentials for tag-triggered publication.
+- BTW remains unchanged between `v0.41.0` and the release parent. If it becomes selected for the
+  shared release, pause and revise the BTW version/publication sequence before tagging.
+- Pi 0.83 remains the runtime conformance target for this release.
+
+## Risks
+
+- **Publishing an awkward test API:** migration may reveal missing or misleading semantics after the
+  subpath is public. Mitigation: dogfood two named consumers before release and fix the package in a
+  separate pre-release PR.
+- **False cleanup:** root helpers still support many Kit and specialized tests. Mitigation: require an
+  exact usage/ownership audit and delete only zero-consumer logic.
+- **Release package drift:** concurrent merges can change the tag's selected package set. Mitigation:
+  recompute the list from the latest `origin/main`, inspect each selected manifest/tarball, and require
+  approval immediately before dispatch.
+- **Partial npm publication:** some packages may publish before a workflow failure. Mitigation: query
+  every selected `name@version`, rerun the idempotent workflow or publish only missing artifacts, and
+  never overwrite an existing version.
+- **BTW dependency mismatch:** a migrated BTW cannot depend on unpublished API 5 under `^0.41.0`.
+  Mitigation: gate after Kit `0.42.x` is visible and add a bounded `^0.42.0` dependency only in the
+  successful migration.
+- **BTW capability loss:** a generic review/menu can erase editor or selection behavior. Mitigation:
+  characterize invariants first and accept a documented no-go.
+
+## Rollback / Recovery
+
+- Before npm publication, revert or amend the bounded consumer/package PR that fails; existing tests
+  can continue using repository-local support.
+- After publication, keep both package roots and fix defects additively in a patch. Do not remove
+  `@narumitw/pi-tui-kit/testing` from a published minor.
+- If the shared bump commit/tag is wrong but nothing published, stop the publish workflow, delete the
+  remote tag only with explicit approval, revert the release commit, and rerun from clean `main`.
+- If publication is partial, preserve every published artifact, inventory missing packages with
+  `npm view`, and resume only the missing versions. If npm shows a dist-tag but `npm view` returns 404,
+  use `just npm-public <package>` after confirming the package exists.
+- If BTW's intended version was already published before migration, do not reuse it. Keep BTW on its
+  current implementation and schedule the migration for the next shared version.
+- A BTW no-go requires no runtime rollback: retain the specialized components, record evidence, and
+  close the roadmap gate explicitly.
+
+## Plan
+
+### 1. Establish the execution baseline and exact ownership matrix
+
+- [x] Synchronize a clean `main` with `origin/main`, verify PR #487 is present, and record HEAD, npm
+  Kit version/API, repository Kit version/API, latest release tag, and current test count; verify with
+  `git status`, `npm view @narumitw/pi-tui-kit version`, package-root imports, and `npm test`.
+  Evidence: clean tracked `main` is synchronized at PR #487 merge `9f2c9dc`; tag/npm remain
+  `v0.41.0`/`0.41.0`, the built source root reports API 5, and all 1,937 tests pass.
+- [x] Run `npm run check --workspace @narumitw/pi-tui-kit` followed by `npm run check`; record a green
+  pre-migration baseline and do not run package/root builds concurrently because both replace
+  `packages/pi-tui-kit/dist`. Evidence: both sequential gates pass; the root gate again passes all
+  1,937 tests with zero failures, skips, cancellations, or todos.
+- [x] Inventory every `createCustomSelectorHarness`, `driveCustomSelector`, implicit
+  `createMockContext({ select/input })` Kit adapter, and direct custom-factory driver; classify each as
+  Kit-standard, specialized UI, consumer-domain context, deprecated, or already supported, and add
+  the exact retained/deletion candidates to this plan's evidence. Evidence: 80 direct references in
+  21 files span four Kit test files, 13 active extension files, one experimental file, one deprecated
+  file, and root support; nine files also name `driveCustomSelector`. Stamp/Image direct drivers are
+  Kit menu/input/loader or specialized confirmation hosts, while broad context/domain fixtures and
+  non-Kit components remain retained owners. Full helper deletion is therefore not a candidate.
+- [x] Freeze the Stamp and Image Drop behavioral matrix before editing—TUI render/input/focus,
+  rejected retry, pending drain, Escape Back, Ctrl+C Close, RPC order, cancellation, owner abort,
+  persistence, and notifications—and verify each claimed invariant already has a named assertion or
+  add a characterization assertion without changing production behavior. Evidence: nine named tests
+  cover Stamp TUI retry/Close, RPC retry/adaptation/abort, Image Drop loader Back/Close and abort
+  ordering, specialized confirmation, rejected limit retry, replacement during save, and Ctrl+C
+  closure; the green 1,937-test baseline freezes their existing assertions.
+
+### 2. Migrate Stamp tests in an independent PR
+
+- [x] Create a Stamp-only branch from the latest merged `main` and update
+  `extensions/pi-stamp/test/menu.test.ts` to import the public testing subpath while retaining
+  `createMockContext()` only for context/domain ownership; verify no Stamp source or manifest diff.
+  Evidence: branch `test/pi-stamp-testing-harness` changes only the active plan and Stamp menu test;
+  source, manifest, lockfile, and root support have no diff.
+- [x] Replace the inline TUI custom callback in the rejected-locale flow with one
+  `createTuiHarness()` that externally drives all sequential screens, focuses/types the input, drains
+  the rejected action, proves the draft remains visible, accepts the corrected locale, and closes via
+  Ctrl+C; verify the original patch/result assertions remain unchanged. Evidence: the supported host
+  drives five screen openings, explicit focus/raw Ctrl+U input, pending drains, rejected draft render,
+  canonical `en-US` patch, and Ctrl+C closure while preserving all prior assertions.
+- [x] Replace the callback-scripted Stamp RPC retry with `createRpcHarness()` steps that assert exact
+  input/select kind and order, exact raw responses/cancellation, zero custom TUI, and complete script
+  consumption; retain only product-significant title/options assertions. Evidence: seven strict steps
+  lock exact main/settings/locale/input cadence, both raw values, updated state, cancellation, Close,
+  the custom trap, and `assertConsumed()`.
+- [x] Compile the repository test project and run the focused Stamp menu test from its generated real
+  path, then run `npm run check --workspace @narumitw/pi-stamp`, LSP diagnostics on touched TypeScript,
+  and root `npm run check`; verify all prior Stamp behavior and the repository gate remain green.
+  Evidence: all 7 focused tests pass, Stamp's 14-file check/typecheck passes, LSP reports zero
+  diagnostics, and root check passes all 1,937 tests.
+- [ ] Audit the Stamp diff against the test-adoption boundary, update this plan with evidence, open a
+  focused PR, and merge only after CI passes; verify the merged PR changes tests/plan evidence only
+  and leaves production source, package metadata, settings semantics, and root support unchanged.
+
+### 3. Migrate Image Drop tests in an independent PR
+
+- [ ] Create an Image Drop-only branch from the latest merged `main` and update
+  `extensions/pi-image-drop/test/menu.test.ts` to compose `createTuiHarness()` with its existing
+  context fixture; verify initialization still uses Pi's public theme setup required by
+  `BorderedLoader`.
+- [ ] Replace the loader and specialized-confirmation factory drivers with semantic harness operations
+  covering Escape Back/cancel, Ctrl+C Close, abort-before-UI-close ordering, disposal, and ignored late
+  input; verify loader work is drained or explicitly released so no animation/task keeps Node alive.
+- [ ] Migrate the representative rejected resource-limit input flow in
+  `extensions/pi-image-drop/test/lifecycle.test.ts` from implicit select/input automation to an
+  externally driven `createTuiHarness()` sequence; verify the invalid draft remains rendered, the
+  corrected value persists once, review confirmation uses raw identity, and session/domain assertions
+  remain extension-owned.
+- [ ] Add or migrate one representative Image Drop RPC resource-limit flow to `createRpcHarness()` with
+  exact dialog order, cancellation/Close behavior, owner abort where applicable, complete-script
+  assertion, and a failing custom-TUI trap; do not convert unrelated lifecycle fixtures.
+- [ ] Compile and run focused Image Drop menu/lifecycle tests, then run
+  `npm run check --workspace @narumitw/pi-image-drop`, `npm run check:web`, LSP diagnostics on touched
+  TypeScript, and root `npm run check`; verify generated web assets and production source are
+  byte-for-byte unchanged.
+- [ ] Audit the Image Drop diff, update this plan with evidence, open a focused PR, and merge only after
+  CI passes; verify the merged PR changes tests/plan evidence only and preserves settings,
+  persistence, server, browser, and runtime behavior.
+
+### 4. Apply the deletion test and update the roadmap
+
+- [ ] Re-run the repository-wide helper inventory after both consumer PRs; verify Stamp and Image Drop
+  no longer import `createCustomSelectorHarness()` for the migrated Kit flows and list every remaining
+  owner by category.
+- [ ] Remove only root helper functions, branches, imports, or marker-based Kit automation with zero
+  remaining consumers; if no safe deletion exists, mark this item complete as not applicable with the
+  exact retained owners and do not manufacture a cleanup diff. Verify any deletion with focused
+  affected tests and root `npm run check`.
+- [ ] Update `docs/roadmaps/pi-tui-kit-roadmap.md` to mark Stamp/Image Drop supported-host adoption
+  complete, state the bounded root-support result, keep unrelated consumer migrations and the BTW
+  gate explicit, and record the new regression count; verify roadmap claims against merged files and
+  test output.
+- [ ] Open and merge a cleanup/roadmap PR only when it contains a real independently reviewable
+  deletion or canonical roadmap update; verify CI passes and `main` is clean before release preflight.
+
+### 5. Preflight and publish the shared minor release
+
+- [ ] Fetch the latest `origin/main`, recompute the previous stable tag and all changed publish roots,
+  and verify Pi TUI Kit, Stamp, and Image Drop are selected while BTW is not; if BTW is selected or the
+  list differs materially from reviewed evidence, stop and revise the release/BTW sequence before any
+  tag is created.
+- [ ] Derive the shared minor version with the repository version script in a disposable copy or by
+  inspecting the current highest workspace version; verify the expected result is `0.42.0`, package
+  versions are not edited in the working tree, and no target `name@version` already exists on npm.
+- [ ] Run `just doctor-all`, verify npm identity, registry, visibility, and current versions for every
+  selected workspace, and resolve any scoped-package visibility anomaly before release approval.
+- [ ] Run `npm run check` sequentially, dry-pack every selected workspace, inspect each `files` boundary
+  and dependency range, and run `just pack-tui-kit`, `just pack-stamp`, and `just pack-image-drop` as
+  named evidence; verify no source tests, private files, or bundled Pi peers leak into tarballs.
+- [ ] Install the actual Kit tarball into a disposable non-workspace fixture and verify Node plus strict
+  NodeNext TypeScript resolve production and `/testing` imports, menu API version 5, adaptive review,
+  exact runtime exports, external Pi peers, and unchanged production compatibility.
+- [ ] Present the exact version, selected package list/order, checks, tarball evidence, and rollback
+  status to the user and obtain explicit approval immediately before triggering the irreversible
+  release workflow.
+- [ ] Dispatch `.github/workflows/bump-version.yml` on `main` with `version_bump=minor`, then verify its
+  commit is exactly `chore(release): v<version>`, changes only all shared manifest versions plus the
+  lockfile, points the matching tag at that commit, and passes the canonical release-selection tests.
+- [ ] Watch the tag-triggered publish workflow through completion and verify its reported package
+  order publishes Kit before selected dependents; on failure, inventory already-published versions
+  before any retry and recover only missing artifacts.
+- [ ] Query npm for every selected `name@version`, install the registry Kit in a fresh fixture, and
+  verify both package roots, API version 5, declarations, peer resolution, provenance/visibility, and
+  Stamp/Image Drop installability; record registry URLs and immutable versions in this plan.
+- [ ] Update the roadmap's published baseline and decision log from API 3/source-only testing to the
+  verified registry release, open a documentation-only PR, and merge after link/check validation.
+
+### 6. Rerun the BTW gate against the published Kit
+
+- [ ] Confirm the shared release omitted `@narumitw/pi-btw@<version>` and that repository BTW remains
+  behaviorally identical to `v0.41.0`; if the target BTW version already exists, record the conflict
+  and move any migration to the next shared release rather than reusing a version.
+- [ ] Add focused characterization tests for editor text captured before custom UI, editor changes
+  observed at completion, post-await restoration, root Back versus Ctrl+C Close, initial question
+  selection, preview Back restoration, exact text-range state, narrow/large terminal bounds, resize,
+  and owner/session replacement; verify all pass on the existing implementation before migration.
+- [ ] Build a disposable Kit-backed prototype or test-only adapter for standard BTW choice and adaptive
+  review flows, leaving `BtwTextRangeSelector` untouched; verify every admission invariant in the
+  Architecture section and record a binary go/no-go decision in the roadmap.
+- [ ] If the gate is no-go, mark the migration/publication items below not applicable with the failed
+  invariant, retain specialized code unchanged, run root `npm run check`, and complete Phase 3 with a
+  durable no-go decision.
+- [ ] If the gate is go, create a BTW-only branch, add a bounded runtime dependency on the published
+  Kit minor (expected `^0.42.0`), run `npm install` to update the lockfile, and verify boundary checks
+  accept the library dependency without any extension-to-extension edge.
+- [ ] If the gate is go, replace only `BtwMenuSelector` and `BtwBringToMainPreview` ownership with
+  declarative choice/adaptive-review flows, preserve the editor wrapper and generation checks across
+  every await, and keep exact character/line selection specialized; verify obsolete classes/tests are
+  deleted only when no caller remains.
+- [ ] If the gate is go, run focused BTW tests, package typecheck/check, LSP diagnostics, root
+  `npm run check`, `just pack-btw`, and a timeout-bounded real Pi TUI smoke for editor preservation,
+  restored selection, Back, Close, adaptive resize, and bring-to-main completion.
+- [ ] If the gate is go, audit and merge the BTW PR after CI, obtain explicit publication approval,
+  run `just publish-btw` only if the target version is still absent, and verify the registry package
+  depends on the published Kit minor and installs/loads in a disposable Pi environment.
+- [ ] Update the roadmap with the final BTW gate result, package publication state when applicable,
+  final regression count, and any separately scoped testing-adoption follow-ups for other extensions;
+  verify no Phase 4 work is claimed complete.
+
+### 7. Final audit and handoff
+
+- [ ] Audit the complete sequence against this plan, both convention guides, the roadmap, merged PRs,
+  tags, GitHub Actions, and npm registry state; verify no unrecorded API expansion, production consumer
+  change, helper deletion, package selection, skipped check, or accepted deviation remains.
+- [ ] Synchronize local `main` to `origin/main`, verify a clean worktree and all expected merge/release
+  commits, archive this fully checked plan under `docs/plans/archived/`, and report PRs, versions,
+  registry links, checks, smokes, deletion outcome, and BTW decision.
+
+## Completion Checklist
+
+- [ ] Stamp's representative TUI and RPC menu tests use `@narumitw/pi-tui-kit/testing` without changing
+  Stamp production source, package metadata, settings behavior, or results.
+- [ ] Image Drop's representative loader, confirmation, rejected-input/review, and RPC tests use the
+  supported testing seam without changing production or generated web assets.
+- [ ] Root test-support cleanup is evidence-based: only zero-consumer Kit automation is removed, and
+  retained specialized/general fixtures have named owners and follow-up scope.
+- [ ] The shared minor release is canonical, all selected GitHub checks pass, and every selected npm
+  package/version is visible and installable with no partial-publication ambiguity.
+- [ ] Registry `@narumitw/pi-tui-kit` exposes menu API version 5 plus production and `/testing` roots;
+  Node, strict NodeNext TypeScript, tarball contents, and peer resolution pass from a clean fixture.
+- [ ] The BTW gate has a durable go/no-go result covering editor preservation, selection restoration,
+  exact text selection, adaptive review, Back/Close, cancellation, replacement, and width/height
+  bounds; a successful migration is merged and published on a compatible Kit range.
+- [ ] The roadmap accurately distinguishes completed test adoption, published Kit state, retained root
+  support, BTW outcome, other-extension follow-ups, and still-open Phase 4 work.
+- [ ] All focused tests, package checks, LSP diagnostics, root `npm run check`, relevant pack dry runs,
+  generated-package/registry smokes, CI checks, release workflows, and npm verification pass or have an
+  explicitly accepted, recorded alternative.
+- [ ] Every plan task is checked with evidence, the final worktree is clean on synchronized `main`, and
+  the plan is archived without overwriting an existing file.

--- a/extensions/pi-stamp/test/menu.test.ts
+++ b/extensions/pi-stamp/test/menu.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
-import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext } from "../../../test/support.js";
 import { DEFAULT_STAMP_SETTINGS } from "../src/format.js";
 import { createStampMenu, showStampMenu } from "../src/menu.js";
 import type {
@@ -198,73 +199,120 @@ test("custom locale and time-zone screens validate and save canonical raw input"
 
 test("TUI custom input retains a rejected draft and Ctrl+C closes the menu", async () => {
 	const runtime = memorySettingsRuntime();
-	let customCalls = 0;
-	let rejectedRender = "";
+	const tui = createTuiHarness({ width: 60, rows: 24 });
 	const { ctx } = createMockContext({
 		mode: "tui",
 		hasUI: true,
-		custom: async (factory: unknown) => {
-			customCalls += 1;
-			const harness = createCustomSelectorHarness(factory, 60);
-			if (customCalls === 1) harness.handleInput("tui.select.confirm");
-			else if (customCalls === 2) {
-				for (let index = 0; index < 3; index += 1) harness.handleInput("tui.select.down");
-				harness.handleInput("tui.select.confirm");
-			} else if (customCalls === 3) {
-				harness.handleInput("tui.select.down");
-				harness.handleInput("tui.select.down");
-				harness.handleInput("tui.select.confirm");
-			} else if (customCalls === 4) {
-				harness.setFocused(true);
-				harness.handleInput("not_a_locale");
-				harness.handleInput("tui.input.submit");
-				await harness.waitForPending();
-				rejectedRender = harness.render().join("\n");
-				harness.handleInput("\u0015");
-				harness.handleInput("EN-us");
-				harness.handleInput("tui.input.submit");
-				await harness.waitForPending();
-			} else harness.handleInput("\u0003");
-			return harness.result ?? harness.resultPromise;
-		},
+		custom: tui.custom,
 	});
-	const result = await showStampMenu(ctx, runtime, {
+	const running = showStampMenu(ctx, runtime, {
 		signal: new AbortController().signal,
 		isCurrent: () => true,
 	});
 
+	await tui.waitForOpen();
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("not_a_locale");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	const rejectedRender = tui.render().join("\n");
+	tui.send("\u0015");
+	tui.type("EN-us");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("ctrl+c");
+
+	const result = await running;
 	assert.equal(result.kind, "closed");
-	assert.equal(customCalls, 5);
+	assert.equal(tui.openCount, 5);
 	assert.match(rejectedRender, /not_a_locale/u);
 	assert.deepEqual(runtime.patches, [{ locale: "en-US" }]);
 });
 
 test("RPC custom input retries a rejected value before saving", async () => {
 	const runtime = memorySettingsRuntime();
-	let mainVisits = 0;
-	let settingsVisits = 0;
-	let inputCalls = 0;
-	const values = ["not_a_locale", "EN-us"];
+	const rpc = createRpcHarness([
+		{
+			kind: "select",
+			title:
+				"Stamp\n24-hour · seconds · Day changes · Invariant · Local · Timing off · Metadata off · Tool stamps hidden",
+			options: ["Settings", "Status", "Help", "Close"],
+			response: "Settings",
+		},
+		{
+			kind: "select",
+			title: "Stamp Settings\nUser settings · /tmp/pi-stamp.json",
+			options: [
+				"Hour cycle (24-hour)",
+				"Seconds (Show)",
+				"Date context (Day changes)",
+				"Locale (Invariant)",
+				"Time zone (Local)",
+				"Response timing (Off)",
+				"Assistant metadata (Off)",
+				"Tool stamps (Hide)",
+				"Back",
+			],
+			response: "Locale (Invariant)",
+		},
+		{
+			kind: "select",
+			title: "Stamp Locale\nCurrent: Invariant",
+			options: ["Invariant (default)", "System locale", "Custom BCP 47 locale…"],
+			response: "Custom BCP 47 locale…",
+		},
+		{
+			kind: "input",
+			title: "Custom BCP 47 locale\nCurrent: Invariant",
+			placeholder: "Examples: en-US, fr-FR, zh-TW",
+			response: "not_a_locale",
+		},
+		{
+			kind: "input",
+			title: "Custom BCP 47 locale\nCurrent: Invariant",
+			placeholder: "Examples: en-US, fr-FR, zh-TW",
+			response: "EN-us",
+		},
+		{
+			kind: "select",
+			title: "Stamp Settings\nUser settings · /tmp/pi-stamp.json",
+			options: [
+				"Hour cycle (24-hour)",
+				"Seconds (Show)",
+				"Date context (Day changes)",
+				"Locale (en-US)",
+				"Time zone (Local)",
+				"Response timing (Off)",
+				"Assistant metadata (Off)",
+				"Tool stamps (Hide)",
+				"Back",
+			],
+			response: undefined,
+		},
+		{
+			kind: "select",
+			title:
+				"Stamp\n24-hour · seconds · Day changes · en-US · Local · Timing off · Metadata off · Tool stamps hidden",
+			options: ["Settings", "Status", "Help", "Close"],
+			response: "Close",
+		},
+	]);
 	const { ctx } = createMockContext({
 		mode: "rpc",
 		hasUI: true,
-		input: async () => {
-			inputCalls += 1;
-			return values.shift();
-		},
-		select: async (title: string, options: string[]) => {
-			if (title.startsWith("Stamp Settings")) {
-				settingsVisits += 1;
-				return settingsVisits === 1
-					? options.find((option) => option.startsWith("Locale"))
-					: undefined;
-			}
-			if (title.startsWith("Stamp Locale")) {
-				return options.find((option) => option.startsWith("Custom BCP 47"));
-			}
-			mainVisits += 1;
-			return mainVisits === 1 ? "Settings" : "Close";
-		},
+		...rpc.ui,
 	});
 
 	const result = await showStampMenu(ctx, runtime, {
@@ -273,8 +321,9 @@ test("RPC custom input retries a rejected value before saving", async () => {
 	});
 
 	assert.equal(result.kind, "closed");
-	assert.equal(inputCalls, 2);
+	assert.equal(rpc.dialogs.filter((dialog) => dialog.kind === "input").length, 2);
 	assert.deepEqual(runtime.patches, [{ locale: "en-US" }]);
+	rpc.assertConsumed();
 });
 
 test("save failure is rejected without changing effective settings", async () => {


### PR DESCRIPTION
## Summary

- drive the rejected Stamp locale TUI flow through the supported `createTuiHarness()` API
- replace callback-derived RPC choices with an exact `createRpcHarness()` script
- add the tracked adoption/release execution plan without changing Stamp production source or metadata

## Verification

- focused Stamp menu tests: 7 passed
- `npm run check --workspace @narumitw/pi-stamp`
- LSP diagnostics: 0
- `npm run check`: 1,937 passed

## Scope audit

Only the Stamp menu test and active plan change. Settings, production source, manifest, lockfile, and root support remain unchanged.