### PR TITLE
feat(pi-starship)!: align built-in styles with Starship

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -29,6 +29,7 @@
 - Keep pi-lsp Docker profiles synchronized with production initialization as well as diagnostics policy; compare their commands against Linux launchers rather than host-evaluated platform wrappers.
 - pi-statusline owns footer rendering and its `/statusline` settings command; keep it out of prompt interception.
 - Symptom: a pi-starship module's configured `$symbol` disappears when an optional value is absent. Cause: module values override the renderer-provided symbol. Fix: keep `$symbol` standard and make optional labels conditional in the default format.
+- Pi-starship periodic workspace refreshes that retain module values must also retain separately stored private style selectors, or state-selected styles silently revert.
 - Symptom: an idle optional statusline segment leaves a blank multiline row. Cause: filtering the segment while preserving both adjacent `line_break` entries. Fix: group configured rows first, drop only dynamically empty rows, then flatten while preserving explicitly empty rows.
 - Model IDs can come from llama.cpp paths or custom providers and become terminal text; strip OSC, CSI, C0, and C1 sequences at the display boundary—including C1 string terminators—without mutating the runtime ID.
 - In Pi extensions, do not call action methods such as `getThinkingLevel()` during the factory load; defer them to `session_start` or later handlers.

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -8,8 +8,8 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 
 ## ✨ Features
 
-- Uses a readable built-in Tokyo Night configuration until the user explicitly saves settings.
-- Starship-style root/module formats, conditional groups, `$all`, styles, and palettes.
+- Uses a readable, palette-free Starship-style built-in configuration until settings are saved.
+- Starship-style root/module formats, conditional groups, `$all`, styles, and opt-in palettes.
 - Pi modules for model, thinking, activity, context, tokens, prompt cache, cost, turn, and extension statuses.
 - Cached Git branch, commit, operation state, line metrics, detailed status, and linked-worktree identity.
 - Native current-branch GitHub pull request links, checks, review state, and terminal-state retention.
@@ -41,7 +41,11 @@ The only configuration source is:
 <getAgentDir()>/pi-starship.toml
 ```
 
-When this file is absent, the extension uses its readable Tokyo Night default without creating the file or parent directory. The first successful settings save creates it atomically. Existing malformed documents are never overwritten.
+When this file is absent, the extension uses its readable palette-free default without creating the
+file or parent directory. The built-in root is the explicit sequence `$brand$model$thinking$directory`
+`$git_branch$git_status$activity$context$time`; it does not start the opt-in GitHub PR query. The first
+successful settings save creates the file atomically. Existing malformed documents are never
+overwritten.
 
 The extension does **not** read project overrides, `pi-statusline.json`, `PI_STATUSLINE_PRESET`, or `~/.config/starship.toml`, and does not migrate statusline settings.
 
@@ -60,65 +64,72 @@ shows the specialized width-aware preview and requires explicit overwrite confir
 ### 📝 Example
 
 ```toml
-format = "$brand$provider$model$thinking\n$directory$git_branch$github_pr$git_status\n$activity$context$tokens$cache$cost$time$turn\n$extension_status"
-palette = "tokyo-night"
-
-[palettes.tokyo-night]
-header = "#7aa2f7"
-header_fg = "#1a1b26"
-custom = "208"
+format = """
+$brand\
+$model\
+$thinking\
+$directory\
+$git_branch\
+$git_status\
+$activity\
+$context\
+$time"""
 
 [model]
 format = "[ $symbol$model ]($style)"
 symbol = "◆ "
-style = "bold fg:header_fg bg:header"
-disabled = false
+style = "bold blue"
 truncation_length = 36
 truncation_symbol = "…"
 truncation_direction = "middle"
 
-[activity]
-format = "([ $text ]($style))"
-style = "fg:custom"
+[directory]
+style = "cyan bold"
+
+[git_branch]
+style = "bold purple"
 
 [context]
 format = "[$symbol $percentage/$window ]($style)"
 
-[cache]
-format = "[$symbol (R$read )(W$write )(CH$rate )]($style)"
+[[context.display]]
+threshold = 0
+style = "bold green"
+hidden = true
+
+[[context.display]]
+threshold = 30
+style = "bold green"
+hidden = false
+
+[[context.display]]
+threshold = 60
+style = "bold yellow"
+hidden = false
+
+[[context.display]]
+threshold = 80
+style = "bold red"
+hidden = false
+
+[git_metrics]
+added_style = "bold green"
+deleted_style = "bold red"
 disabled = false
 
-[cost]
-format = "[ $symbol \\$$cost( $subscription) ]($style)"
-
-[git_branch]
-format = "[ $symbol $branch ]($style)"
-
-[github_pr]
-format = "[ $symbol$link( · $status) ]($style)"
-symbol = "PR "
-style = "fg:git_fg bg:git"
-disabled = false
-
-[package]
-version_format = "v$raw"
-
-[nodejs]
-detect_files = ["package.json", "!deno.json"]
-detect_extensions = ["js", "ts"]
-
-[hostname]
-ssh_only = true
-trim_at = "."
-aliases = { "build.example.test" = "builder" }
+[username]
+style_user = "yellow bold"
+style_root = "red bold"
 
 [extension_status]
 format = "([$statuses ]($style))"
 icons = { "foo:*" = "🧪", "third_party/key" = "◎", fallback = "•" }
 ```
 
-All module tables support `format`, `symbol`, `style`, and `disabled`. Module-specific
-options are catalog-owned, type-checked, and listed below; unknown options warn and stay inactive.
+Every module table supports `format`, `symbol`, and `disabled`. Most modules also support one `style`.
+The exceptions are `git_metrics` (`added_style` and `deleted_style`), `username` (`style_user` and
+`style_root`), and the threshold-selected `context` and `cost` `display` arrays described below.
+Module-specific options are catalog-owned and type-checked; unknown options warn and stay inactive.
 Version formats replace `$raw`. Detection arrays replace defaults when non-empty and inspect only one
 listing of the current directory. A leading `!` is supported by language detection arrays and rejects
 a matching project.
@@ -155,11 +166,91 @@ Style expressions support:
 - Hex RGB (`#7aa2f7`).
 - `fg:<color>` and `bg:<color>`; an unprefixed color is foreground.
 - `bold`, `dimmed`, `italic`, `underline`, `blink`, `inverted`, `hidden`, and `strikethrough`.
-- `none`, `fg:none`, and `bg:none`.
-- `prev_fg` and `prev_bg` to inherit the previous rendered chunk's colors.
-- Color names from the active `[palettes.<name>]` table. The active palette overlays the built-in Tokyo Night colors so the default module styles remain available.
+- `none` and `fg:none`, which make the complete expression unstyled regardless of position.
+- `bg:none`, which clears only the absolute background; an unknown `bg:<value>` has the same
+  Starship-compatible reset behavior.
+- `prev_fg` and `prev_bg`, which use the previous rendered chunk's colors when present and retain any
+  absolute foreground/background in the expression as the no-previous fallback.
+- Direct color names from one explicitly selected `[palettes.<name>]` table.
 
-An invalid root format falls back to the built-in root format. An invalid module format or style falls back only for that module. `/starship status` reports warnings.
+There is no built-in or fallback palette. A custom palette is active only when its table is explicitly
+selected, and its values must be direct named, ANSI, or RGB colors—palette entries cannot reference
+other entries. Palette names override terminal color names such as `blue`:
+
+```toml
+palette = "company"
+
+[palettes.company]
+blue = "#86BBD8"
+accent = "208"
+
+[model]
+style = "bold blue"
+```
+
+Style tokens are case-insensitive and ordinary foreground/background colors are last-wins.
+`prev_fg`/`prev_bg` override their absolute fallback only when a previous chunk exists. Empty styled
+groups still advance previous-color state. Invalid literal style expressions warn and render
+unstyled. An invalid root format falls back to the built-in root format; an invalid module format or
+catalog-owned style field falls back only at that field's module scope. `/starship status` reports
+warnings.
+
+The background-free direct defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`,
+`thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`,
+`github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` =
+`"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`,
+`extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
+Context, cost, Git metrics, and username use the state/multi-style defaults below.
+
+### State-selected styles
+
+`context` and `cost` select the last entry at the highest threshold less than or equal to the current
+value. A later entry wins when thresholds are equal. Each display entry requires a finite `threshold`,
+a valid `style`, and boolean `hidden`. Invalid entries warn and are ignored; module defaults are used
+if none remain.
+
+The default context thresholds are hidden at `0`, `bold green` at `30`, `bold yellow` at `60`, and
+`bold red` at `80`. The default cost thresholds are hidden at `0`, `bold yellow` at `1`, and `bold red`
+at `5`:
+
+```toml
+[[cost.display]]
+threshold = 0
+style = "bold green"
+hidden = true
+
+[[cost.display]]
+threshold = 1
+style = "bold yellow"
+hidden = false
+
+[[cost.display]]
+threshold = 5
+style = "bold red"
+hidden = false
+```
+
+`git_metrics` exposes `$added_style` and `$deleted_style` in its module format. `username` still uses
+`$style` in its format, but selects `style_user` or `style_root` from private execution metadata; the
+selector is not a format variable.
+
+### Breaking palette migration
+
+The previous implicit `tokyo-night` palette and its `lead`, `header`, `header_fg`, `directory`,
+`directory_fg`, `git`, `git_fg`, `runtime`, `runtime_fg`, `meter`, `meter_fg`, and `extension` aliases
+were removed. Existing files are not rewritten. Old alias-based module styles warn and fall back to
+the module's new direct-color default; alias-based literal Powerline groups warn and render unstyled.
+
+Choose one migration:
+
+1. Replace old aliases with direct styles such as `cyan bold`, `bold bright-yellow`, or
+   `fg:#e3e5e5 bg:#769ff0`.
+2. Define every needed alias under your own `[palettes.<name>]` table and explicitly select it with
+   `palette = "<name>"`.
+3. Use **Advanced → Restore built-in** to preview and replace the document with the new plain
+   nine-module configuration.
+
+There is no hidden compatibility overlay or automatic migration.
 
 ## 🧱 Modules
 
@@ -218,11 +309,10 @@ An invalid root format falls back to the built-in root format. An invalid module
 - Cache `$read` and `$write` are cumulative. `$rate` uses only the latest assistant prompt:
   `cacheRead / (input + cacheRead + cacheWrite) * 100`. The module is empty when Pi has reported no
   cache reads or writes.
-- `cache` is disabled by default, but the built-in root format already contains `$cache`; users who
-  inherit that format can enable it with only `[cache] disabled = false`. A custom root format must
-  reference `$cache` or `$all` normally.
-- Context `$percentage` uses native one-decimal precision. For a native-style display, use
-  `format = "[$symbol $percentage/$window ]($style)"` under `[context]`; the module name remains
+- `cache` is disabled and absent from the built-in root. Enable it and add `$cache` to a custom root
+  format (or use `$all`) to display it.
+- Context `$percentage` uses native one-decimal precision. Its default display hides values below 30%;
+  customize `[[context.display]]` when lower values should remain visible. The module name remains
   `context`, not `context_usage`.
 - Subscription-backed OAuth models and `kimi-coding` set cost `$subscription` to `(sub)`. The dollar
   value is usage cost, not proof of an amount billed under a subscription.
@@ -309,8 +399,10 @@ disable or remove that extension when adopting the native module to avoid duplic
 
 ### 📦 Package and language modules
 
-The native behavior is inspired by Starship pinned at
-`9f4d07ed45804e280d6884bb8ced7ea3d3033093`; it is not complete Starship compatibility.
+Module behavior is inspired by Starship pinned at
+`9f4d07ed45804e280d6884bb8ced7ea3d3033093`; formatter style semantics and the approved
+multi/state-style surfaces are aligned with the checked-in Starship source at `cad50cd8`. This is not
+complete Starship module or configuration compatibility.
 
 | Area | Adopted | Adapted | Intentionally omitted |
 | --- | --- | --- | --- |

--- a/extensions/pi-starship/src/config.ts
+++ b/extensions/pi-starship/src/config.ts
@@ -18,7 +18,11 @@ import {
 } from "./format/formatter.js";
 import { type ColorPalette, isValidStyle, parseColor } from "./format/style.js";
 import { MODULE_DEFINITIONS, MODULE_NAMES, type ModuleName } from "./modules/catalog.js";
-import type { ModuleOptionSchema, ModuleOptionValue } from "./modules/types.js";
+import type {
+	ModuleDisplayConfig,
+	ModuleOptionSchema,
+	ModuleOptionValue,
+} from "./modules/types.js";
 
 export const CONFIG_FILE_NAME = "pi-starship.toml";
 export { MODULE_NAMES, type ModuleName } from "./modules/catalog.js";
@@ -32,6 +36,8 @@ export interface ModuleConfig {
 	formatAst: FormatNode[];
 	symbol: string;
 	style: string;
+	styles: Record<string, string>;
+	display: ModuleDisplayConfig[];
 	disabled: boolean;
 	options: Record<string, ModuleOptionValue>;
 }
@@ -45,7 +51,7 @@ export interface ExtensionStatusConfig {
 export interface StarshipConfig {
 	format: string;
 	formatAst: FormatNode[];
-	palette: string;
+	palette?: string;
 	palettes: Record<string, Record<string, string>>;
 	modules: Record<ModuleName, ModuleConfig>;
 	extensionStatus: ExtensionStatusConfig;
@@ -67,52 +73,26 @@ export interface LoadedStarshipConfig {
 }
 
 const BUILT_IN_FORMAT_DOCUMENT = String.raw`format = """
-[░▒▓](lead)\
 $brand\
-$provider\
 $model\
 $thinking\
-[](fg:header bg:directory)\
 $directory\
-[](fg:directory bg:git)\
-$git_worktree\
 $git_branch\
-$github_pr\
 $git_status\
-[](fg:git bg:runtime)\
 $activity\
 $context\
-$tokens\
-$cache\
-[](fg:runtime bg:meter)\
-$cost\
-$time\
-[](fg:meter)\
-(\n$extension_status)"""`;
+$time"""`;
 
 const BUILT_IN_FORMAT = parseBuiltInFormat(BUILT_IN_FORMAT_DOCUMENT);
 
-const BUILT_IN_PALETTE = {
-	lead: "#a3aed2",
-	header: "#a3aed2",
-	header_fg: "#090c0c",
-	directory: "#769ff0",
-	directory_fg: "#e3e5e5",
-	git: "#394260",
-	git_fg: "#769ff0",
-	runtime: "#212736",
-	runtime_fg: "#769ff0",
-	meter: "#1d2230",
-	meter_fg: "#a0a9cb",
-	extension: "#a0a9cb",
-};
-
 const BUILT_IN_MODULES = Object.fromEntries(
-	MODULE_DEFINITIONS.map(({ name, defaults, options }) => [
+	MODULE_DEFINITIONS.map(({ name, defaults, styleDefaults, displayDefaults, options }) => [
 		name,
 		{
 			...defaults,
 			formatAst: parseFormat(defaults.format),
+			styles: { ...styleDefaults },
+			display: structuredClone(displayDefaults ?? []),
 			options: Object.fromEntries(
 				Object.entries(options ?? {}).map(([key, schema]) => [
 					key,
@@ -126,17 +106,13 @@ const BUILT_IN_MODULES = Object.fromEntries(
 export const BUILT_IN_CONFIG: StarshipConfig = {
 	format: BUILT_IN_FORMAT,
 	formatAst: parseFormat(BUILT_IN_FORMAT),
-	palette: "tokyo-night",
-	palettes: { "tokyo-night": BUILT_IN_PALETTE },
+	palette: undefined,
+	palettes: {},
 	modules: BUILT_IN_MODULES,
 	extensionStatus: { separator: " • ", maxStatuses: 5, icons: {} },
 };
 
-export const BUILT_IN_EXAMPLE = `# Native Pi modules with Starship-compatible format and style syntax.\n${BUILT_IN_FORMAT_DOCUMENT}\npalette = "tokyo-night"\n\n[palettes.tokyo-night]\n${Object.entries(
-	BUILT_IN_PALETTE,
-)
-	.map(([name, color]) => `${name} = "${color}"`)
-	.join("\n")}\n`;
+export const BUILT_IN_EXAMPLE = `# Native Pi modules with Starship-compatible format and style syntax.\n${BUILT_IN_FORMAT_DOCUMENT}\n`;
 
 function parseBuiltInFormat(document: string): string {
 	const format = parse(document).format;
@@ -253,11 +229,14 @@ export function normalizeConfig(value: unknown): {
 
 	if (value.palette !== undefined) {
 		if (typeof value.palette !== "string") diagnostics.push(typeDiagnostic("palette", "string"));
-		else if (!Object.hasOwn(config.palettes, value.palette)) {
-			diagnostics.push(
-				diagnostic("warning", "palette", `Unknown palette ${JSON.stringify(value.palette)}`),
-			);
-		} else config.palette = value.palette;
+		else {
+			config.palette = value.palette;
+			if (!Object.hasOwn(config.palettes, value.palette)) {
+				diagnostics.push(
+					diagnostic("warning", "palette", `Unknown palette ${JSON.stringify(value.palette)}`),
+				);
+			}
+		}
 	}
 
 	for (const name of MODULE_NAMES) {
@@ -278,7 +257,9 @@ export function normalizeConfig(value: unknown): {
 	);
 	validateStyleVariables(config.formatAst, new Set(), "format", diagnostics);
 	const palette = activePalette(config);
-	for (const name of MODULE_NAMES) {
+	validateLiteralStyles(config.formatAst, palette, "format", diagnostics);
+	for (const definition of MODULE_DEFINITIONS) {
+		const name = definition.name;
 		const module = config.modules[name];
 		validateFormatVariables(
 			module.formatAst,
@@ -286,16 +267,19 @@ export function normalizeConfig(value: unknown): {
 			`${name}.format`,
 			diagnostics,
 		);
-		validateStyleVariables(module.formatAst, new Set(["style"]), `${name}.format`, diagnostics);
-		if (!isValidStyle(module.style, palette)) {
-			diagnostics.push(
-				diagnostic(
-					"warning",
-					`${name}.style`,
-					`Invalid style ${JSON.stringify(module.style)}; using the module default`,
-				),
-			);
-			module.style = BUILT_IN_CONFIG.modules[name].style;
+		validateStyleVariables(
+			module.formatAst,
+			new Set(definition.styleVariables ?? ["style"]),
+			`${name}.format`,
+			diagnostics,
+		);
+		validateLiteralStyles(module.formatAst, palette, `${name}.format`, diagnostics);
+		if (definition.styleDefaults) {
+			for (const field of Object.keys(definition.styleDefaults)) {
+				validateModuleStyleField(name, field, module, palette, diagnostics);
+			}
+		} else if (!definition.displayDefaults) {
+			validateModuleStyleField(name, "style", module, palette, diagnostics);
 		}
 	}
 
@@ -309,8 +293,13 @@ function normalizeModule(
 	diagnostics: ConfigDiagnostic[],
 ) {
 	const definition = MODULE_DEFINITIONS.find((candidate) => candidate.name === name);
-	const optionSchemas: Readonly<Record<string, ModuleOptionSchema>> = definition?.options ?? {};
-	const known = new Set(["format", "symbol", "style", "disabled", ...Object.keys(optionSchemas)]);
+	if (!definition) return;
+	const optionSchemas: Readonly<Record<string, ModuleOptionSchema>> = definition.options ?? {};
+	const known = new Set(["format", "symbol", "disabled", ...Object.keys(optionSchemas)]);
+	if (definition.styleDefaults) {
+		for (const field of Object.keys(definition.styleDefaults)) known.add(field);
+	} else if (!definition.displayDefaults) known.add("style");
+	if (definition.displayDefaults) known.add("display");
 	if (name === "extension_status") {
 		known.add("separator");
 		known.add("max_statuses");
@@ -338,11 +327,31 @@ function normalizeModule(
 			}
 		}
 	}
-	for (const field of ["symbol", "style"] as const) {
-		if (value[field] === undefined) continue;
-		if (typeof value[field] !== "string") {
-			diagnostics.push(typeDiagnostic(`${name}.${field}`, "string"));
-		} else module[field] = value[field];
+	if (value.symbol !== undefined) {
+		if (typeof value.symbol !== "string") {
+			diagnostics.push(typeDiagnostic(`${name}.symbol`, "string"));
+		} else module.symbol = value.symbol;
+	}
+	if (definition.styleDefaults) {
+		for (const field of Object.keys(definition.styleDefaults)) {
+			if (value[field] === undefined) continue;
+			if (typeof value[field] !== "string") {
+				diagnostics.push(typeDiagnostic(`${name}.${field}`, "string"));
+			} else module.styles[field] = value[field];
+		}
+	} else if (!definition.displayDefaults && value.style !== undefined) {
+		if (typeof value.style !== "string") {
+			diagnostics.push(typeDiagnostic(`${name}.style`, "string"));
+		} else module.style = value.style;
+	}
+	if (definition.displayDefaults && value.display !== undefined) {
+		module.display = normalizeDisplay(
+			name,
+			value.display,
+			definition.displayDefaults,
+			activePalette(config),
+			diagnostics,
+		);
 	}
 	if (value.disabled !== undefined) {
 		if (typeof value.disabled !== "boolean") {
@@ -514,6 +523,8 @@ function cloneBuiltInConfig(): StarshipConfig {
 				{
 					...BUILT_IN_CONFIG.modules[name],
 					formatAst: structuredClone(BUILT_IN_CONFIG.modules[name].formatAst),
+					styles: { ...BUILT_IN_CONFIG.modules[name].styles },
+					display: structuredClone(BUILT_IN_CONFIG.modules[name].display),
 					options: structuredClone(BUILT_IN_CONFIG.modules[name].options),
 				},
 			]),
@@ -558,6 +569,107 @@ function validateStyleVariables(
 				`Unknown style variable ${JSON.stringify(variable)} in ${path} was ignored`,
 			),
 		);
+	}
+}
+
+function validateModuleStyleField(
+	name: ModuleName,
+	field: string,
+	module: ModuleConfig,
+	palette: ColorPalette,
+	diagnostics: ConfigDiagnostic[],
+) {
+	const style = field === "style" ? module.style : module.styles[field];
+	if (style === undefined || isValidStyle(style, palette)) return;
+	diagnostics.push(
+		diagnostic(
+			"warning",
+			`${name}.${field}`,
+			`Invalid style ${JSON.stringify(style)}; using the module default`,
+		),
+	);
+	if (field === "style") module.style = BUILT_IN_CONFIG.modules[name].style;
+	else {
+		const fallback = BUILT_IN_CONFIG.modules[name].styles[field];
+		if (fallback !== undefined) module.styles[field] = fallback;
+	}
+}
+
+function normalizeDisplay(
+	name: ModuleName,
+	value: unknown,
+	defaults: readonly ModuleDisplayConfig[],
+	palette: ColorPalette,
+	diagnostics: ConfigDiagnostic[],
+): ModuleDisplayConfig[] {
+	if (!Array.isArray(value)) {
+		diagnostics.push(typeDiagnostic(`${name}.display`, "array of tables"));
+		return defaults.map((entry) => ({ ...entry }));
+	}
+	const result: ModuleDisplayConfig[] = [];
+	for (const [index, entry] of value.entries()) {
+		const path = `${name}.display.${index}`;
+		if (!isRecord(entry)) {
+			diagnostics.push(typeDiagnostic(path, "table"));
+			continue;
+		}
+		for (const field of Object.keys(entry)) {
+			if (!new Set(["threshold", "style", "hidden"]).has(field)) {
+				diagnostics.push(unknownDiagnostic(`${path}.${field}`));
+			}
+		}
+		let valid = true;
+		if (typeof entry.threshold !== "number" || !Number.isFinite(entry.threshold)) {
+			diagnostics.push(diagnostic("warning", `${path}.threshold`, "Expected a finite number"));
+			valid = false;
+		}
+		if (typeof entry.style !== "string" || !isValidStyle(entry.style, palette)) {
+			diagnostics.push(
+				diagnostic("warning", `${path}.style`, "Expected a valid Starship style string"),
+			);
+			valid = false;
+		}
+		if (typeof entry.hidden !== "boolean") {
+			diagnostics.push(typeDiagnostic(`${path}.hidden`, "boolean"));
+			valid = false;
+		}
+		if (valid) {
+			result.push({
+				threshold: entry.threshold as number,
+				style: entry.style as string,
+				hidden: entry.hidden as boolean,
+			});
+		}
+	}
+	if (result.length > 0) return result;
+	diagnostics.push(
+		diagnostic("warning", `${name}.display`, "Expected at least one valid entry; using defaults"),
+	);
+	return defaults.map((entry) => ({ ...entry }));
+}
+
+function validateLiteralStyles(
+	ast: readonly FormatNode[],
+	palette: ColorPalette,
+	path: string,
+	diagnostics: ConfigDiagnostic[],
+) {
+	for (const node of ast) {
+		if (node.type === "group" && node.style.every((part) => part.type === "text")) {
+			const style = node.style.map((part) => (part.type === "text" ? part.value : "")).join("");
+			if (!isValidStyle(style, palette)) {
+				diagnostics.push(
+					diagnostic(
+						"warning",
+						path,
+						`Invalid literal style ${JSON.stringify(style)}; rendered unstyled`,
+					),
+				);
+			}
+		}
+		if (node.type === "group" || node.type === "conditional") {
+			validateLiteralStyles(node.children, palette, path, diagnostics);
+		}
 	}
 }
 
@@ -667,15 +779,12 @@ function formatError(error: unknown): string {
 }
 
 export function activePalette(config: StarshipConfig): ColorPalette {
-	return {
-		...ownPalette(config.palettes, BUILT_IN_CONFIG.palette),
-		...ownPalette(config.palettes, config.palette),
-	};
+	return ownPalette(config.palettes, config.palette) ?? {};
 }
 
 function ownPalette(
 	palettes: Readonly<Record<string, Record<string, string>>>,
-	name: string,
+	name: string | undefined,
 ): Record<string, string> | undefined {
-	return Object.hasOwn(palettes, name) ? palettes[name] : undefined;
+	return name !== undefined && Object.hasOwn(palettes, name) ? palettes[name] : undefined;
 }

--- a/extensions/pi-starship/src/format/style.ts
+++ b/extensions/pi-starship/src/format/style.ts
@@ -19,12 +19,15 @@ export type NamedColor =
 export type ColorSpec =
 	| { kind: "named"; name: NamedColor }
 	| { kind: "fixed"; value: number }
-	| { kind: "rgb"; red: number; green: number; blue: number }
-	| { kind: "previous"; source: "foreground" | "background" };
+	| { kind: "rgb"; red: number; green: number; blue: number };
+
+export type PreviousColorSource = "foreground" | "background";
 
 export interface TextStyle {
 	foreground?: ColorSpec;
 	background?: ColorSpec;
+	foregroundPrevious?: PreviousColorSource;
+	backgroundPrevious?: PreviousColorSource;
 	bold?: boolean;
 	italic?: boolean;
 	underline?: boolean;
@@ -34,6 +37,10 @@ export interface TextStyle {
 	hidden?: boolean;
 	strikethrough?: boolean;
 }
+
+export type StyleParseResult =
+	| { valid: true; style: TextStyle | undefined }
+	| { valid: false; style: undefined };
 
 export interface StyledChunk {
 	text: string;
@@ -92,41 +99,53 @@ const FOREGROUND_CODES: Record<NamedColor, number> = {
 };
 
 export function isValidStyle(styleString: string, palette: ColorPalette = {}): boolean {
-	for (const rawToken of styleString.split(/\s+/u).filter(Boolean)) {
-		const token = rawToken.toLowerCase();
-		if (token === "none" || token === "fg:none" || token === "bg:none") continue;
-		const probe: TextStyle = {};
-		if (applyModifier(probe, token)) continue;
-		const colorToken = token.startsWith("fg:") || token.startsWith("bg:") ? token.slice(3) : token;
-		if (!parseColor(colorToken, palette)) return false;
-	}
-	return true;
+	return parseStyleResult(styleString, palette).valid;
 }
 
-export function parseStyle(styleString: string, palette: ColorPalette = {}): TextStyle | undefined {
+export function parseStyleResult(
+	styleString: string,
+	palette: ColorPalette = {},
+): StyleParseResult {
+	const tokens = styleString.split(/\s+/u).filter(Boolean).map(normalizeStyleToken);
+	if (tokens.some(({ token, foreground }) => foreground && token === "none")) {
+		return { valid: true, style: undefined };
+	}
+
 	const style: TextStyle = {};
-	for (const rawToken of styleString.split(/\s+/u).filter(Boolean)) {
-		const token = rawToken.toLowerCase();
-		if (token === "none") return undefined;
-		if (token === "fg:none") {
-			delete style.foreground;
+	for (const { token, foreground } of tokens) {
+		if (applyModifier(style, token)) continue;
+		if (token === "prev_fg" || token === "prev_bg") {
+			const source = token === "prev_fg" ? "foreground" : "background";
+			if (foreground) style.foregroundPrevious = source;
+			else style.backgroundPrevious = source;
 			continue;
 		}
-		if (applyModifier(style, token)) continue;
-
-		const foreground = token.startsWith("fg:");
-		const background = token.startsWith("bg:");
-		const colorToken = foreground || background ? token.slice(3) : token;
-		if (background && colorToken === "none") {
+		const color = parseColor(token, palette);
+		if (!foreground && !color) {
 			delete style.background;
 			continue;
 		}
-		const color = parseColor(colorToken, palette);
-		if (!color) return undefined;
-		if (background) style.background = color;
-		else style.foreground = color;
+		if (!color) return { valid: false, style: undefined };
+		if (foreground) style.foreground = color;
+		else style.background = color;
 	}
-	return Object.keys(style).length > 0 ? style : undefined;
+	return { valid: true, style };
+}
+
+export function parseStyle(styleString: string, palette: ColorPalette = {}): TextStyle | undefined {
+	return parseStyleResult(styleString, palette).style;
+}
+
+function normalizeStyleToken(rawToken: string): { token: string; foreground: boolean } {
+	let token = rawToken.toLowerCase();
+	if (token.startsWith("fg:")) {
+		return { token: token.replace(/^(?:fg:)+/u, ""), foreground: true };
+	}
+	if (token.startsWith("bg:")) {
+		token = token.replace(/^(?:bg:)+/u, "");
+		return { token, foreground: false };
+	}
+	return { token, foreground: true };
 }
 
 function applyModifier(style: TextStyle, token: string): boolean {
@@ -161,8 +180,6 @@ function applyModifier(style: TextStyle, token: string): boolean {
 }
 
 export function parseColor(token: string, palette: ColorPalette = {}): ColorSpec | undefined {
-	if (token === "prev_fg") return { kind: "previous", source: "foreground" };
-	if (token === "prev_bg") return { kind: "previous", source: "background" };
 	const paletteValue = Object.hasOwn(palette, token) ? palette[token] : undefined;
 	if (paletteValue !== undefined) return parseColor(paletteValue.toLowerCase(), {});
 	if (NAMED_COLORS.has(token as NamedColor)) {
@@ -182,9 +199,13 @@ export function parseColor(token: string, palette: ColorPalette = {}): ColorSpec
 	};
 }
 
-interface ResolvedStyle extends Omit<TextStyle, "foreground" | "background"> {
-	foreground?: Exclude<ColorSpec, { kind: "previous" }>;
-	background?: Exclude<ColorSpec, { kind: "previous" }>;
+interface ResolvedStyle
+	extends Omit<
+		TextStyle,
+		"foreground" | "background" | "foregroundPrevious" | "backgroundPrevious"
+	> {
+	foreground?: ColorSpec;
+	background?: ColorSpec;
 }
 
 export function renderChunksToAnsi(chunks: readonly LayoutChunk[]): string {
@@ -215,20 +236,21 @@ function resolveStyle(
 	previous: ResolvedStyle | undefined,
 ): ResolvedStyle {
 	if (!style) return {};
+	const { foregroundPrevious, backgroundPrevious, ...resolved } = style;
 	return {
-		...style,
-		foreground: resolveColor(style.foreground, previous),
-		background: resolveColor(style.background, previous),
+		...resolved,
+		foreground: resolveColor(style.foreground, foregroundPrevious, previous),
+		background: resolveColor(style.background, backgroundPrevious, previous),
 	};
 }
 
 function resolveColor(
-	color: ColorSpec | undefined,
+	fallback: ColorSpec | undefined,
+	source: PreviousColorSource | undefined,
 	previous: ResolvedStyle | undefined,
-): ResolvedStyle["foreground"] {
-	if (!color) return undefined;
-	if (color.kind !== "previous") return color;
-	return color.source === "foreground" ? previous?.foreground : previous?.background;
+): ColorSpec | undefined {
+	if (!source || !previous) return fallback;
+	return source === "foreground" ? previous.foreground : previous.background;
 }
 
 function ansiCodes(style: ResolvedStyle): string[] {
@@ -246,10 +268,7 @@ function ansiCodes(style: ResolvedStyle): string[] {
 	return codes;
 }
 
-function colorCodes(
-	color: Exclude<ColorSpec, { kind: "previous" }>,
-	background: boolean,
-): string[] {
+function colorCodes(color: ColorSpec, background: boolean): string[] {
 	if (color.kind === "named") {
 		const foreground = FOREGROUND_CODES[color.name];
 		return [`${background ? foreground + 10 : foreground}`];

--- a/extensions/pi-starship/src/modules/activity.ts
+++ b/extensions/pi-starship/src/modules/activity.ts
@@ -6,7 +6,7 @@ export const activityModule = defineModule({
 	defaults: {
 		format: "[ $text ]($style)",
 		symbol: "⚙",
-		style: "fg:runtime_fg bg:runtime",
+		style: "bold yellow",
 		disabled: false,
 	},
 	values: ({ runtime, symbol }) => {

--- a/extensions/pi-starship/src/modules/brand.ts
+++ b/extensions/pi-starship/src/modules/brand.ts
@@ -6,7 +6,7 @@ export const brandModule = defineModule({
 	defaults: {
 		format: "[ $symbol ]($style)",
 		symbol: "π",
-		style: "bold fg:header_fg bg:header",
+		style: "bold white",
 		disabled: false,
 	},
 	values: () => ({}),

--- a/extensions/pi-starship/src/modules/cache.ts
+++ b/extensions/pi-starship/src/modules/cache.ts
@@ -7,7 +7,7 @@ export const cacheModule = defineModule({
 	defaults: {
 		format: "[$symbol (CH$rate )]($style)",
 		symbol: "📦",
-		style: "fg:runtime_fg bg:runtime",
+		style: "bold green",
 		disabled: true,
 	},
 	values: ({ runtime }) => {

--- a/extensions/pi-starship/src/modules/context.ts
+++ b/extensions/pi-starship/src/modules/context.ts
@@ -1,3 +1,4 @@
+import { resolveDisplayStyle } from "./display.js";
 import { formatCount } from "./helpers.js";
 import { defineModule } from "./types.js";
 
@@ -7,8 +8,19 @@ export const contextModule = defineModule({
 	defaults: {
 		format: "[$symbol ctx $percentage ]($style)",
 		symbol: "🪟",
-		style: "fg:runtime_fg bg:runtime",
+		style: "none",
 		disabled: false,
+	},
+	displayDefaults: [
+		{ threshold: 0, style: "bold green", hidden: true },
+		{ threshold: 30, style: "bold green", hidden: false },
+		{ threshold: 60, style: "bold yellow", hidden: false },
+		{ threshold: 80, style: "bold red", hidden: false },
+	],
+	styleVariables: ["style"],
+	resolveStyleVariables: ({ runtime, display }) => {
+		const style = resolveDisplayStyle(display, runtime.contextUsage?.percent);
+		return style === undefined ? undefined : { style };
 	},
 	values: ({ runtime }) => {
 		const percent = runtime.contextUsage?.percent;

--- a/extensions/pi-starship/src/modules/cost.ts
+++ b/extensions/pi-starship/src/modules/cost.ts
@@ -1,3 +1,4 @@
+import { resolveDisplayStyle } from "./display.js";
 import { defineModule } from "./types.js";
 
 export const costModule = defineModule({
@@ -6,8 +7,18 @@ export const costModule = defineModule({
 	defaults: {
 		format: "[ $symbol \\$$cost( $subscription) ]($style)",
 		symbol: "💸",
-		style: "fg:meter_fg bg:meter",
+		style: "none",
 		disabled: false,
+	},
+	displayDefaults: [
+		{ threshold: 0, style: "bold green", hidden: true },
+		{ threshold: 1, style: "bold yellow", hidden: false },
+		{ threshold: 5, style: "bold red", hidden: false },
+	],
+	styleVariables: ["style"],
+	resolveStyleVariables: ({ runtime, display }) => {
+		const style = resolveDisplayStyle(display, runtime.tokenTotals.cost);
+		return style === undefined ? undefined : { style };
 	},
 	values: ({ runtime }) => ({
 		cost: formatCost(runtime.tokenTotals.cost),

--- a/extensions/pi-starship/src/modules/development.ts
+++ b/extensions/pi-starship/src/modules/development.ts
@@ -43,7 +43,7 @@ export const direnvModule = developmentModule({
 	variables: ["rc_path", "allowed", "loaded"],
 	format: "[$symbol$loaded]($style) ",
 	symbol: "direnv ",
-	style: "bold 208",
+	style: "bold bright-yellow",
 	options: directDetection,
 });
 

--- a/extensions/pi-starship/src/modules/directory.ts
+++ b/extensions/pi-starship/src/modules/directory.ts
@@ -7,7 +7,7 @@ export const directoryModule = defineModule({
 	defaults: {
 		format: "[ $symbol $path ]($style)",
 		symbol: "📁",
-		style: "fg:directory_fg bg:directory",
+		style: "cyan bold",
 		disabled: false,
 	},
 	values: ({ runtime }) => ({

--- a/extensions/pi-starship/src/modules/display.ts
+++ b/extensions/pi-starship/src/modules/display.ts
@@ -1,0 +1,14 @@
+import type { ModuleDisplayConfig } from "./types.js";
+
+export function resolveDisplayStyle(
+	display: readonly ModuleDisplayConfig[],
+	value: number | null | undefined,
+): string | undefined {
+	if (value === null || value === undefined || !Number.isFinite(value)) return undefined;
+	let selected: ModuleDisplayConfig | undefined;
+	for (const entry of display) {
+		if (entry.threshold > value) continue;
+		if (!selected || entry.threshold >= selected.threshold) selected = entry;
+	}
+	return selected && !selected.hidden ? selected.style : undefined;
+}

--- a/extensions/pi-starship/src/modules/execution.ts
+++ b/extensions/pi-starship/src/modules/execution.ts
@@ -54,9 +54,20 @@ export const usernameModule = defineModule({
 	defaults: {
 		format: "[$user]($style) in ",
 		symbol: "",
-		style: "yellow bold",
+		style: "none",
 		disabled: false,
 	},
+	styleDefaults: {
+		style_user: "yellow bold",
+		style_root: "red bold",
+	},
+	styleVariables: ["style"],
+	resolveStyleVariables: ({ runtime, styles }) => ({
+		style:
+			runtime.workspace?.styleSelectors?.username === "root"
+				? (styles.style_root ?? "")
+				: (styles.style_user ?? ""),
+	}),
 	options: {
 		show_always: { kind: "boolean", default: false },
 		aliases: { kind: "string-map", default: {} },

--- a/extensions/pi-starship/src/modules/extension-status.ts
+++ b/extensions/pi-starship/src/modules/extension-status.ts
@@ -6,7 +6,7 @@ export const extensionStatusModule = defineModule({
 	defaults: {
 		format: "[$statuses]($style)",
 		symbol: "",
-		style: "fg:extension",
+		style: "dimmed white",
 		disabled: false,
 	},
 	values: ({ runtime, extensionStatus }) => {

--- a/extensions/pi-starship/src/modules/fill.ts
+++ b/extensions/pi-starship/src/modules/fill.ts
@@ -6,7 +6,7 @@ export const fillModule = defineModule({
 	defaults: {
 		format: "[$symbol]($style)",
 		symbol: " ",
-		style: "none",
+		style: "bold black",
 		disabled: false,
 	},
 	layout: "fill",

--- a/extensions/pi-starship/src/modules/git/branch.ts
+++ b/extensions/pi-starship/src/modules/git/branch.ts
@@ -6,7 +6,7 @@ export const gitBranchModule = defineModule({
 	defaults: {
 		format: "[ $symbol $branch ]($style)",
 		symbol: "🌿",
-		style: "fg:git_fg bg:git",
+		style: "bold purple",
 		disabled: false,
 	},
 	values: ({ runtime }) => {

--- a/extensions/pi-starship/src/modules/git/commit.ts
+++ b/extensions/pi-starship/src/modules/git/commit.ts
@@ -8,7 +8,7 @@ export const gitCommitModule = defineModule({
 	defaults: {
 		format: "[ ($hash) ]($style)",
 		symbol: "",
-		style: "fg:git_fg bg:git",
+		style: "green bold",
 		disabled: false,
 	},
 	values: ({ runtime }) => {

--- a/extensions/pi-starship/src/modules/git/metrics.ts
+++ b/extensions/pi-starship/src/modules/git/metrics.ts
@@ -4,11 +4,17 @@ export const gitMetricsModule = defineModule({
 	name: "git_metrics",
 	variables: ["symbol", "added", "deleted"],
 	defaults: {
-		format: "[(+$added)( -$deleted) ]($style)",
+		format: "([+$added]($added_style) )([-$deleted]($deleted_style) )",
 		symbol: "",
-		style: "fg:git_fg bg:git",
+		style: "none",
 		disabled: true,
 	},
+	styleDefaults: {
+		added_style: "bold green",
+		deleted_style: "bold red",
+	},
+	styleVariables: ["added_style", "deleted_style"],
+	resolveStyleVariables: ({ styles }) => styles,
 	values: ({ runtime }) => {
 		const metrics = runtime.gitMetrics;
 		if (!metrics || (metrics.added === 0 && metrics.deleted === 0)) return undefined;

--- a/extensions/pi-starship/src/modules/git/state.ts
+++ b/extensions/pi-starship/src/modules/git/state.ts
@@ -6,7 +6,7 @@ export const gitStateModule = defineModule({
 	defaults: {
 		format: "[ ($state( $progress_current/$progress_total)) ]($style)",
 		symbol: "",
-		style: "bold yellow bg:git",
+		style: "bold yellow",
 		disabled: false,
 	},
 	values: ({ runtime }) => {

--- a/extensions/pi-starship/src/modules/git/status.ts
+++ b/extensions/pi-starship/src/modules/git/status.ts
@@ -31,7 +31,7 @@ export const gitStatusModule = defineModule({
 	defaults: {
 		format: "[$all_status( $ahead_behind) ]($style)",
 		symbol: "",
-		style: "fg:git_fg bg:git",
+		style: "red bold",
 		disabled: false,
 	},
 	values: ({ runtime }) => {

--- a/extensions/pi-starship/src/modules/git/worktree.ts
+++ b/extensions/pi-starship/src/modules/git/worktree.ts
@@ -6,7 +6,7 @@ export const gitWorktreeModule = defineModule({
 	defaults: {
 		format: "[ $symbol $name ]($style)",
 		symbol: "🌳",
-		style: "fg:git_fg bg:git",
+		style: "cyan bold",
 		disabled: false,
 	},
 	values: ({ runtime }) =>

--- a/extensions/pi-starship/src/modules/github-pr.ts
+++ b/extensions/pi-starship/src/modules/github-pr.ts
@@ -6,7 +6,7 @@ export const githubPrModule = defineModule({
 	defaults: {
 		format: "[ $symbol$link( · $status) ]($style)",
 		symbol: "PR ",
-		style: "fg:git_fg bg:git",
+		style: "bold blue",
 		disabled: false,
 	},
 	values: ({ runtime }) => {

--- a/extensions/pi-starship/src/modules/model.ts
+++ b/extensions/pi-starship/src/modules/model.ts
@@ -10,7 +10,7 @@ export const modelModule = defineModule({
 	defaults: {
 		format: "[$symbol $model ]($style)",
 		symbol: "🤖",
-		style: "fg:header_fg bg:header",
+		style: "bold blue",
 		disabled: false,
 	},
 	options: {

--- a/extensions/pi-starship/src/modules/provider.ts
+++ b/extensions/pi-starship/src/modules/provider.ts
@@ -6,7 +6,7 @@ export const providerModule = defineModule({
 	defaults: {
 		format: "[$symbol $provider ]($style)",
 		symbol: "🔌",
-		style: "fg:header_fg bg:header",
+		style: "bold blue",
 		disabled: false,
 	},
 	values: ({ runtime }) => (runtime.model ? { provider: runtime.model.provider } : undefined),

--- a/extensions/pi-starship/src/modules/render.ts
+++ b/extensions/pi-starship/src/modules/render.ts
@@ -24,12 +24,30 @@ export function renderStatusline(
 	}
 	for (const definition of MODULE_DEFINITIONS) {
 		const name = definition.name;
+		const module = config.modules[name];
 		const values = definition.values(valueContext(config, name, runtime));
 		if (!values) continue;
-		const rendered = renderModule(config.modules[name], values, palette);
+		const styleVariables = definition.resolveStyleVariables
+			? definition.resolveStyleVariables({
+					runtime,
+					values,
+					style: module.style,
+					styles: module.styles,
+					display: module.display,
+				})
+			: { style: module.style };
+		if (!styleVariables) continue;
+		const contentValues = Object.fromEntries(
+			definition.variables.flatMap((variable) =>
+				variable !== "symbol" && Object.hasOwn(values, variable)
+					? [[variable, values[variable]]]
+					: [],
+			),
+		);
+		const rendered = renderModule(module, contentValues, styleVariables, palette);
 		modules[name] = rendered;
 		layoutModules[name] =
-			definition.layout === "fill" && !config.modules[name].disabled
+			definition.layout === "fill" && !module.disabled
 				? [{ type: "fill", pattern: rendered }]
 				: rendered;
 	}
@@ -65,12 +83,13 @@ function valueContext(
 function renderModule(
 	module: ModuleConfig,
 	values: Readonly<Record<string, FormatValue>>,
+	styleVariables: Readonly<Record<string, string>>,
 	palette: Readonly<Record<string, string>>,
 ): StyledChunk[] {
 	if (module.disabled) return [];
 	return renderFormat(module.formatAst, {
 		variables: { symbol: module.symbol, ...values },
-		styleVariables: { style: module.style },
+		styleVariables,
 		palette,
 	}).filter((chunk): chunk is StyledChunk => !isFillChunk(chunk));
 }

--- a/extensions/pi-starship/src/modules/thinking.ts
+++ b/extensions/pi-starship/src/modules/thinking.ts
@@ -6,7 +6,7 @@ export const thinkingModule = defineModule({
 	defaults: {
 		format: "[$symbol $level ]($style)",
 		symbol: "🧠",
-		style: "fg:header_fg bg:header",
+		style: "bold purple",
 		disabled: false,
 	},
 	values: ({ runtime }) => ({ level: runtime.thinkingLevel }),

--- a/extensions/pi-starship/src/modules/time.ts
+++ b/extensions/pi-starship/src/modules/time.ts
@@ -6,7 +6,7 @@ export const timeModule = defineModule({
 	defaults: {
 		format: "[$symbol $time ]($style)",
 		symbol: "🕒",
-		style: "fg:meter_fg bg:meter",
+		style: "bold yellow",
 		disabled: false,
 	},
 	values: ({ runtime }) => ({ time: formatTime(runtime.now) }),

--- a/extensions/pi-starship/src/modules/tokens.ts
+++ b/extensions/pi-starship/src/modules/tokens.ts
@@ -7,7 +7,7 @@ export const tokensModule = defineModule({
 	defaults: {
 		format: "[$symbol ↑$input ↓$output ]($style)",
 		symbol: "🔢",
-		style: "fg:runtime_fg bg:runtime",
+		style: "bold cyan",
 		disabled: false,
 	},
 	values: ({ runtime }) => ({

--- a/extensions/pi-starship/src/modules/turn.ts
+++ b/extensions/pi-starship/src/modules/turn.ts
@@ -6,7 +6,7 @@ export const turnModule = defineModule({
 	defaults: {
 		format: "[$symbol #$count ]($style)",
 		symbol: "🔁",
-		style: "fg:meter_fg bg:meter",
+		style: "bold purple",
 		disabled: false,
 	},
 	values: ({ runtime }) => ({ count: `${runtime.turnCount}` }),

--- a/extensions/pi-starship/src/modules/types.ts
+++ b/extensions/pi-starship/src/modules/types.ts
@@ -73,6 +73,7 @@ export interface GitSnapshot {
 
 export interface WorkspaceSnapshot {
 	modules: Readonly<Record<string, Readonly<Record<string, string>>>>;
+	styleSelectors?: Readonly<Record<string, string>>;
 }
 
 export interface StarshipRuntimeSnapshot {
@@ -138,6 +139,12 @@ export type ModuleOptionSchema =
 	| { kind: "string-array"; default: readonly string[]; allowNegative?: boolean }
 	| { kind: "string-map"; default: Readonly<Record<string, string>> };
 
+export interface ModuleDisplayConfig {
+	threshold: number;
+	style: string;
+	hidden: boolean;
+}
+
 export interface ModuleDefaults {
 	format: string;
 	symbol: string;
@@ -145,10 +152,22 @@ export interface ModuleDefaults {
 	disabled: boolean;
 }
 
+export interface ModuleStyleContext {
+	runtime: StarshipRuntimeSnapshot;
+	values: Readonly<Record<string, string>>;
+	style: string;
+	styles: Readonly<Record<string, string>>;
+	display: readonly ModuleDisplayConfig[];
+}
+
 export interface ModuleDefinition<Name extends string> {
 	name: Name;
 	variables: readonly string[];
 	defaults: ModuleDefaults;
+	styleDefaults?: Readonly<Record<string, string>>;
+	displayDefaults?: readonly ModuleDisplayConfig[];
+	styleVariables?: readonly string[];
+	resolveStyleVariables?(context: ModuleStyleContext): Readonly<Record<string, string>> | undefined;
 	options?: Readonly<Record<string, ModuleOptionSchema>>;
 	layout?: "fill";
 	values(context: ModuleValueContext): Record<string, string> | undefined;

--- a/extensions/pi-starship/src/runtime/execution.ts
+++ b/extensions/pi-starship/src/runtime/execution.ts
@@ -6,14 +6,23 @@ import {
 	optionStrings,
 	safeMetadata,
 } from "./helpers.js";
-import type { CollectorContext, MutableModuleSnapshot } from "./types.js";
+import {
+	type CollectorContext,
+	type MutableModuleSnapshot,
+	PRIVATE_STYLE_SELECTOR,
+} from "./types.js";
 
 export async function collectExecution(context: CollectorContext): Promise<MutableModuleSnapshot> {
 	if (context.input.reason === "periodic" && context.input.previous) {
 		const retained: MutableModuleSnapshot = {};
 		for (const name of ["os", "container", "hostname", "username"] as const) {
 			const values = context.input.previous.modules[name];
-			if (context.needs(name) && values) retained[name] = { ...values };
+			if (!context.needs(name) || !values) continue;
+			const selector = context.input.previous.styleSelectors?.[name];
+			retained[name] = {
+				...values,
+				...(selector === undefined ? {} : { [PRIVATE_STYLE_SELECTOR]: selector }),
+			};
 		}
 		return retained;
 	}
@@ -116,7 +125,10 @@ function usernameValues(context: CollectorContext): Record<string, string> | und
 	) {
 		return undefined;
 	}
-	return { user: exactAlias(user, optionMap(context, "username", "aliases")) ?? user };
+	return {
+		user: exactAlias(user, optionMap(context, "username", "aliases")) ?? user,
+		[PRIVATE_STYLE_SELECTOR]: privileged ? "root" : "user",
+	};
 }
 
 function isSsh(context: CollectorContext): boolean {

--- a/extensions/pi-starship/src/runtime/types.ts
+++ b/extensions/pi-starship/src/runtime/types.ts
@@ -58,4 +58,6 @@ export interface CollectorContext {
 	needs(name: ModuleName, variable?: string): boolean;
 }
 
+export const PRIVATE_STYLE_SELECTOR = "__pi_style_selector";
+
 export type MutableModuleSnapshot = Record<string, Record<string, string>>;

--- a/extensions/pi-starship/src/runtime/workspace.ts
+++ b/extensions/pi-starship/src/runtime/workspace.ts
@@ -8,11 +8,12 @@ import { collectExecution } from "./execution.js";
 import { createFileSystem } from "./helpers.js";
 import { collectLanguages } from "./languages.js";
 import { collectPackage } from "./package.js";
-import type {
-	CollectorContext,
-	MutableModuleSnapshot,
-	WorkspaceEntry,
-	WorkspaceRefreshInput,
+import {
+	type CollectorContext,
+	type MutableModuleSnapshot,
+	PRIVATE_STYLE_SELECTOR,
+	type WorkspaceEntry,
+	type WorkspaceRefreshInput,
 } from "./types.js";
 
 export { parseTerraformVersion } from "./deployment.js";
@@ -108,6 +109,19 @@ function mergeModules(target: MutableModuleSnapshot, source: MutableModuleSnapsh
 }
 
 function freezeSnapshot(modules: MutableModuleSnapshot): WorkspaceSnapshot {
-	for (const values of Object.values(modules)) Object.freeze(values);
-	return Object.freeze({ modules: Object.freeze(modules) });
+	const styleSelectors: Record<string, string> = {};
+	for (const [name, values] of Object.entries(modules)) {
+		const selector = Object.hasOwn(values, PRIVATE_STYLE_SELECTOR)
+			? values[PRIVATE_STYLE_SELECTOR]
+			: undefined;
+		delete values[PRIVATE_STYLE_SELECTOR];
+		if (selector !== undefined) styleSelectors[name] = selector;
+		Object.freeze(values);
+	}
+	return Object.freeze({
+		modules: Object.freeze(modules),
+		...(Object.keys(styleSelectors).length > 0
+			? { styleSelectors: Object.freeze(styleSelectors) }
+			: {}),
+	});
 }

--- a/extensions/pi-starship/test/commands.test.ts
+++ b/extensions/pi-starship/test/commands.test.ts
@@ -511,7 +511,8 @@ test("Advanced restore previews, confirms, and atomically applies the built-in f
 		});
 		await mock.commands.get("starship")?.handler("", context.ctx);
 		assert.match(restorePreview, /Restore preview/u);
-		assert.match(restorePreview, /░▒▓/u);
+		assert.match(restorePreview, /\$brand\$model/u);
+		assert.doesNotMatch(restorePreview, /░▒▓|/u);
 		assert.equal(applied, 1);
 		assert.equal(readFileSync(path, "utf8"), BUILT_IN_EXAMPLE);
 	} finally {

--- a/extensions/pi-starship/test/config.test.ts
+++ b/extensions/pi-starship/test/config.test.ts
@@ -63,43 +63,32 @@ test("unreadable Starship settings report an I/O diagnostic instead of appearing
 	}
 });
 
-test("built-in example uses readable TOML continuations without changing the format", () => {
+test("built-in example is a palette-free nine-module Starship document", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-config-"));
 	const path = join(root, CONFIG_FILE_NAME);
 	try {
 		assert.match(BUILT_IN_EXAMPLE, /^format = """/mu);
-		assert.match(BUILT_IN_EXAMPLE, /\[░▒▓\]\(lead\)\\\n\$brand\\\n\$provider\\\n/u);
-		assert.doesNotMatch(BUILT_IN_EXAMPLE, /format = '''/u);
+		assert.match(BUILT_IN_EXAMPLE, /\$brand\\\n\$model\\\n\$thinking\\\n\$directory/u);
+		assert.doesNotMatch(BUILT_IN_EXAMPLE, /format = '''|palette\s*=|\[palettes\.|░▒▓|/u);
 		writeFileSync(path, BUILT_IN_EXAMPLE);
 		const loaded = loadStarshipConfig(path);
 		assert.equal(
 			loaded.config.format,
 			[
-				"[░▒▓](lead)",
 				"$brand",
-				"$provider",
 				"$model",
 				"$thinking",
-				"[](fg:header bg:directory)",
 				"$directory",
-				"[](fg:directory bg:git)",
-				"$git_worktree",
 				"$git_branch",
-				"$github_pr",
 				"$git_status",
-				"[](fg:git bg:runtime)",
 				"$activity",
 				"$context",
-				"$tokens",
-				"$cache",
-				"[](fg:runtime bg:meter)",
-				"$cost",
 				"$time",
-				"[](fg:meter)",
-				"(\n$extension_status)",
 			].join(""),
 		);
 		assert.equal(loaded.config.format, BUILT_IN_CONFIG.format);
+		assert.equal(loaded.config.palette, undefined);
+		assert.deepEqual(loaded.config.palettes, {});
 		assert.deepEqual(loaded.diagnostics, []);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
@@ -117,7 +106,8 @@ test("Git and GitHub PR modules use deterministic display order", () => {
 		"git_status",
 	]);
 	assert.equal(MODULE_NAMES.indexOf("github_pr"), MODULE_NAMES.indexOf("git_branch") + 1);
-	assert.match(BUILT_IN_CONFIG.format, /\$git_branch\$github_pr\$git_status/u);
+	assert.match(BUILT_IN_CONFIG.format, /\$git_branch\$git_status/u);
+	assert.doesNotMatch(BUILT_IN_CONFIG.format, /\$github_pr/u);
 });
 
 test("removed git_branch $pr settings use the generic unknown-variable diagnostic", () => {
@@ -282,7 +272,7 @@ test("invalid recognized fields fall back independently and unknown fields warn"
 		const loaded = loadStarshipConfig(path);
 		assert.equal(loaded.source, "user");
 		assert.equal(loaded.config.format, BUILT_IN_CONFIG.format);
-		assert.equal(loaded.config.palette, BUILT_IN_CONFIG.palette);
+		assert.equal(loaded.config.palette, "missing");
 		assert.equal(loaded.config.modules.model.style, BUILT_IN_CONFIG.modules.model.style);
 		assert.equal(loaded.config.modules.model.disabled, false);
 		assert.ok(loaded.diagnostics.length >= 6);
@@ -298,7 +288,7 @@ test("palette normalization handles prototype-like names as exact own properties
 	try {
 		writeFileSync(path, "palette = 'toString'\n\n[model]\nstyle = 'toString'\n");
 		const inherited = loadStarshipConfig(path);
-		assert.equal(inherited.config.palette, BUILT_IN_CONFIG.palette);
+		assert.equal(inherited.config.palette, "toString");
 		assert.equal(inherited.config.modules.model.style, BUILT_IN_CONFIG.modules.model.style);
 		assert.match(
 			inherited.diagnostics.map((item) => item.message).join("\n"),
@@ -318,6 +308,141 @@ test("palette normalization handles prototype-like names as exact own properties
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test("only an explicitly selected custom palette is active", () => {
+	const unselected = normalizeConfig({
+		palettes: { mine: { blue: "#010203", accent: "17" } },
+		model: { style: "accent" },
+	});
+	assert.equal(unselected.config.palette, undefined);
+	assert.equal(unselected.config.modules.model.style, BUILT_IN_CONFIG.modules.model.style);
+	assert.match(unselected.diagnostics.map((item) => item.message).join("\n"), /invalid style/iu);
+
+	const selected = normalizeConfig({
+		palette: "mine",
+		palettes: { mine: { blue: "#010203", accent: "17" } },
+		model: { style: "accent" },
+	});
+	assert.equal(selected.config.palette, "mine");
+	assert.equal(selected.config.modules.model.style, "accent");
+	assert.deepEqual(selected.diagnostics, []);
+});
+
+test("legacy palette aliases warn and receive no hidden fallback colors", () => {
+	const normalized = normalizeConfig({
+		format: "[root](header)$directory",
+		directory: { style: "fg:directory_fg bg:directory" },
+	});
+	assert.equal(normalized.config.palette, undefined);
+	assert.equal(normalized.config.modules.directory.style, BUILT_IN_CONFIG.modules.directory.style);
+	const messages = normalized.diagnostics.map((item) => `${item.path}: ${item.message}`).join("\n");
+	assert.match(messages, /format.*invalid literal style.*header/iu);
+	assert.match(messages, /directory\.style.*invalid style/iu);
+});
+
+test("built-in module styles use direct colors without backgrounds", () => {
+	const expected = {
+		brand: "bold white",
+		provider: "bold blue",
+		model: "bold blue",
+		thinking: "bold purple",
+		directory: "cyan bold",
+		git_worktree: "cyan bold",
+		git_branch: "bold purple",
+		github_pr: "bold blue",
+		git_commit: "green bold",
+		git_state: "bold yellow",
+		git_status: "red bold",
+		activity: "bold yellow",
+		tokens: "bold cyan",
+		cache: "bold green",
+		time: "bold yellow",
+		turn: "bold purple",
+		extension_status: "dimmed white",
+		direnv: "bold bright-yellow",
+		fill: "bold black",
+	} as const;
+	for (const [name, style] of Object.entries(expected)) {
+		assert.equal(BUILT_IN_CONFIG.modules[name as keyof typeof expected].style, style, name);
+	}
+	for (const module of Object.values(BUILT_IN_CONFIG.modules)) {
+		for (const style of [
+			module.style,
+			...Object.values(module.styles),
+			...module.display.map((entry) => entry.style),
+		]) {
+			assert.doesNotMatch(style, /(?:^|\s)bg:/u);
+		}
+	}
+});
+
+test("invalid direct palette values warn and palette aliases cannot reference aliases", () => {
+	const normalized = normalizeConfig({
+		palette: "mine",
+		palettes: { mine: { direct: "#010203", recursive: "direct" } },
+		model: { style: "recursive" },
+	});
+	assert.deepEqual(normalized.config.palettes.mine, { direct: "#010203" });
+	assert.equal(normalized.config.modules.model.style, BUILT_IN_CONFIG.modules.model.style);
+	assert.match(
+		normalized.diagnostics.map((item) => `${item.path}: ${item.message}`).join("\n"),
+		/palettes\.mine\.recursive.*named.*ANSI.*#RRGGBB|model\.style.*invalid style/iu,
+	);
+});
+
+test("multi-style and display settings normalize independently", () => {
+	const normalized = normalizeConfig({
+		git_metrics: {
+			added_style: "not-a-color",
+			deleted_style: "blue",
+			style: "red",
+		},
+		username: { style_user: "cyan bold", style_root: "bright-red bold" },
+		context: {
+			display: [
+				{ threshold: 0, style: "bold green", hidden: true },
+				{ threshold: 50, style: "fg:not-a-color", hidden: false },
+				{ threshold: 80, style: "bold red", hidden: false, future: true },
+			],
+		},
+		cost: { display: [{ threshold: Number.NaN, style: "yellow", hidden: false }] },
+	});
+	assert.deepEqual(normalized.config.modules.git_metrics.styles, {
+		added_style: "bold green",
+		deleted_style: "blue",
+	});
+	assert.deepEqual(normalized.config.modules.username.styles, {
+		style_user: "cyan bold",
+		style_root: "bright-red bold",
+	});
+	assert.deepEqual(normalized.config.modules.context.display, [
+		{ threshold: 0, style: "bold green", hidden: true },
+		{ threshold: 80, style: "bold red", hidden: false },
+	]);
+	assert.deepEqual(normalized.config.modules.cost.display, BUILT_IN_CONFIG.modules.cost.display);
+	const messages = normalized.diagnostics.map((item) => `${item.path}: ${item.message}`).join("\n");
+	assert.match(messages, /git_metrics\.style.*unknown setting/iu);
+	assert.match(messages, /git_metrics\.added_style.*invalid style/iu);
+	assert.match(messages, /context\.display\.1\.style/iu);
+	assert.match(messages, /context\.display\.2\.future/iu);
+	assert.match(messages, /cost\.display\.0\.threshold/iu);
+});
+
+test("display arrays use module defaults when no valid entries remain", () => {
+	const normalized = normalizeConfig({
+		context: { display: [] },
+		cost: { display: "wrong" },
+	});
+	assert.deepEqual(
+		normalized.config.modules.context.display,
+		BUILT_IN_CONFIG.modules.context.display,
+	);
+	assert.deepEqual(normalized.config.modules.cost.display, BUILT_IN_CONFIG.modules.cost.display);
+	assert.deepEqual(
+		normalized.diagnostics.map((item) => item.path),
+		["context.display", "cost.display"],
+	);
 });
 
 test("unknown root/module/style variables warn and invalid styles fall back", () => {

--- a/extensions/pi-starship/test/formatter.test.ts
+++ b/extensions/pi-starship/test/formatter.test.ts
@@ -7,7 +7,7 @@ import {
 	parseFormat,
 	renderFormat,
 } from "../src/format/formatter.js";
-import { renderChunksToAnsi } from "../src/format/style.js";
+import { isValidStyle, renderChunksToAnsi } from "../src/format/style.js";
 
 function stripAnsi(value: string): string {
 	const escapeSequence = String.fromCharCode(27);
@@ -18,11 +18,13 @@ function render(
 	format: string,
 	variables: Record<string, string> = {},
 	styleVariables: Record<string, string> = {},
+	palette: Record<string, string> = {},
 ) {
 	return renderChunksToAnsi(
 		renderFormat(parseFormat(format), {
 			variables,
 			styleVariables,
+			palette,
 		}),
 	);
 }
@@ -80,26 +82,62 @@ test("formatter rejects unescaped functional characters and incomplete variables
 });
 
 test("styles support named, ANSI, RGB, modifiers, none, and palettes", () => {
-	const output = renderChunksToAnsi(
-		renderFormat(parseFormat("[a](bold fg:accent bg:17)[b](#010203 underline)[c](none)"), {
-			variables: {},
-			palette: { accent: "bright-purple" },
-		}),
+	const output = render(
+		"[a](bold fg:accent bg:17)[b](#010203 underline)[c](none)",
+		{},
+		{},
+		{ accent: "bright-purple" },
 	);
 	assert.ok(output.includes("\u001b[95;48;5;17;1ma"));
 	assert.ok(output.includes("\u001b[38;2;1;2;3;4mb"));
 	assert.ok(output.endsWith("c"));
-
-	const foregroundReset = render("[x](bold bg:red fg:none)");
-	assert.ok(foregroundReset.includes("\u001b[41;1mx"));
-	assert.equal(render("[x](fg:none)"), "x");
 	assert.ok(render("[x](bold fg:red bg:none)").includes("\u001b[31;1mx"));
 });
 
-test("prev_fg and prev_bg inherit the previous rendered chunk colors", () => {
-	const output = render("[a](fg:#112233 bg:17)[b](fg:prev_bg bg:prev_fg)");
+test("none and fg:none override the complete style expression", () => {
+	for (const style of [
+		"none fg:red bg:green bold",
+		"fg:red none bg:green bold",
+		"fg:red bg:green bold none",
+		"fg:none bg:black bold",
+		"bg:black bold fg:none",
+		"not-a-color none",
+	]) {
+		assert.equal(render(`[x](${style})`), "x", style);
+		assert.equal(isValidStyle(style), true, style);
+	}
+});
+
+test("background resets and color ordering match Starship", () => {
+	assert.ok(render("[x](fg:red bg:green bold bg:none)").includes("\u001b[31;1mx"));
+	assert.ok(render("[x](fg:red bg:green bg:not-a-color)").includes("\u001b[31mx"));
+	assert.ok(render("[x](bg:bold fg:red)").includes("\u001b[31;1mx"));
+	const ordered = render("[x](bg:120 bg:125 bg:127 fg:127 122 125)");
+	assert.ok(ordered.includes("\u001b[38;5;125;48;5;127mx"));
+	assert.equal(render("[x](fg:not-a-color)"), "x");
+});
+
+test("prev_fg and prev_bg override absolute fallbacks only when a previous style exists", () => {
+	const output = render(
+		"[a](fg:#112233 bg:17)[b](bold fg:black fg:prev_bg bg:green bg:prev_fg underline)",
+	);
 	assert.ok(output.includes("\u001b[38;2;17;34;51;48;5;17ma"));
-	assert.ok(output.includes("\u001b[38;5;17;48;2;17;34;51mb"));
+	assert.ok(output.includes("\u001b[38;5;17;48;2;17;34;51;1;4mb"));
+
+	const fallback = render("[b](bold fg:black fg:prev_bg bg:green bg:prev_fg underline)");
+	assert.ok(fallback.includes("\u001b[30;42;1;4mb"));
+});
+
+test("empty styled groups propagate previous colors", () => {
+	const output = render("[](bg:#9a348e)[x](bg:prev_bg)");
+	assert.ok(output.includes("\u001b[48;2;154;52;142mx"));
+});
+
+test("selected palettes override named colors without recursive aliases", () => {
+	const selected = { blue: "17", accent: "#010203", recursive: "accent" };
+	assert.ok(render("[a](blue)[b](accent)", {}, {}, selected).includes("\u001b[38;5;17ma"));
+	assert.ok(render("[a](blue)[b](accent)", {}, {}, selected).includes("\u001b[38;2;1;2;3mb"));
+	assert.equal(render("[x](recursive)", {}, {}, selected), "x");
 });
 
 test("formatter preserves OSC-8 hyperlinks and visible width", () => {

--- a/extensions/pi-starship/test/lifecycle.test.ts
+++ b/extensions/pi-starship/test/lifecycle.test.ts
@@ -39,6 +39,12 @@ function piStarship(pi: Parameters<typeof piStarshipRuntime>[0]) {
 	});
 }
 
+function useLifecycleConfig(t: { after(callback: () => void): void }, rawDocument: string) {
+	const path = join(lifecycleAgentDir, "pi-starship.toml");
+	writeFileSync(path, rawDocument);
+	t.after(() => rmSync(path, { force: true }));
+}
+
 type FooterFactory = (
 	tui: { requestRender(): void },
 	theme: unknown,
@@ -126,7 +132,8 @@ test("unreachable and disabled native PR modules execute no gh command", async (
 	}
 });
 
-test("native PR refresh clears branch state, aborts stale work, and stops on footer disposal", async () => {
+test("native PR refresh clears branch state, aborts stale work, and stops on footer disposal", async (t) => {
+	useLifecycleConfig(t, "format = '$github_pr'\n");
 	const mock = createMockPi();
 	const stale = deferred<ExecResult>();
 	const fresh = deferred<ExecResult>();
@@ -203,6 +210,7 @@ test("accepted settings disable and re-enable native PR refresh immediately", as
 	const previous = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = root;
 	try {
+		writeFileSync(join(root, "pi-starship.toml"), "format = '$github_pr'\n");
 		const mock = createMockPi();
 		const stale = deferred<ExecResult>();
 		const prSignals: AbortSignal[] = [];
@@ -299,7 +307,8 @@ test("session replacement cancels an awaited settings edit before saving or appl
 	}
 });
 
-test("same-cwd session replacement aborts and rejects stale native PR publication", async () => {
+test("same-cwd session replacement aborts and rejects stale native PR publication", async (t) => {
+	useLifecycleConfig(t, "format = '$github_pr'\n");
 	const mock = createMockPi();
 	const oldResult = deferred<ExecResult>();
 	const newResult = deferred<ExecResult>();
@@ -373,6 +382,7 @@ test("same-cwd session replacement aborts and rejects stale native PR publicatio
 });
 
 test("reachable native PR refresh uses its own 60-second fallback", async (t) => {
+	useLifecycleConfig(t, "format = '$github_pr'\n");
 	t.mock.timers.enable({ apis: ["setInterval"] });
 	const mock = createMockPi();
 	let prCalls = 0;
@@ -410,6 +420,7 @@ test("reachable native PR refresh uses its own 60-second fallback", async (t) =>
 });
 
 test("terminal native PR snapshots clear at their lifecycle expiry", async (t) => {
+	useLifecycleConfig(t, "format = '$github_pr'\n");
 	t.mock.timers.enable({ apis: ["setTimeout"] });
 	let now = Date.parse("2026-08-01T12:00:00.000Z");
 	t.mock.method(Date, "now", () => now);
@@ -449,6 +460,7 @@ test("terminal native PR snapshots clear at their lifecycle expiry", async (t) =
 });
 
 test("terminal native PR expiry revalidates the wall clock before clearing", async (t) => {
+	useLifecycleConfig(t, "format = '$github_pr'\n");
 	t.mock.timers.enable({ apis: ["setTimeout"] });
 	let now = Date.parse("2026-08-01T12:00:00.000Z");
 	t.mock.method(Date, "now", () => now);
@@ -543,7 +555,7 @@ test("TUI footer uses all-entry usage totals and marks subscription-backed cost"
 	try {
 		writeFileSync(
 			join(root, "pi-starship.toml"),
-			"format = '$cache$tokens$cost'\n\n[cache]\ndisabled = false\nformat = 'R$read W$write CH$rate '\n",
+			"format = '$cache$tokens$cost'\n\n[cache]\ndisabled = false\nformat = 'R$read W$write CH$rate '\n\n[[cost.display]]\nthreshold = 0\nstyle = 'bold yellow'\nhidden = false\n",
 		);
 		const makeUsage = (
 			input: number,
@@ -620,7 +632,8 @@ test("TUI footer uses all-entry usage totals and marks subscription-backed cost"
 	}
 });
 
-test("TUI footer renders cached state and parallel tool activity without executing during render", async () => {
+test("TUI footer renders cached state and parallel tool activity without executing during render", async (t) => {
+	useLifecycleConfig(t, "format = '$git_worktree$git_status$activity'\n");
 	const mock = createMockPi({ thinkingLevel: "high" });
 	let calls = 0;
 	let worktreeCalls = 0;
@@ -725,7 +738,8 @@ test("stale Git results from a replaced session cannot overwrite the new footer"
 	await emit(mock.events, "session_shutdown", {}, newContext.ctx);
 });
 
-test("stale worktree identity from a replaced session cannot overwrite the new footer", async () => {
+test("stale worktree identity from a replaced session cannot overwrite the new footer", async (t) => {
+	useLifecycleConfig(t, "format = '$git_worktree'\n");
 	const mock = createMockPi();
 	const oldWorktree = deferred<ExecResult>();
 	const newWorktree = deferred<ExecResult>();

--- a/extensions/pi-starship/test/modules.test.ts
+++ b/extensions/pi-starship/test/modules.test.ts
@@ -11,6 +11,7 @@ import {
 	shortenModel,
 } from "../src/modules/index.js";
 
+const ESC = String.fromCharCode(27);
 const LINK = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
 
 function stripAnsi(value: string): string {
@@ -82,23 +83,26 @@ function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRunt
 	};
 }
 
-test("built-in modules expose Pi values through the default format", () => {
+test("built-in root renders exactly the reachable nine module categories without backgrounds", () => {
 	const rendered = renderStatusline(BUILT_IN_CONFIG, fixture());
 	const plain = stripAnsi(rendered.ansi);
-	assert.match(plain, /π/);
-	assert.match(plain, /anthropic/);
-	assert.match(plain, /sonnet-4/);
-	assert.match(plain, /high/);
-	assert.match(plain, /pi-extensions/);
-	assert.match(plain, /feature/);
-	assert.match(plain, /PR #123 · 2 failing/);
-	assert.match(plain, /=1 !4 \+3 \?5 ⇕⇡2⇣1/);
-	assert.match(plain, /read/);
-	assert.match(plain, /75\.0%/);
-	assert.match(plain, /↑1\.5k ↓200/);
-	assert.match(plain, /\$0\.123/);
-	assert.match(plain, /09:05/);
-	assert.match(plain, /🔌 active/);
+	for (const expected of [
+		/π/u,
+		/sonnet-4/u,
+		/high/u,
+		/pi-extensions/u,
+		/feature/u,
+		/=1 !4 \+3 \?5 ⇕⇡2⇣1/u,
+		/read/u,
+		/75\.0%/u,
+		/09:05/u,
+	]) {
+		assert.match(plain, expected);
+	}
+	for (const omitted of [/anthropic/u, /PR #123/u, /↑1\.5k/u, /\$0\.123/u, /🔌 active/u]) {
+		assert.doesNotMatch(plain, omitted);
+	}
+	assert.ok(rendered.chunks.every((chunk) => chunk.style?.background === undefined));
 });
 
 test("context supports native percentage/window precision", () => {
@@ -107,6 +111,7 @@ test("context supports native percentage/window precision", () => {
 	config.formatAst = parseFormat(config.format);
 	config.modules.context.format = "$percentage/$window";
 	config.modules.context.formatAst = parseFormat(config.modules.context.format);
+	config.modules.context.display = [{ threshold: 0, style: "bold green", hidden: false }];
 
 	assert.equal(
 		stripAnsi(
@@ -121,11 +126,97 @@ test("context supports native percentage/window precision", () => {
 	);
 });
 
+test("context display thresholds hide and select the highest matching style", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$context";
+	config.formatAst = parseFormat(config.format);
+	const renderAt = (percent: number) =>
+		renderStatusline(
+			config,
+			fixture({ contextUsage: { percent, tokens: 100, contextWindow: 1000 } }),
+		).ansi;
+
+	assert.equal(renderAt(0), "");
+	assert.equal(renderAt(29.999), "");
+	assert.ok(renderAt(30).includes(`${ESC}[32;1m`));
+	assert.ok(renderAt(59.999).includes(`${ESC}[32;1m`));
+	assert.ok(renderAt(60).includes(`${ESC}[33;1m`));
+	assert.ok(renderAt(79.999).includes(`${ESC}[33;1m`));
+	assert.ok(renderAt(80).includes(`${ESC}[31;1m`));
+
+	config.modules.context.display = [
+		{ threshold: 0, style: "green", hidden: false },
+		{ threshold: 50, style: "yellow", hidden: false },
+		{ threshold: 50, style: "blue", hidden: false },
+	];
+	assert.ok(renderAt(50).includes(`${ESC}[34m`));
+});
+
+test("cost display thresholds hide low values and select yellow then red", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$cost";
+	config.formatAst = parseFormat(config.format);
+	const renderAt = (cost: number) =>
+		renderStatusline(
+			config,
+			fixture({ tokenTotals: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost } }),
+		).ansi;
+
+	assert.equal(renderAt(0), "");
+	assert.equal(renderAt(0.999), "");
+	assert.ok(renderAt(1).includes(`${ESC}[33;1m`));
+	assert.ok(renderAt(4.999).includes(`${ESC}[33;1m`));
+	assert.ok(renderAt(5).includes(`${ESC}[31;1m`));
+});
+
+test("git metrics render additions and deletions with independent styles", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$git_metrics";
+	config.formatAst = parseFormat(config.format);
+	config.modules.git_metrics.disabled = false;
+	const runtime = fixture({ gitMetrics: { added: 12, deleted: 3 } });
+	const rendered = renderStatusline(config, runtime).ansi;
+	assert.ok(rendered.includes(`${ESC}[32;1m+12`));
+	assert.ok(rendered.includes(`${ESC}[31;1m-3`));
+
+	config.modules.git_metrics.styles.added_style = "blue";
+	config.modules.git_metrics.styles.deleted_style = "yellow";
+	const custom = renderStatusline(config, runtime).ansi;
+	assert.ok(custom.includes(`${ESC}[34m+12`));
+	assert.ok(custom.includes(`${ESC}[33m-3`));
+});
+
+test("username selects user and root styles without exposing private selector metadata", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$username";
+	config.formatAst = parseFormat(config.format);
+	config.modules.username.format = "[$user]($style)$__pi_style_selector";
+	config.modules.username.formatAst = parseFormat(config.modules.username.format);
+	const renderUser = (selector: "user" | "root") =>
+		renderStatusline(
+			config,
+			fixture({
+				workspace: {
+					modules: { username: { user: selector === "root" ? "root" : "alice" } },
+					styleSelectors: { username: selector },
+				},
+			}),
+		).ansi;
+
+	assert.ok(renderUser("user").startsWith(`${ESC}[33;1malice`));
+	assert.ok(renderUser("root").startsWith(`${ESC}[31;1mroot`));
+	assert.doesNotMatch(stripAnsi(renderUser("root")), /selector/u);
+
+	config.modules.username.styles.style_root = "bright-purple";
+	assert.ok(renderUser("root").startsWith(`${ESC}[95mroot`));
+});
+
 test("cache and subscription modules expose native usage semantics", () => {
 	const config = structuredClone(BUILT_IN_CONFIG);
 	config.format = "$cache|$cost";
 	config.formatAst = parseFormat(config.format);
 	config.modules.cache.disabled = false;
+	config.modules.cost.display = [{ threshold: 0, style: "bold yellow", hidden: false }];
 	const runtime = fixture({
 		tokenTotals: {
 			input: 100,
@@ -293,6 +384,8 @@ test("module format, symbol, style, and disabled settings apply", () => {
 	config.modules.model.style = "red bold";
 	const rendered = renderStatusline(config, fixture()).ansi;
 	assert.ok(rendered.includes("\u001b[31;1mM:sonnet-4"));
+	config.modules.model.style = "bold bg:#86BBD8";
+	assert.ok(renderStatusline(config, fixture()).ansi.includes("\u001b[48;2;134;187;216;1m"));
 	config.modules.model.disabled = true;
 	assert.equal(renderStatusline(config, fixture()).ansi, "");
 });

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -433,6 +433,11 @@ test("execution context rules are fixture-driven and sanitize terminal metadata"
 	});
 	assert.equal(snapshot.modules.hostname?.hostname, "builder");
 	assert.equal(snapshot.modules.username?.user, "root");
+	assert.equal(snapshot.styleSelectors?.username, "root");
+	assert.equal(
+		Object.keys(snapshot.modules.username ?? {}).some((key) => key.startsWith("__")),
+		false,
+	);
 	assert.equal(snapshot.modules.container?.name, "Dev Container");
 	assert.equal(JSON.stringify(snapshot).includes(String.fromCharCode(27)), false);
 	assert.equal(JSON.stringify(snapshot).includes(String.fromCharCode(7)), false);
@@ -471,6 +476,7 @@ test("execution fixtures cover macOS, Windows, WSL, Docker, Podman, and contextu
 	const windows = await run("win32", {}, "Administrator");
 	assert.equal(windows.modules.os?.type, "windows");
 	assert.equal(windows.modules.username?.user, "Administrator");
+	assert.equal(windows.styleSelectors?.username, "root");
 	const wsl = await run("linux", { WSL_DISTRO_NAME: "Ubuntu" }, "developer");
 	assert.equal(wsl.modules.os?.type, "wsl");
 	assert.equal(wsl.modules.container?.type, "wsl");
@@ -754,12 +760,14 @@ test("ordinary local identity stays hidden and periodic refresh retains executio
 	});
 	assert.equal(contextual.modules.hostname?.hostname, "local");
 	assert.equal(contextual.modules.username?.user, "developer");
+	assert.equal(contextual.styleSelectors?.username, "user");
 	const periodic = await collectWorkspaceSnapshot({
 		...base,
 		reason: "periodic",
 		previous: contextual,
 	});
 	assert.deepEqual(periodic.modules, contextual.modules);
+	assert.deepEqual(periodic.styleSelectors, contextual.styleSelectors);
 });
 
 test("gcloud selector cannot escape its configuration directory", async () => {


### PR DESCRIPTION
## Summary

- replace the implicit Tokyo Night/Powerline built-in with the requested palette-free nine-module root and background-free direct styles
- align style parsing, selected-palette, `none`, background reset, and previous-color behavior with checked-in Starship semantics
- add Git metrics added/deleted styles, username user/root styles, and context/cost threshold displays with lifecycle-safe private selector retention

## Breaking changes

- removes the implicit `tokyo-night` palette and its built-in aliases
- replaces generic `style` settings for `git_metrics`, `username`, `context`, and `cost` with their documented multi/state-style settings
- existing files are not rewritten; README migration guidance covers direct colors, explicit custom palettes, and restore-built-in

## Verification

- `npm run check` — 2,075 tests passed
- `npm --workspace @narumitw/pi-starship run check`
- focused pi-starship formatter, config, module, lifecycle, and workspace tests
- `just pack-starship`
- independent final review: no findings
