### PR TITLE
feat: align statusline modules with Starship

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -34,6 +34,7 @@
 ### TUI and rendering
 
 - Treat model IDs, session text, and pasted search text as untrusted terminal input. Strip or escape OSC, CSI, C0, and C1 controls at the display boundary without mutating raw payloads.
+- Sanitize terminal escapes before path splitting or truncation; OSC payloads can contain `/` and otherwise change path-component semantics before final-sink sanitization.
 - `wrapTextWithAnsi` trims whitespace at word-wrap boundaries; use cell-aware hard wrapping or horizontal scrolling for exact code/text previews.
 - A custom component embedding `Input` or `Editor` must implement `Focusable` and forward `focused`. Sanitize pasted input after handling but before rendering/filtering so the child retains its own cursor escapes.
 - Pi's public `SelectList.handleInput()` reads global keybindings, while `ctx.ui.select()` maps both Escape and Ctrl+C to `undefined`. Wrappers needing injected keys or distinct Back/Close outcomes must dispatch those keys themselves.

--- a/docs/plans/archived/2026-08-02_starship-module-alignment-plan.md
+++ b/docs/plans/archived/2026-08-02_starship-module-alignment-plan.md
@@ -1,0 +1,43 @@
+# Starship module alignment plan
+
+## Goal
+
+Align module-owned display behavior in `pi-starship` with the checked-in Starship reference, and use the same directly applicable presentation defaults in `pi-statusline`, without changing pi-statusline's configured segment list, responsive layout policy, or Pi-native module semantics.
+
+## Context
+
+- Reference implementation: `third_party/starship` at `cad50cd8`.
+- `pi-starship` owns Starship-inspired TOML module options and should implement compatible behavior in each analogous module rather than in the root renderer.
+- `pi-statusline` keeps its JSON settings, Powerline layout, information profiles, and Pi-native model/activity/status behavior; only directly analogous segment presentation defaults change.
+- The applicable extension and settings guides are `docs/extension-conventions.md` and `docs/extension-settings.md`.
+
+## Architecture
+
+- Keep domain policy in the owning module or segment: directory path contraction in `directory`, branch truncation in `git_branch`, environment-path contraction in `conda`, and model aliases/truncation in `model`.
+- Share only pure primitives within each independently installable extension; do not introduce extension-to-extension imports or a generic renderer-level truncation policy.
+- Publish plain home/repository path data into immutable runtime snapshots where directory rendering requires it; rendering remains synchronous and side-effect free.
+
+## Non-Goals
+
+- Do not change pi-statusline information profiles, segment retention priorities, root layout, or extension-status layout.
+- Do not copy Starship's module `disabled` defaults into pi-statusline.
+- Do not claim complete Starship configuration compatibility or add unsupported Starship modules.
+- Do not change Pi-native model truncation directions, activity lifecycle, usage accounting, or status-map semantics.
+
+## Plan
+
+- [x] Add focused failing `pi-starship` tests for Starship-compatible directory contraction/truncation, Git branch grapheme truncation, configurable commit hash length, empty hostname `trim_at`, configurable Conda path truncation, and exact model aliases; verified red failures through the compiled Node test path on 2026-08-02.
+- [x] Implement pure module-owned path/text primitives and the `pi-starship` catalog options/runtime snapshot data needed by those tests; focused config, module, Git runtime, workspace runtime, and lifecycle tests pass.
+- [x] Add focused failing `pi-statusline` tests for Starship-default directory presentation (home/repository contraction and three-component truncation) while preserving the existing segment list and Pi-native model behavior; verified the expected basename-to-contracted-path red failure.
+- [x] Implement cached repository-root publication plus module-owned directory presentation in `pi-statusline`, using Starship defaults internally without adding renderer-level overflow policy; focused renderer, lifecycle, cancellation, settings, and responsive coverage passes.
+- [x] Update both package READMEs to document the supported module options/defaults, adaptations, and intentional compatibility limits; examples match the tested defaults and schemas.
+- [x] Audit the final diff against the extension/settings touched-area checklists: render paths consume snapshots only; Git refreshes are generation-guarded and abort on replacement/branch change/disposal; existing settings loading, validation, unknown-field preservation, and atomic publication remain covered by the full suite. Documented deviations are bounded integer sentinels, literal-only substitutions, and unavailable logical/repo-split formatting.
+- [x] Run `npm run check`, then dry-run packs for `@narumitw/pi-starship` and `@narumitw/pi-statusline`; `npm run check` passed 2,184 tests plus all validators, and pack inspection found the forwarding entrypoints, new directory/truncation sources, READMEs, and no tests in 62/27 published entries respectively.
+
+## Completion Checklist
+
+- [x] `pi-starship` analogous modules expose and honor the agreed Starship-compatible options with deterministic Unicode/path behavior.
+- [x] `pi-statusline` uses Starship directory presentation defaults without changing its default segment membership or Pi-native module defaults.
+- [x] No renderer-wide truncation or cross-extension dependency was introduced.
+- [x] Focused tests, full repository checks, and both package dry runs pass.
+- [x] The completed plan is archived under `docs/plans/archived/` with all evidence checked.

--- a/extensions/pi-starship/README.md
+++ b/extensions/pi-starship/README.md
@@ -339,22 +339,74 @@ There is no hidden compatibility overlay or automatic migration.
 - Pi's public extension API does not expose the current auto-compaction toggle, so pi-starship cannot
   reliably provide the native `(auto)` marker.
 
-### Model truncation
+### Directory, Git, and environment contraction
 
-The model module accepts Starship-style `truncation_length` and `truncation_symbol` options plus the
-Pi-specific `truncation_direction` option:
+The analogous modules keep their display policy local and use Starship defaults:
+
+```toml
+[directory]
+truncation_length = 3
+truncate_to_repo = true
+fish_style_pwd_dir_length = 0
+truncation_symbol = ""
+home_symbol = "~"
+use_os_path_sep = true
+substitutions = { "/Volumes/network/path" = "/net" }
+
+[git_branch]
+truncation_length = 0 # pi-starship's bounded no-truncation sentinel
+truncation_symbol = "…"
+
+[git_commit]
+commit_hash_length = 7
+
+[conda]
+ignore_base = true
+truncation_length = 1
+
+[hostname]
+trim_at = "." # set to "" to keep the complete hostname
+```
+
+Directory `$path` contracts the home directory and, by default, the current Git repository root
+before retaining the last three path components. `$full_path` remains the unmodified absolute cwd.
+A positive `fish_style_pwd_dir_length` abbreviates otherwise omitted parent components when no
+substitution is configured. `substitutions` is an ordered TOML string table of literal replacements.
+Pi exposes one cwd rather than separate logical and physical paths, and pi-starship does not implement
+Starship's regex substitution array or repo-root-specific split style/format fields. Directory
+rendering reads only immutable home and repository-root snapshot data and performs no filesystem or
+Git work.
+
+Git branch truncation retains the first `N` grapheme clusters and appends the first grapheme of
+`truncation_symbol` only when truncation occurs. The same rule applies independently to `$branch`,
+`$remote_name`, and `$remote_branch`. Upstream Starship represents its unlimited default as
+`2^63 - 1`; pi-starship uses `0` for the same behavior because its settings integers are deliberately
+bounded. `commit_hash_length` accepts 0 through 64.
+
+Conda retains the last path component by default; `0` keeps the complete environment path. Hostname
+trimming runs before exact alias lookup, matching Starship. These are display transformations only:
+collectors retain bounded, control-sanitized source metadata.
+
+### Model aliases and truncation
+
+The model module accepts exact `model_aliases`, Starship-style `truncation_length` and
+`truncation_symbol` options, plus the Pi-specific `truncation_direction` option:
 
 ```toml
 [model]
+model_aliases = { "/models/Qwen3.6-35B-Q4.gguf" = "Qwen 35B Q4" }
 truncation_length = 36
 truncation_symbol = "…"
 truncation_direction = "middle"
 ```
 
-`truncation_length` counts model grapheme clusters retained before the symbol; `0` disables
+An exact alias is selected before the built-in Claude/GPT shortening rules, then the resulting label
+is subject to the configured truncation. `truncation_length` counts model grapheme clusters retained
+before the symbol; `0` disables
 truncation and is the default. The direction names the removed portion: `start` retains the suffix,
-`end` retains the prefix and is the default, and `middle` retains both ends. Truncation runs after the
-built-in Claude/GPT shortening rules and changes display only—the provider model ID is untouched.
+`end` retains the prefix and is the default, and `middle` retains both ends. When no alias matches,
+truncation runs after the built-in Claude/GPT shortening rules. It always changes display only—the
+provider model ID is untouched.
 Terminal control sequences in model IDs and truncation symbols are removed at render time. An empty
 symbol truncates without a marker. For example, `middle` can retain both a Hugging Face model
 family and its variant, while `start` is useful when a llama.cpp server reports an absolute model path.

--- a/extensions/pi-starship/src/modules/development.ts
+++ b/extensions/pi-starship/src/modules/development.ts
@@ -1,3 +1,4 @@
+import { truncatePathComponents } from "./truncation.js";
 import { defineModule, type ModuleDefinition, type ModuleOptionSchema } from "./types.js";
 import { workspaceModuleValues } from "./workspace-helpers.js";
 
@@ -47,13 +48,29 @@ export const direnvModule = developmentModule({
 	options: directDetection,
 });
 
-export const condaModule = developmentModule({
+export const condaModule = defineModule({
 	name: "conda",
-	variables: ["environment"],
-	format: "via [$symbol$environment]($style) ",
-	symbol: "🅒 ",
-	style: "green bold",
-	options: { ignore_base: { kind: "boolean", default: true } },
+	variables: ["symbol", "environment"],
+	defaults: {
+		format: "via [$symbol$environment]($style) ",
+		symbol: "🅒 ",
+		style: "green bold",
+		disabled: false,
+	},
+	options: {
+		ignore_base: { kind: "boolean", default: true },
+		truncation_length: { kind: "integer", default: 1, minimum: 0, maximum: 1_000_000 },
+	},
+	values: (context) => {
+		const values = workspaceModuleValues("conda", context);
+		const environment = values?.environment;
+		if (!environment) return undefined;
+		const length =
+			typeof context.options.truncation_length === "number" ? context.options.truncation_length : 1;
+		return {
+			environment: truncatePathComponents(environment, length).value,
+		};
+	},
 });
 
 export const pixiModule = developmentModule({

--- a/extensions/pi-starship/src/modules/directory.ts
+++ b/extensions/pi-starship/src/modules/directory.ts
@@ -1,4 +1,5 @@
-import { basename } from "node:path";
+import { basename, isAbsolute, relative, sep } from "node:path";
+import { sanitizeTerminalText } from "./terminal.js";
 import {
 	graphemes,
 	toSlashPath,
@@ -27,18 +28,17 @@ export const directoryModule = defineModule({
 	},
 	values: ({ runtime, options }) => {
 		const fullPath = runtime.cwd;
-		const source = toSlashPath(fullPath);
-		const home = runtime.homeDir ? toSlashPath(runtime.homeDir) : undefined;
-		const repoRoot = runtime.gitRoot ? toSlashPath(runtime.gitRoot) : undefined;
+		const home = runtime.homeDir;
+		const repoRoot = runtime.gitRoot;
 		const homeSymbol = stringOption(options, "home_symbol", "~");
 		const truncateToRepo = booleanOption(options, "truncate_to_repo", true);
 		const substitutions = mapOption(options, "substitutions");
-		const homeContracted = contractPath(source, home, homeSymbol);
+		const homeContracted = contractPath(fullPath, home, homeSymbol);
 		const repoContracted =
-			truncateToRepo && repoRoot && repoRoot !== home
-				? contractRepositoryPath(source, repoRoot)
+			truncateToRepo && repoRoot && (!home || !samePath(repoRoot, home))
+				? contractRepositoryPath(fullPath, repoRoot)
 				: undefined;
-		let path = repoContracted ?? homeContracted;
+		let path = sanitizeTerminalText(repoContracted ?? homeContracted);
 		let truncated = repoContracted !== undefined;
 
 		for (const [from, to] of Object.entries(substitutions)) {
@@ -62,26 +62,37 @@ export const directoryModule = defineModule({
 		}
 
 		if (booleanOption(options, "use_os_path_sep", true)) path = useNativePathSeparator(path);
-		return { path: path || basename(fullPath) || fullPath, full_path: fullPath };
+		const fallback = basename(fullPath) || fullPath;
+		return {
+			path: sanitizeTerminalText(path || fallback),
+			full_path: sanitizeTerminalText(fullPath),
+		};
 	},
 });
 
 function contractPath(path: string, root: string | undefined, replacement: string): string {
-	if (!root || !isWithin(path, root)) return path;
-	if (path === root) return replacement;
-	return `${replacement}/${path.slice(root.length).replace(/^\/+/, "")}`;
+	if (!root) return toSlashPath(path);
+	const child = relativeWithin(path, root);
+	if (child === undefined) return toSlashPath(path);
+	return child ? `${replacement}/${child}` : replacement;
 }
 
 function contractRepositoryPath(path: string, root: string): string | undefined {
-	if (!isWithin(path, root)) return undefined;
-	const name = basename(root) || root;
-	if (path === root) return name;
-	return `${name}/${path.slice(root.length).replace(/^\/+/, "")}`;
+	const child = relativeWithin(path, root);
+	if (child === undefined) return undefined;
+	const name = basename(root) || toSlashPath(root);
+	return child ? `${name}/${child}` : name;
 }
 
-function isWithin(path: string, root: string): boolean {
-	const normalizedRoot = root.replace(/\/+$/u, "");
-	return path === normalizedRoot || path.startsWith(`${normalizedRoot}/`);
+function relativeWithin(path: string, root: string): string | undefined {
+	const child = relative(root, path);
+	if (child === "") return "";
+	if (child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) return undefined;
+	return toSlashPath(child);
+}
+
+function samePath(left: string, right: string): boolean {
+	return relative(left, right) === "";
 }
 
 function fishPrefix(source: string, displayed: string, length: number): string {

--- a/extensions/pi-starship/src/modules/directory.ts
+++ b/extensions/pi-starship/src/modules/directory.ts
@@ -1,5 +1,11 @@
 import { basename } from "node:path";
-import { defineModule } from "./types.js";
+import {
+	graphemes,
+	toSlashPath,
+	truncatePathComponents,
+	useNativePathSeparator,
+} from "./truncation.js";
+import { defineModule, type ModuleOptionValue } from "./types.js";
 
 export const directoryModule = defineModule({
 	name: "directory",
@@ -10,8 +16,125 @@ export const directoryModule = defineModule({
 		style: "cyan bold",
 		disabled: false,
 	},
-	values: ({ runtime }) => ({
-		path: basename(runtime.cwd) || runtime.cwd,
-		full_path: runtime.cwd,
-	}),
+	options: {
+		truncation_length: { kind: "integer", default: 3, minimum: 0, maximum: 1_000_000 },
+		truncate_to_repo: { kind: "boolean", default: true },
+		fish_style_pwd_dir_length: { kind: "integer", default: 0, minimum: 0, maximum: 1_000 },
+		truncation_symbol: { kind: "string", default: "" },
+		home_symbol: { kind: "string", default: "~" },
+		use_os_path_sep: { kind: "boolean", default: true },
+		substitutions: { kind: "string-map", default: {} },
+	},
+	values: ({ runtime, options }) => {
+		const fullPath = runtime.cwd;
+		const source = toSlashPath(fullPath);
+		const home = runtime.homeDir ? toSlashPath(runtime.homeDir) : undefined;
+		const repoRoot = runtime.gitRoot ? toSlashPath(runtime.gitRoot) : undefined;
+		const homeSymbol = stringOption(options, "home_symbol", "~");
+		const truncateToRepo = booleanOption(options, "truncate_to_repo", true);
+		const substitutions = mapOption(options, "substitutions");
+		const homeContracted = contractPath(source, home, homeSymbol);
+		const repoContracted =
+			truncateToRepo && repoRoot && repoRoot !== home
+				? contractRepositoryPath(source, repoRoot)
+				: undefined;
+		let path = repoContracted ?? homeContracted;
+		let truncated = repoContracted !== undefined;
+
+		for (const [from, to] of Object.entries(substitutions)) {
+			if (from) path = path.replaceAll(from, to);
+		}
+
+		const componentResult = truncatePathComponents(
+			path,
+			numberOption(options, "truncation_length", 3),
+		);
+		path = componentResult.value;
+		truncated ||= componentResult.truncated;
+
+		if (truncated) {
+			const fishLength = numberOption(options, "fish_style_pwd_dir_length", 0);
+			if (fishLength > 0 && Object.keys(substitutions).length === 0) {
+				path = `${fishPrefix(homeContracted, path, fishLength)}${path}`;
+			} else {
+				path = `${stringOption(options, "truncation_symbol", "")}${path}`;
+			}
+		}
+
+		if (booleanOption(options, "use_os_path_sep", true)) path = useNativePathSeparator(path);
+		return { path: path || basename(fullPath) || fullPath, full_path: fullPath };
+	},
 });
+
+function contractPath(path: string, root: string | undefined, replacement: string): string {
+	if (!root || !isWithin(path, root)) return path;
+	if (path === root) return replacement;
+	return `${replacement}/${path.slice(root.length).replace(/^\/+/, "")}`;
+}
+
+function contractRepositoryPath(path: string, root: string): string | undefined {
+	if (!isWithin(path, root)) return undefined;
+	const name = basename(root) || root;
+	if (path === root) return name;
+	return `${name}/${path.slice(root.length).replace(/^\/+/, "")}`;
+}
+
+function isWithin(path: string, root: string): boolean {
+	const normalizedRoot = root.replace(/\/+$/u, "");
+	return path === normalizedRoot || path.startsWith(`${normalizedRoot}/`);
+}
+
+function fishPrefix(source: string, displayed: string, length: number): string {
+	const prefix = source.endsWith(displayed) ? source.slice(0, -displayed.length) : "";
+	if (!prefix) return "";
+	return prefix
+		.split("/")
+		.map((component) => abbreviateComponent(component, length))
+		.join("/");
+}
+
+function abbreviateComponent(component: string, length: number): string {
+	if (!component) return "";
+	const parts = graphemes(component);
+	if (parts.length <= length) return component;
+	return component.startsWith(".")
+		? parts.slice(0, length + 1).join("")
+		: parts.slice(0, length).join("");
+}
+
+function numberOption(
+	options: Readonly<Record<string, ModuleOptionValue>>,
+	name: string,
+	fallback: number,
+): number {
+	const value = options[name];
+	return typeof value === "number" ? value : fallback;
+}
+
+function stringOption(
+	options: Readonly<Record<string, ModuleOptionValue>>,
+	name: string,
+	fallback: string,
+): string {
+	const value = options[name];
+	return typeof value === "string" ? value : fallback;
+}
+
+function booleanOption(
+	options: Readonly<Record<string, ModuleOptionValue>>,
+	name: string,
+	fallback: boolean,
+): boolean {
+	const value = options[name];
+	return typeof value === "boolean" ? value : fallback;
+}
+
+function mapOption(
+	options: Readonly<Record<string, ModuleOptionValue>>,
+	name: string,
+): Readonly<Record<string, string>> {
+	const value = options[name];
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Readonly<Record<string, string>>)
+		: {};
+}

--- a/extensions/pi-starship/src/modules/execution.ts
+++ b/extensions/pi-starship/src/modules/execution.ts
@@ -42,7 +42,7 @@ export const hostnameModule = defineModule({
 	},
 	options: {
 		ssh_only: { kind: "boolean", default: true },
-		trim_at: { kind: "string", default: ".", allowEmpty: false },
+		trim_at: { kind: "string", default: "." },
 		aliases: { kind: "string-map", default: {} },
 	},
 	values: (context) => workspaceModuleValues("hostname", context),

--- a/extensions/pi-starship/src/modules/git/branch.ts
+++ b/extensions/pi-starship/src/modules/git/branch.ts
@@ -1,3 +1,4 @@
+import { truncateLeadingGraphemes } from "../truncation.js";
 import { defineModule } from "../types.js";
 
 export const gitBranchModule = defineModule({
@@ -9,14 +10,22 @@ export const gitBranchModule = defineModule({
 		style: "bold purple",
 		disabled: false,
 	},
-	values: ({ runtime }) => {
+	options: {
+		// Starship uses i64::MAX as its effective no-truncation default. Zero is the
+		// equivalent stable TOML representation in pi-starship's bounded integer schema.
+		truncation_length: { kind: "integer", default: 0, minimum: 0, maximum: 1_000_000 },
+		truncation_symbol: { kind: "string", default: "…" },
+	},
+	values: ({ runtime, options }) => {
 		const branch = runtime.gitBranchDetails;
 		const name = branch?.name ?? runtime.gitBranch;
 		if (!name) return undefined;
+		const length = typeof options.truncation_length === "number" ? options.truncation_length : 0;
+		const symbol = typeof options.truncation_symbol === "string" ? options.truncation_symbol : "…";
 		return {
-			branch: name,
-			remote_name: branch?.remoteName ?? "",
-			remote_branch: branch?.remoteBranch ?? "",
+			branch: truncateLeadingGraphemes(name, length, symbol),
+			remote_name: truncateLeadingGraphemes(branch?.remoteName ?? "", length, symbol),
+			remote_branch: truncateLeadingGraphemes(branch?.remoteBranch ?? "", length, symbol),
 		};
 	},
 });

--- a/extensions/pi-starship/src/modules/git/commit.ts
+++ b/extensions/pi-starship/src/modules/git/commit.ts
@@ -11,11 +11,18 @@ export const gitCommitModule = defineModule({
 		style: "green bold",
 		disabled: false,
 	},
-	values: ({ runtime }) => {
+	options: {
+		commit_hash_length: { kind: "integer", default: DEFAULT_HASH_LENGTH, minimum: 0, maximum: 64 },
+	},
+	values: ({ runtime, options }) => {
 		const commit = runtime.gitCommit;
 		if (!commit) return undefined;
+		const hashLength =
+			typeof options.commit_hash_length === "number"
+				? options.commit_hash_length
+				: DEFAULT_HASH_LENGTH;
 		return {
-			hash: commit.hash.slice(0, DEFAULT_HASH_LENGTH),
+			hash: commit.hash.slice(0, hashLength),
 			tag: commit.tag ? ` 🏷 ${commit.tag}` : "",
 		};
 	},

--- a/extensions/pi-starship/src/modules/git/runtime.ts
+++ b/extensions/pi-starship/src/modules/git/runtime.ts
@@ -77,6 +77,7 @@ export async function readGitSnapshot(
 
 	return {
 		...parsed,
+		root: metadata?.root,
 		commit,
 		state: metadata ? parseGitState(metadata.gitDirectory) : undefined,
 		metrics,
@@ -250,6 +251,7 @@ export function parseGitState(gitDirectory: string): GitStateSnapshot | undefine
 }
 
 interface GitRepositoryMetadata {
+	root: string;
 	gitDirectory: string;
 	worktree?: GitWorktreeSnapshot;
 }
@@ -261,6 +263,7 @@ function parseGitRepositoryMetadata(output: string): GitRepositoryMetadata | und
 	if (!path || !commonDir || !gitDirectory) return undefined;
 	if (![path, commonDir, gitDirectory].every(isAbsolute)) return undefined;
 	return {
+		root: path,
 		gitDirectory,
 		worktree: samePath(commonDir, gitDirectory)
 			? undefined

--- a/extensions/pi-starship/src/modules/model.ts
+++ b/extensions/pi-starship/src/modules/model.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalText } from "./terminal.js";
 import { defineModule } from "./types.js";
 
 const TRUNCATION_DIRECTIONS = ["start", "middle", "end"] as const;
@@ -51,11 +52,11 @@ export function truncateModel(
 	symbol: string,
 	direction: TruncationDirection,
 ): string {
-	const safeModel = sanitizeModelDisplay(model);
+	const safeModel = sanitizeTerminalText(model);
 	if (length === 0) return safeModel;
 	const graphemes = [...graphemeSegmenter.segment(safeModel)].map(({ segment }) => segment);
 	if (graphemes.length <= length) return safeModel;
-	const safeSymbol = sanitizeModelDisplay(symbol);
+	const safeSymbol = sanitizeTerminalText(symbol);
 
 	switch (direction) {
 		case "start":
@@ -69,67 +70,6 @@ export function truncateModel(
 		case "end":
 			return `${graphemes.slice(0, length).join("")}${safeSymbol}`;
 	}
-}
-
-function sanitizeModelDisplay(value: string): string {
-	let result = "";
-	for (let index = 0; index < value.length; ) {
-		const codePoint = value.codePointAt(index) ?? 0;
-		const character = String.fromCodePoint(codePoint);
-		if (codePoint === 0x1b || codePoint === 0x9b || codePoint === 0x9d) {
-			index = skipTerminalEscape(value, index, codePoint);
-			continue;
-		}
-		if (
-			codePoint <= 0x1f ||
-			(codePoint >= 0x7f && codePoint <= 0x9f) ||
-			codePoint === 0x2028 ||
-			codePoint === 0x2029
-		) {
-			if (
-				codePoint === 0x09 ||
-				codePoint === 0x0a ||
-				codePoint === 0x0d ||
-				codePoint === 0x85 ||
-				codePoint === 0x2028 ||
-				codePoint === 0x2029
-			) {
-				result += " ";
-			}
-			index += character.length;
-			continue;
-		}
-		result += character;
-		index += character.length;
-	}
-	return result;
-}
-
-function skipTerminalEscape(value: string, start: number, codePoint: number): number {
-	let index = start + 1;
-	const next = value.charCodeAt(index);
-	const isOsc = codePoint === 0x9d || (codePoint === 0x1b && next === 0x5d);
-	if (isOsc) {
-		if (codePoint === 0x1b) index += 1;
-		while (index < value.length) {
-			const current = value.charCodeAt(index);
-			if (current === 0x07 || current === 0x9c) return index + 1;
-			if (current === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 2;
-			index += 1;
-		}
-		return index;
-	}
-	const isCsi = codePoint === 0x9b || (codePoint === 0x1b && next === 0x5b);
-	if (isCsi) {
-		if (codePoint === 0x1b) index += 1;
-		while (index < value.length) {
-			const current = value.charCodeAt(index);
-			index += 1;
-			if (current >= 0x40 && current <= 0x7e) break;
-		}
-		return index;
-	}
-	return Math.min(value.length, start + (codePoint === 0x1b ? 2 : 1));
 }
 
 function isTruncationDirection(value: unknown): value is TruncationDirection {

--- a/extensions/pi-starship/src/modules/model.ts
+++ b/extensions/pi-starship/src/modules/model.ts
@@ -21,6 +21,7 @@ export const modelModule = defineModule({
 			default: "end",
 			values: TRUNCATION_DIRECTIONS,
 		},
+		model_aliases: { kind: "string-map", default: {} },
 	},
 	values: ({ runtime, options }) => {
 		if (!runtime.model) return undefined;
@@ -29,8 +30,17 @@ export const modelModule = defineModule({
 		const direction = isTruncationDirection(options.truncation_direction)
 			? options.truncation_direction
 			: "end";
+		const aliases = options.model_aliases;
+		const aliasMap =
+			aliases && typeof aliases === "object" && !Array.isArray(aliases)
+				? (aliases as Readonly<Record<string, string>>)
+				: undefined;
+		const alias =
+			aliasMap && Object.hasOwn(aliasMap, runtime.model.id)
+				? aliasMap[runtime.model.id]
+				: undefined;
 		return {
-			model: truncateModel(shortenModel(runtime.model.id), length, symbol, direction),
+			model: truncateModel(alias ?? shortenModel(runtime.model.id), length, symbol, direction),
 		};
 	},
 });

--- a/extensions/pi-starship/src/modules/terminal.ts
+++ b/extensions/pi-starship/src/modules/terminal.ts
@@ -1,0 +1,60 @@
+export function sanitizeTerminalText(value: string): string {
+	let result = "";
+	for (let index = 0; index < value.length; ) {
+		const codePoint = value.codePointAt(index) ?? 0;
+		const character = String.fromCodePoint(codePoint);
+		if (codePoint === 0x1b || codePoint === 0x9b || codePoint === 0x9d) {
+			index = skipTerminalEscape(value, index, codePoint);
+			continue;
+		}
+		if (
+			codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			codePoint === 0x2028 ||
+			codePoint === 0x2029
+		) {
+			if (
+				codePoint === 0x09 ||
+				codePoint === 0x0a ||
+				codePoint === 0x0d ||
+				codePoint === 0x85 ||
+				codePoint === 0x2028 ||
+				codePoint === 0x2029
+			) {
+				result += " ";
+			}
+			index += character.length;
+			continue;
+		}
+		result += character;
+		index += character.length;
+	}
+	return result;
+}
+
+function skipTerminalEscape(value: string, start: number, codePoint: number): number {
+	let index = start + 1;
+	const next = value.charCodeAt(index);
+	const isOsc = codePoint === 0x9d || (codePoint === 0x1b && next === 0x5d);
+	if (isOsc) {
+		if (codePoint === 0x1b) index += 1;
+		while (index < value.length) {
+			const current = value.charCodeAt(index);
+			if (current === 0x07 || current === 0x9c) return index + 1;
+			if (current === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 2;
+			index += 1;
+		}
+		return index;
+	}
+	const isCsi = codePoint === 0x9b || (codePoint === 0x1b && next === 0x5b);
+	if (isCsi) {
+		if (codePoint === 0x1b) index += 1;
+		while (index < value.length) {
+			const current = value.charCodeAt(index);
+			index += 1;
+			if (current >= 0x40 && current <= 0x7e) break;
+		}
+		return index;
+	}
+	return Math.min(value.length, start + (codePoint === 0x1b ? 2 : 1));
+}

--- a/extensions/pi-starship/src/modules/truncation.ts
+++ b/extensions/pi-starship/src/modules/truncation.ts
@@ -18,7 +18,7 @@ export function truncateLeadingGraphemes(value: string, length: number, symbol: 
 }
 
 export function toSlashPath(value: string): string {
-	return value.replaceAll("\\", "/");
+	return sep === "\\" ? value.replaceAll("\\", "/") : value;
 }
 
 export function truncatePathComponents(

--- a/extensions/pi-starship/src/modules/truncation.ts
+++ b/extensions/pi-starship/src/modules/truncation.ts
@@ -1,0 +1,37 @@
+import { sep } from "node:path";
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export function graphemes(value: string): string[] {
+	return [...graphemeSegmenter.segment(value)].map(({ segment }) => segment);
+}
+
+export function firstGrapheme(value: string): string {
+	return graphemes(value)[0] ?? "";
+}
+
+export function truncateLeadingGraphemes(value: string, length: number, symbol: string): string {
+	if (length <= 0) return value;
+	const parts = graphemes(value);
+	if (parts.length <= length) return value;
+	return `${parts.slice(0, length).join("")}${firstGrapheme(symbol)}`;
+}
+
+export function toSlashPath(value: string): string {
+	return value.replaceAll("\\", "/");
+}
+
+export function truncatePathComponents(
+	value: string,
+	length: number,
+): { value: string; truncated: boolean } {
+	if (length <= 0) return { value, truncated: false };
+	const normalized = toSlashPath(value);
+	const components = normalized.split("/").filter((component) => component.length > 0);
+	if (components.length <= length) return { value: normalized, truncated: false };
+	return { value: components.slice(-length).join("/"), truncated: true };
+}
+
+export function useNativePathSeparator(value: string): string {
+	return sep === "/" ? value : value.replaceAll("/", sep);
+}

--- a/extensions/pi-starship/src/modules/types.ts
+++ b/extensions/pi-starship/src/modules/types.ts
@@ -63,6 +63,7 @@ export interface GithubPrSnapshot {
 }
 
 export interface GitSnapshot {
+	root?: string;
 	branch?: GitBranchSnapshot;
 	commit?: GitCommitSnapshot;
 	state?: GitStateSnapshot;
@@ -78,6 +79,8 @@ export interface WorkspaceSnapshot {
 
 export interface StarshipRuntimeSnapshot {
 	cwd: string;
+	homeDir?: string;
+	gitRoot?: string;
 	model?: { provider: string; id: string };
 	thinkingLevel: string;
 	turnCount: number;

--- a/extensions/pi-starship/src/pi-starship.ts
+++ b/extensions/pi-starship/src/pi-starship.ts
@@ -90,7 +90,10 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 	const gitController = new AsyncRefreshController<GitRefreshInput, GitSnapshot | undefined>({
 		async read(input, signal) {
 			const requirements = reachableModuleRequirements(input.config);
-			const gitReachable = [...requirements.keys()].some((name) => name.startsWith("git_"));
+			const gitReachable =
+				[...requirements.keys()].some((name) => name.startsWith("git_")) ||
+				(requirements.has("directory") &&
+					input.config.modules.directory.options.truncate_to_repo === true);
 			if (!gitReachable) return undefined;
 			try {
 				return await readGitSnapshot(pi, input.cwd, {
@@ -521,6 +524,8 @@ function runtimeSnapshot(
 ): StarshipRuntimeSnapshot {
 	return {
 		cwd: ctx.cwd,
+		homeDir: homedir(),
+		gitRoot: runtime.git?.root,
 		model: ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined,
 		thinkingLevel: runtime.thinkingLevel,
 		turnCount: userTurnCount(ctx),

--- a/extensions/pi-starship/src/runtime/development.ts
+++ b/extensions/pi-starship/src/runtime/development.ts
@@ -8,7 +8,6 @@ import {
 	optionBoolean,
 	optionString,
 	optionStrings,
-	pathName,
 	runBounded,
 	safeMetadata,
 	setString,
@@ -51,7 +50,7 @@ export async function collectDevelopment(
 		conda &&
 		!(optionBoolean(context, "conda", "ignore_base") && conda === "base")
 	) {
-		result.conda = { environment: pathName(conda) };
+		result.conda = { environment: conda };
 	}
 
 	if (context.needs("pixi") && detected(context, entries, "pixi", ["pixi.toml", "pixi.lock"])) {

--- a/extensions/pi-starship/src/runtime/execution.ts
+++ b/extensions/pi-starship/src/runtime/execution.ts
@@ -100,7 +100,7 @@ function hostnameValues(context: CollectorContext): Record<string, string> | und
 	const aliases = optionMap(context, "hostname", "aliases");
 	const trimAt = optionString(context, "hostname", "trim_at");
 	const index = trimAt ? raw.indexOf(trimAt) : -1;
-	const trimmed = index > 0 ? raw.slice(0, index) : raw;
+	const trimmed = index >= 0 ? raw.slice(0, index) : raw;
 	const hostname = exactAlias(trimmed, aliases) ?? trimmed;
 	return { hostname, ssh_symbol: ssh ? "🌐 " : "" };
 }

--- a/extensions/pi-starship/src/runtime/execution.ts
+++ b/extensions/pi-starship/src/runtime/execution.ts
@@ -98,12 +98,10 @@ function hostnameValues(context: CollectorContext): Record<string, string> | und
 	const raw = safeMetadata(context.input.hostname);
 	if (!raw) return undefined;
 	const aliases = optionMap(context, "hostname", "aliases");
-	let hostname = exactAlias(raw, aliases) ?? raw;
-	if (hostname === raw) {
-		const trimAt = optionString(context, "hostname", "trim_at");
-		const index = trimAt ? hostname.indexOf(trimAt) : -1;
-		if (index > 0) hostname = hostname.slice(0, index);
-	}
+	const trimAt = optionString(context, "hostname", "trim_at");
+	const index = trimAt ? raw.indexOf(trimAt) : -1;
+	const trimmed = index > 0 ? raw.slice(0, index) : raw;
+	const hostname = exactAlias(trimmed, aliases) ?? trimmed;
 	return { hostname, ssh_symbol: ssh ? "🌐 " : "" };
 }
 

--- a/extensions/pi-starship/test/config.test.ts
+++ b/extensions/pi-starship/test/config.test.ts
@@ -183,20 +183,55 @@ test("catalog-owned module options normalize values and diagnose invalid input",
 	assert.match(invalidMessages, /cache\.future/iu);
 });
 
+test("Starship-aligned module options normalize their public defaults", () => {
+	assert.deepEqual(BUILT_IN_CONFIG.modules.directory.options, {
+		truncation_length: 3,
+		truncate_to_repo: true,
+		fish_style_pwd_dir_length: 0,
+		truncation_symbol: "",
+		home_symbol: "~",
+		use_os_path_sep: true,
+		substitutions: {},
+	});
+	assert.deepEqual(BUILT_IN_CONFIG.modules.git_branch.options, {
+		truncation_length: 0,
+		truncation_symbol: "…",
+	});
+	assert.deepEqual(BUILT_IN_CONFIG.modules.git_commit.options, { commit_hash_length: 7 });
+	assert.deepEqual(BUILT_IN_CONFIG.modules.conda.options, {
+		ignore_base: true,
+		truncation_length: 1,
+	});
+
+	const valid = loadFromText(
+		"[directory]\ntruncation_length = 2\ntruncate_to_repo = false\nfish_style_pwd_dir_length = 1\ntruncation_symbol = '…/'\nhome_symbol = '⌂'\nuse_os_path_sep = false\nsubstitutions = { workspace = 'w' }\n\n[git_branch]\ntruncation_length = 24\ntruncation_symbol = ''\n\n[git_commit]\ncommit_hash_length = 10\n\n[conda]\ntruncation_length = 0\n\n[hostname]\ntrim_at = ''\n",
+	);
+	assert.deepEqual(valid.diagnostics, []);
+	assert.equal(valid.config.modules.directory.options.truncation_length, 2);
+	assert.deepEqual(valid.config.modules.directory.options.substitutions, { workspace: "w" });
+	assert.equal(valid.config.modules.git_branch.options.truncation_length, 24);
+	assert.equal(valid.config.modules.git_commit.options.commit_hash_length, 10);
+	assert.deepEqual(loadFromText("[git_commit]\ncommit_hash_length = 0\n").diagnostics, []);
+	assert.equal(valid.config.modules.conda.options.truncation_length, 0);
+	assert.equal(valid.config.modules.hostname.options.trim_at, "");
+});
+
 test("model truncation options normalize values and reject invalid directions independently", () => {
 	assert.deepEqual(BUILT_IN_CONFIG.modules.model.options, {
 		truncation_length: 0,
 		truncation_symbol: "…",
 		truncation_direction: "end",
+		model_aliases: {},
 	});
 
 	const valid = loadFromText(
-		"[model]\ntruncation_length = 36\ntruncation_symbol = ''\ntruncation_direction = 'middle'\n",
+		"[model]\ntruncation_length = 36\ntruncation_symbol = ''\ntruncation_direction = 'middle'\nmodel_aliases = { raw = 'short' }\n",
 	);
 	assert.deepEqual(valid.config.modules.model.options, {
 		truncation_length: 36,
 		truncation_symbol: "",
 		truncation_direction: "middle",
+		model_aliases: { raw: "short" },
 	});
 	assert.deepEqual(valid.diagnostics, []);
 
@@ -207,6 +242,7 @@ test("model truncation options normalize values and reject invalid directions in
 		truncation_length: 0,
 		truncation_symbol: "…",
 		truncation_direction: "end",
+		model_aliases: {},
 	});
 	assert.deepEqual(
 		invalid.diagnostics.map((item) => item.path),

--- a/extensions/pi-starship/test/git-runtime.test.ts
+++ b/extensions/pi-starship/test/git-runtime.test.ts
@@ -123,6 +123,7 @@ test("Git snapshot refresh collects optional commit tags and line metrics outsid
 			includeMetrics: true,
 			includeTag: true,
 		});
+		assert.equal(snapshot?.root, root);
 		assert.equal(snapshot?.commit?.tag, "v2.0.0");
 		assert.deepEqual(snapshot?.metrics, { added: 8, deleted: 2 });
 		assert.equal(commands.length, 4);

--- a/extensions/pi-starship/test/lifecycle.test.ts
+++ b/extensions/pi-starship/test/lifecycle.test.ts
@@ -101,6 +101,27 @@ test("non-TUI sessions install no footer and execute no Git or GitHub subprocess
 	assert.equal(calls, 0);
 });
 
+test("reachable directory alone collects repository-root metadata", async (t) => {
+	useLifecycleConfig(t, "format = '$directory'\n");
+	const mock = createMockPi();
+	let statusCalls = 0;
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (_command: string, args: string[]) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args) => {
+		if (args.includes("status")) statusCalls += 1;
+		if (args[0] === "rev-parse") return gitResult("/workspace\n/workspace/.git\n/workspace/.git\n");
+		return gitResult("# branch.oid 0123456789abcdef\n# branch.head main\n");
+	};
+	piStarship(mock.pi);
+	const context = createMockContext({ mode: "tui", cwd: "/workspace/src" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+	await flushAsync();
+	assert.equal(statusCalls, 1);
+	await emit(mock.events, "session_shutdown", {}, context.ctx);
+});
+
 test("unreachable and disabled native PR modules execute no gh command", async () => {
 	for (const source of ["format = '$model'\n", "[github_pr]\ndisabled = true\n"]) {
 		const root = mkdtempSync(join(tmpdir(), "pi-starship-pr-gate-"));

--- a/extensions/pi-starship/test/modules.test.ts
+++ b/extensions/pi-starship/test/modules.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { sep } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { BUILT_IN_CONFIG } from "../src/config.js";
@@ -525,6 +526,66 @@ test("directory applies Starship home, repository, substitution, and component d
 	);
 });
 
+test("directory normalizes equivalent roots before contraction", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$directory";
+	config.formatAst = parseFormat(config.format);
+	config.modules.directory.format = "$path";
+	config.modules.directory.formatAst = parseFormat(config.modules.directory.format);
+	config.modules.directory.options.truncation_length = 0;
+
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({ cwd: "/repository", homeDir: "/home/alice", gitRoot: "/repository/" }),
+			).ansi,
+		),
+		"repository",
+	);
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({ cwd: "/home/alice", homeDir: "/home/alice", gitRoot: "/home/alice/" }),
+			).ansi,
+		),
+		"~",
+	);
+});
+
+test("directory preserves POSIX backslashes and strips terminal controls", {
+	skip: sep !== "/",
+}, () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$directory";
+	config.formatAst = parseFormat(config.format);
+	config.modules.directory.format = "$path|$full_path";
+	config.modules.directory.formatAst = parseFormat(config.modules.directory.format);
+
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({ cwd: "/home/alice/team\\name/project", homeDir: "/home/alice" }),
+			).ansi,
+		),
+		"~/team\\name/project|/home/alice/team\\name/project",
+	);
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({
+					cwd: "/home/alice/team\x1b]8;;https://evil.example\x07click\x1b]8;;\x07/repo\nline",
+					homeDir: "/home/alice",
+				}),
+			).ansi,
+		),
+		"~/teamclick/repo line|/home/alice/teamclick/repo line",
+	);
+});
+
 test("Git branch and commit honor Starship truncation options", () => {
 	const config = structuredClone(BUILT_IN_CONFIG);
 	config.format = "$git_branch|$git_commit";
@@ -708,6 +769,19 @@ test("Conda applies Starship path-component truncation in its owning module", ()
 	assert.equal(stripAnsi(renderStatusline(config, runtime).ansi), "team/work");
 	config.modules.conda.options.truncation_length = 0;
 	assert.equal(stripAnsi(renderStatusline(config, runtime).ansi), "/envs/team/work");
+
+	if (sep === "/") {
+		config.modules.conda.options.truncation_length = 1;
+		assert.equal(
+			stripAnsi(
+				renderStatusline(
+					config,
+					fixture({ workspace: { modules: { conda: { environment: "/envs/team\\work" } } } }),
+				).ansi,
+			),
+			"team\\work",
+		);
+	}
 });
 
 test("first-wave workspace modules render documented snapshot variables", () => {

--- a/extensions/pi-starship/test/modules.test.ts
+++ b/extensions/pi-starship/test/modules.test.ts
@@ -462,6 +462,137 @@ test("$all expands enabled modules in default order without explicit duplicates"
 	assert.match(rendered.ansi, /#7/);
 });
 
+test("directory applies Starship home, repository, substitution, and component defaults", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$directory";
+	config.formatAst = parseFormat(config.format);
+	config.modules.directory.format = "$path|$full_path";
+	config.modules.directory.formatAst = parseFormat(config.modules.directory.format);
+
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({
+					cwd: "/home/alice/work/repository/src/lib/deep",
+					homeDir: "/home/alice",
+					gitRoot: "/home/alice/work/repository",
+				}),
+			).ansi,
+		),
+		"src/lib/deep|/home/alice/work/repository/src/lib/deep",
+	);
+
+	config.modules.directory.options.substitutions = { repository: "repo" };
+	config.modules.directory.options.truncation_length = 0;
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({
+					cwd: "/home/alice/work/repository/src",
+					homeDir: "/home/alice",
+					gitRoot: "/home/alice/work/repository",
+				}),
+			).ansi,
+		),
+		"repo/src|/home/alice/work/repository/src",
+	);
+
+	config.modules.directory.options.truncate_to_repo = false;
+	config.modules.directory.options.truncation_length = 2;
+	config.modules.directory.options.truncation_symbol = "…/";
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({ cwd: "/home/alice/work/repository/src", homeDir: "/home/alice" }),
+			).ansi,
+		),
+		"…/repo/src|/home/alice/work/repository/src",
+	);
+
+	config.modules.directory.options.substitutions = {};
+	config.modules.directory.options.fish_style_pwd_dir_length = 1;
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({ cwd: "/home/alice/built/this/city", homeDir: "/home/alice" }),
+			).ansi,
+		),
+		"~/b/this/city|/home/alice/built/this/city",
+	);
+});
+
+test("Git branch and commit honor Starship truncation options", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$git_branch|$git_commit";
+	config.formatAst = parseFormat(config.format);
+	config.modules.git_branch.format = "$branch:$remote_name/$remote_branch";
+	config.modules.git_branch.formatAst = parseFormat(config.modules.git_branch.format);
+	config.modules.git_branch.options.truncation_length = 4;
+	config.modules.git_branch.options.truncation_symbol = "…more";
+	config.modules.git_commit.format = "$hash";
+	config.modules.git_commit.formatAst = parseFormat(config.modules.git_commit.format);
+	config.modules.git_commit.options.commit_hash_length = 10;
+
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({
+					gitBranchDetails: {
+						name: "feature",
+						remoteName: "origin",
+						remoteBranch: "remote-main",
+						detached: false,
+					},
+				}),
+			).ansi,
+		),
+		"feat…:orig…/remo…|0123456789",
+	);
+
+	config.format = "$git_branch";
+	config.formatAst = parseFormat(config.format);
+	config.modules.git_branch.format = "$branch";
+	config.modules.git_branch.formatAst = parseFormat(config.modules.git_branch.format);
+	config.modules.git_branch.options.truncation_length = 2;
+	assert.equal(
+		stripAnsi(
+			renderStatusline(
+				config,
+				fixture({
+					gitBranchDetails: { name: "A👨‍👩‍👧‍👦BC", detached: false },
+				}),
+			).ansi,
+		),
+		"A👨‍👩‍👧‍👦…",
+	);
+});
+
+test("model exact aliases apply before Pi-specific shortening and truncation", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$model";
+	config.formatAst = parseFormat(config.format);
+	config.modules.model.format = "$model";
+	config.modules.model.formatAst = parseFormat(config.modules.model.format);
+	config.modules.model.options.model_aliases = {
+		"claude-sonnet-4-20250514": "Team Sonnet Model",
+	};
+	config.modules.model.options.truncation_length = 9;
+	config.modules.model.options.truncation_direction = "end";
+
+	assert.equal(stripAnsi(renderStatusline(config, fixture()).ansi), "Team Sonn…");
+	assert.equal(
+		stripAnsi(
+			renderStatusline(config, fixture({ model: { provider: "custom", id: "constructor" } })).ansi,
+		),
+		"construct…",
+	);
+});
+
 test("Starship Git modules expose branch, commit, state, metrics, and detailed status", () => {
 	const config = structuredClone(BUILT_IN_CONFIG);
 	config.format = "$git_branch|$git_commit|$git_state|$git_metrics|$git_status";
@@ -560,6 +691,23 @@ test("git worktree renders linked worktree values and stays empty for the primar
 		"pi-extensions-feature:/work/pi-extensions-feature",
 	);
 	assert.equal(renderStatusline(config, fixture({ gitWorktree: undefined })).ansi, "");
+});
+
+test("Conda applies Starship path-component truncation in its owning module", () => {
+	const config = structuredClone(BUILT_IN_CONFIG);
+	config.format = "$conda";
+	config.formatAst = parseFormat(config.format);
+	config.modules.conda.format = "$environment";
+	config.modules.conda.formatAst = parseFormat(config.modules.conda.format);
+	const runtime = fixture({
+		workspace: { modules: { conda: { environment: "/envs/team/work" } } },
+	});
+
+	assert.equal(stripAnsi(renderStatusline(config, runtime).ansi), "work");
+	config.modules.conda.options.truncation_length = 2;
+	assert.equal(stripAnsi(renderStatusline(config, runtime).ansi), "team/work");
+	config.modules.conda.options.truncation_length = 0;
+	assert.equal(stripAnsi(renderStatusline(config, runtime).ansi), "/envs/team/work");
 });
 
 test("first-wave workspace modules render documented snapshot variables", () => {

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -417,7 +417,7 @@ test("execution context rules are fixture-driven and sanitize terminal metadata"
 		cwd: "/workspace",
 		config: config("$os$container$hostname$username", {
 			os: { disabled: false },
-			hostname: { aliases: { "build.example": "builder" } },
+			hostname: { aliases: { build: "builder" } },
 		}),
 		environment: {
 			SSH_CONNECTION: "local remote",
@@ -442,6 +442,18 @@ test("execution context rules are fixture-driven and sanitize terminal metadata"
 	assert.equal(JSON.stringify(snapshot).includes(String.fromCharCode(27)), false);
 	assert.equal(JSON.stringify(snapshot).includes(String.fromCharCode(7)), false);
 	assert.equal(JSON.stringify(snapshot).includes("\\ud800"), false);
+
+	const untrimmed = await collectWorkspaceSnapshot({
+		cwd: "/workspace",
+		config: config("$hostname", { hostname: { ssh_only: false, trim_at: "" } }),
+		environment: {},
+		homeDir: "/home/user",
+		platform: "linux",
+		hostname: "build.example",
+		username: "user",
+		exec: noExec,
+	});
+	assert.equal(untrimmed.modules.hostname?.hostname, "build.example");
 });
 
 test("execution fixtures cover macOS, Windows, WSL, Docker, Podman, and contextual users", async () => {
@@ -594,7 +606,7 @@ test("development environment modules use allowlisted activation data and lazy c
 		assert.deepEqual(calls, ["mise doctor", "direnv status --json", "pixi --version"]);
 		assert.deepEqual(snapshot.modules.mise, { health: "healthy" });
 		assert.equal(snapshot.modules.direnv?.allowed, "allowed");
-		assert.deepEqual(snapshot.modules.conda, { environment: "work" });
+		assert.deepEqual(snapshot.modules.conda, { environment: "/envs/work" });
 		assert.deepEqual(snapshot.modules.pixi, {
 			environment: "default",
 			project_name: "demo",

--- a/extensions/pi-starship/test/workspace-runtime.test.ts
+++ b/extensions/pi-starship/test/workspace-runtime.test.ts
@@ -454,6 +454,18 @@ test("execution context rules are fixture-driven and sanitize terminal metadata"
 		exec: noExec,
 	});
 	assert.equal(untrimmed.modules.hostname?.hostname, "build.example");
+
+	const emptyTrimmed = await collectWorkspaceSnapshot({
+		cwd: "/workspace",
+		config: config("$hostname", { hostname: { ssh_only: false, trim_at: "build.example" } }),
+		environment: {},
+		homeDir: "/home/user",
+		platform: "linux",
+		hostname: "build.example",
+		username: "user",
+		exec: noExec,
+	});
+	assert.equal(emptyTrimmed.modules.hostname?.hostname, "");
 });
 
 test("execution fixtures cover macOS, Windows, WSL, Docker, Podman, and contextual users", async () => {

--- a/extensions/pi-statusline/README.md
+++ b/extensions/pi-statusline/README.md
@@ -109,11 +109,16 @@ Retention priority is highest to lowest:
 context model branch tools cwd thinking cost provider cache tokens time turn brand
 ```
 
-Explicit `line_break` entries remain row boundaries. A single segment that is still too wide is
-ANSI-safely truncated.
+Explicit `line_break` entries remain row boundaries. If the last remaining segment is itself wider
+than the row, that row renders empty rather than emitting an over-width line.
 
-### Activity, Git, and PR state
+### Directory, activity, Git, and PR state
 
+- `cwd` uses Starship's directory presentation defaults: contract the home directory to `~`, contract
+  to the Git repository root when available, then retain at most the last three path components. This
+  changes display only; the configured segment list and Pi working directory are untouched.
+- Repository-root discovery is cached with Git status outside footer rendering; a failed root query
+  falls back to home/path-component contraction without hiding the segment.
 - During active work, `tools` shows `💭 thinking` or `⚙ <tool>` with parallel counts.
 - Activity disappears after the agent settles and resets across session replacement or shutdown.
 - Clean repositories show no Git counters.
@@ -334,6 +339,7 @@ extensions/pi-statusline/
 │   ├── index.ts
 │   ├── statusline.ts
 │   ├── render.ts
+│   ├── directory.ts
 │   ├── usage.ts
 │   ├── powerline.ts
 │   ├── information-profiles.ts

--- a/extensions/pi-statusline/src/directory.ts
+++ b/extensions/pi-statusline/src/directory.ts
@@ -1,4 +1,5 @@
-import { basename, sep } from "node:path";
+import { basename, isAbsolute, relative, sep } from "node:path";
+import { sanitizeTerminalText } from "./terminal.js";
 
 const DEFAULT_TRUNCATION_LENGTH = 3;
 const DEFAULT_HOME_SYMBOL = "~";
@@ -9,39 +10,45 @@ export function formatDirectoryPath(
 	homeDir: string | undefined,
 	gitRoot: string | undefined,
 ): string {
-	const source = toSlashPath(cwd);
-	const home = homeDir ? toSlashPath(homeDir) : undefined;
-	const root = gitRoot ? toSlashPath(gitRoot) : undefined;
 	const contracted =
-		root && root !== home && isWithin(source, root)
-			? contractRepositoryPath(source, root)
-			: contractPath(source, home, DEFAULT_HOME_SYMBOL);
-	const components = contracted.split("/").filter((component) => component.length > 0);
+		gitRoot && (!homeDir || !samePath(gitRoot, homeDir))
+			? (contractRepositoryPath(cwd, gitRoot) ?? contractPath(cwd, homeDir, DEFAULT_HOME_SYMBOL))
+			: contractPath(cwd, homeDir, DEFAULT_HOME_SYMBOL);
+	const safeContracted = sanitizeTerminalText(contracted);
+	const components = safeContracted.split("/").filter((component) => component.length > 0);
 	const displayed =
 		components.length > DEFAULT_TRUNCATION_LENGTH
 			? components.slice(-DEFAULT_TRUNCATION_LENGTH).join("/")
-			: contracted;
+			: safeContracted;
 	const native = sep === "/" ? displayed : displayed.replaceAll("/", sep);
-	return native || basename(cwd) || cwd;
+	return sanitizeTerminalText(native || basename(cwd) || cwd);
 }
 
 function toSlashPath(value: string): string {
-	return value.replaceAll("\\", "/");
+	return sep === "\\" ? value.replaceAll("\\", "/") : value;
 }
 
 function contractPath(path: string, root: string | undefined, replacement: string): string {
-	if (!root || !isWithin(path, root)) return path;
-	if (path === root) return replacement;
-	return `${replacement}/${path.slice(root.length).replace(/^\/+/, "")}`;
+	if (!root) return toSlashPath(path);
+	const child = relativeWithin(path, root);
+	if (child === undefined) return toSlashPath(path);
+	return child ? `${replacement}/${child}` : replacement;
 }
 
-function contractRepositoryPath(path: string, root: string): string {
-	const name = basename(root) || root;
-	if (path === root) return name;
-	return `${name}/${path.slice(root.length).replace(/^\/+/, "")}`;
+function contractRepositoryPath(path: string, root: string): string | undefined {
+	const child = relativeWithin(path, root);
+	if (child === undefined) return undefined;
+	const name = basename(root) || toSlashPath(root);
+	return child ? `${name}/${child}` : name;
 }
 
-function isWithin(path: string, root: string): boolean {
-	const normalizedRoot = root.replace(/\/+$/u, "");
-	return path === normalizedRoot || path.startsWith(`${normalizedRoot}/`);
+function relativeWithin(path: string, root: string): string | undefined {
+	const child = relative(root, path);
+	if (child === "") return "";
+	if (child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) return undefined;
+	return toSlashPath(child);
+}
+
+function samePath(left: string, right: string): boolean {
+	return relative(left, right) === "";
 }

--- a/extensions/pi-statusline/src/directory.ts
+++ b/extensions/pi-statusline/src/directory.ts
@@ -1,0 +1,47 @@
+import { basename, sep } from "node:path";
+
+const DEFAULT_TRUNCATION_LENGTH = 3;
+const DEFAULT_HOME_SYMBOL = "~";
+
+/** Apply Starship's default directory presentation without exposing a format language. */
+export function formatDirectoryPath(
+	cwd: string,
+	homeDir: string | undefined,
+	gitRoot: string | undefined,
+): string {
+	const source = toSlashPath(cwd);
+	const home = homeDir ? toSlashPath(homeDir) : undefined;
+	const root = gitRoot ? toSlashPath(gitRoot) : undefined;
+	const contracted =
+		root && root !== home && isWithin(source, root)
+			? contractRepositoryPath(source, root)
+			: contractPath(source, home, DEFAULT_HOME_SYMBOL);
+	const components = contracted.split("/").filter((component) => component.length > 0);
+	const displayed =
+		components.length > DEFAULT_TRUNCATION_LENGTH
+			? components.slice(-DEFAULT_TRUNCATION_LENGTH).join("/")
+			: contracted;
+	const native = sep === "/" ? displayed : displayed.replaceAll("/", sep);
+	return native || basename(cwd) || cwd;
+}
+
+function toSlashPath(value: string): string {
+	return value.replaceAll("\\", "/");
+}
+
+function contractPath(path: string, root: string | undefined, replacement: string): string {
+	if (!root || !isWithin(path, root)) return path;
+	if (path === root) return replacement;
+	return `${replacement}/${path.slice(root.length).replace(/^\/+/, "")}`;
+}
+
+function contractRepositoryPath(path: string, root: string): string {
+	const name = basename(root) || root;
+	if (path === root) return name;
+	return `${name}/${path.slice(root.length).replace(/^\/+/, "")}`;
+}
+
+function isWithin(path: string, root: string): boolean {
+	const normalizedRoot = root.replace(/\/+$/u, "");
+	return path === normalizedRoot || path.startsWith(`${normalizedRoot}/`);
+}

--- a/extensions/pi-statusline/src/git-status.ts
+++ b/extensions/pi-statusline/src/git-status.ts
@@ -1,8 +1,10 @@
+import { isAbsolute } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const GIT_STATUS_TIMEOUT_MS = 3_000;
 
 export interface GitStatusSummary {
+	root?: string;
 	ahead: number;
 	behind: number;
 	staged: number;
@@ -14,14 +16,29 @@ export interface GitStatusSummary {
 export async function readGitStatus(
 	pi: ExtensionAPI,
 	cwd: string,
+	signal?: AbortSignal,
 ): Promise<GitStatusSummary | undefined> {
-	const result = await pi.exec(
-		"git",
-		["--no-optional-locks", "status", "--porcelain=v1", "--branch", "--untracked-files=normal"],
-		{ cwd, timeout: GIT_STATUS_TIMEOUT_MS },
-	);
-	if (result.code !== 0 || result.killed) return undefined;
-	return parseGitStatusPorcelain(result.stdout);
+	const [statusResult, rootResult] = await Promise.all([
+		pi.exec(
+			"git",
+			["--no-optional-locks", "status", "--porcelain=v1", "--branch", "--untracked-files=normal"],
+			{ cwd, timeout: GIT_STATUS_TIMEOUT_MS, signal },
+		),
+		pi
+			.exec("git", ["rev-parse", "--path-format=absolute", "--show-toplevel"], {
+				cwd,
+				timeout: GIT_STATUS_TIMEOUT_MS,
+				signal,
+			})
+			.catch(() => undefined),
+	]);
+	if (statusResult.code !== 0 || statusResult.killed) return undefined;
+	const summary = parseGitStatusPorcelain(statusResult.stdout);
+	if (rootResult && rootResult.code === 0 && !rootResult.killed) {
+		const root = parseGitRoot(rootResult.stdout);
+		if (root) summary.root = root;
+	}
+	return summary;
 }
 
 export function parseGitStatusPorcelain(output: string): GitStatusSummary {
@@ -71,6 +88,11 @@ function isChangedStatus(status: string): boolean {
 	return status !== " " && status !== "?" && status !== "!";
 }
 
+export function parseGitRoot(output: string): string | undefined {
+	const root = output.split(/\r?\n/u)[0]?.trim();
+	return root && isAbsolute(root) ? root : undefined;
+}
+
 export function formatGitStatusSummary(summary: GitStatusSummary | undefined): string {
 	if (!summary) return "";
 	const tokens = [
@@ -111,6 +133,7 @@ export function gitStatusSummaryEqual(
 ): boolean {
 	if (!left || !right) return left === right;
 	return (
+		left.root === right.root &&
 		left.ahead === right.ahead &&
 		left.behind === right.behind &&
 		left.staged === right.staged &&

--- a/extensions/pi-statusline/src/render.ts
+++ b/extensions/pi-statusline/src/render.ts
@@ -1,4 +1,3 @@
-import { basename } from "node:path";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -6,6 +5,7 @@ import type {
 	Theme,
 	ThemeColor,
 } from "@earendil-works/pi-coding-agent";
+import { formatDirectoryPath } from "./directory.js";
 import {
 	type ExtensionStatusRuntime,
 	formatExtensionStatuses,
@@ -26,6 +26,7 @@ import { type FooterUsageSummary, summarizeFooterUsage } from "./usage.js";
 
 type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
 export interface RuntimeState extends ExtensionStatusRuntime {
+	homeDir?: string;
 	turnCount: number;
 	activeTools: Map<string, number>;
 	isStreaming: boolean;
@@ -138,7 +139,13 @@ function buildSegment(
 			);
 		}
 		case "cwd":
-			return segment(name, basename(ctx.cwd) || ctx.cwd, config, "accent", "directory");
+			return segment(
+				name,
+				formatDirectoryPath(ctx.cwd, runtime.homeDir, runtime.gitStatus?.root),
+				config,
+				"accent",
+				"directory",
+			);
 		case "tools": {
 			const activity = formatToolActivity(runtime);
 			return activity ? segment(name, activity, config, "accent", "runtime") : undefined;

--- a/extensions/pi-statusline/src/render.ts
+++ b/extensions/pi-statusline/src/render.ts
@@ -13,6 +13,7 @@ import {
 } from "./extension-status.js";
 import { formatGitBranchValue, type GitStatusSummary } from "./git-status.js";
 import { renderPowerlineStatusline } from "./powerline.js";
+import { sanitizeTerminalText } from "./terminal.js";
 import {
 	LINE_BREAK_SEGMENT_NAME,
 	type PowerlineBlockName,
@@ -327,11 +328,11 @@ export function truncateModel(
 	symbol: string,
 	direction: TruncationDirection,
 ): string {
-	const safeModel = sanitizeModelDisplay(model);
+	const safeModel = sanitizeTerminalText(model);
 	if (length === 0) return safeModel;
 	const graphemes = [...graphemeSegmenter.segment(safeModel)].map(({ segment }) => segment);
 	if (graphemes.length <= length) return safeModel;
-	const safeSymbol = sanitizeModelDisplay(symbol);
+	const safeSymbol = sanitizeTerminalText(symbol);
 
 	switch (direction) {
 		case "start":
@@ -345,67 +346,6 @@ export function truncateModel(
 		case "end":
 			return `${graphemes.slice(0, length).join("")}${safeSymbol}`;
 	}
-}
-
-function sanitizeModelDisplay(value: string): string {
-	let result = "";
-	for (let index = 0; index < value.length; ) {
-		const codePoint = value.codePointAt(index) ?? 0;
-		const character = String.fromCodePoint(codePoint);
-		if (codePoint === 0x1b || codePoint === 0x9b || codePoint === 0x9d) {
-			index = skipTerminalEscape(value, index, codePoint);
-			continue;
-		}
-		if (
-			codePoint <= 0x1f ||
-			(codePoint >= 0x7f && codePoint <= 0x9f) ||
-			codePoint === 0x2028 ||
-			codePoint === 0x2029
-		) {
-			if (
-				codePoint === 0x09 ||
-				codePoint === 0x0a ||
-				codePoint === 0x0d ||
-				codePoint === 0x85 ||
-				codePoint === 0x2028 ||
-				codePoint === 0x2029
-			) {
-				result += " ";
-			}
-			index += character.length;
-			continue;
-		}
-		result += character;
-		index += character.length;
-	}
-	return result;
-}
-
-function skipTerminalEscape(value: string, start: number, codePoint: number): number {
-	let index = start + 1;
-	const next = value.charCodeAt(index);
-	const isOsc = codePoint === 0x9d || (codePoint === 0x1b && next === 0x5d);
-	if (isOsc) {
-		if (codePoint === 0x1b) index += 1;
-		while (index < value.length) {
-			const current = value.charCodeAt(index);
-			if (current === 0x07 || current === 0x9c) return index + 1;
-			if (current === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 2;
-			index += 1;
-		}
-		return index;
-	}
-	const isCsi = codePoint === 0x9b || (codePoint === 0x1b && next === 0x5b);
-	if (isCsi) {
-		if (codePoint === 0x1b) index += 1;
-		while (index < value.length) {
-			const current = value.charCodeAt(index);
-			index += 1;
-			if (current >= 0x40 && current <= 0x7e) break;
-		}
-		return index;
-	}
-	return Math.min(value.length, start + (codePoint === 0x1b ? 2 : 1));
 }
 
 export function shortenModel(model: string): string {

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -242,6 +242,7 @@ export default function statusline(pi: ExtensionAPI) {
 		activeSessionManager = undefined;
 		previewPalettePreset = undefined;
 		activeGitStatusTarget = undefined;
+		abortGitStatusRefresh("Statusline session shut down");
 		clearGitStatusDebounce();
 		pendingGitStatusRefresh = undefined;
 		runtime.gitStatus = undefined;

--- a/extensions/pi-statusline/src/statusline.ts
+++ b/extensions/pi-statusline/src/statusline.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import {
 	type ExtensionAPI,
 	type ExtensionContext,
@@ -44,6 +45,7 @@ export default function statusline(pi: ExtensionAPI) {
 	let gitStatusRequestId = 0;
 	let activeGitStatusTarget: { cwd: string; generation: number } | undefined;
 	let gitStatusRefreshInFlight = false;
+	let gitStatusAbortController: AbortController | undefined;
 	let gitStatusDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 	let pendingGitStatusRefresh: { cwd: string; generation: number; requestId: number } | undefined;
 
@@ -62,6 +64,10 @@ export default function statusline(pi: ExtensionAPI) {
 		gitStatusDebounceTimer = undefined;
 	};
 
+	const abortGitStatusRefresh = (reason: string) => {
+		gitStatusAbortController?.abort(new DOMException(reason, "AbortError"));
+	};
+
 	const isActiveGitStatusTarget = (cwd: string, generation: number) =>
 		activeGitStatusTarget?.cwd === cwd &&
 		activeGitStatusTarget.generation === generation &&
@@ -78,14 +84,17 @@ export default function statusline(pi: ExtensionAPI) {
 		}
 
 		gitStatusRefreshInFlight = true;
+		const abortController = new AbortController();
+		gitStatusAbortController = abortController;
 		void (async () => {
 			try {
-				const summary = await readGitStatus(pi, cwd);
+				const summary = await readGitStatus(pi, cwd, abortController.signal);
 				if (isCurrentGitStatusRequest(cwd, generation, requestId)) setGitStatus(summary);
 			} catch {
 				if (isCurrentGitStatusRequest(cwd, generation, requestId)) setGitStatus(undefined);
 			} finally {
 				gitStatusRefreshInFlight = false;
+				if (gitStatusAbortController === abortController) gitStatusAbortController = undefined;
 				const pending = pendingGitStatusRefresh;
 				pendingGitStatusRefresh = undefined;
 				if (pending) runGitStatusRefresh(pending.cwd, pending.generation, pending.requestId);
@@ -119,7 +128,9 @@ export default function statusline(pi: ExtensionAPI) {
 		menuController = new AbortController();
 		const cwd = ctx.cwd;
 		activeSessionManager = ctx.sessionManager;
+		runtime.homeDir = homedir();
 		previewPalettePreset = undefined;
+		abortGitStatusRefresh("Statusline session context replaced");
 		clearGitStatusDebounce();
 		activeGitStatusTarget = ctx.mode === "tui" ? { cwd, generation } : undefined;
 		runtime.gitStatus = undefined;
@@ -136,6 +147,7 @@ export default function statusline(pi: ExtensionAPI) {
 			const refreshFooterGitStatus = () => refreshGitStatus(cwd, generation);
 			const branchUnsubscribe = footerData.onBranchChange(() => {
 				runtime.gitStatus = undefined;
+				abortGitStatusRefresh("Statusline Git branch changed");
 				clearGitStatusDebounce();
 				refreshFooterGitStatus();
 				tui.requestRender();
@@ -152,6 +164,7 @@ export default function statusline(pi: ExtensionAPI) {
 					clearInterval(clock);
 					if (isActiveGitStatusTarget(cwd, generation)) {
 						activeGitStatusTarget = undefined;
+						abortGitStatusRefresh("Statusline footer disposed");
 						clearGitStatusDebounce();
 						pendingGitStatusRefresh = undefined;
 						runtime.gitStatus = undefined;
@@ -324,7 +337,9 @@ export {
 	formatGitBranchValue,
 	formatGitStatusSummary,
 	type GitStatusSummary,
+	parseGitRoot,
 	parseGitStatusPorcelain,
+	readGitStatus,
 } from "./git-status.js";
 export {
 	contextColor,

--- a/extensions/pi-statusline/src/terminal.ts
+++ b/extensions/pi-statusline/src/terminal.ts
@@ -1,0 +1,60 @@
+export function sanitizeTerminalText(value: string): string {
+	let result = "";
+	for (let index = 0; index < value.length; ) {
+		const codePoint = value.codePointAt(index) ?? 0;
+		const character = String.fromCodePoint(codePoint);
+		if (codePoint === 0x1b || codePoint === 0x9b || codePoint === 0x9d) {
+			index = skipTerminalEscape(value, index, codePoint);
+			continue;
+		}
+		if (
+			codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			codePoint === 0x2028 ||
+			codePoint === 0x2029
+		) {
+			if (
+				codePoint === 0x09 ||
+				codePoint === 0x0a ||
+				codePoint === 0x0d ||
+				codePoint === 0x85 ||
+				codePoint === 0x2028 ||
+				codePoint === 0x2029
+			) {
+				result += " ";
+			}
+			index += character.length;
+			continue;
+		}
+		result += character;
+		index += character.length;
+	}
+	return result;
+}
+
+function skipTerminalEscape(value: string, start: number, codePoint: number): number {
+	let index = start + 1;
+	const next = value.charCodeAt(index);
+	const isOsc = codePoint === 0x9d || (codePoint === 0x1b && next === 0x5d);
+	if (isOsc) {
+		if (codePoint === 0x1b) index += 1;
+		while (index < value.length) {
+			const current = value.charCodeAt(index);
+			if (current === 0x07 || current === 0x9c) return index + 1;
+			if (current === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 2;
+			index += 1;
+		}
+		return index;
+	}
+	const isCsi = codePoint === 0x9b || (codePoint === 0x1b && next === 0x5b);
+	if (isCsi) {
+		if (codePoint === 0x1b) index += 1;
+		while (index < value.length) {
+			const current = value.charCodeAt(index);
+			index += 1;
+			if (current >= 0x40 && current <= 0x7e) break;
+		}
+		return index;
+	}
+	return Math.min(value.length, start + (codePoint === 0x1b ? 2 : 1));
+}

--- a/extensions/pi-statusline/test/lifecycle-settings.test.ts
+++ b/extensions/pi-statusline/test/lifecycle-settings.test.ts
@@ -174,7 +174,7 @@ test("a replacement session reloads JSON settings and uses configured segment te
 		);
 		await emit(mock.events, "session_start", {}, context.ctx);
 		footer = createFooter(context.footer as FooterFactory);
-		assert.match(footer.render(200).join("\n"), /📁 project!/u);
+		assert.match(footer.render(200).join("\n"), /📁 \/workspace\/project!/u);
 		assert.doesNotMatch(footer.render(200).join("\n"), /sonnet-4/u);
 		footer.dispose();
 		await emit(mock.events, "session_shutdown", {}, context.ctx);

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -148,6 +148,49 @@ test("idle contextual activity rows collapse while explicit empty rows remain", 
 	assert.deepEqual(explicitEmptyRows.split("\n"), ["", "░▒▓ 🤖 sonnet-4", ""]);
 });
 
+test("cwd uses Starship repository and three-component directory defaults", () => {
+	const config = createDefaultConfig();
+	config.segments = ["cwd"];
+	const context = createMockContext({
+		cwd: "/home/alice/work/repository/src",
+	});
+	const footerData: ReadonlyFooterDataProvider = {
+		getGitBranch: () => "main",
+		getExtensionStatuses: () => new Map<string, string>(),
+		onBranchChange: () => () => undefined,
+		getAvailableProviderCount: () => 1,
+	};
+	const runtime: RuntimeState = {
+		homeDir: "/home/alice",
+		turnCount: 0,
+		activeTools: new Map(),
+		isStreaming: false,
+		thinkingLevel: "off",
+		gitStatus: {
+			root: "/home/alice/work/repository",
+			ahead: 0,
+			behind: 0,
+			staged: 0,
+			modified: 0,
+			untracked: 0,
+			conflicts: 0,
+		},
+		duplicateExtensions: [],
+		extensionStatusIconAliases: new Map(),
+	};
+
+	assert.equal(
+		plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
+		"░▒▓ 📁 repository/src",
+	);
+
+	runtime.gitStatus = undefined;
+	assert.equal(
+		plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
+		"░▒▓ 📁 work/repository/src",
+	);
+});
+
 test("model truncation supports all directions before prefixes and responsive fitting", () => {
 	const config = createDefaultConfig();
 	config.segments = ["model"];

--- a/extensions/pi-statusline/test/renderer.test.ts
+++ b/extensions/pi-statusline/test/renderer.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { sep } from "node:path";
 import test from "node:test";
 import type { ReadonlyFooterDataProvider, Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -188,6 +189,53 @@ test("cwd uses Starship repository and three-component directory defaults", () =
 	assert.equal(
 		plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
 		"░▒▓ 📁 work/repository/src",
+	);
+
+	(context.ctx as { cwd: string }).cwd = "/home/alice";
+	runtime.gitStatus = {
+		root: "/home/alice/",
+		ahead: 0,
+		behind: 0,
+		staged: 0,
+		modified: 0,
+		untracked: 0,
+		conflicts: 0,
+	};
+	assert.equal(
+		plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
+		"░▒▓ 📁 ~",
+	);
+});
+
+test("cwd preserves POSIX backslashes and strips terminal controls", { skip: sep !== "/" }, () => {
+	const config = createDefaultConfig();
+	config.segments = ["cwd"];
+	const context = createMockContext({ cwd: "/home/alice/team\\name/project" });
+	const footerData: ReadonlyFooterDataProvider = {
+		getGitBranch: () => null,
+		getExtensionStatuses: () => new Map(),
+		onBranchChange: () => () => undefined,
+		getAvailableProviderCount: () => 1,
+	};
+	const runtime: RuntimeState = {
+		homeDir: "/home/alice",
+		turnCount: 0,
+		activeTools: new Map(),
+		isStreaming: false,
+		thinkingLevel: "off",
+		duplicateExtensions: [],
+		extensionStatusIconAliases: new Map(),
+	};
+
+	assert.equal(
+		plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
+		"░▒▓ 📁 ~/team\\name/project",
+	);
+	(context.ctx as { cwd: string }).cwd =
+		"/home/alice/team\x1b]8;;https://evil.example\x07click\x1b]8;;\x07/repo\nline";
+	assert.equal(
+		plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
+		"░▒▓ 📁 ~/teamclick/repo line",
 	);
 });
 

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -384,6 +384,36 @@ test("statusline aborts an in-flight Git refresh when its footer is disposed", a
 	await flushAsync();
 });
 
+test("statusline aborts an in-flight Git refresh during session shutdown", async () => {
+	const mock = createMockPi();
+	const pending = deferred<ExecResult>();
+	let statusSignal: AbortSignal | undefined;
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (
+				command: string,
+				args: string[],
+				options?: { signal?: AbortSignal },
+			) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args, options) => {
+		if (args[0] === "rev-parse") {
+			return { stdout: "/workspace\n", stderr: "", code: 0, killed: false };
+		}
+		statusSignal = options?.signal;
+		return pending.promise;
+	};
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+
+	assert.equal(statusSignal?.aborted, false);
+	await emit(mock.events, "session_shutdown", {}, context.ctx);
+	assert.equal(statusSignal?.aborted, true);
+	pending.resolve({ stdout: "## main\n", stderr: "", code: 0, killed: false });
+	await flushAsync();
+});
+
 test("statusline does not render stale in-flight git status after a branch change", async () => {
 	const mock = createMockPi();
 	const firstStatus = deferred<ExecResult>();

--- a/extensions/pi-statusline/test/statusline.test.ts
+++ b/extensions/pi-statusline/test/statusline.test.ts
@@ -27,9 +27,11 @@ import statusline, {
 	formatGitStatusSummary,
 	formatToolActivity,
 	npmPackageName,
+	parseGitRoot,
 	parseGitStatusPorcelain,
 	prContextFromStatuses,
 	prLinkFromStatuses,
+	readGitStatus,
 	readStatuslineSettings,
 	shortenModel,
 	simplifyExtensionStatusText,
@@ -258,7 +260,10 @@ test("statusline renders cached git status without executing git during render",
 	assert.equal(execCalls, callsBeforeRender);
 	assert.equal(callsBeforeRender, 1);
 
-	async function execGitStatus() {
+	async function execGitStatus(_command: string, args: string[]) {
+		if (args[0] === "rev-parse") {
+			return { stdout: "/workspace\n", stderr: "", code: 0, killed: false };
+		}
 		execCalls += 1;
 		return { stdout: "## main\n M changed.ts\n", stderr: "", code: 0, killed: false };
 	}
@@ -282,7 +287,10 @@ test("statusline ignores stale git refresh events from a previous cwd", async ()
 
 	assert.deepEqual(cwdCalls, [oldCwd, newCwd]);
 
-	async function execGitStatus(_command: string, _args: string[], options?: { cwd?: string }) {
+	async function execGitStatus(_command: string, args: string[], options?: { cwd?: string }) {
+		if (args[0] === "rev-parse") {
+			return { stdout: `${options?.cwd ?? "/workspace"}\n`, stderr: "", code: 0, killed: false };
+		}
 		cwdCalls.push(options?.cwd ?? "");
 		return { stdout: "## main\n", stderr: "", code: 0, killed: false };
 	}
@@ -320,10 +328,60 @@ test("statusline stops git refreshes after its footer is disposed", async () => 
 
 	assert.equal(execCalls, 1);
 
-	async function execGitStatus() {
+	async function execGitStatus(_command: string, args: string[]) {
+		if (args[0] === "rev-parse") {
+			return { stdout: "/workspace\n", stderr: "", code: 0, killed: false };
+		}
 		execCalls += 1;
 		return { stdout: "## main\n", stderr: "", code: 0, killed: false };
 	}
+});
+
+test("statusline aborts an in-flight Git refresh when its footer is disposed", async () => {
+	const mock = createMockPi();
+	const pending = deferred<ExecResult>();
+	let statusSignal: AbortSignal | undefined;
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (
+				command: string,
+				args: string[],
+				options?: { signal?: AbortSignal },
+			) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args, options) => {
+		if (args[0] === "rev-parse") {
+			return { stdout: "/workspace\n", stderr: "", code: 0, killed: false };
+		}
+		statusSignal = options?.signal;
+		return pending.promise;
+	};
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, context.ctx);
+	const footerFactory = context.footer as (
+		tui: { requestRender(): void },
+		theme: { fg(_color: string, text: string): string; bold(text: string): string },
+		footerData: {
+			getGitBranch(): string | null;
+			getExtensionStatuses(): ReadonlyMap<string, string>;
+			onBranchChange(callback: () => void): () => void;
+		},
+	) => { dispose(): void };
+	const footer = footerFactory(
+		{ requestRender() {} },
+		{ fg: (_color, text) => text, bold: (text) => text },
+		{
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+			onBranchChange: () => () => undefined,
+		},
+	);
+	assert.equal(statusSignal?.aborted, false);
+	footer.dispose();
+	assert.equal(statusSignal?.aborted, true);
+	pending.resolve({ stdout: "## main\n", stderr: "", code: 0, killed: false });
+	await flushAsync();
 });
 
 test("statusline does not render stale in-flight git status after a branch change", async () => {
@@ -331,6 +389,7 @@ test("statusline does not render stale in-flight git status after a branch chang
 	const firstStatus = deferred<ExecResult>();
 	const secondStatus = deferred<ExecResult>();
 	const execResults = [firstStatus.promise, secondStatus.promise];
+	const statusSignals: AbortSignal[] = [];
 	let execCalls = 0;
 	(mock.rawPi as typeof mock.rawPi & { exec: typeof execGitStatus }).exec = execGitStatus;
 	statusline(mock.pi);
@@ -365,6 +424,7 @@ test("statusline does not render stale in-flight git status after a branch chang
 	assert.equal(execCalls, 1);
 	assert.ok(branchChange);
 	branchChange();
+	assert.equal(statusSignals[0]?.aborted, true);
 	firstStatus.resolve({ stdout: "## main\n M stale.ts\n", stderr: "", code: 0, killed: false });
 	await flushAsync();
 
@@ -377,7 +437,15 @@ test("statusline does not render stale in-flight git status after a branch chang
 	assert.match(footer.render(120).join("\n"), /\?1/u);
 	footer.dispose();
 
-	async function execGitStatus() {
+	async function execGitStatus(
+		_command: string,
+		args: string[],
+		options?: { signal?: AbortSignal },
+	) {
+		if (args[0] === "rev-parse") {
+			return { stdout: "/workspace\n", stderr: "", code: 0, killed: false };
+		}
+		if (options?.signal) statusSignals.push(options.signal);
 		const result = execResults[execCalls];
 		execCalls += 1;
 		if (!result) throw new Error("unexpected git status refresh");
@@ -431,7 +499,10 @@ test("statusline invalidates in-flight git status while a debounced refresh is p
 	assert.match(footer.render(120).join("\n"), /\?1/u);
 	footer.dispose();
 
-	async function execGitStatus() {
+	async function execGitStatus(_command: string, args: string[]) {
+		if (args[0] === "rev-parse") {
+			return { stdout: "/workspace\n", stderr: "", code: 0, killed: false };
+		}
 		const result = execResults[execCalls];
 		execCalls += 1;
 		if (!result) throw new Error("unexpected git status refresh");
@@ -497,6 +568,32 @@ test("prContextFromStatuses chooses one actionable state by precedence", () => {
 	assert.equal(context("checks passing"), `${link} · checks passing`);
 	assert.equal(context("no checks"), `${link} · no checks`);
 	assert.equal(context("unknown"), undefined);
+});
+
+test("Git status remains available when repository-root discovery fails", async () => {
+	const mock = createMockPi();
+	(
+		mock.rawPi as typeof mock.rawPi & {
+			exec: (_command: string, args: string[]) => Promise<ExecResult>;
+		}
+	).exec = async (_command, args) => {
+		if (args[0] === "rev-parse") throw new Error("root unavailable");
+		return { stdout: "## main\n M changed.ts\n", stderr: "", code: 0, killed: false };
+	};
+	assert.deepEqual(await readGitStatus(mock.pi, "/workspace"), {
+		ahead: 0,
+		behind: 0,
+		staged: 0,
+		modified: 1,
+		untracked: 0,
+		conflicts: 0,
+	});
+});
+
+test("git root parser accepts only an absolute first line", () => {
+	assert.equal(parseGitRoot("/workspace/repo\n"), "/workspace/repo");
+	assert.equal(parseGitRoot("relative/repo\n"), undefined);
+	assert.equal(parseGitRoot(""), undefined);
 });
 
 test("git status parser and formatter produce compact dirty tokens", () => {


### PR DESCRIPTION
## Summary

- add Starship-aligned directory, Git branch/commit, Conda, hostname, and model-alias presentation to `pi-starship`
- apply Starship directory presentation defaults to `pi-statusline` without changing its information profiles or Pi-native module behavior
- cache repository-root metadata outside rendering and cancel stale Git refreshes across branch/session/footer lifecycle boundaries
- document bounded compatibility adaptations and archive the completed implementation plan

## Verification

- `npm run check` — 2,184 tests plus Biome, boundaries, and workspace typechecks passed
- `npm pack --workspace @narumitw/pi-starship --dry-run --json` — 62 expected publish entries, including the new module sources; no tests
- `npm pack --workspace @narumitw/pi-statusline --dry-run --json` — 27 expected publish entries, including `src/directory.ts`; no tests
