### PR TITLE
fix(pi-subagents): resolve child CLI from core package

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -75,6 +75,7 @@
 - OAuth/account cleanup must invalidate in-flight work instead of waiting behind a serialized conversion. Guard both credential mutation and outer status/connection publication with latest-task ownership.
 - For detached subagents, snapshot terminal state before resolving waiters, inject completion with `deliverAs: "steer", triggerTurn: false`, and serialize persistence callbacks in invocation order.
 - Blocking a Pi `tool_call` returns a non-terminating error, so agent-core may continue. Abort the turn too when a bounded flow must stop after the blocked call.
+- Pi-subagents subprocess tests must provide fake Pi through a test-owned `PI_PACKAGE_DIR` and `package.json#bin.pi`; `process.argv[1]` belongs to the host and is intentionally ignored.
 
 - Symptom: concurrent `@tursodatabase/database` file transactions fail with `statement was interrupted`, and `BEGIN CONCURRENT` fails unless MVCC is separately enabled. Cause: connection timeout does not serialize cross-connection exclusive/immediate transactions, and default file databases do not enable MVCC. Fix: use short immediate/exclusive transactions with bounded whole-transaction retry and in-transaction rechecks; pre-create/chmod the database and WAL because both defaulted to `0644`, and include both files in stopped-process backups because committed data can remain in the WAL.
 

--- a/docs/plans/archived/2026-08-03_issue-527-pi-subagents-cli-resolution-plan.md
+++ b/docs/plans/archived/2026-08-03_issue-527-pi-subagents-cli-resolution-plan.md
@@ -1,0 +1,122 @@
+# Issue 527 Pi subagent CLI resolution plan
+
+## Goal
+
+Fix [issue #527](https://github.com/narumiruna/pi-extensions/issues/527) by making
+`@narumitw/pi-subagents` launch subprocess children through the exact
+`@earendil-works/pi-coding-agent` installation already loaded by the extension, never through an
+unverified host entrypoint or an unrelated `pi` found on `PATH`.
+
+## Context
+
+- `extensions/pi-subagents/src/runner.ts` currently treats every existing `process.argv[1]` as the Pi
+  CLI. Under `@agegr/pi-web`, that value is the pi-web entrypoint, so Pi CLI arguments are sent back
+  to pi-web and `-p` is misparsed as `--port`.
+- `@narumitw/pi-subagents` already declares `@earendil-works/pi-coding-agent` as a peer dependency and
+  imports its public runtime API. Pi core exports `getPackageDir()`, and its package manifest declares
+  the `pi` executable through `bin.pi`.
+- `PI_CODING_AGENT` is not sufficient entrypoint validation: both Pi's CLI and RPC entrypoints set the
+  process-wide marker, and another host or descendant can inherit it.
+- The applicable guide is `docs/extension-conventions.md`: this change touches subprocess launch
+  behavior, deterministic tests, extension boundaries, lifecycle cleanup review, root verification,
+  and package inspection. It adds no extension-owned setting, so `docs/extension-settings.md` is out
+  of scope.
+
+## Architecture
+
+- Add `extensions/pi-subagents/src/pi-invocation.ts` as the single owner of child Pi executable
+  resolution. `runner.ts` will supply built Pi arguments and consume only its resolved
+  `{ command, args }` result.
+- Support two validated launch forms:
+  1. an official standalone Pi executable identified from Pi core's package directory/manifest and
+     the current executable; or
+  2. the `bin.pi` target from the loaded Pi core package, executed by its supported Node/Bun script
+     runtime.
+- Validate that the discovered manifest belongs to `@earendil-works/pi-coding-agent`, require an
+  explicit string-valued `bin.pi`, resolve that target relative to the package directory, and require
+  the expected file/executable form before launch.
+- Do not infer CLI identity from `process.argv[1]`, host names, Next.js, pi-web, another extension,
+  `PI_CODING_AGENT` alone, or arbitrary executable basenames.
+- Do not fall back to `command: "pi"`. An unresolved, malformed, or unsupported loaded Pi package
+  must fail before spawn with a bounded actionable launch error; this avoids silently selecting a
+  different Pi version from `PATH`.
+- Keep the resolver synchronous and side-effect free apart from reading the trusted loaded Pi package
+  metadata. Expose a narrow test seam for test-owned package directories and runtime facts rather
+  than mutating the developer's installation or inspecting the repository's real manifest as test
+  data.
+
+## Non-Goals
+
+- Do not add pi-web, Next.js, or any other extension/package-specific detection or dependency.
+- Do not add a user setting, environment override, shell command string, or executable search path.
+- Do not change child CLI arguments, subprocess isolation, extension/tool loading policy, process
+  termination, timeout, cancellation, stateful transport selection, or in-process transport behavior.
+- Do not publish a package, close the GitHub issue, or post externally without separate approval.
+
+## Risks
+
+- **Standalone and package installs have different layouts:** derive both from Pi core's own package
+  directory and manifest, and cover each layout with test-owned fixtures.
+- **A malformed package could fail after temporary prompts are created:** route resolution failures
+  through the existing bounded `launchFailed` result path and verify prompt cleanup without starting
+  a process.
+- **Overfitting to the current `dist/cli.js` layout could break a future core release:** consume
+  `package.json#bin.pi` instead of hard-coding the current relative path.
+- **A permissive fallback could reintroduce version skew:** fail closed and include the package path
+  and recovery direction without echoing manifest contents.
+- **Resolver extraction could accidentally alter child lifecycle behavior:** keep spawn ownership in
+  `runner.ts` and audit cancellation, process disposal, session replacement, and shutdown separately
+  after integration.
+
+## Plan
+
+- [x] Extract the existing invocation policy without behavior changes from
+  `extensions/pi-subagents/src/runner.ts` into an exported resolver in
+  `extensions/pi-subagents/src/pi-invocation.ts`, with a narrow runtime/package-directory input that
+  production fills from process facts and `getPackageDir()` and tests can fill from temporary
+  fixtures; package typechecking and 68 focused runner, blocking, and orchestration tests remained
+  green on 2026-08-03.
+- [x] Add `extensions/pi-subagents/test/pi-invocation.test.ts` with a test-owned fake Pi package and a
+  fake existing non-Pi host entrypoint; the focused compiled Node test failed on 2026-08-03 because
+  the extracted current policy selected `host.js` instead of the fixture package's `dist/cli.js`.
+- [x] Extend the focused resolver tests for an explicit string-valued `bin.pi`, symlink/normalized
+  paths, a validated standalone Pi executable fixture, unsupported runtimes, wrong package names,
+  malformed/missing manifests, non-object or non-string `bin.pi` values, and missing/escaping bin
+  targets; the focused run recorded six intended failures and one legacy standalone pass on
+  2026-08-03, including the old `command: "pi"` fallback and missing fail-closed errors.
+- [x] Replace the extracted policy with Pi core's public `getPackageDir()` plus validated package
+  metadata, and remove the `process.argv[1]`, Bun virtual-script, and PATH fallback branches; all
+  seven focused resolver tests and package typechecking passed on 2026-08-03.
+- [x] Add a `runSingleAgent()` regression test proving a resolution failure is reported as a bounded
+  `launchFailed` result before spawn and that any temporary prompt files are removed; the test first
+  failed by rejecting with `PiInvocationError`, then passed with 76 focused resolver, runner,
+  blocking, and orchestration tests including spawn errors, timeout, abort, and process-group cleanup.
+- [x] Audit the final diff against `docs/extension-conventions.md`: the resolver references only Pi
+  core and Node built-ins, adds no dependency/settings/factory work, and leaves child cancellation,
+  process disposal, session replacement, and shutdown ownership unchanged. Resolution is synchronous,
+  failures return before spawn through existing bounded details, and the enclosing `finally` removes
+  prompts; component disposal is not applicable because no UI path changed. No deviation accepted.
+- [x] Run `npm test`, `npm run check`, and `just pack subagents`; both repository test runs passed
+  2,197 tests on 2026-08-03, all format/boundary/typecheck gates passed, and the 37-file dry-run
+  tarball contained `src/index.ts`, `src/pi-invocation.ts`, and `src/runner.ts` without test files or
+  new runtime dependencies.
+- [x] Reproduce the issue's host condition with the non-interactive
+  `subagent launch does not re-execute a pi-web-like host entrypoint` fixture: it set an existing host
+  in `process.argv[1]`, launched the loaded fake package's CLI with
+  `--mode json -p --no-session`, and verified the host marker was never created. The PR handoff will
+  reference this regression plus `npm test`, `npm run check`, and the package dry run.
+
+## Completion Checklist
+
+- [x] An existing non-Pi `process.argv[1]` can never become the child Pi command.
+- [x] Package installs launch the exact loaded Pi core package's declared `bin.pi`; validated
+  standalone installs reuse only their own executable.
+- [x] Missing or invalid Pi CLI metadata fails clearly before spawn, with no PATH fallback and no
+  leaked temporary resources.
+- [x] The implementation contains no pi-web, Next.js, or other extension-specific dependency,
+  setting, environment contract, or behavior branch.
+- [x] Focused regression coverage, existing subprocess lifecycle tests, `npm test`, `npm run check`,
+  the host-condition smoke, and `just pack subagents` all pass with recorded evidence.
+- [x] Archived as
+  `docs/plans/archived/2026-08-03_issue-527-pi-subagents-cli-resolution-plan.md` after every task and
+  completion check had evidence; no package was published and issue #527 was not closed.

--- a/extensions/pi-subagents/src/pi-invocation.ts
+++ b/extensions/pi-subagents/src/pi-invocation.ts
@@ -1,0 +1,163 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getPackageDir } from "@earendil-works/pi-coding-agent";
+
+const CORE_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+const MAX_DISPLAY_PATH_LENGTH = 500;
+
+export interface PiInvocation {
+	command: string;
+	args: string[];
+}
+
+export interface PiInvocationRuntime {
+	execPath: string;
+	packageDir: string;
+	runtimeKind: "node" | "bun" | "unsupported";
+}
+
+export class PiInvocationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PiInvocationError";
+	}
+}
+
+function displayPath(value: string): string {
+	const suffix = value.length > MAX_DISPLAY_PATH_LENGTH ? "…" : "";
+	return JSON.stringify(`${value.slice(0, MAX_DISPLAY_PATH_LENGTH)}${suffix}`);
+}
+
+function resolutionError(packageDir: string, reason: string): PiInvocationError {
+	return new PiInvocationError(
+		`Unable to resolve the Pi CLI from the loaded ${CORE_PACKAGE_NAME} package at ${displayPath(packageDir)}: ${reason}. Reinstall the matching Pi core package before using the subprocess transport.`,
+	);
+}
+
+function currentRuntime(): PiInvocationRuntime {
+	let packageDir: string;
+	try {
+		packageDir = getPackageDir();
+	} catch {
+		throw resolutionError("<unavailable>", "Pi core did not provide its package directory");
+	}
+	const runtimeKind = process.versions.bun
+		? "bun"
+		: process.release.name === "node" && !process.versions.electron
+			? "node"
+			: "unsupported";
+	return {
+		execPath: process.execPath,
+		packageDir,
+		runtimeKind,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isWithinDirectory(parent: string, candidate: string): boolean {
+	const relative = path.relative(parent, candidate);
+	return (
+		relative === "" ||
+		(!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+	);
+}
+
+function readCoreManifest(packageDir: string): Record<string, unknown> {
+	const manifestPath = path.join(packageDir, "package.json");
+	let source: string;
+	try {
+		source = fs.readFileSync(manifestPath, "utf8");
+	} catch {
+		throw resolutionError(packageDir, "the package manifest is unavailable");
+	}
+	let manifest: unknown;
+	try {
+		manifest = JSON.parse(source);
+	} catch {
+		throw resolutionError(packageDir, "the package manifest is invalid JSON");
+	}
+	if (!isRecord(manifest)) {
+		throw resolutionError(packageDir, "the package manifest is invalid");
+	}
+	if (manifest.name !== CORE_PACKAGE_NAME) {
+		throw resolutionError(packageDir, "the package manifest has an unexpected package name");
+	}
+	return manifest;
+}
+
+function resolveDeclaredBin(packageDir: string, manifest: Record<string, unknown>): string {
+	const bin = manifest.bin;
+	const piBin = isRecord(bin) ? bin.pi : undefined;
+	if (typeof piBin !== "string" || !piBin.trim()) {
+		throw resolutionError(packageDir, "package.json bin.pi must be a non-empty string");
+	}
+	const candidate = path.resolve(packageDir, piBin);
+	if (path.isAbsolute(piBin) || !isWithinDirectory(packageDir, candidate)) {
+		throw resolutionError(packageDir, "the declared bin.pi target escapes the package directory");
+	}
+	return candidate;
+}
+
+function resolveExistingFile(packageDir: string, candidate: string, reason: string): string {
+	let resolved: string;
+	try {
+		resolved = fs.realpathSync(candidate);
+		if (!fs.statSync(resolved).isFile()) throw new Error("not a file");
+	} catch {
+		throw resolutionError(packageDir, reason);
+	}
+	if (!isWithinDirectory(packageDir, resolved)) {
+		throw resolutionError(packageDir, "the declared bin.pi target escapes the package directory");
+	}
+	return resolved;
+}
+
+function resolveStandaloneExecutable(packageDir: string, execPath: string): string | undefined {
+	if (!/^pi(?:\.exe)?$/i.test(path.basename(execPath))) return undefined;
+	let resolved: string;
+	let mode: number;
+	try {
+		resolved = fs.realpathSync(execPath);
+		const stat = fs.statSync(resolved);
+		if (!stat.isFile()) throw new Error("not a file");
+		mode = stat.mode;
+	} catch {
+		throw resolutionError(packageDir, "the standalone Pi executable is unavailable");
+	}
+	if (path.dirname(resolved) !== packageDir) return undefined;
+	if (process.platform !== "win32" && (mode & 0o111) === 0) {
+		throw resolutionError(packageDir, "the standalone Pi executable is not executable");
+	}
+	return resolved;
+}
+
+export function resolvePiInvocation(
+	args: string[],
+	runtime: PiInvocationRuntime = currentRuntime(),
+): PiInvocation {
+	let packageDir: string;
+	try {
+		packageDir = fs.realpathSync(runtime.packageDir);
+		if (!fs.statSync(packageDir).isDirectory()) throw new Error("not a directory");
+	} catch {
+		throw resolutionError(runtime.packageDir, "the package directory is unavailable");
+	}
+
+	const manifest = readCoreManifest(packageDir);
+	const declaredBin = resolveDeclaredBin(packageDir, manifest);
+	const standalone = resolveStandaloneExecutable(packageDir, runtime.execPath);
+	if (standalone) return { command: standalone, args: [...args] };
+
+	if (runtime.runtimeKind !== "node" && runtime.runtimeKind !== "bun") {
+		throw resolutionError(packageDir, "the host does not provide a supported Node or Bun runtime");
+	}
+	const cliPath = resolveExistingFile(
+		packageDir,
+		declaredBin,
+		"the declared bin.pi target is unavailable",
+	);
+	return { command: runtime.execPath, args: [cliPath, ...args] };
+}

--- a/extensions/pi-subagents/src/pi-invocation.ts
+++ b/extensions/pi-subagents/src/pi-invocation.ts
@@ -115,7 +115,12 @@ function resolveExistingFile(packageDir: string, candidate: string, reason: stri
 	return resolved;
 }
 
-function resolveStandaloneExecutable(packageDir: string, execPath: string): string | undefined {
+function resolveStandaloneExecutable(
+	packageDir: string,
+	runtime: PiInvocationRuntime,
+): string | undefined {
+	if (runtime.runtimeKind !== "bun") return undefined;
+	const { execPath } = runtime;
 	if (!/^pi(?:\.exe)?$/i.test(path.basename(execPath))) return undefined;
 	let resolved: string;
 	let mode: number;
@@ -148,7 +153,7 @@ export function resolvePiInvocation(
 
 	const manifest = readCoreManifest(packageDir);
 	const declaredBin = resolveDeclaredBin(packageDir, manifest);
-	const standalone = resolveStandaloneExecutable(packageDir, runtime.execPath);
+	const standalone = resolveStandaloneExecutable(packageDir, runtime);
 	if (standalone) return { command: standalone, args: [...args] };
 
 	if (runtime.runtimeKind !== "node" && runtime.runtimeKind !== "bun") {

--- a/extensions/pi-subagents/src/runner.ts
+++ b/extensions/pi-subagents/src/runner.ts
@@ -16,6 +16,7 @@ import {
 	MAX_SUBAGENT_TIMEOUT_MS,
 	truncateUtf8,
 } from "./limits.js";
+import { resolvePiInvocation } from "./pi-invocation.js";
 import { JsonLineDecoder } from "./protocol.js";
 
 export const KILL_GRACE_MS = 5000;
@@ -353,22 +354,6 @@ export function buildPiArgs(options: PiArgsOptions): string[] {
 	return args;
 }
 
-function getPiInvocation(args: string[]): { command: string; args: string[] } {
-	const currentScript = process.argv[1];
-	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
-	if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
-		return { command: process.execPath, args: [currentScript, ...args] };
-	}
-
-	const execName = path.basename(process.execPath).toLowerCase();
-	const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
-	if (!isGenericRuntime) {
-		return { command: process.execPath, args };
-	}
-
-	return { command: "pi", args };
-}
-
 function signalProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
 	if (process.platform !== "win32" && proc.pid) {
 		try {
@@ -576,16 +561,26 @@ export async function runSingleAgent(
 			systemPromptPath: tmpPromptPath ?? undefined,
 			task,
 		});
-		let wasAborted = false;
-		let timedOut = false;
-
-		const exitCode = await new Promise<number>((resolve) => {
-			const invocation = invocationOverride
+		let invocation: { command: string; args: string[] };
+		try {
+			invocation = invocationOverride
 				? {
 						command: invocationOverride.command,
 						args: [...(invocationOverride.argsPrefix ?? []), ...args],
 					}
-				: getPiInvocation(args);
+				: resolvePiInvocation(args);
+		} catch (error) {
+			currentResult.launchFailed = true;
+			currentResult.exitCode = 1;
+			currentResult.stderr = setErrorMessage(
+				error instanceof Error ? error.message : String(error),
+			);
+			return currentResult;
+		}
+		let wasAborted = false;
+		let timedOut = false;
+
+		const exitCode = await new Promise<number>((resolve) => {
 			let settled = false;
 			let cleanupTermination: (() => void) | undefined;
 			let timeout: NodeJS.Timeout | undefined;

--- a/extensions/pi-subagents/test/orchestration.test.ts
+++ b/extensions/pi-subagents/test/orchestration.test.ts
@@ -926,8 +926,15 @@ test("stateful subprocess uses the retained resolved trust decision", async () =
 			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
 		].join(""),
 	);
-	const previousScript = process.argv[1];
-	process.argv[1] = fakePi;
+	writeFileSync(
+		path.join(root, "package.json"),
+		JSON.stringify({
+			name: "@earendil-works/pi-coding-agent",
+			bin: { pi: path.basename(fakePi) },
+		}),
+	);
+	const previousPackageDir = process.env.PI_PACKAGE_DIR;
+	process.env.PI_PACKAGE_DIR = root;
 	try {
 		const transport = new SubprocessTransport({
 			getSettings: () => ({ agents: { scout: { tools: [] } } }),
@@ -956,7 +963,8 @@ test("stateful subprocess uses the retained resolved trust decision", async () =
 			assert.match(outcome.output, /--no-tools/);
 		}
 	} finally {
-		process.argv[1] = previousScript;
+		if (previousPackageDir === undefined) delete process.env.PI_PACKAGE_DIR;
+		else process.env.PI_PACKAGE_DIR = previousPackageDir;
 		rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/extensions/pi-subagents/test/pi-invocation.test.ts
+++ b/extensions/pi-subagents/test/pi-invocation.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { type PiInvocationRuntime, resolvePiInvocation } from "../src/pi-invocation.js";
+import { runSingleAgent } from "../src/runner.js";
+
+const CORE_PACKAGE = "@earendil-works/pi-coding-agent";
+
+function createRoot(): string {
+	return mkdtempSync(path.join(os.tmpdir(), "pi-subagents-invocation-"));
+}
+
+function writeManifest(root: string, manifest: unknown): void {
+	writeFileSync(path.join(root, "package.json"), JSON.stringify(manifest));
+}
+
+function writeCli(root: string, relativePath = "dist/cli.js"): string {
+	const cliPath = path.resolve(root, relativePath);
+	mkdirSync(path.dirname(cliPath), { recursive: true });
+	writeFileSync(cliPath, "process.stdout.write('fake pi')\n");
+	chmodSync(cliPath, 0o755);
+	return cliPath;
+}
+
+function nodeRuntime(
+	packageDir: string,
+	overrides: Partial<PiInvocationRuntime> = {},
+): PiInvocationRuntime {
+	return {
+		execPath: process.execPath,
+		packageDir,
+		runtimeKind: "node",
+		...overrides,
+	};
+}
+
+function withRoot(run: (root: string) => void): void {
+	const root = createRoot();
+	try {
+		run(root);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+test("Pi invocation ignores an existing non-Pi host and selects the loaded core CLI", () => {
+	withRoot((root) => {
+		writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });
+		const cliPath = writeCli(root);
+		const hostPath = path.join(root, "host.js");
+		writeFileSync(hostPath, "throw new Error('host must not run')\n");
+		const runtime = { ...nodeRuntime(root), argvEntry: hostPath };
+
+		assert.deepEqual(resolvePiInvocation(["--mode", "json"], runtime), {
+			command: process.execPath,
+			args: [cliPath, "--mode", "json"],
+		});
+	});
+});
+
+test("subagent launch does not re-execute a pi-web-like host entrypoint", async () => {
+	const root = createRoot();
+	const marker = path.join(root, "host-ran");
+	const hostPath = path.join(root, "pi-web.js");
+	const cliPath = path.join(root, "dist", "cli.js");
+	mkdirSync(path.dirname(cliPath), { recursive: true });
+	writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });
+	writeFileSync(
+		hostPath,
+		`import{writeFileSync}from'node:fs';writeFileSync(${JSON.stringify(marker)},'ran');`,
+	);
+	writeFileSync(
+		cliPath,
+		[
+			"const text=JSON.stringify(process.argv.slice(2));",
+			"const message={role:'assistant',content:[{type:'text',text}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const previousEntry = process.argv[1];
+	const previousPackageDir = process.env.PI_PACKAGE_DIR;
+	process.argv[1] = hostPath;
+	process.env.PI_PACKAGE_DIR = root;
+	try {
+		const result = await runSingleAgent(
+			root,
+			[
+				{
+					name: "test",
+					description: "test",
+					systemPrompt: "",
+					source: "built-in",
+					filePath: "built-in:test",
+				},
+			],
+			"test",
+			"inspect",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			1_000,
+			undefined,
+			(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.finalOutput ?? "", /"--mode","json","-p","--no-session"/);
+		assert.equal(existsSync(marker), false);
+	} finally {
+		process.argv[1] = previousEntry;
+		if (previousPackageDir === undefined) delete process.env.PI_PACKAGE_DIR;
+		else process.env.PI_PACKAGE_DIR = previousPackageDir;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Pi invocation normalizes the package directory and declared bin target", {
+	skip: process.platform === "win32" ? "directory symlinks require additional privileges" : false,
+}, () => {
+	withRoot((root) => {
+		const packageRoot = path.join(root, "package");
+		mkdirSync(packageRoot);
+		writeManifest(packageRoot, {
+			name: CORE_PACKAGE,
+			bin: { pi: "dist/../dist/cli.js" },
+		});
+		const cliPath = writeCli(packageRoot);
+		const packageLink = path.join(root, "package-link");
+		symlinkSync(packageRoot, packageLink, "dir");
+
+		assert.deepEqual(resolvePiInvocation(["--no-session"], nodeRuntime(packageLink)), {
+			command: process.execPath,
+			args: [realpathSync(cliPath), "--no-session"],
+		});
+	});
+});
+
+test("Pi invocation reuses only a validated standalone Pi executable", () => {
+	withRoot((root) => {
+		writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });
+		const executable = path.join(root, process.platform === "win32" ? "pi.exe" : "pi");
+		writeFileSync(executable, "standalone pi fixture\n");
+		chmodSync(executable, 0o755);
+
+		assert.deepEqual(
+			resolvePiInvocation(["--mode", "json"], {
+				execPath: executable,
+				packageDir: root,
+				runtimeKind: "bun",
+			}),
+			{ command: realpathSync(executable), args: ["--mode", "json"] },
+		);
+	});
+});
+
+test("Pi invocation rejects unsupported script runtimes", () => {
+	withRoot((root) => {
+		writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });
+		writeCli(root);
+		assert.throws(
+			() =>
+				resolvePiInvocation([], {
+					execPath: path.join(root, "embedded-host"),
+					packageDir: root,
+					runtimeKind: "unsupported",
+				}),
+			/Unable to resolve the Pi CLI.*supported Node or Bun runtime/i,
+		);
+	});
+});
+
+test("Pi invocation rejects unverified standalone executables", () => {
+	withRoot((root) => {
+		writeManifest(root, { name: "embedded-host", bin: { pi: "host.js" } });
+		const executable = path.join(root, process.platform === "win32" ? "pi.exe" : "pi");
+		writeFileSync(executable, "not core pi\n");
+		chmodSync(executable, 0o755);
+		assert.throws(
+			() =>
+				resolvePiInvocation([], {
+					execPath: executable,
+					packageDir: root,
+					runtimeKind: "bun",
+				}),
+			/Unable to resolve the Pi CLI.*unexpected package name/i,
+		);
+	});
+});
+
+test("Pi invocation fails closed for invalid loaded core metadata", () => {
+	const cases: Array<{
+		name: string;
+		prepare: (root: string) => void;
+		expected: RegExp;
+	}> = [
+		{
+			name: "missing manifest",
+			prepare: () => {},
+			expected: /package manifest is unavailable/i,
+		},
+		{
+			name: "malformed manifest",
+			prepare: (root) => writeFileSync(path.join(root, "package.json"), "{"),
+			expected: /package manifest is invalid/i,
+		},
+		{
+			name: "wrong package",
+			prepare: (root) => writeManifest(root, { name: "other", bin: { pi: "dist/cli.js" } }),
+			expected: /unexpected package name/i,
+		},
+		{
+			name: "non-object bin",
+			prepare: (root) => writeManifest(root, { name: CORE_PACKAGE, bin: "dist/cli.js" }),
+			expected: /bin\.pi must be a non-empty string/i,
+		},
+		{
+			name: "non-string pi bin",
+			prepare: (root) => writeManifest(root, { name: CORE_PACKAGE, bin: { pi: 42 } }),
+			expected: /bin\.pi must be a non-empty string/i,
+		},
+		{
+			name: "missing target",
+			prepare: (root) => writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } }),
+			expected: /declared bin\.pi target is unavailable/i,
+		},
+	];
+
+	for (const fixture of cases) {
+		withRoot((root) => {
+			fixture.prepare(root);
+			assert.throws(
+				() => resolvePiInvocation([], nodeRuntime(root)),
+				(error) => {
+					assert.ok(error instanceof Error, fixture.name);
+					assert.match(error.message, /Unable to resolve the Pi CLI/i, fixture.name);
+					assert.match(error.message, fixture.expected, fixture.name);
+					assert.doesNotMatch(error.message, /command:\s*pi/i, fixture.name);
+					return true;
+				},
+				fixture.name,
+			);
+		});
+	}
+});
+
+test("Pi invocation rejects a bin target outside the loaded package", () => {
+	withRoot((root) => {
+		const packageRoot = path.join(root, "package");
+		mkdirSync(packageRoot);
+		writeManifest(packageRoot, { name: CORE_PACKAGE, bin: { pi: "../outside.js" } });
+		writeCli(root, "outside.js");
+		assert.throws(
+			() => resolvePiInvocation([], nodeRuntime(packageRoot)),
+			/Unable to resolve the Pi CLI.*bin\.pi target escapes the package directory/i,
+		);
+	});
+});

--- a/extensions/pi-subagents/test/pi-invocation.test.ts
+++ b/extensions/pi-subagents/test/pi-invocation.test.ts
@@ -164,6 +164,43 @@ test("Pi invocation reuses only a validated standalone Pi executable", () => {
 	});
 });
 
+test("Pi invocation treats a Node executable named pi as a script runtime", () => {
+	withRoot((root) => {
+		writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });
+		const cliPath = writeCli(root);
+		const executable = path.join(root, process.platform === "win32" ? "pi.exe" : "pi");
+		writeFileSync(executable, "node runtime fixture\n");
+		chmodSync(executable, 0o755);
+		assert.deepEqual(
+			resolvePiInvocation(["--mode", "json"], {
+				execPath: executable,
+				packageDir: root,
+				runtimeKind: "node",
+			}),
+			{ command: executable, args: [cliPath, "--mode", "json"] },
+		);
+	});
+});
+
+test("Pi invocation rejects a standalone-looking executable from an unsupported runtime", () => {
+	withRoot((root) => {
+		writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });
+		writeCli(root);
+		const executable = path.join(root, process.platform === "win32" ? "pi.exe" : "pi");
+		writeFileSync(executable, "unsupported standalone fixture\n");
+		chmodSync(executable, 0o755);
+		assert.throws(
+			() =>
+				resolvePiInvocation([], {
+					execPath: executable,
+					packageDir: root,
+					runtimeKind: "unsupported",
+				}),
+			/Unable to resolve the Pi CLI.*supported Node or Bun runtime/i,
+		);
+	});
+});
+
 test("Pi invocation rejects unsupported script runtimes", () => {
 	withRoot((root) => {
 		writeManifest(root, { name: CORE_PACKAGE, bin: { pi: "dist/cli.js" } });

--- a/extensions/pi-subagents/test/runner-render.test.ts
+++ b/extensions/pi-subagents/test/runner-render.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -180,6 +181,56 @@ test("runSingleAgent distinguishes child launch failures", async () => {
 	);
 	assert.equal(result.launchFailed, true);
 	assert.equal(result.exitCode, 1);
+});
+
+test("runSingleAgent reports Pi CLI resolution failures and removes temporary prompts", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-resolution-failure-"));
+	const tempDir = path.join(root, "tmp");
+	const packageDir = path.join(root, "missing-core");
+	mkdirSync(tempDir);
+	mkdirSync(packageDir);
+	const previousTmpDir = process.env.TMPDIR;
+	const previousPackageDir = process.env.PI_PACKAGE_DIR;
+	process.env.TMPDIR = tempDir;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	try {
+		const result = await runSingleAgent(
+			process.cwd(),
+			[
+				{
+					name: "test",
+					description: "test",
+					systemPrompt: "temporary private prompt",
+					source: "built-in",
+					filePath: "built-in:test",
+				},
+			],
+			"test",
+			"task",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			1_000,
+			undefined,
+			(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		);
+		assert.equal(result.launchFailed, true);
+		assert.equal(result.processStarted, undefined);
+		assert.equal(result.exitCode, 1);
+		assert.match(
+			result.errorMessage ?? "",
+			/Unable to resolve the Pi CLI.*manifest is unavailable/i,
+		);
+		assert.ok(Buffer.byteLength(result.errorMessage ?? "", "utf8") <= DEFAULT_MAX_STDERR_BYTES);
+		assert.deepEqual(readdirSync(tempDir), []);
+	} finally {
+		if (previousTmpDir === undefined) delete process.env.TMPDIR;
+		else process.env.TMPDIR = previousTmpDir;
+		if (previousPackageDir === undefined) delete process.env.PI_PACKAGE_DIR;
+		else process.env.PI_PACKAGE_DIR = previousPackageDir;
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("runSingleAgent normalizes invalid cwd without spawning or throwing", async () => {

--- a/extensions/pi-subagents/test/subagents.test.ts
+++ b/extensions/pi-subagents/test/subagents.test.ts
@@ -73,6 +73,21 @@ type SchemaObject = {
 	description?: string;
 };
 
+const CORE_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+
+function useFakePiPackage(packageDir: string, cliPath: string): () => void {
+	writeFileSync(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: CORE_PACKAGE_NAME, bin: { pi: path.relative(packageDir, cliPath) } }),
+	);
+	const previous = process.env.PI_PACKAGE_DIR;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	return () => {
+		if (previous === undefined) delete process.env.PI_PACKAGE_DIR;
+		else process.env.PI_PACKAGE_DIR = previous;
+	};
+}
+
 type SubagentTool = {
 	execute: (...args: unknown[]) => Promise<{
 		content?: Array<{ type: string; text: string }>;
@@ -1996,9 +2011,8 @@ test("blocking delegation preflights every target and passes explicit saved trus
 		].join(""),
 	);
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	const previousScript = process.argv[1];
+	const restorePiPackage = useFakePiPackage(root, fakePi);
 	process.env.PI_CODING_AGENT_DIR = agentDir;
-	process.argv[1] = fakePi;
 	try {
 		const mock = createMockPi();
 		subagents(mock.pi);
@@ -2063,7 +2077,7 @@ test("blocking delegation preflights every target and passes explicit saved trus
 		assert.match(anywhere.content?.[0]?.text ?? "", /--no-approve/);
 		assert.equal(anywhere.details?.results[0]?.target?.trust.kind, "saved-denied");
 	} finally {
-		process.argv[1] = previousScript;
+		restorePiPackage();
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { recursive: true, force: true });
@@ -2087,8 +2101,7 @@ test("parallel execution ignores an empty optional aggregator and preserves work
 			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
 		].join(""),
 	);
-	const originalScript = process.argv[1];
-	process.argv[1] = fakePi;
+	const restorePiPackage = useFakePiPackage(dir, fakePi);
 	try {
 		const result = await tool.execute(
 			"empty-aggregator",
@@ -2109,7 +2122,7 @@ test("parallel execution ignores an empty optional aggregator and preserves work
 		assert.match(result.content?.[0]?.text ?? "", /PROOF_OK/);
 		assert.match(result.content?.[0]?.text ?? "", /CALC_OK/);
 	} finally {
-		process.argv[1] = originalScript;
+		restorePiPackage();
 		rmSync(dir, { recursive: true, force: true });
 	}
 });
@@ -2186,8 +2199,7 @@ test("parallel updates keep failed fan-out pending while fan-in starts", async (
 			aggregator?: { exitCode: number };
 		};
 	}> = [];
-	const originalScript = process.argv[1];
-	process.argv[1] = fakePi;
+	const restorePiPackage = useFakePiPackage(dir, fakePi);
 	try {
 		const result = await tool.execute(
 			"pending-fan-in",
@@ -2209,7 +2221,7 @@ test("parallel updates keep failed fan-out pending while fan-in starts", async (
 			"expected a failed fan-out update with a pending fan-in result",
 		);
 	} finally {
-		process.argv[1] = originalScript;
+		restorePiPackage();
 		rmSync(dir, { recursive: true, force: true });
 	}
 });
@@ -2233,8 +2245,7 @@ test("parallel summaries classify provider errors and retain partial output", as
 			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
 		].join(""),
 	);
-	const originalScript = process.argv[1];
-	process.argv[1] = fakePi;
+	const restorePiPackage = useFakePiPackage(dir, fakePi);
 	try {
 		const result = await tool.execute(
 			"parallel-errors",
@@ -2254,7 +2265,7 @@ test("parallel summaries classify provider errors and retain partial output", as
 		assert.match(text, /Partial output:\nPARTIAL/);
 		assert.match(text, /\[scout\] completed: DONE/);
 	} finally {
-		process.argv[1] = originalScript;
+		restorePiPackage();
 		rmSync(dir, { recursive: true, force: true });
 	}
 });


### PR DESCRIPTION
## Summary

- resolve subprocess child launches from the loaded `@earendil-works/pi-coding-agent` package's declared `bin.pi`
- validate standalone Pi executables only for the Bun standalone runtime and fail closed instead of reusing `process.argv[1]` or falling back to a different `pi` on `PATH`
- report resolution failures through bounded launch details, clean temporary prompts, and cover the pi-web-like host regression

Fixes #527.

## Verification

- `npm test` — 2,199 tests passed
- `npm run check` — Biome, boundaries, workspace typechecks, and 2,199 tests passed
- `just pack subagents` — inspected 37 published files; includes `src/index.ts`, `src/pi-invocation.ts`, and `src/runner.ts`, excludes tests
- non-interactive host-condition regression verified `--mode json -p --no-session` reached the loaded fake core CLI and the host entrypoint was not re-executed

## Convention audit

Read `docs/extension-conventions.md`; settings were not changed, so `docs/extension-settings.md` was out of scope. The resolver depends only on Pi core and Node built-ins, adds no extension-to-extension or host-specific dependency, and leaves cancellation, process disposal, session replacement, and shutdown ownership unchanged. Resolution is synchronous, and failures return before spawn through existing bounded details while the enclosing cleanup removes temporary prompts. No deviations were accepted.

The completed executable plan is archived at `docs/plans/archived/2026-08-03_issue-527-pi-subagents-cli-resolution-plan.md`.

