### PR TITLE
feat(pi-plan-mode): add plan export

### DIFF
--- a/docs/plans/archived/2026-08-03_pi-plan-mode-export-plan.md
+++ b/docs/plans/archived/2026-08-03_pi-plan-mode-export-plan.md
@@ -1,0 +1,62 @@
+# pi-plan-mode plan export
+
+## Goal
+
+Add a safe `/plan export [path]` route and interactive export flow that write the currently ready,
+saved, or active implementation plan to a user-selected Markdown path without overwriting an
+existing target or changing Plan-mode state.
+
+## Context
+
+- Default export path: `PLAN.md` relative to `ctx.cwd`; a supplied relative or absolute path is the
+  command's text payload.
+- Ready, saved, and active-plan menus navigate from **Export plan…** to Pi TUI Kit's standard
+  single-line input screen. An empty submission uses `PLAN.md`; a non-empty submission is the path.
+- A rejected export keeps the input draft available for correction. Escape returns to the owning
+  menu without writing, while session replacement or shutdown aborts the owned interaction.
+- Existing targets must fail closed in every mode. Successful file creation is the observable result
+  in print/JSON; TUI/RPC additionally receive notifications.
+- Touched convention areas: public slash-command routes, async menu actions, file mutation, non-TUI
+  behavior, dependency metadata, tests, and package documentation. Pi TUI Kit input screens require
+  `@narumitw/pi-tui-kit` 0.41.0 or newer, so the package compatibility floor moves to `^0.41.0`.
+  Applicable MUST checks are command-route tests, lifecycle review, `withFileMutationQueue()` use,
+  `npm run check`, and a package dry run.
+
+## Plan
+
+- [x] Establish red-first command/file behavior tests for default and custom paths, no-overwrite,
+      state retention, supported plan states/modes, and autocomplete; evidence: the new focused test
+      file initially failed all 7 cases because `export` was not implemented.
+- [x] Add `src/plan-export.ts` and `/plan export [path]` with queued exclusive creation and unchanged
+      Plan state; evidence: 7 focused export tests and all 105 pi-plan-mode tests passed before the
+      filename-input follow-up.
+- [x] Add focused TUI/RPC tests for **Export plan…**, custom and empty path submission, rejected-draft
+      retention, Back cancellation, and ready/saved/active menu availability; evidence: the initial
+      input-flow run failed because menus still exported directly to `PLAN.md`.
+- [x] Replace fixed default-export menu actions in the ready, saved, and active menu modules with
+      Pi TUI Kit input screens; submit through the existing writer, close on success, and retain the
+      draft on rejection; evidence: 14 focused export tests and all 112 pi-plan-mode tests passed.
+- [x] Raise the package's Pi TUI Kit floor from `^0.40.0` to `^0.41.0`, the first release with input
+      screens, and regenerate the lockfile with npm 12.0.2; evidence: the nested workspace dependency
+      resolves to 0.41.0 and package typechecking accepts the input-screen contract.
+- [x] Finalize `extensions/pi-plan-mode/README.md` with command syntax, input-menu behavior, path
+      resolution, no-overwrite semantics, and non-TUI behavior; evidence: package Biome and typecheck
+      passed through `npm run check --workspace @narumitw/pi-plan-mode`.
+- [x] Audit cancellation, menu disposal, session replacement, shutdown, command-mode behavior, and
+      file-write serialization against `docs/extension-conventions.md`; evidence: queued actions are
+      cancelled and drained in focused tests, `npm run check` passed 2,221 tests, and
+      `just pack plan-mode` included the declared entrypoint, `src/plan-export.ts`, README, and license
+      in a 22-file dry-run tarball.
+
+## Completion Checklist
+
+- [x] `/plan export` writes the selected plan to `PLAN.md`, and `/plan export <path>` writes to the
+      requested path without triggering a model turn or mutating Plan-mode state.
+- [x] Ready, saved, and active-plan menus expose **Export plan…**, including the automatic completion
+      menu; the input accepts a custom path and treats an empty submission as `PLAN.md`.
+- [x] Existing-target rejection retains the interactive path draft; Back, disposal, replacement, and
+      shutdown do not write or change Plan state.
+- [x] Existing files, directories, and symlinks are never overwritten; failures leave plan state and
+      existing content unchanged.
+- [x] TUI, RPC, print, and JSON behavior is tested and documented.
+- [x] Repository checks and the pi-plan-mode package dry run pass with no accepted deviations.

--- a/docs/plans/archived/2026-08-03_pi-plan-mode-export-plan.md
+++ b/docs/plans/archived/2026-08-03_pi-plan-mode-export-plan.md
@@ -4,7 +4,8 @@
 
 Add a safe `/plan export [path]` route and interactive export flow that write the currently ready,
 saved, or active implementation plan to a user-selected Markdown path without overwriting an
-existing target or changing Plan-mode state.
+existing target. A successful ready-plan export completes and exits Plan mode; saved and active
+implementation exports retain their state.
 
 ## Context
 
@@ -15,7 +16,9 @@ existing target or changing Plan-mode state.
 - A rejected export keeps the input draft available for correction. Escape returns to the owning
   menu without writing, while session replacement or shutdown aborts the owned interaction.
 - Existing targets must fail closed in every mode. Successful file creation is the observable result
-  in print/JSON; TUI/RPC additionally receive notifications.
+  in print/JSON; TUI/RPC additionally receive notifications. After a ready plan is written, Plan mode
+  restores its tools and thinking level and clears the ready state without triggering a model turn.
+  Saved and active implementation exports remain copy-only.
 - Touched convention areas: public slash-command routes, async menu actions, file mutation, non-TUI
   behavior, dependency metadata, tests, and package documentation. Pi TUI Kit input screens require
   `@narumitw/pi-tui-kit` 0.41.0 or newer, so the package compatibility floor moves to `^0.41.0`.
@@ -35,7 +38,11 @@ existing target or changing Plan-mode state.
       input-flow run failed because menus still exported directly to `PLAN.md`.
 - [x] Replace fixed default-export menu actions in the ready, saved, and active menu modules with
       Pi TUI Kit input screens; submit through the existing writer, close on success, and retain the
-      draft on rejection; evidence: 14 focused export tests and all 112 pi-plan-mode tests passed.
+      draft on rejection; evidence: 15 focused export tests and all 113 pi-plan-mode tests passed.
+- [x] Correct the ready-plan success transition so export exits Plan mode only after the file is
+      written, restores tools and thinking, clears persisted ready state, and starts no model turn;
+      evidence: the regression test failed first on the stale `plan ready` status, then passed with
+      direct, TUI, RPC, saved-plan, active-plan, failure, and cancellation coverage.
 - [x] Raise the package's Pi TUI Kit floor from `^0.40.0` to `^0.41.0`, the first release with input
       screens, and regenerate the lockfile with npm 12.0.2; evidence: the nested workspace dependency
       resolves to 0.41.0 and package typechecking accepts the input-screen contract.
@@ -44,14 +51,15 @@ existing target or changing Plan-mode state.
       passed through `npm run check --workspace @narumitw/pi-plan-mode`.
 - [x] Audit cancellation, menu disposal, session replacement, shutdown, command-mode behavior, and
       file-write serialization against `docs/extension-conventions.md`; evidence: queued actions are
-      cancelled and drained in focused tests, `npm run check` passed 2,221 tests, and
+      cancelled and drained in focused tests, `npm run check` passed 2,222 tests, and
       `just pack plan-mode` included the declared entrypoint, `src/plan-export.ts`, README, and license
       in a 22-file dry-run tarball.
 
 ## Completion Checklist
 
 - [x] `/plan export` writes the selected plan to `PLAN.md`, and `/plan export <path>` writes to the
-      requested path without triggering a model turn or mutating Plan-mode state.
+      requested path without triggering a model turn; a ready export exits Plan mode, while saved and
+      active implementation exports retain their state.
 - [x] Ready, saved, and active-plan menus expose **Export plan…**, including the automatic completion
       menu; the input accepts a custom path and treats an empty submission as `PLAN.md`.
 - [x] Existing-target rejection retains the interactive path draft; Back, disposal, replacement, and

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -16,7 +16,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finalize only when decision-complete.
 - Adds required `plan_mode_question` and `plan_mode_complete` tools for structured questions and completion.
 - Presents the complete plan and prompts you to implement, export it to a chosen Markdown file, save it for later, stay in Plan mode, or exit and discard it.
-- Exports ready, saved, or active implementation plans with `/plan export [path]` without overwriting existing paths.
+- Exports ready, saved, or active implementation plans with `/plan export [path]` without overwriting existing paths; exporting a ready plan completes and exits Plan mode.
 - Keeps legacy `<proposed_plan>` responses compatible without advertising XML as the primary workflow.
 - Shows Plan mode state in Pi's statusline as `plan active`, `plan ready`, `plan saved`, or `plan implementing`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
 - Persists Plan mode, one session-local saved plan, and active implementation state so resume and compaction retain the exact accepted plan.
@@ -67,22 +67,27 @@ plan without starting a model turn, including the accepted plan while implementa
 `/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material
 question, `/plan save` stores a completed ready plan for later and leaves Plan mode, `/plan
 export [path]` writes a ready, saved, or active implementation plan to Markdown, and `/plan
-implement` hands a ready or saved plan to a normal implementation turn. `show`, `save`, `export`,
-and `implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
+implement` hands a ready or saved plan to a normal implementation turn. A successful ready-plan
+export also leaves Plan mode; saved and active implementation exports retain their existing state.
+`show`, `save`, `export`, and `implement` fail closed when no applicable plan is stored; `finalize`
+requires active Plan mode.
 
 `/plan export` creates `PLAN.md` in Pi's current working directory. Supply a path to choose another
 location; relative paths resolve from that directory, absolute paths remain absolute, and missing
 parent directories are created. Export never overwrites an existing file, directory, or symbolic
 link: choose another path or remove the existing target first. A successful export adds one trailing
-newline but otherwise preserves the accepted Markdown exactly. It neither changes Plan-mode state nor
-starts a model turn, and the resulting file is available to the agent through its normal file-reading
-tools. Export is an explicit user-requested file mutation; model-initiated Plan-mode writes remain
-blocked.
+newline but otherwise preserves the accepted Markdown exactly. After a ready plan is written, Plan
+mode ends, its tools and thinking level are restored, and the ready state is cleared without starting
+a model turn. Exporting a saved or active implementation plan leaves that state unchanged. Failed or
+cancelled exports leave every Plan-mode state unchanged. The resulting file is available to the agent
+through its normal file-reading tools. Export is an explicit user-requested file mutation;
+model-initiated Plan-mode writes remain blocked.
 
 In TUI and RPC, **Export plan…** opens a single-line path input from every ready, saved, or active
 plan menu. Submit an empty value to use `PLAN.md`, or enter a relative or absolute custom path. A
 failed TUI export retains the draft for correction; RPC reopens its input dialog. Escape returns to
-the owning menu without writing a file.
+the owning menu without writing a file. A successful ready-plan export closes the menu and ends Plan
+mode; saved and active implementation menus close without changing their stored state.
 
 When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation. It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
 
@@ -102,11 +107,11 @@ A complete Plan mode answer should appear only after the agent has resolved disc
 
 Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines. That compatibility path remains accepted, but it is not the primary workflow. Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
-After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Export plan…** asks for a destination and keeps the plan ready after writing it. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
+After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
 
 A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, Export, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan <prompt>` or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
 
-Text print and JSON modes can export any stored plan with `/plan export [path]`, save a ready plan with `/plan save`, and clear it with `/plan exit` or `/plan off`. Successful export is observable through the created file; an existing target or missing plan fails the command. These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
+Text print and JSON modes can export any stored plan with `/plan export [path]`, save a ready plan with `/plan save`, and clear it with `/plan exit` or `/plan off`. Successful export is observable through the created file; exporting a ready plan also leaves Plan mode, while saved and active implementation state remains unchanged. An existing target or missing plan fails the command without changing state. These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
 
 Once implemented, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
 
@@ -115,7 +120,7 @@ While implementation is active, `/plan show` displays the accepted plan. Interac
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 
 - `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
-- `plan ready`: A completed plan is stored until you implement it, save it, continue planning, or exit Plan mode.
+- `plan ready`: A completed plan is stored until you implement it, export it, save it, continue planning, or exit Plan mode.
 - `plan saved`: One completed plan is stored outside model context in the current session until you implement or clear it.
 - `plan implementing`: The exact accepted plan remains active until you clear or supersede it.
 

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -15,7 +15,8 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Blocks `update_plan`, mutating built-in tools, and unsafe `bash` forms such as writes, substitutions, background jobs, dependency installs, and mutating Git commands.
 - Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finalize only when decision-complete.
 - Adds required `plan_mode_question` and `plan_mode_complete` tools for structured questions and completion.
-- Presents the complete plan and prompts you to implement, save it for later, stay in Plan mode, or exit and discard it.
+- Presents the complete plan and prompts you to implement, export it to a chosen Markdown file, save it for later, stay in Plan mode, or exit and discard it.
+- Exports ready, saved, or active implementation plans with `/plan export [path]` without overwriting existing paths.
 - Keeps legacy `<proposed_plan>` responses compatible without advertising XML as the primary workflow.
 - Shows Plan mode state in Pi's statusline as `plan active`, `plan ready`, `plan saved`, or `plan implementing`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
 - Persists Plan mode, one session-local saved plan, and active implementation state so resume and compaction retain the exact accepted plan.
@@ -50,6 +51,7 @@ pi -e ./extensions/pi-plan-mode
 /plan finalize
 /plan implement
 /plan save
+/plan export [path]
 /plan exit
 ```
 
@@ -63,9 +65,24 @@ the query to restore the stable tool cursor. RPC keeps the complete unfiltered t
 model-requested planning interaction, not command-menu navigation. `/plan show` displays the stored
 plan without starting a model turn, including the accepted plan while implementation is active.
 `/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material
-question, `/plan save` stores a completed ready plan for later and leaves Plan mode, and `/plan
-implement` hands a ready or saved plan to a normal implementation turn. `show`, `save`, and
-`implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
+question, `/plan save` stores a completed ready plan for later and leaves Plan mode, `/plan
+export [path]` writes a ready, saved, or active implementation plan to Markdown, and `/plan
+implement` hands a ready or saved plan to a normal implementation turn. `show`, `save`, `export`,
+and `implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
+
+`/plan export` creates `PLAN.md` in Pi's current working directory. Supply a path to choose another
+location; relative paths resolve from that directory, absolute paths remain absolute, and missing
+parent directories are created. Export never overwrites an existing file, directory, or symbolic
+link: choose another path or remove the existing target first. A successful export adds one trailing
+newline but otherwise preserves the accepted Markdown exactly. It neither changes Plan-mode state nor
+starts a model turn, and the resulting file is available to the agent through its normal file-reading
+tools. Export is an explicit user-requested file mutation; model-initiated Plan-mode writes remain
+blocked.
+
+In TUI and RPC, **Export plan…** opens a single-line path input from every ready, saved, or active
+plan menu. Submit an empty value to use `PLAN.md`, or enter a relative or absolute custom path. A
+failed TUI export retains the draft for correction; RPC reopens its input dialog. Escape returns to
+the owning menu without writing a file.
 
 When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation. It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
 
@@ -85,15 +102,15 @@ A complete Plan mode answer should appear only after the agent has resolved disc
 
 Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines. That compatibility path remains accepted, but it is not the primary workflow. Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
-After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
+After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Export plan…** asks for a destination and keeps the plan ready after writing it. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
 
-A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, or Clear it; `/plan show`, `/plan implement`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan <prompt>` or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
+A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, Export, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan <prompt>` or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
 
-Text print and JSON modes can save a ready plan with `/plan save` and clear it with `/plan exit` or `/plan off`. They reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns in those modes; resume the session in TUI or RPC to show or implement it.
+Text print and JSON modes can export any stored plan with `/plan export [path]`, save a ready plan with `/plan save`, and clear it with `/plan exit` or `/plan off`. Successful export is observable through the created file; an existing target or missing plan fails the command. These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
 
 Once implemented, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
 
-While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
+While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Export plan…, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
 
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 

--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -43,6 +43,6 @@
 		"directory": "extensions/pi-plan-mode"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.41.0"
 	}
 }

--- a/extensions/pi-plan-mode/src/active-implementation-menu.ts
+++ b/extensions/pi-plan-mode/src/active-implementation-menu.ts
@@ -6,6 +6,7 @@ interface ActiveImplementationMenuOptions {
 	signal: AbortSignal;
 	isCurrent(): boolean;
 	show(): void;
+	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	startNew(): void;
 	clear(): void;
 }
@@ -14,8 +15,9 @@ export async function showActiveImplementationMenu(
 	ctx: ExtensionContext,
 	options: ActiveImplementationMenuOptions,
 ) {
-	type Action = "show" | "start-new" | "clear";
-	const menu = defineMenu<undefined, "active", Action, ExtensionContext>({
+	type Screen = "active" | "export";
+	type Action = "show" | "export" | "start-new" | "clear";
+	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "active",
 		screens: {
 			active: () => ({
@@ -24,10 +26,19 @@ export async function showActiveImplementationMenu(
 				lines: [options.statusText],
 				items: [
 					{ id: "show", label: "Show active implementation plan", action: "show" },
+					{ id: "export", label: "Export plan…", to: "export" },
 					{ id: "start-new", label: "Start a new plan", action: "start-new" },
 					{ id: "clear", label: "Clear active implementation plan", action: "clear" },
 				],
 				hint: "close",
+			}),
+			export: () => ({
+				kind: "input",
+				title: "Export plan",
+				lines: ["Existing paths are never overwritten."],
+				placeholder: "PLAN.md",
+				action: "export",
+				hint: "back",
 			}),
 		},
 		actions: {
@@ -35,6 +46,8 @@ export async function showActiveImplementationMenu(
 				options.show();
 				return { kind: "close" };
 			},
+			export: async ({ value, signal }) =>
+				(await options.exportPlan(value ?? "", signal)) ? { kind: "close" } : { kind: "rejected" },
 			"start-new": async () => {
 				options.startNew();
 				return { kind: "close" };

--- a/extensions/pi-plan-mode/src/command.ts
+++ b/extensions/pi-plan-mode/src/command.ts
@@ -9,6 +9,7 @@ const PLAN_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 	{ value: "finalize", label: "finalize", description: "Request a completed plan" },
 	{ value: "implement", label: "implement", description: "Implement the completed or saved plan" },
 	{ value: "save", label: "save", description: "Save the completed plan for later" },
+	{ value: "export", label: "export", description: "Export the stored plan to a Markdown file" },
 	{ value: "exit", label: "exit", description: "Leave Plan mode or clear a saved/active plan" },
 	{ value: "off", label: "off", description: "Leave Plan mode or clear a saved/active plan" },
 	{ value: "tools", label: "tools", description: "Select tools allowed in Plan mode" },

--- a/extensions/pi-plan-mode/src/plan-action-menus.ts
+++ b/extensions/pi-plan-mode/src/plan-action-menus.ts
@@ -12,6 +12,7 @@ interface PlanMenuOptions extends MenuLifecycle {
 	show(): void;
 	finalize(): void;
 	implement(): void | Promise<void>;
+	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
 	tools(): Promise<void>;
 	stay(): void;
@@ -19,8 +20,9 @@ interface PlanMenuOptions extends MenuLifecycle {
 }
 
 export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuOptions) {
-	type Action = "show" | "finalize" | "implement" | "save" | "tools" | "stay" | "exit";
-	const menu = defineMenu<undefined, "main", Action, ExtensionContext>({
+	type Screen = "main" | "export";
+	type Action = "show" | "finalize" | "implement" | "export" | "save" | "tools" | "stay" | "exit";
+	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "main",
 		screens: {
 			main: () => ({
@@ -31,6 +33,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 					? [
 							{ id: "show", label: "Show latest proposed plan", action: "show" },
 							{ id: "implement", label: "Implement this plan", action: "implement" },
+							{ id: "export", label: "Export plan…", to: "export" },
 							{ id: "save", label: "Save for later", action: "save" },
 							{ id: "tools", label: "Configure Plan-mode tools", action: "tools" },
 							{ id: "stay", label: "Stay in Plan mode", action: "stay" },
@@ -43,6 +46,14 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 							{ id: "exit", label: "Exit Plan mode", action: "exit" },
 						],
 				hint: "close",
+			}),
+			export: () => ({
+				kind: "input",
+				title: "Export plan",
+				lines: ["Existing paths are never overwritten."],
+				placeholder: "PLAN.md",
+				action: "export",
+				hint: "back",
 			}),
 		},
 		actions: {
@@ -58,6 +69,8 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 				await options.implement();
 				return { kind: "close" };
 			},
+			export: async ({ value, signal }) =>
+				(await options.exportPlan(value ?? "", signal)) ? { kind: "close" } : { kind: "rejected" },
 			save: async () => {
 				options.save();
 				return { kind: "close" };
@@ -85,14 +98,16 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 
 interface ReadyPlanMenuOptions extends MenuLifecycle {
 	implement(): void | Promise<void>;
+	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
 	stay(): void;
 	exit(): void;
 }
 
 export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPlanMenuOptions) {
-	type Action = "implement" | "save" | "stay" | "exit";
-	const menu = defineMenu<undefined, "ready", Action, ExtensionContext>({
+	type Screen = "ready" | "export";
+	type Action = "implement" | "export" | "save" | "stay" | "exit";
+	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "ready",
 		screens: {
 			ready: () => ({
@@ -100,11 +115,20 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 				title: "Proposed plan ready. What next?",
 				items: [
 					{ id: "implement", label: "Implement this plan", action: "implement" },
+					{ id: "export", label: "Export plan…", to: "export" },
 					{ id: "save", label: "Save for later", action: "save" },
 					{ id: "stay", label: "Stay in Plan mode", action: "stay" },
 					{ id: "exit", label: "Exit Plan mode", action: "exit" },
 				],
 				hint: "close",
+			}),
+			export: () => ({
+				kind: "input",
+				title: "Export plan",
+				lines: ["Existing paths are never overwritten."],
+				placeholder: "PLAN.md",
+				action: "export",
+				hint: "back",
 			}),
 		},
 		actions: {
@@ -112,6 +136,8 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 				await options.implement();
 				return { kind: "close" };
 			},
+			export: async ({ value, signal }) =>
+				(await options.exportPlan(value ?? "", signal)) ? { kind: "close" } : { kind: "rejected" },
 			save: async () => {
 				options.save();
 				return { kind: "close" };

--- a/extensions/pi-plan-mode/src/plan-export.ts
+++ b/extensions/pi-plan-mode/src/plan-export.ts
@@ -43,7 +43,7 @@ export async function exportStoredPlan(
 	try {
 		result = await exportPlanToFile(plan, requestedPath, ctx.cwd, lifecycle?.signal, isCurrent);
 	} catch (error: unknown) {
-		if (!isCurrent()) return false;
+		if (lifecycle?.signal.aborted || !isCurrent()) return false;
 		if (!ctx.hasUI) throw error;
 		const detail = error instanceof Error ? error.message : String(error);
 		ctx.ui.notify(safeNotification(`Unable to export plan: ${detail}`), "error");

--- a/extensions/pi-plan-mode/src/plan-export.ts
+++ b/extensions/pi-plan-mode/src/plan-export.ts
@@ -1,0 +1,118 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { type ExtensionContext, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import type { PlanModeState } from "./state.js";
+
+export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
+
+export interface PlanExportResult {
+	path: string;
+}
+
+export interface PlanExportLifecycle {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+	getState?(): PlanModeState;
+}
+
+export async function exportStoredPlan(
+	state: PlanModeState,
+	requestedPath: string | undefined,
+	ctx: ExtensionContext,
+	lifecycle?: PlanExportLifecycle,
+) {
+	const plan =
+		(state.enabled ? state.latestPlan : undefined)?.trim() ??
+		state.savedPlan?.plan.trim() ??
+		state.activeImplementation?.plan.trim();
+	if (!plan) {
+		const error = new Error(
+			"No completed plan is available to export. Use /plan finalize when planning is complete.",
+		);
+		if (!ctx.hasUI) throw error;
+		ctx.ui.notify(error.message, "warning");
+		return false;
+	}
+
+	const isCurrent = () =>
+		!lifecycle ||
+		(lifecycle.isCurrent() && (!lifecycle.getState || lifecycle.getState() === state));
+	try {
+		const result = await exportPlanToFile(
+			plan,
+			requestedPath,
+			ctx.cwd,
+			lifecycle?.signal,
+			isCurrent,
+		);
+		if (!isCurrent()) return false;
+		ctx.ui.notify(safeNotification(`Plan exported to ${result.path}.`), "info");
+		return true;
+	} catch (error: unknown) {
+		if (!isCurrent()) return false;
+		if (!ctx.hasUI) throw error;
+		const detail = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(safeNotification(`Unable to export plan: ${detail}`), "error");
+		return false;
+	}
+}
+
+export async function exportPlanToFile(
+	plan: string,
+	requestedPath: string | undefined,
+	cwd: string,
+	signal?: AbortSignal,
+	isCurrent: () => boolean = () => true,
+): Promise<PlanExportResult> {
+	const path = resolvePlanExportPath(requestedPath, cwd);
+	await withFileMutationQueue(path, async () => {
+		throwIfCancelled(signal, isCurrent);
+		await mkdir(dirname(path), { recursive: true });
+		throwIfCancelled(signal, isCurrent);
+		try {
+			await writeFile(path, `${plan}\n`, { encoding: "utf8", flag: "wx" });
+		} catch (error: unknown) {
+			if (isNodeError(error) && error.code === "EEXIST") {
+				throw new Error(
+					`Plan export target already exists: ${path}. Choose another path or remove it first.`,
+				);
+			}
+			throw error;
+		}
+	});
+	return { path };
+}
+
+export function resolvePlanExportPath(requestedPath: string | undefined, cwd: string) {
+	const rawPath = requestedPath?.trim() || DEFAULT_PLAN_EXPORT_PATH;
+	const normalizedPath = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
+	if (!normalizedPath.trim()) throw new Error("Plan export path must not be empty.");
+	if (normalizedPath.includes("\0")) {
+		throw new Error("Plan export path must not contain NUL bytes.");
+	}
+	return resolve(cwd, normalizedPath);
+}
+
+function safeNotification(value: string) {
+	let sanitized = "";
+	for (const character of stripVTControlCharacters(value)) {
+		const codePoint = character.codePointAt(0);
+		sanitized +=
+			codePoint !== undefined && codePoint > 0x1f && !(codePoint >= 0x7f && codePoint <= 0x9f)
+				? character
+				: " ";
+	}
+	return sanitized;
+}
+
+function throwIfCancelled(signal: AbortSignal | undefined, isCurrent: () => boolean) {
+	if (!signal?.aborted && isCurrent()) return;
+	throw signal?.reason instanceof Error
+		? signal.reason
+		: new DOMException("Plan export cancelled", "AbortError");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}

--- a/extensions/pi-plan-mode/src/plan-export.ts
+++ b/extensions/pi-plan-mode/src/plan-export.ts
@@ -14,6 +14,7 @@ export interface PlanExportLifecycle {
 	signal: AbortSignal;
 	isCurrent(): boolean;
 	getState?(): PlanModeState;
+	finishReady?(): void;
 }
 
 export async function exportStoredPlan(
@@ -38,17 +39,9 @@ export async function exportStoredPlan(
 	const isCurrent = () =>
 		!lifecycle ||
 		(lifecycle.isCurrent() && (!lifecycle.getState || lifecycle.getState() === state));
+	let result: PlanExportResult;
 	try {
-		const result = await exportPlanToFile(
-			plan,
-			requestedPath,
-			ctx.cwd,
-			lifecycle?.signal,
-			isCurrent,
-		);
-		if (!isCurrent()) return false;
-		ctx.ui.notify(safeNotification(`Plan exported to ${result.path}.`), "info");
-		return true;
+		result = await exportPlanToFile(plan, requestedPath, ctx.cwd, lifecycle?.signal, isCurrent);
 	} catch (error: unknown) {
 		if (!isCurrent()) return false;
 		if (!ctx.hasUI) throw error;
@@ -56,6 +49,14 @@ export async function exportStoredPlan(
 		ctx.ui.notify(safeNotification(`Unable to export plan: ${detail}`), "error");
 		return false;
 	}
+
+	if (!isCurrent()) return false;
+	const finishedReady =
+		state.enabled && Boolean(state.latestPlan?.trim()) && lifecycle?.finishReady !== undefined;
+	if (finishedReady) lifecycle.finishReady?.();
+	const detail = finishedReady ? " Plan mode disabled." : "";
+	ctx.ui.notify(safeNotification(`Plan exported to ${result.path}.${detail}`), "info");
+	return true;
 }
 
 export async function exportPlanToFile(

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -29,10 +29,11 @@ import {
 	stripProposedPlanBlocksFromMessage,
 } from "./message-transform.js";
 import { showPlanModeMenu, showReadyPlanMenu } from "./plan-action-menus.js";
+import { exportStoredPlan } from "./plan-export.js";
 import {
 	clearPlanModeUi,
 	planModeStatusText as formatPlanModeStatusText,
-	showPlanModePlan,
+	showStoredPlan,
 	updatePlanModeUi,
 } from "./presentation.js";
 import { buildPlanModePrompt } from "./prompt.js";
@@ -168,7 +169,7 @@ export default function planMode(
 			const prompt = args.trim();
 			const command = prompt.toLowerCase();
 			if (command === "show") {
-				showStoredPlan(ctx);
+				showStoredPlan(pi, ctx, state);
 				return;
 			}
 			if (command === "finalize") {
@@ -185,6 +186,17 @@ export default function planMode(
 			}
 			if (command === "save") {
 				savePlanForLater(ctx);
+				return;
+			}
+			const exportMatch = /^export(?:\s+([\s\S]+))?$/iu.exec(prompt);
+			if (exportMatch) {
+				const lifecycle = captureMenuLifecycle();
+				await exportStoredPlan(
+					state,
+					exportMatch[1],
+					ctx,
+					exportLifecycle(lifecycle.signal, lifecycle.isCurrent),
+				);
 				return;
 			}
 			if (command === "exit" || command === "off") {
@@ -526,29 +538,6 @@ export default function planMode(
 		return completedPlanIsCurrent(intent) && readyPresentationIntent?.nonce === intent.nonce;
 	}
 
-	function showStoredPlan(ctx: ExtensionContext) {
-		const readyPlan = state.enabled ? state.latestPlan?.trim() : undefined;
-		const savedPlan = state.savedPlan?.plan.trim();
-		if (savedPlan && (ctx.mode === "print" || ctx.mode === "json")) {
-			throw new Error("Saved plan display is unavailable in print/JSON mode. Use TUI or RPC.");
-		}
-		const activePlan = state.activeImplementation?.plan.trim();
-		const plan = readyPlan ?? savedPlan ?? activePlan;
-		if (!plan) {
-			ctx.ui.notify(
-				"No completed plan is available. Use /plan finalize when planning is complete.",
-				"info",
-			);
-			return;
-		}
-		const title = readyPlan
-			? "Proposed Plan"
-			: savedPlan
-				? "Saved Plan"
-				: "Active Implementation Plan";
-		showPlanModePlan(pi, ctx, title, plan);
-	}
-
 	function requestFinalPlan(ctx: ExtensionContext) {
 		if (!state.enabled) {
 			ctx.ui.notify("Plan mode is not active. Use /plan first.", "warning");
@@ -665,7 +654,9 @@ export default function planMode(
 			statusText: planStatusText(),
 			signal: lifecycle.signal,
 			isCurrent: lifecycle.isCurrent,
-			show: () => showStoredPlan(ctx),
+			show: () => showStoredPlan(pi, ctx, state),
+			exportPlan: (path, signal) =>
+				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
 			startNew: () => {
 				enterPlanMode(ctx);
 				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
@@ -683,8 +674,10 @@ export default function planMode(
 			statusText: planStatusText(),
 			signal: lifecycle.signal,
 			isCurrent: lifecycle.isCurrent,
-			show: () => showStoredPlan(ctx),
+			show: () => showStoredPlan(pi, ctx, state),
 			implement: () => startImplementation(ctx),
+			exportPlan: (path, signal) =>
+				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
 			clear: () => {
 				exitPlanMode(ctx);
 				ctx.ui.notify("Saved plan cleared.", "info");
@@ -702,9 +695,11 @@ export default function planMode(
 			statusText: planStatusText(),
 			hasReadyPlan: state.latestPlan !== undefined,
 			...lifecycle,
-			show: () => showStoredPlan(ctx),
+			show: () => showStoredPlan(pi, ctx, state),
 			finalize: () => requestFinalPlan(ctx),
 			implement: () => startImplementation(ctx),
+			exportPlan: (path, signal) =>
+				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
 			save: () => savePlanForLater(ctx),
 			tools: () => showToolSelector(ctx),
 			stay: () => updateUi(ctx),
@@ -720,6 +715,8 @@ export default function planMode(
 		await showReadyPlanMenu(ctx, {
 			...lifecycle,
 			implement: () => startImplementation(ctx),
+			exportPlan: (path, signal) =>
+				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
 			save: () => savePlanForLater(ctx),
 			stay: () => undefined,
 			exit: () => {
@@ -792,6 +789,10 @@ export default function planMode(
 		applyPlanModeTools();
 		persistState();
 		updateUi(ctx);
+	}
+
+	function exportLifecycle(signal: AbortSignal, isCurrent: () => boolean) {
+		return { signal, isCurrent, getState: () => state };
 	}
 
 	function captureMenuLifecycle() {

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -195,7 +195,7 @@ export default function planMode(
 					state,
 					exportMatch[1],
 					ctx,
-					exportLifecycle(lifecycle.signal, lifecycle.isCurrent),
+					exportOwner(ctx, lifecycle.signal, lifecycle.isCurrent),
 				);
 				return;
 			}
@@ -656,7 +656,7 @@ export default function planMode(
 			isCurrent: lifecycle.isCurrent,
 			show: () => showStoredPlan(pi, ctx, state),
 			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
+				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
 			startNew: () => {
 				enterPlanMode(ctx);
 				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
@@ -677,7 +677,7 @@ export default function planMode(
 			show: () => showStoredPlan(pi, ctx, state),
 			implement: () => startImplementation(ctx),
 			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
+				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
 			clear: () => {
 				exitPlanMode(ctx);
 				ctx.ui.notify("Saved plan cleared.", "info");
@@ -699,7 +699,7 @@ export default function planMode(
 			finalize: () => requestFinalPlan(ctx),
 			implement: () => startImplementation(ctx),
 			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
+				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
 			save: () => savePlanForLater(ctx),
 			tools: () => showToolSelector(ctx),
 			stay: () => updateUi(ctx),
@@ -716,7 +716,7 @@ export default function planMode(
 			...lifecycle,
 			implement: () => startImplementation(ctx),
 			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportLifecycle(signal, lifecycle.isCurrent)),
+				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
 			save: () => savePlanForLater(ctx),
 			stay: () => undefined,
 			exit: () => {
@@ -791,8 +791,8 @@ export default function planMode(
 		updateUi(ctx);
 	}
 
-	function exportLifecycle(signal: AbortSignal, isCurrent: () => boolean) {
-		return { signal, isCurrent, getState: () => state };
+	function exportOwner(ctx: ExtensionContext, signal: AbortSignal, isCurrent: () => boolean) {
+		return { signal, isCurrent, getState: () => state, finishReady: () => exitPlanMode(ctx) };
 	}
 
 	function captureMenuLifecycle() {

--- a/extensions/pi-plan-mode/src/presentation.ts
+++ b/extensions/pi-plan-mode/src/presentation.ts
@@ -41,6 +41,29 @@ export function clearPlanModeUi(ctx: ExtensionContext) {
 	ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
 }
 
+export function showStoredPlan(pi: ExtensionAPI, ctx: ExtensionContext, state: PlanModeState) {
+	const readyPlan = state.enabled ? state.latestPlan?.trim() : undefined;
+	const savedPlan = state.savedPlan?.plan.trim();
+	if (savedPlan && (ctx.mode === "print" || ctx.mode === "json")) {
+		throw new Error("Saved plan display is unavailable in print/JSON mode. Use TUI or RPC.");
+	}
+	const activePlan = state.activeImplementation?.plan.trim();
+	const plan = readyPlan ?? savedPlan ?? activePlan;
+	if (!plan) {
+		ctx.ui.notify(
+			"No completed plan is available. Use /plan finalize when planning is complete.",
+			"info",
+		);
+		return;
+	}
+	const title = readyPlan
+		? "Proposed Plan"
+		: savedPlan
+			? "Saved Plan"
+			: "Active Implementation Plan";
+	showPlanModePlan(pi, ctx, title, plan);
+}
+
 export function showPlanModePlan(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,

--- a/extensions/pi-plan-mode/src/saved-plan-menu.ts
+++ b/extensions/pi-plan-mode/src/saved-plan-menu.ts
@@ -7,15 +7,19 @@ interface SavedPlanMenuOptions {
 	isCurrent(): boolean;
 	show(): void;
 	implement(): void | Promise<void>;
+	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	clear(): void;
 }
 
 export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPlanMenuOptions) {
 	if (!ctx.hasUI) {
-		throw new Error(`${options.statusText} Use /plan show, /plan implement, or /plan exit.`);
+		throw new Error(
+			`${options.statusText} Use /plan show, /plan implement, /plan export, or /plan exit.`,
+		);
 	}
-	type Action = "show" | "implement" | "clear";
-	const menu = defineMenu<undefined, "saved", Action, ExtensionContext>({
+	type Screen = "saved" | "export";
+	type Action = "show" | "implement" | "export" | "clear";
+	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "saved",
 		screens: {
 			saved: () => ({
@@ -25,9 +29,18 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 				items: [
 					{ id: "show", label: "Show saved plan", action: "show" },
 					{ id: "implement", label: "Implement saved plan", action: "implement" },
+					{ id: "export", label: "Export plan…", to: "export" },
 					{ id: "clear", label: "Clear saved plan", action: "clear" },
 				],
 				hint: "close",
+			}),
+			export: () => ({
+				kind: "input",
+				title: "Export plan",
+				lines: ["Existing paths are never overwritten."],
+				placeholder: "PLAN.md",
+				action: "export",
+				hint: "back",
 			}),
 		},
 		actions: {
@@ -39,6 +52,8 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 				await options.implement();
 				return { kind: "close" };
 			},
+			export: async ({ value, signal }) =>
+				(await options.exportPlan(value ?? "", signal)) ? { kind: "close" } : { kind: "rejected" },
 			clear: async () => {
 				options.clear();
 				return { kind: "close" };

--- a/extensions/pi-plan-mode/test/plan-export.test.ts
+++ b/extensions/pi-plan-mode/test/plan-export.test.ts
@@ -49,31 +49,69 @@ test("plan export autocomplete exposes a path-taking public route", () => {
 	assert.equal(completePlanArguments("export "), null);
 });
 
-test("plan export writes default and custom paths without changing ready state", async () => {
+test("ready plan export ends Plan mode without triggering a model turn", async () => {
 	await withTempDirectory(async (directory) => {
-		const mock = createMockPi({ activeTools: ["read"] });
-		planMode(mock.pi);
+		const mock = createMockPi({
+			activeTools: ["read", "edit"],
+			thinkingLevel: "low",
+		});
+		planMode(mock.pi, {
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: { thinkingLevel: "medium" as const },
+			}),
+		});
 		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.equal(mock.thinkingLevel, "medium");
 		await completePlan(mock, context.ctx);
 		const entriesBeforeExport = mock.entries.length;
 
 		await mock.commands.get("plan")?.handler("export", context.ctx);
+
 		assert.equal(await readFile(join(directory, "PLAN.md"), "utf8"), `${PLAN}\n`);
-		assert.equal(context.statuses.get("plan-mode"), "plan ready");
-		assert.equal(mock.entries.length, entriesBeforeExport);
+		assert.equal(context.statuses.get("plan-mode"), undefined);
+		assert.equal(mock.entries.length, entriesBeforeExport + 1);
+		const persistedState = mock.entries.at(-1)?.data as Record<string, unknown>;
+		assert.equal(persistedState.enabled, false);
+		assert.equal(persistedState.latestPlan, undefined);
+		assert.equal(persistedState.awaitingAction, false);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
+		assert.equal(mock.thinkingLevel, "low");
 		assert.equal(mock.sentUserMessages.length, 0);
 		assert.equal(mock.sentMessages.length, 0);
-		assert.match(context.notifications.at(-1)?.message ?? "", /exported.*PLAN\.md/i);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			/exported.*PLAN\.md.*Plan mode disabled/i,
+		);
+	});
+});
 
-		await mock.commands.get("plan")?.handler("export docs/custom plan.md", context.ctx);
-		assert.equal(await readFile(join(directory, "docs", "custom plan.md"), "utf8"), `${PLAN}\n`);
-		const absolutePath = join(directory, "absolute-plan.md");
-		await mock.commands.get("plan")?.handler(`export ${absolutePath}`, context.ctx);
-		assert.equal(await readFile(absolutePath, "utf8"), `${PLAN}\n`);
-		await mock.commands.get("plan")?.handler("export unsafe\u001b[31m.md", context.ctx);
-		assert.equal(containsTerminalControl(context.notifications.at(-1)?.message ?? ""), false);
-		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+test("ready plan export supports custom relative and absolute paths", async () => {
+	await withTempDirectory(async (directory) => {
+		for (const { requestedPath, expectedPath } of [
+			{
+				requestedPath: "docs/custom plan.md",
+				expectedPath: join(directory, "docs", "custom plan.md"),
+			},
+			{
+				requestedPath: join(directory, "absolute-plan.md"),
+				expectedPath: join(directory, "absolute-plan.md"),
+			},
+		]) {
+			const mock = createMockPi({ activeTools: ["read"] });
+			planMode(mock.pi);
+			const context = createMockContext({ cwd: directory, hasUI: true });
+			await mock.commands.get("plan")?.handler("", context.ctx);
+			await completePlan(mock, context.ctx);
+
+			await mock.commands.get("plan")?.handler(`export ${requestedPath}`, context.ctx);
+
+			assert.equal(await readFile(expectedPath, "utf8"), `${PLAN}\n`);
+			assert.equal(context.statuses.get("plan-mode"), undefined);
+			assert.equal(containsTerminalControl(context.notifications.at(-1)?.message ?? ""), false);
+		}
 	});
 });
 
@@ -119,9 +157,9 @@ test("concurrent exports serialize and create the target only once", async () =>
 		assert.equal(
 			context.notifications.filter((notification) => /already exists/u.test(notification.message))
 				.length,
-			1,
+			0,
 		);
-		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+		assert.equal(context.statuses.get("plan-mode"), undefined);
 	});
 });
 
@@ -336,6 +374,14 @@ test("completion and management TUI menus accept an export path", async () => {
 			}
 
 			assert.equal(await readFile(join(directory, expectedPath), "utf8"), `${PLAN}\n`);
+			assert.equal(
+				context.statuses.get("plan-mode"),
+				scenario === "active"
+					? "plan implementing"
+					: scenario === "saved"
+						? "plan saved"
+						: undefined,
+			);
 			assert.equal(mock.sentUserMessages.length, scenario === "active" ? 1 : 0);
 		});
 	}
@@ -397,7 +443,7 @@ test("RPC export menu accepts a custom path", async () => {
 
 		assert.equal(inputCalls, 1);
 		assert.equal(await readFile(join(directory, "rpc-export.md"), "utf8"), `${PLAN}\n`);
-		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+		assert.equal(context.statuses.get("plan-mode"), undefined);
 	});
 });
 
@@ -441,7 +487,7 @@ test("rejected TUI export retains the path draft for correction", async () => {
 
 		assert.equal(await readFile(join(directory, "PLAN.md"), "utf8"), "keep\n");
 		assert.equal(await readFile(join(directory, "corrected.md"), "utf8"), `${PLAN}\n`);
-		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+		assert.equal(context.statuses.get("plan-mode"), undefined);
 	});
 });
 

--- a/extensions/pi-plan-mode/test/plan-export.test.ts
+++ b/extensions/pi-plan-mode/test/plan-export.test.ts
@@ -1,0 +1,566 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import planMode, { completePlanArguments } from "../src/plan-mode.js";
+
+const PLAN = "# Exported plan\n\n1. Keep the exact plan.\n2. Make it readable to the agent.";
+const STATE_ENTRY_TYPE = "plan-mode-state";
+
+function stateEntry(data: Record<string, unknown>) {
+	return { type: "custom", customType: STATE_ENTRY_TYPE, data };
+}
+
+async function completePlan(
+	mock: ReturnType<typeof createMockPi>,
+	ctx: ReturnType<typeof createMockContext>["ctx"],
+) {
+	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+	assert.ok(complete);
+	await complete("complete", { plan: PLAN }, undefined, undefined, ctx);
+}
+
+async function withTempDirectory(run: (directory: string) => Promise<void>) {
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-export-"));
+	try {
+		await run(directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+test("plan export autocomplete exposes a path-taking public route", () => {
+	assert.deepEqual(
+		completePlanArguments("")?.map((item) => item.value),
+		["show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+	);
+	assert.deepEqual(
+		completePlanArguments("ex")?.map((item) => item.value),
+		["export", "exit"],
+	);
+	assert.equal(completePlanArguments("export "), null);
+});
+
+test("plan export writes default and custom paths without changing ready state", async () => {
+	await withTempDirectory(async (directory) => {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+		const entriesBeforeExport = mock.entries.length;
+
+		await mock.commands.get("plan")?.handler("export", context.ctx);
+		assert.equal(await readFile(join(directory, "PLAN.md"), "utf8"), `${PLAN}\n`);
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+		assert.equal(mock.entries.length, entriesBeforeExport);
+		assert.equal(mock.sentUserMessages.length, 0);
+		assert.equal(mock.sentMessages.length, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /exported.*PLAN\.md/i);
+
+		await mock.commands.get("plan")?.handler("export docs/custom plan.md", context.ctx);
+		assert.equal(await readFile(join(directory, "docs", "custom plan.md"), "utf8"), `${PLAN}\n`);
+		const absolutePath = join(directory, "absolute-plan.md");
+		await mock.commands.get("plan")?.handler(`export ${absolutePath}`, context.ctx);
+		assert.equal(await readFile(absolutePath, "utf8"), `${PLAN}\n`);
+		await mock.commands.get("plan")?.handler("export unsafe\u001b[31m.md", context.ctx);
+		assert.equal(containsTerminalControl(context.notifications.at(-1)?.message ?? ""), false);
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	});
+});
+
+test("plan export refuses existing files and leaves their content and plan state unchanged", async () => {
+	await withTempDirectory(async (directory) => {
+		const existingPath = join(directory, "PLAN.md");
+		await writeFile(existingPath, "user-owned content\n", "utf8");
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+		const entriesBeforeExport = mock.entries.length;
+
+		await mock.commands.get("plan")?.handler("export", context.ctx);
+
+		assert.equal(await readFile(existingPath, "utf8"), "user-owned content\n");
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+		assert.equal(mock.entries.length, entriesBeforeExport);
+		assert.match(context.notifications.at(-1)?.message ?? "", /already exists/i);
+	});
+});
+
+test("concurrent exports serialize and create the target only once", async () => {
+	await withTempDirectory(async (directory) => {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+
+		await Promise.all([
+			mock.commands.get("plan")?.handler("export shared.md", context.ctx),
+			mock.commands.get("plan")?.handler("export shared.md", context.ctx),
+		]);
+
+		assert.equal(await readFile(join(directory, "shared.md"), "utf8"), `${PLAN}\n`);
+		assert.equal(
+			context.notifications.filter((notification) => /Plan exported to/u.test(notification.message))
+				.length,
+			1,
+		);
+		assert.equal(
+			context.notifications.filter((notification) => /already exists/u.test(notification.message))
+				.length,
+			1,
+		);
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	});
+});
+
+test("queued export stops when the ready plan is superseded", async () => {
+	await withTempDirectory(async (directory) => {
+		const exportPath = join(directory, "PLAN.md");
+		let releaseMutation!: () => void;
+		let markMutationHeld!: () => void;
+		const mutationHeld = new Promise<void>((resolve) => {
+			markMutationHeld = resolve;
+		});
+		const mutationRelease = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+		const blocker = withFileMutationQueue(exportPath, async () => {
+			markMutationHeld();
+			await mutationRelease;
+		});
+		await mutationHeld;
+
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+		const pendingExport = mock.commands.get("plan")?.handler("export", context.ctx);
+		await Promise.resolve();
+		await mock.events.get("before_agent_start")?.[0]?.({ systemPrompt: "base" }, context.ctx);
+		releaseMutation();
+		await blocker;
+		await pendingExport;
+
+		await assert.rejects(readFile(exportPath, "utf8"), /ENOENT/u);
+		assert.equal(context.statuses.get("plan-mode"), "plan active");
+		assert.equal(
+			context.notifications.some((notification) => /Plan exported to/u.test(notification.message)),
+			false,
+		);
+	});
+});
+
+test("plan export refuses an existing symbolic link", {
+	skip: process.platform === "win32" ? "Windows symlink creation requires privileges" : false,
+}, async () => {
+	await withTempDirectory(async (directory) => {
+		const targetPath = join(directory, "owned.md");
+		const exportPath = join(directory, "PLAN.md");
+		await writeFile(targetPath, "user-owned content\n", "utf8");
+		await symlink(targetPath, exportPath);
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+
+		await mock.commands.get("plan")?.handler("export", context.ctx);
+
+		assert.equal(await readFile(targetPath, "utf8"), "user-owned content\n");
+		assert.equal((await lstat(exportPath)).isSymbolicLink(), true);
+		assert.match(context.notifications.at(-1)?.message ?? "", /already exists/i);
+	});
+});
+
+test("plan export supports saved and active plans in print and JSON modes", async () => {
+	for (const scenario of [
+		{
+			mode: "print",
+			status: "plan saved",
+			data: {
+				enabled: false,
+				awaitingAction: false,
+				savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+			},
+		},
+		{
+			mode: "json",
+			status: "plan implementing",
+			data: {
+				enabled: false,
+				awaitingAction: false,
+				activeImplementation: {
+					id: "implementation-1",
+					plan: PLAN,
+					source: "plan_mode_complete",
+					startedAt: 42,
+				},
+			},
+		},
+	] as const) {
+		await withTempDirectory(async (directory) => {
+			const entry = stateEntry(scenario.data);
+			const mock = createMockPi({ activeTools: ["read", "edit"] });
+			planMode(mock.pi);
+			const context = createMockContext({
+				cwd: directory,
+				mode: scenario.mode,
+				hasUI: false,
+				sessionManager: {
+					getBranch: () => [entry],
+					getEntries: () => [entry],
+				},
+			});
+			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+
+			await mock.commands.get("plan")?.handler("export exported.md", context.ctx);
+
+			assert.equal(await readFile(join(directory, "exported.md"), "utf8"), `${PLAN}\n`);
+			assert.equal(context.statuses.get("plan-mode"), scenario.status);
+			assert.equal(mock.entries.length, 0);
+			assert.equal(mock.sentUserMessages.length, 0);
+		});
+	}
+});
+
+test("plan export fails observably without a plan or on an existing path in no-UI modes", async () => {
+	await withTempDirectory(async (directory) => {
+		const missing = createMockPi({ activeTools: ["read"] });
+		planMode(missing.pi);
+		const printContext = createMockContext({ cwd: directory, mode: "print", hasUI: false });
+		await assert.rejects(
+			missing.commands.get("plan")?.handler("export", printContext.ctx) as Promise<unknown>,
+			/no completed plan/i,
+		);
+
+		const savedEntry = stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+		});
+		await writeFile(join(directory, "PLAN.md"), "keep\n", "utf8");
+		const existing = createMockPi({ activeTools: ["read"] });
+		planMode(existing.pi);
+		const jsonContext = createMockContext({
+			cwd: directory,
+			mode: "json",
+			hasUI: false,
+			sessionManager: {
+				getBranch: () => [savedEntry],
+				getEntries: () => [savedEntry],
+			},
+		});
+		await existing.events.get("session_start")?.[0]?.({}, jsonContext.ctx);
+		await assert.rejects(
+			existing.commands.get("plan")?.handler("export", jsonContext.ctx) as Promise<unknown>,
+			/already exists/i,
+		);
+		assert.equal(await readFile(join(directory, "PLAN.md"), "utf8"), "keep\n");
+		assert.equal(jsonContext.statuses.get("plan-mode"), "plan saved");
+	});
+});
+
+test("completion and management TUI menus accept an export path", async () => {
+	for (const scenario of ["automatic-ready", "manual-ready", "saved", "active"] as const) {
+		await withTempDirectory(async (directory) => {
+			const expectedPath = scenario === "automatic-ready" ? "PLAN.md" : `${scenario}-export.md`;
+			const mock = createMockPi({ activeTools: ["read", "edit"] });
+			planMode(mock.pi);
+			const custom = async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory);
+				if (!harness.isFocusable) {
+					chooseExportMenu(harness);
+					return harness.resultPromise;
+				}
+				assert.match(harness.render().join("\n"), /Export plan.*PLAN\.md/is);
+				harness.setFocused(true);
+				if (scenario !== "automatic-ready") harness.handleInput(expectedPath);
+				harness.handleInput("tui.input.submit");
+				await harness.waitForPending();
+				return harness.resultPromise;
+			};
+			const baseContext = {
+				cwd: directory,
+				mode: "tui",
+				hasUI: true,
+				custom,
+			};
+			const context = createMockContext(
+				scenario === "saved"
+					? {
+							...baseContext,
+							sessionManager: {
+								getBranch: () => [
+									stateEntry({
+										enabled: false,
+										awaitingAction: false,
+										savedPlan: { plan: PLAN, source: "plan_mode_complete" },
+									}),
+								],
+								getEntries: () => [],
+							},
+						}
+					: baseContext,
+			);
+
+			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+			if (scenario === "saved") {
+				await mock.commands.get("plan")?.handler("", context.ctx);
+				assert.equal(context.statuses.get("plan-mode"), "plan saved");
+			} else {
+				await mock.commands.get("plan")?.handler("", context.ctx);
+				await completePlan(mock, context.ctx);
+				if (scenario === "automatic-ready") {
+					await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+				} else if (scenario === "manual-ready") {
+					await mock.commands.get("plan")?.handler("", context.ctx);
+				} else {
+					await mock.commands.get("plan")?.handler("implement", context.ctx);
+					await mock.commands.get("plan")?.handler("", context.ctx);
+					assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+				}
+			}
+
+			assert.equal(await readFile(join(directory, expectedPath), "utf8"), `${PLAN}\n`);
+			assert.equal(mock.sentUserMessages.length, scenario === "active" ? 1 : 0);
+		});
+	}
+});
+
+function containsTerminalControl(value: string) {
+	return Array.from(value).some((character) => {
+		const codePoint = character.codePointAt(0);
+		return (
+			codePoint !== undefined && (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+		);
+	});
+}
+
+function chooseExportMenu(harness: ReturnType<typeof createCustomSelectorHarness>) {
+	for (let index = 0; index < 10; index += 1) {
+		if (selectedMenuLabel(harness.render()).startsWith("Export plan")) break;
+		harness.handleInput("tui.select.down");
+	}
+	assert.match(selectedMenuLabel(harness.render()), /^Export plan/u);
+	harness.handleInput("tui.select.confirm");
+}
+
+function selectedMenuLabel(lines: readonly string[]) {
+	const line = lines.find((candidate) => candidate.startsWith("→ ") || candidate.startsWith("› "));
+	return line
+		? (line
+				.slice(2)
+				.split(/\s{2,}/u)[0]
+				?.trim() ?? "")
+		: "";
+}
+
+test("RPC export menu accepts a custom path", async () => {
+	await withTempDirectory(async (directory) => {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		let inputCalls = 0;
+		const context = createMockContext({
+			cwd: directory,
+			mode: "rpc",
+			hasUI: true,
+			select: async (_title: string, options: string[]) => {
+				assert.ok(options.includes("Export plan…"));
+				return "Export plan…";
+			},
+			input: async (title: string, placeholder?: string) => {
+				inputCalls += 1;
+				assert.match(title, /Export plan/i);
+				assert.equal(placeholder, "PLAN.md");
+				return "rpc-export.md";
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+
+		await mock.commands.get("plan")?.handler("", context.ctx);
+
+		assert.equal(inputCalls, 1);
+		assert.equal(await readFile(join(directory, "rpc-export.md"), "utf8"), `${PLAN}\n`);
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	});
+});
+
+test("rejected TUI export retains the path draft for correction", async () => {
+	await withTempDirectory(async (directory) => {
+		await writeFile(join(directory, "PLAN.md"), "keep\n", "utf8");
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({
+			cwd: directory,
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory);
+				if (!harness.isFocusable) {
+					chooseExportMenu(harness);
+					return harness.resultPromise;
+				}
+				harness.setFocused(true);
+				harness.handleInput("PLAN.md");
+				harness.handleInput("tui.input.submit");
+				await harness.waitForPending();
+
+				assert.equal(harness.result, undefined);
+				assert.equal(harness.isFocusable, true);
+				assert.match(harness.render().join("\n"), /PLAN\.md/u);
+				assert.match(context.notifications.at(-1)?.message ?? "", /already exists/i);
+
+				harness.handleInput("\u0015");
+				harness.handleInput("corrected.md");
+				harness.handleInput("tui.input.submit");
+				await harness.waitForPending();
+				return harness.resultPromise;
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+
+		await mock.commands.get("plan")?.handler("", context.ctx);
+
+		assert.equal(await readFile(join(directory, "PLAN.md"), "utf8"), "keep\n");
+		assert.equal(await readFile(join(directory, "corrected.md"), "utf8"), `${PLAN}\n`);
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	});
+});
+
+test("Back from the export input returns without writing or changing ready state", async () => {
+	await withTempDirectory(async (directory) => {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		let returnedFromInput = false;
+		const context = createMockContext({
+			cwd: directory,
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory);
+				if (harness.isFocusable) {
+					returnedFromInput = true;
+					harness.handleInput("tui.select.cancel");
+					return harness.resultPromise;
+				}
+				if (!returnedFromInput) chooseExportMenu(harness);
+				else harness.handleInput("tui.select.cancel");
+				return harness.resultPromise;
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+		const entriesBeforeMenu = mock.entries.length;
+
+		await mock.commands.get("plan")?.handler("", context.ctx);
+
+		await assert.rejects(readFile(join(directory, "PLAN.md"), "utf8"), /ENOENT/u);
+		assert.equal(context.statuses.get("plan-mode"), "plan ready");
+		assert.equal(mock.entries.length, entriesBeforeMenu);
+	});
+});
+
+test("pending export is cancelled by disposal, session replacement, and shutdown", async () => {
+	for (const ending of ["dispose", "replacement", "shutdown"] as const) {
+		await withTempDirectory(async (directory) => {
+			const exportPath = join(directory, "PLAN.md");
+			let releaseMutation!: () => void;
+			let markMutationHeld!: () => void;
+			const mutationHeld = new Promise<void>((resolve) => {
+				markMutationHeld = resolve;
+			});
+			const mutationRelease = new Promise<void>((resolve) => {
+				releaseMutation = resolve;
+			});
+			const blocker = withFileMutationQueue(exportPath, async () => {
+				markMutationHeld();
+				await mutationRelease;
+			});
+			await mutationHeld;
+
+			let harness: ReturnType<typeof createCustomSelectorHarness> | undefined;
+			let markSubmitted!: () => void;
+			let releaseDisposed!: () => void;
+			const submitted = new Promise<void>((resolve) => {
+				markSubmitted = resolve;
+			});
+			const externallyDisposed = new Promise<void>((resolve) => {
+				releaseDisposed = resolve;
+			});
+			const mock = createMockPi({ activeTools: ["read"] });
+			planMode(mock.pi);
+			const context = createMockContext({
+				cwd: directory,
+				mode: "tui",
+				hasUI: true,
+				custom: async (factory: unknown) => {
+					const currentHarness = createCustomSelectorHarness(factory);
+					if (!currentHarness.isFocusable) {
+						chooseExportMenu(currentHarness);
+						return currentHarness.resultPromise;
+					}
+					harness = currentHarness;
+					currentHarness.handleInput("tui.input.submit");
+					markSubmitted();
+					return ending === "dispose"
+						? Promise.race([currentHarness.resultPromise, externallyDisposed])
+						: currentHarness.resultPromise;
+				},
+			});
+			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+			await mock.commands.get("plan")?.handler("", context.ctx);
+			await completePlan(mock, context.ctx);
+			const pendingMenu = mock.commands.get("plan")?.handler("", context.ctx);
+			await submitted;
+			assert.ok(harness);
+
+			try {
+				if (ending === "dispose") {
+					harness.dispose();
+					releaseDisposed();
+				} else if (ending === "replacement") {
+					await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+				} else await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+			} finally {
+				releaseMutation();
+			}
+			await blocker;
+			await pendingMenu;
+
+			await assert.rejects(readFile(exportPath, "utf8"), /ENOENT/u);
+			assert.equal(mock.sentUserMessages.length, 0);
+		});
+	}
+});
+
+test("plan export refuses an existing directory", async () => {
+	await withTempDirectory(async (directory) => {
+		await mkdir(join(directory, "PLAN.md"));
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ cwd: directory, hasUI: true });
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		await completePlan(mock, context.ctx);
+		await mock.commands.get("plan")?.handler("export", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /already exists/i);
+	});
+});

--- a/extensions/pi-plan-mode/test/plan-export.test.ts
+++ b/extensions/pi-plan-mode/test/plan-export.test.ts
@@ -594,6 +594,12 @@ test("pending export is cancelled by disposal, session replacement, and shutdown
 
 			await assert.rejects(readFile(exportPath, "utf8"), /ENOENT/u);
 			assert.equal(mock.sentUserMessages.length, 0);
+			assert.equal(
+				context.notifications.some((notification) =>
+					/Unable to export plan/u.test(notification.message),
+				),
+				false,
+			);
 		});
 	}
 });

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -64,7 +64,7 @@ test("plan_mode_complete result renders the plan as Markdown", () => {
 test("completePlanArguments suggests management tokens only", () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.label),
-		["show", "finalize", "implement", "save", "exit", "off", "tools"],
+		["show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
 	);
 	assert.deepEqual(
 		completePlanArguments("to")?.map((item) => item.value),

--- a/extensions/pi-plan-mode/test/saved-plan.test.ts
+++ b/extensions/pi-plan-mode/test/saved-plan.test.ts
@@ -168,10 +168,17 @@ test("automatic and manual ready menus expose Save for later", async () => {
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					automatic
-						? ["Implement this plan", "Save for later", "Stay in Plan mode", "Exit Plan mode"]
+						? [
+								"Implement this plan",
+								"Export plan…",
+								"Save for later",
+								"Stay in Plan mode",
+								"Exit Plan mode",
+							]
 						: [
 								"Show latest proposed plan",
 								"Implement this plan",
+								"Export plan…",
 								"Save for later",
 								"Configure Plan-mode tools",
 								"Stay in Plan mode",
@@ -216,7 +223,7 @@ test("saved Plan management can show, implement, clear, or cancel", async () => 
 			select: async (_title: string, options: string[]) => {
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
-					["Show saved plan", "Implement saved plan", "Clear saved plan"],
+					["Show saved plan", "Implement saved plan", "Export plan…", "Clear saved plan"],
 				);
 				return scenario.selection;
 			},
@@ -553,7 +560,7 @@ test("session shutdown disposes a saved Plan menu without a late transition", as
 test("plan save autocomplete is public and saving fails closed without a ready plan", async () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.value),
-		["show", "finalize", "implement", "save", "exit", "off", "tools"],
+		["show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
 	);
 	assert.deepEqual(
 		completePlanArguments("sa")?.map((item) => item.value),

--- a/package-lock.json
+++ b/package-lock.json
@@ -433,7 +433,7 @@
 			"version": "0.46.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.41.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -447,9 +447,9 @@
 			}
 		},
 		"extensions/pi-plan-mode/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.41.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.41.0.tgz",
+			"integrity": "sha512-JgbIsQMhabONyPnxSpnEwcg7rW8ddlwJl7vmNK5khEVEXczynz00kmsd5dNfV8fkb1LIsQbAI8PC715CS/GUHQ==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",


### PR DESCRIPTION
## Summary

- add `/plan export [path]` for ready, saved, and active implementation plans
- add **Export plan…** filename input flows to TUI and RPC plan menus
- end Plan mode after a successful ready-plan export, restoring tools and thinking without starting a model turn
- keep saved and active implementation state unchanged when those plans are exported
- create Markdown exports exclusively without overwriting files, directories, or symlinks
- preserve Plan-mode state on failed or cancelled exports and cancel stale work across disposal, session replacement, and shutdown
- document the workflow and raise the Pi TUI Kit compatibility floor for input screens

## Testing

- `npm run check` (2,222 tests passed)
- `just pack plan-mode` (22-file dry-run tarball inspected)

Closes #529
