### PR TITLE
feat(pi-codex-compact): add remote compaction extension

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -14,6 +14,7 @@
 - Root Biome checks reject nested worktrees with another `biome.json`, ignore nested `.gitignore` rules for generated JSON, and honor the root `.gitignore`. Keep worktrees outside the repository, ignore generated paths at the root, and never blanket-ignore `src/`.
 - Tests compiled under root `node_modules/.cache` resolve Pi packages from the root, not a source workspace. Keep imported Pi packages as root devDependencies so the alternate-Pi matrix installs matching copies.
 - Treat `package.json#packageManager` plus CI/release workflows as the npm-version authority. A different npm can rewrite unrelated lock metadata or mishandle the alternate-Pi install matrix.
+- The pinned npm 12.0.2 rejects Node 25; run lockfile work under an installed supported runtime such as Node 22.22.2 instead of tolerating npm's compatibility warning.
 - Official Pi can misresolve static `@earendil-works/pi-ai/api/*` imports beneath its compatibility alias. Prefer root exports; otherwise use a variable-specifier dynamic import.
 
 ### Processes, lifecycle, and state

--- a/docs/implementation-notes/codex-compaction-mechanism.md
+++ b/docs/implementation-notes/codex-compaction-mechanism.md
@@ -1,0 +1,807 @@
+# Codex compaction mechanism research
+
+Research date: 2026-08-03.
+
+## Scope and authority
+
+This note describes the implementation in the `~/workspace/codex` checkout at:
+
+- commit `bb5054fe47abe73ecbbd454751066a28c89f4bb9`;
+- commit subject `Capture rollout budget units from response usage (#36641)`.
+
+The Codex workspace source remains authoritative. Unless otherwise stated, source paths below are
+relative to `~/workspace/codex/codex-rs`. The main implementation surfaces are:
+
+- `~/workspace/codex/codex-rs/core/src/session/turn.rs`;
+- `~/workspace/codex/codex-rs/core/src/tasks/compact.rs`;
+- `~/workspace/codex/codex-rs/core/src/compact.rs`;
+- `~/workspace/codex/codex-rs/core/src/compact_remote.rs`;
+- `~/workspace/codex/codex-rs/core/src/compact_remote_v2.rs`;
+- `~/workspace/codex/codex-rs/core/src/session/mod.rs`;
+- `~/workspace/codex/codex-rs/core/src/session/rollout_reconstruction.rs`.
+
+This is an internal implementation note, not a claim about every Codex release or the hosted
+backend's undocumented internals.
+
+## Executive summary
+
+Codex compaction is not merely "ask a model for a summary and append it." It establishes a new,
+persisted context-window checkpoint:
+
+1. detect a manual or automatic compaction trigger;
+2. run pre-compaction lifecycle hooks;
+3. select token-budget reset, remote V2, legacy remote, or local summarization;
+4. construct a bounded replacement history;
+5. advance the context-window generation and UUID chain;
+6. replace the live model history;
+7. persist the exact replacement history so resume and fork can replay it;
+8. restore the appropriate turn/world-state baseline;
+9. emit completion lifecycle and post-compaction hooks.
+
+The core invariant is that the history installed in memory and the history stored in the rollout are
+the same replacement checkpoint. Summary generation is only one way to produce that checkpoint.
+
+## Terminology
+
+| Term | Meaning in the implementation |
+| --- | --- |
+| Active history | The `ContextManager` history currently sent to the model. |
+| Replacement history | The bounded `Vec<ResponseItem>` that replaces active history after successful compaction. |
+| Context window | One generation of active history between compactions. It has a monotonic number and UUID identity. |
+| Local compaction | A normal Responses inference asks the current model for a plaintext handoff summary. |
+| Legacy remote compaction | The client calls `POST responses/compact`, and the server returns replacement items. |
+| Remote compaction V2 | A normal Responses stream receives a `compaction_trigger` and returns one opaque `compaction` item. |
+| Initial context | Canonical developer/system/environment/world-state material rebuilt from the current session. |
+| Pre-turn compaction | Compaction before context updates and the incoming user message are recorded. |
+| Mid-turn compaction | Inline compaction while the model/tool loop still needs another sampling request. |
+| Standalone compaction | User-requested `/compact` represented as its own session task. |
+
+## End-to-end control flow
+
+```text
+manual /compact
+or pre-turn threshold/model transition
+or mid-turn threshold/new-context request
+              |
+              v
+        PreCompact hooks
+              |
+              v
+      select implementation
+      +-------------------------------+
+      | token-budget reset            |
+      | remote compaction V2          |
+      | legacy responses/compact      |
+      | local Responses summarization |
+      +-------------------------------+
+              |
+              v
+      build replacement history
+              |
+              v
+      advance context-window identity
+              |
+              v
+      replace live history
+      persist CompactedItem
+      persist world/turn baseline
+              |
+              v
+      ContextCompaction completed
+        PostCompact hooks
+```
+
+The implementation-selection order is significant:
+
+1. the experimental `TokenBudget` feature overrides every summarizing implementation;
+2. a provider that supports remote compaction uses remote V2 when that feature is enabled;
+3. otherwise a remote-capable provider uses legacy `responses/compact`;
+4. non-remote providers use local summarization.
+
+See `CompactTask::run` in `core/src/tasks/compact.rs:25-82` and `run_auto_compact` in
+`core/src/session/turn.rs:1147-1223`.
+
+## Entry points
+
+### Manual compact
+
+The TUI slash command eventually submits `Op::Compact`. App-server exposes the asynchronous
+`thread/compact/start` request, which loads the thread, submits `Op::Compact`, and returns an empty
+start response. Completion is observed through subsequent lifecycle notifications rather than the
+request response itself.
+
+Relevant paths:
+
+- `protocol/src/protocol.rs:656` defines `Op::Compact`;
+- `core/src/session/handlers.rs:453-460` creates `CompactTask`;
+- `app-server/src/request_processors/thread_processor.rs:1876-1887` handles
+  `thread/compact/start`;
+- `tui/src/app_server_session.rs:1127-1140` invokes the app-server request.
+
+Standalone local and remote compaction emit a `TurnStarted` event because they own a separate task
+boundary.
+
+### Automatic pre-turn compact
+
+`run_turn` calls `run_pre_sampling_compact` before it records current context updates or the new user
+input. This check can compact for:
+
+- exhausted automatic-compaction budget;
+- exhausted effective context window;
+- changed model compaction compatibility hash;
+- downshift to a smaller context-window model that cannot safely accept the existing context.
+
+Relevant code:
+
+- `core/src/session/turn.rs:158-177` calls the pre-sampling check;
+- `core/src/session/turn.rs:981-1011` checks the token limit;
+- `core/src/session/turn.rs:1049-1144` handles model transitions.
+
+A source TODO at `core/src/session/turn.rs:158-161` documents a known gap: this check does not yet
+estimate the context diffs, full context reinjection, and user input that are about to be added. A
+large incoming turn may therefore cross the threshold after the pre-turn decision.
+
+### Automatic mid-turn compact
+
+After every sampling response, Codex gathers:
+
+- whether the model needs a tool/continuation request;
+- whether user steering is pending;
+- current active and scoped token usage;
+- whether a tool requested a new context window.
+
+It compacts immediately only when more work is required:
+
+```rust
+let should_roll_over = needs_follow_up
+    && (sess.take_new_context_window_request().await || token_limit_reached);
+```
+
+See `core/src/session/turn.rs:376-454`.
+
+This gate avoids paying for compaction at the end of an otherwise completed turn. If the completed
+turn crosses the threshold, the next real user turn handles it in the pre-turn phase.
+
+Pending steering is deliberately not drained into the compaction request. After mid-turn
+compaction, Codex first resumes the model/tool continuation when required, then delivers queued
+steering at the appropriate later request boundary. The state comments are at
+`core/src/session/turn.rs:260-268`; integration coverage is in
+`core/tests/suite/pending_input.rs:953-1251`.
+
+## Token threshold and context-window accounting
+
+### Default limit
+
+`ModelInfo::auto_compact_token_limit` derives a default of 90% of the resolved model context window.
+An explicit model/config limit is clamped to that 90% value when a context window is known:
+
+```text
+derived_limit = resolved_context_window * 0.9
+effective_auto_limit = min(configured_limit, derived_limit)
+```
+
+See `protocol/src/openai_models.rs:413-418` and `:459-470`.
+
+A root `model_auto_compact_token_limit` override is copied into the resolved `ModelInfo` by
+`models-manager/src/model_info.rs:22-38`.
+
+### Effective hard cap
+
+The hard context limit used by a turn is the resolved context window multiplied by the model's
+`effective_context_window_percent`:
+
+- `core/src/session/turn_context.rs:220-228`.
+
+The post-sampling status forces compaction when either the buffered automatic limit or this effective
+hard cap is reached. See `core/src/session/context_window.rs:54-80`.
+
+### Limit scopes
+
+`model_auto_compact_token_limit_scope` has two modes:
+
+- `total`: charge the entire active context against the limit;
+- `body_after_prefix`: charge only growth after the carried prefix for the current compact window.
+
+The enum is defined in `protocol/src/config_types.rs:23-37`. Scope calculation is in
+`core/src/session/context_window.rs:24-50`.
+
+For `body_after_prefix`, `AutoCompactWindow` tracks an absolute prefill-input baseline. The first
+server-observed input usage wins over a local estimate; later body usage is:
+
+```text
+active_context_tokens - prefill_input_tokens
+```
+
+The baseline and one-shot reminder flags reset when advancing to a new compact window. See
+`core/src/state/auto_compact_window.rs:33-115`.
+
+### Model transitions
+
+Codex persists the previous turn's model slug and optional `comp_hash`. Before the next sampling
+request it prefers compacting with the previous model when:
+
+1. both old and new models provide a `comp_hash` and the hashes differ; or
+2. the model changed to one with a smaller context window and existing usage is too large.
+
+A missing hash does not trigger compatibility compaction. If previous-model compaction fails with a
+model-sensitive request, capacity, context, quota, overload, internal-server, or retry-limit error,
+Codex may retry using the current model. The fallback is available only when using the Codex backend,
+the provider is OpenAI, and the model actually changed.
+
+Relevant code:
+
+- `core/src/session/turn.rs:1013-1144`;
+- `core/src/compact_model_fallback.rs:8-31`.
+
+If the fallback also fails, the original previous-model error is retained as the operation result;
+telemetry separately records whether fallback succeeded.
+
+## Implementation A: local plaintext summarization
+
+### Prompt
+
+Local compaction uses `config.compact_prompt`, falling back to the workspace prompt in
+`prompts/templates/compact/prompt.md`:
+
+```text
+You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that
+will resume the task.
+
+Include:
+- Current progress and key decisions made
+- Important context, constraints, or user preferences
+- What remains to be done (clear next steps)
+- Any critical data, examples, or references needed to continue
+
+Be concise, structured, and focused on helping the next LLM seamlessly continue the work.
+```
+
+The prompt is synthesized as a user input and added only to the cloned history used for the compact
+request. It is not treated as a real user turn in the final replacement history.
+
+See `core/src/compact.rs:112-142` and `:241-274`.
+
+### Sampling and retries
+
+Local compaction uses the ordinary Responses streaming path with:
+
+- the cloned conversation as input;
+- normal base instructions;
+- the turn's model, reasoning effort, reasoning-summary mode, and service tier;
+- no rollout inference trace for the local compaction stream.
+
+`drain_to_completed` records completed output items and waits for `response.completed`. It also
+updates rate limits, server-reasoning state, raw response usage, and session token usage.
+
+Failure handling in `core/src/compact.rs:275-341` is:
+
+- interruption or explicit turn abort returns immediately;
+- session budget exhaustion emits an error without retry;
+- context-window overflow removes one oldest prompt item and retries while more than one item
+  remains;
+- other stream errors retry with provider backoff up to `stream_max_retries`;
+- retries reuse one `ModelClientSession` so sticky routing and websocket incremental state survive.
+
+### Extracting the summary
+
+After a successful stream, Codex obtains the last assistant message recorded for the compact turn.
+It prefixes that text with `prompts/templates/compact/summary_prefix.md`:
+
+```text
+Another language model started to solve this problem and produced a summary of its thinking process.
+You also have access to the state of the tools that were used by that language model. Use this to
+build on the work that has already been done and avoid duplicating work. Here is the summary produced
+by the other language model, use the information in this summary to assist with your own analysis:
+```
+
+The complete prefixed summary is encoded as a user-role `ResponseItem::Message`. Existing compaction
+summaries are recognized by that prefix and excluded when collecting real user messages, preventing
+summary-as-user duplication across repeated local compactions.
+
+See `core/src/compact.rs:343-359` and `:531-552`.
+
+### Local replacement shape
+
+The replacement history contains:
+
+1. a bounded suffix of original real user messages;
+2. the prefixed summary as the final user-role message;
+3. initial context only when the compaction phase requires immediate reinjection.
+
+User-message retention is newest-first under an approximate 20,000-token aggregate budget. If the
+oldest retained message only partially fits, that message is token-truncated. Selected messages are
+then restored to chronological order. Images, assistant messages, reasoning, tool calls, and tool
+outputs are not directly retained; important information from them survives only through the model's
+summary.
+
+See `COMPACT_USER_MESSAGE_MAX_TOKENS` and `build_compacted_history_with_limit` in
+`core/src/compact.rs:57` and `:593-660`.
+
+This path is intentionally lossy. It emits a user warning that long threads and repeated compactions
+can reduce accuracy.
+
+## Implementation B: legacy remote `responses/compact`
+
+### Provider selection
+
+Remote compaction is used for OpenAI and Azure Responses providers. Provider detection is in
+`model-provider-info/src/lib.rs:422-424`.
+
+When `RemoteCompactionV2` is disabled, Codex uses the legacy unary endpoint:
+
+```text
+POST responses/compact
+```
+
+The endpoint implementation is in `codex-api/src/endpoint/compact.rs:18-82`.
+
+### Request shape
+
+The canonical payload contains:
+
+- `model`;
+- `input` history;
+- fully resolved base `instructions`;
+- optional tools;
+- `parallel_tool_calls`;
+- optional reasoning controls;
+- optional service tier;
+- optional prompt-cache key;
+- optional text controls.
+
+See `codex-api/src/common.rs:26-45` and `core/src/client.rs:550-638`.
+
+The request also carries installation, originator, session, thread, compatibility, window, optional
+attestation, Responses Lite, and compaction metadata headers. During inline compaction it can retain
+the server's `x-codex-turn-state` value so subsequent requests in the same turn stay consistent.
+
+For API-key authentication, the legacy compact attempt deliberately omits configured service tier;
+other authentication modes can pass it through. See `core/src/compact_remote_request.rs:70-89`.
+
+`compact_prompt` is not sent as a special summarization instruction on this route. The hosted
+compaction endpoint owns the compaction behavior; the request carries ordinary resolved base
+instructions.
+
+### Pre-request output shrinking
+
+Before calling the endpoint, Codex estimates whether base instructions plus history exceed the
+effective context window. While traversing the newest suffix, it can rewrite:
+
+- `FunctionCallOutput` and `CustomToolCallOutput` bodies to
+  `Output exceeded the available model context and was truncated`;
+- `ToolSearchOutput` to retain execution metadata but drop returned tool definitions.
+
+Rewriting stops once the estimate fits or a non-rewritable suffix item is reached. This is a bounded
+pre-compaction survival mechanism, not the final semantic compaction. See
+`core/src/compact_remote.rs:365-465`.
+
+### Server output processing
+
+The endpoint returns `output: Vec<ResponseItem>`, treated as candidate replacement history. Before
+installation, `process_compacted_history` filters it:
+
+- developer messages are dropped to avoid stale or duplicated instructions;
+- user-role wrappers that do not parse as a real `UserMessage` or `HookPrompt` are dropped;
+- assistant and agent messages are kept;
+- `Compaction` and `ContextCompaction` items are kept;
+- reasoning, tool calls, tool outputs, image generation, unknown items, and request-only
+  `CompactionTrigger` items are dropped.
+
+Fresh canonical context is then injected only when required by the phase. See
+`core/src/compact_remote.rs:302-363`.
+
+## Implementation C: remote compaction V2
+
+### Status and transport
+
+`RemoteCompactionV2` is marked stable and default-enabled in
+`features/src/lib.rs:1450-1456`. It is therefore the normal path for remote-capable OpenAI/Azure
+providers in this revision.
+
+Unlike legacy remote compaction, V2 does not call `responses/compact`. It reuses a normal Responses
+stream and appends exactly one request-control item to the prompt:
+
+```json
+{ "type": "compaction_trigger" }
+```
+
+See `core/src/compact_remote_v2_attempt.rs:70-82` and
+`protocol/src/models.rs:1030-1031`.
+
+The prompt still includes current base instructions, model-visible tool specifications, parallel-tool
+support, model/reasoning settings, service tier, window metadata, and the current history.
+
+### Response contract
+
+The stream collector waits for `response.completed` and requires exactly one completed
+`ResponseItem::Compaction` output. That item contains opaque `encrypted_content`:
+
+```json
+{
+  "type": "compaction",
+  "encrypted_content": "..."
+}
+```
+
+Other output items may appear but do not replace the required compaction item. Zero or multiple
+compaction items produce a fatal validation error. A stream closing before `response.completed` is
+also an error.
+
+See `core/src/compact_remote_v2.rs:385-440` and `protocol/src/models.rs:1020-1029`.
+
+The client does not decode the opaque summary. It persists and sends the item back in later model
+requests, leaving semantic recovery to the backend.
+
+### Retry behavior
+
+V2 uses normal Responses retry classification but caps transport retries at two, even when the
+provider allows more. It reuses the current turn's `ModelClientSession` for inline compaction; a
+standalone compact creates and retains an owned session until lifecycle completion.
+
+See `MAX_REMOTE_COMPACTION_V2_STREAM_RETRIES` and
+`run_remote_compaction_request_v2` in `core/src/compact_remote_v2.rs:60` and `:333-383`.
+
+### V2 replacement shape
+
+After receiving the opaque compaction item, the client locally constructs replacement history from:
+
+1. bounded retained messages from the pre-compaction prompt;
+2. the new opaque compaction item as the final item;
+3. phase-dependent canonical initial context.
+
+Candidate retention first permits:
+
+- user/developer/system role messages;
+- non-final `AgentMessage` items no larger than 10,000 estimated tokens.
+
+The shared remote-output filter then removes developer/system/context wrappers. In practice the
+installed retained suffix consists primarily of real user messages, hook prompts, and bounded
+non-final agent/collaboration messages. Standard assistant final messages, reasoning, tool calls,
+tool outputs, and old compaction items are not retained directly.
+
+The retained text budget is approximately 64,000 tokens, newest first. The oldest partially fitting
+message can be token-truncated. Input images and audio are preserved with a minimum one-token budget
+charge for otherwise text-free messages; retained input images are counted for analytics.
+
+See:
+
+- `core/src/compact_remote_v2.rs:55-60` for limits;
+- `:442-497` for item eligibility;
+- `:499-580` for reverse truncation and media preservation.
+
+The request-only `compaction_trigger` is popped before retention and is never durable history. See
+`core/src/compact_remote_v2_attempt.rs:123-133`.
+
+### Usage and tracing
+
+A successful V2 response publishes `RawResponseCompleted`, records rollout-budget usage, and captures:
+
+- input tokens before compaction;
+- summary output tokens;
+- cached input tokens;
+- prompt-cache write tokens;
+- retained image count.
+
+The rollout trace records both the request attempt and the checkpoint installation, joining them to
+the UI compaction item ID. See `core/src/compact_remote_v2.rs:270-307`.
+
+## Implementation D: experimental token-budget reset
+
+`TokenBudget` is under development and default-disabled in `features/src/lib.rs:1336-1342`.
+When enabled, it takes precedence over local and remote summarization.
+
+Compaction in this mode does not call a model or remote compact endpoint. It:
+
+1. captures the current step and world state;
+2. emits the normal context-compaction lifecycle item;
+3. advances the context window;
+4. builds fresh canonical initial context;
+5. installs that context as replacement history.
+
+See `core/src/compact_token_budget.rs:20-92` and `Session::start_new_context_window` in
+`core/src/session/mod.rs:3634-3663`.
+
+The surrounding token-budget feature can inject a one-shot reminder and a model-provided fallback
+prompt before the buffered hard rollover. This gives the model an opportunity to write durable notes
+before the later summary-free reset. The fallback buffer is reserved only when such a prompt exists.
+See `core/src/session/token_budget.rs:54-113` and `core/src/session/context_window.rs:65-79`.
+
+Manual compact in this mode resets immediately rather than asking for a summary.
+
+## Initial-context reinjection
+
+Compaction must preserve two competing requirements:
+
+1. current developer/environment/world-state context must not be lost;
+2. the compaction summary or opaque compaction item must remain at the model-trained history boundary.
+
+`InitialContextInjection` makes this explicit:
+
+- `DoNotInject` for standalone/manual and pre-turn compaction;
+- `BeforeLastUserMessage` for mid-turn compaction.
+
+See `core/src/compact.rs:60-72`.
+
+### Standalone and pre-turn
+
+These phases install the compacted history without initial context and clear the reference-context
+item. The next normal turn sees that the reference is absent and appends a full, freshly rendered
+initial context after the compaction checkpoint before adding normal turn input.
+
+This avoids compacting stale developer/environment fragments and guarantees that the next user turn
+uses current session state.
+
+### Mid-turn
+
+The model must resume immediately without waiting for a new user turn, so Codex builds canonical
+initial context from the exact `StepContext` and `WorldState` used by the current turn. It inserts
+that context:
+
+1. before the last real user or non-final agent message, when present;
+2. otherwise before the textual summary;
+3. otherwise before the last remote compaction item;
+4. otherwise at the end.
+
+This keeps the local summary or remote compaction item last. The corresponding `TurnContextItem` and
+full world-state baseline are persisted so resume/fork can reproduce the same boundary.
+
+See `build_compaction_initial_context` and
+`insert_initial_context_before_last_real_user_or_summary` in `core/src/compact.rs:87-105` and
+`:554-591`.
+
+## Installing and persisting the checkpoint
+
+All summarizing implementations converge on `Session::replace_compacted_history` in
+`core/src/session/mod.rs:3236-3280`.
+
+The method:
+
+1. assigns IDs to replacement items that do not already have one;
+2. builds a `CompactedItem` containing the exact replacement history;
+3. updates live `SessionState` history and its reference-context item;
+4. installs a full world-state baseline when supplied;
+5. persists `RolloutItem::Compacted`;
+6. persists the world-state snapshot after the checkpoint;
+7. persists the reference `TurnContextItem` after the snapshot;
+8. queues `SessionStartSource::Compact` for the next session-start hook boundary.
+
+The order makes the compacted checkpoint the durable semantic boundary before later baseline
+records. Disk persistence is not described as a multi-record transaction, but the rollout stores the
+same replacement item vector that was installed into live history.
+
+After replacement, implementations recompute local token usage against the new history.
+
+## Context-window identity
+
+`AutoCompactWindow` tracks:
+
+- a monotonic `window_number`;
+- UUIDv7 `first_window_id`;
+- optional UUIDv7 `previous_window_id`;
+- UUIDv7 current `window_id`;
+- prefill usage for scoped accounting;
+- one-shot reminder/fallback flags;
+- an explicit pending new-context request.
+
+On advance:
+
+- `window_number` increments with saturation;
+- current UUID becomes `previous_window_id`;
+- a fresh UUIDv7 becomes current;
+- reminder, fallback, and pending-request state reset.
+
+See `core/src/state/auto_compact_window.rs:8-99`.
+
+`Session::current_window_id` separately exposes the request/cache header identity as
+`<thread-id>:<window-number>`. The persisted UUID chain provides stronger durable lineage. See
+`core/src/session/mod.rs:3613-3623`.
+
+## Resume, fork, and rollback semantics
+
+`CompactedItem` persists:
+
+- plaintext `message` for local or legacy compatibility;
+- optional exact `replacement_history`;
+- window number and UUID lineage.
+
+See `protocol/src/protocol.rs:3241-3257`.
+
+During reconstruction, the newest applicable compaction with `replacement_history` becomes the base
+history verbatim; later rollout items are replayed on top. This avoids re-running summary generation
+and keeps resumed model input aligned with the original live checkpoint. See
+`core/src/session/rollout_reconstruction.rs:318-346`.
+
+Legacy rollouts without `replacement_history` are still supported. Reconstruction re-collects user
+messages and rebuilds a local-style compacted history from the old `message` field, clears the
+reference context, and accepts a temporarily less ideal prompt shape. See
+`core/src/session/rollout_reconstruction.rs:347-381`.
+
+Rollback and fork logic must treat compaction as a history reset rather than a normal appended
+message. Existing integration coverage is concentrated in:
+
+- `core/tests/suite/compact_resume_fork.rs`;
+- `core/src/session/rollout_reconstruction_tests.rs`;
+- `core/src/agent/control_tests.rs`.
+
+## Lifecycle, hooks, and cancellation
+
+All implementations run `PreCompact` before modifying history. A supported stop decision returns
+`TurnAborted`. Successful compaction runs `PostCompact` after the checkpoint is installed. See
+`core/src/hook_runtime.rs:400-469`.
+
+A post-compact stop does not roll the history back: installation has already happened. It aborts the
+surrounding operation after recording the completed compact state.
+
+The user-visible lifecycle item is `TurnItem::ContextCompaction`:
+
+1. emit item started;
+2. perform and install compaction;
+3. emit item completed.
+
+Remote implementations use the same item ID as the rollout compaction trace join key. In this
+revision, the older `EventMsg::ContextCompacted` protocol variant remains defined but the core
+compaction paths use item-started/item-completed lifecycle events.
+
+Automatic compaction propagates failure into the current turn so it cannot continue indefinitely
+with an exhausted context. Remote and local implementations emit structured errors for non-abort
+failures. `CompactTask` propagates `TurnAborted`; other standalone errors have already been surfaced
+as events and the task returns without a model answer.
+
+## Failure and retry matrix
+
+| Path | Failure | Behavior |
+| --- | --- | --- |
+| Any | PreCompact stop | Return `TurnAborted`; do not install replacement history. |
+| Any successful install | PostCompact stop | Keep installed checkpoint; abort surrounding operation. |
+| Local | Context-window exceeded | Remove oldest compact prompt item and retry while more than one remains. |
+| Local | Retryable stream error | Provider backoff up to `stream_max_retries`. |
+| Local | Session budget exhausted | Emit error and fail without stream retry. |
+| Legacy remote | Oversized recent tool outputs | Rewrite a bounded trailing output suffix before endpoint call. |
+| Remote V2 | Retryable stream failure | Responses retry handling, capped at two retries. |
+| Remote V2 | Missing/multiple compaction items | Fatal validation error; do not install checkpoint. |
+| Remote V2 | Stream closes before completed | Stream error; do not install checkpoint. |
+| Previous-model remote compact | Model-sensitive failure | Optionally retry once using current-model step context. |
+| Automatic compact | Non-abort failure | Emit turn error lifecycle and stop the current continuation. |
+
+## Configuration and feature controls
+
+| Surface | Effect | Important caveat |
+| --- | --- | --- |
+| `model_auto_compact_token_limit` | Overrides model automatic threshold before the 90% clamp. | Does not override the effective context hard cap. |
+| `model_auto_compact_token_limit_scope` | Chooses `total` or `body_after_prefix`. | Prefix baseline is window-specific and refreshed from usage. |
+| `compact_prompt` | Replaces the local summarization prompt. | Remote compaction does not use it as a dedicated summary prompt. |
+| `experimental_compact_prompt_file` | Loads a local compact prompt from a file. | Only used when no higher-precedence compact prompt exists. |
+| `features.remote_compaction_v2` | Chooses V2 over legacy remote compaction. | Stable and default-enabled in the researched revision. |
+| `features.token_budget` | Replaces summary compaction with a fresh context reset. | Under development and default-disabled. |
+| Model `comp_hash` | Declares compatibility of compacted model configurations. | A missing hash does not trigger model-switch compaction. |
+| Model context metadata | Supplies context window, effective percent, and default threshold. | Config overrides are resolved through the models manager. |
+
+Configuration fields are declared around `core/src/config/mod.rs:632-710` and
+`config/src/config_toml.rs:163-239`.
+
+## Observable protocol and analytics surfaces
+
+Compaction is visible through:
+
+- standalone `TurnStarted` for manual compact;
+- `ContextCompaction` item started/completed events;
+- raw response completion usage for local and V2 requests;
+- warning events on local compaction;
+- error events on failed compaction;
+- hook started/completed events;
+- request metadata identifying trigger, reason, implementation, and phase;
+- context-window request headers and persisted lineage;
+- analytics status, duration, before/after tokens, summary tokens, cache usage, and retained images.
+
+Analytics classify:
+
+- trigger: manual or auto;
+- reason: user requested, context limit, model downshift, or `comp_hash` change;
+- phase: standalone turn, pre-turn, or mid-turn;
+- implementation: normal Responses, `responses/compact`, or Responses compaction V2;
+- status: completed, interrupted, or failed.
+
+See `core/src/compact.rs:400-506`, `core/src/responses_metadata.rs`, and
+`analytics/src/events.rs:813-844`.
+
+## Important behavioral consequences
+
+### Compact is lossy even when the checkpoint is exact
+
+Persistence exactly reproduces the selected replacement history, but selection itself is lossy:
+
+- local compact delegates semantic retention to a plaintext model summary;
+- legacy remote delegates selection to the compact endpoint and filters its output;
+- V2 retains bounded recent messages plus an opaque backend summary;
+- token-budget reset relies on prior reminders/notes rather than a summary operation.
+
+The exact checkpoint guarantee should not be confused with lossless conversation recovery.
+
+### Current context is rebuilt, not trusted from compact output
+
+Remote-produced developer and context wrappers are intentionally discarded. Codex rebuilds
+canonical context from current session state to avoid stale instructions, stale cwd/environment,
+duplicated policy, or mismatched world-state baselines.
+
+### Mid-turn compaction is a continuation protocol
+
+It is not equivalent to a manual `/compact`. It must preserve the exact current step, defer steering,
+keep the summary/opaque compaction item at the trained boundary, and make the next model request
+without a new user turn.
+
+### Prompt-cache identity follows window boundaries
+
+Compaction advances a window generation used in request metadata and headers. Replacing history
+necessarily changes the model-visible prefix; explicit generations keep usage, tracing, and cache
+behavior attributable to the correct pre- or post-compaction window.
+
+### Custom local prompts do not provide remote parity
+
+A configuration that changes `compact_prompt` can materially alter local summary quality but does
+not redefine the hosted legacy or V2 remote compaction protocol. Tests comparing local and remote
+must account for that ownership difference.
+
+## Verification map in the Codex checkout suite
+
+| Behavior | Existing source coverage |
+| --- | --- |
+| Manual and automatic local compact | `core/tests/suite/compact.rs` |
+| Legacy remote endpoint and output processing | `core/tests/suite/compact_remote.rs` |
+| Local/remote/V2 parity expectations | `core/tests/suite/compact_remote_parity.rs` |
+| Manual app-server API lifecycle | `app-server/tests/suite/v2/compaction.rs` |
+| Pending steering across mid-turn compact | `core/tests/suite/pending_input.rs` |
+| Resume, fork, and rollback | `core/tests/suite/compact_resume_fork.rs` |
+| Request window identity across compact | `core/tests/suite/window_headers.rs` |
+| Context replacement helpers | `core/src/compact_tests.rs` |
+| V2 collector and retention bounds | inline tests in `core/src/compact_remote_v2.rs` |
+| Token-budget reset behavior | `core/tests/suite/token_budget.rs` |
+| Rollout reconstruction compatibility | `core/src/session/rollout_reconstruction_tests.rs` |
+
+This research pass inspected implementation and existing tests but did not modify or execute the
+`~/workspace/codex` code.
+
+## Design lessons for Pi extensions and other agents
+
+The transferable design is the checkpoint protocol rather than any one summary prompt:
+
+1. **Separate pre-turn, mid-turn, and standalone semantics.** They have different input ordering and
+   context reinjection requirements.
+2. **Persist the exact replacement history.** Persisting only summary text cannot guarantee resume
+   parity when retained messages, opaque items, and context placement also matter.
+3. **Treat pending input as concurrent state.** Do not accidentally summarize steering that arrived
+   after the compaction boundary or deliver it before the old continuation resumes.
+4. **Rebuild canonical policy/environment context.** Do not trust model-produced copies of mutable
+   system or developer state.
+5. **Bound every retained channel.** Summary text, user suffixes, agent messages, media, and fallback
+   prompts all need explicit caps.
+6. **Track context-window identity.** Generation and lineage make retries, usage, caches, tracing,
+   resume, and rollback auditable.
+7. **Validate remote outputs before installation.** A malformed compact response must not partially
+   replace live history.
+8. **Keep installation distinct from generation.** Generation may retry or fall back; installation is
+   the semantic point at which the new checkpoint becomes live.
+9. **Do not infer losslessness from persistence.** An exactly replayable summary checkpoint can still
+   omit critical task state, so long conversations and repeated compactions remain accuracy risks.
+
+## Experimental Pi extension boundary
+
+This repository now contains
+[`experimental/pi-codex-compact`](../../experimental/pi-codex-compact/README.md), an experimental
+Pi extension for the built-in `openai-codex` OAuth provider. It implements the Remote V2 wire path
+inside Pi's public extension boundary:
+
+- add `compaction_trigger` to an extension-owned Codex Responses request;
+- validate and persist the opaque `compaction` item in versioned `CompactionEntry.details`;
+- collapse Pi's fallback summary and verified kept suffix to a marker;
+- replace that marker with bounded remote replacement history in `before_provider_request`;
+- fall back to native Pi compaction on unsupported providers or Remote V2 failure.
+
+The package deliberately keeps Pi's threshold, `/compact`, overflow retry, append-only session tree,
+and `CompactionEntry` publication. A TUI control menu, opened with `/codex-compact`, provides
+manual compaction and writes bounded user options to `pi-codex-compact.json`.
+
+This is payload replay, not full Codex-core parity. A pure Pi extension cannot own Codex's context
+window generations, exact pre-turn and mid-turn continuation state, pending-input boundary,
+provider `comp_hash` compatibility checks, request lineage headers, or prompt-cache window identity.
+Successful opaque checkpoints also remain tied to the same Codex provider/model and require the
+extension for full resume history.

--- a/experimental/pi-codex-compact/LICENSE
+++ b/experimental/pi-codex-compact/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Narumi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/experimental/pi-codex-compact/README.md
+++ b/experimental/pi-codex-compact/README.md
@@ -1,0 +1,108 @@
+# @narumitw/pi-codex-compact
+
+> [!WARNING]
+> This extension is experimental. It depends on an undocumented OpenAI Codex Responses wire
+> contract and stores provider-specific opaque checkpoints. Keep backups of important sessions.
+
+Codex Remote Compaction V2 for Pi's built-in `openai-codex` OAuth provider. It replaces Pi's
+plaintext summary-generation call with a server-generated opaque compaction item, then replays
+that item in later OpenAI Codex Responses requests.
+
+Pi still owns compaction thresholds, `/compact`, overflow retries, retained-message selection, and
+the append-only session tree. This package does not reproduce Codex core's context-window lineage
+or exact pre-turn and mid-turn lifecycle.
+
+## Install
+
+```bash
+pi install npm:@narumitw/pi-codex-compact
+```
+
+From this repository:
+
+```bash
+just try codex-compact
+```
+
+Loading the package enables it. Use Pi normally, including its built-in `/compact` command. Open
+the extension's TUI control menu with:
+
+```text
+/codex-compact
+```
+
+The menu shows the active model and whether compaction will use Codex Remote V2 or Pi's native
+fallback. Choose **Compact now** to close the menu and compact immediately, or **Settings** to edit
+user settings in `~/.pi/agent/pi-codex-compact.json` (or the active Pi agent directory). Invalid
+files are never overwritten; manual compaction remains available, while Settings opens read-only
+repair guidance until the file is fixed and `/reload` is run.
+
+| Setting | Default | Accepted values |
+| --- | ---: | --- |
+| `enabled` | `true` | Boolean |
+| `requestTimeoutMs` | `300000` | Integer from 30,000 to 600,000 ms |
+| `maxRetries` | `2` | Integer from 0 to 2 |
+| `replacementTokenBudget` | `64000` | Integer from 8,000 to 128,000 tokens |
+| `notifyOnFallback` | `true` | Boolean |
+
+Missing fields use built-in defaults; the file has no environment-variable or project-level
+override. Settings reload on every `session_start`, including `/reload`, resume, and fork. Menu
+writes apply immediately, preserve unknown JSON fields, serialize within the current Pi process, and
+use a conflict check plus atomic rename. Separate Pi processes are not coordinated by a shared lock;
+a detected concurrent edit is rejected for the user to reopen and retry.
+
+## Requirements
+
+- Pi `0.83.0`-compatible extension APIs.
+- A model using provider `openai-codex` and API `openai-codex-responses`.
+- A working OpenAI Codex OAuth login in Pi.
+
+OpenAI API-key, Azure, Copilot, proxies, and generic Responses-compatible providers are not
+supported. Unsupported models continue to use Pi's native compaction.
+
+## How it works
+
+1. Pi decides when compaction is needed.
+2. The extension sends the current Codex Responses input with a final `compaction_trigger`.
+3. It validates and persists the server's encrypted `compaction` item in the Pi
+   `CompactionEntry.details` field.
+4. Later Codex requests replace Pi's fallback summary and kept suffix with the opaque replacement
+   history before dispatch.
+
+The SSE response is limited to 8 MiB, the opaque item to 2 MiB, and the persisted replacement
+history to the configured text budget (64,000 tokens by default) and 8 MiB. Oversized media
+retention is dropped rather than creating an unbounded session entry.
+
+## Failure and portability
+
+Remote auth, transport, protocol, or validation failures fall back to Pi's native plaintext
+compaction. User cancellation does not start that fallback.
+
+After a successful remote compaction, full older history can be replayed only when this extension
+is loaded with the same `openai-codex` model. If the extension is removed or the model/provider is
+changed, Pi exposes a warning summary plus its retained recent messages. Switching back restores
+opaque replay. Repeated compaction after an opaque checkpoint also requires the checkpoint to be
+projected safely; otherwise Pi falls back rather than guessing.
+
+## Privacy and storage
+
+Remote compaction sends the active conversation context, system prompt, and active tool schemas to
+the same OpenAI Codex backend used by the selected model. The extension stores the encrypted
+compaction item and bounded recent user-role Responses items in the Pi session. It never persists
+the OAuth token or request headers.
+
+## Development
+
+```bash
+npm --workspace @narumitw/pi-codex-compact run check
+npm test
+just pack codex-compact
+```
+
+See
+[`docs/implementation-notes/codex-compaction-mechanism.md`](../../docs/implementation-notes/codex-compaction-mechanism.md)
+for the underlying Codex mechanism research and the extension boundary.
+
+## License
+
+MIT

--- a/experimental/pi-codex-compact/package.json
+++ b/experimental/pi-codex-compact/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@narumitw/pi-codex-compact",
+	"version": "0.47.0",
+	"description": "Experimental Codex Remote Compaction V2 for Pi's OpenAI Codex provider.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"codex",
+		"compaction",
+		"openai"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check --vcs-use-ignore-file=false src test package.json tsconfig.json README.md && npm run typecheck",
+		"format": "biome check --write --vcs-use-ignore-file=false src test package.json tsconfig.json README.md",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.45.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-agent-core": "*",
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.6",
+		"@earendil-works/pi-agent-core": "0.83.0",
+		"@earendil-works/pi-ai": "0.83.0",
+		"@earendil-works/pi-coding-agent": "0.83.0",
+		"@types/node": "26.1.2",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "experimental/pi-codex-compact"
+	}
+}

--- a/experimental/pi-codex-compact/src/checkpoint.ts
+++ b/experimental/pi-codex-compact/src/checkpoint.ts
@@ -1,0 +1,257 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { CompactionEntry, SessionEntry } from "@earendil-works/pi-coding-agent";
+import { type JsonObject, validateCompactionItem } from "./protocol.js";
+
+export const CHECKPOINT_KIND = "pi-codex-remote-compaction";
+export const CHECKPOINT_VERSION = 1;
+export const REPLACEMENT_TOKEN_BUDGET = 64_000;
+export const REPLACEMENT_BYTE_BUDGET = 8 * 1024 * 1024;
+const MAX_MEDIA_ITEM_BYTES = 2 * 1024 * 1024;
+
+export interface CodexCheckpointDetails {
+	kind: typeof CHECKPOINT_KIND;
+	version: typeof CHECKPOINT_VERSION;
+	checkpointId: string;
+	provider: "openai-codex";
+	api: "openai-codex-responses";
+	modelId: string;
+	protocol: "remote-compaction-v2";
+	replacementHistory: JsonObject[];
+	keptMessageFingerprints: string[];
+	createdAt: string;
+}
+
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (!isObject(value)) return value;
+	return Object.fromEntries(
+		Object.entries(value)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, child]) => [key, stableValue(child)]),
+	);
+}
+
+function serializedBytes(value: unknown): number {
+	return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+export function fingerprintMessage(message: AgentMessage): string {
+	return createHash("sha256")
+		.update(JSON.stringify(stableValue(message)))
+		.digest("hex");
+}
+
+export function checkpointMarker(checkpointId: string): string {
+	return [
+		`[PI_CODEX_REMOTE_CHECKPOINT:${checkpointId}]`,
+		"Opaque checkpoint injection failed. Do not infer missing history; tell the user to re-enable",
+		"@narumitw/pi-codex-compact with an openai-codex model.",
+	].join(" ");
+}
+
+export function fallbackSummary(checkpointId: string): string {
+	return [
+		`OpenAI Codex Remote Compaction V2 checkpoint ${checkpointId} stores the older history opaquely.`,
+		"Full replay requires @narumitw/pi-codex-compact and an openai-codex model.",
+		"Without them, only Pi's retained recent messages remain available.",
+	].join(" ");
+}
+
+function markerMessage(checkpointId: string, timestamp: number): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text: checkpointMarker(checkpointId) }],
+		timestamp,
+	};
+}
+
+export function parseCheckpointDetails(value: unknown): CodexCheckpointDetails | undefined {
+	if (!isObject(value)) return undefined;
+	if (
+		value.kind !== CHECKPOINT_KIND ||
+		value.version !== CHECKPOINT_VERSION ||
+		typeof value.checkpointId !== "string" ||
+		value.checkpointId.length < 8 ||
+		value.provider !== "openai-codex" ||
+		value.api !== "openai-codex-responses" ||
+		typeof value.modelId !== "string" ||
+		value.protocol !== "remote-compaction-v2" ||
+		!Array.isArray(value.replacementHistory) ||
+		!Array.isArray(value.keptMessageFingerprints) ||
+		typeof value.createdAt !== "string"
+	) {
+		return undefined;
+	}
+	if (
+		value.replacementHistory.length === 0 ||
+		!value.replacementHistory.every(isObject) ||
+		!value.keptMessageFingerprints.every(
+			(fingerprint) => typeof fingerprint === "string" && /^[a-f0-9]{64}$/.test(fingerprint),
+		) ||
+		serializedBytes(value.replacementHistory) > REPLACEMENT_BYTE_BUDGET
+	) {
+		return undefined;
+	}
+	const last = value.replacementHistory.at(-1);
+	try {
+		validateCompactionItem(last);
+	} catch {
+		return undefined;
+	}
+	return structuredClone(value) as unknown as CodexCheckpointDetails;
+}
+
+export function latestCheckpoint(entries: readonly SessionEntry[]):
+	| {
+			entry: CompactionEntry<CodexCheckpointDetails>;
+			details: CodexCheckpointDetails;
+	  }
+	| undefined {
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry.type !== "compaction") continue;
+		const details = parseCheckpointDetails(entry.details);
+		return details
+			? { entry: entry as CompactionEntry<CodexCheckpointDetails>, details }
+			: undefined;
+	}
+	return undefined;
+}
+
+export function projectCheckpointContext(
+	messages: readonly AgentMessage[],
+	details: CodexCheckpointDetails,
+): AgentMessage[] | undefined {
+	const summary = fallbackSummary(details.checkpointId);
+	const summaryIndex = messages.findIndex(
+		(message) => message.role === "compactionSummary" && message.summary === summary,
+	);
+	if (summaryIndex < 0) return undefined;
+	const keptStart = summaryIndex + 1;
+	const keptEnd = keptStart + details.keptMessageFingerprints.length;
+	if (keptEnd > messages.length) return undefined;
+	for (let index = keptStart; index < keptEnd; index++) {
+		if (
+			fingerprintMessage(messages[index]) !== details.keptMessageFingerprints[index - keptStart]
+		) {
+			return undefined;
+		}
+	}
+	const timestamp = messages[summaryIndex].timestamp;
+	return [
+		...messages.slice(0, summaryIndex),
+		markerMessage(details.checkpointId, timestamp),
+		...messages.slice(keptEnd),
+	];
+}
+
+function rawText(item: JsonObject): string {
+	if (!Array.isArray(item.content)) return "";
+	return item.content
+		.flatMap((part) =>
+			isObject(part) && typeof part.text === "string" && part.type === "input_text"
+				? [part.text]
+				: [],
+		)
+		.join("\n");
+}
+
+function hasMedia(item: JsonObject): boolean {
+	return (
+		Array.isArray(item.content) &&
+		item.content.some((part) => isObject(part) && part.type === "input_image")
+	);
+}
+
+function truncateTextItem(item: JsonObject, maxChars: number): JsonObject | undefined {
+	if (!Array.isArray(item.content) || maxChars <= 32) return undefined;
+	let remaining = maxChars - 16;
+	const content = [...item.content].reverse().flatMap((part) => {
+		if (
+			!isObject(part) ||
+			part.type !== "input_text" ||
+			typeof part.text !== "string" ||
+			remaining <= 0
+		) {
+			return [];
+		}
+		const text = part.text.slice(-remaining);
+		remaining -= text.length;
+		return [{ ...part, text: `[truncated]\n${text}` }];
+	});
+	if (content.length === 0) return undefined;
+	return { ...item, content: content.reverse() };
+}
+
+export function buildReplacementHistory(
+	input: readonly unknown[],
+	compactionItem: JsonObject,
+	options: { tokenBudget?: number; byteBudget?: number } = {},
+): JsonObject[] {
+	const tokenBudget = options.tokenBudget ?? REPLACEMENT_TOKEN_BUDGET;
+	const byteBudget = options.byteBudget ?? REPLACEMENT_BYTE_BUDGET;
+	const opaque = validateCompactionItem(compactionItem);
+	let remainingBytes = byteBudget - serializedBytes(opaque);
+	let remainingChars = tokenBudget * 4;
+	if (remainingBytes <= 0)
+		throw new Error("Opaque compaction item exceeds replacement history budget");
+	const retainedNewestFirst: JsonObject[] = [];
+	const candidates = input.filter(
+		(item): item is JsonObject =>
+			isObject(item) && item.role === "user" && item.type !== "compaction_trigger",
+	);
+	for (let index = candidates.length - 1; index >= 0; index--) {
+		const candidate = candidates[index];
+		const bytes = serializedBytes(candidate);
+		if (hasMedia(candidate) && bytes > MAX_MEDIA_ITEM_BYTES) continue;
+		const text = rawText(candidate);
+		let retained = candidate;
+		if (text.length > remainingChars) {
+			if (hasMedia(candidate)) continue;
+			const truncated = truncateTextItem(candidate, remainingChars);
+			if (!truncated) continue;
+			retained = truncated;
+		}
+		if (serializedBytes(retained) > remainingBytes) {
+			if (hasMedia(retained)) continue;
+			const maxCharsByBytes = Math.max(0, remainingBytes - 128);
+			const truncated = truncateTextItem(retained, Math.min(remainingChars, maxCharsByBytes));
+			if (!truncated || serializedBytes(truncated) > remainingBytes) continue;
+			retained = truncated;
+		}
+		retainedNewestFirst.push(structuredClone(retained));
+		remainingBytes -= serializedBytes(retained);
+		remainingChars -= Math.min(remainingChars, rawText(retained).length);
+		if (remainingBytes <= 128 || remainingChars <= 32) break;
+	}
+	return [...retainedNewestFirst.reverse(), opaque];
+}
+
+export function createCheckpointDetails(input: {
+	modelId: string;
+	replacementHistory: JsonObject[];
+	keptMessages: readonly AgentMessage[];
+	checkpointId?: string;
+	createdAt?: string;
+}): CodexCheckpointDetails {
+	const details: CodexCheckpointDetails = {
+		kind: CHECKPOINT_KIND,
+		version: CHECKPOINT_VERSION,
+		checkpointId: input.checkpointId ?? randomUUID(),
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		modelId: input.modelId,
+		protocol: "remote-compaction-v2",
+		replacementHistory: structuredClone(input.replacementHistory),
+		keptMessageFingerprints: input.keptMessages.map(fingerprintMessage),
+		createdAt: input.createdAt ?? new Date().toISOString(),
+	};
+	const parsed = parseCheckpointDetails(details);
+	if (!parsed) throw new Error("Created an invalid Codex checkpoint");
+	return parsed;
+}

--- a/experimental/pi-codex-compact/src/codex-compact.ts
+++ b/experimental/pi-codex-compact/src/codex-compact.ts
@@ -1,0 +1,283 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Api, Context, Model, Tool } from "@earendil-works/pi-ai";
+import { hasApi } from "@earendil-works/pi-ai";
+import {
+	buildContextEntries,
+	buildSessionContext,
+	convertToLlm,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type SessionBeforeCompactEvent,
+	sessionEntryToContextMessages,
+} from "@earendil-works/pi-coding-agent";
+import {
+	buildReplacementHistory,
+	type CodexCheckpointDetails,
+	checkpointMarker,
+	createCheckpointDetails,
+	fallbackSummary,
+	latestCheckpoint,
+	projectCheckpointContext,
+} from "./checkpoint.js";
+import { hasCheckpointMarker, rewriteCheckpointMarker } from "./protocol.js";
+import { requestRemoteCompaction } from "./remote.js";
+import {
+	type CodexCompactSettings,
+	type CodexCompactSettingsRuntime,
+	type CodexCompactSettingsState,
+	createCodexCompactSettingsRuntime,
+} from "./settings.js";
+import { showCodexCompactMenu } from "./settings-menu.js";
+
+const STATUS_KEY = "codex-compact";
+const EXPERIMENTAL_WARNING =
+	"Experimental: Codex Remote Compaction V2 uses an opaque, provider-specific checkpoint. Sessions require this extension and openai-codex for full replay.";
+
+function isSupportedModel(model: Model<Api> | undefined): model is Model<"openai-codex-responses"> {
+	return model?.provider === "openai-codex" && hasApi(model, "openai-codex-responses");
+}
+
+function activeCheckpoint(ctx: ExtensionContext) {
+	return latestCheckpoint(ctx.sessionManager.getBranch());
+}
+
+function isCheckpointCompatible(
+	details: CodexCheckpointDetails,
+	model: Model<Api> | undefined,
+): model is Model<"openai-codex-responses"> {
+	return isSupportedModel(model) && model.id === details.modelId;
+}
+
+function keptMessages(event: SessionBeforeCompactEvent): AgentMessage[] {
+	const leafId = event.branchEntries.at(-1)?.id ?? null;
+	const contextEntries = buildContextEntries(event.branchEntries, leafId);
+	const keptIndex = contextEntries.findIndex(
+		(entry) => entry.id === event.preparation.firstKeptEntryId,
+	);
+	if (keptIndex < 0) {
+		throw new Error("Pi compaction cut point is not present in the active context");
+	}
+	return contextEntries.slice(keptIndex).flatMap(sessionEntryToContextMessages);
+}
+
+function activeTools(pi: ExtensionAPI): Tool[] {
+	const enabled = new Set(pi.getActiveTools());
+	return pi
+		.getAllTools()
+		.filter((tool) => enabled.has(tool.name))
+		.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters,
+		}));
+}
+
+function projectedCurrentMessages(
+	event: SessionBeforeCompactEvent,
+	model: Model<"openai-codex-responses">,
+): { messages: AgentMessage[]; prior?: CodexCheckpointDetails } {
+	const leafId = event.branchEntries.at(-1)?.id ?? null;
+	const session = buildSessionContext(event.branchEntries, leafId);
+	const prior = latestCheckpoint(event.branchEntries)?.details;
+	if (!prior) return { messages: session.messages };
+	if (prior.modelId !== model.id) {
+		throw new Error("The active opaque checkpoint belongs to a different Codex model");
+	}
+	const projected = projectCheckpointContext(session.messages, prior);
+	if (!projected) {
+		throw new Error("The previous opaque checkpoint could not be projected safely");
+	}
+	return { messages: projected, prior };
+}
+
+function notifyFailure(
+	ctx: ExtensionContext,
+	error: unknown,
+	settings: CodexCompactSettings,
+): void {
+	if (!ctx.hasUI || !settings.notifyOnFallback) return;
+	const message = error instanceof Error ? error.message : String(error);
+	ctx.ui.notify(`Codex remote compaction failed; using Pi compaction. ${message}`, "warning");
+}
+
+function sessionStillOwned(ctx: ExtensionContext, sessionId: string, signal: AbortSignal): boolean {
+	return !signal.aborted && ctx.sessionManager.getSessionId() === sessionId;
+}
+
+async function compactRemotely(
+	pi: ExtensionAPI,
+	event: SessionBeforeCompactEvent,
+	ctx: ExtensionContext,
+	settings: CodexCompactSettings,
+	fetch?: typeof globalThis.fetch,
+) {
+	const model = ctx.model;
+	if (!settings.enabled || !isSupportedModel(model)) return undefined;
+	const sessionId = ctx.sessionManager.getSessionId();
+	ctx.ui.setStatus(STATUS_KEY, "Codex remote compaction…");
+	try {
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+		if (!sessionStillOwned(ctx, sessionId, event.signal)) return { cancel: true };
+		if (!auth.ok || !auth.apiKey) {
+			throw new Error(auth.ok ? "OpenAI Codex OAuth token is unavailable" : auth.error);
+		}
+		const provider = ctx.modelRegistry.getProvider(model.provider);
+		if (!provider) throw new Error("OpenAI Codex provider is unavailable");
+		const current = projectedCurrentMessages(event, model);
+		const context: Context = {
+			systemPrompt: ctx.getSystemPrompt(),
+			messages: convertToLlm(current.messages),
+			tools: activeTools(pi),
+		};
+		const response = await requestRemoteCompaction({
+			provider,
+			model,
+			context,
+			apiKey: auth.apiKey,
+			headers: auth.headers,
+			env: auth.env,
+			signal: event.signal,
+			priorCheckpoint: current.prior
+				? {
+						marker: checkpointMarker(current.prior.checkpointId),
+						replacementHistory: current.prior.replacementHistory,
+					}
+				: undefined,
+			requestTimeoutMs: settings.requestTimeoutMs,
+			maxRetries: settings.maxRetries,
+			fetch,
+		});
+		if (!sessionStillOwned(ctx, sessionId, event.signal)) return { cancel: true };
+		const replacementHistory = buildReplacementHistory(response.promptInput, response.item, {
+			tokenBudget: settings.replacementTokenBudget,
+		});
+		const details = createCheckpointDetails({
+			modelId: model.id,
+			replacementHistory,
+			keptMessages: keptMessages(event),
+		});
+		return {
+			compaction: {
+				summary: fallbackSummary(details.checkpointId),
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+				usage: response.usage,
+				details,
+			},
+		};
+	} catch (error) {
+		if (event.signal.aborted || ctx.sessionManager.getSessionId() !== sessionId) {
+			return { cancel: true };
+		}
+		notifyFailure(ctx, error, settings);
+		return undefined;
+	} finally {
+		if (ctx.sessionManager.getSessionId() === sessionId) ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
+}
+
+export function createCodexCompactExtension(
+	options: { fetch?: typeof globalThis.fetch; settingsRuntime?: CodexCompactSettingsRuntime } = {},
+): (pi: ExtensionAPI) => void {
+	return (pi) => {
+		const providerWarnings = new Set<string>();
+		const settingsRuntime = options.settingsRuntime ?? createCodexCompactSettingsRuntime();
+		let sessionController = new AbortController();
+		let generation = 0;
+
+		pi.registerCommand("codex-compact", {
+			description: "Compact now or configure experimental Codex Remote Compaction V2",
+			handler: async (_args, ctx) => {
+				const ownerGeneration = generation;
+				await showCodexCompactMenu(settingsRuntime, ctx, {
+					signal: sessionController.signal,
+					isCurrent: () => ownerGeneration === generation && !sessionController.signal.aborted,
+				});
+			},
+		});
+
+		pi.on("session_start", async (_event, ctx) => {
+			sessionController.abort();
+			sessionController = new AbortController();
+			generation += 1;
+			const ownerGeneration = generation;
+			const sessionId = ctx.sessionManager.getSessionId();
+			providerWarnings.clear();
+			let state: Readonly<CodexCompactSettingsState>;
+			try {
+				state = await settingsRuntime.reload(sessionController.signal);
+			} catch (error) {
+				if (sessionController.signal.aborted || ownerGeneration !== generation) return;
+				if (ctx.hasUI) {
+					ctx.ui.notify(
+						`Could not load pi-codex-compact.json; using defaults. ${error instanceof Error ? error.message : String(error)}`,
+						"warning",
+					);
+				}
+				return;
+			}
+			if (
+				sessionController.signal.aborted ||
+				ownerGeneration !== generation ||
+				ctx.sessionManager.getSessionId() !== sessionId
+			) {
+				return;
+			}
+			if (ctx.hasUI) {
+				ctx.ui.notify(EXPERIMENTAL_WARNING, "warning");
+				if (state.kind === "invalid") {
+					ctx.ui.notify(
+						`Invalid pi-codex-compact.json; using defaults without overwriting it. ${state.issue}`,
+						"warning",
+					);
+				}
+			}
+		});
+
+		pi.on("session_before_compact", (event, ctx) =>
+			compactRemotely(pi, event, ctx, settingsRuntime.get().settings, options.fetch),
+		);
+
+		pi.on("context", (event, ctx) => {
+			if (!settingsRuntime.get().settings.enabled) return undefined;
+			const checkpoint = activeCheckpoint(ctx);
+			if (!checkpoint || !isCheckpointCompatible(checkpoint.details, ctx.model)) return undefined;
+			const messages = projectCheckpointContext(event.messages, checkpoint.details);
+			return messages ? { messages } : undefined;
+		});
+
+		pi.on("before_provider_request", (event, ctx) => {
+			if (!settingsRuntime.get().settings.enabled) return undefined;
+			const checkpoint = activeCheckpoint(ctx);
+			if (!checkpoint || !isCheckpointCompatible(checkpoint.details, ctx.model)) return undefined;
+			const marker = checkpointMarker(checkpoint.details.checkpointId);
+			if (!hasCheckpointMarker(event.payload, marker)) return undefined;
+			return rewriteCheckpointMarker(event.payload, marker, checkpoint.details.replacementHistory);
+		});
+
+		pi.on("model_select", (event, ctx) => {
+			if (!settingsRuntime.get().settings.enabled) return;
+			const checkpoint = activeCheckpoint(ctx);
+			if (!checkpoint || isCheckpointCompatible(checkpoint.details, event.model)) return;
+			const key = `${ctx.sessionManager.getSessionId()}:${event.model.provider}:${event.model.id}`;
+			if (providerWarnings.has(key)) return;
+			providerWarnings.add(key);
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					"The active Codex checkpoint cannot replay on this model; Pi will expose only its fallback marker and retained recent messages.",
+					"warning",
+				);
+			}
+		});
+
+		pi.on("session_shutdown", async (_event, ctx) => {
+			generation += 1;
+			sessionController.abort();
+			providerWarnings.clear();
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			await settingsRuntime.flush();
+		});
+	};
+}
+
+export default createCodexCompactExtension();

--- a/experimental/pi-codex-compact/src/index.ts
+++ b/experimental/pi-codex-compact/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./codex-compact.js";

--- a/experimental/pi-codex-compact/src/protocol.ts
+++ b/experimental/pi-codex-compact/src/protocol.ts
@@ -1,0 +1,224 @@
+export const MAX_SSE_BYTES = 8 * 1024 * 1024;
+export const MAX_COMPACTION_ITEM_BYTES = 2 * 1024 * 1024;
+
+export type JsonObject = Record<string, unknown>;
+
+export class CodexCompactionProtocolError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CodexCompactionProtocolError";
+	}
+}
+
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function byteLength(value: unknown): number {
+	return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+export function isCompactionItem(value: unknown): value is JsonObject {
+	return (
+		isObject(value) &&
+		value.type === "compaction" &&
+		typeof value.encrypted_content === "string" &&
+		value.encrypted_content.length > 0
+	);
+}
+
+export function validateCompactionItem(
+	value: unknown,
+	maxBytes = MAX_COMPACTION_ITEM_BYTES,
+): JsonObject {
+	if (!isCompactionItem(value)) {
+		throw new CodexCompactionProtocolError(
+			"Remote response did not contain a valid compaction item",
+		);
+	}
+	if (byteLength(value) > maxBytes) {
+		throw new CodexCompactionProtocolError("Remote compaction item exceeded the size limit");
+	}
+	return structuredClone(value);
+}
+
+export interface CollectedCompaction {
+	item: JsonObject;
+	completedResponse?: JsonObject;
+}
+
+function compactionItemsFromEvent(event: JsonObject): unknown[] {
+	const items: unknown[] = [];
+	if (event.type === "response.output_item.done" && isObject(event.item)) {
+		items.push(event.item);
+	}
+	if (event.type === "response.completed" && isObject(event.response)) {
+		const output = event.response.output;
+		if (Array.isArray(output)) items.push(...output);
+	}
+	return items.filter((item) => isObject(item) && item.type === "compaction");
+}
+
+export async function collectCompactionSse(
+	stream: ReadableStream<Uint8Array>,
+	options: {
+		signal?: AbortSignal;
+		maxBytes?: number;
+		maxItemBytes?: number;
+	} = {},
+): Promise<CollectedCompaction> {
+	const maxBytes = options.maxBytes ?? MAX_SSE_BYTES;
+	const reader = stream.getReader();
+	const onAbort = () => {
+		void reader.cancel(new DOMException("Compaction aborted", "AbortError")).catch(() => undefined);
+	};
+	options.signal?.addEventListener("abort", onAbort, { once: true });
+	const decoder = new TextDecoder();
+	let bytes = 0;
+	let pending = "";
+	let dataLines: string[] = [];
+	let completedResponse: JsonObject | undefined;
+	const items = new Map<string, JsonObject>();
+
+	const checkAbort = () => {
+		if (options.signal?.aborted) throw new DOMException("Compaction aborted", "AbortError");
+	};
+	const dispatch = () => {
+		if (dataLines.length === 0) return;
+		const data = dataLines.join("\n");
+		dataLines = [];
+		if (data === "[DONE]") return;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(data);
+		} catch {
+			throw new CodexCompactionProtocolError("Remote compaction returned malformed SSE JSON");
+		}
+		if (!isObject(parsed)) return;
+		if (parsed.type === "response.completed") {
+			completedResponse = isObject(parsed.response) ? parsed.response : {};
+		}
+		for (const candidate of compactionItemsFromEvent(parsed)) {
+			const item = validateCompactionItem(candidate, options.maxItemBytes);
+			items.set(JSON.stringify(item), item);
+		}
+	};
+	const processLine = (line: string) => {
+		if (line === "") {
+			dispatch();
+			return;
+		}
+		if (line.startsWith(":")) return;
+		if (line === "data") dataLines.push("");
+		else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+	};
+
+	try {
+		while (true) {
+			checkAbort();
+			const { done, value } = await reader.read();
+			if (done) break;
+			bytes += value.byteLength;
+			if (bytes > maxBytes) {
+				throw new CodexCompactionProtocolError("Remote compaction stream exceeded the size limit");
+			}
+			pending += decoder.decode(value, { stream: true });
+			let newline = pending.indexOf("\n");
+			while (newline !== -1) {
+				const rawLine = pending.slice(0, newline);
+				pending = pending.slice(newline + 1);
+				processLine(rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine);
+				newline = pending.indexOf("\n");
+			}
+		}
+		pending += decoder.decode();
+		if (pending.length > 0) processLine(pending.endsWith("\r") ? pending.slice(0, -1) : pending);
+		dispatch();
+		checkAbort();
+	} catch (error) {
+		await reader.cancel(error).catch(() => undefined);
+		throw error;
+	} finally {
+		options.signal?.removeEventListener("abort", onAbort);
+		reader.releaseLock();
+	}
+
+	if (!completedResponse) {
+		throw new CodexCompactionProtocolError(
+			"Remote compaction stream ended without response.completed",
+		);
+	}
+	if (items.size !== 1) {
+		throw new CodexCompactionProtocolError(
+			`Remote compaction returned ${items.size} distinct compaction items; expected exactly one`,
+		);
+	}
+	return { item: [...items.values()][0], completedResponse };
+}
+
+function markerTextFromItem(item: unknown): string | undefined {
+	if (!isObject(item) || item.role !== "user" || !Array.isArray(item.content)) return undefined;
+	if (item.content.length !== 1) return undefined;
+	const content = item.content[0];
+	if (!isObject(content) || content.type !== "input_text" || typeof content.text !== "string") {
+		return undefined;
+	}
+	return content.text;
+}
+
+export function rewriteCheckpointMarker(
+	payload: unknown,
+	marker: string,
+	replacementHistory: readonly unknown[],
+): JsonObject {
+	if (!isObject(payload) || !Array.isArray(payload.input)) {
+		throw new CodexCompactionProtocolError("OpenAI Codex payload is missing an input array");
+	}
+	const matches = payload.input
+		.map((item, index) => (markerTextFromItem(item) === marker ? index : -1))
+		.filter((index) => index >= 0);
+	if (matches.length !== 1) {
+		throw new CodexCompactionProtocolError(
+			`Provider payload contained ${matches.length} checkpoint markers; expected exactly one`,
+		);
+	}
+	const index = matches[0];
+	return {
+		...payload,
+		input: [
+			...payload.input.slice(0, index),
+			...structuredClone(replacementHistory),
+			...payload.input.slice(index + 1),
+		],
+	};
+}
+
+export function appendCompactionTrigger(payload: unknown): JsonObject {
+	if (!isObject(payload) || !Array.isArray(payload.input)) {
+		throw new CodexCompactionProtocolError("OpenAI Codex payload is missing an input array");
+	}
+	if (payload.input.some((item) => isObject(item) && item.type === "compaction_trigger")) {
+		throw new CodexCompactionProtocolError(
+			"Provider payload already contains a compaction trigger",
+		);
+	}
+	return { ...payload, input: [...payload.input, { type: "compaction_trigger" }] };
+}
+
+export function prepareRemoteCompactionPayload(
+	payload: unknown,
+	checkpoint?: { marker: string; replacementHistory: readonly unknown[] },
+): JsonObject {
+	const expanded = checkpoint
+		? rewriteCheckpointMarker(payload, checkpoint.marker, checkpoint.replacementHistory)
+		: payload;
+	return appendCompactionTrigger(expanded);
+}
+
+export function hasCheckpointMarker(payload: unknown, marker: string): boolean {
+	return (
+		isObject(payload) &&
+		Array.isArray(payload.input) &&
+		payload.input.some((item) => markerTextFromItem(item) === marker)
+	);
+}

--- a/experimental/pi-codex-compact/src/remote.ts
+++ b/experimental/pi-codex-compact/src/remote.ts
@@ -1,0 +1,117 @@
+import type { Context, Model, Provider, Usage } from "@earendil-works/pi-ai";
+import {
+	CodexCompactionProtocolError,
+	type CollectedCompaction,
+	collectCompactionSse,
+	type JsonObject,
+	prepareRemoteCompactionPayload,
+} from "./protocol.js";
+
+interface PriorCheckpointPayload {
+	marker: string;
+	replacementHistory: readonly unknown[];
+}
+
+export interface RemoteCompactionRequest {
+	provider: Provider;
+	model: Model<"openai-codex-responses">;
+	context: Context;
+	apiKey?: string;
+	headers?: Record<string, string>;
+	env?: Record<string, string>;
+	signal: AbortSignal;
+	priorCheckpoint?: PriorCheckpointPayload;
+	requestTimeoutMs?: number;
+	maxRetries?: number;
+	fetch?: typeof globalThis.fetch;
+}
+
+export interface RemoteCompactionResponse {
+	item: JsonObject;
+	promptInput: JsonObject[];
+	usage: Usage;
+}
+
+const EMPTY_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function abortError(): DOMException {
+	return new DOMException("Compaction aborted", "AbortError");
+}
+
+export async function requestRemoteCompaction(
+	request: RemoteCompactionRequest,
+): Promise<RemoteCompactionResponse> {
+	if (request.signal.aborted) throw abortError();
+	let sentInput: JsonObject[] | undefined;
+	const inspections: Promise<
+		{ ok: true; value: CollectedCompaction } | { ok: false; error: unknown }
+	>[] = [];
+	const baseFetch = request.fetch ?? globalThis.fetch;
+	const inspectedFetch: typeof globalThis.fetch = async (input, init) => {
+		const response = await baseFetch(input, init);
+		if (!response.ok || !response.body) return response;
+		const [providerBody, inspectionBody] = response.body.tee();
+		const inspection = collectCompactionSse(inspectionBody, { signal: request.signal }).then(
+			(value) => ({ ok: true as const, value }),
+			(error: unknown) => ({ ok: false as const, error }),
+		);
+		inspections.push(inspection);
+		return new Response(providerBody, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
+
+	const stream = request.provider.stream(request.model, request.context, {
+		apiKey: request.apiKey,
+		headers: request.headers,
+		env: request.env,
+		signal: request.signal,
+		transport: "sse",
+		cacheRetention: "none",
+		timeoutMs: request.requestTimeoutMs ?? 5 * 60 * 1000,
+		maxRetries: request.maxRetries ?? 2,
+		fetch: inspectedFetch,
+		onPayload: (payload) => {
+			const prepared = prepareRemoteCompactionPayload(payload, request.priorCheckpoint);
+			if (!Array.isArray(prepared.input) || !prepared.input.every(isObject)) {
+				throw new CodexCompactionProtocolError(
+					"Prepared compaction payload has invalid input items",
+				);
+			}
+			sentInput = structuredClone(prepared.input.slice(0, -1)) as JsonObject[];
+			return prepared;
+		},
+	});
+
+	let usage = EMPTY_USAGE;
+	for await (const event of stream) {
+		if (request.signal.aborted) throw abortError();
+		if (event.type === "error") {
+			throw new Error(event.error.errorMessage ?? "OpenAI Codex compaction request failed");
+		}
+		if (event.type === "done") usage = event.message.usage;
+	}
+	if (request.signal.aborted) throw abortError();
+	if (!sentInput)
+		throw new CodexCompactionProtocolError("Provider did not expose a request payload");
+	if (inspections.length === 0) {
+		throw new CodexCompactionProtocolError("Provider response did not expose an SSE body");
+	}
+	const inspection = await inspections.at(-1);
+	if (request.signal.aborted) throw abortError();
+	if (!inspection?.ok) throw inspection?.error ?? new Error("Remote compaction inspection failed");
+	return { item: inspection.value.item, promptInput: sentInput, usage };
+}

--- a/experimental/pi-codex-compact/src/settings-menu.ts
+++ b/experimental/pi-codex-compact/src/settings-menu.ts
@@ -1,0 +1,232 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import type {
+	CodexCompactSettings,
+	CodexCompactSettingsRuntime,
+	CodexCompactSettingsState,
+} from "./settings.js";
+
+type Screen = "main" | "settings" | "invalid";
+type Action =
+	| "compact-now"
+	| "set-enabled"
+	| "set-timeout"
+	| "set-retries"
+	| "set-retention"
+	| "set-notify";
+
+export interface SettingsMenuOwner {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+interface CompactMenuStatus {
+	model: string;
+	remoteCompatible: boolean;
+}
+
+function safeText(value: string): string {
+	return Array.from(value, (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint < 32 || (codePoint >= 127 && codePoint <= 159) ? " " : character;
+	}).join("");
+}
+
+function timeoutLabel(milliseconds: number): string {
+	return `${milliseconds / 60_000} min`;
+}
+
+function retentionLabel(tokens: number): string {
+	return `${tokens / 1000}K tokens`;
+}
+
+async function update(
+	runtime: CodexCompactSettingsRuntime,
+	ctx: ExtensionCommandContext,
+	patch: Partial<CodexCompactSettings>,
+	signal: AbortSignal,
+) {
+	try {
+		await runtime.update(patch, signal);
+		ctx.ui.notify("Codex compaction settings saved.", "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		if (signal.aborted) return { kind: "rejected" as const };
+		ctx.ui.notify(
+			`Could not save pi-codex-compact.json: ${safeText(error instanceof Error ? error.message : String(error))}`,
+			"error",
+		);
+		return { kind: "rejected" as const };
+	}
+}
+
+export function createCodexCompactMenu(
+	runtime: CodexCompactSettingsRuntime,
+	options: { onCompactRequested?: () => void; status?: CompactMenuStatus } = {},
+) {
+	return defineMenu<CodexCompactSettingsState, Screen, Action, ExtensionCommandContext>({
+		start: "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: "Codex Remote Compaction",
+				lines: [
+					`Remote V2: ${state.settings.enabled ? "On" : "Off"}`,
+					`Active model: ${safeText(options.status?.model ?? "none")}`,
+					`Compact route: ${safeText(compactRoute(state, options.status))}`,
+				],
+				items: [
+					{
+						id: "compact-now",
+						label: "Compact now",
+						description: "Close this menu and compact the active session immediately.",
+						action: "compact-now",
+					},
+					state.kind === "invalid"
+						? {
+								id: "settings",
+								label: "Settings",
+								description: "Read-only until the invalid settings file is repaired.",
+								to: "invalid" as const,
+							}
+						: { id: "settings", label: "Settings", to: "settings" as const },
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+			settings: ({ state }) => ({
+				kind: "settings",
+				title: "Codex Remote Compaction Settings",
+				lines: [`User settings · ${safeText(state.path)}`],
+				items: [
+					{
+						id: "enabled",
+						label: "Remote compaction",
+						description: "Use Codex Remote V2 when the active model is compatible.",
+						currentValue: state.settings.enabled ? "On" : "Off",
+						values: ["On", "Off"],
+						action: "set-enabled",
+					},
+					{
+						id: "requestTimeoutMs",
+						label: "Request timeout",
+						description: "Maximum time for the extension-owned remote compaction request.",
+						currentValue: timeoutLabel(state.settings.requestTimeoutMs),
+						values: ["2 min", "5 min", "10 min"],
+						action: "set-timeout",
+					},
+					{
+						id: "maxRetries",
+						label: "Transport retries",
+						description: "Retry transient provider failures before falling back to Pi.",
+						currentValue: String(state.settings.maxRetries),
+						values: ["0", "1", "2"],
+						action: "set-retries",
+					},
+					{
+						id: "replacementTokenBudget",
+						label: "Retained user history",
+						description: "Approximate user-message budget kept beside the opaque checkpoint.",
+						currentValue: retentionLabel(state.settings.replacementTokenBudget),
+						values: ["32K tokens", "64K tokens", "96K tokens", "128K tokens"],
+						action: "set-retention",
+					},
+					{
+						id: "notifyOnFallback",
+						label: "Fallback notifications",
+						description: "Warn when Remote V2 fails and native Pi compaction takes over.",
+						currentValue: state.settings.notifyOnFallback ? "On" : "Off",
+						values: ["On", "Off"],
+						action: "set-notify",
+					},
+				],
+			}),
+			invalid: ({ state }) => ({
+				kind: "detail",
+				title: "Codex Compact Settings · Read only",
+				lines: [
+					`Invalid settings file: ${safeText(state.path)}`,
+					`Issue: ${safeText(state.issue ?? "unknown validation error")}`,
+					"Built-in defaults are active. Repair the file and run /reload; it will not be overwritten.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			"compact-now": async () => {
+				options.onCompactRequested?.();
+				return { kind: "close" };
+			},
+			"set-enabled": ({ ctx, value, signal }) =>
+				update(runtime, ctx, { enabled: value === "On" }, signal),
+			"set-timeout": ({ ctx, value, signal }) =>
+				update(
+					runtime,
+					ctx,
+					{ requestTimeoutMs: Number.parseInt(value ?? "5", 10) * 60_000 },
+					signal,
+				),
+			"set-retries": ({ ctx, value, signal }) =>
+				update(runtime, ctx, { maxRetries: Number.parseInt(value ?? "2", 10) }, signal),
+			"set-retention": ({ ctx, value, signal }) =>
+				update(
+					runtime,
+					ctx,
+					{ replacementTokenBudget: Number.parseInt(value ?? "64", 10) * 1000 },
+					signal,
+				),
+			"set-notify": ({ ctx, value, signal }) =>
+				update(runtime, ctx, { notifyOnFallback: value === "On" }, signal),
+		},
+	});
+}
+
+export async function showCodexCompactMenu(
+	runtime: CodexCompactSettingsRuntime,
+	ctx: ExtensionCommandContext,
+	owner: SettingsMenuOwner,
+): Promise<void> {
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify(`Edit Codex compaction settings at ${safeText(runtime.get().path)}.`, "info");
+		return;
+	}
+	let compactRequested = false;
+	await runMenu(
+		ctx,
+		createCodexCompactMenu(runtime, {
+			onCompactRequested: () => {
+				compactRequested = true;
+			},
+			status: compactMenuStatus(ctx),
+		}),
+		{
+			getState: () => runtime.get(),
+			signal: owner.signal,
+			isCurrent: owner.isCurrent,
+		},
+	);
+	if (!compactRequested || owner.signal.aborted || !owner.isCurrent()) return;
+	ctx.compact({
+		onError: (error) => {
+			if (!owner.signal.aborted && owner.isCurrent()) {
+				ctx.ui.notify(`Compaction failed: ${safeText(error.message)}`, "error");
+			}
+		},
+	});
+}
+
+function compactMenuStatus(ctx: ExtensionCommandContext): CompactMenuStatus {
+	const model = ctx.model;
+	return {
+		model: model ? `${model.provider}/${model.id}` : "none",
+		remoteCompatible: model?.provider === "openai-codex" && model.api === "openai-codex-responses",
+	};
+}
+
+function compactRoute(
+	state: Readonly<CodexCompactSettingsState>,
+	status: CompactMenuStatus | undefined,
+): string {
+	if (!state.settings.enabled) return "Pi native (Remote V2 off)";
+	return status?.remoteCompatible ? "Codex Remote V2" : "Pi native (model not compatible)";
+}

--- a/experimental/pi-codex-compact/src/settings.ts
+++ b/experimental/pi-codex-compact/src/settings.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const CODEX_COMPACT_SETTINGS_FILE = "pi-codex-compact.json";
+export const MAX_SETTINGS_BYTES = 64 * 1024;
+
+export interface CodexCompactSettings {
+	enabled: boolean;
+	requestTimeoutMs: number;
+	maxRetries: number;
+	replacementTokenBudget: number;
+	notifyOnFallback: boolean;
+}
+
+export const DEFAULT_CODEX_COMPACT_SETTINGS: Readonly<CodexCompactSettings> = Object.freeze({
+	enabled: true,
+	requestTimeoutMs: 300_000,
+	maxRetries: 2,
+	replacementTokenBudget: 64_000,
+	notifyOnFallback: true,
+});
+
+const LIMITS = Object.freeze({
+	requestTimeoutMs: { minimum: 30_000, maximum: 600_000 },
+	maxRetries: { minimum: 0, maximum: 2 },
+	replacementTokenBudget: { minimum: 8_000, maximum: 128_000 },
+});
+
+export interface CodexCompactSettingsState {
+	kind: "missing" | "loaded" | "invalid";
+	path: string;
+	settings: CodexCompactSettings;
+	document?: Record<string, unknown>;
+	issue?: string;
+}
+
+export interface CodexCompactSettingsRuntime {
+	get(): Readonly<CodexCompactSettingsState>;
+	reload(signal?: AbortSignal): Promise<Readonly<CodexCompactSettingsState>>;
+	update(
+		patch: Partial<CodexCompactSettings>,
+		signal?: AbortSignal,
+	): Promise<Readonly<CodexCompactSettingsState>>;
+	flush(): Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validInteger(value: unknown, minimum: number, maximum: number): value is number {
+	return (
+		typeof value === "number" && Number.isSafeInteger(value) && value >= minimum && value <= maximum
+	);
+}
+
+export function normalizeCodexCompactSettings(value: unknown): CodexCompactSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	if (Object.hasOwn(value, "enabled") && typeof value.enabled !== "boolean") return undefined;
+	if (Object.hasOwn(value, "notifyOnFallback") && typeof value.notifyOnFallback !== "boolean") {
+		return undefined;
+	}
+	for (const [field, limits] of Object.entries(LIMITS) as Array<
+		[keyof typeof LIMITS, { minimum: number; maximum: number }]
+	>) {
+		if (
+			Object.hasOwn(value, field) &&
+			!validInteger(value[field], limits.minimum, limits.maximum)
+		) {
+			return undefined;
+		}
+	}
+	return {
+		enabled:
+			typeof value.enabled === "boolean" ? value.enabled : DEFAULT_CODEX_COMPACT_SETTINGS.enabled,
+		requestTimeoutMs:
+			typeof value.requestTimeoutMs === "number"
+				? value.requestTimeoutMs
+				: DEFAULT_CODEX_COMPACT_SETTINGS.requestTimeoutMs,
+		maxRetries:
+			typeof value.maxRetries === "number"
+				? value.maxRetries
+				: DEFAULT_CODEX_COMPACT_SETTINGS.maxRetries,
+		replacementTokenBudget:
+			typeof value.replacementTokenBudget === "number"
+				? value.replacementTokenBudget
+				: DEFAULT_CODEX_COMPACT_SETTINGS.replacementTokenBudget,
+		notifyOnFallback:
+			typeof value.notifyOnFallback === "boolean"
+				? value.notifyOnFallback
+				: DEFAULT_CODEX_COMPACT_SETTINGS.notifyOnFallback,
+	};
+}
+
+export function codexCompactSettingsPath(): string {
+	return join(getAgentDir(), CODEX_COMPACT_SETTINGS_FILE);
+}
+
+function aborted(signal?: AbortSignal): void {
+	if (signal?.aborted) throw new DOMException("Settings operation aborted", "AbortError");
+}
+
+export async function loadCodexCompactSettings(
+	path = codexCompactSettingsPath(),
+	signal?: AbortSignal,
+): Promise<CodexCompactSettingsState> {
+	aborted(signal);
+	try {
+		const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+		let text: string;
+		try {
+			const stats = await handle.stat();
+			aborted(signal);
+			if (!stats.isFile()) throw new Error("settings path is not a regular file");
+			if (stats.size > MAX_SETTINGS_BYTES) throw new Error("settings file exceeds 64 KiB");
+			text = await handle.readFile("utf8");
+		} finally {
+			await handle.close();
+		}
+		aborted(signal);
+		const document = JSON.parse(text) as unknown;
+		const settings = normalizeCodexCompactSettings(document);
+		if (!settings || !isRecord(document)) throw new Error("invalid settings shape or bounds");
+		return { kind: "loaded", path, settings, document };
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return {
+				kind: "missing",
+				path,
+				settings: { ...DEFAULT_CODEX_COMPACT_SETTINGS },
+				document: {},
+			};
+		}
+		return {
+			kind: "invalid",
+			path,
+			settings: { ...DEFAULT_CODEX_COMPACT_SETTINGS },
+			issue:
+				isNodeError(error) && error.code === "ELOOP"
+					? "symbolic links are not accepted"
+					: error instanceof Error
+						? error.message
+						: String(error),
+		};
+	}
+}
+
+async function savePatch(
+	path: string,
+	patch: Partial<CodexCompactSettings>,
+	signal?: AbortSignal,
+): Promise<CodexCompactSettingsState> {
+	const latest = await loadCodexCompactSettings(path, signal);
+	if (latest.kind === "invalid") {
+		throw new Error(
+			"Cannot overwrite an invalid pi-codex-compact.json; repair it and reload first",
+		);
+	}
+	const document = { ...latest.document, ...patch };
+	const settings = normalizeCodexCompactSettings(document);
+	if (!settings) throw new Error("Refusing to save invalid Codex compaction settings");
+	const temporaryPath = join(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
+	await mkdir(dirname(path), { recursive: true });
+	aborted(signal);
+	try {
+		await writeFile(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+		});
+		aborted(signal);
+		const current = await loadCodexCompactSettings(path, signal);
+		if (
+			current.kind === "invalid" ||
+			current.kind !== latest.kind ||
+			JSON.stringify(current.document) !== JSON.stringify(latest.document)
+		) {
+			throw new Error("pi-codex-compact.json changed while saving; reopen settings and retry");
+		}
+		await rename(temporaryPath, path);
+	} finally {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+	return { kind: "loaded", path, settings, document };
+}
+
+export function createCodexCompactSettingsRuntime(
+	path = codexCompactSettingsPath(),
+): CodexCompactSettingsRuntime {
+	let state: CodexCompactSettingsState = {
+		kind: "missing",
+		path,
+		settings: { ...DEFAULT_CODEX_COMPACT_SETTINGS },
+		document: {},
+	};
+	let queue = Promise.resolve();
+	const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+		const result = queue.then(operation, operation);
+		queue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+	return {
+		get: () => structuredClone(state),
+		reload: (signal) =>
+			enqueue(async () => {
+				state = await loadCodexCompactSettings(path, signal);
+				return structuredClone(state);
+			}),
+		update: (patch, signal) =>
+			enqueue(async () => {
+				state = await savePatch(path, patch, signal);
+				return structuredClone(state);
+			}),
+		flush: () => queue,
+	};
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}

--- a/experimental/pi-codex-compact/test/checkpoint.test.ts
+++ b/experimental/pi-codex-compact/test/checkpoint.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { CompactionEntry, SessionEntry } from "@earendil-works/pi-coding-agent";
+import {
+	buildReplacementHistory,
+	checkpointMarker,
+	createCheckpointDetails,
+	fallbackSummary,
+	fingerprintMessage,
+	latestCheckpoint,
+	parseCheckpointDetails,
+	projectCheckpointContext,
+} from "../src/checkpoint.js";
+
+function user(text: string, timestamp = 1): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function rawUser(text: string) {
+	return { role: "user", content: [{ type: "input_text", text }] };
+}
+
+const opaque = { type: "compaction", encrypted_content: "opaque" };
+
+function checkpoint(kept: AgentMessage[] = [user("kept", 2)], id = "checkpoint-123") {
+	return createCheckpointDetails({
+		modelId: "gpt-5.6",
+		replacementHistory: [rawUser("old"), opaque],
+		keptMessages: kept,
+		checkpointId: id,
+		createdAt: "2026-01-01T00:00:00.000Z",
+	});
+}
+
+test("builds newest-first bounded replacement history and puts opaque item last", () => {
+	const history = buildReplacementHistory(
+		[rawUser("oldest"), { type: "compaction", encrypted_content: "old" }, rawUser("newest")],
+		opaque,
+		{ tokenBudget: 2, byteBudget: 2048 },
+	);
+	assert.equal(history.at(-1)?.type, "compaction");
+	assert.equal(history.at(-1)?.encrypted_content, "opaque");
+	assert.match(JSON.stringify(history), /newest/);
+	assert.doesNotMatch(JSON.stringify(history), /encrypted_content":"old/);
+});
+
+test("partially truncates the oldest fitting text item", () => {
+	const history = buildReplacementHistory(
+		[rawUser("abcdefghijklmnopqrstuvwxyz".repeat(4))],
+		opaque,
+		{
+			tokenBudget: 10,
+			byteBudget: 2048,
+		},
+	);
+	assert.equal(history.length, 2);
+	assert.match(JSON.stringify(history[0]), /\[truncated\]/);
+	assert.match(JSON.stringify(history[0]), /wxyz/);
+});
+
+test("drops media that cannot fit the checkpoint byte budget", () => {
+	const media = {
+		role: "user",
+		content: [{ type: "input_image", image_url: `data:image/png;base64,${"x".repeat(1024)}` }],
+	};
+	const history = buildReplacementHistory([rawUser("small"), media], opaque, {
+		tokenBudget: 100,
+		byteBudget: 512,
+	});
+	assert.equal(history.length, 2);
+	assert.match(JSON.stringify(history[0]), /small/);
+	assert.doesNotMatch(JSON.stringify(history), /input_image/);
+});
+
+test("validates versioned details and rejects malformed or unbounded persisted data", () => {
+	const details = checkpoint();
+	assert.deepEqual(parseCheckpointDetails(details), details);
+	assert.equal(parseCheckpointDetails({ ...details, version: 2 }), undefined);
+	assert.equal(parseCheckpointDetails({ ...details, replacementHistory: [] }), undefined);
+	assert.equal(parseCheckpointDetails({ ...details, keptMessageFingerprints: ["bad"] }), undefined);
+	assert.doesNotMatch(JSON.stringify(details), /token|authorization|header/i);
+});
+
+test("projects only an exact summary and kept suffix while preserving unrelated context", () => {
+	const before = user("before", 0);
+	const kept = user("kept", 2);
+	const after = user("after", 3);
+	const details = checkpoint([kept]);
+	const summary: AgentMessage = {
+		role: "compactionSummary",
+		summary: fallbackSummary(details.checkpointId),
+		tokensBefore: 100,
+		timestamp: 1,
+	};
+	const projected = projectCheckpointContext([before, summary, kept, after], details);
+	assert.ok(projected);
+	assert.deepEqual(projected?.[0], before);
+	assert.equal(projected?.[1].role, "user");
+	assert.match(JSON.stringify(projected?.[1]), new RegExp(details.checkpointId));
+	assert.deepEqual(projected?.[2], after);
+	assert.equal(projectCheckpointContext([summary, user("changed", 2), after], details), undefined);
+	assert.equal(projectCheckpointContext([kept, after], details), undefined);
+});
+
+test("uses canonical SHA-256 message fingerprints", () => {
+	const message = user("same");
+	assert.match(fingerprintMessage(message), /^[a-f0-9]{64}$/);
+	assert.equal(fingerprintMessage(message), fingerprintMessage({ ...message }));
+	assert.notEqual(fingerprintMessage(message), fingerprintMessage(user("different")));
+	assert.match(checkpointMarker("checkpoint-123"), /injection failed/i);
+});
+
+test("selects the newest checkpoint on the active branch and ignores forks before it", () => {
+	const first = checkpoint([], "checkpoint-first");
+	const second = checkpoint([], "checkpoint-second");
+	const entry = (
+		id: string,
+		details: ReturnType<typeof checkpoint>,
+		parentId: string | null,
+	): CompactionEntry => ({
+		type: "compaction",
+		id,
+		parentId,
+		timestamp: "2026-01-01T00:00:00.000Z",
+		summary: fallbackSummary(details.checkpointId),
+		firstKeptEntryId: "kept",
+		tokensBefore: 10,
+		details,
+	});
+	const branch = [entry("first", first, null), entry("second", second, "first")] as SessionEntry[];
+	assert.equal(latestCheckpoint(branch)?.details.checkpointId, "checkpoint-second");
+	assert.equal(latestCheckpoint(branch.slice(0, 1))?.details.checkpointId, "checkpoint-first");
+	const native = {
+		...entry("native", second, "second"),
+		details: undefined,
+		summary: "native summary",
+	};
+	assert.equal(latestCheckpoint([...branch, native]), undefined);
+	assert.equal(latestCheckpoint([]), undefined);
+});

--- a/experimental/pi-codex-compact/test/lifecycle.test.ts
+++ b/experimental/pi-codex-compact/test/lifecycle.test.ts
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	createAssistantMessageEventStream,
+	type Model,
+	type OpenAICodexResponsesOptions,
+	type Provider,
+} from "@earendil-works/pi-ai";
+import type { SessionBeforeCompactEvent, SessionEntry } from "@earendil-works/pi-coding-agent";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { parseCheckpointDetails } from "../src/checkpoint.js";
+import { createCodexCompactExtension } from "../src/codex-compact.js";
+import {
+	type CodexCompactSettingsRuntime,
+	type CodexCompactSettingsState,
+	DEFAULT_CODEX_COMPACT_SETTINGS,
+} from "../src/settings.js";
+
+const model = {
+	id: "gpt-5.6",
+	name: "GPT-5.6",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://example.test",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 100_000,
+	maxTokens: 10_000,
+} as Model<"openai-codex-responses">;
+
+const usage = {
+	input: 20,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 21,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function settingsRuntime(overrides = {}): CodexCompactSettingsRuntime {
+	let state: CodexCompactSettingsState = {
+		kind: "loaded",
+		path: "/tmp/test-pi-codex-compact.json",
+		settings: { ...DEFAULT_CODEX_COMPACT_SETTINGS, ...overrides },
+		document: {},
+	};
+	return {
+		get: () => structuredClone(state),
+		async reload() {
+			return structuredClone(state);
+		},
+		async update(patch) {
+			state = { ...state, settings: { ...state.settings, ...patch } };
+			return structuredClone(state);
+		},
+		async flush() {},
+	};
+}
+
+function fakeProvider(): Provider {
+	return {
+		id: "openai-codex",
+		name: "OpenAI Codex",
+		auth: {} as Provider["auth"],
+		getModels: () => [model],
+		stream(_model, context, options) {
+			const stream = createAssistantMessageEventStream();
+			void (async () => {
+				try {
+					const input = context.messages.map((message) => {
+						const content =
+							typeof message.content === "string" ? message.content : message.content[0];
+						const text =
+							typeof content === "string" ? content : "text" in content ? content.text : "image";
+						return { role: "user", content: [{ type: "input_text", text }] };
+					});
+					const payload = await options?.onPayload?.({ model: model.id, input }, model);
+					assert.deepEqual((payload as { input: unknown[] }).input.at(-1), {
+						type: "compaction_trigger",
+					});
+					const response = await options?.fetch?.("https://example.test", { method: "POST" });
+					await response?.text();
+					const message = {
+						role: "assistant" as const,
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage,
+						stopReason: "stop" as const,
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "done", reason: "stop", message });
+					stream.end(message);
+				} catch (error) {
+					const message = {
+						role: "assistant" as const,
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage,
+						stopReason: "error" as const,
+						errorMessage: error instanceof Error ? error.message : String(error),
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "error", reason: "error", error: message });
+					stream.end(message);
+				}
+			})();
+			assert.equal((options as OpenAICodexResponsesOptions).maxRetries, 2);
+			return stream;
+		},
+		streamSimple() {
+			throw new Error("not used");
+		},
+	};
+}
+
+function branch(): SessionEntry[] {
+	return [
+		{
+			type: "message",
+			id: "user",
+			parentId: null,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 },
+		},
+		{
+			type: "message",
+			id: "assistant",
+			parentId: "user",
+			timestamp: "2026-01-01T00:00:01.000Z",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "hi" }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage,
+				stopReason: "stop",
+				timestamp: 2,
+			},
+		},
+	];
+}
+
+function event(signal = new AbortController().signal): SessionBeforeCompactEvent {
+	return {
+		type: "session_before_compact",
+		preparation: {
+			firstKeptEntryId: "assistant",
+			messagesToSummarize: [],
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 123,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
+		},
+		branchEntries: branch(),
+		reason: "manual",
+		willRetry: false,
+		signal,
+	};
+}
+
+function sseResponse() {
+	const item = { type: "compaction", encrypted_content: "opaque" };
+	return new Response(
+		`data: ${JSON.stringify({ type: "response.output_item.done", item })}\n\ndata: ${JSON.stringify({ type: "response.completed", response: { output: [item] } })}\n\n`,
+	);
+}
+
+test("registers the settings command and returns a versioned Remote V2 compaction with usage", async () => {
+	const mock = createMockPi();
+	const runtime = settingsRuntime();
+	createCodexCompactExtension({ settingsRuntime: runtime, fetch: async () => sseResponse() })(
+		mock.pi,
+	);
+	assert.ok(mock.commands.has("codex-compact"));
+	const handler = mock.events.get("session_before_compact")?.[0];
+	assert.ok(handler);
+	const entries = branch();
+	const { ctx, statuses } = createMockContext({
+		model,
+		getSystemPrompt: () => "system",
+		sessionManager: {
+			getSessionId: () => "session",
+			getBranch: () => entries,
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "secret-oauth" }),
+			getProvider: () => fakeProvider(),
+		},
+	});
+	const result = (await handler?.(event(), ctx)) as {
+		compaction: { usage: unknown; details: unknown; summary: string };
+	};
+	assert.deepEqual(result.compaction.usage, usage);
+	const details = parseCheckpointDetails(result.compaction.details);
+	assert.ok(details);
+	assert.doesNotMatch(JSON.stringify(details), /secret-oauth/);
+	assert.match(result.compaction.summary, /requires @narumitw\/pi-codex-compact/);
+	assert.equal(statuses.get("codex-compact"), undefined);
+
+	const kept = entries[1].type === "message" ? entries[1].message : assert.fail("kept message");
+	const compactionEntry = {
+		type: "compaction" as const,
+		id: "compact",
+		parentId: "assistant",
+		timestamp: "2026-01-01T00:00:02.000Z",
+		summary: result.compaction.summary,
+		firstKeptEntryId: "assistant",
+		tokensBefore: 123,
+		details,
+	};
+	const replayContext = createMockContext({
+		model,
+		sessionManager: {
+			getSessionId: () => "session",
+			getBranch: () => [...entries, compactionEntry],
+		},
+	}).ctx;
+	const summaryMessage = {
+		role: "compactionSummary" as const,
+		summary: result.compaction.summary,
+		tokensBefore: 123,
+		timestamp: 3,
+	};
+	const later = {
+		role: "user" as const,
+		content: [{ type: "text" as const, text: "later" }],
+		timestamp: 4,
+	};
+	const contextHandler = mock.events.get("context")?.[0];
+	const projected = (await contextHandler?.(
+		{ type: "context", messages: [summaryMessage, kept, later] },
+		replayContext,
+	)) as { messages: Array<{ content: Array<{ text: string }> }> };
+	assert.equal(projected.messages.length, 2);
+	const marker = projected.messages[0].content[0].text;
+	const payloadHandler = mock.events.get("before_provider_request")?.[0];
+	const rewritten = (await payloadHandler?.(
+		{
+			type: "before_provider_request",
+			payload: {
+				input: [
+					{ role: "user", content: [{ type: "input_text", text: marker }] },
+					{ role: "user", content: [{ type: "input_text", text: "later" }] },
+				],
+			},
+		},
+		replayContext,
+	)) as { input: Array<Record<string, unknown>> };
+	assert.equal(rewritten.input.at(-2)?.type, "compaction");
+	assert.match(JSON.stringify(rewritten.input.at(-1)), /later/);
+});
+
+test("session lifecycle reloads settings, warns once current, and drops stale reload continuations", async () => {
+	const mock = createMockPi();
+	let reloads = 0;
+	let flushes = 0;
+	let release!: () => void;
+	const blocked = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const runtime = settingsRuntime();
+	const delayed: CodexCompactSettingsRuntime = {
+		...runtime,
+		async reload(signal) {
+			reloads += 1;
+			await blocked;
+			if (signal?.aborted) throw new DOMException("aborted", "AbortError");
+			return runtime.get();
+		},
+		async flush() {
+			flushes += 1;
+		},
+	};
+	createCodexCompactExtension({ settingsRuntime: delayed })(mock.pi);
+	const start = mock.events.get("session_start")?.[0];
+	const shutdown = mock.events.get("session_shutdown")?.[0];
+	const { ctx, notifications, statuses } = createMockContext({
+		hasUI: true,
+		sessionManager: { getSessionId: () => "session", getBranch: () => [] },
+	});
+	const pending = Promise.resolve(start?.({ type: "session_start", reason: "startup" }, ctx));
+	await Promise.resolve();
+	await shutdown?.({ type: "session_shutdown", reason: "reload" }, ctx);
+	release();
+	await pending;
+	assert.equal(reloads, 1);
+	assert.equal(flushes, 1);
+	assert.equal(notifications.length, 0, "stale startup does not notify through the old session");
+	assert.equal(statuses.get("codex-compact"), undefined);
+});
+
+test("disabled, unsupported, auth-failed, and aborted compaction paths remain safe", async () => {
+	const run = async (options: {
+		settings?: CodexCompactSettingsRuntime;
+		model?: unknown;
+		auth?: unknown;
+		signal?: AbortSignal;
+	}) => {
+		const mock = createMockPi();
+		createCodexCompactExtension({
+			settingsRuntime: options.settings ?? settingsRuntime(),
+			fetch: async () => sseResponse(),
+		})(mock.pi);
+		const handler = mock.events.get("session_before_compact")?.[0];
+		const { ctx, notifications, statuses } = createMockContext({
+			model: options.model ?? model,
+			getSystemPrompt: () => "system",
+			sessionManager: { getSessionId: () => "session", getBranch: () => branch() },
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => options.auth ?? { ok: false, error: "missing auth" },
+				getProvider: () => fakeProvider(),
+			},
+			hasUI: true,
+		});
+		return {
+			result: await handler?.(event(options.signal), ctx),
+			notifications,
+			statuses,
+		};
+	};
+	assert.equal((await run({ settings: settingsRuntime({ enabled: false }) })).result, undefined);
+	assert.equal(
+		(
+			await run({
+				model: { ...model, provider: "openai", api: "openai-responses" },
+			})
+		).result,
+		undefined,
+	);
+	const failed = await run({});
+	assert.equal(failed.result, undefined);
+	assert.match(failed.notifications.at(-1)?.message ?? "", /using Pi compaction/);
+	assert.equal(failed.statuses.get("codex-compact"), undefined);
+	const controller = new AbortController();
+	controller.abort();
+	assert.deepEqual((await run({ signal: controller.signal })).result, { cancel: true });
+});

--- a/experimental/pi-codex-compact/test/protocol.test.ts
+++ b/experimental/pi-codex-compact/test/protocol.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	appendCompactionTrigger,
+	CodexCompactionProtocolError,
+	collectCompactionSse,
+	prepareRemoteCompactionPayload,
+	rewriteCheckpointMarker,
+} from "../src/protocol.js";
+
+const encoder = new TextEncoder();
+
+function fragmentedStream(text: string, chunkSize = 1): ReadableStream<Uint8Array> {
+	const bytes = encoder.encode(text);
+	return new ReadableStream({
+		start(controller) {
+			for (let index = 0; index < bytes.length; index += chunkSize) {
+				controller.enqueue(bytes.slice(index, index + chunkSize));
+			}
+			controller.close();
+		},
+	});
+}
+
+function validSse(item = { type: "compaction", encrypted_content: "opaque" }): string {
+	return [
+		": keepalive\r\n",
+		`data: ${JSON.stringify({ type: "response.output_item.done", item })}\r\n\r\n`,
+		`data: ${JSON.stringify({ type: "response.completed", response: { output: [item] } })}\r\n\r\n`,
+	].join("");
+}
+
+test("collects one compaction from fragmented CRLF SSE and deduplicates completed output", async () => {
+	const result = await collectCompactionSse(fragmentedStream(validSse()));
+	assert.deepEqual(result.item, { type: "compaction", encrypted_content: "opaque" });
+	assert.ok(result.completedResponse);
+});
+
+test("joins multiline data fields and ignores unrelated events", async () => {
+	const outputItem = JSON.stringify({
+		type: "response.output_item.done",
+		item: { type: "compaction", encrypted_content: "opaque" },
+	});
+	const stream = fragmentedStream(
+		`data: ${outputItem}\n\ndata: {"type":"response.completed",\ndata: "response":{"output":[]}}\n\n`,
+		3,
+	);
+	const result = await collectCompactionSse(stream);
+	assert.equal(result.item.encrypted_content, "opaque");
+});
+
+test("rejects incomplete, missing, duplicate, malformed, empty, oversized, and aborted streams", async (t) => {
+	await t.test("missing completion", async () => {
+		await assert.rejects(
+			collectCompactionSse(
+				fragmentedStream(
+					'data: {"type":"response.output_item.done","item":{"type":"compaction","encrypted_content":"x"}}\n\n',
+				),
+			),
+			/without response.completed/,
+		);
+	});
+	await t.test("missing item", async () => {
+		await assert.rejects(
+			collectCompactionSse(
+				fragmentedStream('data: {"type":"response.completed","response":{"output":[]}}\n\n'),
+			),
+			/returned 0 distinct/,
+		);
+	});
+	await t.test("duplicate items", async () => {
+		const text = [
+			'data: {"type":"response.output_item.done","item":{"type":"compaction","encrypted_content":"a"}}\n\n',
+			'data: {"type":"response.completed","response":{"output":[{"type":"compaction","encrypted_content":"b"}]}}\n\n',
+		].join("");
+		await assert.rejects(collectCompactionSse(fragmentedStream(text)), /returned 2 distinct/);
+	});
+	await t.test("malformed JSON", async () => {
+		await assert.rejects(
+			collectCompactionSse(fragmentedStream("data: {nope}\n\n")),
+			/malformed SSE/,
+		);
+	});
+	await t.test("empty content", async () => {
+		await assert.rejects(
+			collectCompactionSse(
+				fragmentedStream(validSse({ type: "compaction", encrypted_content: "" })),
+			),
+			/valid compaction/,
+		);
+	});
+	await t.test("oversized item", async () => {
+		await assert.rejects(
+			collectCompactionSse(fragmentedStream(validSse()), { maxItemBytes: 10 }),
+			/size limit/,
+		);
+	});
+	await t.test("oversized stream", async () => {
+		await assert.rejects(
+			collectCompactionSse(fragmentedStream(validSse()), { maxBytes: 10 }),
+			/stream exceeded/,
+		);
+	});
+	await t.test("abort", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await assert.rejects(
+			collectCompactionSse(fragmentedStream(validSse()), { signal: controller.signal }),
+			/aborted/i,
+		);
+	});
+	await t.test("abort while waiting for the next chunk", async () => {
+		const controller = new AbortController();
+		const pending = collectCompactionSse(new ReadableStream<Uint8Array>({}), {
+			signal: controller.signal,
+		});
+		queueMicrotask(() => controller.abort());
+		await assert.rejects(pending, /aborted/i);
+	});
+});
+
+test("rewrites exactly one marker and appends exactly one final trigger", () => {
+	const marker = "checkpoint";
+	const payload = {
+		model: "gpt",
+		input: [
+			{ role: "user", content: [{ type: "input_text", text: marker }] },
+			{ role: "user", content: [{ type: "input_text", text: "later" }] },
+		],
+	};
+	const replacement = [
+		{ role: "user", content: [{ type: "input_text", text: "old" }] },
+		{ type: "compaction", encrypted_content: "opaque" },
+	];
+	const prepared = prepareRemoteCompactionPayload(payload, {
+		marker,
+		replacementHistory: replacement,
+	});
+	assert.deepEqual(prepared.input, [
+		...replacement,
+		payload.input[1],
+		{ type: "compaction_trigger" },
+	]);
+	assert.equal(payload.input.length, 2, "does not mutate caller payload");
+});
+
+test("payload validators reject malformed inputs, missing/duplicate markers, and duplicate triggers", () => {
+	assert.throws(() => appendCompactionTrigger({}), CodexCompactionProtocolError);
+	assert.throws(() => rewriteCheckpointMarker({ input: [] }, "x", []), /0 checkpoint markers/);
+	const markerItem = { role: "user", content: [{ type: "input_text", text: "x" }] };
+	assert.throws(
+		() => rewriteCheckpointMarker({ input: [markerItem, markerItem] }, "x", []),
+		/2 checkpoint markers/,
+	);
+	assert.throws(
+		() => appendCompactionTrigger({ input: [{ type: "compaction_trigger" }] }),
+		/already contains/,
+	);
+});

--- a/experimental/pi-codex-compact/test/remote.test.ts
+++ b/experimental/pi-codex-compact/test/remote.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	type Context,
+	createAssistantMessageEventStream,
+	type Model,
+	type OpenAICodexResponsesOptions,
+	type Provider,
+} from "@earendil-works/pi-ai";
+import { requestRemoteCompaction } from "../src/remote.js";
+
+const model = {
+	id: "gpt-5.6",
+	name: "GPT-5.6",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://example.test",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 100_000,
+	maxTokens: 10_000,
+} as Model<"openai-codex-responses">;
+
+const usage = {
+	input: 10,
+	output: 2,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 12,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function fakeProvider(
+	observe: (payload: unknown, options: OpenAICodexResponsesOptions) => void,
+	inputText = "current",
+): Provider {
+	return {
+		id: "openai-codex",
+		name: "OpenAI Codex",
+		auth: {} as Provider["auth"],
+		getModels: () => [model],
+		stream(_model, _context, options) {
+			const stream = createAssistantMessageEventStream();
+			void (async () => {
+				try {
+					const payload = await options?.onPayload?.(
+						{
+							model: model.id,
+							input: [{ role: "user", content: [{ type: "input_text", text: inputText }] }],
+						},
+						model,
+					);
+					observe(payload, options as OpenAICodexResponsesOptions);
+					const response = await options?.fetch?.("https://example.test/codex/responses", {
+						method: "POST",
+					});
+					await response?.text();
+					const message = {
+						role: "assistant" as const,
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage,
+						stopReason: "stop" as const,
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+					stream.end();
+				} catch (error) {
+					const message = {
+						role: "assistant" as const,
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage,
+						stopReason: "error" as const,
+						errorMessage: error instanceof Error ? error.message : String(error),
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "error", reason: "error", error: message });
+					stream.end(message);
+				}
+			})();
+			return stream;
+		},
+		streamSimple() {
+			throw new Error("not used");
+		},
+	};
+}
+
+function responseSse(content = "opaque") {
+	const item = { type: "compaction", encrypted_content: content };
+	const body = [
+		`data: ${JSON.stringify({ type: "response.output_item.done", item })}\n\n`,
+		`data: ${JSON.stringify({ type: "response.completed", response: { output: [item] } })}\n\n`,
+	].join("");
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+test("uses the public provider stream with SSE, bounded retry options, and a final trigger", async () => {
+	let sent: unknown;
+	const provider = fakeProvider((payload, options) => {
+		sent = payload;
+		assert.equal(options.transport, "sse");
+		assert.equal(options.cacheRetention, "none");
+		assert.equal(options.timeoutMs, 300_000);
+		assert.equal(options.maxRetries, 2);
+	});
+	const result = await requestRemoteCompaction({
+		provider,
+		model,
+		context: { messages: [] } satisfies Context,
+		apiKey: "oauth-token",
+		signal: new AbortController().signal,
+		fetch: async () => responseSse(),
+	});
+	assert.deepEqual((sent as { input: unknown[] }).input.at(-1), { type: "compaction_trigger" });
+	assert.equal(result.item.encrypted_content, "opaque");
+	assert.deepEqual(result.usage, usage);
+	assert.equal(result.promptInput.length, 1);
+});
+
+test("expands a previous checkpoint before requesting repeated compaction", async () => {
+	const marker = "checkpoint marker";
+	let sentInput: unknown[] = [];
+	const provider = fakeProvider((payload) => {
+		sentInput = (payload as { input: unknown[] }).input;
+	}, marker);
+	await requestRemoteCompaction({
+		provider,
+		model,
+		context: { messages: [] },
+		apiKey: "oauth-token",
+		signal: new AbortController().signal,
+		priorCheckpoint: {
+			marker,
+			replacementHistory: [{ type: "compaction", encrypted_content: "prior" }],
+		},
+		fetch: async () => responseSse("new"),
+	});
+	assert.equal(
+		sentInput[0] && (sentInput[0] as { encrypted_content?: string }).encrypted_content,
+		"prior",
+	);
+	assert.deepEqual(sentInput.at(-1), { type: "compaction_trigger" });
+});
+
+test("propagates abort and malformed remote output", async () => {
+	const provider = fakeProvider(() => undefined);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		requestRemoteCompaction({
+			provider,
+			model,
+			context: { messages: [] },
+			apiKey: "oauth-token",
+			signal: controller.signal,
+			fetch: async () => responseSse(),
+		}),
+		/aborted/i,
+	);
+	await assert.rejects(
+		requestRemoteCompaction({
+			provider,
+			model,
+			context: { messages: [] },
+			apiKey: "oauth-token",
+			signal: new AbortController().signal,
+			fetch: async () =>
+				new Response('data: {"type":"response.completed","response":{"output":[]}}\n\n'),
+		}),
+		/returned 0 distinct/,
+	);
+});

--- a/experimental/pi-codex-compact/test/settings-menu.test.ts
+++ b/experimental/pi-codex-compact/test/settings-menu.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
+import { createMockContext } from "../../../test/support.js";
+import {
+	type CodexCompactSettingsRuntime,
+	type CodexCompactSettingsState,
+	DEFAULT_CODEX_COMPACT_SETTINGS,
+} from "../src/settings.js";
+import { createCodexCompactMenu, showCodexCompactMenu } from "../src/settings-menu.js";
+
+function memoryRuntime(kind: CodexCompactSettingsState["kind"] = "missing") {
+	let state: CodexCompactSettingsState = {
+		kind,
+		path: "/tmp/pi-codex-compact.json",
+		settings: { ...DEFAULT_CODEX_COMPACT_SETTINGS },
+		...(kind === "invalid" ? { issue: "bad file" } : { document: {} }),
+	};
+	const patches: unknown[] = [];
+	const runtime: CodexCompactSettingsRuntime = {
+		get: () => structuredClone(state),
+		async reload() {
+			return structuredClone(state);
+		},
+		async update(patch) {
+			patches.push(patch);
+			state = { ...state, kind: "loaded", settings: { ...state.settings, ...patch } };
+			return structuredClone(state);
+		},
+		async flush() {},
+	};
+	return { runtime, patches };
+}
+
+test("root menu makes manual compaction primary and exposes its effective route", () => {
+	const current = memoryRuntime();
+	const menu = createCodexCompactMenu(current.runtime, {
+		status: { model: "openai-codex/gpt-5.6", remoteCompatible: true },
+	});
+	assert.equal(menu.start, "main");
+	const main = resolveMenuScreen(menu, "main", current.runtime.get());
+	assert.equal(main.kind, "actions");
+	if (main.kind !== "actions") assert.fail("Expected actions screen");
+	assert.deepEqual(
+		main.items.map((item) => item.label),
+		["Compact now", "Settings", "Close"],
+	);
+	assert.match(main.lines?.join("\n") ?? "", /openai-codex\/gpt-5\.6/);
+	assert.match(main.lines?.join("\n") ?? "", /Codex Remote V2/);
+	const disabled = resolveMenuScreen(menu, "main", {
+		...current.runtime.get(),
+		settings: { ...current.runtime.get().settings, enabled: false },
+	});
+	assert.equal(disabled.kind, "actions");
+	if (disabled.kind !== "actions") assert.fail("Expected disabled actions screen");
+	assert.match(disabled.lines?.join("\n") ?? "", /Pi native \(Remote V2 off\)/);
+});
+
+test("settings screen exposes bounded controls and invalid files remain repairable", () => {
+	const current = memoryRuntime();
+	const menu = createCodexCompactMenu(current.runtime);
+	const screen = resolveMenuScreen(menu, "settings", current.runtime.get());
+	assert.equal(screen.kind, "settings");
+	if (screen.kind !== "settings") assert.fail("Expected settings screen");
+	assert.deepEqual(
+		screen.items.map((item) => [item.id, item.currentValue]),
+		[
+			["enabled", "On"],
+			["requestTimeoutMs", "5 min"],
+			["maxRetries", "2"],
+			["replacementTokenBudget", "64K tokens"],
+			["notifyOnFallback", "On"],
+		],
+	);
+
+	const invalid = memoryRuntime("invalid");
+	const invalidMenu = createCodexCompactMenu(invalid.runtime);
+	const invalidMain = resolveMenuScreen(invalidMenu, "main", invalid.runtime.get());
+	assert.equal(invalidMain.kind, "actions");
+	if (invalidMain.kind !== "actions") assert.fail("Expected invalid root actions");
+	assert.equal("to" in invalidMain.items[1] ? invalidMain.items[1].to : undefined, "invalid");
+	const detail = resolveMenuScreen(invalidMenu, "invalid", invalid.runtime.get());
+	assert.equal(detail.kind, "detail");
+	if (detail.kind !== "detail") assert.fail("Expected invalid detail");
+	assert.match(detail.lines.join("\n"), /will not be overwritten/);
+});
+
+test("manual action closes the menu and records one explicit request", async () => {
+	const memory = memoryRuntime();
+	let requests = 0;
+	const menu = createCodexCompactMenu(memory.runtime, {
+		onCompactRequested: () => {
+			requests += 1;
+		},
+	});
+	const result = await menu.actions["compact-now"]({
+		ctx: createMockContext({ mode: "tui" }).ctx,
+		state: memory.runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "compact-now",
+	});
+	assert.deepEqual(result, { kind: "close" });
+	assert.equal(requests, 1);
+});
+
+test("menu actions persist exact setting patches", async () => {
+	const memory = memoryRuntime();
+	const menu = createCodexCompactMenu(memory.runtime);
+	const { ctx } = createMockContext({ mode: "tui" });
+	const action = (value: string) => ({
+		ctx,
+		state: memory.runtime.get(),
+		signal: new AbortController().signal,
+		itemId: "setting",
+		value,
+	});
+	await menu.actions["set-enabled"](action("Off"));
+	await menu.actions["set-timeout"](action("10 min"));
+	await menu.actions["set-retries"](action("1"));
+	await menu.actions["set-retention"](action("96K tokens"));
+	await menu.actions["set-notify"](action("Off"));
+	assert.deepEqual(memory.patches, [
+		{ enabled: false },
+		{ requestTimeoutMs: 600_000 },
+		{ maxRetries: 1 },
+		{ replacementTokenBudget: 96_000 },
+		{ notifyOnFallback: false },
+	]);
+});
+
+test("TUI manual action compacts once after close and reports core errors", async () => {
+	const memory = memoryRuntime();
+	let compactions = 0;
+	let compactOptions: { onError?: (error: Error) => void } | undefined;
+	const { ctx, notifications } = createMockContext({
+		mode: "tui",
+		model: { provider: "openai-codex", id: "gpt-5.6", api: "openai-codex-responses" },
+		select: async (_title: string, options: string[]) =>
+			options.find((option) => option.startsWith("Compact now")),
+		compact: (options: { onError?: (error: Error) => void }) => {
+			compactions += 1;
+			compactOptions = options;
+		},
+	});
+	await showCodexCompactMenu(memory.runtime, ctx, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+	assert.equal(compactions, 1);
+	compactOptions?.onError?.(new Error("nothing to compact"));
+	assert.match(notifications.at(-1)?.message ?? "", /nothing to compact/);
+	assert.equal(notifications.at(-1)?.level, "error");
+});
+
+test("stale menu ownership cannot trigger delayed manual compaction", async () => {
+	const memory = memoryRuntime();
+	let current = true;
+	let compactions = 0;
+	const { ctx } = createMockContext({
+		mode: "tui",
+		select: async (_title: string, options: string[]) => {
+			current = false;
+			return options.find((option) => option.startsWith("Compact now"));
+		},
+		compact: () => {
+			compactions += 1;
+		},
+	});
+	await showCodexCompactMenu(memory.runtime, ctx, {
+		signal: new AbortController().signal,
+		isCurrent: () => current,
+	});
+	assert.equal(compactions, 0);
+});
+
+test("non-TUI command reports the settings path without compacting", async () => {
+	const memory = memoryRuntime();
+	let compactions = 0;
+	const { ctx, notifications } = createMockContext({
+		mode: "print",
+		hasUI: false,
+		compact: () => {
+			compactions += 1;
+		},
+	});
+	await showCodexCompactMenu(memory.runtime, ctx, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+	assert.match(notifications[0]?.message ?? "", /pi-codex-compact\.json/);
+	assert.equal(compactions, 0);
+});

--- a/experimental/pi-codex-compact/test/settings.test.ts
+++ b/experimental/pi-codex-compact/test/settings.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+import {
+	createCodexCompactSettingsRuntime,
+	DEFAULT_CODEX_COMPACT_SETTINGS,
+	loadCodexCompactSettings,
+	normalizeCodexCompactSettings,
+} from "../src/settings.js";
+
+const temporaryDirectories: string[] = [];
+
+async function tempSettingsPath(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-codex-compact-test-"));
+	temporaryDirectories.push(directory);
+	return join(directory, "pi-codex-compact.json");
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+	);
+});
+
+test("normalizes defaults and bounded user settings", () => {
+	assert.deepEqual(normalizeCodexCompactSettings({}), DEFAULT_CODEX_COMPACT_SETTINGS);
+	assert.deepEqual(normalizeCodexCompactSettings({ enabled: false, maxRetries: 0 }), {
+		...DEFAULT_CODEX_COMPACT_SETTINGS,
+		enabled: false,
+		maxRetries: 0,
+	});
+	assert.equal(normalizeCodexCompactSettings({ maxRetries: 3 }), undefined);
+	assert.equal(normalizeCodexCompactSettings({ requestTimeoutMs: 10 }), undefined);
+	assert.equal(normalizeCodexCompactSettings({ replacementTokenBudget: 1_000_000 }), undefined);
+});
+
+test("loads missing and valid files without consulting real user settings", async () => {
+	const path = await tempSettingsPath();
+	assert.equal((await loadCodexCompactSettings(path)).kind, "missing");
+	await writeFile(path, '{"enabled":false,"futureField":"kept"}\n');
+	const loaded = await loadCodexCompactSettings(path);
+	assert.equal(loaded.kind, "loaded");
+	assert.equal(loaded.settings.enabled, false);
+	assert.equal(loaded.document?.futureField, "kept");
+});
+
+test("rejects invalid, oversized, and symbolic-link settings without overwriting", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(path, "{invalid");
+	assert.equal((await loadCodexCompactSettings(path)).kind, "invalid");
+	const runtime = createCodexCompactSettingsRuntime(path);
+	await runtime.reload();
+	await assert.rejects(runtime.update({ enabled: false }), /Cannot overwrite an invalid/);
+	assert.equal(await readFile(path, "utf8"), "{invalid");
+
+	const oversized = await tempSettingsPath();
+	await writeFile(oversized, JSON.stringify({ padding: "x".repeat(70 * 1024) }));
+	assert.match((await loadCodexCompactSettings(oversized)).issue ?? "", /64 KiB/);
+
+	const target = await tempSettingsPath();
+	const link = await tempSettingsPath();
+	await writeFile(target, "{}");
+	await symlink(target, link);
+	assert.match((await loadCodexCompactSettings(link)).issue ?? "", /symbolic links/);
+});
+
+test("first explicit save creates a private settings file", async () => {
+	const path = await tempSettingsPath();
+	const runtime = createCodexCompactSettingsRuntime(path);
+	await runtime.update({ enabled: false });
+	assert.equal(JSON.parse(await readFile(path, "utf8")).enabled, false);
+	if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o600);
+});
+
+test("serialized updates reread latest content, preserve unknown fields, and publish atomically", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(path, '{"enabled":true,"external":"first"}\n');
+	const runtime = createCodexCompactSettingsRuntime(path);
+	await runtime.reload();
+	await writeFile(path, '{"enabled":true,"external":"newer"}\n');
+	await Promise.all([runtime.update({ enabled: false }), runtime.update({ maxRetries: 0 })]);
+	await runtime.flush();
+	const document = JSON.parse(await readFile(path, "utf8"));
+	assert.equal(document.enabled, false);
+	assert.equal(document.maxRetries, 0);
+	assert.equal(document.external, "newer");
+	assert.deepEqual(
+		(await readdir(join(path, ".."))).filter((name) => name.endsWith(".tmp")),
+		[],
+	);
+});
+
+test("aborted settings operations do not publish", async () => {
+	const path = await tempSettingsPath();
+	const runtime = createCodexCompactSettingsRuntime(path);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(runtime.update({ enabled: false }, controller.signal), /aborted/i);
+	assert.equal((await loadCodexCompactSettings(path)).kind, "missing");
+});

--- a/experimental/pi-codex-compact/tsconfig.json
+++ b/experimental/pi-codex-compact/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -100,6 +100,9 @@ pack-caffeinate:
 pack-chrome-devtools:
     just pack chrome-devtools
 
+pack-codex-compact:
+    just pack codex-compact
+
 pack-accounts:
     just pack accounts
 
@@ -166,6 +169,9 @@ try-caffeinate:
 
 try-chrome-devtools:
     just try chrome-devtools
+
+try-codex-compact:
+    just try codex-compact
 
 try-accounts:
     just try accounts

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,37 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"experimental/pi-codex-compact": {
+			"name": "@narumitw/pi-codex-compact",
+			"version": "0.47.0",
+			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.45.0"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.6",
+				"@earendil-works/pi-agent-core": "0.83.0",
+				"@earendil-works/pi-ai": "0.83.0",
+				"@earendil-works/pi-coding-agent": "0.83.0",
+				"@types/node": "26.1.2",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-agent-core": "*",
+				"@earendil-works/pi-ai": "*",
+				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
+		"experimental/pi-codex-compact/node_modules/@narumitw/pi-tui-kit": {
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.45.0.tgz",
+			"integrity": "sha512-tF1rYX+/rODdY6Dxs01h+zIZlhmMPDnRkjvhEhOajhaWYfQ0z7ECHx1NhpSDOSuasyCVwTYKiB7LlUxvKOsRyQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
 		"experimental/pi-file-context": {
 			"name": "@narumitw/pi-file-context",
 			"version": "0.47.0",
@@ -2864,6 +2895,10 @@
 		},
 		"node_modules/@narumitw/pi-chrome-devtools": {
 			"resolved": "extensions/pi-chrome-devtools",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-codex-compact": {
+			"resolved": "experimental/pi-codex-compact",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-file-context": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"pack:btw": "npm --workspace @narumitw/pi-btw pack --dry-run",
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",
+		"pack:codex-compact": "npm --workspace @narumitw/pi-codex-compact pack --dry-run",
 		"pack:accounts": "npm --workspace @narumitw/pi-accounts pack --dry-run",
 		"pack:analytics": "npm --workspace @narumitw/pi-analytics pack --dry-run",
 		"pack:usage": "npm --workspace @narumitw/pi-usage pack --dry-run",


### PR DESCRIPTION
## Summary

- add the experimental `@narumitw/pi-codex-compact` extension for OpenAI Codex OAuth models using the `openai-codex-responses` API
- request Codex Remote Compaction V2, validate one bounded opaque checkpoint, persist it in `CompactionEntry.details`, and replay its replacement history through Pi's provider-payload hook
- preserve Pi's compaction thresholds, `/compact`, overflow handling, append-only session lifecycle, cancellation semantics, and native plaintext fallback
- add `/codex-compact` with a **Compact now** action, effective Remote V2/native route display, and a settings menu for bounded request, retry, retention, and notification controls
- protect settings with validation, unknown-field preservation, invalid/symlink/oversize rejection, conflict detection, private atomic publication, and session-owned cancellation
- document Codex's compaction mechanism, the extension boundary, privacy/portability constraints, package usage, and experimental behavior

## Verification

- `npm run check` — Biome, boundary checks, workspace typechecks, and 2,262 tests passed
- `npm --workspace @narumitw/pi-codex-compact run check` — passed
- `just pack codex-compact` — inspected 10 intended files (`src`, README, license, and manifest; no tests)
- non-interactive declared-entrypoint load smoke — passed
- bounded live `openai-codex/gpt-5.6-sol` `/compact` smoke — produced a version 1 `pi-codex-remote-compaction` checkpoint with the opaque compaction item last and no persisted OAuth token or request headers

## Convention audit

Read `docs/extension-conventions.md` and `docs/extension-settings.md`. Audited provider/extension independence, active-branch persistence, bounded stream/checkpoint/settings data, cancellation, component disposal, session replacement, shutdown, atomic settings publication, unknown-field preservation, secret handling, non-TUI behavior, experimental warning, and package contents.

The extension intentionally cannot reproduce Codex core's complete window lineage or exact mid-turn ownership through Pi's public extension boundary; this limitation and opaque-checkpoint portability requirement are documented. Settings mutations are serialized within one Pi process and use a final conflict check, but separate processes do not share a lock; detected concurrent edits are rejected for retry.

No package publication, visibility change, release, or tag is included.
