### PR TITLE
feat(pi-subagents): advertise consult agents

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -63,11 +63,13 @@ The available tools are:
 - `subagent_inspect` — inspect agent/model/run/runtime metadata without launching work or changing state.
 - `subagent_consult` — run one ephemeral read-only consultation and wait for its answer.
 
-After each session starts, both delegation tools include a bounded parent-facing catalog of the agents
-available in that session. Entries show the source (`built-in`, `user`, or `project`) and the
-`agentScope` needed to invoke them; the `agent` parameters remain unconstrained strings for cwd and
-scope flexibility. The catalog is rebuilt on `/reload` or the next session start, and omitted entries
-are reported explicitly when the catalog exceeds its metadata bounds.
+After each session starts, the descriptions of the registered `subagent`, `subagent_spawn`, and
+`subagent_consult` tools include the same bounded parent-facing catalog of the agents available in
+that session. Entries show the source (`built-in`, `user`, or `project`) and the `agentScope` needed to
+invoke them; the `agent` parameters remain unconstrained strings for cwd and scope flexibility. The
+catalog is rebuilt on
+`/reload` or the next session start, and omitted entries are reported explicitly when the catalog
+exceeds its metadata bounds.
 
 Choose the API by lifecycle:
 
@@ -102,10 +104,11 @@ When registered, the blocking `subagent` tool advertises only blocking guidance.
 are registered, `subagent_spawn` adds detached guidance for the active completion-delivery policy.
 Changing the policy through `/subagents settings` refreshes that guidance immediately.
 
-The same descriptions also advertise the current agent catalog automatically; no preliminary list call is
-needed. Built-ins and user agents appear under the default `agentScope: "user"`. Trusted project
-agents appear separately and explicitly require `agentScope: "project"` or `"both"`; project-authored
-names and descriptions are not read into metadata for untrusted projects. If a project definition
+The `subagent`, `subagent_spawn`, and `subagent_consult` descriptions advertise the current agent
+catalog automatically; no preliminary list call is needed. Built-ins and user agents appear under the
+default `agentScope: "user"`. Trusted project agents appear separately and explicitly require
+`agentScope: "project"` or `"both"`; project-authored names and descriptions are not read into
+metadata for untrusted projects. If a project definition
 shares a name with a user or built-in definition, the user version is the default and the project
 version is used only for `"project"`/`"both"`. A user override of a built-in also shows the
 built-in fallback available with `agentScope: "project"`; `"both"` keeps the user definition. The
@@ -206,7 +209,15 @@ Compatibility: `subagent_manage({ "action": "list" })` remains supported with it
 }
 ```
 
-The actionless schema requires `agent` and `task` and accepts optional `agentScope`, `confirmProjectAgents`, `cwd`, `timeoutMs`, and `thinkingLevel`. Project scope is rejected before discovery when the project is untrusted. A trusted project agent still asks for confirmation by default; non-interactive calls fail closed unless they explicitly send `confirmProjectAgents: false`. Declining an interactive confirmation returns a normal cancelled result without launching or charging a child.
+The actionless schema requires `agent` and `task` and accepts optional `agentScope`,
+`confirmProjectAgents`, `cwd`, `timeoutMs`, and `thinkingLevel`. Any agent resolved from that scope may
+be selected; consultation always intersects its configured tools with the enforced read-only
+allow-list rather than defining a separate read-only agent category. An unknown name fails before
+launch with a bounded name/source list for the requested scope. Project scope is rejected before
+discovery when the project is untrusted. A trusted project agent still asks for confirmation by
+default; non-interactive calls fail closed unless they explicitly send
+`confirmProjectAgents: false`. Declining an interactive confirmation returns a normal cancelled result
+without launching or charging a child.
 
 `consult.resources` controls automatically inherited instruction resources:
 

--- a/extensions/pi-subagents/src/consult.ts
+++ b/extensions/pi-subagents/src/consult.ts
@@ -6,12 +6,15 @@ import {
 	type ExtensionAPI,
 	type ExtensionContext,
 	getAgentDir,
+	type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import {
 	type AgentConfig,
+	type AgentDiscoveryResult,
 	type AgentScope,
 	type ConsultResourcePolicy,
+	DEFAULT_AGENT_CATALOG_MAX_ITEMS,
 	discoverAgents,
 	isThinkingLevel,
 	type SubagentSettings,
@@ -115,11 +118,12 @@ const READ_ONLY_INSTRUCTION = [
 
 const MINIMAL_CONSULT_SYSTEM_PROMPT =
 	"You are a read-only consultation assistant. Analyze the delegated task using only executor-provided capabilities and return a grounded answer.";
+const MAX_UNKNOWN_AGENT_NAME_BYTES = 128;
 
 export function registerSubagentConsult(
 	pi: ExtensionAPI,
 	options: RegisterSubagentConsultOptions,
-): void {
+): (catalog: string) => void {
 	let generation = 0;
 	const active = new Set<AbortController>();
 	const activeChildren = new Set<Promise<SingleResult>>();
@@ -139,11 +143,12 @@ export function registerSubagentConsult(
 		cancelAndWaitForChildren("Subagent consultation session shut down"),
 	);
 
-	pi.registerTool<typeof SubagentConsultParams, ConsultDetails>({
+	const baseDescription =
+		"Run one ephemeral subagent synchronously under enforced read-only tool and resource policies and return its answer. The child can use only the effective subset of Pi's built-in read, grep, find, and ls tools. Shell commands, file writes, extension tools, detached lifecycle operations, and persistent agent state are disabled.";
+	const definition: ToolDefinition<typeof SubagentConsultParams, ConsultDetails> = {
 		name: "subagent_consult",
 		label: "Consult Read-only Subagent",
-		description:
-			"Run one ephemeral subagent synchronously under enforced read-only tool and resource policies and return its answer. The child can use only the effective subset of Pi's built-in read, grep, find, and ls tools. Shell commands, file writes, extension tools, detached lifecycle operations, and persistent agent state are disabled.",
+		description: baseDescription,
 		promptSnippet: "Consult one constrained read-only subagent and wait for its answer",
 		promptGuidelines: [
 			"Use subagent_consult for bounded reconnaissance, planning, or review whose result is required in the current turn.",
@@ -182,11 +187,33 @@ export function registerSubagentConsult(
 				active.delete(ownedController);
 			}
 		},
-	});
+	};
+	pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
 	pi.on("tool_result", (event) => {
 		if (event.toolName !== "subagent_consult") return;
 		if ((event.details as ConsultDetails | undefined)?.isError) return { isError: true };
 	});
+	return (catalog: string) => {
+		definition.description = catalog ? `${baseDescription}\n\n${catalog}` : baseDescription;
+		pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
+	};
+}
+
+function formatAvailableConsultAgents(discovery: AgentDiscoveryResult): string {
+	const listed = discovery.agents.slice(0, DEFAULT_AGENT_CATALOG_MAX_ITEMS);
+	const labels = listed.map(
+		(agent) => `${safeTerminalLine(agent.name, MAX_UNKNOWN_AGENT_NAME_BYTES)} (${agent.source})`,
+	);
+	const omitted =
+		discovery.agents.length - listed.length + (discovery.omittedAgentDefinitions ?? 0);
+	const parts = [labels.join(", ") || "none"];
+	if (omitted > 0) {
+		parts.push(`[${omitted} additional agent definition${omitted === 1 ? "" : "s"} omitted.]`);
+	}
+	if (discovery.metadataDiscoveryIncomplete) {
+		parts.push("[Agent metadata discovery was incomplete; some definitions may be unavailable.]");
+	}
+	return parts.join(" ");
 }
 
 function validateConsultParams(
@@ -270,7 +297,10 @@ async function executeConsult(
 	const discovery = discoverAgents(ctx.cwd, operation.agentScope, settings);
 	const agent = discovery.agents.find((candidate) => candidate.name === operation.agent);
 	if (!agent) {
-		throw new Error(`Unknown subagent definition: ${boundedPrivateText(operation.agent, 256)}`);
+		throw new Error(
+			`Unknown subagent definition: ${boundedPrivateText(operation.agent, 256)}. ` +
+				`Available agents for agentScope "${operation.agentScope}": ${formatAvailableConsultAgents(discovery)}`,
+		);
 	}
 	const setup = resolveConsultSetup(operation, agent, settings, ctx);
 

--- a/extensions/pi-subagents/src/subagents.ts
+++ b/extensions/pi-subagents/src/subagents.ts
@@ -39,6 +39,7 @@ export default function (pi: ExtensionAPI) {
 	const blockingEnabled = settings?.blocking?.enabled !== false;
 	const refreshBlockingCatalog = blockingEnabled ? registerBlockingSubagent(pi) : () => undefined;
 	let refreshStatefulCatalog: (catalog: string) => void = () => undefined;
+	let refreshConsultCatalog: (catalog: string) => void = () => undefined;
 
 	pi.on("session_start", (_event, ctx) => {
 		// Preserve a one-shot migration notice from extension load while refreshing
@@ -57,6 +58,7 @@ export default function (pi: ExtensionAPI) {
 		).text;
 		refreshBlockingCatalog(catalog);
 		refreshStatefulCatalog(catalog);
+		refreshConsultCatalog(catalog);
 	});
 
 	const statefulRuntime = registerStatefulSubagents(pi, {
@@ -73,7 +75,9 @@ export default function (pi: ExtensionAPI) {
 		getConsultResourcePolicy,
 	});
 	if (blockingEnabled) {
-		registerSubagentConsult(pi, { getSettings: () => currentSettings });
+		refreshConsultCatalog = registerSubagentConsult(pi, {
+			getSettings: () => currentSettings,
+		});
 	}
 	registerSubagentConfigCommand(pi, {
 		...statefulRuntime,

--- a/extensions/pi-subagents/test/consult.test.ts
+++ b/extensions/pi-subagents/test/consult.test.ts
@@ -108,6 +108,66 @@ test("subagent_consult registers a strict actionless single-agent schema", async
 	await assert.rejects(() => execute(tool, { agent: "worker" }), /requires task/);
 });
 
+test("subagent_consult reports actionable available agents before launching a child", async () => {
+	const { tool, requests } = setup();
+	await assert.rejects(
+		() => execute(tool, { agent: "tester-one", task: "inspect" }),
+		(error: unknown) => {
+			assert.ok(error instanceof Error);
+			assert.match(error.message, /Unknown subagent definition: tester-one/);
+			assert.match(error.message, /Available agents for agentScope "user":/);
+			assert.match(error.message, /scout \(built-in\)/);
+			assert.match(error.message, /reviewer \(built-in\)/);
+			return true;
+		},
+	);
+	assert.equal(requests.length, 0);
+});
+
+test("subagent_consult bounds unknown-agent recovery metadata", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-consult-agent-error-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = path.join(root, "agent-home");
+	const agentsDir = path.join(process.env.PI_CODING_AGENT_DIR, "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	try {
+		for (let index = 0; index < 40; index += 1) {
+			const name =
+				index === 0 ? `custom-${"x".repeat(300)}` : `custom-${String(index).padStart(2, "0")}`;
+			writeFileSync(
+				path.join(agentsDir, `${String(index).padStart(2, "0")}.md`),
+				`---\nname: ${name}\ndescription: Agent ${index}\n---\nInspect only.`,
+			);
+		}
+		const { tool, requests } = setup();
+		let message = "";
+		await assert.rejects(
+			() => execute(tool, { agent: "missing", task: "inspect" }),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				message = error.message;
+				return true;
+			},
+		);
+		assert.equal(requests.length, 0);
+		assert.ok(Buffer.byteLength(message, "utf8") <= 6 * 1024);
+		assert.doesNotMatch(message, /x{200}/);
+		assert.match(message, /14 additional agent definitions? omitted/);
+
+		rmSync(agentsDir, { recursive: true, force: true });
+		writeFileSync(agentsDir, "not a directory");
+		await assert.rejects(
+			() => execute(tool, { agent: "still-missing", task: "inspect" }),
+			/Agent metadata discovery was incomplete/,
+		);
+		assert.equal(requests.length, 0);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("subagent_consult rejects unsafe CLI-bound tasks and timer overflow before launch", async () => {
 	for (const [params, expected] of [
 		[{ agent: "worker", task: "界".repeat(20_000) }, /UTF-8 bytes/i],

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -1269,7 +1269,7 @@ test("formatAgentCatalog advertises scope variants deterministically and within 
 	}
 });
 
-test("session start refreshes both catalogs and gates project metadata on trust", async () => {
+test("session start refreshes every agent catalog and gates project metadata on trust", async () => {
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-catalog-user-"));
 	const trustedCwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-catalog-trusted-"));
 	const untrustedCwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-catalog-untrusted-"));
@@ -1310,26 +1310,35 @@ test("session start refreshes both catalogs and gates project metadata on trust"
 				spawn: String(
 					mock.tools.filter((tool) => tool.name === "subagent_spawn").at(-1)?.description ?? "",
 				),
+				consult: String(
+					mock.tools.filter((tool) => tool.name === "subagent_consult").at(-1)?.description ?? "",
+				),
 			};
 		};
 		const untrusted = await start(untrustedCwd, false);
-		assert.match(untrusted.blocking, /api-reviewer/);
-		assert.match(untrusted.blocking, /User scout override/);
-		assert.doesNotMatch(
-			untrusted.blocking,
-			/Project-only description|Project scout override|local \[source: project|scout \[source: project/,
-		);
-		assert.doesNotMatch(
-			untrusted.spawn,
-			/Project-only description|Project scout override|scout \[source: project/,
-		);
+		for (const description of Object.values(untrusted)) {
+			assert.match(description, /api-reviewer/);
+			assert.match(description, /User scout override/);
+			assert.doesNotMatch(
+				description,
+				/Project-only description|Project scout override|local \[source: project|scout \[source: project/,
+			);
+		}
 		const trusted = await start(trustedCwd, true);
-		assert.match(trusted.blocking, /local \[source: project/);
-		assert.match(trusted.blocking, /agentScope: "project" or "both"/);
-		assert.match(trusted.spawn, /local \[source: project/);
-		assert.match(trusted.spawn, /Project-only description/);
-		assert.match(trusted.blocking, /Project scout override/);
-		assert.doesNotMatch(trusted.blocking, /untrusted/);
+		for (const description of Object.values(trusted)) {
+			assert.match(description, /local \[source: project/);
+			assert.match(description, /agentScope: "project" or "both"/);
+			assert.match(description, /Project-only description/);
+			assert.match(description, /Project scout override/);
+			assert.doesNotMatch(description, /untrusted/);
+		}
+		const untrustedAgain = await start(untrustedCwd, false);
+		for (const description of Object.values(untrustedAgain)) {
+			assert.doesNotMatch(
+				description,
+				/Project-only description|Project scout override|local \[source: project|scout \[source: project/,
+			);
+		}
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;


### PR DESCRIPTION
## Summary

- add the bounded session agent catalog to `subagent_consult`
- return scoped, bounded agent names and sources when consultation receives an unknown agent
- preserve project trust boundaries and read-only tool intersection behavior
- document and test trusted, untrusted, stale-catalog, omission, and incomplete-discovery cases

## Testing

- `npm test`
- `npm run check`
