### PR TITLE
feat(pi-starship)!: add native GitHub PR module

### DIFF
--- a/docs/plans/2026-08-01_pi-starship-native-github-pr-plan.md
+++ b/docs/plans/2026-08-01_pi-starship-native-github-pr-plan.md
@@ -1,0 +1,136 @@
+# pi-starship native GitHub PR plan
+
+## Goal
+
+Remove pi-starship's runtime integration with the `github-pr` extension status and add an independent
+native `$github_pr` module. This is an explicitly approved breaking change: do not retain a
+`$git_branch.$pr` compatibility alias or perform automatic migration.
+
+## Architecture
+
+- Root module: `$github_pr`.
+- Settings table: `[github_pr]`.
+- Data source: `gh pr view` for the current branch, using GitHub CLI authentication and repository
+  host resolution, including GitHub Enterprise Server.
+- `github_pr` owns querying, parsing, caching, and presentation. `git_branch` owns only local Git
+  branch/upstream data.
+- Query only in TUI sessions when `github_pr` is reachable and enabled.
+- Keep `render()` pure: it reads a cached immutable snapshot and performs no subprocess, network,
+  filesystem, timer, or environment work.
+
+Default configuration shape:
+
+```toml
+format = "$directory$git_branch$github_pr$git_status"
+
+[git_branch]
+format = "[ $symbol $branch ]($style)"
+
+[github_pr]
+format = "[ $symbol$link( · $status) ]($style)"
+symbol = "PR "
+style = "fg:git_fg bg:git"
+disabled = false
+```
+
+Variable contract:
+
+- `$number`: plain digits, for example `123`.
+- `$link`: terminal-safe OSC 8 `#123` link, falling back to plain text when the URL is invalid.
+- `$state`: `open`, `draft`, `merged`, or `closed`.
+- `$checks`: `checks passing`, `<n> failing`, `<n> pending`, or `no checks`.
+- `$review`: `approved`, `changes requested`, `review required`, or empty when unknown.
+- `$status`: the compact priority-selected summary: merged → closed → draft → failing → changes
+  requested → pending → approved → review required → passing → no checks.
+
+Lifecycle contract:
+
+- Refresh at session start, after branch changes, after agent runs, after accepted settings changes,
+  and every 60 seconds while reachable.
+- Clear stale PR state immediately on branch change, then query the new branch.
+- Cancel or release every owned request and timer on module disable, footer disposal, session
+  replacement, reload, and shutdown.
+- Suppress stale publication with request and session-generation ownership checks after every await.
+- Missing `gh`, missing authentication, no current PR, timeout, malformed output, and network failure
+  degrade to an empty module without exposing raw errors or credentials.
+- Closed or merged pull requests remain visible for 24 hours, matching the current user-facing
+  behavior.
+
+## Non-Goals
+
+- Do not modify, deprecate, or remove `extensions/pi-github-pr`.
+- Do not provide a `$git_branch.$pr` compatibility alias or automatic migration.
+- Do not call the GitHub API directly or manage GitHub tokens.
+- Do not read comments, review bodies, inline comments, or review-thread content.
+- Do not add package dependencies solely for this feature.
+- Do not bump versions, publish packages, or create a release.
+
+## Plan
+
+- [ ] Add failing behavior tests under `extensions/pi-starship/test/` for the `$github_pr` module
+  variables, status priority, terminal-state expiry, OSC 8 safety, GitHub Enterprise URLs, no-PR and
+  failure degradation, and the removal of `$git_branch.$pr`; verify the intended red state with
+  `npm test`.
+- [ ] Add a native PR snapshot type plus `extensions/pi-starship/src/modules/github-pr.ts`, register
+  `github_pr` immediately after `git_branch`, and update the built-in root/default module formats;
+  verify module and configuration behavior with the focused Starship tests.
+- [ ] Remove `$pr` and `prContextFromStatuses()` from
+  `extensions/pi-starship/src/modules/git/branch.ts`; rely on the existing generic unknown-variable
+  diagnostic for old `$pr` settings and add a regression assertion proving no compatibility alias is
+  retained.
+- [ ] Add `extensions/pi-starship/src/runtime/github-pr.ts` to execute a cancellable, 10-second
+  `gh pr view --json number,isDraft,url,state,closedAt,mergedAt,reviewDecision,statusCheckRollup`,
+  infer the repository host without mutating process environment, validate bounded JSON fields, and
+  build the immutable native snapshot; verify with mocked argv/result tests for POSIX, Windows,
+  GitHub Enterprise, malformed output, missing `gh`, missing auth, and no PR.
+- [ ] Integrate a PR refresh controller into `extensions/pi-starship/src/pi-starship.ts` for initial,
+  branch-change, agent-end, settings-apply, and 60-second refreshes; verify immediate stale clearing,
+  coalescing, cancellation, session replacement, footer disposal, shutdown, non-TUI behavior, and
+  unreachable/disabled no-exec behavior in lifecycle tests.
+- [ ] Extend `extensions/pi-starship/src/runtime/refresh-controller.ts` with AbortSignal-aware
+  cancellation for started/stopped generations without weakening latest-request coalescing; verify
+  abort and stale-publication behavior in controller tests.
+- [ ] Remove `consumedExtensionStatusKeys`, `hiddenExtensionStatusKeys`, the renderer's `github-pr`
+  suppression, and the built-in `github-pr` icon mapping so `extension_status` treats every external
+  status generically; verify an independently supplied `github-pr` status remains visible rather than
+  being consumed.
+- [ ] Update `extensions/pi-starship/README.md` with the `$github_pr` module, variables and TOML
+  example; document `gh auth login`, GitHub Enterprise setup, network/privacy/refresh behavior, the
+  accepted breaking migration, and that `pi-github-pr` is no longer required. Remove documentation
+  that claims `$git_branch.$pr` consumes an extension status.
+- [ ] Audit the final diff against `docs/extension-conventions.md` and
+  `docs/extension-settings.md`, covering module/settings ownership, package independence, subprocess
+  trust boundaries, cancellation, footer disposal, session replacement, shutdown, and post-await
+  generation checks; record any accepted deviation in the handoff.
+- [ ] Run `npm test`, `npm run check --workspace @narumitw/pi-starship`, `npm run check`, and
+  `just pack-starship`; inspect the dry-run tarball for the new runtime/module source and no unintended
+  files.
+- [ ] After every item and completion check has evidence, move this plan to
+  `docs/plans/archived/2026-08-01_pi-starship-native-github-pr-plan.md` without overwriting an existing
+  archive and report the archived path.
+
+## Risks
+
+- The default `$github_pr` module introduces an external `gh` network query. Reachability gating,
+  cached refresh, timeout, coalescing, and cancellation bound the cost.
+- If `pi-github-pr` remains installed, its independent status may also appear under
+  `$extension_status`. Do not add special suppression; document that users should disable or remove
+  it when adopting the native module.
+- Existing TOML containing `$git_branch.$pr` stops rendering PR data. This breaking change is
+  explicitly accepted and must be documented clearly.
+- GitHub CLI output and URLs cross a terminal-display boundary. Strict schema checks, HTTP(S)-only
+  OSC 8 links, control-character stripping, and bounded parsing prevent terminal injection.
+
+## Completion Checklist
+
+- [ ] No pi-starship production path reads, parses, consumes, hides, or otherwise coordinates the
+  `github-pr` extension status.
+- [ ] `git_branch` no longer exposes `$pr`, and no compatibility alias or migration remains.
+- [ ] `$github_pr` displays the current branch PR without installing `pi-github-pr`.
+- [ ] `$github_pr` exposes the documented variables and preserves compact checks/review semantics.
+- [ ] Unreachable, disabled, and non-TUI paths execute no `gh` command.
+- [ ] Branch, settings, footer, replacement, reload, and shutdown paths cancel owned work and reject
+  stale publication.
+- [ ] README behavior, prerequisites, privacy, failures, and breaking migration match implementation.
+- [ ] Focused tests, root tests, package check, CI-equivalent check, and package dry-run all pass.
+- [ ] The completed plan is archived with verification evidence and no open checklist items.

--- a/docs/plans/archived/2026-08-01_pi-starship-native-github-pr-plan.md
+++ b/docs/plans/archived/2026-08-01_pi-starship-native-github-pr-plan.md
@@ -67,47 +67,55 @@ Lifecycle contract:
 
 ## Plan
 
-- [ ] Add failing behavior tests under `extensions/pi-starship/test/` for the `$github_pr` module
+- [x] Add failing behavior tests under `extensions/pi-starship/test/` for the `$github_pr` module
   variables, status priority, terminal-state expiry, OSC 8 safety, GitHub Enterprise URLs, no-PR and
   failure degradation, and the removal of `$git_branch.$pr`; verify the intended red state with
-  `npm test`.
-- [ ] Add a native PR snapshot type plus `extensions/pi-starship/src/modules/github-pr.ts`, register
+  `npm test`. Red evidence: TypeScript failed on the intentionally absent `github_pr` module/runtime,
+  snapshot property, and AbortSignal-aware controller contract.
+- [x] Add a native PR snapshot type plus `extensions/pi-starship/src/modules/github-pr.ts`, register
   `github_pr` immediately after `git_branch`, and update the built-in root/default module formats;
-  verify module and configuration behavior with the focused Starship tests.
-- [ ] Remove `$pr` and `prContextFromStatuses()` from
+  verify module and configuration behavior with the focused Starship tests. Evidence: focused config,
+  module, and GitHub PR tests pass.
+- [x] Remove `$pr` and `prContextFromStatuses()` from
   `extensions/pi-starship/src/modules/git/branch.ts`; rely on the existing generic unknown-variable
   diagnostic for old `$pr` settings and add a regression assertion proving no compatibility alias is
-  retained.
-- [ ] Add `extensions/pi-starship/src/runtime/github-pr.ts` to execute a cancellable, 10-second
+  retained. Evidence: focused config and module regressions pass.
+- [x] Add `extensions/pi-starship/src/runtime/github-pr.ts` to execute a cancellable, 10-second
   `gh pr view --json number,isDraft,url,state,closedAt,mergedAt,reviewDecision,statusCheckRollup`,
   infer the repository host without mutating process environment, validate bounded JSON fields, and
   build the immutable native snapshot; verify with mocked argv/result tests for POSIX, Windows,
-  GitHub Enterprise, malformed output, missing `gh`, missing auth, and no PR.
-- [ ] Integrate a PR refresh controller into `extensions/pi-starship/src/pi-starship.ts` for initial,
+  GitHub Enterprise, malformed output, missing `gh`, missing auth, and no PR. Evidence:
+  `github-pr.test.ts` passes all runtime cases.
+- [x] Integrate a PR refresh controller into `extensions/pi-starship/src/pi-starship.ts` for initial,
   branch-change, agent-end, settings-apply, and 60-second refreshes; verify immediate stale clearing,
   coalescing, cancellation, session replacement, footer disposal, shutdown, non-TUI behavior, and
-  unreachable/disabled no-exec behavior in lifecycle tests.
-- [ ] Extend `extensions/pi-starship/src/runtime/refresh-controller.ts` with AbortSignal-aware
+  unreachable/disabled no-exec behavior in lifecycle tests. Evidence: focused lifecycle tests pass.
+- [x] Extend `extensions/pi-starship/src/runtime/refresh-controller.ts` with AbortSignal-aware
   cancellation for started/stopped generations without weakening latest-request coalescing; verify
-  abort and stale-publication behavior in controller tests.
-- [ ] Remove `consumedExtensionStatusKeys`, `hiddenExtensionStatusKeys`, the renderer's `github-pr`
+  abort and stale-publication behavior in controller tests. Evidence: focused refresh-controller tests
+  pass.
+- [x] Remove `consumedExtensionStatusKeys`, `hiddenExtensionStatusKeys`, the renderer's `github-pr`
   suppression, and the built-in `github-pr` icon mapping so `extension_status` treats every external
   status generically; verify an independently supplied `github-pr` status remains visible rather than
-  being consumed.
-- [ ] Update `extensions/pi-starship/README.md` with the `$github_pr` module, variables and TOML
+  being consumed. Evidence: focused module tests render the independent status with generic policy.
+- [x] Update `extensions/pi-starship/README.md` with the `$github_pr` module, variables and TOML
   example; document `gh auth login`, GitHub Enterprise setup, network/privacy/refresh behavior, the
   accepted breaking migration, and that `pi-github-pr` is no longer required. Remove documentation
   that claims `$git_branch.$pr` consumes an extension status.
-- [ ] Audit the final diff against `docs/extension-conventions.md` and
+- [x] Audit the final diff against `docs/extension-conventions.md` and
   `docs/extension-settings.md`, covering module/settings ownership, package independence, subprocess
   trust boundaries, cancellation, footer disposal, session replacement, shutdown, and post-await
-  generation checks; record any accepted deviation in the handoff.
-- [ ] Run `npm test`, `npm run check --workspace @narumitw/pi-starship`, `npm run check`, and
+  generation checks; record any accepted deviation in the handoff. Evidence: manual audit plus final
+  independent reviewer PASS. Accepted limitation: already-started bounded local filesystem operations
+  may finish, but cancellation checks and generation ownership prevent stale publication.
+- [x] Run `npm test`, `npm run check --workspace @narumitw/pi-starship`, `npm run check`, and
   `just pack-starship`; inspect the dry-run tarball for the new runtime/module source and no unintended
-  files.
-- [ ] After every item and completion check has evidence, move this plan to
+  files. Evidence: package check passed; `npm test` and final `npm run check` each passed 2,044 tests;
+  the 58-file dry run includes `src/modules/github-pr.ts` and `src/runtime/github-pr.ts`.
+- [x] After every item and completion check has evidence, move this plan to
   `docs/plans/archived/2026-08-01_pi-starship-native-github-pr-plan.md` without overwriting an existing
-  archive and report the archived path.
+  archive and report the archived path. Evidence: the target was verified absent and this completed
+  plan now resides at that path.
 
 ## Risks
 
@@ -123,14 +131,14 @@ Lifecycle contract:
 
 ## Completion Checklist
 
-- [ ] No pi-starship production path reads, parses, consumes, hides, or otherwise coordinates the
+- [x] No pi-starship production path reads, parses, consumes, hides, or otherwise coordinates the
   `github-pr` extension status.
-- [ ] `git_branch` no longer exposes `$pr`, and no compatibility alias or migration remains.
-- [ ] `$github_pr` displays the current branch PR without installing `pi-github-pr`.
-- [ ] `$github_pr` exposes the documented variables and preserves compact checks/review semantics.
-- [ ] Unreachable, disabled, and non-TUI paths execute no `gh` command.
-- [ ] Branch, settings, footer, replacement, reload, and shutdown paths cancel owned work and reject
+- [x] `git_branch` no longer exposes `$pr`, and no compatibility alias or migration remains.
+- [x] `$github_pr` displays the current branch PR without installing `pi-github-pr`.
+- [x] `$github_pr` exposes the documented variables and preserves compact checks/review semantics.
+- [x] Unreachable, disabled, and non-TUI paths execute no `gh` command.
+- [x] Branch, settings, footer, replacement, reload, and shutdown paths cancel owned work and reject
   stale publication.
-- [ ] README behavior, prerequisites, privacy, failures, and breaking migration match implementation.
-- [ ] Focused tests, root tests, package check, CI-equivalent check, and package dry-run all pass.
-- [ ] The completed plan is archived with verification evidence and no open checklist items.
+- [x] README behavior, prerequisites, privacy, failures, and breaking migration match implementation.
+- [x] Focused tests, root tests, package check, CI-equivalent check, and package dry-run all pass.
+- [x] The completed plan is archived with verification evidence and no open checklist items.

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -12,6 +12,7 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 - Starship-style root/module formats, conditional groups, `$all`, styles, and palettes.
 - Pi modules for model, thinking, activity, context, tokens, prompt cache, cost, turn, and extension statuses.
 - Cached Git branch, commit, operation state, line metrics, detailed status, and linked-worktree identity.
+- Native current-branch GitHub pull request links, checks, review state, and terminal-state retention.
 - Opt-in package, language, development-shell, deployment, cloud, and execution-context modules.
 - Width-aware `$fill` alignment for native multiline left/right layouts.
 - Footer rendering is pure: no subprocess, network, filesystem, timer, or environment work runs from `render()`.
@@ -50,7 +51,7 @@ Open the interactive menu in TUI mode:
 /starship
 ```
 
-Choose **Customize footer** to edit the TOML. Closing the editor validates the draft and opens a width-aware preview; saving happens only after a separate confirmation. Confirmed changes are atomically saved and applied immediately. Editor cancellation, preview cancellation, invalid drafts, write failures, and runtime application failures preserve the previous file and effective footer.
+Choose **Customize footer** to edit the TOML. Closing the editor validates the draft and opens a width-aware preview; saving happens only after a separate confirmation. Confirmed changes are atomically saved and applied immediately. Manual TOML edits load on the next `session_start`, including `/reload` and session replacement. Editor cancellation, preview cancellation, invalid drafts, write failures, and runtime application failures preserve the previous file and effective footer.
 
 The standard **Advanced** menu is one level deep and contains configuration details plus **Restore
 built-in**. Standard diagnostics, details, and help are Back-navigable detail screens. Restore still
@@ -59,7 +60,7 @@ shows the specialized width-aware preview and requires explicit overwrite confir
 ### 📝 Example
 
 ```toml
-format = "$brand$provider$model$thinking\n$directory$git_branch$git_status\n$activity$context$tokens$cache$cost$time$turn\n$extension_status"
+format = "$brand$provider$model$thinking\n$directory$git_branch$github_pr$git_status\n$activity$context$tokens$cache$cost$time$turn\n$extension_status"
 palette = "tokyo-night"
 
 [palettes.tokyo-night]
@@ -91,7 +92,13 @@ disabled = false
 format = "[ $symbol \\$$cost( $subscription) ]($style)"
 
 [git_branch]
-format = "[ $symbol$branch$pr ]($style)"
+format = "[ $symbol $branch ]($style)"
+
+[github_pr]
+format = "[ $symbol$link( · $status) ]($style)"
+symbol = "PR "
+style = "fg:git_fg bg:git"
+disabled = false
 
 [package]
 version_format = "v$raw"
@@ -107,7 +114,7 @@ aliases = { "build.example.test" = "builder" }
 
 [extension_status]
 format = "([$statuses ]($style))"
-icons = { "github-pr" = "PR", "foo:*" = "🧪", "@narumitw/pi-goal" = "◎", fallback = "•" }
+icons = { "foo:*" = "🧪", "@narumitw/pi-goal" = "◎", fallback = "•" }
 ```
 
 All module tables support `format`, `symbol`, `style`, and `disabled`. Module-specific
@@ -162,7 +169,8 @@ An invalid root format falls back to the built-in root format. An invalid module
 | `thinking` | `$symbol`, `$level` | Thinking level |
 | `directory` | `$symbol`, `$path`, `$full_path` | Current working directory |
 | `git_worktree` | `$symbol`, `$name`, `$path` | Linked worktree name and top-level path |
-| `git_branch` | `$symbol`, `$branch`, `$remote_name`, `$remote_branch`, `$pr` | Branch, upstream, and actionable PR state |
+| `git_branch` | `$symbol`, `$branch`, `$remote_name`, `$remote_branch` | Local branch and upstream |
+| `github_pr` | `$symbol`, `$number`, `$link`, `$state`, `$checks`, `$review`, `$status` | Current-branch GitHub pull request |
 | `git_commit` | `$symbol`, `$hash`, `$tag` | Seven-character HEAD hash and optional exact tag |
 | `git_state` | `$symbol`, `$state`, `$progress_current`, `$progress_total` | Rebase, merge, revert, cherry-pick, bisect, or mail-apply state |
 | `git_metrics` | `$symbol`, `$added`, `$deleted` | Added/deleted line totals from the working tree diff |
@@ -248,7 +256,54 @@ truncation-direction setting.
 
 `git_commit`, `git_state`, and `git_metrics` are intentionally not present in the built-in root format. Add their variables to `format` to opt in; also set `[git_metrics].disabled = false`, matching Starship's opt-in metrics default. `$tag` resolves only an exact tag on HEAD and is queried only when the configured `git_commit` format references it.
 
-If `$git_branch.$pr` is present in the module format, its selected PR token is removed from `extension_status` to avoid duplication.
+### 🔎 Native GitHub pull requests
+
+`$github_pr` is independent of `pi-github-pr`; installing that extension is not required. It runs one
+bounded GitHub CLI query for the current branch:
+
+```text
+gh pr view --json number,isDraft,url,state,closedAt,mergedAt,reviewDecision,statusCheckRollup
+```
+
+Install and authenticate `gh` first:
+
+```bash
+gh auth login
+```
+
+For GitHub Enterprise Server, authenticate the repository host and keep that host in the repository
+remote, for example `gh auth login --hostname github.example.com`. pi-starship starts `gh` directly
+with child-only environment data that omits ambient `GH_HOST` and `GH_REPO` overrides, so `gh` resolves
+the correct repository and host from the current checkout. It never mutates Pi's environment, calls
+the GitHub API directly, or manages tokens.
+
+Variables have these values:
+
+- `$number`: digits such as `123`.
+- `$link`: an OSC 8 `#123` link for a safe HTTP(S) URL, otherwise plain `#123`.
+- `$state`: `open`, `draft`, `merged`, or `closed`.
+- `$checks`: `checks passing`, `<n> failing`, `<n> pending`, or `no checks`.
+- `$review`: `approved`, `changes requested`, `review required`, or empty when unknown.
+- `$status`: one compact result selected in this order: merged, closed, draft, failing, changes
+  requested, pending, approved, review required, passing, then no checks.
+
+The query runs only in TUI sessions when the enabled module is reachable from the root format. It
+refreshes at session start, immediately after a branch change, after each agent run, after accepted
+settings changes, and every 60 seconds. Each query has a 10-second timeout. Branch changes clear the
+old PR before querying the new branch. Closed and merged PRs remain visible for 24 hours, then expire
+without waiting for the next refresh. Missing `gh`, missing authentication, no current PR, timeout,
+malformed or oversized output, and network failures all render an empty module without exposing raw
+errors or credentials.
+
+The query sends the repository/current-branch context through authenticated `gh` to the GitHub host
+configured by the repository. It requests only the fields above—never comments, review bodies,
+inline comments, or review threads. Footer rendering and previews read only the immutable cached
+snapshot and perform no network or subprocess work.
+
+**Breaking migration:** `$git_branch.$pr` has been removed without a compatibility alias or automatic
+migration. Replace it with root `$github_pr` and an optional `[github_pr]` table. If `pi-github-pr`
+remains installed, its independent `github-pr` status can also appear under `$extension_status`;
+disable or remove that extension when adopting the native module to avoid duplicate information.
 
 ### 📦 Package and language modules
 
@@ -346,19 +401,22 @@ whole-catalog layout is intended. There is no `line_break` module; use literal n
 
 ### 🔄 Cached refresh lifecycle
 
-Workspace and Git readers start only in TUI sessions and only for reachable enabled modules. Root
-format reachability, `$all`, module `disabled`, and module-format variables determine file and command
-requirements. Refreshes run at session start, after accepted settings, branch changes, tool/turn
-completion, and a 30-second fallback. One read runs with at most one latest pending refresh; immutable
-snapshot equality suppresses redraws, and session/config generations reject stale results. Shutdown,
-replacement, and footer disposal stop timers, clear pending work, and prevent late publication.
-Execution identity is retained rather than re-read by the periodic fallback. Render and live preview
-consume snapshots synchronously and perform zero reads or commands.
+Workspace, Git, and GitHub PR readers start only in TUI sessions and only for reachable enabled
+modules. Root format reachability, `$all`, module `disabled`, and module-format variables determine
+file and command requirements. Workspace/Git refreshes run at session start, after accepted settings,
+branch changes, tool/turn completion, and a 30-second fallback. GitHub PR uses the narrower lifecycle
+and 60-second network refresh described above. One read runs with at most one latest pending refresh;
+immutable snapshot equality suppresses redraws, and session/request generations reject stale results.
+Shutdown, replacement, footer disposal, branch changes, and accepted settings abort active command
+work before starting replacements; disabling `github_pr` also stops its query and timers. Bounded local
+filesystem operations may finish, but stale generations cannot publish them. Execution identity is
+retained rather than re-read by the periodic fallback. Render and live preview consume snapshots
+synchronously and perform zero reads or commands.
 
 Missing, unreadable, malformed, oversized, timed-out, or unavailable sources fail to empty values.
-Readers cap direct files at 64 KiB, use one bounded current-directory listing, never recurse, and make
-no network calls. Package's explicitly documented Cargo lookup is the only ancestor walk and is capped
-at eight parents.
+Workspace/Git readers cap direct files at 64 KiB, use one bounded current-directory listing, never
+recurse, and make no network calls. The native GitHub PR query is the documented network exception.
+Package's explicitly documented Cargo lookup is the only ancestor walk and is capped at eight parents.
 
 ## 💬 Commands
 
@@ -393,7 +451,7 @@ modules until separately approved semantics exist.
 
 Create `src/modules/<name>.ts` with its format variables, defaults, and runtime value resolver, then register it in display order in `src/modules/catalog.ts`. Configuration names, validation variables, defaults, and `$all` ordering are derived from that catalog. Add the module to the built-in root format when it should be visible by default, then document and test its user-facing values.
 
-Keep `extension_status` last in the catalog so earlier modules can consume extension-owned status values without rendering duplicates.
+Keep `extension_status` last in the catalog so arbitrary third-party statuses follow native module output.
 
 ## 🗂️ Package layout
 
@@ -404,13 +462,15 @@ Keep `extension_status` last in the catalog so earlier modules can consume exten
 - `src/config.ts` — TOML loading, draft validation, defaults, atomic persistence, and rollback.
 - `src/format/` — native format/style parser and renderer.
 - `src/modules/` — domain module definitions, ordered registry, reachability, and width-aware renderer.
-- `src/modules/git/` — bounded Git reader plus branch, status, and worktree modules.
+- `src/modules/git/` — bounded local Git reader plus branch, status, and worktree modules.
+- `src/modules/github-pr.ts` — pure native GitHub PR snapshot presentation.
+- `src/runtime/github-pr.ts` — bounded `gh` query, validation, terminal-safe links, and expiry data.
 - `src/runtime/` — shared refresh controller and bounded package/language/context collectors.
 
 ## 🔎 Keywords
 
-Pi Coding Agent, Starship statusline, Starship TOML, terminal footer, native statusline, prompt cache,
-cache hit rate, Pi extension
+Pi Coding Agent, Starship statusline, Starship TOML, terminal footer, native statusline, GitHub pull
+request, prompt cache, cache hit rate, Pi extension
 
 ## 📄 License
 

--- a/extensions/pi-starship/src/commands.ts
+++ b/extensions/pi-starship/src/commands.ts
@@ -60,6 +60,11 @@ interface MenuItem extends SelectItem {
 	value: string;
 }
 
+interface WorkflowOwner {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
 export function registerStarshipCommand(pi: ExtensionAPI, options: StarshipCommandOptions) {
 	pi.registerCommand("starship", {
 		description: "Customize or inspect the native Starship-style footer",
@@ -236,6 +241,8 @@ async function editSettings(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
 ): Promise<boolean> {
+	const owner = workflowOwner(options);
+	if (!isCurrentOwner(owner)) return false;
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${options.settingsPath}`, "info");
 		return false;
@@ -243,7 +250,7 @@ async function editSettings(
 	let draft = options.getLoaded().rawDocument ?? BUILT_IN_EXAMPLE;
 	while (true) {
 		const edited = await ctx.ui.editor("Customize footer — close to preview", draft);
-		if (edited === undefined) return false;
+		if (!isCurrentOwner(owner) || edited === undefined) return false;
 		draft = edited;
 		let validated: LoadedStarshipConfig;
 		try {
@@ -259,11 +266,12 @@ async function editSettings(
 					{ value: PREVIEW_ACTIONS.cancel, label: "Back" },
 				],
 			);
+			if (!isCurrentOwner(owner)) return false;
 			if (action === PREVIEW_ACTIONS.edit) continue;
 			return false;
 		}
 
-		const result = await reviewAndApply(ctx, options, validated, "Footer preview", false);
+		const result = await reviewAndApply(ctx, options, validated, "Footer preview", false, owner);
 		if (result === "edit") continue;
 		return result === "applied";
 	}
@@ -273,11 +281,15 @@ async function restoreBuiltIn(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
 ): Promise<boolean> {
+	const owner = workflowOwner(options);
+	if (!isCurrentOwner(owner)) return false;
 	const validated = (options.validate ?? validateConfigDocument)(
 		options.settingsPath,
 		BUILT_IN_EXAMPLE,
 	);
-	return (await reviewAndApply(ctx, options, validated, "Restore preview", true)) === "applied";
+	return (
+		(await reviewAndApply(ctx, options, validated, "Restore preview", true, owner)) === "applied"
+	);
 }
 
 async function reviewAndApply(
@@ -286,6 +298,7 @@ async function reviewAndApply(
 	validated: LoadedStarshipConfig,
 	title: string,
 	restore: boolean,
+	owner: WorkflowOwner,
 ): Promise<"applied" | "edit" | "cancel"> {
 	while (true) {
 		const selection = await showPreviewActionMenu(
@@ -298,6 +311,7 @@ async function reviewAndApply(
 				{ value: PREVIEW_ACTIONS.cancel, label: "Cancel" },
 			],
 		);
+		if (!isCurrentOwner(owner)) return "cancel";
 		if (selection === PREVIEW_ACTIONS.edit) return "edit";
 		if (selection !== PREVIEW_ACTIONS.continue) return "cancel";
 
@@ -307,6 +321,7 @@ async function reviewAndApply(
 				? `Replace ${options.settingsPath} with the built-in configuration?`
 				: "Save this configuration and apply it immediately?",
 		);
+		if (!isCurrentOwner(owner)) return "cancel";
 		if (!confirmed) continue;
 
 		const save = options.save ?? atomicSaveConfigDocument;
@@ -347,6 +362,16 @@ async function reviewAndApply(
 		);
 		return "applied";
 	}
+}
+
+function workflowOwner(options: StarshipCommandOptions): WorkflowOwner {
+	if (options.getMenuOwner) return options.getMenuOwner();
+	const controller = new AbortController();
+	return { signal: controller.signal, isCurrent: () => true };
+}
+
+function isCurrentOwner(owner: WorkflowOwner): boolean {
+	return !owner.signal.aborted && owner.isCurrent();
 }
 
 function restorePreviousConfiguration(

--- a/extensions/pi-starship/src/config.ts
+++ b/extensions/pi-starship/src/config.ts
@@ -77,6 +77,7 @@ $directory\
 [](fg:directory bg:git)\
 $git_worktree\
 $git_branch\
+$github_pr\
 $git_status\
 [](fg:git bg:runtime)\
 $activity\

--- a/extensions/pi-starship/src/modules/catalog.ts
+++ b/extensions/pi-starship/src/modules/catalog.ts
@@ -16,6 +16,7 @@ import { gitMetricsModule } from "./git/metrics.js";
 import { gitStateModule } from "./git/state.js";
 import { gitStatusModule } from "./git/status.js";
 import { gitWorktreeModule } from "./git/worktree.js";
+import { githubPrModule } from "./github-pr.js";
 import { languageModules } from "./languages.js";
 import { modelModule } from "./model.js";
 import { packageModule } from "./package.js";
@@ -34,6 +35,7 @@ export const MODULE_DEFINITIONS = [
 	directoryModule,
 	gitWorktreeModule,
 	gitBranchModule,
+	githubPrModule,
 	gitCommitModule,
 	gitStateModule,
 	gitMetricsModule,
@@ -52,7 +54,7 @@ export const MODULE_DEFINITIONS = [
 	timeModule,
 	turnModule,
 	fillModule,
-	// Render last so earlier modules can consume extension-owned status values.
+	// Keep arbitrary third-party statuses after the native modules.
 	extensionStatusModule,
 ] as const satisfies readonly ModuleDefinition<string>[];
 

--- a/extensions/pi-starship/src/modules/extension-status.ts
+++ b/extensions/pi-starship/src/modules/extension-status.ts
@@ -6,7 +6,6 @@ const DEFAULT_EXTENSION_STATUS_ICONS: Record<string, string> = {
 	"chrome-devtools": "🌐",
 	"codex-usage": "📊",
 	firecrawl: "🔥",
-	"github-pr": "🔎",
 	goal: "🎯",
 	"google-genai": "✨",
 	lsp: "🧰",
@@ -35,11 +34,9 @@ export const extensionStatusModule = defineModule({
 		style: "fg:extension",
 		disabled: false,
 	},
-	values: ({ runtime, extensionStatus, hiddenExtensionStatusKeys }) => {
+	values: ({ runtime, extensionStatus }) => {
 		const statuses = [...runtime.extensionStatuses.entries()]
-			.filter(
-				([key, value]) => key !== "starship" && !hiddenExtensionStatusKeys.has(key) && value.trim(),
-			)
+			.filter(([key, value]) => key !== "starship" && value.trim())
 			.map(([key, value]) =>
 				formatExtensionStatus(
 					key,

--- a/extensions/pi-starship/src/modules/git/branch.ts
+++ b/extensions/pi-starship/src/modules/git/branch.ts
@@ -2,9 +2,9 @@ import { defineModule } from "../types.js";
 
 export const gitBranchModule = defineModule({
 	name: "git_branch",
-	variables: ["symbol", "branch", "remote_name", "remote_branch", "pr"],
+	variables: ["symbol", "branch", "remote_name", "remote_branch"],
 	defaults: {
-		format: "[ $symbol $branch( $pr) ]($style)",
+		format: "[ $symbol $branch ]($style)",
 		symbol: "🌿",
 		style: "fg:git_fg bg:git",
 		disabled: false,
@@ -17,40 +17,6 @@ export const gitBranchModule = defineModule({
 			branch: name,
 			remote_name: branch?.remoteName ?? "",
 			remote_branch: branch?.remoteBranch ?? "",
-			pr: prContextFromStatuses(runtime.extensionStatuses) ?? "",
 		};
 	},
 });
-
-export function prContextFromStatuses(statuses: ReadonlyMap<string, string>): string | undefined {
-	const value = statuses.get("github-pr");
-	if (!value) return undefined;
-	const link = prLink(value);
-	if (!link) return undefined;
-	const state = compactPrState(value.replace(link, ""));
-	return state ? `${link} · ${state}` : undefined;
-}
-
-function prLink(value: string): string | undefined {
-	const open = value.indexOf("\x1b]8;;");
-	if (open === -1) return undefined;
-	const closeMarker = "\x1b]8;;\x07";
-	const close = value.indexOf(closeMarker, open + 1);
-	return close === -1 ? undefined : value.slice(open, close + closeMarker.length);
-}
-
-function compactPrState(value: string): string | undefined {
-	if (/:\s*merged\s*$/u.test(value)) return "merged";
-	if (/:\s*closed\s*$/u.test(value)) return "closed";
-	if (/\bdraft\b/u.test(value)) return "draft";
-	const failing = /\bchecks failing \((\d+)\)/u.exec(value);
-	if (failing?.[1]) return `${failing[1]} failing`;
-	if (/\bchanges requested\b/u.test(value)) return "changes requested";
-	const pending = /\bchecks pending \((\d+)\)/u.exec(value);
-	if (pending?.[1]) return `${pending[1]} pending`;
-	if (/\bapproved\b/u.test(value)) return "approved";
-	if (/\breview required\b/u.test(value)) return "review required";
-	if (/\bchecks passing\b/u.test(value)) return "checks passing";
-	if (/\bno checks\b/u.test(value)) return "no checks";
-	return undefined;
-}

--- a/extensions/pi-starship/src/modules/git/runtime.ts
+++ b/extensions/pi-starship/src/modules/git/runtime.ts
@@ -16,6 +16,7 @@ const GIT_TIMEOUT_MS = 3_000;
 export interface ReadGitSnapshotOptions {
 	includeMetrics: boolean;
 	includeTag: boolean;
+	signal?: AbortSignal;
 }
 
 export async function readGitSnapshot(
@@ -33,22 +34,24 @@ export async function readGitSnapshot(
 			"--show-stash",
 			"--untracked-files=normal",
 		],
-		{ cwd, timeout: GIT_TIMEOUT_MS },
+		{ cwd, signal: options.signal, timeout: GIT_TIMEOUT_MS },
 	);
 	const metadataPromise = pi.exec(
 		"git",
 		["rev-parse", "--path-format=absolute", "--show-toplevel", "--git-common-dir", "--git-dir"],
-		{ cwd, timeout: GIT_TIMEOUT_MS },
+		{ cwd, signal: options.signal, timeout: GIT_TIMEOUT_MS },
 	);
 	const metricsPromise = options.includeMetrics
 		? pi.exec("git", ["--no-optional-locks", "diff", "--shortstat", "HEAD", "--"], {
 				cwd,
+				signal: options.signal,
 				timeout: GIT_TIMEOUT_MS,
 			})
 		: Promise.resolve(undefined);
 	const tagPromise = options.includeTag
 		? pi.exec("git", ["describe", "--tags", "--exact-match", "HEAD"], {
 				cwd,
+				signal: options.signal,
 				timeout: GIT_TIMEOUT_MS,
 			})
 		: Promise.resolve(undefined);

--- a/extensions/pi-starship/src/modules/github-pr.ts
+++ b/extensions/pi-starship/src/modules/github-pr.ts
@@ -1,0 +1,24 @@
+import { defineModule } from "./types.js";
+
+export const githubPrModule = defineModule({
+	name: "github_pr",
+	variables: ["symbol", "number", "link", "state", "checks", "review", "status"],
+	defaults: {
+		format: "[ $symbol$link( · $status) ]($style)",
+		symbol: "PR ",
+		style: "fg:git_fg bg:git",
+		disabled: false,
+	},
+	values: ({ runtime }) => {
+		const snapshot = runtime.githubPr;
+		if (!snapshot) return undefined;
+		return {
+			number: snapshot.number,
+			link: snapshot.link,
+			state: snapshot.state,
+			checks: snapshot.checks,
+			review: snapshot.review,
+			status: snapshot.status,
+		};
+	},
+});

--- a/extensions/pi-starship/src/modules/index.ts
+++ b/extensions/pi-starship/src/modules/index.ts
@@ -3,7 +3,6 @@ export {
 	buildExtensionStatusIconAliases,
 	formatExtensionStatus,
 } from "./extension-status.js";
-export { prContextFromStatuses } from "./git/branch.js";
 export { formatCount } from "./helpers.js";
 export { shortenModel } from "./model.js";
 export { reachableModuleRequirements, renderStatusline } from "./render.js";
@@ -11,6 +10,8 @@ export type {
 	ExtensionStatusIconAliasMap,
 	GitBranchSnapshot,
 	GitCommitSnapshot,
+	GithubPrSnapshot,
+	GithubPrState,
 	GitMetricsSnapshot,
 	GitSnapshot,
 	GitStateSnapshot,

--- a/extensions/pi-starship/src/modules/render.ts
+++ b/extensions/pi-starship/src/modules/render.ts
@@ -22,13 +22,9 @@ export function renderStatusline(
 		modules[name] = [];
 		layoutModules[name] = [];
 	}
-	const consumedExtensionStatusKeys = new Set<string>();
-
 	for (const definition of MODULE_DEFINITIONS) {
 		const name = definition.name;
-		const values = definition.values(
-			valueContext(config, name, runtime, consumedExtensionStatusKeys),
-		);
+		const values = definition.values(valueContext(config, name, runtime));
 		if (!values) continue;
 		const rendered = renderModule(config.modules[name], values, palette);
 		modules[name] = rendered;
@@ -36,14 +32,6 @@ export function renderStatusline(
 			definition.layout === "fill" && !config.modules[name].disabled
 				? [{ type: "fill", pattern: rendered }]
 				: rendered;
-		if (
-			name === "git_branch" &&
-			values.pr &&
-			formatVariables(config.modules.git_branch.formatAst).has("pr") &&
-			rendered.some((chunk) => chunk.text.includes(values.pr ?? ""))
-		) {
-			consumedExtensionStatusKeys.add("github-pr");
-		}
 	}
 
 	const explicitModules = formatVariables(config.formatAst);
@@ -58,7 +46,6 @@ export function renderStatusline(
 		ansi: renderChunksToAnsi(chunks),
 		chunks,
 		modules,
-		consumedExtensionStatusKeys,
 	};
 }
 
@@ -66,14 +53,12 @@ function valueContext(
 	config: StarshipConfig,
 	name: ModuleName,
 	runtime: StarshipRuntimeSnapshot,
-	hiddenExtensionStatusKeys: ReadonlySet<string>,
 ): ModuleValueContext {
 	return {
 		runtime,
 		symbol: config.modules[name].symbol,
 		options: config.modules[name].options,
 		extensionStatus: config.extensionStatus,
-		hiddenExtensionStatusKeys,
 	};
 }
 

--- a/extensions/pi-starship/src/modules/types.ts
+++ b/extensions/pi-starship/src/modules/types.ts
@@ -50,6 +50,18 @@ export interface GitWorktreeSnapshot {
 	path: string;
 }
 
+export type GithubPrState = "open" | "draft" | "merged" | "closed";
+
+export interface GithubPrSnapshot {
+	readonly number: string;
+	readonly link: string;
+	readonly state: GithubPrState;
+	readonly checks: string;
+	readonly review: string;
+	readonly status: string;
+	readonly expiresAt?: number;
+}
+
 export interface GitSnapshot {
 	branch?: GitBranchSnapshot;
 	commit?: GitCommitSnapshot;
@@ -94,6 +106,7 @@ export interface StarshipRuntimeSnapshot {
 	gitMetrics?: GitMetricsSnapshot;
 	gitStatus?: GitStatusSnapshot;
 	gitWorktree?: GitWorktreeSnapshot;
+	githubPr?: GithubPrSnapshot;
 	extensionStatuses: ReadonlyMap<string, string>;
 	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	now: Date;
@@ -118,7 +131,6 @@ export interface ModuleValueContext {
 	symbol: string;
 	options: Readonly<Record<string, ModuleOptionValue>>;
 	extensionStatus: ExtensionStatusPresentation;
-	hiddenExtensionStatusKeys: ReadonlySet<string>;
 }
 
 export type ModuleOptionSchema =
@@ -155,5 +167,4 @@ export interface RenderedStatusline<Name extends string = string> {
 	ansi: string;
 	chunks: StyledChunk[];
 	modules: Record<Name, StyledChunk[]>;
-	consumedExtensionStatusKeys: ReadonlySet<string>;
 }

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -38,6 +38,7 @@ import { summarizeFooterUsage } from "./usage.js";
 const REFRESH_INTERVAL_MS = 30_000;
 const GITHUB_PR_REFRESH_INTERVAL_MS = 60_000;
 const EVENT_DEBOUNCE_MS = 250;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const EMPTY_ALIASES: ExtensionStatusIconAliasMap = new Map();
 
 interface RuntimeState {
@@ -222,13 +223,14 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 			refresh();
 			return;
 		}
-		githubPrExpiryTimer = setTimeout(() => {
-			githubPrExpiryTimer = undefined;
-			if (!isActiveTarget(target) || runtime.githubPr !== snapshot) return;
-			runtime.githubPr = undefined;
-			githubPrController.clear();
-			refresh();
-		}, delay);
+		githubPrExpiryTimer = setTimeout(
+			() => {
+				githubPrExpiryTimer = undefined;
+				if (!isActiveTarget(target) || runtime.githubPr !== snapshot) return;
+				scheduleGithubPrExpiry(snapshot);
+			},
+			Math.min(delay, MAX_TIMER_DELAY_MS),
+		);
 		githubPrExpiryTimer.unref?.();
 	}
 

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -17,6 +17,7 @@ import { readInstalledPackageInfo } from "./installed-packages.js";
 import { gitSnapshotEqual, readGitSnapshot } from "./modules/git/runtime.js";
 import {
 	type ExtensionStatusIconAliasMap,
+	type GithubPrSnapshot,
 	type GitSnapshot,
 	reachableModuleRequirements,
 	renderStatusline,
@@ -24,15 +25,18 @@ import {
 	type WorkspaceSnapshot,
 } from "./modules/index.js";
 import { execWorkspaceCommand } from "./runtime/command.js";
+import { githubPrSnapshotEqual, queryGithubPr } from "./runtime/github-pr.js";
 import { AsyncRefreshController } from "./runtime/refresh-controller.js";
 import {
 	collectWorkspaceSnapshot,
+	type WorkspaceExec,
 	type WorkspaceRefreshInput,
 	workspaceSnapshotEqual,
 } from "./runtime/workspace.js";
 import { summarizeFooterUsage } from "./usage.js";
 
 const REFRESH_INTERVAL_MS = 30_000;
+const GITHUB_PR_REFRESH_INTERVAL_MS = 60_000;
 const EVENT_DEBOUNCE_MS = 250;
 const EMPTY_ALIASES: ExtensionStatusIconAliasMap = new Map();
 
@@ -42,6 +46,7 @@ interface RuntimeState {
 	thinkingLevel: string;
 	lastCompletedTool?: string;
 	git?: GitSnapshot;
+	githubPr?: GithubPrSnapshot;
 	workspace?: WorkspaceSnapshot;
 	extensionStatusIconAliases: ExtensionStatusIconAliasMap;
 	requestRender?: () => void;
@@ -51,6 +56,7 @@ interface RuntimeState {
 interface RefreshTarget {
 	cwd: string;
 	generation: number;
+	sessionManager: ExtensionContext["sessionManager"];
 }
 
 interface GitRefreshInput {
@@ -58,7 +64,11 @@ interface GitRefreshInput {
 	config: StarshipConfig;
 }
 
-export default function piStarship(pi: ExtensionAPI) {
+interface PiStarshipOptions {
+	githubPrExec?: WorkspaceExec;
+}
+
+export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions = {}) {
 	let loaded: LoadedStarshipConfig | undefined;
 	const runtime: RuntimeState = {
 		activeTools: new Map(),
@@ -69,12 +79,17 @@ export default function piStarship(pi: ExtensionAPI) {
 	let conflictWarningShown = false;
 	let sessionGeneration = 0;
 	let menuController = new AbortController();
+	let sessionOwner: ExtensionContext["sessionManager"] | undefined;
 	let activeTarget: RefreshTarget | undefined;
 	let eventDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let githubPrRefreshTimer: ReturnType<typeof setInterval> | undefined;
+	let githubPrExpiryTimer: ReturnType<typeof setTimeout> | undefined;
+	let githubPrGeneration = 0;
 
 	const refresh = () => runtime.requestRender?.();
+	const githubPrExec = options.githubPrExec ?? execWorkspaceCommand;
 	const gitController = new AsyncRefreshController<GitRefreshInput, GitSnapshot | undefined>({
-		async read(input) {
+		async read(input, signal) {
 			const requirements = reachableModuleRequirements(input.config);
 			const gitReachable = [...requirements.keys()].some((name) => name.startsWith("git_"));
 			if (!gitReachable) return undefined;
@@ -82,6 +97,7 @@ export default function piStarship(pi: ExtensionAPI) {
 				return await readGitSnapshot(pi, input.cwd, {
 					includeMetrics: requirements.has("git_metrics"),
 					includeTag: requirements.get("git_commit")?.has("tag") ?? false,
+					signal,
 				});
 			} catch {
 				return undefined;
@@ -93,10 +109,22 @@ export default function piStarship(pi: ExtensionAPI) {
 			refresh();
 		},
 	});
+	const githubPrController = new AsyncRefreshController<
+		Pick<RefreshTarget, "cwd">,
+		GithubPrSnapshot | undefined
+	>({
+		read: (input, signal) => queryGithubPr(githubPrExec, input.cwd, signal),
+		equal: githubPrSnapshotEqual,
+		publish(snapshot) {
+			runtime.githubPr = snapshot;
+			scheduleGithubPrExpiry(snapshot);
+			refresh();
+		},
+	});
 	const workspaceController = new AsyncRefreshController<WorkspaceRefreshInput, WorkspaceSnapshot>({
-		async read(input) {
+		async read(input, signal) {
 			try {
-				return await collectWorkspaceSnapshot(input);
+				return await collectWorkspaceSnapshot({ ...input, signal });
 			} catch {
 				return { modules: {} };
 			}
@@ -116,6 +144,7 @@ export default function piStarship(pi: ExtensionAPI) {
 	const isActiveTarget = (target: RefreshTarget) =>
 		activeTarget?.cwd === target.cwd &&
 		activeTarget.generation === target.generation &&
+		activeTarget.sessionManager === target.sessionManager &&
 		target.generation === sessionGeneration;
 
 	const requestRefresh = (
@@ -130,7 +159,9 @@ export default function piStarship(pi: ExtensionAPI) {
 	};
 	const scheduleRefresh = (ctx: ExtensionContext) => {
 		const target = activeTarget;
-		if (!target || target.cwd !== ctx.cwd) return;
+		if (!target || target.cwd !== ctx.cwd || target.sessionManager !== ctx.sessionManager) {
+			return;
+		}
 		clearDebounce();
 		eventDebounceTimer = setTimeout(() => {
 			eventDebounceTimer = undefined;
@@ -138,14 +169,79 @@ export default function piStarship(pi: ExtensionAPI) {
 		}, EVENT_DEBOUNCE_MS);
 	};
 
+	function restartLocalControllers(target: RefreshTarget) {
+		if (!isActiveTarget(target)) return;
+		gitController.start(target.generation);
+		workspaceController.start(target.generation);
+	}
+
+	function clearGithubPrTimers() {
+		if (githubPrRefreshTimer) clearInterval(githubPrRefreshTimer);
+		if (githubPrExpiryTimer) clearTimeout(githubPrExpiryTimer);
+		githubPrRefreshTimer = undefined;
+		githubPrExpiryTimer = undefined;
+	}
+
+	function stopGithubPr() {
+		clearGithubPrTimers();
+		githubPrController.stop();
+		runtime.githubPr = undefined;
+	}
+
+	function githubPrReachable(): boolean {
+		return Boolean(loaded && reachableModuleRequirements(loaded.config).has("github_pr"));
+	}
+
+	function startGithubPr(target: RefreshTarget): boolean {
+		if (!isActiveTarget(target)) return false;
+		stopGithubPr();
+		if (!githubPrReachable()) return false;
+		githubPrController.start(++githubPrGeneration);
+		githubPrRefreshTimer = setInterval(() => {
+			requestGithubPr(target);
+		}, GITHUB_PR_REFRESH_INTERVAL_MS);
+		githubPrRefreshTimer.unref?.();
+		return true;
+	}
+
+	function requestGithubPr(target: RefreshTarget) {
+		if (!isActiveTarget(target) || !githubPrReachable()) return;
+		githubPrController.request({ cwd: target.cwd });
+	}
+
+	function scheduleGithubPrExpiry(snapshot: GithubPrSnapshot | undefined) {
+		if (githubPrExpiryTimer) clearTimeout(githubPrExpiryTimer);
+		githubPrExpiryTimer = undefined;
+		if (snapshot?.expiresAt === undefined) return;
+		const target = activeTarget;
+		if (!target) return;
+		const delay = snapshot.expiresAt - Date.now();
+		if (delay <= 0) {
+			runtime.githubPr = undefined;
+			githubPrController.clear();
+			refresh();
+			return;
+		}
+		githubPrExpiryTimer = setTimeout(() => {
+			githubPrExpiryTimer = undefined;
+			if (!isActiveTarget(target) || runtime.githubPr !== snapshot) return;
+			runtime.githubPr = undefined;
+			githubPrController.clear();
+			refresh();
+		}, delay);
+		githubPrExpiryTimer.unref?.();
+	}
+
 	const installFooter = (ctx: ExtensionContext) => {
 		const generation = ++sessionGeneration;
+		sessionOwner = ctx.sessionManager;
 		menuController.abort(new DOMException("Starship session context replaced", "AbortError"));
 		menuController = new AbortController();
-		const target = { cwd: ctx.cwd, generation };
+		const target: RefreshTarget = { cwd: ctx.cwd, generation, sessionManager: ctx.sessionManager };
 		clearDebounce();
 		gitController.stop();
 		workspaceController.stop();
+		stopGithubPr();
 		runtime.git = undefined;
 		runtime.workspace = undefined;
 		runtime.requestRender = undefined;
@@ -155,6 +251,7 @@ export default function piStarship(pi: ExtensionAPI) {
 		if (!activeTarget || !loaded) return;
 		gitController.start(generation);
 		workspaceController.start(generation);
+		startGithubPr(target);
 
 		const installed = readInstalledPackageInfo(getAgentDir(), target.cwd, ctx.isProjectTrusted());
 		runtime.extensionStatusIconAliases = installed.aliases;
@@ -176,13 +273,17 @@ export default function piStarship(pi: ExtensionAPI) {
 				);
 			};
 			const unsubscribe = footerData.onBranchChange(() => {
+				if (!isActiveTarget(target)) return;
 				runtime.git = undefined;
-				gitController.clear();
+				restartLocalControllers(target);
 				clearDebounce();
+				startGithubPr(target);
 				requestRefresh(target);
+				requestGithubPr(target);
 				tui.requestRender();
 			});
 			const timer = setInterval(() => {
+				if (!isActiveTarget(target)) return;
 				clearDebounce();
 				requestRefresh(target, "periodic");
 				tui.requestRender();
@@ -200,6 +301,7 @@ export default function piStarship(pi: ExtensionAPI) {
 						clearDebounce();
 						gitController.stop();
 						workspaceController.stop();
+						stopGithubPr();
 						runtime.git = undefined;
 						runtime.workspace = undefined;
 						runtime.requestRender = undefined;
@@ -218,6 +320,7 @@ export default function piStarship(pi: ExtensionAPI) {
 			};
 		});
 		requestRefresh(target, "initial");
+		requestGithubPr(target);
 	};
 
 	const configPath = settingsFilePath(getAgentDir());
@@ -231,10 +334,18 @@ export default function piStarship(pi: ExtensionAPI) {
 				isCurrent: () => generation === sessionGeneration && !menuController.signal.aborted,
 			};
 		},
-		apply(next) {
+		apply(next, ctx) {
+			if (sessionOwner !== ctx.sessionManager) {
+				throw new Error("Starship session context was replaced");
+			}
 			loaded = next;
 			const target = activeTarget;
-			if (target) requestRefresh(target);
+			if (target) {
+				restartLocalControllers(target);
+				startGithubPr(target);
+				requestRefresh(target);
+				requestGithubPr(target);
+			}
 			refresh();
 		},
 		renderPreview(preview, width) {
@@ -261,12 +372,15 @@ export default function piStarship(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
+		if (sessionOwner !== ctx.sessionManager) return;
+		sessionOwner = undefined;
 		sessionGeneration += 1;
 		menuController.abort(new DOMException("Starship session shut down", "AbortError"));
 		activeTarget = undefined;
 		clearDebounce();
 		gitController.stop();
 		workspaceController.stop();
+		stopGithubPr();
 		runtime.git = undefined;
 		runtime.workspace = undefined;
 		runtime.extensionStatusIconAliases = EMPTY_ALIASES;
@@ -288,6 +402,8 @@ export default function piStarship(pi: ExtensionAPI) {
 	pi.on("agent_end", (_event, ctx) => {
 		runtime.isStreaming = false;
 		scheduleRefresh(ctx);
+		const target = activeTarget;
+		if (target?.sessionManager === ctx.sessionManager) requestGithubPr(target);
 		refresh();
 	});
 	pi.on("turn_start", () => {
@@ -415,6 +531,7 @@ function runtimeSnapshot(
 		gitMetrics: runtime.git?.metrics,
 		gitStatus: runtime.git?.status,
 		gitWorktree: runtime.git?.worktree,
+		githubPr: runtime.githubPr,
 		workspace: runtime.workspace,
 		extensionStatuses: footerData.getExtensionStatuses(),
 		extensionStatusIconAliases: runtime.extensionStatusIconAliases,

--- a/extensions/pi-starship/src/runtime/command.ts
+++ b/extensions/pi-starship/src/runtime/command.ts
@@ -93,8 +93,12 @@ export const execWorkspaceCommand: WorkspaceExec = async (command, args, options
 
 		child.stdout?.on("data", collect(stdout));
 		child.stderr?.on("data", collect(stderr));
-		child.once("error", () => finish(1));
-		child.once("close", (code) => finish(code ?? 1));
+		child.once("error", () => {
+			if (!killed) finish(1);
+		});
+		child.once("close", (code) => {
+			if (!killed) finish(code ?? 1);
+		});
 		options.signal?.addEventListener("abort", terminate, { once: true });
 		if (options.signal?.aborted) terminate();
 		timeoutTimer = setTimeout(terminate, options.timeout);

--- a/extensions/pi-starship/src/runtime/command.ts
+++ b/extensions/pi-starship/src/runtime/command.ts
@@ -5,10 +5,16 @@ const FORCE_KILL_DELAY_MS = 250;
 
 export const execWorkspaceCommand: WorkspaceExec = async (command, args, options) =>
 	new Promise((resolve) => {
+		if (options.signal?.aborted) {
+			resolve({ stdout: "", stderr: "", code: 1, killed: true });
+			return;
+		}
+
 		let child: ReturnType<typeof spawn>;
 		try {
 			child = spawn(command, args, {
 				cwd: options.cwd,
+				detached: process.platform !== "win32",
 				env: explicitEnvironment(options.environment),
 				shell: false,
 				stdio: ["ignore", "pipe", "pipe"],
@@ -25,12 +31,14 @@ export const execWorkspaceCommand: WorkspaceExec = async (command, args, options
 		let killed = false;
 		let settled = false;
 		let forceKillTimer: NodeJS.Timeout | undefined;
+		let timeoutTimer: NodeJS.Timeout | undefined;
 
 		const finish = (code: number) => {
 			if (settled) return;
 			settled = true;
-			clearTimeout(timeoutTimer);
+			if (timeoutTimer) clearTimeout(timeoutTimer);
 			if (forceKillTimer) clearTimeout(forceKillTimer);
+			options.signal?.removeEventListener("abort", terminate);
 			resolve({
 				stdout: Buffer.concat(stdout).toString("utf8"),
 				stderr: Buffer.concat(stderr).toString("utf8"),
@@ -39,17 +47,41 @@ export const execWorkspaceCommand: WorkspaceExec = async (command, args, options
 			});
 		};
 
-		const terminate = () => {
+		const signalProcessTree = (signal: NodeJS.Signals) => {
+			const pid = child.pid;
+			if (pid === undefined) return;
+			if (process.platform !== "win32") {
+				try {
+					process.kill(-pid, signal);
+					return;
+				} catch {
+					child.kill(signal);
+					return;
+				}
+			}
+			try {
+				const killer = spawn("taskkill.exe", ["/pid", String(pid), "/t", "/f"], {
+					stdio: "ignore",
+					windowsHide: true,
+				});
+				killer.once("error", () => child.kill(signal));
+				killer.unref();
+			} catch {
+				child.kill(signal);
+			}
+		};
+
+		function terminate() {
 			if (killed || settled) return;
 			killed = true;
-			child.kill("SIGTERM");
+			signalProcessTree("SIGTERM");
 			forceKillTimer = setTimeout(() => {
-				child.kill("SIGKILL");
+				signalProcessTree("SIGKILL");
 				child.stdout?.destroy();
 				child.stderr?.destroy();
 				finish(1);
 			}, FORCE_KILL_DELAY_MS);
-		};
+		}
 
 		const collect = (target: Buffer[]) => (data: Buffer | string) => {
 			const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
@@ -63,7 +95,9 @@ export const execWorkspaceCommand: WorkspaceExec = async (command, args, options
 		child.stderr?.on("data", collect(stderr));
 		child.once("error", () => finish(1));
 		child.once("close", (code) => finish(code ?? 1));
-		const timeoutTimer = setTimeout(terminate, options.timeout);
+		options.signal?.addEventListener("abort", terminate, { once: true });
+		if (options.signal?.aborted) terminate();
+		timeoutTimer = setTimeout(terminate, options.timeout);
 	});
 
 function explicitEnvironment(

--- a/extensions/pi-starship/src/runtime/github-pr.ts
+++ b/extensions/pi-starship/src/runtime/github-pr.ts
@@ -1,0 +1,287 @@
+import type { GithubPrSnapshot, GithubPrState } from "../modules/types.js";
+import type { WorkspaceExec } from "./types.js";
+
+const GH_TIMEOUT_MS = 10_000;
+const MAX_GH_OUTPUT_BYTES = 128 * 1024;
+const MAX_URL_LENGTH = 4_096;
+const MAX_CHECKS = 1_000;
+const MAX_FIELD_LENGTH = 128;
+export const TERMINAL_PR_LIFETIME_MS = 24 * 60 * 60 * 1_000;
+
+const GH_PR_FIELDS = [
+	"number",
+	"isDraft",
+	"url",
+	"state",
+	"closedAt",
+	"mergedAt",
+	"reviewDecision",
+	"statusCheckRollup",
+] as const;
+
+interface GithubPrQueryOptions {
+	platform?: NodeJS.Platform;
+	environment?: Readonly<Record<string, string | undefined>>;
+}
+
+interface CheckSummary {
+	failed: number;
+	pending: number;
+	total: number;
+}
+
+type PullRequestState = "OPEN" | "CLOSED" | "MERGED";
+type ReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "";
+
+export function ghPrViewInvocation(platform: NodeJS.Platform = process.platform): {
+	command: string;
+	args: string[];
+} {
+	return {
+		command: platform === "win32" ? "gh.exe" : "gh",
+		args: ["pr", "view", "--json", GH_PR_FIELDS.join(",")],
+	};
+}
+
+export function githubPrEnvironment(
+	source: Readonly<Record<string, string | undefined>> = process.env,
+): Record<string, string | undefined> {
+	const environment: Record<string, string | undefined> = Object.create(null);
+	for (const [name, value] of Object.entries(source)) {
+		const normalized = name.toUpperCase();
+		if (normalized === "GH_HOST" || normalized === "GH_REPO") continue;
+		Object.defineProperty(environment, name, {
+			value,
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		});
+	}
+	return environment;
+}
+
+export async function queryGithubPr(
+	exec: WorkspaceExec,
+	cwd: string,
+	signal?: AbortSignal,
+	now = Date.now(),
+	options: GithubPrQueryOptions = {},
+): Promise<GithubPrSnapshot | undefined> {
+	const invocation = ghPrViewInvocation(options.platform);
+	try {
+		const result = await exec(invocation.command, invocation.args, {
+			cwd,
+			signal,
+			timeout: GH_TIMEOUT_MS,
+			maxOutputBytes: MAX_GH_OUTPUT_BYTES,
+			environment: githubPrEnvironment(options.environment),
+		});
+		if (result.killed || result.code !== 0) return undefined;
+		if (Buffer.byteLength(result.stdout) > MAX_GH_OUTPUT_BYTES) return undefined;
+		return buildGithubPrSnapshot(JSON.parse(result.stdout), now);
+	} catch {
+		return undefined;
+	}
+}
+
+export function buildGithubPrSnapshot(
+	value: unknown,
+	now = Date.now(),
+): GithubPrSnapshot | undefined {
+	try {
+		const pr = record(value);
+		const number = positiveInteger(pr.number);
+		const isDraft = requiredBoolean(pr.isDraft);
+		const url = requiredBoundedString(pr.url, MAX_URL_LENGTH, true);
+		const state = pullRequestState(pr.state);
+		const closedAt = optionalTimestamp(pr.closedAt);
+		const mergedAt = optionalTimestamp(pr.mergedAt);
+		const reviewDecision = reviewDecisionValue(pr.reviewDecision);
+		const checks = summarizeChecks(pr.statusCheckRollup);
+		const expiresAt = terminalExpiry(state, closedAt, mergedAt);
+		if (state !== "OPEN" && (expiresAt === undefined || now >= expiresAt)) return undefined;
+
+		const presentationState: GithubPrState =
+			state === "MERGED" ? "merged" : state === "CLOSED" ? "closed" : isDraft ? "draft" : "open";
+		const checksText = formatChecks(checks);
+		const review = formatReview(reviewDecision);
+		const status = compactStatus(presentationState, checks, checksText, review);
+		const snapshot: GithubPrSnapshot = {
+			number: String(number),
+			link: osc8Link(url, `#${number}`),
+			state: presentationState,
+			checks: checksText,
+			review,
+			status,
+			...(expiresAt === undefined ? {} : { expiresAt }),
+		};
+		return Object.freeze(snapshot);
+	} catch {
+		return undefined;
+	}
+}
+
+export function githubPrSnapshotEqual(
+	left: GithubPrSnapshot | undefined,
+	right: GithubPrSnapshot | undefined,
+): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function terminalExpiry(
+	state: PullRequestState,
+	closedAt: number | undefined,
+	mergedAt: number | undefined,
+): number | undefined {
+	if (state === "OPEN") return undefined;
+	const terminalAt = state === "MERGED" ? mergedAt : closedAt;
+	return terminalAt === undefined ? undefined : terminalAt + TERMINAL_PR_LIFETIME_MS;
+}
+
+function summarizeChecks(value: unknown): CheckSummary {
+	if (!Array.isArray(value) || value.length > MAX_CHECKS) throw new Error("Invalid PR checks");
+	const summary: CheckSummary = { failed: 0, pending: 0, total: value.length };
+	for (const item of value) {
+		const check = record(item);
+		const state = optionalUppercase(check.state);
+		const status = optionalUppercase(check.status);
+		const conclusion = optionalUppercase(check.conclusion);
+		if (state === "SUCCESS") continue;
+		if (state === "FAILURE" || state === "ERROR") {
+			summary.failed += 1;
+			continue;
+		}
+		if (state === "PENDING" || state === "EXPECTED") {
+			summary.pending += 1;
+			continue;
+		}
+		if (status && status !== "COMPLETED") {
+			summary.pending += 1;
+			continue;
+		}
+		if (conclusion === "SUCCESS" || conclusion === "SKIPPED" || conclusion === "NEUTRAL") {
+			continue;
+		}
+		if (
+			conclusion === "FAILURE" ||
+			conclusion === "CANCELLED" ||
+			conclusion === "TIMED_OUT" ||
+			conclusion === "ACTION_REQUIRED" ||
+			conclusion === "STARTUP_FAILURE"
+		) {
+			summary.failed += 1;
+			continue;
+		}
+		summary.pending += 1;
+	}
+	return summary;
+}
+
+function formatChecks(checks: CheckSummary): string {
+	if (checks.total === 0) return "no checks";
+	if (checks.failed > 0) return `${checks.failed} failing`;
+	if (checks.pending > 0) return `${checks.pending} pending`;
+	return "checks passing";
+}
+
+function formatReview(review: ReviewDecision): string {
+	if (review === "APPROVED") return "approved";
+	if (review === "CHANGES_REQUESTED") return "changes requested";
+	if (review === "REVIEW_REQUIRED") return "review required";
+	return "";
+}
+
+function compactStatus(
+	state: GithubPrState,
+	checks: CheckSummary,
+	checksText: string,
+	review: string,
+): string {
+	if (state === "merged" || state === "closed" || state === "draft") return state;
+	if (checks.failed > 0) return checksText;
+	if (review === "changes requested") return review;
+	if (checks.pending > 0) return checksText;
+	if (review === "approved" || review === "review required") return review;
+	return checksText;
+}
+
+function osc8Link(value: string, label: string): string {
+	if (hasTerminalControls(value)) return label;
+	try {
+		const url = new URL(value);
+		if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password) {
+			return label;
+		}
+		const normalized = url.toString();
+		if (normalized.length > MAX_URL_LENGTH || hasTerminalControls(normalized)) return label;
+		return `\u001b]8;;${normalized}\u0007${label}\u001b]8;;\u0007`;
+	} catch {
+		return label;
+	}
+}
+
+function hasTerminalControls(value: string): boolean {
+	return Array.from(value).some((character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return (
+			codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			(codePoint >= 0xd800 && codePoint <= 0xdfff)
+		);
+	});
+}
+
+function record(value: unknown): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("Expected PR object");
+	}
+	return value as Record<string, unknown>;
+}
+
+function positiveInteger(value: unknown): number {
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+		throw new Error("Invalid PR number");
+	}
+	return value;
+}
+
+function requiredBoolean(value: unknown): boolean {
+	if (typeof value !== "boolean") throw new Error("Invalid PR boolean");
+	return value;
+}
+
+function requiredBoundedString(value: unknown, maxLength: number, allowEmpty = false): string {
+	if (
+		typeof value !== "string" ||
+		value.length > maxLength ||
+		(!allowEmpty && value.length === 0)
+	) {
+		throw new Error("Invalid PR string");
+	}
+	return value;
+}
+
+function optionalUppercase(value: unknown): string | undefined {
+	if (value === null || value === undefined || value === "") return undefined;
+	return requiredBoundedString(value, MAX_FIELD_LENGTH).toUpperCase();
+}
+
+function optionalTimestamp(value: unknown): number | undefined {
+	if (value === null || value === undefined || value === "") return undefined;
+	const timestamp = Date.parse(requiredBoundedString(value, MAX_FIELD_LENGTH));
+	if (!Number.isFinite(timestamp)) throw new Error("Invalid PR timestamp");
+	return timestamp;
+}
+
+function pullRequestState(value: unknown): PullRequestState {
+	if (value === "OPEN" || value === "CLOSED" || value === "MERGED") return value;
+	throw new Error("Invalid PR state");
+}
+
+function reviewDecisionValue(value: unknown): ReviewDecision {
+	if (value === null || value === undefined || value === "" || value === "UNKNOWN") return "";
+	if (value === "APPROVED" || value === "CHANGES_REQUESTED" || value === "REVIEW_REQUIRED") {
+		return value;
+	}
+	throw new Error("Invalid PR review decision");
+}

--- a/extensions/pi-starship/src/runtime/github-pr.ts
+++ b/extensions/pi-starship/src/runtime/github-pr.ts
@@ -6,6 +6,8 @@ const MAX_GH_OUTPUT_BYTES = 128 * 1024;
 const MAX_URL_LENGTH = 4_096;
 const MAX_CHECKS = 1_000;
 const MAX_FIELD_LENGTH = 128;
+const RFC3339_TIMESTAMP =
+	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-](\d{2}):(\d{2}))$/u;
 export const TERMINAL_PR_LIFETIME_MS = 24 * 60 * 60 * 1_000;
 
 const GH_PR_FIELDS = [
@@ -268,9 +270,52 @@ function optionalUppercase(value: unknown): string | undefined {
 
 function optionalTimestamp(value: unknown): number | undefined {
 	if (value === null || value === undefined || value === "") return undefined;
-	const timestamp = Date.parse(requiredBoundedString(value, MAX_FIELD_LENGTH));
+	const text = requiredBoundedString(value, MAX_FIELD_LENGTH);
+	const match = RFC3339_TIMESTAMP.exec(text);
+	if (!match) throw new Error("Invalid PR timestamp");
+	const [
+		,
+		yearText,
+		monthText,
+		dayText,
+		hourText,
+		minuteText,
+		secondText,
+		offsetHourText,
+		offsetMinuteText,
+	] = match;
+	const year = Number(yearText);
+	const month = Number(monthText);
+	const day = Number(dayText);
+	const hour = Number(hourText);
+	const minute = Number(minuteText);
+	const second = Number(secondText);
+	const offsetHour = Number(offsetHourText ?? 0);
+	const offsetMinute = Number(offsetMinuteText ?? 0);
+	if (
+		month < 1 ||
+		month > 12 ||
+		day < 1 ||
+		day > daysInMonth(year, month) ||
+		hour > 23 ||
+		minute > 59 ||
+		second > 59 ||
+		offsetHour > 23 ||
+		offsetMinute > 59
+	) {
+		throw new Error("Invalid PR timestamp");
+	}
+	const timestamp = Date.parse(text);
 	if (!Number.isFinite(timestamp)) throw new Error("Invalid PR timestamp");
 	return timestamp;
+}
+
+function daysInMonth(year: number, month: number): number {
+	if (month === 2) {
+		const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+		return leapYear ? 29 : 28;
+	}
+	return month === 4 || month === 6 || month === 9 || month === 11 ? 30 : 31;
 }
 
 function pullRequestState(value: unknown): PullRequestState {

--- a/extensions/pi-starship/src/runtime/helpers.ts
+++ b/extensions/pi-starship/src/runtime/helpers.ts
@@ -161,6 +161,7 @@ export async function runBounded(
 			cwd: context.input.cwd,
 			timeout: COMMAND_TIMEOUT_MS,
 			maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
+			signal: context.input.signal,
 			environment: context.input.environment,
 		});
 		if (result.code !== 0 || result.killed) return undefined;

--- a/extensions/pi-starship/src/runtime/refresh-controller.ts
+++ b/extensions/pi-starship/src/runtime/refresh-controller.ts
@@ -1,5 +1,5 @@
 export interface AsyncRefreshControllerOptions<Input, Snapshot> {
-	read(input: Input): Promise<Snapshot>;
+	read(input: Input, signal: AbortSignal): Promise<Snapshot>;
 	equal(left: Snapshot | undefined, right: Snapshot): boolean;
 	publish(snapshot: Snapshot): void;
 	onError?(error: unknown): void;
@@ -11,17 +11,23 @@ interface RefreshRequest<Input> {
 	input: Input;
 }
 
+interface ActiveRefresh<Input> {
+	request: RefreshRequest<Input>;
+	controller: AbortController;
+}
+
 /** Coalesces refreshes to one active read plus the latest pending request. */
 export class AsyncRefreshController<Input, Snapshot> {
 	private generation: number | undefined;
 	private requestId = 0;
-	private inFlight = false;
+	private active: ActiveRefresh<Input> | undefined;
 	private pending: RefreshRequest<Input> | undefined;
 	private current: Snapshot | undefined;
 
 	constructor(private readonly options: AsyncRefreshControllerOptions<Input, Snapshot>) {}
 
 	start(generation: number): void {
+		this.cancelActive("Refresh generation replaced");
 		this.generation = generation;
 		this.requestId += 1;
 		this.pending = undefined;
@@ -39,7 +45,7 @@ export class AsyncRefreshController<Input, Snapshot> {
 			requestId: ++this.requestId,
 			input,
 		};
-		if (this.inFlight) {
+		if (this.active) {
 			this.pending = request;
 			return;
 		}
@@ -51,28 +57,46 @@ export class AsyncRefreshController<Input, Snapshot> {
 		this.requestId += 1;
 		this.pending = undefined;
 		this.current = undefined;
+		this.cancelActive("Refresh controller stopped");
 	}
 
 	private run(request: RefreshRequest<Input>): void {
 		if (!this.isCurrentTarget(request)) return;
-		this.inFlight = true;
+		const active: ActiveRefresh<Input> = {
+			request,
+			controller: new AbortController(),
+		};
+		this.active = active;
 		void this.options
-			.read(request.input)
+			.read(request.input, active.controller.signal)
 			.then((snapshot) => {
-				if (!this.isCurrentRequest(request)) return;
+				if (this.active !== active || !this.isCurrentRequest(request)) return;
 				if (this.options.equal(this.current, snapshot)) return;
 				this.current = snapshot;
 				this.options.publish(snapshot);
 			})
 			.catch((error: unknown) => {
-				if (this.isCurrentRequest(request)) this.options.onError?.(error);
+				if (
+					this.active === active &&
+					this.isCurrentRequest(request) &&
+					!active.controller.signal.aborted
+				) {
+					this.options.onError?.(error);
+				}
 			})
 			.finally(() => {
-				this.inFlight = false;
+				if (this.active !== active) return;
+				this.active = undefined;
 				const pending = this.pending;
 				this.pending = undefined;
 				if (pending) this.run(pending);
 			});
+	}
+
+	private cancelActive(reason: string): void {
+		const active = this.active;
+		this.active = undefined;
+		active?.controller.abort(new DOMException(reason, "AbortError"));
 	}
 
 	private isCurrentTarget(request: RefreshRequest<Input>): boolean {

--- a/extensions/pi-starship/src/runtime/refresh-controller.ts
+++ b/extensions/pi-starship/src/runtime/refresh-controller.ts
@@ -94,9 +94,7 @@ export class AsyncRefreshController<Input, Snapshot> {
 	}
 
 	private cancelActive(reason: string): void {
-		const active = this.active;
-		this.active = undefined;
-		active?.controller.abort(new DOMException(reason, "AbortError"));
+		this.active?.controller.abort(new DOMException(reason, "AbortError"));
 	}
 
 	private isCurrentTarget(request: RefreshRequest<Input>): boolean {

--- a/extensions/pi-starship/src/runtime/types.ts
+++ b/extensions/pi-starship/src/runtime/types.ts
@@ -16,6 +16,7 @@ export type WorkspaceExec = (
 		cwd: string;
 		timeout: number;
 		maxOutputBytes: number;
+		signal?: AbortSignal;
 		environment: Readonly<Record<string, string | undefined>>;
 	},
 ) => Promise<WorkspaceExecResult>;
@@ -45,6 +46,7 @@ export interface WorkspaceRefreshInput {
 	fileExists?(path: string): Promise<boolean>;
 	reason?: "initial" | "event" | "periodic";
 	previous?: WorkspaceSnapshot;
+	signal?: AbortSignal;
 }
 
 export interface CollectorContext {

--- a/extensions/pi-starship/src/runtime/workspace.ts
+++ b/extensions/pi-starship/src/runtime/workspace.ts
@@ -18,13 +18,13 @@ import type {
 export { parseTerraformVersion } from "./deployment.js";
 export { parseDirenvStatus, parseMiseHealth } from "./development.js";
 export { parseRuntimeVersion } from "./languages.js";
-export type { WorkspaceExec, WorkspaceRefreshInput } from "./types.js";
+export type { WorkspaceExec, WorkspaceExecResult, WorkspaceRefreshInput } from "./types.js";
 
 export async function collectWorkspaceSnapshot(
 	input: WorkspaceRefreshInput,
 ): Promise<WorkspaceSnapshot> {
 	const requirements = reachableModuleRequirements(input.config);
-	if (!hasWorkspaceRequirement(requirements)) return freezeSnapshot({});
+	if (input.signal?.aborted || !hasWorkspaceRequirement(requirements)) return freezeSnapshot({});
 	const fs = createFileSystem(input);
 	let listing: Promise<readonly WorkspaceEntry[]> | undefined;
 	const context: CollectorContext = {
@@ -45,6 +45,7 @@ export async function collectWorkspaceSnapshot(
 	};
 	const modules: MutableModuleSnapshot = {};
 	const packageValues = await collectPackage(context);
+	if (input.signal?.aborted) return freezeSnapshot({});
 	if (packageValues) modules.package = packageValues;
 	for (const collector of [
 		collectLanguages,
@@ -53,9 +54,10 @@ export async function collectWorkspaceSnapshot(
 		collectCloud,
 		collectExecution,
 	]) {
+		if (input.signal?.aborted) return freezeSnapshot({});
 		mergeModules(modules, await collector(context));
 	}
-	return freezeSnapshot(modules);
+	return input.signal?.aborted ? freezeSnapshot({}) : freezeSnapshot(modules);
 }
 
 export function workspaceSnapshotEqual(
@@ -79,6 +81,7 @@ const BUILT_IN_ONLY_MODULES = new Set<ModuleName>([
 	"directory",
 	"git_worktree",
 	"git_branch",
+	"github_pr",
 	"git_commit",
 	"git_state",
 	"git_metrics",

--- a/extensions/pi-starship/test/commands.test.ts
+++ b/extensions/pi-starship/test/commands.test.ts
@@ -7,7 +7,18 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
 import { registerStarshipCommand } from "../src/commands.js";
 import { BUILT_IN_EXAMPLE, loadStarshipConfig, settingsFilePath } from "../src/config.js";
-import piStarship from "../src/pi-starship.js";
+import piStarshipRuntime from "../src/pi-starship.js";
+
+function piStarship(pi: Parameters<typeof piStarshipRuntime>[0]) {
+	return piStarshipRuntime(pi, {
+		githubPrExec: (command, args, options) =>
+			pi.exec(command, args, {
+				cwd: options.cwd,
+				signal: options.signal,
+				timeout: options.timeout,
+			}),
+	});
+}
 
 test("/starship keeps direct routes and opens a stateful narrow TUI menu", async () => {
 	const mock = createMockPi();

--- a/extensions/pi-starship/test/config.test.ts
+++ b/extensions/pi-starship/test/config.test.ts
@@ -18,6 +18,7 @@ import {
 	CONFIG_FILE_NAME,
 	loadStarshipConfig,
 	MODULE_NAMES,
+	normalizeConfig,
 	settingsFilePath,
 	validateConfigDocument,
 } from "../src/config.js";
@@ -84,6 +85,7 @@ test("built-in example uses readable TOML continuations without changing the for
 				"[](fg:directory bg:git)",
 				"$git_worktree",
 				"$git_branch",
+				"$github_pr",
 				"$git_status",
 				"[](fg:git bg:runtime)",
 				"$activity",
@@ -104,7 +106,7 @@ test("built-in example uses readable TOML continuations without changing the for
 	}
 });
 
-test("Git modules use Starship display order", () => {
+test("Git and GitHub PR modules use deterministic display order", () => {
 	const gitModules = MODULE_NAMES.filter((name) => name.startsWith("git_"));
 	assert.deepEqual(gitModules, [
 		"git_worktree",
@@ -114,6 +116,20 @@ test("Git modules use Starship display order", () => {
 		"git_metrics",
 		"git_status",
 	]);
+	assert.equal(MODULE_NAMES.indexOf("github_pr"), MODULE_NAMES.indexOf("git_branch") + 1);
+	assert.match(BUILT_IN_CONFIG.format, /\$git_branch\$github_pr\$git_status/u);
+});
+
+test("removed git_branch $pr settings use the generic unknown-variable diagnostic", () => {
+	const normalized = normalizeConfig({
+		format: "$git_branch",
+		git_branch: { format: "$branch$pr" },
+	});
+	assert.equal(BUILT_IN_CONFIG.modules.git_branch.format.includes("$pr"), false);
+	assert.match(
+		normalized.diagnostics.map((item) => `${item.path}: ${item.message}`).join("\n"),
+		/git_branch\.format.*unknown variable.*pr/iu,
+	);
 });
 
 test("first-wave modules are registered in deterministic domain order", () => {

--- a/extensions/pi-starship/test/github-pr.test.ts
+++ b/extensions/pi-starship/test/github-pr.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BUILT_IN_CONFIG } from "../src/config.js";
+import { parseFormat } from "../src/format/formatter.js";
+import { renderStatusline, type StarshipRuntimeSnapshot } from "../src/modules/index.js";
+import {
+	buildGithubPrSnapshot,
+	ghPrViewInvocation,
+	githubPrEnvironment,
+	queryGithubPr,
+	TERMINAL_PR_LIFETIME_MS,
+} from "../src/runtime/github-pr.js";
+import type { WorkspaceExec, WorkspaceExecResult } from "../src/runtime/workspace.js";
+
+const NOW = Date.parse("2026-08-01T12:00:00.000Z");
+const GH_FIELDS = "number,isDraft,url,state,closedAt,mergedAt,reviewDecision,statusCheckRollup";
+
+function rawPr(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		number: 123,
+		isDraft: false,
+		url: "https://github.com/o/r/pull/123",
+		state: "OPEN",
+		closedAt: null,
+		mergedAt: null,
+		reviewDecision: "APPROVED",
+		statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+		...overrides,
+	};
+}
+
+function runtime(
+	githubPr: NonNullable<StarshipRuntimeSnapshot["githubPr"]>,
+): StarshipRuntimeSnapshot {
+	return {
+		cwd: "/work/repo",
+		thinkingLevel: "off",
+		turnCount: 0,
+		activeTools: new Map(),
+		isStreaming: false,
+		tokenTotals: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+		usingSubscription: false,
+		gitBranch: "feature",
+		githubPr,
+		extensionStatuses: new Map(),
+		extensionStatusIconAliases: new Map(),
+		now: new Date(NOW),
+	};
+}
+
+function stripSgr(value: string): string {
+	const escapeSequence = String.fromCharCode(27);
+	return value.replace(new RegExp(`${escapeSequence}\\[[0-9;]*m`, "gu"), "");
+}
+
+test("github_pr exposes native variables and compact status priority", () => {
+	const snapshot = buildGithubPrSnapshot(
+		rawPr({
+			reviewDecision: "CHANGES_REQUESTED",
+			statusCheckRollup: [
+				{ status: "COMPLETED", conclusion: "FAILURE" },
+				{ status: "COMPLETED", conclusion: "TIMED_OUT" },
+				{ status: "IN_PROGRESS", conclusion: null },
+			],
+		}),
+		NOW,
+	);
+	assert.ok(snapshot);
+	assert.deepEqual(
+		{
+			number: snapshot.number,
+			state: snapshot.state,
+			checks: snapshot.checks,
+			review: snapshot.review,
+			status: snapshot.status,
+		},
+		{
+			number: "123",
+			state: "open",
+			checks: "2 failing",
+			review: "changes requested",
+			status: "2 failing",
+		},
+	);
+
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$github_pr";
+	config.formatAst = parseFormat(config.format);
+	config.modules.github_pr.format = "$number|$link|$state|$checks|$review|$status";
+	config.modules.github_pr.formatAst = parseFormat(config.modules.github_pr.format);
+	const rendered = stripSgr(renderStatusline(config, runtime(snapshot)).ansi);
+	assert.equal(
+		rendered,
+		`123|\u001b]8;;https://github.com/o/r/pull/123\u0007#123\u001b]8;;\u0007|open|2 failing|changes requested|2 failing`,
+	);
+
+	const cases: Array<[Record<string, unknown>, string]> = [
+		[
+			{
+				state: "MERGED",
+				mergedAt: new Date(NOW - 1_000).toISOString(),
+			},
+			"merged",
+		],
+		[
+			{
+				state: "CLOSED",
+				closedAt: new Date(NOW - 1_000).toISOString(),
+			},
+			"closed",
+		],
+		[{ isDraft: true }, "draft"],
+		[{ statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }] }, "1 failing"],
+		[{ reviewDecision: "CHANGES_REQUESTED" }, "changes requested"],
+		[{ statusCheckRollup: [{ status: "IN_PROGRESS", conclusion: null }] }, "1 pending"],
+		[{ reviewDecision: "APPROVED" }, "approved"],
+		[{ reviewDecision: "REVIEW_REQUIRED" }, "review required"],
+		[{ reviewDecision: "", statusCheckRollup: [{ state: "SUCCESS" }] }, "checks passing"],
+		[{ reviewDecision: "", statusCheckRollup: [] }, "no checks"],
+	];
+	for (const [overrides, expected] of cases) {
+		assert.equal(buildGithubPrSnapshot(rawPr(overrides), NOW)?.status, expected);
+	}
+});
+
+test("terminal pull requests expire at the exact 24-hour boundary", () => {
+	const terminalAt = NOW - TERMINAL_PR_LIFETIME_MS;
+	const merged = rawPr({ state: "MERGED", mergedAt: new Date(terminalAt).toISOString() });
+	assert.ok(buildGithubPrSnapshot(merged, NOW - 1));
+	assert.equal(buildGithubPrSnapshot(merged, NOW), undefined);
+
+	const closed = rawPr({ state: "CLOSED", closedAt: new Date(terminalAt).toISOString() });
+	assert.ok(buildGithubPrSnapshot(closed, NOW - 1));
+	assert.equal(buildGithubPrSnapshot(closed, NOW), undefined);
+	assert.equal(buildGithubPrSnapshot(rawPr({ state: "CLOSED", closedAt: null }), NOW), undefined);
+});
+
+test("github_pr creates terminal-safe GitHub Enterprise links and falls back to plain text", () => {
+	const enterprise = buildGithubPrSnapshot(
+		rawPr({ url: "https://github.enterprise.test:8443/o/r/pull/123" }),
+		NOW,
+	);
+	assert.equal(
+		enterprise?.link,
+		"\u001b]8;;https://github.enterprise.test:8443/o/r/pull/123\u0007#123\u001b]8;;\u0007",
+	);
+	for (const url of [
+		"javascript:alert(1)",
+		"https://user:secret@github.test/o/r/pull/123",
+		"https://github.test/o/r/pull/123\u001b]8;;https://evil.test\u0007",
+		"https://github.test/o/r/pull/123\u009d8;;https://evil.test\u009c",
+	]) {
+		const snapshot = buildGithubPrSnapshot(rawPr({ url }), NOW);
+		assert.equal(snapshot?.link, "#123");
+	}
+});
+
+test("gh invocation is direct on POSIX and Windows and strips repository overrides", () => {
+	assert.deepEqual(ghPrViewInvocation("linux"), {
+		command: "gh",
+		args: ["pr", "view", "--json", GH_FIELDS],
+	});
+	assert.deepEqual(ghPrViewInvocation("win32"), {
+		command: "gh.exe",
+		args: ["pr", "view", "--json", GH_FIELDS],
+	});
+	const source = {
+		PATH: "/bin",
+		GH_HOST: "github.enterprise.test",
+		gh_repo: "other/repository",
+		KEEP: "value",
+	};
+	assert.deepEqual({ ...githubPrEnvironment(source) }, { PATH: "/bin", KEEP: "value" });
+	assert.equal(source.GH_HOST, "github.enterprise.test");
+	assert.equal(source.gh_repo, "other/repository");
+});
+
+test("queryGithubPr executes one direct cancellable bounded gh query", async () => {
+	const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+	const controller = new AbortController();
+	const exec: WorkspaceExec = async (command, args, options) => {
+		calls.push({
+			command,
+			args,
+			options: { ...options, environment: { ...options.environment } },
+		});
+		return { stdout: JSON.stringify(rawPr()), stderr: "", code: 0, killed: false };
+	};
+	const snapshot = await queryGithubPr(exec, "/work/repo", controller.signal, NOW, {
+		platform: "linux",
+		environment: { PATH: "/bin", GH_HOST: "wrong", GH_REPO: "wrong/repo" },
+	});
+	assert.equal(snapshot?.number, "123");
+	assert.deepEqual(calls, [
+		{
+			command: "gh",
+			args: ["pr", "view", "--json", GH_FIELDS],
+			options: {
+				cwd: "/work/repo",
+				signal: controller.signal,
+				timeout: 10_000,
+				maxOutputBytes: 128 * 1024,
+				environment: { PATH: "/bin" },
+			},
+		},
+	]);
+});
+
+test("no PR, missing gh or auth, timeout, malformed, and oversized output degrade empty", async () => {
+	const results: Array<unknown> = [
+		{ stdout: "", stderr: "no pull requests found", code: 1, killed: false },
+		{ stdout: "", stderr: "run gh auth login", code: 1, killed: false },
+		{ stdout: "", stderr: "", code: 1, killed: true },
+		{ stdout: "{", stderr: "", code: 0, killed: false },
+		{ stdout: JSON.stringify(rawPr({ number: -1 })), stderr: "", code: 0, killed: false },
+		{
+			stdout: JSON.stringify(rawPr({ url: `https://github.test/${"x".repeat(4_096)}` })),
+			stderr: "",
+			code: 0,
+			killed: false,
+		},
+		{
+			stdout: JSON.stringify(
+				rawPr({ statusCheckRollup: Array.from({ length: 1_001 }, () => ({})) }),
+			),
+			stderr: "",
+			code: 0,
+			killed: false,
+		},
+		{
+			stdout: JSON.stringify(rawPr({ statusCheckRollup: [null] })),
+			stderr: "",
+			code: 0,
+			killed: false,
+		},
+		{
+			stdout: JSON.stringify(
+				rawPr({ statusCheckRollup: [{ status: "x".repeat(129), conclusion: null }] }),
+			),
+			stderr: "",
+			code: 0,
+			killed: false,
+		},
+		{ stdout: "x".repeat(256 * 1024), stderr: "", code: 0, killed: false },
+		Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }),
+	];
+	for (const result of results) {
+		const exec: WorkspaceExec = async () => {
+			if (result instanceof Error) throw result;
+			return result as WorkspaceExecResult;
+		};
+		assert.equal(
+			await queryGithubPr(exec, "/work/repo", undefined, NOW, {
+				platform: "linux",
+				environment: {},
+			}),
+			undefined,
+		);
+	}
+});

--- a/extensions/pi-starship/test/github-pr.test.ts
+++ b/extensions/pi-starship/test/github-pr.test.ts
@@ -135,6 +135,20 @@ test("terminal pull requests expire at the exact 24-hour boundary", () => {
 	assert.equal(buildGithubPrSnapshot(rawPr({ state: "CLOSED", closedAt: null }), NOW), undefined);
 });
 
+test("terminal pull requests require GitHub-style RFC3339 timestamps", () => {
+	for (const mergedAt of [
+		"Sat, 01 Aug 2026 11:59:59 GMT",
+		"2026-08-01",
+		"2026-02-30T11:59:59Z",
+		"2026-08-01T11:59:59+24:00",
+	]) {
+		assert.equal(buildGithubPrSnapshot(rawPr({ state: "MERGED", mergedAt }), NOW), undefined);
+	}
+	assert.ok(
+		buildGithubPrSnapshot(rawPr({ state: "MERGED", mergedAt: "2026-08-01T13:59:59+02:00" }), NOW),
+	);
+});
+
 test("github_pr creates terminal-safe GitHub Enterprise links and falls back to plain text", () => {
 	const enterprise = buildGithubPrSnapshot(
 		rawPr({ url: "https://github.enterprise.test:8443/o/r/pull/123" }),

--- a/extensions/pi-starship/test/lifecycle.test.ts
+++ b/extensions/pi-starship/test/lifecycle.test.ts
@@ -177,12 +177,13 @@ test("native PR refresh clears branch state, aborts stale work, and stops on foo
 	await emit(mock.events, "agent_end", {}, context.ctx);
 	assert.equal(prCalls, 2);
 	branchChange?.();
-	assert.equal(prCalls, 3);
+	assert.equal(prCalls, 2);
 	assert.equal(prSignals[1]?.aborted, true);
 	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
 
 	stale.resolve(pullRequestResult(999));
 	await flushAsync();
+	assert.equal(prCalls, 3);
 	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#999/u);
 	fresh.resolve(pullRequestResult(456));
 	await flushAsync();
@@ -250,6 +251,9 @@ test("accepted settings disable and re-enable native PR refresh immediately", as
 		assert.equal(prSignals[1]?.aborted, true);
 		assert.equal(prCalls, 2);
 		assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
+		stale.resolve(pullRequestResult(999));
+		await flushAsync();
+		assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#999/u);
 
 		await mock.commands.get("starship")?.handler("settings", context.ctx);
 		await flushAsync();
@@ -407,6 +411,8 @@ test("reachable native PR refresh uses its own 60-second fallback", async (t) =>
 
 test("terminal native PR snapshots clear at their lifecycle expiry", async (t) => {
 	t.mock.timers.enable({ apis: ["setTimeout"] });
+	let now = Date.parse("2026-08-01T12:00:00.000Z");
+	t.mock.method(Date, "now", () => now);
 	const mock = createMockPi();
 	(
 		mock.rawPi as typeof mock.rawPi & {
@@ -432,11 +438,59 @@ test("terminal native PR snapshots clear at their lifecycle expiry", async (t) =
 			onBranchChange: () => () => undefined,
 		},
 	);
+	t.after(async () => {
+		footer.dispose();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+	});
 	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+	now += 1_000;
 	t.mock.timers.tick(1_000);
 	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
-	footer.dispose();
-	await emit(mock.events, "session_shutdown", {}, context.ctx);
+});
+
+test("terminal native PR expiry revalidates the wall clock before clearing", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	let now = Date.parse("2026-08-01T12:00:00.000Z");
+	t.mock.method(Date, "now", () => now);
+	const expiresAt = now + 500;
+	const mock = createMockPi();
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (_command: string, args: string[]) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args) =>
+		isGithubPrCall(args)
+			? pullRequestResult(123, {
+					state: "MERGED",
+					mergedAt: new Date(expiresAt - 24 * 60 * 60 * 1_000).toISOString(),
+				})
+			: gitResult();
+	piStarship(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+	await flushAsync();
+	const footer = (context.footer as FooterFactory)(
+		{ requestRender() {} },
+		{},
+		{
+			getGitBranch: () => "feature",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	t.after(async () => {
+		footer.dispose();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+	});
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+
+	now -= 10_000;
+	t.mock.timers.tick(500);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+
+	now = expiresAt;
+	t.mock.timers.tick(10_500);
+	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
 });
 
 test("turn module counts user messages instead of repeated LLM turns", async () => {

--- a/extensions/pi-starship/test/lifecycle.test.ts
+++ b/extensions/pi-starship/test/lifecycle.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { createMockContext, createMockPi } from "../../../test/support.js";
-import piStarship, {
+import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
+import piStarshipRuntime, {
 	parseGitStatusPorcelain,
 	parseGitWorktree,
 	wrapFormattedStatusline,
@@ -26,6 +26,17 @@ async function emit(
 	...args: unknown[]
 ) {
 	for (const handler of events.get(name) ?? []) await handler(...args);
+}
+
+function piStarship(pi: Parameters<typeof piStarshipRuntime>[0]) {
+	return piStarshipRuntime(pi, {
+		githubPrExec: (command, args, options) =>
+			pi.exec(command, args, {
+				cwd: options.cwd,
+				signal: options.signal,
+				timeout: options.timeout,
+			}),
+	});
 }
 
 type FooterFactory = (
@@ -69,7 +80,7 @@ test("session start uses built-in settings without materializing a missing file"
 	}
 });
 
-test("non-TUI sessions install no footer and execute no git subprocess", async () => {
+test("non-TUI sessions install no footer and execute no Git or GitHub subprocess", async () => {
 	const mock = createMockPi();
 	let calls = 0;
 	(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () => {
@@ -82,6 +93,350 @@ test("non-TUI sessions install no footer and execute no git subprocess", async (
 	await emit(mock.events, "tool_execution_end", { toolName: "read" }, context.ctx);
 	assert.equal(context.footer, undefined);
 	assert.equal(calls, 0);
+});
+
+test("unreachable and disabled native PR modules execute no gh command", async () => {
+	for (const source of ["format = '$model'\n", "[github_pr]\ndisabled = true\n"]) {
+		const root = mkdtempSync(join(tmpdir(), "pi-starship-pr-gate-"));
+		const previous = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = root;
+		try {
+			writeFileSync(join(root, "pi-starship.toml"), source);
+			const mock = createMockPi();
+			let prCalls = 0;
+			(
+				mock.rawPi as typeof mock.rawPi & {
+					exec: (_command: string, args: string[]) => Promise<ExecResult>;
+				}
+			).exec = async (_command, args) => {
+				if (isGithubPrCall(args)) prCalls += 1;
+				return gitResult();
+			};
+			piStarship(mock.pi);
+			const context = createMockContext({ mode: "tui" });
+			await emit(mock.events, "session_start", {}, context.ctx);
+			await flushAsync();
+			assert.equal(prCalls, 0, source);
+			await emit(mock.events, "session_shutdown", {}, context.ctx);
+		} finally {
+			if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previous;
+			rmSync(root, { recursive: true, force: true });
+		}
+	}
+});
+
+test("native PR refresh clears branch state, aborts stale work, and stops on footer disposal", async () => {
+	const mock = createMockPi();
+	const stale = deferred<ExecResult>();
+	const fresh = deferred<ExecResult>();
+	const disposal = deferred<ExecResult>();
+	const prResults: Array<Promise<ExecResult>> = [
+		Promise.resolve(pullRequestResult(123)),
+		stale.promise,
+		fresh.promise,
+		disposal.promise,
+	];
+	const prSignals: AbortSignal[] = [];
+	let prCalls = 0;
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (
+				command: string,
+				args: string[],
+				options: { signal?: AbortSignal },
+			) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args, options) => {
+		if (!isGithubPrCall(args)) return gitResult();
+		prCalls += 1;
+		if (options.signal) prSignals.push(options.signal);
+		const result = prResults.shift();
+		if (!result) throw new Error("unexpected gh pr view call");
+		return result;
+	};
+	piStarship(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+	await flushAsync();
+	let branchChange: (() => void) | undefined;
+	const footer = (context.footer as FooterFactory)(
+		{ requestRender() {} },
+		{},
+		{
+			getGitBranch: () => "feature",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: (callback) => {
+				branchChange = callback;
+				return () => undefined;
+			},
+		},
+	);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /PR #123 · checks passing/u);
+
+	await emit(mock.events, "agent_end", {}, context.ctx);
+	assert.equal(prCalls, 2);
+	branchChange?.();
+	assert.equal(prCalls, 3);
+	assert.equal(prSignals[1]?.aborted, true);
+	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
+
+	stale.resolve(pullRequestResult(999));
+	await flushAsync();
+	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#999/u);
+	fresh.resolve(pullRequestResult(456));
+	await flushAsync();
+	assert.match(stripAnsi(footer.render(300).join("\n")), /PR #456/u);
+
+	await emit(mock.events, "agent_end", {}, context.ctx);
+	assert.equal(prCalls, 4);
+	footer.dispose();
+	assert.equal(prSignals[3]?.aborted, true);
+	disposal.resolve(pullRequestResult(777));
+	await flushAsync();
+	await emit(mock.events, "session_shutdown", {}, context.ctx);
+});
+
+test("accepted settings disable and re-enable native PR refresh immediately", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-pr-settings-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		const stale = deferred<ExecResult>();
+		const prSignals: AbortSignal[] = [];
+		let prCalls = 0;
+		(
+			mock.rawPi as typeof mock.rawPi & {
+				exec: (
+					command: string,
+					args: string[],
+					options: { signal?: AbortSignal },
+				) => Promise<ExecResult>;
+			}
+		).exec = async (_command, args, options) => {
+			if (!isGithubPrCall(args)) return gitResult();
+			prCalls += 1;
+			if (options.signal) prSignals.push(options.signal);
+			if (prCalls === 1) return pullRequestResult(123);
+			if (prCalls === 2) return stale.promise;
+			return pullRequestResult(456);
+		};
+		piStarship(mock.pi);
+		const drafts = ["format = '$model'\n", "format = '$github_pr'\n"];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => drafts.shift(),
+			custom: async (factory: unknown) => driveCustomSelector(factory, ["\r"], 80).result,
+			confirm: async () => true,
+		});
+		await emit(mock.events, "session_start", {}, context.ctx);
+		await flushAsync();
+		const footer = (context.footer as FooterFactory)(
+			{ requestRender() {} },
+			{},
+			{
+				getGitBranch: () => "feature",
+				getExtensionStatuses: () => new Map(),
+				onBranchChange: () => () => undefined,
+			},
+		);
+		assert.match(stripAnsi(footer.render(300).join("\n")), /#123/u);
+
+		await emit(mock.events, "agent_end", {}, context.ctx);
+		assert.equal(prCalls, 2);
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.equal(prSignals[1]?.aborted, true);
+		assert.equal(prCalls, 2);
+		assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
+
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		await flushAsync();
+		assert.equal(prCalls, 3);
+		assert.match(stripAnsi(footer.render(300).join("\n")), /#456/u);
+		footer.dispose();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("session replacement cancels an awaited settings edit before saving or applying", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-stale-settings-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () => ({
+			stdout: "",
+			stderr: "no PR",
+			code: 1,
+			killed: false,
+		});
+		piStarship(mock.pi);
+		const edited = deferred<string | undefined>();
+		const oldContext = createMockContext({ mode: "tui", editor: async () => edited.promise });
+		const newContext = createMockContext({ mode: "tui", cwd: "/work/replacement" });
+		await emit(mock.events, "session_start", {}, oldContext.ctx);
+		const command = mock.commands.get("starship")?.handler("settings", oldContext.ctx);
+		await flushAsync();
+		await emit(mock.events, "session_start", {}, newContext.ctx);
+		edited.resolve("format = '$github_pr'\n");
+		await command;
+		assert.equal(existsSync(join(root, "pi-starship.toml")), false);
+		await emit(mock.events, "session_shutdown", {}, newContext.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("same-cwd session replacement aborts and rejects stale native PR publication", async () => {
+	const mock = createMockPi();
+	const oldResult = deferred<ExecResult>();
+	const newResult = deferred<ExecResult>();
+	const shutdownResult = deferred<ExecResult>();
+	const results = [oldResult.promise, newResult.promise, shutdownResult.promise];
+	const signals: AbortSignal[] = [];
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (
+				command: string,
+				args: string[],
+				options: { signal?: AbortSignal },
+			) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args, options) => {
+		if (!isGithubPrCall(args)) return gitResult();
+		if (options.signal) signals.push(options.signal);
+		const result = results.shift();
+		if (!result) throw new Error("unexpected gh pr view call");
+		return result;
+	};
+	piStarship(mock.pi);
+	const oldContext = createMockContext({ mode: "tui", cwd: "/work/shared" });
+	const newContext = createMockContext({ mode: "tui", cwd: "/work/shared" });
+	await emit(mock.events, "session_start", {}, oldContext.ctx);
+	let staleBranchChange: (() => void) | undefined;
+	const oldFooter = (oldContext.footer as FooterFactory)(
+		{ requestRender() {} },
+		{},
+		{
+			getGitBranch: () => "feature",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: (callback) => {
+				staleBranchChange = callback;
+				return () => undefined;
+			},
+		},
+	);
+	await emit(mock.events, "session_start", {}, newContext.ctx);
+	assert.equal(signals[0]?.aborted, true);
+	oldResult.resolve(pullRequestResult(111));
+	newResult.resolve(pullRequestResult(222));
+	await flushAsync();
+	const footer = (newContext.footer as FooterFactory)(
+		{ requestRender() {} },
+		{},
+		{
+			getGitBranch: () => "feature",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	const rendered = stripAnsi(footer.render(300).join("\n"));
+	assert.match(rendered, /#222/u);
+	assert.doesNotMatch(rendered, /#111/u);
+
+	staleBranchChange?.();
+	await emit(mock.events, "session_shutdown", {}, oldContext.ctx);
+	assert.equal(signals.length, 2);
+	assert.equal(signals[1]?.aborted, false);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#222/u);
+
+	await emit(mock.events, "agent_end", {}, newContext.ctx);
+	assert.equal(signals.length, 3);
+	await emit(mock.events, "session_shutdown", {}, newContext.ctx);
+	assert.equal(signals[2]?.aborted, true);
+	shutdownResult.resolve(pullRequestResult(333));
+	await flushAsync();
+	footer.dispose();
+	oldFooter.dispose();
+});
+
+test("reachable native PR refresh uses its own 60-second fallback", async (t) => {
+	t.mock.timers.enable({ apis: ["setInterval"] });
+	const mock = createMockPi();
+	let prCalls = 0;
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (_command: string, args: string[]) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args) => {
+		if (!isGithubPrCall(args)) return gitResult();
+		prCalls += 1;
+		return pullRequestResult(prCalls);
+	};
+	piStarship(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+	await flushAsync();
+	assert.equal(prCalls, 1);
+	t.mock.timers.tick(59_999);
+	await flushAsync();
+	assert.equal(prCalls, 1);
+	t.mock.timers.tick(1);
+	await flushAsync();
+	assert.equal(prCalls, 2);
+	const footer = (context.footer as FooterFactory)(
+		{ requestRender() {} },
+		{},
+		{
+			getGitBranch: () => "feature",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	footer.dispose();
+	await emit(mock.events, "session_shutdown", {}, context.ctx);
+});
+
+test("terminal native PR snapshots clear at their lifecycle expiry", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const mock = createMockPi();
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (_command: string, args: string[]) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args) =>
+		isGithubPrCall(args)
+			? pullRequestResult(123, {
+					state: "MERGED",
+					mergedAt: new Date(Date.now() - 24 * 60 * 60 * 1_000 + 500).toISOString(),
+				})
+			: gitResult();
+	piStarship(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+	await flushAsync();
+	const footer = (context.footer as FooterFactory)(
+		{ requestRender() {} },
+		{},
+		{
+			getGitBranch: () => "feature",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+	t.mock.timers.tick(1_000);
+	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
+	footer.dispose();
+	await emit(mock.events, "session_shutdown", {}, context.ctx);
 });
 
 test("turn module counts user messages instead of repeated LLM turns", async () => {
@@ -277,6 +632,7 @@ test("stale Git results from a replaced session cannot overwrite the new footer"
 			exec: (_command: string, args: string[]) => Promise<ExecResult>;
 		}
 	).exec = async (_command, args) => {
+		if (isGithubPrCall(args)) return { stdout: "", stderr: "no PR", code: 1, killed: false };
 		if (args[0] === "rev-parse") {
 			return gitResult("/work/main\n/work/main/.git\n/work/main/.git\n");
 		}
@@ -457,13 +813,45 @@ test("Git worktree parser distinguishes linked and primary worktrees", () => {
 
 type ExecResult = { stdout: string; stderr: string; code: number; killed: boolean };
 
+function isGithubPrCall(args: readonly string[]): boolean {
+	return args.includes("pr") && args.includes("view") && args.includes("--json");
+}
+
+function pullRequestResult(number: number, overrides: Record<string, unknown> = {}): ExecResult {
+	return {
+		stdout: JSON.stringify({
+			number,
+			isDraft: false,
+			url: `https://github.com/o/r/pull/${number}`,
+			state: "OPEN",
+			closedAt: null,
+			mergedAt: null,
+			reviewDecision: "",
+			statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+			...overrides,
+		}),
+		stderr: "",
+		code: 0,
+		killed: false,
+	};
+}
+
 function gitResult(stdout = "## main\n"): ExecResult {
 	return { stdout, stderr: "", code: 0, killed: false };
 }
 
 function stripAnsi(value: string): string {
 	const escapeSequence = String.fromCharCode(27);
-	return value.replace(new RegExp(`${escapeSequence}\\[[0-9;]*m`, "gu"), "");
+	let result = value.replace(new RegExp(`${escapeSequence}\\[[0-9;]*m`, "gu"), "");
+	const osc8Prefix = `${escapeSequence}]8;;`;
+	const terminator = String.fromCharCode(7);
+	while (true) {
+		const start = result.indexOf(osc8Prefix);
+		if (start === -1) return result;
+		const end = result.indexOf(terminator, start + osc8Prefix.length);
+		if (end === -1) return result.slice(0, start);
+		result = result.slice(0, start) + result.slice(end + terminator.length);
+	}
 }
 
 function deferred<T>() {

--- a/extensions/pi-starship/test/modules.test.ts
+++ b/extensions/pi-starship/test/modules.test.ts
@@ -7,7 +7,6 @@ import {
 	buildExtensionStatusIconAliases,
 	formatCount,
 	formatExtensionStatus,
-	prContextFromStatuses,
 	renderStatusline,
 	type StarshipRuntimeSnapshot,
 	shortenModel,
@@ -17,7 +16,16 @@ const LINK = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
 
 function stripAnsi(value: string): string {
 	const escapeSequence = String.fromCharCode(27);
-	return value.replace(new RegExp(`${escapeSequence}\\[[0-9;]*m`, "gu"), "");
+	let result = value.replace(new RegExp(`${escapeSequence}\\[[0-9;]*m`, "gu"), "");
+	const osc8Prefix = `${escapeSequence}]8;;`;
+	const terminator = String.fromCharCode(7);
+	while (true) {
+		const start = result.indexOf(osc8Prefix);
+		if (start === -1) return result;
+		const end = result.indexOf(terminator, start + osc8Prefix.length);
+		if (end === -1) return result.slice(0, start);
+		result = result.slice(0, start) + result.slice(end + terminator.length);
+	}
 }
 
 function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRuntimeSnapshot {
@@ -41,6 +49,14 @@ function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRunt
 		gitBranch: "feature",
 		gitBranchDetails: { name: "feature", detached: false },
 		gitCommit: { hash: "0123456789abcdef", detached: false },
+		githubPr: {
+			number: "123",
+			link: LINK,
+			state: "open",
+			checks: "2 failing",
+			review: "approved",
+			status: "2 failing",
+		},
 		gitStatus: {
 			ahead: 2,
 			behind: 1,
@@ -61,10 +77,7 @@ function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRunt
 			indexModified: 0,
 			indexTypechanged: 0,
 		},
-		extensionStatuses: new Map([
-			["github-pr", `PR ${LINK}: checks failing (2), approved`],
-			["goal", "active"],
-		]),
+		extensionStatuses: new Map([["goal", "active"]]),
 		extensionStatusIconAliases: new Map(),
 		now: new Date(2026, 0, 1, 9, 5),
 		...overrides,
@@ -80,6 +93,7 @@ test("built-in modules expose Pi values through the default format", () => {
 	assert.match(plain, /high/);
 	assert.match(plain, /pi-extensions/);
 	assert.match(plain, /feature/);
+	assert.match(plain, /PR #123 · 2 failing/);
 	assert.match(plain, /=1 !4 \+3 \?5 ⇕⇡2⇣1/);
 	assert.match(plain, /read/);
 	assert.match(plain, /75\.0%/);
@@ -87,8 +101,6 @@ test("built-in modules expose Pi values through the default format", () => {
 	assert.match(plain, /\$0\.123/);
 	assert.match(plain, /09:05/);
 	assert.match(plain, /🎯 active/);
-	assert.doesNotMatch(plain, /PR .*checks failing/);
-	assert.ok(rendered.consumedExtensionStatusKeys.has("github-pr"));
 });
 
 test("context supports native percentage/window precision", () => {
@@ -211,19 +223,22 @@ test("cache read and write remain available when the latest rate is unknown", ()
 	assert.equal(stripAnsi(renderStatusline(config, runtime).ansi).trim(), "C");
 });
 
-test("git branch consumes github-pr only when its module format references pr", () => {
+test("external github-pr statuses remain generic extension statuses", () => {
 	const config = structuredClone(BUILT_IN_CONFIG);
-	config.format = "$git_branch\n$extension_status";
-	config.formatAst = [
-		{ type: "variable", name: "git_branch" },
-		{ type: "text", value: "\n" },
-		{ type: "variable", name: "extension_status" },
-	];
-	config.modules.git_branch.format = "$branch";
-	config.modules.git_branch.formatAst = [{ type: "variable", name: "branch" }];
-	const rendered = renderStatusline(config, fixture());
-	assert.equal(rendered.consumedExtensionStatusKeys.has("github-pr"), false);
-	assert.match(rendered.ansi, /checks failing/);
+	config.format = "$extension_status";
+	config.formatAst = [{ type: "variable", name: "extension_status" }];
+	const rendered = stripAnsi(
+		renderStatusline(
+			config,
+			fixture({
+				githubPr: undefined,
+				extensionStatuses: new Map([["github-pr", `PR ${LINK}: checks failing (2), approved`]]),
+			}),
+		).ansi,
+	);
+	assert.match(rendered, /🔌 PR/u);
+	assert.match(rendered, /checks failing/u);
+	assert.doesNotMatch(rendered, /🔎/u);
 });
 
 test("empty and disabled modules disappear and make conditionals empty", () => {
@@ -623,12 +638,8 @@ test("extension status icons honor exact keys, aliases, suppression, defaults, a
 	assert.doesNotMatch(rendered, /🔌 waiting/);
 });
 
-test("format helpers are compact and PR state is actionable", () => {
+test("format helpers stay compact and OSC links retain visible width", () => {
 	assert.equal(formatCount(1530), "1.5k");
 	assert.equal(shortenModel("claude-sonnet-4-20250514"), "sonnet-4");
-	assert.equal(
-		prContextFromStatuses(new Map([["github-pr", `PR ${LINK}: checks failing (2), approved`]])),
-		`${LINK} · 2 failing`,
-	);
 	assert.equal(visibleWidth(LINK), 4);
 });

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -35,6 +35,26 @@ test("workspace commands stream output and terminate at the byte limit", async (
 	assert.ok(Date.now() - started < 1_500);
 });
 
+test("workspace commands honor caller cancellation", async () => {
+	const controller = new AbortController();
+	const started = Date.now();
+	const resultPromise = execWorkspaceCommand(
+		process.execPath,
+		["-e", "setInterval(() => {}, 10_000);"],
+		{
+			cwd: process.cwd(),
+			timeout: 2_000,
+			maxOutputBytes: 1_024,
+			environment: {},
+			signal: controller.signal,
+		},
+	);
+	setTimeout(() => controller.abort(), 20);
+	const result = await resultPromise;
+	assert.equal(result.killed, true);
+	assert.ok(Date.now() - started < 1_000);
+});
+
 test("workspace commands receive only the explicit allowlisted environment", async () => {
 	const secretName = `PI_STARSHIP_SENTINEL_${process.pid}`;
 	process.env[secretName] = "secret";
@@ -181,6 +201,32 @@ test("package parser supports Cargo inheritance and Python metadata without ance
 			exec: noExec,
 		});
 		assert.equal(snapshot.modules.package, undefined);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("workspace collectors forward refresh cancellation to commands", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-workspace-signal-"));
+	try {
+		writeFileSync(join(root, "package.json"), "{}");
+		const controller = new AbortController();
+		let received: AbortSignal | undefined;
+		await collectWorkspaceSnapshot({
+			cwd: root,
+			config: config("$nodejs", { nodejs: { format: "$version" } }),
+			environment: {},
+			homeDir: root,
+			platform: "linux",
+			hostname: "host",
+			username: "user",
+			signal: controller.signal,
+			exec: async (_command, _args, options) => {
+				received = options.signal;
+				return { stdout: "v22.1.0", stderr: "", code: 0, killed: false };
+			},
+		});
+		assert.equal(received, controller.signal);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -699,7 +745,60 @@ test("oversized and malformed metadata files fail empty without leaking source t
 	}
 });
 
-test("refresh controller coalesces, suppresses equality, and rejects stale generations", async () => {
+test("refresh controller aborts work from replaced and stopped generations", () => {
+	const signals: AbortSignal[] = [];
+	const controller = new AsyncRefreshController<string, string>({
+		read: (_input, signal) => {
+			signals.push(signal);
+			return new Promise(() => undefined);
+		},
+		equal: (left, right) => left === right,
+		publish() {},
+	});
+	controller.start(1);
+	controller.request("old");
+	assert.equal(signals.length, 1);
+	assert.equal(signals[0]?.aborted, false);
+
+	controller.start(2);
+	assert.equal(signals[0]?.aborted, true);
+	controller.request("replacement");
+	assert.equal(signals.length, 2);
+	assert.equal(signals[1]?.aborted, false);
+
+	controller.stop();
+	assert.equal(signals[1]?.aborted, true);
+});
+
+test("refresh controller keeps only the latest same-generation pending request", async () => {
+	const pending: Array<(value: string) => void> = [];
+	const reads: string[] = [];
+	const published: string[] = [];
+	const controller = new AsyncRefreshController<string, string>({
+		read: (input) => {
+			reads.push(input);
+			return new Promise((resolve) => pending.push(resolve));
+		},
+		equal: (left, right) => left === right,
+		publish: (value) => published.push(value),
+	});
+	controller.start(1);
+	controller.request("active");
+	controller.request("superseded");
+	controller.request("latest");
+	assert.deepEqual(reads, ["active"]);
+
+	pending.shift()?.("active-result");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(published, []);
+	assert.deepEqual(reads, ["active", "latest"]);
+	pending.shift()?.("latest-result");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(published, ["latest-result"]);
+	controller.stop();
+});
+
+test("refresh controller suppresses equality and rejects stale generations", async () => {
 	const pending: Array<(value: string) => void> = [];
 	const published: string[] = [];
 	const controller = new AsyncRefreshController<string, string>({

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -19,6 +19,24 @@ function config(format: string, document: Record<string, unknown> = {}) {
 const noExec: WorkspaceExec = async () => {
 	throw new Error("unexpected command");
 };
+
+async function waitFor(predicate: () => boolean, timeout = 1_000): Promise<boolean> {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	return predicate();
+}
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
 
 test("workspace commands stream output and terminate at the byte limit", async () => {
 	const started = Date.now();
@@ -53,6 +71,54 @@ test("workspace commands honor caller cancellation", async () => {
 	const result = await resultPromise;
 	assert.equal(result.killed, true);
 	assert.ok(Date.now() - started < 1_000);
+});
+
+test("workspace cancellation force-kills descendants after the process-group leader exits", {
+	skip: process.platform === "win32",
+}, async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-process-tree-"));
+	const pidPath = join(root, "descendant.pid");
+	const readyPath = join(root, "descendant.ready");
+	const controller = new AbortController();
+	let descendantPid: number | undefined;
+	try {
+		const childScript = [
+			'const { writeFileSync } = require("node:fs");',
+			'process.on("SIGTERM", () => undefined);',
+			`writeFileSync(${JSON.stringify(readyPath)}, "ready");`,
+			"setInterval(() => undefined, 10_000);",
+		].join("\n");
+		const parentScript = [
+			'const { spawn } = require("node:child_process");',
+			'const { writeFileSync } = require("node:fs");',
+			`const child = spawn(${JSON.stringify(process.execPath)}, ["-e", ${JSON.stringify(childScript)}], { stdio: "ignore" });`,
+			`writeFileSync(${JSON.stringify(pidPath)}, String(child.pid));`,
+			'process.on("SIGTERM", () => process.exit(0));',
+			"setInterval(() => undefined, 10_000);",
+		].join("\n");
+		const resultPromise = execWorkspaceCommand(process.execPath, ["-e", parentScript], {
+			cwd: root,
+			timeout: 2_000,
+			maxOutputBytes: 1_024,
+			environment: {},
+			signal: controller.signal,
+		});
+		assert.equal(await waitFor(() => existsSync(pidPath) && existsSync(readyPath)), true);
+		descendantPid = Number(readFileSync(pidPath, "utf8"));
+		assert.equal(Number.isSafeInteger(descendantPid), true);
+		assert.equal(processExists(descendantPid), true);
+
+		controller.abort();
+		const result = await resultPromise;
+		assert.equal(result.killed, true);
+		assert.equal(await waitFor(() => !processExists(descendantPid as number)), true);
+	} finally {
+		controller.abort();
+		if (descendantPid !== undefined && processExists(descendantPid)) {
+			process.kill(descendantPid, "SIGKILL");
+		}
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("workspace commands receive only the explicit allowlisted environment", async () => {
@@ -745,25 +811,32 @@ test("oversized and malformed metadata files fail empty without leaking source t
 	}
 });
 
-test("refresh controller aborts work from replaced and stopped generations", () => {
+test("refresh controller drains replaced work before starting its replacement", async () => {
+	const reads: string[] = [];
 	const signals: AbortSignal[] = [];
+	const pending: Array<(value: string) => void> = [];
 	const controller = new AsyncRefreshController<string, string>({
-		read: (_input, signal) => {
+		read: (input, signal) => {
+			reads.push(input);
 			signals.push(signal);
-			return new Promise(() => undefined);
+			return new Promise((resolve) => pending.push(resolve));
 		},
 		equal: (left, right) => left === right,
 		publish() {},
 	});
 	controller.start(1);
 	controller.request("old");
-	assert.equal(signals.length, 1);
+	assert.deepEqual(reads, ["old"]);
 	assert.equal(signals[0]?.aborted, false);
 
 	controller.start(2);
-	assert.equal(signals[0]?.aborted, true);
 	controller.request("replacement");
-	assert.equal(signals.length, 2);
+	assert.equal(signals[0]?.aborted, true);
+	assert.deepEqual(reads, ["old"]);
+
+	pending.shift()?.("stale");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.deepEqual(reads, ["old", "replacement"]);
 	assert.equal(signals[1]?.aborted, false);
 
 	controller.stop();


### PR DESCRIPTION
## Summary

- add a native cached `$github_pr` module backed by a bounded, cancellable `gh pr view` query, including GitHub Enterprise host discovery, terminal-safe links, compact checks/review state, and 24-hour terminal-state retention
- remove `$git_branch.$pr` and all special consumption, hiding, and icon policy for the external `github-pr` status
- refresh on branch, agent, settings, and 60-second lifecycle boundaries with stale-publication guards and owned subprocess cancellation
- harden replacement draining, POSIX process-tree termination, GitHub timestamp validation, and wall-clock-aware expiry
- document prerequisites, privacy/network behavior, failure degradation, and the breaking migration

## Breaking change

`$git_branch.$pr` is removed without an alias or automatic migration. Configure root `$github_pr` and `[github_pr]` instead.

## Verification

- `npm test` — 2,047 tests passed
- `npm run check --workspace @narumitw/pi-starship` — passed
- `npm run check` — 2,047 tests passed
- `just pack-starship` — 58 intended files; includes both new native PR source files
- independent final implementation and hardening reviews — PASS

## Lifecycle note

Already-started bounded local filesystem operations may finish after cancellation, but generation ownership prevents stale publication; command and network work is actively terminated and drained before replacement.
