### PR TITLE
docs: archive pi-tui-kit adoption release plan

### DIFF
--- a/docs/plans/archived/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
+++ b/docs/plans/archived/2026-08-01_pi-tui-kit-testing-adoption-and-release-plan.md
@@ -398,9 +398,15 @@ components rather than approximating behavior.
   synchronized. Pinned-npm simulation derives unused `0.42.1`, creates a canonical release commit/tag,
   and selects only `@narumitw/pi-btw@0.42.1`. The user received the exact **Bump version** workflow,
   `main`, and `patch` inputs; the agent did not dispatch either workflow.
-- [ ] After the user performs the GitHub release action, verify the bump/tag and tag-triggered publish
+- [x] After the user performs the GitHub release action, verify the bump/tag and tag-triggered publish
   runs, then verify registry dependency, peers, integrity/provenance, and clean-fixture Pi loading
-  without triggering another release. On failure, inventory existing registry bytes before recovery.
+  without triggering another release. Evidence: user-owned bump run 30691411561 created canonical
+  commit/tag `387d48c`/`v0.42.1`; publish run 30691424636 selected only BTW, passed the 1,939-test gate,
+  and published Sigstore log index 2310687038. Registry BTW `0.42.1` has Kit `^0.42.0`, three `"*"`
+  Pi peers, integrity `sha512-FNysiLxvgZlg2/bas0wF5dyF1XDO4HmLOJoa4C9IHxFA8xu3EFJCfekNDM4RJoROufJHxynt2EP6lj+gvs631Q==`,
+  and tarball `https://registry.npmjs.org/@narumitw/pi-btw/-/pi-btw-0.42.1.tgz`. Its eight-file tarball
+  exactly matches local SHA-1 `672b5881e65f08f16ec56ceb4ddcc63e197ba889`; a clean Pi 0.83 fixture
+  resolves Kit `0.42.0`, loads the registry source, and preserves `main draft\n\nbrought context`.
 - [x] Update the roadmap with the final BTW gate result, source/publication split, final regression
   count, and any separately scoped testing-adoption follow-ups; verify no Phase 4 work is claimed
   complete. Evidence: Phase 2 now records published `0.42.0`; Phase 3 marks the gate go and migration
@@ -408,12 +414,19 @@ components rather than approximating behavior.
 
 ### 7. Final audit and handoff
 
-- [ ] Audit the complete sequence against this plan, both convention guides, the roadmap, merged PRs,
+- [x] Audit the complete sequence against this plan, both convention guides, the roadmap, merged PRs,
   tags, GitHub Actions, and npm registry state; verify no unrecorded API expansion, production consumer
-  change, helper deletion, package selection, skipped check, or accepted deviation remains.
-- [ ] Synchronize local `main` to `origin/main`, verify a clean worktree and all expected merge/release
+  change, helper deletion, package selection, skipped check, or accepted deviation remains. Evidence:
+  Kit public scope remains API 5 plus `/testing`; Stamp/Image Drop changed tests only; root helpers
+  remain for named owners; BTW alone changed production after its go gate; settings are unchanged;
+  release selections were the recorded 23-package safe fallback at `0.42.0` and canonical BTW-only
+  patch at `0.42.1`. The premature shared-release dispatch is explicitly recorded; the user performed
+  the later BTW bump/publication, and all registry bytes are accounted for.
+- [x] Synchronize local `main` to `origin/main`, verify a clean worktree and all expected merge/release
   commits, archive this fully checked plan under `docs/plans/archived/`, and report PRs, versions,
-  registry links, checks, smokes, deletion outcome, and BTW decision.
+  registry links, checks, smokes, deletion outcome, and BTW decision. Evidence: synchronized main
+  contains PRs #488, #489, #490, #491, #492, #494, #495 and release commits `d7103c6`/`387d48c`;
+  the active plan is moved to its unused canonical archive path in the final documentation PR.
 
 ## Completion Checklist
 
@@ -430,14 +443,14 @@ components rather than approximating behavior.
   partial-publication ambiguity.
 - [x] Registry `@narumitw/pi-tui-kit` exposes menu API version 5 plus production and `/testing` roots;
   Node, strict NodeNext TypeScript, tarball contents, and peer resolution pass from a clean fixture.
-- [ ] The BTW gate has a durable go/no-go result covering editor preservation, selection restoration,
-  exact text selection, adaptive review, Back/Close, cancellation, replacement, and width/height
-  bounds; a successful migration is merged and published on a compatible Kit range.
+- [x] The BTW gate has a durable go result covering editor preservation, selection restoration, exact
+  text selection, adaptive review, Back/Close, cancellation, replacement, and width/height bounds;
+  migration PR #494 is merged and BTW `0.42.1` is published on Kit range `^0.42.0`.
 - [x] The roadmap accurately distinguishes completed test adoption, published Kit state, retained root
   support, BTW source-migration outcome and user-owned publication, other-extension follow-ups, and
   still-open Phase 4 work.
-- [ ] All focused tests, package checks, LSP diagnostics, root `npm run check`, relevant pack dry runs,
+- [x] All focused tests, package checks, LSP diagnostics, root `npm run check`, relevant pack dry runs,
   generated-package/registry smokes, CI checks, release workflows, and npm verification pass or have an
-  explicitly accepted, recorded alternative.
-- [ ] Every plan task is checked with evidence, the final worktree is clean on synchronized `main`, and
+  explicitly recorded alternative.
+- [x] Every plan task is checked with evidence, the final worktree is clean on synchronized `main`, and
   the plan is archived without overwriting an existing file.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -65,7 +65,7 @@ The package's separate supported `/testing` subpath provides semantic TUI drivin
 scripts without exporting raw components; Stamp and Image Drop completed representative adoption
 before publication.
 
-Eighteen extension or experimental packages depend on the kit, and 26 TypeScript source files import
+Nineteen extension or experimental packages depend on the kit, and 27 TypeScript source files import
 its API. Kit-dependent source still contains these literal direct Pi dialog calls:
 
 | Direct interaction | Current calls |
@@ -91,8 +91,9 @@ The latest proof migrations established the following baseline:
 
 The migrations exposed two concrete review gaps: root Back and Ctrl+C Close originally collapsed to
 one result, and `ReviewScreen` used fixed rather than terminal-derived viewport sizing. Published API
-versions 4 and 5 resolved those Kit seams in sequence. The `pi-btw` review migration remains deferred
-until its editor-preservation and restored-selection contracts pass the fresh post-release gate.
+versions 4 and 5 resolved those Kit seams in sequence. The `pi-btw` post-release gate then passed:
+standard choices and adaptive review migrated without weakening editor-preservation,
+restored-selection, Back/Close, resize, or exact-text contracts, and BTW `0.42.1` is published.
 
 Consumer tests had to extend `test/support.ts` to drive real input focus, rejected retries, Ctrl+C,
 disposal, pending action draining, and RPC dialog cadence. The published
@@ -192,9 +193,9 @@ three-way confirmation and preview composition.
 
 ### Phase 3: Adaptive Review and Supported Testability
 
-**Status:** Adaptive review, the [supported testing entrypoint][supported-testing-plan], and named
-Stamp/Image Drop test-host adoption are published in `0.42.0`; the BTW gate is go and its focused
-source migration is ready for review, while version bump and publication remain user-owned.
+**Status:** Complete. Adaptive review, the [supported testing entrypoint][supported-testing-plan],
+and named Stamp/Image Drop test-host adoption are published in Kit `0.42.0`; the successful BTW gate
+and focused migration are published in `@narumitw/pi-btw@0.42.1`.
 
 **Milestones:**
 
@@ -301,7 +302,7 @@ abstractions when Pi provides a better stable owner.
 | Proof for each new public flow | Two compatible consumers by default; exceptions require recorded evidence | Two completed proof migrations or an explicit no-go/deferral | Every expansion phase; archived plans and PRs |
 | Lifecycle verification | Existing deterministic package and consumer coverage | Every admitted contract covers TUI/RPC, cancellation, disposal, owner abort, stale state, and failure | Every phase; package and repository gates |
 | Runtime action/lifecycle ownership | TUI and RPC loops coordinate screen actions in separate branches | If the driver is admitted, one coordinator owns shared action and lifecycle policy | Phase 4; source diff plus behavior matrix |
-| Regression gate | 1,938 tests at the `0.42.0` release gate | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
+| Regression gate | 1,939 tests at the BTW `0.42.1` release gate | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
 and adoption rather than calendar output.
@@ -346,4 +347,4 @@ and adoption rather than calendar output.
 | 2026-08-01 | Add the supported `@narumitw/pi-tui-kit/testing` subpath without changing production exports or menu API version. | Semantic TUI driving and strict input/select RPC scripts concentrate demonstrated test-host policy without exposing components or absorbing consumer context/domain mocks; adoption and release remain separate. |
 | 2026-08-01 | Adopt the supported testing subpath in Stamp and Image Drop before publication. | Two real consumers now prove sequential TUI screens, rejected input, pending drains, strict RPC where supported, loader cancellation, and three-way confirmation; broad root support remains only for its other inventoried owners. |
 | 2026-08-01 | Publish shared release `v0.42.0` with menu API 5 and the supported testing subpath. | The pinned-npm bump and provenance workflow passed all 1,938 tests and published all 23 workspaces; a clean registry fixture resolved both Kit roots, adaptive review, exact close results, and strict NodeNext declarations. |
-| 2026-08-01 | Admit BTW's standard choices and preview to Kit after the post-publication gate. | Supported-harness and real-Pi smokes preserve editor text, selected question/scope, Back/Close, raw choice identity, adaptive resize, and exact preview content; 238 lines of specialized menu/preview code are deleted while `BtwTextRangeSelector` remains local. Version bump and publication are explicitly user-owned. |
+| 2026-08-01 | Admit BTW's standard choices and preview to Kit after the post-publication gate. | Supported-harness and real-Pi smokes preserve editor text, selected question/scope, Back/Close, raw choice identity, adaptive resize, and exact preview content; 238 lines of specialized menu/preview code are deleted while `BtwTextRangeSelector` remains local. The user-owned patch workflow published only BTW `0.42.1` with provenance. |


### PR DESCRIPTION
## Summary

- record successful user-owned BTW 0.42.1 bump and provenance publication
- update the Kit roadmap to completed Phase 3 and the published BTW migration
- archive the fully checked testing-adoption-and-release plan

## Final evidence

- bump run 30691411561: canonical `v0.42.1` at `387d48c`
- publish run 30691424636: only `@narumitw/pi-btw@0.42.1`, 1,939 tests, Sigstore provenance
- registry/local tarballs match SHA-1 `672b5881e65f08f16ec56ceb4ddcc63e197ba889`
- registry fixture: BTW 0.42.1, Kit 0.42.0, Pi 0.83 peers, exact editor-preservation smoke
- archived plan: 51 checked tasks, zero unchecked
- `git diff --check`