### PR TITLE
feat: add experimental local analytics extension

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -75,6 +75,8 @@
 - For detached subagents, snapshot terminal state before resolving waiters, inject completion with `deliverAs: "steer", triggerTurn: false`, and serialize persistence callbacks in invocation order.
 - Blocking a Pi `tool_call` returns a non-terminating error, so agent-core may continue. Abort the turn too when a bounded flow must stop after the blocked call.
 
+- Symptom: concurrent `@tursodatabase/database` file transactions fail with `statement was interrupted`, and `BEGIN CONCURRENT` fails unless MVCC is separately enabled. Cause: connection timeout does not serialize cross-connection exclusive/immediate transactions, and default file databases do not enable MVCC. Fix: use short immediate/exclusive transactions with bounded whole-transaction retry and in-transaction rechecks; pre-create/chmod the database and WAL because both defaulted to `0644`, and include both files in stopped-process backups because committed data can remain in the WAL.
+
 ## TASTE
 
 - Prefer canonical JSON and explicit argv arrays for pi-lsp configuration; avoid extension-specific environment-variable settings while retaining `servers[].env` for child-process needs.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ commands, settings persistence, confirmations, and specialized UI.
 
 | Package | Use it for | Install |
 | --- | --- | --- |
+| [`pi-analytics`](./experimental/pi-analytics) | Review private, content-free local metrics for model calls, skills, tools, response cycles, and observed provider reliability through `/analytics`. | `pi install npm:@narumitw/pi-analytics` |
 | [`pi-file-context`](./experimental/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it by typing `@` at a word boundary or running `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-jupyter`](./experimental/pi-jupyter) | Choose and preview saved Jupyter notebooks from one `/jupyter` current-state menu without running a kernel. | `pi install npm:@narumitw/pi-jupyter` |
 | [`pi-webui`](./experimental/pi-webui) | Use a private loopback browser companion for the current terminal session with live activity and text/image input. | `pi install npm:@narumitw/pi-webui` |

--- a/docs/plans/archived/2026-08-02_pi-analytics-mvp-plan.md
+++ b/docs/plans/archived/2026-08-02_pi-analytics-mvp-plan.md
@@ -1,0 +1,304 @@
+# Pi Analytics MVP Plan
+
+> Follow-up: the completed package was moved to `experimental/pi-analytics` and now shows the
+> repository-required experimental warning in both its README and Pi UI.
+
+## Goal
+
+Add a publishable `@narumitw/pi-analytics` extension that collects content-free Pi response, model,
+skill, tool, and provider-reliability metadata into a local Turso Database and exposes useful
+Today/7-day/30-day/all-time summaries through a lifecycle-safe `/analytics` TUI/RPC dashboard.
+
+## Context
+
+- The extension is local-first and zero-configuration. It must not contact Turso Cloud or any other
+  remote analytics service.
+- Storage uses `@tursodatabase/database` directly, without Prisma. The driver is a pre-1.0,
+  SQLite-compatible Turso engine with native packages for Linux glibc x64/arm64, macOS arm64, and
+  Windows x64; unsupported platforms must fail observably without preventing Pi from loading the
+  extension.
+- Pi exposes exact lifecycle events for response settlement, logical model generations, HTTP
+  responses, and tool execution. It does not expose a first-class skill-invocation or connection-error
+  event, so the MVP uses documented, conservative detection rules rather than claiming perfect
+  attribution.
+- The approved UI presents Overview, Skills, Tools, Provider reliability, Response cycles, and Data &
+  privacy. It includes only settled response cycles and defaults to the last seven days.
+- This plan touches new-package metadata, extension lifecycle/events, local persistence and
+  migrations, an asynchronous command/menu, privacy-sensitive classification, tests, documentation,
+  and package/runtime verification. Applicable MUST rules come from `docs/extension-conventions.md`:
+  canonical entrypoint/package boundaries, factory/session resource ownership, TUI/mode safety,
+  command argument behavior, lifecycle cancellation/disposal, deterministic tests, root checks, pack
+  inspection, and Pi loading smoke. The MVP adds no extension-owned settings, so
+  `docs/extension-settings.md` is not in scope.
+
+## Architecture
+
+- `experimental/pi-analytics/src/index.ts` remains a thin default-export forwarder to the extension
+  factory in `analytics.ts`.
+- `analytics.ts` owns Pi event registration, per-session generations, database startup/shutdown,
+  ordered persistence, and command registration; it starts no resource during factory evaluation.
+- `collector.ts` is a Pi-independent state machine for one response cycle. It correlates attempts,
+  generations, ordered provider responses, parallel tools, skill activations, conservative error
+  categories, retries, outcomes, and settlement without retaining event content.
+- `skills.ts` maps Pi-provided skill provenance to explicit `/skill:<name>` input and successful
+  built-in `read` results. One skill is counted once per response cycle, with explicit user use taking
+  precedence over model loading.
+- `storage/database.ts` dynamically imports the Turso native driver during `session_start`, opens
+  `<agent-dir>/pi-analytics.db`, bounds connection/query waits, and closes only after its write queue
+  drains.
+- `storage/migrations.ts` owns immutable, contiguous, checksummed forward migrations recorded in
+  `schema_migrations`. Every pending migration rechecks and applies inside an exclusive transaction;
+  checksum mismatch, a newer unknown schema, or migration failure leaves existing data intact and
+  disables collection for that extension instance.
+- `storage/store.ts` publishes a settled run and all child observations atomically. It also owns
+  indexed aggregate queries and transactional data clearing; callers do not issue SQL.
+- `menu.ts` projects typed query results into `@narumitw/pi-tui-kit` action, choice, browse, and detail
+  screens. The menu owns no database connection and revalidates session/menu identity after every
+  await.
+- The database stores timestamps, model/provider IDs, thinking level, tool and skill names, durations,
+  counters, HTTP statuses, and classified errors. It never stores prompts, model/thinking output,
+  tool arguments/results, raw errors, headers, cwd/project/file paths, session names/IDs, or
+  credentials.
+- One database file is shared by Pi processes. Each process serializes its own mutations; Turso
+  transactions arbitrate cross-process writes. Schema evolution is additive-first so an already
+  running older Pi process is not broken by a newly started process.
+
+Expected package layout:
+
+```text
+experimental/pi-analytics/
+├── src/
+│   ├── index.ts
+│   ├── analytics.ts
+│   ├── collector.ts
+│   ├── errors.ts
+│   ├── menu.ts
+│   ├── skills.ts
+│   ├── types.ts
+│   └── storage/
+│       ├── database.ts
+│       ├── migrations.ts
+│       ├── queries.ts
+│       └── store.ts
+├── test/
+├── README.md
+├── LICENSE
+├── package.json
+└── tsconfig.json
+```
+
+## Tech Stack
+
+- Pi extension APIs from `@earendil-works/pi-coding-agent` as peer/runtime-provided surfaces.
+- `@tursodatabase/database` as the direct embedded database dependency; no Prisma, ORM, sync client,
+  or cloud credentials.
+- `@narumitw/pi-tui-kit` for standard cross-mode screens and lifecycle adaptation; select a published
+  compatibility floor only after verifying the exact API used exists at that floor.
+- Node built-ins for paths, cryptographic migration checksums, file permissions, clocks, and IDs.
+- TypeScript strict NodeNext sources, Biome, the repository test compiler/Node test runner, boundary
+  validator, package dry run, and non-interactive Pi smokes.
+
+## Non-Goals
+
+- Prometheus, JSON/CSV export, a browser dashboard, Turso Cloud sync, Prisma, or another ORM.
+- Prompt/response capture, token/cost reporting, project attribution, raw error diagnostics, or
+  general-purpose tracing that overlaps `pi-langfuse`.
+- Configurable retention, settings files, statusline/widgets, background HTTP servers, or persistent
+  UI outside `/analytics`.
+- Exact detection of skills loaded through shell commands or provider-internal retries/errors that Pi
+  does not expose.
+- Automatic downgrade, destructive schema contraction, secure erase, database repair, or automatic
+  replacement of a malformed/newer database.
+- Publishing to npm as part of MVP implementation.
+
+## Assumptions
+
+- The package starts at the repository's current shared workspace version and follows existing active
+  extension metadata/README conventions.
+- Analytics data is non-critical derived metadata. Transaction rollback and fail-closed startup are
+  sufficient recovery for the MVP; no automatic backup is required.
+- Today uses local calendar boundaries; 7-day and 30-day ranges are rolling windows; All time has no
+  lower bound.
+- A response cycle begins with the first accepted `before_agent_start` in an idle collector and ends
+  at `agent_settled`; queued automatic retries/compaction recovery/continuations remain in that cycle.
+- An active, unsettled cycle is excluded from dashboard results and is persisted as `interrupted` only
+  during graceful session shutdown/replacement.
+- Clearing data removes currently committed observation rows in one transaction but preserves
+  migration history; another running Pi process may publish a later settled run after the clear.
+
+## Unknowns
+
+- Confirm in an early spike that the selected Turso release loads through Pi's normal npm runtime and
+  the supported local environment, and that an unsupported/missing native binding can be caught by a
+  delayed dynamic import.
+- Confirm with two independent connections that `transactionAsync(...).exclusive(...)` serializes
+  concurrent DDL migration attempts and that normal concurrent run transactions do not corrupt or
+  partially publish data.
+- Confirm the driver's file creation/permission behavior and close semantics before finalizing the
+  `0600` enforcement and shutdown adapter.
+- Confirm the smallest published `pi-tui-kit` caret-minor floor containing the browse/detail APIs used
+  by the dashboard before recording the dependency range.
+
+## Risks
+
+- **Native driver reduces portability:** gate startup through dynamic import, document the exact native
+  support matrix, inject the storage dependency in deterministic tests, and add a real supported-host
+  load smoke.
+- **Concurrent migrations or writers could race:** perform version checks inside exclusive migration
+  transactions, keep writes short and atomic, use bounded busy/query timeouts, and test two live
+  connections against one temporary database.
+- **A newer process could break an older running process:** prefer nullable columns/new tables and
+  dual-read/dual-write transitions; do not rename/drop existing schema in the MVP migration policy.
+- **Attribution could overstate precision:** label connection results as observed provider errors,
+  discard raw errors after conservative classification, count only successful exact skill-file reads,
+  and document non-standard/invisible paths.
+- **Lifecycle replacement could write stale state or use a closed database:** generation-guard all
+  async continuations, serialize writes before prerequisite awaits, abort menus on replacement, and
+  drain the owner queue before close.
+- **Queries could block cancellation:** keep every query indexed and timeout-bounded, let the menu
+  lifecycle drain in-flight work before disposal, and never publish a result after its owner signal or
+  session generation becomes stale.
+- **Analytics metadata can still reveal local tool/skill/model names:** use private file permissions,
+  no remote transport, a visible privacy inventory, display sanitization, and a transactional clear
+  action.
+- **Pre-1.0 database changes can break compatibility:** use a bounded dependency range and lockfile,
+  isolate all driver calls behind `storage/database.ts`, and verify the package/runtime smoke before
+  upgrades.
+
+## Rollback / Recovery
+
+- Before release, remove the new workspace and its focused root aliases, then restore the lockfile;
+  no existing package behavior or data is changed.
+- After users have data, never roll back the schema automatically. An older extension encountering a
+  newer migration version must open no writer and report that the extension needs updating.
+- A failed migration rolls back its transaction and leaves the last successfully recorded version;
+  collection and ordinary queries remain disabled until a compatible extension starts successfully.
+- A failed settled-run write leaves the prior database valid, remains in a bounded process-local retry
+  queue, and produces at most one actionable notification per failure episode; shutdown drains the
+  queue before giving up observably.
+- A malformed or unsupported database is never deleted or recreated automatically. The UI reports its
+  path and safe recovery guidance; the user-owned clear action operates only after a valid database is
+  open.
+
+## Plan
+
+- [x] Run a Turso integration spike in temporary test fixtures that dynamically imports
+  `@tursodatabase/database`, opens/closes a file database, enforces or repairs `0600` on Unix, executes
+  an async transaction, catches a simulated missing native binding, and exercises two connections
+  contending on one exclusive DDL migration; accept with focused Node tests plus a non-interactive Pi
+  load on the supported development host, and resolve every Turso unknown above before production
+  storage code depends on it.
+- [x] Scaffold `experimental/pi-analytics/` with the thin `src/index.ts`, package metadata, strict
+  `tsconfig.json`, MIT `LICENSE`, at least one loader test, and the canonical
+  `pi.extensions: ["./src/index.ts"]`; add only the verified Turso and Pi TUI Kit runtime dependencies,
+  Pi peer dependencies, lockfile changes, root `pack:analytics`, and `just` pack/try/install/publish
+  aliases, accepting with package typecheck, `npm run check:boundaries`, and manifest review showing no
+  extension-to-extension dependency.
+- [x] Define content-free domain types and a reducer in `src/types.ts`, `src/collector.ts`, and
+  `src/errors.ts` for response cycles, attempts, logical generations, ordered HTTP responses, parallel
+  tools, outcomes, durations, retries, and conservative error categories; drive implementation with
+  tests for success, tool loops, parallel completion order, 429/5xx recovery, terminal errors,
+  abort/length/interruption, duplicate events, and absent active runs, accepting when no reducer state
+  can retain prompt, output, arguments, results, raw errors, headers, cwd, or session identity.
+- [x] Implement `src/skills.ts` and collector integration for pending interactive/RPC
+  `/skill:<name>` inputs, Pi-provided skill provenance, canonical successful built-in `read` matches,
+  per-cycle deduplication, and user precedence over model detection; accept with tests for command
+  arguments, extension input exclusion, handled/no-agent input discard, failed reads, repeated reads,
+  same-name path collisions, terminal-control names, and non-standard bash reads remaining uncounted.
+- [x] Implement `src/storage/migrations.ts` with an immutable contiguous migration registry,
+  SHA-256 checksums, the initial tables/indexes, exclusive in-transaction rechecks, and fail-closed
+  handling for checksum mismatch, gaps, migration failure, and databases newer than the extension;
+  accept with fresh/latest/idempotent/every-prior-version fixtures, forced rollback, modified-history,
+  newer-schema, and concurrent two-connection migration tests.
+- [x] Implement `src/storage/database.ts` and `src/storage/store.ts` with delayed driver loading,
+  agent-directory path resolution, bounded connection/query waits, private permissions, one
+  process-local mutation queue, atomic settled-run publication, bounded failed-write retention,
+  transactional clear, and idempotent close; accept with temporary-database tests for reopen,
+  concurrent writers, partial-write rollback, queue order, transient/permanent failures, shutdown
+  drain, repeated close, and no access to the developer's real Pi agent directory.
+- [x] Implement indexed aggregate queries in `src/storage/queries.ts` for overview totals,
+  per-response generation distributions (average, median, nearest-rank P95, maximum, and
+  1/2–3/4–6/7+ buckets), skill source/model breakdowns, tool success/error/duration/model breakdowns,
+  and observed provider reliability across Today/7-day/30-day/all-time ranges; accept with fixed-clock
+  database fixtures covering exact boundaries, empty ranges, long names, mixed models, retries,
+  interrupted runs, and cross-query count reconciliation.
+- [x] Integrate the collector and store in `src/analytics.ts` through `input`,
+  `before_agent_start`, `agent_start`, `turn_start`, `before_provider_request`,
+  `after_provider_response`, assistant message/error, tool lifecycle, `agent_end`, `agent_settled`, and
+  session lifecycle events; accept with an extension harness proving event ordering, active-run
+  ownership, queued continuation/retry behavior, parallel tools, one atomic settlement, replacement,
+  reload, fork/new/resume/quit shutdown, stale-continuation rejection after every await, and graceful
+  operation when storage never initializes.
+- [x] Build `src/menu.ts` with `pi-tui-kit` standard screens for the seven-row root dashboard,
+  transient time-range choice, searchable Skills and Tools browse/detail views, Provider reliability,
+  Response cycles, Data & privacy, and exact transactional clear confirmation; accept with TUI/RPC
+  harness tests for loading, empty, success, partial, unsupported-platform, migration/query/write
+  error, clear-cancel/confirm/racing-writer, Back/Escape/Ctrl+C, owner disposal, query timeout, stale
+  results, selection restoration, and widths of 40/80/120 columns without overflow or terminal escape
+  injection.
+- [x] Register `/analytics` as a no-argument manager command in `src/analytics.ts`, rejecting all
+  arguments and trailing input, running only standard TUI/RPC flows, and throwing an observable
+  unsupported-mode error in print/JSON without ad hoc protocol output; accept with exact command-mode
+  tests and a non-interactive `pi -p -e ./experimental/pi-analytics "/analytics"` load/rejection smoke
+  that does not invoke a model.
+- [x] Write `experimental/pi-analytics/README.md` with the approved emoji/badges and standard sections,
+  installation/local-try commands, metric definitions, dashboard flow, local database path,
+  supported native platforms, no-cloud guarantee, privacy inventory, skill/error detection limits,
+  migration/upgrade/newer-schema behavior, data clearing semantics, pre-1.0 database caveat, package
+  layout, keywords, and license; accept by cross-checking every public claim against source/tests and
+  retaining `🗂️ Package layout`, `🔎 Keywords`, and `📄 License`.
+- [x] Audit the complete extension against `docs/extension-conventions.md`: package/entrypoint and
+  dependency boundaries; factory/session resource ownership; cancellation, disposal, replacement, and
+  shutdown after every await; command/mode behavior; output/privacy bounds; stable UI ownership; and
+  focused deterministic coverage. Resolve every same-class failure across the whole new package and
+  record any accepted deviation next to its owner before running final gates.
+- [x] Run `npm run check`, `just pack analytics`, inspect the dry-run tarball for only declared source,
+  README, license, and metadata, run the supported-host Turso file/concurrency smoke, and run the
+  non-interactive local Pi entrypoint/command smoke; accept only when all pass, no external network or
+  real agent data is touched, and every skipped platform/runtime path is documented in the handoff.
+
+## Execution Evidence
+
+- Turso spike and permanent tests proved supported-host native loading, private database and WAL files,
+  linked-file rejection, idempotent close, bounded cross-connection migration/write retries, atomic
+  rollback, and two live writers. The spike also established that default file databases require
+  immediate/exclusive retry rather than `BEGIN CONCURRENT`.
+- `experimental/pi-analytics/test/` contains 48 deterministic tests covering collection, retries,
+  automatic continuation, streaming and model skill attribution, migrations, permissions,
+  concurrency, aggregation boundaries, loading/cancellation, TUI/RPC rendering, clear commit
+  semantics, unsupported storage, replacement, shutdown, and command modes.
+- `npm run check` passed the final tree: Biome checked 665 files, boundaries accepted 23 active
+  extensions, every workspace typechecked, and all 2,174 repository tests passed.
+- `just pack analytics` produced a 14-file dry run containing only `src/`, `README.md`, `LICENSE`, and
+  `package.json`; no tests, generated output, or undeclared files were included.
+- A non-interactive Pi smoke with an isolated `PI_CODING_AGENT_DIR` loaded the extension, rejected
+  `/analytics` observably in print mode without invoking a model, and created only private `0600`
+  analytics database/WAL files plus Pi's private auth file.
+- `npm audit --omit=dev` reported zero vulnerabilities. The supported-host native runtime was verified
+  on Linux x64 glibc; other declared native platforms remain unexecuted locally and are documented as
+  the upstream package's support matrix rather than claimed smoke coverage.
+- Final semantic review used `docs/extension-conventions.md` and the official Pi extension, skill,
+  session-format, and TUI documentation. Extension-owned settings are absent, so
+  `docs/extension-settings.md` remained out of scope. No convention deviation was accepted.
+
+## Completion Checklist
+
+- [x] `@narumitw/pi-analytics` is an independently installable experimental extension with a thin canonical
+  entrypoint, bounded runtime dependencies, root workflow aliases, tests, practical English README,
+  and inspected package contents.
+- [x] The extension records only the approved content-free fields, never contacts a remote service,
+  and exposes transparent skill/error attribution limits and local clearing behavior.
+- [x] Response, generation, HTTP retry, tool, skill, outcome, and reliability semantics match the
+  approved definitions under success, retry, parallelism, cancellation, replacement, and shutdown.
+- [x] Turso startup, permissions, migrations, concurrent connections, atomic writes, query bounds,
+  failed-write recovery, newer/malformed database handling, and idempotent closure are verified on a
+  supported native host.
+- [x] `/analytics` provides the approved Today/7-day/30-day/all-time TUI/RPC flows with tested loading,
+  empty, success, error, partial, unsupported, cancellation, disposal, accessibility, and destructive
+  confirmation states; print/JSON and arguments reject observably.
+- [x] The final semantic audit names `docs/extension-conventions.md` as read, confirms settings are not
+  touched, and records checks/smokes plus any accepted deviation or unverified native platform.
+- [x] `npm run check`, `just pack analytics`, the Turso runtime/concurrency smoke, and the
+  non-interactive Pi load/command smoke pass against the final diff.
+- [x] After all items above have evidence, archive this plan as
+  `docs/plans/archived/2026-08-02_pi-analytics-mvp-plan.md` and report the archived path.

--- a/experimental/pi-analytics/LICENSE
+++ b/experimental/pi-analytics/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/experimental/pi-analytics/README.md
+++ b/experimental/pi-analytics/README.md
@@ -1,0 +1,205 @@
+# 📈 pi-analytics — Local Analytics for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-analytics)](https://www.npmjs.com/package/@narumitw/pi-analytics) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+> [!WARNING]
+> This extension is experimental. Its metrics, storage format, and dashboard may change between releases.
+
+`@narumitw/pi-analytics` is a local-first [Pi coding agent](https://pi.dev) extension that counts model calls, skill activations, tool activity, and observed provider errors without storing conversation or tool content.
+
+## ✨ Features
+
+- Starts collecting settled Pi response cycles after installation with no configuration.
+- Breaks skill activations down by explicit user invocation, model loading, provider, and model.
+- Counts tool calls, failures, average duration, and model attribution.
+- Reports logical LLM calls per response with average, median, P95, maximum, and distribution buckets.
+- Separates HTTP 429/5xx responses, conservative connection-error categories, recovered errors, and terminal provider failures.
+- Offers Today, rolling 7-day, rolling 30-day, and all-time views through one `/analytics` TUI/RPC dashboard.
+- Stores only content-free metadata in one private local Turso Database.
+- Uses forward-only, checksummed, transactional schema migrations and fails closed on unknown newer schemas.
+- Never starts a server, contacts Turso Cloud, or sends analytics anywhere.
+
+## 📦 Install
+
+Install persistently:
+
+```bash
+pi install npm:@narumitw/pi-analytics
+```
+
+Try the published package without installing:
+
+```bash
+pi -e npm:@narumitw/pi-analytics
+```
+
+Try a local checkout from the repository root:
+
+```bash
+pi -e ./experimental/pi-analytics
+```
+
+### Supported platforms
+
+The embedded `@tursodatabase/database` dependency currently publishes native binaries for:
+
+- Linux x64 and arm64 with glibc;
+- macOS arm64; and
+- Windows x64.
+
+On another platform, Pi still loads the extension and `/analytics` remains available, but collection is disabled and the dashboard explains the supported platform boundary. The database engine is pre-1.0. Analytics are treated as non-critical derived metadata. If the history itself matters, stop every Pi process using the extension and back up both `pi-analytics.db` and `pi-analytics.db-wal`; copying only the main file is not a complete backup.
+
+## 🚀 Quick start
+
+Complete at least one Pi response, then run:
+
+```text
+/analytics
+```
+
+The default overview covers the last seven rolling days:
+
+```text
+Analytics · Last 7 days
+
+Response cycles                    83
+LLM calls                         192
+Calls per response        2.31 · P95 6
+Tool calls                        414
+Tool errors                         7
+Skill activations                  31
+Provider errors                     4
+Recovered errors                    3
+```
+
+Use the menu to change the time range or browse Skills, Tools, Provider reliability, Response cycles, and Data & privacy. Only fully settled cycles are included; active work is omitted until Pi settles.
+
+## 📐 Metric definitions
+
+### Response cycles and LLM calls
+
+A **response cycle** starts when Pi begins agent work and ends at `agent_settled`. Automatic retries, overflow-compaction recovery, tool follow-ups, and queued continuations before settlement stay in that cycle.
+
+An **LLM call** is one logical provider generation. A provider may make several HTTP attempts inside it, so `429 → 429 → 200` is one LLM call, three observed HTTP responses, two provider errors, and a recovered generation.
+
+### Skills
+
+An activation is **User initiated** when an observed interactive or RPC `/skill:<name>` input is associated with an active or subsequently started response cycle. This includes skill commands queued while Pi is streaming. It is **Model initiated** when the built-in `read` tool successfully loads the exact canonical `SKILL.md` path Pi discovered. A skill is counted at most once per response cycle, and explicit user use takes precedence.
+
+Pi does not expose a first-class skill-invocation event or a post-chain acceptance event for input observers. Non-standard loading such as `bash` plus `cat SKILL.md`, unsuccessful reads, and provider behavior invisible to Pi are not counted; an explicit skill input intercepted later by another extension while a response is active may still be observed.
+
+### Tools
+
+A tool call starts at Pi's `tool_execution_start` event and finishes at `tool_execution_end`. The extension stores the tool name, model attribution, timing, completion state, and final error flag. It cannot reliably distinguish another extension blocking a call from every other tool error, so the MVP reports both as errors rather than claiming a separate blocked count.
+
+### Provider reliability
+
+Pi exposes HTTP responses and final assistant failures, not every provider-SDK transport retry. The dashboard therefore labels these values as **observed provider errors**. It reports:
+
+- HTTP 429 and 5xx counts;
+- DNS, timeout, connection-refused, connection-reset, TLS, other-network, and other-provider categories;
+- recovered errors; and
+- terminal failures.
+
+Error messages are classified in memory and discarded. Raw error text is never stored.
+
+## 💬 Command
+
+```text
+/analytics
+```
+
+The command accepts no arguments. TUI mode uses the full dashboard; RPC mode adapts the same standard screens to dialogs. Print and JSON modes reject the interactive command observably instead of writing ad hoc protocol output.
+
+The root menu contains seven actions:
+
+```text
+Change time range
+Skills
+Tools
+Provider reliability
+Response cycles
+Data & privacy
+Close
+```
+
+Skills and Tools are searchable browse views with details and model breakdowns. Escape goes Back from nested screens and closes the root. Ctrl+C closes the menu. Cancelling data deletion has no side effects.
+
+## 🔐 Local data and privacy
+
+The database is stored at:
+
+```text
+<pi-agent-directory>/pi-analytics.db
+```
+
+On Unix, the extension pre-creates and restricts the database and WAL files to mode `0600`, repairs their permissions after migration, and refuses linked database files.
+
+Stored fields are limited to:
+
+- timestamps and durations;
+- provider/model IDs and thinking level;
+- tool and skill names;
+- user/model skill source;
+- counts, outcomes, and completion states;
+- HTTP status codes; and
+- classified provider-error categories.
+
+The extension does **not** store:
+
+- prompts, responses, or thinking content;
+- tool arguments or results;
+- raw error messages or HTTP headers;
+- cwd, project names, file paths, session names, or Pi session IDs; or
+- credentials.
+
+It imports only the local embedded database package. It does not install `@tursodatabase/sync`, request Turso credentials, contact Turso Cloud, or perform any other remote telemetry.
+
+Choose **Data & privacy → Clear analytics data…** to transactionally remove all currently committed response, model, skill, tool, and reliability observations. Migration history remains so the valid schema can continue to be used. Another running Pi process may commit a newly settled response after the clear operation.
+
+## 🧱 Database migrations and recovery
+
+Schema migrations are numbered, immutable, contiguous, and checksummed. Pending migrations recheck and apply inside an exclusive transaction with bounded conflict retry, so two Pi processes cannot publish half of a migration. Runtime schema changes follow additive-first compatibility: add nullable columns or tables before considering any later contraction.
+
+The extension never downgrades, repairs, deletes, or recreates a database automatically. If a migration fails, an applied checksum differs, or the database was created by a newer extension version, collection fails closed and existing bytes remain in place. Update the extension or restore a user-managed backup before retrying.
+
+Settled response publication is one atomic transaction. A failed write leaves prior data valid and is retained for bounded retry while that Pi session remains open. Graceful shutdown drains pending writes and closes the session-owned connection.
+
+## 🚧 MVP limitations
+
+- There are no retention settings; records remain until explicitly cleared.
+- Prometheus, JSON/CSV export, Turso Cloud sync, browser dashboards, token/cost reporting, and project attribution are not included.
+- Statistics cover only events visible through Pi's public extension API.
+- Clearing rows is logical deletion, not a secure-erasure guarantee for underlying storage media.
+
+## 🗂️ Package layout
+
+```text
+experimental/pi-analytics/
+├── src/
+│   ├── index.ts              # Thin Pi entrypoint
+│   ├── analytics.ts          # Pi lifecycle, command, and session ownership
+│   ├── collector.ts          # Content-free response-cycle state machine
+│   ├── errors.ts             # Conservative error classification
+│   ├── skills.ts             # Explicit and model skill detection
+│   ├── menu.ts               # TUI/RPC analytics dashboard
+│   ├── types.ts              # Observation records
+│   └── storage/
+│       ├── database.ts       # Dynamic driver startup and private file lifecycle
+│       ├── migrations.ts     # Transactional checksummed schema history
+│       ├── queries.ts        # Indexed aggregate projections
+│       └── store.ts          # Atomic writes, retries, queries, and clear
+├── test/
+├── README.md
+├── LICENSE
+├── package.json
+└── tsconfig.json
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, local analytics, agent skills, tool usage, model calls, provider reliability, Turso Database, SQLite-compatible metrics.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/experimental/pi-analytics/package.json
+++ b/experimental/pi-analytics/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@narumitw/pi-analytics",
+	"version": "0.45.0",
+	"description": "Local-first usage analytics for Pi models, skills, tools, and reliability.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"analytics",
+		"metrics",
+		"turso"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check --vcs-use-ignore-file=false src test package.json tsconfig.json README.md && npm run typecheck",
+		"format": "biome check --write --vcs-use-ignore-file=false src test package.json tsconfig.json README.md",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.45.0",
+		"@tursodatabase/database": "^0.7.2"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.6",
+		"@earendil-works/pi-coding-agent": "0.83.0",
+		"@types/node": "26.1.2",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "experimental/pi-analytics"
+	}
+}

--- a/experimental/pi-analytics/src/analytics.ts
+++ b/experimental/pi-analytics/src/analytics.ts
@@ -1,0 +1,406 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+	type ExtensionAPI,
+	type ExtensionContext,
+	getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+import { ResponseCollector } from "./collector.js";
+import { type AnalyticsMenuDataSource, showAnalyticsMenu } from "./menu.js";
+import { SkillTracker } from "./skills.js";
+import { AnalyticsDatabaseOpenError, openAnalyticsDatabase } from "./storage/database.js";
+import {
+	ChecksumMismatchError,
+	MigrationFailedError,
+	NewerSchemaError,
+} from "./storage/migrations.js";
+import type { AnalyticsSnapshot, TimeRange } from "./storage/queries.js";
+import { AnalyticsStore } from "./storage/store.js";
+import type { ModelIdentity, SettledRun, TriggerSource } from "./types.js";
+
+const EXPERIMENTAL_WARNING = "pi-analytics is experimental; its metrics and dashboard may change.";
+
+export interface AnalyticsStorePort {
+	readonly path: string;
+	recordRun(run: SettledRun): Promise<void>;
+	getSnapshot(range: TimeRange): Promise<AnalyticsSnapshot>;
+	clearAll(): Promise<number>;
+	close(): Promise<void>;
+}
+
+interface AnalyticsDependencies {
+	openStore(path: string): Promise<AnalyticsStorePort>;
+	getAgentDir(): string;
+	now(): number;
+	createId(): string;
+	platform(): string;
+}
+
+export function createAnalyticsExtension(
+	dependencies: Partial<AnalyticsDependencies> = {},
+): (pi: ExtensionAPI) => void {
+	const deps: AnalyticsDependencies = {
+		openStore:
+			dependencies.openStore ??
+			(async (databasePath) =>
+				new AnalyticsStore(await openAnalyticsDatabase({ path: databasePath }))),
+		getAgentDir: dependencies.getAgentDir ?? getAgentDir,
+		now: dependencies.now ?? Date.now,
+		createId: dependencies.createId ?? randomUUID,
+		platform: dependencies.platform ?? runtimePlatform,
+	};
+
+	return function analyticsExtension(pi: ExtensionAPI): void {
+		let sessionGeneration = 0;
+		let sessionController = new AbortController();
+		let collector = new ResponseCollector();
+		let skillTracker: SkillTracker | undefined;
+		let store: AnalyticsStorePort | undefined;
+		let storageFailure: string | undefined;
+		let startupTask: Promise<void> | undefined;
+		let writeFailureActive = false;
+		let pendingTriggerSource: TriggerSource = "unknown";
+		let pendingAttemptWithoutRun = false;
+
+		pi.registerCommand("analytics", {
+			description: "Open local Pi usage analytics",
+			handler: async (args, ctx) => {
+				if (args.trim()) {
+					if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+						throw new Error("/analytics does not accept arguments.");
+					}
+					ctx.ui.notify("/analytics does not accept arguments.", "warning");
+					return;
+				}
+				if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+					throw new Error("/analytics requires Pi TUI or RPC mode.");
+				}
+				const generation = sessionGeneration;
+				const owner = sessionController;
+				const source = menuSource(generation, owner.signal);
+				await showAnalyticsMenu(ctx, source, {
+					signal: owner.signal,
+					isCurrent: () => generation === sessionGeneration && !owner.signal.aborted,
+				});
+			},
+		});
+
+		pi.on("session_start", async (_event, ctx) => {
+			const generation = ++sessionGeneration;
+			if (ctx.hasUI) ctx.ui.notify(EXPERIMENTAL_WARNING, "warning");
+			sessionController.abort(new DOMException("Analytics session replaced", "AbortError"));
+			sessionController = new AbortController();
+			collector = new ResponseCollector();
+			skillTracker = new SkillTracker(ctx.cwd);
+			store = undefined;
+			storageFailure = undefined;
+			writeFailureActive = false;
+			pendingTriggerSource = "unknown";
+			pendingAttemptWithoutRun = false;
+			const databasePath = path.join(deps.getAgentDir(), "pi-analytics.db");
+			const task = (async () => {
+				try {
+					const opened = await deps.openStore(databasePath);
+					if (generation !== sessionGeneration) {
+						await opened.close();
+						return;
+					}
+					store = opened;
+				} catch (error) {
+					if (generation !== sessionGeneration) return;
+					storageFailure = storageFailureMessage(error, deps.platform());
+					safeNotify(ctx, storageFailure, "warning");
+				}
+			})();
+			startupTask = task;
+			await task;
+			if (startupTask === task) startupTask = undefined;
+		});
+
+		pi.on("input", (event, ctx) => {
+			const now = deps.now();
+			const tracker = skillTracker;
+			tracker?.observeInput(event.text, event.source, now);
+			if (event.source !== "extension") pendingTriggerSource = event.source;
+			if (!tracker || !collector.hasActiveRun()) return;
+			const explicit = tracker.consumeExplicitSkill();
+			if (!explicit || !tracker.hasAvailableSkill(explicit.name)) return;
+			collector.activateSkill({
+				name: explicit.name,
+				initiatedBy: "user",
+				now: explicit.observedAtMs,
+				model: modelIdentity(ctx, pi),
+			});
+		});
+
+		pi.on("before_agent_start", async (event, ctx) => {
+			const generation = sessionGeneration;
+			const tracker = skillTracker;
+			if (!tracker) return;
+			const skills = availableSkills(pi, event.systemPromptOptions.skills ?? []);
+			await tracker.setAvailableSkills(skills);
+			if (generation !== sessionGeneration || tracker !== skillTracker) return;
+			const explicit = tracker.consumeExplicitSkill();
+			const interrupted = collector.begin({
+				id: deps.createId(),
+				now: deps.now(),
+				triggerSource: explicit?.source ?? pendingTriggerSource,
+				model: modelIdentity(ctx, pi),
+			});
+			pendingTriggerSource = "unknown";
+			if (interrupted) await persistRun(interrupted, ctx, generation);
+			if (explicit && skills.some(({ name }) => name === explicit.name)) {
+				collector.activateSkill({
+					name: explicit.name,
+					initiatedBy: "user",
+					now: explicit.observedAtMs,
+					model: modelIdentity(ctx, pi),
+				});
+			}
+		});
+
+		pi.on("agent_start", () => {
+			if (collector.hasActiveRun()) collector.beginAttempt();
+			else pendingAttemptWithoutRun = true;
+		});
+
+		pi.on("turn_start", (_event, ctx) => {
+			ensureRun(ctx, "extension");
+		});
+
+		pi.on("before_provider_request", (_event, ctx) => {
+			ensureRun(ctx, "extension");
+			collector.beginGeneration({
+				id: deps.createId(),
+				now: deps.now(),
+				model: modelIdentity(ctx, pi),
+			});
+		});
+
+		pi.on("after_provider_response", (event) => {
+			collector.recordProviderResponse({ status: event.status, now: deps.now() });
+		});
+
+		pi.on("message_end", (event) => {
+			if (event.message.role !== "assistant") return;
+			collector.finishGeneration({
+				now: deps.now(),
+				stopReason: event.message.stopReason,
+				errorMessage: event.message.errorMessage,
+			});
+		});
+
+		pi.on("tool_execution_start", (event, ctx) => {
+			ensureRun(ctx, "extension");
+			collector.beginTool({
+				id: event.toolCallId,
+				name: event.toolName,
+				now: deps.now(),
+				model: modelIdentity(ctx, pi),
+			});
+		});
+
+		pi.on("tool_result", async (event, ctx) => {
+			if (event.toolName === "read" && !isBuiltinReadTool(pi)) return;
+			const generation = sessionGeneration;
+			const tracker = skillTracker;
+			if (!tracker) return;
+			const name = await tracker.matchSuccessfulRead({
+				toolName: event.toolName,
+				input: event.input,
+				isError: event.isError,
+			});
+			if (!name || generation !== sessionGeneration || tracker !== skillTracker) return;
+			collector.activateSkill({
+				name,
+				initiatedBy: "model",
+				now: deps.now(),
+				model: modelIdentity(ctx, pi),
+			});
+		});
+
+		pi.on("tool_execution_end", (event) => {
+			collector.finishTool({ id: event.toolCallId, now: deps.now(), isError: event.isError });
+		});
+
+		pi.on("agent_settled", async (_event, ctx) => {
+			const generation = sessionGeneration;
+			const run = collector.settle(deps.now());
+			pendingAttemptWithoutRun = false;
+			pendingTriggerSource = "unknown";
+			skillTracker?.clearPending();
+			if (run) await persistRun(run, ctx, generation);
+		});
+
+		pi.on("session_shutdown", async (_event, ctx) => {
+			const activeStore = store;
+			const activeStartup = startupTask;
+			++sessionGeneration;
+			sessionController.abort(new DOMException("Analytics session shut down", "AbortError"));
+			skillTracker?.clearPending();
+			skillTracker = undefined;
+			store = undefined;
+			const run = collector.interrupt(deps.now());
+			if (run && activeStore) {
+				await activeStore.recordRun(run).catch(() => {
+					safeNotify(ctx, "Analytics could not save the interrupted response cycle.", "warning");
+				});
+			}
+			await activeStartup?.catch(() => undefined);
+			await activeStore?.close().catch(() => {
+				safeNotify(
+					ctx,
+					"Analytics storage shutdown was incomplete; some pending metrics may not have been saved.",
+					"warning",
+				);
+			});
+		});
+
+		function ensureRun(ctx: ExtensionContext, triggerSource: TriggerSource): void {
+			if (collector.hasActiveRun()) return;
+			collector.begin({
+				id: deps.createId(),
+				now: deps.now(),
+				triggerSource,
+				model: modelIdentity(ctx, pi),
+			});
+			if (pendingAttemptWithoutRun) {
+				pendingAttemptWithoutRun = false;
+				collector.beginAttempt();
+			}
+		}
+
+		async function persistRun(
+			run: SettledRun,
+			ctx: ExtensionContext,
+			generation: number,
+		): Promise<void> {
+			const activeStore = store;
+			if (!activeStore) return;
+			try {
+				await activeStore.recordRun(run);
+				if (generation !== sessionGeneration || activeStore !== store) return;
+				if (writeFailureActive) {
+					writeFailureActive = false;
+					safeNotify(ctx, "Local analytics storage recovered.", "info");
+				}
+			} catch {
+				if (generation !== sessionGeneration || activeStore !== store || writeFailureActive) return;
+				writeFailureActive = true;
+				safeNotify(
+					ctx,
+					"Analytics could not save a response cycle; it will retry while this Pi session remains open.",
+					"warning",
+				);
+			}
+		}
+
+		function menuSource(generation: number, signal: AbortSignal): AnalyticsMenuDataSource {
+			return {
+				path: store?.path ?? path.join(deps.getAgentDir(), "pi-analytics.db"),
+				async load(range) {
+					assertCurrent(generation, signal);
+					const activeStore = store;
+					if (!activeStore) {
+						return {
+							kind: "unavailable",
+							message: storageFailure ?? unavailableMessage(deps.platform()),
+						};
+					}
+					const snapshot = await activeStore.getSnapshot(range);
+					assertCurrent(generation, signal);
+					return { kind: "ready", snapshot };
+				},
+				async clearAll() {
+					assertCurrent(generation, signal);
+					const activeStore = store;
+					if (!activeStore) return 0;
+					const count = await activeStore.clearAll();
+					assertCurrent(generation, signal);
+					return count;
+				},
+			};
+		}
+
+		function assertCurrent(generation: number, signal: AbortSignal): void {
+			if (generation !== sessionGeneration || signal.aborted) {
+				throw new DOMException("Analytics interaction replaced", "AbortError");
+			}
+		}
+	};
+}
+
+function modelIdentity(ctx: ExtensionContext, pi: ExtensionAPI): ModelIdentity | undefined {
+	if (!ctx.model) return undefined;
+	return {
+		provider: ctx.model.provider,
+		model: ctx.model.id,
+		thinkingLevel: pi.getThinkingLevel(),
+	};
+}
+
+export function isBuiltinReadTool(pi: ExtensionAPI): boolean {
+	const read = pi.getAllTools().find(({ name }) => name === "read");
+	return read?.sourceInfo.source === "builtin";
+}
+
+function availableSkills(
+	pi: ExtensionAPI,
+	systemSkills: ReadonlyArray<{ name: string; filePath: string }>,
+): Array<{ name: string; filePath: string }> {
+	const result = [...systemSkills];
+	const seen = new Set(result.map(({ name }) => name));
+	const getCommands = (pi as ExtensionAPI & { getCommands?: ExtensionAPI["getCommands"] })
+		.getCommands;
+	for (const command of typeof getCommands === "function" ? getCommands.call(pi) : []) {
+		if (command.source !== "skill" || seen.has(command.name.replace(/^skill:/u, ""))) continue;
+		const name = command.name.replace(/^skill:/u, "");
+		seen.add(name);
+		result.push({ name, filePath: command.sourceInfo.path });
+	}
+	return result;
+}
+
+function runtimePlatform(): string {
+	if (process.platform !== "linux") return `${process.platform}-${process.arch}`;
+	const report = process.report?.getReport() as
+		| { header?: { glibcVersionRuntime?: unknown } }
+		| undefined;
+	const glibc = report?.header?.glibcVersionRuntime;
+	return `linux-${process.arch}-${glibc ? "glibc" : "non-glibc"}`;
+}
+
+function storageFailureMessage(error: unknown, platform: string): string {
+	if (error instanceof AnalyticsDatabaseOpenError) {
+		return `${error.message}\nExisting files were not replaced. Repair or restore them before retrying.\nNo analytics are being collected.`;
+	}
+	if (error instanceof NewerSchemaError) {
+		return `${error.message}\nUpdate pi-analytics before using this database.\nNo analytics are being collected.`;
+	}
+	if (error instanceof ChecksumMismatchError) {
+		return `${error.message}\nRestore a known database backup or update pi-analytics.\nNo analytics are being collected.`;
+	}
+	if (error instanceof MigrationFailedError) {
+		return `${error.message}\nThe previous valid schema was preserved.\nNo analytics are being collected.`;
+	}
+	return unavailableMessage(platform);
+}
+
+function unavailableMessage(platform: string): string {
+	return [
+		"Analytics storage is unavailable.",
+		`Platform: ${platform}`,
+		"Supported: Linux glibc x64/arm64, macOS arm64, Windows x64.",
+		"No analytics are being collected.",
+	].join("\n");
+}
+
+function safeNotify(ctx: ExtensionContext, message: string, level: "info" | "warning"): void {
+	try {
+		ctx.ui.notify(message, level);
+	} catch {
+		// A replaced Pi context cannot receive lifecycle feedback.
+	}
+}
+
+export default createAnalyticsExtension();

--- a/experimental/pi-analytics/src/collector.ts
+++ b/experimental/pi-analytics/src/collector.ts
@@ -1,0 +1,297 @@
+import { randomUUID } from "node:crypto";
+import { classifyProviderError } from "./errors.js";
+import type {
+	GenerationOutcome,
+	GenerationRecord,
+	ModelIdentity,
+	ProviderErrorRecord,
+	RunOutcome,
+	SettledRun,
+	SkillActivationRecord,
+	ToolCallRecord,
+	TriggerSource,
+} from "./types.js";
+
+interface ActiveRun {
+	id: string;
+	startedAtMs: number;
+	triggerSource: TriggerSource;
+	initialModel?: ModelIdentity;
+	attemptCount: number;
+	generations: GenerationRecord[];
+	generationIds: Set<string>;
+	tools: ToolCallRecord[];
+	toolIds: Set<string>;
+	skills: SkillActivationRecord[];
+	skillIndexes: Map<string, number>;
+	providerErrors: ProviderErrorRecord[];
+}
+
+export class ResponseCollector {
+	private active: ActiveRun | undefined;
+
+	hasActiveRun(): boolean {
+		return this.active !== undefined;
+	}
+
+	begin(input: {
+		id: string;
+		now: number;
+		triggerSource: TriggerSource;
+		model?: ModelIdentity;
+	}): SettledRun | undefined {
+		const interrupted = this.active ? this.finalize(input.now, "interrupted") : undefined;
+		this.active = {
+			id: input.id,
+			startedAtMs: input.now,
+			triggerSource: input.triggerSource,
+			initialModel: input.model,
+			attemptCount: 0,
+			generations: [],
+			generationIds: new Set(),
+			tools: [],
+			toolIds: new Set(),
+			skills: [],
+			skillIndexes: new Map(),
+			providerErrors: [],
+		};
+		return interrupted;
+	}
+
+	beginAttempt(): void {
+		if (this.active) this.active.attemptCount += 1;
+	}
+
+	beginGeneration(input: { id: string; now: number; model?: ModelIdentity }): void {
+		const active = this.active;
+		if (!active || active.generationIds.has(input.id)) return;
+		active.generationIds.add(input.id);
+		active.generations.push({
+			id: input.id,
+			ordinal: active.generations.length,
+			provider: input.model?.provider,
+			model: input.model?.model,
+			thinkingLevel: input.model?.thinkingLevel,
+			startedAtMs: input.now,
+			outcome: "pending",
+			responses: [],
+		});
+	}
+
+	recordProviderResponse(input: { status: number; now: number }): void {
+		const generation = this.latestGeneration();
+		if (generation?.outcome !== "pending") return;
+		generation.responses.push({
+			ordinal: generation.responses.length,
+			occurredAtMs: input.now,
+			status: input.status,
+		});
+	}
+
+	finishGeneration(input: { now: number; stopReason: string; errorMessage?: string }): void {
+		const active = this.active;
+		const generation = this.latestGeneration();
+		if (!active || !generation || generation.outcome !== "pending") return;
+		generation.finishedAtMs = input.now;
+		generation.durationMs = elapsed(generation.startedAtMs, input.now);
+		generation.stopReason = input.stopReason;
+		generation.outcome = generationOutcome(input.stopReason);
+		if (generation.outcome === "error") {
+			active.providerErrors.push({
+				id: randomUUID(),
+				generationId: generation.id,
+				occurredAtMs: input.now,
+				provider: generation.provider,
+				model: generation.model,
+				category: classifyProviderError(input.errorMessage),
+				recovered: false,
+				terminal: true,
+			});
+		}
+	}
+
+	beginTool(input: { id: string; name: string; now: number; model?: ModelIdentity }): void {
+		const active = this.active;
+		if (!active || active.toolIds.has(input.id)) return;
+		active.toolIds.add(input.id);
+		active.tools.push({
+			id: input.id,
+			ordinal: active.tools.length,
+			name: input.name,
+			provider: input.model?.provider,
+			model: input.model?.model,
+			startedAtMs: input.now,
+			isError: false,
+			completionState: "running",
+		});
+	}
+
+	finishTool(input: { id: string; now: number; isError: boolean }): void {
+		const tool = this.active?.tools.find(({ id }) => id === input.id);
+		if (tool?.completionState !== "running") return;
+		tool.finishedAtMs = input.now;
+		tool.durationMs = elapsed(tool.startedAtMs, input.now);
+		tool.isError = input.isError;
+		tool.completionState = "finished";
+	}
+
+	activateSkill(input: {
+		name: string;
+		initiatedBy: "user" | "model";
+		now: number;
+		model?: ModelIdentity;
+	}): void {
+		const active = this.active;
+		if (!active) return;
+		const existingIndex = active.skillIndexes.get(input.name);
+		if (existingIndex !== undefined) {
+			const existing = active.skills[existingIndex];
+			if (existing && existing.initiatedBy === "model" && input.initiatedBy === "user") {
+				existing.initiatedBy = "user";
+				existing.occurredAtMs = input.now;
+				existing.provider = input.model?.provider;
+				existing.model = input.model?.model;
+			}
+			return;
+		}
+		active.skillIndexes.set(input.name, active.skills.length);
+		active.skills.push({
+			id: randomUUID(),
+			name: input.name,
+			initiatedBy: input.initiatedBy,
+			occurredAtMs: input.now,
+			provider: input.model?.provider,
+			model: input.model?.model,
+		});
+	}
+
+	settle(now: number): SettledRun | undefined {
+		return this.finalize(now);
+	}
+
+	interrupt(now: number): SettledRun | undefined {
+		return this.finalize(now, "interrupted");
+	}
+
+	private latestGeneration(): GenerationRecord | undefined {
+		return this.active?.generations.at(-1);
+	}
+
+	private finalize(now: number, forcedOutcome?: RunOutcome): SettledRun | undefined {
+		const active = this.active;
+		if (!active) return undefined;
+		this.active = undefined;
+
+		for (const generation of active.generations) {
+			if (generation.outcome !== "pending") continue;
+			generation.outcome = "interrupted";
+			generation.finishedAtMs = now;
+			generation.durationMs = elapsed(generation.startedAtMs, now);
+		}
+		for (const tool of active.tools) {
+			if (tool.completionState !== "running") continue;
+			tool.completionState = "interrupted";
+			tool.finishedAtMs = now;
+			tool.durationMs = elapsed(tool.startedAtMs, now);
+		}
+
+		const successfulGenerationIndexes = new Set(
+			active.generations
+				.map((generation, index) => ({ generation, index }))
+				.filter(({ generation }) => isSuccessfulGeneration(generation))
+				.map(({ index }) => index),
+		);
+		let recoveredHttpErrors = 0;
+		let httpErrors = 0;
+		for (const [generationIndex, generation] of active.generations.entries()) {
+			const hasLaterSuccess = [...successfulGenerationIndexes].some(
+				(index) => index > generationIndex,
+			);
+			for (const [responseIndex, response] of generation.responses.entries()) {
+				if (response.status < 400) continue;
+				httpErrors += 1;
+				const laterSuccessInGeneration = generation.responses
+					.slice(responseIndex + 1)
+					.some(({ status }) => status >= 200 && status < 400);
+				if (laterSuccessInGeneration || hasLaterSuccess) recoveredHttpErrors += 1;
+			}
+		}
+		for (const error of active.providerErrors) {
+			const generationIndex = active.generations.findIndex(({ id }) => id === error.generationId);
+			error.recovered = [...successfulGenerationIndexes].some((index) => index > generationIndex);
+			error.terminal = !error.recovered;
+		}
+
+		const recoveredGenerationErrors = active.providerErrors.filter(
+			({ recovered }) => recovered,
+		).length;
+		const providerErrorCount = httpErrors + active.providerErrors.length;
+		const recoveredErrorCount = recoveredHttpErrors + recoveredGenerationErrors;
+		const outcome = forcedOutcome ?? deriveOutcome(active.generations, providerErrorCount);
+
+		return {
+			id: active.id,
+			startedAtMs: active.startedAtMs,
+			finishedAtMs: now,
+			durationMs: elapsed(active.startedAtMs, now),
+			triggerSource: active.triggerSource,
+			initialProvider: active.initialModel?.provider,
+			initialModel: active.initialModel?.model,
+			outcome,
+			attemptCount: active.attemptCount,
+			generations: active.generations,
+			tools: active.tools,
+			skills: active.skills,
+			providerErrors: active.providerErrors,
+			toolErrorCount: active.tools.filter(({ isError }) => isError).length,
+			providerErrorCount,
+			recoveredErrorCount,
+		};
+	}
+}
+
+function elapsed(start: number, end: number): number {
+	return Math.max(0, end - start);
+}
+
+function generationOutcome(stopReason: string): GenerationOutcome {
+	switch (stopReason) {
+		case "stop":
+			return "stop";
+		case "toolUse":
+			return "tool_use";
+		case "error":
+			return "error";
+		case "aborted":
+			return "aborted";
+		case "length":
+			return "length";
+		default:
+			return "interrupted";
+	}
+}
+
+function isSuccessfulGeneration(generation: GenerationRecord): boolean {
+	return generation.outcome === "stop" || generation.outcome === "tool_use";
+}
+
+function deriveOutcome(
+	generations: readonly GenerationRecord[],
+	providerErrors: number,
+): RunOutcome {
+	const last = generations.at(-1);
+	if (!last) return providerErrors > 0 ? "error" : "success";
+	switch (last.outcome) {
+		case "stop":
+		case "tool_use":
+			return providerErrors > 0 ? "recovered_success" : "success";
+		case "error":
+			return "error";
+		case "aborted":
+			return "aborted";
+		case "length":
+			return "length";
+		default:
+			return "interrupted";
+	}
+}

--- a/experimental/pi-analytics/src/errors.ts
+++ b/experimental/pi-analytics/src/errors.ts
@@ -1,0 +1,16 @@
+import type { ProviderErrorCategory } from "./types.js";
+
+export function classifyProviderError(message: string | undefined): ProviderErrorCategory {
+	const value = message?.toLowerCase() ?? "";
+	if (/\b(enotfound|eai_again|dns|getaddrinfo)\b/u.test(value)) return "dns";
+	if (/\b(etimedout|timeout|timed out)\b/u.test(value)) return "timeout";
+	if (/\b(econnrefused|connection refused)\b/u.test(value)) return "connection_refused";
+	if (/\b(econnreset|connection reset|socket hang up)\b/u.test(value)) {
+		return "connection_reset";
+	}
+	if (/\b(tls|ssl|certificate|cert_|handshake)\b/u.test(value)) return "tls";
+	if (/\b(fetch failed|network|socket|connection|transport)\b/u.test(value)) {
+		return "network_other";
+	}
+	return "provider_other";
+}

--- a/experimental/pi-analytics/src/index.ts
+++ b/experimental/pi-analytics/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./analytics.js";

--- a/experimental/pi-analytics/src/menu.ts
+++ b/experimental/pi-analytics/src/menu.ts
@@ -1,0 +1,372 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
+import type {
+	AnalyticsSnapshot,
+	SkillStats,
+	TimeRange,
+	TimeRangeId,
+	ToolStats,
+} from "./storage/queries.js";
+import { resolveTimeRange } from "./storage/queries.js";
+
+export type AnalyticsLoadResult =
+	| { kind: "ready"; snapshot: AnalyticsSnapshot }
+	| { kind: "unavailable"; message: string };
+
+export interface AnalyticsMenuDataSource {
+	path: string;
+	load(range: TimeRange, signal: AbortSignal): Promise<AnalyticsLoadResult>;
+	clearAll(signal: AbortSignal): Promise<number>;
+}
+
+export interface AnalyticsMenuState {
+	rangeId: TimeRangeId;
+	range: TimeRange;
+	path: string;
+	result: AnalyticsLoadResult;
+}
+
+type Screen = "main" | "range" | "skills" | "tools" | "reliability" | "responses" | "privacy";
+type Action = "setRange" | "clearData";
+
+const RANGE_LABELS: Record<TimeRangeId, string> = {
+	today: "Today",
+	"7d": "Last 7 days",
+	"30d": "Last 30 days",
+	all: "All time",
+};
+
+export function createAnalyticsMenu(source: AnalyticsMenuDataSource, now: () => number = Date.now) {
+	let rangeId: TimeRangeId = "7d";
+	let cachedState: AnalyticsMenuState | undefined;
+	const loadState = async (signal: AbortSignal): Promise<AnalyticsMenuState> => {
+		if (cachedState?.rangeId === rangeId) return cachedState;
+		const range = resolveTimeRange(rangeId, now());
+		const loaded = { rangeId, range, path: source.path, result: await source.load(range, signal) };
+		if (!signal.aborted && rangeId === loaded.rangeId) cachedState = loaded;
+		return loaded;
+	};
+	const getState = ({ signal }: { signal: AbortSignal }): Promise<AnalyticsMenuState> =>
+		loadState(signal);
+	const menu = defineMenu<AnalyticsMenuState, Screen, Action>({
+		start: "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: `Analytics · ${RANGE_LABELS[state.rangeId]}`,
+				lines: overviewLines(state.result),
+				items: [
+					{ id: "range", label: "Change time range", to: "range" },
+					{ id: "skills", label: "Skills", to: "skills" },
+					{ id: "tools", label: "Tools", to: "tools" },
+					{ id: "reliability", label: "Provider reliability", to: "reliability" },
+					{ id: "responses", label: "Response cycles", to: "responses" },
+					{ id: "privacy", label: "Data & privacy", to: "privacy" },
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+			range: ({ state }) => ({
+				kind: "choice",
+				title: "Analytics time range",
+				items: (Object.keys(RANGE_LABELS) as TimeRangeId[]).map((id) => ({
+					id,
+					label: RANGE_LABELS[id],
+				})),
+				action: "setRange",
+				currentItemId: state.rangeId,
+				initialItemId: state.rangeId,
+				hint: "back",
+			}),
+			skills: ({ state }) => skillsScreen(state.result),
+			tools: ({ state }) => toolsScreen(state.result),
+			reliability: ({ state }) => ({
+				kind: "detail",
+				title: `Provider reliability · ${RANGE_LABELS[state.rangeId]}`,
+				lines: reliabilityLines(state.result),
+				hint: "back",
+			}),
+			responses: ({ state }) => ({
+				kind: "detail",
+				title: `Response cycles · ${RANGE_LABELS[state.rangeId]}`,
+				lines: responseLines(state.result),
+				hint: "back",
+			}),
+			privacy: ({ state }) => ({
+				kind: "actions",
+				title: "Analytics data & privacy",
+				lines: privacyLines(state),
+				items: [
+					{
+						id: "clear",
+						label: "Clear analytics data…",
+						action: "clearData",
+						disabled: state.result.kind !== "ready",
+					},
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			setRange: async ({ itemId, signal }) => {
+				if (!isRangeId(itemId)) return { kind: "rejected", error: new Error("Unknown range") };
+				rangeId = itemId;
+				cachedState = undefined;
+				await loadState(signal);
+				return signal.aborted ? { kind: "close" } : { kind: "to", screen: "main" };
+			},
+			clearData: async ({ ctx, state, signal }) => {
+				if (state.result.kind !== "ready") return { kind: "stay" };
+				const count = state.result.snapshot.overview.responseCycles;
+				const confirmed = await ctx.ui.confirm(
+					"Delete analytics data?",
+					`This will delete ${count} response cycles and their tool, skill, and reliability records from:\n\n${state.path}\n\nOther running Pi processes may add new records afterward.`,
+					{ signal },
+				);
+				if (!confirmed || signal.aborted) return { kind: "stay" };
+				const deleted = await source.clearAll(signal);
+				cachedState = undefined;
+				try {
+					ctx.ui.notify(`Deleted ${deleted} response cycles from local analytics.`, "info");
+				} catch {
+					// Session replacement can invalidate the UI after the database commit.
+				}
+				return signal.aborted ? { kind: "close" } : { kind: "to", screen: "main" };
+			},
+		},
+	});
+	return {
+		menu,
+		getState,
+		preload: (signal: AbortSignal) => loadState(signal),
+		get rangeId() {
+			return rangeId;
+		},
+	};
+}
+
+export async function showAnalyticsMenu(
+	ctx: ExtensionCommandContext,
+	source: AnalyticsMenuDataSource,
+	options: { signal: AbortSignal; isCurrent: () => boolean },
+): Promise<void> {
+	const controller = createAnalyticsMenu(source);
+	const loading = await runTask(ctx, {
+		label: "Loading local analytics…",
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		task: ({ signal }) => controller.preload(signal),
+		onError: () => undefined,
+	});
+	if (loading.kind !== "completed") {
+		if (loading.kind === "error") {
+			ctx.ui.notify(
+				"Analytics failed: The local analytics query could not be completed. Existing data was not changed.",
+				"error",
+			);
+		}
+		return;
+	}
+	await runMenu(ctx, controller.menu, {
+		getState: controller.getState,
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onError: (_ctx, error) => {
+			ctx.ui.notify(`Analytics failed: ${safeErrorMessage(error)}`, "error");
+		},
+	});
+}
+
+function overviewLines(result: AnalyticsLoadResult): string[] {
+	if (result.kind === "unavailable") {
+		return [result.message, "", "No analytics are being collected."];
+	}
+	const stats = result.snapshot.overview;
+	if (stats.responseCycles === 0) {
+		return [
+			"No analytics yet.",
+			"Collection is active. Complete one Pi response cycle, then open /analytics again.",
+			"",
+			"Includes settled response cycles only.",
+		];
+	}
+	return [
+		metric("Response cycles", stats.responseCycles),
+		metric("LLM calls", stats.llmCalls),
+		metric(
+			"Calls per response",
+			`${formatDecimal(stats.callsPerResponse)} · P95 ${stats.p95CallsPerResponse}`,
+		),
+		metric("Tool calls", stats.toolCalls),
+		metric("Tool errors", stats.toolErrors),
+		metric("Skill activations", stats.skillActivations),
+		metric("Provider errors", stats.providerErrors),
+		metric("Recovered errors", stats.recoveredErrors),
+		"",
+		"Includes settled response cycles only.",
+	];
+}
+
+function skillsScreen(result: AnalyticsLoadResult) {
+	if (result.kind === "unavailable") {
+		return {
+			kind: "browse" as const,
+			title: "Skills",
+			lines: [result.message],
+			items: [],
+			hint: "back" as const,
+		};
+	}
+	return {
+		kind: "browse" as const,
+		title: "Skills",
+		lines:
+			result.snapshot.skills.length === 0
+				? ["No skill activations detected in this time range."]
+				: undefined,
+		items: result.snapshot.skills.map(skillItem),
+		viewportSize: "adaptive" as const,
+		hint: "back" as const,
+	};
+}
+
+function skillItem(skill: SkillStats) {
+	return {
+		id: skill.name,
+		label: skill.name,
+		statusText: `${skill.count} · ${skill.modelInitiated} model / ${skill.userInitiated} user`,
+		searchText: skill.models.map(modelLabel).join(" "),
+		details: [
+			metric("Activations", skill.count),
+			metric("Model initiated", skill.modelInitiated),
+			metric("User initiated", skill.userInitiated),
+			"",
+			"By model",
+			...skill.models.map((model) => `${modelLabel(model)}: ${model.count}`),
+			"",
+			`Last detected: ${formatTimestamp(skill.lastOccurredAtMs)}`,
+		],
+	};
+}
+
+function toolsScreen(result: AnalyticsLoadResult) {
+	if (result.kind === "unavailable") {
+		return {
+			kind: "browse" as const,
+			title: "Tools",
+			lines: [result.message],
+			items: [],
+			hint: "back" as const,
+		};
+	}
+	return {
+		kind: "browse" as const,
+		title: "Tools",
+		lines:
+			result.snapshot.tools.length === 0
+				? ["No tool calls detected in this time range."]
+				: undefined,
+		items: result.snapshot.tools.map(toolItem),
+		viewportSize: "adaptive" as const,
+		hint: "back" as const,
+	};
+}
+
+function toolItem(tool: ToolStats) {
+	return {
+		id: tool.name,
+		label: tool.name,
+		statusText: `${tool.count} · ${tool.errors} errors`,
+		searchText: tool.models.map(modelLabel).join(" "),
+		details: [
+			metric("Calls", tool.count),
+			metric("Errors", tool.errors),
+			`Average duration: ${formatDecimal(tool.averageDurationMs)} ms`,
+			"",
+			"By model",
+			...tool.models.map((model) => `${modelLabel(model)}: ${model.count}`),
+			"",
+			`Last detected: ${formatTimestamp(tool.lastOccurredAtMs)}`,
+		],
+	};
+}
+
+function reliabilityLines(result: AnalyticsLoadResult): string[] {
+	if (result.kind === "unavailable") return [result.message];
+	const value = result.snapshot.reliability;
+	return [
+		"Observed provider errors only; provider-internal failures may be invisible.",
+		"",
+		metric("HTTP 429", value.http429),
+		metric("HTTP 5xx", value.http5xx),
+		metric("DNS", value.categories.dns),
+		metric("Connection timeout", value.categories.timeout),
+		metric("Connection refused", value.categories.connection_refused),
+		metric("Connection reset", value.categories.connection_reset),
+		metric("TLS", value.categories.tls),
+		metric("Other network", value.categories.network_other),
+		metric("Other provider", value.categories.provider_other),
+		"",
+		metric("Recovered", value.recovered),
+		metric("Terminal failures", value.terminal),
+	];
+}
+
+function responseLines(result: AnalyticsLoadResult): string[] {
+	if (result.kind === "unavailable") return [result.message];
+	const value = result.snapshot.responses;
+	return [
+		metric("Cycles", value.count),
+		metric("LLM calls", value.llmCalls),
+		metric("Average", formatDecimal(value.average)),
+		metric("Median", formatDecimal(value.median)),
+		metric("P95", value.p95),
+		metric("Maximum", value.maximum),
+		"",
+		"Calls per response",
+		metric("1 call", value.distribution.one),
+		metric("2–3 calls", value.distribution.twoToThree),
+		metric("4–6 calls", value.distribution.fourToSix),
+		metric("7+ calls", value.distribution.sevenPlus),
+	];
+}
+
+function privacyLines(state: AnalyticsMenuState): string[] {
+	return [
+		"Local database:",
+		state.path,
+		"",
+		"Stored: timestamps, model/provider IDs, thinking level, tool and skill names, durations, counts, HTTP statuses, and classified errors.",
+		"Not stored: prompts, responses, thinking, tool arguments/results, raw errors, headers, cwd/file paths, session identity, or credentials.",
+		"",
+		"No Turso Cloud connection or other remote telemetry is used.",
+		"Turso Database is pre-1.0; analytics are non-critical derived metadata.",
+	];
+}
+
+function metric(label: string, value: string | number): string {
+	return `${label.padEnd(24)} ${value}`;
+}
+
+function formatDecimal(value: number): string {
+	return Number.isInteger(value)
+		? String(value)
+		: value.toFixed(2).replace(/0+$/u, "").replace(/\.$/u, "");
+}
+
+function formatTimestamp(value: number): string {
+	return new Date(value).toLocaleString();
+}
+
+function modelLabel(model: { provider?: string; model?: string }): string {
+	if (!model.provider && !model.model) return "unknown";
+	return `${model.provider ?? "unknown"}/${model.model ?? "unknown"}`;
+}
+
+function isRangeId(value: string): value is TimeRangeId {
+	return value === "today" || value === "7d" || value === "30d" || value === "all";
+}
+
+function safeErrorMessage(_error: unknown): string {
+	return "The local analytics query could not be completed. Try again; existing data was not changed.";
+}

--- a/experimental/pi-analytics/src/skills.ts
+++ b/experimental/pi-analytics/src/skills.ts
@@ -1,0 +1,83 @@
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+import type { InputSource } from "@earendil-works/pi-coding-agent";
+
+export interface AvailableSkill {
+	name: string;
+	filePath: string;
+}
+
+export interface PendingExplicitSkill {
+	name: string;
+	observedAtMs: number;
+	source: "interactive" | "rpc";
+}
+
+export function explicitSkillName(text: string): string | undefined {
+	return text.match(/^\/skill:([a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)(?:\s|$)/u)?.[1];
+}
+
+export class SkillTracker {
+	private pending: PendingExplicitSkill | undefined;
+	private readonly skillByPath = new Map<string, string>();
+	private readonly availableNames = new Set<string>();
+
+	constructor(private readonly cwd: string) {}
+
+	observeInput(text: string, source: InputSource, now: number): void {
+		if (source === "extension") return;
+		const name = explicitSkillName(text);
+		this.pending = name ? { name, observedAtMs: now, source } : undefined;
+	}
+
+	consumeExplicitSkill(): PendingExplicitSkill | undefined {
+		const pending = this.pending;
+		this.pending = undefined;
+		return pending;
+	}
+
+	clearPending(): void {
+		this.pending = undefined;
+	}
+
+	hasAvailableSkill(name: string): boolean {
+		return this.availableNames.has(name);
+	}
+
+	async setAvailableSkills(skills: readonly AvailableSkill[]): Promise<void> {
+		this.skillByPath.clear();
+		this.availableNames.clear();
+		const seenNames = new Set<string>();
+		for (const skill of skills) {
+			if (seenNames.has(skill.name)) continue;
+			seenNames.add(skill.name);
+			this.availableNames.add(skill.name);
+			const canonical = await canonicalPath(skill.filePath).catch(() =>
+				path.resolve(this.cwd, skill.filePath),
+			);
+			this.skillByPath.set(canonical, skill.name);
+		}
+	}
+
+	async matchSuccessfulRead(input: {
+		toolName: string;
+		input: unknown;
+		isError: boolean;
+	}): Promise<string | undefined> {
+		if (input.toolName !== "read" || input.isError || !isRecord(input.input)) return undefined;
+		const rawPath = input.input.path;
+		if (typeof rawPath !== "string" || rawPath.length === 0) return undefined;
+		const normalized = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
+		const absolute = path.resolve(this.cwd, normalized);
+		const canonical = await canonicalPath(absolute).catch(() => absolute);
+		return this.skillByPath.get(canonical);
+	}
+}
+
+function canonicalPath(filePath: string): Promise<string> {
+	return realpath(filePath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/experimental/pi-analytics/src/storage/database.ts
+++ b/experimental/pi-analytics/src/storage/database.ts
@@ -1,0 +1,126 @@
+import { chmod, lstat, mkdir, open } from "node:fs/promises";
+import path from "node:path";
+import type { Database } from "@tursodatabase/database";
+import {
+	ChecksumMismatchError,
+	MigrationFailedError,
+	migrateDatabase,
+	NewerSchemaError,
+} from "./migrations.js";
+
+export interface TursoModule {
+	connect(
+		path: string,
+		options?: { timeout?: number; defaultQueryTimeout?: number },
+	): Promise<Database>;
+}
+
+export class AnalyticsStorageUnavailableError extends Error {
+	constructor(cause: unknown) {
+		super("Local analytics storage is unavailable on this runtime.", { cause });
+		this.name = "AnalyticsStorageUnavailableError";
+	}
+}
+
+export class AnalyticsDatabaseOpenError extends Error {
+	constructor(cause: unknown) {
+		super("The local analytics database could not be opened safely.", { cause });
+		this.name = "AnalyticsDatabaseOpenError";
+	}
+}
+
+export interface OpenedAnalyticsDatabase {
+	readonly connection: Database;
+	readonly path: string;
+	close(): Promise<void>;
+}
+
+export async function openAnalyticsDatabase(options: {
+	path: string;
+	loadModule?: () => Promise<TursoModule>;
+	connectionTimeoutMs?: number;
+	queryTimeoutMs?: number;
+}): Promise<OpenedAnalyticsDatabase> {
+	const loadModule = options.loadModule ?? defaultModuleLoader;
+	let module: TursoModule;
+	try {
+		module = await loadModule();
+	} catch (error) {
+		throw new AnalyticsStorageUnavailableError(error);
+	}
+
+	let database: Database | undefined;
+	try {
+		await mkdir(path.dirname(options.path), { recursive: true, mode: 0o700 });
+		await preparePrivateFile(options.path);
+		await preparePrivateFile(`${options.path}-wal`);
+		database = await module.connect(options.path, {
+			timeout: options.connectionTimeoutMs ?? 5_000,
+			defaultQueryTimeout: options.queryTimeoutMs ?? 5_000,
+		});
+		await migrateDatabase(database);
+		await protectDatabaseFiles(options.path);
+		let closed = false;
+		return {
+			connection: database,
+			path: options.path,
+			async close() {
+				if (closed) return;
+				closed = true;
+				await database?.close();
+			},
+		};
+	} catch (error) {
+		await database?.close().catch(() => undefined);
+		if (isMigrationError(error)) throw error;
+		throw new AnalyticsDatabaseOpenError(error);
+	}
+}
+
+async function protectDatabaseFiles(databasePath: string): Promise<void> {
+	for (const filePath of [databasePath, `${databasePath}-wal`, `${databasePath}-shm`]) {
+		await preparePrivateFile(filePath, filePath.endsWith("-shm"));
+	}
+}
+
+async function preparePrivateFile(filePath: string, optional = false): Promise<void> {
+	if (optional) {
+		try {
+			await lstat(filePath);
+		} catch (error) {
+			if (isNodeError(error) && error.code === "ENOENT") return;
+			throw error;
+		}
+	} else {
+		try {
+			const handle = await open(filePath, "wx", 0o600);
+			await handle.close();
+		} catch (error) {
+			if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+		}
+	}
+	const metadata = await lstat(filePath);
+	if (!metadata.isFile() || metadata.isSymbolicLink()) {
+		throw new Error("Analytics database files must be regular files, not links.");
+	}
+	if (process.platform !== "win32") await chmod(filePath, 0o600);
+}
+
+function isMigrationError(
+	error: unknown,
+): error is ChecksumMismatchError | MigrationFailedError | NewerSchemaError {
+	return (
+		error instanceof ChecksumMismatchError ||
+		error instanceof MigrationFailedError ||
+		error instanceof NewerSchemaError
+	);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+async function defaultModuleLoader(): Promise<TursoModule> {
+	const specifier = "@tursodatabase/database";
+	return import(specifier);
+}

--- a/experimental/pi-analytics/src/storage/migrations.ts
+++ b/experimental/pi-analytics/src/storage/migrations.ts
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+import type { Database, Transaction } from "@tursodatabase/database";
+
+export interface SchemaMigration {
+	version: number;
+	name: string;
+	statements: readonly string[];
+}
+
+export class ChecksumMismatchError extends Error {
+	constructor(version: number) {
+		super(`Analytics migration v${version} no longer matches its applied checksum.`);
+		this.name = "ChecksumMismatchError";
+	}
+}
+
+export class MigrationFailedError extends Error {
+	readonly version: number;
+	readonly migrationName: string;
+
+	constructor(migration: SchemaMigration, cause: unknown) {
+		super(`Analytics migration v${migration.version} (${migration.name}) failed.`, { cause });
+		this.name = "MigrationFailedError";
+		this.version = migration.version;
+		this.migrationName = migration.name;
+	}
+}
+
+export class NewerSchemaError extends Error {
+	constructor(databaseVersion: number, supportedVersion: number) {
+		super(
+			`Analytics database schema v${databaseVersion} is newer than supported v${supportedVersion}.`,
+		);
+		this.name = "NewerSchemaError";
+	}
+}
+
+const CREATE_MIGRATIONS_TABLE = `
+CREATE TABLE IF NOT EXISTS schema_migrations (
+	version INTEGER PRIMARY KEY,
+	name TEXT NOT NULL,
+	checksum TEXT NOT NULL,
+	applied_at_ms INTEGER NOT NULL
+)`;
+
+export const ANALYTICS_MIGRATIONS: readonly SchemaMigration[] = [
+	{
+		version: 1,
+		name: "initial-analytics-schema",
+		statements: [
+			`CREATE TABLE response_runs (
+				id TEXT PRIMARY KEY,
+				started_at_ms INTEGER NOT NULL,
+				finished_at_ms INTEGER NOT NULL,
+				duration_ms INTEGER NOT NULL,
+				trigger_source TEXT NOT NULL,
+				initial_provider TEXT,
+				initial_model TEXT,
+				outcome TEXT NOT NULL,
+				attempt_count INTEGER NOT NULL,
+				generation_count INTEGER NOT NULL,
+				tool_call_count INTEGER NOT NULL,
+				tool_error_count INTEGER NOT NULL,
+				skill_activation_count INTEGER NOT NULL,
+				provider_error_count INTEGER NOT NULL,
+				recovered_error_count INTEGER NOT NULL
+			)`,
+			`CREATE TABLE model_generations (
+				id TEXT PRIMARY KEY,
+				run_id TEXT NOT NULL,
+				ordinal INTEGER NOT NULL,
+				provider TEXT,
+				model TEXT,
+				thinking_level TEXT,
+				started_at_ms INTEGER NOT NULL,
+				finished_at_ms INTEGER,
+				duration_ms INTEGER,
+				stop_reason TEXT,
+				outcome TEXT NOT NULL,
+				UNIQUE(run_id, ordinal)
+			)`,
+			`CREATE TABLE provider_responses (
+				generation_id TEXT NOT NULL,
+				ordinal INTEGER NOT NULL,
+				occurred_at_ms INTEGER NOT NULL,
+				status INTEGER NOT NULL,
+				PRIMARY KEY(generation_id, ordinal)
+			)`,
+			`CREATE TABLE provider_errors (
+				id TEXT PRIMARY KEY,
+				run_id TEXT NOT NULL,
+				generation_id TEXT,
+				occurred_at_ms INTEGER NOT NULL,
+				provider TEXT,
+				model TEXT,
+				category TEXT NOT NULL,
+				recovered INTEGER NOT NULL,
+				terminal INTEGER NOT NULL
+			)`,
+			`CREATE TABLE tool_calls (
+				id TEXT PRIMARY KEY,
+				run_id TEXT NOT NULL,
+				ordinal INTEGER NOT NULL,
+				tool_name TEXT NOT NULL,
+				provider TEXT,
+				model TEXT,
+				started_at_ms INTEGER NOT NULL,
+				finished_at_ms INTEGER,
+				duration_ms INTEGER,
+				is_error INTEGER NOT NULL,
+				completion_state TEXT NOT NULL,
+				UNIQUE(run_id, ordinal)
+			)`,
+			`CREATE TABLE skill_activations (
+				id TEXT PRIMARY KEY,
+				run_id TEXT NOT NULL,
+				occurred_at_ms INTEGER NOT NULL,
+				skill_name TEXT NOT NULL,
+				initiated_by TEXT NOT NULL,
+				provider TEXT,
+				model TEXT,
+				UNIQUE(run_id, skill_name)
+			)`,
+			"CREATE INDEX response_runs_by_time ON response_runs(started_at_ms)",
+			"CREATE INDEX generations_by_model_time ON model_generations(provider, model, started_at_ms)",
+			"CREATE INDEX tools_by_name_time ON tool_calls(tool_name, started_at_ms)",
+			"CREATE INDEX skills_by_name_time ON skill_activations(skill_name, occurred_at_ms)",
+			"CREATE INDEX skills_by_model_time ON skill_activations(provider, model, occurred_at_ms)",
+			"CREATE INDEX provider_errors_by_category_time ON provider_errors(category, occurred_at_ms)",
+			"CREATE INDEX provider_responses_by_time ON provider_responses(occurred_at_ms)",
+		],
+	},
+];
+
+export async function migrateDatabase(
+	database: Database,
+	options: {
+		migrations?: readonly SchemaMigration[];
+		retryAttempts?: number;
+		retryDelayMs?: number;
+	} = {},
+): Promise<void> {
+	const migrations = options.migrations ?? ANALYTICS_MIGRATIONS;
+	validateRegistry(migrations);
+	const attempts = options.retryAttempts ?? 8;
+	const retryDelayMs = options.retryDelayMs ?? 10;
+	await withConflictRetry(() => database.exec(CREATE_MIGRATIONS_TABLE), attempts, retryDelayMs);
+	await withConflictRetry(() => applyMigrations(database, migrations), attempts, retryDelayMs);
+}
+
+function applyMigrations(
+	database: Database,
+	migrations: readonly SchemaMigration[],
+): Promise<void> {
+	const apply = database.transactionAsync(async (transaction) => {
+		const applied = (await transaction.all(
+			"SELECT version, name, checksum FROM schema_migrations ORDER BY version",
+		)) as Array<{ version: number; name: string; checksum: string }>;
+		const supportedVersion = migrations.at(-1)?.version ?? 0;
+		const databaseVersion = applied.at(-1)?.version ?? 0;
+		if (databaseVersion > supportedVersion) {
+			throw new NewerSchemaError(databaseVersion, supportedVersion);
+		}
+		for (const [index, row] of applied.entries()) {
+			const migration = migrations[index];
+			if (!migration || row.version !== migration.version) {
+				throw new Error("Analytics migration history is not contiguous.");
+			}
+			if (row.name !== migration.name || row.checksum !== migrationChecksum(migration)) {
+				throw new ChecksumMismatchError(row.version);
+			}
+		}
+		for (const migration of migrations.slice(applied.length)) {
+			await applyOne(transaction, migration);
+		}
+	});
+	return apply.exclusive();
+}
+
+async function applyOne(transaction: Transaction, migration: SchemaMigration): Promise<void> {
+	try {
+		for (const statement of migration.statements) await transaction.exec(statement);
+		await transaction.run(
+			"INSERT INTO schema_migrations(version, name, checksum, applied_at_ms) VALUES (?, ?, ?, ?)",
+			migration.version,
+			migration.name,
+			migrationChecksum(migration),
+			Date.now(),
+		);
+	} catch (error) {
+		throw new MigrationFailedError(migration, error);
+	}
+}
+
+export function migrationChecksum(migration: SchemaMigration): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify({
+				version: migration.version,
+				name: migration.name,
+				statements: migration.statements,
+			}),
+		)
+		.digest("hex");
+}
+
+function validateRegistry(migrations: readonly SchemaMigration[]): void {
+	for (const [index, migration] of migrations.entries()) {
+		const expected = index + 1;
+		if (migration.version !== expected) {
+			throw new Error(
+				`Analytics migration versions must be contiguous; expected v${expected}, received v${migration.version}.`,
+			);
+		}
+		if (!migration.name.trim()) throw new Error(`Analytics migration v${expected} has no name.`);
+		if (migration.statements.length === 0) {
+			throw new Error(`Analytics migration v${expected} has no statements.`);
+		}
+	}
+}
+
+async function withConflictRetry<T>(
+	operation: () => Promise<T>,
+	attempts: number,
+	delayMs: number,
+): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < Math.max(1, attempts); attempt += 1) {
+		try {
+			return await operation();
+		} catch (error) {
+			lastError = error;
+			if (!isTransactionConflict(error) || attempt + 1 >= attempts) throw error;
+			await delay(delayMs * (attempt + 1));
+		}
+	}
+	throw lastError;
+}
+
+function isTransactionConflict(error: unknown): boolean {
+	const message =
+		error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+	if (
+		message.includes("statement was interrupted") ||
+		message.includes("database is locked") ||
+		message.includes("database is busy")
+	) {
+		return true;
+	}
+	return error instanceof Error && error.cause !== undefined
+		? isTransactionConflict(error.cause)
+		: false;
+}
+
+function delay(milliseconds: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, Math.max(0, milliseconds)));
+}

--- a/experimental/pi-analytics/src/storage/queries.ts
+++ b/experimental/pi-analytics/src/storage/queries.ts
@@ -1,0 +1,313 @@
+import type { Database } from "@tursodatabase/database";
+import type { ProviderErrorCategory } from "../types.js";
+
+export type TimeRangeId = "today" | "7d" | "30d" | "all";
+export interface TimeRange {
+	id?: TimeRangeId;
+	fromMs: number;
+	toMs: number;
+}
+
+export interface OverviewStats {
+	responseCycles: number;
+	llmCalls: number;
+	callsPerResponse: number;
+	p95CallsPerResponse: number;
+	toolCalls: number;
+	toolErrors: number;
+	skillActivations: number;
+	providerErrors: number;
+	recoveredErrors: number;
+}
+
+export interface ModelCount {
+	provider?: string;
+	model?: string;
+	count: number;
+}
+
+export interface SkillStats {
+	name: string;
+	count: number;
+	modelInitiated: number;
+	userInitiated: number;
+	lastOccurredAtMs: number;
+	models: ModelCount[];
+}
+
+export interface ToolStats {
+	name: string;
+	count: number;
+	errors: number;
+	averageDurationMs: number;
+	lastOccurredAtMs: number;
+	models: ModelCount[];
+}
+
+export interface ReliabilityStats {
+	http429: number;
+	http5xx: number;
+	recovered: number;
+	terminal: number;
+	categories: Record<ProviderErrorCategory, number>;
+}
+
+export interface ResponseStats {
+	count: number;
+	llmCalls: number;
+	average: number;
+	median: number;
+	p95: number;
+	maximum: number;
+	distribution: { one: number; twoToThree: number; fourToSix: number; sevenPlus: number };
+}
+
+export interface AnalyticsSnapshot {
+	overview: OverviewStats;
+	skills: SkillStats[];
+	tools: ToolStats[];
+	reliability: ReliabilityStats;
+	responses: ResponseStats;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const ERROR_CATEGORIES: readonly ProviderErrorCategory[] = [
+	"dns",
+	"timeout",
+	"connection_refused",
+	"connection_reset",
+	"tls",
+	"network_other",
+	"provider_other",
+];
+
+export function resolveTimeRange(id: TimeRangeId, now = Date.now()): TimeRange {
+	let fromMs = 0;
+	if (id === "today") {
+		const date = new Date(now);
+		fromMs = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+	} else if (id === "7d") fromMs = now - 7 * DAY_MS;
+	else if (id === "30d") fromMs = now - 30 * DAY_MS;
+	return { id, fromMs, toMs: now + 1 };
+}
+
+export async function querySnapshot(
+	database: Database,
+	range: TimeRange,
+): Promise<AnalyticsSnapshot> {
+	const [runs, skillRows, toolRows, categoryRows, statusRows] = await Promise.all([
+		database.all(
+			`SELECT generation_count, tool_call_count, tool_error_count,
+			        skill_activation_count, provider_error_count, recovered_error_count
+			 FROM response_runs
+			 WHERE started_at_ms >= ? AND started_at_ms < ?
+			 ORDER BY generation_count`,
+			range.fromMs,
+			range.toMs,
+		),
+		database.all(
+			`SELECT s.skill_name, s.initiated_by, s.provider, s.model,
+			        COUNT(*) AS count, MAX(s.occurred_at_ms) AS last_at
+			 FROM skill_activations s
+			 JOIN response_runs r ON r.id = s.run_id
+			 WHERE r.started_at_ms >= ? AND r.started_at_ms < ?
+			 GROUP BY s.skill_name, s.initiated_by, s.provider, s.model`,
+			range.fromMs,
+			range.toMs,
+		),
+		database.all(
+			`SELECT t.tool_name, t.provider, t.model, COUNT(*) AS count,
+			        SUM(t.is_error) AS errors, AVG(COALESCE(t.duration_ms, 0)) AS average_duration,
+			        MAX(t.started_at_ms) AS last_at
+			 FROM tool_calls t
+			 JOIN response_runs r ON r.id = t.run_id
+			 WHERE r.started_at_ms >= ? AND r.started_at_ms < ?
+			 GROUP BY t.tool_name, t.provider, t.model`,
+			range.fromMs,
+			range.toMs,
+		),
+		database.all(
+			`SELECT e.category, COUNT(*) AS count, SUM(e.terminal) AS terminal
+			 FROM provider_errors e
+			 JOIN response_runs r ON r.id = e.run_id
+			 WHERE r.started_at_ms >= ? AND r.started_at_ms < ?
+			 GROUP BY e.category`,
+			range.fromMs,
+			range.toMs,
+		),
+		database.all(
+			`SELECT p.status, COUNT(*) AS count
+			 FROM provider_responses p
+			 JOIN model_generations g ON g.id = p.generation_id
+			 JOIN response_runs r ON r.id = g.run_id
+			 WHERE r.started_at_ms >= ? AND r.started_at_ms < ?
+			 GROUP BY p.status`,
+			range.fromMs,
+			range.toMs,
+		),
+	]);
+
+	const generationCounts = runs.map((row) => numberValue(row.generation_count));
+	const responseStats = responseStatistics(generationCounts);
+	const overview: OverviewStats = {
+		responseCycles: runs.length,
+		llmCalls: sum(generationCounts),
+		callsPerResponse: responseStats.average,
+		p95CallsPerResponse: responseStats.p95,
+		toolCalls: sum(runs.map((row) => numberValue(row.tool_call_count))),
+		toolErrors: sum(runs.map((row) => numberValue(row.tool_error_count))),
+		skillActivations: sum(runs.map((row) => numberValue(row.skill_activation_count))),
+		providerErrors: sum(runs.map((row) => numberValue(row.provider_error_count))),
+		recoveredErrors: sum(runs.map((row) => numberValue(row.recovered_error_count))),
+	};
+
+	const categories = Object.fromEntries(
+		ERROR_CATEGORIES.map((category) => [category, 0]),
+	) as Record<ProviderErrorCategory, number>;
+	let terminal = 0;
+	for (const row of categoryRows) {
+		const category = String(row.category) as ProviderErrorCategory;
+		if (category in categories) categories[category] = numberValue(row.count);
+		terminal += numberValue(row.terminal);
+	}
+	let http429 = 0;
+	let http5xx = 0;
+	for (const row of statusRows) {
+		const status = numberValue(row.status);
+		if (status === 429) http429 += numberValue(row.count);
+		if (status >= 500 && status < 600) http5xx += numberValue(row.count);
+	}
+
+	return {
+		overview,
+		skills: foldSkills(skillRows),
+		tools: foldTools(toolRows),
+		reliability: {
+			http429,
+			http5xx,
+			recovered: overview.recoveredErrors,
+			terminal,
+			categories,
+		},
+		responses: responseStats,
+	};
+}
+
+function foldSkills(rows: Array<Record<string, unknown>>): SkillStats[] {
+	const result = new Map<string, SkillStats>();
+	for (const row of rows) {
+		const name = String(row.skill_name);
+		const count = numberValue(row.count);
+		const item = result.get(name) ?? {
+			name,
+			count: 0,
+			modelInitiated: 0,
+			userInitiated: 0,
+			lastOccurredAtMs: 0,
+			models: [],
+		};
+		item.count += count;
+		if (row.initiated_by === "user") item.userInitiated += count;
+		else item.modelInitiated += count;
+		item.lastOccurredAtMs = Math.max(item.lastOccurredAtMs, numberValue(row.last_at));
+		mergeModelCount(item.models, {
+			provider: optionalString(row.provider),
+			model: optionalString(row.model),
+			count,
+		});
+		result.set(name, item);
+	}
+	return [...result.values()]
+		.map((item) => ({ ...item, models: sortModels(item.models) }))
+		.sort((left, right) => right.count - left.count || left.name.localeCompare(right.name));
+}
+
+function foldTools(rows: Array<Record<string, unknown>>): ToolStats[] {
+	const result = new Map<string, ToolStats & { weightedDuration: number }>();
+	for (const row of rows) {
+		const name = String(row.tool_name);
+		const count = numberValue(row.count);
+		const average = numberValue(row.average_duration);
+		const item = result.get(name) ?? {
+			name,
+			count: 0,
+			errors: 0,
+			averageDurationMs: 0,
+			weightedDuration: 0,
+			lastOccurredAtMs: 0,
+			models: [],
+		};
+		item.count += count;
+		item.errors += numberValue(row.errors);
+		item.weightedDuration += average * count;
+		item.averageDurationMs = item.count > 0 ? item.weightedDuration / item.count : 0;
+		item.lastOccurredAtMs = Math.max(item.lastOccurredAtMs, numberValue(row.last_at));
+		mergeModelCount(item.models, {
+			provider: optionalString(row.provider),
+			model: optionalString(row.model),
+			count,
+		});
+		result.set(name, item);
+	}
+	return [...result.values()]
+		.map(({ weightedDuration: _, ...item }) => ({ ...item, models: sortModels(item.models) }))
+		.sort((left, right) => right.count - left.count || left.name.localeCompare(right.name));
+}
+
+function responseStatistics(generationCounts: number[]): ResponseStats {
+	const sorted = [...generationCounts].sort((left, right) => left - right);
+	const count = sorted.length;
+	const llmCalls = sum(sorted);
+	const nearestRank = (percentile: number) =>
+		count === 0 ? 0 : (sorted[Math.max(0, Math.ceil(percentile * count) - 1)] ?? 0);
+	const median =
+		count === 0
+			? 0
+			: count % 2 === 1
+				? (sorted[Math.floor(count / 2)] ?? 0)
+				: ((sorted[count / 2 - 1] ?? 0) + (sorted[count / 2] ?? 0)) / 2;
+	return {
+		count,
+		llmCalls,
+		average: count > 0 ? llmCalls / count : 0,
+		median,
+		p95: nearestRank(0.95),
+		maximum: sorted.at(-1) ?? 0,
+		distribution: {
+			one: sorted.filter((value) => value === 1).length,
+			twoToThree: sorted.filter((value) => value >= 2 && value <= 3).length,
+			fourToSix: sorted.filter((value) => value >= 4 && value <= 6).length,
+			sevenPlus: sorted.filter((value) => value >= 7).length,
+		},
+	};
+}
+
+function mergeModelCount(models: ModelCount[], next: ModelCount): void {
+	const existing = models.find(
+		({ provider, model }) => provider === next.provider && model === next.model,
+	);
+	if (existing) existing.count += next.count;
+	else models.push(next);
+}
+
+function sortModels(models: ModelCount[]): ModelCount[] {
+	return models.sort(
+		(left, right) =>
+			right.count - left.count ||
+			`${left.provider ?? ""}/${left.model ?? ""}`.localeCompare(
+				`${right.provider ?? ""}/${right.model ?? ""}`,
+			),
+	);
+}
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : Number(value) || 0;
+}
+
+function sum(values: readonly number[]): number {
+	return values.reduce((total, value) => total + value, 0);
+}

--- a/experimental/pi-analytics/src/storage/store.ts
+++ b/experimental/pi-analytics/src/storage/store.ts
@@ -1,0 +1,249 @@
+import type { Database, Transaction } from "@tursodatabase/database";
+import type { SettledRun } from "../types.js";
+import type { OpenedAnalyticsDatabase } from "./database.js";
+import type { AnalyticsSnapshot, TimeRange } from "./queries.js";
+import { querySnapshot } from "./queries.js";
+
+const MAX_PENDING_RUNS = 100;
+const WRITE_ATTEMPTS = 6;
+
+export class AnalyticsStore {
+	private readonly pending: SettledRun[] = [];
+	private readonly activeQueries = new Set<Promise<unknown>>();
+	private readonly query: typeof querySnapshot;
+	private mutationTail: Promise<void> = Promise.resolve();
+	private closed = false;
+	private closePromise: Promise<void> | undefined;
+
+	constructor(
+		private readonly opened: OpenedAnalyticsDatabase,
+		dependencies: { querySnapshot?: typeof querySnapshot } = {},
+	) {
+		this.query = dependencies.querySnapshot ?? querySnapshot;
+	}
+
+	get path(): string {
+		return this.opened.path;
+	}
+
+	recordRun(run: SettledRun): Promise<void> {
+		if (this.closed) return Promise.reject(new Error("Analytics store is closed."));
+		if (this.pending.length >= MAX_PENDING_RUNS) this.pending.shift();
+		this.pending.push(run);
+		return this.enqueueMutation(() => this.flushPending());
+	}
+
+	getSnapshot(range: TimeRange): Promise<AnalyticsSnapshot> {
+		if (this.closed) return Promise.reject(new Error("Analytics store is closed."));
+		const query = (async () => {
+			await this.mutationTail;
+			return this.query(this.opened.connection, range);
+		})();
+		this.activeQueries.add(query);
+		void query.finally(() => this.activeQueries.delete(query)).catch(() => undefined);
+		return query;
+	}
+
+	clearAll(): Promise<number> {
+		if (this.closed) return Promise.reject(new Error("Analytics store is closed."));
+		let deleted = 0;
+		return this.enqueueMutation(async () => {
+			await withWriteRetry(async () => {
+				const transaction = this.opened.connection.transactionAsync(async (tx) => {
+					const row = (await tx.get("SELECT COUNT(*) AS count FROM response_runs")) as {
+						count?: number;
+					};
+					deleted = Number(row?.count ?? 0);
+					for (const table of [
+						"provider_responses",
+						"provider_errors",
+						"tool_calls",
+						"skill_activations",
+						"model_generations",
+						"response_runs",
+					]) {
+						await tx.exec(`DELETE FROM ${table}`);
+					}
+				});
+				await transaction.immediate();
+			});
+		}).then(() => deleted);
+	}
+
+	close(): Promise<void> {
+		if (this.closePromise) return this.closePromise;
+		this.closed = true;
+		this.closePromise = (async () => {
+			await this.mutationTail.catch(() => undefined);
+			await Promise.allSettled([...this.activeQueries]);
+			let pendingError: unknown;
+			try {
+				await this.flushPending();
+			} catch (error) {
+				pendingError = error;
+				this.pending.length = 0;
+			}
+			await this.opened.close();
+			if (pendingError !== undefined) {
+				throw new Error("Analytics pending writes could not be saved before close.", {
+					cause: pendingError,
+				});
+			}
+		})();
+		return this.closePromise;
+	}
+
+	private enqueueMutation(operation: () => Promise<void>): Promise<void> {
+		const result = this.mutationTail.then(operation);
+		this.mutationTail = result.catch(() => undefined);
+		return result;
+	}
+
+	private async flushPending(): Promise<void> {
+		while (this.pending.length > 0) {
+			const run = this.pending[0];
+			if (!run) return;
+			await withWriteRetry(() => writeRun(this.opened.connection, run));
+			this.pending.shift();
+		}
+	}
+}
+
+async function writeRun(database: Database, run: SettledRun): Promise<void> {
+	const transaction = database.transactionAsync(async (tx) => {
+		const existing = await tx.get("SELECT id FROM response_runs WHERE id = ?", run.id);
+		if (existing) return;
+		await insertRun(tx, run);
+		for (const generation of run.generations) {
+			await tx.run(
+				`INSERT INTO model_generations(
+					id, run_id, ordinal, provider, model, thinking_level, started_at_ms,
+					finished_at_ms, duration_ms, stop_reason, outcome
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				generation.id,
+				run.id,
+				generation.ordinal,
+				generation.provider ?? null,
+				generation.model ?? null,
+				generation.thinkingLevel ?? null,
+				generation.startedAtMs,
+				generation.finishedAtMs ?? null,
+				generation.durationMs ?? null,
+				generation.stopReason ?? null,
+				generation.outcome,
+			);
+			for (const response of generation.responses) {
+				await tx.run(
+					`INSERT INTO provider_responses(generation_id, ordinal, occurred_at_ms, status)
+					 VALUES (?, ?, ?, ?)`,
+					generation.id,
+					response.ordinal,
+					response.occurredAtMs,
+					response.status,
+				);
+			}
+		}
+		for (const tool of run.tools) {
+			await tx.run(
+				`INSERT INTO tool_calls(
+					id, run_id, ordinal, tool_name, provider, model, started_at_ms,
+					finished_at_ms, duration_ms, is_error, completion_state
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				tool.id,
+				run.id,
+				tool.ordinal,
+				tool.name,
+				tool.provider ?? null,
+				tool.model ?? null,
+				tool.startedAtMs,
+				tool.finishedAtMs ?? null,
+				tool.durationMs ?? null,
+				tool.isError ? 1 : 0,
+				tool.completionState,
+			);
+		}
+		for (const skill of run.skills) {
+			await tx.run(
+				`INSERT INTO skill_activations(
+					id, run_id, occurred_at_ms, skill_name, initiated_by, provider, model
+				) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				skill.id,
+				run.id,
+				skill.occurredAtMs,
+				skill.name,
+				skill.initiatedBy,
+				skill.provider ?? null,
+				skill.model ?? null,
+			);
+		}
+		for (const error of run.providerErrors) {
+			await tx.run(
+				`INSERT INTO provider_errors(
+					id, run_id, generation_id, occurred_at_ms, provider, model,
+					category, recovered, terminal
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				error.id,
+				run.id,
+				error.generationId ?? null,
+				error.occurredAtMs,
+				error.provider ?? null,
+				error.model ?? null,
+				error.category,
+				error.recovered ? 1 : 0,
+				error.terminal ? 1 : 0,
+			);
+		}
+	});
+	await transaction.immediate();
+}
+
+function insertRun(tx: Transaction, run: SettledRun): Promise<unknown> {
+	return tx.run(
+		`INSERT INTO response_runs(
+			id, started_at_ms, finished_at_ms, duration_ms, trigger_source,
+			initial_provider, initial_model, outcome, attempt_count, generation_count,
+			tool_call_count, tool_error_count, skill_activation_count,
+			provider_error_count, recovered_error_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.id,
+		run.startedAtMs,
+		run.finishedAtMs,
+		run.durationMs,
+		run.triggerSource,
+		run.initialProvider ?? null,
+		run.initialModel ?? null,
+		run.outcome,
+		run.attemptCount,
+		run.generations.length,
+		run.tools.length,
+		run.toolErrorCount,
+		run.skills.length,
+		run.providerErrorCount,
+		run.recoveredErrorCount,
+	);
+}
+
+async function withWriteRetry(operation: () => Promise<void>): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < WRITE_ATTEMPTS; attempt += 1) {
+		try {
+			await operation();
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isConflict(error) || attempt + 1 >= WRITE_ATTEMPTS) throw error;
+			await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+		}
+	}
+	throw lastError;
+}
+
+function isConflict(error: unknown): boolean {
+	const message =
+		error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+	return (
+		message.includes("statement was interrupted") ||
+		message.includes("database is locked") ||
+		message.includes("database is busy")
+	);
+}

--- a/experimental/pi-analytics/src/types.ts
+++ b/experimental/pi-analytics/src/types.ts
@@ -1,0 +1,102 @@
+export type TriggerSource = "interactive" | "rpc" | "extension" | "unknown";
+export type RunOutcome =
+	| "success"
+	| "recovered_success"
+	| "error"
+	| "aborted"
+	| "length"
+	| "interrupted";
+export type GenerationOutcome =
+	| "pending"
+	| "stop"
+	| "tool_use"
+	| "error"
+	| "aborted"
+	| "length"
+	| "interrupted";
+export type ProviderErrorCategory =
+	| "dns"
+	| "timeout"
+	| "connection_refused"
+	| "connection_reset"
+	| "tls"
+	| "network_other"
+	| "provider_other";
+
+export interface ModelIdentity {
+	provider: string;
+	model: string;
+	thinkingLevel?: string;
+}
+
+export interface ProviderResponseRecord {
+	ordinal: number;
+	occurredAtMs: number;
+	status: number;
+}
+
+export interface GenerationRecord {
+	id: string;
+	ordinal: number;
+	provider?: string;
+	model?: string;
+	thinkingLevel?: string;
+	startedAtMs: number;
+	finishedAtMs?: number;
+	durationMs?: number;
+	stopReason?: string;
+	outcome: GenerationOutcome;
+	responses: ProviderResponseRecord[];
+}
+
+export interface ToolCallRecord {
+	id: string;
+	ordinal: number;
+	name: string;
+	provider?: string;
+	model?: string;
+	startedAtMs: number;
+	finishedAtMs?: number;
+	durationMs?: number;
+	isError: boolean;
+	completionState: "running" | "finished" | "interrupted";
+}
+
+export interface SkillActivationRecord {
+	id: string;
+	name: string;
+	initiatedBy: "user" | "model";
+	occurredAtMs: number;
+	provider?: string;
+	model?: string;
+}
+
+export interface ProviderErrorRecord {
+	id: string;
+	generationId?: string;
+	occurredAtMs: number;
+	provider?: string;
+	model?: string;
+	category: ProviderErrorCategory;
+	recovered: boolean;
+	terminal: boolean;
+}
+
+export interface SettledRun {
+	id: string;
+	startedAtMs: number;
+	finishedAtMs: number;
+	durationMs: number;
+	triggerSource: TriggerSource;
+	initialProvider?: string;
+	initialModel?: string;
+	outcome: RunOutcome;
+	attemptCount: number;
+	generations: GenerationRecord[];
+	tools: ToolCallRecord[];
+	skills: SkillActivationRecord[];
+	providerErrors: ProviderErrorRecord[];
+	toolErrorCount: number;
+	providerErrorCount: number;
+	recoveredErrorCount: number;
+}

--- a/experimental/pi-analytics/test/collector.test.ts
+++ b/experimental/pi-analytics/test/collector.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ResponseCollector } from "../src/collector.js";
+import { classifyProviderError } from "../src/errors.js";
+
+const model = { provider: "openai", model: "gpt-test", thinkingLevel: "high" };
+
+test("collector summarizes a settled tool loop without retaining content", () => {
+	const collector = new ResponseCollector();
+	collector.begin({ id: "run-1", now: 100, triggerSource: "interactive", model });
+	collector.beginAttempt();
+	collector.beginGeneration({ id: "gen-1", now: 110, model });
+	collector.recordProviderResponse({ status: 200, now: 115 });
+	collector.finishGeneration({ now: 120, stopReason: "toolUse" });
+	collector.beginTool({ id: "call-1", name: "read", now: 121, model });
+	collector.finishTool({ id: "call-1", now: 131, isError: false });
+	collector.beginGeneration({ id: "gen-2", now: 140, model });
+	collector.recordProviderResponse({ status: 200, now: 145 });
+	collector.finishGeneration({ now: 150, stopReason: "stop" });
+
+	const run = collector.settle(160);
+	assert.ok(run);
+	assert.equal(run.outcome, "success");
+	assert.equal(run.attemptCount, 1);
+	assert.equal(run.generations.length, 2);
+	assert.equal(run.tools.length, 1);
+	assert.equal(run.tools[0]?.durationMs, 10);
+	assert.equal(run.providerErrorCount, 0);
+	assert.doesNotMatch(JSON.stringify(run), /prompt|secret|arguments|result/i);
+});
+
+test("collector keeps parallel tools independent and interrupts unfinished work", () => {
+	const collector = new ResponseCollector();
+	collector.begin({ id: "run-2", now: 0, triggerSource: "rpc", model });
+	collector.beginAttempt();
+	collector.beginGeneration({ id: "gen-1", now: 1, model });
+	collector.finishGeneration({ now: 2, stopReason: "toolUse" });
+	collector.beginTool({ id: "a", name: "bash", now: 3, model });
+	collector.beginTool({ id: "b", name: "read", now: 4, model });
+	collector.finishTool({ id: "b", now: 6, isError: true });
+
+	const run = collector.interrupt(10);
+	assert.ok(run);
+	assert.equal(run.outcome, "interrupted");
+	assert.deepEqual(
+		run.tools.map(({ name, completionState, isError }) => ({ name, completionState, isError })),
+		[
+			{ name: "bash", completionState: "interrupted", isError: false },
+			{ name: "read", completionState: "finished", isError: true },
+		],
+	);
+	assert.equal(run.toolErrorCount, 1);
+});
+
+test("collector records recovered HTTP and generation failures conservatively", () => {
+	const collector = new ResponseCollector();
+	collector.begin({ id: "run-3", now: 0, triggerSource: "interactive", model });
+	collector.beginAttempt();
+	collector.beginGeneration({ id: "gen-1", now: 1, model });
+	collector.recordProviderResponse({ status: 429, now: 2 });
+	collector.recordProviderResponse({ status: 200, now: 3 });
+	collector.finishGeneration({
+		now: 4,
+		stopReason: "error",
+		errorMessage: "connect ETIMEDOUT https://secret.example/token",
+	});
+	collector.beginAttempt();
+	collector.beginGeneration({ id: "gen-2", now: 5, model });
+	collector.recordProviderResponse({ status: 200, now: 6 });
+	collector.finishGeneration({ now: 7, stopReason: "stop" });
+
+	const run = collector.settle(8);
+	assert.ok(run);
+	assert.equal(run.outcome, "recovered_success");
+	assert.equal(run.providerErrorCount, 2);
+	assert.equal(run.recoveredErrorCount, 2);
+	assert.equal(run.providerErrors[0]?.category, "timeout");
+	assert.equal(run.providerErrors[0]?.recovered, true);
+	assert.doesNotMatch(JSON.stringify(run), /secret\.example|token/);
+});
+
+test("skill activation is deduplicated and explicit user use takes precedence", () => {
+	const collector = new ResponseCollector();
+	collector.begin({ id: "run-4", now: 0, triggerSource: "interactive", model });
+	collector.activateSkill({ name: "reviewing-code", initiatedBy: "model", now: 1, model });
+	collector.activateSkill({ name: "reviewing-code", initiatedBy: "model", now: 2, model });
+	collector.activateSkill({ name: "reviewing-code", initiatedBy: "user", now: 3, model });
+	collector.activateSkill({ name: "applying-tdd", initiatedBy: "model", now: 4, model });
+
+	const run = collector.settle(5);
+	assert.ok(run);
+	assert.deepEqual(
+		run.skills.map(({ name, initiatedBy }) => ({ name, initiatedBy })),
+		[
+			{ name: "reviewing-code", initiatedBy: "user" },
+			{ name: "applying-tdd", initiatedBy: "model" },
+		],
+	);
+});
+
+test("collector ignores duplicate or out-of-run events", () => {
+	const collector = new ResponseCollector();
+	assert.equal(collector.settle(1), undefined);
+	collector.begin({ id: "run-5", now: 2, triggerSource: "unknown", model: undefined });
+	collector.beginGeneration({ id: "same", now: 3, model });
+	collector.beginGeneration({ id: "same", now: 4, model });
+	collector.beginTool({ id: "same", name: "read", now: 5, model });
+	collector.beginTool({ id: "same", name: "read", now: 6, model });
+	const run = collector.settle(7);
+	assert.equal(run?.generations.length, 1);
+	assert.equal(run?.tools.length, 1);
+});
+
+test("provider errors are classified without preserving their messages", () => {
+	assert.equal(classifyProviderError("getaddrinfo ENOTFOUND api.example.com"), "dns");
+	assert.equal(classifyProviderError("connect ECONNREFUSED 127.0.0.1"), "connection_refused");
+	assert.equal(classifyProviderError("socket ECONNRESET"), "connection_reset");
+	assert.equal(classifyProviderError("certificate verify failed"), "tls");
+	assert.equal(classifyProviderError("fetch failed"), "network_other");
+	assert.equal(classifyProviderError("invalid API response"), "provider_other");
+});

--- a/experimental/pi-analytics/test/extension.test.ts
+++ b/experimental/pi-analytics/test/extension.test.ts
@@ -1,0 +1,494 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	type AnalyticsStorePort,
+	createAnalyticsExtension,
+	isBuiltinReadTool,
+} from "../src/analytics.js";
+import { NewerSchemaError } from "../src/storage/migrations.js";
+import type { AnalyticsSnapshot, TimeRange } from "../src/storage/queries.js";
+import type { SettledRun } from "../src/types.js";
+
+const emptySnapshot: AnalyticsSnapshot = {
+	overview: {
+		responseCycles: 0,
+		llmCalls: 0,
+		callsPerResponse: 0,
+		p95CallsPerResponse: 0,
+		toolCalls: 0,
+		toolErrors: 0,
+		skillActivations: 0,
+		providerErrors: 0,
+		recoveredErrors: 0,
+	},
+	skills: [],
+	tools: [],
+	reliability: {
+		http429: 0,
+		http5xx: 0,
+		recovered: 0,
+		terminal: 0,
+		categories: {
+			dns: 0,
+			timeout: 0,
+			connection_refused: 0,
+			connection_reset: 0,
+			tls: 0,
+			network_other: 0,
+			provider_other: 0,
+		},
+	},
+	responses: {
+		count: 0,
+		llmCalls: 0,
+		average: 0,
+		median: 0,
+		p95: 0,
+		maximum: 0,
+		distribution: { one: 0, twoToThree: 0, fourToSix: 0, sevenPlus: 0 },
+	},
+};
+
+class FakeStore implements AnalyticsStorePort {
+	readonly path = "/tmp/pi-analytics.db";
+	readonly runs: SettledRun[] = [];
+	closed = 0;
+	clears = 0;
+	failWrites = false;
+
+	async recordRun(run: SettledRun): Promise<void> {
+		if (this.failWrites) throw new Error("write failed with /private/path");
+		this.runs.push(run);
+	}
+	async getSnapshot(_range: TimeRange): Promise<AnalyticsSnapshot> {
+		return emptySnapshot;
+	}
+	async clearAll(): Promise<number> {
+		this.clears += 1;
+		return this.runs.length;
+	}
+	async close(): Promise<void> {
+		this.closed += 1;
+	}
+}
+
+function lifecycleContext(overrides: Record<string, unknown> = {}) {
+	return createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		cwd: "/workspace",
+		model: { provider: "openai", id: "gpt-test" },
+		...overrides,
+	});
+}
+
+async function emit(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	event: Record<string, unknown>,
+	ctx: unknown,
+): Promise<void> {
+	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
+}
+
+test("skill read attribution requires Pi's built-in read tool", () => {
+	assert.equal(
+		isBuiltinReadTool(
+			createMockPi({
+				allTools: [{ name: "read", sourceInfo: { source: "builtin" } }],
+			}).pi,
+		),
+		true,
+	);
+	assert.equal(
+		isBuiltinReadTool(
+			createMockPi({
+				allTools: [{ name: "read", sourceInfo: { source: "custom-extension" } }],
+			}).pi,
+		),
+		false,
+	);
+});
+
+test("session start visibly warns that analytics is experimental", async () => {
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => new FakeStore() })(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	assert.deepEqual(started.notifications[0], {
+		message: "pi-analytics is experimental; its metrics and dashboard may change.",
+		level: "warning",
+	});
+});
+
+test("factory registers one command and lifecycle collectors without opening storage", () => {
+	let opens = 0;
+	const mock = createMockPi();
+	createAnalyticsExtension({
+		openStore: async () => {
+			opens += 1;
+			return new FakeStore();
+		},
+	})(mock.pi);
+	assert.equal(opens, 0);
+	assert.ok(mock.commands.has("analytics"));
+	assert.deepEqual([...mock.events.keys()].sort(), [
+		"after_provider_response",
+		"agent_settled",
+		"agent_start",
+		"before_agent_start",
+		"before_provider_request",
+		"input",
+		"message_end",
+		"session_shutdown",
+		"session_start",
+		"tool_execution_end",
+		"tool_execution_start",
+		"tool_result",
+		"turn_start",
+	]);
+});
+
+test("a settled tool loop is collected once and shutdown closes its store", async () => {
+	const store = new FakeStore();
+	let now = 100;
+	let id = 0;
+	const mock = createMockPi({ thinkingLevel: "high" });
+	createAnalyticsExtension({
+		openStore: async () => store,
+		now: () => now++,
+		createId: () => `id-${++id}`,
+	})(mock.pi);
+	const { ctx } = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await emit(mock, "input", { text: "Fix it", source: "interactive", images: undefined }, ctx);
+	await emit(
+		mock,
+		"before_agent_start",
+		{ prompt: "Fix it", systemPromptOptions: { skills: [] } },
+		ctx,
+	);
+	await emit(mock, "agent_start", {}, ctx);
+	await emit(mock, "turn_start", { turnIndex: 0, timestamp: now }, ctx);
+	await emit(mock, "before_provider_request", { payload: {} }, ctx);
+	await emit(mock, "after_provider_response", { status: 200, headers: {} }, ctx);
+	await emit(mock, "message_end", { message: { role: "assistant", stopReason: "toolUse" } }, ctx);
+	await emit(
+		mock,
+		"tool_execution_start",
+		{ toolCallId: "call-1", toolName: "read", args: { path: "README.md" } },
+		ctx,
+	);
+	await emit(
+		mock,
+		"tool_execution_end",
+		{ toolCallId: "call-1", toolName: "read", result: {}, isError: false },
+		ctx,
+	);
+	await emit(mock, "turn_start", { turnIndex: 1, timestamp: now }, ctx);
+	await emit(mock, "before_provider_request", { payload: {} }, ctx);
+	await emit(mock, "message_end", { message: { role: "assistant", stopReason: "stop" } }, ctx);
+	await emit(mock, "agent_settled", {}, ctx);
+	assert.equal(store.runs.length, 1);
+	assert.equal(store.runs[0]?.generations.length, 2);
+	assert.equal(store.runs[0]?.tools.length, 1);
+	await emit(mock, "session_shutdown", { reason: "quit" }, ctx);
+	assert.equal(store.closed, 1);
+});
+
+test("automatic retry remains in one response and becomes recovered success", async () => {
+	const store = new FakeStore();
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(
+		mock,
+		"before_agent_start",
+		{ prompt: "run", systemPromptOptions: { skills: [] } },
+		started.ctx,
+	);
+	for (const stopReason of ["error", "stop"]) {
+		await emit(mock, "agent_start", {}, started.ctx);
+		await emit(mock, "turn_start", { turnIndex: 0, timestamp: 1 }, started.ctx);
+		await emit(mock, "before_provider_request", { payload: {} }, started.ctx);
+		await emit(
+			mock,
+			"message_end",
+			{
+				message: {
+					role: "assistant",
+					stopReason,
+					...(stopReason === "error" ? { errorMessage: "fetch failed" } : {}),
+				},
+			},
+			started.ctx,
+		);
+	}
+	await emit(mock, "agent_settled", {}, started.ctx);
+	assert.equal(store.runs.length, 1);
+	assert.equal(store.runs[0]?.attemptCount, 2);
+	assert.equal(store.runs[0]?.outcome, "recovered_success");
+});
+
+test("an automatic continuation that starts without a prompt retains its attempt", async () => {
+	const store = new FakeStore();
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(mock, "agent_start", {}, started.ctx);
+	await emit(mock, "turn_start", { turnIndex: 0, timestamp: 1 }, started.ctx);
+	await emit(mock, "before_provider_request", { payload: {} }, started.ctx);
+	await emit(
+		mock,
+		"message_end",
+		{ message: { role: "assistant", stopReason: "stop" } },
+		started.ctx,
+	);
+	await emit(mock, "agent_settled", {}, started.ctx);
+	assert.equal(store.runs[0]?.attemptCount, 1);
+	assert.equal(store.runs[0]?.triggerSource, "extension");
+});
+
+test("explicit and successful read skill activations are attributed and deduplicated", async (t) => {
+	const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+	const { tmpdir } = await import("node:os");
+	const path = await import("node:path");
+	const cwd = await mkdtemp(path.join(tmpdir(), "pi-analytics-extension-skill-"));
+	t.after(() => rm(cwd, { recursive: true, force: true }));
+	const skillDir = path.join(cwd, "skill");
+	await mkdir(skillDir);
+	const skillFile = path.join(skillDir, "SKILL.md");
+	await writeFile(skillFile, "skill");
+	const store = new FakeStore();
+	const mock = createMockPi({
+		allTools: [{ name: "read", sourceInfo: { source: "builtin" } }],
+	});
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const { ctx } = lifecycleContext({ cwd });
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await emit(mock, "input", { text: "/skill:reviewing-code inspect", source: "interactive" }, ctx);
+	await emit(
+		mock,
+		"before_agent_start",
+		{
+			prompt: "expanded",
+			systemPromptOptions: {
+				skills: [{ name: "reviewing-code", filePath: skillFile }],
+			},
+		},
+		ctx,
+	);
+	await emit(mock, "agent_start", {}, ctx);
+	await emit(mock, "before_provider_request", { payload: {} }, ctx);
+	await emit(
+		mock,
+		"tool_result",
+		{
+			toolCallId: "read-1",
+			toolName: "read",
+			input: { path: skillFile },
+			content: [],
+			isError: false,
+		},
+		ctx,
+	);
+	await emit(mock, "message_end", { message: { role: "assistant", stopReason: "stop" } }, ctx);
+	await emit(mock, "agent_settled", {}, ctx);
+	assert.deepEqual(
+		store.runs[0]?.skills.map(({ name, initiatedBy }) => ({ name, initiatedBy })),
+		[{ name: "reviewing-code", initiatedBy: "user" }],
+	);
+});
+
+test("a skill command queued during streaming belongs to the active response", async () => {
+	const store = new FakeStore();
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(
+		mock,
+		"before_agent_start",
+		{
+			prompt: "initial",
+			systemPromptOptions: {
+				skills: [{ name: "reviewing-code", filePath: "/missing/reviewing-code/SKILL.md" }],
+			},
+		},
+		started.ctx,
+	);
+	await emit(
+		mock,
+		"input",
+		{
+			text: "/skill:reviewing-code continue",
+			source: "interactive",
+			streamingBehavior: "followUp",
+		},
+		started.ctx,
+	);
+	await emit(mock, "before_provider_request", { payload: {} }, started.ctx);
+	await emit(
+		mock,
+		"message_end",
+		{ message: { role: "assistant", stopReason: "stop" } },
+		started.ctx,
+	);
+	await emit(mock, "agent_settled", {}, started.ctx);
+	assert.deepEqual(
+		store.runs[0]?.skills.map(({ name, initiatedBy }) => ({ name, initiatedBy })),
+		[{ name: "reviewing-code", initiatedBy: "user" }],
+	);
+});
+
+test("replacement invalidates a delayed startup and closes the stale store", async () => {
+	let resolveFirst!: (store: FakeStore) => void;
+	const firstOpening = new Promise<FakeStore>((resolve) => {
+		resolveFirst = resolve;
+	});
+	const first = new FakeStore();
+	const second = new FakeStore();
+	let calls = 0;
+	const mock = createMockPi();
+	createAnalyticsExtension({
+		openStore: async () => (++calls === 1 ? firstOpening : second),
+	})(mock.pi);
+	const { ctx } = lifecycleContext();
+	const starting = emit(mock, "session_start", { reason: "startup" }, ctx);
+	const shuttingDown = emit(mock, "session_shutdown", { reason: "new" }, ctx);
+	resolveFirst(first);
+	await Promise.all([starting, shuttingDown]);
+	await emit(mock, "session_start", { reason: "new" }, ctx);
+	assert.equal(first.closed, 1);
+	assert.equal(second.closed, 0);
+});
+
+test("arguments and noninteractive command modes reject before querying", async () => {
+	const store = new FakeStore();
+	let loads = 0;
+	store.getSnapshot = async () => {
+		loads += 1;
+		return emptySnapshot;
+	};
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const command = mock.commands.get("analytics");
+	assert.ok(command);
+	const interactive = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, interactive.ctx);
+	await command.handler("trailing", interactive.ctx);
+	assert.ok(
+		interactive.notifications.some(({ message }) => message.includes("does not accept arguments")),
+	);
+	for (const mode of ["print", "json"] as const) {
+		const noninteractive = lifecycleContext({ hasUI: false, mode });
+		await assert.rejects(async () => command.handler("", noninteractive.ctx), /TUI or RPC/);
+		await assert.rejects(
+			async () => command.handler("trailing", noninteractive.ctx),
+			/does not accept arguments/,
+		);
+	}
+	assert.equal(loads, 0);
+});
+
+test("write failure notifies once and a later success reports recovery", async () => {
+	const store = new FakeStore();
+	store.failWrites = true;
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	for (let index = 0; index < 2; index += 1) {
+		await emit(
+			mock,
+			"before_agent_start",
+			{ prompt: "run", systemPromptOptions: { skills: [] } },
+			started.ctx,
+		);
+		await emit(mock, "before_provider_request", { payload: {} }, started.ctx);
+		await emit(
+			mock,
+			"message_end",
+			{ message: { role: "assistant", stopReason: "stop" } },
+			started.ctx,
+		);
+		await emit(mock, "agent_settled", {}, started.ctx);
+	}
+	assert.equal(
+		started.notifications.filter(({ message }) => message.includes("could not save")).length,
+		1,
+	);
+	store.failWrites = false;
+	await emit(
+		mock,
+		"before_agent_start",
+		{ prompt: "run", systemPromptOptions: { skills: [] } },
+		started.ctx,
+	);
+	await emit(mock, "before_provider_request", { payload: {} }, started.ctx);
+	await emit(
+		mock,
+		"message_end",
+		{ message: { role: "assistant", stopReason: "stop" } },
+		started.ctx,
+	);
+	await emit(mock, "agent_settled", {}, started.ctx);
+	assert.ok(started.notifications.some(({ message }) => message.includes("storage recovered")));
+	assert.doesNotMatch(
+		started.notifications.map(({ message }) => message).join("\n"),
+		/private\/path/,
+	);
+});
+
+test("graceful shutdown persists an active response as interrupted", async () => {
+	const store = new FakeStore();
+	const mock = createMockPi();
+	createAnalyticsExtension({ openStore: async () => store })(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(
+		mock,
+		"before_agent_start",
+		{ prompt: "run", systemPromptOptions: { skills: [] } },
+		started.ctx,
+	);
+	await emit(mock, "before_provider_request", { payload: {} }, started.ctx);
+	await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+	assert.equal(store.runs[0]?.outcome, "interrupted");
+	assert.equal(store.closed, 1);
+});
+
+test("newer schemas produce actionable fail-closed guidance", async () => {
+	const mock = createMockPi();
+	createAnalyticsExtension({
+		openStore: async () => {
+			throw new NewerSchemaError(3, 1);
+		},
+	})(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	const message = started.notifications.find(({ message }) => message.includes("schema"))?.message;
+	assert.match(message ?? "", /schema v3 is newer than supported v1/);
+	assert.match(message ?? "", /Update pi-analytics/);
+});
+
+test("storage failure is content-free and keeps the command available", async () => {
+	const mock = createMockPi();
+	createAnalyticsExtension({
+		openStore: async () => {
+			throw new Error("native binding /home/private/user failed");
+		},
+		platform: () => "linux-arm64-musl",
+	})(mock.pi);
+	const started = lifecycleContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	const message = started.notifications.find(({ message }) =>
+		message.includes("linux-arm64-musl"),
+	)?.message;
+	assert.match(message ?? "", /linux-arm64-musl/);
+	assert.doesNotMatch(message ?? "", /private\/user/);
+	assert.ok(mock.commands.has("analytics"));
+});

--- a/experimental/pi-analytics/test/menu.test.ts
+++ b/experimental/pi-analytics/test/menu.test.ts
@@ -1,0 +1,322 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { resolveMenuScreen, runMenu } from "@narumitw/pi-tui-kit";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext } from "../../../test/support.js";
+import {
+	type AnalyticsMenuDataSource,
+	type AnalyticsMenuState,
+	createAnalyticsMenu,
+	showAnalyticsMenu,
+} from "../src/menu.js";
+import type { AnalyticsSnapshot } from "../src/storage/queries.js";
+
+initTheme("dark", false);
+
+const snapshot: AnalyticsSnapshot = {
+	overview: {
+		responseCycles: 83,
+		llmCalls: 192,
+		callsPerResponse: 2.31,
+		p95CallsPerResponse: 6,
+		toolCalls: 414,
+		toolErrors: 7,
+		skillActivations: 31,
+		providerErrors: 4,
+		recoveredErrors: 3,
+	},
+	skills: [
+		{
+			name: "reviewing-code",
+			count: 18,
+			modelInitiated: 13,
+			userInitiated: 5,
+			lastOccurredAtMs: 1_786_000_000_000,
+			models: [{ provider: "openai", model: "gpt-test", count: 18 }],
+		},
+	],
+	tools: [
+		{
+			name: "read",
+			count: 182,
+			errors: 2,
+			averageDurationMs: 12.5,
+			lastOccurredAtMs: 1_786_000_000_000,
+			models: [{ provider: "openai", model: "gpt-test", count: 182 }],
+		},
+	],
+	reliability: {
+		http429: 3,
+		http5xx: 1,
+		recovered: 3,
+		terminal: 1,
+		categories: {
+			dns: 0,
+			timeout: 2,
+			connection_refused: 0,
+			connection_reset: 1,
+			tls: 0,
+			network_other: 0,
+			provider_other: 0,
+		},
+	},
+	responses: {
+		count: 83,
+		llmCalls: 192,
+		average: 2.31,
+		median: 2,
+		p95: 6,
+		maximum: 9,
+		distribution: { one: 31, twoToThree: 34, fourToSix: 15, sevenPlus: 3 },
+	},
+};
+
+function source(overrides: Partial<AnalyticsMenuDataSource> = {}): AnalyticsMenuDataSource {
+	return {
+		path: "/home/test/.pi/agent/pi-analytics.db",
+		async load() {
+			return { kind: "ready", snapshot };
+		},
+		async clearAll() {
+			return 83;
+		},
+		...overrides,
+	};
+}
+
+async function state(
+	controller: ReturnType<typeof createAnalyticsMenu>,
+): Promise<AnalyticsMenuState> {
+	return controller.getState({ signal: new AbortController().signal });
+}
+
+test("dashboard exposes seven primary rows and concise settled metrics", async () => {
+	const controller = createAnalyticsMenu(source());
+	const screen = resolveMenuScreen(controller.menu, "main", await state(controller));
+	assert.equal(screen.kind, "actions");
+	if (screen.kind !== "actions") return;
+	assert.equal(screen.items.length, 7);
+	assert.deepEqual(
+		screen.items.map(({ label }) => label),
+		[
+			"Change time range",
+			"Skills",
+			"Tools",
+			"Provider reliability",
+			"Response cycles",
+			"Data & privacy",
+			"Close",
+		],
+	);
+	assert.match(screen.title, /Last 7 days/);
+	assert.match(screen.lines?.join("\n") ?? "", /Response cycles\s+83/);
+	assert.match(screen.lines?.join("\n") ?? "", /Includes settled response cycles only/);
+});
+
+test("skill and tool browse details preserve attribution and model breakdowns", async () => {
+	const controller = createAnalyticsMenu(source());
+	const current = await state(controller);
+	const skills = resolveMenuScreen(controller.menu, "skills", current);
+	const tools = resolveMenuScreen(controller.menu, "tools", current);
+	assert.equal(skills.kind, "browse");
+	assert.equal(tools.kind, "browse");
+	if (skills.kind !== "browse" || tools.kind !== "browse") return;
+	assert.equal(skills.items[0]?.statusText, "18 · 13 model / 5 user");
+	assert.match(skills.items[0]?.details?.join("\n") ?? "", /openai\/gpt-test: 18/);
+	assert.equal(tools.items[0]?.statusText, "182 · 2 errors");
+	assert.match(tools.items[0]?.details?.join("\n") ?? "", /Average duration: 12.5 ms/);
+});
+
+test("range selection updates the next state load without creating settings", async () => {
+	const loaded: string[] = [];
+	const controller = createAnalyticsMenu(
+		source({
+			async load(range) {
+				loaded.push(range.id ?? "custom");
+				return { kind: "ready", snapshot };
+			},
+		}),
+	);
+	await state(controller);
+	const action = controller.menu.actions.setRange;
+	await action({
+		ctx: createMockContext({ hasUI: true, mode: "rpc" }).ctx,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "30d",
+	});
+	await state(controller);
+	assert.deepEqual(loaded, ["7d", "30d"]);
+});
+
+test("clear cancellation is side-effect free and confirmation clears committed rows", async () => {
+	let clears = 0;
+	const controller = createAnalyticsMenu(
+		source({
+			async clearAll() {
+				clears += 1;
+				return 83;
+			},
+		}),
+	);
+	const current = await state(controller);
+	const cancelled = createMockContext({ hasUI: true, mode: "rpc", confirm: async () => false });
+	await controller.menu.actions.clearData({
+		ctx: cancelled.ctx,
+		state: current,
+		signal: new AbortController().signal,
+		itemId: "clear",
+	});
+	assert.equal(clears, 0);
+	const confirmed = createMockContext({ hasUI: true, mode: "rpc", confirm: async () => true });
+	await controller.menu.actions.clearData({
+		ctx: confirmed.ctx,
+		state: current,
+		signal: new AbortController().signal,
+		itemId: "clear",
+	});
+	assert.equal(clears, 1);
+	assert.match(confirmed.notifications[0]?.message ?? "", /Deleted 83 response cycles/);
+});
+
+test("clear completion remains visible when cancellation races after confirmation", async () => {
+	let release!: () => void;
+	const blocked = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const controller = createAnalyticsMenu(
+		source({
+			async clearAll() {
+				await blocked;
+				return 83;
+			},
+		}),
+	);
+	const current = await state(controller);
+	const confirmed = createMockContext({ hasUI: true, mode: "rpc", confirm: async () => true });
+	const owner = new AbortController();
+	const clearing = controller.menu.actions.clearData({
+		ctx: confirmed.ctx,
+		state: current,
+		signal: owner.signal,
+		itemId: "clear",
+	});
+	await Promise.resolve();
+	owner.abort();
+	release();
+	assert.deepEqual(await clearing, { kind: "close" });
+	assert.match(confirmed.notifications[0]?.message ?? "", /Deleted 83 response cycles/);
+});
+
+test("empty and unavailable states remain actionable", async () => {
+	const emptySnapshot: AnalyticsSnapshot = {
+		...snapshot,
+		overview: { ...snapshot.overview, responseCycles: 0 },
+		skills: [],
+		tools: [],
+	};
+	const empty = createAnalyticsMenu(
+		source({
+			async load() {
+				return { kind: "ready", snapshot: emptySnapshot };
+			},
+		}),
+	);
+	const emptyMain = resolveMenuScreen(empty.menu, "main", await state(empty));
+	assert.match(emptyMain.lines?.join("\n") ?? "", /No analytics yet/);
+	const unavailable = createAnalyticsMenu(
+		source({
+			async load() {
+				return { kind: "unavailable", message: "Native binding unavailable on linux-arm64-musl" };
+			},
+		}),
+	);
+	const unavailableMain = resolveMenuScreen(unavailable.menu, "main", await state(unavailable));
+	assert.match(unavailableMain.lines?.join("\n") ?? "", /No analytics are being collected/);
+	assert.match(unavailableMain.lines?.join("\n") ?? "", /linux-arm64-musl/);
+});
+
+test("RPC adapts the same dashboard without opening custom TUI", async () => {
+	const rpc = createRpcHarness([{ kind: "select", response: "Close" }]);
+	const base = createMockContext({ hasUI: true, mode: "rpc" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const ctx = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	const owner = new AbortController();
+	await showAnalyticsMenu(ctx, source(), {
+		signal: owner.signal,
+		isCurrent: () => !owner.signal.aborted,
+	});
+	rpc.assertConsumed();
+});
+
+test("TUI shows a cancellable loader before opening the dashboard", async () => {
+	let customCalls = 0;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) =>
+			new Promise<unknown>((resolve) => {
+				if (typeof factory !== "function") return resolve(undefined);
+				customCalls += 1;
+				let component: { dispose?(): void; handleInput(data: string): void };
+				const done = (value: unknown) => {
+					component.dispose?.();
+					resolve(value);
+				};
+				component = (
+					factory as (
+						tui: { requestRender(): void },
+						theme: { fg(_color: string, text: string): string },
+						keybindings: object,
+						done: (value: unknown) => void,
+					) => typeof component
+				)({ requestRender() {} }, { fg: (_color, text) => text }, {}, done);
+				setImmediate(() => component.handleInput("\u001b"));
+			}),
+	});
+	const owner = new AbortController();
+	await showAnalyticsMenu(
+		ctx,
+		source({
+			async load(_range, signal) {
+				await new Promise<void>((_resolve, reject) => {
+					signal.addEventListener(
+						"abort",
+						() => reject(new DOMException("cancelled", "AbortError")),
+						{ once: true },
+					);
+				});
+				return { kind: "ready", snapshot };
+			},
+		}),
+		{ signal: owner.signal, isCurrent: () => !owner.signal.aborted },
+	);
+	assert.equal(customCalls, 1);
+});
+
+test("dashboard rendering is width-safe and owner cancellation settles the menu", async () => {
+	const controller = createAnalyticsMenu(source());
+	const tui = createTuiHarness({ width: 40, rows: 20 });
+	const owner = new AbortController();
+	const base = createMockContext({ hasUI: true, mode: "tui" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const ctx = { ...base, ui: { ...base.ui, custom: tui.custom } } as never;
+	const running = runMenu(ctx, controller.menu, {
+		getState: controller.getState,
+		signal: owner.signal,
+		isCurrent: () => !owner.signal.aborted,
+	});
+	await tui.waitForOpen();
+	for (const width of [40, 80, 120]) {
+		tui.resize({ width, rows: 20 });
+		for (const line of tui.render()) assert.ok(visibleWidth(line) <= width);
+	}
+	owner.abort();
+	assert.equal((await running).kind, "stale");
+});

--- a/experimental/pi-analytics/test/migrations.test.ts
+++ b/experimental/pi-analytics/test/migrations.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { connect } from "@tursodatabase/database";
+import {
+	ChecksumMismatchError,
+	MigrationFailedError,
+	migrateDatabase,
+	NewerSchemaError,
+	type SchemaMigration,
+} from "../src/storage/migrations.js";
+
+async function withDatabase(
+	t: test.TestContext,
+	callback: (file: string) => Promise<void>,
+): Promise<void> {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-migration-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	await callback(path.join(directory, "analytics.db"));
+}
+
+const first: SchemaMigration = {
+	version: 1,
+	name: "first",
+	statements: ["CREATE TABLE first_table(id INTEGER PRIMARY KEY, value TEXT)"],
+};
+
+test("fresh migration applies the analytics schema and is idempotent", async (t) => {
+	await withDatabase(t, async (file) => {
+		const db = await connect(file);
+		t.after(() => db.close());
+		await migrateDatabase(db);
+		await migrateDatabase(db);
+
+		const versions = await db.all(
+			"SELECT version, name, checksum FROM schema_migrations ORDER BY version",
+		);
+		assert.equal(versions.length, 1);
+		assert.equal(versions[0]?.version, 1);
+		assert.equal(typeof versions[0]?.checksum, "string");
+		for (const table of [
+			"response_runs",
+			"model_generations",
+			"provider_responses",
+			"provider_errors",
+			"tool_calls",
+			"skill_activations",
+		]) {
+			const row = await db.get(
+				"SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?",
+				table,
+			);
+			assert.equal(row?.name, table);
+		}
+	});
+});
+
+test("migration rejects modified applied history and a newer database", async (t) => {
+	await withDatabase(t, async (file) => {
+		const db = await connect(file);
+		t.after(() => db.close());
+		await migrateDatabase(db, { migrations: [first] });
+
+		await assert.rejects(
+			migrateDatabase(db, {
+				migrations: [{ ...first, statements: [...first.statements, "SELECT 1"] }],
+			}),
+			ChecksumMismatchError,
+		);
+
+		await db.run(
+			"INSERT INTO schema_migrations(version, name, checksum, applied_at_ms) VALUES (?, ?, ?, ?)",
+			2,
+			"future",
+			"future-checksum",
+			Date.now(),
+		);
+		await assert.rejects(migrateDatabase(db, { migrations: [first] }), NewerSchemaError);
+	});
+});
+
+test("failed migration rolls back its schema and history row", async (t) => {
+	await withDatabase(t, async (file) => {
+		const db = await connect(file);
+		t.after(() => db.close());
+		const broken: SchemaMigration = {
+			version: 2,
+			name: "broken",
+			statements: ["CREATE TABLE should_rollback(id INTEGER PRIMARY KEY)", "THIS IS NOT SQL"],
+		};
+		await assert.rejects(
+			migrateDatabase(db, { migrations: [first, broken] }),
+			MigrationFailedError,
+		);
+		assert.equal(
+			await db.get(
+				"SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'should_rollback'",
+			),
+			undefined,
+		);
+		assert.equal(
+			await db.get("SELECT version FROM schema_migrations WHERE version = 2"),
+			undefined,
+		);
+	});
+});
+
+test("migration validates an immutable contiguous registry", async (t) => {
+	await withDatabase(t, async (file) => {
+		const db = await connect(file);
+		t.after(() => db.close());
+		await assert.rejects(
+			migrateDatabase(db, { migrations: [{ ...first, version: 2 }] }),
+			/contiguous/i,
+		);
+		await assert.rejects(
+			migrateDatabase(db, { migrations: [first, first] }),
+			/contiguous|duplicate/i,
+		);
+	});
+});
+
+test("two connections serialize the same migration with bounded retry", async (t) => {
+	await withDatabase(t, async (file) => {
+		const left = await connect(file);
+		const right = await connect(file);
+		t.after(async () => {
+			await Promise.all([left.close(), right.close()]);
+		});
+		await Promise.all([
+			migrateDatabase(left, { migrations: [first], retryDelayMs: 2 }),
+			migrateDatabase(right, { migrations: [first], retryDelayMs: 2 }),
+		]);
+		const rows = await left.all("SELECT version FROM schema_migrations");
+		assert.deepEqual(rows, [{ version: 1 }]);
+	});
+});

--- a/experimental/pi-analytics/test/skills.test.ts
+++ b/experimental/pi-analytics/test/skills.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { explicitSkillName, SkillTracker } from "../src/skills.js";
+
+test("explicit skill parsing accepts exact commands with arguments", () => {
+	assert.equal(explicitSkillName("/skill:reviewing-code"), "reviewing-code");
+	assert.equal(explicitSkillName("/skill:reviewing-code inspect this"), "reviewing-code");
+	assert.equal(explicitSkillName(" /skill:reviewing-code"), undefined);
+	assert.equal(explicitSkillName("/skill:Reviewing-Code"), undefined);
+	assert.equal(explicitSkillName("/skill:reviewing-code!"), undefined);
+	assert.equal(explicitSkillName("hello /skill:reviewing-code"), undefined);
+});
+
+test("pending explicit skill is replaced by later ordinary user input and ignores extension input", () => {
+	const tracker = new SkillTracker("/workspace");
+	tracker.observeInput("/skill:reviewing-code", "interactive", 1);
+	tracker.observeInput("extension note", "extension", 2);
+	assert.equal(tracker.consumeExplicitSkill()?.name, "reviewing-code");
+	tracker.observeInput("/skill:applying-tdd", "rpc", 3);
+	tracker.observeInput("normal user prompt", "interactive", 4);
+	assert.equal(tracker.consumeExplicitSkill(), undefined);
+});
+
+test("successful canonical built-in reads match discovered skill paths", async (t) => {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-skills-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const skillDirectory = path.join(directory, "skills", "review");
+	await mkdir(skillDirectory, { recursive: true });
+	const file = path.join(skillDirectory, "SKILL.md");
+	await writeFile(file, "---\nname: reviewing-code\n---\n");
+	const alias = path.join(directory, "alias.md");
+	await symlink(file, alias);
+	const tracker = new SkillTracker(directory);
+	await tracker.setAvailableSkills([{ name: "reviewing-code", filePath: file }]);
+
+	assert.equal(
+		await tracker.matchSuccessfulRead({ toolName: "read", input: { path: alias }, isError: false }),
+		"reviewing-code",
+	);
+	assert.equal(
+		await tracker.matchSuccessfulRead({
+			toolName: "read",
+			input: { path: `@${path.relative(directory, file)}` },
+			isError: false,
+		}),
+		"reviewing-code",
+	);
+	assert.equal(
+		await tracker.matchSuccessfulRead({ toolName: "read", input: { path: file }, isError: true }),
+		undefined,
+	);
+	assert.equal(
+		await tracker.matchSuccessfulRead({ toolName: "bash", input: { path: file }, isError: false }),
+		undefined,
+	);
+});
+
+test("colliding names retain Pi's first discovered canonical path", async (t) => {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-collision-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const first = path.join(directory, "first.md");
+	const second = path.join(directory, "second.md");
+	await writeFile(first, "first");
+	await writeFile(second, "second");
+	const tracker = new SkillTracker(directory);
+	await tracker.setAvailableSkills([
+		{ name: "same", filePath: first },
+		{ name: "same", filePath: second },
+	]);
+	assert.equal(
+		await tracker.matchSuccessfulRead({ toolName: "read", input: { path: first }, isError: false }),
+		"same",
+	);
+	assert.equal(
+		await tracker.matchSuccessfulRead({
+			toolName: "read",
+			input: { path: second },
+			isError: false,
+		}),
+		undefined,
+	);
+});

--- a/experimental/pi-analytics/test/storage.test.ts
+++ b/experimental/pi-analytics/test/storage.test.ts
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	AnalyticsDatabaseOpenError,
+	AnalyticsStorageUnavailableError,
+	openAnalyticsDatabase,
+} from "../src/storage/database.js";
+import { type AnalyticsSnapshot, resolveTimeRange } from "../src/storage/queries.js";
+import { AnalyticsStore } from "../src/storage/store.js";
+import type { SettledRun } from "../src/types.js";
+
+function emptyAnalyticsSnapshot(): AnalyticsSnapshot {
+	return {
+		overview: {
+			responseCycles: 0,
+			llmCalls: 0,
+			callsPerResponse: 0,
+			p95CallsPerResponse: 0,
+			toolCalls: 0,
+			toolErrors: 0,
+			skillActivations: 0,
+			providerErrors: 0,
+			recoveredErrors: 0,
+		},
+		skills: [],
+		tools: [],
+		reliability: {
+			http429: 0,
+			http5xx: 0,
+			recovered: 0,
+			terminal: 0,
+			categories: {
+				dns: 0,
+				timeout: 0,
+				connection_refused: 0,
+				connection_reset: 0,
+				tls: 0,
+				network_other: 0,
+				provider_other: 0,
+			},
+		},
+		responses: {
+			count: 0,
+			llmCalls: 0,
+			average: 0,
+			median: 0,
+			p95: 0,
+			maximum: 0,
+			distribution: { one: 0, twoToThree: 0, fourToSix: 0, sevenPlus: 0 },
+		},
+	};
+}
+
+function run(id: string, startedAtMs: number, options: Partial<SettledRun> = {}): SettledRun {
+	return {
+		id,
+		startedAtMs,
+		finishedAtMs: startedAtMs + 100,
+		durationMs: 100,
+		triggerSource: "interactive",
+		initialProvider: "openai",
+		initialModel: "gpt-test",
+		outcome: "success",
+		attemptCount: 1,
+		generations: [],
+		tools: [],
+		skills: [],
+		providerErrors: [],
+		toolErrorCount: 0,
+		providerErrorCount: 0,
+		recoveredErrorCount: 0,
+		...options,
+	};
+}
+
+async function fixture(t: test.TestContext): Promise<{ file: string; store: AnalyticsStore }> {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-store-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const file = path.join(directory, "analytics.db");
+	const database = await openAnalyticsDatabase({ path: file });
+	const store = new AnalyticsStore(database);
+	t.after(() => store.close().catch(() => undefined));
+	return { file, store };
+}
+
+test("store close drains an in-flight dashboard query before closing the driver", async () => {
+	let release!: () => void;
+	const blocked = new Promise<AnalyticsSnapshot>((resolve) => {
+		release = () => resolve(emptyAnalyticsSnapshot());
+	});
+	let driverClosed = false;
+	const store = new AnalyticsStore(
+		{
+			connection: {} as never,
+			path: "/tmp/test.db",
+			async close() {
+				driverClosed = true;
+			},
+		},
+		{ querySnapshot: async () => blocked },
+	);
+	const reading = store.getSnapshot({ fromMs: 0, toMs: 1 });
+	const closing = store.close();
+	await Promise.resolve();
+	assert.equal(driverClosed, false);
+	release();
+	await reading;
+	await closing;
+	assert.equal(driverClosed, true);
+});
+
+test("database opens privately, migrates, and closes idempotently", async (t) => {
+	const { file, store } = await fixture(t);
+	if (process.platform !== "win32") {
+		assert.equal((await stat(file)).mode & 0o777, 0o600);
+		assert.equal((await stat(`${file}-wal`)).mode & 0o777, 0o600);
+	}
+	await store.close();
+	await store.close();
+});
+
+test("database startup refuses linked database and WAL files", async (t) => {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-linked-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const target = path.join(directory, "target");
+	await writeFile(target, "do not replace");
+	const databasePath = path.join(directory, "analytics.db");
+	await symlink(target, databasePath);
+	await assert.rejects(openAnalyticsDatabase({ path: databasePath }), AnalyticsDatabaseOpenError);
+	assert.equal(await readFile(target, "utf8"), "do not replace");
+	await rm(databasePath);
+	await writeFile(databasePath, "");
+	await symlink(target, `${databasePath}-wal`);
+	await assert.rejects(openAnalyticsDatabase({ path: databasePath }), AnalyticsDatabaseOpenError);
+	assert.equal(await readFile(target, "utf8"), "do not replace");
+});
+
+test("missing native storage is a typed local failure", async (t) => {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-unavailable-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	await assert.rejects(
+		openAnalyticsDatabase({
+			path: path.join(directory, "analytics.db"),
+			loadModule: async () => {
+				throw new Error("missing native binding at /private/user/path");
+			},
+		}),
+		AnalyticsStorageUnavailableError,
+	);
+});
+
+test("store atomically publishes a run and returns reconciled analytics", async (t) => {
+	const { store } = await fixture(t);
+	const started = new Date(2026, 7, 2, 12).getTime();
+	await store.recordRun(
+		run("run-1", started, {
+			outcome: "recovered_success",
+			attemptCount: 2,
+			generations: [
+				{
+					id: "g1",
+					ordinal: 0,
+					provider: "openai",
+					model: "gpt-a",
+					startedAtMs: started,
+					finishedAtMs: started + 10,
+					durationMs: 10,
+					stopReason: "error",
+					outcome: "error",
+					responses: [
+						{ ordinal: 0, occurredAtMs: started + 1, status: 429 },
+						{ ordinal: 1, occurredAtMs: started + 2, status: 500 },
+					],
+				},
+				{
+					id: "g2",
+					ordinal: 1,
+					provider: "anthropic",
+					model: "claude-b",
+					startedAtMs: started + 20,
+					finishedAtMs: started + 40,
+					durationMs: 20,
+					stopReason: "stop",
+					outcome: "stop",
+					responses: [{ ordinal: 0, occurredAtMs: started + 21, status: 200 }],
+				},
+			],
+			tools: [
+				{
+					id: "tool-1",
+					ordinal: 0,
+					name: "read",
+					provider: "openai",
+					model: "gpt-a",
+					startedAtMs: started + 5,
+					finishedAtMs: started + 15,
+					durationMs: 10,
+					isError: true,
+					completionState: "finished",
+				},
+			],
+			skills: [
+				{
+					id: "skill-1",
+					name: "reviewing-code",
+					initiatedBy: "model",
+					occurredAtMs: started + 5,
+					provider: "openai",
+					model: "gpt-a",
+				},
+			],
+			providerErrors: [
+				{
+					id: "error-1",
+					generationId: "g1",
+					occurredAtMs: started + 10,
+					provider: "openai",
+					model: "gpt-a",
+					category: "timeout",
+					recovered: true,
+					terminal: false,
+				},
+			],
+			toolErrorCount: 1,
+			providerErrorCount: 3,
+			recoveredErrorCount: 3,
+		}),
+	);
+
+	const snapshot = await store.getSnapshot({ fromMs: started - 1, toMs: started + 1_000 });
+	assert.deepEqual(snapshot.overview, {
+		responseCycles: 1,
+		llmCalls: 2,
+		callsPerResponse: 2,
+		p95CallsPerResponse: 2,
+		toolCalls: 1,
+		toolErrors: 1,
+		skillActivations: 1,
+		providerErrors: 3,
+		recoveredErrors: 3,
+	});
+	assert.equal(snapshot.skills[0]?.name, "reviewing-code");
+	assert.deepEqual(snapshot.skills[0]?.models, [{ provider: "openai", model: "gpt-a", count: 1 }]);
+	assert.equal(snapshot.tools[0]?.averageDurationMs, 10);
+	assert.equal(snapshot.reliability.http429, 1);
+	assert.equal(snapshot.reliability.http5xx, 1);
+	assert.equal(snapshot.reliability.categories.timeout, 1);
+	assert.deepEqual(snapshot.responses.distribution, {
+		one: 0,
+		twoToThree: 1,
+		fourToSix: 0,
+		sevenPlus: 0,
+	});
+});
+
+test("skill model breakdown merges user and model activation rows", async (t) => {
+	const { store } = await fixture(t);
+	for (const [index, initiatedBy] of ["model", "user"].entries()) {
+		await store.recordRun(
+			run(`skill-run-${index}`, index + 1, {
+				skills: [
+					{
+						id: `skill-${index}`,
+						name: "reviewing-code",
+						initiatedBy: initiatedBy as "model" | "user",
+						occurredAtMs: index + 1,
+						provider: "openai",
+						model: "gpt-test",
+					},
+				],
+			}),
+		);
+	}
+	const skill = (await store.getSnapshot({ fromMs: 0, toMs: 10 })).skills[0];
+	assert.equal(skill?.modelInitiated, 1);
+	assert.equal(skill?.userInitiated, 1);
+	assert.deepEqual(skill?.models, [{ provider: "openai", model: "gpt-test", count: 2 }]);
+});
+
+test("run publication is idempotent and rolls back conflicting child rows", async (t) => {
+	const { store } = await fixture(t);
+	await store.recordRun(run("one", 1));
+	await store.recordRun(run("one", 1));
+	await store.recordRun(
+		run("two", 2, {
+			tools: [
+				{
+					id: "shared",
+					ordinal: 0,
+					name: "read",
+					startedAtMs: 2,
+					isError: false,
+					completionState: "finished",
+				},
+			],
+		}),
+	);
+	await assert.rejects(
+		store.recordRun(
+			run("three", 3, {
+				tools: [
+					{
+						id: "shared",
+						ordinal: 0,
+						name: "bash",
+						startedAtMs: 3,
+						isError: false,
+						completionState: "finished",
+					},
+				],
+			}),
+		),
+	);
+	const snapshot = await store.getSnapshot({ fromMs: 0, toMs: 10 });
+	assert.equal(snapshot.overview.responseCycles, 2);
+	await assert.rejects(store.close(), /pending writes could not be saved/i);
+});
+
+test("two stores write the same database and clear committed observations transactionally", async (t) => {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-analytics-concurrent-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const file = path.join(directory, "analytics.db");
+	const left = new AnalyticsStore(await openAnalyticsDatabase({ path: file }));
+	const right = new AnalyticsStore(await openAnalyticsDatabase({ path: file }));
+	t.after(async () => Promise.all([left.close(), right.close()]));
+	await Promise.all(
+		Array.from({ length: 20 }, (_, index) =>
+			(index % 2 ? left : right).recordRun(run(`run-${index}`, index + 1)),
+		),
+	);
+	assert.equal((await left.getSnapshot({ fromMs: 0, toMs: 100 })).overview.responseCycles, 20);
+	assert.equal(await left.clearAll(), 20);
+	assert.equal((await left.getSnapshot({ fromMs: 0, toMs: 100 })).overview.responseCycles, 0);
+});
+
+test("response statistics honor exact bounds and nearest-rank percentiles", async (t) => {
+	const { store } = await fixture(t);
+	for (const [index, calls] of [1, 2, 3, 4, 7, 9].entries()) {
+		await store.recordRun(
+			run(`range-${index}`, 100 + index, {
+				generations: Array.from({ length: calls }, (_, ordinal) => ({
+					id: `range-${index}-generation-${ordinal}`,
+					ordinal,
+					startedAtMs: 100 + index,
+					outcome: "stop" as const,
+					responses: [],
+				})),
+			}),
+		);
+	}
+	const snapshot = await store.getSnapshot({ fromMs: 101, toMs: 105 });
+	assert.equal(snapshot.responses.count, 4);
+	assert.equal(snapshot.responses.average, 4);
+	assert.equal(snapshot.responses.median, 3.5);
+	assert.equal(snapshot.responses.p95, 7);
+	assert.equal(snapshot.responses.maximum, 7);
+	assert.deepEqual(snapshot.responses.distribution, {
+		one: 0,
+		twoToThree: 2,
+		fourToSix: 1,
+		sevenPlus: 1,
+	});
+});
+
+test("time ranges use local Today and rolling windows", () => {
+	const now = new Date(2026, 7, 2, 15, 30).getTime();
+	assert.equal(resolveTimeRange("today", now).fromMs, new Date(2026, 7, 2).getTime());
+	assert.equal(resolveTimeRange("7d", now).fromMs, now - 7 * 24 * 60 * 60 * 1_000);
+	assert.equal(resolveTimeRange("30d", now).fromMs, now - 30 * 24 * 60 * 60 * 1_000);
+	assert.equal(resolveTimeRange("all", now).fromMs, 0);
+	assert.equal(resolveTimeRange("all", now).toMs, now + 1);
+});

--- a/experimental/pi-analytics/tsconfig.json
+++ b/experimental/pi-analytics/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -103,6 +103,9 @@ pack-chrome-devtools:
 pack-accounts:
     just pack accounts
 
+pack-analytics:
+    just pack analytics
+
 pack-usage:
     just pack usage
 
@@ -166,6 +169,9 @@ try-chrome-devtools:
 
 try-accounts:
     just try accounts
+
+try-analytics:
+    just try analytics
 
 try-usage:
     just try usage
@@ -231,6 +237,9 @@ install-chrome-devtools:
 install-accounts:
     just install accounts
 
+install-analytics:
+    just install analytics
+
 install-usage:
     just install usage
 
@@ -291,6 +300,9 @@ publish-chrome-devtools:
 
 publish-accounts:
     just publish accounts
+
+publish-analytics:
+    just publish analytics
 
 publish-usage:
     just publish usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,24 @@
 				"typescript": "^7.0.2"
 			}
 		},
+		"experimental/pi-analytics": {
+			"name": "@narumitw/pi-analytics",
+			"version": "0.45.0",
+			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.45.0",
+				"@tursodatabase/database": "^0.7.2"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.6",
+				"@earendil-works/pi-coding-agent": "0.83.0",
+				"@types/node": "26.1.2",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
 		"experimental/pi-file-context": {
 			"name": "@narumitw/pi-file-context",
 			"version": "0.45.0",
@@ -2802,6 +2820,10 @@
 			"resolved": "extensions/pi-accounts",
 			"link": true
 		},
+		"node_modules/@narumitw/pi-analytics": {
+			"resolved": "experimental/pi-analytics",
+			"link": true
+		},
 		"node_modules/@narumitw/pi-btw": {
 			"resolved": "extensions/pi-btw",
 			"link": true
@@ -4826,6 +4848,79 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@tursodatabase/database": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@tursodatabase/database/-/database-0.7.2.tgz",
+			"integrity": "sha512-B84QicyDYnKt97qxgb7861cQQC26kuv/LkUlCnpxGs4tuGT9zgS2z/Mt+BkG/wOo1fB4rsSycOgGCbi0xU0YOQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tursodatabase/database-common": "^0.7.2"
+			},
+			"optionalDependencies": {
+				"@tursodatabase/database-darwin-arm64": "0.7.2",
+				"@tursodatabase/database-linux-arm64-gnu": "0.7.2",
+				"@tursodatabase/database-linux-x64-gnu": "0.7.2",
+				"@tursodatabase/database-win32-x64-msvc": "0.7.2"
+			}
+		},
+		"node_modules/@tursodatabase/database-common": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@tursodatabase/database-common/-/database-common-0.7.2.tgz",
+			"integrity": "sha512-c4uWaA5m7nyDemUrjvX6lQQ89cBxv1jCv7nmwq5JoagyXgbMxDeBfLcY7N5kn0oEcnD0Y+cf09S0wKEXKFKbfg==",
+			"license": "MIT"
+		},
+		"node_modules/@tursodatabase/database-darwin-arm64": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@tursodatabase/database-darwin-arm64/-/database-darwin-arm64-0.7.2.tgz",
+			"integrity": "sha512-pDYbrPnmsqzWsf21bQXXGKmGhcLdfQQVjx+yrpC/IboCue5o/h9fDZ1QFzQEP6CHRXXoc+pwQCyF8KBntI8fdA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@tursodatabase/database-linux-arm64-gnu": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@tursodatabase/database-linux-arm64-gnu/-/database-linux-arm64-gnu-0.7.2.tgz",
+			"integrity": "sha512-/Blz7cRssWh7dk8vGs7Cq3kupHOnI0GROAg+u9J4MD5U5ABAabJGN7iW5YQ16jZW35Bv2AkmJAyjvsCWdTyfTg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@tursodatabase/database-linux-x64-gnu": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@tursodatabase/database-linux-x64-gnu/-/database-linux-x64-gnu-0.7.2.tgz",
+			"integrity": "sha512-rXxInfTxKRPG3XeOAZvzJuX4wF+m9t9BjLbFnKU83Ad8ob2z88r1x+EV7IBzEFhz2FbvrRgriH7PhIEZ7Lx5ug==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@tursodatabase/database-win32-x64-msvc": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@tursodatabase/database-win32-x64-msvc/-/database-win32-x64-msvc-0.7.2.tgz",
+			"integrity": "sha512-AUvN3KO1bZOpsXVofRIMM2+MJ6OghUhgK62t8/3Bsb0Zzt6PztaMvJrtaWI6u5Olx0WCfGdhaVKyegcjYPNAeA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@types/node": {
 			"version": "26.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
 		"pack:accounts": "npm --workspace @narumitw/pi-accounts pack --dry-run",
+		"pack:analytics": "npm --workspace @narumitw/pi-analytics pack --dry-run",
 		"pack:usage": "npm --workspace @narumitw/pi-usage pack --dry-run",
 		"pack:firecrawl": "npm --workspace @narumitw/pi-firecrawl pack --dry-run",
 		"pack:github-pr": "npm --workspace @narumitw/pi-github-pr pack --dry-run",


### PR DESCRIPTION
## Summary

- add experimental `@narumitw/pi-analytics` with local-only, content-free Turso Database collection
- provide a lifecycle-safe `/analytics` TUI/RPC dashboard for response cycles, model calls, skills, tools, and observed provider reliability
- add private DB/WAL handling, transactional checksummed migrations, concurrent-write retries, clear/privacy flows, experimental warnings, documentation, and workflow aliases
- cover collector, storage, migration, query, menu, command-mode, replacement, cancellation, and shutdown behavior with 48 focused tests

## Verification

- `npm run check` — 2,174 tests passed; Biome, boundaries, and all workspace typechecks passed
- `npm run check --workspace @narumitw/pi-analytics`
- `just pack analytics` — inspected 14 intended package files
- isolated `pi -p --no-session -e ./experimental/pi-analytics "/analytics"` load/rejection smoke — DB and WAL created with `0600`
- `npm audit --omit=dev --audit-level=moderate` — 0 vulnerabilities

The native runtime smoke was run on Linux x64 glibc. Other documented native targets use the upstream Turso package support matrix.
