### PR TITLE
feat(btw): add side-thread thinking settings

### DIFF
--- a/docs/plans/archived/2026-08-01_pi-btw-thinking-settings-plan.md
+++ b/docs/plans/archived/2026-08-01_pi-btw-thinking-settings-plan.md
@@ -1,0 +1,155 @@
+# pi-btw Thinking Settings Plan
+
+## Goal
+
+Give `/btw` a menu-first no-argument flow and extension-owned thinking settings while preserving
+`/btw <question>` as the fast path. Inside a side thread, Pi's configured
+`app.thinking.cycle` shortcut must always change that thread's level immediately; by default it
+must also remember the latest level in `pi-btw.json`, without changing the main session.
+
+## Context
+
+- The approved `/btw` menu has two rows: **Start side thread** (initially selected) and
+  **Settings**. `/btw <question>` continues to start immediately.
+- Settings own a pi-btw thinking level and **Remember thinking level changes**, which defaults to
+  on. There is no user-facing "inherit main session" setting.
+- For backward compatibility, an existing file with no `thinkingLevel` remains valid and uses the
+  current session level until the user explicitly selects or remembers a pi-btw level.
+- A side-thread shortcut change applies to every later question in that thread until changed again.
+  Remembering off leaves `pi-btw.json` unchanged; remembering on writes the concrete level for the
+  next invocation.
+- A shortcut save failure keeps the new thread-local level and reports that it was not remembered.
+  A Settings-screen save failure rolls back the setting row because persistence is that action's
+  primary purpose.
+- The current worktree already contains partial, uncommitted local-cycling UI, tests, and README
+  edits. Execution must reconcile that work with this approved design rather than assume it is the
+  finished implementation.
+- Applicable guidance: `docs/extension-conventions.md`, `docs/extension-settings.md`, Pi extension,
+  TUI, and keybinding documentation. Touched areas are command routing, standard menus, settings
+  storage/UI, custom TUI keyboard input, asynchronous persistence, documentation, and tests.
+
+## Architecture
+
+- Move settings ownership out of the growing `src/btw.ts` into `src/settings.ts`: schema/defaults,
+  canonical path, side-effect-free reads, validation, queued read-modify-write updates, unknown-field
+  preservation, and same-directory temporary-file-plus-rename publication.
+- Put the two-screen command menu and Pi-style settings screen in a descriptive UI module such as
+  `src/menu.ts`, declared with `@narumitw/pi-tui-kit`. Keep command routing and side-thread
+  orchestration in `src/btw.ts` and specialized transcript input in `src/transcript-pager.ts`.
+- Use the JSON field `rememberThinkingLevelChanges` for the persisted boolean and the user-facing
+  label **Remember thinking level changes**. Its code default is `true`; a missing file/read never
+  materializes that default on disk.
+- Treat all settings reads and writes as one in-process ordering protocol. Enqueue the complete
+  mutation before asynchronous prerequisites, re-read the latest valid document inside the queue,
+  preserve unknown fields, block malformed documents, and keep the queue usable after failure.
+- Keep side-thread thinking state separate from Pi's main-session state. Clamp the initial value and
+  cycle candidates with the selected side model's supported levels; never call
+  `pi.setThinkingLevel()` from the side-thread flow.
+- Apply shortcut changes locally before optional persistence. Serialize rapid remembered changes and
+  drain owned writes before the command finishes. On write failure retain the local level, leave the
+  prior file intact, and issue one actionable warning through a still-current context.
+- Standard Settings actions save before publishing the new effective setting. Rejection leaves the
+  previous displayed/effective value selected, while cancellation and disposal make no mutation.
+
+## Non-Goals
+
+- Add a project-scoped settings file, environment variable, or cross-process writer lock.
+- Add a model selector or expose the existing `model` field in the new Settings screen.
+- Change the main session's model or thinking level.
+- Reset thinking after one side question or persist side-thread transcript content.
+- Add a textual settings subcommand or remove the established `/btw <question>` route.
+
+## Risks
+
+- Rapid shortcut input could let an older write overwrite a newer level; one ordered mutation queue
+  and focused failure/recovery tests must prevent this.
+- A malformed or concurrently edited file could be overwritten; every mutation must start from the
+  latest valid document and publish atomically while preserving unknown fields.
+- Menu or save continuations could outlive their custom component/session; owner/disposal checks and
+  post-`await` revalidation must prevent stale UI or state use.
+- Adding menu and settings behavior directly to `src/btw.ts` would push it toward the 1,000-line
+  review threshold; responsibility-based extraction is part of the implementation, not follow-up.
+
+## Rollback / Recovery
+
+- The new boolean is optional and older pi-btw releases ignore unknown fields, so no destructive
+  migration is required. Existing `model`, `thinkingLevel`, and unknown fields remain intact.
+- Atomic publication keeps the previous valid file when saving fails. A malformed file remains
+  byte-for-byte unchanged and the UI tells the user to repair it manually.
+- Reverting the feature restores the prior no-argument command flow; files containing
+  `rememberThinkingLevelChanges` remain readable by the prior implementation because it ignores
+  unknown fields.
+
+## Plan
+
+- [x] Add failing settings tests in `extensions/pi-btw/test/settings.test.ts` for the default-on
+  `rememberThinkingLevelChanges` field, side-effect-free missing-file reads, valid/invalid documents,
+  and backward-compatible omitted `thinkingLevel`; the compiled test failed because
+  `../src/settings.js` did not exist.
+- [x] Implement `extensions/pi-btw/src/settings.ts` as the single settings owner, including canonical
+  `getAgentDir()` path resolution, runtime validation, a recoverable in-process mutation queue,
+  latest-document read-modify-write updates, unknown-field preservation, and atomic rename; all 7
+  focused settings tests pass, including malformed-file and publication-failure cases.
+- [x] Add failing command/menu tests in `extensions/pi-btw/test/btw.test.ts` and
+  `extensions/pi-btw/test/menu.test.ts` proving `/btw` opens a two-row menu with **Start side
+  thread** initially selected, Settings reachable, cancellation read-only, `/btw <question>` still
+  direct, and unsupported non-TUI modes rejected before custom UI; the menu module import and
+  dependency-aware command signature supplied the intended red states.
+- [x] Implement the menu-first route in a new `extensions/pi-btw/src/menu.ts` using
+  `@narumitw/pi-tui-kit`, preserving the main-editor draft and deferring model credential resolution
+  until **Start side thread** is chosen; focused command/menu tests pass.
+- [x] Add Settings-screen tests for a Pi-style thinking-level row and **Remember thinking level
+  changes** row, immediate ordered saves, default-on display, rollback after save rejection,
+  malformed-file protection, bounded rendering, cancellation, disposal, and unknown-field
+  preservation; all focused menu tests pass.
+- [x] Implement the Settings screen in `extensions/pi-btw/src/menu.ts` against the settings owner,
+  presenting fixed pi-btw levels supported by the effective side model and applying each accepted
+  change immediately; tests prove the existing manual `model` and unknown fields remain untouched.
+- [x] Extend the side-thread behavior tests in `extensions/pi-btw/test/side-thread.test.ts` to prove
+  the injected `app.thinking.cycle` binding (default or customized) changes all later questions,
+  remembering off never writes, remembering on writes the concrete level in input order, no main
+  thinking API is called, and a save failure keeps the local level while warning once; new controller
+  fields supplied the intended red state and focused tests pass.
+- [x] Integrate an owned thinking controller across `src/btw.ts` and `src/transcript-pager.ts` that
+  clamps to side-model capabilities, updates the header/footer immediately, queues optional saves,
+  drains writes on close/disposal, and catches stale-context notification failures; focused tests
+  cover rapid changes, real settings persistence, remembering off, and failed-save recovery.
+- [x] Update `extensions/pi-btw/README.md` to document the menu, Settings rows, JSON field/default,
+  direct-question compatibility, shortcut customization, thread-local lifetime, writeback success
+  and failure behavior, canonical path, atomic in-process persistence scope, and the fact that the
+  main session is never changed; examples and accepted values match production code.
+- [x] Audit the final pi-btw diff against the touched-area checklists in
+  `docs/extension-conventions.md` and `docs/extension-settings.md`: focused tests cover TUI width and
+  invalidation, cancellation, idle/action disposal, side-component disposal, ordered saves,
+  malformed-file protection, and atomic failure. All production files remain below 1,000 lines.
+  Accepted product distinction: shortcut persistence is secondary and retains the approved local
+  change on save failure, while Settings actions reject and roll back.
+- [x] Run focused compiled pi-btw tests, `npm run typecheck --workspace @narumitw/pi-btw`, and LSP
+  diagnostics on changed TypeScript files; 110 focused tests and workspace typecheck pass, with zero
+  Biome LSP diagnostics across all pi-btw source and test files.
+- [x] Run the CI-equivalent `npm run check` on the exact final patch in a temporary normal clone with
+  repository-pinned npm 12.0.2 after rebasing onto current `origin/main`, avoiding the documented
+  linked-worktree `GIT_DIR` false failure; all 1,985 tests and every format, boundary, and workspace
+  typecheck gate pass.
+- [x] Run `npm pack --workspace @narumitw/pi-btw --dry-run --json` and a non-interactive local Pi
+  entrypoint load smoke; the 10-entry package contains only the manifest, README, license, and seven
+  declared source files, and `pi --no-extensions -e ./extensions/pi-btw --list-models ...` exits 0
+  without factory-time thinking/settings access.
+
+## Completion Checklist
+
+- [x] `/btw` opens the approved menu with **Start side thread** selected, while `/btw <question>`
+  remains a one-step compatibility route.
+- [x] Settings persist a pi-btw-specific level and default-on remembering without deleting or
+  replacing unrelated `pi-btw.json` content.
+- [x] The configured Pi thinking shortcut always changes the current side thread immediately and
+  never changes the main session.
+- [x] Remembering off is thread-local; remembering on survives the next invocation; shortcut save
+  failure keeps the local level and Settings save failure rolls back.
+- [x] Missing, malformed, invalid, concurrent, rapid-save, cancellation, disposal, replacement, and
+  atomic-publication paths have deterministic evidence.
+- [x] README behavior, settings schema/defaults, and package contents match the verified code.
+- [x] Focused checks, LSP diagnostics, full `npm run check`, package dry run, and entrypoint smoke all
+  pass with no unaccepted deviations.
+- [x] Archive this completed plan under `docs/plans/archived/` only after every item above is checked
+  with current evidence.

--- a/extensions/pi-btw/README.md
+++ b/extensions/pi-btw/README.md
@@ -8,13 +8,14 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 
 ## ✨ Features
 
-- Adds a `/btw` side-thread command to Pi, with an optional initial question.
+- Adds a `/btw` menu for starting a side thread or changing pi-btw settings.
+- Keeps `/btw <question>` as a direct fast path.
 - Answers side questions in a temporary, scrollable UI.
 - Supports follow-up questions in the same ephemeral side thread.
 - Optionally brings the latest answer, a question-to-end suffix, an exact line range, or the entire side thread into the main editor.
 - Uses the current session branch as context.
 - Uses Pi's current model or an independent model selected in `pi-btw.json`.
-- Inherits Pi's current thinking level or uses a fixed level from `pi-btw.json`.
+- Uses a pi-btw thinking level that can be changed with Pi's configured thinking shortcut and remembered for next time.
 - Does not append the side question or answer to the main conversation.
 - Works as an independently installable npm Pi extension package.
 
@@ -38,7 +39,7 @@ pi -e ./extensions/pi-btw
 
 ## 🚀 Usage
 
-Start an empty side thread or provide its first question immediately:
+Open the pi-btw menu or provide the first question immediately:
 
 ```text
 /btw
@@ -54,16 +55,23 @@ Examples:
 /btw is this API name idiomatic?
 ```
 
-Running `/btw` alone opens an empty ephemeral side thread with its editor ready. When an
-initial question is provided, its answer opens above the same editor. A compact
-`btw · side thread` header stays fixed above the content so the ephemeral workspace remains
-recognizable while scrolling. Messages use Pi's normal user and assistant presentation without
-numbered turns or role labels. Type each question and press `Enter`; no follow-up shortcut is
-required.
+Running `/btw` alone opens a two-row menu. **Start side thread** is selected first, so pressing
+`Enter` opens an empty ephemeral side thread; **Settings** changes the starting thinking level
+and whether shortcut changes are remembered. `/btw <question>` bypasses this menu, and its answer
+opens above the side-thread editor. A compact `btw · side thread` header stays fixed above the
+content so the ephemeral workspace remains recognizable while scrolling. Messages use Pi's normal
+user and assistant presentation without numbered turns or role labels. Type each question and press
+`Enter`; no follow-up shortcut is required.
 Previous side questions and answers remain available to the model and visible for that
-invocation. While a response is running, the transcript stays visible above a compact
-`Answering…` status. The footer shows `PgUp`/`PgDn` only when history can scroll; press
-`Ctrl+C` to cancel an in-progress answer or leave the side thread.
+invocation. The side-thread header shows its current thinking level. Press Pi's configured
+`app.thinking.cycle` shortcut (`Shift+Tab` by default) in the composer to cycle the levels
+supported by the side-thread model; every later question uses the displayed level until it is
+changed again. By default, each shortcut change is also written to `pi-btw.json` for the next
+invocation. Turn **Remember thinking level changes** off in Settings to keep changes local to the
+current side thread. Neither path changes the main session's thinking level. While a response is
+running, the transcript stays visible above a compact `Answering…` status.
+The footer shows `PgUp`/`PgDn` only when history can scroll; press `Ctrl+C` to cancel an
+in-progress answer or leave the side thread.
 
 After at least one successful answer, press `Ctrl+R` to bring selected context to the main
 editor. The scope menu shows the size of the latest question and answer and the entire side
@@ -106,7 +114,8 @@ setting; pi-btw does not add any environment variables.
 ```json
 {
   "model": "anthropic/claude-sonnet-4-5",
-  "thinkingLevel": "low"
+  "thinkingLevel": "low",
+  "rememberThinkingLevelChanges": true
 }
 ```
 
@@ -117,17 +126,25 @@ cannot be found or authenticated, pi-btw warns and falls back to the current ses
 If neither model is available, `/btw` reports an error and stops. This selection affects only
 `/btw`; it does not change the main session model.
 
-Pi calls its reasoning setting the **thinking level**. By default, `/btw` inherits the
-current runtime level, including changes made through `/settings` or `Shift+Tab`. It does
-not read or change `defaultThinkingLevel` directly. Supported fixed values are `off`,
-`minimal`, `low`, `medium`, `high`, and `xhigh`. The selected value applies to the model
-actually used by `/btw` and does not change the main session. Pi's provider layer may clamp
-a requested level when that model does not support it.
+Pi calls its reasoning setting the **thinking level**. `thinkingLevel` sets pi-btw's starting
+level; accepted values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. When the
+field is absent for backward compatibility, the next invocation starts from the current session
+level. The initial value and shortcut cycle are clamped to the selected side model's capabilities
+using Pi's model rules. Pi-btw does not read, write, or change the main session's
+`defaultThinkingLevel`.
 
-The settings file is optional and is never created automatically. A missing file, `{}`, or
-omitted fields silently inherit the current Pi model and thinking level. The file is read for
-each `/btw` invocation, so edits apply to the next side question without `/reload`. Invalid
-or unreadable settings produce a warning and fall back to the current Pi defaults.
+`rememberThinkingLevelChanges` controls only persistence and defaults to `true` when omitted. A
+side-thread shortcut always changes that side thread immediately. When remembering is on, the
+concrete level is written for the next invocation; when off, `pi-btw.json` stays unchanged. If a
+shortcut write fails, the local change remains active and pi-btw warns that it was not remembered.
+A failed Settings-screen save instead restores the previous displayed value.
+
+A missing settings file is a side-effect-free read: pi-btw creates it only after a Settings change
+or a remembered shortcut change. Saves are ordered within the Pi process and published atomically
+with a same-directory temporary file and rename. They preserve `model` and unknown fields; malformed
+or invalid files block saves and remain unchanged. Separate Pi processes and external editors are
+outside this in-process ordering boundary. The file is read for each `/btw` invocation, so edits
+apply without `/reload`.
 
 ## 🧠 Why use pi-btw?
 
@@ -141,6 +158,8 @@ extensions/pi-btw/
 │   ├── index.ts
 │   ├── btw.ts
 │   ├── bring-to-main.ts
+│   ├── menu.ts
+│   ├── settings.ts
 │   ├── side-thread.ts
 │   └── transcript-pager.ts
 ├── README.md

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -1,11 +1,13 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import {
+	type Api,
+	clampThinkingLevel,
+	getSupportedThinkingLevels,
+	type Model,
+} from "@earendil-works/pi-ai";
 import {
 	BorderedLoader,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
-	getAgentDir,
 	type KeybindingsManager,
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
@@ -23,6 +25,18 @@ import {
 	summarizeBringToMain,
 } from "./bring-to-main.js";
 import {
+	type BtwCommandMenuResult,
+	runBtwMenuPreservingEditor,
+	showBtwCommandMenu,
+} from "./menu.js";
+import {
+	type BtwSettings,
+	effectiveRememberThinkingLevelChanges,
+	parseBtwModelReference,
+	readBtwSettings,
+	updateBtwSettings,
+} from "./settings.js";
+import {
 	BTW_THINKING_LEVELS,
 	type BtwThinkingLevel,
 	completeSideThreadTurn,
@@ -32,10 +46,19 @@ import {
 } from "./side-thread.js";
 import {
 	BtwAnsweringView,
+	type BtwThinkingControl,
 	BtwTranscriptPager,
 	type TranscriptPagerAction,
 } from "./transcript-pager.js";
 
+export {
+	BTW_SETTINGS_FILE,
+	type BtwSettings,
+	type BtwSettingsLoadResult,
+	normalizeBtwSettings,
+	parseBtwModelReference,
+	readBtwSettings,
+} from "./settings.js";
 export {
 	BTW_THINKING_LEVELS,
 	type BtwThinkingLevel,
@@ -45,17 +68,6 @@ export {
 } from "./side-thread.js";
 
 const MAX_CONTEXT_CHARS = 40_000;
-export const BTW_SETTINGS_FILE = "pi-btw.json";
-
-export interface BtwSettings {
-	model?: string;
-	thinkingLevel?: BtwThinkingLevel;
-}
-
-export type BtwSettingsLoadResult =
-	| { kind: "missing" }
-	| { kind: "invalid"; reason: string }
-	| { kind: "loaded"; settings: BtwSettings };
 
 interface LoadBtwThinkingLevelOptions {
 	settingsPath?: string;
@@ -82,32 +94,6 @@ interface ResolveBtwModelOptions {
 export interface ResolvedBtwModel {
 	model: Model<Api>;
 	auth: SideQuestionAuth;
-}
-
-export function normalizeBtwSettings(value: unknown): BtwSettings | undefined {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-
-	const settings: BtwSettings = {};
-	if (Object.hasOwn(value, "model")) {
-		const model = Reflect.get(value, "model");
-		if (typeof model !== "string" || !parseBtwModelReference(model)) return undefined;
-		settings.model = model;
-	}
-	if (Object.hasOwn(value, "thinkingLevel")) {
-		const thinkingLevel = Reflect.get(value, "thinkingLevel");
-		if (!isBtwThinkingLevel(thinkingLevel)) return undefined;
-		settings.thinkingLevel = thinkingLevel;
-	}
-	return settings;
-}
-
-export function parseBtwModelReference(
-	reference: string,
-): { provider: string; modelId: string } | undefined {
-	if (/\s/.test(reference)) return undefined;
-	const separator = reference.indexOf("/");
-	if (separator <= 0 || separator === reference.length - 1) return undefined;
-	return { provider: reference.slice(0, separator), modelId: reference.slice(separator + 1) };
 }
 
 export async function resolveBtwModel({
@@ -168,26 +154,6 @@ function hasRequestAuth(auth: SideQuestionAuth): boolean {
 	);
 }
 
-export async function readBtwSettings(
-	settingsPath = join(getAgentDir(), BTW_SETTINGS_FILE),
-): Promise<BtwSettingsLoadResult> {
-	let contents: string;
-	try {
-		contents = await readFile(settingsPath, "utf8");
-	} catch (error: unknown) {
-		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
-		return { kind: "invalid", reason: `${settingsPath}: ${formatError(error)}` };
-	}
-
-	try {
-		const settings = normalizeBtwSettings(JSON.parse(contents) as unknown);
-		if (settings) return { kind: "loaded", settings };
-		return { kind: "invalid", reason: `${settingsPath}: invalid settings shape` };
-	} catch (error: unknown) {
-		return { kind: "invalid", reason: `${settingsPath}: ${formatError(error)}` };
-	}
-}
-
 export async function loadBtwThinkingLevel(
 	currentThinkingLevel: BtwThinkingLevel,
 	options: LoadBtwThinkingLevelOptions = {},
@@ -199,24 +165,30 @@ export async function loadBtwThinkingLevel(
 	}
 
 	options.warn?.(
-		`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id" and thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}". Using current Pi thinking level.`,
+		`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id", thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}", and boolean rememberThinkingLevelChanges. Using current Pi thinking level.`,
 	);
 	return currentThinkingLevel;
-}
-
-function isBtwThinkingLevel(value: unknown): value is BtwThinkingLevel {
-	return BTW_THINKING_LEVELS.includes(value as BtwThinkingLevel);
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-	return error instanceof Error && "code" in error;
 }
 
 function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-export default function btw(pi: ExtensionAPI) {
+export interface BtwExtensionDependencies {
+	showCommandMenu?: (
+		pi: ExtensionAPI,
+		ctx: ExtensionCommandContext,
+	) => Promise<BtwCommandMenuResult>;
+	loadSettings?: typeof loadSettingsForCommand;
+	resolveModel?: typeof resolveBtwModelWithLoader;
+	runThread?: typeof runBtwThread;
+}
+
+export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependencies = {}) {
+	const showCommandMenu = dependencies.showCommandMenu ?? showCommandMenuForBtw;
+	const loadSettings = dependencies.loadSettings ?? loadSettingsForCommand;
+	const resolveModel = dependencies.resolveModel ?? resolveBtwModelWithLoader;
+	const runThread = dependencies.runThread ?? runBtwThread;
 	pi.registerCommand("btw", {
 		description: "Ask a quick side question without adding it to the main conversation",
 		handler: async (args, ctx) => {
@@ -225,9 +197,10 @@ export default function btw(pi: ExtensionAPI) {
 				ctx.ui.notify("/btw requires interactive TUI mode", "error");
 				return;
 			}
+			if (!question && (await showCommandMenu(pi, ctx)) !== "start") return;
 
-			const settings = await loadSettingsForCommand(ctx);
-			const resolution = await resolveBtwModelWithLoader(settings, ctx);
+			const settings = await loadSettings(ctx);
+			const resolution = await resolveModel(settings, ctx);
 			if (resolution.kind === "cancelled") {
 				ctx.ui.notify("Cancelled", "info");
 				return;
@@ -237,13 +210,31 @@ export default function btw(pi: ExtensionAPI) {
 				return;
 			}
 
-			await runBtwThread({
+			await runThread({
 				initialQuestion: question || undefined,
 				selected: resolution.selected,
 				thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
+				rememberThinkingLevelChanges: effectiveRememberThinkingLevelChanges(settings),
 				ctx,
 			});
 		},
+	});
+}
+
+async function showCommandMenuForBtw(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+): Promise<BtwCommandMenuResult> {
+	const loaded = await readBtwSettings();
+	const settings = loaded.kind === "loaded" ? loaded.settings : {};
+	const configured = settings.model ? parseBtwModelReference(settings.model) : undefined;
+	const configuredModel = configured
+		? ctx.modelRegistry.find(configured.provider, configured.modelId)
+		: undefined;
+	const model = configuredModel ?? ctx.model;
+	return showBtwCommandMenu(ctx, {
+		currentThinkingLevel: pi.getThinkingLevel(),
+		availableThinkingLevels: model ? getSupportedThinkingLevels(model) : BTW_THINKING_LEVELS,
 	});
 }
 
@@ -302,9 +293,12 @@ interface RunBtwThreadDependencies {
 	interact?: typeof showThreadComposer;
 	chooseBringToMain?: typeof chooseBringToMain;
 	deliverBringToMain?: typeof loadBringToMainDraft;
+	persistThinkingLevel?: (level: BtwThinkingLevel) => Promise<unknown>;
 }
 
 export type BtwThreadResult = { kind: "closed" };
+
+type BtwThreadThinkingControl = Omit<BtwThinkingControl, "keybindings">;
 
 type BtwBringToMainChoice =
 	| BtwThreadResult
@@ -322,6 +316,8 @@ interface RunBtwThreadOptions {
 	initialQuestion?: string;
 	selected: ResolvedBtwModel;
 	thinkingLevel: BtwThinkingLevel;
+	rememberThinkingLevelChanges?: boolean;
+	settingsPath?: string;
 	ctx: ExtensionCommandContext;
 	dependencies?: RunBtwThreadDependencies;
 }
@@ -330,6 +326,8 @@ export async function runBtwThread({
 	initialQuestion,
 	selected,
 	thinkingLevel,
+	rememberThinkingLevelChanges = false,
+	settingsPath,
 	ctx,
 	dependencies = {},
 }: RunBtwThreadOptions): Promise<BtwThreadResult> {
@@ -337,44 +335,84 @@ export async function runBtwThread({
 	const interact = dependencies.interact ?? showThreadComposer;
 	const chooseBringToMainAction = dependencies.chooseBringToMain ?? chooseBringToMain;
 	const deliverBringToMainDraft = dependencies.deliverBringToMain ?? loadBringToMainDraft;
+	const persistThinkingLevel =
+		dependencies.persistThinkingLevel ??
+		((level: BtwThinkingLevel) => updateBtwSettings({ thinkingLevel: level }, { settingsPath }));
 	const thread = createSideThread(buildConversationContext(ctx.sessionManager.getBranch()));
+	const thinkingLevels = getSupportedThinkingLevels(selected.model);
+	const pendingWrites = new Set<Promise<void>>();
+	let activeThinkingLevel = clampThinkingLevel(selected.model, thinkingLevel);
 	let pendingQuestion = initialQuestion;
 	let composerDraft: string | undefined;
 
-	while (true) {
-		if (!pendingQuestion) {
-			const action = await interact(thread, thread.turns.length > 0, ctx, composerDraft);
-			if (action.kind === "close") return { kind: "closed" };
-			if (action.kind === "bringToMain") {
-				const choice = await chooseBringToMainAction(thread, ctx);
-				if (choice.kind === "closed") return choice;
-				if (choice.kind === "back") {
+	try {
+		while (true) {
+			if (!pendingQuestion) {
+				const thinking: BtwThreadThinkingControl = {
+					level: activeThinkingLevel,
+					levels: thinkingLevels,
+					onChange: (level) => {
+						if (!thinkingLevels.includes(level)) return;
+						activeThinkingLevel = level;
+						if (!rememberThinkingLevelChanges) return;
+						let write!: Promise<void>;
+						write = Promise.resolve(persistThinkingLevel(level))
+							.then(() => undefined)
+							.catch((error: unknown) => {
+								try {
+									ctx.ui.notify(
+										`Thinking level changed to ${level}, but could not be remembered in pi-btw.json: ${formatError(error)}`,
+										"warning",
+									);
+								} catch {
+									// The side-thread change remains valid after a session context is replaced.
+								}
+							})
+							.finally(() => pendingWrites.delete(write));
+						pendingWrites.add(write);
+					},
+				};
+				const action = await interact(
+					thread,
+					thread.turns.length > 0,
+					ctx,
+					composerDraft,
+					thinking,
+				);
+				if (action.kind === "close") return { kind: "closed" };
+				if (action.kind === "bringToMain") {
+					const choice = await chooseBringToMainAction(thread, ctx);
+					if (choice.kind === "closed") return choice;
+					if (choice.kind === "back") {
+						composerDraft = action.questionDraft;
+						continue;
+					}
+					const delivery = await deliverBringToMainDraft(choice.draft, ctx, choice.summary);
+					if (delivery === "loaded" || delivery === "closed") return { kind: "closed" };
 					composerDraft = action.questionDraft;
 					continue;
 				}
-				const delivery = await deliverBringToMainDraft(choice.draft, ctx, choice.summary);
-				if (delivery === "loaded" || delivery === "closed") return { kind: "closed" };
-				composerDraft = action.questionDraft;
-				continue;
+				composerDraft = undefined;
+				pendingQuestion = action.question;
 			}
-			composerDraft = undefined;
-			pendingQuestion = action.question;
-		}
 
-		const result = await ask(thread, pendingQuestion, selected, thinkingLevel, ctx);
-		if (result.kind === "aborted") {
-			ctx.ui.notify("Cancelled", "info");
-			return { kind: "closed" };
-		}
-		if (result.kind === "error") {
-			thread.turns.push({
-				kind: "error",
-				question: pendingQuestion,
-				answer: result.message,
-			});
-		}
+			const result = await ask(thread, pendingQuestion, selected, activeThinkingLevel, ctx);
+			if (result.kind === "aborted") {
+				ctx.ui.notify("Cancelled", "info");
+				return { kind: "closed" };
+			}
+			if (result.kind === "error") {
+				thread.turns.push({
+					kind: "error",
+					question: pendingQuestion,
+					answer: result.message,
+				});
+			}
 
-		pendingQuestion = undefined;
+			pendingQuestion = undefined;
+		}
+	} finally {
+		await Promise.allSettled([...pendingWrites]);
 	}
 }
 
@@ -602,35 +640,6 @@ async function showBtwMenu(
 		: terminalBtwMenuAction(result);
 }
 
-async function runBtwMenuPreservingEditor(
-	ctx: ExtensionCommandContext,
-	run: (menuContext: MenuContext) => Promise<RunMenuResult>,
-): Promise<RunMenuResult> {
-	let liveEditorText = ctx.ui.getEditorText();
-	let completed = false;
-	const ui = new Proxy(ctx.ui, {
-		get(target, property) {
-			if (property === "custom") {
-				return <Value>(factory: BtwCustomFactory<Value>) =>
-					target.custom<Value>((tui, theme, keybindings, done) =>
-						factory(tui, theme, keybindings, (value) => {
-							liveEditorText = target.getEditorText();
-							completed = true;
-							done(value);
-						}),
-					);
-			}
-			const value = Reflect.get(target, property, target) as unknown;
-			return typeof value === "function" ? value.bind(target) : value;
-		},
-	});
-	const result = await run({ mode: ctx.mode, hasUI: ctx.hasUI, ui });
-	if (result.kind !== "stale" && completed && ctx.ui.getEditorText() !== liveEditorText) {
-		ctx.ui.setEditorText(liveEditorText);
-	}
-	return result;
-}
-
 function terminalBtwMenuAction(result: RunMenuResult): { kind: "back" } | { kind: "close" } {
 	if (result.kind === "closed") return { kind: result.reason };
 	if (result.kind === "error") throw result.error;
@@ -715,11 +724,18 @@ async function askThreadQuestion(
 	return ctx.ui.custom<Awaited<ReturnType<typeof completeSideThreadTurn>>>(
 		(tui, theme, _keybindings, done) => {
 			let settled = false;
-			const view = new BtwAnsweringView(tui, theme, thread.turns, question, () => {
-				if (settled) return;
-				settled = true;
-				done({ kind: "aborted" });
-			});
+			const view = new BtwAnsweringView(
+				tui,
+				theme,
+				thread.turns,
+				question,
+				() => {
+					if (settled) return;
+					settled = true;
+					done({ kind: "aborted" });
+				},
+				thinkingLevel,
+			);
 			completeSideThreadTurn({
 				thread,
 				question,
@@ -742,13 +758,15 @@ async function showThreadComposer(
 	thread: SideThread,
 	startAtBottom: boolean,
 	ctx: ExtensionCommandContext,
-	initialQuestion?: string,
+	initialQuestion: string | undefined,
+	thinking: BtwThreadThinkingControl,
 ): Promise<TranscriptPagerAction> {
 	return ctx.ui.custom<TranscriptPagerAction>(
-		(tui, theme, _keybindings, done) =>
+		(tui, theme, keybindings, done) =>
 			new BtwTranscriptPager(tui, theme, thread.turns, done, {
 				startAtBottom,
 				initialQuestion,
+				thinking: { ...thinking, keybindings },
 			}),
 	);
 }

--- a/extensions/pi-btw/src/menu.ts
+++ b/extensions/pi-btw/src/menu.ts
@@ -1,0 +1,233 @@
+import type {
+	ExtensionCommandContext,
+	KeybindingsManager,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { defineMenu, type MenuContext, type RunMenuResult, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	type BtwSettings,
+	btwSettingsPath,
+	effectiveRememberThinkingLevelChanges,
+	readBtwSettings,
+	type UpdateBtwSettingsOptions,
+	updateBtwSettings,
+} from "./settings.js";
+import { BTW_THINKING_LEVELS, type BtwThinkingLevel } from "./side-thread.js";
+
+interface BtwMenuState {
+	kind: "valid" | "invalid";
+	settings: BtwSettings;
+	reason?: string;
+}
+
+export interface ShowBtwCommandMenuOptions {
+	currentThinkingLevel: BtwThinkingLevel;
+	availableThinkingLevels: readonly BtwThinkingLevel[];
+	settingsPath?: string;
+	readSettings?: typeof readBtwSettings;
+	updateSettings?: (
+		patch: Partial<Pick<BtwSettings, "thinkingLevel" | "rememberThinkingLevelChanges">>,
+		options: UpdateBtwSettingsOptions,
+	) => Promise<BtwSettings>;
+}
+
+export type BtwCommandMenuResult = "start" | "closed";
+
+type BtwMenuScreen = "main" | "settings" | "invalid";
+type BtwMenuAction = "start" | "set-thinking" | "set-remember";
+type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
+
+type BtwCustomFactory<T> = (
+	tui: TUI,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (result: T) => void,
+) => Component;
+
+export async function showBtwCommandMenu(
+	ctx: ExtensionCommandContext,
+	options: ShowBtwCommandMenuOptions,
+): Promise<BtwCommandMenuResult> {
+	if (ctx.mode !== "tui") return "closed";
+	const settingsPath = options.settingsPath ?? btwSettingsPath();
+	const readSettings = options.readSettings ?? readBtwSettings;
+	const updateSettings = options.updateSettings ?? updateBtwSettings;
+	const levels =
+		options.availableThinkingLevels.length > 0
+			? [...options.availableThinkingLevels]
+			: (["off"] satisfies BtwThinkingLevel[]);
+	let startSelected = false;
+
+	const loadState = async (): Promise<BtwMenuState> => {
+		const loaded = await readSettings(settingsPath);
+		if (loaded.kind === "invalid") {
+			return { kind: "invalid", settings: {}, reason: loaded.reason };
+		}
+		return { kind: "valid", settings: loaded.kind === "loaded" ? loaded.settings : {} };
+	};
+	const displayThinkingLevel = (settings: BtwSettings): BtwThinkingLevel =>
+		clampToAvailableThinkingLevel(settings.thinkingLevel ?? options.currentThinkingLevel, levels);
+
+	const menu = defineMenu<BtwMenuState, BtwMenuScreen, BtwMenuAction, MenuContext>({
+		start: "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: "Pi BTW",
+				lines: [
+					`Thinking: ${displayThinkingLevel(state.settings)} · Remember changes: ${effectiveRememberThinkingLevelChanges(state.settings) ? "On" : "Off"}`,
+				],
+				items: [
+					{
+						id: "start",
+						label: "Start side thread",
+						description: "Open an empty side thread",
+						action: "start",
+					},
+					{
+						id: "settings",
+						label: "Settings",
+						description: "Choose pi-btw thinking and whether shortcut changes are remembered",
+						to: state.kind === "invalid" ? "invalid" : "settings",
+					},
+				],
+				hint: "close",
+			}),
+			settings: ({ state }) => ({
+				kind: "settings",
+				title: "Pi BTW Settings",
+				lines: [`User settings · ${settingsPath}`],
+				items: [
+					{
+						id: "thinkingLevel",
+						label: "Thinking level",
+						description: "Set the starting level for future pi-btw side threads.",
+						currentValue: displayThinkingLevel(state.settings),
+						values: levels,
+						action: "set-thinking",
+					},
+					{
+						id: "rememberThinkingLevelChanges",
+						label: "Remember thinking level changes",
+						description: "Save side-thread shortcut changes to pi-btw.json for next time.",
+						currentValue: effectiveRememberThinkingLevelChanges(state.settings) ? "On" : "Off",
+						values: ["On", "Off"],
+						action: "set-remember",
+					},
+				],
+			}),
+			invalid: ({ state }) => ({
+				kind: "detail",
+				title: "Pi BTW Settings · Read only",
+				lines: [
+					`Invalid settings file. Fix ${settingsPath} before saving.`,
+					state.reason ?? "The settings file is invalid.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			start: async () => {
+				startSelected = true;
+				return { kind: "close" };
+			},
+			"set-thinking": async ({ value, signal }) => {
+				if (!value || !levels.includes(value as BtwThinkingLevel)) return { kind: "rejected" };
+				try {
+					await updateSettings(
+						{ thinkingLevel: value as BtwThinkingLevel },
+						{ settingsPath, signal },
+					);
+					if (signal.aborted) return { kind: "rejected" };
+					ctx.ui.notify(`Pi BTW thinking level: ${value}.`, "info");
+					return { kind: "stay" };
+				} catch (error) {
+					if (!signal.aborted) notifySaveFailure(ctx, error);
+					return { kind: "rejected" };
+				}
+			},
+			"set-remember": async ({ value, signal }) => {
+				if (value !== "On" && value !== "Off") return { kind: "rejected" };
+				try {
+					await updateSettings(
+						{ rememberThinkingLevelChanges: value === "On" },
+						{ settingsPath, signal },
+					);
+					if (signal.aborted) return { kind: "rejected" };
+					ctx.ui.notify(`Remember thinking level changes: ${value}.`, "info");
+					return { kind: "stay" };
+				} catch (error) {
+					if (!signal.aborted) notifySaveFailure(ctx, error);
+					return { kind: "rejected" };
+				}
+			},
+		},
+	});
+
+	const result = await runBtwMenuPreservingEditor(ctx, (menuContext) =>
+		runMenu(menuContext, menu, { getState: loadState }),
+	);
+	return startSelected && result.kind === "closed" && result.reason === "close"
+		? "start"
+		: "closed";
+}
+
+export async function runBtwMenuPreservingEditor(
+	ctx: ExtensionCommandContext,
+	run: (menuContext: MenuContext) => Promise<RunMenuResult>,
+): Promise<RunMenuResult> {
+	let liveEditorText = ctx.ui.getEditorText();
+	let completed = false;
+	const ui = new Proxy(ctx.ui, {
+		get(target, property) {
+			if (property === "custom") {
+				return <Value>(factory: BtwCustomFactory<Value>, customOptions?: BtwCustomOptions) =>
+					target.custom<Value>(
+						(tui, theme, keybindings, done) =>
+							factory(tui, theme, keybindings, (value) => {
+								liveEditorText = target.getEditorText();
+								completed = true;
+								done(value);
+							}),
+						customOptions,
+					);
+			}
+			const value = Reflect.get(target, property, target) as unknown;
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+	const result = await run({ mode: ctx.mode, hasUI: ctx.hasUI, ui });
+	if (result.kind !== "stale" && completed && ctx.ui.getEditorText() !== liveEditorText) {
+		ctx.ui.setEditorText(liveEditorText);
+	}
+	return result;
+}
+
+function clampToAvailableThinkingLevel(
+	requested: BtwThinkingLevel,
+	available: readonly BtwThinkingLevel[],
+): BtwThinkingLevel {
+	if (available.includes(requested)) return requested;
+	const requestedIndex = BTW_THINKING_LEVELS.indexOf(requested);
+	for (let index = requestedIndex; index < BTW_THINKING_LEVELS.length; index += 1) {
+		const candidate = BTW_THINKING_LEVELS[index];
+		if (candidate && available.includes(candidate)) return candidate;
+	}
+	for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+		const candidate = BTW_THINKING_LEVELS[index];
+		if (candidate && available.includes(candidate)) return candidate;
+	}
+	return available[0] ?? "off";
+}
+
+function notifySaveFailure(ctx: ExtensionCommandContext, error: unknown): void {
+	ctx.ui.notify(
+		`Pi BTW settings were not saved; the previous value remains active: ${formatError(error)}`,
+		"error",
+	);
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-btw/src/settings.ts
+++ b/extensions/pi-btw/src/settings.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { BTW_THINKING_LEVELS, type BtwThinkingLevel } from "./side-thread.js";
+
+export const BTW_SETTINGS_FILE = "pi-btw.json";
+export const DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES = true;
+
+export interface BtwSettings {
+	model?: string;
+	thinkingLevel?: BtwThinkingLevel;
+	rememberThinkingLevelChanges?: boolean;
+}
+
+export type BtwSettingsLoadResult =
+	| { kind: "missing" }
+	| { kind: "invalid"; reason: string }
+	| { kind: "loaded"; settings: BtwSettings };
+
+export interface UpdateBtwSettingsOptions {
+	settingsPath?: string;
+	signal?: AbortSignal;
+	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>;
+}
+
+type SettingsDocument = Record<string, unknown>;
+
+const mutationQueues = new Map<string, Promise<void>>();
+
+export function btwSettingsPath(): string {
+	return join(getAgentDir(), BTW_SETTINGS_FILE);
+}
+
+export function normalizeBtwSettings(value: unknown): BtwSettings | undefined {
+	if (!isSettingsDocument(value)) return undefined;
+
+	const settings: BtwSettings = {};
+	if (Object.hasOwn(value, "model")) {
+		const model = Reflect.get(value, "model");
+		if (typeof model !== "string" || !parseBtwModelReference(model)) return undefined;
+		settings.model = model;
+	}
+	if (Object.hasOwn(value, "thinkingLevel")) {
+		const thinkingLevel = Reflect.get(value, "thinkingLevel");
+		if (!isBtwThinkingLevel(thinkingLevel)) return undefined;
+		settings.thinkingLevel = thinkingLevel;
+	}
+	if (Object.hasOwn(value, "rememberThinkingLevelChanges")) {
+		const remember = Reflect.get(value, "rememberThinkingLevelChanges");
+		if (typeof remember !== "boolean") return undefined;
+		settings.rememberThinkingLevelChanges = remember;
+	}
+	return settings;
+}
+
+export function parseBtwModelReference(
+	reference: string,
+): { provider: string; modelId: string } | undefined {
+	if (/\s/.test(reference)) return undefined;
+	const separator = reference.indexOf("/");
+	if (separator <= 0 || separator === reference.length - 1) return undefined;
+	return { provider: reference.slice(0, separator), modelId: reference.slice(separator + 1) };
+}
+
+export function effectiveRememberThinkingLevelChanges(settings: BtwSettings): boolean {
+	return settings.rememberThinkingLevelChanges ?? DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES;
+}
+
+export async function readBtwSettings(
+	settingsPath = btwSettingsPath(),
+): Promise<BtwSettingsLoadResult> {
+	await awaitBtwSettingsWrites(settingsPath);
+	return readBtwSettingsUncoordinated(settingsPath);
+}
+
+export function updateBtwSettings(
+	patch: Partial<Pick<BtwSettings, "thinkingLevel" | "rememberThinkingLevelChanges">>,
+	options: UpdateBtwSettingsOptions = {},
+): Promise<BtwSettings> {
+	const settingsPath = options.settingsPath ?? btwSettingsPath();
+	return enqueueMutation(settingsPath, async () => {
+		options.signal?.throwIfAborted();
+		const current = await readSettingsDocumentForUpdate(settingsPath);
+		const updated: SettingsDocument = { ...current, ...patch };
+		const settings = normalizeBtwSettings(updated);
+		if (!settings) throw invalidSettingsError(settingsPath, "invalid settings shape");
+		await publishSettings(settingsPath, updated, options.signal, options.beforeRename);
+		return settings;
+	});
+}
+
+export async function awaitBtwSettingsWrites(settingsPath = btwSettingsPath()): Promise<void> {
+	await mutationQueues.get(settingsPath);
+}
+
+function enqueueMutation<T>(settingsPath: string, mutation: () => Promise<T>): Promise<T> {
+	const previous = mutationQueues.get(settingsPath) ?? Promise.resolve();
+	const result = previous.then(mutation, mutation);
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	mutationQueues.set(settingsPath, settled);
+	void settled.finally(() => {
+		if (mutationQueues.get(settingsPath) === settled) mutationQueues.delete(settingsPath);
+	});
+	return result;
+}
+
+async function readBtwSettingsUncoordinated(settingsPath: string): Promise<BtwSettingsLoadResult> {
+	let contents: string;
+	try {
+		contents = await readFile(settingsPath, "utf8");
+	} catch (error: unknown) {
+		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
+		return { kind: "invalid", reason: `${settingsPath}: ${formatError(error)}` };
+	}
+
+	try {
+		const settings = normalizeBtwSettings(JSON.parse(contents) as unknown);
+		return settings
+			? { kind: "loaded", settings }
+			: { kind: "invalid", reason: `${settingsPath}: invalid settings shape` };
+	} catch (error: unknown) {
+		return { kind: "invalid", reason: `${settingsPath}: invalid JSON (${formatError(error)})` };
+	}
+}
+
+async function readSettingsDocumentForUpdate(settingsPath: string): Promise<SettingsDocument> {
+	let contents: string;
+	try {
+		contents = await readFile(settingsPath, "utf8");
+	} catch (error: unknown) {
+		if (isNodeError(error) && error.code === "ENOENT") return {};
+		throw invalidSettingsError(settingsPath, formatError(error));
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(contents) as unknown;
+	} catch (error: unknown) {
+		throw invalidSettingsError(settingsPath, `invalid JSON (${formatError(error)})`);
+	}
+	if (!isSettingsDocument(parsed) || !normalizeBtwSettings(parsed)) {
+		throw invalidSettingsError(settingsPath, "invalid settings shape");
+	}
+	return parsed;
+}
+
+async function publishSettings(
+	settingsPath: string,
+	document: SettingsDocument,
+	signal?: AbortSignal,
+	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>,
+): Promise<void> {
+	signal?.throwIfAborted();
+	const directory = dirname(settingsPath);
+	await mkdir(directory, { recursive: true });
+	signal?.throwIfAborted();
+	const temporaryPath = join(
+		directory,
+		`.${basename(settingsPath)}.${process.pid}.${randomUUID()}.tmp`,
+	);
+	try {
+		await writeFile(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+			signal,
+		});
+		await beforeRename?.(temporaryPath, settingsPath);
+		signal?.throwIfAborted();
+		await rename(temporaryPath, settingsPath);
+	} catch (error) {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
+function isSettingsDocument(value: unknown): value is SettingsDocument {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBtwThinkingLevel(value: unknown): value is BtwThinkingLevel {
+	return BTW_THINKING_LEVELS.includes(value as BtwThinkingLevel);
+}
+
+function invalidSettingsError(settingsPath: string, reason: string): Error {
+	return new Error(`pi-btw settings at ${settingsPath} are invalid: ${reason}`);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/pi-btw/src/transcript-pager.ts
+++ b/extensions/pi-btw/src/transcript-pager.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import {
 	AssistantMessageComponent,
 	getMarkdownTheme,
+	type KeybindingsManager,
 	type Theme,
 	UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
@@ -18,7 +19,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import type { SideThreadTurn } from "./side-thread.js";
+import type { BtwThinkingLevel, SideThreadTurn } from "./side-thread.js";
 
 const TRANSCRIPT_CHROME_LINES = 2;
 const OSC133_MARKERS = ["\u001b]133;A\u0007", "\u001b]133;B\u0007", "\u001b]133;C\u0007"];
@@ -29,6 +30,13 @@ export type TranscriptPagerAction =
 	| { kind: "submit"; question: string }
 	| { kind: "bringToMain"; questionDraft: string }
 	| { kind: "close" };
+
+export interface BtwThinkingControl {
+	level: BtwThinkingLevel;
+	levels: readonly BtwThinkingLevel[];
+	keybindings: KeybindingsManager;
+	onChange: (level: BtwThinkingLevel) => void;
+}
 
 export class BtwTranscriptPager implements Component {
 	private readonly transcriptComponents: Component[];
@@ -41,17 +49,23 @@ export class BtwTranscriptPager implements Component {
 	private warning: string | undefined;
 	private finished = false;
 	private isFocused = false;
+	private thinkingLevel: BtwThinkingLevel | undefined;
 
 	constructor(
 		private readonly tui: TUI,
 		private readonly theme: Theme,
 		turns: readonly SideThreadTurn[],
 		private readonly onAction: (action: TranscriptPagerAction) => void,
-		options: { startAtBottom?: boolean; initialQuestion?: string } = {},
+		private readonly options: {
+			startAtBottom?: boolean;
+			initialQuestion?: string;
+			thinking?: BtwThinkingControl;
+		} = {},
 	) {
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme);
 		this.canBringToMain = turns.some((turn) => turn.kind === "answered");
 		this.followBottom = options.startAtBottom ?? false;
+		this.thinkingLevel = options.thinking?.level;
 		const editorTheme: EditorTheme = {
 			borderColor: (text) => this.theme.fg("accent", text),
 			selectList: {
@@ -102,7 +116,7 @@ export class BtwTranscriptPager implements Component {
 		this.clampScrollOffset();
 
 		return fitComposerLayout(
-			renderSideThreadHeader(safeWidth, this.theme),
+			renderSideThreadHeader(safeWidth, this.theme, this.thinkingLevel),
 			contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
 			this.renderFooter(safeWidth),
 			editorLines,
@@ -120,6 +134,22 @@ export class BtwTranscriptPager implements Component {
 		if (this.canBringToMain && matchesKey(data, Key.ctrl("r"))) {
 			this.finished = true;
 			this.onAction({ kind: "bringToMain", questionDraft: this.editor.getExpandedText() });
+			return;
+		}
+		const thinking = this.options.thinking;
+		if (
+			thinking &&
+			thinking.levels.length > 1 &&
+			thinking.keybindings.matches(data, "app.thinking.cycle")
+		) {
+			const currentIndex = thinking.levels.indexOf(this.thinkingLevel ?? thinking.level);
+			const nextLevel = thinking.levels[(currentIndex + 1) % thinking.levels.length];
+			if (nextLevel) {
+				this.thinkingLevel = nextLevel;
+				thinking.onChange(nextLevel);
+				this.warning = undefined;
+				this.tui.requestRender();
+			}
 			return;
 		}
 		if (matchesKey(data, Key.pageUp)) {
@@ -144,23 +174,38 @@ export class BtwTranscriptPager implements Component {
 		this.editor.invalidate();
 	}
 
+	dispose(): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.onAction({ kind: "close" });
+	}
+
 	private renderFooter(width: number): string {
 		if (this.warning) {
 			const warning = width < 32 ? "Empty • Ctrl+C" : `${this.warning} • Ctrl+C exit`;
 			return truncateToWidth(this.theme.fg("warning", warning), width);
 		}
 		const scrollable = this.getMaxScrollOffset() > 0;
-		const fullBase = this.canBringToMain
+		const thinking = this.options.thinking;
+		const cycleHint =
+			thinking && thinking.levels.length > 1 && this.thinkingLevel
+				? ` • thinking ${this.thinkingLevel} • ${thinkingKeyLabel(thinking.keybindings)} cycle`
+				: "";
+		const base = this.canBringToMain
 			? "btw • Enter send • Ctrl+R bring to main • Ctrl+C exit"
 			: "btw • Enter send • Ctrl+C exit";
+		const fullBase = `${base}${cycleHint}`;
 		const fallbackBase = "btw • Enter • Ctrl+C";
 		const compactBase = this.canBringToMain ? "btw • Enter • Ctrl+R • Ctrl+C" : fallbackBase;
+		const compactWithThinking = `${compactBase}${cycleHint}`;
 		let hints =
 			visibleWidth(fullBase) <= width
 				? fullBase
-				: visibleWidth(compactBase) <= width
-					? compactBase
-					: fallbackBase;
+				: visibleWidth(compactWithThinking) <= width
+					? compactWithThinking
+					: visibleWidth(compactBase) <= width
+						? compactBase
+						: fallbackBase;
 		if (scrollable) {
 			const history = ` • ${this.scrollOffset > 0 ? "↑ older" : "↓ newer"} • PgUp/PgDn history`;
 			const compactHistory = " • PgUp/PgDn";
@@ -212,6 +257,7 @@ export class BtwAnsweringView implements Component {
 		turns: readonly SideThreadTurn[],
 		pendingQuestion: string,
 		private readonly onCancel: () => void,
+		private readonly thinkingLevel?: BtwThinkingLevel,
 	) {
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme, pendingQuestion);
 		this.loader = new Loader(
@@ -239,7 +285,7 @@ export class BtwAnsweringView implements Component {
 		const loaderWidth = Math.max(1, safeWidth - visibleWidth(cancelHint) - 3);
 		const loaderLine = this.loader.render(loaderWidth).at(-1) ?? "Answering…";
 		const lines = [
-			renderSideThreadHeader(safeWidth, this.theme),
+			renderSideThreadHeader(safeWidth, this.theme, this.thinkingLevel),
 			...contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
 			truncateToWidth(`${loaderLine} • ${this.theme.fg("muted", cancelHint)}`, safeWidth),
 		];
@@ -278,8 +324,15 @@ export class BtwAnsweringView implements Component {
 	}
 
 	dispose(): void {
-		this.finish();
+		if (this.finished) {
+			this.loader.stop();
+			this.controller.abort();
+			return;
+		}
+		this.finished = true;
+		this.loader.stop();
 		this.controller.abort();
+		this.onCancel();
 	}
 
 	private scrollBy(delta: number): void {
@@ -350,10 +403,31 @@ function renderTranscriptLines(components: readonly Component[], width: number):
 		.map(stripShellIntegrationMarkers);
 }
 
-function renderSideThreadHeader(width: number, theme: Theme): string {
-	const title = truncateToWidth("─ btw · side thread ", width);
+function renderSideThreadHeader(
+	width: number,
+	theme: Theme,
+	thinkingLevel?: BtwThinkingLevel,
+): string {
+	const thinking = thinkingLevel ? ` · thinking ${thinkingLevel}` : "";
+	const title = truncateToWidth(`─ btw · side thread${thinking} `, width);
 	const ruleWidth = Math.max(0, width - visibleWidth(title));
 	return theme.fg("muted", `${title}${"─".repeat(ruleWidth)}`);
+}
+
+function thinkingKeyLabel(keybindings: KeybindingsManager): string {
+	const key = String(keybindings.getKeys("app.thinking.cycle")[0] ?? "shift+tab");
+	return key
+		.split("+")
+		.map((part) => {
+			const lower = part.toLowerCase();
+			if (lower === "shift") return "Shift";
+			if (lower === "ctrl") return "Ctrl";
+			if (lower === "alt") return "Alt";
+			return part.length === 1
+				? part.toUpperCase()
+				: `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`;
+		})
+		.join("+");
 }
 
 function fitComposerLayout(

--- a/extensions/pi-btw/test/btw.test.ts
+++ b/extensions/pi-btw/test/btw.test.ts
@@ -343,6 +343,75 @@ test("side-question completion maps thinking levels into provider-neutral option
 	}
 });
 
+test("btw command routes no arguments through the menu and preserves direct questions", async () => {
+	const mock = createMockPi({ thinkingLevel: "low" });
+	const selected = {
+		model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+		auth: { apiKey: "key" },
+	};
+	const menuCalls: string[] = [];
+	const threadStarts: Array<{
+		initialQuestion?: string;
+		thinkingLevel: string;
+		rememberThinkingLevelChanges?: boolean;
+	}> = [];
+	btw(mock.pi, {
+		showCommandMenu: async () => {
+			menuCalls.push("menu");
+			return "start";
+		},
+		loadSettings: async () => ({ thinkingLevel: "medium" }),
+		resolveModel: async () => ({ kind: "selected", selected }),
+		runThread: async (options) => {
+			threadStarts.push({
+				initialQuestion: options.initialQuestion,
+				thinkingLevel: options.thinkingLevel,
+				rememberThinkingLevelChanges: options.rememberThinkingLevelChanges,
+			});
+			return { kind: "closed" };
+		},
+	});
+	const command = mock.commands.get("btw");
+	assert.ok(command);
+	const interactive = createMockContext({ mode: "tui", hasUI: true });
+
+	await command.handler("", interactive.ctx);
+	await command.handler("direct question", interactive.ctx);
+
+	assert.deepEqual(menuCalls, ["menu"]);
+	assert.deepEqual(threadStarts, [
+		{
+			initialQuestion: undefined,
+			thinkingLevel: "medium",
+			rememberThinkingLevelChanges: true,
+		},
+		{
+			initialQuestion: "direct question",
+			thinkingLevel: "medium",
+			rememberThinkingLevelChanges: true,
+		},
+	]);
+	assert.deepEqual(mock.thinkingLevels, []);
+});
+
+test("btw command cancellation at the no-argument menu does not resolve a model", async () => {
+	const mock = createMockPi();
+	let modelResolutions = 0;
+	btw(mock.pi, {
+		showCommandMenu: async () => "closed",
+		loadSettings: async () => ({}),
+		resolveModel: async () => {
+			modelResolutions += 1;
+			return { kind: "unavailable" };
+		},
+	});
+	const command = mock.commands.get("btw");
+	assert.ok(command);
+	await command.handler("", createMockContext({ mode: "tui", hasUI: true }).ctx);
+
+	assert.equal(modelResolutions, 0);
+});
+
 test("btw command rejects non-TUI mode before reading the runtime thinking level", async () => {
 	const mock = createMockPi();
 	let thinkingLevelReads = 0;

--- a/extensions/pi-btw/test/menu.test.ts
+++ b/extensions/pi-btw/test/menu.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext } from "../../../test/support.js";
+import { showBtwCommandMenu } from "../src/menu.js";
+import { BTW_SETTINGS_FILE } from "../src/settings.js";
+
+async function withMenu(
+	run: (host: {
+		settingsPath: string;
+		tui: ReturnType<typeof createTuiHarness>;
+		ctx: ExtensionCommandContext;
+		notifications: ReturnType<typeof createMockContext>["notifications"];
+	}) => Promise<void>,
+): Promise<void> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-btw-menu-test-"));
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const mock = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		editorText: "draft",
+	});
+	try {
+		await run({
+			settingsPath: join(directory, BTW_SETTINGS_FILE),
+			tui,
+			ctx: mock.ctx,
+			notifications: mock.notifications,
+		});
+	} finally {
+		tui.dispose();
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+test("btw no-argument menu selects Start side thread first and preserves the editor", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+		});
+		await tui.waitForOpen();
+		const rendered = tui.render().join("\n");
+		assert.match(rendered, /Pi BTW/);
+		assert.match(rendered, /→ Start side thread/);
+		assert.match(rendered, /Settings/);
+		tui.press("tui.select.confirm");
+
+		assert.equal(await running, "start");
+		assert.equal(ctx.ui.getEditorText(), "draft");
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+async function openSettings(tui: ReturnType<typeof createTuiHarness>): Promise<void> {
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	assert.match(tui.render().join("\n"), /→ Settings/);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+}
+
+test("disposing the idle btw menu closes without writing or changing the editor", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low"],
+		});
+		await tui.waitForOpen();
+		tui.dispose();
+
+		assert.equal(await running, "closed");
+		assert.equal(ctx.ui.getEditorText(), "draft");
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("btw menu opens Pi-style thinking settings and cancellation is read-only", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "medium",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+		});
+		await openSettings(tui);
+		const settings = tui.render().join("\n");
+		assert.match(settings, /Pi BTW Settings/);
+		assert.match(settings, /Thinking level\s+medium/);
+		assert.match(settings, /Remember thinking level changes\s+On/);
+		tui.press("ctrl+c");
+
+		assert.equal(await running, "closed");
+		assert.equal(ctx.ui.getEditorText(), "draft");
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("btw settings save thinking and remembering immediately while preserving unknown fields", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
+		await writeFile(settingsPath, '{"model":"test/side","future":{"kept":true}}\n', "utf8");
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "medium",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+		});
+		await openSettings(tui);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		let saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(saved, {
+			model: "test/side",
+			future: { kept: true },
+			thinkingLevel: "high",
+		});
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.equal(saved.rememberThinkingLevelChanges, false);
+		assert.equal(saved.thinkingLevel, "high");
+		assert.ok(notifications.some(({ message }) => /thinking level: high/i.test(message)));
+		assert.ok(notifications.some(({ message }) => /changes: Off/i.test(message)));
+		tui.press("ctrl+c");
+		assert.equal(await running, "closed");
+	});
+});
+
+test("btw settings reject failed saves and restore the prior displayed value", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "medium",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+			updateSettings: async () => {
+				throw new Error("disk full");
+			},
+		});
+		await openSettings(tui);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		const narrow = tui.render(32);
+		assert.ok(narrow.every((line) => visibleWidth(line) <= 32));
+		assert.match(tui.render(80).join("\n"), /Thinking level\s+medium/);
+		assert.match(notifications[0]?.message ?? "", /previous value remains active.*disk full/i);
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+		tui.press("ctrl+c");
+		assert.equal(await running, "closed");
+	});
+});
+
+test("btw menu exposes malformed settings as read-only", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		await writeFile(settingsPath, "{broken", "utf8");
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low"],
+		});
+		await openSettings(tui);
+		assert.match(tui.render().join("\n"), /Read only/);
+		assert.match(tui.render().join("\n"), /Fix .*pi-btw\.json before\s+saving/);
+		tui.press("ctrl+c");
+		assert.equal(await running, "closed");
+		assert.equal(await readFile(settingsPath, "utf8"), "{broken");
+	});
+});
+
+test("disposing btw settings aborts and drains an in-flight save without notification", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
+		let started!: () => void;
+		const saveStarted = new Promise<void>((resolve) => {
+			started = resolve;
+		});
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low", "medium"],
+			updateSettings: async (_patch, { signal }) => {
+				started();
+				return new Promise((_resolve, reject) => {
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+				});
+			},
+		});
+		await openSettings(tui);
+		tui.press("tui.select.confirm");
+		await saveStarted;
+		tui.dispose();
+
+		assert.equal(await running, "closed");
+		assert.deepEqual(notifications, []);
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});

--- a/extensions/pi-btw/test/settings.test.ts
+++ b/extensions/pi-btw/test/settings.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	BTW_SETTINGS_FILE,
+	DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES,
+	effectiveRememberThinkingLevelChanges,
+	normalizeBtwSettings,
+	readBtwSettings,
+	updateBtwSettings,
+} from "../src/settings.js";
+
+async function withTempSettings(run: (settingsPath: string) => Promise<void>): Promise<void> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-btw-settings-test-"));
+	try {
+		await run(join(directory, "nested", BTW_SETTINGS_FILE));
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+test("btw settings default remembering on without materializing a missing file", async () => {
+	await withTempSettings(async (settingsPath) => {
+		assert.equal(DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES, true);
+		assert.deepEqual(await readBtwSettings(settingsPath), { kind: "missing" });
+		assert.equal(effectiveRememberThinkingLevelChanges({}), true);
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("btw settings validate the optional remembered-change setting", () => {
+	assert.deepEqual(normalizeBtwSettings({ rememberThinkingLevelChanges: true }), {
+		rememberThinkingLevelChanges: true,
+	});
+	assert.deepEqual(normalizeBtwSettings({ rememberThinkingLevelChanges: false }), {
+		rememberThinkingLevelChanges: false,
+	});
+	assert.equal(normalizeBtwSettings({ rememberThinkingLevelChanges: "yes" }), undefined);
+});
+
+test("btw settings preserve omitted thinking levels for backward compatibility", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await updateBtwSettings({ rememberThinkingLevelChanges: false }, { settingsPath });
+		assert.deepEqual(await readBtwSettings(settingsPath), {
+			kind: "loaded",
+			settings: { rememberThinkingLevelChanges: false },
+		});
+	});
+});
+
+test("btw settings updates preserve unknown fields and create only on explicit save", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await updateBtwSettings(
+			{ thinkingLevel: "low", rememberThinkingLevelChanges: true },
+			{ settingsPath },
+		);
+		const first = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(first, { thinkingLevel: "low", rememberThinkingLevelChanges: true });
+
+		await writeFile(settingsPath, '{"future":{"kept":true},"thinkingLevel":"low"}\n', "utf8");
+		await updateBtwSettings({ thinkingLevel: "high" }, { settingsPath });
+		const updated = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(updated, { future: { kept: true }, thinkingLevel: "high" });
+	});
+});
+
+test("btw settings reject malformed or invalid documents without changing their bytes", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await updateBtwSettings({ thinkingLevel: "low" }, { settingsPath });
+		for (const contents of ["{broken", '{"thinkingLevel":"huge"}\n']) {
+			await writeFile(settingsPath, contents, "utf8");
+			await assert.rejects(
+				updateBtwSettings({ thinkingLevel: "high" }, { settingsPath }),
+				/pi-btw settings.*(?:invalid|JSON)/i,
+			);
+			assert.equal(await readFile(settingsPath, "utf8"), contents);
+		}
+	});
+});
+
+test("btw settings atomic publication failure preserves the previous document", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await updateBtwSettings({ thinkingLevel: "low" }, { settingsPath });
+		const before = await readFile(settingsPath, "utf8");
+		await assert.rejects(
+			updateBtwSettings(
+				{ thinkingLevel: "high" },
+				{
+					settingsPath,
+					beforeRename: async () => {
+						throw new Error("publication failed");
+					},
+				},
+			),
+			/publication failed/,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), before);
+	});
+});
+
+test("btw settings serialize rapid updates in invocation order and recover after failure", async () => {
+	await withTempSettings(async (settingsPath) => {
+		let releaseFirst: (() => void) | undefined;
+		const first = updateBtwSettings(
+			{ thinkingLevel: "low" },
+			{
+				settingsPath,
+				beforeRename: () =>
+					new Promise<void>((resolve) => {
+						releaseFirst = resolve;
+					}),
+			},
+		);
+		const second = updateBtwSettings({ thinkingLevel: "medium" }, { settingsPath });
+		const coordinatedRead = readBtwSettings(settingsPath);
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		assert.ok(releaseFirst);
+		releaseFirst();
+		await Promise.all([first, second]);
+		assert.deepEqual(await coordinatedRead, {
+			kind: "loaded",
+			settings: { thinkingLevel: "medium" },
+		});
+		assert.equal(
+			(JSON.parse(await readFile(settingsPath, "utf8")) as { thinkingLevel: string }).thinkingLevel,
+			"medium",
+		);
+
+		await assert.rejects(
+			updateBtwSettings(
+				{ thinkingLevel: "high" },
+				{ settingsPath, beforeRename: async () => Promise.reject(new Error("failed once")) },
+			),
+			/failed once/,
+		);
+		await updateBtwSettings({ thinkingLevel: "max" }, { settingsPath });
+		assert.equal(
+			(JSON.parse(await readFile(settingsPath, "utf8")) as { thinkingLevel: string }).thinkingLevel,
+			"max",
+		);
+	});
+});
+
+test("btw settings abort before publication leaves the canonical path absent", async () => {
+	await withTempSettings(async (settingsPath) => {
+		const controller = new AbortController();
+		await assert.rejects(
+			updateBtwSettings(
+				{ thinkingLevel: "high" },
+				{
+					settingsPath,
+					signal: controller.signal,
+					beforeRename: async () => controller.abort(new Error("settings disposed")),
+				},
+			),
+			/settings disposed/,
+		);
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});

--- a/extensions/pi-btw/test/side-thread.test.ts
+++ b/extensions/pi-btw/test/side-thread.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type {
 	Api,
@@ -64,6 +67,7 @@ function keybindings(mapping: Record<string, string> = {}) {
 		"tui.select.pageDown": "\u001b[6~",
 		"tui.select.confirm": "\r",
 		"tui.select.cancel": "\u001b",
+		"app.thinking.cycle": "\u001b[Z",
 	};
 	const labels: Record<string, string> = {
 		"tui.select.up": "up",
@@ -72,6 +76,7 @@ function keybindings(mapping: Record<string, string> = {}) {
 		"tui.select.pageDown": "pageDown",
 		"tui.select.confirm": "enter",
 		"tui.select.cancel": "escape",
+		"app.thinking.cycle": "shift+tab",
 	};
 	return {
 		matches(data: string, key: string) {
@@ -733,7 +738,7 @@ test("side-thread command loop immediately accepts another question after each a
 		},
 	} as never;
 	const selected: ResolvedBtwModel = {
-		model: { provider: "test", id: "side" } as Model<Api>,
+		model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
 		auth: { apiKey: "key" },
 	};
 	const questions: string[] = [];
@@ -768,6 +773,243 @@ test("side-thread command loop immediately accepts another question after each a
 
 	assert.deepEqual(questions, ["Q1", "Q2"]);
 	assert.deepEqual(transcriptSizes, [1, 2]);
+});
+
+test("side-thread thinking changes apply to later questions without changing the initial level", async () => {
+	const ctx = {
+		ui: { notify() {} },
+		sessionManager: { getBranch: () => [] },
+	} as never;
+	const selected: ResolvedBtwModel = {
+		model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+		auth: { apiKey: "key" },
+	};
+	const thinkingLevels: string[] = [];
+	let interactions = 0;
+
+	await runBtwThread({
+		initialQuestion: "Q1",
+		selected,
+		thinkingLevel: "low",
+		ctx,
+		dependencies: {
+			ask: async (thread, question, _selected, thinkingLevel) => {
+				thinkingLevels.push(thinkingLevel);
+				const assistant = response("answer");
+				thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+				return { kind: "answered", response: assistant, answer: "answer" };
+			},
+			interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+				interactions += 1;
+				if (interactions === 1) {
+					assert.equal(thinking.level, "low");
+					thinking.onChange("high");
+					return { kind: "submit", question: "Q2" };
+				}
+				assert.equal(thinking.level, "high");
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(thinkingLevels, ["low", "high"]);
+});
+
+test("side-thread remembers rapid thinking changes in order and uses the latest level", async () => {
+	const persisted: string[] = [];
+	const askedWith: string[] = [];
+	let interactions = 0;
+	await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "low",
+		rememberThinkingLevelChanges: true,
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => [] },
+		} as never,
+		dependencies: {
+			persistThinkingLevel: async (level) => {
+				persisted.push(level);
+			},
+			ask: async (thread, question, _selected, level) => {
+				askedWith.push(level);
+				const assistant = response("answer");
+				thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+				return { kind: "answered", response: assistant, answer: "answer" };
+			},
+			interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+				interactions += 1;
+				if (interactions === 1) {
+					thinking.onChange("medium");
+					thinking.onChange("high");
+					return { kind: "submit", question: "Q2" };
+				}
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(askedWith, ["low", "high"]);
+	assert.deepEqual(persisted, ["medium", "high"]);
+});
+
+test("side-thread remembered thinking survives in pi-btw settings", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-btw-thread-settings-test-"));
+	const settingsPath = join(directory, "pi-btw.json");
+	try {
+		let interactions = 0;
+		await runBtwThread({
+			initialQuestion: "Q1",
+			selected: {
+				model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+				auth: { apiKey: "key" },
+			},
+			thinkingLevel: "low",
+			rememberThinkingLevelChanges: true,
+			settingsPath,
+			ctx: {
+				ui: { notify() {} },
+				sessionManager: { getBranch: () => [] },
+			} as never,
+			dependencies: {
+				ask: async (thread, question) => {
+					const assistant = response("answer");
+					thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+					return { kind: "answered", response: assistant, answer: "answer" };
+				},
+				interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+					interactions += 1;
+					if (interactions === 1) thinking.onChange("high");
+					return { kind: "close" };
+				},
+			},
+		});
+		assert.equal(
+			(JSON.parse(await readFile(settingsPath, "utf8")) as { thinkingLevel: string }).thinkingLevel,
+			"high",
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("side-thread remembering off changes locally without writing settings", async () => {
+	const askedWith: string[] = [];
+	let interactions = 0;
+	await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "low",
+		rememberThinkingLevelChanges: false,
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => [] },
+		} as never,
+		dependencies: {
+			persistThinkingLevel: async () => assert.fail("remembering off must not persist"),
+			ask: async (thread, question, _selected, level) => {
+				askedWith.push(level);
+				const assistant = response("answer");
+				thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+				return { kind: "answered", response: assistant, answer: "answer" };
+			},
+			interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+				interactions += 1;
+				if (interactions === 1) {
+					thinking.onChange("high");
+					return { kind: "submit", question: "Q2" };
+				}
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(askedWith, ["low", "high"]);
+});
+
+test("side-thread save failure keeps the local thinking level and warns once", async () => {
+	const notifications: Array<{ message: string; level: string }> = [];
+	const askedWith: string[] = [];
+	let interactions = 0;
+	await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "low",
+		rememberThinkingLevelChanges: true,
+		ctx: {
+			ui: {
+				notify(message: string, level: string) {
+					notifications.push({ message, level });
+				},
+			},
+			sessionManager: { getBranch: () => [] },
+		} as never,
+		dependencies: {
+			persistThinkingLevel: async () => Promise.reject(new Error("read-only filesystem")),
+			ask: async (thread, question, _selected, level) => {
+				askedWith.push(level);
+				const assistant = response("answer");
+				thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+				return { kind: "answered", response: assistant, answer: "answer" };
+			},
+			interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+				interactions += 1;
+				if (interactions === 1) {
+					thinking.onChange("high");
+					return { kind: "submit", question: "Q2" };
+				}
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(askedWith, ["low", "high"]);
+	assert.equal(notifications.length, 1);
+	assert.equal(notifications[0]?.level, "warning");
+	assert.match(
+		notifications[0]?.message ?? "",
+		/changed to high.*could not be remembered.*read-only/i,
+	);
+});
+
+test("side-thread thinking starts clamped to the selected model's capabilities", async () => {
+	const captured: string[] = [];
+	await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "plain", reasoning: false } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "high",
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => [] },
+		} as never,
+		dependencies: {
+			ask: async (thread, question, _selected, thinkingLevel) => {
+				captured.push(thinkingLevel);
+				const assistant = response("answer");
+				thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+				return { kind: "answered", response: assistant, answer: "answer" };
+			},
+			interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+				captured.push(thinking.level);
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(captured, ["off", "off"]);
 });
 
 test("cancelling an in-progress side answer exits without reopening the composer", async () => {
@@ -1108,6 +1350,58 @@ test("empty transcript composer accepts the first side-thread question", () => {
 	composer.handleInput("\r");
 
 	assert.deepEqual(actions, [{ kind: "submit", question: "first question" }]);
+});
+
+test("transcript cycles its local thinking level with Pi's configured thinking shortcut", () => {
+	initTheme("dark");
+	const changes: string[] = [];
+	const tui = { terminal: { rows: 24 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const pager = new BtwTranscriptPager(
+		tui as never,
+		theme as never,
+		[{ question: "Q1", answer: "A1", kind: "answered", response: response("A1") }],
+		() => undefined,
+		{
+			thinking: {
+				level: "low",
+				levels: ["off", "low", "high"],
+				keybindings: keybindings({ "app.thinking.cycle": "t" }) as never,
+				onChange: (level) => changes.push(level),
+			},
+		},
+	);
+
+	assert.match(pager.render(80).join("\n"), /thinking low.*T cycle/i);
+	pager.handleInput("t");
+
+	assert.deepEqual(changes, ["high"]);
+	assert.match(pager.render(80).join("\n"), /thinking high/i);
+});
+
+test("disposing the side-thread composer closes it exactly once", () => {
+	const actions: unknown[] = [];
+	const pager = new BtwTranscriptPager(
+		{ terminal: { rows: 24 }, requestRender() {} } as never,
+		{
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		[],
+		(action) => actions.push(action),
+	);
+	pager.dispose();
+	pager.dispose();
+	pager.handleInput("question");
+
+	assert.deepEqual(actions, [{ kind: "close" }]);
 });
 
 test("transcript offers opt-in bring-to-main action only after a successful answer", () => {
@@ -1918,6 +2212,28 @@ test("answering view preserves the transcript and offers compact cancellation", 
 	} finally {
 		view.dispose();
 	}
+});
+
+test("disposing an answering view aborts and closes it exactly once", () => {
+	initTheme("dark");
+	let cancelled = 0;
+	const view = new BtwAnsweringView(
+		{ terminal: { rows: 24 }, requestRender() {} } as never,
+		{
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		[],
+		"question",
+		() => {
+			cancelled += 1;
+		},
+	);
+	view.dispose();
+	view.dispose();
+
+	assert.equal(cancelled, 1);
+	assert.equal(view.signal.aborted, true);
 });
 
 test("answering view never exceeds the available height in a short terminal", () => {


### PR DESCRIPTION
## Summary

- make bare `/btw` open a two-row Start/Settings menu while preserving `/btw <question>` as the fast path
- add pi-btw thinking settings with default-on shortcut persistence, ordered atomic writes, invalid-file protection, and unknown-field preservation
- reuse Pi's configured `app.thinking.cycle` shortcut inside side threads without changing the main session
- keep a shortcut-selected local level when remembering fails, while Settings-screen save failures roll back

## Verification

- focused compiled pi-btw tests: 110 passed
- `npm run typecheck --workspace @narumitw/pi-btw`
- Biome LSP diagnostics: 0 across pi-btw source and tests
- CI-equivalent `npm run check` on the rebased commit in a normal clone with npm 12.0.2: 1,985 passed
- `npm pack --workspace @narumitw/pi-btw --dry-run --json`
- `pi --no-extensions -e ./extensions/pi-btw --list-models openai-codex/gpt-5.6-sol`

## Semantic audit

Read and audited `docs/extension-conventions.md` and `docs/extension-settings.md` for command routing, standard/settings UI, custom TUI input, cancellation/disposal, session replacement, save ordering, malformed-file protection, atomic publication, documentation, and package contents.

Accepted product distinction: shortcut persistence is secondary, so a failed write warns but retains the current side-thread level. Settings actions remain persistence-first and reject/roll back on save failure. No unverified required path remains.
