### PR TITLE
docs(pi-tui-kit): record testing harness adoption

### DIFF
--- a/docs/plans/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
+++ b/docs/plans/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
@@ -259,23 +259,30 @@ components rather than approximating behavior.
   byte-for-byte unchanged. Evidence: all 42 focused tests pass; the 30-file package check/typecheck and
   both web checks pass; LSP reports zero diagnostics; root check passes all 1,937 tests; source,
   generated web assets, package metadata, and lockfile have no diff.
-- [ ] Audit the Image Drop diff, update this plan with evidence, open a focused PR, and merge only after
+- [x] Audit the Image Drop diff, update this plan with evidence, open a focused PR, and merge only after
   CI passes; verify the merged PR changes tests/plan evidence only and preserves settings,
-  persistence, server, browser, and runtime behavior.
+  persistence, server, browser, and runtime behavior. Evidence: PR #489 merged as `4d014d2` after CI
+  and all CodeQL checks passed; its three-file diff is limited to two tests and plan evidence, with no
+  production, settings, server/browser, manifest, generated asset, or lockfile change.
 
 ### 4. Apply the deletion test and update the roadmap
 
-- [ ] Re-run the repository-wide helper inventory after both consumer PRs; verify Stamp and Image Drop
+- [x] Re-run the repository-wide helper inventory after both consumer PRs; verify Stamp and Image Drop
   no longer import `createCustomSelectorHarness()` for the migrated Kit flows and list every remaining
-  owner by category.
-- [ ] Remove only root helper functions, branches, imports, or marker-based Kit automation with zero
-  remaining consumers; if no safe deletion exists, mark this item complete as not applicable with the
-  exact retained owners and do not manufacture a cleanup diff. Verify any deletion with focused
-  affected tests and root `npm run check`.
-- [ ] Update `docs/roadmaps/pi-tui-kit-roadmap.md` to mark Stamp/Image Drop supported-host adoption
+  owner by category. Evidence: neither named consumer has a direct import; 75 references remain in 19
+  files across Kit tests, active specialized/standard extension tests, one experiment, one deprecated
+  package, and root support, while nine files still use `driveCustomSelector`.
+- [x] Not applicable: remove root helper functions, branches, imports, or marker-based Kit automation.
+  `selectedKitRow`, the marker probe, `createCustomSelectorHarness`, and `driveCustomSelector` all
+  retain direct owners after the named migrations; deleting or reshaping them would broaden this
+  milestone into unrelated consumers. The green 1,937-test gates on both migration PRs prove retention
+  without manufacturing a cleanup diff.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` to mark Stamp/Image Drop supported-host adoption
   complete, state the bounded root-support result, keep unrelated consumer migrations and the BTW
   gate explicit, and record the new regression count; verify roadmap claims against merged files and
-  test output.
+  test output. Evidence: Phase 3 and its success metric now mark named adoption complete, explicitly
+  retain inventoried root owners, keep BTW/release open, record the two-consumer decision, and retain
+  the verified 1,937-test regression count.
 - [ ] Open and merge a cleanup/roadmap PR only when it contains a real independently reviewable
   deletion or canonical roadmap update; verify CI passes and `main` is clean before release preflight.
 
@@ -354,13 +361,14 @@ components rather than approximating behavior.
 
 ## Completion Checklist
 
-- [ ] Stamp's representative TUI and RPC menu tests use `@narumitw/pi-tui-kit/testing` without changing
+- [x] Stamp's representative TUI and RPC menu tests use `@narumitw/pi-tui-kit/testing` without changing
   Stamp production source, package metadata, settings behavior, or results.
-- [ ] Image Drop's representative loader, confirmation, and rejected-input/review tests use the
+- [x] Image Drop's representative loader, confirmation, and rejected-input/review tests use the
   supported testing seam without changing production or generated web assets; RPC is explicitly not
   applicable because the command rejects non-TUI modes before opening any dialog.
-- [ ] Root test-support cleanup is evidence-based: only zero-consumer Kit automation is removed, and
-  retained specialized/general fixtures have named owners and follow-up scope.
+- [x] Root test-support cleanup is evidence-based: only zero-consumer Kit automation is removed, and
+  retained specialized/general fixtures have named owners and follow-up scope. No candidate reached
+  zero consumers, so retention is the verified bounded outcome.
 - [ ] The shared minor release is canonical, all selected GitHub checks pass, and every selected npm
   package/version is visible and installable with no partial-publication ambiguity.
 - [ ] Registry `@narumitw/pi-tui-kit` exposes menu API version 5 plus production and `/testing` roots;

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -192,8 +192,8 @@ three-way confirmation and preview composition.
 
 ### Phase 3: Adaptive Review and Supported Testability
 
-**Status:** Adaptive review and the [supported testing entrypoint][supported-testing-plan] are
-complete in repository source; Stamp/Image Drop test-host adoption, the BTW gate/migration, and npm
+**Status:** Adaptive review, the [supported testing entrypoint][supported-testing-plan], and named
+Stamp/Image Drop test-host adoption are complete in repository source; the BTW gate/migration and npm
 release remain open.
 
 **Milestones:**
@@ -204,8 +204,10 @@ release remain open.
   including wrapped headers, position indicators, resize, and scroll-offset clamping.
 - [x] A separate `@narumitw/pi-tui-kit/testing` entry point drives real TUI components and RPC dialogs
   through focus, text input, key events, rejected retries, pending actions, disposal, and owner abort.
-- [ ] Stamp and Image Drop consumer tests use the supported test host, allowing equivalent generic
-  input orchestration to leave repository-level `test/support.ts`.
+- [x] Stamp and Image Drop representative menu/input tests use the supported test host. Their direct
+  ad hoc Kit drivers are gone; repository-level `test/support.ts` remains for explicitly inventoried
+  Kit, specialized-component, experimental, and deprecated test owners rather than being deleted
+  prematurely.
 - [ ] The BTW review gate is rerun against close reasons and adaptive viewport; migration proceeds only
   if editor-preservation and restored-selection invariants also remain explicit and testable.
 
@@ -293,7 +295,7 @@ abstractions when Pi provides a better stable owner.
 | Pi private `dist/*` imports in kit source | 0 | Remain 0 | Every phase; boundary check and source search |
 | Ordinary `runMenu()` close outcomes visible to callers | Published API 3 collapses Back and Close | Repository API 4 distinguishes root Back and explicit Close | Phase 2 complete in source; runtime TUI/RPC matrix |
 | Review TUI viewport policy | Published API 3 is fixed, default 14 rows | Repository API 5 provides opt-in adaptive sizing within the live terminal budget | Adaptive source milestone complete; review component and built-package smokes |
-| Reusable consumer input-host logic | Generic behavior added to repository `test/support.ts` | Supported `/testing` source is complete; Stamp and Image Drop adoption remains | Phase 3; package and consumer diffs/tests |
+| Reusable consumer input-host logic | Generic behavior added to repository `test/support.ts` | Supported `/testing` source plus Stamp and Image Drop adoption are complete; retained root owners are inventoried | Phase 3; package and consumer diffs/tests |
 | Proof for each new public flow | Two compatible consumers by default; exceptions require recorded evidence | Two completed proof migrations or an explicit no-go/deferral | Every expansion phase; archived plans and PRs |
 | Lifecycle verification | Existing deterministic package and consumer coverage | Every admitted contract covers TUI/RPC, cancellation, disposal, owner abort, stale state, and failure | Every phase; package and repository gates |
 | Runtime action/lifecycle ownership | TUI and RPC loops coordinate screen actions in separate branches | If the driver is admitted, one coordinator owns shared action and lifecycle policy | Phase 4; source diff plus behavior matrix |
@@ -340,3 +342,4 @@ and adoption rather than calendar output.
 | 2026-08-01 | Implement mandatory `RunMenuResult.closed.reason` and raise repository menu API to version 4. | The navigator already owns root Back versus Close; exposing that reason removes a proven composition blocker while leaving domain completion values local. Publication remains a separate workflow. |
 | 2026-08-01 | Implement opt-in adaptive review and raise repository menu API to version 5. | Live public TUI rows now bound complete review frames while fixed/default TUI output and deterministic RPC pages remain unchanged; the testing entry point, BTW gate/migration, and package release remain separate work. |
 | 2026-08-01 | Add the supported `@narumitw/pi-tui-kit/testing` subpath without changing production exports or menu API version. | Semantic TUI driving and strict input/select RPC scripts concentrate demonstrated test-host policy without exposing components or absorbing consumer context/domain mocks; adoption and release remain separate. |
+| 2026-08-01 | Adopt the supported testing subpath in Stamp and Image Drop before publication. | Two real consumers now prove sequential TUI screens, rejected input, pending drains, strict RPC where supported, loader cancellation, and three-way confirmation; broad root support remains only for its other inventoried owners. |


### PR DESCRIPTION
## Summary

- mark Stamp and Image Drop supported testing-host adoption complete
- record that broad root testing helpers remain owned by 19 files and cannot be safely deleted in this milestone
- preserve the open npm release and BTW gate while updating the active execution plan

## Evidence

- Stamp PR #488 and Image Drop PR #489 merged with green CI/CodeQL
- neither consumer directly imports `createCustomSelectorHarness()`
- 75 references remain across 19 explicitly categorized files
- latest migration gates each passed all 1,937 repository tests

No production source, test behavior, package metadata, or lockfile changes.