### PR TITLE
refactor(pi-subagents): use core session services

### DIFF
--- a/extensions/pi-subagents/README.md
+++ b/extensions/pi-subagents/README.md
@@ -457,12 +457,12 @@ Reasoning, tool results, custom transport messages, and non-text parts are exclu
 Stateful execution uses a transport boundary:
 
 - `subprocess` is the default compatibility and rollback path.
-- `in-process` uses only public Pi SDK APIs: `createAgentSession()`, `SessionManager.inMemory()`, `DefaultResourceLoader`, and normal session lifecycle methods. It isolates conversation/tool selection, not memory or crashes; child failures share the parent Node.js process.
+- `in-process` uses only public Pi SDK APIs: `createAgentSessionServices()`, `createAgentSessionFromServices()`, `SessionManager.inMemory()`, and normal session lifecycle methods. It isolates conversation/tool selection, not memory or crashes; child failures share the parent Node.js process.
 - Child resource loading sets `noExtensions: true`, preventing recursive `pi-subagents` loading and duplicate extension side effects while retaining trust-eligible context/skill resources and the selected agent prompt. Both transports receive the same resolved target-trust boolean: subprocess children get explicit `--approve`/`--no-approve`, and in-process children set the same `SettingsManager.projectTrusted` value.
 - Agent model strings use Pi core's CLI resolver, including provider/model patterns, fuzzy matching, custom provider model IDs, and `:<thinking>` suffixes. Thinking level and built-in tool allow-list overrides are applied when the child is created. Parent model/thinking changes are snapshotted for subsequently created children; an existing child keeps its own session configuration.
 - Extension/custom tool names are rejected in-process with an actionable recommendation to use `subprocess`; permissions are never silently widened.
 - Timeout, parent abort, close, expiry, and session shutdown abort/dispose owned child sessions. A child that does not settle after abort grace is discarded rather than reused.
-- In-process startup failures do not silently retry through subprocesses, preventing duplicate side effects. If the loaded Pi core lacks public `ModelRuntime` or `resolveCliModel` support, startup fails with an actionable instruction to select `stateful.transport: "subprocess"`.
+- In-process startup failures do not silently retry through subprocesses, preventing duplicate side effects. If the loaded Pi core lacks public `createAgentSessionServices()`, `createAgentSessionFromServices()`, or `resolveCliModel()` support, startup fails with an actionable instruction to select `stateful.transport: "subprocess"`.
 
 No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used. Approval policy, sandbox profile, provider-header hooks, extension state, global scheduling, and parent/child transcript switching are not inherited or provided by the in-process transport.
 

--- a/extensions/pi-subagents/src/in-process-transport.ts
+++ b/extensions/pi-subagents/src/in-process-transport.ts
@@ -1,8 +1,6 @@
-import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import {
-	createAgentSession,
-	DefaultResourceLoader,
+	type AgentSessionServices,
 	getAgentDir,
 	type ModelRegistry,
 	type ModelRuntime,
@@ -29,14 +27,19 @@ interface ChildModelRuntime {
 }
 
 interface CodingAgentRuntimeModule {
-	ModelRuntime?: {
-		create(options?: { authPath?: string; modelsPath?: string | null }): Promise<ModelRuntime>;
-	};
+	createAgentSessionFromServices?: typeof import("@earendil-works/pi-coding-agent").createAgentSessionFromServices;
+	createAgentSessionServices?: typeof import("@earendil-works/pi-coding-agent").createAgentSessionServices;
 	resolveCliModel?: typeof import("@earendil-works/pi-coding-agent").resolveCliModel;
 }
 
 interface CoreModelSupport {
 	modelRuntime: ModelRuntime;
+	resolveCliModel: typeof import("@earendil-works/pi-coding-agent").resolveCliModel;
+}
+
+interface CoreSessionSupport {
+	createAgentSessionFromServices: typeof import("@earendil-works/pi-coding-agent").createAgentSessionFromServices;
+	createAgentSessionServices: typeof import("@earendil-works/pi-coding-agent").createAgentSessionServices;
 	resolveCliModel: typeof import("@earendil-works/pi-coding-agent").resolveCliModel;
 }
 
@@ -338,35 +341,36 @@ export async function createSdkChildSession(
 	options: ChildSessionCreateOptions,
 ): Promise<ChildSession> {
 	const agentDir = getAgentDir();
-	const { loader: resourceLoader, settingsManager } = await createInProcessResourceLoader(
+	const projectTrusted =
+		options.agent.target?.trust.projectTrusted ??
+		(options.agent.agentScope === "project" || options.agent.agentScope === "both");
+	const { services, support: coreSupport } = await prepareInProcessServices(
 		options.agent.cwd,
 		agentDir,
 		options.agentConfig.systemPrompt,
-		options.agent.target?.trust.projectTrusted ??
-			(options.agent.agentScope === "project" || options.agent.agentScope === "both"),
+		projectTrusted,
 	);
-	const modelSupport = await createChildModelSupport(options.modelRegistry, agentDir);
-	if (!modelSupport) throw unsupportedInProcessCoreError();
+	copyRegisteredProviders(
+		options.modelRegistry as unknown as RegisteredProviderRegistry,
+		services.modelRuntime as unknown as ChildModelRuntime,
+	);
+	const modelSupport: CoreModelSupport = {
+		modelRuntime: services.modelRuntime,
+		resolveCliModel: coreSupport.resolveCliModel,
+	};
 	const resolved = await resolveChildModel(options, modelSupport);
-	await transferChildModelAuth(options.modelRegistry, resolved.model, modelSupport.modelRuntime);
+	await transferChildModelAuth(options.modelRegistry, resolved.model, services.modelRuntime);
 	const model = resolved.model;
 	const sessionManager = SessionManager.inMemory(options.agent.cwd);
 	seedChildSessionManager(sessionManager, options, model);
-	const sessionOptions: Record<string, unknown> = {
-		cwd: options.agent.cwd,
-		agentDir,
-		model,
-		modelRuntime: modelSupport.modelRuntime,
-		thinkingLevel: resolved.thinkingLevel,
-		resourceLoader,
-		settingsManager,
+	const created = await coreSupport.createAgentSessionFromServices({
+		services,
 		sessionManager,
+		model,
+		thinkingLevel: resolved.thinkingLevel,
 		tools: options.tools,
 		noTools: options.tools?.length === 0 ? "all" : undefined,
-	};
-	const created = await createAgentSession(
-		sessionOptions as NonNullable<Parameters<typeof createAgentSession>[0]>,
-	);
+	});
 	const session = created.session;
 	if (options.tools !== undefined) {
 		const active = session.getActiveToolNames();
@@ -396,24 +400,22 @@ export async function createSdkChildSession(
 	};
 }
 
-async function createChildModelSupport(
-	modelRegistry: ModelRegistry,
-	agentDir: string,
-): Promise<CoreModelSupport | undefined> {
+async function loadCoreSessionSupport(): Promise<CoreSessionSupport | undefined> {
 	const codingAgentModule = (await import(
 		"@earendil-works/pi-coding-agent"
 	)) as unknown as CodingAgentRuntimeModule;
-	if (!codingAgentModule.ModelRuntime || !codingAgentModule.resolveCliModel) return undefined;
-
-	const modelRuntime = await codingAgentModule.ModelRuntime.create({
-		authPath: join(agentDir, "auth.json"),
-		modelsPath: join(agentDir, "models.json"),
-	});
-	copyRegisteredProviders(
-		modelRegistry as unknown as RegisteredProviderRegistry,
-		modelRuntime as unknown as ChildModelRuntime,
-	);
-	return { modelRuntime, resolveCliModel: codingAgentModule.resolveCliModel };
+	if (
+		!codingAgentModule.createAgentSessionFromServices ||
+		!codingAgentModule.createAgentSessionServices ||
+		!codingAgentModule.resolveCliModel
+	) {
+		return undefined;
+	}
+	return {
+		createAgentSessionFromServices: codingAgentModule.createAgentSessionFromServices,
+		createAgentSessionServices: codingAgentModule.createAgentSessionServices,
+		resolveCliModel: codingAgentModule.resolveCliModel,
+	};
 }
 
 async function transferChildModelAuth(
@@ -479,27 +481,40 @@ export async function resolveChildModel(
 
 function unsupportedInProcessCoreError(): Error {
 	return new Error(
-		'In-process subagents require Pi core ModelRuntime and resolveCliModel support; set stateful.transport to "subprocess".',
+		'In-process subagents require Pi core createAgentSessionServices, createAgentSessionFromServices, and resolveCliModel support; set stateful.transport to "subprocess".',
 	);
 }
 
-export async function createInProcessResourceLoader(
+async function prepareInProcessServices(
+	cwd: string,
+	agentDir: string,
+	agentSystemPrompt: string,
+	projectTrusted: boolean,
+): Promise<{ services: AgentSessionServices; support: CoreSessionSupport }> {
+	assertPiPromptSourcesAreReadableFiles(cwd, agentDir, projectTrusted, ["SYSTEM.md"]);
+	const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+	const support = await loadCoreSessionSupport();
+	if (!support) throw unsupportedInProcessCoreError();
+	const services = await support.createAgentSessionServices({
+		cwd,
+		agentDir,
+		settingsManager,
+		resourceLoaderOptions: {
+			noExtensions: true,
+			appendSystemPrompt: agentSystemPrompt.trim() ? [agentSystemPrompt] : [],
+		},
+	});
+	return { services, support };
+}
+
+export async function createInProcessServices(
 	cwd: string,
 	agentDir: string,
 	agentSystemPrompt: string,
 	projectTrusted = false,
-): Promise<{ loader: DefaultResourceLoader; settingsManager: SettingsManager }> {
-	assertPiPromptSourcesAreReadableFiles(cwd, agentDir, projectTrusted, ["SYSTEM.md"]);
-	const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
-	const loader = new DefaultResourceLoader({
-		cwd,
-		agentDir,
-		settingsManager,
-		noExtensions: true,
-		appendSystemPrompt: agentSystemPrompt.trim() ? [agentSystemPrompt] : [],
-	});
-	await loader.reload();
-	return { loader, settingsManager };
+): Promise<AgentSessionServices> {
+	return (await prepareInProcessServices(cwd, agentDir, agentSystemPrompt, projectTrusted))
+		.services;
 }
 
 export function seedChildSessionManager(

--- a/extensions/pi-subagents/test/in-process-transport.test.ts
+++ b/extensions/pi-subagents/test/in-process-transport.test.ts
@@ -16,7 +16,7 @@ import {
 	type ChildSession,
 	type ChildSessionCreateOptions,
 	copyRegisteredProviders,
-	createInProcessResourceLoader,
+	createInProcessServices,
 	createSdkChildSession,
 	InProcessTransport,
 	resolveChildModel,
@@ -503,16 +503,15 @@ test("child resource loader excludes extensions while retaining the agent prompt
 	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-cwd-"));
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-agent-"));
 	writeFileSync(path.join(cwd, "AGENTS.md"), "Trusted child context.");
-	const { loader, settingsManager } = await createInProcessResourceLoader(
-		cwd,
-		agentDir,
-		"Agent role prompt.",
-		true,
+	const services = await createInProcessServices(cwd, agentDir, "Agent role prompt.", true);
+	assert.equal(services.settingsManager.isProjectTrusted(), true);
+	assert.deepEqual(services.resourceLoader.getExtensions().extensions, []);
+	assert.deepEqual(services.resourceLoader.getAppendSystemPrompt(), ["Agent role prompt."]);
+	assert.equal(
+		services.resourceLoader.getAgentsFiles().agentsFiles.at(-1)?.content,
+		"Trusted child context.",
 	);
-	assert.equal(settingsManager.isProjectTrusted(), true);
-	assert.deepEqual(loader.getExtensions().extensions, []);
-	assert.deepEqual(loader.getAppendSystemPrompt(), ["Agent role prompt."]);
-	assert.equal(loader.getAgentsFiles().agentsFiles.at(-1)?.content, "Trusted child context.");
+	assert.deepEqual(services.diagnostics, []);
 });
 
 test("untrusted in-process resource loading never reads project settings", async () => {
@@ -524,15 +523,10 @@ test("untrusted in-process resource loading never reads project settings", async
 		'{"SECRET_UNTRUSTED_PROJECT_SETTINGS":"unterminated',
 	);
 	try {
-		const { settingsManager } = await createInProcessResourceLoader(
-			cwd,
-			agentDir,
-			"Agent role prompt.",
-			false,
-		);
-		assert.equal(settingsManager.isProjectTrusted(), false);
-		assert.deepEqual(settingsManager.getProjectSettings(), {});
-		assert.deepEqual(settingsManager.drainErrors(), []);
+		const services = await createInProcessServices(cwd, agentDir, "Agent role prompt.", false);
+		assert.equal(services.settingsManager.isProjectTrusted(), false);
+		assert.deepEqual(services.settingsManager.getProjectSettings(), {});
+		assert.deepEqual(services.settingsManager.drainErrors(), []);
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 		rmSync(agentDir, { recursive: true, force: true });
@@ -545,7 +539,7 @@ test("in-process resource loading rejects a non-regular system prompt source", a
 	mkdirSync(path.join(cwd, ".pi", "SYSTEM.md"), { recursive: true });
 	try {
 		await assert.rejects(
-			() => createInProcessResourceLoader(cwd, agentDir, "Agent role prompt.", true),
+			() => createInProcessServices(cwd, agentDir, "Agent role prompt.", true),
 			/readable regular file/i,
 		);
 	} finally {
@@ -944,7 +938,7 @@ test("in-process model resolution fails actionably when the installed core is un
 				modelRegistry: {} as never,
 				parentRuntime: { model: undefined, thinkingLevel: "off" },
 			}),
-		/require Pi core ModelRuntime and resolveCliModel.*subprocess/i,
+		/require Pi core createAgentSessionServices, createAgentSessionFromServices, and resolveCliModel.*subprocess/i,
 	);
 });
 


### PR DESCRIPTION
## Summary

- delegate in-process child runtime/resource setup to Pi core's `createAgentSessionServices()`
- create child sessions through `createAgentSessionFromServices()` while preserving trust preflight, provider/auth projection, model resolution, tool restrictions, and lifecycle ownership
- dynamically detect the required public APIs, keep the actionable subprocess fallback, and update the in-process documentation and coverage

Follow-up to #531.

## Verification

- `npm run check` — 2,207 tests passed
- focused `in-process-transport` suite — 22 tests passed
- `just pack subagents` — 39 intended files
