### PR TITLE
test(pi-image-drop): adopt TUI Kit testing harness

### DIFF
--- a/docs/plans/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
+++ b/docs/plans/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
@@ -222,31 +222,43 @@ components rather than approximating behavior.
   and root `npm run check`; verify all prior Stamp behavior and the repository gate remain green.
   Evidence: all 7 focused tests pass, Stamp's 14-file check/typecheck passes, LSP reports zero
   diagnostics, and root check passes all 1,937 tests.
-- [ ] Audit the Stamp diff against the test-adoption boundary, update this plan with evidence, open a
+- [x] Audit the Stamp diff against the test-adoption boundary, update this plan with evidence, open a
   focused PR, and merge only after CI passes; verify the merged PR changes tests/plan evidence only
   and leaves production source, package metadata, settings semantics, and root support unchanged.
+  Evidence: PR #488 merged as `67a8048` after CI and all CodeQL checks passed; its two-file diff is
+  limited to the active plan and Stamp menu test, with no production, metadata, lockfile, settings, or
+  root-support change.
 
 ### 3. Migrate Image Drop tests in an independent PR
 
-- [ ] Create an Image Drop-only branch from the latest merged `main` and update
+- [x] Create an Image Drop-only branch from the latest merged `main` and update
   `extensions/pi-image-drop/test/menu.test.ts` to compose `createTuiHarness()` with its existing
   context fixture; verify initialization still uses Pi's public theme setup required by
-  `BorderedLoader`.
-- [ ] Replace the loader and specialized-confirmation factory drivers with semantic harness operations
+  `BorderedLoader`. Evidence: branch `test/pi-image-drop-testing-harness` imports only the supported
+  testing subpath and retains `initTheme("dark", false)`; no production, manifest, or lockfile diff.
+- [x] Replace the loader and specialized-confirmation factory drivers with semantic harness operations
   covering Escape Back/cancel, Ctrl+C Close, abort-before-UI-close ordering, disposal, and ignored late
   input; verify loader work is drained or explicitly released so no animation/task keeps Node alive.
-- [ ] Migrate the representative rejected resource-limit input flow in
+  Evidence: three menu tests drive named keys through the supported host, assert closed ownership and
+  abort ordering, and all five menu tests terminate without retained loader timers.
+- [x] Migrate the representative rejected resource-limit input flow in
   `extensions/pi-image-drop/test/lifecycle.test.ts` from implicit select/input automation to an
   externally driven `createTuiHarness()` sequence; verify the invalid draft remains rendered, the
   corrected value persists once, review confirmation uses raw identity, and session/domain assertions
-  remain extension-owned.
-- [ ] Add or migrate one representative Image Drop RPC resource-limit flow to `createRpcHarness()` with
-  exact dialog order, cancellation/Close behavior, owner abort where applicable, complete-script
-  assertion, and a failing custom-TUI trap; do not convert unrelated lifecycle fixtures.
-- [ ] Compile and run focused Image Drop menu/lifecycle tests, then run
+  remain extension-owned. Evidence: one seven-screen host drives main/settings/limits/input/review,
+  retains the invalid draft, saves `{ maxImages: 12 }` once through the raw review action, closes with
+  Ctrl+C, and preserves notification/domain assertions.
+- [x] Not applicable: add or migrate one representative Image Drop RPC resource-limit flow to
+  `createRpcHarness()`. Authoritative `ImageDropRuntime.register()` rejects every non-TUI command at
+  line 117 before `runMenu()`, and the existing unsupported-mode test locks that contract. An attempted
+  harness integration recorded zero dialogs, proving an RPC script would require the forbidden
+  production-mode expansion; the attempt was removed and Stamp remains the consumer RPC proof.
+- [x] Compile and run focused Image Drop menu/lifecycle tests, then run
   `npm run check --workspace @narumitw/pi-image-drop`, `npm run check:web`, LSP diagnostics on touched
   TypeScript, and root `npm run check`; verify generated web assets and production source are
-  byte-for-byte unchanged.
+  byte-for-byte unchanged. Evidence: all 42 focused tests pass; the 30-file package check/typecheck and
+  both web checks pass; LSP reports zero diagnostics; root check passes all 1,937 tests; source,
+  generated web assets, package metadata, and lockfile have no diff.
 - [ ] Audit the Image Drop diff, update this plan with evidence, open a focused PR, and merge only after
   CI passes; verify the merged PR changes tests/plan evidence only and preserves settings,
   persistence, server, browser, and runtime behavior.
@@ -344,8 +356,9 @@ components rather than approximating behavior.
 
 - [ ] Stamp's representative TUI and RPC menu tests use `@narumitw/pi-tui-kit/testing` without changing
   Stamp production source, package metadata, settings behavior, or results.
-- [ ] Image Drop's representative loader, confirmation, rejected-input/review, and RPC tests use the
-  supported testing seam without changing production or generated web assets.
+- [ ] Image Drop's representative loader, confirmation, and rejected-input/review tests use the
+  supported testing seam without changing production or generated web assets; RPC is explicitly not
+  applicable because the command rejects non-TUI modes before opening any dialog.
 - [ ] Root test-support cleanup is evidence-based: only zero-consumer Kit automation is removed, and
   retained specialized/general fixtures have named owners and follow-up scope.
 - [ ] The shared minor release is canonical, all selected GitHub checks pass, and every selected npm

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -2,6 +2,7 @@
 // verify ordering across menu, browser processing, message attachment, replacement, and shutdown.
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { digestImages, type ProcessedImage } from "../src/batch.js";
 import type { ConfirmDialogResult, ImageDropLimitsMenuState } from "../src/menu.js";
@@ -55,6 +56,7 @@ function createHarness(
 			| "close"
 		>;
 		confirm?: () => Promise<boolean>;
+		custom?: ReturnType<typeof createTuiHarness>["custom"];
 		input?: (render?: string) => Promise<string | undefined>;
 		confirmDialog?: () => Promise<ConfirmDialogResult>;
 		inputDialog?: () => Promise<
@@ -130,65 +132,68 @@ function createHarness(
 		mode: "tui",
 		hasUI: true,
 		confirm: options.confirm,
-		input: options.inputDialog ?? options.input,
-		select: async (title: string) => {
-			if (/Image Drop Status/u.test(title)) {
-				options.onStatus?.(title.split("\n").slice(1));
-				return {
-					open: "Open staging page",
-					refresh: "Refresh status",
-					back: undefined,
-					close: "Close",
-				}[options.statusActions?.shift() ?? "back"];
-			}
-			if (/Image Drop Settings/u.test(title)) {
-				const action = options.settingsActions?.shift() ?? "back";
-				return action === "toggle-start"
-					? "Start with each Pi session"
-					: action === "limits"
-						? "Image limits"
-						: undefined;
-			}
-			if (/Review resource-limit changes/u.test(title)) {
-				options.onConfirm?.("Review resource-limit changes", title);
-				const result = options.confirmDialog
-					? await options.confirmDialog()
-					: ((await options.confirm?.()) ?? true)
-						? "confirmed"
-						: "cancelled";
-				return result === "close"
-					? "\u0003"
-					: result === "confirmed"
-						? "Save resource limits"
-						: undefined;
-			}
-			if (/Image limits/u.test(title)) {
-				const action = options.limitActions?.shift() ?? "back";
-				const labels: Record<string, string | undefined> = {
-					maxImages: "Images per message",
-					maxImageBytes: "Max file size per image",
-					maxBatchBytes: "Max total size per message",
-					maxImagePixels: "Max image resolution",
-					maxRetainedImages: "Staged + sent image count",
-					maxRetainedBytes: "Staged + sent image memory",
-					save: "Review changes before saving",
-					defaults: "Restore recommended defaults",
-					back: "Back to Settings",
-					close: "Close Image Drop",
-				};
-				return labels[action];
-			}
-			const action = options.showMainMenu
-				? await options.showMainMenu()
-				: (options.menuActions?.shift() ?? "close");
-			return {
-				open: "Add images in browser",
-				status: "Check image status",
-				settings: "Change Image Drop settings",
-				help: "How Image Drop works",
-				close: "Close menu",
-			}[action];
-		},
+		custom: options.custom,
+		input: options.custom ? undefined : (options.inputDialog ?? options.input),
+		select: options.custom
+			? undefined
+			: async (title: string) => {
+					if (/Image Drop Status/u.test(title)) {
+						options.onStatus?.(title.split("\n").slice(1));
+						return {
+							open: "Open staging page",
+							refresh: "Refresh status",
+							back: undefined,
+							close: "Close",
+						}[options.statusActions?.shift() ?? "back"];
+					}
+					if (/Image Drop Settings/u.test(title)) {
+						const action = options.settingsActions?.shift() ?? "back";
+						return action === "toggle-start"
+							? "Start with each Pi session"
+							: action === "limits"
+								? "Image limits"
+								: undefined;
+					}
+					if (/Review resource-limit changes/u.test(title)) {
+						options.onConfirm?.("Review resource-limit changes", title);
+						const result = options.confirmDialog
+							? await options.confirmDialog()
+							: ((await options.confirm?.()) ?? true)
+								? "confirmed"
+								: "cancelled";
+						return result === "close"
+							? "\u0003"
+							: result === "confirmed"
+								? "Save resource limits"
+								: undefined;
+					}
+					if (/Image limits/u.test(title)) {
+						const action = options.limitActions?.shift() ?? "back";
+						const labels: Record<string, string | undefined> = {
+							maxImages: "Images per message",
+							maxImageBytes: "Max file size per image",
+							maxBatchBytes: "Max total size per message",
+							maxImagePixels: "Max image resolution",
+							maxRetainedImages: "Staged + sent image count",
+							maxRetainedBytes: "Staged + sent image memory",
+							save: "Review changes before saving",
+							defaults: "Restore recommended defaults",
+							back: "Back to Settings",
+							close: "Close Image Drop",
+						};
+						return labels[action];
+					}
+					const action = options.showMainMenu
+						? await options.showMainMenu()
+						: (options.menuActions?.shift() ?? "close");
+					return {
+						open: "Add images in browser",
+						status: "Check image status",
+						settings: "Change Image Drop settings",
+						help: "How Image Drop works",
+						close: "Close menu",
+					}[action];
+				},
 		model: { id: "vision", provider: "test", input: ["text", "image"] },
 		isIdle: options.idle ?? (() => true),
 		hasPendingMessages: options.pending ?? (() => false),
@@ -555,27 +560,54 @@ test("Settings preview and save future limits without changing current-session l
 });
 
 test("limit input retains a rejected draft before saving the corrected value", async () => {
-	let inputCalls = 0;
-	let rejectedRender = "";
 	let saved: Partial<ImageDropSettings> | undefined;
+	const tui = createTuiHarness({ width: 80, rows: 24 });
 	const harness = createHarness({
-		menuActions: ["settings", "close"],
-		settingsActions: ["limits", "back"],
-		limitActions: ["maxImages", "save"],
-		input: async (render) => {
-			inputCalls += 1;
-			if (inputCalls === 2) rejectedRender = render ?? "";
-			return inputCalls === 1 ? "not-a-number" : "12";
-		},
-		confirm: async () => true,
+		custom: tui.custom,
 		onSave: async (patch) => {
 			saved = patch;
 		},
 	});
 	await emit(harness.mock, "session_start", {}, harness.context.ctx);
-	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+	const running = Promise.resolve(
+		harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx),
+	);
 
-	assert.equal(inputCalls, 2);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("not-a-number");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	const rejectedRender = tui.render().join("\n");
+	tui.send("\u0015");
+	tui.type("12");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	for (let index = 0; index < 6; index += 1) tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /Images for next message: 8 → 12/u);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("ctrl+c");
+	await running;
+
+	assert.equal(tui.openCount, 7);
 	assert.match(rejectedRender, /not-a-number/u);
 	assert.deepEqual(saved, { maxImages: 12 });
 	assert.ok(harness.context.notifications.some((notice) => /positive value/u.test(notice.message)));

--- a/extensions/pi-image-drop/test/menu.test.ts
+++ b/extensions/pi-image-drop/test/menu.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
-import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext } from "../../../test/support.js";
 import {
 	createLimitInputScreen,
 	createLimitReviewScreen,
@@ -82,71 +83,55 @@ test("limit input and review projections preserve exact domain values", () => {
 });
 
 test("status loading distinguishes Escape back from Ctrl+C close", async () => {
-	async function loadWith(input: string) {
-		const context = createMockContext({
-			mode: "tui",
-			custom: async (factory: unknown) => {
-				const harness = createCustomSelectorHarness(factory, 40);
-				harness.handleInput(input);
-				const result = harness.result;
-				harness.dispose();
-				return result;
-			},
-		});
-		return runImageDropMenuLoad(
+	async function loadWith(key: "tui.select.cancel" | "ctrl+c") {
+		const tui = createTuiHarness({ width: 40, rows: 24 });
+		const context = createMockContext({ mode: "tui", custom: tui.custom });
+		const running = runImageDropMenuLoad(
 			context.ctx,
 			"Refreshing Image Drop status…",
 			async () => new Promise<never>(() => undefined),
 		);
+		await tui.waitForOpen();
+		tui.press(key);
+		const result = await running;
+		assert.equal(tui.isOpen, false);
+		return result;
 	}
-	assert.equal((await loadWith("\u001b")).kind, "cancelled");
-	assert.equal((await loadWith("\u0003")).kind, "closed");
+	assert.equal((await loadWith("tui.select.cancel")).kind, "cancelled");
+	assert.equal((await loadWith("ctrl+c")).kind, "closed");
 });
 
 test("Ctrl+C aborts loader work before closing its UI", async () => {
 	let uiClosed = false;
 	let abortedBeforeClose = false;
-	const context = createMockContext({
-		mode: "tui",
-		custom: async (factory: unknown) => {
-			if (typeof factory !== "function") throw new Error("Expected a custom component factory");
-			let result: unknown;
-			const component = factory(
-				{ requestRender() {} },
-				{ fg: (_color: string, text: string) => text },
-				{},
-				(value: unknown) => {
-					uiClosed = true;
-					result = value;
-				},
-			) as { handleInput(data: string): void; dispose(): void };
-			component.handleInput("\u0003");
-			component.dispose();
-			return result;
-		},
-	});
-	const result = await runImageDropMenuLoad(context.ctx, "Loading…", async (signal) => {
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", custom: tui.custom });
+	const running = runImageDropMenuLoad(context.ctx, "Loading…", async (signal) => {
 		signal.addEventListener("abort", () => {
 			abortedBeforeClose = !uiClosed;
 		});
 		return new Promise<never>(() => undefined);
 	});
+	void running.then(() => {
+		uiClosed = true;
+	});
+	await tui.waitForOpen();
+	tui.press("ctrl+c");
+	const result = await running;
 	assert.equal(result.kind, "closed");
 	assert.equal(abortedBeforeClose, true);
+	assert.equal(tui.isOpen, false);
 });
 
 test("specialized confirmation distinguishes cancellation from closing Image Drop", async () => {
-	async function drive(input: string) {
-		const context = createMockContext({
-			mode: "tui",
-			custom: async (factory: unknown) => {
-				const harness = createCustomSelectorHarness(factory, 80);
-				harness.handleInput(input);
-				return harness.result;
-			},
-		});
-		return showImageDropConfirmDialog(context.ctx, "Save?", "Review");
+	async function drive(key: "tui.select.cancel" | "ctrl+c") {
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const context = createMockContext({ mode: "tui", custom: tui.custom });
+		const running = showImageDropConfirmDialog(context.ctx, "Save?", "Review");
+		await tui.waitForOpen();
+		tui.press(key);
+		return running;
 	}
-	assert.equal(await drive("\u0003"), "close");
-	assert.equal(await drive("\u001b"), "cancelled");
+	assert.equal(await drive("ctrl+c"), "close");
+	assert.equal(await drive("tui.select.cancel"), "cancelled");
 });


### PR DESCRIPTION
## Summary

- replace Image Drop loader and confirmation component drivers with `createTuiHarness()`
- drive the representative rejected resource-limit input/review lifecycle through seven supported harness screens
- preserve the deliberate TUI-only command boundary; RPC is not applicable because non-TUI commands reject before opening dialogs

## Verification

- focused Image Drop menu/lifecycle tests: 42 passed
- `npm run check --workspace @narumitw/pi-image-drop`
- `npm run check:web --workspace @narumitw/pi-image-drop`
- LSP diagnostics: 0 across 2 files
- `npm run check`: 1,937 passed

## Scope audit

Only Image Drop tests and active plan evidence change. Production source, settings behavior, generated web assets, package metadata, and lockfile remain unchanged.