### PR TITLE
feat(pi-plan-mode): save plans for later

### DIFF
--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -15,10 +15,10 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Blocks `update_plan`, mutating built-in tools, and unsafe `bash` forms such as writes, substitutions, background jobs, dependency installs, and mutating Git commands.
 - Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finalize only when decision-complete.
 - Adds required `plan_mode_question` and `plan_mode_complete` tools for structured questions and completion.
-- Presents the complete plan and prompts you to implement, stay in Plan mode, or exit and discard it.
+- Presents the complete plan and prompts you to implement, save it for later, stay in Plan mode, or exit and discard it.
 - Keeps legacy `<proposed_plan>` responses compatible without advertising XML as the primary workflow.
-- Shows Plan mode state in Pi's statusline as `plan active`, `plan ready`, or `plan implementing`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
-- Persists Plan mode and active implementation state in the Pi session so resume and compaction retain the exact accepted plan.
+- Shows Plan mode state in Pi's statusline as `plan active`, `plan ready`, `plan saved`, or `plan implementing`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
+- Persists Plan mode, one session-local saved plan, and active implementation state so resume and compaction retain the exact accepted plan.
 
 ## 📦 Install
 
@@ -49,6 +49,7 @@ pi -e ./extensions/pi-plan-mode
 /plan show
 /plan finalize
 /plan implement
+/plan save
 /plan exit
 ```
 
@@ -62,7 +63,8 @@ the query to restore the stable tool cursor. RPC keeps the complete unfiltered t
 model-requested planning interaction, not command-menu navigation. `/plan show` displays the stored
 plan without starting a model turn, including the accepted plan while implementation is active.
 `/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material
-question, and `/plan implement` hands a stored plan to a normal implementation turn. `show` and
+question, `/plan save` stores a completed ready plan for later and leaves Plan mode, and `/plan
+implement` hands a ready or saved plan to a normal implementation turn. `show`, `save`, and
 `implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
 
 When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation. It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
@@ -83,17 +85,24 @@ A complete Plan mode answer should appear only after the agent has resolved disc
 
 Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines. That compatibility path remains accepted, but it is not the primary workflow. Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
-After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. The exact accepted plan then remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
+After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
 
-While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context. Without interactive UI, use `/plan show`, `/plan implement`, or `/plan exit` directly.
+A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, or Clear it; `/plan show`, `/plan implement`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan <prompt>` or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
+
+Text print and JSON modes can save a ready plan with `/plan save` and clear it with `/plan exit` or `/plan off`. They reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns in those modes; resume the session in TUI or RPC to show or implement it.
+
+Once implemented, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
+
+While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
 
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 
 - `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
-- `plan ready`: A completed plan is stored until you implement it, continue planning, or exit Plan mode.
+- `plan ready`: A completed plan is stored until you implement it, save it, continue planning, or exit Plan mode.
+- `plan saved`: One completed plan is stored outside model context in the current session until you implement or clear it.
 - `plan implementing`: The exact accepted plan remains active until you clear or supersede it.
 
-You can also exit directly. Before implementation, direct exit discards the latest proposed plan instead of treating it as an implementation request. During implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
+You can also exit directly. Before implementation, direct exit discards the latest proposed plan; while a plan is saved, it clears that saved plan. During implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
 
 ```text
 /plan exit
@@ -175,7 +184,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
 - The agent completes with a standalone `plan_mode_complete` tool call instead of relying on semantic prose detection.
 - `update_plan` checklist use is blocked while Plan mode is active.
-- The implementation boundary is explicit: Plan mode restores tools before starting implementation, choosing implementation immediately triggers a normal agent turn with full tool access, and the accepted plan remains active across compaction until exit/off or a replacement workflow clears it.
+- The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, choosing implementation immediately triggers a normal agent turn with full tool access, and the accepted plan remains active across compaction until exit/off or a replacement workflow clears it.
 - Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 

--- a/extensions/pi-plan-mode/src/command.ts
+++ b/extensions/pi-plan-mode/src/command.ts
@@ -5,11 +5,12 @@ export interface CommandArgumentCompletion {
 }
 
 const PLAN_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
-	{ value: "show", label: "show", description: "Show the ready or active plan" },
+	{ value: "show", label: "show", description: "Show the ready, saved, or active plan" },
 	{ value: "finalize", label: "finalize", description: "Request a completed plan" },
-	{ value: "implement", label: "implement", description: "Implement the completed plan" },
-	{ value: "exit", label: "exit", description: "Leave Plan mode or clear the active plan" },
-	{ value: "off", label: "off", description: "Leave Plan mode or clear the active plan" },
+	{ value: "implement", label: "implement", description: "Implement the completed or saved plan" },
+	{ value: "save", label: "save", description: "Save the completed plan for later" },
+	{ value: "exit", label: "exit", description: "Leave Plan mode or clear a saved/active plan" },
+	{ value: "off", label: "off", description: "Leave Plan mode or clear a saved/active plan" },
 	{ value: "tools", label: "tools", description: "Select tools allowed in Plan mode" },
 ];
 

--- a/extensions/pi-plan-mode/src/plan-action-menus.ts
+++ b/extensions/pi-plan-mode/src/plan-action-menus.ts
@@ -1,0 +1,134 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+
+interface MenuLifecycle {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+interface PlanMenuOptions extends MenuLifecycle {
+	statusText: string;
+	hasReadyPlan: boolean;
+	show(): void;
+	finalize(): void;
+	implement(): void | Promise<void>;
+	save(): void;
+	tools(): Promise<void>;
+	stay(): void;
+	exit(): void;
+}
+
+export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuOptions) {
+	type Action = "show" | "finalize" | "implement" | "save" | "tools" | "stay" | "exit";
+	const menu = defineMenu<undefined, "main", Action, ExtensionContext>({
+		start: "main",
+		screens: {
+			main: () => ({
+				kind: "actions",
+				title: "Plan mode",
+				lines: [options.statusText],
+				items: options.hasReadyPlan
+					? [
+							{ id: "show", label: "Show latest proposed plan", action: "show" },
+							{ id: "implement", label: "Implement this plan", action: "implement" },
+							{ id: "save", label: "Save for later", action: "save" },
+							{ id: "tools", label: "Configure Plan-mode tools", action: "tools" },
+							{ id: "stay", label: "Stay in Plan mode", action: "stay" },
+							{ id: "exit", label: "Exit Plan mode", action: "exit" },
+						]
+					: [
+							{ id: "finalize", label: "Request final plan", action: "finalize" },
+							{ id: "tools", label: "Configure Plan-mode tools", action: "tools" },
+							{ id: "stay", label: "Stay in Plan mode", action: "stay" },
+							{ id: "exit", label: "Exit Plan mode", action: "exit" },
+						],
+				hint: "close",
+			}),
+		},
+		actions: {
+			show: async () => {
+				options.show();
+				return { kind: "close" };
+			},
+			finalize: async () => {
+				options.finalize();
+				return { kind: "close" };
+			},
+			implement: async () => {
+				await options.implement();
+				return { kind: "close" };
+			},
+			save: async () => {
+				options.save();
+				return { kind: "close" };
+			},
+			tools: async () => {
+				await options.tools();
+				return { kind: "stay" };
+			},
+			stay: async () => {
+				options.stay();
+				return { kind: "close" };
+			},
+			exit: async () => {
+				options.exit();
+				return { kind: "close" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+	});
+}
+
+interface ReadyPlanMenuOptions extends MenuLifecycle {
+	implement(): void | Promise<void>;
+	save(): void;
+	stay(): void;
+	exit(): void;
+}
+
+export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPlanMenuOptions) {
+	type Action = "implement" | "save" | "stay" | "exit";
+	const menu = defineMenu<undefined, "ready", Action, ExtensionContext>({
+		start: "ready",
+		screens: {
+			ready: () => ({
+				kind: "actions",
+				title: "Proposed plan ready. What next?",
+				items: [
+					{ id: "implement", label: "Implement this plan", action: "implement" },
+					{ id: "save", label: "Save for later", action: "save" },
+					{ id: "stay", label: "Stay in Plan mode", action: "stay" },
+					{ id: "exit", label: "Exit Plan mode", action: "exit" },
+				],
+				hint: "close",
+			}),
+		},
+		actions: {
+			implement: async () => {
+				await options.implement();
+				return { kind: "close" };
+			},
+			save: async () => {
+				options.save();
+				return { kind: "close" };
+			},
+			stay: async () => {
+				options.stay();
+				return { kind: "close" };
+			},
+			exit: async () => {
+				options.exit();
+				return { kind: "close" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+	});
+}

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -28,9 +28,11 @@ import {
 	stripPlanModeCompletionCallsFromMessage,
 	stripProposedPlanBlocksFromMessage,
 } from "./message-transform.js";
+import { showPlanModeMenu, showReadyPlanMenu } from "./plan-action-menus.js";
 import {
 	clearPlanModeUi,
 	planModeStatusText as formatPlanModeStatusText,
+	showPlanModePlan,
 	updatePlanModeUi,
 } from "./presentation.js";
 import { buildPlanModePrompt } from "./prompt.js";
@@ -42,6 +44,11 @@ import {
 	planModeQuestionCancelled,
 } from "./question-tool.js";
 import { withoutRequiredPlanModeTools, withRequiredPlanModeTools } from "./required-tools.js";
+import { showSavedPlanMenu } from "./saved-plan-menu.js";
+import {
+	preflightSavedPlanImplementation,
+	savedPlanBlocksNewWorkflow,
+} from "./saved-plan-preflight.js";
 import {
 	configuredThinkingLevel,
 	type PlanModeSettings,
@@ -169,36 +176,49 @@ export default function planMode(
 				return;
 			}
 			if (command === "implement") {
-				if (!state.enabled || !state.latestPlan?.trim()) {
+				if (!(state.enabled && state.latestPlan?.trim()) && !state.savedPlan?.plan.trim()) {
 					ctx.ui.notify("No completed plan is available to implement.", "warning");
 					return;
 				}
-				startImplementation(ctx);
+				await startImplementation(ctx);
+				return;
+			}
+			if (command === "save") {
+				savePlanForLater(ctx);
 				return;
 			}
 			if (command === "exit" || command === "off") {
-				const hadActiveImplementation = state.activeImplementation !== undefined;
+				const notification = state.activeImplementation
+					? "Active implementation plan cleared."
+					: state.savedPlan
+						? "Saved plan cleared."
+						: state.latestPlan
+							? "Plan mode disabled. Proposed plan discarded."
+							: "Plan mode disabled.";
 				exitPlanMode(ctx);
-				ctx.ui.notify(
-					hadActiveImplementation
-						? "Active implementation plan cleared."
-						: "Plan mode disabled. Proposed plan discarded.",
-					"info",
-				);
+				ctx.ui.notify(notification, "info");
 				return;
 			}
 			if (command === "tools") {
+				if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined && !state.enabled))
+					return;
 				if (!state.enabled) enterPlanMode(ctx);
 				await showToolSelector(ctx);
 				return;
 			}
 			if (prompt) {
+				if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined && !state.enabled))
+					return;
 				enterPlanModeWithPrompt(prompt, ctx);
 				return;
 			}
 			if (!state.enabled) {
 				if (state.activeImplementation && ctx.hasUI) {
 					await showActivePlanMenu(ctx);
+					return;
+				}
+				if (state.savedPlan) {
+					await showSavedPlanActions(ctx);
 					return;
 				}
 				enterPlanMode(ctx);
@@ -225,7 +245,17 @@ export default function planMode(
 		if (loadedSettings.notice) ctx.ui.notify(loadedSettings.notice, "warning");
 		const persistFlagActivation = pi.getFlag("plan") === true && !state.enabled;
 		if (persistFlagActivation) {
-			state = { ...state, enabled: true, activeImplementation: undefined };
+			state = state.savedPlan
+				? {
+						...state,
+						enabled: true,
+						latestPlan: state.savedPlan.plan,
+						latestPlanSource: state.savedPlan.source,
+						awaitingAction: true,
+						savedPlan: undefined,
+						activeImplementation: undefined,
+					}
+				: { ...state, enabled: true, activeImplementation: undefined };
 		}
 		if (state.enabled) {
 			activatePlanModeTools();
@@ -391,6 +421,7 @@ export default function planMode(
 			...state,
 			enabled: true,
 			awaitingAction: false,
+			savedPlan: undefined,
 			activeImplementation: undefined,
 		};
 		activatePlanModeTools();
@@ -426,6 +457,7 @@ export default function planMode(
 			latestPlan: undefined,
 			latestPlanSource: undefined,
 			awaitingAction: false,
+			savedPlan: undefined,
 			activeImplementation: undefined,
 			manualThinkingLevel: undefined,
 		};
@@ -496,8 +528,12 @@ export default function planMode(
 
 	function showStoredPlan(ctx: ExtensionContext) {
 		const readyPlan = state.enabled ? state.latestPlan?.trim() : undefined;
+		const savedPlan = state.savedPlan?.plan.trim();
+		if (savedPlan && (ctx.mode === "print" || ctx.mode === "json")) {
+			throw new Error("Saved plan display is unavailable in print/JSON mode. Use TUI or RPC.");
+		}
 		const activePlan = state.activeImplementation?.plan.trim();
-		const plan = readyPlan ?? activePlan;
+		const plan = readyPlan ?? savedPlan ?? activePlan;
 		if (!plan) {
 			ctx.ui.notify(
 				"No completed plan is available. Use /plan finalize when planning is complete.",
@@ -505,19 +541,12 @@ export default function planMode(
 			);
 			return;
 		}
-		try {
-			pi.sendMessage(
-				{
-					customType: PROPOSED_PLAN_MESSAGE_TYPE,
-					content: `**${readyPlan ? "Proposed Plan" : "Active Implementation Plan"}**\n\n${plan}`,
-					display: true,
-				},
-				{ triggerTurn: false },
-			);
-		} catch (error: unknown) {
-			const detail = error instanceof Error ? error.message : String(error);
-			ctx.ui.notify(`Unable to show completed plan: ${detail}`, "error");
-		}
+		const title = readyPlan
+			? "Proposed Plan"
+			: savedPlan
+				? "Saved Plan"
+				: "Active Implementation Plan";
+		showPlanModePlan(pi, ctx, title, plan);
 	}
 
 	function requestFinalPlan(ctx: ExtensionContext) {
@@ -531,15 +560,59 @@ export default function planMode(
 		);
 	}
 
-	function startImplementation(ctx: ExtensionContext) {
-		const plan = state.latestPlan?.trim();
+	function savePlanForLater(ctx: ExtensionContext) {
+		const plan = state.enabled ? state.latestPlan?.trim() : undefined;
+		if (!plan) {
+			const message = "No completed plan is available to save.";
+			if (!ctx.hasUI) throw new Error(message);
+			ctx.ui.notify(message, "warning");
+			return;
+		}
 		const source = state.latestPlanSource ?? "legacy_proposed_plan";
+
+		workflowGeneration += 1;
+		readyPresentationIntent = undefined;
+		state = {
+			...state,
+			enabled: false,
+			latestPlan: undefined,
+			latestPlanSource: undefined,
+			awaitingAction: false,
+			savedPlan: { plan, source },
+			activeImplementation: undefined,
+			manualThinkingLevel: undefined,
+		};
+		restoreTools();
+		restoreThinkingLevel();
+		state = { ...state, manualThinkingLevel: undefined };
+		persistState();
+		updateUi(ctx);
+		ctx.ui.notify("Plan saved for later. Plan mode disabled.", "info");
+	}
+
+	async function startImplementation(ctx: ExtensionContext) {
+		const savedPlan = state.enabled ? undefined : state.savedPlan;
+		if (savedPlan) {
+			const sessionGeneration = menuGeneration;
+			const planWorkflowGeneration = workflowGeneration;
+			const isCurrent = () =>
+				sessionGeneration === menuGeneration &&
+				planWorkflowGeneration === workflowGeneration &&
+				!menuController.signal.aborted &&
+				!state.enabled &&
+				state.savedPlan === savedPlan;
+			if (!(await preflightSavedPlanImplementation(ctx, isCurrent))) return;
+		}
+		const plan = (state.enabled ? state.latestPlan : savedPlan?.plan)?.trim();
+		const source =
+			(state.enabled ? state.latestPlanSource : savedPlan?.source) ?? "legacy_proposed_plan";
 		if (!plan) {
 			ctx.ui.notify("Plan mode disabled. No proposed plan is available to implement.", "warning");
 			return;
 		}
 
 		workflowGeneration += 1;
+		const previousState = state;
 		const wasEnabled = state.enabled;
 		readyPresentationIntent = undefined;
 		state = {
@@ -548,6 +621,7 @@ export default function planMode(
 			latestPlan: undefined,
 			latestPlanSource: undefined,
 			awaitingAction: false,
+			savedPlan: undefined,
 			activeImplementation: {
 				id: randomUUID(),
 				plan,
@@ -569,8 +643,13 @@ export default function planMode(
 			ctx,
 		);
 		if (!sent) {
-			enterPlanMode(ctx);
-			state = { ...state, latestPlan: plan, latestPlanSource: source, awaitingAction: true };
+			if (savedPlan) {
+				state = previousState;
+			} else {
+				enterPlanMode(ctx);
+				state = previousState;
+				applyPlanThinkingLevel();
+			}
 			persistState();
 			updateUi(ctx);
 		}
@@ -598,104 +677,55 @@ export default function planMode(
 		});
 	}
 
+	async function showSavedPlanActions(ctx: ExtensionContext) {
+		const lifecycle = captureMenuLifecycle();
+		await showSavedPlanMenu(ctx, {
+			statusText: planStatusText(),
+			signal: lifecycle.signal,
+			isCurrent: lifecycle.isCurrent,
+			show: () => showStoredPlan(ctx),
+			implement: () => startImplementation(ctx),
+			clear: () => {
+				exitPlanMode(ctx);
+				ctx.ui.notify("Saved plan cleared.", "info");
+			},
+		});
+	}
+
 	async function showPlanMenu(ctx: ExtensionContext) {
 		if (!ctx.hasUI) {
 			ctx.ui.notify(planStatusText(), "info");
 			return;
 		}
 		const lifecycle = captureMenuLifecycle();
-		type Action = "show" | "finalize" | "implement" | "tools" | "stay" | "exit";
-		const menu = defineMenu<undefined, "main", Action, ExtensionContext>({
-			start: "main",
-			screens: {
-				main: () => ({
-					kind: "actions",
-					title: "Plan mode",
-					lines: [planStatusText()],
-					items: state.latestPlan
-						? [
-								{ id: "show", label: "Show latest proposed plan", action: "show" },
-								{ id: "implement", label: "Implement this plan", action: "implement" },
-								{ id: "tools", label: "Configure Plan-mode tools", action: "tools" },
-								{ id: "stay", label: "Stay in Plan mode", action: "stay" },
-								{ id: "exit", label: "Exit Plan mode", action: "exit" },
-							]
-						: [
-								{ id: "finalize", label: "Request final plan", action: "finalize" },
-								{ id: "tools", label: "Configure Plan-mode tools", action: "tools" },
-								{ id: "stay", label: "Stay in Plan mode", action: "stay" },
-								{ id: "exit", label: "Exit Plan mode", action: "exit" },
-							],
-					hint: "close",
-				}),
-			},
-			actions: {
-				show: async () => {
-					showStoredPlan(ctx);
-					return { kind: "close" };
-				},
-				finalize: async () => {
-					requestFinalPlan(ctx);
-					return { kind: "close" };
-				},
-				implement: async () => {
-					startImplementation(ctx);
-					return { kind: "close" };
-				},
-				tools: async () => {
-					await showToolSelector(ctx);
-					return { kind: "stay" };
-				},
-				stay: async () => {
-					updateUi(ctx);
-					return { kind: "close" };
-				},
-				exit: async () => {
-					exitPlanMode(ctx);
-					ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
-					return { kind: "close" };
-				},
-			},
-		});
-		await runMenu(ctx, menu, {
-			getState: () => undefined,
+		await showPlanModeMenu(ctx, {
+			statusText: planStatusText(),
+			hasReadyPlan: state.latestPlan !== undefined,
 			...lifecycle,
+			show: () => showStoredPlan(ctx),
+			finalize: () => requestFinalPlan(ctx),
+			implement: () => startImplementation(ctx),
+			save: () => savePlanForLater(ctx),
+			tools: () => showToolSelector(ctx),
+			stay: () => updateUi(ctx),
+			exit: () => {
+				exitPlanMode(ctx);
+				ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
+			},
 		});
 	}
 
 	async function showPlanReadyMenu(ctx: ExtensionContext) {
 		const lifecycle = captureMenuLifecycle();
-		type Action = "implement" | "stay" | "exit";
-		const menu = defineMenu<undefined, "ready", Action, ExtensionContext>({
-			start: "ready",
-			screens: {
-				ready: () => ({
-					kind: "actions",
-					title: "Proposed plan ready. What next?",
-					items: [
-						{ id: "implement", label: "Implement this plan", action: "implement" },
-						{ id: "stay", label: "Stay in Plan mode", action: "stay" },
-						{ id: "exit", label: "Exit Plan mode", action: "exit" },
-					],
-					hint: "close",
-				}),
-			},
-			actions: {
-				implement: async () => {
-					startImplementation(ctx);
-					return { kind: "close" };
-				},
-				stay: async () => ({ kind: "close" }),
-				exit: async () => {
-					exitPlanMode(ctx);
-					ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
-					return { kind: "close" };
-				},
-			},
-		});
-		await runMenu(ctx, menu, {
-			getState: () => undefined,
+		await showReadyPlanMenu(ctx, {
 			...lifecycle,
+			implement: () => startImplementation(ctx),
+			save: () => savePlanForLater(ctx),
+			stay: () => undefined,
+			exit: () => {
+				exitPlanMode(ctx);
+				ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
+			},
 		});
 	}
 

--- a/extensions/pi-plan-mode/src/presentation.ts
+++ b/extensions/pi-plan-mode/src/presentation.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PlanModeState } from "./state.js";
 
 const STATUS_KEY = "plan-mode";
@@ -13,13 +13,18 @@ export function updatePlanModeUi(
 	if (state.enabled && state.latestPlan) {
 		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
 			"Proposed plan ready",
-			"Use /plan to implement, revise, or exit Plan mode.",
+			"Use /plan to implement, save, revise, or exit Plan mode.",
 		]);
 	} else if (state.enabled) {
 		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
 			"Plan mode: planning",
 			toolSummary(),
 			"Finish with plan_mode_complete when decision-ready.",
+		]);
+	} else if (state.savedPlan) {
+		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
+			"Plan saved for later",
+			"Use /plan to show, implement, or clear it.",
 		]);
 	} else if (state.activeImplementation) {
 		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
@@ -36,6 +41,27 @@ export function clearPlanModeUi(ctx: ExtensionContext) {
 	ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
 }
 
+export function showPlanModePlan(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	title: string,
+	plan: string,
+) {
+	try {
+		pi.sendMessage(
+			{
+				customType: "proposed-plan",
+				content: `**${title}**\n\n${plan}`,
+				display: true,
+			},
+			{ triggerTurn: false },
+		);
+	} catch (error: unknown) {
+		const detail = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(`Unable to show completed plan: ${detail}`, "error");
+	}
+}
+
 export function planModeStatusText(state: PlanModeState, toolSummary: () => string) {
 	if (state.enabled) {
 		if (state.latestPlan) {
@@ -43,6 +69,7 @@ export function planModeStatusText(state: PlanModeState, toolSummary: () => stri
 		}
 		return `Plan mode is active. ${toolSummary()} Explore, ask, and finish with plan_mode_complete when decision-ready.`;
 	}
+	if (state.savedPlan) return "A plan is saved for later.";
 	if (state.activeImplementation) return "An implementation plan is active.";
 	return "Plan mode is off.";
 }
@@ -52,6 +79,7 @@ function formatStatus(state: PlanModeState) {
 		if (state.awaitingAction || state.latestPlan) return "plan ready";
 		return "plan active";
 	}
+	if (state.savedPlan) return "plan saved";
 	if (state.activeImplementation) return "plan implementing";
 	return undefined;
 }

--- a/extensions/pi-plan-mode/src/saved-plan-menu.ts
+++ b/extensions/pi-plan-mode/src/saved-plan-menu.ts
@@ -1,0 +1,53 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+
+interface SavedPlanMenuOptions {
+	statusText: string;
+	signal: AbortSignal;
+	isCurrent(): boolean;
+	show(): void;
+	implement(): void | Promise<void>;
+	clear(): void;
+}
+
+export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPlanMenuOptions) {
+	if (!ctx.hasUI) {
+		throw new Error(`${options.statusText} Use /plan show, /plan implement, or /plan exit.`);
+	}
+	type Action = "show" | "implement" | "clear";
+	const menu = defineMenu<undefined, "saved", Action, ExtensionContext>({
+		start: "saved",
+		screens: {
+			saved: () => ({
+				kind: "actions",
+				title: "Saved plan",
+				lines: [options.statusText],
+				items: [
+					{ id: "show", label: "Show saved plan", action: "show" },
+					{ id: "implement", label: "Implement saved plan", action: "implement" },
+					{ id: "clear", label: "Clear saved plan", action: "clear" },
+				],
+				hint: "close",
+			}),
+		},
+		actions: {
+			show: async () => {
+				options.show();
+				return { kind: "close" };
+			},
+			implement: async () => {
+				await options.implement();
+				return { kind: "close" };
+			},
+			clear: async () => {
+				options.clear();
+				return { kind: "close" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+	});
+}

--- a/extensions/pi-plan-mode/src/saved-plan-preflight.ts
+++ b/extensions/pi-plan-mode/src/saved-plan-preflight.ts
@@ -1,0 +1,39 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+export function savedPlanBlocksNewWorkflow(ctx: ExtensionContext, hasSavedPlan: boolean) {
+	if (!hasSavedPlan) return false;
+	const message =
+		"A plan is saved for later. Implement or clear it before starting another Plan-mode workflow.";
+	if (!ctx.hasUI) throw new Error(message);
+	ctx.ui.notify(message, "warning");
+	return true;
+}
+
+export async function preflightSavedPlanImplementation(
+	ctx: ExtensionContext,
+	isCurrent: () => boolean,
+) {
+	if (ctx.mode === "print" || ctx.mode === "json") {
+		throw new Error("Saved plan implementation is unavailable in print/JSON mode. Use TUI or RPC.");
+	}
+	const model = ctx.model;
+	if (!model) {
+		ctx.ui.notify("Unable to implement saved plan: no model is selected.", "warning");
+		return false;
+	}
+	let auth: Awaited<ReturnType<ExtensionContext["modelRegistry"]["getApiKeyAndHeaders"]>>;
+	try {
+		auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	} catch (error: unknown) {
+		if (!isCurrent()) return false;
+		const detail = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(`Unable to implement saved plan: ${detail}`, "error");
+		return false;
+	}
+	if (!isCurrent()) return false;
+	if (!auth.ok) {
+		ctx.ui.notify(`Unable to implement saved plan: ${auth.error}`, "warning");
+		return false;
+	}
+	return true;
+}

--- a/extensions/pi-plan-mode/src/state.ts
+++ b/extensions/pi-plan-mode/src/state.ts
@@ -14,11 +14,17 @@ export interface ActiveImplementationPlan {
 	startedAt: number;
 }
 
+export interface SavedPlan {
+	plan: string;
+	source: PlanCompletionSource;
+}
+
 export interface PlanModeState {
 	enabled: boolean;
 	latestPlan?: string;
 	latestPlanSource?: PlanCompletionSource;
 	awaitingAction: boolean;
+	savedPlan?: SavedPlan;
 	activeImplementation?: ActiveImplementationPlan;
 	selectedToolNames?: string[];
 	selectedToolKeys?: string[];
@@ -60,6 +66,8 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 	const activeImplementation = enabled
 		? undefined
 		: normalizeActiveImplementation(entry.data.activeImplementation);
+	const savedPlan =
+		enabled || activeImplementation ? undefined : normalizeSavedPlan(entry.data.savedPlan);
 	return {
 		enabled,
 		latestPlan,
@@ -68,6 +76,7 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 				(recoveredPlan ? PLAN_MODE_COMPLETE_TOOL_NAME : undefined))
 			: undefined,
 		awaitingAction: enabled && latestPlan !== undefined,
+		savedPlan,
 		activeImplementation,
 		selectedToolNames: stringArray(entry.data.selectedToolNames),
 		selectedToolKeys: stringArray(entry.data.selectedToolKeys),
@@ -77,6 +86,14 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 		appliedThinkingLevel: enabled ? fixedThinkingLevel(entry.data.appliedThinkingLevel) : undefined,
 		manualThinkingLevel: enabled ? fixedThinkingLevel(entry.data.manualThinkingLevel) : undefined,
 	};
+}
+
+function normalizeSavedPlan(value: unknown): SavedPlan | undefined {
+	if (!isRecord(value)) return undefined;
+	const source = planCompletionSource(value.source);
+	const normalized = normalizePlanModeCompletion({ plan: value.plan });
+	if (!source || !normalized.ok) return undefined;
+	return { plan: normalized.plan, source };
 }
 
 function normalizeActiveImplementation(value: unknown): ActiveImplementationPlan | undefined {

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -64,7 +64,7 @@ test("plan_mode_complete result renders the plan as Markdown", () => {
 test("completePlanArguments suggests management tokens only", () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.label),
-		["show", "finalize", "implement", "exit", "off", "tools"],
+		["show", "finalize", "implement", "save", "exit", "off", "tools"],
 	);
 	assert.deepEqual(
 		completePlanArguments("to")?.map((item) => item.value),

--- a/extensions/pi-plan-mode/test/saved-plan.test.ts
+++ b/extensions/pi-plan-mode/test/saved-plan.test.ts
@@ -1,0 +1,579 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import planMode, { completePlanArguments } from "../src/plan-mode.js";
+import { restorePlanModeState } from "../src/state.js";
+
+const PLAN = `# Saved implementation plan
+
+1. Preserve the plan in this session.
+2. Implement it later.`;
+const STATE_ENTRY_TYPE = "plan-mode-state";
+const MODEL = { provider: "test-provider", id: "test-model" };
+const AVAILABLE_MODEL_REGISTRY = {
+	getApiKeyAndHeaders: async () => ({ ok: true as const }),
+};
+
+function stateEntry(data: Record<string, unknown>) {
+	return { type: "custom", customType: STATE_ENTRY_TYPE, data };
+}
+
+function latestState(entries: readonly { data: unknown }[]) {
+	return entries.at(-1)?.data as
+		| {
+				enabled?: boolean;
+				latestPlan?: string;
+				savedPlan?: { plan?: string; source?: string };
+				activeImplementation?: { plan?: string };
+		  }
+		| undefined;
+}
+
+async function completePlan(
+	mock: ReturnType<typeof createMockPi>,
+	ctx: ReturnType<typeof createMockContext>["ctx"],
+) {
+	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+	assert.ok(complete);
+	await complete("complete", { plan: PLAN }, undefined, undefined, ctx);
+}
+
+test("saved Plan state restores from the active branch and rejects malformed values", () => {
+	const savedPlan = { plan: PLAN, source: "plan_mode_complete" };
+	const restored = restorePlanModeState(
+		[stateEntry({ enabled: false, awaitingAction: false, savedPlan })],
+		STATE_ENTRY_TYPE,
+	) as ReturnType<typeof restorePlanModeState> & { savedPlan?: unknown };
+	assert.deepEqual(restored.savedPlan, savedPlan);
+	assert.equal(restored.enabled, false);
+	assert.equal(restored.latestPlan, undefined);
+	assert.equal(restored.activeImplementation, undefined);
+
+	for (const invalidSavedPlan of [
+		undefined,
+		null,
+		{},
+		{ plan: " \n", source: "plan_mode_complete" },
+		{ plan: "x".repeat(50_001), source: "plan_mode_complete" },
+		{ plan: PLAN, source: "unknown" },
+	]) {
+		const invalid = restorePlanModeState(
+			[stateEntry({ enabled: false, awaitingAction: false, savedPlan: invalidSavedPlan })],
+			STATE_ENTRY_TYPE,
+		) as ReturnType<typeof restorePlanModeState> & { savedPlan?: unknown };
+		assert.equal(invalid.savedPlan, undefined);
+	}
+
+	const activeImplementation = {
+		id: "implementation-1",
+		plan: "# Active implementation",
+		source: "plan_mode_complete",
+		startedAt: 42,
+	};
+	const mixed = restorePlanModeState(
+		[
+			stateEntry({
+				enabled: false,
+				awaitingAction: false,
+				activeImplementation,
+				savedPlan,
+			}),
+		],
+		STATE_ENTRY_TYPE,
+	) as ReturnType<typeof restorePlanModeState> & { savedPlan?: unknown };
+	assert.deepEqual(mixed.activeImplementation, activeImplementation);
+	assert.equal(mixed.savedPlan, undefined);
+});
+
+test("plan save exits Plan mode, restores runtime state, and keeps the plan out of context", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"], thinkingLevel: "low" });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "medium" as const },
+		}),
+	});
+	const context = createMockContext({ hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	assert.equal(mock.thinkingLevel, "medium");
+	await completePlan(mock, context.ctx);
+
+	await mock.commands.get("plan")?.handler("save", context.ctx);
+
+	assert.equal(context.statuses.get("plan-mode"), "plan saved");
+	assert.match(JSON.stringify(context.widgets.get("plan-mode-plan")), /saved for later/i);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
+	assert.equal(mock.thinkingLevel, "low");
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /saved for later/i);
+	assert.deepEqual(latestState(mock.entries)?.savedPlan, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+	});
+	assert.equal(latestState(mock.entries)?.enabled, false);
+	assert.equal(latestState(mock.entries)?.latestPlan, undefined);
+	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
+
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const transformed = (await contextHook(
+		{
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							id: "complete-1",
+							name: "plan_mode_complete",
+							arguments: { plan: PLAN },
+						},
+					],
+				},
+				{
+					role: "toolResult",
+					toolCallId: "complete-1",
+					toolName: "plan_mode_complete",
+					content: [{ type: "text", text: PLAN }],
+					details: { version: 1, source: "plan_mode_complete", plan: PLAN },
+				},
+				{ role: "custom", customType: "proposed-plan", content: PLAN },
+				{ role: "user", content: "Unrelated work" },
+			],
+		},
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.deepEqual(transformed.messages, [{ role: "user", content: "Unrelated work" }]);
+
+	const entriesBeforeRepeat = mock.entries.length;
+	await mock.commands.get("plan")?.handler("save", context.ctx);
+	assert.equal(mock.entries.length, entriesBeforeRepeat);
+	assert.equal(context.statuses.get("plan-mode"), "plan saved");
+	assert.match(context.notifications.at(-1)?.message ?? "", /no completed plan/i);
+});
+
+test("automatic and manual ready menus expose Save for later", async () => {
+	for (const automatic of [true, false]) {
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi);
+		const context = createMockContext({
+			hasUI: true,
+			select: async (_title: string, options: string[]) => {
+				assert.deepEqual(
+					options.filter((option) => option !== "Close"),
+					automatic
+						? ["Implement this plan", "Save for later", "Stay in Plan mode", "Exit Plan mode"]
+						: [
+								"Show latest proposed plan",
+								"Implement this plan",
+								"Save for later",
+								"Configure Plan-mode tools",
+								"Stay in Plan mode",
+								"Exit Plan mode",
+							],
+				);
+				return "Save for later";
+			},
+		});
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+		if (automatic) await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		else await mock.commands.get("plan")?.handler("", context.ctx);
+
+		assert.equal(context.statuses.get("plan-mode"), "plan saved");
+		assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+	}
+});
+
+test("saved Plan management can show, implement, clear, or cancel", async () => {
+	for (const scenario of [
+		{ mode: "tui", selection: "Show saved plan", expected: "saved" },
+		{ mode: "rpc", selection: "Implement saved plan", expected: "implementing" },
+		{ mode: "tui", selection: "Clear saved plan", expected: "cleared" },
+		{ mode: "tui", selection: undefined, expected: "saved" },
+	] as const) {
+		const savedEntry = stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+		});
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi);
+		const context = createMockContext({
+			mode: scenario.mode,
+			model: MODEL,
+			modelRegistry: AVAILABLE_MODEL_REGISTRY,
+			sessionManager: {
+				getBranch: () => [savedEntry],
+				getEntries: () => [savedEntry],
+			},
+			select: async (_title: string, options: string[]) => {
+				assert.deepEqual(
+					options.filter((option) => option !== "Close"),
+					["Show saved plan", "Implement saved plan", "Clear saved plan"],
+				);
+				return scenario.selection;
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const entriesBeforeMenu = mock.entries.length;
+		await mock.commands.get("plan")?.handler("", context.ctx);
+
+		if (scenario.expected === "saved") {
+			assert.equal(context.statuses.get("plan-mode"), "plan saved");
+			if (scenario.selection) {
+				assert.match(
+					String((mock.sentMessages.at(-1)?.message as { content?: string })?.content),
+					/Saved Plan.*Saved implementation plan/is,
+				);
+			} else {
+				assert.equal(mock.entries.length, entriesBeforeMenu);
+			}
+			await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+			assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+		} else if (scenario.expected === "implementing") {
+			assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+			assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /Saved implementation plan/);
+			assert.equal(latestState(mock.entries)?.savedPlan, undefined);
+			assert.equal(latestState(mock.entries)?.activeImplementation?.plan, PLAN);
+		} else {
+			assert.equal(context.statuses.get("plan-mode"), undefined);
+			assert.equal(latestState(mock.entries)?.savedPlan, undefined);
+		}
+	}
+});
+
+test("failed ready implementation restores a manual Plan thinking level", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"], thinkingLevel: "low" });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "medium" as const },
+		}),
+	});
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	mock.rawPi.setThinkingLevel("high");
+	await mock.events.get("thinking_level_select")?.[0]?.(
+		{ level: "high", previousLevel: "medium" },
+		context.ctx,
+	);
+	await completePlan(mock, context.ctx);
+	mock.rawPi.sendUserMessage = () => {
+		throw new Error("ready handoff failed");
+	};
+
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+
+	assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(latestState(mock.entries)?.latestPlan, PLAN);
+	assert.match(context.notifications.at(-1)?.message ?? "", /ready handoff failed/);
+});
+
+test("saved Plan direct routes show, implement, roll back failures, and clear", async () => {
+	const savedEntry = stateEntry({
+		enabled: false,
+		awaitingAction: false,
+		savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+	});
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext({
+		isIdle: () => false,
+		model: MODEL,
+		modelRegistry: AVAILABLE_MODEL_REGISTRY,
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+	await mock.commands.get("plan")?.handler("show", context.ctx);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(
+		String((mock.sentMessages.at(-1)?.message as { content?: string })?.content),
+		/Saved Plan.*Saved implementation plan/is,
+	);
+
+	mock.rawPi.sendUserMessage = () => {
+		throw new Error("saved handoff failed");
+	};
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), "plan saved");
+	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
+	assert.match(context.notifications.at(-1)?.message ?? "", /saved handoff failed/);
+
+	mock.rawPi.sendUserMessage = (text: string, options?: unknown) => {
+		mock.sentUserMessages.push({ text, options });
+	};
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+	assert.equal(latestState(mock.entries)?.savedPlan, undefined);
+	assert.equal(latestState(mock.entries)?.activeImplementation?.plan, PLAN);
+
+	const clearMock = createMockPi({ activeTools: ["read"] });
+	planMode(clearMock.pi);
+	const clearContext = createMockContext({
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+	});
+	await clearMock.events.get("session_start")?.[0]?.({}, clearContext.ctx);
+	await clearMock.commands.get("plan")?.handler("exit", clearContext.ctx);
+	assert.equal(clearContext.statuses.get("plan-mode"), undefined);
+	assert.equal(latestState(clearMock.entries)?.savedPlan, undefined);
+	assert.match(clearContext.notifications.at(-1)?.message ?? "", /saved plan cleared/i);
+});
+
+test("saved Plan implementation preflight retains state on auth failure or session replacement", async () => {
+	const savedEntry = stateEntry({
+		enabled: false,
+		awaitingAction: false,
+		savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+	});
+	const authFailure = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(authFailure.pi);
+	const authFailureContext = createMockContext({
+		hasUI: true,
+		model: MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: false as const, error: "No test auth" }),
+		},
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+	});
+	await authFailure.events.get("session_start")?.[0]?.({}, authFailureContext.ctx);
+	await authFailure.commands.get("plan")?.handler("implement", authFailureContext.ctx);
+	assert.equal(authFailureContext.statuses.get("plan-mode"), "plan saved");
+	assert.equal(authFailure.sentUserMessages.length, 0);
+	assert.match(authFailureContext.notifications.at(-1)?.message ?? "", /No test auth/);
+
+	let resolveAuth!: (result: { ok: true }) => void;
+	const authPending = new Promise<{ ok: true }>((resolve) => {
+		resolveAuth = resolve;
+	});
+	const replaced = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(replaced.pi);
+	const replacedContext = createMockContext({
+		hasUI: true,
+		model: MODEL,
+		modelRegistry: { getApiKeyAndHeaders: () => authPending },
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+	});
+	await replaced.events.get("session_start")?.[0]?.({}, replacedContext.ctx);
+	const pendingImplementation = replaced.commands
+		.get("plan")
+		?.handler("implement", replacedContext.ctx);
+	await replaced.events.get("session_shutdown")?.[0]?.({}, replacedContext.ctx);
+	resolveAuth({ ok: true });
+	await pendingImplementation;
+	assert.equal(replaced.sentUserMessages.length, 0);
+	assert.equal(latestState(replaced.entries)?.savedPlan?.plan, PLAN);
+});
+
+test("saved Plan blocks replacement workflows and --plan restores it as ready", async () => {
+	const savedEntry = stateEntry({
+		enabled: false,
+		awaitingAction: false,
+		savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+	});
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext({
+		hasUI: true,
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("design something else", context.ctx);
+	await mock.commands.get("plan")?.handler("tools", context.ctx);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
+	assert.equal(context.statuses.get("plan-mode"), "plan saved");
+	assert.equal(latestState(mock.entries)?.savedPlan?.plan ?? PLAN, PLAN);
+	assert.match(context.notifications.at(-1)?.message ?? "", /implement or clear/i);
+
+	const flagged = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(flagged.pi);
+	const flag = flagged.flags.get("plan");
+	assert.ok(flag);
+	flag.value = true;
+	const flaggedContext = createMockContext({
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+	});
+	await flagged.events.get("session_start")?.[0]?.({}, flaggedContext.ctx);
+	assert.equal(flaggedContext.statuses.get("plan-mode"), "plan ready");
+	assert.equal(latestState(flagged.entries)?.latestPlan, PLAN);
+	assert.equal(latestState(flagged.entries)?.savedPlan, undefined);
+	assert.deepEqual(flagged.rawPi.getActiveTools(), [
+		"read",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+});
+
+test("saved Plan no-UI management is observable without changing state", async () => {
+	for (const mode of ["print", "json"] as const) {
+		const savedEntry = stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+		});
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi);
+		const context = createMockContext({
+			mode,
+			hasUI: false,
+			sessionManager: {
+				getBranch: () => [savedEntry],
+				getEntries: () => [savedEntry],
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>,
+			/\/plan show.*\/plan implement.*\/plan exit/i,
+		);
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("design something else", context.ctx) as Promise<unknown>,
+			/implement or clear/i,
+		);
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("tools", context.ctx) as Promise<unknown>,
+			/implement or clear/i,
+		);
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("show", context.ctx) as Promise<unknown>,
+			/saved plan.*print|print.*saved plan/i,
+		);
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("implement", context.ctx) as Promise<unknown>,
+			/saved plan.*print|print.*saved plan/i,
+		);
+		assert.equal(context.statuses.get("plan-mode"), "plan saved");
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+	}
+});
+
+test("print and JSON modes can save and clear a ready plan", async () => {
+	for (const mode of ["print", "json"] as const) {
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi);
+		const context = createMockContext({ mode, hasUI: false });
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+
+		await mock.commands.get("plan")?.handler("save", context.ctx);
+		assert.equal(context.statuses.get("plan-mode"), "plan saved");
+		assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
+
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("show", context.ctx) as Promise<unknown>,
+			/saved plan.*print|print.*saved plan/i,
+		);
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("implement", context.ctx) as Promise<unknown>,
+			/saved plan.*print|print.*saved plan/i,
+		);
+		assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+		assert.equal(mock.sentUserMessages.length, 0);
+
+		await mock.commands.get("plan")?.handler(mode === "json" ? "off" : "exit", context.ctx);
+		assert.equal(context.statuses.get("plan-mode"), undefined);
+		assert.equal(latestState(mock.entries)?.savedPlan, undefined);
+	}
+});
+
+test("session shutdown disposes a saved Plan menu without a late transition", async () => {
+	let menuHarness: ReturnType<typeof createCustomSelectorHarness> | undefined;
+	let markStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		markStarted = resolve;
+	});
+	const savedEntry = stateEntry({
+		enabled: false,
+		awaitingAction: false,
+		savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+	});
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext({
+		mode: "tui",
+		sessionManager: {
+			getBranch: () => [savedEntry],
+			getEntries: () => [savedEntry],
+		},
+		custom: async (factory: unknown) => {
+			menuHarness = createCustomSelectorHarness(factory);
+			markStarted();
+			return menuHarness.resultPromise;
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const pendingMenu = mock.commands.get("plan")?.handler("", context.ctx);
+	await started;
+	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	await pendingMenu;
+
+	assert.ok(menuHarness);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
+	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
+	assert.equal(mock.sentMessages.length, 0);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("plan save autocomplete is public and saving fails closed without a ready plan", async () => {
+	assert.deepEqual(
+		completePlanArguments("")?.map((item) => item.value),
+		["show", "finalize", "implement", "save", "exit", "off", "tools"],
+	);
+	assert.deepEqual(
+		completePlanArguments("sa")?.map((item) => item.value),
+		["save"],
+	);
+	assert.equal(completePlanArguments("save "), null);
+
+	const mock = createMockPi({ activeTools: ["read"] });
+	planMode(mock.pi);
+	const context = createMockContext({ hasUI: true });
+	await mock.commands.get("plan")?.handler("save", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.equal(latestState(mock.entries)?.savedPlan, undefined);
+	assert.match(context.notifications.at(-1)?.message ?? "", /no completed plan/i);
+
+	const printMock = createMockPi({ activeTools: ["read"] });
+	planMode(printMock.pi);
+	const printContext = createMockContext({ mode: "print", hasUI: false });
+	await assert.rejects(
+		printMock.commands.get("plan")?.handler("save", printContext.ctx) as Promise<unknown>,
+		/no completed plan/i,
+	);
+});

--- a/extensions/pi-plan-mode/test/saved-plan.test.ts
+++ b/extensions/pi-plan-mode/test/saved-plan.test.ts
@@ -409,7 +409,7 @@ test("saved Plan blocks replacement workflows and --plan restores it as ready", 
 	assert.equal(mock.sentUserMessages.length, 0);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
-	assert.equal(latestState(mock.entries)?.savedPlan?.plan ?? PLAN, PLAN);
+	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
 	assert.match(context.notifications.at(-1)?.message ?? "", /implement or clear/i);
 
 	const flagged = createMockPi({ activeTools: ["read", "edit"] });

--- a/extensions/pi-plan-mode/test/saved-plan.test.ts
+++ b/extensions/pi-plan-mode/test/saved-plan.test.ts
@@ -409,8 +409,9 @@ test("saved Plan blocks replacement workflows and --plan restores it as ready", 
 	assert.equal(mock.sentUserMessages.length, 0);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
-	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
 	assert.match(context.notifications.at(-1)?.message ?? "", /implement or clear/i);
+	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
 
 	const flagged = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(flagged.pi);


### PR DESCRIPTION
## Summary

- add a session-local, single-slot **Save for later** flow for completed plans
- add saved-plan menus and `/plan save`, `/plan show`, `/plan implement`, `/plan exit`, and `/plan off` state transitions with context isolation, runtime restoration, preflight checks, and lifecycle guards
- restore saved plans across the active session branch and document the workflow, non-interactive behavior, and conflict rules
- add focused coverage for persistence validation, menus, direct commands, rollback, print/JSON modes, session replacement, and shutdown

## Testing

- `npm --workspace @narumitw/pi-plan-mode run check`
- `node --test $(realpath node_modules/.cache/pi-extensions-test/extensions/pi-plan-mode/test/*.test.js)` — 98 passed
- `npm run biome:check`
- `npm run check:boundaries`
- `npm run typecheck`
- `pi -ne -e ./extensions/pi-plan-mode --help`
- `npm --workspace @narumitw/pi-plan-mode pack --dry-run --json`

A clean-clone full check passed before the final test-only coverage expansion. The latest full-suite retries passed 2,037 of 2,038 tests but hit the existing timing-sensitive `pi-btw` settings test under concurrent load; its isolated suite passed 12/12 on each retry.
