### PR TITLE
feat(pi-lsp)!: make configuration file-only

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -146,6 +146,7 @@
 
 ### General
 
+- Prefer canonical JSON and explicit argv arrays for pi-lsp configuration; avoid pi-lsp-specific environment-variable settings while retaining `servers[].env` for child-process needs.
 - Prefer storage-oriented pi-sync setup that completes credentials in a masked TUI and reviews one exact backend path; storage connections and sync setups are the only managed user concepts.
 - Prefer direct, user-owned context selection; avoid dedicated shortcuts or manual copy steps for routine quoting workflows.
 - Prefer reading GitHub issue and pull request links with `gh --json` first; use web tools only when `gh` cannot access the needed content.

--- a/docs/plans/archived/2026-08-01_pi-lsp-config-environment-cleanup-plan.md
+++ b/docs/plans/archived/2026-08-01_pi-lsp-config-environment-cleanup-plan.md
@@ -1,0 +1,64 @@
+# pi-lsp config environment cleanup
+
+## Goal
+
+Remove pi-lsp's extension-specific environment-variable configuration surfaces while preserving its explicit argv-array server configuration and `servers[].env` forwarding to LSP server processes.
+
+After the change, pi-lsp configuration comes from its user/trusted-project JSON files or the built-in catalog. Existing JSON commands such as `{"command":["uv","run","--no-sync","ruff","server"],"extensions":[".py",".pyi"]}` remain supported.
+
+## Context
+
+- `PI_LSP_CONFIG` currently supplies inline JSON or a config-file path above all file-based settings.
+- Each adapter currently derives `PI_<SERVER>_LSP_COMMAND`, which can replace the configured argv through a shell-like string parser.
+- Canonical settings already exist at `<getAgentDir()>/pi-lsp.json` and trusted `<workspace>/.pi/pi-lsp.json`; current legacy `lsp.json` compatibility remains in scope only as unchanged behavior.
+- `servers[].env` is not a pi-lsp settings source. It intentionally overrides values passed to one LSP child process and may provide `JAVA_HOME`, logging, proxy/CA, memory, or an effective `PATH`.
+
+## Architecture
+
+Configuration precedence becomes:
+
+```text
+trusted project pi-lsp.json (or existing legacy fallback)
+→ user pi-lsp.json (or existing legacy fallback)
+→ built-in catalog
+```
+
+Command resolution becomes:
+
+```text
+server command argv from JSON/catalog
+→ resolve command[0] with cwd and the server's effective PATH
+→ spawn with inherited process environment plus servers[].env overrides
+```
+
+`PI_CODING_AGENT_DIR` remains Pi infrastructure handled indirectly through `getAgentDir()`; standard process variables such as `PATH` and Windows `ComSpec` remain runtime inputs rather than pi-lsp-specific settings.
+
+## Non-Goals
+
+- Managed runtimes, package installation, registries, isolated caches, or LSP value benchmarking.
+- Removing or changing `servers[].env` or inherited child-process environment behavior.
+- Changing argv-array `command`, `extensions`, initialization, skip-directory, or diagnostics-timing fields.
+- Changing current server-map replacement semantics, flat/wrapper JSON compatibility, canonical paths, project trust gating, or legacy `lsp.json` fallback.
+- Adding replacement environment variables, shell command strings, runtime selectors, settings UI, or implicit command fallback.
+
+## Plan
+
+- [x] Add focused regression tests proving `PI_LSP_CONFIG` cannot override user/trusted-project settings and `PI_<SERVER>_LSP_COMMAND` cannot override configured argv, while existing `servers[].env` forwarding and effective-`PATH` command resolution still work. Red evidence: file-source expectations received `explicit`, then command status received `overridden-user --stdio`; green evidence: all 24 focused pi-lsp tests pass, including child-environment forwarding.
+- [x] Update `extensions/pi-lsp/src/adapters.ts` and `extensions/pi-lsp/src/types.ts` to remove `PI_LSP_CONFIG` loading and per-adapter command-environment metadata, leaving canonical/legacy file loading, project trust, validation, and explicit argv normalization unchanged; focused canonical, legacy-race, trust, and validation tests pass.
+- [x] Update `extensions/pi-lsp/src/runner.ts`, `extensions/pi-lsp/src/routes.ts`, `extensions/pi-lsp/src/pi-lsp.ts`, and `extensions/pi-lsp/src/command.ts` to execute adapter argv directly, remove shell-string environment override parsing and `PI_*` installation hints, and preserve cwd/effective-`PATH` resolution plus child environment merging; focused command, route, and LSP-client tests pass.
+- [x] Update `extensions/pi-lsp/README.md` to document file-only settings precedence, migration from `PI_LSP_CONFIG` to canonical JSON, migration from `PI_<SERVER>_LSP_COMMAND` to `servers.<name>.command`, and the distinct retained purpose of `servers[].env`; examples use argv arrays and no longer recommend pi-lsp-specific environment variables.
+- [x] Audit the final settings and asynchronous process paths against `docs/extension-conventions.md` and `docs/extension-settings.md`: missing-file reads remain side-effect free, project settings remain trust-gated, invalid files still fail without overwrite, no persistence path changed, and command selection no longer changes timeout/cancellation/session/shutdown ownership.
+- [x] Run focused pi-lsp tests and typecheck, `lsp_diagnostics` with an explicit configured command, `just pack-lsp`, and the repository CI-equivalent `npm run check`. Evidence: 24 focused tests and package check pass; the explicit file-config SDK smoke ignores both removed variables and returns the expected diagnostic; the 13-file pack dry run contains the edited sources/README; and a normal-clone root check passes all 2,026 tests. Windows runtime execution remains untested on this Linux host, while deterministic Windows PATH/batch-wrapper coverage passes.
+
+## Risks
+
+- Existing automation that depends on inline/path `PI_LSP_CONFIG` or per-server command variables will break immediately. Mitigation: preserve equivalent JSON argv configuration and provide a direct README migration table.
+- Removing command-string parsing also removes quoting behavior users may rely on. Mitigation: JSON argv arrays represent each argument without shell quoting ambiguity.
+- Broad environment-variable searches can confuse Pi infrastructure or server-owned variables with removed pi-lsp settings. Mitigation: audit production reads by ownership and retain `getAgentDir()`, standard process environment, and `servers[].env` behavior explicitly.
+
+## Completion Checklist
+
+- [x] Production pi-lsp code no longer reads `PI_LSP_CONFIG` or generated `PI_<SERVER>_LSP_COMMAND` variables and exposes no replacement pi-lsp-specific environment setting.
+- [x] Explicit argv-array server commands and `servers[].env`, including effective-`PATH` resolution, have regression coverage and unchanged documented behavior.
+- [x] Canonical user/trusted-project settings precedence, project trust, validation, current JSON shapes, and legacy file fallback remain verified.
+- [x] Focused checks, package dry run, runtime smoke, and full repository gate pass, with no unintended source, metadata, or public tool changes.

--- a/extensions/pi-lsp/README.md
+++ b/extensions/pi-lsp/README.md
@@ -119,14 +119,23 @@ Ensure the Go install directory (`$GOBIN` or `$(go env GOPATH)/bin`) is also on 
 
 Custom config is resolved in this order:
 
-1. `PI_LSP_CONFIG` as inline JSON or a path to a JSON file
-2. `<workspace>/.pi/pi-lsp.json`, only when Pi trusts the current project
-3. `~/.pi/agent/pi-lsp.json`
-4. the built-in server catalog
+1. `<workspace>/.pi/pi-lsp.json`, only when Pi trusts the current project
+2. `~/.pi/agent/pi-lsp.json`
+3. the built-in server catalog
 
-`PI_LSP_CONFIG` only accepts JSON or a JSON file path; JavaScript and TypeScript config files are not evaluated. An untrusted project's canonical and legacy files are ignored. A `root` passed to an LSP tool selects files and the server working directory; it does not grant that directory authority to provide project settings. Project settings always come from the trusted Pi session workspace.
+An untrusted project's canonical and legacy files are ignored. A `root` passed to an LSP tool selects files and the server working directory; it does not grant that directory authority to provide project settings. Project settings always come from the trusted Pi session workspace.
 
 Compatibility: user-scoped `lsp.json` and trusted project-scoped `.pi/lsp.json` remain readable with a warning and are never modified automatically; rename them to their canonical `pi-lsp.json` names. New paths take precedence when both names exist.
+
+pi-lsp-specific environment settings have been removed. Move their values into canonical JSON:
+
+| Removed setting | JSON replacement |
+| --- | --- |
+| `PI_LSP_CONFIG` inline JSON | Save the same object as user `pi-lsp.json` or trusted project `.pi/pi-lsp.json` |
+| `PI_LSP_CONFIG=/path/to/file.json` | Move or copy that configuration to one of the canonical paths above |
+| `PI_<SERVER>_LSP_COMMAND` | Set the server's `command` to an argv array, with one string per executable or argument |
+
+`servers[].env` remains supported because it configures the launched LSP child process rather than pi-lsp itself.
 
 Providing custom config replaces the default server map. The following `pi-lsp.json` example intentionally keeps five selected servers:
 
@@ -194,7 +203,7 @@ Each server entry supports:
 
 - `command`: argv array used to start the LSP server.
 - `extensions`: file extensions that should route to this server.
-- `env`: extra environment variables for the LSP server process.
+- `env`: environment overrides for the LSP server process. The child inherits Pi's environment, then applies these values; an `env.PATH` value is also used to resolve `command[0]`.
 - `initialization`: LSP initialization options and workspace configuration values.
 - `skipDirectories`: additional directory names to exclude from recursive discovery. Explicitly requested paths remain available.
 - `diagnosticsSettleMs`: positive number of milliseconds without another push-diagnostics publication before using the latest result. Defaults to `800`; the built-in intelephense route uses `4000`. The global timeout remains the upper bound.
@@ -207,12 +216,17 @@ Global options:
 
 pi-lsp infers `languageId` from common extensions and falls back to the extension without the leading dot.
 
-Per-server command overrides still use the normalized server name:
+For example, run the configured Ruff server through the project's uv environment without shell-string parsing:
 
-```bash
-PI_TY_LSP_COMMAND="uvx ty server" \
-PI_RUFF_LSP_COMMAND="uvx ruff server" \
-pi -e ./extensions/pi-lsp
+```json
+{
+  "servers": {
+    "ruff": {
+      "command": ["uv", "run", "--no-sync", "ruff", "server"],
+      "extensions": [".py", ".pyi"]
+    }
+  }
+}
 ```
 
 ## ⚠️ Tool changes

--- a/extensions/pi-lsp/src/adapters.ts
+++ b/extensions/pi-lsp/src/adapters.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -246,8 +245,6 @@ let pendingConfigNotice: string | undefined;
 
 function loadConfiguredConfig(cwd: string, projectTrusted: boolean): LspConfig | undefined {
 	pendingConfigNotice = undefined;
-	const rawConfig = process.env.PI_LSP_CONFIG?.trim();
-	if (rawConfig) return parseConfigSource(rawConfig, cwd, "PI_LSP_CONFIG");
 
 	if (projectTrusted) {
 		const projectConfig = path.join(cwd, CONFIG_DIR_NAME, "pi-lsp.json");
@@ -288,15 +285,6 @@ export function consumeLspConfigNotice() {
 	const notice = pendingConfigNotice;
 	pendingConfigNotice = undefined;
 	return notice;
-}
-
-function parseConfigSource(source: string, cwd: string, label: string): LspConfig {
-	if (source.startsWith("{")) return normalizeConfig(JSON.parse(source), label);
-	const expandedSource = expandHome(source);
-	const filePath = path.isAbsolute(expandedSource)
-		? expandedSource
-		: path.resolve(cwd, expandedSource);
-	return parseConfigFile(filePath);
 }
 
 function parseConfigFile(filePath: string): LspConfig {
@@ -397,8 +385,7 @@ function configToAdapter(config: InternalLspServer): LspServerAdapter {
 		name: config.name,
 		isDefault: config.isDefault ?? false,
 		defaultCommand: { command, args },
-		commandEnvVar: envName(config.name, "COMMAND"),
-		missingCommandHint: `Install ${config.name} or set ${envName(config.name, "COMMAND")}.`,
+		missingCommandHint: `Install ${config.name} or update its command in pi-lsp.json.`,
 		extensions: config.extensions,
 		env: config.env,
 		initialization: config.initialization,
@@ -486,17 +473,6 @@ const LANGUAGE_IDS: Record<string, string> = {
 	".zsh": "shellscript",
 };
 
-function commandFromEnvName(name: string): string {
-	return name
-		.replace(/[^a-zA-Z0-9]+/g, "_")
-		.replace(/^_+|_+$/g, "")
-		.toUpperCase();
-}
-
-function envName(name: string, suffix: "COMMAND") {
-	return `PI_${commandFromEnvName(name)}_LSP_${suffix}`;
-}
-
 function normalizeExtension(extension: string) {
 	return extension.startsWith(".") ? extension : `.${extension}`;
 }
@@ -556,14 +532,6 @@ function optionalDirectoryNamesField(value: Record<string, unknown>, field: stri
 		);
 	}
 	return [...new Set(names)];
-}
-
-function expandHome(filePath: string) {
-	if (filePath === "~") return os.homedir();
-	if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
-		return path.join(os.homedir(), filePath.slice(2));
-	}
-	return filePath;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/extensions/pi-lsp/src/command.ts
+++ b/extensions/pi-lsp/src/command.ts
@@ -1,17 +1,6 @@
 import { accessSync, constants, existsSync, statSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import type { ServerCommand } from "./types.js";
-
-export function commandFromEnv(envVar: string, fallback: ServerCommand): ServerCommand {
-	const customCommand = process.env[envVar]?.trim();
-	if (customCommand) {
-		const [command, ...args] = splitCommand(customCommand);
-		if (command) return { command, args };
-	}
-
-	return fallback;
-}
 
 export function commandExists(
 	command: string,
@@ -100,50 +89,4 @@ function isRunnableFile(filePath: string, platform: NodeJS.Platform) {
 	} catch {
 		return false;
 	}
-}
-
-export function splitCommand(input: string) {
-	const parts: string[] = [];
-	let current = "";
-	let quote: '"' | "'" | undefined;
-
-	for (let index = 0; index < input.length; index += 1) {
-		const char = input[index];
-		const next = input[index + 1];
-
-		if (char === "\\" && next !== undefined && shouldEscapeNextCharacter(next, quote)) {
-			current += next;
-			index += 1;
-			continue;
-		}
-
-		if ((char === '"' || char === "'") && !quote) {
-			quote = char;
-			continue;
-		}
-
-		if (char === quote) {
-			quote = undefined;
-			continue;
-		}
-
-		if (/\s/.test(char) && !quote) {
-			if (current) {
-				parts.push(current);
-				current = "";
-			}
-			continue;
-		}
-
-		current += char;
-	}
-
-	if (current) parts.push(current);
-	return parts;
-}
-
-function shouldEscapeNextCharacter(next: string, quote: '"' | "'" | undefined) {
-	if (next === "\\") return true;
-	if (quote) return next === quote;
-	return next === '"' || next === "'" || /\s/.test(next);
 }

--- a/extensions/pi-lsp/src/pi-lsp.ts
+++ b/extensions/pi-lsp/src/pi-lsp.ts
@@ -1,7 +1,7 @@
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { consumeLspConfigNotice, loadRuntime } from "./adapters.js";
-import { commandExists, commandFromEnv, commandPathValue } from "./command.js";
+import { commandExists, commandPathValue } from "./command.js";
 import { resolveRoot } from "./files.js";
 import { selectDiagnosticRoutes, selectFixRoute } from "./routes.js";
 import { DEFAULT_FILE_LIMIT, runDiagnostics, runFix, textResult } from "./runner.js";
@@ -54,7 +54,7 @@ const lspDiagnosticsTool = defineTool({
 	promptGuidelines: [
 		"Use lsp_diagnostics when files need diagnostics from a configured LSP server.",
 		"Use the server parameter only when the user asks for a specific configured LSP server or multiple servers match the same extension.",
-		"If a configured server command is missing, report the configuration error and suggest installing the command or setting its PI_<SERVER>_LSP_COMMAND environment variable.",
+		"If a configured server command is missing, report the configuration error and suggest installing it or updating the server's command in pi-lsp.json.",
 	],
 	parameters: DiagnosticsParameters,
 	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -189,7 +189,7 @@ function textFromResult(result: { content?: Array<{ type?: string; text?: string
 function buildStatusMessage(adapters: ReturnType<typeof loadRuntime>["adapters"], cwd: string) {
 	return adapters
 		.flatMap((adapter) => {
-			const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
+			const command = adapter.defaultCommand;
 			return [
 				`${adapter.name} LSP command: ${command.command} ${command.args.join(" ")}`.trim(),
 				`${adapter.name} status: ${
@@ -204,7 +204,7 @@ function buildStatusMessage(adapters: ReturnType<typeof loadRuntime>["adapters"]
 
 function statusLevel(adapters: ReturnType<typeof loadRuntime>["adapters"], cwd: string) {
 	return adapters.every((adapter) => {
-		const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
+		const command = adapter.defaultCommand;
 		return commandExists(command.command, cwd, commandPathValue(adapter.env));
 	})
 		? "info"

--- a/extensions/pi-lsp/src/routes.ts
+++ b/extensions/pi-lsp/src/routes.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { commandExists, commandFromEnv, commandPathValue } from "./command.js";
+import { commandExists, commandPathValue } from "./command.js";
 import { collectSupportedFiles, resolveRoot } from "./files.js";
 import type { LspServerAdapter } from "./types.js";
 
@@ -44,7 +44,7 @@ export function selectDiagnosticRoutes(
 		? candidates
 		: candidates.filter((adapter) => {
 				if (!adapter.isDefault) return true;
-				const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
+				const command = adapter.defaultCommand;
 				if (commandExists(command.command, root, commandPathValue(adapter.env))) return true;
 				skipped.push({ adapter, reason: `${adapter.name} command missing`, files: [] });
 				return false;

--- a/extensions/pi-lsp/src/runner.ts
+++ b/extensions/pi-lsp/src/runner.ts
@@ -1,7 +1,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { commandFromEnv } from "./command.js";
 import { collectSupportedFiles, resolveRoot, resolveSupportedFile } from "./files.js";
 import { LspClient } from "./lsp-client.js";
 import { applyTextEdits, collectWorkspaceEdits, hasOverlappingTextEdits } from "./text-edits.js";
@@ -24,7 +23,7 @@ export async function runDiagnostics(
 	statusKey: string,
 ) {
 	const root = resolveRoot(params.root);
-	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
+	const command = adapter.defaultCommand;
 	const files =
 		params.files ??
 		collectSupportedFiles(adapter, root, params.paths, params.limit ?? DEFAULT_FILE_LIMIT);
@@ -92,7 +91,7 @@ export async function runFix(
 	const file = resolveSupportedFile(adapter, root, params.path);
 	const actionKind = params.kind?.trim() || "source.fixAll";
 
-	const command = commandFromEnv(adapter.commandEnvVar, adapter.defaultCommand);
+	const command = adapter.defaultCommand;
 	const client = new LspClient(adapter, command, root, timeoutMs);
 	const abort = () => client.close();
 	signal?.addEventListener("abort", abort, { once: true });

--- a/extensions/pi-lsp/src/types.ts
+++ b/extensions/pi-lsp/src/types.ts
@@ -89,7 +89,6 @@ export interface LspServerAdapter {
 	name: string;
 	isDefault: boolean;
 	defaultCommand: ServerCommand;
-	commandEnvVar: string;
 	missingCommandHint: string;
 	extensions: string[];
 	env?: Record<string, string>;

--- a/extensions/pi-lsp/test/docker/run-smoke.mjs
+++ b/extensions/pi-lsp/test/docker/run-smoke.mjs
@@ -82,10 +82,13 @@ async function runCase(caseName, repeat) {
 		...profile.policy,
 	};
 	process.env.PI_CODING_AGENT_DIR = agentDir;
-	process.env.PI_LSP_CONFIG = JSON.stringify({
-		timeout: profile.timeoutMs ?? matrix.timeoutMs,
-		servers: { [profile.name]: serverConfig },
-	});
+	writeFileSync(
+		path.join(agentDir, "pi-lsp.json"),
+		JSON.stringify({
+			timeout: profile.timeoutMs ?? matrix.timeoutMs,
+			servers: { [profile.name]: serverConfig },
+		}),
+	);
 	process.env.PI_OFFLINE = "1";
 
 	const settingsManager = SettingsManager.inMemory({});

--- a/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/extensions/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -30,6 +30,14 @@ function publish(uri, diagnostics) {
 
 function handle(message) {
 	if (message.method === "initialize") {
+		if (scenario === "require-environment" && process.env.PI_LSP_TEST_ENV !== "forwarded") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				error: { code: -32002, message: "required server environment was not forwarded" },
+			});
+			return;
+		}
 		send({
 			jsonrpc: "2.0",
 			id: message.id,

--- a/extensions/pi-lsp/test/lsp-client.test.ts
+++ b/extensions/pi-lsp/test/lsp-client.test.ts
@@ -10,6 +10,21 @@ import type { LspServerAdapter } from "../src/types.js";
 
 const fixture = path.resolve("extensions/pi-lsp/test/fixtures/diagnostics-server.mjs");
 
+test("server environment overrides are forwarded to the LSP process", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-server-environment-"));
+	const adapter = fixtureAdapter("require-environment", 30);
+	adapter.env = { PI_LSP_TEST_ENV: "forwarded" };
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("pull diagnostics omit optional params when no values are available", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-pull-strict-optional-params-"));
 	const file = path.join(root, "main.go");
@@ -261,7 +276,6 @@ function fixtureAdapter(
 			command: process.execPath,
 			args: [fixture, scenario, ...(expectedFiles === undefined ? [] : [String(expectedFiles)])],
 		},
-		commandEnvVar: `PI_LSP_FIXTURE_${scenario.toUpperCase().replaceAll("-", "_")}_COMMAND`,
 		missingCommandHint: "Node is required for the test fixture.",
 		extensions: [".go"],
 		skipDirectories: new Set(),

--- a/extensions/pi-lsp/test/lsp.test.ts
+++ b/extensions/pi-lsp/test/lsp.test.ts
@@ -24,11 +24,9 @@ import {
 } from "../src/adapters.js";
 import {
 	commandExists,
-	commandFromEnv,
 	commandPathValue,
 	mergeEnvironment,
 	resolveCommandPath,
-	splitCommand,
 } from "../src/command.js";
 import { collectSupportedFiles, directoryUri, resolveSupportedFile } from "../src/files.js";
 import { resolveSpawnCommand } from "../src/lsp-client.js";
@@ -105,9 +103,7 @@ test("default catalog routes common languages and skips generated trees", () => 
 	writeFileSync(path.join(project, "target", "generated.rs"), "fn generated() {}\n");
 	writeFileSync(path.join(project, "vendor", "dependency.go"), "package dependency\n");
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	const previousConfig = process.env.PI_LSP_CONFIG;
 	process.env.PI_CODING_AGENT_DIR = agentDir;
-	delete process.env.PI_LSP_CONFIG;
 
 	try {
 		const { adapters } = loadRuntime(project);
@@ -365,13 +361,11 @@ test("default catalog routes common languages and skips generated trees", () => 
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		if (previousConfig === undefined) delete process.env.PI_LSP_CONFIG;
-		else process.env.PI_LSP_CONFIG = previousConfig;
 		rmSync(root, { recursive: true, force: true });
 	}
 });
 
-test("command helpers split shell-like strings and honor environment overrides", () => {
+test("command helpers honor server environments and platform wrappers", () => {
 	const windowsBin = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-windows-bin-"));
 	const commandShim = path.join(windowsBin, "language-server.cmd");
 	writeFileSync(commandShim, "@echo off\r\n");
@@ -400,22 +394,6 @@ test("command helpers split shell-like strings and honor environment overrides",
 		command: "language_server.sh",
 		args: [],
 	});
-	assert.deepEqual(splitCommand("cmd --flag 'two words' a\\ b"), [
-		"cmd",
-		"--flag",
-		"two words",
-		"a b",
-	]);
-	process.env.PI_TEST_LSP_COMMAND = "custom --stdio";
-	try {
-		assert.deepEqual(commandFromEnv("PI_TEST_LSP_COMMAND", { command: "fallback", args: [] }), {
-			command: "custom",
-			args: ["--stdio"],
-		});
-	} finally {
-		delete process.env.PI_TEST_LSP_COMMAND;
-	}
-
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-command-"));
 	const executable = path.join(root, "tool");
 	writeFileSync(executable, "#!/bin/sh\nexit 0\n");
@@ -442,6 +420,7 @@ test("LSP config uses canonical paths while preserving project legacy files", ()
 	mkdirSync(path.join(project, ".pi"), { recursive: true });
 	mkdirSync(agentDir, { recursive: true });
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousConfig = process.env.PI_LSP_CONFIG;
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	const config = (name: string) => ({
 		servers: { [name]: { command: [name], extensions: [`.${name}`] } },
@@ -478,10 +457,11 @@ test("LSP config uses canonical paths while preserving project legacy files", ()
 		assert.equal(existsSync(userLegacy), true);
 
 		process.env.PI_LSP_CONFIG = JSON.stringify(config("explicit"));
-		assert.equal(loadTrustedConfig().servers[0]?.name, "explicit");
-		assert.equal(consumeLspConfigNotice(), undefined);
+		assert.equal(loadTrustedConfig().servers[0]?.name, "fallback");
+		assert.match(consumeLspConfigNotice() ?? "", /using legacy lsp\.json/i);
 	} finally {
-		delete process.env.PI_LSP_CONFIG;
+		if (previousConfig === undefined) delete process.env.PI_LSP_CONFIG;
+		else process.env.PI_LSP_CONFIG = previousConfig;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { recursive: true, force: true });
@@ -553,6 +533,7 @@ test("LSP project config requires trust across loaders and command handlers", as
 	mkdirSync(path.join(project, ".pi"), { recursive: true });
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	const previousConfig = process.env.PI_LSP_CONFIG;
+	const previousUserCommand = process.env.PI_USER_LSP_COMMAND;
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	delete process.env.PI_LSP_CONFIG;
 	const config = (name: string) => ({
@@ -569,14 +550,17 @@ test("LSP project config requires trust across loaders and command handlers", as
 		assert.equal(loadConfig(project, { projectTrusted: false }).servers[0]?.name, "user");
 
 		process.env.PI_LSP_CONFIG = JSON.stringify(config("explicit"));
-		assert.equal(loadConfig(project, { projectTrusted: false }).servers[0]?.name, "explicit");
+		assert.equal(loadConfig(project, { projectTrusted: false }).servers[0]?.name, "user");
+		assert.equal(loadConfig(project, { projectTrusted: true }).servers[0]?.name, "legacy-project");
 		delete process.env.PI_LSP_CONFIG;
+		process.env.PI_USER_LSP_COMMAND = "overridden-user --stdio";
 
 		const mock = createMockPi();
 		lsp(mock.pi);
 		const context = createMockContext({ cwd: project, isProjectTrusted: () => false });
 		await mock.commands.get("lsp")?.handler("", context.ctx);
-		assert.match(context.notifications.at(-1)?.message ?? "", /user LSP command/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /user LSP command: user/u);
+		assert.doesNotMatch(context.notifications.at(-1)?.message ?? "", /overridden-user/u);
 		assert.doesNotMatch(context.notifications.at(-1)?.message ?? "", /legacy-project/u);
 
 		const diagnostics = mock.tools.find((tool) => tool.name === "lsp_diagnostics");
@@ -589,6 +573,8 @@ test("LSP project config requires trust across loaders and command handlers", as
 	} finally {
 		delete process.env.PI_LSP_CONFIG;
 		if (previousConfig !== undefined) process.env.PI_LSP_CONFIG = previousConfig;
+		if (previousUserCommand === undefined) delete process.env.PI_USER_LSP_COMMAND;
+		else process.env.PI_USER_LSP_COMMAND = previousUserCommand;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { recursive: true, force: true });
@@ -605,15 +591,17 @@ test("LSP config applies safe server-specific skip directories", () => {
 	writeFileSync(path.join(project, "src", "main.foo"), "source\n");
 	writeFileSync(path.join(project, "generated", "output.foo"), "generated\n");
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	const previousConfig = process.env.PI_LSP_CONFIG;
+	const userConfig = path.join(agentDir, "pi-lsp.json");
+	const writeConfig = (config: unknown) => writeFileSync(userConfig, JSON.stringify(config));
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 
 	try {
-		process.env.PI_LSP_CONFIG = JSON.stringify({
+		writeConfig({
 			servers: {
 				custom: {
 					command: ["custom-lsp"],
 					extensions: [".foo"],
+					env: { LSP_LOG: "debug", PATH: path.join(project, "lsp-bin") },
 					skipDirectories: ["generated"],
 					diagnosticsSettleMs: 250,
 					pushDiagnosticsGraceMs: 375,
@@ -627,6 +615,10 @@ test("LSP config applies safe server-specific skip directories", () => {
 		assert.equal(adapter.diagnosticsSettleMs, 250);
 		assert.equal(adapter.pushDiagnosticsGraceMs, 375);
 		assert.equal(adapter.pullDiagnosticsGraceMs, 500);
+		assert.deepEqual(adapter.env, {
+			LSP_LOG: "debug",
+			PATH: path.join(project, "lsp-bin"),
+		});
 		assert.deepEqual(collectSupportedFiles(adapter, project, undefined, 50), [
 			path.join(project, "src", "main.foo"),
 		]);
@@ -634,7 +626,7 @@ test("LSP config applies safe server-specific skip directories", () => {
 			path.join(project, "generated", "output.foo"),
 		]);
 
-		process.env.PI_LSP_CONFIG = JSON.stringify({
+		writeConfig({
 			servers: {
 				custom: {
 					command: ["custom-lsp"],
@@ -645,7 +637,7 @@ test("LSP config applies safe server-specific skip directories", () => {
 		});
 		assert.throws(() => loadConfig(project), /skipDirectories.*directory names/);
 
-		process.env.PI_LSP_CONFIG = JSON.stringify({
+		writeConfig({
 			servers: {
 				custom: {
 					command: ["custom-lsp"],
@@ -656,7 +648,7 @@ test("LSP config applies safe server-specific skip directories", () => {
 		});
 		assert.throws(() => loadConfig(project), /diagnosticsSettleMs.*positive number/);
 
-		process.env.PI_LSP_CONFIG = JSON.stringify({
+		writeConfig({
 			servers: {
 				custom: {
 					command: ["custom-lsp"],
@@ -669,8 +661,6 @@ test("LSP config applies safe server-specific skip directories", () => {
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		if (previousConfig === undefined) delete process.env.PI_LSP_CONFIG;
-		else process.env.PI_LSP_CONFIG = previousConfig;
 		rmSync(root, { recursive: true, force: true });
 	}
 });
@@ -849,7 +839,6 @@ function testAdapter(name: string, extensions: string[]): LspServerAdapter {
 		isDefault: false,
 		extensions,
 		skipDirectories: new Set(["node_modules"]),
-		commandEnvVar: `PI_${name.toUpperCase()}_COMMAND`,
 		defaultCommand: { command: name, args: [] },
 		missingCommandHint: `install ${name}`,
 		languageIdFor() {


### PR DESCRIPTION
## Summary

- remove `PI_LSP_CONFIG` and generated `PI_<SERVER>_LSP_COMMAND` configuration paths so pi-lsp reads only trusted project/user JSON files or its built-in catalog
- execute configured argv arrays directly and remove shell-string parsing, adapter environment metadata, and obsolete command hints
- preserve `servers[].env`, including child-process forwarding and effective-`PATH` command resolution, with regression coverage and migration documentation

## Breaking change

Users must move `PI_LSP_CONFIG` values into `~/.pi/agent/pi-lsp.json` or a trusted project's `.pi/pi-lsp.json`. Per-server command variables must become `servers.<name>.command` argv arrays.

## Verification

- focused pi-lsp suites: 24 tests passed
- `npm --workspace @narumitw/pi-lsp run check`
- explicit file-config SDK smoke with both removed variables set to invalid overrides
- `just pack-lsp` dry run: 13 expected package files
- post-rebase `npm run check` in a normal clone: 2,026 tests passed

Windows runtime execution was not available on this Linux host; deterministic Windows PATH and batch-wrapper tests pass.
