### PR TITLE
feat(subagents): add native tool progress rendering

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -19,6 +19,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
 - Supports per-task `cwd`, hard subprocess `timeoutMs`, task-selected `thinkingLevel`, abort propagation, and streaming progress.
+- Renders all seven tools with Pi-native compact/expanded transcript rows; long-running blocking and consultation calls show bounded live activity.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
 - Enforces a recursion-depth guard and deterministic process-group termination.
 - Provides addressable stateful agents with follow-up, consolidated mailbox/management actions, context selection, and persistence.
@@ -62,6 +63,18 @@ The available tools are:
 - `subagent_spawn` and related lifecycle tools — when enabled, start reusable detached work, return immediately, and receive bounded completion messages automatically.
 - `subagent_inspect` — inspect agent/model/run/runtime metadata without launching work or changing state.
 - `subagent_consult` — run one ephemeral read-only consultation and wait for its answer.
+
+### Interactive tool rows
+
+In Pi's interactive TUI, every registered tool uses Pi's native tool shell and theme. Call rows identify the action, agent or retained id, scope, and a bounded task/message preview. Result rows use explicit `Starting`, `Running`, `Completed`, `Failed`, `Cancelled`, `Interrupted`, or `Closed` text in addition to icons and color.
+
+Collapsed rows stay scan-friendly: consultation and blocking calls show recent activity while running, completed answers show up to three lines, and list actions show up to five items. Use Pi's configured `app.tools.expand` keybinding (Ctrl+O by default) for the additional bounded task, policy, activity, answer, usage, inspection, or mailbox details available to that tool. The hint follows the user's keybinding rather than assuming Ctrl+O.
+
+`subagent_consult` emits an initial starting update before launching its child and then reports the actual provider/model, thinking request, usage, and a safe projection of recent `read`, `grep`, `find`, and `ls` activity. Progress never includes full child messages, prompts, credentials, headers, or environment values. Tool-row previews remove terminal controls and redact private text.
+
+`subagent_spawn` remains deliberately detached and non-polling: its tool row ends after returning the new `agentId` and initial retained state. It does not pretend to stream the background child after the tool call has completed; the existing completion message and configured delivery policy report eventual completion.
+
+Custom transcript rendering is TUI presentation only. Tool names, parameter schemas, model-facing final content/details, errors, completion delivery, and print/JSON/RPC final output remain unchanged; JSON/RPC observers may see additive bounded consultation partial-progress details.
 
 After each session starts, the descriptions of the registered `subagent`, `subagent_spawn`, and
 `subagent_consult` tools include the same bounded parent-facing catalog of the agents available in

--- a/extensions/pi-subagents/src/consult-render.ts
+++ b/extensions/pi-subagents/src/consult-render.ts
@@ -1,0 +1,194 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import {
+	getMarkdownTheme,
+	type Theme,
+	type ToolRenderResultOptions,
+} from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+import type { ConsultDetails, SubagentConsultParams } from "./consult.js";
+import { formatUsageStats } from "./render.js";
+import {
+	COLLAPSED_ANSWER_LINES,
+	COLLAPSED_LIST_LIMIT,
+	expansionHint,
+	previewLines,
+	projectRenderActivity,
+	type RenderStatus,
+	recordValue,
+	renderActivityLines,
+	renderFallbackResult,
+	safeBlock,
+	safeLine,
+	statusBadge,
+	stringValue,
+	type ToolRendererContext,
+	textResult,
+	toolHeader,
+} from "./render-common.js";
+
+export function renderConsultCall(args: Partial<SubagentConsultParams>, theme: Theme) {
+	const scope = args.agentScope ?? "user";
+	const text = [
+		toolHeader(theme, "subagent_consult", args.agent, [`[${scope}]`, "read-only"]),
+		`  ${theme.fg("dim", safeLine(args.task, "...", 2 * 1024))}`,
+	].join("\n");
+	return new Text(text, 0, 0);
+}
+
+export function renderConsultResult(
+	result: AgentToolResult<ConsultDetails>,
+	options: ToolRenderResultOptions,
+	theme: Theme,
+	context: ToolRendererContext<SubagentConsultParams>,
+) {
+	const details = recordValue(result.details);
+	if (!details || !recordValue(details.policy)) {
+		return renderFallbackResult(result, options, theme, context.isError);
+	}
+
+	const progress = recordValue(details.progress);
+	const child = recordValue(details.child);
+	const status = consultStatus(details, progress, options, context.isError);
+	const agent = safeLine(details.agent, safeLine(context.args?.agent, "subagent"), 256);
+	const source = safeLine(details.agentSource, "unknown", 128);
+	const usage = recordValue(progress?.usage ?? child?.usage);
+	const usageText = formatUnknownUsage(
+		usage,
+		stringValue(details.model) || undefined,
+		stringValue(details.thinkingLevel) || undefined,
+		stringValue(progress?.actualProvider ?? child?.actualProvider) || undefined,
+		stringValue(progress?.actualModel ?? child?.actualModel) || undefined,
+	);
+	const effectiveTools = stringList(recordValue(details.policy)?.effectiveTools);
+	const activity = projectRenderActivity(progress?.recentActivity);
+	const activityTotal = Math.max(
+		activity.length,
+		typeof progress?.recentActivityTotal === "number" ? progress.recentActivityTotal : 0,
+	);
+	const answer = safeBlock(textResult(result), "", 50 * 1024).trim();
+
+	if (options.expanded) {
+		const container = new Container();
+		container.addChild(
+			new Text(
+				`${statusBadge(theme, status)} · ${theme.fg("toolTitle", theme.bold(agent))}${theme.fg("muted", ` (${source})`)}`,
+				0,
+				0,
+			),
+		);
+		if (usageText) container.addChild(new Text(theme.fg("dim", usageText), 0, 0));
+		container.addChild(new Spacer(1));
+		container.addChild(new Text(theme.fg("muted", "─── Task ───"), 0, 0));
+		container.addChild(
+			new Text(theme.fg("dim", safeBlock(context.args?.task, "(unavailable)", 50 * 1024)), 0, 0),
+		);
+		container.addChild(new Spacer(1));
+		container.addChild(new Text(theme.fg("muted", "─── Policy ───"), 0, 0));
+		container.addChild(new Text(theme.fg("dim", policySummary(details.policy)), 0, 0));
+		if (activity.length > 0) {
+			container.addChild(new Spacer(1));
+			container.addChild(new Text(theme.fg("muted", "─── Activity ───"), 0, 0));
+			container.addChild(
+				new Text(renderActivityLines(activity, theme, undefined, activityTotal), 0, 0),
+			);
+		}
+		container.addChild(new Spacer(1));
+		container.addChild(new Text(theme.fg("muted", "─── Answer ───"), 0, 0));
+		if (answer) container.addChild(new Markdown(answer, 0, 0, getMarkdownTheme()));
+		else
+			container.addChild(
+				new Text(
+					theme.fg("muted", options.isPartial ? "(waiting for output)" : "(no output)"),
+					0,
+					0,
+				),
+			);
+		return container;
+	}
+
+	const lines = [
+		`${statusBadge(theme, status)} · ${theme.fg("toolTitle", theme.bold(agent))}${theme.fg("muted", ` (${source})`)}`,
+	];
+	if (usageText) lines.push(theme.fg("dim", usageText));
+	if (effectiveTools.length > 0 && options.isPartial) {
+		lines.push(theme.fg("dim", `tools: ${effectiveTools.join(", ")}`));
+	}
+	if (activity.length > 0) {
+		lines.push(renderActivityLines(activity, theme, COLLAPSED_LIST_LIMIT, activityTotal));
+	} else if (options.isPartial) {
+		lines.push(
+			theme.fg("muted", status === "starting" ? "(starting child)" : "(waiting for activity)"),
+		);
+	} else if (answer) {
+		lines.push(theme.fg("toolOutput", previewLines(answer, COLLAPSED_ANSWER_LINES)));
+	} else {
+		const error = safeBlock(child?.error, "", 2 * 1024).trim();
+		lines.push(theme.fg(status === "failed" ? "error" : "muted", error || "(no output)"));
+	}
+	if (!options.isPartial) lines.push(expansionHint());
+	return new Text(lines.filter(Boolean).join("\n"), 0, 0);
+}
+
+function consultStatus(
+	details: Record<string, unknown>,
+	progress: Record<string, unknown> | undefined,
+	options: ToolRenderResultOptions,
+	isError: boolean,
+): RenderStatus {
+	if (details.cancelled === true) return "cancelled";
+	if (isError || details.isError === true) {
+		const child = recordValue(details.child);
+		return child?.aborted === true && child?.timedOut !== true ? "cancelled" : "failed";
+	}
+	if (options.isPartial) return progress?.phase === "starting" ? "starting" : "running";
+	return "completed";
+}
+
+function stringList(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.flatMap((item) => (typeof item === "string" ? [safeLine(item, "", 256)] : []))
+		: [];
+}
+
+function policySummary(value: unknown): string {
+	const policy = recordValue(value);
+	if (!policy) return "(unavailable)";
+	const resources = recordValue(policy.effectiveResources);
+	const tools = stringList(policy.effectiveTools);
+	return [
+		`tools: ${tools.length > 0 ? tools.join(", ") : "none"}`,
+		`resources: ${safeLine(resources?.policy ?? policy.requestedResources, "unknown", 256)}`,
+		`extensions: ${safeLine(policy.extensions, "unknown", 128)}`,
+		`session persistence: ${safeLine(policy.sessionPersistence, "unknown", 128)}`,
+		`retained agent: ${policy.retainedAgent === false ? "no" : "unknown"}`,
+	].join("\n");
+}
+
+function formatUnknownUsage(
+	value: Record<string, unknown> | undefined,
+	model?: string,
+	thinkingLevel?: string,
+	actualProvider?: string,
+	actualModel?: string,
+): string {
+	const usage = value ?? {};
+	return formatUsageStats(
+		{
+			input: safeNumber(usage.input),
+			output: safeNumber(usage.output),
+			cacheRead: safeNumber(usage.cacheRead),
+			cacheWrite: safeNumber(usage.cacheWrite),
+			cost: safeNumber(usage.cost),
+			contextTokens: safeNumber(usage.contextTokens),
+			turns: safeNumber(usage.turns),
+		},
+		model,
+		thinkingLevel as never,
+		actualProvider,
+		actualModel,
+	);
+}
+
+function safeNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}

--- a/extensions/pi-subagents/src/consult.ts
+++ b/extensions/pi-subagents/src/consult.ts
@@ -21,6 +21,7 @@ import {
 	THINKING_LEVELS,
 } from "./agents.js";
 import { resolveConsultTools } from "./consult-policy.js";
+import { renderConsultCall, renderConsultResult } from "./consult-render.js";
 import { assertSubagentDepthAllowed, resolveDefaultSubagentTimeoutMs } from "./execution.js";
 import {
 	DEFAULT_MAX_CONTEXT_BYTES,
@@ -80,6 +81,30 @@ export interface RegisterSubagentConsultOptions {
 	invocationOverride?: { command: string; argsPrefix?: string[] };
 }
 
+export interface ConsultProgressActivity {
+	type: "text" | "toolCall";
+	text?: string;
+	name?: "read" | "grep" | "find" | "ls";
+	args?: Record<string, string | number | boolean>;
+}
+
+export interface ConsultProgress {
+	phase: "starting" | "running";
+	recentActivity: ConsultProgressActivity[];
+	recentActivityTotal: number;
+	actualProvider?: string;
+	actualModel?: string;
+	usage: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		cost: number;
+		contextTokens: number;
+		turns: number;
+	};
+}
+
 export interface ConsultDetails {
 	agent: string;
 	agentSource: string;
@@ -104,6 +129,7 @@ export interface ConsultDetails {
 		retainedAgent: false;
 	};
 	child?: Record<string, unknown>;
+	progress?: ConsultProgress;
 	cancelled?: boolean;
 	isError?: boolean;
 	truncated?: boolean;
@@ -186,6 +212,12 @@ export function registerSubagentConsult(
 				combined.dispose();
 				active.delete(ownedController);
 			}
+		},
+		renderCall(args, theme) {
+			return renderConsultCall(args, theme);
+		},
+		renderResult(result, renderOptions, theme, context) {
+			return renderConsultResult(result, renderOptions, theme, context);
 		},
 	};
 	pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
@@ -322,6 +354,8 @@ async function executeConsult(
 			};
 		}
 	}
+	assertCurrentRequest(signal, isCurrent);
+	emitUpdate(consultStartingUpdate(setup.details));
 	assertCurrentRequest(signal, isCurrent);
 	const runChild = options.runChild ?? ((request) => runConsultChild(request, options));
 	const child = runChild({
@@ -471,6 +505,21 @@ async function runConsultChild(
 	);
 }
 
+function consultStartingUpdate(details: ConsultDetails): AgentToolResult<ConsultDetails> {
+	return {
+		content: [{ type: "text", text: "Read-only subagent consultation starting." }],
+		details: {
+			...details,
+			progress: {
+				phase: "starting",
+				recentActivity: [],
+				recentActivityTotal: 0,
+				usage: emptyProgressUsage(),
+			},
+		},
+	};
+}
+
 function consultUpdate(
 	result: SingleResult,
 	details: ConsultDetails,
@@ -478,7 +527,69 @@ function consultUpdate(
 	const output = boundText(getResultFinalOutput(result) || "(running...)");
 	return {
 		content: [{ type: "text", text: output.text }],
-		details: { ...details, child: projectChildResult(result) },
+		details: {
+			...details,
+			child: projectChildResult(result),
+			progress: projectConsultProgress(result),
+		},
+	};
+}
+
+const CONSULT_ACTIVITY_ARGUMENTS: Record<"read" | "grep" | "find" | "ls", readonly string[]> = {
+	read: ["path", "file_path", "offset", "limit"],
+	grep: ["pattern", "path", "glob", "limit"],
+	find: ["pattern", "path", "limit"],
+	ls: ["path", "limit"],
+};
+
+function projectConsultProgress(result: SingleResult): ConsultProgress {
+	const recentActivity: ConsultProgressActivity[] = [];
+	for (const item of result.recentActivity ?? []) {
+		if (item.type === "text") {
+			const text = boundedPrivateText(item.text, 1024).trim();
+			if (text) recentActivity.push({ type: "text", text });
+			continue;
+		}
+		if (!Object.hasOwn(CONSULT_ACTIVITY_ARGUMENTS, item.name)) continue;
+		const name = item.name as keyof typeof CONSULT_ACTIVITY_ARGUMENTS;
+		const args: Record<string, string | number | boolean> = {};
+		for (const key of CONSULT_ACTIVITY_ARGUMENTS[name]) {
+			const value = item.args[key];
+			if (typeof value === "string") args[key] = safeTerminalLine(value, 512);
+			else if (typeof value === "number" && Number.isFinite(value)) args[key] = value;
+			else if (typeof value === "boolean") args[key] = value;
+		}
+		recentActivity.push({ type: "toolCall", name, args });
+	}
+	return {
+		phase: "running",
+		recentActivity,
+		recentActivityTotal: Math.max(recentActivity.length, result.recentActivityTotal ?? 0),
+		actualProvider: result.actualProvider
+			? boundedPrivateText(result.actualProvider, 256)
+			: undefined,
+		actualModel: result.actualModel ? boundedPrivateText(result.actualModel, 256) : undefined,
+		usage: {
+			input: result.usage.input,
+			output: result.usage.output,
+			cacheRead: result.usage.cacheRead,
+			cacheWrite: result.usage.cacheWrite,
+			cost: result.usage.cost,
+			contextTokens: result.usage.contextTokens,
+			turns: result.usage.turns,
+		},
+	};
+}
+
+function emptyProgressUsage(): ConsultProgress["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: 0,
+		contextTokens: 0,
+		turns: 0,
 	};
 }
 

--- a/extensions/pi-subagents/src/inspect-render.ts
+++ b/extensions/pi-subagents/src/inspect-render.ts
@@ -1,0 +1,234 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { Theme, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import type { SubagentInspectParams } from "./inspect.js";
+import {
+	booleanValue,
+	COLLAPSED_LIST_LIMIT,
+	expansionHint,
+	numberValue,
+	recordList,
+	recordValue,
+	renderFallbackResult,
+	safeBlock,
+	safeLine,
+	statusBadge,
+	stringValue,
+	type ToolRendererContext,
+	toolHeader,
+} from "./render-common.js";
+
+export function renderInspectCall(args: Partial<SubagentInspectParams>, theme: Theme) {
+	const action = safeLine(args.action, "...", 128);
+	const metadata: string[] = [];
+	if (args.agentScope) metadata.push(`[${args.agentScope}]`);
+	if (args.agent) metadata.push(`agent:${safeLine(args.agent, "", 256)}`);
+	if (args.agentId) metadata.push(`id:${safeLine(args.agentId, "", 256)}`);
+	if (args.includeClosed) metadata.push("include closed");
+	return new Text(toolHeader(theme, "subagent_inspect", action, metadata), 0, 0);
+}
+
+export function renderInspectResult(
+	result: AgentToolResult<Record<string, unknown>>,
+	options: ToolRenderResultOptions,
+	theme: Theme,
+	context: ToolRendererContext<SubagentInspectParams>,
+) {
+	const details = recordValue(result.details);
+	const action = stringValue(details?.action);
+	if (!details || !action) return renderFallbackResult(result, options, theme, context.isError);
+
+	const rendered = renderAction(action, details, options.expanded, theme);
+	if (!rendered) return renderFallbackResult(result, options, theme, context.isError);
+	return new Text(rendered, 0, 0);
+}
+
+function renderAction(
+	action: string,
+	details: Record<string, unknown>,
+	expanded: boolean,
+	theme: Theme,
+): string | undefined {
+	switch (action) {
+		case "list_agents":
+			return renderList("agent", recordList(details.agents), details, expanded, theme, formatAgent);
+		case "get_agent": {
+			const agent = recordValue(details.agent);
+			if (!agent) return undefined;
+			const lines = [
+				`${statusBadge(theme, "completed")} · ${theme.fg("toolTitle", theme.bold(safeLine(agent.name, "agent", 256)))}${theme.fg("muted", ` (${safeLine(agent.source, "unknown", 128)})`)}`,
+				formatAgent(agent, theme, true),
+			];
+			if (!expanded) lines.push(expansionHint());
+			return lines.join("\n");
+		}
+		case "list_runs":
+			return renderList("run", recordList(details.runs), details, expanded, theme, formatRun);
+		case "get_run": {
+			const run = recordValue(details.run);
+			if (!run) return undefined;
+			const lines = [
+				`${statusBadge(theme, "completed")} · run ${theme.fg("accent", safeLine(run.id, "run", 256))}`,
+				formatRun(run, theme, true),
+			];
+			if (!expanded) lines.push(expansionHint());
+			return lines.join("\n");
+		}
+		case "list_models":
+			return renderList(
+				"model",
+				recordList(details.models),
+				details,
+				expanded,
+				theme,
+				formatModel,
+				stringValue(details.source),
+			);
+		case "status":
+			return renderStatus(details, expanded, theme);
+		case "diagnose":
+			return renderDiagnose(details, expanded, theme);
+		default:
+			return undefined;
+	}
+}
+
+function renderList(
+	label: string,
+	items: Record<string, unknown>[],
+	details: Record<string, unknown>,
+	expanded: boolean,
+	theme: Theme,
+	format: (item: Record<string, unknown>, theme: Theme, expanded: boolean) => string,
+	source = "",
+): string {
+	const returned = numberValue(details.returned, items.length);
+	const omitted = numberValue(details.omitted);
+	const noun = `${label}${returned === 1 ? "" : "s"}`;
+	const lines = [
+		`${statusBadge(theme, "completed")} · ${returned} ${noun}${source ? theme.fg("muted", ` · ${safeLine(source, "", 256)}`) : ""}`,
+	];
+	const selected = expanded ? items : items.slice(0, COLLAPSED_LIST_LIMIT);
+	for (const item of selected) lines.push(format(item, theme, expanded));
+	const hidden = Math.max(0, items.length - selected.length) + omitted;
+	if (hidden > 0) lines.push(theme.fg("muted", `… ${hidden} omitted`));
+	if (items.length === 0) lines.push(theme.fg("muted", `(no ${label}s)`));
+	if (!expanded && (items.length > 0 || omitted > 0)) lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function formatAgent(agent: Record<string, unknown>, theme: Theme, expanded: boolean): string {
+	const name = safeLine(agent.name, "agent", 256);
+	const source = safeLine(agent.source, "unknown", 128);
+	const model = stringValue(agent.model);
+	const toolCount = typeof agent.toolCount === "number" ? agent.toolCount : undefined;
+	const description = safeBlock(agent.description, "", 512).trim();
+	const lines = [
+		`${theme.fg("muted", "• ")}${theme.fg("accent", name)} ${theme.fg("muted", source)}${model ? theme.fg("dim", ` · ${safeLine(model, "", 256)}`) : ""}${toolCount !== undefined ? theme.fg("dim", ` · ${toolCount} tools`) : ""}`,
+	];
+	if (description) lines.push(`  ${theme.fg("toolOutput", description)}`);
+	if (expanded) {
+		const path = stringValue(agent.path);
+		const consultTools = stringList(agent.consultTools);
+		if (path) lines.push(`  ${theme.fg("dim", `path: ${safeLine(path, "", 2 * 1024)}`)}`);
+		lines.push(`  ${theme.fg("dim", `consult tools: ${consultTools.join(", ") || "none"}`)}`);
+	}
+	return lines.join("\n");
+}
+
+function formatRun(run: Record<string, unknown>, theme: Theme, expanded: boolean): string {
+	const id = safeLine(run.id, "run", 256);
+	const agent = safeLine(run.agent, "agent", 256);
+	const state = safeLine(run.state, "unknown", 128);
+	const unread = numberValue(run.unreadMessages);
+	const lines = [
+		`${theme.fg("muted", "• ")}${theme.fg("accent", id)} ${theme.fg("toolOutput", agent)} ${theme.fg("muted", state)}${unread > 0 ? theme.fg("warning", ` · unread:${unread}`) : ""}`,
+	];
+	if (expanded) {
+		const thinking = stringValue(run.thinkingLevel);
+		const task = safeBlock(run.currentTask, "", 2 * 1024).trim();
+		const error = safeBlock(run.error, "", 2 * 1024).trim();
+		lines.push(
+			`  ${theme.fg("dim", `${numberValue(run.historyCount)} history · ${thinking ? `thinking:${safeLine(thinking, "", 128)} · ` : ""}${numberValue(run.children)} children`)}`,
+		);
+		if (task) lines.push(`  ${theme.fg("dim", `task: ${task}`)}`);
+		if (error) lines.push(`  ${theme.fg("error", `error: ${error}`)}`);
+	}
+	return lines.join("\n");
+}
+
+function formatModel(model: Record<string, unknown>, theme: Theme, expanded: boolean): string {
+	const identity = `${safeLine(model.provider, "provider", 256)}/${safeLine(model.id, "model", 256)}`;
+	const current = booleanValue(model.current) ? theme.fg("success", " · current") : "";
+	const reasoning = booleanValue(model.reasoning) ? theme.fg("dim", " · reasoning") : "";
+	const lines = [`${theme.fg("muted", "• ")}${theme.fg("accent", identity)}${current}${reasoning}`];
+	if (expanded) {
+		const name = stringValue(model.name);
+		const thinking = stringValue(model.thinkingLevel);
+		if (name) lines.push(`  ${theme.fg("toolOutput", safeLine(name, "", 512))}`);
+		lines.push(
+			`  ${theme.fg("dim", `context:${numberValue(model.contextWindow)} · max:${numberValue(model.maxTokens)}${thinking ? ` · thinking:${safeLine(thinking, "", 128)}` : ""}`)}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderStatus(
+	details: Record<string, unknown>,
+	expanded: boolean,
+	theme: Theme,
+): string | undefined {
+	const status = recordValue(details.status);
+	const stateful = recordValue(status?.stateful);
+	if (!status || !stateful) return undefined;
+	const lines = [
+		`${statusBadge(theme, "completed")} · runtime status`,
+		`${theme.fg("muted", "workflow: ")}${theme.fg("accent", safeLine(status.workflow, "unknown", 128))} · ${numberValue(stateful.activeAgents)} active · ${numberValue(stateful.retainedAgents)} retained`,
+		`${theme.fg("muted", "stateful: ")}${stateful.initialized === true ? "initialized" : "not initialized"} · resources: ${safeLine(status.consultResources, "unknown", 128)}`,
+	];
+	if (expanded) {
+		const delivery = stringValue(stateful.completionDelivery);
+		const transport = stringValue(stateful.transport);
+		if (transport || delivery) {
+			lines.push(
+				theme.fg(
+					"dim",
+					[
+						transport && `transport:${safeLine(transport)}`,
+						delivery && `delivery:${safeLine(delivery)}`,
+					]
+						.filter(Boolean)
+						.join(" · "),
+				),
+			);
+		}
+	} else lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function renderDiagnose(details: Record<string, unknown>, expanded: boolean, theme: Theme): string {
+	const checks = recordList(details.checks);
+	const hasFail = checks.some((check) => check.status === "fail");
+	const hasWarning = checks.some((check) => check.status === "warning");
+	const overall = hasFail ? "failed" : hasWarning ? "warnings" : "passed";
+	const status = hasFail ? "failed" : hasWarning ? "warning" : "completed";
+	const lines = [`${statusBadge(theme, status)} · Diagnostics ${overall}`];
+	const selected = expanded ? checks : checks.slice(0, COLLAPSED_LIST_LIMIT);
+	for (const check of selected) {
+		const checkStatus = safeLine(check.status, "unknown", 64);
+		const color =
+			checkStatus === "fail" ? "error" : checkStatus === "warning" ? "warning" : "success";
+		lines.push(
+			`${theme.fg(color, checkStatus.toUpperCase())} ${theme.fg("accent", safeLine(check.name, "check", 256))} · ${theme.fg("toolOutput", safeBlock(check.message, "", 2 * 1024))}`,
+		);
+	}
+	if (checks.length === 0) lines.push(theme.fg("muted", "(no diagnostic checks)"));
+	if (!expanded && checks.length > 0) lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function stringList(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.flatMap((item) => (typeof item === "string" ? [safeLine(item, "", 256)] : []))
+		: [];
+}

--- a/extensions/pi-subagents/src/inspect.ts
+++ b/extensions/pi-subagents/src/inspect.ts
@@ -4,6 +4,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { type Static, Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
 import { resolveConsultTools } from "./consult-policy.js";
+import { renderInspectCall, renderInspectResult } from "./inspect-render.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "./registry.js";
 import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalLine } from "./safe-text.js";
 import {
@@ -78,6 +79,12 @@ export function registerSubagentInspect(pi: ExtensionAPI, runtime: SubagentInspe
 		parameters: SubagentInspectParams,
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<InspectToolResult> {
 			return executeSubagentInspect(validateInspectParams(params), ctx, runtime);
+		},
+		renderCall(args, theme) {
+			return renderInspectCall(args, theme);
+		},
+		renderResult(result, options, theme, context) {
+			return renderInspectResult(result, options, theme, context);
 		},
 	});
 }

--- a/extensions/pi-subagents/src/render-common.ts
+++ b/extensions/pi-subagents/src/render-common.ts
@@ -1,0 +1,252 @@
+import * as os from "node:os";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import {
+	keyHint,
+	type Theme,
+	type ThemeColor,
+	type ToolRenderResultOptions,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { boundedPrivateText, safeTerminalLine } from "./safe-text.js";
+
+export const COLLAPSED_LIST_LIMIT = 5;
+export const COLLAPSED_ANSWER_LINES = 3;
+
+export interface ToolRendererContext<TArgs> {
+	args: TArgs;
+	isError: boolean;
+}
+
+export type RenderStatus =
+	| "starting"
+	| "running"
+	| "completed"
+	| "failed"
+	| "cancelled"
+	| "interrupted"
+	| "idle"
+	| "closed"
+	| "warning";
+
+const STATUS_PRESENTATION: Record<
+	RenderStatus,
+	{ icon: string; label: string; color: ThemeColor }
+> = {
+	starting: { icon: "⏳", label: "Starting", color: "warning" },
+	running: { icon: "⏳", label: "Running", color: "warning" },
+	completed: { icon: "✓", label: "Completed", color: "success" },
+	failed: { icon: "✗", label: "Failed", color: "error" },
+	cancelled: { icon: "■", label: "Cancelled", color: "warning" },
+	interrupted: { icon: "■", label: "Interrupted", color: "warning" },
+	idle: { icon: "○", label: "Idle", color: "muted" },
+	closed: { icon: "✓", label: "Closed", color: "muted" },
+	warning: { icon: "◐", label: "Warning", color: "warning" },
+};
+
+export function recordValue(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+export function recordList(value: unknown): Record<string, unknown>[] {
+	return Array.isArray(value)
+		? value.flatMap((item) => {
+				const record = recordValue(item);
+				return record ? [record] : [];
+			})
+		: [];
+}
+
+export function stringValue(value: unknown, fallback = ""): string {
+	return typeof value === "string" ? value : fallback;
+}
+
+export function numberValue(value: unknown, fallback = 0): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function booleanValue(value: unknown): boolean {
+	return value === true;
+}
+
+export function safeLine(value: unknown, fallback = "...", maxBytes = 2 * 1024): string {
+	if (typeof value !== "string" || !value.trim()) return fallback;
+	return safeTerminalLine(value, maxBytes) || fallback;
+}
+
+export function safeBlock(value: unknown, fallback = "", maxBytes = 50 * 1024): string {
+	if (typeof value !== "string" || !value) return fallback;
+	return boundedPrivateText(value, maxBytes);
+}
+
+export function previewLines(value: unknown, maxLines = COLLAPSED_ANSWER_LINES): string {
+	const text = safeBlock(value, "", 8 * 1024).trim();
+	return text.split("\n").slice(0, maxLines).join("\n");
+}
+
+export function textResult(result: AgentToolResult<unknown>): string {
+	return result.content
+		.flatMap((part) => (part.type === "text" ? [part.text] : []))
+		.join("\n")
+		.trim();
+}
+
+export function toolHeader(
+	theme: Theme,
+	toolName: string,
+	primary?: unknown,
+	metadata: readonly string[] = [],
+): string {
+	let text = theme.fg("toolTitle", theme.bold(`${toolName} `));
+	if (primary !== undefined) text += theme.fg("accent", safeLine(primary));
+	const safeMetadata = metadata.filter(Boolean).map((item) => safeLine(item, "", 512));
+	if (safeMetadata.length > 0) text += theme.fg("muted", ` · ${safeMetadata.join(" · ")}`);
+	return text.trimEnd();
+}
+
+export function statusBadge(theme: Theme, status: RenderStatus, suffix?: string): string {
+	const presentation = STATUS_PRESENTATION[status];
+	const label = suffix
+		? `${presentation.label} · ${safeLine(suffix, "", 2 * 1024)}`
+		: presentation.label;
+	return `${theme.fg(presentation.color, presentation.icon)} ${theme.fg(presentation.color, label)}`;
+}
+
+export function renderFallbackResult(
+	result: AgentToolResult<unknown>,
+	options: ToolRenderResultOptions,
+	theme: Theme,
+	isError = false,
+) {
+	const status: RenderStatus = isError ? "failed" : options.isPartial ? "running" : "completed";
+	const content = safeBlock(textResult(result), "(no output)", 8 * 1024);
+	return new Text(`${statusBadge(theme, status)}\n${theme.fg("toolOutput", content)}`, 0, 0);
+}
+
+export function expansionHint(): string {
+	return keyHint("app.tools.expand", "to expand");
+}
+
+export interface RenderActivityItem {
+	type: "text" | "toolCall";
+	text?: string;
+	name?: string;
+	args?: Record<string, unknown>;
+}
+
+export function projectRenderActivity(value: unknown): RenderActivityItem[] {
+	if (!Array.isArray(value)) return [];
+	const items: RenderActivityItem[] = [];
+	for (const item of value) {
+		const record = recordValue(item);
+		if (!record) continue;
+		if (record.type === "text" && typeof record.text === "string") {
+			items.push({ type: "text", text: safeBlock(record.text, "", 1024) });
+			continue;
+		}
+		if (record.type === "toolCall" && typeof record.name === "string") {
+			items.push({
+				type: "toolCall",
+				name: safeLine(record.name, "tool", 256),
+				args: recordValue(record.args) ?? {},
+			});
+		}
+	}
+	return items;
+}
+
+export function renderActivityLines(
+	items: readonly RenderActivityItem[],
+	theme: Theme,
+	limit?: number,
+	total = items.length,
+): string {
+	const selected = limit === undefined ? items : items.slice(-limit);
+	const lines: string[] = [];
+	const skipped = Math.max(0, total - selected.length);
+	if (skipped > 0) lines.push(theme.fg("muted", `… ${skipped} earlier activities`));
+	for (const item of selected) {
+		if (item.type === "text") {
+			const text = safeBlock(item.text, "", 1024).trim();
+			if (text) lines.push(theme.fg("toolOutput", text));
+		} else {
+			lines.push(
+				theme.fg("muted", "→ ") +
+					formatToolActivity(item.name ?? "tool", item.args ?? {}, theme.fg.bind(theme)),
+			);
+		}
+	}
+	return lines.join("\n");
+}
+
+export function formatToolActivity(
+	toolNameValue: unknown,
+	argsValue: unknown,
+	themeFg: (color: ThemeColor, text: string) => string,
+): string {
+	const toolName = safeLine(toolNameValue, "tool", 256);
+	const args = recordValue(argsValue) ?? {};
+	const shortenPath = (value: unknown, fallback = ".") => {
+		const filePath = safeLine(value, fallback, 2 * 1024);
+		const home = os.homedir();
+		return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+	};
+
+	switch (toolName) {
+		case "bash": {
+			const command = safeLine(args.command, "...", 512);
+			return themeFg("muted", "$ ") + themeFg("toolOutput", command);
+		}
+		case "read": {
+			const filePath = shortenPath(args.file_path ?? args.path, "...");
+			const offset = typeof args.offset === "number" ? args.offset : undefined;
+			const limit = typeof args.limit === "number" ? args.limit : undefined;
+			let text = themeFg("accent", filePath);
+			if (offset !== undefined || limit !== undefined) {
+				const startLine = offset ?? 1;
+				const endLine = limit !== undefined ? startLine + limit - 1 : "";
+				text += themeFg("warning", `:${startLine}${endLine ? `-${endLine}` : ""}`);
+			}
+			return themeFg("muted", "read ") + text;
+		}
+		case "write": {
+			const filePath = shortenPath(args.file_path ?? args.path, "...");
+			const content = safeBlock(args.content, "", 2 * 1024);
+			const lines = content ? content.split("\n").length : 0;
+			return (
+				themeFg("muted", "write ") +
+				themeFg("accent", filePath) +
+				(lines > 1 ? themeFg("dim", ` (${lines} lines)`) : "")
+			);
+		}
+		case "edit":
+			return (
+				themeFg("muted", "edit ") +
+				themeFg("accent", shortenPath(args.file_path ?? args.path, "..."))
+			);
+		case "ls":
+			return themeFg("muted", "ls ") + themeFg("accent", shortenPath(args.path));
+		case "find":
+			return (
+				themeFg("muted", "find ") +
+				themeFg("accent", safeLine(args.pattern, "*", 512)) +
+				themeFg("dim", ` in ${shortenPath(args.path)}`)
+			);
+		case "grep":
+			return (
+				themeFg("muted", "grep ") +
+				themeFg("accent", `/${safeLine(args.pattern, "", 512)}/`) +
+				themeFg("dim", ` in ${shortenPath(args.path)}`)
+			);
+		default: {
+			let serialized = "{}";
+			try {
+				serialized = JSON.stringify(args);
+			} catch {
+				serialized = "{…}";
+			}
+			return themeFg("accent", toolName) + themeFg("dim", ` ${safeLine(serialized, "{}", 512)}`);
+		}
+	}
+}

--- a/extensions/pi-subagents/src/render.ts
+++ b/extensions/pi-subagents/src/render.ts
@@ -1,4 +1,3 @@
-import * as os from "node:os";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Message } from "@earendil-works/pi-ai";
 import {
@@ -10,6 +9,7 @@ import {
 import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import type { AgentScope, SubagentThinkingLevel } from "./agents.js";
 import { hasUsableAggregator, type SubagentParams } from "./params.js";
+import { expansionHint, formatToolActivity, safeBlock, safeLine } from "./render-common.js";
 import {
 	getResultFinalOutput,
 	isResultError,
@@ -17,15 +17,15 @@ import {
 	type SubagentDetails,
 } from "./runner.js";
 
-const COLLAPSED_ITEM_COUNT = 10;
+const COLLAPSED_ITEM_COUNT = 5;
 
 function previewTask(task: unknown, maxLength = 40): string {
-	if (typeof task !== "string" || task.length === 0) return "...";
-	return task.length > maxLength ? `${task.slice(0, maxLength)}...` : task;
+	const safe = safeLine(task, "...", 2 * 1024);
+	return safe.length > maxLength ? `${safe.slice(0, maxLength)}...` : safe;
 }
 
 function previewAgent(agent: unknown): string {
-	return typeof agent === "string" && agent.length > 0 ? agent : "...";
+	return safeLine(agent, "...", 256);
 }
 
 export function formatTokens(count: number): string {
@@ -59,12 +59,12 @@ export function formatUsageStats(
 	if (usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
 	if (usage.contextTokens && usage.contextTokens > 0)
 		parts.push(`ctx:${formatTokens(usage.contextTokens)}`);
+	const safeProvider = actualProvider ? safeLine(actualProvider, "", 256) : undefined;
+	const safeModel = actualModel ? safeLine(actualModel, "", 256) : undefined;
 	const actual =
-		actualProvider && actualModel
-			? `${actualProvider}/${actualModel}`
-			: (actualModel ?? actualProvider);
-	if (actual ?? model) parts.push(actual ?? model ?? "");
-	if (thinkingLevel) parts.push(`requested-thinking:${thinkingLevel}`);
+		safeProvider && safeModel ? `${safeProvider}/${safeModel}` : (safeModel ?? safeProvider);
+	if (actual ?? model) parts.push(actual ?? safeLine(model, "", 256));
+	if (thinkingLevel) parts.push(`requested-thinking:${safeLine(thinkingLevel, "", 128)}`);
 	return parts.join(" ");
 }
 
@@ -83,71 +83,7 @@ function formatToolCall(
 	args: Record<string, unknown>,
 	themeFg: (color: ThemeColor, text: string) => string,
 ): string {
-	const shortenPath = (p: string) => {
-		const home = os.homedir();
-		return p.startsWith(home) ? `~${p.slice(home.length)}` : p;
-	};
-
-	switch (toolName) {
-		case "bash": {
-			const command = (args.command as string) || "...";
-			const preview = command.length > 60 ? `${command.slice(0, 60)}...` : command;
-			return themeFg("muted", "$ ") + themeFg("toolOutput", preview);
-		}
-		case "read": {
-			const rawPath = (args.file_path || args.path || "...") as string;
-			const filePath = shortenPath(rawPath);
-			const offset = args.offset as number | undefined;
-			const limit = args.limit as number | undefined;
-			let text = themeFg("accent", filePath);
-			if (offset !== undefined || limit !== undefined) {
-				const startLine = offset ?? 1;
-				const endLine = limit !== undefined ? startLine + limit - 1 : "";
-				text += themeFg("warning", `:${startLine}${endLine ? `-${endLine}` : ""}`);
-			}
-			return themeFg("muted", "read ") + text;
-		}
-		case "write": {
-			const rawPath = (args.file_path || args.path || "...") as string;
-			const filePath = shortenPath(rawPath);
-			const content = (args.content || "") as string;
-			const lines = content.split("\n").length;
-			let text = themeFg("muted", "write ") + themeFg("accent", filePath);
-			if (lines > 1) text += themeFg("dim", ` (${lines} lines)`);
-			return text;
-		}
-		case "edit": {
-			const rawPath = (args.file_path || args.path || "...") as string;
-			return themeFg("muted", "edit ") + themeFg("accent", shortenPath(rawPath));
-		}
-		case "ls": {
-			const rawPath = (args.path || ".") as string;
-			return themeFg("muted", "ls ") + themeFg("accent", shortenPath(rawPath));
-		}
-		case "find": {
-			const pattern = (args.pattern || "*") as string;
-			const rawPath = (args.path || ".") as string;
-			return (
-				themeFg("muted", "find ") +
-				themeFg("accent", pattern) +
-				themeFg("dim", ` in ${shortenPath(rawPath)}`)
-			);
-		}
-		case "grep": {
-			const pattern = (args.pattern || "") as string;
-			const rawPath = (args.path || ".") as string;
-			return (
-				themeFg("muted", "grep ") +
-				themeFg("accent", `/${pattern}/`) +
-				themeFg("dim", ` in ${shortenPath(rawPath)}`)
-			);
-		}
-		default: {
-			const argsStr = JSON.stringify(args);
-			const preview = argsStr.length > 50 ? `${argsStr.slice(0, 50)}...` : argsStr;
-			return themeFg("accent", toolName) + themeFg("dim", ` ${preview}`);
-		}
-	}
+	return formatToolActivity(toolName, args, themeFg);
 }
 
 type DisplayItem =
@@ -160,10 +96,14 @@ function getDisplayItems(messages: Message[]): DisplayItem[] {
 		if (msg.role === "assistant") {
 			for (const part of msg.content) {
 				if (part.type === "text") {
-					const text = part.text.trim();
+					const text = safeBlock(part.text, "", 8 * 1024).trim();
 					if (text) items.push({ type: "text", text });
 				} else if (part.type === "toolCall") {
-					items.push({ type: "toolCall", name: part.name, args: part.arguments });
+					items.push({
+						type: "toolCall",
+						name: safeLine(part.name, "tool", 256),
+						args: part.arguments,
+					});
 				}
 			}
 		}
@@ -179,6 +119,47 @@ function getCollapsedDisplayItems(result: SingleResult): { items: DisplayItem[];
 	}
 	const items = getDisplayItems(result.messages);
 	return { items, total: items.length };
+}
+
+function sanitizeSingleResultForRender(result: SingleResult): SingleResult {
+	return {
+		...result,
+		agent: safeLine(result.agent, "subagent", 256),
+		task: safeBlock(result.task, "", 50 * 1024),
+		stderr: safeBlock(result.stderr, "", 8 * 1024),
+		model: result.model ? safeLine(result.model, "", 256) : undefined,
+		actualProvider: result.actualProvider ? safeLine(result.actualProvider, "", 256) : undefined,
+		actualModel: result.actualModel ? safeLine(result.actualModel, "", 256) : undefined,
+		stopReason: result.stopReason ? safeLine(result.stopReason, "", 256) : undefined,
+		errorMessage: result.errorMessage ? safeBlock(result.errorMessage, "", 8 * 1024) : undefined,
+		finalOutput: result.finalOutput ? safeBlock(result.finalOutput, "", 50 * 1024) : undefined,
+	};
+}
+
+function renderResultStatus(result: SingleResult, isPartial: boolean): string {
+	if (isResultError(result)) {
+		return result.stopReason === "aborted" || result.aborted ? "Cancelled" : "Failed";
+	}
+	return isPartial || result.exitCode === -1 ? "Running" : "Completed";
+}
+
+function coloredStatus(theme: Theme, status: string): string {
+	const color: ThemeColor =
+		status === "Failed" ? "error" : status === "Completed" ? "success" : "warning";
+	return theme.fg(color, status);
+}
+
+function coloredResultStatus(theme: Theme, result: SingleResult, isPartial: boolean): string {
+	return coloredStatus(theme, renderResultStatus(result, isPartial));
+}
+
+function formatResultPolicy(result: SingleResult): string {
+	if (!result.policy) return "";
+	return [
+		`inherited: ${result.policy.inherited.map((tool) => safeLine(tool, "", 256)).join(", ") || "none"}`,
+		`overridden: ${result.policy.overridden.map((tool) => safeLine(tool, "", 256)).join(", ") || "none"}`,
+		`unsupported: ${result.policy.unsupported.map((tool) => safeLine(tool, "", 256)).join(", ") || "none"}`,
+	].join("\n");
 }
 
 export function renderSubagentCall(args: SubagentParams, theme: Theme) {
@@ -239,11 +220,22 @@ export function renderSubagentResult(
 	{ expanded, isPartial }: ToolRenderResultOptions,
 	theme: Theme,
 ) {
-	const details = result.details as SubagentDetails | undefined;
-	if (!details || details.results.length === 0) {
+	const rawDetails = result.details as SubagentDetails | undefined;
+	if (!rawDetails || rawDetails.results.length === 0) {
 		const text = result.content[0];
-		return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
+		return new Text(
+			text?.type === "text" ? safeBlock(text.text, "(no output)", 8 * 1024) : "(no output)",
+			0,
+			0,
+		);
 	}
+	const details: SubagentDetails = {
+		...rawDetails,
+		results: rawDetails.results.map(sanitizeSingleResultForRender),
+		aggregator: rawDetails.aggregator
+			? sanitizeSingleResultForRender(rawDetails.aggregator)
+			: undefined,
+	};
 
 	const mdTheme = getMarkdownTheme();
 
@@ -254,7 +246,8 @@ export function renderSubagentResult(
 		if (skipped > 0) text += theme.fg("muted", `... ${skipped} earlier items\n`);
 		for (const item of toShow) {
 			if (item.type === "text") {
-				const preview = expanded ? item.text : item.text.split("\n").slice(0, 3).join("\n");
+				const safeText = safeBlock(item.text, "", 8 * 1024);
+				const preview = expanded ? safeText : safeText.split("\n").slice(0, 3).join("\n");
 				text += `${theme.fg("toolOutput", preview)}\n`;
 			} else {
 				text += `${theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`;
@@ -276,7 +269,7 @@ export function renderSubagentResult(
 
 		if (expanded) {
 			const container = new Container();
-			let header = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+			let header = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${safeLine(r.agentSource, "unknown", 128)})`)} · ${coloredResultStatus(theme, r, isPartial)}`;
 			if (isError && r.stopReason) header += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
 			container.addChild(new Text(header, 0, 0));
 			if (isError && r.errorMessage)
@@ -284,6 +277,12 @@ export function renderSubagentResult(
 			container.addChild(new Spacer(1));
 			container.addChild(new Text(theme.fg("muted", "─── Task ───"), 0, 0));
 			container.addChild(new Text(theme.fg("dim", r.task), 0, 0));
+			const policy = formatResultPolicy(r);
+			if (policy) {
+				container.addChild(new Spacer(1));
+				container.addChild(new Text(theme.fg("muted", "─── Policy ───"), 0, 0));
+				container.addChild(new Text(theme.fg("dim", policy), 0, 0));
+			}
 			container.addChild(new Spacer(1));
 			container.addChild(new Text(theme.fg("muted", "─── Output ───"), 0, 0));
 			if (displayItems.length === 0 && !finalOutput) {
@@ -314,15 +313,16 @@ export function renderSubagentResult(
 		}
 
 		const collapsed = getCollapsedDisplayItems(r);
-		let text = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+		let text = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${safeLine(r.agentSource, "unknown", 128)})`)} · ${coloredResultStatus(theme, r, isPartial)}`;
 		if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
 		if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
 		if (collapsed.items.length > 0) {
 			text += `\n${renderDisplayItems(collapsed.items, COLLAPSED_ITEM_COUNT, collapsed.total)}`;
-			if (collapsed.total > COLLAPSED_ITEM_COUNT)
-				text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+			if (collapsed.total > COLLAPSED_ITEM_COUNT) text += `\n${expansionHint()}`;
 		} else if (finalOutput.trim()) {
-			text += `\n${theme.fg("toolOutput", finalOutput.trim().split("\n").slice(0, 3).join("\n"))}`;
+			const outputLines = finalOutput.trim().split("\n");
+			text += `\n${theme.fg("toolOutput", outputLines.slice(0, 3).join("\n"))}`;
+			if (outputLines.length > 3) text += `\n${expansionHint()}`;
 		} else if (!isError || !r.errorMessage) {
 			text += `\n${theme.fg("muted", isPartial && !isError ? "(running...)" : "(no output)")}`;
 		}
@@ -356,6 +356,11 @@ export function renderSubagentResult(
 			: successCount === details.results.length
 				? theme.fg("success", "✓")
 				: theme.fg("error", "✗");
+		const overallStatus = currentIsRunning
+			? "Running"
+			: successCount === details.results.length
+				? "Completed"
+				: "Failed";
 
 		if (expanded) {
 			const container = new Container();
@@ -364,7 +369,8 @@ export function renderSubagentResult(
 					icon +
 						" " +
 						theme.fg("toolTitle", theme.bold("chain ")) +
-						theme.fg("accent", `${successCount}/${details.results.length} steps`),
+						theme.fg("accent", `${successCount}/${details.results.length} steps`) +
+						` · ${coloredStatus(theme, overallStatus)}`,
 					0,
 					0,
 				),
@@ -383,12 +389,17 @@ export function renderSubagentResult(
 				container.addChild(new Spacer(1));
 				container.addChild(
 					new Text(
-						`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon}`,
+						`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon} ${coloredResultStatus(theme, r, currentIsRunning && r === currentResult)}`,
 						0,
 						0,
 					),
 				);
 				container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
+				const policy = formatResultPolicy(r);
+				if (policy)
+					container.addChild(
+						new Text(theme.fg("muted", "Policy:\n") + theme.fg("dim", policy), 0, 0),
+					);
 				if (rFailed && r.errorMessage)
 					container.addChild(new Text(theme.fg("error", `Error: ${r.errorMessage}`), 0, 0));
 
@@ -429,7 +440,8 @@ export function renderSubagentResult(
 			icon +
 			" " +
 			theme.fg("toolTitle", theme.bold("chain ")) +
-			theme.fg("accent", `${successCount}/${details.results.length} steps`);
+			theme.fg("accent", `${successCount}/${details.results.length} steps`) +
+			` · ${coloredStatus(theme, overallStatus)}`;
 		for (const r of details.results) {
 			const rFailed = isResultError(r);
 			const rIcon = rFailed
@@ -439,7 +451,7 @@ export function renderSubagentResult(
 					: theme.fg("success", "✓");
 			const collapsed = getCollapsedDisplayItems(r);
 			const finalOutput = getResultFinalOutput(r).trim();
-			text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}`;
+			text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon} ${coloredResultStatus(theme, r, currentIsRunning && r === currentResult)}`;
 			if (rFailed && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
 			if (collapsed.items.length > 0)
 				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
@@ -451,7 +463,7 @@ export function renderSubagentResult(
 		}
 		const usageStr = formatUsageStats(aggregateUsage(details.results));
 		if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
-		text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+		text += `\n${expansionHint()}`;
 		return new Text(text, 0, 0);
 	}
 
@@ -485,12 +497,17 @@ export function renderSubagentResult(
 			: aggregator
 				? `${successCount}/${details.results.length} tasks + fan-in`
 				: `${successCount}/${details.results.length} tasks`;
+		const overallStatus = isRunning
+			? "Running"
+			: failCount > 0 || aggregatorFailed
+				? "Failed"
+				: "Completed";
 
 		if (expanded && !isRunning) {
 			const container = new Container();
 			container.addChild(
 				new Text(
-					`${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`,
+					`${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)} · ${coloredStatus(theme, overallStatus)}`,
 					0,
 					0,
 				),
@@ -508,9 +525,18 @@ export function renderSubagentResult(
 
 				container.addChild(new Spacer(1));
 				container.addChild(
-					new Text(`${theme.fg("muted", "─── ") + theme.fg("accent", r.agent)} ${rIcon}`, 0, 0),
+					new Text(
+						`${theme.fg("muted", "─── ") + theme.fg("accent", r.agent)} ${rIcon} ${coloredResultStatus(theme, r, resultIsRunning(r))}`,
+						0,
+						0,
+					),
 				);
 				container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
+				const policy = formatResultPolicy(r);
+				if (policy)
+					container.addChild(
+						new Text(theme.fg("muted", "Policy:\n") + theme.fg("dim", policy), 0, 0),
+					);
 				if (rFailed && r.errorMessage)
 					container.addChild(new Text(theme.fg("error", `Error: ${r.errorMessage}`), 0, 0));
 
@@ -550,7 +576,7 @@ export function renderSubagentResult(
 				container.addChild(new Spacer(1));
 				container.addChild(
 					new Text(
-						`${theme.fg("muted", "─── fan-in → ") + theme.fg("accent", aggregator.agent)} ${rIcon}`,
+						`${theme.fg("muted", "─── fan-in → ") + theme.fg("accent", aggregator.agent)} ${rIcon} ${coloredResultStatus(theme, aggregator, aggregatorRunning)}`,
 						0,
 						0,
 					),
@@ -558,6 +584,11 @@ export function renderSubagentResult(
 				container.addChild(
 					new Text(theme.fg("muted", "Task: ") + theme.fg("dim", aggregator.task), 0, 0),
 				);
+				const aggregatorPolicy = formatResultPolicy(aggregator);
+				if (aggregatorPolicy)
+					container.addChild(
+						new Text(theme.fg("muted", "Policy:\n") + theme.fg("dim", aggregatorPolicy), 0, 0),
+					);
 				if (aggregatorFailed && aggregator.errorMessage)
 					container.addChild(
 						new Text(theme.fg("error", `Error: ${aggregator.errorMessage}`), 0, 0),
@@ -592,7 +623,7 @@ export function renderSubagentResult(
 		}
 
 		// Collapsed view (or still running)
-		let text = `${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`;
+		let text = `${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)} · ${coloredStatus(theme, overallStatus)}`;
 		for (const r of details.results) {
 			const rFailed = isResultError(r);
 			const rRunning = resultIsRunning(r);
@@ -603,7 +634,7 @@ export function renderSubagentResult(
 					: theme.fg("success", "✓");
 			const collapsed = getCollapsedDisplayItems(r);
 			const finalOutput = getResultFinalOutput(r).trim();
-			text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", r.agent)} ${rIcon}`;
+			text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", r.agent)} ${rIcon} ${coloredResultStatus(theme, r, rRunning)}`;
 			if (rFailed && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
 			if (collapsed.items.length > 0)
 				text += `\n${renderDisplayItems(collapsed.items, 5, collapsed.total)}`;
@@ -620,7 +651,7 @@ export function renderSubagentResult(
 					: theme.fg("success", "✓");
 			const collapsed = getCollapsedDisplayItems(aggregator);
 			const finalOutput = getResultFinalOutput(aggregator).trim();
-			text += `\n\n${theme.fg("muted", "─── fan-in → ")}${theme.fg("accent", aggregator.agent)} ${rIcon}`;
+			text += `\n\n${theme.fg("muted", "─── fan-in → ")}${theme.fg("accent", aggregator.agent)} ${rIcon} ${coloredResultStatus(theme, aggregator, aggregatorRunning)}`;
 			if (aggregatorFailed && aggregator.errorMessage)
 				text += `\n${theme.fg("error", `Error: ${aggregator.errorMessage}`)}`;
 			if (collapsed.items.length > 0)
@@ -636,10 +667,14 @@ export function renderSubagentResult(
 			const usageStr = formatUsageStats(aggregateUsage(usageResults));
 			if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
 		}
-		if (!expanded) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+		if (!expanded) text += `\n${expansionHint()}`;
 		return new Text(text, 0, 0);
 	}
 
 	const text = result.content[0];
-	return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
+	return new Text(
+		text?.type === "text" ? safeBlock(text.text, "(no output)", 8 * 1024) : "(no output)",
+		0,
+		0,
+	);
 }

--- a/extensions/pi-subagents/src/stateful-render.ts
+++ b/extensions/pi-subagents/src/stateful-render.ts
@@ -1,0 +1,247 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { Theme, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import {
+	COLLAPSED_LIST_LIMIT,
+	expansionHint,
+	type RenderStatus,
+	recordList,
+	recordValue,
+	renderFallbackResult,
+	safeBlock,
+	safeLine,
+	statusBadge,
+	stringValue,
+	type ToolRendererContext,
+	textResult,
+	toolHeader,
+} from "./render-common.js";
+
+export type StatefulRenderTool = "spawn" | "send" | "manage" | "mailbox";
+
+export function createStatefulToolRenderer(tool: StatefulRenderTool) {
+	return {
+		renderCall(args: unknown, theme: Theme) {
+			return renderStatefulCall(tool, recordValue(args) ?? {}, theme);
+		},
+		renderResult(
+			result: AgentToolResult<unknown>,
+			options: ToolRenderResultOptions,
+			theme: Theme,
+			context: ToolRendererContext<unknown>,
+		) {
+			return renderStatefulResult(tool, result, options, theme, context);
+		},
+	};
+}
+
+function renderStatefulCall(tool: StatefulRenderTool, args: Record<string, unknown>, theme: Theme) {
+	if (tool === "spawn") {
+		const metadata = [
+			`[${safeLine(args.agentScope, "user", 64)}]`,
+			"detached",
+			safeLine(args.workspaceMode, "shared", 64),
+		];
+		if (typeof args.thinkingLevel === "string") metadata.push(`thinking:${args.thinkingLevel}`);
+		return new Text(
+			[
+				toolHeader(theme, "subagent_spawn", args.agent, metadata),
+				`  ${theme.fg("dim", safeLine(args.task, "...", 2 * 1024))}`,
+			].join("\n"),
+			0,
+			0,
+		);
+	}
+	if (tool === "send") {
+		return new Text(
+			[
+				toolHeader(theme, "subagent_send", args.agentId, ["follow-up"]),
+				`  ${theme.fg("dim", safeLine(args.task, "...", 2 * 1024))}`,
+			].join("\n"),
+			0,
+			0,
+		);
+	}
+	if (tool === "manage") {
+		const metadata: string[] = [];
+		if (typeof args.agentId === "string") metadata.push(`id:${safeLine(args.agentId, "", 256)}`);
+		if (args.subtree === true) metadata.push("subtree");
+		if (args.includeClosed === true) metadata.push("include closed");
+		return new Text(toolHeader(theme, "subagent_manage", args.action, metadata), 0, 0);
+	}
+	const metadata = [`id:${safeLine(args.agentId, "...", 256)}`];
+	if (args.action === "read") {
+		metadata.push(args.acknowledge === false ? "leave unread" : "acknowledge");
+	}
+	const lines = [toolHeader(theme, "subagent_mailbox", args.action, metadata)];
+	if (args.action === "send") {
+		lines.push(`  ${theme.fg("dim", safeLine(args.message, "...", 2 * 1024))}`);
+	}
+	return new Text(lines.join("\n"), 0, 0);
+}
+
+function renderStatefulResult(
+	tool: StatefulRenderTool,
+	result: AgentToolResult<unknown>,
+	options: ToolRenderResultOptions,
+	theme: Theme,
+	context: ToolRendererContext<unknown>,
+) {
+	const details = recordValue(result.details);
+	const args = recordValue(context.args) ?? {};
+	if (!details) return renderFallbackResult(result, options, theme, context.isError);
+	if (tool === "spawn" || tool === "send") {
+		const agent = recordValue(details.agent);
+		if (!agent) return renderFallbackResult(result, options, theme, context.isError);
+		return new Text(renderAgentResult(agent, result, options.expanded, theme), 0, 0);
+	}
+	if (tool === "manage") {
+		return new Text(renderManageResult(args, details, result, options.expanded, theme), 0, 0);
+	}
+	return new Text(renderMailboxResult(args, details, options.expanded, theme), 0, 0);
+}
+
+function renderAgentResult(
+	agent: Record<string, unknown>,
+	result: AgentToolResult<unknown>,
+	expanded: boolean,
+	theme: Theme,
+): string {
+	const state = safeLine(agent.state, "unknown", 128);
+	const lines = [
+		`${statusBadge(theme, lifecycleStatus(state))} · ${theme.fg("accent", safeLine(agent.id, "agent", 256))} · ${theme.fg("toolOutput", safeLine(agent.agent, "subagent", 256))} · ${theme.fg("muted", state)}`,
+	];
+	const thinking = stringValue(agent.thinkingLevel);
+	const unread = typeof agent.unreadMessages === "number" ? agent.unreadMessages : 0;
+	if (thinking || unread > 0) {
+		lines.push(
+			theme.fg(
+				"dim",
+				[thinking && `thinking:${safeLine(thinking, "", 128)}`, unread > 0 && `unread:${unread}`]
+					.filter(Boolean)
+					.join(" · "),
+			),
+		);
+	}
+	if (expanded) {
+		const task = safeBlock(agent.currentTask, "", 2 * 1024).trim();
+		const error = safeBlock(agent.error, "", 2 * 1024).trim();
+		if (task) lines.push(theme.fg("dim", `task: ${task}`));
+		if (error) lines.push(theme.fg("error", `error: ${error}`));
+		const content = safeBlock(textResult(result), "", 8 * 1024).trim();
+		if (content) lines.push(theme.fg("toolOutput", content));
+	} else lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function renderManageResult(
+	args: Record<string, unknown>,
+	details: Record<string, unknown>,
+	result: AgentToolResult<unknown>,
+	expanded: boolean,
+	theme: Theme,
+): string {
+	const action = safeLine(args.action, "action", 128);
+	const agents = recordList(details.agents);
+	const primary = recordValue(details.agent);
+	if (action === "list") {
+		const lines = [
+			`${statusBadge(theme, "completed")} · list · ${agents.length} agent${agents.length === 1 ? "" : "s"}`,
+		];
+		const selected = expanded ? agents : agents.slice(0, COLLAPSED_LIST_LIMIT);
+		for (const agent of selected) lines.push(formatAgentLine(agent, theme, expanded));
+		if (agents.length === 0) lines.push(theme.fg("muted", "(no retained agents)"));
+		if (agents.length > selected.length)
+			lines.push(theme.fg("muted", `… ${agents.length - selected.length} omitted`));
+		if (!expanded && agents.length > 0) lines.push(expansionHint());
+		return lines.join("\n");
+	}
+
+	const subtree = args.subtree === true;
+	const affected = subtree ? agents.length : agents.length > 0 ? agents.length : primary ? 1 : 0;
+	const status: RenderStatus = action === "interrupt" ? "interrupted" : "closed";
+	const lines = [
+		`${statusBadge(theme, status)} · ${affected} agent${affected === 1 ? "" : "s"}${subtree ? theme.fg("muted", " · subtree") : ""}`,
+	];
+	const selected = agents.length > 0 ? agents : !subtree && primary ? [primary] : [];
+	for (const agent of expanded ? selected : selected.slice(0, COLLAPSED_LIST_LIMIT)) {
+		lines.push(formatAgentLine(agent, theme, expanded));
+	}
+	if (selected.length === 0) {
+		const content = safeBlock(textResult(result), "(no output)", 8 * 1024);
+		lines.push(theme.fg("toolOutput", content));
+	}
+	if (!expanded && selected.length > 0) lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function renderMailboxResult(
+	args: Record<string, unknown>,
+	details: Record<string, unknown>,
+	expanded: boolean,
+	theme: Theme,
+): string {
+	const action = safeLine(args.action, "action", 64);
+	if (action === "send") {
+		const message = recordValue(details.message);
+		if (!message) return `${statusBadge(theme, "completed")} · Queued message`;
+		const lines = [
+			`${theme.fg("success", "✓")} ${theme.fg("success", "Queued")} · ${theme.fg("accent", safeLine(message.id, "message", 256))} · ${theme.fg("muted", `to ${safeLine(message.recipientId, safeLine(args.agentId), 256)}`)}`,
+		];
+		if (expanded) {
+			lines.push(theme.fg("toolOutput", safeBlock(message.content, "(empty message)", 2 * 1024)));
+		} else lines.push(expansionHint());
+		return lines.join("\n");
+	}
+
+	const messages = recordList(details.messages);
+	const acknowledged = args.acknowledge === false ? "left unread" : "acknowledged";
+	const lines = [
+		`${statusBadge(theme, "completed")} · ${messages.length} message${messages.length === 1 ? "" : "s"} · ${acknowledged}`,
+	];
+	const selected = expanded ? messages : messages.slice(0, COLLAPSED_LIST_LIMIT);
+	for (const message of selected) {
+		const content = safeBlock(message.content, "(empty message)", expanded ? 2 * 1024 : 512);
+		lines.push(
+			`${theme.fg("muted", "• ")}${theme.fg("accent", safeLine(message.id, "message", 256))} ${theme.fg("muted", `from ${safeLine(message.senderId, "unknown", 256)}: `)}${theme.fg("toolOutput", content)}`,
+		);
+	}
+	if (messages.length === 0) lines.push(theme.fg("muted", "(no unread messages)"));
+	if (messages.length > selected.length)
+		lines.push(theme.fg("muted", `… ${messages.length - selected.length} omitted`));
+	if (!expanded && messages.length > 0) lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function formatAgentLine(agent: Record<string, unknown>, theme: Theme, expanded: boolean): string {
+	const unread = typeof agent.unreadMessages === "number" ? agent.unreadMessages : 0;
+	const lines = [
+		`${theme.fg("muted", "• ")}${theme.fg("accent", safeLine(agent.id, "agent", 256))} ${theme.fg("toolOutput", safeLine(agent.agent, "subagent", 256))} ${theme.fg("muted", safeLine(agent.state, "unknown", 128))}${unread > 0 ? theme.fg("warning", ` · unread:${unread}`) : ""}`,
+	];
+	if (expanded) {
+		const task = safeBlock(agent.currentTask, "", 2 * 1024).trim();
+		const error = safeBlock(agent.error, "", 2 * 1024).trim();
+		if (task) lines.push(`  ${theme.fg("dim", `task: ${task}`)}`);
+		if (error) lines.push(`  ${theme.fg("error", `error: ${error}`)}`);
+	}
+	return lines.join("\n");
+}
+
+function lifecycleStatus(state: string): RenderStatus {
+	switch (state) {
+		case "starting":
+			return "starting";
+		case "running":
+			return "running";
+		case "idle":
+			return "idle";
+		case "failed":
+			return "failed";
+		case "interrupted":
+			return "interrupted";
+		case "closed":
+			return "closed";
+		default:
+			return "completed";
+	}
+}

--- a/extensions/pi-subagents/src/stateful.ts
+++ b/extensions/pi-subagents/src/stateful.ts
@@ -33,6 +33,7 @@ import {
 } from "./registry.js";
 import { safeTerminalLine } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
+import { createStatefulToolRenderer } from "./stateful-render.js";
 import {
 	MailboxParamsSchema,
 	ManageParamsSchema,
@@ -362,6 +363,7 @@ export function registerStatefulSubagents(
 				}),
 			),
 		}),
+		...createStatefulToolRenderer("spawn"),
 		async execute(_id, params, _signal, _update, ctx) {
 			const scope = (params.agentScope ?? "user") as AgentScope;
 			assertSubagentDepthAllowed();
@@ -437,6 +439,7 @@ export function registerStatefulSubagents(
 				Type.Boolean({ description: "Override the shared-workspace write conflict guard." }),
 			),
 		}),
+		...createStatefulToolRenderer("send"),
 		async execute(_id, params, _signal, _update, ctx) {
 			const existing = requireRegistry().get(params.agentId);
 			if (!existing) throw new Error(`Unknown subagent: ${params.agentId}`);
@@ -465,6 +468,7 @@ export function registerStatefulSubagents(
 			"List retained subagents through the compatibility route, interrupt active work while keeping an agent reusable, or close agents and release their resources. Prefer subagent_inspect when the whole activated capability must be read-only.",
 		promptSnippet: "List or control retained detached subagents",
 		parameters: ManageParamsSchema,
+		...createStatefulToolRenderer("manage"),
 		async execute(_id, params): Promise<StatefulActionToolResult> {
 			const operation = validateManageParams(params);
 			if (operation.action === "list") {
@@ -533,6 +537,7 @@ export function registerStatefulSubagents(
 			"Queue a bounded message without starting a turn, or read unread mailbox messages. Read acknowledges returned messages by default; use subagent_inspect for metadata-only unread counts.",
 		promptSnippet: "Send or read queue-only detached-subagent mailbox messages",
 		parameters: MailboxParamsSchema,
+		...createStatefulToolRenderer("mailbox"),
 		async execute(_id, params): Promise<StatefulActionToolResult> {
 			const operation = validateMailboxParams(params);
 			if (operation.action === "send") {

--- a/extensions/pi-subagents/test/consult.test.ts
+++ b/extensions/pi-subagents/test/consult.test.ts
@@ -79,8 +79,12 @@ function execute(
 	params: Record<string, unknown>,
 	ctx = createMockContext().ctx,
 	signal?: AbortSignal,
+	onUpdate?: (result: {
+		content: Array<{ type: string; text: string }>;
+		details: Record<string, unknown>;
+	}) => void,
 ) {
-	return tool.execute("consult-1", params, signal, undefined, ctx);
+	return tool.execute("consult-1", params, signal, onUpdate, ctx);
 }
 
 test("subagent_consult registers a strict actionless single-agent schema", async () => {
@@ -204,6 +208,102 @@ test("subagent_consult enforces default, empty, and intersected tool policy with
 		assert.equal(result.usage?.cost.total, 0.25);
 		assert.doesNotMatch(JSON.stringify(result.details), /messages/);
 	}
+});
+
+test("subagent_consult emits safe starting and running progress projections", async () => {
+	const updates: Array<{
+		content: Array<{ type: string; text: string }>;
+		details: Record<string, unknown>;
+	}> = [];
+	const { tool } = setup({
+		runChild: async (request) => {
+			request.onUpdate?.(
+				childResult({
+					actualProvider: "actual-provider",
+					actualModel: "actual-model",
+					recentActivityTotal: 4,
+					recentActivity: [
+						{
+							type: "text",
+							text: "Planning <private>PROGRESS_SECRET</private>\u001b]8;;bad\u0007",
+						},
+						{
+							type: "toolCall",
+							name: "read",
+							args: {
+								path: "src/auth.ts\u001b[31m",
+								offset: 2,
+								limit: 5,
+								secret: "ARG_SECRET",
+							},
+						},
+						{ type: "toolCall", name: "bash", args: { command: "echo ARG_SECRET" } },
+					],
+				}),
+			);
+			return childResult();
+		},
+	});
+	const final = await execute(
+		tool,
+		{ agent: "worker", task: "inspect", thinkingLevel: "high" },
+		undefined,
+		undefined,
+		(update) => updates.push(structuredClone(update)),
+	);
+
+	assert.equal(updates.length, 2);
+	const starting = updates[0].details.progress as {
+		phase: string;
+		recentActivity: unknown[];
+		recentActivityTotal: number;
+	};
+	assert.equal(starting.phase, "starting");
+	assert.deepEqual(starting.recentActivity, []);
+	assert.equal(starting.recentActivityTotal, 0);
+	assert.match(updates[0].content[0].text, /starting/i);
+
+	const running = updates[1].details.progress as {
+		phase: string;
+		recentActivity: Array<{ type: string; name?: string; args?: Record<string, unknown> }>;
+		recentActivityTotal: number;
+		actualProvider: string;
+		actualModel: string;
+	};
+	assert.equal(running.phase, "running");
+	assert.equal(running.recentActivityTotal, 4);
+	assert.deepEqual(
+		running.recentActivity.map((item) => (item.type === "toolCall" ? item.name : item.type)),
+		["text", "read"],
+	);
+	assert.deepEqual(running.recentActivity[1].args, {
+		path: "src/auth.ts?[31m",
+		offset: 2,
+		limit: 5,
+	});
+	assert.equal(running.actualProvider, "actual-provider");
+	assert.equal(running.actualModel, "actual-model");
+	assert.doesNotMatch(JSON.stringify(updates), /PROGRESS_SECRET|ARG_SECRET|messages/);
+	assert.equal(final.details.progress, undefined);
+});
+
+test("subagent_consult revalidates cancellation after its starting update", async () => {
+	const controller = new AbortController();
+	let launches = 0;
+	const { tool } = setup({
+		runChild: async () => {
+			launches++;
+			return childResult();
+		},
+	});
+	await assert.rejects(
+		() =>
+			execute(tool, { agent: "worker", task: "inspect" }, undefined, controller.signal, () =>
+				controller.abort(),
+			),
+		(error) => error instanceof Error && error.name === "AbortError",
+	);
+	assert.equal(launches, 0);
 });
 
 test("subagent_consult production runner emits enforced child arguments without provider traffic", async () => {

--- a/extensions/pi-subagents/test/runner-render.test.ts
+++ b/extensions/pi-subagents/test/runner-render.test.ts
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import {
 	DEFAULT_MAX_CONTEXT_BYTES,
 	DEFAULT_MAX_OUTPUT_BYTES,
@@ -19,6 +21,15 @@ import {
 	type SubagentDetails,
 	terminateProcess,
 } from "../src/runner.js";
+
+initTheme("dark", false);
+
+const ESCAPE = String.fromCharCode(27);
+const SGR_PATTERN = new RegExp(`${ESCAPE}\\[[0-9;]*m`, "gu");
+
+function withoutSgr(value: string): string {
+	return value.replace(SGR_PATTERN, "");
+}
 
 test("buildPiArgs emits explicit read-only child launch policy flags", () => {
 	assert.deepEqual(
@@ -747,6 +758,85 @@ test("renderSubagentResult keeps collapsed partial output dense and current", ()
 			.join("\n");
 	assert.match(empty(true), /\(running\.\.\.\)/);
 	assert.match(empty(false), /\(no output\)/);
+});
+
+test("blocking subagent renderer uses safe text, explicit states, and native expansion hints", () => {
+	const identityTheme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+	const rawCall = renderSubagentCall(
+		{
+			agent: "worker <private>AGENT_SECRET</private>\u001b[31m",
+			task: "Inspect <private>TASK_SECRET</private> safely",
+		},
+		identityTheme as never,
+	)
+		.render(20)
+		.join("\n");
+	const call = withoutSgr(rawCall);
+	assert.doesNotMatch(call, /AGENT_SECRET|TASK_SECRET/u);
+	assert.equal(rawCall.includes(ESCAPE), false);
+
+	const result = {
+		content: [],
+		details: {
+			mode: "single",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results: [
+				{
+					agent: "worker",
+					agentSource: "built-in",
+					task: "Inspect <private>TASK_SECRET</private>",
+					exitCode: 0,
+					messages: [],
+					stderr: "",
+					finalOutput:
+						"safe line\nsecond\nthird\nfourth <private>OUTPUT_SECRET</private>\u001b]8;;bad\u0007",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						cost: 0,
+						contextTokens: 2,
+						turns: 1,
+					},
+					policy: {
+						inherited: ["read"],
+						overridden: ["grep"],
+						unsupported: ["missing"],
+					},
+				},
+			],
+		},
+	} as never;
+	const rendered = renderSubagentResult(
+		result,
+		{ expanded: false, isPartial: false } as never,
+		identityTheme as never,
+	);
+	const lines = rendered.render(12);
+	const text = withoutSgr(lines.join("\n"));
+	assert.match(text, /Completed/);
+	assert.match(text, /expand/);
+	assert.doesNotMatch(text, /\(Ctrl\+O to expand\)|OUTPUT_SECRET/u);
+	assert.equal(text.includes(ESCAPE), false);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 12));
+	const expanded = withoutSgr(
+		renderSubagentResult(
+			result,
+			{ expanded: true, isPartial: false } as never,
+			identityTheme as never,
+		)
+			.render(80)
+			.join("\n"),
+	);
+	assert.match(expanded, /Policy/);
+	assert.match(expanded, /inherited: read/);
+	assert.match(expanded, /overridden: grep/);
+	assert.match(expanded, /unsupported: missing/);
 });
 
 test("renderSubagentResult keeps partial views running and renders final-only previews", () => {

--- a/extensions/pi-subagents/test/tool-rendering.test.ts
+++ b/extensions/pi-subagents/test/tool-rendering.test.ts
@@ -1,0 +1,608 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createMockPi } from "../../../test/support.js";
+import subagents from "../src/subagents.js";
+
+initTheme("dark", false);
+
+interface RegisteredTool {
+	name: string;
+	renderCall?: (
+		args: unknown,
+		theme: unknown,
+		context: unknown,
+	) => { render(width: number): string[] };
+	renderResult?: (
+		result: unknown,
+		options: { expanded: boolean; isPartial: boolean },
+		theme: unknown,
+		context: unknown,
+	) => { render(width: number): string[] };
+}
+
+const identityTheme = {
+	fg: (_color: string, text: string) => text,
+	bg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+};
+const ESCAPE = String.fromCharCode(27);
+const SGR_PATTERN = new RegExp(`${ESCAPE}\\[[0-9;]*m`, "gu");
+
+function withoutSgr(value: string): string {
+	return value.replace(SGR_PATTERN, "");
+}
+
+function rendererContext(args: unknown, isError = false) {
+	return {
+		args,
+		toolCallId: "call-1",
+		invalidate() {},
+		lastComponent: undefined,
+		state: {},
+		cwd: process.cwd(),
+		executionStarted: true,
+		argsComplete: true,
+		isPartial: false,
+		expanded: false,
+		showImages: false,
+		isError,
+	};
+}
+
+function registeredTools(): Map<string, RegisteredTool> {
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-tool-rendering-"));
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		return new Map(
+			mock.tools.map((tool) => [String(tool.name), tool as unknown as RegisteredTool]),
+		);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+function renderCall(tool: RegisteredTool, args: unknown, width = 80): string[] {
+	assert.ok(tool.renderCall, `${tool.name} must register renderCall`);
+	return tool.renderCall(args, identityTheme, rendererContext(args)).render(width);
+}
+
+function renderResult(
+	tool: RegisteredTool,
+	args: unknown,
+	result: unknown,
+	options = { expanded: false, isPartial: false },
+	width = 80,
+	isError = false,
+): string[] {
+	assert.ok(tool.renderResult, `${tool.name} must register renderResult`);
+	return tool
+		.renderResult(result, options, identityTheme, rendererContext(args, isError))
+		.render(width);
+}
+
+const statefulAgent = {
+	id: "sa_worker",
+	agent: "worker",
+	state: "running",
+	createdAt: 1,
+	updatedAt: 2,
+	historyCount: 1,
+	unreadMessages: 2,
+	thinkingLevel: "high",
+	currentTask: "Inspect the renderer",
+};
+
+const consultDetails = {
+	agent: "reviewer",
+	agentSource: "built-in",
+	agentScope: "user",
+	cwd: ".",
+	model: "requested-model",
+	thinkingLevel: "high",
+	timeoutMs: 10_000,
+	policy: {
+		requestedTools: null,
+		effectiveTools: ["read", "grep", "find", "ls"],
+		requestedResources: "project-context",
+		effectiveResources: {
+			policy: "project-context",
+			projectResources: true,
+			contextFiles: true,
+			skills: false,
+			promptTemplates: false,
+		},
+		extensions: "disabled",
+		sessionPersistence: "disabled",
+		retainedAgent: false,
+	},
+	progress: {
+		phase: "running",
+		recentActivity: [
+			{ type: "toolCall", name: "read", args: { path: "src/auth.ts" } },
+			{ type: "toolCall", name: "grep", args: { pattern: "token", path: "src" } },
+		],
+		recentActivityTotal: 2,
+		actualProvider: "actual-provider",
+		actualModel: "actual-model",
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.25,
+			contextTokens: 15,
+			turns: 1,
+		},
+	},
+};
+
+test("all seven subagent tools register native call and result renderers", () => {
+	const tools = registeredTools();
+	assert.deepEqual([...tools.keys()].sort(), [
+		"subagent",
+		"subagent_consult",
+		"subagent_inspect",
+		"subagent_mailbox",
+		"subagent_manage",
+		"subagent_send",
+		"subagent_spawn",
+	]);
+	for (const tool of tools.values()) {
+		assert.equal(typeof tool.renderCall, "function", `${tool.name} renderCall`);
+		assert.equal(typeof tool.renderResult, "function", `${tool.name} renderResult`);
+	}
+});
+
+test("consult renderer shows bounded live activity and progressive disclosure", () => {
+	const tool = registeredTools().get("subagent_consult");
+	assert.ok(tool);
+	const args = {
+		agent: "reviewer",
+		task: "Inspect authentication <private>CALL_SECRET</private>\u001b]8;;bad\u0007 changes",
+		agentScope: "user",
+		thinkingLevel: "high",
+	};
+	const call = withoutSgr(renderCall(tool, args).join("\n"));
+	assert.match(call, /subagent_consult.*reviewer.*user.*read-only/is);
+	assert.match(call, /Inspect authentication/);
+	assert.doesNotMatch(call, /CALL_SECRET/u);
+	assert.equal(call.includes(ESCAPE), false);
+
+	const partial = withoutSgr(
+		renderResult(
+			tool,
+			args,
+			{ content: [{ type: "text", text: "(running...)" }], details: consultDetails },
+			{ expanded: false, isPartial: true },
+		).join("\n"),
+	);
+	assert.match(partial, /Running/);
+	assert.match(partial, /actual-provider\/actual-model/);
+	assert.match(partial, /requested-thinking:high/);
+	assert.match(partial, /read src\/auth\.ts/);
+	assert.match(partial, /grep \/token\/ in src/);
+
+	const finalDetails = {
+		...consultDetails,
+		progress: undefined,
+		child: {
+			actualProvider: "actual-provider",
+			actualModel: "actual-model",
+			usage: consultDetails.progress.usage,
+		},
+	};
+	const answer = "line one\nline two\nline three\nline four";
+	const collapsed = withoutSgr(
+		renderResult(tool, args, {
+			content: [{ type: "text", text: answer }],
+			details: finalDetails,
+		}).join("\n"),
+	);
+	assert.match(collapsed, /Completed/);
+	assert.match(collapsed, /line three/);
+	assert.doesNotMatch(collapsed, /line four/);
+	assert.match(collapsed, /expand/);
+	assert.doesNotMatch(collapsed, /\(Ctrl\+O to expand\)/);
+
+	const expanded = withoutSgr(
+		renderResult(
+			tool,
+			args,
+			{ content: [{ type: "text", text: answer }], details: finalDetails },
+			{ expanded: true, isPartial: false },
+		).join("\n"),
+	);
+	assert.match(expanded, /Task/);
+	assert.match(expanded, /Policy/);
+	assert.match(expanded, /line four/);
+});
+
+test("consult renderer distinguishes starting, cancellation, timeout, and abort states", () => {
+	const tool = registeredTools().get("subagent_consult");
+	assert.ok(tool);
+	const args = { agent: "reviewer", task: "Inspect" };
+	const renderState = (details: Record<string, unknown>, isPartial = false, isError = false) =>
+		withoutSgr(
+			renderResult(
+				tool,
+				args,
+				{ content: [{ type: "text", text: "state output" }], details },
+				{ expanded: false, isPartial },
+				80,
+				isError,
+			).join("\n"),
+		);
+
+	assert.match(
+		renderState(
+			{
+				...consultDetails,
+				progress: { ...consultDetails.progress, phase: "starting", recentActivity: [] },
+			},
+			true,
+		),
+		/Starting/,
+	);
+	assert.match(
+		renderState({ ...consultDetails, progress: undefined, cancelled: true }),
+		/Cancelled/,
+	);
+	assert.match(
+		renderState(
+			{
+				...consultDetails,
+				progress: undefined,
+				isError: true,
+				child: { timedOut: true, error: "timed out" },
+			},
+			false,
+			true,
+		),
+		/Failed/,
+	);
+	assert.match(
+		renderState(
+			{
+				...consultDetails,
+				progress: undefined,
+				isError: true,
+				child: { aborted: true, timedOut: false, error: "aborted" },
+			},
+			false,
+			true,
+		),
+		/Cancelled/,
+	);
+});
+
+test("inspect renderer summarizes every action instead of dumping collapsed JSON", () => {
+	const tool = registeredTools().get("subagent_inspect");
+	assert.ok(tool);
+	const cases = [
+		{
+			args: { action: "list_agents", agentScope: "user" },
+			details: {
+				action: "list_agents",
+				agents: [{ name: "scout", source: "built-in", toolCount: 4, consultTools: ["read"] }],
+				returned: 1,
+				omitted: 0,
+			},
+			expected: /1 agent.*scout/is,
+		},
+		{
+			args: { action: "get_agent", agent: "scout" },
+			details: {
+				action: "get_agent",
+				agent: { name: "scout", source: "built-in", description: "Scout files" },
+			},
+			expected: /scout.*built-in.*Scout files/is,
+		},
+		{
+			args: { action: "list_runs" },
+			details: { action: "list_runs", runs: [statefulAgent], returned: 1, omitted: 0 },
+			expected: /1 run.*sa_worker.*running/is,
+		},
+		{
+			args: { action: "get_run", agentId: "sa_worker" },
+			details: { action: "get_run", run: statefulAgent },
+			expected: /sa_worker.*worker.*running/is,
+		},
+		{
+			args: { action: "list_models" },
+			details: {
+				action: "list_models",
+				models: [
+					{ provider: "provider", id: "model", name: "Model", current: true, reasoning: true },
+				],
+				returned: 1,
+				omitted: 0,
+				source: "session scope",
+			},
+			expected: /1 model.*provider\/model.*current/is,
+		},
+		{
+			args: { action: "status" },
+			details: {
+				action: "status",
+				status: {
+					workflow: "all",
+					consultResources: "project-context",
+					stateful: { initialized: true, activeAgents: 1, retainedAgents: 2 },
+				},
+			},
+			expected: /workflow: all.*1 active.*2 retained/is,
+		},
+		{
+			args: { action: "diagnose" },
+			details: {
+				action: "diagnose",
+				ok: false,
+				checks: [
+					{ name: "settings", status: "pass", message: "Settings are valid." },
+					{ name: "runtime", status: "warning", message: "Not initialized." },
+					{ name: "models", status: "fail", message: "No models." },
+				],
+			},
+			expected: /Diagnostics failed.*PASS.*WARNING.*FAIL/is,
+		},
+	] as const;
+
+	for (const fixture of cases) {
+		const text = withoutSgr(
+			renderResult(tool, fixture.args, {
+				content: [{ type: "text", text: JSON.stringify(fixture.details) }],
+				details: fixture.details,
+			}).join("\n"),
+		);
+		assert.match(text, fixture.expected);
+		assert.doesNotMatch(text, /^\s*\{/u);
+	}
+});
+
+test("detached lifecycle renderers summarize calls and action-specific results", () => {
+	const tools = registeredTools();
+	const fixtures = [
+		{
+			name: "subagent_spawn",
+			args: {
+				agent: "worker",
+				task: "Review files",
+				agentScope: "user",
+				workspaceMode: "worktree",
+				thinkingLevel: "high",
+			},
+			result: { content: [{ type: "text", text: "Spawned." }], details: { agent: statefulAgent } },
+			expected: /worker.*detached.*worktree.*sa_worker.*running/is,
+		},
+		{
+			name: "subagent_send",
+			args: { agentId: "sa_worker", task: "Review again" },
+			result: { content: [{ type: "text", text: "Started." }], details: { agent: statefulAgent } },
+			expected: /sa_worker.*follow-up.*running/is,
+		},
+		{
+			name: "subagent_manage",
+			args: { action: "list", includeClosed: true },
+			result: { content: [{ type: "text", text: "listed" }], details: { agents: [statefulAgent] } },
+			expected: /list.*1 agent.*sa_worker/is,
+		},
+		{
+			name: "subagent_manage",
+			args: { action: "interrupt", agentId: "sa_worker", subtree: true },
+			result: {
+				content: [{ type: "text", text: "Interrupted 1 active agent(s)." }],
+				details: { agent: { ...statefulAgent, state: "interrupted" }, agents: [statefulAgent] },
+			},
+			expected: /interrupt.*subtree.*Interrupted.*1 agent/is,
+		},
+		{
+			name: "subagent_manage",
+			args: { action: "close", agentId: "sa_worker" },
+			result: {
+				content: [{ type: "text", text: "Closed." }],
+				details: { agent: { ...statefulAgent, state: "closed" } },
+			},
+			expected: /close.*Closed.*sa_worker/is,
+		},
+		{
+			name: "subagent_mailbox",
+			args: { action: "send", agentId: "sa_worker", message: "Queue this" },
+			result: {
+				content: [{ type: "text", text: "Queued." }],
+				details: {
+					message: {
+						id: "msg_1",
+						senderId: "root",
+						recipientId: "sa_worker",
+						content: "Queue this",
+					},
+				},
+			},
+			expected: /send.*sa_worker.*Queued.*msg_1/is,
+		},
+		{
+			name: "subagent_mailbox",
+			args: { action: "read", agentId: "sa_worker", acknowledge: true },
+			result: {
+				content: [{ type: "text", text: "message" }],
+				details: {
+					messages: [
+						{ id: "msg_1", senderId: "worker", recipientId: "sa_worker", content: "Done" },
+					],
+				},
+			},
+			expected: /read.*sa_worker.*1 message.*acknowledged.*Done/is,
+		},
+	] as const;
+
+	for (const fixture of fixtures) {
+		const tool = tools.get(fixture.name);
+		assert.ok(tool);
+		const text = withoutSgr(
+			[...renderCall(tool, fixture.args), ...renderResult(tool, fixture.args, fixture.result)].join(
+				"\n",
+			),
+		);
+		assert.match(text, fixture.expected, fixture.name);
+	}
+
+	const manage = tools.get("subagent_manage");
+	assert.ok(manage);
+	const noActiveDescendants = withoutSgr(
+		renderResult(
+			manage,
+			{ action: "interrupt", agentId: "sa_worker", subtree: true },
+			{
+				content: [{ type: "text", text: "Interrupted 0 active agent(s)." }],
+				details: { agent: { ...statefulAgent, state: "completed" }, agents: [] },
+			},
+		).join("\n"),
+	);
+	assert.match(noActiveDescendants, /Interrupted.*0 agents/is);
+	assert.doesNotMatch(noActiveDescendants, /1 agent/);
+});
+
+test("structured tool views remain width-safe when collapsed and expanded", () => {
+	const tools = registeredTools();
+	const fixtures = [
+		{
+			name: "subagent_consult",
+			args: { agent: "reviewer", task: "Inspect authentication behavior in the current workspace" },
+			result: {
+				content: [{ type: "text", text: "A long consultation answer that must wrap safely." }],
+				details: {
+					...consultDetails,
+					progress: undefined,
+					child: { usage: consultDetails.progress.usage },
+				},
+			},
+		},
+		{
+			name: "subagent_inspect",
+			args: { action: "list_runs" },
+			result: {
+				content: [{ type: "text", text: "runs" }],
+				details: { action: "list_runs", runs: [statefulAgent], returned: 1, omitted: 0 },
+			},
+		},
+		{
+			name: "subagent_spawn",
+			args: { agent: "worker", task: "Review a long detached task", workspaceMode: "worktree" },
+			result: { content: [{ type: "text", text: "spawned" }], details: { agent: statefulAgent } },
+		},
+		{
+			name: "subagent_send",
+			args: { agentId: "sa_worker", task: "Continue a long retained task" },
+			result: { content: [{ type: "text", text: "sent" }], details: { agent: statefulAgent } },
+		},
+		{
+			name: "subagent_manage",
+			args: { action: "list", includeClosed: true },
+			result: { content: [{ type: "text", text: "listed" }], details: { agents: [statefulAgent] } },
+		},
+		{
+			name: "subagent_mailbox",
+			args: { action: "read", agentId: "sa_worker", acknowledge: true },
+			result: {
+				content: [{ type: "text", text: "message" }],
+				details: {
+					messages: [
+						{
+							id: "message_one",
+							senderId: "worker",
+							recipientId: "sa_worker",
+							content: "A long mailbox message that must wrap safely.",
+						},
+					],
+				},
+			},
+		},
+	] as const;
+
+	for (const fixture of fixtures) {
+		const tool = tools.get(fixture.name);
+		assert.ok(tool);
+		for (const width of [12, 24]) {
+			const renderedViews: string[][] = [
+				renderCall(tool, fixture.args, width),
+				renderResult(
+					tool,
+					fixture.args,
+					fixture.result,
+					{ expanded: false, isPartial: false },
+					width,
+				),
+				renderResult(
+					tool,
+					fixture.args,
+					fixture.result,
+					{ expanded: true, isPartial: false },
+					width,
+				),
+			];
+			assert.ok(
+				renderedViews.flat().every((line) => visibleWidth(line) <= width),
+				`${fixture.name} exceeded width ${width}: ${JSON.stringify(renderedViews)}`,
+			);
+		}
+	}
+
+	const mailbox = tools.get("subagent_mailbox");
+	assert.ok(mailbox);
+	assert.match(
+		withoutSgr(
+			renderResult(
+				mailbox,
+				{ action: "read", agentId: "sa_worker" },
+				{ content: [{ type: "text", text: "No unread messages." }], details: { messages: [] } },
+			).join("\n"),
+		),
+		/no unread messages/i,
+	);
+});
+
+test("tool renderers tolerate partial args, sanitize fallback text, and respect narrow widths", () => {
+	const tools = registeredTools();
+	for (const [name, tool] of tools) {
+		assert.doesNotThrow(() => renderCall(tool, {}, 12), `${name} partial call args`);
+	}
+
+	const unsafe = "visible <private>RESULT_SECRET</private>\u001b]8;;https://bad.invalid\u0007 tail";
+	for (const name of [
+		"subagent_consult",
+		"subagent_inspect",
+		"subagent_spawn",
+		"subagent_send",
+		"subagent_manage",
+		"subagent_mailbox",
+	]) {
+		const tool = tools.get(name);
+		assert.ok(tool);
+		const lines = renderResult(
+			tool,
+			{},
+			{ content: [{ type: "text", text: unsafe }], details: undefined },
+			{ expanded: false, isPartial: false },
+			12,
+			true,
+		);
+		const plain = withoutSgr(lines.join("\n"));
+		assert.doesNotMatch(plain, /RESULT_SECRET/u, name);
+		assert.equal(plain.includes(ESCAPE), false, name);
+		assert.match(plain, /visible.*tail/s, name);
+		assert.ok(
+			lines.every((line) => visibleWidth(line) <= 12),
+			`${name} exceeded narrow width: ${JSON.stringify(lines)}`,
+		);
+	}
+});


### PR DESCRIPTION
## Summary

- add Pi-native `renderCall`/`renderResult` views for all seven subagent tools without extending `pi-tui-kit`
- stream bounded, redacted starting/running consultation progress with model, usage, and allow-listed read-only activity
- add compact/expanded action-specific views for inspection and detached lifecycle tools, plus safer blocking renderer output and keybinding-aware expansion hints
- document the interactive transcript behavior and detached non-polling boundary

## Testing

- `npm run check`
- `npm run typecheck --workspace @narumitw/pi-subagents`
- focused compiled tests for consultation, blocking rendering, inspection, orchestration, and unified tool rendering
