### PR TITLE
refactor(pi-tui-kit): centralize interaction semantics

### DIFF
--- a/docs/plans/2026-08-01_pi-tui-kit-interaction-driver-plan.md
+++ b/docs/plans/2026-08-01_pi-tui-kit-interaction-driver-plan.md
@@ -214,19 +214,30 @@ versions. Do not retain parallel old/new action-resolution paths.
 
 ### 4. Verification and roadmap evidence
 
-- [ ] Run LSP diagnostics on every touched TypeScript file and
+- [x] Run LSP diagnostics on every touched TypeScript file and
   `npm run check --workspace @narumitw/pi-tui-kit`; verify strict NodeNext types, Biome, generated
-  package output, and all focused Kit tests.
-- [ ] Run timeout-bounded generated-package TUI and strict RPC smokes covering one accepted action,
+  package output, and all focused Kit tests. Evidence: Biome LSP reports zero findings on all four
+  touched TypeScript files; the 34-file Kit check/typecheck/build passes; all 116 Kit tests pass.
+- [x] Run timeout-bounded generated-package TUI and strict RPC smokes covering one accepted action,
   one rejected retry, Back, Close, owner abort, and zero cross-mode custom-UI calls; compare observed
-  results/dialog cadence with the pre-refactor contract.
-- [ ] Run `npm test` and then `npm run check` sequentially after the shared Kit build; verify every
-  repository test passes without a build race.
-- [ ] Run `just pack-tui-kit`, inspect the tarball and generated declarations/exports, and verify no
-  internal driver type or new package content crosses the public boundary.
-- [ ] Update `docs/roadmaps/pi-tui-kit-roadmap.md` with the Phase 4 driver go/no-go, actual runtime line
+  results/dialog cadence with the pre-refactor contract. Evidence: the 30-second package-root smoke
+  passed rejected-then-accepted input, distinct TUI Back/Close, TUI/RPC owner abort, strict RPC Back
+  and hint-driven Close, and the RPC harness custom trap.
+- [x] Run `npm test` and then `npm run check` sequentially after the shared Kit build; verify every
+  repository test passes without a build race. Evidence: the linked worktree reproduced its documented
+  Git-admin `GIT_DIR` alias limitation, so an independent clone of the identical rebased tree ran the
+  commands sequentially; both passed 1,930/1,930 tests with zero failures, cancellations, skips, or
+  todos, and every CI-equivalent gate passed.
+- [x] Run `just pack-tui-kit`, inspect the tarball and generated declarations/exports, and verify no
+  internal driver type or new package content crosses the public boundary. Evidence: the 37-file pack
+  contains the built internal driver but no source/tests/dependencies; a clean tarball fixture exposes
+  exactly the unchanged production root and two testing factories, reports API 5, and rejects the
+  unexported `/interaction` subpath with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` with the Phase 4 driver go/no-go, actual runtime line
   count, behavior-matrix evidence, checks, and retained standalone-confirmation/deferred-multi-select
-  status; do not claim unrelated Phase 4 milestones.
+  status; do not claim unrelated Phase 4 milestones. Evidence: Phase 4 is accurately in progress with
+  only the driver checked; the roadmap records 526 runtime/285 driver lines, the internal ownership
+  boundary, the 1,930-test gate, and both still-open qualification milestones.
 - [ ] Audit the final diff against this plan, `docs/extension-conventions.md`, and the roadmap; verify
   public API/version, TUI/RPC cadence, lifecycle ownership, consumers, package metadata, settings,
   generated artifacts, and release state are unchanged, then open a focused PR and require green CI

--- a/docs/plans/2026-08-01_pi-tui-kit-interaction-driver-plan.md
+++ b/docs/plans/2026-08-01_pi-tui-kit-interaction-driver-plan.md
@@ -1,0 +1,249 @@
+# Pi TUI Kit Semantic Interaction Driver Plan
+
+## Goal
+
+Qualify and, only if the deletion test passes, introduce one internal semantic interaction driver for
+`@narumitw/pi-tui-kit`. The driver must concentrate action lookup, disabled/mismatched interaction
+rejection, action invocation, composed cancellation, accepted/rejected results, stale checks, error
+routing, and returned transitions that are currently coordinated separately by TUI and RPC runtime
+branches.
+
+This is a behavior-preserving internal refactor. Public screen definitions, exports, menu API version
+5, TUI rendering and pending-component cadence, RPC dialog cadence, navigator behavior, package
+metadata, and every consumer remain unchanged.
+
+## Context
+
+- `packages/pi-tui-kit/src/runtime.ts` is 773 authored lines and has changed for every recent screen or
+  lifecycle addition. It owns both adapters, state loading, screen-specific action lookup, signal
+  composition, action execution, stale/error handling, and navigator application.
+- TUI currently resolves settings, multi-select, and input actions in component callbacks, then
+  separately resolves choice, review, action, and pinned multi-select activation after the component
+  closes. RPC independently resolves each of those screen kinds after each dialog response.
+- `invokeAction()` and `activateActionItem()` already concentrate part of the policy. A useful driver
+  must deepen that seam by deleting mode-specific action-resolution knowledge; moving the same switch
+  into another file or wrapping existing calls without deletion is a no-go.
+- The current package has seven screen kinds and 28 focused runtime tests. The roadmap requires a
+  complete TUI/RPC behavior matrix before admitting the driver.
+- Guides read before planning: `MEMORY.md`, `docs/extension-conventions.md`, the complete Pi
+  `extensions.md`, `tui.md`, `rpc.md`, and `packages.md`, the canonical roadmap and linked archived
+  Kit plans, package runtime/types/components, runtime tests, and repository test support. Applicable
+  MUST areas are TUI-only custom UI, public callback inputs, mode-safe RPC dialogs, cancellation and
+  disposal, post-await stale checks, deterministic tests, package boundaries, the root check, and a
+  pack dry run. Settings guidance is not applicable because no settings behavior is touched.
+
+## Architecture
+
+Add one package-internal `src/interaction.ts` module if qualification passes.
+
+The module accepts a resolved screen plus one semantic intent:
+
+- activate an action/choice/review confirmation or pinned multi-select action by raw item id;
+- change one settings value;
+- toggle one multi-select item; or
+- submit one input value.
+
+It owns:
+
+- validating that the intent fits the screen kind;
+- resolving raw ids to enabled items and action handlers;
+- mapping `value` and `selected` into the existing action context;
+- composing an optional screen-owned signal with the menu-owner signal;
+- ordinary and busy action execution;
+- accepted/rejected/stale classification, action error reporting, and returned transition semantics;
+  and
+- revalidating owner state after every await it owns.
+
+The TUI adapter retains component creation/disposal, pending-work draining, raw screen events,
+selection memory, and conversion of accepted component callbacks into component closure. The RPC
+adapter retains dialog titles/options, pagination, response cadence, and cancellation flattening.
+`runtime.ts` retains state loading, the navigator, and application of the driver's returned
+transition because those operations define the outer menu loop rather than one interaction.
+
+No production or test module outside this package may import the internal driver. No new public type,
+export, dependency, screen field, or API-version change is allowed.
+
+### Admission and deletion gate
+
+Admit implementation only if the final structure:
+
+1. gives both TUI and RPC the same action-resolution entry point for every actionable screen kind;
+2. removes their duplicated handler lookup, disabled checks, input mapping, signal composition, and
+   action-result interpretation;
+3. leaves presentation and component/dialog lifecycle mode-owned;
+4. reduces `runtime.ts` materially without increasing total action-coordination complexity or adding a
+   pass-through facade; and
+5. keeps the full behavior matrix byte/result/cadence compatible.
+
+If those conditions cannot be met, record a finite no-go in this plan and the roadmap without adding
+`interaction.ts`.
+
+## Qualification Evidence
+
+### Seven-screen TUI/RPC behavior matrix
+
+| Screen | TUI semantic interaction and cadence | RPC semantic interaction and cadence | Rejection / transition / evidence |
+| --- | --- | --- | --- |
+| `actions` | A component activation carries the raw item id after the custom component closes; `to` and `close` items do not invoke a handler. | One flat `select()` response maps its unique display label back to the indexed raw item. Busy labels do not open TUI. | Missing/disabled items stay; action results supply the transition. Covered by `runMenu navigates…`, `TUI action Close…`, and `RPC uses dialog adaptation…`. |
+| `detail` | No action exists. Escape applies the screen hint; Ctrl+C closes. | A selected exit row applies the hint, while an undefined generic `select()` cancellation remains Back. | Always non-actionable. Covered by `TUI root Back…` and `RPC preserves generic Back…`. |
+| `choice` | Activation carries the selected raw id after current/initial/remembered cursor handling. | A unique label maps back to the raw item id; duplicate and disabled labels remain deterministic. | Disabled/missing rows stay; accepted/rejected action transitions are preserved. Covered by the five choice runtime tests. |
+| `settings` | A value change invokes the item's action inside the open component with a screen-owned signal; the component serializes, rolls back rejection, and closes only after an accepted transition settles. | Selecting a row cycles directly to its next configured value and invokes the same raw item/action; no value subdialog opens. | Disabled/missing rows stay. TUI coverage is in the three settings runtime tests and component queue tests; cross-mode raw payload coverage is added before extraction. |
+| `input` | Submit sends raw `{ itemId: "input", value }` through a screen-owned signal; rejection keeps the same draft/component. | `input()` sends the raw value through the menu signal and reopens after rejection. Undefined applies the screen hint. | Stale closes the component and returns stale; accepted transition closes it. Covered by all seven `input-screen.test.ts` cases. |
+| `review` | Only the declared confirmation raw id activates; scrolling and Back/Close remain component-owned. | Bounded pages loop through `select()`; Previous/Next stay in the adapter and only Confirm invokes the action. Undefined/exit applies the hint. | Missing confirmation stays non-actionable; rejection keeps the current page. Covered by review TUI/RPC confirmation, pagination, cancellation, and owner-abort tests. |
+| `multiSelect` | Toggle sends raw id plus the next selected boolean through a screen-owned signal while optimistic state/pending queues remain component-owned. Pinned action activation resolves after component closure. | The full unfiltered dialog maps item rows to toggles and pinned rows to action items. | Disabled rows stay; rejected toggles roll back by raw id; action/toggle transitions are unchanged. Covered by searchable/raw-id, disabled RPC, pinned-action, rollback, and pending-drain tests. |
+
+Shared lifecycle rows are already characterized independently: owner abort during state load, idle TUI,
+RPC dialog, ordinary action, choice action, settings action, and busy action; stale continuation;
+component disposal and drain; rejecting error reporters; Back/Close; unsupported modes; and shutdown-
+equivalent owner replacement. The pre-refactor cross-mode characterization will close the remaining
+single-test gap for settings and one-table raw payload comparison without replacing these tests.
+
+### Admission result: go
+
+The concrete extraction passes the pre-edit deletion gate. One internal coordinator can replace the
+TUI action-resolution blocks currently at runtime lines 97–148 and 167–208 plus the RPC resolution
+blocks at lines 516–585 and the input/review invocation fragments, while reusing and moving the
+existing action/busy/stale/error helpers. TUI component lifecycle, optimistic state, and selection
+memory remain outside; RPC dialogs and review paging remain outside. The expected result is one
+screen/intent resolution switch instead of two mode-specific switches, a material runtime reduction,
+and no new caller or public interface. Rollback is one internal module plus its runtime wiring.
+
+## Non-Goals
+
+- Do not add standalone confirmation, deferred multi-select, catalog, editor, wizard, or another
+  screen kind.
+- Do not change TUI frames, keybindings, focus, review sizing, RPC labels/pages, dialog count, Back or
+  Close results, state reload frequency, selection restoration, action payloads, or error wording.
+- Do not merge TUI and RPC presentation adapters or claim presentation parity Pi cannot expose.
+- Do not modify extension source, settings, manifests, lockfile, generated `dist/`, package versions,
+  release workflows, or npm state.
+- Do not split files merely to reduce line counts, introduce a class hierarchy, or add a public
+  runtime-driver abstraction.
+
+## Assumptions
+
+- The existing public `MenuActionHandler` and `MenuTransition` contracts are sufficient; qualification
+  should not discover a need for a public API change.
+- Selection memory remains TUI-only because RPC clients own their own cursor/dialog presentation.
+- Component callbacks must still receive an accepted transition before the TUI screen closes, while
+  RPC can apply the same transition directly after a dialog settles.
+
+## Risks
+
+- A generic intent union could hide important screen differences. Mitigation: keep four explicit
+  semantic intent variants and reject intent/screen mismatches deterministically.
+- Moving signal composition could change whether screen disposal is rejection or whole-menu stale.
+  Mitigation: characterize menu-owner and screen-owner abort independently before moving code.
+- Busy actions intentionally treat user cancellation as rejected/stay rather than stale. Mitigation:
+  keep that policy in the driver and preserve existing task regressions.
+- A broad test rewrite could merely follow the refactor. Mitigation: add behavior-matrix
+  characterization before production edits and retain all existing runtime assertions unchanged.
+- The module could become a shallow indirection. Mitigation: compare before/after line ownership,
+  call-site knowledge, and net action-routing code; reject the extraction if the deletion test fails.
+
+## Rollback / Recovery
+
+There is no persisted data or public API migration. Keep characterization tests independently useful.
+Before merge, reverting the internal module and runtime wiring restores the old implementation. If a
+regression appears after merge, revert the focused refactor without changing package or consumer
+versions. Do not retain parallel old/new action-resolution paths.
+
+## Plan
+
+### 1. Baseline and qualification
+
+- [x] Install the clean linked worktree with the repository-pinned npm, run the Kit workspace check,
+  compile tests, and run all focused Kit tests; record runtime/test counts and verify the branch has
+  only this plan before characterization work. Evidence: npm 12.0.2 performed a clean install; the Kit
+  check/build passed; test compilation and 113/113 Kit tests passed. Baseline is 3,516 Kit source
+  lines, 773 runtime lines, 28 runtime tests, and nine Kit test files; only this plan is untracked.
+- [x] Write a complete behavior matrix in this plan for all seven screen kinds across TUI and RPC,
+  covering semantic intent, raw payload, action/transition owner, rejection, mode-specific cadence,
+  Back/Close, and non-action screens; verify each cell against source and an existing or newly named
+  test. Evidence: the Qualification Evidence matrix maps every screen to exact runtime/component test
+  owners and identifies only cross-mode settings/raw-payload consolidation for characterization.
+- [x] Apply the admission/deletion gate to a concrete before/after ownership sketch. Record go/no-go,
+  the exact duplicated branches expected to disappear, mode-specific policy that must remain, and a
+  bounded rollback shape before editing production source. Evidence: the gate is go; the recorded
+  line ranges contain duplicated action resolution, while TUI component lifecycle and RPC dialog
+  cadence remain mode-owned and rollback is limited to one internal module plus runtime wiring.
+
+### 2. Characterize the shared contract
+
+- [x] Add focused pre-refactor runtime characterization proving TUI and RPC deliver identical raw
+  action payloads and transitions for actions, settings, choice, multi-select toggles/actions, input,
+  and review confirmation while detail remains non-actionable; verify it passes against the current
+  runtime and fails if action lookup or payload mapping is deliberately perturbed. Evidence: the new
+  seven-screen matrix test passes both modes for eight actionable/non-actionable cases and exact
+  `itemId`/`value`/`selected` payloads; changing the initial settings key or input payload produced the
+  expected focused failures before correction.
+- [x] Add or identify focused pre-refactor coverage for rejected/disabled/mismatched interactions,
+  thrown and reported errors, user cancellation, component disposal, screen-owner abort, menu-owner
+  abort, `isCurrent()` failure, session replacement, and busy-action cancellation/draining; close any
+  behavior-matrix gap before extraction. Evidence: a new two-mode ordinary-action error test proves
+  report-once and retry/exit behavior; existing choice/input/settings/multi-select rejection and
+  disabled tests plus runtime owner-abort, stale, disposal, drain, and busy-action tests cover every
+  externally reachable path. Intent/screen mismatch is not externally constructible and will be
+  checked directly at the new internal seam.
+
+### 3. Implement the admitted internal driver
+
+- [x] Add `packages/pi-tui-kit/src/interaction.ts` with the four bounded semantic intent variants and
+  one internal invocation entry point; move existing action invocation, busy action, stale checking,
+  error routing, and result classification into that owner without adding a production export.
+  Evidence: the 285-line internal module owns activate/setting/multi-select/input resolution, composed
+  signals, ordinary/busy actions, stale/error classification, and transitions; package-root exports
+  and API version 5 are unchanged.
+- [x] Rewire the TUI runtime to translate component callbacks/events into semantic intents while
+  retaining component disposal, pending drains, selection memory, and screen closure cadence; verify
+  focused TUI tests after the change. Evidence: TUI now has one `interact()` adapter; all component
+  lifecycle remains in `showTuiScreen()`, and the 116-test Kit suite passes its matrix, close-reason,
+  selection, rejection, disposal, drain, owner-abort, stale, and busy-action cases.
+- [x] Rewire the RPC runtime to translate dialog responses into the same semantic intents while
+  retaining titles, unique labels, pagination, cancellation flattening, and dialog cadence; verify
+  focused RPC tests after the change. Evidence: dialog rows now carry semantic intents, while input
+  and review retain their dedicated dialog loops; all strict identity, unfiltered multi-select,
+  pagination, cancellation, and abort tests pass.
+- [x] Remove the superseded runtime action-resolution helpers and branches, then apply the deletion
+  test using source diff, runtime/driver line counts, import graph, and repository search; reject or
+  simplify any layer that merely forwards the same knowledge. Evidence: `runtime.ts` falls from 773
+  to 526 lines (32%); the driver is 285 lines and total Kit source grows only 38 lines while adding one
+  owner. Repository search finds `definition.actions`, action disabled checks, and interaction signal
+  composition only in `interaction.ts`; runtime retains disabled text solely for RPC presentation.
+  The direct internal test proves mismatched, missing, and disabled intents never invoke actions.
+
+### 4. Verification and roadmap evidence
+
+- [ ] Run LSP diagnostics on every touched TypeScript file and
+  `npm run check --workspace @narumitw/pi-tui-kit`; verify strict NodeNext types, Biome, generated
+  package output, and all focused Kit tests.
+- [ ] Run timeout-bounded generated-package TUI and strict RPC smokes covering one accepted action,
+  one rejected retry, Back, Close, owner abort, and zero cross-mode custom-UI calls; compare observed
+  results/dialog cadence with the pre-refactor contract.
+- [ ] Run `npm test` and then `npm run check` sequentially after the shared Kit build; verify every
+  repository test passes without a build race.
+- [ ] Run `just pack-tui-kit`, inspect the tarball and generated declarations/exports, and verify no
+  internal driver type or new package content crosses the public boundary.
+- [ ] Update `docs/roadmaps/pi-tui-kit-roadmap.md` with the Phase 4 driver go/no-go, actual runtime line
+  count, behavior-matrix evidence, checks, and retained standalone-confirmation/deferred-multi-select
+  status; do not claim unrelated Phase 4 milestones.
+- [ ] Audit the final diff against this plan, `docs/extension-conventions.md`, and the roadmap; verify
+  public API/version, TUI/RPC cadence, lifecycle ownership, consumers, package metadata, settings,
+  generated artifacts, and release state are unchanged, then open a focused PR and require green CI
+  and CodeQL before merge.
+- [ ] After merge, synchronize a clean worktree to `origin/main`, record the merge commit and checks,
+  mark every task with evidence, archive this completed plan under `docs/plans/archived/`, and merge a
+  final documentation PR.
+
+## Completion Checklist
+
+- [ ] The admission decision is backed by a complete seven-screen TUI/RPC behavior matrix and an
+  explicit deletion test.
+- [ ] If admitted, both adapters use one internal semantic interaction entry point and no parallel
+  action-resolution path remains; if rejected, no speculative driver source remains.
+- [ ] Public exports, API version 5, screen definitions, TUI output/cadence, RPC dialogs/pagination,
+  raw action payloads, transitions, lifecycle outcomes, and consumers remain compatible.
+- [ ] Focused matrix/lifecycle tests, Kit checks, LSP diagnostics, generated-package smokes, root tests,
+  root CI-equivalent checks, pack inspection, CI, and CodeQL pass with no unrecorded skip.
+- [ ] The roadmap records only the proven Phase 4 result, the completed plan is archived, and the final
+  worktree is clean and synchronized on `main`.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -101,10 +101,11 @@ disposal, pending action draining, and RPC dialog cadence. The published
 Image Drop representative flows. Repository support remains for its explicitly inventoried Kit,
 specialized-component, experimental, and deprecated owners rather than being deleted prematurely.
 
-The main maintainability hotspot is `packages/pi-tui-kit/src/runtime.ts`, currently 767 lines. It owns
-both TUI and RPC loops, state loading, action dispatch, navigation, signal composition, stale checks,
-and error routing. The concern is not the line count alone: screen action semantics are recognized in
-multiple mode-specific branches, so new contracts can require coordinated central edits.
+The Phase 4 interaction-driver gate passed after a seven-screen TUI/RPC behavior matrix. Runtime is
+now 526 lines and retains adapter cadence, state loading, navigation, and component/dialog lifecycle;
+the 285-line internal `interaction.ts` owns screen-intent validation, raw action resolution, composed
+action signals, accepted/rejected/stale outcomes, error routing, and returned transitions once for
+both modes. This is an internal source boundary, not a new public API.
 
 ## Guiding Principles
 
@@ -219,19 +220,22 @@ contracts without private component knowledge.
 
 ### Phase 4: Qualified Shared Flows and Runtime Locality
 
+**Status:** In progress. The internal interaction driver is source-complete; standalone confirmation
+and deferred multi-select remain independently gated follow-ups.
+
 **Milestones:**
 
-- A decision on the internal semantic interaction driver is grounded in a complete TUI/RPC behavior
-  matrix. If admitted, one coordinator owns action invocation, accepted/rejected results,
-  transitions, composed signals, stale checks, and error routing while adapters retain presentation
-  cadence.
-- Standalone confirmation either proves confirmed, Back, Close, Stale, Unsupported, and Error through
-  Image Drop plus a second compatible consumer, or remains deferred with the missing shared contract
-  recorded.
-- Deferred or batched multi-select either proves common draft, Save, Discard, rejection, and RPC
+- [x] A complete seven-screen TUI/RPC behavior matrix admitted the internal semantic interaction
+  driver. One coordinator now owns action lookup/invocation, intent mismatch and disabled rejection,
+  transitions, composed action signals, stale checks, and error routing while adapters retain TUI
+  component and RPC dialog cadence.
+- [ ] Standalone confirmation either proves confirmed, Back, Close, Stale, Unsupported, and Error
+  through Image Drop plus a second compatible consumer, or remains deferred with the missing shared
+  contract recorded.
+- [ ] Deferred or batched multi-select either proves common draft, Save, Discard, rejection, and RPC
   semantics through Pi Sync and Subagents, or remains extension-owned.
-- Immediate-save multi-select behavior remains unchanged for Chrome DevTools, Firecrawl, Google GenAI,
-  and Plan mode.
+- [ ] Immediate-save multi-select behavior remains unchanged for Chrome DevTools, Firecrawl,
+  Google GenAI, and Plan mode during any deferred-flow work.
 
 **Outcome:** Repeated lifecycle policy moves behind bounded public or internal seams without absorbing
 consumer transactions or creating a universal UI framework.
@@ -255,8 +259,9 @@ abstractions when Pi provides a better stable owner.
 
 - Keep TypeScript strict, NodeNext-compatible, and built as published JavaScript plus declarations.
 - Keep Pi private `dist/*` imports at zero and package-root consumer imports as the supported boundary.
-- Treat the 767-line runtime as a change-locality hotspot; split only when responsibility ownership
-  becomes clearer and duplicated coordination is actually deleted.
+- Keep the 526-line runtime and 285-line interaction driver on their demonstrated ownership boundary:
+  adapters own presentation cadence and the driver owns semantic action coordination. Recombine or
+  split further only when a new behavior matrix proves better locality and deletes coordination.
 - Maintain deterministic model, component, runtime, package-root usage, and README tests for every
   public contract.
 - Maintain a TUI/RPC behavior matrix covering success, rejection, user cancellation, component
@@ -301,7 +306,7 @@ abstractions when Pi provides a better stable owner.
 | Reusable consumer input-host logic | Generic behavior added to repository `test/support.ts` | Supported `/testing` source plus Stamp and Image Drop adoption are complete; retained root owners are inventoried | Phase 3; package and consumer diffs/tests |
 | Proof for each new public flow | Two compatible consumers by default; exceptions require recorded evidence | Two completed proof migrations or an explicit no-go/deferral | Every expansion phase; archived plans and PRs |
 | Lifecycle verification | Existing deterministic package and consumer coverage | Every admitted contract covers TUI/RPC, cancellation, disposal, owner abort, stale state, and failure | Every phase; package and repository gates |
-| Runtime action/lifecycle ownership | TUI and RPC loops coordinate screen actions in separate branches | If the driver is admitted, one coordinator owns shared action and lifecycle policy | Phase 4; source diff plus behavior matrix |
+| Runtime action/lifecycle ownership | TUI and RPC formerly coordinated screen actions in separate branches | One internal driver now owns shared semantic action policy; adapters retain presentation lifecycle | Phase 4 source-complete; seven-screen matrix plus source diff |
 | Regression gate | 1,939 tests at the BTW `0.42.1` release gate | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
@@ -348,3 +353,4 @@ and adoption rather than calendar output.
 | 2026-08-01 | Adopt the supported testing subpath in Stamp and Image Drop before publication. | Two real consumers now prove sequential TUI screens, rejected input, pending drains, strict RPC where supported, loader cancellation, and three-way confirmation; broad root support remains only for its other inventoried owners. |
 | 2026-08-01 | Publish shared release `v0.42.0` with menu API 5 and the supported testing subpath. | The pinned-npm bump and provenance workflow passed all 1,938 tests and published all 23 workspaces; a clean registry fixture resolved both Kit roots, adaptive review, exact close results, and strict NodeNext declarations. |
 | 2026-08-01 | Admit BTW's standard choices and preview to Kit after the post-publication gate. | Supported-harness and real-Pi smokes preserve editor text, selected question/scope, Back/Close, raw choice identity, adaptive resize, and exact preview content; 238 lines of specialized menu/preview code are deleted while `BtwTextRangeSelector` remains local. The user-owned patch workflow published only BTW `0.42.1` with provenance. |
+| 2026-08-01 | Admit the internal semantic interaction driver after the Phase 4 deletion gate. | A seven-screen TUI/RPC matrix proves compatible raw payloads, transitions, errors, cancellation, disposal, and stale ownership. Runtime falls from 773 to 526 lines; one 285-line internal owner replaces mode-specific action resolution without changing exports or API version 5. |

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -307,7 +307,7 @@ abstractions when Pi provides a better stable owner.
 | Proof for each new public flow | Two compatible consumers by default; exceptions require recorded evidence | Two completed proof migrations or an explicit no-go/deferral | Every expansion phase; archived plans and PRs |
 | Lifecycle verification | Existing deterministic package and consumer coverage | Every admitted contract covers TUI/RPC, cancellation, disposal, owner abort, stale state, and failure | Every phase; package and repository gates |
 | Runtime action/lifecycle ownership | TUI and RPC formerly coordinated screen actions in separate branches | One internal driver now owns shared semantic action policy; adapters retain presentation lifecycle | Phase 4 source-complete; seven-screen matrix plus source diff |
-| Regression gate | 1,939 tests at the BTW `0.42.1` release gate | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
+| Regression gate | 1,930 tests at the Phase 4 interaction-driver gate | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
 and adoption rather than calendar output.

--- a/packages/pi-tui-kit/src/interaction.ts
+++ b/packages/pi-tui-kit/src/interaction.ts
@@ -1,0 +1,285 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { safeMenuText } from "./components/index.js";
+import { runTask } from "./task.js";
+import type {
+	ActionMenuItem,
+	MenuActionHandler,
+	MenuActionResult,
+	MenuContext,
+	MenuDefinition,
+	MenuScreen,
+	MenuTransition,
+} from "./types.js";
+
+export type MenuInteraction =
+	| { kind: "activate"; itemId: string }
+	| { kind: "setting"; itemId: string; value: string }
+	| { kind: "multiSelect"; itemId: string; selected: boolean }
+	| { kind: "input"; value: string };
+
+export interface InteractionInvocation<ScreenId extends string> {
+	accepted: boolean;
+	stale: boolean;
+	transition: MenuTransition<ScreenId>;
+	selectionItemId?: string;
+}
+
+interface InteractionRuntimeOptions<Context extends MenuContext> {
+	isCurrent?(): boolean;
+	onError?(ctx: Context, error: unknown): void | Promise<void>;
+}
+
+interface InvokeMenuInteractionOptions<
+	State,
+	ScreenId extends string,
+	ActionId extends string,
+	Context extends MenuContext,
+> {
+	ctx: Context;
+	definition: MenuDefinition<State, ScreenId, ActionId, Context>;
+	screen: MenuScreen<ScreenId, ActionId>;
+	state: State;
+	menuSignal: AbortSignal;
+	interactionSignal?: AbortSignal;
+	runtime: InteractionRuntimeOptions<Context>;
+	interaction: MenuInteraction;
+}
+
+export async function invokeMenuInteraction<
+	State,
+	ScreenId extends string,
+	ActionId extends string,
+	Context extends MenuContext,
+>(
+	options: InvokeMenuInteractionOptions<State, ScreenId, ActionId, Context>,
+): Promise<InteractionInvocation<ScreenId>> {
+	const { ctx, definition, screen, state, menuSignal, runtime, interaction } = options;
+	const signal = options.interactionSignal
+		? AbortSignal.any([menuSignal, options.interactionSignal])
+		: menuSignal;
+
+	switch (interaction.kind) {
+		case "activate": {
+			if (screen.kind === "actions") {
+				const item = screen.items.find((candidate) => candidate.id === interaction.itemId);
+				if (!item || item.disabled) return rejected();
+				return activateActionItem(ctx, definition, item, state, signal, runtime);
+			}
+			if (screen.kind === "choice") {
+				const item = screen.items.find((candidate) => candidate.id === interaction.itemId);
+				if (!item || item.disabled) return rejected();
+				return withSelection(
+					await invokeAction(
+						ctx,
+						definition.actions[screen.action],
+						state,
+						signal,
+						item.id,
+						runtime,
+					),
+					item.id,
+				);
+			}
+			if (screen.kind === "review") {
+				if (!screen.confirm || screen.confirm.id !== interaction.itemId) return rejected();
+				return invokeAction(
+					ctx,
+					definition.actions[screen.confirm.action],
+					state,
+					signal,
+					screen.confirm.id,
+					runtime,
+				);
+			}
+			if (screen.kind === "multiSelect") {
+				const item = screen.actions?.find((candidate) => candidate.id === interaction.itemId);
+				if (!item || item.disabled) return rejected();
+				return activateActionItem(ctx, definition, item, state, signal, runtime);
+			}
+			return rejected();
+		}
+		case "setting": {
+			if (screen.kind !== "settings") return rejected();
+			const item = screen.items.find((candidate) => candidate.id === interaction.itemId);
+			if (!item || item.disabled) return rejected();
+			return withSelection(
+				await invokeAction(ctx, definition.actions[item.action], state, signal, item.id, runtime, {
+					value: interaction.value,
+				}),
+				item.id,
+			);
+		}
+		case "multiSelect": {
+			if (screen.kind !== "multiSelect") return rejected();
+			const item = screen.items.find((candidate) => candidate.id === interaction.itemId);
+			if (!item || item.disabled) return rejected();
+			return withSelection(
+				await invokeAction(
+					ctx,
+					definition.actions[screen.action],
+					state,
+					signal,
+					item.id,
+					runtime,
+					{ selected: interaction.selected },
+				),
+				item.id,
+			);
+		}
+		case "input":
+			if (screen.kind !== "input") return rejected();
+			return invokeAction(ctx, definition.actions[screen.action], state, signal, "input", runtime, {
+				value: interaction.value,
+			});
+	}
+}
+
+async function activateActionItem<
+	State,
+	ScreenId extends string,
+	ActionId extends string,
+	Context extends MenuContext,
+>(
+	ctx: Context,
+	definition: MenuDefinition<State, ScreenId, ActionId, Context>,
+	item: ActionMenuItem<ScreenId, ActionId>,
+	state: State,
+	signal: AbortSignal,
+	runtime: InteractionRuntimeOptions<Context>,
+): Promise<InteractionInvocation<ScreenId>> {
+	if ("to" in item && item.to !== undefined) {
+		return accepted({ kind: "to", screen: item.to }, item.id);
+	}
+	if ("close" in item) return accepted({ kind: "close" }, item.id);
+	if (!("action" in item) || item.action === undefined) return rejected();
+	const handler = definition.actions[item.action];
+	const invocation =
+		"busyLabel" in item && item.busyLabel && ctx.mode === "tui" && ctx.hasUI
+			? await invokeBusyAction(ctx, handler, state, item.id, item.busyLabel, signal, runtime)
+			: await invokeAction(ctx, handler, state, signal, item.id, runtime);
+	return withSelection(invocation, item.id);
+}
+
+async function invokeBusyAction<State, ScreenId extends string, Context extends MenuContext>(
+	ctx: Context,
+	handler: MenuActionHandler<State, ScreenId, Context>,
+	state: State,
+	itemId: string,
+	label: string,
+	signal: AbortSignal,
+	runtime: InteractionRuntimeOptions<Context>,
+): Promise<InteractionInvocation<ScreenId>> {
+	const result = await runTask(ctx, {
+		label,
+		signal,
+		isCurrent: runtime.isCurrent,
+		onError: () => undefined,
+		task: ({ signal: taskSignal }) =>
+			invokeAction(ctx, handler, state, taskSignal, itemId, runtime, {}, false),
+	});
+	switch (result.kind) {
+		case "completed":
+			return result.value;
+		case "cancelled":
+			return rejected();
+		case "stale":
+			return { ...rejected<ScreenId>(), stale: true };
+		case "error":
+			throw result.error;
+	}
+}
+
+async function invokeAction<State, ScreenId extends string, Context extends MenuContext>(
+	ctx: Context,
+	handler: MenuActionHandler<State, ScreenId, Context>,
+	state: State,
+	signal: AbortSignal,
+	itemId: string,
+	runtime: InteractionRuntimeOptions<Context>,
+	input: { value?: string; selected?: boolean } = {},
+	abortIsStale = true,
+): Promise<InteractionInvocation<ScreenId>> {
+	if (!isMenuCurrent(runtime)) return { ...rejected<ScreenId>(), stale: true };
+	if (signal.aborted) {
+		return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
+	}
+	let result: MenuActionResult<ScreenId>;
+	try {
+		result = await handler({ ctx, state, signal, itemId, ...input });
+	} catch (error) {
+		if (!isMenuCurrent(runtime)) return { ...rejected<ScreenId>(), stale: true };
+		if (signal.aborted) {
+			return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
+		}
+		await reportMenuError(ctx, runtime, error);
+		if (!isMenuCurrent(runtime)) return { ...rejected<ScreenId>(), stale: true };
+		if (signal.aborted) {
+			return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
+		}
+		return rejected();
+	}
+	if (!isMenuCurrent(runtime)) return { ...rejected<ScreenId>(), stale: true };
+	if (signal.aborted) {
+		return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
+	}
+	if (result?.kind === "rejected") {
+		if (result.error !== undefined) await reportMenuError(ctx, runtime, result.error);
+		if (!isMenuCurrent(runtime)) return { ...rejected<ScreenId>(), stale: true };
+		if (signal.aborted) {
+			return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
+		}
+		return rejected();
+	}
+	return accepted(result ?? { kind: "stay" });
+}
+
+export async function reportMenuError<Context extends MenuContext>(
+	ctx: Context,
+	runtime: InteractionRuntimeOptions<Context>,
+	error: unknown,
+) {
+	if (runtime.onError) {
+		try {
+			await runtime.onError(ctx, error);
+			return;
+		} catch {
+			// Fall back to Pi's notifier when a custom reporter is no longer available.
+		}
+	}
+	if (ctx.hasUI) {
+		const message = error instanceof Error ? error.message : String(error);
+		try {
+			uiFor(ctx).notify(`Menu action failed: ${safeMenuText(message)}`, "error");
+		} catch {
+			// Error reporting must never escape the documented menu result contract.
+		}
+	}
+}
+
+export function isMenuCurrent<Context extends MenuContext>(
+	runtime: InteractionRuntimeOptions<Context>,
+) {
+	return runtime.isCurrent?.() ?? true;
+}
+
+function accepted<ScreenId extends string>(
+	transition: MenuTransition<ScreenId>,
+	selectionItemId?: string,
+): InteractionInvocation<ScreenId> {
+	return { accepted: true, stale: false, transition, selectionItemId };
+}
+
+function rejected<ScreenId extends string>(): InteractionInvocation<ScreenId> {
+	return { accepted: false, stale: false, transition: { kind: "stay" } };
+}
+
+function withSelection<ScreenId extends string>(
+	invocation: InteractionInvocation<ScreenId>,
+	selectionItemId: string,
+): InteractionInvocation<ScreenId> {
+	return { ...invocation, selectionItemId };
+}
+
+function uiFor(ctx: MenuContext): ExtensionCommandContext["ui"] {
+	return ctx.ui as ExtensionCommandContext["ui"];
+}

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -9,13 +9,16 @@ import {
 	reviewDialogPages,
 	safeMenuText,
 } from "./components/index.js";
+import {
+	type InteractionInvocation,
+	invokeMenuInteraction,
+	isMenuCurrent,
+	type MenuInteraction,
+	reportMenuError,
+} from "./interaction.js";
 import { resolveMenuScreen } from "./model.js";
 import { createMenuNavigator } from "./navigator.js";
-import { runTask } from "./task.js";
 import type {
-	ActionMenuItem,
-	MenuActionHandler,
-	MenuActionResult,
 	MenuCloseReason,
 	MenuContext,
 	MenuDefinition,
@@ -37,12 +40,6 @@ export interface RunMenuOptions<State, Context extends MenuContext = ExtensionCo
 	isCurrent?(): boolean;
 	onError?(ctx: Context, error: unknown): void | Promise<void>;
 	onUnsupportedMode?(ctx: Context, mode: ExtensionMode): void | Promise<void>;
-}
-
-interface ActionInvocation<ScreenId extends string> {
-	accepted: boolean;
-	stale: boolean;
-	transition: MenuTransition<ScreenId>;
 }
 
 type InternalScreenEvent<ScreenId extends string> =
@@ -87,6 +84,23 @@ async function runTuiMenu<
 			const state = loaded.state;
 			const screen = resolveMenuScreen(definition, navigator.current, state);
 			let staleAction = false;
+			const interact = async (interaction: MenuInteraction, interactionSignal?: AbortSignal) => {
+				const invocation = await invokeMenuInteraction({
+					ctx,
+					definition,
+					screen,
+					state,
+					menuSignal,
+					interactionSignal,
+					runtime: options,
+					interaction,
+				});
+				if (invocation.selectionItemId) {
+					navigator.rememberSelection(navigator.current, invocation.selectionItemId);
+				}
+				if (invocation.stale) staleAction = true;
+				return invocation;
+			};
 			const event = await showTuiScreen(
 				ctx,
 				screen,
@@ -94,62 +108,24 @@ async function runTuiMenu<
 				menuSignal,
 				{
 					onSelectionChange: (itemId) => navigator.rememberSelection(navigator.current, itemId),
-					onSettingChange: async (change, signal) => {
-						const item =
-							screen.kind === "settings"
-								? screen.items.find((candidate) => candidate.id === change.itemId)
-								: undefined;
-						if (!item || item.disabled) return rejected();
-						navigator.rememberSelection(navigator.current, change.itemId);
-						const invocation = await invokeAction(
-							ctx,
-							definition.actions[item.action],
-							state,
-							AbortSignal.any([menuSignal, signal]),
-							change.itemId,
-							options,
-							{ value: change.value },
-						);
-						if (invocation.stale) staleAction = true;
-						return invocation;
-					},
-					onMultiSelectChange: async (change, signal) => {
-						if (screen.kind !== "multiSelect") return rejected();
-						const item = screen.items.find((candidate) => candidate.id === change.itemId);
-						if (!item || item.disabled) return rejected();
-						navigator.rememberSelection(navigator.current, change.itemId);
-						const invocation = await invokeAction(
-							ctx,
-							definition.actions[screen.action],
-							state,
-							AbortSignal.any([menuSignal, signal]),
-							change.itemId,
-							options,
-							{ selected: change.selected },
-						);
-						if (invocation.stale) staleAction = true;
-						return invocation;
-					},
+					onSettingChange: (change, signal) =>
+						interact({ kind: "setting", itemId: change.itemId, value: change.value }, signal),
+					onMultiSelectChange: (change, signal) =>
+						interact(
+							{
+								kind: "multiSelect",
+								itemId: change.itemId,
+								selected: change.selected,
+							},
+							signal,
+						),
 					onInputSubmit: async (change, signal) => {
-						if (screen.kind !== "input") return rejected();
-						const invocation = await invokeAction(
-							ctx,
-							definition.actions[screen.action],
-							state,
-							AbortSignal.any([menuSignal, signal]),
-							"input",
-							options,
-							{ value: change.value },
-						);
-						if (invocation.stale) {
-							staleAction = true;
-							return accepted({ kind: "close" });
-						}
-						return invocation;
+						const invocation = await interact({ kind: "input", value: change.value }, signal);
+						return invocation.stale ? componentCloseInvocation<ScreenId>() : invocation;
 					},
 				},
 			);
-			if (staleAction || !isCurrent(options) || menuSignal.aborted) {
+			if (staleAction || !isMenuCurrent(options) || menuSignal.aborted) {
 				return { kind: "stale" };
 			}
 			if (!event) {
@@ -164,54 +140,15 @@ async function runTuiMenu<
 				navigator.apply(event.transition);
 				continue;
 			}
-			if (screen.kind === "choice") {
-				const item = screen.items.find((candidate) => candidate.id === event.itemId);
-				if (!item || item.disabled) continue;
-				navigator.rememberSelection(navigator.current, item.id);
-				const outcome = await invokeAction(
-					ctx,
-					definition.actions[screen.action],
-					state,
-					menuSignal,
-					item.id,
-					options,
-				);
-				if (outcome.stale) return { kind: "stale" };
-				navigator.apply(outcome.transition);
-				continue;
-			}
-			if (screen.kind === "review") {
-				if (!screen.confirm || screen.confirm.id !== event.itemId) continue;
-				const outcome = await invokeAction(
-					ctx,
-					definition.actions[screen.confirm.action],
-					state,
-					menuSignal,
-					screen.confirm.id,
-					options,
-				);
-				if (outcome.stale) return { kind: "stale" };
-				navigator.apply(outcome.transition);
-				continue;
-			}
-			const actionItems =
-				screen.kind === "actions"
-					? screen.items
-					: screen.kind === "multiSelect"
-						? (screen.actions ?? [])
-						: [];
-			const item = actionItems.find((candidate) => candidate.id === event.itemId);
-			if (!item || item.disabled) continue;
-			navigator.rememberSelection(navigator.current, item.id);
-			const outcome = await activateActionItem(ctx, definition, item, state, menuSignal, options);
+			const outcome = await interact({ kind: "activate", itemId: event.itemId });
 			if (outcome.stale) return { kind: "stale" };
 			navigator.apply(outcome.transition);
 		}
 		return closedMenuResult(navigator.closeReason);
 	} catch (error) {
-		if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
-		await reportError(ctx, options, error);
-		if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+		if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+		await reportMenuError(ctx, options, error);
+		if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
 		return { kind: "error", error };
 	} finally {
 		menuController.abort(new DOMException("Menu closed", "AbortError"));
@@ -247,15 +184,15 @@ async function showTuiScreen<
 		onSettingChange(
 			change: MenuSettingChange,
 			signal: AbortSignal,
-		): Promise<ActionInvocation<ScreenId>>;
+		): Promise<InteractionInvocation<ScreenId>>;
 		onMultiSelectChange(
 			change: MenuMultiSelectChange,
 			signal: AbortSignal,
-		): Promise<ActionInvocation<ScreenId>>;
+		): Promise<InteractionInvocation<ScreenId>>;
 		onInputSubmit(
 			change: MenuInputSubmit,
 			signal: AbortSignal,
-		): Promise<ActionInvocation<ScreenId>>;
+		): Promise<InteractionInvocation<ScreenId>>;
 	},
 ): Promise<InternalScreenEvent<ScreenId> | undefined> {
 	let component: MenuScreenComponent | undefined;
@@ -304,101 +241,6 @@ async function showTuiScreen<
 	}
 }
 
-async function activateActionItem<
-	State,
-	ScreenId extends string,
-	ActionId extends string,
-	Context extends MenuContext,
->(
-	ctx: Context,
-	definition: MenuDefinition<State, ScreenId, ActionId, Context>,
-	item: ActionMenuItem<ScreenId, ActionId>,
-	state: State,
-	menuSignal: AbortSignal,
-	options: RunMenuOptions<State, Context>,
-): Promise<ActionInvocation<ScreenId>> {
-	if ("to" in item && item.to !== undefined) return accepted({ kind: "to", screen: item.to });
-	if ("close" in item) return accepted({ kind: "close" });
-	if (!("action" in item) || item.action === undefined) return rejected();
-	const handler = definition.actions[item.action];
-	if ("busyLabel" in item && item.busyLabel && ctx.mode === "tui" && ctx.hasUI) {
-		return invokeBusyAction(ctx, handler, state, item.id, item.busyLabel, menuSignal, options);
-	}
-	return invokeAction(ctx, handler, state, menuSignal, item.id, options);
-}
-
-async function invokeBusyAction<State, ScreenId extends string, Context extends MenuContext>(
-	ctx: Context,
-	handler: MenuActionHandler<State, ScreenId, Context>,
-	state: State,
-	itemId: string,
-	label: string,
-	menuSignal: AbortSignal,
-	options: RunMenuOptions<State, Context>,
-): Promise<ActionInvocation<ScreenId>> {
-	const result = await runTask(ctx, {
-		label,
-		signal: menuSignal,
-		isCurrent: options.isCurrent,
-		onError: () => undefined,
-		task: ({ signal }) => invokeAction(ctx, handler, state, signal, itemId, options, {}, false),
-	});
-	switch (result.kind) {
-		case "completed":
-			return result.value;
-		case "cancelled":
-			return rejected();
-		case "stale":
-			return { ...rejected<ScreenId>(), stale: true };
-		case "error":
-			throw result.error;
-	}
-}
-
-async function invokeAction<State, ScreenId extends string, Context extends MenuContext>(
-	ctx: Context,
-	handler: MenuActionHandler<State, ScreenId, Context>,
-	state: State,
-	signal: AbortSignal,
-	itemId: string,
-	options: RunMenuOptions<State, Context>,
-	input: { value?: string; selected?: boolean } = {},
-	abortIsStale = true,
-): Promise<ActionInvocation<ScreenId>> {
-	if (!isCurrent(options)) return { ...rejected<ScreenId>(), stale: true };
-	if (signal.aborted) {
-		return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
-	}
-	let result: MenuActionResult<ScreenId>;
-	try {
-		result = await handler({ ctx, state, signal, itemId, ...input });
-	} catch (error) {
-		if (!isCurrent(options)) return { ...rejected<ScreenId>(), stale: true };
-		if (signal.aborted) {
-			return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
-		}
-		await reportError(ctx, options, error);
-		if (!isCurrent(options)) return { ...rejected<ScreenId>(), stale: true };
-		if (signal.aborted) {
-			return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
-		}
-		return rejected();
-	}
-	if (!isCurrent(options)) return { ...rejected<ScreenId>(), stale: true };
-	if (signal.aborted) {
-		return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
-	}
-	if (result?.kind === "rejected") {
-		if (result.error !== undefined) await reportError(ctx, options, result.error);
-		if (!isCurrent(options)) return { ...rejected<ScreenId>(), stale: true };
-		if (signal.aborted) {
-			return abortIsStale ? { ...rejected<ScreenId>(), stale: true } : rejected();
-		}
-		return rejected();
-	}
-	return accepted(result ?? { kind: "stay" });
-}
-
 async function runDialogMenu<
 	State,
 	ScreenId extends string,
@@ -420,26 +262,28 @@ async function runDialogMenu<
 			if (loaded.kind !== "loaded") return loaded.result;
 			const state = loaded.state;
 			const screen = resolveMenuScreen(definition, navigator.current, state);
+			const interact = (interaction: MenuInteraction) =>
+				invokeMenuInteraction({
+					ctx,
+					definition,
+					screen,
+					state,
+					menuSignal,
+					runtime: options,
+					interaction,
+				});
 			if (screen.kind === "input") {
 				const value = await uiFor(ctx).input(
 					dialogTitle(screen),
 					safeMenuText(screen.placeholder ?? ""),
 					{ signal: menuSignal },
 				);
-				if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+				if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
 				if (value === undefined) {
 					navigator.apply({ kind: screen.hint ?? "back" });
 					continue;
 				}
-				const outcome = await invokeAction(
-					ctx,
-					definition.actions[screen.action],
-					state,
-					menuSignal,
-					"input",
-					options,
-					{ value },
-				);
+				const outcome = await interact({ kind: "input", value });
 				if (outcome.stale) return { kind: "stale" };
 				navigator.apply(outcome.transition);
 				continue;
@@ -469,7 +313,7 @@ async function runDialogMenu<
 						choices.map((row) => row.label),
 						{ signal: menuSignal },
 					);
-					if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+					if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
 					const selected = choices.find((row) => row.label === choice);
 					if (!selected || selected.kind === "exit") {
 						navigator.apply({ kind: screen.hint ?? "back" });
@@ -478,14 +322,7 @@ async function runDialogMenu<
 					else if (selected.kind === "next") {
 						pageIndex = Math.min(pages.length - 1, pageIndex + 1);
 					} else if (screen.confirm) {
-						const outcome = await invokeAction(
-							ctx,
-							definition.actions[screen.confirm.action],
-							state,
-							menuSignal,
-							screen.confirm.id,
-							options,
-						);
+						const outcome = await interact({ kind: "activate", itemId: screen.confirm.id });
 						if (outcome.stale) return { kind: "stale" };
 						if (outcome.accepted) {
 							navigator.apply(outcome.transition);
@@ -501,94 +338,27 @@ async function runDialogMenu<
 				rows.map((row) => row.label),
 				{ signal: menuSignal },
 			);
-			if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+			if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
 			if (!choice) {
 				navigator.apply({ kind: "back" });
 				continue;
 			}
 			const selectedRow = rows.find((row) => row.label === choice);
 			if (!selectedRow) continue;
-			if (selectedRow.kind === "exit" || screen.kind === "detail") {
+			if (selectedRow.kind === "exit") {
 				const destination = "hint" in screen ? (screen.hint ?? "back") : "back";
 				navigator.apply({ kind: destination });
 				continue;
 			}
-			if (screen.kind === "actions") {
-				const item = screen.items[selectedRow.index];
-				if (!item || item.disabled) continue;
-				const outcome = await activateActionItem(ctx, definition, item, state, menuSignal, options);
-				if (outcome.stale) return { kind: "stale" };
-				navigator.apply(outcome.transition);
-				continue;
-			}
-			if (screen.kind === "settings") {
-				const item = screen.items[selectedRow.index];
-				if (!item || item.disabled) continue;
-				const values = item.values ?? [item.currentValue];
-				const currentIndex = Math.max(0, values.indexOf(item.currentValue));
-				const value = values[(currentIndex + 1) % values.length] ?? item.currentValue;
-				const outcome = await invokeAction(
-					ctx,
-					definition.actions[item.action],
-					state,
-					menuSignal,
-					item.id,
-					options,
-					{ value },
-				);
-				if (outcome.stale) return { kind: "stale" };
-				navigator.apply(outcome.transition);
-				continue;
-			}
-			if (screen.kind === "choice") {
-				const item = screen.items[selectedRow.index];
-				if (!item || item.disabled) continue;
-				const outcome = await invokeAction(
-					ctx,
-					definition.actions[screen.action],
-					state,
-					menuSignal,
-					item.id,
-					options,
-				);
-				if (outcome.stale) return { kind: "stale" };
-				navigator.apply(outcome.transition);
-				continue;
-			}
-			if (selectedRow.kind === "action") {
-				const actionItem = screen.actions?.[selectedRow.index];
-				if (!actionItem || actionItem.disabled) continue;
-				const outcome = await activateActionItem(
-					ctx,
-					definition,
-					actionItem,
-					state,
-					menuSignal,
-					options,
-				);
-				if (outcome.stale) return { kind: "stale" };
-				navigator.apply(outcome.transition);
-				continue;
-			}
-			const item = screen.items[selectedRow.index];
-			if (!item || item.disabled) continue;
-			const outcome = await invokeAction(
-				ctx,
-				definition.actions[screen.action],
-				state,
-				menuSignal,
-				item.id,
-				options,
-				{ selected: !item.selected },
-			);
+			const outcome = await interact(selectedRow.interaction);
 			if (outcome.stale) return { kind: "stale" };
 			navigator.apply(outcome.transition);
 		}
 		return closedMenuResult(navigator.closeReason);
 	} catch (error) {
-		if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
-		await reportError(ctx, options, error);
-		if (!isCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+		if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+		await reportMenuError(ctx, options, error);
+		if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
 		return { kind: "error", error };
 	} finally {
 		controller.abort(new DOMException("Menu closed", "AbortError"));
@@ -606,11 +376,9 @@ function dialogTitle<ScreenId extends string, ActionId extends string>(
 		.join("\n");
 }
 
-interface DialogRow {
-	kind: "item" | "action" | "exit";
-	index: number;
-	label: string;
-}
+type DialogRow =
+	| { kind: "interaction"; interaction: MenuInteraction; label: string }
+	| { kind: "exit"; label: string };
 
 interface ReviewDialogChoice {
 	kind: "previous" | "next" | "confirm" | "exit";
@@ -622,51 +390,67 @@ function dialogRows<ScreenId extends string, ActionId extends string>(
 ): DialogRow[] {
 	let rows: DialogRow[];
 	if (screen.kind === "detail") {
-		rows = [{ kind: "exit", index: 0, label: dialogExitChoice(screen) }];
+		rows = [{ kind: "exit", label: dialogExitChoice(screen) }];
 	} else if (screen.kind === "actions") {
-		rows = screen.items.map((item, index) => ({
-			kind: "item",
-			index,
+		rows = screen.items.map((item) => ({
+			kind: "interaction",
+			interaction: { kind: "activate", itemId: item.id },
 			label: safeMenuText(item.label),
 		}));
 	} else if (screen.kind === "settings") {
 		rows = [
-			...screen.items.map((item, index) => ({
-				kind: "item" as const,
-				index,
-				label: `${safeMenuText(item.label)} (${safeMenuText(item.currentValue)})`,
-			})),
-			{ kind: "exit", index: 0, label: dialogExitChoice(screen) },
+			...screen.items.map((item) => {
+				const values = item.values ?? [item.currentValue];
+				const currentIndex = Math.max(0, values.indexOf(item.currentValue));
+				return {
+					kind: "interaction" as const,
+					interaction: {
+						kind: "setting" as const,
+						itemId: item.id,
+						value: values[(currentIndex + 1) % values.length] ?? item.currentValue,
+					},
+					label: `${safeMenuText(item.label)} (${safeMenuText(item.currentValue)})`,
+				};
+			}),
+			{ kind: "exit", label: dialogExitChoice(screen) },
 		];
 	} else if (screen.kind === "input" || screen.kind === "review") {
 		rows = [];
 	} else if (screen.kind === "choice") {
 		rows = [
-			...screen.items.map((item, index) => {
+			...screen.items.map((item) => {
 				const label = safeMenuText(item.label);
 				const current = item.id === screen.currentItemId ? " (current)" : "";
 				const unavailable = item.disabled
 					? `[-] ${label} (unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""})`
 					: `${label}${current}`;
-				return { kind: "item" as const, index, label: unavailable };
+				return {
+					kind: "interaction" as const,
+					interaction: { kind: "activate" as const, itemId: item.id },
+					label: unavailable,
+				};
 			}),
-			{ kind: "exit", index: 0, label: dialogExitChoice(screen) },
+			{ kind: "exit", label: dialogExitChoice(screen) },
 		];
 	} else {
 		rows = [
-			...screen.items.map((item, index) => ({
-				kind: "item" as const,
-				index,
+			...screen.items.map((item) => ({
+				kind: "interaction" as const,
+				interaction: {
+					kind: "multiSelect" as const,
+					itemId: item.id,
+					selected: !item.selected,
+				},
 				label: item.disabled
 					? `[-] ${safeMenuText(item.label)} (unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""})`
 					: `${item.selected ? "[x]" : "[ ]"} ${safeMenuText(item.label)}`,
 			})),
-			...(screen.actions ?? []).map((item, index) => ({
-				kind: "action" as const,
-				index,
+			...(screen.actions ?? []).map((item) => ({
+				kind: "interaction" as const,
+				interaction: { kind: "activate" as const, itemId: item.id },
 				label: safeMenuText(item.label),
 			})),
-			{ kind: "exit", index: 0, label: dialogExitChoice(screen) },
+			{ kind: "exit", label: dialogExitChoice(screen) },
 		];
 	}
 	return uniqueDialogRows(rows);
@@ -705,65 +489,34 @@ async function loadState<State, Context extends MenuContext>(
 	options: RunMenuOptions<State, Context>,
 	signal: AbortSignal,
 ): Promise<{ kind: "loaded"; state: State } | { kind: "result"; result: RunMenuResult }> {
-	if (signal.aborted || !isCurrent(options)) return { kind: "result", result: { kind: "stale" } };
+	if (signal.aborted || !isMenuCurrent(options)) {
+		return { kind: "result", result: { kind: "stale" } };
+	}
 	try {
 		const state = await options.getState({ ctx, signal });
-		if (signal.aborted || !isCurrent(options)) {
+		if (signal.aborted || !isMenuCurrent(options)) {
 			return { kind: "result", result: { kind: "stale" } };
 		}
 		return { kind: "loaded", state };
 	} catch (error) {
-		if (signal.aborted || !isCurrent(options)) {
+		if (signal.aborted || !isMenuCurrent(options)) {
 			return { kind: "result", result: { kind: "stale" } };
 		}
-		await reportError(ctx, options, error);
-		if (signal.aborted || !isCurrent(options)) {
+		await reportMenuError(ctx, options, error);
+		if (signal.aborted || !isMenuCurrent(options)) {
 			return { kind: "result", result: { kind: "stale" } };
 		}
 		return { kind: "result", result: { kind: "error", error } };
 	}
 }
 
-async function reportError<State, Context extends MenuContext>(
-	ctx: Context,
-	options: RunMenuOptions<State, Context>,
-	error: unknown,
-) {
-	if (options.onError) {
-		try {
-			await options.onError(ctx, error);
-			return;
-		} catch {
-			// Fall back to Pi's notifier when a custom reporter is no longer available.
-		}
-	}
-	if (ctx.hasUI) {
-		const message = error instanceof Error ? error.message : String(error);
-		try {
-			uiFor(ctx).notify(`Menu action failed: ${safeMenuText(message)}`, "error");
-		} catch {
-			// Error reporting must never escape the documented menu result contract.
-		}
-	}
+function componentCloseInvocation<ScreenId extends string>(): InteractionInvocation<ScreenId> {
+	return { accepted: true, stale: false, transition: { kind: "close" } };
 }
 
 function closedMenuResult(reason: MenuCloseReason | undefined): RunMenuResult {
 	if (reason === undefined) throw new Error("Menu navigator closed without a termination reason");
 	return { kind: "closed", reason };
-}
-
-function accepted<ScreenId extends string>(
-	transition: MenuTransition<ScreenId>,
-): ActionInvocation<ScreenId> {
-	return { accepted: true, stale: false, transition };
-}
-
-function rejected<ScreenId extends string>(): ActionInvocation<ScreenId> {
-	return { accepted: false, stale: false, transition: { kind: "stay" } };
-}
-
-function isCurrent<State, Context extends MenuContext>(options: RunMenuOptions<State, Context>) {
-	return options.isCurrent?.() ?? true;
 }
 
 function uiFor(ctx: MenuContext): ExtensionCommandContext["ui"] {

--- a/packages/pi-tui-kit/test/interaction.test.ts
+++ b/packages/pi-tui-kit/test/interaction.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { invokeMenuInteraction, type MenuInteraction } from "../src/interaction.js";
+import { defineMenu } from "../src/model.js";
+import type { MenuScreen } from "../src/types.js";
+
+test("the internal driver rejects mismatched and disabled interactions without invoking actions", async () => {
+	let actionCalls = 0;
+	const context = createMockContext({ mode: "rpc", hasUI: true });
+	const enabled: MenuScreen<"main", "act"> = {
+		kind: "actions",
+		title: "Actions",
+		items: [{ id: "run", label: "Run", action: "act" }],
+	};
+	const disabled: MenuScreen<"main", "act"> = {
+		...enabled,
+		items: [{ id: "run", label: "Run", action: "act", disabled: true }],
+	};
+	const definition = defineMenu<undefined, "main", "act">({
+		start: "main",
+		screens: { main: () => enabled },
+		actions: {
+			act: async () => {
+				actionCalls += 1;
+				return { kind: "close" };
+			},
+		},
+	});
+	const invoke = (screen: MenuScreen<"main", "act">, interaction: MenuInteraction) =>
+		invokeMenuInteraction({
+			ctx: context.ctx,
+			definition,
+			screen,
+			state: undefined,
+			menuSignal: new AbortController().signal,
+			runtime: {},
+			interaction,
+		});
+
+	assert.deepEqual(await invoke(enabled, { kind: "setting", itemId: "run", value: "On" }), {
+		accepted: false,
+		stale: false,
+		transition: { kind: "stay" },
+	});
+	assert.deepEqual(await invoke(disabled, { kind: "activate", itemId: "run" }), {
+		accepted: false,
+		stale: false,
+		transition: { kind: "stay" },
+	});
+	assert.deepEqual(await invoke(enabled, { kind: "activate", itemId: "missing" }), {
+		accepted: false,
+		stale: false,
+		transition: { kind: "stay" },
+	});
+	assert.equal(actionCalls, 0);
+});

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -6,7 +6,13 @@ import {
 	createMockContext,
 	driveCustomSelector,
 } from "../../../test/support.js";
-import { defineMenu, type MenuDefinition, type RunMenuResult, runMenu } from "../src/index.js";
+import {
+	defineMenu,
+	type MenuDefinition,
+	type MenuScreen,
+	type RunMenuResult,
+	runMenu,
+} from "../src/index.js";
 
 initTheme("dark", false);
 
@@ -301,6 +307,211 @@ test("RPC uses dialog adaptation without custom TUI and print mode delegates uns
 		{ kind: "unsupported", mode: "tui" },
 	);
 	assert.equal(unsupportedMode, "tui");
+});
+
+test("TUI and RPC preserve the seven-screen semantic action matrix", async () => {
+	type MatrixScreen = MenuScreen<"main", "act">;
+	type MatrixPayload = { itemId: string; value?: string; selected?: boolean };
+	const cases: Array<{
+		name: string;
+		screen: MatrixScreen;
+		expected?: MatrixPayload;
+	}> = [
+		{
+			name: "actions",
+			screen: {
+				kind: "actions",
+				title: "Actions",
+				items: [{ id: "action-raw", label: "Run", action: "act" }],
+			},
+			expected: { itemId: "action-raw", value: undefined, selected: undefined },
+		},
+		{
+			name: "detail",
+			screen: { kind: "detail", title: "Detail", lines: ["Read only"] },
+		},
+		{
+			name: "choice",
+			screen: {
+				kind: "choice",
+				title: "Choice",
+				items: [{ id: "choice-raw", label: "Choose" }],
+				action: "act",
+			},
+			expected: { itemId: "choice-raw", value: undefined, selected: undefined },
+		},
+		{
+			name: "settings",
+			screen: {
+				kind: "settings",
+				title: "Settings",
+				items: [
+					{
+						id: "setting-raw",
+						label: "Setting",
+						currentValue: "Off",
+						values: ["Off", "On\u0007raw"],
+						action: "act",
+					},
+				],
+			},
+			expected: { itemId: "setting-raw", value: "On\u0007raw", selected: undefined },
+		},
+		{
+			name: "input",
+			screen: { kind: "input", title: "Input", action: "act" },
+			expected: { itemId: "input", value: "input raw", selected: undefined },
+		},
+		{
+			name: "review",
+			screen: {
+				kind: "review",
+				title: "Review",
+				content: "Content",
+				confirm: { id: "confirm-raw", label: "Apply", action: "act" },
+			},
+			expected: { itemId: "confirm-raw", value: undefined, selected: undefined },
+		},
+		{
+			name: "multi-select toggle",
+			screen: {
+				kind: "multiSelect",
+				title: "Multi-select",
+				items: [{ id: "toggle-raw", label: "Toggle", selected: false }],
+				action: "act",
+			},
+			expected: { itemId: "toggle-raw", value: undefined, selected: true },
+		},
+		{
+			name: "multi-select action",
+			screen: {
+				kind: "multiSelect",
+				title: "Multi-select action",
+				items: [],
+				action: "act",
+				actions: [{ id: "bulk-raw", label: "Save", action: "act" }],
+			},
+			expected: { itemId: "bulk-raw", value: undefined, selected: undefined },
+		},
+	];
+
+	for (const entry of cases) {
+		for (const mode of ["tui", "rpc"] as const) {
+			const invoked: MatrixPayload[] = [];
+			const menu = defineMenu<undefined, "main", "act">({
+				start: "main",
+				screens: { main: () => entry.screen },
+				actions: {
+					act: async ({ itemId, value, selected }) => {
+						invoked.push({ itemId, value, selected });
+						return { kind: "close" };
+					},
+				},
+			});
+			const context = createMockContext(
+				mode === "tui"
+					? {
+							mode,
+							hasUI: true,
+							custom: async (factory: unknown) => {
+								const harness = createCustomSelectorHarness(factory, 80);
+								if (entry.name === "detail") {
+									harness.handleInput("tui.select.cancel");
+								} else if (entry.name === "settings") {
+									harness.handleInput("tui.select.confirm");
+								} else if (entry.name === "input") {
+									harness.setFocused(true);
+									harness.handleInput("input raw");
+									harness.handleInput("tui.input.submit");
+								} else {
+									harness.handleInput("tui.select.confirm");
+								}
+								await harness.waitForPending();
+								return harness.result;
+							},
+						}
+					: {
+							mode,
+							hasUI: true,
+							input: async () => "input raw",
+							select: async (_title: string, choices: string[]) =>
+								entry.name === "review"
+									? choices.find((choice) => choice.startsWith("Apply"))
+									: choices[0],
+						},
+			);
+
+			const result = await runMenu(context.ctx, menu, { getState: () => undefined });
+			assert.deepEqual(
+				result,
+				entry.name === "detail"
+					? { kind: "closed", reason: "back" }
+					: { kind: "closed", reason: "close" },
+				`${mode} ${entry.name} result`,
+			);
+			assert.deepEqual(invoked, entry.expected ? [entry.expected] : [], `${mode} ${entry.name}`);
+		}
+	}
+});
+
+test("TUI and RPC ordinary action failures report once and leave the menu usable", async () => {
+	for (const mode of ["tui", "rpc"] as const) {
+		const actionError = new Error(`${mode} action failed`);
+		let actionCalls = 0;
+		let reporterCalls = 0;
+		let customCalls = 0;
+		let selectCalls = 0;
+		const context = createMockContext(
+			mode === "tui"
+				? {
+						mode,
+						hasUI: true,
+						custom: async (factory: unknown) => {
+							customCalls += 1;
+							const harness = createCustomSelectorHarness(factory, 40);
+							harness.handleInput(customCalls === 1 ? "tui.select.confirm" : "\u0003");
+							return harness.result;
+						},
+					}
+				: {
+						mode,
+						hasUI: true,
+						select: async (_title: string, choices: string[]) => {
+							selectCalls += 1;
+							return selectCalls === 1 ? choices[0] : undefined;
+						},
+					},
+		);
+		const menu = defineMenu<undefined, "main", "run">({
+			start: "main",
+			screens: {
+				main: () => ({
+					kind: "actions",
+					title: "Retry",
+					items: [{ id: "run", label: "Run", action: "run" }],
+				}),
+			},
+			actions: {
+				run: async () => {
+					actionCalls += 1;
+					throw actionError;
+				},
+			},
+		});
+
+		assert.deepEqual(
+			await runMenu(context.ctx, menu, {
+				getState: () => undefined,
+				onError: (_ctx, error) => {
+					reporterCalls += 1;
+					assert.equal(error, actionError);
+				},
+			}),
+			mode === "tui" ? { kind: "closed", reason: "close" } : { kind: "closed", reason: "back" },
+		);
+		assert.equal(actionCalls, 1, mode);
+		assert.equal(reporterCalls, 1, mode);
+	}
 });
 
 test("choice TUI prefers initial over current and invokes the confirmed raw item id", async () => {


### PR DESCRIPTION
## Summary

- add one internal semantic interaction driver for action lookup/invocation, mismatch and disabled rejection, composed action signals, stale/error classification, and returned transitions
- translate both TUI component events and RPC dialog rows into four bounded semantic intents while retaining mode-specific presentation and lifecycle cadence
- reduce `runtime.ts` from 773 to 526 lines; the internal driver is 285 lines and the Kit source grows only 38 lines overall
- record the Phase 4 go decision while leaving standalone confirmation and deferred multi-select open

## Compatibility boundary

- no public export, screen field, dependency, manifest, lockfile, consumer, or API-version change
- menu API remains 5
- fixed/adaptive rendering and deterministic RPC pagination are unchanged
- the internal file ships in `dist/`, but package exports reject `/interaction`
- no version bump or publication is included

## Verification

- pre-refactor seven-screen TUI/RPC matrix and ordinary error characterizations
- 116/116 focused Kit tests
- `npm run check --workspace @narumitw/pi-tui-kit`
- LSP diagnostics: 0
- generated production/testing-root TUI and strict RPC smoke: accepted/rejected, Back/Close, owner abort
- independent-clone `npm test`: 1,930/1,930
- independent-clone `npm run check`: 1,930/1,930
- `just pack-tui-kit`: 37 files; unchanged exact export roots; private subpath blocked

## Convention audit

Read `docs/extension-conventions.md` and complete Pi extension/TUI/RPC/package docs. Touched internal library runtime, TUI/RPC action lifecycle, tests, package output, plan, and roadmap. Custom UI guards/callback inputs, cancellation/disposal, post-await stale checks, public boundaries, and mode cadence remain intact. Settings and consumers are unchanged.