### PR TITLE
fix(pi-starship): restore published tui-kit floor

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -142,6 +142,7 @@
 - Kit settings and multi-select actions settle asynchronously; test adapters that drive `ctx.ui.custom()` must drain `waitForPending()`, observe an accepted transition, and close a rejected screen instead of returning before the callback settles.
 - Consumer tests load `@narumitw/pi-tui-kit` from its built `dist/`; rebuild the kit after source changes or consumer behavior tests can exercise stale UI code.
 - Symptom: a newer extension screen can make Pi focus `undefined` and crash. Cause: a broad zero-major helper range lets Pi's npm lock retain an older `pi-tui-kit` without that screen kind. Fix: use a bounded caret minor range and keep shared version bumps from rewriting consumer-owned compatibility ranges.
+- Before raising an internal dependency floor to the workspace's shared version, verify that exact minor exists on npm and that the consumer needs its API; selective publishing can leave manifest-only shared versions unavailable to later bumps.
 - Searchable TUI wrappers should reserve only a standalone Space key for activation; stripping spaces from whole input chunks corrupts bracketed-paste token queries.
 
 ## TASTE

--- a/extensions/pi-starship/package.json
+++ b/extensions/pi-starship/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.44.0",
+		"@narumitw/pi-tui-kit": "^0.43.0",
 		"smol-toml": "^1.7.1",
 		"yaml": "^2.9.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -462,7 +462,7 @@
 			"version": "0.44.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.44.0",
+				"@narumitw/pi-tui-kit": "^0.43.0",
 				"smol-toml": "^1.7.1",
 				"yaml": "^2.9.0"
 			},
@@ -473,6 +473,16 @@
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
 			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"extensions/pi-starship/node_modules/@narumitw/pi-tui-kit": {
+			"version": "0.43.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.43.0.tgz",
+			"integrity": "sha512-C0jdBbOnlUiJPvCFT8X+XNE5sEd375RsFdacjaaQ8RMzPitXut8rmhPxMTLJRHKu64QpRhk8uptdynNm2ZqOXw==",
+			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"


### PR DESCRIPTION
## Summary

- restore pi-starship's `@narumitw/pi-tui-kit` dependency floor to the published `^0.43.0` line
- restore the nested 0.43.0 lockfile resolution so shared minor bumps do not depend on the unpublished 0.44.0 artifact
- record the selective-publishing dependency-floor gotcha

`pi-tui-kit` had no source changes between v0.43.0 and v0.44.0, and pi-starship does not consume the API-v6 work added after v0.44.0.

## Verification

- `npm ls @narumitw/pi-tui-kit --workspace @narumitw/pi-starship --depth=0` — resolves 0.43.0
- `npm run check --workspace @narumitw/pi-starship`
- `npm run check` — 2,119 tests passed
- `just pack-starship` — 61 expected files
- isolated repository-pinned npm simulation: shared minor bump produced 0.45.0 with nested pi-tui-kit 0.43.0 and subsequent `npm ci` passed
- `git diff --check`
