### PR TITLE
feat(plan-mode): add launch menu

### DIFF
--- a/docs/plans/archived/2026-08-03_pi-plan-mode-launch-menu-plan.md
+++ b/docs/plans/archived/2026-08-03_pi-plan-mode-launch-menu-plan.md
@@ -1,0 +1,130 @@
+# pi-plan-mode launch menu
+
+## Goal
+
+Change bare `/plan` from immediately enabling Plan mode into an explicit, state-aware launch menu
+when no plan workflow is active. Let users start with the current tool selection, stage a different
+tool selection before starting, or read a concise explanation, while preserving existing ready,
+saved, active-implementation, inline-prompt, flag, and management-command behavior.
+
+## Context
+
+- Today, bare `/plan` immediately enables Plan mode only when the extension is inactive with no saved
+  or active implementation plan. Other Plan states already open dedicated menus.
+- The approved inactive menu shows that Plan mode is off, summarizes the tools that will be active,
+  and offers **Start Plan mode**, **Choose tools, then start…**, and **How Plan mode works**.
+- Tool changes made in the launch flow are draft-only until the user chooses the explicit
+  **Done — start Plan mode** action. Back, Escape, Ctrl+C, owner disposal, session replacement, and
+  shutdown must leave Plan state, active tools, thinking level, and persisted tool selection
+  unchanged.
+- `/plan start` becomes the deterministic no-prompt activation route and a completed argument. This
+  intentionally reserves the exact payload `start`; `/plan start <more text>` remains an inline
+  planning prompt. `/plan <prompt>`, `/plan tools`, `--plan`, and all existing management routes keep
+  their current behavior.
+- Bare `/plan` in print and JSON modes cannot open the approved menu, so it must fail observably
+  before mutation and direct users to `/plan start` or `/plan <prompt>`. TUI and RPC use Pi TUI Kit's
+  standard menu adapters.
+- Touched convention areas are the public slash-command surface, TUI/RPC menu behavior, non-TUI
+  fallback, session-owned interaction lifecycle, session-persisted tool selection, tests, and
+  package documentation. No global settings schema or file persistence format changes are planned.
+
+## Architecture
+
+- Add `extensions/pi-plan-mode/src/plan-launch-menu.ts` as the declarative Pi TUI Kit surface for the
+  inactive main, staged tool-selection, and help screens. It owns only interaction-local draft state
+  and delegates activation, tool validation/commit, status text, and lifecycle ownership through
+  callbacks. Keep the existing immediate active selector in `src/plan-tool-menu.ts` so standard menu
+  presentation is separate from the extension orchestrator without merging the two commit models.
+- Keep `extensions/pi-plan-mode/src/plan-mode.ts` as the domain orchestrator. It decides which Plan
+  state owns bare `/plan`, captures the current menu lifecycle, provides a read-only effective tool
+  snapshot, commits a validated staged selection only at activation, and performs the existing
+  `enterPlanMode()` transition.
+- Keep the active `/plan tools` selector's immediate session-update behavior unchanged. Share pure
+  tool-row projection or effective-selection helpers where that prevents launch-menu and active-menu
+  policy drift, but do not merge their different commit semantics.
+- Use the existing `menuController`, `menuGeneration`, and `workflowGeneration` ownership checks.
+  Every action checks its supplied abort signal/current owner before a domain mutation; Pi TUI Kit
+  drains pending toggles and classifies replacement or disposal as stale.
+
+## Non-Goals
+
+- Do not add a prompt editor to the launch menu.
+- Do not redesign the ready, saved, active Plan-mode, or active implementation menus.
+- Do not add a global settings UI or change `pi-plan-mode.json`.
+- Do not change Plan-mode tool safety policy, thinking-level policy, plan completion, export, save,
+  or implementation behavior.
+
+## Risks
+
+- Ninety-two existing tests currently use bare `/plan` as a setup shortcut. They must move to the
+  public `/plan start` route except where the test intentionally exercises a no-argument menu, or the
+  suite could accidentally bypass the new contract.
+- Computing the inactive tool summary through the current mutating selection resolver could migrate
+  or filter session state merely by opening and cancelling the menu. The launch path needs a pure
+  snapshot and must commit migration/filtering only when activation is accepted.
+- Pi TUI Kit multi-select toggles invoke actions immediately. Those actions must update only a
+  launch-local draft; the pinned **Done — start Plan mode** action is the sole commit path. The
+  standard Back/Close row must never be treated as acceptance.
+- Reserving exact `start` narrows the existing free-form prompt namespace. README migration text and
+  autocomplete must make the new meaning explicit.
+
+## Plan
+
+- [x] Add focused red tests in `extensions/pi-plan-mode/test/launch-menu.test.ts` for inactive bare
+      `/plan` opening (without activation) in TUI and RPC, **Start Plan mode**, staged tool selection
+      plus **Done — start Plan mode**, the help/back path, and root cancellation; evidence: the first
+      focused run executed 7 tests and all failed because bare `/plan` activated immediately, no RPC
+      dialog opened, `start` was absent, and print/JSON did not reject.
+- [x] Add command-contract red tests for exact `/plan start`, `start` autocomplete, unchanged inline
+      prompt and `--plan` activation, rejection of inactive bare `/plan` in print/JSON before any
+      state or tool mutation, and unchanged dispatch to ready/saved/implementation menus; evidence:
+      the focused red run failed on both the missing direct route and unsupported-mode contract.
+- [x] Implement `src/plan-launch-menu.ts` with Pi TUI Kit `actions`, `multiSelect`, and `detail`
+      screens, width-safe/status copy, a launch-local selected-name draft, disabled policy rows,
+      explicit **Done — start Plan mode** commit, and Back/Close transitions; evidence: 10 focused
+      launch-menu TUI/RPC tests pass, including a 42-column render and staged RPC tool selection.
+- [x] Update `src/plan-mode.ts`, `src/command.ts`, and shared tool-selection behavior to route only
+      the inactive/empty bare command into the launch menu, expose a pure effective-tool snapshot,
+      validate and persist staged names atomically with `enterPlanMode()`, add exact `/plan start`,
+      and throw the actionable print/JSON fallback before mutation; evidence: focused direct-command,
+      inline-prompt, autocomplete, default-tool, and unsupported-mode assertions pass.
+- [x] Add focused cancellation and lifecycle coverage for draft toggles followed by Back, Escape,
+      Ctrl+C, external component disposal, session replacement, and shutdown, asserting no launch
+      selection is persisted and no tool activation, stale notification, or model turn occurs;
+      evidence: all 10 focused tests settle and pass across those owner endings.
+- [x] Replace bare `/plan` setup calls throughout `extensions/pi-plan-mode/test/*.test.ts` with
+      `/plan start` where direct activation is the test precondition, retain bare calls only for
+      state-menu assertions, and run all pi-plan-mode tests to prove existing planning, safety,
+      completion, export, save, implementation, resume, and compaction behavior remains compatible;
+      evidence: all 126 compiled pi-plan-mode tests pass.
+- [x] Update `extensions/pi-plan-mode/README.md` with the new inactive menu, `/plan start`, the exact
+      `start` reservation, staged tool commit/cancellation semantics, unchanged state-specific menus,
+      and print/JSON migration guidance; package formatting/typecheck evidence is collected in the
+      final verification task, with no new Pi TUI Kit API or dependency-floor change required.
+- [x] Audit the final diff against `docs/extension-conventions.md` for command routes, all claimed
+      modes, menu lifecycle, cancellation/disposal/replacement/shutdown, and session-state
+      persistence; evidence: `npm run check` passed 2,275 tests, the final focused package run passed
+      all 126 pi-plan-mode tests, print-mode Pi smokes loaded `/plan start` and surfaced the bare-menu
+      recovery error, and `just pack plan-mode` included the declared entrypoint, both menu modules,
+      README, and license in a 24-file dry-run tarball.
+
+## Completion Checklist
+
+- [x] In inactive empty TUI and RPC sessions, bare `/plan` opens the approved menu and does not enable
+      Plan mode until an explicit start action is accepted.
+- [x] **Start Plan mode** activates the existing default/current Plan tools and thinking policy
+      without starting a model turn; `/plan start` provides the same deterministic direct behavior.
+- [x] **Choose tools, then start…** stages only valid selectable tools, commits them only through
+      **Done — start Plan mode**, and shows blocked tools as unavailable with textual reasons.
+- [x] Help and every cancellation, Back, disposal, replacement, and shutdown path leave Plan state,
+      active tools, thinking level, persisted selection, and queued model messages unchanged.
+- [x] Ready, saved, active Plan-mode, and active implementation bare-command menus remain unchanged;
+      `/plan <prompt>`, `/plan tools`, `--plan`, and all existing management routes retain their
+      documented behavior.
+- [x] Bare `/plan` in print and JSON fails observably before mutation with `/plan start` and
+      `/plan <prompt>` recovery guidance, and every accepted direct route remains tested in its
+      claimed modes.
+- [x] TUI/RPC keyboard operation, focus, narrow-width rendering, and terminal-text safety are covered
+      through Pi TUI Kit's supported testing boundary.
+- [x] `npm run check` and `just pack plan-mode` pass, documentation matches behavior, and the final
+      semantic audit records no unapproved deviations or unverified required paths.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -8,7 +8,7 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 
 ## ✨ Features
 
-- Adds `/plan` to enter or manage Plan mode.
+- Adds a state-aware `/plan` launch and management menu, plus `/plan start` for direct activation.
 - Adds `--plan` to start a session in Plan mode.
 - Enables built-in read-only tools by default while Plan mode is active.
 - Disables extension and custom tools by default, with a `/plan tools` selector for explicit user-risk opt-in.
@@ -45,6 +45,7 @@ pi -e ./extensions/pi-plan-mode
 
 ```text
 /plan
+/plan start
 /plan <prompt>
 /plan tools
 /plan show
@@ -55,14 +56,26 @@ pi -e ./extensions/pi-plan-mode
 /plan exit
 ```
 
-Use `/plan` to enter Plan mode before writing your planning prompt. Use `/plan <prompt>` to enter
-Plan mode and immediately submit `<prompt>` as the first Plan-mode user message. Use `/plan tools`
-to choose which tools are active while Plan mode is enabled; the standard bounded multi-select shows
-10 rows at a time, supports viewport paging, descriptions, and explicit unavailable rows for blocked
-tools. In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; clear
-the query to restore the stable tool cursor. RPC keeps the complete unfiltered tool list. The
-`plan_mode_question` tool keeps its one-off question/choice dialog because it is a
-model-requested planning interaction, not command-menu navigation. `/plan show` displays the stored
+In TUI and RPC, use bare `/plan` to open the menu for the current Plan state. When Plan mode is off
+and no plan is stored, the launch menu shows the effective next-start tools and offers **Start Plan
+mode**, **Choose tools, then start…**, and **How Plan mode works**. Launch-menu tool changes remain a
+draft until **Done — start Plan mode** is selected; Back, Escape, Ctrl+C, disposal, session
+replacement, and shutdown discard the draft without changing Plan state, active tools, thinking, or
+the stored selection.
+
+Use `/plan start` when you want to enter Plan mode directly without sending a model message. Use
+`/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user
+message. The exact argument `start` is reserved for direct activation; longer text such as `/plan
+start a migration` remains an inline planning prompt. `--plan` also remains a direct activation path.
+
+Use `/plan tools` to enter Plan mode when needed and choose which tools are active in the current
+Plan workflow; unlike the launch-menu draft, this active selector applies accepted toggles to the
+session immediately. The standard bounded multi-select shows 10 rows at a time, supports viewport
+paging, descriptions, and explicit unavailable rows for blocked tools. In TUI mode, type to
+fuzzy-search tool names, descriptions, policy, and source metadata; clear the query to restore the
+stable tool cursor. RPC keeps the complete unfiltered tool list. The `plan_mode_question` tool keeps
+its one-off question/choice dialog because it is a model-requested planning interaction, not
+command-menu navigation. `/plan show` displays the stored
 plan without starting a model turn, including the accepted plan while implementation is active.
 `/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material
 question, `/plan save` stores a completed ready plan for later and leaves Plan mode, `/plan
@@ -109,9 +122,17 @@ Legacy sessions and models may still submit one non-empty `<proposed_plan>` bloc
 
 After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
 
-A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, Export, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan <prompt>` or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
+A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, Export, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan start`, `/plan <prompt>`, or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
 
-Text print and JSON modes can export any stored plan with `/plan export [path]`, save a ready plan with `/plan save`, and clear it with `/plan exit` or `/plan off`. Successful export is observable through the created file; exporting a ready plan also leaves Plan mode, while saved and active implementation state remains unchanged. An existing target or missing plan fails the command without changing state. These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
+Text print and JSON modes cannot display the bare `/plan` menu and reject that route before changing
+state; use `/plan start` for direct no-prompt activation or `/plan <prompt>` to start planning with a
+prompt. These modes can export any stored plan with `/plan export [path]`, save a ready plan with
+`/plan save`, and clear it with `/plan exit` or `/plan off`. Successful export is observable through
+the created file; exporting a ready plan also leaves Plan mode, while saved and active implementation
+state remains unchanged. An existing target or missing plan fails the command without changing state.
+These modes reject saved-plan display and implementation before changing state because Pi provides
+neither printable custom-message output nor acknowledged extension-triggered turns; resume the
+session in TUI or RPC to show or implement it.
 
 Once implemented, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
 

--- a/extensions/pi-plan-mode/src/command.ts
+++ b/extensions/pi-plan-mode/src/command.ts
@@ -5,6 +5,7 @@ export interface CommandArgumentCompletion {
 }
 
 const PLAN_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
+	{ value: "start", label: "start", description: "Start Plan mode without sending a prompt" },
 	{ value: "show", label: "show", description: "Show the ready, saved, or active plan" },
 	{ value: "finalize", label: "finalize", description: "Request a completed plan" },
 	{ value: "implement", label: "implement", description: "Implement the completed or saved plan" },

--- a/extensions/pi-plan-mode/src/plan-launch-menu.ts
+++ b/extensions/pi-plan-mode/src/plan-launch-menu.ts
@@ -1,0 +1,108 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+
+export interface PlanLaunchTool {
+	name: string;
+	description: string;
+	searchText: string;
+	selected: boolean;
+	disabled: boolean;
+	disabledReason?: string;
+}
+
+interface PlanLaunchMenuOptions {
+	statusText: string;
+	toolSummary: string;
+	tools: readonly PlanLaunchTool[];
+	signal: AbortSignal;
+	isCurrent(): boolean;
+	start(signal: AbortSignal): void;
+	startWithTools(toolNames: string[], signal: AbortSignal): void;
+}
+
+export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLaunchMenuOptions) {
+	type Screen = "main" | "tools" | "help";
+	type Action = "start" | "toggle-tool" | "start-with-tools";
+	const selectedNames = new Set(
+		options.tools.filter((tool) => tool.selected && !tool.disabled).map((tool) => tool.name),
+	);
+	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
+		start: "main",
+		screens: {
+			main: () => ({
+				kind: "actions",
+				title: "Plan mode",
+				lines: [options.statusText, options.toolSummary],
+				items: [
+					{ id: "start", label: "Start Plan mode", action: "start" },
+					{ id: "tools", label: "Choose tools, then start…", to: "tools" },
+					{ id: "help", label: "How Plan mode works", to: "help" },
+				],
+				hint: "close",
+			}),
+			tools: () => ({
+				kind: "multiSelect",
+				title: "Choose Plan-mode tools",
+				lines: [
+					"Changes apply only when you start Plan mode.",
+					"Non-built-in tools run at user risk.",
+				],
+				enableSearch: true,
+				viewportSize: 10,
+				items: options.tools.map((tool) => ({
+					id: tool.name,
+					label: tool.name,
+					description: tool.description,
+					searchText: tool.searchText,
+					selected: selectedNames.has(tool.name),
+					disabled: tool.disabled,
+					disabledReason: tool.disabledReason,
+				})),
+				action: "toggle-tool",
+				actions: [
+					{
+						id: "start-with-tools",
+						label: "Done — start Plan mode",
+						action: "start-with-tools",
+					},
+				],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "How Plan mode works",
+				lines: [
+					"Plan mode uses read-only exploration to understand the project before implementation.",
+					"The agent can ask important decision questions, then returns a complete implementation-ready plan.",
+					"File mutation stays blocked until you explicitly choose to implement the completed plan.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			start: async ({ signal }) => {
+				if (signal.aborted || !options.isCurrent()) return { kind: "rejected" };
+				options.start(signal);
+				return { kind: "close" };
+			},
+			"toggle-tool": async ({ itemId, selected, signal }) => {
+				if (signal.aborted || !options.isCurrent()) return { kind: "rejected" };
+				const tool = options.tools.find((candidate) => candidate.name === itemId);
+				if (!tool || tool.disabled) return { kind: "rejected" };
+				if (selected) selectedNames.add(tool.name);
+				else selectedNames.delete(tool.name);
+				return { kind: "stay" };
+			},
+			"start-with-tools": async ({ signal }) => {
+				if (signal.aborted || !options.isCurrent()) return { kind: "rejected" };
+				options.startWithTools(Array.from(selectedNames), signal);
+				return { kind: "close" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+	});
+}

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { showActiveImplementationMenu } from "./active-implementation-menu.js";
 import { completePlanArguments } from "./command.js";
 import {
@@ -30,6 +29,8 @@ import {
 } from "./message-transform.js";
 import { showPlanModeMenu, showReadyPlanMenu } from "./plan-action-menus.js";
 import { exportStoredPlan } from "./plan-export.js";
+import { showPlanLaunchMenu } from "./plan-launch-menu.js";
+import { showPlanToolMenu } from "./plan-tool-menu.js";
 import {
 	clearPlanModeUi,
 	planModeStatusText as formatPlanModeStatusText,
@@ -60,24 +61,25 @@ import {
 	canSelectToolInPlanMode,
 	classifyPlanModeTool,
 	findBlockedCommandSegment,
-	isBuiltinTool,
 	readCommand,
-	SAFE_BUILTIN_PLAN_TOOLS,
 } from "./tool-policy.js";
-import { compareTools, toolNameFromLegacyKey, toolPolicyLabel, unique } from "./tool-selection.js";
+import {
+	compareTools,
+	filterAvailableSelectedToolNames,
+	snapshotPlanModeSelectedNames,
+	snapshotPlanModeToolNames,
+	toolPolicyLabel,
+} from "./tool-selection.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
 const BLOCKED_BUILTIN_TOOLS = new Set(["edit", "write"]);
 const DEFAULT_TOOLS = ["read", "bash", "edit", "write"];
-const TOOL_SELECTOR_VIEWPORT_SIZE = 10;
-
 interface ReadyPresentationIntent {
 	nonce: number;
 	plan: string;
 	source: PlanCompletionSource;
 }
-
 export default function planMode(
 	pi: ExtensionAPI,
 	dependencies: { readSettings?(): ReturnType<typeof readPlanModeSettings> } = {},
@@ -168,6 +170,17 @@ export default function planMode(
 		handler: async (args, ctx) => {
 			const prompt = args.trim();
 			const command = prompt.toLowerCase();
+			if (command === "start") {
+				if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined && !state.enabled))
+					return;
+				if (state.enabled) {
+					ctx.ui.notify("Plan mode is already active.", "info");
+					return;
+				}
+				enterPlanMode(ctx);
+				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+				return;
+			}
 			if (command === "show") {
 				showStoredPlan(pi, ctx, state);
 				return;
@@ -224,6 +237,11 @@ export default function planMode(
 				enterPlanModeWithPrompt(prompt, ctx);
 				return;
 			}
+			if (!ctx.hasUI) {
+				throw new Error(
+					"The interactive /plan menu is unavailable in print and JSON modes. Use /plan start or /plan <prompt>.",
+				);
+			}
 			if (!state.enabled) {
 				if (state.activeImplementation && ctx.hasUI) {
 					await showActivePlanMenu(ctx);
@@ -233,8 +251,7 @@ export default function planMode(
 					await showSavedPlanActions(ctx);
 					return;
 				}
-				enterPlanMode(ctx);
-				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+				await showLaunchMenu(ctx);
 				return;
 			}
 			await showPlanMenu(ctx);
@@ -644,6 +661,47 @@ export default function planMode(
 		}
 	}
 
+	async function showLaunchMenu(ctx: ExtensionContext) {
+		const lifecycle = captureMenuLifecycle();
+		const tools = selectableTools();
+		const selection = toolSelectionSnapshot();
+		const selectedNames = snapshotPlanModeSelectedNames(tools, selection);
+		const launchToolNames = snapshotPlanModeToolNames(tools, selectedNames, selection);
+		await showPlanLaunchMenu(ctx, {
+			statusText: "Status: Off — normal tools are active.",
+			toolSummary: `When started: ${launchToolNames.join(", ")}`,
+			tools: tools.map((tool) => {
+				const selectable = canSelectToolInPlanMode(tool);
+				const policy = toolPolicyLabel(tool);
+				const description = tool.description ?? "No description available";
+				return {
+					name: tool.name,
+					description: `${policy} · ${description}`,
+					searchText: [policy, description].join(" "),
+					selected: selectedNames.has(tool.name),
+					disabled: !selectable,
+					disabledReason: selectable ? undefined : "Blocked by Plan-mode policy",
+				};
+			}),
+			...lifecycle,
+			start: (signal) => {
+				if (signal.aborted || !lifecycle.isCurrent()) return;
+				enterPlanMode(ctx);
+				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+			},
+			startWithTools: (names, signal) => {
+				if (signal.aborted || !lifecycle.isCurrent()) return;
+				state = {
+					...state,
+					selectedToolNames: filterAvailableSelectedToolNames(names, tools),
+					selectedToolKeys: undefined,
+				};
+				enterPlanMode(ctx);
+				ctx.ui.notify("Plan mode enabled with the selected tools.", "info");
+			},
+		});
+	}
+
 	async function showActivePlanMenu(ctx: ExtensionContext) {
 		if (!ctx.hasUI) {
 			ctx.ui.notify(planStatusText(), "info");
@@ -733,57 +791,24 @@ export default function planMode(
 		}
 		const lifecycle = captureMenuLifecycle();
 		const tools = selectableTools();
-		const toolById = new Map(tools.map((tool, index) => [`${index}:${tool.name}`, tool]));
-		const menu = defineMenu<undefined, "tools", "toggle", ExtensionContext>({
-			start: "tools",
-			screens: {
-				tools: () => {
-					const selectedNames = planModeSelectedNames(tools);
-					return {
-						kind: "multiSelect",
-						title: "Plan-mode tools",
-						lines: ["Non-built-in tools run at user risk."],
-						enableSearch: true,
-						viewportSize: TOOL_SELECTOR_VIEWPORT_SIZE,
-						items: tools.map((tool, index) => {
-							const selectable = canSelectToolInPlanMode(tool);
-							return {
-								id: `${index}:${tool.name}`,
-								label: tool.name,
-								description: `${toolPolicyLabel(tool)} · ${tool.description}`,
-								searchText: [toolPolicyLabel(tool), tool.description].filter(Boolean).join(" "),
-								selected: selectedNames.has(tool.name),
-								disabled: !selectable,
-								disabledReason: selectable ? undefined : "Blocked by Plan-mode policy",
-							};
-						}),
-						action: "toggle",
-						hint: "close",
-						doneLabel: "Done",
-					};
-				},
-			},
-			actions: {
-				toggle: async ({ itemId, selected }) => {
-					const tool = toolById.get(itemId);
-					if (!tool || !canSelectToolInPlanMode(tool)) return { kind: "rejected" };
-					const names = planModeSelectedNames(tools);
-					if (selected) names.add(tool.name);
-					else names.delete(tool.name);
-					state = {
-						...state,
-						selectedToolNames: filterAvailableSelectedNames(Array.from(names), tools),
-					};
-					applyPlanModeTools();
-					persistState();
-					updateUi(ctx);
-					return { kind: "stay" };
-				},
-			},
-		});
-		await runMenu(ctx, menu, {
-			getState: () => undefined,
+		await showPlanToolMenu(ctx, {
+			tools,
 			...lifecycle,
+			getSelectedNames: () => snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()),
+			toggle: (toolName, selected, signal) => {
+				if (signal.aborted || !lifecycle.isCurrent()) return;
+				const names = snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot());
+				if (selected) names.add(toolName);
+				else names.delete(toolName);
+				state = {
+					...state,
+					selectedToolNames: filterAvailableSelectedToolNames(Array.from(names), tools),
+					selectedToolKeys: undefined,
+				};
+				applyPlanModeTools();
+				persistState();
+				updateUi(ctx);
+			},
 		});
 		if (!lifecycle.isCurrent()) return;
 		applyPlanModeTools();
@@ -828,7 +853,7 @@ export default function planMode(
 			return ["read", "bash", PLAN_MODE_QUESTION_TOOL_NAME, PLAN_MODE_COMPLETE_TOOL_NAME];
 		}
 
-		const selectedNames = planModeSelectedNames(tools);
+		const selectedNames = snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot());
 		return withRequiredPlanModeTools(
 			tools
 				.filter((tool) => selectedNames.has(tool.name) && canSelectToolInPlanMode(tool))
@@ -836,37 +861,12 @@ export default function planMode(
 		);
 	}
 
-	function planModeSelectedNames(tools: ToolInfo[]) {
-		const selectedToolNames = state.selectedToolNames ?? migrateSelectedToolKeys(tools);
-		if (selectedToolNames === undefined) return new Set(defaultPlanModeToolNames(tools));
-
-		state = {
-			...state,
-			selectedToolNames: filterAvailableSelectedNames(selectedToolNames, tools),
-			selectedToolKeys: undefined,
+	function toolSelectionSnapshot() {
+		return {
+			selectedToolNames: state.selectedToolNames,
+			selectedToolKeys: state.selectedToolKeys,
+			defaultPlanTools: settings.defaultPlanTools,
 		};
-		return new Set(state.selectedToolNames);
-	}
-
-	function defaultPlanModeToolNames(tools: ToolInfo[]) {
-		if (settings.defaultPlanTools !== undefined) {
-			return filterAvailableSelectedNames(settings.defaultPlanTools, tools);
-		}
-		return tools
-			.filter((tool) => isBuiltinTool(tool) && SAFE_BUILTIN_PLAN_TOOLS.has(tool.name))
-			.map((tool) => tool.name);
-	}
-
-	function migrateSelectedToolKeys(tools: ToolInfo[]) {
-		if (state.selectedToolKeys === undefined) return undefined;
-		return state.selectedToolKeys
-			.map((key) => toolNameFromLegacyKey(key, tools))
-			.filter((name): name is string => name !== undefined);
-	}
-
-	function filterAvailableSelectedNames(names: string[], tools: ToolInfo[]) {
-		const availableNames = new Set(tools.filter(canSelectToolInPlanMode).map((tool) => tool.name));
-		return unique(names.filter((name) => availableNames.has(name)));
 	}
 
 	function selectableTools() {

--- a/extensions/pi-plan-mode/src/plan-tool-menu.ts
+++ b/extensions/pi-plan-mode/src/plan-tool-menu.ts
@@ -1,0 +1,65 @@
+import type { ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { canSelectToolInPlanMode } from "./tool-policy.js";
+import { toolPolicyLabel } from "./tool-selection.js";
+
+const TOOL_SELECTOR_VIEWPORT_SIZE = 10;
+
+interface PlanToolMenuOptions {
+	tools: readonly ToolInfo[];
+	signal: AbortSignal;
+	isCurrent(): boolean;
+	getSelectedNames(): ReadonlySet<string>;
+	toggle(toolName: string, selected: boolean, signal: AbortSignal): void;
+}
+
+export async function showPlanToolMenu(ctx: ExtensionContext, options: PlanToolMenuOptions) {
+	const toolById = new Map(options.tools.map((tool, index) => [`${index}:${tool.name}`, tool]));
+	const menu = defineMenu<undefined, "tools", "toggle", ExtensionContext>({
+		start: "tools",
+		screens: {
+			tools: () => {
+				const selectedNames = options.getSelectedNames();
+				return {
+					kind: "multiSelect",
+					title: "Plan-mode tools",
+					lines: ["Non-built-in tools run at user risk."],
+					enableSearch: true,
+					viewportSize: TOOL_SELECTOR_VIEWPORT_SIZE,
+					items: options.tools.map((tool, index) => {
+						const selectable = canSelectToolInPlanMode(tool);
+						const policy = toolPolicyLabel(tool);
+						const description = tool.description ?? "No description available";
+						return {
+							id: `${index}:${tool.name}`,
+							label: tool.name,
+							description: `${policy} · ${description}`,
+							searchText: `${policy} ${description}`,
+							selected: selectedNames.has(tool.name),
+							disabled: !selectable,
+							disabledReason: selectable ? undefined : "Blocked by Plan-mode policy",
+						};
+					}),
+					action: "toggle",
+					hint: "close",
+					doneLabel: "Done",
+				};
+			},
+		},
+		actions: {
+			toggle: async ({ itemId, selected, signal }) => {
+				const tool = toolById.get(itemId);
+				if (signal.aborted || !options.isCurrent() || !tool || !canSelectToolInPlanMode(tool)) {
+					return { kind: "rejected" };
+				}
+				options.toggle(tool.name, selected === true, signal);
+				return { kind: "stay" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+	});
+}

--- a/extensions/pi-plan-mode/src/tool-selection.ts
+++ b/extensions/pi-plan-mode/src/tool-selection.ts
@@ -1,5 +1,13 @@
 import type { ToolInfo } from "@earendil-works/pi-coding-agent";
-import { classifyPlanModeTool, isBuiltinTool } from "./tool-policy.js";
+import { PLAN_MODE_COMPLETE_TOOL_NAME } from "./completion-tool.js";
+import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
+import { withRequiredPlanModeTools } from "./required-tools.js";
+import {
+	canSelectToolInPlanMode,
+	classifyPlanModeTool,
+	isBuiltinTool,
+	SAFE_BUILTIN_PLAN_TOOLS,
+} from "./tool-policy.js";
 
 export function toolNameFromLegacyKey(key: string, tools: ToolInfo[]) {
 	const directName = tools.find((tool) => tool.name === key)?.name;
@@ -31,4 +39,60 @@ function toolSourceLabel(tool: ToolInfo) {
 
 export function unique(values: string[]) {
 	return Array.from(new Set(values));
+}
+
+export function filterAvailableSelectedToolNames(names: string[], tools: ToolInfo[]) {
+	const availableNames = new Set(tools.filter(canSelectToolInPlanMode).map((tool) => tool.name));
+	return unique(names.filter((name) => availableNames.has(name)));
+}
+
+export function defaultPlanModeToolNames(tools: ToolInfo[], configuredNames: string[] | undefined) {
+	if (configuredNames !== undefined) {
+		return filterAvailableSelectedToolNames(configuredNames, tools);
+	}
+	return tools
+		.filter((tool) => isBuiltinTool(tool) && SAFE_BUILTIN_PLAN_TOOLS.has(tool.name))
+		.map((tool) => tool.name);
+}
+
+interface PlanModeToolSelectionSnapshot {
+	selectedToolNames?: string[];
+	selectedToolKeys?: string[];
+	defaultPlanTools?: string[];
+}
+
+export function snapshotPlanModeSelectedNames(
+	tools: ToolInfo[],
+	selection: PlanModeToolSelectionSnapshot,
+) {
+	const selectedToolNames =
+		selection.selectedToolNames ??
+		selection.selectedToolKeys
+			?.map((key) => toolNameFromLegacyKey(key, tools))
+			.filter((name): name is string => name !== undefined);
+	return new Set(
+		selectedToolNames === undefined
+			? defaultPlanModeToolNames(tools, selection.defaultPlanTools)
+			: filterAvailableSelectedToolNames(selectedToolNames, tools),
+	);
+}
+
+export function snapshotPlanModeToolNames(
+	tools: ToolInfo[],
+	selectedNames: ReadonlySet<string>,
+	selection: PlanModeToolSelectionSnapshot,
+) {
+	if (
+		tools.length === 0 &&
+		selection.selectedToolNames === undefined &&
+		selection.selectedToolKeys === undefined &&
+		selection.defaultPlanTools === undefined
+	) {
+		return ["read", "bash", PLAN_MODE_QUESTION_TOOL_NAME, PLAN_MODE_COMPLETE_TOOL_NAME];
+	}
+	return withRequiredPlanModeTools(
+		tools
+			.filter((tool) => selectedNames.has(tool.name) && canSelectToolInPlanMode(tool))
+			.map((tool) => tool.name),
+	);
 }

--- a/extensions/pi-plan-mode/test/default-tools.test.ts
+++ b/extensions/pi-plan-mode/test/default-tools.test.ts
@@ -37,7 +37,7 @@ test("fresh Plan mode uses configured default tools and restores previous tools"
 		const context = createMockContext();
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", "custom", ...REQUIRED_PLAN_TOOLS]);
 		const hook = mock.events.get("tool_call")?.[0];
 		assert.equal(
@@ -63,7 +63,7 @@ test("missing and empty default tool settings remain distinct", async () => {
 		planMode(missing.pi);
 		const missingContext = createMockContext();
 		await missing.events.get("session_start")?.[0]?.({}, missingContext.ctx);
-		await missing.commands.get("plan")?.handler("", missingContext.ctx);
+		await missing.commands.get("plan")?.handler("start", missingContext.ctx);
 		assert.deepEqual(missing.rawPi.getActiveTools(), [
 			"bash",
 			"grep",
@@ -76,7 +76,7 @@ test("missing and empty default tool settings remain distinct", async () => {
 		planMode(empty.pi);
 		const emptyContext = createMockContext();
 		await empty.events.get("session_start")?.[0]?.({}, emptyContext.ctx);
-		await empty.commands.get("plan")?.handler("", emptyContext.ctx);
+		await empty.commands.get("plan")?.handler("start", emptyContext.ctx);
 		assert.deepEqual(empty.rawPi.getActiveTools(), REQUIRED_PLAN_TOOLS);
 	});
 });
@@ -89,7 +89,7 @@ test("explicit defaults stay fail closed when tool metadata is unavailable", asy
 		planMode(explicit.pi);
 		const explicitContext = createMockContext();
 		await explicit.events.get("session_start")?.[0]?.({}, explicitContext.ctx);
-		await explicit.commands.get("plan")?.handler("", explicitContext.ctx);
+		await explicit.commands.get("plan")?.handler("start", explicitContext.ctx);
 		assert.deepEqual(explicit.rawPi.getActiveTools(), REQUIRED_PLAN_TOOLS);
 
 		await rm(settingsPath);
@@ -97,7 +97,7 @@ test("explicit defaults stay fail closed when tool metadata is unavailable", asy
 		planMode(fallback.pi);
 		const fallbackContext = createMockContext();
 		await fallback.events.get("session_start")?.[0]?.({}, fallbackContext.ctx);
-		await fallback.commands.get("plan")?.handler("", fallbackContext.ctx);
+		await fallback.commands.get("plan")?.handler("start", fallbackContext.ctx);
 		assert.deepEqual(fallback.rawPi.getActiveTools(), ["read", "bash", ...REQUIRED_PLAN_TOOLS]);
 	});
 });
@@ -164,19 +164,19 @@ test("settings reload resets removed or invalid configured defaults", async () =
 		const context = createMockContext();
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", ...REQUIRED_PLAN_TOOLS]);
 		await mock.commands.get("plan")?.handler("exit", context.ctx);
 
 		await rm(settingsPath);
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", "grep", "read", ...REQUIRED_PLAN_TOOLS]);
 		await mock.commands.get("plan")?.handler("exit", context.ctx);
 
 		await writeFile(settingsPath, JSON.stringify({ defaultPlanTools: "read" }));
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", "grep", "read", ...REQUIRED_PLAN_TOOLS]);
 		assert.match(context.notifications.at(-2)?.message ?? "", /settings ignored/i);
 	});
@@ -194,13 +194,13 @@ test("configured names follow effective sources without dynamic auto-activation"
 		const context = createMockContext();
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
 
 		allTools.push(extensionTool("late"));
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
 		await mock.commands.get("plan")?.handler("exit", context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["late", "read", ...REQUIRED_PLAN_TOOLS]);
 	});
 });
@@ -230,7 +230,7 @@ test("the tool selector persists a session override and shutdown restores prior 
 		});
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await mock.commands.get("plan")?.handler("tools", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), [
 			"bash",
@@ -298,7 +298,7 @@ test("the Plan-mode tool selector keeps the cursor on the toggled row", async ()
 		});
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await mock.commands.get("plan")?.handler("tools", context.ctx);
 
 		assert.equal(customCalled, true);
@@ -345,7 +345,7 @@ test("the Plan-mode tool selector searches metadata and toggles the stable tool 
 		});
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await mock.commands.get("plan")?.handler("tools", context.ctx);
 
 		assert.equal(customCalled, true);
@@ -373,7 +373,7 @@ test("implementation handoff restores tools after using configured defaults", as
 		planMode(mock.pi);
 		const context = createMockContext();
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["bash", ...REQUIRED_PLAN_TOOLS]);
 
 		const execute = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as

--- a/extensions/pi-plan-mode/test/issue-302-repro.test.ts
+++ b/extensions/pi-plan-mode/test/issue-302-repro.test.ts
@@ -8,7 +8,7 @@ test("issue 302: re-entered Plan Mode hides the previous implementation handoff"
 	planMode(mock.pi);
 	const context = createMockContext();
 
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const executeComplete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(executeComplete);
@@ -39,7 +39,7 @@ test("issue 302: re-entered Plan Mode hides the previous implementation handoff"
 	)) as { messages: unknown[] };
 	assert.deepEqual(inactiveContext.messages, implementationMessages);
 
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan active");
 	assert.deepEqual(mock.rawPi.getActiveTools(), [
 		"bash",

--- a/extensions/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/extensions/pi-plan-mode/test/issue-471-repro.test.ts
@@ -118,7 +118,7 @@ test("legacy plans obey the completion size bound before restore or readiness", 
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.events.get("agent_end")?.[0]?.(
 		{
 			messages: [
@@ -186,7 +186,7 @@ test("issue 471: an active implementation plan is restored after compaction remo
 	planMode(mock.pi);
 	const context = createMockContext();
 
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
@@ -226,7 +226,7 @@ test("implementation transition persists active state before a busy follow-up an
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext({ isIdle: () => false });
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
@@ -256,7 +256,7 @@ test("failed implementation delivery restores ready state without retained imple
 	const mock = createMockPi({ activeTools: ["read", "custom"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
@@ -282,7 +282,7 @@ test("a failed superseding prompt restores the exact active implementation", asy
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
@@ -308,7 +308,7 @@ test("active context avoids exact handoff duplication and replaces stale injecte
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
@@ -383,7 +383,7 @@ test("active plans can be shown and cleared through existing direct routes", asy
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
@@ -429,7 +429,7 @@ test("a Plan-mode question cannot commit or open its next prompt after Plan mode
 			return selection.promise;
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const question = mock.tools.find((candidate) => candidate.name === "plan_mode_question")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(question);
@@ -463,7 +463,7 @@ test("a Plan-mode question cannot commit or open its next prompt after Plan mode
 	);
 	await selectStarted.promise;
 	await mock.commands.get("plan")?.handler("exit", context.ctx);
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	selection.resolve("1. Narrow — Change only this path.");
 
 	const result = (await pendingAnswer) as { details?: { cancelled?: boolean; reason?: string } };
@@ -490,7 +490,7 @@ test("shutdown cancellation cannot let a stale tool menu reactivate Plan-mode to
 			return harness.resultPromise;
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const pendingMenu = mock.commands.get("plan")?.handler("tools", context.ctx);
 	await selectStarted.promise;
 	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
@@ -519,7 +519,7 @@ test("exiting Plan mode while a tool menu is open cannot reactivate Plan-mode to
 			return menuHarness.resultPromise;
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const pendingMenu = mock.commands.get("plan")?.handler("tools", context.ctx);
 	await selectStarted.promise;
 	await mock.commands.get("plan")?.handler("exit", context.ctx);
@@ -540,7 +540,7 @@ test("the active-plan menu shows without superseding and cancellation is read-on
 			select: async (_title: string, options: string[]) =>
 				selection ? options.find((option) => option.startsWith(selection)) : undefined,
 		});
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 			?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 		assert.ok(complete);
@@ -574,7 +574,7 @@ test("active-plan menu actions work in TUI and RPC without hidden route changes"
 			select: async (_title: string, options: string[]) =>
 				options.find((option) => option.startsWith(scenario.selection)),
 		});
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 			?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 		assert.ok(complete);
@@ -587,11 +587,30 @@ test("active-plan menu actions work in TUI and RPC without hidden route changes"
 	}
 });
 
+test("/plan start supersedes an active implementation without starting a model turn", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+	assert.ok(complete);
+	await complete("complete", { plan: PLAN }, undefined, undefined, context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	const sentBeforeStart = mock.sentUserMessages.length;
+
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
+	assert.equal(mock.sentUserMessages.length, sentBeforeStart);
+});
+
 test("starting a new Plan-mode workflow supersedes the active implementation", async () => {
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);

--- a/extensions/pi-plan-mode/test/launch-menu.test.ts
+++ b/extensions/pi-plan-mode/test/launch-menu.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import {
+	builtinTool,
+	createMockContext,
+	createMockPi,
+	extensionTool,
+} from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+
+const REQUIRED_PLAN_TOOLS = ["plan_mode_question", "plan_mode_complete"];
+
+async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), 2_000);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+async function waitForOpenCount(
+	tui: ReturnType<typeof createTuiHarness>,
+	count: number,
+	running?: Promise<unknown>,
+) {
+	for (let turn = 0; tui.openCount < count && turn < 100; turn += 1) {
+		if (running) {
+			const settled = await Promise.race([
+				running.then(() => true),
+				new Promise<false>((resolve) => setImmediate(() => resolve(false))),
+			]);
+			if (settled) break;
+		} else await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	assert.equal(tui.openCount, count, "expected the launch menu to remain interactive");
+}
+
+function launchFixture() {
+	const mock = createMockPi({
+		activeTools: ["read", "write"],
+		allTools: [builtinTool("read"), builtinTool("write"), extensionTool("custom")],
+	});
+	planMode(mock.pi);
+	return mock;
+}
+
+test("inactive bare /plan opens a TUI launch menu without changing Plan state", async () => {
+	const mock = launchFixture();
+	const tui = createTuiHarness({ width: 42, rows: 18 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	const frame = tui.render();
+	assert.match(frame.join("\n"), /Plan mode/);
+	assert.match(frame.join("\n"), /Status: Off/i);
+	assert.match(frame.join("\n"), /Start Plan mode/);
+	assert.ok(frame.every((line) => line.length <= 42));
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(mock.entries.length, 0);
+
+	tui.press("tui.select.cancel");
+	await running;
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(mock.entries.length, 0);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("the launch menu starts Plan mode only after explicit confirmation", async () => {
+	const mock = launchFixture();
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	tui.press("tui.select.confirm");
+	await running;
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+});
+
+test("launch tool choices remain draft-only until Done starts Plan mode", async () => {
+	const mock = launchFixture();
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await waitForOpenCount(tui, 2);
+	assert.match(tui.render().join("\n"), /Choose Plan-mode tools/);
+	assert.equal(tui.isFocusable, true);
+	tui.setFocused(true);
+	assert.equal(tui.focused, true);
+
+	// read is selected, write is unavailable, custom is opt-in, then the pinned Done action.
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await settleWithin(tui.waitForPending(), "the staged tool toggle");
+	await waitForOpenCount(tui, 3, running);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(mock.entries.length, 0);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await settleWithin(running, "launch menu completion");
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("launch tool drafts and help navigation cancel without side effects", async () => {
+	const mock = launchFixture();
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await waitForOpenCount(tui, 2);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await settleWithin(tui.waitForPending(), "the cancelled staged tool toggle");
+	await waitForOpenCount(tui, 3, running);
+	tui.press("tui.select.cancel");
+	await waitForOpenCount(tui, 4, running);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(mock.entries.length, 0);
+
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await waitForOpenCount(tui, 5, running);
+	assert.match(tui.render().join("\n"), /read-only exploration/i);
+	tui.press("tui.select.cancel");
+	await waitForOpenCount(tui, 6, running);
+	tui.press("tui.select.cancel");
+	await running;
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(mock.entries.length, 0);
+	assert.equal(mock.thinkingLevels.length, 0);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("inactive bare /plan adapts the launch menu to RPC", async () => {
+	const mock = launchFixture();
+	const rpc = createRpcHarness([{ kind: "select", response: "Start Plan mode" }]);
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: rpc.ui.select,
+		input: rpc.ui.input,
+		custom: rpc.ui.custom,
+	});
+
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	rpc.assertConsumed();
+	assert.equal(
+		rpc.dialogs[0]?.title,
+		"Plan mode\nStatus: Off — normal tools are active.\nWhen started: read, plan_mode_question, plan_mode_complete",
+	);
+	assert.deepEqual(rpc.dialogs[0]?.options, [
+		"Start Plan mode",
+		"Choose tools, then start…",
+		"How Plan mode works",
+	]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("RPC stages tool changes until the explicit start action", async () => {
+	const mock = launchFixture();
+	const rpc = createRpcHarness([
+		{ kind: "select", response: "Choose tools, then start…" },
+		{ kind: "select", response: "[ ] custom" },
+		{ kind: "select", response: "Done — start Plan mode" },
+	]);
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: rpc.ui.select,
+		input: rpc.ui.input,
+		custom: rpc.ui.custom,
+	});
+
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	rpc.assertConsumed();
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("Ctrl+C and external disposal discard the inactive launch interaction", async () => {
+	for (const ending of ["ctrl-c", "dispose"] as const) {
+		const mock = launchFixture();
+		const tui = createTuiHarness();
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+		});
+		const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+		await waitForOpenCount(tui, 1, running);
+		if (ending === "ctrl-c") tui.press("ctrl+c");
+		else tui.dispose();
+		await settleWithin(running, `${ending} launch cancellation`);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+		assert.equal(mock.entries.length, 0);
+		assert.equal(mock.thinkingLevels.length, 0);
+		assert.equal(mock.sentUserMessages.length, 0);
+	}
+});
+
+test("session replacement and shutdown discard staged launch tools", async () => {
+	for (const ending of ["replacement", "shutdown"] as const) {
+		const mock = launchFixture();
+		const tui = createTuiHarness();
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+		await waitForOpenCount(tui, 1, running);
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await waitForOpenCount(tui, 2, running);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await settleWithin(tui.waitForPending(), "the lifecycle draft toggle");
+		await waitForOpenCount(tui, 3, running);
+
+		if (ending === "replacement") {
+			await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+		} else await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		await settleWithin(running, `${ending} launch cancellation`);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+		assert.equal(mock.thinkingLevels.length, 0);
+		assert.equal(mock.sentUserMessages.length, 0);
+		const latest = mock.entries.at(-1)?.data as { selectedToolNames?: string[] } | undefined;
+		assert.equal(latest?.selectedToolNames, undefined);
+	}
+});
+
+test("/plan start is deterministic and bare /plan rejects non-interactive modes", async () => {
+	for (const mode of ["print", "json"] as const) {
+		const rejected = launchFixture();
+		const rejectedContext = createMockContext({ mode, hasUI: false });
+		await assert.rejects(
+			rejected.commands.get("plan")?.handler("", rejectedContext.ctx) as Promise<unknown>,
+			/\/plan start.*\/plan <prompt>/i,
+		);
+		assert.deepEqual(rejected.rawPi.getActiveTools(), ["read", "write"]);
+		assert.equal(rejected.entries.length, 0);
+
+		const started = launchFixture();
+		const startedContext = createMockContext({ mode, hasUI: false });
+		await started.commands.get("plan")?.handler("start", startedContext.ctx);
+		assert.deepEqual(started.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+		assert.equal(started.sentUserMessages.length, 0);
+	}
+});
+
+test("start is completed while longer start text remains an inline prompt", async () => {
+	const mock = launchFixture();
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	const completions = mock.commands.get("plan")?.getArgumentCompletions?.("") as
+		| Array<{ value: string }>
+		| undefined;
+	assert.ok(completions?.some((item) => item.value === "start"));
+
+	await mock.commands.get("plan")?.handler("start a migration", context.ctx);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, "start a migration");
+});

--- a/extensions/pi-plan-mode/test/plan-export.test.ts
+++ b/extensions/pi-plan-mode/test/plan-export.test.ts
@@ -40,7 +40,7 @@ async function withTempDirectory(run: (directory: string) => Promise<void>) {
 test("plan export autocomplete exposes a path-taking public route", () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.value),
-		["show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+		["start", "show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
 	);
 	assert.deepEqual(
 		completePlanArguments("ex")?.map((item) => item.value),
@@ -63,7 +63,7 @@ test("ready plan export ends Plan mode without triggering a model turn", async (
 		});
 		const context = createMockContext({ cwd: directory, hasUI: true });
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.equal(mock.thinkingLevel, "medium");
 		await completePlan(mock, context.ctx);
 		const entriesBeforeExport = mock.entries.length;
@@ -103,7 +103,7 @@ test("ready plan export supports custom relative and absolute paths", async () =
 			const mock = createMockPi({ activeTools: ["read"] });
 			planMode(mock.pi);
 			const context = createMockContext({ cwd: directory, hasUI: true });
-			await mock.commands.get("plan")?.handler("", context.ctx);
+			await mock.commands.get("plan")?.handler("start", context.ctx);
 			await completePlan(mock, context.ctx);
 
 			await mock.commands.get("plan")?.handler(`export ${requestedPath}`, context.ctx);
@@ -122,7 +122,7 @@ test("plan export refuses existing files and leaves their content and plan state
 		const mock = createMockPi({ activeTools: ["read"] });
 		planMode(mock.pi);
 		const context = createMockContext({ cwd: directory, hasUI: true });
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 		const entriesBeforeExport = mock.entries.length;
 
@@ -140,7 +140,7 @@ test("concurrent exports serialize and create the target only once", async () =>
 		const mock = createMockPi({ activeTools: ["read"] });
 		planMode(mock.pi);
 		const context = createMockContext({ cwd: directory, hasUI: true });
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 
 		await Promise.all([
@@ -184,7 +184,7 @@ test("queued export stops when the ready plan is superseded", async () => {
 		planMode(mock.pi);
 		const context = createMockContext({ cwd: directory, hasUI: true });
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 		const pendingExport = mock.commands.get("plan")?.handler("export", context.ctx);
 		await Promise.resolve();
@@ -213,7 +213,7 @@ test("plan export refuses an existing symbolic link", {
 		const mock = createMockPi({ activeTools: ["read"] });
 		planMode(mock.pi);
 		const context = createMockContext({ cwd: directory, hasUI: true });
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 
 		await mock.commands.get("plan")?.handler("export", context.ctx);
@@ -360,7 +360,7 @@ test("completion and management TUI menus accept an export path", async () => {
 				await mock.commands.get("plan")?.handler("", context.ctx);
 				assert.equal(context.statuses.get("plan-mode"), "plan saved");
 			} else {
-				await mock.commands.get("plan")?.handler("", context.ctx);
+				await mock.commands.get("plan")?.handler("start", context.ctx);
 				await completePlan(mock, context.ctx);
 				if (scenario === "automatic-ready") {
 					await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
@@ -436,7 +436,7 @@ test("RPC export menu accepts a custom path", async () => {
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 
 		await mock.commands.get("plan")?.handler("", context.ctx);
@@ -480,7 +480,7 @@ test("rejected TUI export retains the path draft for correction", async () => {
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 
 		await mock.commands.get("plan")?.handler("", context.ctx);
@@ -513,7 +513,7 @@ test("Back from the export input returns without writing or changing ready state
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 		const entriesBeforeMenu = mock.entries.length;
 
@@ -573,7 +573,7 @@ test("pending export is cancelled by disposal, session replacement, and shutdown
 				},
 			});
 			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-			await mock.commands.get("plan")?.handler("", context.ctx);
+			await mock.commands.get("plan")?.handler("start", context.ctx);
 			await completePlan(mock, context.ctx);
 			const pendingMenu = mock.commands.get("plan")?.handler("", context.ctx);
 			await submitted;
@@ -610,7 +610,7 @@ test("plan export refuses an existing directory", async () => {
 		const mock = createMockPi({ activeTools: ["read"] });
 		planMode(mock.pi);
 		const context = createMockContext({ cwd: directory, hasUI: true });
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 		await mock.commands.get("plan")?.handler("export", context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /already exists/i);

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -64,7 +64,7 @@ test("plan_mode_complete result renders the plan as Markdown", () => {
 test("completePlanArguments suggests management tokens only", () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.label),
-		["show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+		["start", "show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
 	);
 	assert.deepEqual(
 		completePlanArguments("to")?.map((item) => item.value),
@@ -88,7 +88,7 @@ test("missing settings reset a previously loaded fixed thinking level", async ()
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		await unlink(settingsPath);
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.equal(mock.thinkingLevel, "low");
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -374,12 +374,12 @@ test("Plan thinking level restores only while the extension owns the applied val
 		planMode(mock.pi);
 		const context = createMockContext();
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.equal(mock.thinkingLevel, "medium");
 		await mock.commands.get("plan")?.handler("exit", context.ctx);
 		assert.equal(mock.thinkingLevel, "low");
 
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		mock.rawPi.setThinkingLevel("high");
 		await mock.commands.get("plan")?.handler("exit", context.ctx);
 		assert.equal(mock.thinkingLevel, "high");
@@ -392,7 +392,7 @@ test("Plan thinking level restores only while the extension owns the applied val
 		planMode(clamped.pi);
 		const clampedContext = createMockContext();
 		await clamped.events.get("session_start")?.[0]?.({}, clampedContext.ctx);
-		await clamped.commands.get("plan")?.handler("", clampedContext.ctx);
+		await clamped.commands.get("plan")?.handler("start", clampedContext.ctx);
 		assert.equal(clamped.thinkingLevel, "low");
 		await clamped.commands.get("plan")?.handler("exit", clampedContext.ctx);
 		assert.equal(clamped.thinkingLevel, "high");
@@ -407,7 +407,7 @@ test("Plan mode restores an intentionally empty active-tool set", async () => {
 	const mock = createMockPi({ activeTools: [], allTools: [] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), [
 		"read",
 		"bash",
@@ -428,7 +428,7 @@ test("manual thinking changes survive active Plan-mode shutdown and resume", asy
 		planMode(mock.pi);
 		const context = createMockContext();
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		mock.rawPi.setThinkingLevel("high");
 		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 
@@ -490,7 +490,7 @@ test("plan show displays only a stored plan without triggering a model turn", as
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.commands.get("plan")?.handler("show", context.ctx);
 	assert.equal(mock.sentMessages.length, 0);
 	assert.equal(mock.sentUserMessages.length, 0);
@@ -510,7 +510,7 @@ test("plan show keeps a completed plan ready when display delivery fails", async
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(execute);
@@ -535,7 +535,7 @@ test("plan finalize requires active mode and uses idle-safe delivery", async () 
 	assert.equal(mock.sentUserMessages.length, 0);
 	assert.match(context.notifications.at(-1)?.message ?? "", /not active/i);
 
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.commands.get("plan")?.handler("finalize", context.ctx);
 	assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /plan_mode_complete/);
 	assert.equal(mock.sentUserMessages.at(-1)?.options, undefined);
@@ -545,11 +545,30 @@ test("plan finalize requires active mode and uses idle-safe delivery", async () 
 	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
 });
 
+test("/plan start is a no-op while an active Plan workflow is already ready", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+	assert.ok(execute);
+	await execute("ready", { plan: "# Ready" }, undefined, undefined, context.ctx);
+	const entriesBeforeStart = mock.entries.length;
+
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+
+	assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	assert.equal(mock.entries.length, entriesBeforeStart);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /already active/i);
+});
+
 test("plan implement fails closed without a plan and hands off a stored plan", async () => {
 	const mock = createMockPi({ activeTools: ["read", "custom"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan active");
 	assert.equal(mock.sentUserMessages.length, 0);
@@ -572,7 +591,7 @@ test("failed finalize delivery keeps Plan mode active", async () => {
 	};
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.commands.get("plan")?.handler("finalize", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan active");
 	assert.match(context.notifications.at(-1)?.message ?? "", /no longer active/);
@@ -595,7 +614,7 @@ test("invalid proposed plans remain unready and notify the user", async () => {
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", content: "<proposed_plan>unfinished" }] },
 		context.ctx,
@@ -608,7 +627,7 @@ test("prose-only promise to present a plan remains active without false readines
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 
 	await mock.events.get("agent_end")?.[0]?.(
 		{
@@ -630,7 +649,7 @@ test("plan_mode_complete stores a visible terminating plan contract", async () =
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 
 	const tool = mock.tools.find((candidate) => candidate.name === "plan_mode_complete");
 	assert.ok(tool);
@@ -671,7 +690,7 @@ test("plan completion dispatches the ready menu once after agent_settled", async
 			return "Stay in Plan mode";
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(execute);
@@ -696,7 +715,7 @@ test("legacy plan completion is presented once only after settlement", async () 
 			return "Stay in Plan mode";
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", content: "<proposed_plan>\n# Legacy\n</proposed_plan>" }] },
 		context.ctx,
@@ -726,7 +745,7 @@ test("settled plan presentation waits for idle without pending messages", async 
 			return "Stay in Plan mode";
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(execute);
@@ -753,7 +772,7 @@ test("duplicate and replacement completions present only the latest plan once", 
 			return "Stay in Plan mode";
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(execute);
@@ -778,7 +797,7 @@ test("repeated legacy agent_end events produce one settled presentation", async 
 			return "Stay in Plan mode";
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const event = {
 		messages: [{ role: "assistant", content: "<proposed_plan>\n# Retry\n</proposed_plan>" }],
 	};
@@ -793,7 +812,7 @@ test("no-UI completion remains ready without opening or duplicating presentation
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
 	const context = createMockContext({ hasUI: false });
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(execute);
@@ -810,7 +829,7 @@ test("stale settled legacy presentation is ignored without losing ready state", 
 	};
 	planMode(mock.pi);
 	const context = createMockContext({ hasUI: false });
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.events.get("agent_end")?.[0]?.(
 		{
 			messages: [{ role: "assistant", content: "<proposed_plan>\n# Persisted\n</proposed_plan>" }],
@@ -834,7 +853,7 @@ test("a newer Plan turn cancels stale ready presentation", async () => {
 			return "Stay in Plan mode";
 		},
 	});
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const execute = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(execute);
@@ -857,7 +876,7 @@ test("plan_mode_complete rejects inactive and invalid submissions", async () => 
 		execute("inactive", { plan: "# Plan" }, undefined, undefined, context.ctx),
 		/only available while Plan mode is active/,
 	);
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await assert.rejects(
 		execute("empty", { plan: "  \n" }, undefined, undefined, context.ctx),
 		/must not be empty/,
@@ -888,14 +907,21 @@ test("proposed-plan parser distinguishes valid and malformed output", () => {
 test("active Plan UI advertises the completion tool rather than legacy XML", async () => {
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
-	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	let activeMenu = "";
+	const context = createMockContext({
+		hasUI: true,
+		select: async (title: string) => {
+			activeMenu = title;
+			return undefined;
+		},
+	});
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const widget = context.widgets.get("plan-mode-plan") as string[];
 	assert.match(widget.join("\n"), /plan_mode_complete/);
 	assert.doesNotMatch(widget.join("\n"), /proposed_plan/);
 	await mock.commands.get("plan")?.handler("", context.ctx);
-	assert.match(context.notifications.at(-1)?.message ?? "", /plan_mode_complete/);
-	assert.doesNotMatch(context.notifications.at(-1)?.message ?? "", /proposed_plan/);
+	assert.match(activeMenu, /plan_mode_complete/);
+	assert.doesNotMatch(activeMenu, /proposed_plan/);
 });
 
 test("inactive context discards completed-plan tool results", async () => {
@@ -949,7 +975,7 @@ test("inactive context discards completed-plan tool results", async () => {
 		unrelatedResult,
 	]);
 
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const active = (await contextHook({ messages: allMessages }, context.ctx)) as {
 		messages: unknown[];
 	};

--- a/extensions/pi-plan-mode/test/question-tool.test.ts
+++ b/extensions/pi-plan-mode/test/question-tool.test.ts
@@ -11,7 +11,7 @@ test("plan_mode_question reports non-interactive cancellation", async () => {
 		| undefined;
 	assert.ok(execute);
 	const context = createMockContext({ hasUI: false });
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const result = await execute(
 		"call-1",
 		{

--- a/extensions/pi-plan-mode/test/safe-subcommands.test.ts
+++ b/extensions/pi-plan-mode/test/safe-subcommands.test.ts
@@ -37,7 +37,7 @@ test("active Plan mode enforces session-loaded safe subcommands", async () => {
 			"inactive Plan mode must not enforce its shell policy",
 		);
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.equal(
 			await hook(
 				{ toolName: "bash", input: { command: "git rev-parse --show-toplevel" } },
@@ -92,7 +92,7 @@ test("active Plan mode enforces limited policy for effective bash overrides", as
 		assert.ok(hook);
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.ok(mock.rawPi.getActiveTools().includes("bash"));
 
 		const heredoc = `python - <<'PY'\nfrom pathlib import Path\nPath("plan-mode-write-probe.txt").write_text("unexpected write\\n", encoding="utf-8")\nPY`;
@@ -128,7 +128,7 @@ test("session reload removes stale or invalid safe subcommand policy", async () 
 		assert.ok(hook);
 
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.equal(
 			await hook(
 				{ toolName: "bash", input: { command: "gh pr view 218 --json number,title" } },
@@ -140,7 +140,7 @@ test("session reload removes stale or invalid safe subcommand policy", async () 
 
 		await rm(settingsPath);
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.ok(
 			await hook(
 				{ toolName: "bash", input: { command: "gh pr view 218 --json number,title" } },
@@ -152,7 +152,7 @@ test("session reload removes stale or invalid safe subcommand policy", async () 
 		await writeFile(settingsPath, JSON.stringify({ safeSubcommands: { gh: ["pr merge"] } }));
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /settings ignored/i);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		assert.ok(
 			await hook(
 				{ toolName: "bash", input: { command: "gh pr view 218 --json number,title" } },

--- a/extensions/pi-plan-mode/test/saved-plan.test.ts
+++ b/extensions/pi-plan-mode/test/saved-plan.test.ts
@@ -100,7 +100,7 @@ test("plan save exits Plan mode, restores runtime state, and keeps the plan out 
 	});
 	const context = createMockContext({ hasUI: true });
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	assert.equal(mock.thinkingLevel, "medium");
 	await completePlan(mock, context.ctx);
 
@@ -188,7 +188,7 @@ test("automatic and manual ready menus expose Save for later", async () => {
 				return "Save for later";
 			},
 		});
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 		if (automatic) await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
 		else await mock.commands.get("plan")?.handler("", context.ctx);
@@ -266,7 +266,7 @@ test("failed ready implementation restores a manual Plan thinking level", async 
 	});
 	const context = createMockContext();
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	mock.rawPi.setThinkingLevel("high");
 	await mock.events.get("thinking_level_select")?.[0]?.(
 		{ level: "high", previousLevel: "medium" },
@@ -411,6 +411,7 @@ test("saved Plan blocks replacement workflows and --plan restores it as ready", 
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.commands.get("plan")?.handler("design something else", context.ctx);
 	await mock.commands.get("plan")?.handler("tools", context.ctx);
 	assert.equal(mock.sentUserMessages.length, 0);
@@ -462,7 +463,7 @@ test("saved Plan no-UI management is observable without changing state", async (
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		await assert.rejects(
 			mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>,
-			/\/plan show.*\/plan implement.*\/plan exit/i,
+			/\/plan start.*\/plan <prompt>/i,
 		);
 		await assert.rejects(
 			mock.commands.get("plan")?.handler("design something else", context.ctx) as Promise<unknown>,
@@ -493,7 +494,7 @@ test("print and JSON modes can save and clear a ready plan", async () => {
 		planMode(mock.pi);
 		const context = createMockContext({ mode, hasUI: false });
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await mock.commands.get("plan")?.handler("", context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
 		await completePlan(mock, context.ctx);
 
 		await mock.commands.get("plan")?.handler("save", context.ctx);
@@ -560,7 +561,7 @@ test("session shutdown disposes a saved Plan menu without a late transition", as
 test("plan save autocomplete is public and saving fails closed without a ready plan", async () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.value),
-		["show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+		["start", "show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
 	);
 	assert.deepEqual(
 		completePlanArguments("sa")?.map((item) => item.value),

--- a/extensions/pi-plan-mode/test/tool-policy.test.ts
+++ b/extensions/pi-plan-mode/test/tool-policy.test.ts
@@ -328,7 +328,7 @@ test("active Plan mode blocks update_plan and blocked built-ins at the tool hook
 	});
 	planMode(mock.pi);
 	const context = createMockContext();
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const hook = mock.events.get("tool_call")?.[0];
 	const blocked = await hook?.({ toolName: "update_plan", input: {} }, context.ctx);
 	const blockedBuiltin = await hook?.({ toolName: "danger", input: {} }, context.ctx);


### PR DESCRIPTION
## Summary

- open a state-aware launch menu for inactive bare `/plan` in TUI and RPC
- stage tool choices locally until explicit activation and add deterministic `/plan start`
- preserve existing state menus and direct routes, with actionable print/JSON fallback guidance
- document and test launch behavior, cancellation, lifecycle ownership, and compatibility

## Testing

- `npm run check` (2,275 tests)
- `npm run check --workspace @narumitw/pi-plan-mode`
- `just pack plan-mode`
- Pi print-mode smoke tests for `/plan start` and bare `/plan`
