### PR TITLE
fix(pi-starship): refine starship settings workflow

### DIFF
--- a/docs/plans/archived/2026-08-02_pi-starship-command-ux-plan.md
+++ b/docs/plans/archived/2026-08-02_pi-starship-command-ux-plan.md
@@ -1,0 +1,129 @@
+# pi-starship `/starship` UX plan
+
+## Goal
+
+Make `/starship` present normal built-in defaults accurately, keep configuration and recovery actions
+shallow and safe, and keep every preview action reachable across supported terminal sizes and
+keybindings without changing pi-starship's configuration format or persistence guarantees.
+
+## Context
+
+- The existing editor → validation → preview → confirmation → atomic save → runtime apply flow is
+  sound and already covers cancellation, save failure, apply failure, rollback, session replacement,
+  RPC, and non-TUI behavior.
+- The reviewed gaps are the unbounded preview height, an actionable restore in the normal missing-file
+  state, incomplete restore consequences, an unnecessary Advanced submenu, misleading fallback copy,
+  ignored injected keybindings, and silently accepted trailing command arguments.
+- Applicable guidance: `docs/extension-conventions.md`, `docs/extension-settings.md`,
+  `designing-user-experiences`, `designing-user-interfaces`, and `applying-tdd`.
+- Touched areas are command routing, standard menu information architecture, specialized preview TUI,
+  settings recovery copy, tests, and user-facing command documentation.
+
+## Architecture
+
+- Keep the main, configuration, and help screens on `@narumitw/pi-tui-kit`; do not add a shared kit
+  API for this extension-specific editor/preview transaction.
+- Derive one presentation model from `LoadedStarshipConfig` for state, source, health, and restore
+  availability. Distinguish a healthy absent file from an error-driven built-in fallback.
+- Flatten the menu to `Customize footer`, `Configuration`, `Help`, and `Restore built-in…`.
+  Configuration owns state, source, path, health, and diagnostics. Restore remains visible last but is
+  disabled when there is no document to replace or the exact built-in document is already saved.
+- Move the specialized preview component out of command routing if needed for cohesion. It will use
+  `tui.terminal.rows`, the callback-provided keybindings, a bounded scrollable preview viewport, and a
+  typed result that distinguishes apply, edit, discard, and whole-workflow close.
+- Preserve the existing validator, raw-document handling, atomic publication, unknown-field behavior
+  during ordinary edits, rollback protocol, owner checks after awaits, and missing-file read behavior.
+
+## Non-Goals
+
+- Do not change Starship format/style semantics, built-in module defaults, palette behavior, or the
+  nine-module root.
+- Do not add presets, a structured settings form, project settings, migration, backup files, or
+  automatic settings-file creation.
+- Do not modify `@narumitw/pi-tui-kit`, package dependencies, metadata, versions, or personal
+  `~/.pi/agent/pi-starship.toml`.
+- Do not remove the documented `settings`, `status`, or `help` direct routes or add ad hoc print/JSON
+  output.
+
+## Assumptions
+
+- `Customize footer` and configuration diagnosis are the primary jobs; restore is infrequent recovery.
+- In the healthy missing-file state, a visible disabled restore row communicates that defaults are
+  already active better than hiding the capability.
+- A successful restore intentionally replaces the complete document without retaining a backup, so
+  the review and confirmation must state that consequence explicitly.
+
+## Risks
+
+- An adaptive specialized component can regress keyboard, resize, or lifecycle behavior; use the
+  public TUI harness with width, row, remapped-key, Escape, Ctrl+C, and disposal coverage.
+- Flattening restore makes a destructive action more visible; keep it last, state-gated, suffixed with
+  an ellipsis, previewed, and exactly confirmed.
+- Changing screen transitions can weaken proven save/apply recovery; retain the persistence helpers
+  unchanged and rerun all command and lifecycle regressions.
+
+## Plan
+
+- [x] Add red-first cases to `extensions/pi-starship/test/commands.test.ts` for healthy missing-file,
+      saved built-in, custom, and invalid-file presentations; assert `Built-in defaults · Healthy`, no
+      Advanced screen, one combined Configuration screen, and a disabled no-op restore that does not
+      create `pi-starship.toml`; focused execution failed on the expected current `Built-in fallback`,
+      Advanced navigation, and actionable restore behavior.
+- [x] Update `extensions/pi-starship/src/commands.ts` with the derived configuration presentation and
+      flattened four-action menu; Configuration now shows state/source/path/health/diagnostics and
+      Restore is state-gated; all 19 focused command tests passed after updating the existing navigation
+      expectations.
+- [x] Add red-first TUI-harness cases for a long multiline preview at `20×8`, `28×12`, and `80×24`,
+      dynamic resize, remapped navigation/confirmation/cancel keys, cancellation, Ctrl+C whole-workflow
+      close, and returning to edit/main; focused execution failed on the expected unbounded frame,
+      hard-coded hint/key handling, and preview Ctrl+C reopening the main menu.
+- [x] Implement `extensions/pi-starship/src/command-preview.ts` as the extension-owned adaptive
+      preview surface and wire it through `commands.ts`; frames are row/width bounded, preview content
+      scrolls independently of reachable actions, injected hints are used, and Escape/Ctrl+C differ;
+      all 23 focused command tests passed.
+- [x] Update the customize flow copy in `extensions/pi-starship/src/commands.ts` to use `Apply
+      changes…`, `Continue editing`, and `Discard draft`; unavailable previews remain explicit and
+      recoverable. Valid, warning, invalid, preview-failure, confirmation-cancellation, and successful-
+      apply coverage passed in the 25-test focused command run.
+- [x] Update restore review and confirmation in `extensions/pi-starship/src/commands.ts` to show
+      current state/path and disclose complete-document replacement—including custom settings, unknown
+      fields, and comments—with no post-success backup; custom and malformed recovery plus byte-exact
+      cancellation passed in the 26-test focused command run.
+- [x] Add red-first command-routing cases for unknown and trailing arguments, then update the
+      `/starship` parser to accept only exact documented routes and issue a TUI/RPC usage warning;
+      focused execution first failed on `settings extra`, then all 27 command tests passed with
+      completions plus existing TUI, RPC, print, and JSON safety preserved.
+- [x] Re-run command and lifecycle coverage after auditing user cancellation, external component
+      disposal, session replacement, shutdown, and owner checks after every await; added abort-aware
+      preview disposal plus replacement/shutdown regressions, and all 50 focused command/lifecycle
+      tests passed.
+- [x] Update `extensions/pi-starship/README.md` so the shallow menu, built-in-default state, disabled
+      restore behavior, destructive restore warning, adaptive controls, exact direct routes, and
+      non-TUI behavior match the implementation; `npm --workspace @narumitw/pi-starship run check`
+      accepted the documentation, source, tests, and types.
+- [x] Compile the test tree and run the focused command artifacts directly after the initial relative
+      `node_modules` path was filtered; all 28 command tests passed, an absolute-realpath `node --test`
+      follow-up also passed, and `npm --workspace @narumitw/pi-starship run check` passed package Biome
+      and typechecking.
+- [x] Run the final gates and semantic audit: `git diff --check` passed, `just pack-starship` included
+      the new preview module in 59 expected files, and the second `npm run check` passed all 2,089
+      tests after the first run hit an unrelated `pi-btw` scheduling flake whose focused rerun passed.
+      Command, TUI, settings, lifecycle, and touched-area guide audits found no accepted deviation or
+      unverified implementation path.
+
+## Completion Checklist
+
+- [x] A healthy new user sees `Built-in defaults · Healthy`, and opening/cancelling `/starship` or its
+      editor does not create a settings file.
+- [x] The main menu has four shallow actions, Configuration owns all status details, and restore is
+      disabled for healthy missing/exact-built-in documents but available for custom/invalid recovery.
+- [x] Restore review and confirmation disclose complete-document replacement and cancellation leaves
+      stored and effective settings byte-for-byte unchanged.
+- [x] Preview content and actions remain operable within tested width/height combinations, use injected
+      keybindings, distinguish Escape from Ctrl+C, and restore the main selection predictably.
+- [x] Exact direct routes remain compatible; unknown and trailing arguments are rejected observably in
+      UI-capable modes without corrupting print/JSON protocols.
+- [x] Existing atomic save, rollback, warning, non-TUI, lifecycle, and session-replacement guarantees
+      still pass deterministic tests.
+- [x] README behavior matches the final interaction, focused/package/full checks pass, and the final
+      guide audit reports no unaccepted deviation.

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -55,11 +55,21 @@ Open the interactive menu in TUI mode:
 /starship
 ```
 
-Choose **Customize footer** to edit the TOML. Closing the editor validates the draft and opens a width-aware preview; saving happens only after a separate confirmation. Confirmed changes are atomically saved and applied immediately. Manual TOML edits load on the next `session_start`, including `/reload` and session replacement. Editor cancellation, preview cancellation, invalid drafts, write failures, and runtime application failures preserve the previous file and effective footer.
+Choose **Customize footer** to edit the TOML. Closing the editor validates the draft and opens an
+adaptive, scrollable preview whose **Apply changes…**, **Continue editing**, and **Discard draft**
+actions remain reachable in short or narrow terminals. Saving happens only after a separate
+confirmation. Confirmed changes are atomically saved and applied immediately. Manual TOML edits load
+on the next `session_start`, including `/reload` and session replacement. Editor cancellation, preview
+cancellation, component disposal, invalid drafts, write failures, and runtime application failures
+preserve the previous file and effective footer.
 
-The standard **Advanced** menu is one level deep and contains configuration details plus **Restore
-built-in**. Standard diagnostics, details, and help are Back-navigable detail screens. Restore still
-shows the specialized width-aware preview and requires explicit overwrite confirmation.
+The shallow main menu also exposes **Configuration**, **Help**, and **Restore built-in…**.
+Configuration combines state, source, path, health, and diagnostics. A healthy missing file is shown
+as **Built-in defaults**, while **Built-in fallback** is reserved for read or parse errors. Restore is
+disabled when no settings document exists or the exact built-in document is already saved. For a
+custom or invalid document, Restore previews the result and warns that the complete document,
+including custom settings, unknown fields, and comments, will be replaced without a post-success
+backup before asking for confirmation.
 
 ### 📝 Example
 
@@ -247,8 +257,8 @@ Choose one migration:
    `fg:#e3e5e5 bg:#769ff0`.
 2. Define every needed alias under your own `[palettes.<name>]` table and explicitly select it with
    `palette = "<name>"`.
-3. Use **Advanced → Restore built-in** to preview and replace the document with the new plain
-   nine-module configuration.
+3. Use **Restore built-in…** from `/starship` to review and replace the complete document with the new
+   plain nine-module configuration.
 
 There is no hidden compatibility overlay or automatic migration.
 
@@ -521,12 +531,16 @@ Package's explicitly documented Cargo lookup is the only ancestor walk and is ca
 | `/starship status` | Show config source/path and diagnostics |
 | `/starship help` | Show command and configuration help |
 
-The standard main menu keeps frequent goals visible: **Customize footer**, **Check configuration**,
-and **Help**. It shows whether the footer uses the built-in or custom document and displays the
-current warning count. **Advanced** contains uncommon details and the confirmed restore action, with
-an explicit **Back** path. The TOML editor and live footer previews remain specialized extension UI.
+The standard main menu keeps four goals on one level: **Customize footer**, **Configuration**,
+**Help**, and **Restore built-in…**. It shows whether the footer uses built-in defaults, a saved
+built-in document, a custom document, or an error-driven fallback, together with the current health.
+Restore remains last and unavailable when there is no document to replace. The TOML editor and
+adaptive live footer previews remain specialized extension UI; preview hints follow Pi's injected
+keybindings, Escape discards the draft or restore review, and Ctrl+C closes the whole workflow.
 
-Status and help remain safe in TUI, RPC, JSON, and print modes. RPC receives notifications but never opens custom terminal UI; print and JSON modes produce no ad hoc output. Footer/timer/Git lifecycle work starts only in TUI mode.
+The direct routes accept no trailing arguments. Status and help remain safe in TUI, RPC, JSON, and
+print modes. RPC receives notifications but never opens custom terminal UI; print and JSON modes
+produce no ad hoc output. Footer/timer/Git lifecycle work starts only in TUI mode.
 
 ## 📐 Scope
 
@@ -552,7 +566,8 @@ Keep `extension_status` last in the catalog so arbitrary third-party statuses fo
 - `src/index.ts` — Pi package entrypoint.
 - `src/pi-starship.ts` — extension lifecycle, cached refresh binding, live preview, and footer.
 - `src/usage.ts` — native-aligned session usage and cache aggregation.
-- `src/commands.ts` — goal-oriented menu, preview/confirmation, diagnostics, and compatibility routes.
+- `src/commands.ts` — goal-oriented menu, preview/confirmation flow, diagnostics, and compatibility routes.
+- `src/command-preview.ts` — adaptive, scrollable, keybinding-aware preview action surface.
 - `src/config.ts` — TOML loading, draft validation, defaults, atomic persistence, and rollback.
 - `src/format/` — native format/style parser and renderer.
 - `src/modules/` — domain module definitions, ordered registry, reachability, and width-aware renderer.

--- a/extensions/pi-starship/src/command-preview.ts
+++ b/extensions/pi-starship/src/command-preview.ts
@@ -1,0 +1,206 @@
+import { stripVTControlCharacters } from "node:util";
+import type { ExtensionCommandContext, KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+const RESERVED_HOST_ROWS = 3;
+
+export interface PreviewMenuItem<Value extends string> {
+	value: Value;
+	label: string;
+}
+
+export type PreviewMenuResult<Value extends string> =
+	| { kind: "selected"; value: Value }
+	| { kind: "cancelled" }
+	| { kind: "closed" };
+
+export async function showPreviewActionMenu<Value extends string>(
+	ctx: ExtensionCommandContext,
+	title: string,
+	body: (width: number) => readonly string[],
+	items: readonly PreviewMenuItem<Value>[],
+	signal?: AbortSignal,
+): Promise<PreviewMenuResult<Value> | undefined> {
+	if (signal?.aborted) return { kind: "closed" };
+	return ctx.ui.custom<PreviewMenuResult<Value> | undefined>((tui, theme, keybindings, done) => {
+		let selectedIndex = 0;
+		let scrollOffset = 0;
+		let lastMaximumScroll = 0;
+		let lastViewportSize = 1;
+		let disposed = false;
+		let deferredAbort: ReturnType<typeof setImmediate> | undefined;
+		const closeForAbort = () => {
+			if (disposed) return;
+			if (deferredAbort) clearImmediate(deferredAbort);
+			deferredAbort = undefined;
+			done({ kind: "closed" });
+		};
+		signal?.addEventListener("abort", closeForAbort, { once: true });
+		if (signal?.aborted) deferredAbort = setImmediate(closeForAbort);
+
+		const requestRender = () => {
+			if (!disposed) tui.requestRender();
+		};
+		const moveSelection = (delta: number) => {
+			if (items.length === 0) return;
+			selectedIndex = (selectedIndex + delta + items.length) % items.length;
+			requestRender();
+		};
+		const movePreview = (offset: number) => {
+			scrollOffset = Math.max(0, Math.min(offset, lastMaximumScroll));
+			requestRender();
+		};
+
+		return {
+			render(width: number): string[] {
+				const safeWidth = Math.max(1, width);
+				const terminalRows = Number.isFinite(tui.terminal.rows)
+					? Math.floor(tui.terminal.rows)
+					: 24;
+				const availableRows = Math.max(1, terminalRows - RESERVED_HOST_ROWS);
+				const bodyLines = body(safeWidth).flatMap((line) =>
+					line ? wrapTextWithAnsi(line, safeWidth) : [""],
+				);
+				const layout = allocateLayout(availableRows, items.length, bodyLines.length);
+				lastViewportSize = layout.previewRows;
+				lastMaximumScroll = Math.max(0, bodyLines.length - layout.previewRows);
+				scrollOffset = Math.max(0, Math.min(scrollOffset, lastMaximumScroll));
+				const actionStart = actionWindowStart(selectedIndex, items.length, layout.actionRows);
+				const actionLines = items
+					.slice(actionStart, actionStart + layout.actionRows)
+					.map((item, index) => {
+						const absoluteIndex = actionStart + index;
+						const prefix = absoluteIndex === selectedIndex ? "→ " : "  ";
+						return theme.fg(
+							absoluteIndex === selectedIndex ? "accent" : "text",
+							`${prefix}${safeDisplayText(item.label)}`,
+						);
+					});
+				const position = layout.positionRows
+					? [theme.fg("dim", previewPosition(scrollOffset, layout.previewRows, bodyLines.length))]
+					: [];
+				const lines = [
+					...(layout.titleRows ? [theme.fg("accent", theme.bold(safeDisplayText(title)))] : []),
+					...bodyLines.slice(scrollOffset, scrollOffset + layout.previewRows),
+					...position,
+					...actionLines,
+					...(layout.hintRows ? [theme.fg("dim", previewHint(keybindings))] : []),
+				];
+				return lines.map((line) => truncateToWidth(line, safeWidth, ""));
+			},
+			invalidate() {},
+			handleInput(data: string) {
+				if (disposed) return;
+				if (matchesKey(data, Key.ctrl("c"))) {
+					done({ kind: "closed" });
+				} else if (keybindings.matches(data, "tui.select.cancel")) {
+					done({ kind: "cancelled" });
+				} else if (keybindings.matches(data, "tui.select.up")) {
+					moveSelection(-1);
+				} else if (keybindings.matches(data, "tui.select.down")) {
+					moveSelection(1);
+				} else if (keybindings.matches(data, "tui.select.pageUp")) {
+					movePreview(scrollOffset - lastViewportSize);
+				} else if (keybindings.matches(data, "tui.select.pageDown")) {
+					movePreview(scrollOffset + lastViewportSize);
+				} else if (matchesKey(data, Key.home)) {
+					movePreview(0);
+				} else if (matchesKey(data, Key.end)) {
+					movePreview(lastMaximumScroll);
+				} else if (keybindings.matches(data, "tui.select.confirm")) {
+					const item = items[selectedIndex];
+					if (item) done({ kind: "selected", value: item.value });
+				}
+			},
+			dispose() {
+				if (disposed) return;
+				disposed = true;
+				if (deferredAbort) clearImmediate(deferredAbort);
+				deferredAbort = undefined;
+				signal?.removeEventListener("abort", closeForAbort);
+			},
+		};
+	});
+}
+
+interface PreviewLayout {
+	titleRows: number;
+	previewRows: number;
+	positionRows: number;
+	actionRows: number;
+	hintRows: number;
+}
+
+function allocateLayout(
+	availableRows: number,
+	actionCount: number,
+	bodyLineCount: number,
+): PreviewLayout {
+	if (availableRows === 1) {
+		return { titleRows: 0, previewRows: 0, positionRows: 0, actionRows: 1, hintRows: 0 };
+	}
+	const titleRows = availableRows >= 3 ? 1 : 0;
+	const hintRows = availableRows >= 3 ? 1 : 0;
+	const minimumPreviewRows = bodyLineCount > 0 && availableRows >= 4 ? 1 : 0;
+	const availableActionRows = Math.max(
+		1,
+		availableRows - titleRows - hintRows - minimumPreviewRows,
+	);
+	const actionRows = Math.min(Math.max(1, actionCount), availableActionRows);
+	let previewRows = Math.max(0, availableRows - titleRows - hintRows - actionRows);
+	const positionRows = previewRows >= 2 && bodyLineCount > previewRows ? 1 : 0;
+	previewRows -= positionRows;
+	return { titleRows, previewRows, positionRows, actionRows, hintRows };
+}
+
+function actionWindowStart(selectedIndex: number, itemCount: number, viewportSize: number): number {
+	if (itemCount <= viewportSize) return 0;
+	return Math.max(0, Math.min(selectedIndex, itemCount - viewportSize));
+}
+
+function previewPosition(offset: number, viewportSize: number, lineCount: number): string {
+	if (lineCount === 0) return "0/0";
+	return `${offset + 1}-${Math.min(lineCount, offset + viewportSize)}/${lineCount}`;
+}
+
+function previewHint(keybindings: Pick<KeybindingsManager, "getKeys">): string {
+	const up = bindingText(keybindings, "tui.select.up");
+	const down = bindingText(keybindings, "tui.select.down");
+	const confirm = bindingText(keybindings, "tui.select.confirm");
+	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
+	const pageUp = bindingText(keybindings, "tui.select.pageUp");
+	const pageDown = bindingText(keybindings, "tui.select.pageDown");
+	return [
+		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
+		...(confirm ? [`${confirm} select`] : []),
+		...(cancel ? [`${cancel} discard`] : []),
+		"ctrl+c close",
+		...(pageUp || pageDown ? [`${[pageUp, pageDown].filter(Boolean).join("/")} preview`] : []),
+	].join(" • ");
+}
+
+function bindingText(
+	keybindings: Pick<KeybindingsManager, "getKeys">,
+	binding: Parameters<KeybindingsManager["getKeys"]>[0],
+	excluded?: string,
+): string {
+	return keybindings
+		.getKeys(binding)
+		.filter((key) => key !== excluded)
+		.map((key) => {
+			if (key === "up") return "↑";
+			if (key === "down") return "↓";
+			if (key === "escape") return "esc";
+			if (key === "return") return "enter";
+			return safeDisplayText(key);
+		})
+		.join("/");
+}
+
+function safeDisplayText(value: string): string {
+	return Array.from(stripVTControlCharacters(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const control = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		return control ? "" : character;
+	}).join("");
+}

--- a/extensions/pi-starship/src/commands.ts
+++ b/extensions/pi-starship/src/commands.ts
@@ -1,12 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import {
-	type AutocompleteItem,
-	type SelectItem,
-	SelectList,
-	truncateToWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { type PreviewMenuResult, showPreviewActionMenu } from "./command-preview.js";
 import {
 	atomicRestoreConfigDocument,
 	atomicSaveConfigDocument,
@@ -24,15 +19,9 @@ const SUBCOMMANDS: AutocompleteItem[] = [
 
 const MAIN_ACTIONS = {
 	customize: "customize",
-	diagnostics: "diagnostics",
+	configuration: "configuration",
 	help: "help",
-	advanced: "advanced",
-} as const;
-
-const ADVANCED_ACTIONS = {
-	details: "details",
 	restore: "restore",
-	back: "back",
 } as const;
 
 const PREVIEW_ACTIONS = {
@@ -56,10 +45,6 @@ export interface StarshipCommandOptions {
 	getMenuOwner?(): { signal: AbortSignal; isCurrent(): boolean };
 }
 
-interface MenuItem extends SelectItem {
-	value: string;
-}
-
 interface WorkflowOwner {
 	signal: AbortSignal;
 	isCurrent(): boolean;
@@ -81,8 +66,19 @@ export function registerStarshipCommand(pi: ExtensionAPI, options: StarshipComma
 				return;
 			}
 
-			const subcommand = normalized.split(/\s+/u)[0]?.toLowerCase() ?? "";
-			switch (subcommand) {
+			const [subcommand = "", ...trailing] = normalized.split(/\s+/u);
+			const route = subcommand.toLowerCase();
+			if (trailing.length > 0 || !SUBCOMMANDS.some((item) => item.value === route)) {
+				if (canNotify(ctx)) {
+					const reason =
+						trailing.length > 0
+							? `Unexpected arguments for /starship ${safeText(route)}.`
+							: `Unknown /starship subcommand: ${safeText(route)}.`;
+					ctx.ui.notify(`${reason} Usage: /starship [settings|status|help]`, "warning");
+				}
+				return;
+			}
+			switch (route) {
 				case "settings":
 					await editSettings(ctx, options);
 					return;
@@ -92,10 +88,6 @@ export function registerStarshipCommand(pi: ExtensionAPI, options: StarshipComma
 				case "help":
 					showHelp(ctx, options.settingsPath);
 					return;
-				default:
-					if (canNotify(ctx)) {
-						ctx.ui.notify(`Unknown /starship subcommand: ${subcommand}`, "warning");
-					}
 			}
 		},
 	});
@@ -107,31 +99,30 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 		signal: fallbackController.signal,
 		isCurrent: () => !fallbackController.signal.aborted,
 	};
-	type Screen = "main" | "advanced" | "diagnostics" | "details" | "help";
-	type Action = "customize" | "restore" | "back";
+	type Screen = "main" | "configuration" | "help";
+	type Action = "customize" | "restore";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 		start: "main",
 		screens: {
 			main: () => {
 				const loaded = options.getLoaded();
-				const state = configurationState(loaded);
-				const health = configurationHealth(loaded);
+				const presentation = configurationPresentation(loaded);
 				return {
 					kind: "actions",
 					title: "pi-starship",
-					lines: [`${state} · ${health}`],
+					lines: [`${presentation.state} · ${presentation.health}`],
 					items: [
 						{
 							id: MAIN_ACTIONS.customize,
 							label: "Customize footer",
-							description: `${state} · preview before applying`,
+							description: `${presentation.state} · preview before applying`,
 							action: "customize",
 						},
 						{
-							id: MAIN_ACTIONS.diagnostics,
-							label: "Check configuration",
-							description: health,
-							to: "diagnostics",
+							id: MAIN_ACTIONS.configuration,
+							label: "Configuration",
+							description: presentation.health,
+							to: "configuration",
 						},
 						{
 							id: MAIN_ACTIONS.help,
@@ -140,61 +131,25 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 							to: "help",
 						},
 						{
-							id: MAIN_ACTIONS.advanced,
-							label: "Advanced",
-							description: "Details and restore controls",
-							to: "advanced",
+							id: MAIN_ACTIONS.restore,
+							label: "Restore built-in…",
+							description: presentation.restoreDescription,
+							disabled: presentation.restoreDisabled,
+							action: "restore",
 						},
 					],
 					hint: "close",
 				};
 			},
-			advanced: () => {
+			configuration: () => {
 				const loaded = options.getLoaded();
-				const alreadyBuiltIn = loaded.rawDocument === BUILT_IN_EXAMPLE;
-				return {
-					kind: "actions",
-					title: "Advanced",
-					lines: [configurationState(loaded)],
-					items: [
-						{
-							id: ADVANCED_ACTIONS.details,
-							label: "Configuration details",
-							description: `${configurationSource(loaded)} · ${fileName(options.settingsPath)}`,
-							to: "details",
-						},
-						{
-							id: ADVANCED_ACTIONS.restore,
-							label: "Restore built-in",
-							description: alreadyBuiltIn
-								? "Already active"
-								: "Preview before replacing the document",
-							action: "restore",
-						},
-						{
-							id: ADVANCED_ACTIONS.back,
-							label: "Back",
-							description: "Return to pi-starship",
-							action: "back",
-						},
-					],
-					hint: "back",
-				};
-			},
-			diagnostics: () => ({
-				kind: "detail",
-				title: "Configuration health",
-				lines: diagnosticLines(options.getLoaded(), false),
-				hint: "back",
-			}),
-			details: () => {
-				const loaded = options.getLoaded();
+				const presentation = configurationPresentation(loaded);
 				return {
 					kind: "detail",
-					title: "Configuration details",
+					title: "Configuration",
 					lines: [
-						`State: ${configurationState(loaded)}`,
-						`Source: ${configurationSource(loaded)}`,
+						`State: ${presentation.state}`,
+						`Source: ${presentation.source}`,
 						`Path: ${safeText(options.settingsPath)}`,
 						...diagnosticLines(loaded, true),
 					],
@@ -206,7 +161,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 				title: "pi-starship help",
 				lines: [
 					"Customize footer opens the TOML editor, then previews and confirms before saving.",
-					"Check configuration explains warnings without changing the footer.",
+					"Configuration explains state, source, path, and warnings without changing the footer.",
 					`Settings: ${safeText(options.settingsPath)}`,
 					"Docs: https://github.com/narumiruna/pi-extensions/tree/main/extensions/pi-starship",
 				],
@@ -214,16 +169,19 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 			}),
 		},
 		actions: {
-			customize: async () =>
-				(await editSettings(ctx, options)) ? { kind: "close" } : { kind: "stay" },
+			customize: async () => {
+				const result = await editSettings(ctx, options);
+				return result === "applied" || result === "close" ? { kind: "close" } : { kind: "stay" };
+			},
 			restore: async () => {
-				if (options.getLoaded().rawDocument === BUILT_IN_EXAMPLE) {
-					ctx.ui.notify("The built-in footer configuration is already active.", "info");
+				const presentation = configurationPresentation(options.getLoaded());
+				if (presentation.restoreDisabled) {
+					ctx.ui.notify(presentation.restoreDescription, "info");
 					return { kind: "stay" };
 				}
-				return (await restoreBuiltIn(ctx, options)) ? { kind: "close" } : { kind: "stay" };
+				const result = await restoreBuiltIn(ctx, options);
+				return result === "applied" || result === "close" ? { kind: "close" } : { kind: "stay" };
 			},
-			back: async () => ({ kind: "back" }),
 		},
 	});
 	try {
@@ -240,17 +198,17 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 async function editSettings(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
-): Promise<boolean> {
+): Promise<"applied" | "cancel" | "close"> {
 	const owner = workflowOwner(options);
-	if (!isCurrentOwner(owner)) return false;
+	if (!isCurrentOwner(owner)) return "cancel";
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${options.settingsPath}`, "info");
-		return false;
+		return "cancel";
 	}
 	let draft = options.getLoaded().rawDocument ?? BUILT_IN_EXAMPLE;
 	while (true) {
 		const edited = await ctx.ui.editor("Customize footer — close to preview", draft);
-		if (!isCurrentOwner(owner) || edited === undefined) return false;
+		if (!isCurrentOwner(owner) || edited === undefined) return "cancel";
 		draft = edited;
 		let validated: LoadedStarshipConfig;
 		try {
@@ -263,33 +221,34 @@ async function editSettings(
 				() => [safeText(formatError(error)), "The current footer has not changed."],
 				[
 					{ value: PREVIEW_ACTIONS.edit, label: "Continue editing" },
-					{ value: PREVIEW_ACTIONS.cancel, label: "Back" },
+					{ value: PREVIEW_ACTIONS.cancel, label: "Discard draft" },
 				],
+				owner.signal,
 			);
-			if (!isCurrentOwner(owner)) return false;
-			if (action === PREVIEW_ACTIONS.edit) continue;
-			return false;
+			if (!isCurrentOwner(owner)) return "cancel";
+			if (action?.kind === "closed") return "close";
+			if (selectedPreviewAction(action) === PREVIEW_ACTIONS.edit) continue;
+			return "cancel";
 		}
 
 		const result = await reviewAndApply(ctx, options, validated, "Footer preview", false, owner);
 		if (result === "edit") continue;
-		return result === "applied";
+		return result;
 	}
 }
 
 async function restoreBuiltIn(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
-): Promise<boolean> {
+): Promise<"applied" | "cancel" | "close"> {
 	const owner = workflowOwner(options);
-	if (!isCurrentOwner(owner)) return false;
+	if (!isCurrentOwner(owner)) return "cancel";
 	const validated = (options.validate ?? validateConfigDocument)(
 		options.settingsPath,
 		BUILT_IN_EXAMPLE,
 	);
-	return (
-		(await reviewAndApply(ctx, options, validated, "Restore preview", true, owner)) === "applied"
-	);
+	const result = await reviewAndApply(ctx, options, validated, "Restore preview", true, owner);
+	return result === "edit" ? "cancel" : result;
 }
 
 async function reviewAndApply(
@@ -299,26 +258,38 @@ async function reviewAndApply(
 	title: string,
 	restore: boolean,
 	owner: WorkflowOwner,
-): Promise<"applied" | "edit" | "cancel"> {
+): Promise<"applied" | "edit" | "cancel" | "close"> {
 	while (true) {
 		const selection = await showPreviewActionMenu(
 			ctx,
 			title,
-			(width) => previewBody(ctx, options, validated, width),
+			(width) =>
+				restore
+					? restorePreviewBody(ctx, options, validated, width)
+					: previewBody(ctx, options, validated, width),
 			[
-				{ value: PREVIEW_ACTIONS.continue, label: "Continue to apply" },
+				{
+					value: PREVIEW_ACTIONS.continue,
+					label: restore ? "Replace with built-in…" : "Apply changes…",
+				},
 				...(restore ? [] : [{ value: PREVIEW_ACTIONS.edit, label: "Continue editing" }]),
-				{ value: PREVIEW_ACTIONS.cancel, label: "Cancel" },
+				{
+					value: PREVIEW_ACTIONS.cancel,
+					label: restore ? "Cancel" : "Discard draft",
+				},
 			],
+			owner.signal,
 		);
 		if (!isCurrentOwner(owner)) return "cancel";
-		if (selection === PREVIEW_ACTIONS.edit) return "edit";
-		if (selection !== PREVIEW_ACTIONS.continue) return "cancel";
+		if (selection?.kind === "closed") return "close";
+		const selected = selectedPreviewAction(selection);
+		if (selected === PREVIEW_ACTIONS.edit) return "edit";
+		if (selected !== PREVIEW_ACTIONS.continue) return "cancel";
 
 		const confirmed = await ctx.ui.confirm(
 			restore ? "Restore built-in footer?" : "Apply footer changes?",
 			restore
-				? `Replace ${options.settingsPath} with the built-in configuration?`
+				? `Replace ${safeText(options.settingsPath)} entirely with the built-in configuration? All custom settings, unknown fields, and comments will be removed. No backup is kept after success.`
 				: "Save this configuration and apply it immediately?",
 		);
 		if (!isCurrentOwner(owner)) return "cancel";
@@ -395,6 +366,23 @@ function restorePreviousConfiguration(
 	}
 }
 
+function restorePreviewBody(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	loaded: LoadedStarshipConfig,
+	width: number,
+): string[] {
+	const current = configurationPresentation(options.getLoaded());
+	return [
+		`Current: ${current.state}`,
+		`Path: ${safeText(options.settingsPath)}`,
+		"The entire settings document will be replaced, including custom settings, unknown fields, and comments.",
+		"No backup is kept after a successful restore.",
+		"",
+		...previewBody(ctx, options, loaded, width),
+	];
+}
+
 function previewBody(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
@@ -417,46 +405,10 @@ function previewBody(
 	return [...lines, "", warning];
 }
 
-async function showPreviewActionMenu(
-	ctx: ExtensionCommandContext,
-	title: string,
-	body: (width: number) => readonly string[],
-	items: readonly MenuItem[],
-): Promise<string | null> {
-	return ctx.ui.custom<string | null>((tui, theme, _keybindings, done) => {
-		const list = new SelectList([...items], Math.min(items.length, 8), {
-			selectedPrefix: (text) => theme.fg("accent", text),
-			selectedText: (text) => theme.fg("accent", text),
-			description: (text) => theme.fg("muted", text),
-			scrollInfo: (text) => theme.fg("dim", text),
-			noMatch: (text) => theme.fg("warning", text),
-		});
-		list.onSelect = (item) => done(String(item.value));
-		list.onCancel = () => done(null);
-		return {
-			render(width: number): string[] {
-				const safeWidth = Math.max(1, width);
-				const content = [
-					...wrapTextWithAnsi(theme.fg("accent", theme.bold(title)), safeWidth),
-					...body(safeWidth).flatMap((line) => (line ? wrapTextWithAnsi(line, safeWidth) : [""])),
-					"",
-					...list.render(safeWidth),
-					...wrapTextWithAnsi(
-						theme.fg("dim", "↑↓ navigate • enter select • esc cancel"),
-						safeWidth,
-					),
-				];
-				return content.map((line) => truncateToWidth(line, safeWidth));
-			},
-			invalidate() {
-				list.invalidate();
-			},
-			handleInput(data: string) {
-				list.handleInput(data);
-				tui.requestRender();
-			},
-		};
-	});
+function selectedPreviewAction<Value extends string>(
+	result: PreviewMenuResult<Value> | undefined,
+): Value | null {
+	return result?.kind === "selected" ? result.value : null;
 }
 
 function diagnosticLines(loaded: LoadedStarshipConfig, includeSummary: boolean): string[] {
@@ -471,13 +423,44 @@ function diagnosticLines(loaded: LoadedStarshipConfig, includeSummary: boolean):
 	];
 }
 
-function configurationState(loaded: LoadedStarshipConfig): string {
-	if (loaded.source === "built-in") return "Built-in fallback";
-	return loaded.rawDocument === BUILT_IN_EXAMPLE ? "Built-in footer" : "Custom footer";
+interface ConfigurationPresentation {
+	state: string;
+	source: string;
+	health: string;
+	restoreDisabled: boolean;
+	restoreDescription: string;
 }
 
-function configurationSource(loaded: LoadedStarshipConfig): string {
-	return loaded.source === "user" ? "User file" : "Built-in fallback";
+function configurationPresentation(loaded: LoadedStarshipConfig): ConfigurationPresentation {
+	const healthyMissing =
+		loaded.source === "built-in" &&
+		loaded.rawDocument === undefined &&
+		loaded.diagnostics.length === 0;
+	const savedBuiltIn = loaded.source === "user" && loaded.rawDocument === BUILT_IN_EXAMPLE;
+	const fallback = loaded.source === "built-in" && loaded.diagnostics.length > 0;
+	return {
+		state: healthyMissing
+			? "Built-in defaults"
+			: savedBuiltIn
+				? "Saved built-in configuration"
+				: fallback
+					? "Built-in fallback"
+					: "Custom configuration",
+		source: healthyMissing
+			? "No settings file"
+			: loaded.source === "user"
+				? "User file"
+				: "Built-in fallback",
+		health: configurationHealth(loaded),
+		restoreDisabled: healthyMissing || savedBuiltIn,
+		restoreDescription: healthyMissing
+			? "Already using defaults · no file to replace"
+			: savedBuiltIn
+				? "Built-in configuration already saved"
+				: fallback
+					? "Preview before replacing invalid settings"
+					: "Preview before replacing the document",
+	};
 }
 
 function configurationHealth(loaded: LoadedStarshipConfig): string {
@@ -485,10 +468,6 @@ function configurationHealth(loaded: LoadedStarshipConfig): string {
 	if (errors > 0) return `${errors} error${errors === 1 ? "" : "s"}`;
 	const warnings = loaded.diagnostics.length;
 	return warnings === 0 ? "Healthy" : `${warnings} warning${warnings === 1 ? "" : "s"}`;
-}
-
-function fileName(path: string): string {
-	return path.replaceAll("\\", "/").split("/").at(-1) || path;
 }
 
 function showStatus(ctx: ExtensionCommandContext, options: StarshipCommandOptions) {

--- a/extensions/pi-starship/test/command-lifecycle.test.ts
+++ b/extensions/pi-starship/test/command-lifecycle.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import piStarshipRuntime from "../src/pi-starship.js";
+
+function piStarship(pi: Parameters<typeof piStarshipRuntime>[0]) {
+	return piStarshipRuntime(pi, {
+		githubPrExec: (command, args, options) =>
+			pi.exec(command, args, {
+				cwd: options.cwd,
+				signal: options.signal,
+				timeout: options.timeout,
+			}),
+	});
+}
+
+test("session replacement disposes an open settings preview before returning", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-stale-preview-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const oldContext = createMockContext({
+			mode: "tui",
+			custom: tui.custom,
+			editor: async () => "format = 'draft'\n",
+		});
+		const newContext = createMockContext({ mode: "tui", cwd: "/work/replacement" });
+		await emit(mock.events, "session_start", {}, oldContext.ctx);
+		let settled = false;
+		const command = Promise.resolve(
+			mock.commands.get("starship")?.handler("settings", oldContext.ctx),
+		);
+		void command.then(() => {
+			settled = true;
+		});
+		await tui.waitForOpen();
+		await emit(mock.events, "session_start", {}, newContext.ctx);
+		await flushAsync();
+		try {
+			assert.equal(settled, true);
+			assert.equal(tui.isOpen, false);
+		} finally {
+			if (!settled) tui.dispose();
+			await command;
+		}
+		assert.equal(existsSync(join(root, "pi-starship.toml")), false);
+		await emit(mock.events, "session_shutdown", {}, newContext.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("session shutdown disposes an open settings preview before returning", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-shutdown-preview-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const context = createMockContext({
+			mode: "tui",
+			custom: tui.custom,
+			editor: async () => "format = 'draft'\n",
+		});
+		await emit(mock.events, "session_start", {}, context.ctx);
+		let settled = false;
+		const command = Promise.resolve(
+			mock.commands.get("starship")?.handler("settings", context.ctx),
+		);
+		void command.then(() => {
+			settled = true;
+		});
+		await tui.waitForOpen();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+		await flushAsync();
+		try {
+			assert.equal(settled, true);
+			assert.equal(tui.isOpen, false);
+		} finally {
+			if (!settled) tui.dispose();
+			await command;
+		}
+		assert.equal(existsSync(join(root, "pi-starship.toml")), false);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+async function emit(
+	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
+	name: string,
+	...args: unknown[]
+) {
+	for (const handler of events.get(name) ?? []) await handler(...args);
+}
+
+type ExecResult = { stdout: string; stderr: string; code: number; killed: boolean };
+
+function gitResult(stdout = "## main\n"): ExecResult {
+	return { stdout, stderr: "", code: 0, killed: false };
+}
+
+async function flushAsync() {
+	await Promise.resolve();
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	await Promise.resolve();
+}

--- a/extensions/pi-starship/test/command-ux.test.ts
+++ b/extensions/pi-starship/test/command-ux.test.ts
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { registerStarshipCommand } from "../src/commands.js";
+import { BUILT_IN_EXAMPLE, loadStarshipConfig } from "../src/config.js";
+
+test("/starship distinguishes built-in defaults, saved built-in, custom, and fallback states", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-state-"));
+	try {
+		const cases = [
+			{
+				name: "missing",
+				path: join(root, "missing.toml"),
+				expected: /Built-in defaults · Healthy/u,
+			},
+			{
+				name: "saved built-in",
+				path: join(root, "built-in.toml"),
+				raw: BUILT_IN_EXAMPLE,
+				expected: /Saved built-in configuration · Healthy/u,
+			},
+			{
+				name: "custom",
+				path: join(root, "custom.toml"),
+				raw: "format = 'custom'\n",
+				expected: /Custom configuration · Healthy/u,
+			},
+			{
+				name: "invalid",
+				path: join(root, "invalid.toml"),
+				raw: "format = [\n",
+				expected: /Built-in fallback · 1 error/u,
+			},
+		] as const;
+
+		for (const item of cases) {
+			if ("raw" in item) writeFileSync(item.path, item.raw);
+			const mock = createMockPi();
+			registerStarshipCommand(mock.pi, {
+				getLoaded: () => loadStarshipConfig(item.path),
+				apply() {},
+				settingsPath: item.path,
+			});
+			const tui = createTuiHarness({ width: 40, rows: 24 });
+			const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+			const running = mock.commands.get("starship")?.handler("", context.ctx);
+			await tui.waitForOpen();
+			const frame = tui.render().join("\n");
+			assert.match(frame, item.expected, item.name);
+			assert.match(frame, /Configuration/u, item.name);
+			assert.match(frame, /Restore built-in…/u, item.name);
+			assert.doesNotMatch(frame, /Advanced/u, item.name);
+			tui.press("ctrl+c");
+			await running;
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Configuration combines state, source, path, health, and diagnostics", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-configuration-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "future = true\n");
+	try {
+		const mock = createMockPi();
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /Configuration/u);
+		assert.match(frame, /State: Custom configuration/u);
+		assert.match(frame, /Source: User file/u);
+		assert.match(frame, /Path:[\s\S]*pi-starship\.toml/u);
+		assert.match(frame, /Health: 1 warning/u);
+		assert.match(frame, /future/u);
+		tui.press("ctrl+c");
+		await running;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("healthy missing settings disable restore without creating a document", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-missing-restore-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		let confirmations = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => {
+				confirmations += 1;
+				return true;
+			},
+		});
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Already using defaults · no file to replace/u);
+		assert.equal(confirmations, 0);
+		assert.equal(existsSync(path), false);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preview remains operable across terminal sizes and dynamic resize", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preview-size-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+			renderPreview: () =>
+				Array.from({ length: 40 }, (_, index) => `Preview line ${index + 1}: long content`),
+		});
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async () => "format = 'draft'\n",
+		});
+		const running = mock.commands.get("starship")?.handler("settings", context.ctx);
+		await tui.waitForOpen();
+
+		for (const dimensions of [
+			{ width: 80, rows: 24 },
+			{ width: 20, rows: 8 },
+			{ width: 28, rows: 12 },
+		]) {
+			const frame = tui.resize(dimensions);
+			assert.ok(frame.length <= Math.max(1, dimensions.rows - 3));
+			assert.ok(frame.every((line) => visibleWidth(line) <= dimensions.width));
+			assert.match(frame.join("\n"), /Apply changes…/u);
+		}
+
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /Continue editing/u);
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /Discard draft/u);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preview uses injected keybindings and exposes their hints", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preview-keys-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mapping: Record<string, string> = {
+			"tui.select.up": "k",
+			"tui.select.down": "j",
+			"tui.select.pageUp": "u",
+			"tui.select.pageDown": "d",
+			"tui.select.confirm": "y",
+			"tui.select.cancel": "q",
+		};
+		const keybindings: Pick<KeybindingsManager, "matches" | "getKeys"> = {
+			matches: (data, binding) => data === mapping[binding],
+			getKeys: (binding) => (mapping[binding] ? [mapping[binding] as never] : []),
+		};
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+			renderPreview: () => ["Preview"],
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12, keybindings });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async () => "format = 'draft'\n",
+		});
+		let settled = false;
+		const running = Promise.resolve(
+			mock.commands.get("starship")?.handler("settings", context.ctx),
+		);
+		void running.then(() => {
+			settled = true;
+		});
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /k\/j navigate/u);
+		assert.match(frame, /y select/u);
+		assert.match(frame, /q discard/u);
+		tui.send("j");
+		assert.match(tui.render().join("\n"), /Continue editing/u);
+		tui.send("q");
+		await flushAsyncWork();
+		try {
+			assert.equal(settled, true);
+		} finally {
+			if (!settled) tui.dispose();
+			await running;
+		}
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Escape returns a preview draft to editing and restores the main selection", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preview-edit-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		let editorCalls = 0;
+		const drafts: string[] = [];
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+			renderPreview: () => ["Preview"],
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async (_title: string, draft: string) => {
+				drafts.push(draft);
+				editorCalls += 1;
+				return editorCalls === 1 ? "format = 'draft'\n" : undefined;
+			},
+		});
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.equal(editorCalls, 2);
+		assert.equal(drafts[1], "format = 'draft'\n");
+		assert.match(tui.render().join("\n"), /→ Customize footer/u);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Ctrl+C in preview closes the whole /starship workflow", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preview-close-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+			renderPreview: () => ["Preview"],
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async () => "format = 'draft'\n",
+		});
+		let settled = false;
+		const running = Promise.resolve(mock.commands.get("starship")?.handler("", context.ctx));
+		void running.then(() => {
+			settled = true;
+		});
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await flushAsyncWork();
+		try {
+			assert.equal(settled, true);
+			assert.equal(tui.isOpen, false);
+		} finally {
+			if (!settled) tui.dispose();
+			await running;
+		}
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("external preview disposal cancels without saving", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preview-dispose-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+			renderPreview: () => ["Preview"],
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async () => "format = 'draft'\n",
+		});
+		const running = mock.commands.get("starship")?.handler("settings", context.ctx);
+		await tui.waitForOpen();
+		tui.dispose();
+		await running;
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+async function flushAsyncWork() {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/extensions/pi-starship/test/commands.test.ts
+++ b/extensions/pi-starship/test/commands.test.ts
@@ -3,11 +3,15 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
 import { registerStarshipCommand } from "../src/commands.js";
 import { BUILT_IN_EXAMPLE, loadStarshipConfig, settingsFilePath } from "../src/config.js";
 import piStarshipRuntime from "../src/pi-starship.js";
+
+initTheme("dark", false);
 
 function piStarship(pi: Parameters<typeof piStarshipRuntime>[0]) {
 	return piStarshipRuntime(pi, {
@@ -54,11 +58,13 @@ test("/starship keeps direct routes and opens a stateful narrow TUI menu", async
 	await command.handler("", context.ctx);
 	const screen = renders.flat().join("\n");
 	assert.match(screen, /pi-starship/u);
-	assert.match(screen, /Built-in footer · Healthy/u);
+	assert.match(screen, /Saved built-in configuration/u);
+	assert.match(screen, /Healthy/u);
 	assert.match(screen, /Customize footer/u);
-	assert.match(screen, /Check configuration/u);
+	assert.match(screen, /Configuration/u);
 	assert.match(screen, /Help/u);
-	assert.match(screen, /Advanced/u);
+	assert.match(screen, /Restore built-in…/u);
+	assert.doesNotMatch(screen, /Advanced/u);
 	assert.ok(renders.flat().every((line) => visibleWidth(line) <= 28));
 });
 
@@ -101,7 +107,7 @@ test("settings opens the raw TOML in TUI, saves atomically, and applies immediat
 		assert.equal(initial, BUILT_IN_EXAMPLE);
 		assert.match(preview, /preview/iu);
 		assert.match(preview, /saved/u);
-		assert.match(preview, /Continue to apply/u);
+		assert.match(preview, /Apply changes…/u);
 		assert.equal(readFileSync(settingsFilePath(root), "utf8"), "format = 'saved'\n");
 		assert.match(context.notifications.at(-1)?.message ?? "", /saved/i);
 
@@ -111,6 +117,72 @@ test("settings opens the raw TOML in TUI, saves atomically, and applies immediat
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preview failure remains explicit and offers edit or discard recovery", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preview-failure-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		let preview = "";
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+			renderPreview() {
+				throw new Error("renderer unavailable");
+			},
+		});
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => "format = 'draft'\n",
+			custom: async (factory: unknown) => {
+				const driven = driveCustomSelector(factory, ["\u001b"], 60);
+				preview = driven.renders.flat().join("\n");
+				return driven.result;
+			},
+		});
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.match(preview, /Preview unavailable: renderer unavailable/u);
+		assert.match(preview, /Draft validation: Healthy/u);
+		assert.match(preview, /Apply changes…/u);
+		assert.match(preview, /Continue editing/u);
+		assert.match(preview, /Discard draft/u);
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("warning drafts remain applicable and report their warning count", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-warning-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		let loaded = loadStarshipConfig(path);
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+			},
+			settingsPath: path,
+			renderPreview: () => ["warning preview"],
+		});
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			editor: async () => "format = 'warning'\nfuture = true\n",
+			custom: async (factory: unknown) => driveCustomSelector(factory, ["\r"], 40).result,
+			confirm: async () => true,
+		});
+		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		assert.equal(readFileSync(path, "utf8"), "format = 'warning'\nfuture = true\n");
+		assert.match(context.notifications.at(-1)?.message ?? "", /1 warning/u);
+	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
@@ -132,15 +204,24 @@ test("invalid and cancelled edits keep the old file and effective config", async
 			},
 			settingsPath: path,
 		});
+		let invalidReview = "";
 		const context = createMockContext({
 			mode: "tui",
 			editor: async () => nextEdit,
+			custom: async (factory: unknown) => {
+				const driven = driveCustomSelector(factory, ["\u001b"], 40);
+				invalidReview = driven.renders.flat().join("\n");
+				return driven.result;
+			},
 		});
 		await mock.commands.get("starship")?.handler("settings", context.ctx);
 		assert.equal(readFileSync(path, "utf8"), "format = 'old'\n");
 		assert.equal(loaded.config.format, "old");
 		assert.equal(applied, 0);
 		assert.match(context.notifications.at(-1)?.message ?? "", /parse/i);
+		assert.match(invalidReview, /Continue editing/u);
+		assert.match(invalidReview, /Discard draft/u);
+		assert.match(invalidReview, /current footer has not changed/iu);
 
 		nextEdit = undefined;
 		await mock.commands.get("starship")?.handler("settings", context.ctx);
@@ -380,6 +461,48 @@ test("non-TUI settings never opens an editor and status/help are protocol-safe",
 	}
 });
 
+test("direct routes reject unknown and trailing arguments in UI-capable modes", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-routes-"));
+	const path = settingsFilePath(root);
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		let editorCalls = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+		});
+		for (const mode of ["tui", "rpc"] as const) {
+			const context = createMockContext({
+				mode,
+				hasUI: true,
+				editor: async () => {
+					editorCalls += 1;
+					return undefined;
+				},
+			});
+			for (const args of ["settings extra", "status typo", "help now", "unknown"]) {
+				await mock.commands.get("starship")?.handler(args, context.ctx);
+				assert.match(
+					context.notifications.at(-1)?.message ?? "",
+					/Usage: \/starship \[settings\|status\|help\]/u,
+					`${mode}: ${args}`,
+				);
+			}
+		}
+		assert.equal(editorCalls, 0);
+
+		for (const mode of ["print", "json"] as const) {
+			const context = createMockContext({ mode, hasUI: false });
+			await mock.commands.get("starship")?.handler("status typo", context.ctx);
+			assert.deepEqual(context.notifications, []);
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("preview and confirmation cancellation preserve the previous document and runtime", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
 	const path = settingsFilePath(root);
@@ -438,7 +561,7 @@ test("preview and confirmation cancellation preserve the previous document and r
 	}
 });
 
-test("main and Advanced menus expose current state and a clear Back path", async () => {
+test("main and Configuration menus expose current state and a clear Back path", async () => {
 	const mock = createMockPi();
 	const loaded = loadStarshipConfig("/tmp/missing-pi-starship-menu.toml");
 	registerStarshipCommand(mock.pi, {
@@ -452,12 +575,7 @@ test("main and Advanced menus expose current state and a clear Back path", async
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
-			const inputs =
-				call === 0
-					? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"]
-					: call === 1
-						? ["\u001b[B", "\u001b[B", "\r"]
-						: ["\u001b"];
+			const inputs = call === 0 ? ["\u001b[B", "\r"] : ["\u001b"];
 			const driven = driveCustomSelector(factory, inputs, 26);
 			screens[call++] = driven.renders.flat().join("\n");
 			assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 26));
@@ -466,14 +584,13 @@ test("main and Advanced menus expose current state and a clear Back path", async
 	});
 	await mock.commands.get("starship")?.handler("", context.ctx);
 	assert.equal(call, 3);
-	assert.match(screens[1] ?? "", /Advanced/u);
-	assert.match(screens[1] ?? "", /Configuration details/u);
-	assert.match(screens[1] ?? "", /Restore built-in/u);
-	assert.match(screens[1] ?? "", /Back/u);
+	assert.match(screens[1] ?? "", /Configuration/u);
+	assert.match(screens[1] ?? "", /State: Built-in defaults/u);
+	assert.match(screens[1] ?? "", /Source: No settings file/u);
 	assert.match(screens[2] ?? "", /Customize footer/u);
 });
 
-test("Advanced restore previews, confirms, and atomically applies the built-in footer", async () => {
+test("Restore previews, confirms, and atomically applies the built-in footer", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
 	const path = settingsFilePath(root);
 	writeFileSync(path, "format = 'custom'\nfuture = true\n");
@@ -492,29 +609,73 @@ test("Advanced restore previews, confirms, and atomically applies the built-in f
 		});
 		let call = 0;
 		let restorePreview = "";
+		let confirmation = "";
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
 			custom: async (factory: unknown) => {
-				const inputs =
-					call === 0
-						? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"]
-						: call === 1
-							? ["\u001b[B", "\r"]
-							: ["\r"];
+				const inputs = call === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\r"];
 				const driven = driveCustomSelector(factory, inputs, 32);
-				if (call === 2) restorePreview = driven.renders.flat().join("\n");
+				if (call === 1) restorePreview = driven.renders.flat().join("\n");
 				call += 1;
 				return driven.result;
+			},
+			confirm: async (_title: string, message: string) => {
+				confirmation = message;
+				return true;
+			},
+		});
+		await mock.commands.get("starship")?.handler("", context.ctx);
+		assert.match(restorePreview, /Restore preview/u);
+		assert.match(restorePreview, /Current: Custom configuration/u);
+		assert.match(restorePreview, /entire settings document/iu);
+		assert.match(restorePreview, /unknown fields/iu);
+		assert.match(restorePreview, /No backup/iu);
+		assert.match(restorePreview, /\$brand\$model/u);
+		assert.match(
+			confirmation,
+			/All custom settings, unknown fields, and comments will be removed/u,
+		);
+		assert.match(confirmation, /No backup is kept after success/u);
+		assert.doesNotMatch(restorePreview, /░▒▓|/u);
+		assert.equal(applied, 1);
+		assert.equal(readFileSync(path, "utf8"), BUILT_IN_EXAMPLE);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Restore recovers a malformed settings document", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-malformed-restore-"));
+	const path = settingsFilePath(root);
+	writeFileSync(path, "format = [\n");
+	try {
+		const mock = createMockPi();
+		let loaded = loadStarshipConfig(path);
+		let applied = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+				applied += 1;
+			},
+			settingsPath: path,
+			renderPreview: (draft) => [draft.config.format],
+		});
+		let call = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const inputs = call++ === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\r"];
+				return driveCustomSelector(factory, inputs, 60).result;
 			},
 			confirm: async () => true,
 		});
 		await mock.commands.get("starship")?.handler("", context.ctx);
-		assert.match(restorePreview, /Restore preview/u);
-		assert.match(restorePreview, /\$brand\$model/u);
-		assert.doesNotMatch(restorePreview, /░▒▓|/u);
 		assert.equal(applied, 1);
 		assert.equal(readFileSync(path, "utf8"), BUILT_IN_EXAMPLE);
+		assert.equal(loaded.source, "user");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -559,7 +720,7 @@ test("invalid drafts can return to editing before preview and atomic apply", asy
 	}
 });
 
-test("diagnostics, Help, and configuration details stay shallow and fit narrow terminals", async () => {
+test("Configuration and Help stay shallow and fit narrow terminals", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
 	const path = settingsFilePath(root);
 	writeFileSync(path, "future = true\n");
@@ -571,17 +732,7 @@ test("diagnostics, Help, and configuration details stay shallow and fit narrow t
 			apply() {},
 			settingsPath: path,
 		});
-		const choices = [
-			"Check configuration",
-			undefined,
-			"Help",
-			undefined,
-			"Advanced",
-			"Configuration details",
-			undefined,
-			"Back",
-			undefined,
-		];
+		const choices = ["Configuration", undefined, "Help", undefined, undefined];
 		const screens: string[] = [];
 		const context = createMockContext({
 			mode: "tui",
@@ -592,19 +743,18 @@ test("diagnostics, Help, and configuration details stay shallow and fit narrow t
 			},
 		});
 		await mock.commands.get("starship")?.handler("", context.ctx);
-		assert.equal(screens.length, 9);
+		assert.equal(screens.length, 5);
 		assert.match(screens.join("\n"), /1 warning/u);
-		assert.match(screens.join("\n"), /Configuration health/u);
+		assert.match(screens.join("\n"), /Configuration/u);
 		assert.match(screens.join("\n"), /pi-starship help/u);
-		assert.match(screens.join("\n"), /Configuration details/u);
 		assert.match(screens.join("\n"), /Path:/u);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
 
-test("restore preview cancellation has no side effects in a narrow terminal", async () => {
-	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-"));
+test("restore preview cancellation preserves exact settings and runtime in a narrow terminal", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-restore-cancel-"));
 	const path = settingsFilePath(root);
 	const original = "format = 'custom'\nfuture = true\n";
 	writeFileSync(path, original);
@@ -619,30 +769,34 @@ test("restore preview cancellation has no side effects in a narrow terminal", as
 				applied += 1;
 			},
 			settingsPath: path,
-			renderPreview: (draft, width) => [draft.config.format.slice(0, width)],
+			renderPreview: (draft) => [draft.config.format],
 		});
-		const choices = ["Advanced", "Restore built-in", undefined, "Back", undefined];
-		let previewCalls = 0;
+		const tui = createTuiHarness({ width: 20, rows: 8 });
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
-			select: async () => choices.shift(),
-			custom: async (factory: unknown) => {
-				previewCalls += 1;
-				const driven = driveCustomSelector(factory, ["\u001b"], 20);
-				assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 20));
-				return driven.result;
-			},
+			custom: tui.custom,
 			confirm: async () => {
 				confirmations += 1;
 				return true;
 			},
 		});
-		await mock.commands.get("starship")?.handler("", context.ctx);
-		assert.equal(previewCalls, 1);
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const preview = tui.render();
+		assert.ok(preview.length <= 5);
+		assert.ok(preview.every((line) => visibleWidth(line) <= 20));
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
 		assert.equal(confirmations, 0);
 		assert.equal(applied, 0);
 		assert.equal(readFileSync(path, "utf8"), original);
+		assert.equal(loaded.config.format, "custom");
+		tui.press("ctrl+c");
+		await running;
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- flatten `/starship` to Customize, Configuration, Help, and state-gated Restore actions while distinguishing healthy built-in defaults from error fallback
- add an adaptive, scrollable, injected-keybinding-aware preview whose apply/edit/discard actions remain reachable in short and narrow terminals
- disclose complete-document restore consequences, reject trailing direct-route arguments, and close previews safely on cancellation, disposal, session replacement, and shutdown

## Verification

- focused pi-starship command/lifecycle run — 50 tests passed
- `npm --workspace @narumitw/pi-starship run check`
- `npm run check` — 2,089 tests passed
- `just pack-starship` — expected 59 files, including `src/command-preview.ts`
- `git diff --check`

The first full check hit an unrelated `pi-btw` scheduling assertion; its focused rerun passed, followed by the clean 2,089-test full run above.

## Convention audit

Read and audited `docs/extension-conventions.md` and `docs/extension-settings.md` for command routing, standard/shallow menus, specialized TUI width and lifecycle behavior, missing-file settings semantics, destructive recovery, and non-TUI safety. No deviations or unverified implementation paths remain. Interactive TUI smoke was not run; deterministic public TUI-harness coverage exercises resize, keybindings, cancellation, disposal, replacement, and shutdown.
