### PR TITLE
feat(pi-subagents): add read-only inspection and consultation

### DIFF
--- a/docs/plans/2026-08-01_pi-subagents-read-only-tools-plan.md
+++ b/docs/plans/2026-08-01_pi-subagents-read-only-tools-plan.md
@@ -1,0 +1,287 @@
+# pi-subagents read-only tools plan
+
+## Goal
+
+Add two capability-clean tools to `@narumitw/pi-subagents` without coupling it to Plan mode or changing the documented behavior of its existing delegation and lifecycle APIs:
+
+- `subagent_inspect` reads bounded agent, model, run, runtime, and diagnostic metadata without changing workspace or subagent state.
+- `subagent_consult` runs one ephemeral subagent synchronously under executor-enforced read-only tool and instruction-resource policies and returns its answer.
+
+Users can independently activate these tools wherever a read-only surface is appropriate. `pi-subagents` owns their safety guarantees; other extensions may only use Pi's generic tool APIs.
+
+## Approved Decisions
+
+- Untrusted `project` or `both` agent scope fails before project-agent discovery for both tools. Omitted scope defaults to `user`.
+- Inspection may obtain mailbox unread counts from a dedicated metadata snapshot, but it must not access, copy, expose, or acknowledge message content.
+- `get_run` returns a safe state summary, not history output, context content, or mailbox content.
+- Add the user setting `consult.resources` with `project-context`, `none`, and `all`; default to `project-context`. Project-controlled settings cannot override it, and child extensions are disabled under every value.
+- A missing agent tool list means the default read-only set; an explicit empty list means no tools in both JSON settings and agent markdown frontmatter.
+- Nested consultation usage is returned to Pi for footer, `/session`, and RPC accounting as well as result details.
+- Pre-launch failures throw. A child that fails after launch returns bounded partial evidence and usage and is marked as an actual Pi tool error. User-declined confirmation is a normal `{ cancelled: true }` result with no launch or usage.
+- `/subagents settings` is the single settings screen for completion delivery and consultation resources.
+- A consultation `cwd` outside the canonical current workspace is allowed only when `consult.resources` is `none`. This does not sandbox absolute paths used by read-only tools.
+- Trusted project agents still require confirmation by default. In a non-interactive context, `confirmProjectAgents: true` fails closed; the caller must explicitly pass `false`.
+- `diagnose` returns a successful structured report whose checks are `pass`, `warning`, or `fail`; only failure of the diagnostic operation itself throws.
+- Model and path projections use explicit safe fields. User-agent paths use `~`, and project-agent paths are workspace-relative.
+- Consultation details expose the requested and effective safety policy without exposing prompts, credentials, or environment values.
+- Tasks are not classified with write-related keyword heuristics. Executor policy, not prompt wording, enforces read-only behavior.
+
+## Context
+
+- The current package registers five tools by default: blocking `subagent` plus `subagent_spawn`, `subagent_send`, `subagent_manage`, and `subagent_mailbox` for detached lifecycles.
+- `subagent_manage` mixes read-only `list` with mutating `interrupt`/`close`; `subagent_mailbox` mixes `send` with `read`, whose default acknowledgement changes mailbox state. Neither whole tool is a safe read-only capability.
+- Blocking execution already supports ephemeral subprocesses, cancellation, byte-bounded output, project-agent trust checks, and usage details. Its child CLI arguments currently allow configured extensions and write-capable tools, and it does not return usage through Pi's top-level nested-usage field.
+- `StatefulSubagentController.listAgents()` and `getRuntimeStatus()` currently copy complete retained records, including history and mailbox objects. Inspection therefore needs a dedicated metadata snapshot instead of projecting the existing full-record API.
+- `readSubagentSettings()` updates a pending lifecycle notice. Inspection needs a separate pure settings snapshot so a read cannot consume, replace, or seed that notice.
+- `extensions/pi-subagents/src/stateful.ts` is close to the repository's 1,000-line review threshold. New projection and consultation logic belongs in focused modules; any small controller bridge must be offset by extraction if the final file would exceed the threshold.
+- Existing workflow settings derive `all`, `async-only`, `blocking-only`, or `disabled` from `blocking.enabled` and `stateful.enabled`. This change adds only the optional user-owned `consult.resources` preference; it does not change workflow derivation.
+
+## Architecture
+
+### Tool surface
+
+| Tool | Registration | Safety contract |
+| --- | --- | --- |
+| `subagent_inspect` | Every workflow, including disabled delegation | Does not start a child, read mailbox message content, acknowledge messages, mutate registry/settings/files, or perform network/provider refresh work. |
+| `subagent_consult` | Whenever blocking delegation is enabled | Runs one synchronous, non-retained child with an enforced subset of Pi's built-in `read`, `grep`, `find`, and `ls` tools. |
+| Existing five tools | Preserve current workflow rules and schemas | Preserve current public behavior and compatibility. |
+
+Expected registered surfaces:
+
+- `all`: the existing five tools plus `subagent_inspect` and `subagent_consult`.
+- `async-only`: the four detached lifecycle tools plus `subagent_inspect`.
+- `blocking-only`: `subagent`, `subagent_consult`, and `subagent_inspect`.
+- `disabled`: `subagent_inspect` only.
+
+Keep `subagent_manage({ action: "list" })` as a compatibility route. Its wording may steer new read-only discovery toward `subagent_inspect`, but this change must not remove or alter the old call.
+
+### `subagent_inspect` schema
+
+Use one flat `Type.Object` schema whose `action` uses Google-compatible `StringEnum`. Set `additionalProperties: false` and also perform strict runtime action-specific validation so resumed or direct calls cannot smuggle cross-action fields.
+
+| Action | Accepted fields and defaults |
+| --- | --- |
+| `list_agents` | `action`; optional `agentScope` default `user`; optional integer `limit` default 32, range 1–100 |
+| `get_agent` | `action`; required non-empty `agent`; optional `agentScope` default `user` |
+| `list_runs` | `action`; optional `includeClosed` default `false`; optional integer `limit` default 50, range 1–100 |
+| `get_run` | `action`; required non-empty `agentId`; searches every still-retained record, including closed records |
+| `list_models` | `action`; optional integer `limit` default 50, range 1–100 |
+| `status` | `action` only |
+| `diagnose` | `action` only |
+
+Reject every field not listed for the selected action. Return deterministic ordering plus returned and omitted counts for bounded lists.
+
+### `subagent_inspect` projections
+
+- `list_agents`: name, bounded description, source/scope, safe source path, and enough configured/effective tool metadata to select an agent.
+- `get_agent`: name, description, source/scope, safe path, model, thinking level, configured tools, and consult-effective tools. Never return system-prompt content or raw settings/model objects.
+- `list_runs`: agent ID/name, state, created/updated times, history count, and unread count. Do not copy history entries, context, current task, errors, or mailbox entries for the list action.
+- `get_run`: the list fields plus safe `cwd`, bounded current-task and error summaries, thinking level, and policy summary. Do not return history output, context content/source content, mailbox content, or system prompts.
+- `list_models`: use `ctx.scopedModels` when non-empty, otherwise `ctx.modelRegistry.getAvailable()`. Project only provider, ID, display name, reasoning support, input modalities, context window, max output tokens, scoped thinking level, and whether it is the current model. Never project `baseUrl`, headers, compatibility objects, environment values, auth material, or the raw model object.
+- `status`: effective workflow, stateful transport, completion delivery, active/retained counts, effective consultation-resource policy, and relevant pure settings-load errors.
+- `diagnose`: aggregate settings validity, agent-discovery completeness, model availability, runtime initialization, and consultation support as `pass`, `warning`, or `fail`. A failed check remains report data; throw only when diagnosis itself cannot run.
+
+Use a dedicated registry/controller inspection snapshot that reads only state fields, lengths, timestamps, and mailbox `readAt` metadata. It must not access or copy message `content`, history entries, or stored context. Update runtime counts to avoid `registry.list(true)` full-record copies. Keep the existing `listAgents()` compatibility API unchanged for existing callers.
+
+Use a pure settings document snapshot for inspection and UI previews. It must not modify `pendingSettingsNotice`, create files/directories/locks, or race a pending settings write. Discovery must check `ctx.isProjectTrusted()` before any project-agent directory traversal; explicit untrusted `project`/`both` requests throw, while omitted scope reads only user and built-in definitions.
+
+Normalize model-facing text with terminal-control removal, private-text redaction where applicable, and both Pi limits: at most 50 KB or 2,000 lines, whichever is reached first. Render user paths beneath the agent directory with `~` and project paths relative to the canonical workspace. Arbitrary task/error text is not a confidentiality boundary; document that limitation and never source credential-bearing model/settings fields.
+
+Suggested public wording:
+
+```text
+Name: subagent_inspect
+Label: Inspect Subagents
+Description: Inspect available subagent definitions, models, retained runs, runtime status, and diagnostics without changing subagent or workspace state. This tool never starts a child, sends or acknowledges messages, interrupts or closes runs, changes settings, or modifies files.
+Prompt snippet: Inspect subagent metadata and runtime state without changing it.
+```
+
+### `subagent_consult` schema
+
+Expose one actionless `Type.Object` with `additionalProperties: false`:
+
+- required non-empty `agent` and `task`;
+- optional `agentScope`, default `user`;
+- optional `confirmProjectAgents`, default `true`;
+- optional `cwd`;
+- optional positive `timeoutMs`;
+- optional Google-compatible thinking-level enum.
+
+Do not expose blocking parallel, chain, task-array, or fan-in fields. Do not reject task text through write/edit/shell keyword matching; append an explicit read-only instruction and rely on the executor policy.
+
+Suggested public wording:
+
+```text
+Name: subagent_consult
+Label: Consult Read-only Subagent
+Description: Run one ephemeral subagent synchronously under enforced read-only tool and resource policies and return its answer. The child can use only the effective subset of Pi's built-in read, grep, find, and ls tools. Shell commands, file writes, extension tools, detached lifecycle operations, and persistent agent state are disabled.
+Prompt snippet: Consult one constrained read-only subagent and wait for its answer.
+Prompt guideline: Use subagent_consult for bounded reconnaissance, planning, or review whose result is required in the current turn. An implementation-shaped task remains read-only and can return only analysis or instructions.
+```
+
+### Consultation tool enforcement
+
+Resolve the requested agent while retaining its model, thinking level, timeout, prompt, source, and scope. Preserve tool-list presence separately from its contents:
+
+```text
+missing tools  -> [read, grep, find, ls]
+explicit []    -> []
+explicit list  -> stable, deduplicated intersection with [read, grep, find, ls]
+```
+
+Apply the same absent-versus-empty rule to JSON agent overrides and markdown frontmatter. Support previously ambiguous/unsupported blank or empty frontmatter as an explicit empty list without changing existing valid missing or comma-separated declarations.
+
+Extend the blocking runner with a typed optional launch-policy object. Existing callers receive byte-for-byte-equivalent defaults. Consultation launches with:
+
+- `--no-extensions` on every resource policy, with no explicit extension path;
+- `--tools <effective-list>` or `--no-tools` for an empty intersection;
+- `--no-session` and no stateful registry/persistence record;
+- the configured resource-policy flags and explicit prompt sources described below;
+- an agent prompt followed by a package-owned read-only instruction that cannot widen executor capabilities.
+
+Disable extension discovery rather than trusting a same-name tool allowlist. Prove exact child arguments, no registry/mailbox allocation, and the effective tool list in tests.
+
+### Consultation instruction-resource policy
+
+Add this optional user setting to `pi-subagents.json`:
+
+```json
+{
+  "consult": {
+    "resources": "project-context"
+  }
+}
+```
+
+Accepted values:
+
+| Value | Effective child instruction resources |
+| --- | --- |
+| `project-context` | Default. Retain ordinary user context/system files and trusted current-project `AGENTS.md`/`CLAUDE.md`/`SYSTEM.md`; disable skills and prompt templates. Do not auto-load append-system files beyond the selected agent and package read-only instructions. For an untrusted current project, omit project context before launch; fail closed with `--no-context-files` if Pi cannot separate user from project context. |
+| `none` | Inherit no user/project context, system, skill, prompt-template, or append-system files. Use only Pi's package-owned consultation base, the selected agent prompt, and the read-only instruction. |
+| `all` | Retain ordinarily discoverable trusted context/system/append-system files, skills, and prompt templates, while still forcing `--no-extensions` and the read-only tool intersection. Omit untrusted project resources before launch. |
+
+The setting is user-owned only; do not add a project override or environment variable. Default it in code without creating a file. Reload manual edits on `session_start`. `/subagents settings` edits it immediately for subsequent consultations in the current session, using the existing settings mutation lock, atomic publication, unknown-field preservation, invalid-file protection, ordered save/error recovery, and no required reload.
+
+`cwd` must be canonicalized. An equal or descendant path of the canonical current workspace may use any policy. A path outside that boundary, a symlink escape, or a path whose boundary cannot be verified is allowed only when the effective policy is `none`; otherwise throw before launch. This controls implicit instruction loading, not file access: read-only tools can still read an explicitly requested accessible absolute path.
+
+### Consultation trust, confirmation, and lifecycle
+
+- Check `ctx.isProjectTrusted()` before any `project`/`both` agent discovery. An untrusted explicit project scope always throws, even if a user agent of the same name exists.
+- For a resolved project agent in a trusted project, honor `confirmProjectAgents`, default `true`.
+- When confirmation is required and `ctx.hasUI` is false, throw and require an explicit `confirmProjectAgents: false`; never silently skip confirmation.
+- A user-declined UI confirmation returns a bounded normal result with `cancelled: true`, no child launch, and no usage.
+- After every confirmation or other `await`, revalidate the request/session owner and abort signal before using context or launching work.
+- Abort before launch starts nothing. Abort, timeout, session replacement, or shutdown after launch terminates the process tree, awaits cleanup, removes temporary prompt resources once, and prevents late updates or results from the old owner.
+
+### Consultation result, usage, and errors
+
+Return bounded answer content and details containing:
+
+- agent source/scope, safe `cwd`, model, thinking level, and timeout;
+- requested and effective tools;
+- requested and effective instruction-resource policy;
+- explicit `extensions: disabled`, `sessionPersistence: disabled`, and `retainedAgent: false` facts;
+- bounded child status/error/activity details without prompts, credentials, headers, or environment values;
+- combined nested model usage in both details and Pi's top-level `usage` field.
+
+Aggregate the child usage into Pi's `Usage` shape so footer, `/session`, and RPC totals include consultation cost. Bound both content and details to 50 KB or 2,000 lines and expose truncation/omission metadata.
+
+Validation, trust, unknown-agent, unsafe-`cwd`, pre-launch abort, and spawn failures throw observable tool errors. Once a model process has started, failures, aborts, and timeouts preserve bounded partial evidence and usage, and a `subagent_consult`-specific `tool_result` handler marks the finalized Pi result `isError: true`. Tests must inspect the finalized Pi-visible result, not merely an `isError`-looking details field. This post-launch structured-error path is an explicit compatibility/usage-preservation deviation from the repository's default throw-only tool convention and must be recorded in the final audit.
+
+### Settings and command UI
+
+Extend settings types, normalization, pure inspection snapshots, and atomic updates for `consult.resources`. Unknown top-level and nested fields remain preserved. Invalid/malformed files block writes and leave the current effective policy unchanged.
+
+Make `/subagents settings` and the no-argument manager's **Settings** action open the same standard settings screen. Include rows for:
+
+- async completion delivery;
+- consultation instruction resources.
+
+Update Status and Help with configured/effective values, source, path, default, accepted values, immediate UI application, and manual-edit reload behavior. Non-TUI routes must not open custom UI or corrupt JSON/RPC output.
+
+### Ownership boundaries
+
+- `pi-subagents` owns inspection accuracy, safe projections, trust gates, resource selection, and consultation executor policy.
+- No source, settings, docs, or tests in this change may branch on another extension's name, mode, settings, schema, or runtime state.
+- Other extensions may activate these tools only through Pi's generic tool APIs.
+- Keep `src/index.ts` as a forwarding entrypoint. Put inspection, consultation, launch-policy, and snapshot projections in focused modules, and keep every source file below 1,000 lines unless the final audit documents a concrete justification.
+
+## Non-Goals
+
+- Do not add `subagent_control` or merge the existing lifecycle tools.
+- Do not remove or rename an existing tool or action.
+- Do not add `allowedSubagents`, Plan-specific behavior, mode detection, extension-to-extension communication, a project override for `consult.resources`, or a new environment variable.
+- Do not claim an OS sandbox, general path sandbox, network isolation, arbitrary-data confidentiality boundary, or zero-cost operation.
+- Do not add detached read-only consultation, retained consult sessions, parallel consult arrays, chains, fan-in, mailbox-content inspection, or settings mutation through `subagent_inspect`.
+- Do not publish, bump package versions, or change package metadata unless separately requested.
+
+## Assumptions
+
+- “Read-only consultation” means the child cannot modify workspace files or persistent subagent state through Pi tools. It still starts a temporary process, can read accessible absolute paths, calls a configured model over the network, and incurs token cost.
+- Instruction-resource policy controls automatically loaded instructions; it is not a data-access sandbox.
+- A synchronous single consultation is the primary read-only delegation need. Existing blocking batches and detached workflows remain on the existing tools.
+- Additive tool names are acceptable in the default `all` surface; clear capability boundaries are preferred over minimizing schema count.
+
+## Risks
+
+- A same-name extension override could invalidate a built-in-name allowlist. Disable all child extension discovery and test exact emitted CLI arguments.
+- Pi resource flags may not independently suppress every context/system source. Build an explicit launch policy for each `consult.resources` value and test the child-visible prompt/resources, not only setting normalization.
+- A project trust check performed after discovery would read untrusted definitions. Gate explicit project scope and project resource loading before directory traversal or subprocess launch.
+- Agent prompts may describe unavailable write or shell behavior. Report the enforced policy and append a read-only instruction, but rely on executor capabilities rather than prompt compliance.
+- Full retained records can leak prompts, mailbox content, or history before projection. Add metadata-only registry snapshots and make status counts avoid full-record copies.
+- Broad model/status projection can leak endpoints, headers, or credentials. Return only the approved fields and use already-loaded model snapshots without refresh or auth resolution.
+- Settings inspection can mutate pending notices or stale reads can race writes. Keep inspection pure and participate in the existing settings concurrency protocol.
+- Cancellation, timeout, replacement, or shutdown can leak a child or allow a stale continuation to launch. Test each owner transition separately and reuse process-tree termination.
+- Post-launch structured errors can look successful if middleware is omitted. Test the finalized Pi-visible `isError` and top-level usage.
+- New registration and settings rows can make workflow labels or previews inaccurate. Update exact-surface and UI wording tests together.
+
+## Rollback / Recovery
+
+This is an additive public API with no required migration. A rollback removes the two tool registrations and focused modules, restores prior workflow wording/tool lists, and reverts the optional runner launch policy and consultation settings UI. Existing retained-agent persistence and the five existing tool schemas remain readable.
+
+The optional `consult` object may remain in `pi-subagents.json`; preceding versions treat it as an unknown field and settings updates must preserve it. Users may delete that object manually, but rollback requires no data conversion. A released version can be rolled back by pinning the preceding package release.
+
+## Plan
+
+- [x] Add red settings tests in `extensions/pi-subagents/test/settings.test.ts` for default `project-context`, all three accepted values, invalid-value rejection, side-effect-free pure snapshots, pending-notice preservation, missing-file behavior, unknown-field preservation, atomic update failure recovery, immediate in-memory application, and manual reload. Compile with `./node_modules/.bin/tsc -p tsconfig.test.json`, run the compiled test by real path, implement the `consult.resources` types/normalizer/inspector/updater, and rerun to green.
+- [x] Add red agent-discovery tests in `extensions/pi-subagents/test/agents.test.ts` proving absent tools remain `undefined`, blank or empty markdown frontmatter becomes `[]`, JSON `tools: []` remains `[]`, and existing comma-separated tools still parse. Implement the smallest parser change and rerun the focused compiled test.
+- [x] Add red registry tests for metadata-only counts, list snapshots, and one-record snapshots. Seed history, context, tasks, errors, and mailbox messages with sentinel content; prove snapshots expose approved fields and unread counts without copying/accessing content fields, and prove status counting no longer calls full-record `list()`. Implement focused snapshot types/functions in `registry.ts` plus the smallest controller bridge, extracting code if needed to keep `stateful.ts` below 1,000 lines.
+- [x] Add red `extensions/pi-subagents/test/inspect.test.ts` cases for the exact name, label, wording, `StringEnum` action, strict action-field matrix, defaults/limits, deterministic ordering/omitted counts, safe paths, empty/error states, all approved projections, and structured `diagnose` statuses. Implement `src/inspect.ts`, rerun the compiled test, and verify malformed or cross-action fields throw.
+- [x] Extend inspect tests with untrusted `project`/`both` pre-discovery rejection, trusted same-name precedence, incomplete discovery, invalid settings, empty models/runs, safe model fields, bounded task/error summaries, and sentinels for omitted prompts, history, context, mailbox content, endpoints, headers, and credentials. Prove no child launch, provider refresh/auth resolution/network call, registry mutation, settings notice change/write, or filesystem mutation occurs.
+- [x] Add red runner tests in `extensions/pi-subagents/test/runner-render.test.ts` for a typed optional launch policy: exact `--no-extensions`, tools/`--no-tools`, `--no-session`, trust/resource flags and prompt sources for `project-context`, `none`, and `all`, stable read-only tool intersection, top-level usage aggregation support, and byte/line bounds. Implement the runner extension while proving every existing caller emits its previous argument list and behavior.
+- [x] Add red `extensions/pi-subagents/test/consult.test.ts` cases for the exact actionless schema, unknown-field rejection, required fields, default scope/confirmation, no task-keyword rejection, missing/empty/intersected tools, and the package read-only instruction. Add trust tests proving untrusted project scope reads no project files, trusted confirmation cancellation launches nothing, non-UI confirmation fails closed, and explicit false proceeds only when trusted.
+- [x] Implement `src/consult.ts` agent resolution and preflight ownership. Canonicalize `cwd`; test equal/descendant, outside, nonexistent, and symlink-escape cases against each resource policy. Prove outside-workspace launch is accepted only under `none` and that policy details report requested versus effective resources.
+- [x] Complete consultation execution tests for extension suppression, effective tools, no registry/mailbox/persistence state, no retained ID, streaming updates, successful output, combined Pi-visible usage, spawn failure, malformed child output, child error, abort before launch, abort during execution, timeout, process-tree cleanup, and temporary prompt cleanup. Assert post-launch failures are finalized with actual `isError: true`, while declined confirmation returns normal `cancelled: true` with no usage.
+- [x] Add lifecycle tests that separately replace the session or shut it down while confirmation is pending and while a child is running. Prove late confirmations/updates/results are ignored, no stale continuation launches, all owned processes are reaped, and cleanup is idempotent after every `await` boundary.
+- [x] Wire both modules through `src/subagents.ts` and the metadata snapshot through the stateful controller. Update exact registration tests so `all`, `async-only`, `blocking-only`, and manually disabled settings expose exactly the Architecture table, while the five existing schemas and `subagent_manage({ action: "list" })` remain compatible.
+- [x] Replace the settings UI's completion-only route with one shared standard Settings screen containing completion delivery and consultation resources. Add config-UI tests for all displayed values, immediate save/application, ordered saves, failed-save rollback, session replacement/disposal, non-TUI behavior, safe paths, Status/Help, and the no-argument **Settings** entry.
+- [x] Revise labels, descriptions, snippets, workflow previews, Status/Help, and compatibility wording in `src/subagents.ts`, `src/stateful.ts`, and `src/config-ui.ts`. Clearly distinguish inspection, consultation, blocking batches, detached lifecycles, mailbox acknowledgement, resource policy, cost, confirmation, and the lack of a path/OS sandbox.
+- [x] Update `extensions/pi-subagents/README.md` with the seven-tool default surface, workflow tables, exact inspection action schema, safe projections, consultation tools/resources/trust/confirmation/`cwd`/error/usage behavior, `consult.resources` JSON and UI reference, empty-tool semantics, examples, compatibility note, limits, and package layout. Verify every claim against source/tests.
+- [x] Run `lsp_diagnostics` on changed TypeScript, apply only relevant fixes, and run focused compiled tests after each red/green slice. Then run `npm run check`; resolve Biome, boundary, typecheck, and test failures without weakening safety assertions.
+- [x] Run a representative isolated `pi -e ./extensions/pi-subagents` smoke for registration/settings behavior and consultation launch-policy argument capture without real provider traffic. Record any child-resource path that cannot be exercised locally rather than silently claiming it.
+- [x] Run `just pack-subagents`; inspect the dry-run contents for source modules, README, license, and declared entrypoint, and confirm no tests, caches, settings, credentials, or unrelated files are included.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`: extension independence; public schemas; settings ordering/recovery/unknown fields; trust before reads; prompt/resource policy; tool origins; output limits; Pi-visible errors/usage; user cancellation; subprocess disposal; session replacement/shutdown; compatibility; and the 1,000-line source threshold. Record the approved post-launch structured-error deviation and every unverified path before completion.
+
+## Completion Checklist
+
+- [x] `subagent_inspect` implements the exact seven-action schema and is demonstrably side-effect-free, trust-aware, metadata-only, bounded by bytes and lines, and free of prompts, mailbox/history/context content, credential-bearing model fields, and unsafe paths.
+- [x] `subagent_consult` runs exactly one ephemeral synchronous child with extensions disabled, the approved read-only tool intersection, the configured instruction-resource policy, no retained state, and auditable result details.
+- [x] Project trust is checked before discovery/resource loading; confirmation is fail-closed without UI; external `cwd` obeys the `none` rule; declined confirmation launches nothing.
+- [x] Consultation usage reaches Pi session totals, post-launch failures are actual Pi-visible errors with bounded evidence, and every cancellation/timeout/replacement/shutdown path cleans up its owned process and temporary files.
+- [x] `consult.resources` defaults, validation, pure inspection, atomic persistence, unknown-field preservation, immediate UI application, unified Settings UI, and reload behavior match the settings guide.
+- [x] Existing `subagent`, `subagent_spawn`, `subagent_send`, `subagent_manage`, and `subagent_mailbox` schemas and behavior remain compatible, including `subagent_manage({ action: "list" })`.
+- [x] Every workflow exposes the exact intended tool set, and wording accurately distinguishes all capabilities and limitations.
+- [x] Focused tests, runtime smoke, `npm run check`, `lsp_diagnostics`, and `just pack-subagents` pass with recorded evidence or an explicitly accepted unverified path.
+- [x] The final semantic audit confirms no coupling to `pi-plan-mode` or any other extension and no unknown required decision remains.
+
+## Implementation Evidence
+
+- Guides audited: `docs/extension-conventions.md` and `docs/extension-settings.md`; touched areas were public tool schemas, trust-gated discovery, settings inspection/persistence/UI, subprocess ownership, usage/error reporting, output bounds, workflow surfaces, and documentation.
+- Focused compiled tests passed for agents, settings, registry, inspection, consultation, runner launch policy/rendering, and extension registration. The final repository gate, `npm run check`, passed with 1,955 tests.
+- `lsp_diagnostics` reported zero diagnostics across all 36 `pi-subagents` source and test files.
+- An isolated RPC smoke loaded `pi-subagents`, ran `/subagents status`, and verified the consultation resource status without provider traffic. The production runner was separately exercised against a synthetic JSON child to verify exact launch arguments, appended read-only instructions, output, and usage aggregation.
+- `just pack-subagents` included the declared entrypoint, README, license, and all source modules (28 files), with no tests, caches, settings, credentials, or unrelated files.
+- The largest source file is `src/stateful.ts` at 969 lines; every source file remains below the 1,000-line threshold. No cross-extension coupling was introduced.
+- Approved deviation: after a child process starts, consultation failures return bounded evidence and usage and are marked `isError: true` by the tool-result handler instead of throwing away that evidence. Pre-launch failures continue to throw.
+- Accepted unverified path: no live provider request was made during the isolated smoke, by design. Provider-independent subprocess protocol, launch policy, lifecycle, usage, and finalized Pi-visible error behavior are covered by synthetic-child and extension-event tests.

--- a/docs/plans/2026-08-01_pi-subagents-read-only-tools-plan.md
+++ b/docs/plans/2026-08-01_pi-subagents-read-only-tools-plan.md
@@ -278,7 +278,7 @@ The optional `consult` object may remain in `pi-subagents.json`; preceding versi
 ## Implementation Evidence
 
 - Guides audited: `docs/extension-conventions.md` and `docs/extension-settings.md`; touched areas were public tool schemas, trust-gated discovery, settings inspection/persistence/UI, subprocess ownership, usage/error reporting, output bounds, workflow surfaces, and documentation.
-- Focused compiled tests passed for agents, settings, registry, inspection, consultation, runner launch policy/rendering, and extension registration. The final repository gate, `npm run check`, passed with 1,955 tests.
+- Focused compiled tests passed for agents, settings, registry, inspection, consultation, runner launch policy/rendering, and extension registration. The final repository gate, `npm run check`, passed with 1,959 tests after review and hardening fixes.
 - `lsp_diagnostics` reported zero diagnostics across all 36 `pi-subagents` source and test files.
 - An isolated RPC smoke loaded `pi-subagents`, ran `/subagents status`, and verified the consultation resource status without provider traffic. The production runner was separately exercised against a synthetic JSON child to verify exact launch arguments, appended read-only instructions, output, and usage aggregation.
 - `just pack-subagents` included the declared entrypoint, README, license, and all source modules (28 files), with no tests, caches, settings, credentials, or unrelated files.

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -2,13 +2,15 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-subagents)](https://www.npmjs.com/package/@narumitw/pi-subagents) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-subagents` is a native [Pi coding agent](https://pi.dev) extension for delegating work to specialized agents. By default, the blocking batch `subagent` tool uses isolated Pi subprocesses while four detached tools run reusable agents either as subprocess-backed logical sessions or as public-SDK in-process child sessions. Users can keep all five tools, choose async-only delegation, or retain only blocking batches.
+`@narumitw/pi-subagents` is a native [Pi coding agent](https://pi.dev) extension for delegating work to specialized agents. By default, it exposes seven capability-specific tools: blocking batches, four detached lifecycle tools, side-effect-free inspection, and synchronous read-only consultation. Users can keep every delegation method, choose async-only delegation, retain only blocking delegation, or disable delegation while keeping inspection available.
 
 Use it to split independent research, planning, implementation, and review work across focused workers. Under the default next-turn delivery policy, background delegation is for work the current response does not depend on. Opt-in auto-resume also supports final-answer-dependent background work by requesting a synthesis turn after completion.
 
 ## ✨ Features
 
-- Offers all delegation methods by default, with goal-oriented presets for async-only or blocking-only workflows.
+- Offers all delegation methods by default, with goal-oriented presets for async-only, blocking-only, or disabled delegation.
+- Adds `subagent_inspect` for bounded metadata without child launch, mailbox-content access, acknowledgement, or mutation.
+- Adds `subagent_consult` for one synchronous ephemeral child constrained to built-in `read`, `grep`, `find`, and `ls` tools (or a narrower agent allow-list).
 - Keeps batch workers isolated in `pi --mode json -p --no-session` subprocesses.
 - Registers detached stateful lifecycle tools by default; completion can stay queued for the next turn or opt into an idle root synthesis turn.
 - Supports an opt-in public-SDK `in-process` stateful transport with one reusable child `AgentSession` per `agentId`.
@@ -43,13 +45,14 @@ pi -e ./extensions/pi-subagents
 
 ## 🛠️ Pi tool
 
-`pi-subagents` registers all five tools by default. Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
+`pi-subagents` registers seven tools by default. Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
 
 | Workflow | Registered tools |
 | --- | --- |
-| **All delegation methods** (default) | Blocking `subagent` plus all four detached lifecycle tools |
-| **Async only** | `subagent_spawn`, `subagent_send`, `subagent_manage`, and `subagent_mailbox`; blocking `subagent` is omitted |
-| **Blocking only** | Blocking `subagent` only; equivalent to the existing `stateful.enabled: false` behavior |
+| **All delegation methods** (default) | Existing five delegation/lifecycle tools, `subagent_inspect`, and `subagent_consult` |
+| **Async only** | Four detached lifecycle tools plus `subagent_inspect`; blocking `subagent` and `subagent_consult` are omitted |
+| **Blocking only** | `subagent`, `subagent_consult`, and `subagent_inspect` |
+| **Disabled** | `subagent_inspect` only; delegation is disabled |
 
 The preview compares the selection with the tools registered in the current session, even when a manual settings edit is pending, and remains read-only until confirmation. Escape or **Cancel** leaves settings unchanged. Tool removal requires an extension reload because Pi does not expose extension tool unregistration. To avoid aborting work or removing isolated worktrees during `session_shutdown`, workflow changes are blocked while detached agents are retained; finish or clear them through **Current agents** first. Pi owns reload-error reporting and does not return a success result to extensions, so the save notification also tells users to run `/reload` if the tool surface does not refresh.
 
@@ -57,6 +60,8 @@ The available tools are:
 
 - `subagent` — delegate blocking single, parallel, fan-in, or chained batch work. The main agent cannot process queued steering until the call returns.
 - `subagent_spawn` and related lifecycle tools — when enabled, start reusable detached work, return immediately, and receive bounded completion messages automatically.
+- `subagent_inspect` — inspect agent/model/run/runtime metadata without launching work or changing state.
+- `subagent_consult` — run one ephemeral read-only consultation and wait for its answer.
 
 After each session starts, both delegation tools include a bounded parent-facing catalog of the agents
 available in that session. Entries show the source (`built-in`, `user`, or `project`) and the
@@ -72,6 +77,8 @@ Choose the API by lifecycle:
 | Broad research/review the current response does not depend on | Prefer one `subagent_spawn` covering related branches, when lifecycle tools are enabled |
 | Final-answer-dependent broad work with `completionDelivery: "auto-resume"` | Prefer one `subagent_spawn`; completion requests a synthesis turn |
 | Reusable history, follow-ups, or mailboxes | `subagent_spawn` and lifecycle tools, when enabled |
+| Side-effect-free agent/model/run diagnostics | `subagent_inspect` |
+| Synchronous reconnaissance, planning, or review that must not write | `subagent_consult`, when blocking delegation is enabled |
 | One simple or critical-path action the root can perform directly | No subagent |
 
 Execution modes:
@@ -169,6 +176,50 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
 }
 ```
 
+## 🔎 Read-only inspection
+
+`subagent_inspect` is registered in every workflow, including disabled delegation. It never starts a child, sends or acknowledges mailbox messages, interrupts or closes a run, changes settings, refreshes providers, resolves credentials, or modifies files.
+
+| Action | Parameters | Result |
+| --- | --- | --- |
+| `list_agents` | Optional `agentScope` (default `user`) and `limit` (default 32, maximum 100) | Bounded agent metadata and omission counts |
+| `get_agent` | Required `agent`; optional `agentScope` | One resolved definition, safe source path, configured tools, and consultation-effective tools; never the system prompt |
+| `list_runs` | Optional `includeClosed` and `limit` (default 50, maximum 100) | Metadata-only retained-run summaries and unread counts |
+| `get_run` | Required `agentId` | Safe `cwd`, current-task/error summaries, thinking level, policy, history count, and unread count |
+| `list_models` | Optional `limit` (default 50, maximum 100) | Session-scoped models, or the already-loaded available snapshot |
+| `status` | No additional fields | Effective workflow, runtime counts/transport, completion delivery, and consultation-resource setting |
+| `diagnose` | No additional fields | Structured `pass`, `warning`, and `fail` checks; failed checks are report data rather than a tool error |
+
+The schema rejects fields that do not belong to the selected action. Explicit `project` or `both` scope fails before project-agent discovery unless Pi already trusts the project. Run inspection never returns history output, stored context, or mailbox content; unread counts come from a metadata-only snapshot and do not acknowledge messages. Paths beneath the Pi agent directory use `~`, project paths are workspace-relative, model objects are projected through an allow-list, and model-facing text is bounded to 50 KiB or 2,000 lines.
+
+Compatibility: `subagent_manage({ "action": "list" })` remains supported with its existing behavior. Prefer `subagent_inspect` when a whole tool must be safe to activate on a read-only surface.
+
+## 📖 Read-only consultation
+
+`subagent_consult` is registered whenever blocking delegation is enabled. It runs exactly one synchronous, non-retained child with `--no-session`, `--no-extensions`, and only the effective intersection of the agent tools with `read`, `grep`, `find`, and `ls`. A missing tool list receives those four defaults; an explicit `tools: []` receives `--no-tools`; write, shell, lifecycle, custom, and extension tools cannot enter the child allow-list. The executor policy remains authoritative even when the task or agent prompt asks for implementation.
+
+```json
+{
+  "agent": "reviewer",
+  "task": "Inspect the authentication changes and report correctness and security findings with paths.",
+  "thinkingLevel": "high"
+}
+```
+
+The actionless schema requires `agent` and `task` and accepts optional `agentScope`, `confirmProjectAgents`, `cwd`, `timeoutMs`, and `thinkingLevel`. Project scope is rejected before discovery when the project is untrusted. A trusted project agent still asks for confirmation by default; non-interactive calls fail closed unless they explicitly send `confirmProjectAgents: false`. Declining an interactive confirmation returns a normal cancelled result without launching or charging a child.
+
+`consult.resources` controls automatically inherited instruction resources:
+
+| Value | Behavior |
+| --- | --- |
+| `"project-context"` (default) | Keep ordinary user context/system files and trusted project `AGENTS.md`, `CLAUDE.md`, and `SYSTEM.md`; disable skills and prompt templates |
+| `"none"` | Use only the package consultation base, selected agent prompt, and enforced read-only instruction |
+| `"all"` | Keep ordinarily discoverable trusted context/system/append-system files, skills, and prompt templates |
+
+Extensions remain disabled for all three values. For an untrusted current project, project resources are omitted; because Pi's context-file switch cannot separate user and project `AGENTS.md` files, `project-context` and `all` fail closed by disabling context files while still permitting the user `SYSTEM.md` selected by the extension. The setting is user-owned in `~/.pi/agent/pi-subagents.json`; projects cannot override it. An external or symlink-escaped `cwd` is accepted only with `consult.resources: "none"`, but this is not a path sandbox: read-only tools can still read an explicitly requested accessible absolute path.
+
+Result details report requested/effective tools and resources, agent/model/thinking/timeout metadata, and the facts that extensions, session persistence, and retained-agent state are disabled. Nested model usage is returned through Pi's usage field, so footer, `/session`, and RPC totals include consultation cost. Validation, trust, unsafe-cwd, and launch failures throw. Failures after model launch preserve bounded partial evidence and usage while the finalized Pi tool result is marked as an error. Abort, timeout, session replacement, and shutdown use the existing process-tree termination and temporary-file cleanup path.
+
 ## 🚀 Blocking batch examples
 
 Every example in this section calls `subagent` and keeps the main agent unavailable until the batch
@@ -258,14 +309,12 @@ Auto-resume is best-effort because Pi's custom-message API is fire-and-forget. S
 The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history. Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
 
 Run `/subagents` in TUI mode to open the standard primary manager. It leads with the current
-delegation workflow, human-readable async completion behavior, and active/retained counts. **Change
-delegation**, **Current agents**, and **Completion behavior** cover the common workflows; agent
-permissions, transport/runtime details, source, and settings path remain under **Advanced settings**.
+delegation workflow, human-readable async completion behavior, consultation-resource policy, and active/retained counts. **Change delegation**, **Current agents**, and **Settings** cover the common workflows; agent permissions, transport/runtime details, source, and settings path remain under **Advanced settings**.
 Escape returns from a nested screen to a newly refreshed manager; Ctrl+C closes the full flow.
 Exact workflow/reload and project-agent safety confirmations remain extension-owned because they
 guard live agent and trust-boundary policy rather than ordinary navigation.
 
-The direct routes remain predictable: `/subagents settings` changes user completion delivery and applies it immediately, including refreshing the model-facing spawn guidance; `/subagents status` reports current-session runtime values separately from the configured value, source, and path; `/subagents help` summarizes the single-command interface. In RPC mode, bare `/subagents` emits the same bounded status through Pi's notification protocol instead of opening a custom TUI. JSON and print modes do not emit ad hoc command output. Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
+The direct routes remain predictable: `/subagents settings` changes completion delivery and consultation resources and applies them immediately, including refreshing model-facing spawn guidance; `/subagents status` reports current-session runtime values separately from configured values, sources, and path; `/subagents help` summarizes the single-command interface. In RPC mode, bare `/subagents` emits the same bounded status through Pi's notification protocol instead of opening a custom TUI. JSON and print modes do not emit ad hoc command output. Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
 
 ```json
 {
@@ -285,11 +334,14 @@ The direct routes remain predictable: `/subagents settings` changes user complet
     "idleTtlMs": 3600000,
     "retentionDays": 30,
     "maxStoredAgents": 50
+  },
+  "consult": {
+    "resources": "project-context"
   }
 }
 ```
 
-The settings UI patches the raw JSON atomically and preserves unknown fields; it refuses to overwrite malformed or invalid settings. Supported Pi writers serialize the latest-document read and same-directory temporary-file rename through `pi-subagents.json.mutation-lock`. Editors and older extension versions do not participate in that lock, so avoid manual edits while a settings save is in progress. `blocking.enabled` defaults to `true`; set it to `false` for async-only delegation. `stateful.enabled` also defaults to `true`; its existing `false` value remains the blocking-only workflow. When stateful tools are enabled, their membership stays fixed across spawn, completion, interrupt, close, and mailbox transitions. This avoids lifecycle-driven tool-schema churn and preserves a stable provider prompt prefix for KV caching.
+The settings UI patches the raw JSON atomically and preserves unknown fields; it refuses to overwrite malformed or invalid settings. Supported Pi writers serialize the latest-document read and same-directory temporary-file rename through `pi-subagents.json.mutation-lock`. Editors and older extension versions do not participate in that lock, so avoid manual edits while a settings save is in progress. `blocking.enabled` defaults to `true`; set it to `false` for async-only delegation. `stateful.enabled` also defaults to `true`; its existing `false` value remains the blocking-only workflow. `consult.resources` defaults to `"project-context"`; the Settings UI applies a saved change to subsequent consultations immediately, while manual edits take effect on session start or `/reload`. When stateful tools are enabled, their membership stays fixed across spawn, completion, interrupt, close, and mailbox transitions. This avoids lifecycle-driven tool-schema churn and preserves a stable provider prompt prefix for KV caching.
 
 | Tool | Purpose |
 | --- | --- |
@@ -318,7 +370,7 @@ The action schemas are flat for provider compatibility and reject parameters tha
 
 Use the **Current agents** action in `/subagents` to inspect the indented agent tree, lifecycle state, unread count, and available actions, or to confirm clearing retained agents. Active turns are FIFO-limited by `maxActiveTurns`; excess retained work remains in `starting` state until a slot is available. `maxAgents` separately bounds running, queued, and idle records. `parentId` creates a bounded child relationship; subtree interrupt and close operate child-first.
 
-### Migrating from the seven-tool lifecycle surface
+### Migrating from the previous seven-tool lifecycle surface
 
 The five replaced names are intentionally not registered as aliases. Update explicit prompts and integrations as follows:
 
@@ -418,7 +470,7 @@ Compatibility: a valid legacy `pi-subagents-config.json` remains readable with a
 - Choose **Save changes** to write the draft, choose **Discard draft** to abandon it, or press Esc to
   return to agent selection without writing.
 - Save the default selection to remove a custom override and use the agent defaults again.
-- Deselect every tool and save to run that agent with no tools.
+- Deselect every tool and save to run that agent with no tools. An explicit empty list remains distinct from an absent list; blank `tools:` or `tools: []` in agent frontmatter also means no tools.
 
 Configured tool names that are not currently registered are preserved, so settings for tools from
 other extension sessions are not silently dropped.
@@ -520,7 +572,7 @@ The child event protocol limits each JSON line to 256 KiB. Captured output uses 
 - stderr: 16 KiB;
 - captured messages: 200.
 
-Truncated text includes a `truncated by pi-subagents` marker and details expose `truncated: true`. `PI_SUBAGENT_MAX_DEPTH` controls nested delegation depth and defaults to 1; child processes receive `PI_SUBAGENT_DEPTH` automatically.
+Truncated text includes a `truncated by pi-subagents` marker and details expose `truncated: true`. Inspection and consultation model-facing content also stops at 2,000 lines, whichever limit is reached first. `PI_SUBAGENT_MAX_DEPTH` controls nested delegation depth and defaults to 1; child processes receive `PI_SUBAGENT_DEPTH` automatically.
 
 ## 📡 Runtime status
 
@@ -528,7 +580,7 @@ While the `subagent` tool is running, `pi-subagents` publishes compact activity 
 
 ## 🔒 Safety notes
 
-Subagents have separate processes and context windows, but they are **not security sandboxes**. They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files. Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions.
+Subagents have separate processes and context windows, but they are **not security sandboxes**. They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files. Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions. `subagent_consult` prevents writes through its Pi tool surface and disables extensions, but it can read accessible paths, call the configured model over the network, and incur cost; its instruction-resource policy is not a filesystem or confidentiality boundary.
 
 The runner explicitly reports policy continuity in result details:
 
@@ -547,16 +599,20 @@ extensions/pi-subagents/
 ├── src/
 │   ├── index.ts                  # Pi package entrypoint
 │   ├── subagents.ts              # Extension registration and blocking tool schema
+│   ├── inspect.ts                # Side-effect-free metadata inspection tool
+│   ├── consult.ts                # Synchronous read-only consultation tool
+│   ├── consult-policy.ts         # Enforced read-only tool intersection
+│   ├── safe-text.ts              # Shared byte/line/path sanitization
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
 │   ├── stateful-tool-params.ts   # Consolidated action schemas and validation
-│   └── *.ts                      # Package-local discovery, execution, rendering, and config modules
+│   └── *.ts                      # Package-local discovery, execution, rendering, and settings modules
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json
 └── package.json
 ```
 
-`index.ts` is the Pi entrypoint and forwards to `subagents.ts`; the other source modules are internal. Workflow settings remain backward compatible: older files without `blocking.enabled` keep the five-tool default, existing `stateful.enabled: false` files remain blocking-only, and older package releases ignore the new `blocking` object. The package exposes its Pi extension through `package.json`:
+`index.ts` is the Pi entrypoint and forwards to `subagents.ts`; the other source modules are internal. Workflow settings remain backward compatible: older files without `blocking.enabled` receive the seven-tool default, existing `stateful.enabled: false` files expose blocking delegation plus inspection/consultation, and older package releases ignore and preserve the optional `consult` object. The package exposes its Pi extension through `package.json`:
 
 ```json
 {

--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -497,6 +497,8 @@ You are an API review subagent. Do not edit files. Check compatibility,
 test coverage, and migration risks. Report PASS/FAIL/PARTIAL with evidence.
 ```
 
+`tools` accepts either the comma-separated form above or a YAML string array such as `tools: [read, grep]`. An omitted field keeps the agent's default tools; blank, `null`, or `[]` explicitly selects no tools.
+
 `agentScope` is a top-level tool argument supplied per invocation. It is not a setting in
 `~/.pi/agent/pi-subagents.json` and does not belong in agent frontmatter. The parent-facing tool
 metadata discovers these definitions after session start and labels their source and required scope.
@@ -543,6 +545,7 @@ Each subprocess has a hard timeout to avoid runaway workers.
 
 - Set `timeoutMs` on the top-level call to apply a default for all jobs.
 - Set `timeoutMs` on a task, chain step, or aggregator to override it locally.
+- Valid timeout values range from 1 to 2,147,483,647 milliseconds, matching the runtime timer limit.
 - If omitted, the default is `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset.
 
 Set `thinkingLevel` to request one of Pi's supported levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Blocking subprocess calls pass the resolved value through `--thinking <level>`.

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -257,8 +257,11 @@ function loadAgentsFromDir(
 		const rawTools = frontmatter.tools;
 		let tools: string[] | undefined;
 		if (hasTools) {
-			if (rawTools === null || (Array.isArray(rawTools) && rawTools.length === 0)) {
+			if (rawTools === null) {
 				tools = [];
+			} else if (Array.isArray(rawTools)) {
+				if (!rawTools.every((tool): tool is string => typeof tool === "string")) continue;
+				tools = rawTools.map((tool) => tool.trim()).filter(Boolean);
 			} else if (typeof rawTools === "string") {
 				tools = rawTools
 					.split(",")

--- a/extensions/pi-subagents/src/agents.ts
+++ b/extensions/pi-subagents/src/agents.ts
@@ -41,6 +41,14 @@ export type SubagentTransportKind = "subprocess" | "in-process";
 
 export type CompletionDelivery = "next-turn" | "auto-resume";
 
+export const CONSULT_RESOURCE_POLICIES = ["project-context", "none", "all"] as const;
+
+export type ConsultResourcePolicy = (typeof CONSULT_RESOURCE_POLICIES)[number];
+
+export interface SubagentConsultSettings {
+	resources?: ConsultResourcePolicy;
+}
+
 export interface SubagentBlockingSettings {
 	enabled?: boolean;
 }
@@ -64,6 +72,7 @@ export interface SubagentSettings {
 	agents?: Record<string, SubagentAgentConfig>;
 	blocking?: SubagentBlockingSettings;
 	stateful?: SubagentRuntimeSettings;
+	consult?: SubagentConsultSettings;
 }
 
 const BUILT_IN_AGENTS: AgentConfig[] = [
@@ -238,20 +247,33 @@ function loadAgentsFromDir(
 			continue;
 		}
 
-		const { frontmatter, body } = parseFrontmatter<Record<string, string>>(loaded.content);
+		const { frontmatter, body } = parseFrontmatter<Record<string, unknown>>(loaded.content);
 
-		if (!frontmatter.name || !frontmatter.description) continue;
+		if (typeof frontmatter.name !== "string" || typeof frontmatter.description !== "string") {
+			continue;
+		}
 
-		const tools = frontmatter.tools
-			?.split(",")
-			.map((t: string) => t.trim())
-			.filter(Boolean);
+		const hasTools = hasOwn(frontmatter, "tools");
+		const rawTools = frontmatter.tools;
+		let tools: string[] | undefined;
+		if (hasTools) {
+			if (rawTools === null || (Array.isArray(rawTools) && rawTools.length === 0)) {
+				tools = [];
+			} else if (typeof rawTools === "string") {
+				tools = rawTools
+					.split(",")
+					.map((tool) => tool.trim())
+					.filter(Boolean);
+			} else {
+				continue;
+			}
+		}
 
 		agents.push({
 			name: frontmatter.name,
 			description: frontmatter.description,
-			tools: tools && tools.length > 0 ? tools : undefined,
-			model: frontmatter.model,
+			...(hasTools ? { tools: tools ?? [] } : {}),
+			model: typeof frontmatter.model === "string" ? frontmatter.model : undefined,
 			thinkingLevel: isThinkingLevel(frontmatter.thinkingLevel)
 				? frontmatter.thinkingLevel
 				: undefined,

--- a/extensions/pi-subagents/src/config-ui.ts
+++ b/extensions/pi-subagents/src/config-ui.ts
@@ -1,23 +1,25 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
-import { type CompletionDelivery, discoverAgents } from "./agents.js";
+import { type CompletionDelivery, type ConsultResourcePolicy, discoverAgents } from "./agents.js";
 import type { ManagedAgent } from "./registry.js";
 import {
 	type DelegationWorkflow,
 	hasOwn,
 	inspectCompletionDeliverySettings,
+	inspectConsultResourceSettings,
 	inspectDelegationWorkflowSettings,
 	readSubagentSettings,
 	sameToolSet,
 	uniqueToolNames,
 	updateAgentToolsSetting,
 	updateCompletionDeliverySetting,
+	updateConsultResourceSetting,
 	updateDelegationWorkflowSetting,
 } from "./settings.js";
 import { formatStatefulAgentLine, type StatefulSubagentRuntimeStatus } from "./stateful.js";
 
 const SUBCOMMANDS = [
-	{ value: "settings", label: "settings", description: "Configure completion behavior" },
+	{ value: "settings", label: "settings", description: "Configure subagent user settings" },
 	{ value: "status", label: "status", description: "Show effective subagent settings" },
 	{ value: "help", label: "help", description: "Show subagent settings help" },
 ];
@@ -26,7 +28,9 @@ const TOOL_VIEWPORT_SIZE = 10;
 export interface SubagentSettingsRuntime {
 	getBlockingEnabled(): boolean;
 	getCompletionDelivery(): CompletionDelivery;
+	getConsultResourcePolicy(): ConsultResourcePolicy;
 	setCompletionDelivery(value: CompletionDelivery): void;
+	setConsultResourcePolicy(value: ConsultResourcePolicy): void;
 	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
 	listAgents(includeClosed?: boolean): ManagedAgent[];
 	clearAgents(): Promise<number>;
@@ -114,7 +118,7 @@ async function showSubagentManager(
 		| "main"
 		| "workflow"
 		| "agents"
-		| "completion"
+		| "settings"
 		| "advanced"
 		| "status"
 		| "help"
@@ -124,6 +128,7 @@ async function showSubagentManager(
 		| "set-workflow"
 		| "clear-agents"
 		| "set-completion"
+		| "set-consult-resources"
 		| "load-agent-picker"
 		| "pick-agent"
 		| "toggle-tool"
@@ -154,10 +159,10 @@ async function showSubagentManager(
 							to: "agents",
 						},
 						{
-							id: "completion",
-							label: "Completion behavior",
-							description: "Choose whether async completion waits or resumes automatically",
-							to: "completion",
+							id: "settings",
+							label: "Settings",
+							description: "Configure async completion and read-only consultation resources",
+							to: "settings",
 						},
 						{
 							id: "advanced",
@@ -236,7 +241,7 @@ async function showSubagentManager(
 					hint: "back",
 				};
 			},
-			completion: () => completionSettingsScreen(),
+			settings: () => subagentSettingsScreen(runtime),
 			advanced: () => ({
 				kind: "actions",
 				title: "Advanced Subagent Settings",
@@ -388,6 +393,8 @@ async function showSubagentManager(
 				return { kind: "stay" };
 			},
 			"set-completion": async ({ value }) => applyCompletionSetting(value, ctx, runtime),
+			"set-consult-resources": async ({ value }) =>
+				applyConsultResourceSetting(value, ctx, runtime),
 			"load-agent-picker": async () => {
 				availableAgents = discoverAgents(ctx.cwd, "user", readSubagentSettings() ?? {}).agents;
 				if (availableAgents.length === 0) {
@@ -468,7 +475,7 @@ async function showSubagentSettings(
 	runtime: SubagentSettingsRuntime,
 	owner: MenuOwner,
 ) {
-	const snapshot = inspectCompletionDeliverySettings();
+	const snapshot = inspectConsultResourceSettings();
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) {
 			ctx.ui.notify(
@@ -479,11 +486,14 @@ async function showSubagentSettings(
 		return;
 	}
 	const generation = owner.generation;
-	const menu = defineMenu<undefined, "completion", "set-completion", ExtensionCommandContext>({
-		start: "completion",
-		screens: { completion: () => completionSettingsScreen() },
+	type SettingsAction = "set-completion" | "set-consult-resources";
+	const menu = defineMenu<undefined, "settings", SettingsAction, ExtensionCommandContext>({
+		start: "settings",
+		screens: { settings: () => subagentSettingsScreen(runtime) },
 		actions: {
 			"set-completion": async ({ value }) => applyCompletionSetting(value, ctx, runtime),
+			"set-consult-resources": async ({ value }) =>
+				applyConsultResourceSetting(value, ctx, runtime),
 		},
 	});
 	await runMenu(ctx, menu, {
@@ -493,17 +503,19 @@ async function showSubagentSettings(
 	});
 }
 
-function completionSettingsScreen() {
-	const snapshot = inspectCompletionDeliverySettings();
+function subagentSettingsScreen(runtime: SubagentSettingsRuntime) {
+	const completion = inspectCompletionDeliverySettings();
+	const consult = inspectConsultResourceSettings();
+	const error = completion.error ?? consult.error;
 	return {
 		kind: "settings" as const,
-		title: snapshot.error ? "Subagent User Settings · Read only" : "Subagent User Settings",
+		title: error ? "Subagent User Settings · Read only" : "Subagent User Settings",
 		lines: [
 			"Applies now and to future sessions",
-			safeTerminalText(snapshot.path),
-			...(snapshot.error ? [`Settings cannot be edited: ${safeTerminalText(snapshot.error)}`] : []),
+			safeTerminalText(consult.path),
+			...(error ? [`Settings cannot be edited: ${safeTerminalText(error)}`] : []),
 		],
-		items: snapshot.error
+		items: error
 			? []
 			: [
 					{
@@ -511,9 +523,18 @@ function completionSettingsScreen() {
 						label: "When async work finishes",
 						description:
 							"Wait for your next turn, or request one synthesis turn after the root settles.",
-						currentValue: completionLabel(snapshot.value),
+						currentValue: completionLabel(runtime.getCompletionDelivery()),
 						values: ["Wait until my next turn", "Resume automatically when finished"],
 						action: "set-completion" as const,
+					},
+					{
+						id: "consultResources",
+						label: "Read-only consultation resources",
+						description:
+							"Choose which trusted context, system, skill, and prompt resources a consultation inherits.",
+						currentValue: consultResourceLabel(runtime.getConsultResourcePolicy()),
+						values: ["Project context only", "No inherited resources", "All trusted resources"],
+						action: "set-consult-resources" as const,
 					},
 				],
 	};
@@ -532,6 +553,30 @@ function applyCompletionSetting(
 		updateCompletionDeliverySetting(next);
 		runtime.setCompletionDelivery(next);
 		ctx.ui.notify(`Saved and applied: ${completionLabel(next)}.`, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		ctx.ui.notify(`Subagent settings were not saved: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+}
+
+function applyConsultResourceSetting(
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+	runtime: SubagentSettingsRuntime,
+) {
+	const previous = runtime.getConsultResourcePolicy();
+	const next: ConsultResourcePolicy =
+		value === "No inherited resources"
+			? "none"
+			: value === "All trusted resources"
+				? "all"
+				: "project-context";
+	if (next === previous) return { kind: "stay" as const };
+	try {
+		updateConsultResourceSetting(next);
+		runtime.setConsultResourcePolicy(next);
+		ctx.ui.notify(`Saved and applied: ${consultResourceLabel(next)}.`, "info");
 		return { kind: "stay" as const };
 	} catch (error) {
 		ctx.ui.notify(`Subagent settings were not saved: ${formatError(error)}`, "error");
@@ -597,7 +642,7 @@ function helpLines(): string[] {
 	const snapshot = inspectCompletionDeliverySettings();
 	return [
 		"/subagents — choose delegation workflow, manage current agents, and configure agent tools",
-		"/subagents settings — configure async completion behavior",
+		"/subagents settings — configure async completion and read-only consultation resources",
 		"/subagents status — show current-session and user-setting values",
 		"/subagents help — show this help",
 		`User settings: ${safeTerminalText(snapshot.path)}`,
@@ -613,6 +658,7 @@ function formatManagerSummary(
 	return [
 		`Delegation: ${workflowLabel(current)}`,
 		`Completion: ${completionLabel(status.completionDelivery)}`,
+		`Consult resources: ${consultResourceLabel(runtime.getConsultResourcePolicy())}`,
 		`Agents: ${status.activeAgents} active · ${status.retainedAgents} retained`,
 		...(configured.value !== current
 			? [`Configured after reload: ${workflowLabel(configured.value)}`]
@@ -627,6 +673,7 @@ function formatStatus(
 	runtime?: SubagentSettingsRuntime,
 ): string {
 	const configuredWorkflow = inspectDelegationWorkflowSettings();
+	const consult = inspectConsultResourceSettings();
 	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
 	return [
 		"Current session",
@@ -640,6 +687,8 @@ function formatStatus(
 		`  Configured delegation: ${workflowLabel(configuredWorkflow.value)}`,
 		`  Completion source: ${snapshot.source}`,
 		`  Configured completion: ${completionLabel(snapshot.value)}`,
+		`  Consultation resources: ${consultResourceLabel(runtime?.getConsultResourcePolicy() ?? consult.value)}`,
+		`  Consultation resource source: ${consult.source}`,
 		`  Path: ${safeTerminalText(snapshot.path)}`,
 		configuredWorkflow.error || snapshot.error
 			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? "invalid settings")}`
@@ -688,13 +737,28 @@ function completionLabel(value: CompletionDelivery): string {
 	return value === "auto-resume" ? "Resume automatically when finished" : "Wait until my next turn";
 }
 
+function consultResourceLabel(value: ConsultResourcePolicy): string {
+	switch (value) {
+		case "project-context":
+			return "Project context only";
+		case "none":
+			return "No inherited resources";
+		case "all":
+			return "All trusted resources";
+	}
+}
+
 function workflowEffects(current: DelegationWorkflow, next: DelegationWorkflow): string[] {
 	const blockingEnabled = (value: DelegationWorkflow) =>
 		value === "all" || value === "blocking-only";
 	const asyncEnabled = (value: DelegationWorkflow) => value === "all" || value === "async-only";
 	const effects: string[] = [];
 	if (blockingEnabled(current) !== blockingEnabled(next)) {
-		effects.push(blockingEnabled(next) ? "Add blocking `subagent`" : "Remove blocking `subagent`");
+		effects.push(
+			blockingEnabled(next)
+				? "Add blocking `subagent` and read-only `subagent_consult`"
+				: "Remove blocking `subagent` and read-only `subagent_consult`",
+		);
 	}
 	if (asyncEnabled(current) !== asyncEnabled(next)) {
 		effects.push(

--- a/extensions/pi-subagents/src/consult-policy.ts
+++ b/extensions/pi-subagents/src/consult-policy.ts
@@ -1,0 +1,15 @@
+export const READ_ONLY_CONSULT_TOOLS = ["read", "grep", "find", "ls"] as const;
+
+const READ_ONLY_CONSULT_TOOL_SET = new Set<string>(READ_ONLY_CONSULT_TOOLS);
+
+export function resolveConsultTools(tools: readonly string[] | undefined): string[] {
+	if (tools === undefined) return [...READ_ONLY_CONSULT_TOOLS];
+	const seen = new Set<string>();
+	const effective: string[] = [];
+	for (const tool of tools) {
+		if (!READ_ONLY_CONSULT_TOOL_SET.has(tool) || seen.has(tool)) continue;
+		seen.add(tool);
+		effective.push(tool);
+	}
+	return effective;
+}

--- a/extensions/pi-subagents/src/consult.ts
+++ b/extensions/pi-subagents/src/consult.ts
@@ -19,17 +19,21 @@ import {
 } from "./agents.js";
 import { resolveConsultTools } from "./consult-policy.js";
 import { assertSubagentDepthAllowed, resolveDefaultSubagentTimeoutMs } from "./execution.js";
-import { DEFAULT_MAX_CONTEXT_BYTES } from "./limits.js";
+import {
+	DEFAULT_MAX_CONTEXT_BYTES,
+	DEFAULT_MAX_STDERR_BYTES,
+	MAX_SUBAGENT_TIMEOUT_MS,
+	truncateUtf8,
+} from "./limits.js";
 import {
 	type ChildLaunchPolicy,
-	formatResultFailure,
 	getResultFinalOutput,
 	isResultError,
 	runSingleAgent,
 	type SingleResult,
 	type SubagentDetails,
 } from "./runner.js";
-import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalText } from "./safe-text.js";
+import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalLine } from "./safe-text.js";
 import { DEFAULT_CONSULT_RESOURCE_POLICY, resolveSubagentThinkingLevel } from "./settings.js";
 
 const ConsultScopeSchema = StringEnum(["user", "project", "both"] as const, {
@@ -45,7 +49,7 @@ export const SubagentConsultParams = Type.Object(
 		agentScope: Type.Optional(ConsultScopeSchema),
 		confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
 		cwd: Type.Optional(Type.String({ minLength: 1 })),
-		timeoutMs: Type.Optional(Type.Number({ minimum: 1 })),
+		timeoutMs: Type.Optional(Type.Number({ minimum: 1, maximum: MAX_SUBAGENT_TIMEOUT_MS })),
 		thinkingLevel: Type.Optional(ConsultThinkingSchema),
 	},
 	{ additionalProperties: false },
@@ -208,9 +212,10 @@ function validateConsultParams(
 	if (unexpected) throw new Error(`subagent_consult does not accept ${unexpected}`);
 	const agent = requiredString(values.agent, "agent");
 	const task = requiredString(values.task, "task");
-	if (task.length > DEFAULT_MAX_CONTEXT_BYTES) {
+	if (task.includes("\0")) throw new Error("subagent_consult task must not contain NUL bytes");
+	if (Buffer.byteLength(task, "utf8") > DEFAULT_MAX_CONTEXT_BYTES) {
 		throw new Error(
-			`subagent_consult task must be at most ${DEFAULT_MAX_CONTEXT_BYTES} characters`,
+			`subagent_consult task must be at most ${DEFAULT_MAX_CONTEXT_BYTES} UTF-8 bytes`,
 		);
 	}
 	const agentScope = optionalScope(values.agentScope);
@@ -227,9 +232,10 @@ function validateConsultParams(
 		values.timeoutMs !== undefined &&
 		(typeof values.timeoutMs !== "number" ||
 			!Number.isFinite(values.timeoutMs) ||
-			values.timeoutMs < 1)
+			values.timeoutMs < 1 ||
+			values.timeoutMs > MAX_SUBAGENT_TIMEOUT_MS)
 	) {
-		throw new Error("subagent_consult timeoutMs must be a positive finite number");
+		throw new Error(`subagent_consult timeoutMs must be between 1 and ${MAX_SUBAGENT_TIMEOUT_MS}`);
 	}
 	if (values.thinkingLevel !== undefined && !isThinkingLevel(values.thinkingLevel)) {
 		throw new Error("subagent_consult thinkingLevel is invalid");
@@ -276,7 +282,7 @@ async function executeConsult(
 		}
 		const approved = await ctx.ui.confirm(
 			"Run project-local read-only agent?",
-			`Agent: ${safeTerminalText(agent.name)}\nSource: ${path.posix.join(".pi", "agents", path.basename(agent.filePath))}`,
+			`Agent: ${safeTerminalLine(agent.name, 256)}\nSource: ${safeTerminalLine(path.posix.join(".pi", "agents", path.basename(agent.filePath)))}`,
 		);
 		assertCurrentRequest(signal, isCurrent);
 		if (!approved) {
@@ -320,7 +326,7 @@ async function executeConsult(
 	}
 	const error = isResultError(result);
 	const output = error
-		? formatResultFailure(result)
+		? formatConsultFailure(result)
 		: getResultFinalOutput(result) || "(no output)";
 	const bounded = boundText(output);
 	const details: ConsultDetails = {
@@ -347,7 +353,7 @@ function resolveConsultSetup(
 	const resourcePolicy = settings?.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY;
 	if (!isWithin(cwd, workspace) && resourcePolicy !== "none") {
 		throw new Error(
-			`Subagent consultation cwd is outside the current workspace; consult.resources must be "none": ${safeTerminalText(cwd)}`,
+			`Subagent consultation cwd is outside the current workspace; consult.resources must be "none": ${safeTerminalLine(cwd)}`,
 		);
 	}
 	const effectiveTools = resolveConsultTools(agent.tools);
@@ -356,6 +362,11 @@ function resolveConsultSetup(
 	launchPolicy.tools = effectiveTools;
 	const thinkingLevel = resolveSubagentThinkingLevel([agent], agent.name, operation.thinkingLevel);
 	const timeoutMs = operation.timeoutMs ?? agent.timeoutMs ?? resolveDefaultSubagentTimeoutMs();
+	if (!Number.isFinite(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_SUBAGENT_TIMEOUT_MS) {
+		throw new Error(
+			`Subagent consultation timeout must be between 1 and ${MAX_SUBAGENT_TIMEOUT_MS}ms`,
+		);
+	}
 	const childAgent: AgentConfig = {
 		...agent,
 		tools: effectiveTools,
@@ -373,7 +384,7 @@ function resolveConsultSetup(
 		agentSource: agent.source,
 		agentScope: operation.agentScope,
 		cwd: safeDisplayPath(cwd, workspace),
-		model: agent.model ? safeTerminalText(agent.model) : undefined,
+		model: agent.model ? boundedPrivateText(agent.model, 256) : undefined,
 		thinkingLevel,
 		timeoutMs,
 		policy: {
@@ -482,13 +493,38 @@ function discoverSystemPrompt(workspace: string, projectTrusted: boolean): strin
 		path.join(getAgentDir(), "SYSTEM.md"),
 	];
 	for (const candidate of candidates) {
-		try {
-			if (fs.statSync(candidate).isFile()) return fs.readFileSync(candidate, "utf8");
-		} catch {
-			// Match Pi resource discovery: an unreadable optional prompt is skipped.
-		}
+		const prompt = readBoundedOptionalPrompt(candidate);
+		if (prompt !== undefined) return prompt;
 	}
 	return undefined;
+}
+
+function readBoundedOptionalPrompt(filePath: string): string | undefined {
+	let descriptor: number | undefined;
+	try {
+		descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+		if (!fs.fstatSync(descriptor).isFile()) return undefined;
+		const buffer = Buffer.alloc(DEFAULT_MAX_CONTEXT_BYTES + 4);
+		let bytesRead = 0;
+		while (bytesRead < buffer.length) {
+			const next = fs.readSync(descriptor, buffer, bytesRead, buffer.length - bytesRead, bytesRead);
+			if (next === 0) break;
+			bytesRead += next;
+		}
+		return truncateUtf8(buffer.subarray(0, bytesRead).toString("utf8"), DEFAULT_MAX_CONTEXT_BYTES)
+			.text;
+	} catch {
+		// Match Pi resource discovery: an unreadable optional prompt is skipped.
+		return undefined;
+	} finally {
+		if (descriptor !== undefined) {
+			try {
+				fs.closeSync(descriptor);
+			} catch {
+				// Optional prompt cleanup must not make consultation discovery fail.
+			}
+		}
+	}
 }
 
 function discoverAppendSystemPrompts(cwd: string, projectTrusted: boolean): string[] {
@@ -508,20 +544,34 @@ function discoverAppendSystemPrompts(cwd: string, projectTrusted: boolean): stri
 function projectChildResult(result: SingleResult): Record<string, unknown> {
 	return {
 		exitCode: result.exitCode,
-		stopReason: result.stopReason,
+		stopReason:
+			typeof result.stopReason === "string"
+				? boundedPrivateText(result.stopReason, 256)
+				: undefined,
 		timedOut: result.timedOut,
 		aborted: result.aborted,
 		truncated: result.truncated,
 		malformedEvents: result.malformedEvents,
 		processStarted: result.processStarted,
-		actualProvider: result.actualProvider ? safeTerminalText(result.actualProvider) : undefined,
-		actualModel: result.actualModel ? safeTerminalText(result.actualModel) : undefined,
+		actualProvider: result.actualProvider
+			? boundedPrivateText(result.actualProvider, 256)
+			: undefined,
+		actualModel: result.actualModel ? boundedPrivateText(result.actualModel, 256) : undefined,
 		partialOutput: result.finalOutput
 			? boundedPrivateText(result.finalOutput, 8 * 1024)
 			: undefined,
 		error: result.errorMessage ? boundedPrivateText(result.errorMessage, 2 * 1024) : undefined,
 		usage: { ...result.usage },
 	};
+}
+
+function formatConsultFailure(result: SingleResult): string {
+	const rawError = result.errorMessage || result.stderr.trim();
+	const error = rawError ? boundedPrivateText(rawError, DEFAULT_MAX_STDERR_BYTES) : "";
+	const output = getResultFinalOutput(result);
+	return error && output
+		? `${error}\n\nPartial output:\n${output}`
+		: error || output || "(no output)";
 }
 
 function usageFromResult(result: SingleResult): Usage {
@@ -550,7 +600,7 @@ function canonicalDirectory(value: string, label: string): string {
 		return resolved;
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
-		throw new Error(`Invalid ${label}: ${safeTerminalText(value)} (${reason})`);
+		throw new Error(`Invalid ${label}: ${safeTerminalLine(value)} (${safeTerminalLine(reason)})`);
 	}
 }
 

--- a/extensions/pi-subagents/src/consult.ts
+++ b/extensions/pi-subagents/src/consult.ts
@@ -1,0 +1,608 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { StringEnum, type Usage } from "@earendil-works/pi-ai";
+import {
+	type ExtensionAPI,
+	type ExtensionContext,
+	getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import {
+	type AgentConfig,
+	type AgentScope,
+	type ConsultResourcePolicy,
+	discoverAgents,
+	isThinkingLevel,
+	type SubagentSettings,
+	THINKING_LEVELS,
+} from "./agents.js";
+import { resolveConsultTools } from "./consult-policy.js";
+import { assertSubagentDepthAllowed, resolveDefaultSubagentTimeoutMs } from "./execution.js";
+import { DEFAULT_MAX_CONTEXT_BYTES } from "./limits.js";
+import {
+	type ChildLaunchPolicy,
+	formatResultFailure,
+	getResultFinalOutput,
+	isResultError,
+	runSingleAgent,
+	type SingleResult,
+	type SubagentDetails,
+} from "./runner.js";
+import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalText } from "./safe-text.js";
+import { DEFAULT_CONSULT_RESOURCE_POLICY, resolveSubagentThinkingLevel } from "./settings.js";
+
+const ConsultScopeSchema = StringEnum(["user", "project", "both"] as const, {
+	default: "user",
+	description: "Agent definition scope. Project scopes require a trusted project.",
+});
+const ConsultThinkingSchema = StringEnum(THINKING_LEVELS);
+
+export const SubagentConsultParams = Type.Object(
+	{
+		agent: Type.String({ minLength: 1 }),
+		task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
+		agentScope: Type.Optional(ConsultScopeSchema),
+		confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
+		cwd: Type.Optional(Type.String({ minLength: 1 })),
+		timeoutMs: Type.Optional(Type.Number({ minimum: 1 })),
+		thinkingLevel: Type.Optional(ConsultThinkingSchema),
+	},
+	{ additionalProperties: false },
+);
+
+export type SubagentConsultParams = Static<typeof SubagentConsultParams>;
+
+export interface ConsultChildRequest {
+	agent: AgentConfig;
+	task: string;
+	cwd: string;
+	agentScope: AgentScope;
+	thinkingLevel?: (typeof THINKING_LEVELS)[number];
+	timeoutMs: number;
+	effectiveTools: string[];
+	resourcePolicy: ConsultResourcePolicy;
+	launchPolicy: ChildLaunchPolicy;
+	signal: AbortSignal;
+	onUpdate?: (result: SingleResult) => void;
+}
+
+export interface RegisterSubagentConsultOptions {
+	getSettings(): SubagentSettings | undefined;
+	runChild?: (request: ConsultChildRequest) => Promise<SingleResult>;
+	invocationOverride?: { command: string; argsPrefix?: string[] };
+}
+
+export interface ConsultDetails {
+	agent: string;
+	agentSource: string;
+	agentScope: AgentScope;
+	cwd: string;
+	model?: string;
+	thinkingLevel?: string;
+	timeoutMs: number;
+	policy: {
+		requestedTools: string[] | null;
+		effectiveTools: string[];
+		requestedResources: ConsultResourcePolicy;
+		effectiveResources: {
+			policy: ConsultResourcePolicy;
+			projectResources: boolean;
+			contextFiles: boolean;
+			skills: boolean;
+			promptTemplates: boolean;
+		};
+		extensions: "disabled";
+		sessionPersistence: "disabled";
+		retainedAgent: false;
+	};
+	child?: Record<string, unknown>;
+	cancelled?: boolean;
+	isError?: boolean;
+	truncated?: boolean;
+}
+
+const READ_ONLY_INSTRUCTION = [
+	"This is a read-only consultation.",
+	"Use only the tools made available by the executor to inspect and reason about existing content.",
+	"Do not claim to edit files, run shell commands, mutate state, or persist a session.",
+	"If the task asks for implementation, return analysis or instructions instead of claiming changes.",
+].join("\n");
+
+const MINIMAL_CONSULT_SYSTEM_PROMPT =
+	"You are a read-only consultation assistant. Analyze the delegated task using only executor-provided capabilities and return a grounded answer.";
+
+export function registerSubagentConsult(
+	pi: ExtensionAPI,
+	options: RegisterSubagentConsultOptions,
+): void {
+	let generation = 0;
+	const active = new Set<AbortController>();
+	const activeChildren = new Set<Promise<SingleResult>>();
+	const cancelActive = (reason: string) => {
+		generation++;
+		for (const controller of active) {
+			controller.abort(new DOMException(reason, "AbortError"));
+		}
+		active.clear();
+	};
+	const cancelAndWaitForChildren = async (reason: string) => {
+		cancelActive(reason);
+		await Promise.allSettled([...activeChildren]);
+	};
+	pi.on("session_start", () => cancelAndWaitForChildren("Subagent consultation session replaced"));
+	pi.on("session_shutdown", () =>
+		cancelAndWaitForChildren("Subagent consultation session shut down"),
+	);
+
+	pi.registerTool<typeof SubagentConsultParams, ConsultDetails>({
+		name: "subagent_consult",
+		label: "Consult Read-only Subagent",
+		description:
+			"Run one ephemeral subagent synchronously under enforced read-only tool and resource policies and return its answer. The child can use only the effective subset of Pi's built-in read, grep, find, and ls tools. Shell commands, file writes, extension tools, detached lifecycle operations, and persistent agent state are disabled.",
+		promptSnippet: "Consult one constrained read-only subagent and wait for its answer",
+		promptGuidelines: [
+			"Use subagent_consult for bounded reconnaissance, planning, or review whose result is required in the current turn.",
+			"Implementation-shaped tasks remain read-only and can return only analysis or instructions.",
+		],
+		parameters: SubagentConsultParams,
+		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const operation = validateConsultParams(params);
+			assertSubagentDepthAllowed();
+			if (signal?.aborted) throw abortError("Subagent consultation was aborted before start");
+			const ownerGeneration = generation;
+			const ownedController = new AbortController();
+			active.add(ownedController);
+			const combined = combineAbortSignals(signal, ownedController.signal);
+			try {
+				return await executeConsult(
+					operation,
+					ctx,
+					combined.signal,
+					options,
+					(partial) => {
+						if (ownerGeneration !== generation || combined.signal.aborted) return;
+						onUpdate?.(partial);
+					},
+					() => ownerGeneration === generation,
+					(child) => {
+						activeChildren.add(child);
+						void child.then(
+							() => activeChildren.delete(child),
+							() => activeChildren.delete(child),
+						);
+					},
+				);
+			} finally {
+				combined.dispose();
+				active.delete(ownedController);
+			}
+		},
+	});
+	pi.on("tool_result", (event) => {
+		if (event.toolName !== "subagent_consult") return;
+		if ((event.details as ConsultDetails | undefined)?.isError) return { isError: true };
+	});
+}
+
+function validateConsultParams(
+	params: unknown,
+): Required<Pick<SubagentConsultParams, "agent" | "task" | "agentScope" | "confirmProjectAgents">> &
+	Pick<SubagentConsultParams, "cwd" | "timeoutMs" | "thinkingLevel"> {
+	if (!params || typeof params !== "object" || Array.isArray(params)) {
+		throw new Error("subagent_consult parameters must be an object");
+	}
+	const values = params as Record<string, unknown>;
+	const allowed = [
+		"agent",
+		"task",
+		"agentScope",
+		"confirmProjectAgents",
+		"cwd",
+		"timeoutMs",
+		"thinkingLevel",
+	];
+	const unexpected = Object.keys(values).find(
+		(key) => values[key] !== undefined && !allowed.includes(key),
+	);
+	if (unexpected) throw new Error(`subagent_consult does not accept ${unexpected}`);
+	const agent = requiredString(values.agent, "agent");
+	const task = requiredString(values.task, "task");
+	if (task.length > DEFAULT_MAX_CONTEXT_BYTES) {
+		throw new Error(
+			`subagent_consult task must be at most ${DEFAULT_MAX_CONTEXT_BYTES} characters`,
+		);
+	}
+	const agentScope = optionalScope(values.agentScope);
+	if (
+		values.confirmProjectAgents !== undefined &&
+		typeof values.confirmProjectAgents !== "boolean"
+	) {
+		throw new Error("subagent_consult confirmProjectAgents must be boolean");
+	}
+	if (values.cwd !== undefined && (typeof values.cwd !== "string" || !values.cwd.trim())) {
+		throw new Error("subagent_consult cwd must be a non-empty string");
+	}
+	if (
+		values.timeoutMs !== undefined &&
+		(typeof values.timeoutMs !== "number" ||
+			!Number.isFinite(values.timeoutMs) ||
+			values.timeoutMs < 1)
+	) {
+		throw new Error("subagent_consult timeoutMs must be a positive finite number");
+	}
+	if (values.thinkingLevel !== undefined && !isThinkingLevel(values.thinkingLevel)) {
+		throw new Error("subagent_consult thinkingLevel is invalid");
+	}
+	return {
+		agent,
+		task,
+		agentScope,
+		confirmProjectAgents: values.confirmProjectAgents !== false,
+		cwd: values.cwd as string | undefined,
+		timeoutMs: values.timeoutMs as number | undefined,
+		thinkingLevel: values.thinkingLevel as (typeof THINKING_LEVELS)[number] | undefined,
+	};
+}
+
+async function executeConsult(
+	operation: ReturnType<typeof validateConsultParams>,
+	ctx: ExtensionContext,
+	signal: AbortSignal,
+	options: RegisterSubagentConsultOptions,
+	emitUpdate: (partial: AgentToolResult<ConsultDetails>) => void,
+	isCurrent: () => boolean,
+	trackChild: (child: Promise<SingleResult>) => void,
+): Promise<AgentToolResult<ConsultDetails>> {
+	if (
+		(operation.agentScope === "project" || operation.agentScope === "both") &&
+		!ctx.isProjectTrusted()
+	) {
+		throw new Error("Project-local subagent definitions require a trusted project");
+	}
+	const settings = options.getSettings();
+	const discovery = discoverAgents(ctx.cwd, operation.agentScope, settings);
+	const agent = discovery.agents.find((candidate) => candidate.name === operation.agent);
+	if (!agent) {
+		throw new Error(`Unknown subagent definition: ${boundedPrivateText(operation.agent, 256)}`);
+	}
+	const setup = resolveConsultSetup(operation, agent, settings, ctx);
+
+	if (agent.source === "project" && operation.confirmProjectAgents) {
+		if (!ctx.hasUI) {
+			throw new Error(
+				"Project-local subagent confirmation requires UI; pass confirmProjectAgents: false explicitly in a trusted project",
+			);
+		}
+		const approved = await ctx.ui.confirm(
+			"Run project-local read-only agent?",
+			`Agent: ${safeTerminalText(agent.name)}\nSource: ${path.posix.join(".pi", "agents", path.basename(agent.filePath))}`,
+		);
+		assertCurrentRequest(signal, isCurrent);
+		if (!approved) {
+			return {
+				content: [{ type: "text", text: "Read-only subagent consultation cancelled." }],
+				details: { ...setup.details, cancelled: true },
+			};
+		}
+	}
+	assertCurrentRequest(signal, isCurrent);
+	const runChild = options.runChild ?? ((request) => runConsultChild(request, options));
+	const child = runChild({
+		agent: setup.agent,
+		task: operation.task,
+		cwd: setup.cwd,
+		agentScope: operation.agentScope,
+		thinkingLevel: setup.thinkingLevel,
+		timeoutMs: setup.timeoutMs,
+		effectiveTools: setup.effectiveTools,
+		resourcePolicy: setup.resourcePolicy,
+		launchPolicy: setup.launchPolicy,
+		signal,
+		onUpdate: (result) => {
+			if (signal.aborted || !isCurrent()) return;
+			emitUpdate(consultUpdate(result, setup.details));
+		},
+	});
+	trackChild(child);
+	const result = await child;
+	if (!isCurrent()) throw abortError("Subagent consultation owner was replaced");
+	if (result.aborted && !result.processStarted) {
+		throw abortError(result.errorMessage || "Subagent consultation was aborted before launch");
+	}
+	if (result.launchFailed) {
+		throw new Error(
+			boundedPrivateText(
+				result.errorMessage || result.stderr.trim() || "Subagent consultation failed to launch",
+				2 * 1024,
+			),
+		);
+	}
+	const error = isResultError(result);
+	const output = error
+		? formatResultFailure(result)
+		: getResultFinalOutput(result) || "(no output)";
+	const bounded = boundText(output);
+	const details: ConsultDetails = {
+		...setup.details,
+		child: projectChildResult(result),
+		...(error ? { isError: true } : {}),
+		...(bounded.truncated ? { truncated: true } : {}),
+	};
+	return {
+		content: [{ type: "text", text: bounded.text }],
+		details,
+		usage: usageFromResult(result),
+	};
+}
+
+function resolveConsultSetup(
+	operation: ReturnType<typeof validateConsultParams>,
+	agent: AgentConfig,
+	settings: SubagentSettings | undefined,
+	ctx: ExtensionContext,
+) {
+	const cwd = canonicalDirectory(operation.cwd ?? ctx.cwd, "subagent consultation cwd");
+	const workspace = canonicalDirectory(ctx.cwd, "current workspace");
+	const resourcePolicy = settings?.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY;
+	if (!isWithin(cwd, workspace) && resourcePolicy !== "none") {
+		throw new Error(
+			`Subagent consultation cwd is outside the current workspace; consult.resources must be "none": ${safeTerminalText(cwd)}`,
+		);
+	}
+	const effectiveTools = resolveConsultTools(agent.tools);
+	const projectTrusted = ctx.isProjectTrusted();
+	const launchPolicy = resourceLaunchPolicy(resourcePolicy, projectTrusted, workspace);
+	launchPolicy.tools = effectiveTools;
+	const thinkingLevel = resolveSubagentThinkingLevel([agent], agent.name, operation.thinkingLevel);
+	const timeoutMs = operation.timeoutMs ?? agent.timeoutMs ?? resolveDefaultSubagentTimeoutMs();
+	const childAgent: AgentConfig = {
+		...agent,
+		tools: effectiveTools,
+		systemPrompt: [agent.systemPrompt, READ_ONLY_INSTRUCTION].filter(Boolean).join("\n\n"),
+	};
+	const effectiveResources = {
+		policy: resourcePolicy,
+		projectResources: projectTrusted && resourcePolicy !== "none",
+		contextFiles: !launchPolicy.disableContextFiles,
+		skills: !launchPolicy.disableSkills,
+		promptTemplates: !launchPolicy.disablePromptTemplates,
+	};
+	const details: ConsultDetails = {
+		agent: boundedPrivateText(agent.name, 256),
+		agentSource: agent.source,
+		agentScope: operation.agentScope,
+		cwd: safeDisplayPath(cwd, workspace),
+		model: agent.model ? safeTerminalText(agent.model) : undefined,
+		thinkingLevel,
+		timeoutMs,
+		policy: {
+			requestedTools:
+				agent.tools === undefined
+					? null
+					: agent.tools.slice(0, 100).map((tool) => boundedPrivateText(tool, 256)),
+			effectiveTools,
+			requestedResources: resourcePolicy,
+			effectiveResources,
+			extensions: "disabled",
+			sessionPersistence: "disabled",
+			retainedAgent: false,
+		},
+	};
+	return {
+		agent: childAgent,
+		cwd,
+		resourcePolicy,
+		effectiveTools,
+		thinkingLevel,
+		timeoutMs,
+		launchPolicy,
+		details,
+	};
+}
+
+async function runConsultChild(
+	request: ConsultChildRequest,
+	options: RegisterSubagentConsultOptions,
+): Promise<SingleResult> {
+	return runSingleAgent(
+		request.cwd,
+		[request.agent],
+		request.agent.name,
+		request.task,
+		request.cwd,
+		undefined,
+		request.signal,
+		request.thinkingLevel,
+		request.timeoutMs,
+		(partial) => {
+			const result = partial.details.results[0];
+			if (result) request.onUpdate?.(result);
+		},
+		(results): SubagentDetails => ({
+			mode: "single",
+			agentScope: request.agentScope,
+			projectAgentsDir: null,
+			results,
+		}),
+		options.invocationOverride,
+		request.launchPolicy,
+	);
+}
+
+function consultUpdate(
+	result: SingleResult,
+	details: ConsultDetails,
+): AgentToolResult<ConsultDetails> {
+	const output = boundText(getResultFinalOutput(result) || "(running...)");
+	return {
+		content: [{ type: "text", text: output.text }],
+		details: { ...details, child: projectChildResult(result) },
+	};
+}
+
+function resourceLaunchPolicy(
+	policy: ConsultResourcePolicy,
+	projectTrusted: boolean,
+	workspace: string,
+): ChildLaunchPolicy {
+	if (policy === "none") {
+		return {
+			disableExtensions: true,
+			disableSkills: true,
+			disablePromptTemplates: true,
+			disableContextFiles: true,
+			projectTrust: false,
+			baseSystemPrompt: MINIMAL_CONSULT_SYSTEM_PROMPT,
+		};
+	}
+	const baseSystemPrompt = discoverSystemPrompt(workspace, projectTrusted);
+	if (policy === "project-context") {
+		return {
+			disableExtensions: true,
+			disableSkills: true,
+			disablePromptTemplates: true,
+			disableContextFiles: !projectTrusted,
+			projectTrust: projectTrusted,
+			baseSystemPrompt,
+		};
+	}
+	return {
+		disableExtensions: true,
+		disableContextFiles: !projectTrusted,
+		projectTrust: projectTrusted,
+		baseSystemPrompt,
+		appendSystemPromptPaths: discoverAppendSystemPrompts(workspace, projectTrusted),
+	};
+}
+
+function discoverSystemPrompt(workspace: string, projectTrusted: boolean): string | undefined {
+	const candidates = [
+		...(projectTrusted ? [path.join(workspace, ".pi", "SYSTEM.md")] : []),
+		path.join(getAgentDir(), "SYSTEM.md"),
+	];
+	for (const candidate of candidates) {
+		try {
+			if (fs.statSync(candidate).isFile()) return fs.readFileSync(candidate, "utf8");
+		} catch {
+			// Match Pi resource discovery: an unreadable optional prompt is skipped.
+		}
+	}
+	return undefined;
+}
+
+function discoverAppendSystemPrompts(cwd: string, projectTrusted: boolean): string[] {
+	const candidates = [
+		path.join(getAgentDir(), "APPEND_SYSTEM.md"),
+		...(projectTrusted ? [path.join(cwd, ".pi", "APPEND_SYSTEM.md")] : []),
+	];
+	return candidates.filter((candidate) => {
+		try {
+			return fs.statSync(candidate).isFile();
+		} catch {
+			return false;
+		}
+	});
+}
+
+function projectChildResult(result: SingleResult): Record<string, unknown> {
+	return {
+		exitCode: result.exitCode,
+		stopReason: result.stopReason,
+		timedOut: result.timedOut,
+		aborted: result.aborted,
+		truncated: result.truncated,
+		malformedEvents: result.malformedEvents,
+		processStarted: result.processStarted,
+		actualProvider: result.actualProvider ? safeTerminalText(result.actualProvider) : undefined,
+		actualModel: result.actualModel ? safeTerminalText(result.actualModel) : undefined,
+		partialOutput: result.finalOutput
+			? boundedPrivateText(result.finalOutput, 8 * 1024)
+			: undefined,
+		error: result.errorMessage ? boundedPrivateText(result.errorMessage, 2 * 1024) : undefined,
+		usage: { ...result.usage },
+	};
+}
+
+function usageFromResult(result: SingleResult): Usage {
+	return {
+		input: result.usage.input,
+		output: result.usage.output,
+		cacheRead: result.usage.cacheRead,
+		cacheWrite: result.usage.cacheWrite,
+		totalTokens:
+			result.usage.totalTokens ??
+			result.usage.input + result.usage.output + result.usage.cacheRead + result.usage.cacheWrite,
+		cost: {
+			input: result.usage.costInput ?? 0,
+			output: result.usage.costOutput ?? 0,
+			cacheRead: result.usage.costCacheRead ?? 0,
+			cacheWrite: result.usage.costCacheWrite ?? 0,
+			total: result.usage.cost,
+		},
+	};
+}
+
+function canonicalDirectory(value: string, label: string): string {
+	try {
+		const resolved = fs.realpathSync(value);
+		if (!fs.statSync(resolved).isDirectory()) throw new Error("not a directory");
+		return resolved;
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid ${label}: ${safeTerminalText(value)} (${reason})`);
+	}
+}
+
+function isWithin(candidate: string, root: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function assertCurrentRequest(signal: AbortSignal, isCurrent: () => boolean): void {
+	if (signal.aborted || !isCurrent()) throw abortError("Subagent consultation owner was replaced");
+}
+
+function abortError(message: string): Error {
+	const error = new Error(message);
+	error.name = "AbortError";
+	return error;
+}
+
+function combineAbortSignals(
+	external: AbortSignal | undefined,
+	owned: AbortSignal,
+): { signal: AbortSignal; dispose(): void } {
+	const controller = new AbortController();
+	const signals = [external, owned].filter((value): value is AbortSignal => value !== undefined);
+	const abort = (signal: AbortSignal) => {
+		if (!controller.signal.aborted) controller.abort(signal.reason);
+	};
+	const listeners = signals.map((signal) => {
+		const listener = () => abort(signal);
+		if (signal.aborted) abort(signal);
+		else signal.addEventListener("abort", listener, { once: true });
+		return { signal, listener };
+	});
+	return {
+		signal: controller.signal,
+		dispose() {
+			for (const { signal, listener } of listeners) {
+				signal.removeEventListener("abort", listener);
+			}
+		},
+	};
+}
+
+function requiredString(value: unknown, name: string): string {
+	if (typeof value !== "string" || !value.trim()) {
+		throw new Error(`subagent_consult requires ${name}`);
+	}
+	return value;
+}
+
+function optionalScope(value: unknown): AgentScope {
+	if (value === undefined) return "user";
+	if (value === "user" || value === "project" || value === "both") return value;
+	throw new Error("subagent_consult agentScope must be user, project, or both");
+}

--- a/extensions/pi-subagents/src/execution.ts
+++ b/extensions/pi-subagents/src/execution.ts
@@ -19,6 +19,7 @@ import {
 	type SingleResult,
 	type SubagentDetails,
 } from "./runner.js";
+import { safeTerminalLine } from "./safe-text.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
 
 const MAX_PARALLEL_TASKS = 8;
@@ -107,6 +108,9 @@ export async function executeSubagent(
 ): Promise<AgentToolResult<SubagentDetails> & { isError?: boolean }> {
 	assertSubagentDepthAllowed();
 	const agentScope: AgentScope = params.agentScope ?? "user";
+	if ((agentScope === "project" || agentScope === "both") && !ctx.isProjectTrusted()) {
+		throw new Error("Project-local subagent definitions require a trusted project");
+	}
 	const aggregator = hasUsableAggregator(params.aggregator) ? params.aggregator : undefined;
 	const config = readSubagentSettings();
 	const discovery = discoverAgents(ctx.cwd, agentScope, config);
@@ -168,8 +172,10 @@ export async function executeSubagent(
 				throw new Error("Project-local subagent definitions require a trusted project");
 			}
 			if (confirmProjectAgents && ctx.hasUI) {
-				const names = projectAgentsRequested.map((a) => a.name).join(", ");
-				const dir = discovery.projectAgentsDir ?? "(unknown)";
+				const names = projectAgentsRequested
+					.map((agent) => safeTerminalLine(agent.name, 256))
+					.join(", ");
+				const dir = safeTerminalLine(discovery.projectAgentsDir ?? "(unknown)");
 				const ok = await ctx.ui.confirm(
 					"Run project-local agents?",
 					`Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`,

--- a/extensions/pi-subagents/src/inspect.ts
+++ b/extensions/pi-subagents/src/inspect.ts
@@ -1,0 +1,405 @@
+import * as path from "node:path";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
+import { resolveConsultTools } from "./consult-policy.js";
+import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "./registry.js";
+import { boundedPrivateText, boundText, safeDisplayPath } from "./safe-text.js";
+import {
+	inspectConsultResourceSettings,
+	inspectDelegationWorkflowSettings,
+	inspectSubagentSettings,
+	resolveDelegationWorkflow,
+} from "./settings.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+
+const INSPECT_ACTIONS = [
+	"list_agents",
+	"get_agent",
+	"list_runs",
+	"get_run",
+	"list_models",
+	"status",
+	"diagnose",
+] as const;
+
+const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
+	default: "user",
+	description: "Agent definition scope. Project scopes require a trusted project.",
+});
+
+const LimitSchema = Type.Number({ minimum: 1, maximum: 100, multipleOf: 1 });
+const MAX_DETAILS_LIST_BYTES = 40 * 1024;
+
+export const SubagentInspectParams = Type.Object(
+	{
+		action: StringEnum(INSPECT_ACTIONS),
+		agent: Type.Optional(Type.String({ minLength: 1 })),
+		agentId: Type.Optional(Type.String({ minLength: 1 })),
+		agentScope: Type.Optional(AgentScopeSchema),
+		limit: Type.Optional(LimitSchema),
+		includeClosed: Type.Optional(Type.Boolean({ default: false })),
+	},
+	{ additionalProperties: false },
+);
+
+export type SubagentInspectParams = Static<typeof SubagentInspectParams>;
+
+export interface SubagentInspectRuntime {
+	getBlockingEnabled(): boolean;
+	getConsultResourcePolicy(): "project-context" | "none" | "all";
+	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
+	listRunInspection(includeClosed?: boolean): AgentRunInspectionSummary[];
+	getRunInspection(agentId: string): AgentRunInspectionDetail | undefined;
+}
+
+interface InspectToolResult {
+	content: Array<{ type: "text"; text: string }>;
+	details: Record<string, unknown>;
+}
+
+type ValidatedInspectOperation =
+	| { action: "list_agents"; agentScope: AgentScope; limit: number }
+	| { action: "get_agent"; agent: string; agentScope: AgentScope }
+	| { action: "list_runs"; includeClosed: boolean; limit: number }
+	| { action: "get_run"; agentId: string }
+	| { action: "list_models"; limit: number }
+	| { action: "status" }
+	| { action: "diagnose" };
+
+export function registerSubagentInspect(pi: ExtensionAPI, runtime: SubagentInspectRuntime): void {
+	pi.registerTool({
+		name: "subagent_inspect",
+		label: "Inspect Subagents",
+		description:
+			"Inspect available subagent definitions, models, retained runs, runtime status, and diagnostics without changing subagent or workspace state. This tool never starts a child, sends or acknowledges messages, interrupts or closes runs, changes settings, or modifies files.",
+		promptSnippet: "Inspect subagent metadata and runtime state without changing it",
+		parameters: SubagentInspectParams,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<InspectToolResult> {
+			return executeSubagentInspect(validateInspectParams(params), ctx, runtime);
+		},
+	});
+}
+
+export function validateInspectParams(params: unknown): ValidatedInspectOperation {
+	const values = parameterRecord(params);
+	const rawAction = values.action;
+	if (
+		typeof rawAction !== "string" ||
+		!INSPECT_ACTIONS.includes(rawAction as (typeof INSPECT_ACTIONS)[number])
+	) {
+		throw new Error(`subagent_inspect action must be one of: ${INSPECT_ACTIONS.join(", ")}`);
+	}
+	const action = rawAction as (typeof INSPECT_ACTIONS)[number];
+	const allowed: Record<(typeof INSPECT_ACTIONS)[number], readonly string[]> = {
+		list_agents: ["action", "agentScope", "limit"],
+		get_agent: ["action", "agent", "agentScope"],
+		list_runs: ["action", "includeClosed", "limit"],
+		get_run: ["action", "agentId"],
+		list_models: ["action", "limit"],
+		status: ["action"],
+		diagnose: ["action"],
+	};
+	const unexpected = Object.keys(values).find(
+		(key) => values[key] !== undefined && !allowed[action].includes(key),
+	);
+	if (unexpected)
+		throw new Error(`subagent_inspect action "${action}" does not accept ${unexpected}`);
+
+	if (action === "list_agents" || action === "get_agent") {
+		const agentScope = optionalAgentScope(values.agentScope);
+		if (action === "get_agent") {
+			return { action, agent: requiredString(values.agent, action, "agent"), agentScope };
+		}
+		return { action, agentScope, limit: optionalLimit(values.limit, 32) };
+	}
+	if (action === "list_runs") {
+		if (values.includeClosed !== undefined && typeof values.includeClosed !== "boolean") {
+			throw new Error('subagent_inspect action "list_runs" requires includeClosed to be boolean');
+		}
+		return {
+			action,
+			includeClosed: values.includeClosed === true,
+			limit: optionalLimit(values.limit, 50),
+		};
+	}
+	if (action === "get_run") {
+		return { action, agentId: requiredString(values.agentId, action, "agentId") };
+	}
+	if (action === "list_models") {
+		return { action, limit: optionalLimit(values.limit, 50) };
+	}
+	return { action };
+}
+
+async function executeSubagentInspect(
+	operation: ValidatedInspectOperation,
+	ctx: ExtensionContext,
+	runtime: SubagentInspectRuntime,
+): Promise<InspectToolResult> {
+	if (operation.action === "list_agents" || operation.action === "get_agent") {
+		assertTrustedScope(operation.agentScope, ctx);
+		const settings = inspectSubagentSettings().settings;
+		const discovery = discoverAgents(ctx.cwd, operation.agentScope, settings);
+		const agents = [...discovery.agents].sort((left, right) =>
+			left.name === right.name
+				? left.source.localeCompare(right.source)
+				: left.name.localeCompare(right.name),
+		);
+		if (operation.action === "list_agents") {
+			const selected = boundedProjection(agents, operation.limit, (agent) =>
+				projectAgent(agent, ctx, false),
+			);
+			return inspectResult({
+				action: operation.action,
+				agents: selected.items,
+				returned: selected.items.length,
+				omitted: selected.omitted + (discovery.omittedAgentDefinitions ?? 0),
+				discoveryIncomplete: discovery.metadataDiscoveryIncomplete === true,
+			});
+		}
+		const agent = agents.find((candidate) => candidate.name === operation.agent);
+		if (!agent) {
+			throw new Error(`Unknown subagent definition: ${boundedPrivateText(operation.agent, 256)}`);
+		}
+		return inspectResult({ action: operation.action, agent: projectAgent(agent, ctx) });
+	}
+
+	if (operation.action === "list_runs") {
+		const runs = runtime.listRunInspection(operation.includeClosed);
+		const selected = boundedProjection(runs, operation.limit, projectRunSummary);
+		return inspectResult({
+			action: operation.action,
+			runs: selected.items,
+			returned: selected.items.length,
+			omitted: selected.omitted,
+		});
+	}
+	if (operation.action === "get_run") {
+		const run = runtime.getRunInspection(operation.agentId);
+		if (!run) {
+			throw new Error(`Unknown retained run: ${boundedPrivateText(operation.agentId, 256)}`);
+		}
+		return inspectResult({ action: operation.action, run: projectRun(run, ctx) });
+	}
+	if (operation.action === "list_models") {
+		return inspectResult({ action: operation.action, ...projectModels(ctx, operation.limit) });
+	}
+	if (operation.action === "status") {
+		return inspectResult({ action: operation.action, status: projectStatus(runtime) });
+	}
+
+	const settings = inspectSubagentSettings();
+	const userDiscovery = discoverAgents(ctx.cwd, "user", settings.settings);
+	const modelCount = availableModelCount(ctx);
+	const runtimeStatus = runtime.getRuntimeStatus();
+	const checks = [
+		{
+			name: "settings",
+			status: settings.error ? "fail" : "pass",
+			message: settings.error
+				? boundedPrivateText(settings.error, 2 * 1024)
+				: "Settings are valid or absent.",
+		},
+		{
+			name: "agent-discovery",
+			status:
+				userDiscovery.metadataDiscoveryIncomplete ||
+				(userDiscovery.omittedAgentDefinitions ?? 0) > 0
+					? "warning"
+					: "pass",
+			message: `${userDiscovery.agents.length} user-scope definitions available.`,
+		},
+		{
+			name: "models",
+			status: modelCount > 0 ? "pass" : "fail",
+			message: `${modelCount} session-usable models available.`,
+		},
+		{
+			name: "runtime",
+			status: runtimeStatus.enabled && !runtimeStatus.initialized ? "warning" : "pass",
+			message: runtimeStatus.initialized
+				? "Stateful runtime initialized."
+				: "Stateful runtime not initialized.",
+		},
+		{
+			name: "consultation",
+			status: runtime.getBlockingEnabled() && modelCount > 0 ? "pass" : "fail",
+			message: runtime.getBlockingEnabled()
+				? modelCount > 0
+					? "Read-only consultation is supported."
+					: "Consultation has no available model."
+				: "Blocking delegation is disabled, so consultation is not registered.",
+		},
+	] as const;
+	return inspectResult({
+		action: operation.action,
+		checks,
+		ok: checks.every((check) => check.status !== "fail"),
+	});
+}
+
+function projectAgent(
+	agent: AgentConfig,
+	ctx: ExtensionContext,
+	includeTools = true,
+): Record<string, unknown> {
+	const tools = agent.tools === undefined ? undefined : projectToolNames(agent.tools);
+	return {
+		name: boundedPrivateText(agent.name, 256),
+		description: boundedPrivateText(agent.description, 256),
+		source: agent.source,
+		scope: agent.source === "project" ? "project" : "user",
+		path:
+			agent.source === "project"
+				? path.posix.join(".pi", "agents", path.basename(agent.filePath))
+				: safeDisplayPath(agent.filePath, ctx.cwd),
+		model: agent.model ? boundedPrivateText(agent.model, 256) : undefined,
+		thinkingLevel: agent.thinkingLevel,
+		...(includeTools
+			? { tools, toolCount: agent.tools?.length }
+			: { toolCount: agent.tools?.length }),
+		consultTools: resolveConsultTools(agent.tools),
+	};
+}
+
+function projectRunSummary(run: AgentRunInspectionSummary): Record<string, unknown> {
+	return {
+		id: boundedPrivateText(run.id, 256),
+		agent: boundedPrivateText(run.agent, 256),
+		state: run.state,
+		createdAt: run.createdAt,
+		updatedAt: run.updatedAt,
+		historyCount: run.historyCount,
+		unreadMessages: run.unreadMessages,
+	};
+}
+
+function projectRun(run: AgentRunInspectionDetail, ctx: ExtensionContext): Record<string, unknown> {
+	return {
+		...projectRunSummary(run),
+		cwd: safeDisplayPath(run.cwd, ctx.cwd),
+		thinkingLevel: run.thinkingLevel,
+		currentTask: run.currentTask ? boundedPrivateText(run.currentTask, 2 * 1024) : undefined,
+		error: run.error ? boundedPrivateText(run.error, 2 * 1024) : undefined,
+		policy: run.policy
+			? {
+					inherited: projectToolNames(run.policy.inherited),
+					overridden: projectToolNames(run.policy.overridden),
+					unsupported: projectToolNames(run.policy.unsupported),
+				}
+			: undefined,
+	};
+}
+
+function projectModels(ctx: ExtensionContext, limit: number): Record<string, unknown> {
+	const scoped = ctx.scopedModels ?? [];
+	const candidates =
+		scoped.length > 0
+			? scoped
+			: ctx.modelRegistry.getAvailable().map((model) => ({ model, thinkingLevel: undefined }));
+	const selected = boundedProjection(candidates, limit, ({ model, thinkingLevel }) => ({
+		provider: boundedPrivateText(model.provider, 256),
+		id: boundedPrivateText(model.id, 256),
+		name: boundedPrivateText(model.name, 256),
+		reasoning: model.reasoning,
+		input: [...model.input],
+		contextWindow: model.contextWindow,
+		maxTokens: model.maxTokens,
+		thinkingLevel,
+		current: ctx.model?.provider === model.provider && ctx.model?.id === model.id,
+	}));
+	return {
+		models: selected.items,
+		returned: selected.items.length,
+		omitted: selected.omitted,
+		source: scoped.length > 0 ? "session scope" : "available snapshot",
+	};
+}
+
+function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown> {
+	const stateful = runtime.getRuntimeStatus();
+	const workflow = resolveDelegationWorkflow(runtime.getBlockingEnabled(), stateful.enabled);
+	const configured = inspectDelegationWorkflowSettings();
+	const resources = inspectConsultResourceSettings();
+	return {
+		workflow,
+		configuredWorkflow: configured.value,
+		stateful,
+		consultResources: runtime.getConsultResourcePolicy(),
+		configuredConsultResources: resources.value,
+		consultResourcesSource: resources.source,
+		settingsPath: safeDisplayPath(resources.path, process.cwd()),
+		settingsError:
+			configured.error || resources.error
+				? boundedPrivateText(configured.error ?? resources.error ?? "", 2 * 1024)
+				: undefined,
+	};
+}
+
+function availableModelCount(ctx: ExtensionContext): number {
+	return (ctx.scopedModels?.length ?? 0) > 0
+		? ctx.scopedModels.length
+		: ctx.modelRegistry.getAvailable().length;
+}
+
+function projectToolNames(tools: readonly string[]): string[] {
+	return tools.slice(0, 100).map((tool) => boundedPrivateText(tool, 256));
+}
+
+function boundedProjection<T, TProjected>(
+	values: readonly T[],
+	limit: number,
+	project: (value: T) => TProjected,
+): { items: TProjected[]; omitted: number } {
+	const items: TProjected[] = [];
+	for (const value of values.slice(0, limit)) {
+		const next = project(value);
+		if (Buffer.byteLength(JSON.stringify([...items, next]), "utf8") > MAX_DETAILS_LIST_BYTES) break;
+		items.push(next);
+	}
+	return { items, omitted: Math.max(0, values.length - items.length) };
+}
+
+function inspectResult(details: Record<string, unknown>): InspectToolResult {
+	const rendered = boundText(JSON.stringify(details, null, 2));
+	return {
+		content: [{ type: "text", text: rendered.text }],
+		details: { ...details, ...(rendered.truncated ? { truncated: true } : {}) },
+	};
+}
+
+function assertTrustedScope(scope: AgentScope, ctx: ExtensionContext): void {
+	if ((scope === "project" || scope === "both") && !ctx.isProjectTrusted()) {
+		throw new Error("Project-local subagent definitions require a trusted project");
+	}
+}
+
+function parameterRecord(params: unknown): Record<string, unknown> {
+	if (!params || typeof params !== "object" || Array.isArray(params)) {
+		throw new Error("subagent_inspect parameters must be an object");
+	}
+	return params as Record<string, unknown>;
+}
+
+function optionalAgentScope(value: unknown): AgentScope {
+	if (value === undefined) return "user";
+	if (value === "user" || value === "project" || value === "both") return value;
+	throw new Error("subagent_inspect agentScope must be user, project, or both");
+}
+
+function requiredString(value: unknown, action: string, field: string): string {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`subagent_inspect action "${action}" requires ${field}`);
+	}
+	return value;
+}
+
+function optionalLimit(value: unknown, defaultValue: number): number {
+	if (value === undefined) return defaultValue;
+	if (!Number.isSafeInteger(value) || (value as number) < 1 || (value as number) > 100) {
+		throw new Error("subagent_inspect limit must be an integer between 1 and 100");
+	}
+	return value as number;
+}

--- a/extensions/pi-subagents/src/inspect.ts
+++ b/extensions/pi-subagents/src/inspect.ts
@@ -5,7 +5,7 @@ import { type Static, Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
 import { resolveConsultTools } from "./consult-policy.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "./registry.js";
-import { boundedPrivateText, boundText, safeDisplayPath } from "./safe-text.js";
+import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalLine } from "./safe-text.js";
 import {
 	inspectConsultResourceSettings,
 	inspectDelegationWorkflowSettings,
@@ -253,7 +253,7 @@ function projectAgent(
 		scope: agent.source === "project" ? "project" : "user",
 		path:
 			agent.source === "project"
-				? path.posix.join(".pi", "agents", path.basename(agent.filePath))
+				? safeTerminalLine(path.posix.join(".pi", "agents", path.basename(agent.filePath)))
 				: safeDisplayPath(agent.filePath, ctx.cwd),
 		model: agent.model ? boundedPrivateText(agent.model, 256) : undefined,
 		thinkingLevel: agent.thinkingLevel,

--- a/extensions/pi-subagents/src/limits.ts
+++ b/extensions/pi-subagents/src/limits.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024;
 export const DEFAULT_MAX_STDERR_BYTES = 16 * 1024;
 export const DEFAULT_MAX_CONTEXT_BYTES = 50 * 1024;
+export const MAX_SUBAGENT_TIMEOUT_MS = 2_147_483_647;
 export const DEFAULT_MAX_MESSAGES = 200;
 export const TRUNCATION_MARKER = "\n… [truncated by pi-subagents]";
 export const TAIL_TRUNCATION_MARKER = "… [truncated by pi-subagents]\n";

--- a/extensions/pi-subagents/src/params.ts
+++ b/extensions/pi-subagents/src/params.ts
@@ -1,11 +1,13 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { THINKING_LEVELS } from "./agents.js";
+import { MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
 
 const TimeoutMs = Type.Number({
 	description:
 		"Hard timeout in milliseconds for each subagent subprocess. Defaults to PI_SUBAGENT_TIMEOUT_MS or 600000.",
 	minimum: 1,
+	maximum: MAX_SUBAGENT_TIMEOUT_MS,
 });
 
 const ThinkingLevelSchema = StringEnum(THINKING_LEVELS, {

--- a/extensions/pi-subagents/src/registry.ts
+++ b/extensions/pi-subagents/src/registry.ts
@@ -55,6 +55,29 @@ export interface ManagedAgent {
 	currentMailboxMessageIds?: string[];
 }
 
+export interface AgentRunInspectionSummary {
+	id: string;
+	agent: string;
+	state: AgentLifecycleState;
+	createdAt: number;
+	updatedAt: number;
+	historyCount: number;
+	unreadMessages: number;
+}
+
+export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
+	cwd: string;
+	thinkingLevel?: SubagentThinkingLevel;
+	currentTask?: string;
+	error?: string;
+	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
+}
+
+export interface AgentInspectionCounts {
+	activeAgents: number;
+	retainedAgents: number;
+}
+
 export interface TurnOutcome {
 	output: string;
 	exitCode: number;
@@ -500,6 +523,42 @@ export class AgentRegistry {
 		if (shutdownError) throw shutdownError;
 	}
 
+	inspectionCounts(): AgentInspectionCounts {
+		let activeAgents = 0;
+		let retainedAgents = 0;
+		for (const agent of this.agents.values()) {
+			if (agent.state === "starting" || agent.state === "running") activeAgents++;
+			if (agent.state !== "closed") retainedAgents++;
+		}
+		return { activeAgents, retainedAgents };
+	}
+
+	listInspection(includeClosed = false): AgentRunInspectionSummary[] {
+		return [...this.agents.values()]
+			.filter((agent) => includeClosed || agent.state !== "closed")
+			.sort((left, right) => left.createdAt - right.createdAt)
+			.map((agent) => this.inspectSummary(agent));
+	}
+
+	getInspection(id: string): AgentRunInspectionDetail | undefined {
+		const agent = this.agents.get(id);
+		if (!agent) return undefined;
+		return {
+			...this.inspectSummary(agent),
+			cwd: agent.cwd,
+			thinkingLevel: agent.thinkingLevel,
+			currentTask: agent.currentTask,
+			error: agent.error,
+			policy: agent.policy
+				? {
+						inherited: [...agent.policy.inherited],
+						overridden: [...agent.policy.overridden],
+						unsupported: [...agent.policy.unsupported],
+					}
+				: undefined,
+		};
+	}
+
 	list(includeClosed = false, rootId?: string): ManagedAgent[] {
 		return [...this.agents.values()]
 			.filter((agent) => !rootId || agent.rootId === rootId)
@@ -753,6 +812,22 @@ export class AgentRegistry {
 		});
 		this.changeQueue = next;
 		return next;
+	}
+
+	private inspectSummary(agent: ManagedAgent): AgentRunInspectionSummary {
+		let unreadMessages = 0;
+		for (const message of agent.mailbox) {
+			if (message.readAt === undefined) unreadMessages++;
+		}
+		return {
+			id: agent.id,
+			agent: agent.agent,
+			state: agent.state,
+			createdAt: agent.createdAt,
+			updatedAt: agent.updatedAt,
+			historyCount: agent.history.length,
+			unreadMessages,
+		};
 	}
 
 	private copy(agent: ManagedAgent): ManagedAgent {

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -24,6 +24,11 @@ export interface UsageStats {
 	cacheRead: number;
 	cacheWrite: number;
 	cost: number;
+	costInput?: number;
+	costOutput?: number;
+	costCacheRead?: number;
+	costCacheWrite?: number;
+	totalTokens?: number;
 	contextTokens: number;
 	turns: number;
 }
@@ -58,6 +63,8 @@ export interface SingleResult {
 	aborted?: boolean;
 	truncated?: boolean;
 	malformedEvents?: number;
+	launchFailed?: boolean;
+	processStarted?: boolean;
 	policy?: {
 		inherited: string[];
 		overridden: string[];
@@ -288,19 +295,40 @@ async function writePromptToTempFile(
 	return { dir: tmpDir, filePath };
 }
 
-export function buildPiArgs(options: {
+export interface PiArgsOptions {
 	model?: string;
 	thinkingLevel?: SubagentThinkingLevel;
 	tools?: string[];
+	disableExtensions?: boolean;
+	disableSkills?: boolean;
+	disablePromptTemplates?: boolean;
+	disableContextFiles?: boolean;
+	projectTrust?: boolean;
+	baseSystemPromptPath?: string;
+	appendSystemPromptPaths?: string[];
+	/** Existing single append prompt path retained for compatibility. */
 	systemPromptPath?: string;
 	task: string;
-}): string[] {
+}
+
+export function buildPiArgs(options: PiArgsOptions): string[] {
 	const args: string[] = ["--mode", "json", "-p", "--no-session"];
 	if (options.model) args.push("--model", options.model);
 	if (options.thinkingLevel) args.push("--thinking", options.thinkingLevel);
+	if (options.disableExtensions) args.push("--no-extensions");
+	if (options.disableSkills) args.push("--no-skills");
+	if (options.disablePromptTemplates) args.push("--no-prompt-templates");
+	if (options.disableContextFiles) args.push("--no-context-files");
+	if (options.projectTrust !== undefined) {
+		args.push(options.projectTrust ? "--approve" : "--no-approve");
+	}
 	if (Array.isArray(options.tools)) {
 		if (options.tools.length > 0) args.push("--tools", options.tools.join(","));
 		else args.push("--no-tools");
+	}
+	if (options.baseSystemPromptPath) args.push("--system-prompt", options.baseSystemPromptPath);
+	for (const promptPath of options.appendSystemPromptPaths ?? []) {
+		args.push("--append-system-prompt", promptPath);
 	}
 	if (options.systemPromptPath) args.push("--append-system-prompt", options.systemPromptPath);
 	args.push(`Task: ${options.task}`);
@@ -365,6 +393,17 @@ export function terminateProcess(
 
 export type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
 
+export interface ChildLaunchPolicy {
+	tools?: string[];
+	disableExtensions?: boolean;
+	disableSkills?: boolean;
+	disablePromptTemplates?: boolean;
+	disableContextFiles?: boolean;
+	projectTrust?: boolean;
+	baseSystemPrompt?: string;
+	appendSystemPromptPaths?: string[];
+}
+
 export async function runSingleAgent(
 	defaultCwd: string,
 	agents: AgentConfig[],
@@ -378,6 +417,7 @@ export async function runSingleAgent(
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
 	invocationOverride?: { command: string; argsPrefix?: string[] },
+	launchPolicy?: ChildLaunchPolicy,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 
@@ -405,8 +445,9 @@ export async function runSingleAgent(
 		};
 	}
 
-	let tmpPromptDir: string | null = null;
+	const temporaryPrompts: Array<{ dir: string; filePath: string }> = [];
 	let tmpPromptPath: string | null = null;
+	let baseSystemPromptPath: string | null = null;
 
 	let latestAssistantOutput = "";
 	let terminalAssistantOutput: string | undefined;
@@ -475,16 +516,37 @@ export async function runSingleAgent(
 			return currentResult;
 		}
 
+		if (launchPolicy?.baseSystemPrompt?.trim()) {
+			const tmp = await writePromptToTempFile(`${agent.name}-base`, launchPolicy.baseSystemPrompt);
+			temporaryPrompts.push(tmp);
+			baseSystemPromptPath = tmp.filePath;
+		}
 		if (agent.systemPrompt.trim()) {
 			const tmp = await writePromptToTempFile(agent.name, agent.systemPrompt);
-			tmpPromptDir = tmp.dir;
+			temporaryPrompts.push(tmp);
 			tmpPromptPath = tmp.filePath;
 		}
+		if (signal?.aborted) {
+			currentResult.exitCode = 130;
+			currentResult.aborted = true;
+			currentResult.stopReason = "aborted";
+			setErrorMessage("Subagent was aborted before launch");
+			return currentResult;
+		}
 
+		const effectiveTools =
+			launchPolicy && Object.hasOwn(launchPolicy, "tools") ? launchPolicy.tools : agent.tools;
 		const args = buildPiArgs({
 			model: agent.model,
 			thinkingLevel,
-			tools: agent.tools,
+			tools: effectiveTools,
+			disableExtensions: launchPolicy?.disableExtensions,
+			disableSkills: launchPolicy?.disableSkills,
+			disablePromptTemplates: launchPolicy?.disablePromptTemplates,
+			disableContextFiles: launchPolicy?.disableContextFiles,
+			projectTrust: launchPolicy?.projectTrust,
+			baseSystemPromptPath: baseSystemPromptPath ?? undefined,
+			appendSystemPromptPaths: launchPolicy?.appendSystemPromptPaths,
 			systemPromptPath: tmpPromptPath ?? undefined,
 			task,
 		});
@@ -525,6 +587,7 @@ export async function runSingleAgent(
 					},
 				});
 			} catch (error) {
+				currentResult.launchFailed = true;
 				currentResult.stderr = setErrorMessage(
 					error instanceof Error ? error.message : String(error),
 				);
@@ -582,6 +645,16 @@ export async function runSingleAgent(
 							currentResult.usage.cacheRead += usage.cacheRead || 0;
 							currentResult.usage.cacheWrite += usage.cacheWrite || 0;
 							currentResult.usage.cost += usage.cost?.total || 0;
+							currentResult.usage.costInput =
+								(currentResult.usage.costInput ?? 0) + (usage.cost?.input || 0);
+							currentResult.usage.costOutput =
+								(currentResult.usage.costOutput ?? 0) + (usage.cost?.output || 0);
+							currentResult.usage.costCacheRead =
+								(currentResult.usage.costCacheRead ?? 0) + (usage.cost?.cacheRead || 0);
+							currentResult.usage.costCacheWrite =
+								(currentResult.usage.costCacheWrite ?? 0) + (usage.cost?.cacheWrite || 0);
+							currentResult.usage.totalTokens =
+								(currentResult.usage.totalTokens ?? 0) + (usage.totalTokens || 0);
 							currentResult.usage.contextTokens = usage.totalTokens || 0;
 						}
 						if (msg.provider) currentResult.actualProvider = msg.provider;
@@ -623,6 +696,9 @@ export async function runSingleAgent(
 			}, timeoutMs);
 			timeout.unref();
 
+			proc.once("spawn", () => {
+				currentResult.processStarted = true;
+			});
 			proc.stdout?.on("data", (data) => decoder.push(data));
 			proc.stderr?.on("data", (data) => {
 				const bounded = appendBounded(
@@ -638,6 +714,7 @@ export async function runSingleAgent(
 				finish(timedOut ? 124 : wasAborted ? 130 : (code ?? 0));
 			});
 			proc.on("error", (error) => {
+				currentResult.launchFailed = true;
 				const message = setErrorMessage(error.message);
 				const bounded = appendBounded(
 					currentResult.stderr,
@@ -682,23 +759,27 @@ export async function runSingleAgent(
 				"cwd",
 				...(agent.model ? ["model"] : []),
 				...(thinkingLevel ? ["thinkingLevel"] : []),
-				...(agent.tools ? ["tools"] : []),
+				...(effectiveTools !== undefined ? ["tools"] : []),
+				...(launchPolicy?.disableExtensions ? ["extensions"] : []),
+				...(launchPolicy?.disableSkills ? ["skills"] : []),
+				...(launchPolicy?.disablePromptTemplates ? ["promptTemplates"] : []),
+				...(launchPolicy?.disableContextFiles ? ["contextFiles"] : []),
 			],
 			unsupported: ["approvalPolicy", "sandboxProfile", "providerHeaders"],
 		};
 		return currentResult;
 	} finally {
-		if (tmpPromptPath)
+		for (const temporary of temporaryPrompts.reverse()) {
 			try {
-				fs.unlinkSync(tmpPromptPath);
+				fs.unlinkSync(temporary.filePath);
 			} catch {
 				/* ignore */
 			}
-		if (tmpPromptDir)
 			try {
-				fs.rmdirSync(tmpPromptDir);
+				fs.rmdirSync(temporary.dir);
 			} catch {
 				/* ignore */
 			}
+		}
 	}
 }

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -12,6 +12,7 @@ import {
 	DEFAULT_MAX_MESSAGES,
 	DEFAULT_MAX_OUTPUT_BYTES,
 	DEFAULT_MAX_STDERR_BYTES,
+	MAX_SUBAGENT_TIMEOUT_MS,
 	truncateUtf8,
 } from "./limits.js";
 import { JsonLineDecoder } from "./protocol.js";
@@ -39,6 +40,21 @@ export type RecentActivityItem =
 const MAX_RECENT_ACTIVITY_ITEMS = 10;
 const MAX_RECENT_ACTIVITY_BYTES = 8 * 1024;
 const MAX_RECENT_ACTIVITY_ARGUMENT_BYTES = 1024;
+const MAX_USAGE_VALUE = Number.MAX_SAFE_INTEGER;
+
+function protocolUsageCount(value: unknown): number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function protocolUsageCost(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0
+		? Math.min(value, MAX_USAGE_VALUE)
+		: 0;
+}
+
+function addUsageValue(current: number, addition: number): number {
+	return Math.min(MAX_USAGE_VALUE, current + addition);
+}
 
 export interface SingleResult {
 	agent: string;
@@ -515,6 +531,14 @@ export async function runSingleAgent(
 			setErrorMessage("Subagent was aborted before start");
 			return currentResult;
 		}
+		if (!Number.isFinite(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_SUBAGENT_TIMEOUT_MS) {
+			currentResult.exitCode = 1;
+			currentResult.stopReason = "error";
+			setErrorMessage(
+				`Invalid subagent timeout: expected 1-${MAX_SUBAGENT_TIMEOUT_MS}ms, received ${timeoutMs}`,
+			);
+			return currentResult;
+		}
 
 		if (launchPolicy?.baseSystemPrompt?.trim()) {
 			const tmp = await writePromptToTempFile(`${agent.name}-base`, launchPolicy.baseSystemPrompt);
@@ -639,29 +663,62 @@ export async function runSingleAgent(
 					if (msg.role === "assistant") {
 						currentResult.usage.turns++;
 						const usage = msg.usage;
-						if (usage) {
-							currentResult.usage.input += usage.input || 0;
-							currentResult.usage.output += usage.output || 0;
-							currentResult.usage.cacheRead += usage.cacheRead || 0;
-							currentResult.usage.cacheWrite += usage.cacheWrite || 0;
-							currentResult.usage.cost += usage.cost?.total || 0;
-							currentResult.usage.costInput =
-								(currentResult.usage.costInput ?? 0) + (usage.cost?.input || 0);
-							currentResult.usage.costOutput =
-								(currentResult.usage.costOutput ?? 0) + (usage.cost?.output || 0);
-							currentResult.usage.costCacheRead =
-								(currentResult.usage.costCacheRead ?? 0) + (usage.cost?.cacheRead || 0);
-							currentResult.usage.costCacheWrite =
-								(currentResult.usage.costCacheWrite ?? 0) + (usage.cost?.cacheWrite || 0);
-							currentResult.usage.totalTokens =
-								(currentResult.usage.totalTokens ?? 0) + (usage.totalTokens || 0);
-							currentResult.usage.contextTokens = usage.totalTokens || 0;
+						if (usage && typeof usage === "object") {
+							const input = protocolUsageCount(usage.input);
+							const output = protocolUsageCount(usage.output);
+							const cacheRead = protocolUsageCount(usage.cacheRead);
+							const cacheWrite = protocolUsageCount(usage.cacheWrite);
+							const reportedTotal = protocolUsageCount(usage.totalTokens);
+							const turnTotal =
+								reportedTotal ||
+								addUsageValue(addUsageValue(input, output), addUsageValue(cacheRead, cacheWrite));
+							const cost = usage.cost && typeof usage.cost === "object" ? usage.cost : undefined;
+							currentResult.usage.input = addUsageValue(currentResult.usage.input, input);
+							currentResult.usage.output = addUsageValue(currentResult.usage.output, output);
+							currentResult.usage.cacheRead = addUsageValue(
+								currentResult.usage.cacheRead,
+								cacheRead,
+							);
+							currentResult.usage.cacheWrite = addUsageValue(
+								currentResult.usage.cacheWrite,
+								cacheWrite,
+							);
+							currentResult.usage.cost = addUsageValue(
+								currentResult.usage.cost,
+								protocolUsageCost(cost?.total),
+							);
+							currentResult.usage.costInput = addUsageValue(
+								currentResult.usage.costInput ?? 0,
+								protocolUsageCost(cost?.input),
+							);
+							currentResult.usage.costOutput = addUsageValue(
+								currentResult.usage.costOutput ?? 0,
+								protocolUsageCost(cost?.output),
+							);
+							currentResult.usage.costCacheRead = addUsageValue(
+								currentResult.usage.costCacheRead ?? 0,
+								protocolUsageCost(cost?.cacheRead),
+							);
+							currentResult.usage.costCacheWrite = addUsageValue(
+								currentResult.usage.costCacheWrite ?? 0,
+								protocolUsageCost(cost?.cacheWrite),
+							);
+							currentResult.usage.totalTokens = addUsageValue(
+								currentResult.usage.totalTokens ?? 0,
+								turnTotal,
+							);
+							currentResult.usage.contextTokens = turnTotal;
 						}
-						if (msg.provider) currentResult.actualProvider = msg.provider;
-						if (msg.responseModel ?? msg.model)
-							currentResult.actualModel = msg.responseModel ?? msg.model;
-						if (msg.stopReason) currentResult.stopReason = msg.stopReason;
-						if (msg.errorMessage) setErrorMessage(msg.errorMessage);
+						if (typeof msg.provider === "string") currentResult.actualProvider = msg.provider;
+						const actualModel =
+							typeof msg.responseModel === "string"
+								? msg.responseModel
+								: typeof msg.model === "string"
+									? msg.model
+									: undefined;
+						if (actualModel) currentResult.actualModel = actualModel;
+						if (typeof msg.stopReason === "string") currentResult.stopReason = msg.stopReason;
+						if (typeof msg.errorMessage === "string") setErrorMessage(msg.errorMessage);
 					}
 					emitUpdate();
 				} else if (event.type === "tool_result_end" && event.message) {

--- a/extensions/pi-subagents/src/safe-text.ts
+++ b/extensions/pi-subagents/src/safe-text.ts
@@ -1,0 +1,62 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { redactPrivateText } from "./context.js";
+import { DEFAULT_MAX_OUTPUT_BYTES, TRUNCATION_MARKER, truncateUtf8 } from "./limits.js";
+
+export const DEFAULT_MAX_OUTPUT_LINES = 2_000;
+
+export function safeTerminalText(value: string): string {
+	return (
+		value
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls while preserving newlines.
+			.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, "?")
+			.replace(/\r/gu, "")
+	);
+}
+
+export function boundText(
+	value: string,
+	maxBytes = DEFAULT_MAX_OUTPUT_BYTES,
+	maxLines = DEFAULT_MAX_OUTPUT_LINES,
+): { text: string; truncated: boolean } {
+	const safe = safeTerminalText(value);
+	const lines = safe.split("\n");
+	const lineBounded =
+		lines.length > maxLines
+			? `${lines.slice(0, Math.max(0, maxLines - 1)).join("\n")}${TRUNCATION_MARKER}`
+			: safe;
+	const bounded = truncateUtf8(lineBounded, maxBytes);
+	return { text: bounded.text, truncated: lines.length > maxLines || bounded.truncated };
+}
+
+export function boundedPrivateText(value: string, maxBytes: number): string {
+	return boundText(redactPrivateText(value), maxBytes).text;
+}
+
+export function safeDisplayPath(value: string, workspace: string): string {
+	if (value.startsWith("built-in:")) return safeTerminalText(value);
+	const resolved = path.resolve(value);
+	const agentDir = path.resolve(getAgentDir());
+	const relativeAgent = path.relative(agentDir, resolved);
+	if (
+		relativeAgent === "" ||
+		(!relativeAgent.startsWith("..") && !path.isAbsolute(relativeAgent))
+	) {
+		return relativeAgent ? `~/${safeTerminalText(relativeAgent)}` : "~";
+	}
+	const resolvedWorkspace = path.resolve(workspace);
+	const relativeWorkspace = path.relative(resolvedWorkspace, resolved);
+	if (
+		relativeWorkspace === "" ||
+		(!relativeWorkspace.startsWith("..") && !path.isAbsolute(relativeWorkspace))
+	) {
+		return relativeWorkspace ? safeTerminalText(relativeWorkspace) : ".";
+	}
+	const home = path.resolve(os.homedir());
+	const relativeHome = path.relative(home, resolved);
+	if (relativeHome === "" || (!relativeHome.startsWith("..") && !path.isAbsolute(relativeHome))) {
+		return relativeHome ? `~/${safeTerminalText(relativeHome)}` : "~";
+	}
+	return safeTerminalText(resolved);
+}

--- a/extensions/pi-subagents/src/safe-text.ts
+++ b/extensions/pi-subagents/src/safe-text.ts
@@ -15,6 +15,11 @@ export function safeTerminalText(value: string): string {
 	);
 }
 
+export function safeTerminalLine(value: string, maxBytes = 2 * 1024): string {
+	const singleLine = safeTerminalText(redactPrivateText(value)).replace(/\s+/gu, " ").trim();
+	return truncateUtf8(singleLine, maxBytes).text.replace(/\s+/gu, " ").trim();
+}
+
 export function boundText(
 	value: string,
 	maxBytes = DEFAULT_MAX_OUTPUT_BYTES,
@@ -35,7 +40,7 @@ export function boundedPrivateText(value: string, maxBytes: number): string {
 }
 
 export function safeDisplayPath(value: string, workspace: string): string {
-	if (value.startsWith("built-in:")) return safeTerminalText(value);
+	if (value.startsWith("built-in:")) return safeTerminalLine(value);
 	const resolved = path.resolve(value);
 	const agentDir = path.resolve(getAgentDir());
 	const relativeAgent = path.relative(agentDir, resolved);
@@ -43,7 +48,7 @@ export function safeDisplayPath(value: string, workspace: string): string {
 		relativeAgent === "" ||
 		(!relativeAgent.startsWith("..") && !path.isAbsolute(relativeAgent))
 	) {
-		return relativeAgent ? `~/${safeTerminalText(relativeAgent)}` : "~";
+		return relativeAgent ? `~/${safeTerminalLine(relativeAgent)}` : "~";
 	}
 	const resolvedWorkspace = path.resolve(workspace);
 	const relativeWorkspace = path.relative(resolvedWorkspace, resolved);
@@ -51,12 +56,12 @@ export function safeDisplayPath(value: string, workspace: string): string {
 		relativeWorkspace === "" ||
 		(!relativeWorkspace.startsWith("..") && !path.isAbsolute(relativeWorkspace))
 	) {
-		return relativeWorkspace ? safeTerminalText(relativeWorkspace) : ".";
+		return relativeWorkspace ? safeTerminalLine(relativeWorkspace) : ".";
 	}
 	const home = path.resolve(os.homedir());
 	const relativeHome = path.relative(home, resolved);
 	if (relativeHome === "" || (!relativeHome.startsWith("..") && !path.isAbsolute(relativeHome))) {
-		return relativeHome ? `~/${safeTerminalText(relativeHome)}` : "~";
+		return relativeHome ? `~/${safeTerminalLine(relativeHome)}` : "~";
 	}
-	return safeTerminalText(resolved);
+	return safeTerminalLine(resolved);
 }

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -13,6 +13,7 @@ import {
 	type SubagentSettings,
 	type SubagentThinkingLevel,
 } from "./agents.js";
+import { MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
 
 export function hasOwn(obj: object, key: PropertyKey): boolean {
 	return Object.hasOwn(obj, key);
@@ -63,7 +64,12 @@ export function normalizeAgentSettings(value: unknown): SubagentAgentConfig | un
 	}
 
 	if (hasOwn(value, "timeoutMs")) {
-		if (value.timeoutMs !== null && !isPositiveNumber(value.timeoutMs)) return undefined;
+		if (
+			value.timeoutMs !== null &&
+			(!isPositiveNumber(value.timeoutMs) || value.timeoutMs > MAX_SUBAGENT_TIMEOUT_MS)
+		) {
+			return undefined;
+		}
 		config.timeoutMs = value.timeoutMs;
 		hasKnownField = true;
 	}

--- a/extensions/pi-subagents/src/settings.ts
+++ b/extensions/pi-subagents/src/settings.ts
@@ -5,7 +5,9 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import lockfile from "proper-lockfile";
 import {
 	type AgentConfig,
+	CONSULT_RESOURCE_POLICIES,
 	type CompletionDelivery,
+	type ConsultResourcePolicy,
 	isThinkingLevel,
 	type SubagentAgentConfig,
 	type SubagentSettings,
@@ -136,12 +138,27 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 		}
 		settings.stateful = runtime;
 	}
+	if (hasOwn(value, "consult")) {
+		if (!isPlainObject(value.consult)) return undefined;
+		const consult: NonNullable<SubagentSettings["consult"]> = {};
+		if (hasOwn(value.consult, "resources")) {
+			if (
+				typeof value.consult.resources !== "string" ||
+				!CONSULT_RESOURCE_POLICIES.includes(value.consult.resources as ConsultResourcePolicy)
+			) {
+				return undefined;
+			}
+			consult.resources = value.consult.resources as ConsultResourcePolicy;
+		}
+		settings.consult = consult;
+	}
 	return settings;
 }
 
 const SETTINGS_FILE = "pi-subagents.json";
 const LEGACY_SETTINGS_FILE = "pi-subagents-config.json";
 const DEFAULT_COMPLETION_DELIVERY: CompletionDelivery = "next-turn";
+export const DEFAULT_CONSULT_RESOURCE_POLICY: ConsultResourcePolicy = "project-context";
 const SETTINGS_LOCK_FS_ADAPTER = {
 	mkdir: fs.mkdir,
 	mkdirSync: fs.mkdirSync,
@@ -231,6 +248,20 @@ export interface CompletionDeliverySettingsSnapshot {
 	error?: string;
 }
 
+export interface ConsultResourceSettingsSnapshot {
+	path: string;
+	value: ConsultResourcePolicy;
+	source: "default" | "user settings";
+	error?: string;
+}
+
+export interface SubagentSettingsSnapshot {
+	path: string;
+	settings?: SubagentSettings;
+	source: "default" | "user settings";
+	error?: string;
+}
+
 export function subagentSettingsFilePath(): string {
 	return path.join(getAgentDir(), SETTINGS_FILE);
 }
@@ -275,6 +306,35 @@ function inspectSubagentSettingsPath(configPath: string): {
 	} catch (error) {
 		return { path: configPath, error: formatError(error) };
 	}
+}
+
+export function inspectSubagentSettings(): SubagentSettingsSnapshot {
+	const inspected = inspectSubagentSettingsDocument();
+	return {
+		path: inspected.path,
+		settings: inspected.settings,
+		source: inspected.settings ? "user settings" : "default",
+		...(inspected.error ? { error: inspected.error } : {}),
+	};
+}
+
+export function inspectConsultResourceSettings(): ConsultResourceSettingsSnapshot {
+	const inspected = inspectSubagentSettingsDocument();
+	if (!inspected.raw || !inspected.settings) {
+		return {
+			path: inspected.path,
+			value: DEFAULT_CONSULT_RESOURCE_POLICY,
+			source: "default",
+			...(inspected.error ? { error: inspected.error } : {}),
+		};
+	}
+	const explicit =
+		isPlainObject(inspected.raw.consult) && hasOwn(inspected.raw.consult, "resources");
+	return {
+		path: inspected.path,
+		value: inspected.settings.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY,
+		source: explicit ? "user settings" : "default",
+	};
 }
 
 export function inspectDelegationWorkflowSettings(): DelegationWorkflowSettingsSnapshot {
@@ -364,6 +424,27 @@ export function updateCompletionDeliverySetting(value: CompletionDelivery): void
 				stateful: {
 					...(stateful ?? {}),
 					completionDelivery: value,
+				},
+			},
+			update.replaceCanonical,
+		);
+	});
+}
+
+export function updateConsultResourceSetting(value: ConsultResourcePolicy): void {
+	withSettingsMutationLock(() => {
+		const update = readSettingsObjectForUpdate();
+		const raw = update.document;
+		const consult = raw.consult;
+		if (consult !== undefined && !isPlainObject(consult)) {
+			throw new Error(`Cannot update invalid ${SETTINGS_FILE} consult settings`);
+		}
+		writeSettingsObjectUnlocked(
+			{
+				...raw,
+				consult: {
+					...(consult ?? {}),
+					resources: value,
 				},
 			},
 			update.replaceCanonical,

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -24,7 +24,13 @@ import {
 } from "./in-process-transport.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import { AgentPersistence } from "./persistence.js";
-import { AgentRegistry, type AgentTurnCompletion, type ManagedAgent } from "./registry.js";
+import {
+	AgentRegistry,
+	type AgentRunInspectionDetail,
+	type AgentRunInspectionSummary,
+	type AgentTurnCompletion,
+	type ManagedAgent,
+} from "./registry.js";
 import { readSubagentSettings } from "./settings.js";
 import {
 	MailboxParamsSchema,
@@ -109,6 +115,8 @@ export interface StatefulSubagentController {
 	setAgentCatalog(value: string): void;
 	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
 	listAgents(includeClosed?: boolean): ManagedAgent[];
+	listRunInspection(includeClosed?: boolean): AgentRunInspectionSummary[];
+	getRunInspection(agentId: string): AgentRunInspectionDetail | undefined;
 	clearAgents(): Promise<number>;
 }
 
@@ -168,20 +176,23 @@ export function registerStatefulSubagents(
 			refreshSpawnToolRegistration?.();
 		},
 		getRuntimeStatus() {
-			const agents = registry?.list(true) ?? [];
+			const counts = registry?.inspectionCounts() ?? { activeAgents: 0, retainedAgents: 0 };
 			return {
 				enabled,
 				initialized: registry !== undefined,
 				transport: transportKind,
 				completionDelivery,
-				activeAgents: agents.filter(
-					(agent) => agent.state === "starting" || agent.state === "running",
-				).length,
-				retainedAgents: agents.filter((agent) => agent.state !== "closed").length,
+				...counts,
 			};
 		},
 		listAgents(includeClosed = false) {
 			return registry?.list(includeClosed) ?? [];
+		},
+		listRunInspection(includeClosed = false) {
+			return registry?.listInspection(includeClosed) ?? [];
+		},
+		getRunInspection(agentId) {
+			return registry?.getInspection(agentId);
 		},
 		clearAgents,
 	};
@@ -450,7 +461,7 @@ export function registerStatefulSubagents(
 		name: "subagent_manage",
 		label: "Manage Subagents",
 		description:
-			"List retained subagents, interrupt active work while keeping an agent reusable, or close agents and release their resources.",
+			"List retained subagents through the compatibility route, interrupt active work while keeping an agent reusable, or close agents and release their resources. Prefer subagent_inspect when the whole activated capability must be read-only.",
 		promptSnippet: "List or control retained detached subagents",
 		parameters: ManageParamsSchema,
 		async execute(_id, params): Promise<StatefulActionToolResult> {
@@ -518,7 +529,7 @@ export function registerStatefulSubagents(
 		name: "subagent_mailbox",
 		label: "Subagent Mailbox",
 		description:
-			"Queue a bounded message without starting a turn, or read unread mailbox messages and optionally acknowledge them.",
+			"Queue a bounded message without starting a turn, or read unread mailbox messages. Read acknowledges returned messages by default; use subagent_inspect for metadata-only unread counts.",
 		promptSnippet: "Send or read queue-only detached-subagent mailbox messages",
 		parameters: MailboxParamsSchema,
 		async execute(_id, params): Promise<StatefulActionToolResult> {

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -31,6 +31,7 @@ import {
 	type AgentTurnCompletion,
 	type ManagedAgent,
 } from "./registry.js";
+import { safeTerminalLine } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
 import {
 	MailboxParamsSchema,
@@ -619,19 +620,19 @@ async function confirmProjectAgent(
 	cwd: string,
 ): Promise<void> {
 	if (scope !== "project" && scope !== "both") return;
-	const discovery = discoverAgents(cwd, scope, readSubagentSettings());
-	const agent = discovery.agents.find((candidate) => candidate.name === name);
-	if (agent?.source !== "project") return;
 	if (!isSameCwd(cwd, ctx.cwd)) {
 		throw new Error("Project-local subagent definitions cannot run with an overridden cwd");
 	}
 	if (!ctx.isProjectTrusted()) {
 		throw new Error("Project-local subagent definitions require a trusted project");
 	}
+	const discovery = discoverAgents(cwd, scope, readSubagentSettings());
+	const agent = discovery.agents.find((candidate) => candidate.name === name);
+	if (agent?.source !== "project") return;
 	if (confirm && ctx.hasUI) {
 		const approved = await ctx.ui.confirm(
 			"Run project-local agent?",
-			`Agent: ${name}\nSource: ${agent.filePath}`,
+			`Agent: ${safeTerminalLine(name, 256)}\nSource: ${safeTerminalLine(agent.filePath)}`,
 		);
 		if (!approved) throw new Error("Project-local subagent was not approved");
 	}

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -13,17 +13,29 @@
  */
 
 import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { discoverAgentCatalog, formatAgentCatalog } from "./agents.js";
+import {
+	type ConsultResourcePolicy,
+	discoverAgentCatalog,
+	formatAgentCatalog,
+	type SubagentSettings,
+} from "./agents.js";
 import { registerSubagentConfigCommand } from "./config-ui.js";
+import { registerSubagentConsult } from "./consult.js";
 import { executeSubagent } from "./execution.js";
+import { registerSubagentInspect } from "./inspect.js";
 import { SubagentParams } from "./params.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
 import type { SubagentDetails } from "./runner.js";
-import { consumeSubagentSettingsNotice, readSubagentSettings } from "./settings.js";
+import {
+	consumeSubagentSettingsNotice,
+	DEFAULT_CONSULT_RESOURCE_POLICY,
+	readSubagentSettings,
+} from "./settings.js";
 import { registerStatefulSubagents } from "./stateful.js";
 
 export default function (pi: ExtensionAPI) {
 	const settings = readSubagentSettings();
+	let currentSettings: SubagentSettings | undefined = settings;
 	const blockingEnabled = settings?.blocking?.enabled !== false;
 	const refreshBlockingCatalog = blockingEnabled ? registerBlockingSubagent(pi) : () => undefined;
 	let refreshStatefulCatalog: (catalog: string) => void = () => undefined;
@@ -33,6 +45,7 @@ export default function (pi: ExtensionAPI) {
 		// validation against settings that may have changed before this session.
 		const loadNotice = consumeSubagentSettingsNotice();
 		const refreshedSettings = readSubagentSettings();
+		currentSettings = refreshedSettings;
 		const refreshedNotice = consumeSubagentSettingsNotice();
 		const notice = [
 			...new Set([loadNotice, refreshedNotice].filter((value) => value !== undefined)),
@@ -51,9 +64,27 @@ export default function (pi: ExtensionAPI) {
 		settings: settings?.stateful,
 	});
 	refreshStatefulCatalog = statefulRuntime.setAgentCatalog;
+	const getBlockingEnabled = () => blockingEnabled;
+	const getConsultResourcePolicy = () =>
+		currentSettings?.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY;
+	registerSubagentInspect(pi, {
+		...statefulRuntime,
+		getBlockingEnabled,
+		getConsultResourcePolicy,
+	});
+	if (blockingEnabled) {
+		registerSubagentConsult(pi, { getSettings: () => currentSettings });
+	}
 	registerSubagentConfigCommand(pi, {
 		...statefulRuntime,
-		getBlockingEnabled: () => blockingEnabled,
+		getBlockingEnabled,
+		getConsultResourcePolicy,
+		setConsultResourcePolicy(value: ConsultResourcePolicy) {
+			currentSettings = {
+				...(currentSettings ?? {}),
+				consult: { ...(currentSettings?.consult ?? {}), resources: value },
+			};
+		},
 	});
 }
 
@@ -63,7 +94,7 @@ function registerBlockingSubagent(pi: ExtensionAPI): (catalog: string) => void {
 		"Run specialized subagents as a blocking operation with isolated contexts.",
 		"The call blocks the main agent until every worker and optional aggregator finishes, so queued steering waits.",
 		"Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder).",
-		"Parallel mode may include an aggregator fan-in step that receives all task outputs.",
+		"Parallel mode may include an aggregator fan-in step that receives all task outputs. Use subagent_consult instead for one synchronous child that must be executor-constrained to read-only tools.",
 		'Default agent scope is "user" (from ~/.pi/agent/agents).',
 		'To enable project-local agents in .pi/agents, pass agentScope: "both" (or "project") as a top-level argument for that call.',
 	].join(" ");
@@ -118,8 +149,11 @@ export { parsePositiveInteger } from "./execution.js";
 export { formatTokens, formatUsageStats } from "./render.js";
 export { buildPiArgs } from "./runner.js";
 export {
+	DEFAULT_CONSULT_RESOURCE_POLICY,
 	inspectCompletionDeliverySettings,
+	inspectConsultResourceSettings,
 	inspectDelegationWorkflowSettings,
+	inspectSubagentSettings,
 	normalizeAgentSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
@@ -130,5 +164,6 @@ export {
 	uniqueToolNames,
 	updateAgentToolsSetting,
 	updateCompletionDeliverySetting,
+	updateConsultResourceSetting,
 	updateDelegationWorkflowSetting,
 } from "./settings.js";

--- a/extensions/pi-subagents/test/agents.test.ts
+++ b/extensions/pi-subagents/test/agents.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { discoverAgents } from "../src/agents.js";
+
+function agentMarkdown(name: string, toolsLine?: string): string {
+	return [
+		"---",
+		`name: ${name}`,
+		`description: ${name} agent`,
+		...(toolsLine === undefined ? [] : [toolsLine]),
+		"---",
+		"Agent prompt.",
+	].join("\n");
+}
+
+test("agent frontmatter preserves missing, empty, and comma-separated tool intent", () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agents-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const agentsDir = path.join(directory, "agents");
+		mkdirSync(agentsDir, { recursive: true });
+		writeFileSync(path.join(agentsDir, "missing.md"), agentMarkdown("missing"));
+		writeFileSync(path.join(agentsDir, "blank.md"), agentMarkdown("blank", "tools:"));
+		writeFileSync(path.join(agentsDir, "empty.md"), agentMarkdown("empty", "tools: []"));
+		writeFileSync(
+			path.join(agentsDir, "selected.md"),
+			agentMarkdown("selected", "tools: read, grep, read"),
+		);
+
+		const agents = discoverAgents(directory, "user").agents;
+		assert.equal(agents.find((agent) => agent.name === "missing")?.tools, undefined);
+		assert.deepEqual(agents.find((agent) => agent.name === "blank")?.tools, []);
+		assert.deepEqual(agents.find((agent) => agent.name === "empty")?.tools, []);
+		assert.deepEqual(agents.find((agent) => agent.name === "selected")?.tools, [
+			"read",
+			"grep",
+			"read",
+		]);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});

--- a/extensions/pi-subagents/test/agents.test.ts
+++ b/extensions/pi-subagents/test/agents.test.ts
@@ -30,6 +30,10 @@ test("agent frontmatter preserves missing, empty, and comma-separated tool inten
 			path.join(agentsDir, "selected.md"),
 			agentMarkdown("selected", "tools: read, grep, read"),
 		);
+		writeFileSync(
+			path.join(agentsDir, "array.md"),
+			agentMarkdown("array", 'tools: [read, " grep ", ""]'),
+		);
 
 		const agents = discoverAgents(directory, "user").agents;
 		assert.equal(agents.find((agent) => agent.name === "missing")?.tools, undefined);
@@ -40,6 +44,7 @@ test("agent frontmatter preserves missing, empty, and comma-separated tool inten
 			"grep",
 			"read",
 		]);
+		assert.deepEqual(agents.find((agent) => agent.name === "array")?.tools, ["read", "grep"]);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;

--- a/extensions/pi-subagents/test/consult.test.ts
+++ b/extensions/pi-subagents/test/consult.test.ts
@@ -1,0 +1,453 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import type { SubagentSettings } from "../src/agents.js";
+import { type ConsultChildRequest, registerSubagentConsult } from "../src/consult.js";
+import type { SingleResult } from "../src/runner.js";
+
+function childResult(overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		agent: "worker",
+		agentSource: "built-in",
+		task: "inspect",
+		exitCode: 0,
+		messages: [],
+		stderr: "",
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 2,
+			cacheWrite: 1,
+			cost: 0.25,
+			contextTokens: 18,
+			turns: 1,
+		},
+		finalOutput: "consulted answer",
+		stopReason: "stop",
+		...overrides,
+	};
+}
+
+function setup(
+	options: {
+		settings?: SubagentSettings;
+		runChild?: (request: ConsultChildRequest) => Promise<SingleResult>;
+		invocationOverride?: { command: string; argsPrefix?: string[] };
+	} = {},
+) {
+	const mock = createMockPi();
+	const requests: ConsultChildRequest[] = [];
+	const runChild =
+		options.runChild || !options.invocationOverride
+			? async (request: ConsultChildRequest) => {
+					requests.push(request);
+					return options.runChild
+						? options.runChild(request)
+						: childResult({ agent: request.agent.name });
+				}
+			: undefined;
+	registerSubagentConsult(mock.pi, {
+		getSettings: () => options.settings,
+		invocationOverride: options.invocationOverride,
+		...(runChild ? { runChild } : {}),
+	});
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent_consult") as
+		| {
+				label: string;
+				description: string;
+				parameters: {
+					additionalProperties?: boolean;
+					required?: string[];
+					properties?: Record<string, { enum?: string[]; default?: unknown }>;
+				};
+				execute: (...args: unknown[]) => Promise<{
+					content: Array<{ type: string; text: string }>;
+					details: Record<string, unknown>;
+					usage?: { input: number; output: number; totalTokens: number; cost: { total: number } };
+				}>;
+		  }
+		| undefined;
+	assert.ok(tool);
+	return { mock, requests, tool };
+}
+
+function execute(
+	tool: NonNullable<ReturnType<typeof setup>["tool"]>,
+	params: Record<string, unknown>,
+	ctx = createMockContext().ctx,
+	signal?: AbortSignal,
+) {
+	return tool.execute("consult-1", params, signal, undefined, ctx);
+}
+
+test("subagent_consult registers a strict actionless single-agent schema", async () => {
+	const { tool } = setup();
+	assert.equal(tool.label, "Consult Read-only Subagent");
+	assert.match(tool.description, /read-only/i);
+	assert.equal(tool.parameters.additionalProperties, false);
+	assert.deepEqual(tool.parameters.required?.sort(), ["agent", "task"]);
+	assert.equal(tool.parameters.properties?.agentScope?.default, "user");
+	assert.equal(tool.parameters.properties?.confirmProjectAgents?.default, true);
+	assert.deepEqual(tool.parameters.properties?.thinkingLevel?.enum, [
+		"off",
+		"minimal",
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+		"max",
+	]);
+	await assert.rejects(
+		() => execute(tool, { agent: "worker", task: "x", tasks: [] }),
+		/does not accept tasks/,
+	);
+	await assert.rejects(() => execute(tool, { agent: "worker" }), /requires task/);
+});
+
+test("subagent_consult enforces default, empty, and intersected tool policy with nested usage", async () => {
+	for (const [settings, expected] of [
+		[undefined, ["read", "grep", "find", "ls"]],
+		[{ agents: { worker: { tools: [] } } }, []],
+		[{ agents: { worker: { tools: ["bash", "read", "read", "grep"] } } }, ["read", "grep"]],
+	] as Array<[SubagentSettings | undefined, string[]]>) {
+		const { tool, requests } = setup({ settings });
+		const result = await execute(tool, {
+			agent: "worker",
+			task: "Modify files if useful, but analysis is acceptable",
+		});
+		assert.deepEqual(requests[0].effectiveTools, expected);
+		assert.equal(requests[0].launchPolicy.disableExtensions, true);
+		assert.match(requests[0].agent.systemPrompt, /read-only/i);
+		assert.deepEqual(
+			(result.details.policy as { effectiveTools: string[] }).effectiveTools,
+			expected,
+		);
+		assert.equal(result.usage?.input, 10);
+		assert.equal(result.usage?.output, 5);
+		assert.equal(result.usage?.totalTokens, 18);
+		assert.equal(result.usage?.cost.total, 0.25);
+		assert.doesNotMatch(JSON.stringify(result.details), /messages/);
+	}
+});
+
+test("subagent_consult production runner emits enforced child arguments without provider traffic", async () => {
+	const script = [
+		"const fs=require('node:fs');const args=process.argv.slice(1);",
+		"const promptFlags=['--system-prompt','--append-system-prompt'];const prompts=args.flatMap((arg,index)=>promptFlags.includes(arg)&&args[index+1]?[fs.readFileSync(args[index+1],'utf8')]:[]);",
+		"const text=JSON.stringify({args,prompts});",
+		"const message={role:'assistant',content:[{type:'text',text}],timestamp:Date.now(),provider:'test',model:'test',usage:{input:1,output:1,cacheRead:0,cacheWrite:0,totalTokens:2,cost:{input:0.1,output:0.2,cacheRead:0,cacheWrite:0,total:0.3}},stopReason:'stop'};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+	].join("");
+	const { tool } = setup({
+		settings: { agents: { worker: { tools: [] } }, consult: { resources: "none" } },
+		invocationOverride: { command: process.execPath, argsPrefix: ["-e", script, "--"] },
+	});
+	const result = await execute(tool, { agent: "worker", task: "inspect" });
+	for (const expected of [
+		"--no-session",
+		"--no-extensions",
+		"--no-skills",
+		"--no-prompt-templates",
+		"--no-context-files",
+		"--no-approve",
+		"--no-tools",
+		"--system-prompt",
+		"--append-system-prompt",
+	]) {
+		assert.match(result.content[0].text, new RegExp(expected));
+	}
+	assert.match(result.content[0].text, /read-only consultation assistant/i);
+	assert.match(result.content[0].text, /This is a read-only consultation/i);
+	assert.equal(result.usage?.totalTokens, 2);
+	assert.equal(result.usage?.cost.total, 0.3);
+});
+
+test("subagent_consult maps resource policies and rejects unsafe external cwd", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-consult-cwd-"));
+	const workspace = path.join(root, "workspace");
+	const external = path.join(root, "external");
+	mkdirSync(path.join(workspace, ".pi"), { recursive: true });
+	mkdirSync(external);
+	writeFileSync(path.join(workspace, ".pi", "SYSTEM.md"), "trusted project system");
+	try {
+		const trusted = createMockContext({ cwd: workspace, isProjectTrusted: () => true }).ctx;
+		const projectContext = setup({ settings: { consult: { resources: "project-context" } } });
+		await execute(projectContext.tool, { agent: "worker", task: "inspect" }, trusted);
+		assert.equal(projectContext.requests[0].launchPolicy.disableSkills, true);
+		assert.equal(projectContext.requests[0].launchPolicy.disablePromptTemplates, true);
+		assert.equal(projectContext.requests[0].launchPolicy.projectTrust, true);
+		assert.equal(
+			projectContext.requests[0].launchPolicy.baseSystemPrompt,
+			"trusted project system",
+		);
+
+		await assert.rejects(
+			() =>
+				execute(projectContext.tool, { agent: "worker", task: "inspect", cwd: external }, trusted),
+			/outside the current workspace/i,
+		);
+
+		const none = setup({ settings: { consult: { resources: "none" } } });
+		await execute(none.tool, { agent: "worker", task: "inspect", cwd: external }, trusted);
+		assert.equal(none.requests[0].launchPolicy.disableContextFiles, true);
+		assert.equal(none.requests[0].launchPolicy.disableSkills, true);
+		assert.match(none.requests[0].launchPolicy.baseSystemPrompt ?? "", /read-only consultation/i);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("subagent_consult checks trust before project discovery and fails closed without confirmation UI", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-consult-trust-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = path.join(root, "agent-home");
+	const workspace = path.join(root, "workspace");
+	mkdirSync(path.join(workspace, ".pi", "agents"), { recursive: true });
+	writeFileSync(
+		path.join(workspace, ".pi", "agents", "project.md"),
+		"---\nname: project\ndescription: Project agent\n---\nproject prompt",
+	);
+	try {
+		const { tool, requests } = setup();
+		const untrusted = createMockContext({ cwd: workspace, isProjectTrusted: () => false }).ctx;
+		await assert.rejects(
+			() => execute(tool, { agent: "project", task: "inspect", agentScope: "project" }, untrusted),
+			/trusted project/i,
+		);
+		assert.equal(requests.length, 0);
+
+		const trustedNoUi = createMockContext({ cwd: workspace, isProjectTrusted: () => true }).ctx;
+		await assert.rejects(
+			() =>
+				execute(tool, { agent: "project", task: "inspect", agentScope: "project" }, trustedNoUi),
+			/confirmation.*UI/i,
+		);
+		await execute(
+			tool,
+			{
+				agent: "project",
+				task: "inspect",
+				agentScope: "project",
+				confirmProjectAgents: false,
+			},
+			trustedNoUi,
+		);
+		assert.equal(requests.length, 1);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("subagent_consult treats declined confirmation as normal cancellation", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-consult-cancel-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = path.join(root, "agent-home");
+	const workspace = path.join(root, "workspace");
+	mkdirSync(path.join(workspace, ".pi", "agents"), { recursive: true });
+	writeFileSync(
+		path.join(workspace, ".pi", "agents", "project.md"),
+		"---\nname: project\ndescription: Project agent\n---\nprompt",
+	);
+	try {
+		const { tool, requests } = setup();
+		const ctx = createMockContext({
+			cwd: workspace,
+			hasUI: true,
+			isProjectTrusted: () => true,
+			confirm: async () => false,
+		}).ctx;
+		const result = await execute(
+			tool,
+			{ agent: "project", task: "inspect", agentScope: "project" },
+			ctx,
+		);
+		assert.equal(result.details.cancelled, true);
+		assert.equal(result.usage, undefined);
+		assert.equal(requests.length, 0);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("subagent_consult bounds answer lines and structured details", async () => {
+	const tools = Array.from({ length: 1_000 }, (_, index) =>
+		index % 2 === 0 ? "read" : `unavailable-${index}-${"x".repeat(500)}`,
+	);
+	const { tool } = setup({
+		settings: { agents: { worker: { tools } } },
+		runChild: async () => childResult({ finalOutput: "x\n".repeat(3_000) }),
+	});
+	const result = await execute(tool, { agent: "worker", task: "inspect" });
+	assert.ok(Buffer.byteLength(result.content[0].text, "utf8") <= 50 * 1024);
+	assert.ok(result.content[0].text.split("\n").length <= 2_000);
+	assert.ok(Buffer.byteLength(JSON.stringify(result.details), "utf8") <= 50 * 1024);
+	assert.equal(result.details.truncated, true);
+});
+
+test("subagent_consult preserves post-launch evidence and marks the finalized Pi result as an error", async () => {
+	const { tool, mock } = setup({
+		runChild: async () =>
+			childResult({
+				exitCode: 124,
+				stopReason: "timeout",
+				timedOut: true,
+				finalOutput: "partial evidence",
+				errorMessage: "timed out",
+			}),
+	});
+	const result = await execute(tool, { agent: "worker", task: "inspect" });
+	assert.equal(result.details.isError, true);
+	assert.match(result.content[0].text, /partial evidence|timed out/);
+	assert.equal(result.usage?.cost.total, 0.25);
+	const handler = mock.events
+		.get("tool_result")
+		?.find(
+			(candidate) =>
+				candidate({ toolName: "other", details: {} }, createMockContext().ctx) === undefined,
+		);
+	assert.deepEqual(
+		handler?.(
+			{ toolName: "subagent_consult", details: result.details, usage: result.usage },
+			createMockContext().ctx,
+		),
+		{ isError: true },
+	);
+});
+
+test("subagent_consult preserves a post-launch caller abort as structured evidence", async () => {
+	let started!: () => void;
+	const didStart = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const { tool } = setup({
+		runChild: async (request) => {
+			started();
+			await new Promise<void>((resolve) =>
+				request.signal.addEventListener("abort", () => resolve(), { once: true }),
+			);
+			return childResult({
+				exitCode: 130,
+				stopReason: "aborted",
+				aborted: true,
+				processStarted: true,
+				finalOutput: "partial before abort",
+			});
+		},
+	});
+	const controller = new AbortController();
+	const running = execute(tool, { agent: "worker", task: "inspect" }, undefined, controller.signal);
+	await didStart;
+	controller.abort();
+	const result = await running;
+	assert.equal(result.details.isError, true);
+	assert.match(result.content[0].text, /partial before abort/);
+	assert.equal(result.usage?.cost.total, 0.25);
+});
+
+test("subagent_consult does not launch after a pending confirmation is replaced", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-consult-replaced-confirm-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = path.join(root, "agent-home");
+	const workspace = path.join(root, "workspace");
+	mkdirSync(path.join(workspace, ".pi", "agents"), { recursive: true });
+	writeFileSync(
+		path.join(workspace, ".pi", "agents", "project.md"),
+		"---\nname: project\ndescription: Project agent\n---\nprompt",
+	);
+	let resolveConfirm!: (approved: boolean) => void;
+	const confirming = new Promise<boolean>((resolve) => {
+		resolveConfirm = resolve;
+	});
+	try {
+		const { tool, mock, requests } = setup();
+		const ctx = createMockContext({
+			cwd: workspace,
+			hasUI: true,
+			isProjectTrusted: () => true,
+			confirm: async () => confirming,
+		}).ctx;
+		const running = execute(
+			tool,
+			{ agent: "project", task: "inspect", agentScope: "project" },
+			ctx,
+		);
+		await Promise.resolve();
+		for (const handler of mock.events.get("session_start") ?? []) {
+			await handler({}, createMockContext().ctx);
+		}
+		resolveConfirm(true);
+		await assert.rejects(running, (error) => error instanceof Error && error.name === "AbortError");
+		assert.equal(requests.length, 0);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("subagent_consult aborts owned work on session replacement", async () => {
+	let started!: () => void;
+	const didStart = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const { tool, mock } = setup({
+		runChild: async (request) => {
+			started();
+			await new Promise<void>((resolve) =>
+				request.signal.addEventListener("abort", () => resolve(), { once: true }),
+			);
+			return childResult({
+				exitCode: 130,
+				stopReason: "aborted",
+				aborted: true,
+				finalOutput: "",
+				errorMessage: "replaced",
+			});
+		},
+	});
+	const running = execute(tool, { agent: "worker", task: "inspect" });
+	await didStart;
+	for (const handler of mock.events.get("session_start") ?? []) {
+		await handler({}, createMockContext().ctx);
+	}
+	await assert.rejects(
+		running,
+		(error) =>
+			error instanceof Error &&
+			error.name === "AbortError" &&
+			/owner was replaced/.test(error.message),
+	);
+});
+
+test("subagent_consult waits for owned child cleanup on shutdown", async () => {
+	let started!: () => void;
+	const didStart = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	let cleaned = false;
+	const { tool, mock } = setup({
+		runChild: async (request) => {
+			started();
+			await new Promise<void>((resolve) =>
+				request.signal.addEventListener("abort", () => resolve(), { once: true }),
+			);
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			cleaned = true;
+			return childResult({ exitCode: 130, stopReason: "aborted", aborted: true });
+		},
+	});
+	const running = execute(tool, { agent: "worker", task: "inspect" });
+	await didStart;
+	for (const handler of mock.events.get("session_shutdown") ?? []) {
+		await handler({}, createMockContext().ctx);
+	}
+	assert.equal(cleaned, true);
+	await assert.rejects(running, (error) => error instanceof Error && error.name === "AbortError");
+});

--- a/extensions/pi-subagents/test/consult.test.ts
+++ b/extensions/pi-subagents/test/consult.test.ts
@@ -61,7 +61,7 @@ function setup(
 				parameters: {
 					additionalProperties?: boolean;
 					required?: string[];
-					properties?: Record<string, { enum?: string[]; default?: unknown }>;
+					properties?: Record<string, { enum?: string[]; default?: unknown; maximum?: number }>;
 				};
 				execute: (...args: unknown[]) => Promise<{
 					content: Array<{ type: string; text: string }>;
@@ -91,6 +91,7 @@ test("subagent_consult registers a strict actionless single-agent schema", async
 	assert.deepEqual(tool.parameters.required?.sort(), ["agent", "task"]);
 	assert.equal(tool.parameters.properties?.agentScope?.default, "user");
 	assert.equal(tool.parameters.properties?.confirmProjectAgents?.default, true);
+	assert.equal(tool.parameters.properties?.timeoutMs?.maximum, 2_147_483_647);
 	assert.deepEqual(tool.parameters.properties?.thinkingLevel?.enum, [
 		"off",
 		"minimal",
@@ -105,6 +106,18 @@ test("subagent_consult registers a strict actionless single-agent schema", async
 		/does not accept tasks/,
 	);
 	await assert.rejects(() => execute(tool, { agent: "worker" }), /requires task/);
+});
+
+test("subagent_consult rejects unsafe CLI-bound tasks and timer overflow before launch", async () => {
+	for (const [params, expected] of [
+		[{ agent: "worker", task: "界".repeat(20_000) }, /UTF-8 bytes/i],
+		[{ agent: "worker", task: "inspect\0outside" }, /NUL/i],
+		[{ agent: "worker", task: "inspect", timeoutMs: 2_147_483_648 }, /timeoutMs.*2147483647/i],
+	] as Array<[Record<string, unknown>, RegExp]>) {
+		const { tool, requests } = setup();
+		await assert.rejects(() => execute(tool, params), expected);
+		assert.equal(requests.length, 0);
+	}
 });
 
 test("subagent_consult enforces default, empty, and intersected tool policy with nested usage", async () => {
@@ -163,6 +176,30 @@ test("subagent_consult production runner emits enforced child arguments without 
 	assert.match(result.content[0].text, /This is a read-only consultation/i);
 	assert.equal(result.usage?.totalTokens, 2);
 	assert.equal(result.usage?.cost.total, 0.3);
+});
+
+test("subagent_consult bounds explicitly loaded base system prompts", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-consult-system-prompt-"));
+	const workspace = path.join(root, "workspace");
+	mkdirSync(path.join(workspace, ".pi"), { recursive: true });
+	writeFileSync(
+		path.join(workspace, ".pi", "SYSTEM.md"),
+		`trusted-start\n${"界".repeat(30_000)}\nSHOULD_NOT_SURVIVE`,
+	);
+	try {
+		const { tool, requests } = setup({
+			settings: { consult: { resources: "project-context" } },
+		});
+		const trusted = createMockContext({ cwd: workspace, isProjectTrusted: () => true }).ctx;
+		await execute(tool, { agent: "worker", task: "inspect" }, trusted);
+		const prompt = requests[0].launchPolicy.baseSystemPrompt ?? "";
+		assert.ok(Buffer.byteLength(prompt, "utf8") <= 50 * 1024);
+		assert.match(prompt, /trusted-start/);
+		assert.match(prompt, /truncated by pi-subagents/);
+		assert.doesNotMatch(prompt, /SHOULD_NOT_SURVIVE/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("subagent_consult maps resource policies and rejects unsafe external cwd", async () => {
@@ -250,16 +287,20 @@ test("subagent_consult treats declined confirmation as normal cancellation", asy
 	const workspace = path.join(root, "workspace");
 	mkdirSync(path.join(workspace, ".pi", "agents"), { recursive: true });
 	writeFileSync(
-		path.join(workspace, ".pi", "agents", "project.md"),
+		path.join(workspace, ".pi", "agents", "project-\u001b[31m.md"),
 		"---\nname: project\ndescription: Project agent\n---\nprompt",
 	);
+	let confirmation = "";
 	try {
 		const { tool, requests } = setup();
 		const ctx = createMockContext({
 			cwd: workspace,
 			hasUI: true,
 			isProjectTrusted: () => true,
-			confirm: async () => false,
+			confirm: async (title: string, message: string) => {
+				confirmation = `${title}\n${message}`;
+				return false;
+			},
 		}).ctx;
 		const result = await execute(
 			tool,
@@ -269,6 +310,7 @@ test("subagent_consult treats declined confirmation as normal cancellation", asy
 		assert.equal(result.details.cancelled, true);
 		assert.equal(result.usage, undefined);
 		assert.equal(requests.length, 0);
+		assert.equal(confirmation.includes("\u001b"), false);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;
@@ -281,8 +323,13 @@ test("subagent_consult bounds answer lines and structured details", async () => 
 		index % 2 === 0 ? "read" : `unavailable-${index}-${"x".repeat(500)}`,
 	);
 	const { tool } = setup({
-		settings: { agents: { worker: { tools } } },
-		runChild: async () => childResult({ finalOutput: "x\n".repeat(3_000) }),
+		settings: { agents: { worker: { tools, model: "model-".repeat(20_000) } } },
+		runChild: async () =>
+			childResult({
+				actualProvider: "provider-".repeat(20_000),
+				actualModel: "actual-model-".repeat(20_000),
+				finalOutput: "x\n".repeat(3_000),
+			}),
 	});
 	const result = await execute(tool, { agent: "worker", task: "inspect" });
 	assert.ok(Buffer.byteLength(result.content[0].text, "utf8") <= 50 * 1024);
@@ -299,12 +346,13 @@ test("subagent_consult preserves post-launch evidence and marks the finalized Pi
 				stopReason: "timeout",
 				timedOut: true,
 				finalOutput: "partial evidence",
-				errorMessage: "timed out",
+				errorMessage: "timed out <private>SECRET_ERROR</private>\n[subagent-private] SECRET_LINE",
 			}),
 	});
 	const result = await execute(tool, { agent: "worker", task: "inspect" });
 	assert.equal(result.details.isError, true);
 	assert.match(result.content[0].text, /partial evidence|timed out/);
+	assert.doesNotMatch(JSON.stringify(result), /SECRET_ERROR|SECRET_LINE/);
 	assert.equal(result.usage?.cost.total, 0.25);
 	const handler = mock.events
 		.get("tool_result")

--- a/extensions/pi-subagents/test/inspect.test.ts
+++ b/extensions/pi-subagents/test/inspect.test.ts
@@ -99,7 +99,7 @@ test("subagent_inspect projects safe agent metadata and gates project discovery 
 			"---\nname: safe\ndescription: Safe agent\ntools: read, bash\n---\nSECRET_SYSTEM_PROMPT",
 		);
 		writeFileSync(
-			path.join(workspace, ".pi", "agents", "project.md"),
+			path.join(workspace, ".pi", "agents", "project-\u001b[31m.md"),
 			"---\nname: project\ndescription: Project agent\n---\nUNTRUSTED_PROMPT",
 		);
 		const mock = createMockPi();
@@ -126,7 +126,9 @@ test("subagent_inspect projects safe agent metadata and gates project discovery 
 			{ action: "get_agent", agent: "project", agentScope: "project" },
 			trusted,
 		);
-		assert.equal((project.details.agent as { path: string }).path, ".pi/agents/project.md");
+		const projectPath = (project.details.agent as { path: string }).path;
+		assert.match(projectPath, /^\.pi\/agents\/project-/);
+		assert.equal(projectPath.includes("\u001b"), false);
 		assert.doesNotMatch(JSON.stringify(project), /UNTRUSTED_PROMPT/);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;

--- a/extensions/pi-subagents/test/inspect.test.ts
+++ b/extensions/pi-subagents/test/inspect.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { registerSubagentInspect } from "../src/inspect.js";
+import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "../src/registry.js";
+
+function runtime(
+	options: {
+		runs?: AgentRunInspectionSummary[];
+		detail?: AgentRunInspectionDetail;
+		blocking?: boolean;
+	} = {},
+) {
+	return {
+		getBlockingEnabled: () => options.blocking ?? true,
+		getConsultResourcePolicy: () => "project-context" as const,
+		getRuntimeStatus: () => ({
+			enabled: true,
+			initialized: true,
+			transport: "subprocess" as const,
+			completionDelivery: "next-turn" as const,
+			activeAgents: 1,
+			retainedAgents: 2,
+		}),
+		listRunInspection: () => options.runs ?? [],
+		getRunInspection: (id: string) => (id === options.detail?.id ? options.detail : undefined),
+	};
+}
+
+function registeredTool(mock: ReturnType<typeof createMockPi>) {
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent_inspect");
+	assert.ok(tool);
+	return tool as {
+		label: string;
+		description: string;
+		parameters: {
+			additionalProperties?: boolean;
+			properties?: Record<string, { enum?: string[]; default?: unknown }>;
+		};
+		execute: (...args: unknown[]) => Promise<{
+			content: Array<{ type: string; text: string }>;
+			details: Record<string, unknown>;
+		}>;
+	};
+}
+
+async function execute(
+	tool: ReturnType<typeof registeredTool>,
+	params: Record<string, unknown>,
+	ctx = createMockContext().ctx,
+) {
+	return tool.execute("inspect-1", params, undefined, undefined, ctx);
+}
+
+test("subagent_inspect registers one strict Google-compatible action schema", async () => {
+	const mock = createMockPi();
+	registerSubagentInspect(mock.pi, runtime());
+	const tool = registeredTool(mock);
+	assert.equal(tool.label, "Inspect Subagents");
+	assert.match(tool.description, /without changing/i);
+	assert.equal(tool.parameters.additionalProperties, false);
+	assert.deepEqual(tool.parameters.properties?.action?.enum, [
+		"list_agents",
+		"get_agent",
+		"list_runs",
+		"get_run",
+		"list_models",
+		"status",
+		"diagnose",
+	]);
+	assert.equal(tool.parameters.properties?.agentScope?.default, "user");
+
+	await assert.rejects(
+		() => execute(tool, { action: "status", limit: 1 }),
+		/does not accept limit/,
+	);
+	await assert.rejects(() => execute(tool, { action: "get_agent" }), /requires agent/);
+	await assert.rejects(() => execute(tool, { action: "get_run" }), /requires agentId/);
+	await assert.rejects(
+		() => execute(tool, { action: "list_models", limit: 101 }),
+		/between 1 and 100/,
+	);
+});
+
+test("subagent_inspect projects safe agent metadata and gates project discovery before reads", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-inspect-"));
+	const agentDir = path.join(directory, "agent-home");
+	const workspace = path.join(directory, "workspace");
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		mkdirSync(path.join(agentDir, "agents"), { recursive: true });
+		mkdirSync(path.join(workspace, ".pi", "agents"), { recursive: true });
+		writeFileSync(
+			path.join(agentDir, "agents", "safe.md"),
+			"---\nname: safe\ndescription: Safe agent\ntools: read, bash\n---\nSECRET_SYSTEM_PROMPT",
+		);
+		writeFileSync(
+			path.join(workspace, ".pi", "agents", "project.md"),
+			"---\nname: project\ndescription: Project agent\n---\nUNTRUSTED_PROMPT",
+		);
+		const mock = createMockPi();
+		registerSubagentInspect(mock.pi, runtime());
+		const tool = registeredTool(mock);
+		const ctx = createMockContext({ cwd: workspace, isProjectTrusted: () => false }).ctx;
+		const listed = await execute(tool, { action: "list_agents", limit: 100 }, ctx);
+		assert.match(listed.content[0].text, /safe/);
+		assert.doesNotMatch(JSON.stringify(listed), /SECRET_SYSTEM_PROMPT|UNTRUSTED_PROMPT/);
+
+		const agent = await execute(tool, { action: "get_agent", agent: "safe" }, ctx);
+		assert.deepEqual((agent.details.agent as { tools: string[] }).tools, ["read", "bash"]);
+		assert.deepEqual((agent.details.agent as { consultTools: string[] }).consultTools, ["read"]);
+		assert.match(String((agent.details.agent as { path: string }).path), /^~\//);
+		assert.doesNotMatch(JSON.stringify(agent), /SECRET_SYSTEM_PROMPT/);
+
+		await assert.rejects(
+			() => execute(tool, { action: "list_agents", agentScope: "project" }, ctx),
+			/trusted project/i,
+		);
+		const trusted = createMockContext({ cwd: workspace, isProjectTrusted: () => true }).ctx;
+		const project = await execute(
+			tool,
+			{ action: "get_agent", agent: "project", agentScope: "project" },
+			trusted,
+		);
+		assert.equal((project.details.agent as { path: string }).path, ".pi/agents/project.md");
+		assert.doesNotMatch(JSON.stringify(project), /UNTRUSTED_PROMPT/);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("subagent_inspect returns metadata-only run summaries", async () => {
+	const summary: AgentRunInspectionSummary = {
+		id: "sa_one",
+		agent: "scout",
+		state: "running",
+		createdAt: 1,
+		updatedAt: 2,
+		historyCount: 3,
+		unreadMessages: 4,
+	};
+	const detail: AgentRunInspectionDetail = {
+		...summary,
+		cwd: process.cwd(),
+		thinkingLevel: "high",
+		currentTask: "current task\u001b[31m",
+		error: "bounded error",
+		policy: { inherited: ["environment"], overridden: [], unsupported: [] },
+	};
+	const mock = createMockPi();
+	registerSubagentInspect(mock.pi, runtime({ runs: [summary], detail }));
+	const tool = registeredTool(mock);
+	const listed = await execute(tool, { action: "list_runs" });
+	assert.deepEqual(listed.details.runs, [summary]);
+	assert.equal(JSON.stringify(listed).includes("current task"), false);
+	const got = await execute(tool, { action: "get_run", agentId: "sa_one" });
+	assert.match(String((got.details.run as { currentTask: string }).currentTask), /current task/);
+	assert.equal(JSON.stringify(got).includes("\u001b"), false);
+	await assert.rejects(
+		() => execute(tool, { action: "get_run", agentId: "missing" }),
+		/Unknown retained run/,
+	);
+});
+
+test("subagent_inspect bounds list details as well as model-facing content", async () => {
+	const runs: AgentRunInspectionSummary[] = Array.from({ length: 100 }, (_, index) => ({
+		id: `sa_${index}_${"x".repeat(1_000)}`,
+		agent: `agent_${index}_${"y".repeat(1_000)}`,
+		state: "completed",
+		createdAt: index,
+		updatedAt: index,
+		historyCount: index,
+		unreadMessages: index,
+	}));
+	const mock = createMockPi();
+	registerSubagentInspect(mock.pi, runtime({ runs }));
+	const result = await execute(registeredTool(mock), {
+		action: "list_runs",
+		includeClosed: true,
+		limit: 100,
+	});
+	assert.ok(Buffer.byteLength(result.content[0].text, "utf8") <= 50 * 1024);
+	assert.ok(Buffer.byteLength(JSON.stringify(result.details), "utf8") <= 50 * 1024);
+	assert.ok((result.details.omitted as number) > 0);
+});
+
+test("subagent_inspect uses scoped model snapshots and structured diagnostics without auth calls", async () => {
+	const model = {
+		provider: "test-provider",
+		id: "model-one",
+		name: "Model One",
+		api: "openai-responses",
+		baseUrl: "https://secret.invalid/key",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 200,
+		headers: { Authorization: "SECRET_TOKEN" },
+	};
+	const modelRegistry = {
+		getAvailable: () => {
+			throw new Error("scoped models should win");
+		},
+		refresh: () => {
+			throw new Error("must not refresh");
+		},
+		getApiKeyAndHeaders: () => {
+			throw new Error("must not resolve auth");
+		},
+	};
+	const ctx = createMockContext({
+		model,
+		scopedModels: [{ model, thinkingLevel: "medium" }],
+		modelRegistry,
+	}).ctx;
+	const mock = createMockPi();
+	registerSubagentInspect(mock.pi, runtime({ blocking: false }));
+	const tool = registeredTool(mock);
+	const result = await execute(tool, { action: "list_models" }, ctx);
+	assert.match(result.content[0].text, /model-one/);
+	assert.doesNotMatch(JSON.stringify(result), /secret\.invalid|SECRET_TOKEN|headers|baseUrl/);
+	assert.equal(
+		(result.details.models as Array<{ thinkingLevel: string }>)[0].thinkingLevel,
+		"medium",
+	);
+
+	const diagnosed = await execute(tool, { action: "diagnose" }, ctx);
+	const checks = diagnosed.details.checks as Array<{ status: string }>;
+	assert.ok(checks.length >= 5);
+	assert.ok(checks.every((check) => ["pass", "warning", "fail"].includes(check.status)));
+	assert.equal((diagnosed.details as { ok?: boolean }).ok, false);
+});

--- a/extensions/pi-subagents/test/registry.test.ts
+++ b/extensions/pi-subagents/test/registry.test.ts
@@ -24,6 +24,52 @@ function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	};
 }
 
+test("AgentRegistry exposes metadata-only inspection snapshots", async () => {
+	let finish!: (value: { output: string; exitCode: number; error?: string }) => void;
+	const registry = new AgentRegistry(
+		async () =>
+			new Promise((resolve) => {
+				finish = resolve;
+			}),
+	);
+	const spawned = await registry.spawn({
+		agent: "scout",
+		task: "private current task",
+		cwd: process.cwd(),
+		thinkingLevel: "high",
+		context: "private parent context",
+	});
+	await registry.sendMessage(spawned.id, "private mailbox content");
+
+	assert.deepEqual(registry.inspectionCounts(), { activeAgents: 1, retainedAgents: 1 });
+	const listed = registry.listInspection();
+	assert.equal(listed.length, 1);
+	assert.deepEqual(listed[0], {
+		id: spawned.id,
+		agent: "scout",
+		state: "running",
+		createdAt: spawned.createdAt,
+		updatedAt: listed[0].updatedAt,
+		historyCount: 0,
+		unreadMessages: 1,
+	});
+	assert.doesNotMatch(JSON.stringify(listed), /private/);
+
+	const detail = registry.getInspection(spawned.id);
+	assert.equal(detail?.currentTask, "private current task");
+	assert.equal(detail?.cwd, process.cwd());
+	assert.equal(detail?.thinkingLevel, "high");
+	assert.doesNotMatch(JSON.stringify(detail), /mailbox content|parent context/);
+
+	finish({ output: "private history output", exitCode: 1, error: "private error" });
+	await registry.wait(spawned.id, 100);
+	assert.deepEqual(registry.inspectionCounts(), { activeAgents: 0, retainedAgents: 1 });
+	const completed = registry.getInspection(spawned.id);
+	assert.equal(completed?.historyCount, 1);
+	assert.equal(completed?.error, "private error");
+	assert.doesNotMatch(JSON.stringify(completed), /history output|mailbox content|parent context/);
+});
+
 test("AgentRegistry rejects invalid capacity and wait bounds", async () => {
 	assert.throws(
 		() => new AgentRegistry(async () => ({ output: "", exitCode: 0 }), { maxActiveTurns: 0 }),

--- a/extensions/pi-subagents/test/runner-render.test.ts
+++ b/extensions/pi-subagents/test/runner-render.test.ts
@@ -7,6 +7,7 @@ import {
 	DEFAULT_MAX_CONTEXT_BYTES,
 	DEFAULT_MAX_OUTPUT_BYTES,
 	DEFAULT_MAX_STDERR_BYTES,
+	MAX_SUBAGENT_TIMEOUT_MS,
 } from "../src/limits.js";
 import { renderSubagentCall, renderSubagentResult } from "../src/render.js";
 import {
@@ -195,6 +196,35 @@ test("runSingleAgent normalizes invalid cwd without spawning or throwing", async
 	assert.equal(result.exitCode, 1);
 	assert.equal(result.stopReason, "error");
 	assert.match(result.errorMessage ?? "", /Invalid subagent cwd/);
+});
+
+test("runSingleAgent rejects timer overflow before spawning", async () => {
+	const result = await runSingleAgent(
+		process.cwd(),
+		[
+			{
+				name: "test",
+				description: "test",
+				systemPrompt: "",
+				source: "built-in",
+				filePath: "built-in:test",
+			},
+		],
+		"test",
+		"task",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		MAX_SUBAGENT_TIMEOUT_MS + 1,
+		undefined,
+		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		{ command: path.join(os.tmpdir(), "missing-pi-subagent-command") },
+	);
+	assert.equal(result.exitCode, 1);
+	assert.equal(result.stopReason, "error");
+	assert.equal(result.launchFailed, undefined);
+	assert.match(result.errorMessage ?? "", /Invalid subagent timeout/);
 });
 
 test("runSingleAgent preserves partial output on mid-stream abort and handles pre-abort", async () => {
@@ -413,6 +443,32 @@ test("runSingleAgent preserves final text beyond its history budget and rejects 
 	assert.equal(rollingWindow.actualProvider, "actual-provider");
 	assert.equal(rollingWindow.actualModel, "actual-model");
 	assert.equal(rollingWindow.model, "requested-alias");
+
+	const malformedMetadata = await runScript(
+		[
+			"const message={role:'assistant',provider:{secret:'value'},responseModel:['bad'],content:[{type:'text',text:'SAFE_FINAL'}],stopReason:42,usage:{input:2,output:'bad',cacheRead:-3,cacheWrite:1.5,cost:{input:'bad',output:0.25,total:0.25}}};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	assert.equal(malformedMetadata.exitCode, 0);
+	assert.equal(malformedMetadata.finalOutput, "SAFE_FINAL");
+	assert.equal(malformedMetadata.actualProvider, undefined);
+	assert.equal(malformedMetadata.actualModel, undefined);
+	assert.equal(malformedMetadata.stopReason, undefined);
+	assert.deepEqual(malformedMetadata.usage, {
+		input: 2,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: 0.25,
+		costInput: 0,
+		costOutput: 0.25,
+		costCacheRead: 0,
+		costCacheWrite: 0,
+		totalTokens: 2,
+		contextTokens: 2,
+		turns: 1,
+	});
 	assert.equal(rollingWindow.recentActivityTotal, 202);
 	assert.equal(rollingWindow.recentActivity?.length, 10);
 	assert.ok(Buffer.byteLength(JSON.stringify(rollingWindow.recentActivity), "utf8") <= 8 * 1024);

--- a/extensions/pi-subagents/test/runner-render.test.ts
+++ b/extensions/pi-subagents/test/runner-render.test.ts
@@ -11,12 +11,56 @@ import {
 import { renderSubagentCall, renderSubagentResult } from "../src/render.js";
 import {
 	buildFanInContext,
+	buildPiArgs,
 	formatResultFailure,
 	isResultError,
 	runSingleAgent,
 	type SubagentDetails,
 	terminateProcess,
 } from "../src/runner.js";
+
+test("buildPiArgs emits explicit read-only child launch policy flags", () => {
+	assert.deepEqual(
+		buildPiArgs({
+			task: "inspect",
+			tools: ["read", "grep"],
+			disableExtensions: true,
+			disableSkills: true,
+			disablePromptTemplates: true,
+			disableContextFiles: true,
+			projectTrust: false,
+			baseSystemPromptPath: "/tmp/base.md",
+			appendSystemPromptPaths: ["/tmp/append.md", "/tmp/agent.md"],
+		}),
+		[
+			"--mode",
+			"json",
+			"-p",
+			"--no-session",
+			"--no-extensions",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-context-files",
+			"--no-approve",
+			"--tools",
+			"read,grep",
+			"--system-prompt",
+			"/tmp/base.md",
+			"--append-system-prompt",
+			"/tmp/append.md",
+			"--append-system-prompt",
+			"/tmp/agent.md",
+			"Task: inspect",
+		],
+	);
+	assert.deepEqual(buildPiArgs({ task: "existing" }), [
+		"--mode",
+		"json",
+		"-p",
+		"--no-session",
+		"Task: existing",
+	]);
+});
 
 test("renderSubagentCall handles partial streaming arguments", () => {
 	const identityTheme = {
@@ -63,6 +107,67 @@ test("renderSubagentCall omits an empty optional aggregator", () => {
 
 	assert.match(rendered, /parallel \(1 tasks\)/);
 	assert.doesNotMatch(rendered, /fan-in/);
+});
+
+test("runSingleAgent launch policies preserve agent tools unless explicitly overridden", async () => {
+	const script = [
+		"const text=JSON.stringify(process.argv.slice(1));",
+		"const message={role:'assistant',content:[{type:'text',text}],stopReason:'stop',timestamp:Date.now()};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+	].join("");
+	const result = await runSingleAgent(
+		process.cwd(),
+		[
+			{
+				name: "test",
+				description: "test",
+				tools: ["read"],
+				systemPrompt: "",
+				source: "built-in",
+				filePath: "built-in:test",
+			},
+		],
+		"test",
+		"task",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		1_000,
+		undefined,
+		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },
+		{ disableExtensions: true },
+	);
+	assert.match(result.finalOutput ?? "", /--tools/);
+	assert.match(result.finalOutput ?? "", /read/);
+});
+
+test("runSingleAgent distinguishes child launch failures", async () => {
+	const result = await runSingleAgent(
+		process.cwd(),
+		[
+			{
+				name: "test",
+				description: "test",
+				systemPrompt: "",
+				source: "built-in",
+				filePath: "built-in:test",
+			},
+		],
+		"test",
+		"task",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		1_000,
+		undefined,
+		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		{ command: path.join(os.tmpdir(), "missing-pi-subagent-command") },
+	);
+	assert.equal(result.launchFailed, true);
+	assert.equal(result.exitCode, 1);
 });
 
 test("runSingleAgent normalizes invalid cwd without spawning or throwing", async () => {

--- a/extensions/pi-subagents/test/settings.test.ts
+++ b/extensions/pi-subagents/test/settings.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	consumeSubagentSettingsNotice,
+	inspectConsultResourceSettings,
+	inspectSubagentSettings,
+	normalizeSubagentSettings,
+	readSubagentSettings,
+	updateConsultResourceSetting,
+} from "../src/settings.js";
+
+function withAgentDir(run: (directory: string) => void): void {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-settings-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		run(directory);
+	} finally {
+		consumeSubagentSettingsNotice();
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+test("consult resources normalize strictly and default without creating settings", () => {
+	withAgentDir((directory) => {
+		assert.deepEqual(normalizeSubagentSettings({ consult: { resources: "none" } }), {
+			consult: { resources: "none" },
+		});
+		assert.deepEqual(normalizeSubagentSettings({ consult: { resources: "all" } }), {
+			consult: { resources: "all" },
+		});
+		assert.equal(normalizeSubagentSettings({ consult: { resources: "unsafe" } }), undefined);
+
+		const inspected = inspectConsultResourceSettings();
+		assert.equal(inspected.value, "project-context");
+		assert.equal(inspected.source, "default");
+		assert.equal(inspected.error, undefined);
+		assert.equal(inspected.path, path.join(directory, "pi-subagents.json"));
+		assert.equal(readSubagentSettings(), undefined);
+		assert.throws(() => readFileSync(inspected.path, "utf8"), /ENOENT/);
+	});
+});
+
+test("pure settings inspection preserves pending notices", () => {
+	withAgentDir((directory) => {
+		writeFileSync(
+			path.join(directory, "pi-subagents-config.json"),
+			JSON.stringify({ consult: { resources: "all" } }),
+		);
+		assert.equal(readSubagentSettings()?.consult?.resources, "all");
+		const snapshot = inspectSubagentSettings();
+		assert.equal(snapshot.settings?.consult?.resources, "all");
+		assert.equal(snapshot.source, "user settings");
+		assert.match(consumeSubagentSettingsNotice() ?? "", /legacy/i);
+	});
+});
+
+test("consult resource updates preserve unknown fields and reject invalid files", () => {
+	withAgentDir((directory) => {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ future: { keep: true }, consult: { future: 7, resources: "all" } }),
+		);
+		updateConsultResourceSetting("none");
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			future: { keep: true },
+			consult: { future: 7, resources: "none" },
+		});
+
+		writeFileSync(settingsPath, "{ broken");
+		assert.throws(() => updateConsultResourceSetting("all"), /malformed/i);
+		assert.equal(readFileSync(settingsPath, "utf8"), "{ broken");
+	});
+});

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -1049,22 +1049,89 @@ test("one-shot project agents require project trust even when confirmation is di
 	const mock = createMockPi();
 	subagents(mock.pi);
 	const tool = mock.tools[0] as SubagentTool;
-	await assert.rejects(
-		() =>
-			tool.execute(
-				"call",
-				{
-					agent: "project",
-					task: "task",
-					agentScope: "project",
-					confirmProjectAgents: false,
-				},
-				undefined,
-				undefined,
-				createMockContext({ cwd, isProjectTrusted: () => false }).ctx,
-			),
-		/trusted project/,
+	const spawn = mock.tools.find((candidate) => candidate.name === "subagent_spawn") as
+		| SubagentTool
+		| undefined;
+	assert.ok(spawn);
+	try {
+		await assert.rejects(
+			() =>
+				tool.execute(
+					"call",
+					{
+						agent: "project",
+						task: "task",
+						agentScope: "project",
+						confirmProjectAgents: false,
+					},
+					undefined,
+					undefined,
+					createMockContext({ cwd, isProjectTrusted: () => false }).ctx,
+				),
+			/trusted project/,
+		);
+		await assert.rejects(
+			() =>
+				tool.execute(
+					"call",
+					{ agent: "missing", task: "task", agentScope: "project" },
+					undefined,
+					undefined,
+					createMockContext({ cwd, isProjectTrusted: () => false }).ctx,
+				),
+			/trusted project/,
+		);
+		await assert.rejects(
+			() =>
+				spawn.execute(
+					"call",
+					{ agent: "missing", task: "task", agentScope: "project" },
+					undefined,
+					undefined,
+					createMockContext({ cwd, isProjectTrusted: () => false }).ctx,
+				),
+			/trusted project/,
+		);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("one-shot project confirmation renders project metadata as one safe line", async () => {
+	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-confirm-"));
+	const agentsDir = path.join(cwd, ".pi", "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	const agentName = "project\u001b[31m\nspoof";
+	writeFileSync(
+		path.join(agentsDir, "project.md"),
+		`---\nname: "project\\u001b[31m\\nspoof"\ndescription: project agent\n---\nProject prompt.`,
 	);
+	let confirmation = "";
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools[0] as SubagentTool;
+		const result = await tool.execute(
+			"call",
+			{ agent: agentName, task: "task", agentScope: "project" },
+			undefined,
+			undefined,
+			createMockContext({
+				cwd,
+				hasUI: true,
+				isProjectTrusted: () => true,
+				confirm: async (title: string, message: string) => {
+					confirmation = `${title}\n${message}`;
+					return false;
+				},
+			}).ctx,
+		);
+		assert.match(result.content?.[0]?.text ?? "", /Canceled/);
+		assert.equal(confirmation.includes("\u001b"), false);
+		assert.doesNotMatch(confirmation, /\nspoof\nSource:/);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
 });
 
 test("discoverAgents includes built-ins and lets project agents override by name", () => {
@@ -1282,6 +1349,7 @@ test("subagent settings normalize known override fields only", () => {
 				clearThinking: { thinkingLevel: null },
 				bad: { tools: [1] },
 				badThinking: { thinkingLevel: "huge" },
+				badTimeout: { timeoutMs: 2_147_483_648 },
 			},
 		}),
 		{

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -90,7 +90,15 @@ test("subagents registers consistent blocking guidance and one management comman
 
 	assert.deepEqual(
 		mock.tools.map((candidate) => candidate.name),
-		["subagent", "subagent_spawn", "subagent_send", "subagent_manage", "subagent_mailbox"],
+		[
+			"subagent",
+			"subagent_spawn",
+			"subagent_send",
+			"subagent_manage",
+			"subagent_mailbox",
+			"subagent_inspect",
+			"subagent_consult",
+		],
 	);
 	const tool = mock.tools[0];
 	assert.equal(tool?.name, "subagent");
@@ -145,7 +153,7 @@ test("subagents registers consistent blocking guidance and one management comman
 		["subagents"],
 	);
 	assert.deepEqual(mock.commands.get("subagents")?.getArgumentCompletions?.("s"), [
-		{ value: "settings", label: "settings", description: "Configure completion behavior" },
+		{ value: "settings", label: "settings", description: "Configure subagent user settings" },
 		{ value: "status", label: "status", description: "Show effective subagent settings" },
 	]);
 	const toolResultHandler = mock.events.get("tool_result")?.[0];
@@ -191,7 +199,8 @@ test("bare subagents opens a current-session manager and keeps direct routes pre
 		assert.match(managerText, /Agents: 0 active.*0 retained/);
 		assert.match(managerText, /Change delegation/);
 		assert.match(managerText, /Current agents/);
-		assert.match(managerText, /Completion behavior/);
+		assert.match(managerText, /Settings/);
+		assert.match(managerText, /Consult resources: Project context only/);
 		assert.match(managerText, /Advanced settings/);
 		assert.equal(managerContext.notifications.length, 0);
 
@@ -314,7 +323,9 @@ test("agent tool drafts preserve settings across searchable save, discard, and E
 		const runtime: SubagentSettingsRuntime = {
 			getBlockingEnabled: () => true,
 			getCompletionDelivery: () => "next-turn",
+			getConsultResourcePolicy: () => "project-context",
 			setCompletionDelivery: () => undefined,
+			setConsultResourcePolicy: () => undefined,
 			getRuntimeStatus: () => ({
 				enabled: true,
 				initialized: true,
@@ -610,7 +621,9 @@ test("delegation workflow blocks reload while detached agents are retained", asy
 		const runtime: SubagentSettingsRuntime = {
 			getBlockingEnabled: () => true,
 			getCompletionDelivery: () => "next-turn",
+			getConsultResourcePolicy: () => "project-context",
 			setCompletionDelivery: () => undefined,
+			setConsultResourcePolicy: () => undefined,
 			getRuntimeStatus: () => ({
 				enabled: true,
 				initialized: true,
@@ -718,7 +731,9 @@ test("current-session manager excludes already closed agent records", async () =
 		const runtime: SubagentSettingsRuntime = {
 			getBlockingEnabled: () => true,
 			getCompletionDelivery: () => "next-turn",
+			getConsultResourcePolicy: () => "project-context",
 			setCompletionDelivery: () => undefined,
+			setConsultResourcePolicy: () => undefined,
 			getRuntimeStatus: () => ({
 				enabled: true,
 				initialized: true,
@@ -776,22 +791,30 @@ test("delegation workflow settings control the registered tool surface", () => {
 					"subagent_send",
 					"subagent_manage",
 					"subagent_mailbox",
+					"subagent_inspect",
+					"subagent_consult",
 				],
 			},
 			{
 				name: "async only",
 				settings: { blocking: { enabled: false }, stateful: { enabled: true } },
-				tools: ["subagent_spawn", "subagent_send", "subagent_manage", "subagent_mailbox"],
+				tools: [
+					"subagent_spawn",
+					"subagent_send",
+					"subagent_manage",
+					"subagent_mailbox",
+					"subagent_inspect",
+				],
 			},
 			{
 				name: "blocking only",
 				settings: { blocking: { enabled: true }, stateful: { enabled: false } },
-				tools: ["subagent"],
+				tools: ["subagent", "subagent_inspect", "subagent_consult"],
 			},
 			{
 				name: "disabled",
 				settings: { blocking: { enabled: false }, stateful: { enabled: false } },
-				tools: [],
+				tools: ["subagent_inspect"],
 			},
 		] as const;
 		for (const scenario of cases) {
@@ -832,7 +855,7 @@ test("disabled stateful settings do not advertise unavailable lifecycle tools", 
 		subagents(mock.pi);
 		assert.deepEqual(
 			mock.tools.map((tool) => tool.name),
-			["subagent"],
+			["subagent", "subagent_inspect", "subagent_consult"],
 		);
 		const blockingTool = mock.tools[0];
 		assert.doesNotMatch(String(blockingTool?.description), /subagent_spawn/i);
@@ -891,7 +914,8 @@ test("subagent settings UI preserves unknown JSON and applies completion deliver
 			hasUI: true,
 			custom: async (factory: unknown) => {
 				customCalls++;
-				return driveCustomSelector(factory, ["\r", "\u001b"]).result;
+				const inputs = customCalls === 1 ? ["\r", "\u001b"] : ["\u001b[B", "\r", "\u001b"];
+				return driveCustomSelector(factory, inputs).result;
 			},
 		});
 		await command.handler("settings", context.ctx);
@@ -925,6 +949,20 @@ test("subagent settings UI preserves unknown JSON and applies completion deliver
 			/Completion: Resume automatically when finished/,
 		);
 		assert.match(context.notifications.at(-1)?.message ?? "", /User settings/);
+
+		await command.handler("settings", context.ctx);
+		assert.equal(customCalls, 2);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			futureOption: true,
+			stateful: {
+				futureStatefulOption: "keep",
+				completionDelivery: "auto-resume",
+			},
+			agents: { scout: { tools: ["read"] } },
+			consult: { resources: "none" },
+		});
+		await command.handler("status", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /No inherited resources/);
 
 		const nonTui = createMockContext({
 			mode: "json",


### PR DESCRIPTION
## Summary

- add `subagent_inspect` with seven strict, metadata-only actions for agents, retained runs, models, runtime status, and diagnostics
- add `subagent_consult` for one synchronous ephemeral child constrained to the `read`, `grep`, `find`, and `ls` intersection, with extensions and session persistence disabled
- add user-owned `consult.resources` policy, unified `/subagents settings` UI, trust/confirmation gates, safe `cwd` handling, bounded output, Pi usage propagation, and lifecycle cleanup
- preserve the existing five tool schemas and workflow behavior while documenting the expanded seven-tool surface and security limits

## Safety and compatibility

- project trust is checked before project-agent discovery or project-resource loading
- inspection never exposes prompts, history/context content, mailbox content, credentials, headers, endpoints, or environment values
- explicit empty agent tools remain empty; missing tools keep the read-only default for consultation
- post-launch consultation failures preserve bounded evidence and usage and are finalized as Pi-visible `isError` results; pre-launch failures still throw
- this is executor-level read-only behavior, not an OS, network, or general filesystem sandbox

## Verification

- `npm run check` — passed, 1,955 tests
- focused compiled `pi-subagents` settings, agent, registry, inspect, consult, runner, and registration tests — passed
- `lsp_diagnostics` — 0 diagnostics across 36 source/test files
- isolated Pi RPC smoke — extension loaded and `/subagents status` reported consultation resources
- production runner synthetic-child smoke — exact launch flags, read-only prompt, output, and usage verified without provider traffic
- `just pack-subagents` — dry run contains 28 expected package files and excludes tests, caches, settings, credentials, and unrelated files

Guides audited: `docs/extension-conventions.md` and `docs/extension-settings.md`.
